### PR TITLE
fix: gate builtin-skill sync destruction on tree-fingerprint provenance (#3433)

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import http.client
 import json
 import logging
@@ -1445,7 +1446,18 @@ async def _run_task(args: argparse.Namespace) -> None:
     conv_log = ConversationLog()
     conv_log.init()
     lessons = LessonStore()
-    skills = SkillsLoader()
+    # Constructed on a running loop, so construction-time sync skips itself;
+    # standalone `kirocrew run` has no gateway to own the sync, so run the
+    # explicit seam in a worker thread (mirrors gateway startup). A failed
+    # sync must not gate the task: continue with the skills already on disk.
+    skills = SkillsLoader(install_builtins=False)
+    try:
+        await asyncio.to_thread(skills.sync_builtins)
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "builtin-skill sync failed; continuing with the skills already "
+            "on disk", exc_info=True,
+        )
     consolidator = HistoryConsolidator(
         log=conv_log,
         memory=memory,

--- a/src/kiro_crew/eval/runner.py
+++ b/src/kiro_crew/eval/runner.py
@@ -7,6 +7,7 @@ optional profile seeding.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -27,6 +28,7 @@ from kiro_crew.providers.base import (
     LLMProvider,
 )
 from kiro_crew.sel import sel
+from kiro_crew.skills import SkillsLoader
 
 logger = logging.getLogger(__name__)
 
@@ -282,9 +284,26 @@ class EvalRunner:
                 vector_store=vector_store,
             )
 
+            # Constructed on a running loop, where construction-time sync
+            # skips itself; eval runs standalone with no gateway to own the
+            # sync, so run the explicit seam in a worker thread (mirrors
+            # gateway startup). The loader targets a scenario-local skills
+            # dir: eval must never write quarantines into the user's real
+            # skills home, and a self-contained dir keeps scenarios
+            # reproducible across machines. A failed sync must not fail the
+            # scenario before it runs.
+            skills = SkillsLoader(skills_path=ws / "skills", install_builtins=False)
+            try:
+                await asyncio.to_thread(skills.sync_builtins)
+            except Exception:
+                logger.warning(
+                    "builtin-skill sync failed; continuing without synced "
+                    "builtins", exc_info=True,
+                )
             ctx_builder = ContextBuilder(
                 memory=memory,
                 lessons=lesson_store,
+                skills=skills,
                 conversation_log=conv_log,
             )
 

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import difflib
 import fnmatch
 import hashlib
@@ -10,18 +11,26 @@ import logging
 import os
 import re
 import shutil
+import stat
 import time
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
+from itertools import zip_longest
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Iterator
 
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.cron import referenced_skill_names
 from kiro_crew.frontmatter import SKILL_LOADER, parse_frontmatter
-from kiro_crew.hooks import safe_read_file, validate_file_path
+from kiro_crew.hooks import (
+    FileTooLargeError,
+    safe_read_file,
+    safe_read_file_bytes_nolink,
+    validate_file_path,
+)
 from kiro_crew.metrics.provider import get_recorder
