### PR TITLE
feat: add tag_session MCP tool for agent-driven session tagging

### DIFF
--- a/src/kiro_crew/mcp_tools/sessions.py
+++ b/src/kiro_crew/mcp_tools/sessions.py
@@ -26,6 +26,7 @@ from kiro_crew.validation import (
     GET_CHAT_SESSION_SCHEMA,
     LIST_SESSIONS_SCHEMA,
     SEARCH_CHAT_HISTORY_SCHEMA,
+    TAG_SESSION_SCHEMA,
     validate_tool_args,
 )
 
@@ -147,6 +148,36 @@ def schemas() -> list[dict[str, Any]]:
                         "default": False,
                     },
                 },
+            },
+        },
+        {
+            "name": "tag_session",
+            "description": (
+                "Assign a status or label tag to a dashboard session slot, moving it "
+                "between kanban board columns. Use when transitioning a session's "
+                "lifecycle stage (e.g. to 'implementation' when coding starts, 'review' "
+                "when a PR opens, 'done' when work completes). Status tags advance "
+                "forward only by default (planned->todo->implementation->review->done); "
+                "pass force=true to override. Defaults to tagging your own session."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "tag": {
+                        "type": "string",
+                        "description": "Tag name (case-insensitive). e.g. 'implementation', 'review', 'done'.",
+                    },
+                    "slot_key": {
+                        "type": "string",
+                        "description": "Target session slot key. Defaults to this session's slot.",
+                    },
+                    "force": {
+                        "type": "boolean",
+                        "description": "Allow regressing a status tag to an earlier lifecycle stage (default false).",
+                        "default": False,
+                    },
+                },
+                "required": ["tag"],
             },
         },
     ]
@@ -426,8 +457,115 @@ def list_sessions(name: str, args: dict[str, Any]) -> str:
     return output
 
 
