### PR TITLE
fix: map optional dataclass config fields to nullable schema types (#3468)

### DIFF
--- a/src/kiro_crew/config/schema.py
+++ b/src/kiro_crew/config/schema.py
@@ -162,21 +162,30 @@ def _build_field_schema(
     enum_values: list | None = meta.get("enum", None)
 
     tp: type = resolved_type if resolved_type is not None else str
+    # A field annotated ``X | None`` / ``Optional[X]`` maps to its base type
+    # plus ``"null"``. Without the unwrap, the union itself reaches
+    # ``_python_type_to_json`` and falls through to ``"string"`` with
+    # ``nullable=False`` — making "unset means inherit the downstream default"
+    # unexpressible for numeric fields. The ``nullable`` metadata flag remains
+    # the way to allow ``null`` on a field whose annotation is non-optional
+    # (disable-sentinel fields the loader normalizes, e.g.
+    # session.archive_retention_days: null → "disable cleanup").
+    tp, annotation_nullable = _optional_inner(tp)
+    nullable = annotation_nullable or bool(meta.get("nullable"))
     schema: dict = {}
 
     if _is_dataclass_type(tp):
         # Nested dataclass → recurse
         schema = _build_object_schema(tp)
+        if nullable:
+            schema["type"] = ["object", "null"]
     else:
         json_type = _python_type_to_json(tp)
-        # A field marked ``nullable`` in its metadata accepts JSON ``null`` in
-        # addition to its base type. Needed for disable-sentinel fields where
-        # ``null`` is a meaningful value the loader normalizes (e.g.
-        # session.archive_retention_days: null → "disable cleanup").
-        # Without this the generated schema is ``{"type": "integer"}`` and
-        # jsonschema strips the null on any host where jsonschema is installed
-        # (incl. prod), silently reverting to the default — the opposite intent.
-        if meta.get("nullable"):
+        # Emitting the plain single-type form when the field is not nullable
+        # matters: a ``["integer", "null"]`` schema lets jsonschema accept a
+        # null the loader would otherwise strip, silently reverting the field
+        # to its default — the opposite of the sentinel intent.
+        if nullable:
             schema["type"] = [json_type, "null"]
         else:
             schema["type"] = json_type

--- a/test/test_config_schema.py
+++ b/test/test_config_schema.py
@@ -636,3 +636,50 @@ class TestFieldTypeResolution:
         ap = sc.get("additionalProperties", {})
         assert isinstance(ap, dict) and ap.get("type") == "object"
         assert "properties" in ap and len(ap["properties"]) > 0
+
+
+class TestOptionalFieldMapping:
+    """An ``X | None`` / ``Optional[X]`` dataclass field maps to a nullable
+    base type, not ``"string"``.
+
+    Locks in the field-level ``_optional_inner`` unwrap: without it the union
+    type itself reaches ``_python_type_to_json`` and falls through to the
+    catch-all ``"string"`` with ``nullable=False``, making "unset means
+    inherit the downstream default" unexpressible for numeric config fields.
+    This module uses ``from __future__ import annotations``, so the dataclass
+    below also exercises the string-annotation resolution path end to end.
+    """
+
+    def test_optional_int_field_maps_to_nullable_integer(self) -> None:
+        @dataclasses.dataclass
+        class _Demo:
+            pep604: int | None = None
+            classic: typing.Optional[int] = None
+
+        js = _schema_module.build_json_schema(_Demo)
+        assert js["properties"]["pep604"]["type"] == ["integer", "null"]
+        assert js["properties"]["classic"]["type"] == ["integer", "null"]
+
+        by_path = {e.path: e for e in _schema_module.flatten_to_entries(js, prefix="demo")}
+        for name in ("pep604", "classic"):
+            entry = by_path[f"demo.{name}"]
+            assert entry.type == "integer", (
+                f"{name}: resolved to {entry.type!r} — 'string' here means the "
+                f"Optional unwrap regressed and the union fell through the type map"
+            )
+            assert entry.nullable is True
+
+    def test_non_optional_field_stays_single_typed(self) -> None:
+        # The plain single-type form must survive: widening a non-optional
+        # integer to ["integer", "null"] would let jsonschema accept a null
+        # the loader strips, silently reverting the field to its default.
+        @dataclasses.dataclass
+        class _Demo:
+            plain: int = 3
+
+        js = _schema_module.build_json_schema(_Demo)
+        assert js["properties"]["plain"]["type"] == "integer"
+        by_path = {e.path: e for e in _schema_module.flatten_to_entries(js, prefix="demo")}
+        entry = by_path["demo.plain"]
+        assert entry.type == "integer"
+        assert entry.nullable is False


### PR DESCRIPTION
## Problem

Declaring a config dataclass field as `int | None` (or `typing.Optional[int]`) produces a **string** schema entry — `ConfigEntry(type='string', nullable=False)` — instead of a nullable integer. The machinery for the nullable mapping exists (`_optional_inner()` documents returning `["<base>", "null"]` for `Optional[X]`), but it never fires for a dataclass field's own type, so the union falls through `_python_type_to_json`'s catch-all to `"string"`.

## Why it matters

It removes a whole category of setting: "unset means inherit whatever the downstream tool decides." Any knob wrapping a third-party default must either pin a copy of that default (silently overriding upstream retunes) or invent a magic sentinel like `-1`. This concretely blocked the inherit semantics Design Review asked for on #3465's `agent.tool_search_min_pct` / `tool_search_min_tokens` (shipped in pinned-copy form as a workaround).

## Fix (symptoms → root cause → change)

- **Symptom:** `int | None` field → `type="string"`, `nullable=False`.
- **Root cause:** `_build_field_schema` resolves the field's annotation to a real type (via `typing.get_type_hints` on the owning class) but passes the resulting **union type object** straight to `_python_type_to_json`. `typing.get_origin(int | None)` is `types.UnionType`, which is not in `_TYPE_MAP`, so the field falls through to the `"string"` fallback. `_optional_inner()` was only ever applied to list-item and dict-value annotations, never to the field's own type — the field-level path was dead code.
- **Change:** unwrap the optional at the field level — `tp, annotation_nullable = _optional_inner(tp)` — before dataclass detection and type mapping, and merge it with the existing `nullable` metadata flag. An `X | None` field now emits `{"type": ["<base>", "null"]}` and flattens to `ConfigEntry(type="<base>", nullable=True)`. An `Optional[Dataclass]` field recurses into the object schema and marks it `["object", "null"]`. Non-optional fields keep the plain single-type form, so jsonschema still strips an unexpected `null` on them (the sentinel-protection the prior comment guarded).

Generated output for the current config hierarchy is **byte-identical** to main: the tree has zero `Optional`-annotated fields today (verified by building both sides in-process — 384 entries, same nullable set), so no baseline regeneration is owed and no downstream consumer sees a change until a field opts in.

## Tests

`test/test_config_schema.py::TestOptionalFieldMapping`:
- `test_optional_int_field_maps_to_nullable_integer` — locks in `int | None` (PEP 604) **and** `typing.Optional[int]` mapping to `["integer", "null"]` / `nullable=True`, declared in a module using `from __future__ import annotations` so the string-annotation resolution path is exercised end to end.
- `test_non_optional_field_stays_single_typed` — pins the plain single-type form for non-optional fields, guarding the jsonschema null-stripping sentinel behavior against accidental widening.

Full local gates green: isort, flake8, mypy (941 files), targeted `-k "config or schema"` (2,327 passed), full pytest (50,945 passed; 90 failures are pre-existing host-environment classes, verified identical on clean main).

## Manual verification

N/A — unit coverage sufficient: the change is pure import-time type mapping with no I/O, and the in-process base-vs-head registry comparison above covers the no-regression claim.

Closes #3468