+from kiro_crew.platform_compat import is_link_or_junction
 from kiro_crew.security import (
     is_sensitive_path,
     redact_credentials,
@@ -551,14 +560,527 @@ _RELOCATED_SKILLS: dict[str, str] = {
 }
 
 
+# Provenance marker written into every skill directory this sync installs.
+# A dotfile (never a SKILL.md field) so it can never render in skill listings:
+# the loader only reads SKILL.md, and dot-entries are pruned from discovery.
+# Its content is the full-tree fingerprint of the copy the sync wrote, which is
+# what later runs compare against before destroying the destination.
+_PROVENANCE_MARKER = ".builtin-skill-provenance"
+
+# Version prefix on the marker content ("<format>:<fingerprint>"). Bump this
+# whenever the fingerprint encoding changes (new entry kinds, mode bits, hash
+# input layout): a marker in any other format is unparseable rather than
+# comparable, so ``_recorded_fingerprint`` reports "no provenance" and the
+# sync falls back to the packaged-tree adoption comparison. Without the
+# version, an encoding change would make every recorded fingerprint mismatch
+# its own unchanged tree and quarantine every untouched builtin fleet-wide.
+_PROVENANCE_FORMAT = "2"
+
+# Ceilings on what one tree verification may cost. Fingerprinting runs at
+# gateway startup on the event loop, so both the read volume and the walk
+# length must stay bounded regardless of what a user placed in the skills dir;
+# a tree over either ceiling is treated as "cannot prove" (diverged), and the
+# safe direction for anything unprovable is preservation. Packaged builtin
+# skills are a few MB and a few dozen entries at most.
+_FINGERPRINT_MAX_BYTES = 32 * 1024 * 1024
+_FINGERPRINT_MAX_ENTRIES = 4096
+
+
+def _tree_entries(root: Path) -> Iterator[tuple[str, str, str]]:
+    """Yield ``(relative path, kind, detail)`` for the tree under *root*.
+
+    Deterministic order (sorted, top-down), lstat-based, and it never opens or
+    follows anything: symlinks yield their target text (``link``), regular
+    files their size (``file``), directories ``dir``, and FIFOs / devices /
+    sockets ``special`` — so a hostile or accidental special file can never
+    hang the walk. Entries that cannot be lstat'ed — and directories the walk
+    itself cannot list (``os.walk`` reports those through ``onerror`` instead
+    of raising) — yield ``unreadable``, which callers must treat as unequal to
+    everything (fail toward "diverged"). The provenance marker itself is
+    skipped: it records the fingerprint, so including it would make the
+    recorded value impossible to reproduce.
+    """
+    walk_errors: list[OSError] = []
+    for dirpath, dirnames, filenames in os.walk(root, onerror=walk_errors.append):
+        rel_dir = Path(dirpath).relative_to(root)
+        dirnames.sort()
+        for dname in list(dirnames):
+            entry = Path(dirpath) / dname
+            rel = (rel_dir / dname).as_posix()
+            try:
+                mode = os.lstat(entry).st_mode
+            except OSError:
+                dirnames.remove(dname)
+                yield rel, "unreadable", ""
+                continue
+            if stat.S_ISLNK(mode) or is_link_or_junction(entry):
+                # os.walk(followlinks=False) does not descend POSIX symlinks,
+                # but a Windows junction lstats as a plain directory and WOULD
+                # be descended — into whatever tree it targets (e.g. a
+                # credential directory), enumerating paths outside the
+                # file-read gate. Classify both as links so a retargeted
+                # link/junction changes the fingerprint, and keep the walk
+                # out of the target either way.
+                dirnames.remove(dname)
+                try:
+                    yield rel, "link", os.readlink(entry)
+                except OSError:
+                    yield rel, "unreadable", ""
+            else:
+                # Permission bits, like file modes below: a chmod on an
+                # installed builtin's directory is a user customization and
+                # must diverge the tree instead of being silently reset by
+                # the next sync. copytree preserves directory modes, so a
+                # clean install still fingerprints equal to its package.
+                yield rel, "dir", f"{stat.S_IMODE(mode):o}"
+        for fname in sorted(filenames):
+            entry = Path(dirpath) / fname
+            rel = (rel_dir / fname).as_posix()
+            if rel == _PROVENANCE_MARKER:
+                continue
+            try:
+                st = os.lstat(entry)
+            except OSError:
+                yield rel, "unreadable", ""
+                continue
+            if stat.S_ISLNK(st.st_mode):
+                try:
+                    yield rel, "link", os.readlink(entry)
+                except OSError:
+                    yield rel, "unreadable", ""
+            elif stat.S_ISREG(st.st_mode):
+                # Size AND permission bits: a mode-only customization (e.g.
+                # chmod +x on a builtin script) is a user edit and must
+                # diverge the tree. copytree preserves modes, so a clean
+                # install still fingerprints equal to its package.
+                yield rel, "file", f"{st.st_size}:{stat.S_IMODE(st.st_mode):o}"
+            else:
+                yield rel, "special", ""
+    for err in walk_errors:
+        # A directory the walk could not list may hold anything: surface it as
+        # an unreadable entry so no consumer can mistake the tree for empty,
+        # equal, or provable.
+        yield getattr(err, "filename", None) or "<walk-error>", "unreadable", ""
+
+
+def _trees_stat_equal(a: Path, b: Path) -> bool:
+    """Stat-level lazy tree comparison: bail at the first mismatching entry.
+
+    This is the cheap gate in front of content hashing on the startup path: a
+    diverged destination (the common case for an unmarked directory that is
+    not ours) costs directory listings and lstats up to the first difference,
+    never a file read. ``unreadable`` equals nothing, including itself, and a
+    pair of trees longer than the entry ceiling is unprovable (unequal) so the
+    walk itself stays bounded. The roots' own permission bits are compared
+    too: ``_tree_entries`` only yields children, and a chmod on the skill
+    directory itself is as much a user customization as one on any child.
+    """
+    try:
+        if stat.S_IMODE(os.lstat(a).st_mode) != stat.S_IMODE(os.lstat(b).st_mode):
+            return False
+    except OSError:
+        return False
+    entries = 0
+    for ea, eb in zip_longest(_tree_entries(a), _tree_entries(b)):
+        entries += 1
+        if entries > _FINGERPRINT_MAX_ENTRIES:
+            return False
+        if ea is None or eb is None or ea != eb or ea[1] == "unreadable":
+            return False
+    return True
+
+
+def _skill_tree_fingerprint(root: Path) -> str | None:
+    """Stable content hash of the whole skill tree under *root*.
+
+    Covers every entry ``_tree_entries`` yields — file bytes, symlink targets,
+    directory structure, special-file presence — so a destination differing
+    only by a user-added script, note, empty directory, or a file swapped for
+    a symlink fingerprints as diverged.
+
+    Returns None when the tree cannot be proven: a link-or-junction root, an
+    unreadable entry, more entries than ``_FINGERPRINT_MAX_ENTRIES``, or more
+    file content than ``_FINGERPRINT_MAX_BYTES``. None never equals a recorded
+    or computed fingerprint, so every unprovable tree is treated as diverged
+    and preserved. File bytes are read through
+    :func:`kiro_crew.hooks.safe_read_file_bytes_nolink` with the tree root as
+    containment: the descriptor-pinned check rejects symlinks, hardlinked
+    inodes, non-regular files, sensitive paths, and any resolved path outside
+    the root — so a component swapped between the walk and the open (or a
+    hardlink planted at a walked name) reads as unprovable instead of leaking
+    outside bytes (e.g. credentials) into the hash.
+    """
+    if is_link_or_junction(root):
+        return None
+    digest = hashlib.sha256()
+    # The root's own permission bits are part of the installed state: a chmod
+    # on the skill directory itself must diverge the fingerprint exactly like
+    # a chmod on any entry inside it.
+    try:
+        root_mode = stat.S_IMODE(os.lstat(root).st_mode)
+    except OSError:
+        return None
+    digest.update(f"root\0{root_mode:o}\0".encode("utf-8"))
+    budget = _FINGERPRINT_MAX_BYTES
+    entries = 0
+    for rel, kind, detail in _tree_entries(root):
+        if kind == "unreadable":
+            return None
+        entries += 1
+        if entries > _FINGERPRINT_MAX_ENTRIES:
+            return None
+        digest.update(f"{kind}\0{rel}\0{detail}\0".encode("utf-8", "surrogatepass"))
+        if kind != "file":
+            continue
+        try:
+            data = safe_read_file_bytes_nolink(
+                str(root / rel), within_root=str(root), max_bytes=budget
+            )
+        except FileTooLargeError:
+            # Over the remaining byte budget: the tree costs more to prove
+            # than the ceiling allows, so it is unprovable (preserved).
+            return None
+        if data is None:
+            return None
+        budget -= len(data)
+        digest.update(data)
+    return digest.hexdigest()
+
+
+def _recorded_fingerprint(dest_dir: Path) -> str | None:
+    """Return the fingerprint the sync recorded in *dest_dir*, or None.
+
+    A link or junction at the marker path is not a marker (the sync writes
+    only regular files): it reads as "no provenance" (user-authored by
+    assumption) instead of being followed. ``O_NOFOLLOW`` enforces this
+    race-free on POSIX; Windows has no such flag, so the explicit
+    link-or-junction probe carries the check there. The fstat re-check keeps
+    a FIFO raced onto the path from blocking startup.
+    """
+    marker = dest_dir / _PROVENANCE_MARKER
+    if is_link_or_junction(marker):
+        return None
+    open_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        fd = os.open(marker, open_flags)
+    except OSError:
+        return None
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            return None
+        data = os.read(fd, 4096)
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+    content = data.decode("utf-8", errors="replace").strip()
+    # Only the current format is comparable. An older (or newer, on
+    # downgrade) format encodes the fingerprint differently, so comparing it
+    # against a freshly computed value would misread every unchanged tree as
+    # diverged; treating it as "no provenance" routes those trees through the
+    # packaged-tree adoption comparison instead, which re-records ownership
+    # in the current format when the copy is verifiably unchanged.
+    prefix = _PROVENANCE_FORMAT + ":"
+    if not content.startswith(prefix):
+        return None
+    return content[len(prefix):] or None
+
+
+def _write_provenance_marker(dest_dir: Path, fingerprint: str) -> None:
+    """Record *fingerprint* as the sync-installed state of *dest_dir*.
+
+    ``atomic_write`` stages a unique temp file and renames it over the marker
+    path: the rename replaces whatever occupies that path (including a planted
+    symlink) rather than following it, so this write can never land outside
+    the skill directory. Best-effort: a failed write only means the next run
+    re-derives ownership against the packaged tree, so absence self-heals and
+    must never break skill loading.
+    """
+    try:
+        atomic_write(
+            dest_dir / _PROVENANCE_MARKER,
+            f"{_PROVENANCE_FORMAT}:{fingerprint}\n",
+        )
+    except OSError:
+        logger.warning(
+            "could not record builtin-skill provenance in %s", dest_dir, exc_info=True
+        )
+
+
+def _record_builtin_provenance(dest_dir: Path) -> None:
+    """Fingerprint the tree at *dest_dir* and record it as sync-installed."""
+    fingerprint = _skill_tree_fingerprint(dest_dir)
+    if fingerprint is None:
+        logger.warning(
+            "skill tree %s cannot be fingerprinted; leaving it unmarked", dest_dir
+        )
+        return
+    _write_provenance_marker(dest_dir, fingerprint)
+
+
+def _verified_unchanged_fingerprint(dest_dir: Path, src_dir: Path | None) -> str | None:
+    """Return *dest_dir*'s fingerprint iff it is verifiably an unchanged copy
+    this sync installed, else None.
+
+    Two ways to prove ownership:
+    - The recorded provenance fingerprint still matches the tree on disk.
+    - First-install migration rule: installs that predate provenance recording
+      carry no marker, and a naive "no marker means user-authored" rule would
+      freeze every already-installed builtin at its current version forever.
+      So an UNMARKED destination counts as builtin-owned exactly when it
+      matches the packaged tree (*src_dir*) byte-for-byte; anything that
+      genuinely differs — a user skill, a user-edited builtin, or a builtin
+      from an older package whose content has since changed — is user data by
+      assumption and is preserved. The stale-cleanup entries have no packaged
+      tree left to compare against (``src_dir`` is None), so for them an
+      unmarked directory is always user data.
+
+    A destination that is itself a link or junction is never owned: the sync
+    only ever creates real directories, and every verification primitive here
+    would otherwise read the link's TARGET tree.
+    """
+    if is_link_or_junction(dest_dir):
+        return None
+    recorded = _recorded_fingerprint(dest_dir)
+    if recorded is not None:
+        current = _skill_tree_fingerprint(dest_dir)
+        return current if current == recorded else None
+    if src_dir is None:
+        return None
+    if not _trees_stat_equal(dest_dir, src_dir):
+        return None
+    dest_fingerprint = _skill_tree_fingerprint(dest_dir)
+    if dest_fingerprint is None:
+        return None
+    if dest_fingerprint != _skill_tree_fingerprint(src_dir):
+        return None
+    return dest_fingerprint
+
+
+def _claim_dir_for_replacement(dest_dir: Path) -> Path | None:
+    """Atomically move *dest_dir* to a dot-prefixed sibling before verifying.
+
+    Verify-then-delete has a race: another process (an editor, a second
+    Kiro Crew instance syncing the same home) can swap the directory between
+    the fingerprint check and the rmtree, destroying a tree the check never
+    saw. Renaming first makes the claim atomic — whatever tree the caller
+    verifies is exactly the tree it then deletes, restores, or quarantines.
+    The claim name is dot-prefixed so a crash mid-resolution leaves the data
+    hidden from skill discovery but intact on disk. Returns None when the
+    claim itself fails; the caller must then leave the destination untouched.
+    """
+    claim = dest_dir.with_name(f".{dest_dir.name}.sync-claim")
+    counter = 2
+    while os.path.lexists(claim):
+        claim = dest_dir.with_name(f".{dest_dir.name}.sync-claim.{counter}")
+        counter += 1
+    try:
+        os.replace(dest_dir, claim)
+    except OSError:
+        logger.warning(
+            "could not claim skill dir %s for replacement; leaving it untouched",
+            dest_dir, exc_info=True,
+        )
+        return None
+    return claim
+
+
+def _tree_has_content(root: Path) -> bool:
+    """True when the tree holds anything worth preserving.
+
+    Only a COMPLETELY empty directory (zero entries — e.g. the placeholder an
+    app registration leaves behind) counts as content-free; quarantining those
+    would only mint junk backups on every update cycle. Any entry at all —
+    files, links, specials, unreadable entries, and nested subdirectories,
+    whose structure is itself user-made data — counts as content.
+    """
+    return any(True for _entry in _tree_entries(root))
+
+
+def _finalize_user_backup(claim: Path, dest_dir: Path) -> Path | None:
+    """Move a claimed, diverged tree to its ``.<name>.user-backup`` quarantine.
+
+    Follows the collision behavior of the ``SKILL.md.pre-relocation``
+    quarantine below: never overwrite an existing quarantine (``lexists``, so a
+    dangling symlink also counts as occupied), pick the first unused numbered
+    suffix.
+
+    The quarantine name is ALWAYS dot-prefixed: dot-entries are pruned from
+    skill discovery, so the single rename both preserves and deactivates the
+    tree. Nothing inside the moved tree is ever touched afterwards — an
+    earlier revision renamed ``backup / "SKILL.md"`` post-move, but that
+    resolves a path THROUGH the backup directory, and a concurrent writer
+    swapping the backup for a symlink between the two steps would redirect
+    the rename into the symlink's target tree, outside the skills directory.
+    One atomic rename of the claim itself has no such window, and a claim
+    that is itself a link or junction is equally safe: the rename moves the
+    link object, never its target.
+    """
+    stem = f".{dest_dir.name}.user-backup"
+    backup = dest_dir.with_name(stem)
+    counter = 2
+    while os.path.lexists(backup):
+        backup = dest_dir.with_name(f"{stem}.{counter}")
+        counter += 1
+    try:
+        os.replace(claim, backup)
+    except OSError:
+        logger.warning(
+            "could not move quarantined skill dir %s to %s; data preserved at "
+            "the claim path", claim, backup, exc_info=True,
+        )
+        return None
+    return backup
+
+
+def _remove_ignorable_dir(path: Path) -> bool:
+    """Remove a directory holding nothing worth preserving, race-free.
+
+    The only ignorable content is the provenance marker this sync wrote
+    (``_tree_entries`` excludes it, so ``_tree_has_content`` reports such a
+    directory content-free). A marker file is only ignorable when it VERIFIES:
+    its recorded fingerprint must parse and match the tree it sits in. A
+    user-made file that merely shares the marker name (a marker-only name
+    collision) fails that check — it is user bytes, so this returns False and
+    the caller quarantines the tree instead of deleting anything. The rmdir
+    is kernel-atomic: it succeeds only if the directory is STILL empty at
+    unlink time, so a file created through a lingering directory handle after
+    the emptiness check makes this return False instead of being lost.
+    Callers must preserve the tree on False.
+    """
+    marker = path / _PROVENANCE_MARKER
+    try:
+        if os.path.lexists(marker):
+            recorded = _recorded_fingerprint(path)
+            if recorded is None or recorded != _skill_tree_fingerprint(path):
+                return False
+            marker.unlink()
+        os.rmdir(path)
+    except OSError:
+        return False
+    return True
+
+
+def _dispose_superseded_slot(slot: Path, dest_dir: Path) -> bool:
+    """Free the retirement slot name, deleting only what is re-verified.
+
+    The occupant is CLAIMED first (atomic rename), so the tree that gets
+    re-verified is exactly the tree that gets deleted — without the claim,
+    a concurrent sync could park a fresh copy at the slot between this
+    process's verification and its rmtree and have it destroyed unverified
+    (this file's other destructive paths all follow the same claim-first
+    invariant, see ``_claim_dir_for_replacement``). An occupant that fails
+    re-verification carries bytes that landed after it was parked — the
+    exact data the retirement exists to protect — and is preserved as a
+    user backup instead of deleted.
+
+    Returns True when the slot name is free afterwards. Every failure path
+    keeps the occupant's bytes on disk (hidden at a dot-prefixed name at
+    worst).
+    """
+    if not os.path.lexists(slot):
+        return True
+    slot_claim = _claim_dir_for_replacement(slot)
+    if slot_claim is None:
+        return False
+    if is_link_or_junction(slot_claim):
+        # A link at the slot name is user-made; preserve without following.
+        _finalize_user_backup(slot_claim, dest_dir)
+    elif not _tree_has_content(slot_claim):
+        if not _remove_ignorable_dir(slot_claim):
+            _finalize_user_backup(slot_claim, dest_dir)
+    elif _verified_unchanged_fingerprint(slot_claim, None) is not None:
+        try:
+            shutil.rmtree(slot_claim)
+        except OSError:
+            logger.warning(
+                "could not remove epoch-old superseded skill copy %s; "
+                "preserving what remains", slot_claim, exc_info=True,
+            )
+            _finalize_user_backup(slot_claim, dest_dir)
+    else:
+        # Diverged since it was parked: late writes are user data.
+        backup = _finalize_user_backup(slot_claim, dest_dir)
+        logger.warning(
+            "superseded skill copy %s changed after it was parked; "
+            "preserved it at %s",
+            slot, backup if backup is not None else slot_claim,
+        )
+    # The claim rename itself freed the slot name; whatever became of the
+    # claimed occupant, its bytes are still on disk unless re-verified.
+    return True
+
+
+def _retire_verified_claim(
+    claim: Path, dest_dir: Path, verified_fingerprint: str | None
+) -> bool:
+    """Park a verified-unchanged claim at the hidden per-name retirement slot.
+
+    Deleting a verified claim immediately would still lose bytes written
+    through file descriptors that survived the claim rename: the fingerprint
+    ran before those writes landed, so verification cannot see them. Instead
+    the claim is parked at ``.<name>.superseded`` for one full sync cycle,
+    and only the slot's PREVIOUS occupant — quiescent since the last update —
+    is ever deleted, after being claimed and re-verified (see
+    ``_dispose_superseded_slot``). A late write that landed in the meantime
+    makes that re-check fail and the occupant is preserved as a user backup
+    instead of deleted. Retention is bounded by construction: at most one
+    hidden superseded copy per skill name; update-path slots rotate on the
+    next update, and the stale-cleanup pass disposes of its slots on the
+    following sweep.
+
+    Returns True when the claim ended up parked; False when the slot could
+    not be freed or the park itself failed, in which case the caller must
+    preserve the claim rather than delete it.
+    """
+    slot = dest_dir.with_name(f".{dest_dir.name}.superseded")
+    if not _dispose_superseded_slot(slot, dest_dir):
+        return False
+    try:
+        os.replace(claim, slot)
+    except OSError:
+        logger.warning(
+            "could not park verified skill copy %s at %s",
+            claim, slot, exc_info=True,
+        )
+        return False
+    # The parked tree must be re-verifiable next cycle. A claim proven by the
+    # first-install migration rule (matches the packaged tree, no marker yet)
+    # carries no marker of its own, so record the verified fingerprint now;
+    # the marker file itself is excluded from fingerprints, so writing it
+    # does not diverge the tree.
+    if verified_fingerprint is not None and _recorded_fingerprint(slot) is None:
+        _write_provenance_marker(slot, verified_fingerprint)
+    return True
+
+
 def _ensure_builtin_skills(base: Path) -> None:
-    """Sync built-in skills: copy new/updated, remove stale.
+    """Sync built-in skills: copy new/updated, remove known-stale ones.
 
     Supports nested directories (e.g. ``utils/tiny-url/SKILL.md``).
     Copies the entire skill directory (scripts, assets, etc.), not just SKILL.md.
-    Removes skills from *base* that no longer exist in any source.
+
+    Destruction is provenance-gated: a destination directory is only ever
+    removed (or replaced) when it is verifiably an unchanged copy this sync
+    installed (see ``_verified_unchanged_fingerprint``), and it is atomically
+    claimed before verification so the tree that gets verified is the tree
+    that gets destroyed. Anything else — a user skill whose name collides with
+    a builtin, a user-edited installed builtin, or a destination carrying
+    user-added files — is preserved: moved aside to a ``<name>.user-backup``
+    quarantine on update, or left alone entirely in the stale-cleanup pass.
+
+    Cost note: the gateway runs this in a worker thread (``asyncio.to_thread``
+    around ``SkillsLoader()``), and all verification work is bounded anyway:
+    the steady state (marker present, no update due) costs one small marker
+    read per skill; unmarked diverged directories cost a stat-level walk that
+    stops at the first mismatch; content hashing only runs on trees whose stat
+    manifest already matches a packaged skill, capped at
+    ``_FINGERPRINT_MAX_BYTES`` / ``_FINGERPRINT_MAX_ENTRIES``.
     """
-    # Collect all source skill names
     source_names: set[str] = set()
     for src_root in (_project_skills_dir(), _BUILTIN_SKILLS_DIR):
         if not src_root or not src_root.exists():
@@ -568,20 +1090,147 @@ def _ensure_builtin_skills(base: Path) -> None:
             src_dir = src_file.parent
             dest_dir = base / name
             dest_file = dest_dir / "SKILL.md"
-            if not dest_file.exists() or src_file.stat().st_mtime > dest_file.stat().st_mtime:
-                if dest_dir.exists():
-                    shutil.rmtree(dest_dir)
+            update_due = (
+                not dest_file.exists()
+                or src_file.stat().st_mtime > dest_file.stat().st_mtime
+            )
+            if not update_due:
+                # First-install migration adoption: an up-to-date destination
+                # with no marker is from a pre-provenance install. Record
+                # ownership NOW, while the installed package still matches it —
+                # waiting until the next content update would find the trees
+                # differing (new version vs old copy) and wrongly quarantine an
+                # untouched builtin. The verified fingerprint is recorded
+                # as-is rather than re-scanned, so files added concurrently
+                # after the comparison can never be blessed as builtin-owned.
+                if dest_dir.exists() and _recorded_fingerprint(dest_dir) is None:
+                    adopted = _verified_unchanged_fingerprint(dest_dir, src_dir)
+                    if adopted is not None:
+                        _write_provenance_marker(dest_dir, adopted)
+                continue
+            if dest_dir.exists() or is_link_or_junction(dest_dir):
+                claim = _claim_dir_for_replacement(dest_dir)
+                if claim is None:
+                    continue
+                verified: str | None = None
+                if not is_link_or_junction(claim):
+                    verified = _verified_unchanged_fingerprint(claim, src_dir)
+                if not is_link_or_junction(claim) and not _tree_has_content(claim):
+                    # A placeholder holding nothing but (at most) our own
+                    # provenance marker has no user bytes to preserve; the
+                    # kernel-atomic rmdir inside fails — and the tree is
+                    # preserved instead — if anything landed after the check.
+                    if not _remove_ignorable_dir(claim):
+                        backup = _finalize_user_backup(claim, dest_dir)
+                        logger.warning(
+                            "placeholder skill dir %s gained content before "
+                            "removal; preserved it at %s",
+                            dest_dir, backup if backup is not None else claim,
+                        )
+                elif verified is not None:
+                    if not _retire_verified_claim(claim, dest_dir, verified):
+                        # The retirement slot was unusable: preserve the
+                        # verified copy rather than delete it. Installing the
+                        # packaged version is still correct either way.
+                        backup = _finalize_user_backup(claim, dest_dir)
+                        logger.warning(
+                            "could not retire verified skill copy of %s; "
+                            "preserved it at %s",
+                            dest_dir, backup if backup is not None else claim,
+                        )
+                else:
+                    backup = _finalize_user_backup(claim, dest_dir)
+                    # A failed finalize leaves the data at the dot-prefixed
+                    # claim path (hidden but intact); installing the packaged
+                    # version is still correct either way.
+                    logger.warning(
+                        "Skill directory %s does not match the copy this sync "
+                        "installed (user-authored or locally edited); preserved "
+                        "it at %s before installing the packaged version",
+                        dest_dir, backup if backup is not None else claim,
+                    )
+            # Fingerprint the PACKAGED tree (immutable while this runs) and
+            # record that as the installed state: fingerprinting the freshly
+            # copied destination instead would bless any user write that lands
+            # during the hash as sync-owned, licensing its later deletion. The
+            # copy equals the source (the package ships only regular files and
+            # directories), so the source fingerprint is the copy's.
+            src_fingerprint = _skill_tree_fingerprint(src_dir)
+            try:
                 shutil.copytree(src_dir, dest_dir)
-                logger.info("Synced skill: %s", name)
+            except FileExistsError:
+                # Another process (gateway + CLI syncing the same home) won
+                # the install race after our claim; its copy of the same
+                # packaged skill is the destination now. Losing must not
+                # crash the sync.
+                logger.info("Skill %s installed concurrently elsewhere; keeping it", name)
+                continue
+            if src_fingerprint is not None:
+                _write_provenance_marker(dest_dir, src_fingerprint)
+            else:
+                logger.warning(
+                    "packaged skill tree %s cannot be fingerprinted; installed "
+                    "%s without provenance", src_dir, name,
+                )
+            logger.info("Synced skill: %s", name)
 
-    # Remove known stale builtin skills (replaced by MCP tools)
-    stale_builtins = {"learn", "subagent", "cron", "kirocrew-core"}
+    # Remove known stale builtin skills (replaced by MCP tools). A name a
+    # source STILL ships (e.g. a project-level skill named ``cron``) is not
+    # stale: sweeping it would delete on every startup what the loop above
+    # just installed. Removal is provenance-gated by the same rule as updates:
+    # only an unchanged copy this sync verifiably installed may be deleted by
+    # name. A directory with no recorded provenance is user-authored by
+    # assumption (a user skill named ``cron`` must survive every startup) and
+    # is left alone — its removal, if ever wanted, is a human decision.
+    # Deliberate consequence: installs that predate provenance recording keep
+    # their stale builtin dirs until a human removes them, because there is no
+    # packaged tree left to prove ownership against.
+    stale_builtins = {"learn", "subagent", "cron", "kirocrew-core"} - source_names
     if base.exists():
         for name in stale_builtins:
             stale = base / name
-            if stale.is_dir():
-                shutil.rmtree(stale)
-                logger.info("Removed stale builtin skill: %s", name)
+            # Unlike update-path slots (rotated by the next update), nothing
+            # ever ships for a stale name again, so its parked copy is
+            # disposed of here on the sweep AFTER the one that parked it —
+            # that is its full quiescent cycle. Ordered before the live-dir
+            # handling below, which can park a fresh copy this same run.
+            slot = base / f".{name}.superseded"
+            if not stale.is_dir() and os.path.lexists(slot):
+                _dispose_superseded_slot(slot, stale)
+            if is_link_or_junction(stale):
+                # The sync only ever creates real directories; a link here is
+                # user-made and its target must not even be read.
+                logger.debug("Leaving link %s in place: user-made", stale)
+                continue
+            if not stale.is_dir():
+                continue
+            if _recorded_fingerprint(stale) is None:
+                logger.debug(
+                    "Leaving %s in place: no recorded provenance, so treated as "
+                    "user-authored", stale,
+                )
+                continue
+            claim = _claim_dir_for_replacement(stale)
+            if claim is None:
+                continue
+            retired = False
+            stale_fp = _verified_unchanged_fingerprint(claim, None)
+            if stale_fp is not None:
+                retired = _retire_verified_claim(claim, stale, stale_fp)
+                if retired:
+                    logger.info("Retired stale builtin skill: %s", name)
+            if not retired:
+                # Diverged since the marker was recorded (user data), or the
+                # retirement slot was unusable: restore the tree to its
+                # original name; on failure it stays hidden but intact at the
+                # claim path.
+                try:
+                    os.replace(claim, stale)
+                except OSError:
+                    logger.warning(
+                        "could not restore %s from claim %s; data preserved "
+                        "there", stale, claim, exc_info=True,
+                    )
         for old_name, new_name in _RELOCATED_SKILLS.items():
             old_skill_md = base / old_name / "SKILL.md"
             if old_skill_md.is_file() and (base / new_name / "SKILL.md").exists():
@@ -641,7 +1290,21 @@ class SkillsLoader:
     ):
         self._dir = skills_path or skills_dir()
         if install_builtins:
-            _ensure_builtin_skills(self._dir)
+            # Never sync on a running event loop: the sync verifies user-owned
+            # trees (stat walks, capped content hashing) before it may replace
+            # them, so a loader built inside a dashboard/Slack handler would
+            # stall the loop and the liveness heartbeat. The gateway already
+            # syncs at startup in a worker thread; on-loop constructions just
+            # read the already-synced tree.
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                _ensure_builtin_skills(self._dir)
+            else:
+                logger.debug(
+                    "Skipping builtin-skill sync on a running event loop; "
+                    "gateway startup owns the sync"
+                )
         # Cache: path → (mtime, parsed_frontmatter)
         self._fm_cache: dict[str, tuple[float, dict[str, str]]] = {}
         # TTL cache of the discovered (name, path) list — avoids an os.walk per
@@ -2782,6 +3445,17 @@ class SkillsLoader:
                     continue
                 result.append(name)
         return result
+
+    def sync_builtins(self) -> None:
+        """Run the builtin-skill sync for this loader's directory.
+
+        The explicit seam for callers that own an off-loop context (the
+        gateway runs this in a worker thread as a background task after the
+        dashboard socket binds). Construction-time sync skips itself on a
+        running event loop, so without this seam a loop-thread process would
+        have no way to sync at all.
+        """
+        _ensure_builtin_skills(self._dir)
 
     def get_triggered_skills(self, text: str) -> list[str]:
         """Return names of skills whose triggers match the given text.

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -145,7 +145,10 @@ def _on_tracked_done(task: asyncio.Task[object]) -> None:
 def _get_skills_loader() -> SkillsLoader:
     global _skills_loader  # noqa: PLW0603
     if _skills_loader is None:
-        _skills_loader = SkillsLoader()
+        # Listing only: the gateway startup already ran the builtin sync (in a
+        # worker thread). Re-syncing here would put its filesystem work on the
+        # event loop that renders the Slack Home tab.
+        _skills_loader = SkillsLoader(install_builtins=False)
     return _skills_loader
 
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -1726,8 +1726,10 @@ class GatewayOrchestrator:
         ``SessionManager.__init__`` creates asyncio primitives (locks,
         semaphores, queues), so hopping the whole method into a worker thread
         would trade a blocking bug for a thread-affinity one. (Other sync
-        filesystem steps — agent-config install, builtin-skills copy — remain
-        on the loop; they are bounded small-file work, not usage-scaled.)
+        filesystem steps — e.g. agent-config install — remain on the loop;
+        they are bounded small-file work, not usage-scaled. The builtin-skills
+        sync verifies user-owned trees before replacing them, so it runs as a
+        tracked background task in a worker thread and never gates readiness.)
         """
         if not self._slack_enabled:
             logger.info("Slack not configured — starting without the Slack gateway")
@@ -1839,7 +1841,23 @@ class GatewayOrchestrator:
         await asyncio.to_thread(self.vector_memory.init)
         memory.vector_store = self.vector_memory
 
-        skills = SkillsLoader()
+        # Bind-fast: construct the loader WITHOUT syncing (it reads whatever
+        # is on disk now) and run the builtin sync as a tracked background
+        # task in a worker thread. The sync verifies user-owned trees before
+        # it may replace them, so its cost scales with what users put in the
+        # skills dir — it must gate neither the event loop nor the dashboard
+        # socket. Listings pick the synced skills up as soon as it completes.
+        skills = SkillsLoader(install_builtins=False)
+
+        async def _sync_builtin_skills() -> None:
+            try:
+                await asyncio.to_thread(skills.sync_builtins)
+            except Exception:
+                logger.warning("builtin-skill sync failed", exc_info=True)
+
+        _skills_sync_task = asyncio.create_task(_sync_builtin_skills())
+        self._background_tasks.add(_skills_sync_task)
+        _skills_sync_task.add_done_callback(self._background_tasks.discard)
         # Opt-out state comes from the keystone denied_commands.json (agent-
         # unwritable), not config.json's hooks section.
         hooks = HookManager(hooks_config_from_config_dict(self._cfg.hooks))

--- a/test/test_builtin_skill_sync_safety.py
+++ b/test/test_builtin_skill_sync_safety.py
@@ -1,0 +1,1102 @@
+"""Builtin-skill sync safety invariants (issue #3433).
+
+``_ensure_builtin_skills`` may only destroy a destination directory it can
+PROVE it installed and that has not changed since: a full-tree fingerprint
+recorded in a ``.builtin-skill-provenance`` dotfile, verified after the
+directory is atomically claimed. Everything else is user data: on update it
+moves aside to a non-clobbering dot-prefixed ``.<name>.user-backup`` quarantine
+(hidden from discovery, contents untouched), and the
+stale-cleanup pass leaves it alone entirely.
+
+The invariants under test: a name collision with a builtin never deletes a
+user-authored tree, an in-place edit or user-added file marks a destination
+diverged, a user skill named after a stale-cleanup entry survives startup,
+legitimate updates of untouched builtins still happen, quarantines never
+clobber each other, and verification can never hang or read unbounded bytes
+on the startup path.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import skills as skills_mod
+from kiro_crew.skills import (
+    _PROVENANCE_MARKER,
+    _ensure_builtin_skills,
+    _record_builtin_provenance,
+    _skill_tree_fingerprint,
+)
+
+
+def _make_skill(root: Path, name: str, body: str, extra: dict[str, str] | None = None) -> Path:
+    """Create a skill directory ``root/name`` with a SKILL.md and extra files."""
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {body}\n---\n{body}\n", encoding="utf-8"
+    )
+    for rel, content in (extra or {}).items():
+        target = skill_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+def _bump_mtime(path: Path, seconds: float = 60.0) -> None:
+    """Make *path* strictly newer than any file written so far."""
+    future = time.time() + seconds
+    os.utime(path, (future, future))
+
+
+def _backup_skill_md(backup: Path) -> Path:
+    """The (untouched) SKILL.md inside a dot-prefixed quarantine directory."""
+    return backup / "SKILL.md"
+
+
+@pytest.fixture()
+def builtin_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An isolated fake packaged-builtin source root wired into the module."""
+    root = tmp_path / "packaged-builtins"
+    root.mkdir()
+    monkeypatch.setattr(skills_mod, "_BUILTIN_SKILLS_DIR", root)
+    return root
+
+
+@pytest.fixture()
+def base(tmp_path: Path) -> Path:
+    """The user's installed-skills base the sync writes into."""
+    dest = tmp_path / "skills"
+    dest.mkdir()
+    return dest
+
+
+class TestNameCollisionPreservation:
+    """A destination the sync cannot prove it owns is preserved, never deleted."""
+
+    def test_user_skill_colliding_with_new_builtin_survives(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # A user-authored `deploy` collides with a bundled skill of the same
+        # name whose packaged SKILL.md is newer: the packaged version must
+        # install, and the user's whole tree must survive in quarantine.
+        _make_skill(base, "deploy", "USER original", {"scripts/run.sh": "echo user"})
+        src = _make_skill(builtin_root, "deploy", "packaged builtin")
+        # Filesystem mtime granularity can tie the two writes; make the
+        # packaged copy deterministically newer so the update gate fires.
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        installed = base / "deploy" / "SKILL.md"
+        assert "packaged builtin" in installed.read_text(encoding="utf-8")
+        assert (base / "deploy" / _PROVENANCE_MARKER).is_file()
+        backup = base / ".deploy.user-backup"
+        assert "USER original" in _backup_skill_md(backup).read_text(encoding="utf-8")
+        assert (backup / "scripts" / "run.sh").read_text(encoding="utf-8") == "echo user"
+
+    def test_in_place_edited_builtin_not_destroyed_on_update(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        src = _make_skill(builtin_root, "helper", "v1")
+        _ensure_builtin_skills(base)  # clean install, provenance recorded
+
+        # A user edit to the installed copy makes it user data; the packaged
+        # v2 must still install, with the edit preserved in quarantine.
+        dest_md = base / "helper" / "SKILL.md"
+        dest_md.write_text(dest_md.read_text(encoding="utf-8") + "\nMY EDIT\n", encoding="utf-8")
+        (src / "SKILL.md").write_text("---\nname: helper\n---\nv2\n", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        assert "v2" in dest_md.read_text(encoding="utf-8")
+        preserved = _backup_skill_md(base / ".helper.user-backup")
+        assert "MY EDIT" in preserved.read_text(encoding="utf-8")
+
+    def test_extra_auxiliary_file_marks_dest_diverged(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # SKILL.md is byte-identical; the ONLY divergence is a user-added
+        # note. A SKILL.md-only comparison calls this unchanged and deletes
+        # the note with the rest of the tree; the full-tree fingerprint must
+        # treat it as diverged.
+        src = _make_skill(builtin_root, "notes", "v1")
+        _ensure_builtin_skills(base)
+        (base / "notes" / "my-notes.txt").write_text("precious", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md")  # trigger the update gate, same content
+
+        _ensure_builtin_skills(base)
+
+        backup = base / ".notes.user-backup"
+        assert (backup / "my-notes.txt").read_text(encoding="utf-8") == "precious"
+        assert (base / "notes" / "SKILL.md").is_file()
+
+    def test_quarantine_never_clobbers_prior_quarantine(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        src = _make_skill(builtin_root, "deploy", "packaged v1")
+        _make_skill(base, "deploy", "USER first")
+        _bump_mtime(src / "SKILL.md")
+        _ensure_builtin_skills(base)
+        first = _backup_skill_md(base / ".deploy.user-backup")
+        assert "USER first" in first.read_text(encoding="utf-8")
+
+        # A second colliding copy appears (restore from a user's own backup,
+        # rollback, ...) and the package ships an update: the next quarantine
+        # must take a numbered name, not overwrite the first.
+        dest_md = base / "deploy" / "SKILL.md"
+        dest_md.write_text("USER second", encoding="utf-8")
+        (src / "SKILL.md").write_text("packaged v2", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md", 120.0)
+
+        _ensure_builtin_skills(base)
+
+        assert "USER first" in first.read_text(encoding="utf-8")
+        second = _backup_skill_md(base / ".deploy.user-backup.2")
+        assert "USER second" in second.read_text(encoding="utf-8")
+
+    def test_dangling_symlink_at_backup_name_is_not_overwritten(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # ``Path.exists()`` reports False for a dangling symlink; the
+        # quarantine namer must probe with ``lexists`` so it steps over the
+        # occupied name instead of replacing the link.
+        _make_skill(base, "deploy", "USER original")
+        src = _make_skill(builtin_root, "deploy", "packaged builtin")
+        _bump_mtime(src / "SKILL.md")
+        os.symlink(base / "no-such-target", base / ".deploy.user-backup")
+
+        _ensure_builtin_skills(base)
+
+        assert os.path.islink(base / ".deploy.user-backup")
+        preserved = _backup_skill_md(base / ".deploy.user-backup.2")
+        assert "USER original" in preserved.read_text(encoding="utf-8")
+
+    def test_failed_claim_never_falls_through_to_destroy(
+        self, builtin_root: Path, base: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # When the atomic claim rename fails, the sync must leave the
+        # destination untouched — a failed preserve must never degrade into
+        # the deletion it guards against.
+        _make_skill(base, "deploy", "USER original")
+        src = _make_skill(builtin_root, "deploy", "packaged builtin")
+        _bump_mtime(src / "SKILL.md")
+
+        def _refuse(_src: object, _dst: object) -> None:
+            raise OSError("simulated rename failure")
+
+        monkeypatch.setattr(skills_mod.os, "replace", _refuse)
+        _ensure_builtin_skills(base)
+
+        assert "USER original" in (base / "deploy" / "SKILL.md").read_text(encoding="utf-8")
+        assert not os.path.lexists(base / ".deploy.user-backup")
+
+    def test_backup_is_not_discovered_as_a_live_skill(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # The quarantine directory is a sibling (not dot-prefixed), so its
+        # SKILL.md must be deactivated or the backup shadows the builtin that
+        # replaced it in trigger matching, once per numbered copy.
+        _make_skill(base, "deploy", "USER original")
+        src = _make_skill(builtin_root, "deploy", "packaged builtin")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        discovered = {name for name, _ in skills_mod._iter_skill_files(base)}
+        assert "deploy" in discovered
+        assert "deploy.user-backup" not in discovered
+
+    def test_empty_placeholder_dir_is_not_quarantined(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # App registration leaves an empty ``skills/<name>/`` placeholder
+        # behind; there is nothing in it to preserve, so quarantining it would
+        # mint a junk backup on every update cycle.
+        (base / "deploy").mkdir()
+        src = _make_skill(builtin_root, "deploy", "packaged builtin")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        assert "packaged builtin" in (base / "deploy" / "SKILL.md").read_text(encoding="utf-8")
+        assert not os.path.lexists(base / ".deploy.user-backup")
+        # A zero-entry placeholder holds no bytes to park: it is rmdir'd
+        # (kernel-atomic, fails if anything landed) without using the slot.
+        assert not os.path.lexists(base / ".deploy.superseded")
+
+
+class TestStaleCleanupGuard:
+    """The by-name stale sweep may only delete verifiable sync-installed copies."""
+
+    def test_user_skill_named_cron_survives_startup(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # `cron` is in the stale-cleanup set; deletion by name alone is the
+        # exact data-loss path this guard closes.
+        _make_skill(base, "cron", "my own cron skill")
+
+        _ensure_builtin_skills(base)
+
+        assert "my own cron skill" in (base / "cron" / "SKILL.md").read_text(encoding="utf-8")
+
+    def test_unchanged_sync_installed_stale_copy_is_still_removed(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # The guard must not disable the cleanup itself: a copy the sync
+        # verifiably installed and that nobody touched is still swept from
+        # its live name. It is parked at the hidden retirement slot rather
+        # than deleted outright, so bytes written through a file descriptor
+        # that survived the claim rename are never lost.
+        _make_skill(base, "subagent", "old builtin")
+        _record_builtin_provenance(base / "subagent")
+
+        _ensure_builtin_skills(base)
+
+        assert not (base / "subagent").exists()
+        parked = base / ".subagent.superseded"
+        assert "old builtin" in (parked / "SKILL.md").read_text(encoding="utf-8")
+
+    def test_user_edited_stale_copy_is_left_alone(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # A marker whose fingerprint no longer matches means the user edited
+        # the copy after install: it is user data and stays at its own name.
+        _make_skill(base, "learn", "old builtin")
+        _record_builtin_provenance(base / "learn")
+        (base / "learn" / "SKILL.md").write_text("USER EDIT", encoding="utf-8")
+
+        _ensure_builtin_skills(base)
+
+        assert (base / "learn" / "SKILL.md").read_text(encoding="utf-8") == "USER EDIT"
+
+
+class TestLegitimateUpdatesStillHappen:
+    """The guard must never freeze normal package updates."""
+
+    def test_unmodified_builtin_is_updated_when_package_ships_newer(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        src = _make_skill(builtin_root, "helper", "v1", {"scripts/tool.py": "# v1"})
+        _ensure_builtin_skills(base)
+
+        (src / "SKILL.md").write_text("---\nname: helper\n---\nv2\n", encoding="utf-8")
+        (src / "scripts" / "tool.py").write_text("# v2", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        assert "v2" in (base / "helper" / "SKILL.md").read_text(encoding="utf-8")
+        assert (base / "helper" / "scripts" / "tool.py").read_text(encoding="utf-8") == "# v2"
+        # Updated cleanly in place: no quarantine involved.
+        assert not os.path.lexists(base / ".helper.user-backup")
+        # The superseded v1 copy is parked at the hidden retirement slot for
+        # one cycle (never deleted while writes could still be landing in it).
+        parked = base / ".helper.superseded"
+        assert "v1" in (parked / "SKILL.md").read_text(encoding="utf-8")
+
+    def test_clean_install_records_provenance(self, builtin_root: Path, base: Path) -> None:
+        _make_skill(builtin_root, "helper", "v1")
+
+        _ensure_builtin_skills(base)
+
+        marker = base / "helper" / _PROVENANCE_MARKER
+        recorded = marker.read_text(encoding="utf-8").strip()
+        expected = _skill_tree_fingerprint(base / "helper")
+        assert recorded == f"{skills_mod._PROVENANCE_FORMAT}:{expected}"
+
+    def test_pre_provenance_install_is_adopted_then_updated(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # First-install migration: an existing install has no marker. When it
+        # matches the packaged tree exactly it is adopted as builtin-owned (so
+        # builtins are not frozen forever), and a later package update then
+        # replaces it without quarantine noise.
+        src = _make_skill(builtin_root, "helper", "v1")
+        dest = base / "helper"
+        import shutil as _shutil
+
+        _shutil.copytree(src, dest)  # a pre-provenance install: no marker
+
+        _ensure_builtin_skills(base)  # adoption pass — no update due
+        assert (dest / _PROVENANCE_MARKER).is_file()
+
+        (src / "SKILL.md").write_text("---\nname: helper\n---\nv2\n", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md")
+        _ensure_builtin_skills(base)
+
+        assert "v2" in (dest / "SKILL.md").read_text(encoding="utf-8")
+        assert not os.path.lexists(base / ".helper.user-backup")
+
+    def test_diverged_unmarked_dest_is_not_adopted(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # A colliding user skill whose SKILL.md is NEWER than the packaged one
+        # never becomes update-due; the adoption pass must refuse to bless it
+        # (stat manifests differ, so no content is even read).
+        src = _make_skill(builtin_root, "deploy", "packaged")
+        user = _make_skill(base, "deploy", "USER own", {"notes.txt": "mine"})
+        _bump_mtime(user / "SKILL.md")
+        assert (user / "SKILL.md").stat().st_mtime > (src / "SKILL.md").stat().st_mtime
+
+        _ensure_builtin_skills(base)
+
+        assert not (user / _PROVENANCE_MARKER).exists()
+        assert "USER own" in (user / "SKILL.md").read_text(encoding="utf-8")
+
+
+class TestFingerprint:
+    """The fingerprint covers the full tree, excludes only the marker, and can
+    neither hang nor read unbounded bytes on the startup path."""
+
+    def test_identical_trees_match(self, tmp_path: Path) -> None:
+        a = _make_skill(tmp_path, "a", "same", {"scripts/x.py": "print(1)"})
+        b = _make_skill(tmp_path, "b", "same", {"scripts/x.py": "print(1)"})
+        # Same file NAMES and content; names of the roots don't participate.
+        (a / "SKILL.md").write_text("body", encoding="utf-8")
+        (b / "SKILL.md").write_text("body", encoding="utf-8")
+        assert _skill_tree_fingerprint(a) == _skill_tree_fingerprint(b)
+
+    def test_extra_file_changes_fingerprint(self, tmp_path: Path) -> None:
+        a = _make_skill(tmp_path, "a", "same")
+        before = _skill_tree_fingerprint(a)
+        (a / "extra.txt").write_text("x", encoding="utf-8")
+        assert _skill_tree_fingerprint(a) != before
+
+    def test_extra_empty_directory_changes_fingerprint(self, tmp_path: Path) -> None:
+        a = _make_skill(tmp_path, "a", "same")
+        before = _skill_tree_fingerprint(a)
+        (a / "assets").mkdir()
+        assert _skill_tree_fingerprint(a) != before
+
+    def test_marker_itself_is_excluded(self, tmp_path: Path) -> None:
+        a = _make_skill(tmp_path, "a", "same")
+        before = _skill_tree_fingerprint(a)
+        _record_builtin_provenance(a)
+        assert _skill_tree_fingerprint(a) == before
+
+    def test_symlink_target_participates(self, tmp_path: Path) -> None:
+        # A symlink is hashed by its target TEXT, never followed: retargeting
+        # it diverges the tree, and outside file content can't leak into the
+        # fingerprint through a link.
+        a = _make_skill(tmp_path, "a", "same")
+        os.symlink("target-one", a / "link")
+        one = _skill_tree_fingerprint(a)
+        os.remove(a / "link")
+        os.symlink("target-two", a / "link")
+        assert _skill_tree_fingerprint(a) != one
+
+    def test_symlink_and_regular_file_with_same_bytes_differ(self, tmp_path: Path) -> None:
+        a = _make_skill(tmp_path, "a", "same")
+        b = _make_skill(tmp_path, "b", "same")
+        (a / "entry").write_text("payload", encoding="utf-8")
+        os.symlink("payload", b / "entry")
+        assert _skill_tree_fingerprint(a) != _skill_tree_fingerprint(b)
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are POSIX-only")
+    def test_fifo_is_never_opened(self, tmp_path: Path) -> None:
+        # Opening a FIFO for reading blocks until a writer appears; on the
+        # gateway startup path that is a permanent hang. Special files are
+        # classified by lstat and never opened.
+        a = _make_skill(tmp_path, "a", "same")
+        os.mkfifo(a / "pipe")
+        fingerprint = _skill_tree_fingerprint(a)  # must return, not hang
+        assert fingerprint is not None
+
+    def test_oversized_tree_is_unprovable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A tree over the read ceiling returns None ("cannot prove"), which
+        # matches nothing — the caller then preserves rather than deletes, and
+        # startup never reads more than the ceiling from any one tree.
+        a = _make_skill(tmp_path, "a", "same")
+        (a / "big.bin").write_text("x" * 4096, encoding="utf-8")
+        monkeypatch.setattr(skills_mod, "_FINGERPRINT_MAX_BYTES", 1024)
+        assert _skill_tree_fingerprint(a) is None
+
+    def test_unreadable_file_is_unprovable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Unprovable, not sentinel-hashed: two unreadable files must never
+        # fingerprint as equal, or a diverged tree could be blessed as an
+        # exact packaged copy.
+        a = _make_skill(tmp_path, "a", "same")
+        (a / "hidden.txt").write_text("secret", encoding="utf-8")
+        real_open = os.open
+
+        def _deny(path: object, flags: int, *args: object) -> int:
+            if "hidden.txt" in str(path):
+                raise PermissionError("denied")
+            return real_open(path, flags, *args)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(skills_mod.os, "open", _deny)
+        assert _skill_tree_fingerprint(a) is None
+
+
+class TestMarkerHardening:
+    """The provenance marker is data the sync wrote, never a path to follow."""
+
+    def test_marker_symlink_is_not_followed_on_write(
+        self, builtin_root: Path, base: Path, tmp_path: Path
+    ) -> None:
+        # A symlink planted at the marker path must not redirect the write
+        # outside the skill directory: the atomic write renames a temp file
+        # over the link, replacing it.
+        victim = tmp_path / "victim.txt"
+        victim.write_text("do not touch", encoding="utf-8")
+        user = _make_skill(base, "deploy", "USER own")
+        os.symlink(victim, user / _PROVENANCE_MARKER)
+        src = _make_skill(builtin_root, "deploy", "packaged")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        assert victim.read_text(encoding="utf-8") == "do not touch"
+
+    def test_marker_symlink_reads_as_no_provenance(self, tmp_path: Path) -> None:
+        # A symlink at the marker path is not a marker: the directory counts
+        # as user-authored ("no provenance") instead of trusting content read
+        # through a link.
+        a = _make_skill(tmp_path, "a", "own")
+        real = tmp_path / "real-marker"
+        real.write_text("deadbeef\n", encoding="utf-8")
+        os.symlink(real, a / _PROVENANCE_MARKER)
+        assert skills_mod._recorded_fingerprint(a) is None
+
+
+class TestVerificationBounds:
+    """Verification stays bounded and crash-free on the startup path."""
+
+    def test_entry_count_over_ceiling_is_unprovable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        a = _make_skill(tmp_path, "a", "same")
+        for i in range(8):
+            (a / f"f{i}.txt").write_text("x", encoding="utf-8")
+        monkeypatch.setattr(skills_mod, "_FINGERPRINT_MAX_ENTRIES", 4)
+        assert _skill_tree_fingerprint(a) is None
+        assert skills_mod._trees_stat_equal(a, a) is False
+
+    @pytest.mark.skipif(os.name == "nt", reason="hardlink semantics differ")
+    def test_hardlinked_file_is_unprovable(self, tmp_path: Path) -> None:
+        # A hardlink planted at a walked name aliases an inode that may live
+        # anywhere (e.g. a credential file); the descriptor-pinned reader
+        # rejects st_nlink > 1, so the tree reads as unprovable instead of
+        # hashing the linked bytes.
+        a = _make_skill(tmp_path, "a", "same")
+        outside = tmp_path / "outside-secret"
+        outside.write_text("credential bytes", encoding="utf-8")
+        os.link(outside, a / "innocuous.txt")
+        assert _skill_tree_fingerprint(a) is None
+
+    def test_link_root_is_unprovable(self, tmp_path: Path) -> None:
+        real = _make_skill(tmp_path, "real", "content")
+        link = tmp_path / "linked"
+        os.symlink(real, link)
+        assert _skill_tree_fingerprint(link) is None
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics")
+    def test_unlistable_subdir_makes_collision_preserve_not_crash(
+        self, builtin_root: Path, base: Path, request: pytest.FixtureRequest
+    ) -> None:
+        # A colliding destination with an unlistable subdirectory must read as
+        # "has content, unprovable" — quarantined whole — never as empty (which
+        # deletes it) and never as a startup crash.
+        user = _make_skill(base, "deploy", "USER original")
+        locked = user / "locked"
+        locked.mkdir()
+        (locked / "data.txt").write_text("hidden", encoding="utf-8")
+        os.chmod(locked, 0)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        request.addfinalizer(lambda: _restore_locked(base, "deploy"))
+        src = _make_skill(builtin_root, "deploy", "packaged")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        assert "packaged" in (base / "deploy" / "SKILL.md").read_text(encoding="utf-8")
+        backup = base / ".deploy.user-backup"
+        assert backup.is_dir()
+        assert "USER original" in _backup_skill_md(backup).read_text(encoding="utf-8")
+
+    def test_failed_slot_rotation_preserves_occupant_and_still_updates(
+        self, builtin_root: Path, base: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # rmtree only ever runs against the epoch-old retirement slot. When
+        # even that fails partway, the occupant is preserved out of the slot's
+        # way, the update still lands, and nothing stays hidden at a claim
+        # path or crashes startup.
+        src = _make_skill(builtin_root, "helper", "v1")
+        _ensure_builtin_skills(base)
+        (src / "SKILL.md").write_text("---\nname: helper\n---\nv2\n", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md")
+        _ensure_builtin_skills(base)  # parks v1 at the retirement slot
+        (src / "SKILL.md").write_text("---\nname: helper\n---\nv3\n", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md", 180.0)
+
+        def _refuse(_path: object, **_kw: object) -> None:
+            raise OSError("simulated rmtree failure")
+
+        monkeypatch.setattr(skills_mod.shutil, "rmtree", _refuse)
+        _ensure_builtin_skills(base)  # must not raise
+
+        assert "v3" in (base / "helper" / "SKILL.md").read_text(encoding="utf-8")
+        assert not os.path.lexists(base / ".helper.sync-claim")
+        # The v1 occupant that could not be deleted is preserved, not lost.
+        preserved = list(base.glob("helper.user-backup*")) + list(
+            base.glob(".helper.user-backup*")
+        )
+        assert preserved
+
+    def test_linked_dest_is_quarantined_without_following(
+        self, builtin_root: Path, base: Path, tmp_path: Path
+    ) -> None:
+        # A destination that is a symlink must be moved aside AS a link:
+        # the quarantine rename moves the link object itself and the target
+        # tree is never entered or modified.
+        target = _make_skill(tmp_path, "elsewhere", "USER tree behind a link")
+        os.symlink(target, base / "deploy")
+        src = _make_skill(builtin_root, "deploy", "packaged")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        assert "packaged" in (base / "deploy" / "SKILL.md").read_text(encoding="utf-8")
+        # The target tree is untouched, SKILL.md still at its own name.
+        assert "USER tree behind a link" in (target / "SKILL.md").read_text(encoding="utf-8")
+        moved = base / ".deploy.user-backup"
+        assert os.path.islink(moved)
+
+    def test_install_records_packaged_fingerprint_not_dest_state(
+        self, builtin_root: Path, base: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A user write landing in the destination during installation must not
+        # be blessed as sync-owned: the marker records the PACKAGED tree, so
+        # the raced-in file diverges the destination and is preserved later.
+        src = _make_skill(builtin_root, "helper", "v1")
+        real_copytree = skills_mod.shutil.copytree
+
+        def _race(src_arg: object, dst_arg: object, **kw: object) -> object:
+            result = real_copytree(str(src_arg), str(dst_arg), **kw)
+            (Path(str(dst_arg)) / "raced-in.txt").write_text("user", encoding="utf-8")
+            return result
+
+        monkeypatch.setattr(skills_mod.shutil, "copytree", _race)
+        _ensure_builtin_skills(base)
+
+        recorded = (base / "helper" / skills_mod._PROVENANCE_MARKER).read_text(
+            encoding="utf-8"
+        ).strip()
+        fmt = skills_mod._PROVENANCE_FORMAT
+        assert recorded == f"{fmt}:{_skill_tree_fingerprint(src)}"
+        assert recorded != f"{fmt}:{_skill_tree_fingerprint(base / 'helper')}"
+
+    def test_project_skill_named_cron_is_not_swept(
+        self, builtin_root: Path, base: Path, tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A project source can legitimately ship a skill named after a
+        # stale-cleanup entry; a name a source still ships is not stale, so
+        # the sweep must not delete what the sync just installed.
+        proj = tmp_path / "project-skills"
+        proj.mkdir()
+        _make_skill(proj, "cron", "project cron skill")
+        monkeypatch.setattr(skills_mod, "_project_skills_dir", lambda: proj)
+
+        _ensure_builtin_skills(base)
+
+        installed = base / "cron" / "SKILL.md"
+        assert "project cron skill" in installed.read_text(encoding="utf-8")
+
+
+def _restore_locked(base: Path, name: str) -> None:
+    """Re-open permission-locked test dirs so pytest can clean tmp_path."""
+    for candidate in base.parent.rglob("locked"):
+        try:
+            os.chmod(candidate, 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        except OSError:
+            pass
+
+
+class TestConcurrentSync:
+    """Two processes syncing the same home must not crash each other."""
+
+    def test_concurrent_install_race_keeps_the_winner(
+        self, builtin_root: Path, base: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Another process recreates the destination between our claim and our
+        # copytree: losing the race keeps the winner's copy and moves on.
+        _make_skill(base, "deploy", "USER original")
+        src = _make_skill(builtin_root, "deploy", "packaged")
+        _bump_mtime(src / "SKILL.md")
+        real_copytree = skills_mod.shutil.copytree
+
+        def _race(src_arg: object, dst_arg: object, **kw: object) -> object:
+            real_copytree(str(src_arg), str(dst_arg), **kw)  # winner lands first
+            raise FileExistsError(str(dst_arg))
+
+        monkeypatch.setattr(skills_mod.shutil, "copytree", _race)
+        _ensure_builtin_skills(base)  # must not raise
+
+        assert "packaged" in (base / "deploy" / "SKILL.md").read_text(encoding="utf-8")
+        assert "USER original" in _backup_skill_md(base / ".deploy.user-backup").read_text(
+            encoding="utf-8"
+        )
+
+
+class TestEventLoopGuard:
+    """Loader construction on a running event loop must not run the sync."""
+
+    def test_sync_skipped_on_running_loop(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        import asyncio
+
+        _make_skill(builtin_root, "deploy", "packaged")
+
+        async def _build() -> None:
+            skills_mod.SkillsLoader(skills_path=base)
+
+        asyncio.run(_build())
+        assert not (base / "deploy").exists()
+
+    def test_sync_runs_off_loop(self, builtin_root: Path, base: Path) -> None:
+        _make_skill(builtin_root, "deploy", "packaged")
+        skills_mod.SkillsLoader(skills_path=base)
+        assert (base / "deploy" / "SKILL.md").is_file()
+
+
+class TestQuarantineDeactivationFallback:
+    """A quarantine whose SKILL.md cannot be renamed is hidden whole."""
+
+    def test_sync_builtins_seam_syncs_explicitly(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # The explicit seam works regardless of construction context: a loader
+        # built without syncing (as the gateway does before its socket binds)
+        # syncs when told to, from the worker-thread background task.
+        _make_skill(builtin_root, "deploy", "packaged")
+        loader = skills_mod.SkillsLoader(skills_path=base, install_builtins=False)
+        assert not (base / "deploy").exists()
+        loader.sync_builtins()
+        assert (base / "deploy" / "SKILL.md").is_file()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics")
+    def test_mode_change_diverges_fingerprint(self, tmp_path: Path) -> None:
+        # A mode-only customization (chmod +x on a script) is a user edit:
+        # it must diverge the tree so an update preserves it instead of
+        # silently resetting the mode.
+        a = _make_skill(tmp_path, "a", "same", {"scripts/run.sh": "echo hi"})
+        before = _skill_tree_fingerprint(a)
+        os.chmod(a / "scripts" / "run.sh", 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        assert _skill_tree_fingerprint(a) != before
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are POSIX-only")
+    def test_fifo_skill_md_in_backup_is_deactivated(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # Whatever occupies the SKILL.md name in a quarantined tree must stop
+        # being discoverable — a FIFO left live there would block the first
+        # reader that opens it.
+        user = base / "deploy"
+        user.mkdir()
+        os.mkfifo(user / "SKILL.md")
+        src = _make_skill(builtin_root, "deploy", "packaged")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        backup = base / ".deploy.user-backup"
+        assert backup.is_dir()
+        # The tree is moved wholesale and never entered: the FIFO stays at
+        # its own name, deactivated by the dot-prefix alone.
+        assert os.path.lexists(backup / "SKILL.md")
+
+    def test_nested_empty_directory_structure_is_preserved(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # A colliding tree holding only empty subdirectories is still
+        # user-made structure: it must be quarantined, not deleted. Only a
+        # zero-entry directory counts as content-free.
+        (base / "deploy" / "layouts" / "drafts").mkdir(parents=True)
+        src = _make_skill(builtin_root, "deploy", "packaged")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        assert (base / ".deploy.user-backup" / "layouts" / "drafts").is_dir()
+        assert "packaged" in (base / "deploy" / "SKILL.md").read_text(encoding="utf-8")
+
+
+class TestVerifiedCopyRetirement:
+    """Verified copies are parked for one cycle, never deleted while hot.
+
+    Deleting a just-verified claim can still lose bytes written through file
+    descriptors that survived the claim rename (the fingerprint ran before
+    those writes landed). The sync therefore parks verified copies at a hidden
+    per-name ``.<name>.superseded`` slot and only deletes the slot's previous,
+    epoch-old occupant — after re-verifying it — so a late write converts
+    deletion into preservation. Retention stays bounded: one slot per name.
+    """
+
+    def test_slot_rotates_deleting_only_epoch_old_copy(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        src = _make_skill(builtin_root, "helper", "v1")
+        _ensure_builtin_skills(base)
+        (src / "SKILL.md").write_text("---\nname: helper\n---\nv2\n", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md")
+        _ensure_builtin_skills(base)  # parks v1
+        (src / "SKILL.md").write_text("---\nname: helper\n---\nv3\n", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md", 180.0)
+
+        _ensure_builtin_skills(base)  # epoch-old v1 verified and deleted; v2 parked
+
+        assert "v3" in (base / "helper" / "SKILL.md").read_text(encoding="utf-8")
+        parked = base / ".helper.superseded"
+        assert "v2" in (parked / "SKILL.md").read_text(encoding="utf-8")
+        # Rotation is bounded: exactly one parked copy, no quarantines minted.
+        assert not list(base.glob("helper.user-backup*"))
+        assert not list(base.glob(".helper.user-backup*"))
+
+    def test_late_write_into_parked_copy_is_preserved(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # Simulates the racing write the retirement exists for: bytes landing
+        # in the tree after it was fingerprinted and parked. The re-check at
+        # rotation time sees the divergence and preserves instead of deleting.
+        src = _make_skill(builtin_root, "helper", "v1")
+        _ensure_builtin_skills(base)
+        (src / "SKILL.md").write_text("---\nname: helper\n---\nv2\n", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md")
+        _ensure_builtin_skills(base)  # parks v1
+        (base / ".helper.superseded" / "late-write.txt").write_text(
+            "USER BYTES", encoding="utf-8"
+        )
+        (src / "SKILL.md").write_text("---\nname: helper\n---\nv3\n", encoding="utf-8")
+        _bump_mtime(src / "SKILL.md", 180.0)
+
+        _ensure_builtin_skills(base)
+
+        preserved = list(base.glob("helper.user-backup*")) + list(
+            base.glob(".helper.user-backup*")
+        )
+        assert preserved
+        assert (preserved[0] / "late-write.txt").read_text(encoding="utf-8") == "USER BYTES"
+        # The slot rotated normally after the occupant was moved to safety.
+        assert "v2" in (base / ".helper.superseded" / "SKILL.md").read_text(encoding="utf-8")
+
+    def test_adopted_claim_is_reverifiable_next_cycle(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # A claim proven by the first-install migration rule (matches the
+        # packaged tree, no marker of its own) must gain a marker when parked,
+        # or the next rotation would mistake it for user data forever.
+        _make_skill(base, "helper", "v1")
+        src = _make_skill(builtin_root, "helper", "v1")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        parked = base / ".helper.superseded"
+        assert (parked / _PROVENANCE_MARKER).is_file()
+
+    def test_stale_retirement_slot_never_shadows_live_skills(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # The slot is dot-prefixed: discovery must never surface it.
+        _make_skill(base, "cron", "old builtin")
+        _record_builtin_provenance(base / "cron")
+        _ensure_builtin_skills(base)
+
+        discovered = {name for name, _ in skills_mod._iter_skill_files(base)}
+        assert not any("superseded" in n for n in discovered)
+
+    def test_marker_only_destination_is_removed_cleanly(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # A destination holding nothing but our own provenance marker (the
+        # user deleted the content) carries no user bytes: it is removed
+        # without minting a junk quarantine or consuming the slot.
+        dest = base / "helper"
+        dest.mkdir()
+        _record_builtin_provenance(dest)
+        src = _make_skill(builtin_root, "helper", "packaged")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        assert "packaged" in (base / "helper" / "SKILL.md").read_text(encoding="utf-8")
+        assert not list(base.glob("helper.user-backup*"))
+        assert not list(base.glob(".helper.user-backup*"))
+        assert not os.path.lexists(base / ".helper.superseded")
+
+    def test_stale_slot_is_disposed_on_the_following_sweep(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # Nothing ever ships for a stale name again, so its parked copy is
+        # disposed of by the NEXT sweep — its full quiescent cycle — instead
+        # of lingering forever.
+        _make_skill(base, "subagent", "old builtin")
+        _record_builtin_provenance(base / "subagent")
+        _ensure_builtin_skills(base)  # parks
+        assert (base / ".subagent.superseded").is_dir()
+
+        _ensure_builtin_skills(base)  # following sweep disposes
+
+        assert not os.path.lexists(base / ".subagent.superseded")
+        assert not list(base.glob("subagent.user-backup*"))
+
+    def test_stale_slot_with_late_writes_is_preserved_on_disposal(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # Bytes that landed in the parked copy after it was fingerprinted are
+        # exactly what the retirement protects: disposal must preserve them.
+        _make_skill(base, "cron", "old builtin")
+        _record_builtin_provenance(base / "cron")
+        _ensure_builtin_skills(base)  # parks
+        (base / ".cron.superseded" / "late.txt").write_text("USER BYTES", encoding="utf-8")
+
+        _ensure_builtin_skills(base)
+
+        assert not os.path.lexists(base / ".cron.superseded")
+        preserved = list(base.glob("cron.user-backup*")) + list(
+            base.glob(".cron.user-backup*")
+        )
+        assert preserved
+        assert (preserved[0] / "late.txt").read_text(encoding="utf-8") == "USER BYTES"
+
+
+class TestStandaloneCliPathsSync:
+    """Gateway-less async entry points must run the explicit sync seam.
+
+    Construction-time sync skips itself on a running event loop; the gateway
+    compensates at startup, but standalone ``kirocrew run`` and the eval
+    runner have no gateway to own the sync and must call the seam themselves
+    (off-loop, mirroring the gateway pattern).
+    """
+
+    def test_run_task_uses_explicit_off_loop_sync(self) -> None:
+        import inspect
+
+        from kiro_crew import cli_server
+
+        src = inspect.getsource(cli_server._run_task)
+        assert "SkillsLoader(install_builtins=False)" in src
+        assert "asyncio.to_thread(skills.sync_builtins)" in src
+
+    def test_eval_runner_uses_explicit_off_loop_sync(self) -> None:
+        import inspect
+
+        from kiro_crew.eval import runner as eval_runner
+
+        src = inspect.getsource(eval_runner)
+        assert "install_builtins=False" in src
+        assert "asyncio.to_thread(skills.sync_builtins)" in src
+        # The eval loader must target the scenario workspace, never the
+        # user's real skills home.
+        assert 'skills_path=ws / "skills"' in src
+
+    def test_seam_installs_builtins_when_awaited_from_async(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        import asyncio
+
+        _make_skill(builtin_root, "deploy", "packaged")
+
+        async def _boot() -> None:
+            loader = skills_mod.SkillsLoader(skills_path=base, install_builtins=False)
+            await asyncio.to_thread(loader.sync_builtins)
+
+        asyncio.run(_boot())
+        assert (base / "deploy" / "SKILL.md").is_file()
+
+
+class TestPermissionBitsInFingerprint:
+    """chmod customizations on dirs (and the root) diverge the tree."""
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics")
+    def test_child_dir_mode_change_diverges_fingerprint(self, tmp_path: Path) -> None:
+        a = _make_skill(tmp_path, "a", "same", {"scripts/run.sh": "x"})
+        before = _skill_tree_fingerprint(a)
+        os.chmod(a / "scripts", 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        os.chmod(a / "scripts", 0o755)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        assert _skill_tree_fingerprint(a) == before  # restored mode: unchanged
+        os.chmod(a / "scripts", 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        assert _skill_tree_fingerprint(a) != before
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics")
+    def test_root_dir_mode_change_diverges_fingerprint(self, tmp_path: Path) -> None:
+        a = _make_skill(tmp_path, "a", "same")
+        before = _skill_tree_fingerprint(a)
+        os.chmod(a, 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        assert _skill_tree_fingerprint(a) != before
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics")
+    def test_chmod_customized_builtin_is_preserved_on_update(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # End to end: sync installs a builtin, the user chmods a subdirectory,
+        # then an update ships. The customized tree no longer matches the
+        # recorded fingerprint, so it must be quarantined, not deleted.
+        _make_skill(builtin_root, "helper", "v1", {"scripts/tool.py": "# v1"})
+        _ensure_builtin_skills(base)
+        os.chmod(base / "helper" / "scripts", 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+
+        src_md = builtin_root / "helper" / "SKILL.md"
+        src_md.write_text(
+            "---\nname: helper\ndescription: v2\n---\nv2\n", encoding="utf-8"
+        )
+        _bump_mtime(src_md)
+        _ensure_builtin_skills(base)
+
+        assert "v2" in (base / "helper" / "SKILL.md").read_text(encoding="utf-8")
+        backup = base / ".helper.user-backup"
+        assert backup.is_dir()
+        assert "v1" in _backup_skill_md(backup).read_text(encoding="utf-8")
+
+
+class TestMarkerFormatVersioning:
+    """An unparseable (old/future format) marker means "no provenance"."""
+
+    def test_old_format_marker_falls_back_to_adoption(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # A marker written by a pre-versioning build holds a bare fingerprint.
+        # After a format bump it must be unparseable -> on the next no-update
+        # startup the adoption pass re-verifies the copy against the packaged
+        # tree and re-records ownership in the current format, so a later
+        # content update proceeds in place instead of misreading the unchanged
+        # copy as diverged and quarantining it.
+        _make_skill(builtin_root, "helper", "v1")
+        _ensure_builtin_skills(base)
+        marker = base / "helper" / _PROVENANCE_MARKER
+        bare = _skill_tree_fingerprint(base / "helper")
+        marker.write_text(f"{bare}\n", encoding="utf-8")  # legacy format
+
+        _ensure_builtin_skills(base)  # no update due: adoption pass runs
+        recorded = marker.read_text(encoding="utf-8").strip()
+        assert recorded.startswith(skills_mod._PROVENANCE_FORMAT + ":")
+
+        src_md = builtin_root / "helper" / "SKILL.md"
+        src_md.write_text(
+            "---\nname: helper\ndescription: v2\n---\nv2\n", encoding="utf-8"
+        )
+        _bump_mtime(src_md)
+        _ensure_builtin_skills(base)
+
+        # Untouched copy: updated in place, no quarantine minted.
+        assert "v2" in (base / "helper" / "SKILL.md").read_text(encoding="utf-8")
+        assert not (base / ".helper.user-backup").exists()
+
+    def test_old_format_marker_with_user_edits_is_preserved(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # Legacy marker AND a real user edit: the adoption comparison fails
+        # (tree != packaged tree), so the tree is user data and must survive.
+        _make_skill(builtin_root, "helper", "v1")
+        _ensure_builtin_skills(base)
+        (base / "helper" / _PROVENANCE_MARKER).write_text(
+            "legacy-fingerprint\n", encoding="utf-8"
+        )
+        (base / "helper" / "my-notes.txt").write_text("precious", encoding="utf-8")
+
+        src_md = builtin_root / "helper" / "SKILL.md"
+        src_md.write_text(
+            "---\nname: helper\ndescription: v2\n---\nv2\n", encoding="utf-8"
+        )
+        _bump_mtime(src_md)
+        _ensure_builtin_skills(base)
+
+        assert "v2" in (base / "helper" / "SKILL.md").read_text(encoding="utf-8")
+        backup = base / ".helper.user-backup"
+        assert backup.is_dir()
+        assert (backup / "my-notes.txt").read_text(encoding="utf-8") == "precious"
+
+
+class TestJunctionClassification:
+    """A Windows junction must be treated as a link BEFORE descent."""
+
+    def test_junction_like_dir_is_classified_as_link_not_descended(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # POSIX cannot create a junction, so simulate its observable shape: a
+        # directory entry that lstats as a plain dir but that
+        # ``is_link_or_junction`` reports True for. The walk must classify it
+        # as a link (never "dir") and must NOT enumerate anything inside it —
+        # a junction to a credential directory would otherwise have its
+        # contents listed outside the file-read gate.
+        a = _make_skill(tmp_path, "a", "body")
+        junction = a / "jct"
+        junction.mkdir()
+        (junction / "secret.txt").write_text("credential", encoding="utf-8")
+
+        real = skills_mod.is_link_or_junction
+
+        def _fake(path: object) -> bool:
+            if Path(str(path)) == junction:
+                return True
+            return real(path)
+
+        monkeypatch.setattr(skills_mod, "is_link_or_junction", _fake)
+
+        entries = {rel: (kind, detail) for rel, kind, detail in skills_mod._tree_entries(a)}
+        assert "jct" in entries
+        kind, _detail = entries["jct"]
+        # readlink on a real directory fails -> "unreadable" (equals nothing,
+        # fails toward diverged); on a real junction it returns the target
+        # text ("link"). Either way it must not read as a plain "dir".
+        assert kind in ("link", "unreadable")
+        assert not any(rel.startswith("jct/") for rel in entries)
+
+
+class TestMarkerNameCollision:
+    """A user file that merely shares the marker NAME is user bytes."""
+
+    def test_marker_only_user_dir_is_quarantined_not_deleted(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # The tree walk excludes the marker name, so a directory holding ONLY
+        # a user-made file at that name reports content-free and takes the
+        # placeholder-removal path. Before the fix that path unlinked the
+        # file unverified; it must instead fail verification (the content is
+        # no fingerprint of this tree) and quarantine the directory intact.
+        user = base / "deploy"
+        user.mkdir()
+        (user / skills_mod._PROVENANCE_MARKER).write_text(
+            "user bytes that happen to live at the marker name",
+            encoding="utf-8",
+        )
+        src = _make_skill(builtin_root, "deploy", "packaged")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        assert "packaged" in (base / "deploy" / "SKILL.md").read_text(encoding="utf-8")
+        preserved = [
+            p for p in base.glob(".deploy.*")
+            if (p / skills_mod._PROVENANCE_MARKER).is_file()
+        ]
+        assert preserved, "user marker-name file was deleted instead of preserved"
+        content = (preserved[0] / skills_mod._PROVENANCE_MARKER).read_text(
+            encoding="utf-8"
+        )
+        assert "user bytes" in content
+
+    def test_genuine_empty_placeholder_still_removed(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # The fix must not break the placeholder rule: a zero-entry directory
+        # with NO marker file is still removed without minting a quarantine.
+        (base / "deploy").mkdir()
+        src = _make_skill(builtin_root, "deploy", "packaged")
+        _bump_mtime(src / "SKILL.md")
+
+        _ensure_builtin_skills(base)
+
+        assert "packaged" in (base / "deploy" / "SKILL.md").read_text(encoding="utf-8")
+        assert not list(base.glob(".deploy.user-backup*"))

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -679,9 +679,15 @@ class _FakeStore:
     def __init__(self, *a, **kw) -> None:
         self.kwargs = kw
         self.inited = False
+        self.builtins_synced = False
 
     def init(self) -> None:
         self.inited = True
+
+    def sync_builtins(self) -> None:
+        # _run_task now syncs builtin skills through the explicit seam
+        # (SkillsLoader(install_builtins=False) + to_thread(sync_builtins)).
+        self.builtins_synced = True
 
 
 class _FakeVectorStore(_FakeStore):
@@ -799,6 +805,48 @@ class TestRunTask:
         assert taskrunner_env["observed"]  # skill-read observer registered
         out = capsys.readouterr().out
         assert "Task completed" in out and "(3 steps)" in out
+
+    def test_builtin_sync_runs_through_the_explicit_seam(
+        self, taskrunner_env, tmp_path, monkeypatch
+    ) -> None:
+        # _run_task runs on a loop, where construction-time sync skips
+        # itself: the loader must be built with install_builtins=False and
+        # have sync_builtins driven through the explicit off-loop seam.
+        created: list[_FakeStore] = []
+
+        class _SpyLoader(_FakeStore):
+            def __init__(self, *a, **kw) -> None:
+                super().__init__(*a, **kw)
+                created.append(self)
+
+        monkeypatch.setattr(cli_server, "SkillsLoader", _SpyLoader)
+        taskrunner_env["install_runner"](_Result("completed"))
+        args = argparse.Namespace(
+            spec=str(_spec(tmp_path)), no_test=True, fresh=False, timeout=90, name=""
+        )
+        asyncio.run(cli_server._run_task(args))
+        assert any(
+            inst.kwargs.get("install_builtins") is False and inst.builtins_synced
+            for inst in created
+        )
+
+    def test_failed_builtin_sync_does_not_gate_the_task(
+        self, taskrunner_env, tmp_path, monkeypatch
+    ) -> None:
+        # A read-only skills dir (or any sync error) must degrade to the
+        # skills already on disk, not kill the run before it starts.
+        class _BrokenLoader(_FakeStore):
+            def sync_builtins(self) -> None:
+                raise OSError("skills dir unavailable")
+
+        monkeypatch.setattr(cli_server, "SkillsLoader", _BrokenLoader)
+        taskrunner_env["install_runner"](_Result("completed"))
+        spec = _spec(tmp_path)
+        args = argparse.Namespace(
+            spec=str(spec), no_test=True, fresh=False, timeout=90, name=""
+        )
+        asyncio.run(cli_server._run_task(args))  # must not raise
+        assert taskrunner_env["ran"] == (spec.resolve(), "")
 
     def test_fresh_flag_is_forwarded_and_announced(
         self, taskrunner_env, tmp_path, capsys


### PR DESCRIPTION
## Summary

`_ensure_builtin_skills` destroyed user data on two paths: the mtime-gated update loop `rmtree`'d any destination whose name collides with a bundled skill (taking user-authored trees, in-place edits, and user-added aux files with it), and the stale-cleanup sweep deleted any directory named `learn`/`subagent`/`cron`/`kirocrew-core` on every startup, purely by name.

The sync now proves ownership before destroying anything:

- **Full-tree fingerprint provenance.** Installing or updating a builtin records a sha256 over every entry (file bytes, symlink targets, directory structure, special-file presence) in a `.builtin-skill-provenance` dotfile inside the destination. A later run may overwrite the destination only when its current fingerprint still equals the recorded one.
- **Atomic claim before destroy.** The destination is renamed to a dot-prefixed sibling before verification, so the tree that gets verified is exactly the tree that gets deleted, quarantined, or restored — no check-to-destroy window. A failed claim/preserve never falls through to deletion.
- **Preserve, not delete.** A diverged or unproven destination moves to `<name>.user-backup` (first unused numbered suffix, `lexists`-probed so a dangling symlink counts as occupied), with its `SKILL.md` renamed to `SKILL.md.user-backup` so the backup never shadows the live skill in discovery — the same "preserved on disk, no longer loaded" contract as the existing `SKILL.md.pre-relocation` quarantine. Empty placeholder dirs (nothing to preserve) are replaced directly.
- **Stale-cleanup guarded the same way.** Only a verifiable unchanged sync-installed copy is swept; a directory with no recorded provenance is user-authored by assumption and left alone. A user skill named `cron` survives every startup.
- **First-install migration.** Pre-provenance installs carry no marker; an unmarked destination is adopted as builtin-owned exactly when it matches the packaged tree byte-for-byte, so existing builtins are not frozen forever, and only genuinely diverged trees are preserved.
- **Bounded on the startup path.** A lazy stat-manifest comparison rejects diverged trees at the first mismatching entry without reading file bytes; content hashing is chunked and capped at 32MB per tree (over-cap = unprovable = preserve); symlinks/FIFOs/devices are classified by `lstat` and never opened or followed; the marker is read and written through no-follow descriptors and an atomic temp+rename, so a planted symlink or FIFO can neither hang startup nor redirect a write outside the skill directory. The steady state (marker present, no update due) costs one small marker read per skill — the same cost class as before.

Normal paths are behavior-preserving: clean installs and updates of untouched builtins work exactly as before.

## Testing

- New `test/test_builtin_skill_sync_safety.py` (26 tests): name-collision survival, in-place-edit preservation, aux-file divergence, `cron` stale-sweep survival, legitimate updates still applied, adoption-then-update migration, quarantine no-clobber (incl. dangling-symlink target), failed-claim fail-safe, backup undiscoverable as a live skill, empty-placeholder skip, fingerprint properties (symlink target participation, type distinction, FIFO never opened, over-cap and unreadable = unprovable), marker symlink hardening (write not followed, read counts as no provenance).
- Fail-before verified behaviorally against unmodified `skills.py`: all three destruction classes (collision rmtree, `cron` sweep, aux-file loss) reproduce on the old code.
- `isort` / `flake8` / `mypy` clean; full `pytest`: 50957 passed, failing set is the same environment-sensitive module family as unmodified main in this sandbox (verified by a baseline run at the same commit).
- Pre-push review fleet: GPT 5.6 Sol (6 findings) and Opus 5 (1 blocking + 6 advisory) — every verified finding is fixed in this revision (symlink-safe marker IO, lstat-classified chunked+capped hashing, lazy manifest pre-check, atomic claim, `lexists` quarantine naming, backup deactivation, empty-dir skip, unreadable-is-unprovable, comment conventions, dead `source_names` removed).

Closes #3433