+def tag_session(name: str, args: dict[str, Any]) -> str:
+    args = validate_tool_args(args, TAG_SESSION_SCHEMA)
+    tag_name = args["tag"]
+    force = args.get("force", False)
+
+    # Resolve the target slot key.
+    # STRICT resolution (env-var only, no PID walk): this tool mutates
+    # persistent slot state via PUT, and a subagent lives under the parent
+    # slot's process tree — a PID-walk would let it silently retag the
+    # PARENT session (same hazard as monitor_start/autonudge_stop).
+    session_key = mcp_core._resolve_session_key_strict()
+    slot_key = args.get("slot_key") or ""
+    if not slot_key:
+        # Derive slot_key from session_key by stripping the 'dashboard:' prefix.
+        # Live dashboard session keys are colon-spelled: "dashboard:chat-N-TS".
+        if session_key and session_key.startswith("dashboard:"):
+            slot_key = session_key.removeprefix("dashboard:")
+        elif session_key:
+            slot_key = session_key
+        else:
+            return (
+                "Cannot determine target slot: no session identity resolved "
+                "(subagent or pooled context). Provide slot_key explicitly."
+            )
+    if not slot_key:
+        return "Cannot determine target slot — provide slot_key explicitly."
+
+    # GET /api/chat/tags — find the tag by name (case-insensitive).
+    tags_resp = mcp_core._get("/api/chat/tags")
+    if isinstance(tags_resp, dict) and tags_resp.get("error"):
+        return f"Failed to fetch tags: {tags_resp['error']}"
+    # The endpoint returns a JSON array; _get annotates -> dict but json.loads
+    # can return a list — handle both shapes defensively.
+    tags_list: list[dict] = tags_resp if isinstance(tags_resp, list) else []  # type: ignore[assignment]
+    target_tag: dict | None = None
+    for t in tags_list:
+        if isinstance(t, dict) and t.get("name", "").lower() == tag_name.lower():
+            target_tag = t
+            break
+    if target_tag is None:
+        return f"No tag named '{tag_name}' found (case-insensitive). Available: {', '.join(t.get('name', '?') for t in tags_list if isinstance(t, dict))}."
+
+    target_tag_id = target_tag["id"]
+    is_status_tag = bool(target_tag.get("status"))
+
+    # GET /api/chat/slots — find the slot and read current tags.
+    slots_resp = mcp_core._get("/api/chat/slots")
+    if isinstance(slots_resp, dict) and slots_resp.get("error"):
+        return f"Failed to fetch slots: {slots_resp['error']}"
+    slots_list: list[dict] = slots_resp if isinstance(slots_resp, list) else []  # type: ignore[assignment]
+    target_slot: dict | None = None
+    for s in slots_list:
+        if isinstance(s, dict) and s.get("key") == slot_key:
+            target_slot = s
+            break
+    if target_slot is None:
+        return f"Slot '{slot_key}' not found."
+
+    current_tag_ids: list[str] = list(target_slot.get("tags") or [])
+
+    if is_status_tag:
+        # Status tags: check advancement (order field), replace existing status tags.
+        new_order = target_tag.get("order", 0)
+        # Build a set of all status tag ids for replacement logic.
+        status_tag_ids = {t["id"] for t in tags_list if isinstance(t, dict) and t.get("status")}
+        # Find the current status tag(s) on this slot.
+        current_status_tags = [
+            t for t in tags_list
+            if isinstance(t, dict) and t.get("id") in current_tag_ids and t.get("status")
+        ]
+        if current_status_tags and not force:
+            # Check advancement: new tag must have higher or equal order.
+            max_current_order = max(t.get("order", 0) for t in current_status_tags)
+            if new_order < max_current_order:
+                current_names = ", ".join(t.get("name", "?") for t in current_status_tags)
+                return (
+                    f"Regression blocked: current status is '{current_names}' "
+                    f"(order {max_current_order}), requested '{tag_name}' "
+                    f"(order {new_order}). Pass force=true to override."
+                )
+        # Replace all status tags with the new one.
+        new_tag_ids = [tid for tid in current_tag_ids if tid not in status_tag_ids]
+        new_tag_ids.append(target_tag_id)
+    else:
+        # Non-status tag: add if not already present; no-op if already there.
+        if target_tag_id in current_tag_ids:
+            return f"Tag '{tag_name}' already assigned to slot '{slot_key}'. No change."
+        new_tag_ids = current_tag_ids + [target_tag_id]
+
+    # PUT /api/chat/slots/{slot_key}/tags with new tags.
+    put_resp = mcp_core._put(f"/api/chat/slots/{slot_key}/tags", {"tags": new_tag_ids})
+    if isinstance(put_resp, dict) and put_resp.get("error"):
+        return f"Failed to update slot tags: {put_resp['error']}"
+
+    # SEL audit log.
+    mcp_core.sel().log_tool_invocation(
+        session_key=session_key,
+        source="mcp",
+        tool_name="tag_session",
+        outcome="success",
+        metadata={"tag": tag_name, "slot_key": slot_key, "forced": force},
+    )
+
+    return f"Tagged slot '{slot_key}' with '{tag_name}'."
+
+
 HANDLERS: dict[str, Callable[[str, dict[str, Any]], str]] = {
     "search_chat_history": search_chat_history,
     "get_chat_session": get_chat_session,
     "list_sessions": list_sessions,
+    "tag_session": tag_session,
 }

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2342,6 +2342,15 @@ LIST_SESSIONS_SCHEMA = ToolSchema(
     ],
 )
 
+TAG_SESSION_SCHEMA = ToolSchema(
+    tool_name="tag_session",
+    fields=[
+        FieldSpec("tag", str, required=True, max_len=60),
+        FieldSpec("slot_key", str, required=False, max_len=200),
+        FieldSpec("force", bool, required=False, default=False),
+    ],
+)
+
 # ── Schema Registry ──
 
 MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
@@ -2373,6 +2382,7 @@ MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
     "search_chat_history": SEARCH_CHAT_HISTORY_SCHEMA,
     "get_chat_session": GET_CHAT_SESSION_SCHEMA,
     "list_sessions": LIST_SESSIONS_SCHEMA,
+    "tag_session": TAG_SESSION_SCHEMA,
     "set_project": SET_PROJECT_SCHEMA,
     "suggest_followup": SUGGEST_FOLLOWUP_SCHEMA,
     "artifact_save": ARTIFACT_SAVE_SCHEMA,

--- a/test/test_mcp_sessions_tag.py
+++ b/test/test_mcp_sessions_tag.py
@@ -1,0 +1,159 @@
+"""Tests for the tag_session MCP tool (kiro_crew.mcp_tools.sessions.tag_session)."""
+
+from __future__ import annotations
+
+import unittest.mock
+from typing import Any
+
+import pytest
+
+from kiro_crew.mcp_tools.sessions import tag_session
+
+TAGS_VOCAB = [
+    {"id": "planned", "name": "Planned", "color": "#6b7280", "order": 0, "status": True},
+    {"id": "todo", "name": "ToDo", "color": "#3b82f6", "order": 1, "status": True},
+    {"id": "implementation", "name": "Implementation", "color": "#8b5cf6", "order": 2, "status": True},
+    {"id": "review", "name": "Review", "color": "#f59e0b", "order": 3, "status": True},
+    {"id": "done", "name": "Done", "color": "#10b981", "order": 4, "status": True},
+    {"id": "urgent", "name": "Urgent", "color": "#ef4444", "order": 5, "status": False},
+]
+
+SLOT_KEY = "chat-46-1786668000"
+SESSION_KEY = f"dashboard:{SLOT_KEY}"
+
+
+@pytest.fixture
+def mock_mcp(monkeypatch):
+    """Patch mcp_core helpers used by tag_session."""
+    import kiro_crew.mcp_core as mcp_core
+
+    get_responses: dict[str, Any] = {
+        "/api/chat/tags": TAGS_VOCAB,
+        "/api/chat/slots": [{"key": SLOT_KEY, "name": "chat-46", "tags": ["planned"]}],
+    }
+
+    def _fake_get(path: str) -> Any:
+        return get_responses.get(path, {"error": "not found"})
+
+    put_calls: list[tuple[str, Any]] = []
+
+    def _fake_put(path: str, body: Any) -> dict:
+        put_calls.append((path, body))
+        return {"ok": True, "tags": body.get("tags", [])}
+
+    def _fake_resolve_session_key() -> str:
+        return SESSION_KEY
+
+    sel_mock = unittest.mock.MagicMock()
+
+    def _fake_sel():
+        return sel_mock
+
+    monkeypatch.setattr(mcp_core, "_get", _fake_get)
+    monkeypatch.setattr(mcp_core, "_put", _fake_put)
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", _fake_resolve_session_key)
+    monkeypatch.setattr(mcp_core, "sel", _fake_sel)
+
+    return {
+        "get_responses": get_responses,
+        "put_calls": put_calls,
+        "sel_mock": sel_mock,
+    }
+
+
+def test_tag_session_advances_status(mock_mcp):
+    """Advancing from planned -> implementation succeeds."""
+    result = tag_session("tag_session", {"tag": "implementation"})
+    assert mock_mcp["put_calls"], "PUT should have been called"
+    path, body = mock_mcp["put_calls"][0]
+    assert body["tags"] == ["implementation"]
+    assert "Tagged" in result
+    assert "implementation" in result.lower() or "Implementation" in result
+
+
+def test_tag_session_regression_blocked(mock_mcp):
+    """Regressing from implementation -> planned is blocked without force."""
+    # Slot currently at implementation
+    mock_mcp["get_responses"]["/api/chat/slots"] = [
+        {"key": SLOT_KEY, "name": "chat-46", "tags": ["implementation"]}
+    ]
+    result = tag_session("tag_session", {"tag": "planned", "force": False})
+    assert not mock_mcp["put_calls"], "PUT should NOT have been called"
+    assert "regression" in result.lower() or "blocked" in result.lower()
+
+
+def test_tag_session_force_regression(mock_mcp):
+    """Forcing regression from implementation -> planned succeeds."""
+    mock_mcp["get_responses"]["/api/chat/slots"] = [
+        {"key": SLOT_KEY, "name": "chat-46", "tags": ["implementation"]}
+    ]
+    _result = tag_session("tag_session", {"tag": "planned", "force": True})  # noqa: F841
+    assert mock_mcp["put_calls"], "PUT should have been called with force"
+    path, body = mock_mcp["put_calls"][0]
+    assert body["tags"] == ["planned"]
+
+
+def test_tag_session_unknown_tag(mock_mcp):
+    """Unknown tag name returns error listing available tags."""
+    result = tag_session("tag_session", {"tag": "nonexistent"})
+    assert not mock_mcp["put_calls"]
+    assert "nonexistent" in result
+    # Should list available tag names
+    assert "Planned" in result
+    assert "Done" in result
+
+
+def test_tag_session_case_insensitive(mock_mcp):
+    """Tag lookup is case-insensitive."""
+    _result = tag_session("tag_session", {"tag": "DONE"})  # noqa: F841
+    assert mock_mcp["put_calls"], "PUT should be called for case-insensitive match"
+    path, body = mock_mcp["put_calls"][0]
+    assert "done" in body["tags"]
+
+
+def test_tag_session_non_status_tag_added(mock_mcp):
+    """Non-status tag is added alongside existing status tag."""
+    mock_mcp["get_responses"]["/api/chat/slots"] = [
+        {"key": SLOT_KEY, "name": "chat-46", "tags": ["planned"]}
+    ]
+    _result = tag_session("tag_session", {"tag": "urgent"})  # noqa: F841
+    assert mock_mcp["put_calls"], "PUT should be called"
+    path, body = mock_mcp["put_calls"][0]
+    assert body["tags"] == ["planned", "urgent"]
+
+
+def test_tag_session_non_status_already_present(mock_mcp):
+    """Non-status tag already present is a no-op."""
+    mock_mcp["get_responses"]["/api/chat/slots"] = [
+        {"key": SLOT_KEY, "name": "chat-46", "tags": ["planned", "urgent"]}
+    ]
+    result = tag_session("tag_session", {"tag": "urgent"})
+    assert not mock_mcp["put_calls"], "PUT should NOT be called"
+    assert "already" in result.lower()
+
+
+def test_tag_session_slot_not_found(mock_mcp):
+    """Explicit slot_key that doesn't exist returns error."""
+    result = tag_session("tag_session", {"tag": "planned", "slot_key": "nonexistent-slot"})
+    assert not mock_mcp["put_calls"]
+    assert "not found" in result.lower() or "nonexistent-slot" in result
+
+
+def test_tag_session_defaults_to_own_slot(mock_mcp):
+    """Without slot_key, handler resolves own session and strips dashboard: prefix."""
+    _result = tag_session("tag_session", {"tag": "implementation"})  # noqa: F841
+    # The PUT should target the slot derived from stripping 'dashboard:' from SESSION_KEY
+    assert mock_mcp["put_calls"], "PUT should be called"
+    path, _ = mock_mcp["put_calls"][0]
+    assert SLOT_KEY in path
+    assert "dashboard:" not in path
+
+
+def test_tag_session_subagent_no_identity(mock_mcp, monkeypatch):
+    """Subagent with no session identity and no explicit slot_key fails closed."""
+    import kiro_crew.mcp_core as mcp_core
+
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "")
+    result = tag_session("tag_session", {"tag": "done"})
+    assert not mock_mcp["put_calls"], "PUT should NOT be called"
+    assert "cannot determine" in result.lower() or "no session identity" in result.lower()


### PR DESCRIPTION
## Problem / Motivation

The dashboard has a full kanban board with status tags (Planned, ToDo, Implementation, Review, Done) and sidebar columns, but agents have no way to tag their own sessions. Users must manually drag session cards between columns, which is tedious when running many parallel sessions.

## Why it matters

Power users running 10+ concurrent sessions can't keep their kanban board current without hand-curating it. The board goes stale and loses its value as a workflow tracker. An agent that could move its own session between columns as work progresses (implementation → review → done) would keep the board accurate with zero manual effort.

## What changed

Adds a `tag_session` MCP tool to the `kirocrew-core` server that assigns status/label tags to a session slot via the existing dashboard tag API.

Motivation → approach → change:
- Goal: let an agent set its session's kanban column programmatically.
- Approach: a thin MCP tool over the existing `PUT /api/chat/slots/{slot}/tags` endpoint, resolving the caller's own slot by default and enforcing forward-only lifecycle advancement for status tags.
- Built:
  - `TAG_SESSION_SCHEMA` in `validation.py` (`tag`, optional `slot_key`, optional `force`).
  - `tag_session` handler in `mcp_tools/sessions.py` + registration in `HANDLERS`.
  - Case-insensitive tag-name resolution (agents know names, not internal hex IDs).
  - Status tags advance forward only by default (`planned→todo→implementation→review→done`); `force=true` overrides. Non-status tags are added alongside existing tags.
  - Identity resolved via `_resolve_session_key_strict()` (fail-closed for subagents) with the `dashboard:` slot-key prefix — matching the sibling session-mutating tools (`monitor_start`, `autonudge_stop`).

## Tests

`test/test_mcp_sessions_tag.py` — 10 tests covering:
- Status advancement (happy path)
- Regression blocked without `force`; allowed with `force=true`
- Unknown tag name → error listing available tags
- Case-insensitive matching
- Non-status tag added alongside existing status tag
- Non-status tag already present → no-op
- Slot not found → error
- Default-to-own-slot resolution (strips `dashboard:` prefix)
- Subagent with no identity + no explicit `slot_key` → fail-closed error

## Manual verification

N/A — unit coverage sufficient. The underlying `PUT /api/chat/slots/{slot}/tags` endpoint is already production-proven (the dashboard UI drag-drop uses the same path), and the handler is fully exercised by mocked-API unit tests.

## Related Issues

Fixes #3456

## Checklist

- [x] Single commit with a Conventional Commits title (`feat: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, tool is self-documenting via its MCP schema description
- [x] No secrets, credentials, or internal references in the diff
