### PR TITLE
docs(deploy): state the API Gateway rationale security-first, not as guardrail evasion

### DIFF
--- a/src/kiro_crew/deploy/skills/artifact-deploy/SKILL.md
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/SKILL.md
@@ -332,12 +332,14 @@ cannot).
 - **M2 backend** — DONE via **API Gateway HTTP API → Lambda** behind CloudFront
   `/<slug>/api/*` (`app-apigw.yaml` + `deploy-backend.sh`). Live-validated:
   `/<slug>/` and `/<slug>/api/` both 200 on one public link.
-  Chosen over a raw Lambda Function URL because some managed corporate accounts run
-  automated guardrails that auto-mitigate *world-accessible* Lambda Function URLs
-  (`Principal:*`). API Gateway keeps the Lambda non-world-accessible (scoped
-  `apigateway.amazonaws.com` invoke) so no auto-mitigation fires. `app-lambda.yaml`
-  (Function URL + CloudFront OAC) is kept as the lighter variant for unrestricted
-  accounts.
+  Chosen over a raw Lambda Function URL because a Function URL requires a
+  `Principal:"*"` resource policy, making the Lambda itself world-accessible. With
+  API Gateway the Lambda's resource policy is scoped to `apigateway.amazonaws.com`
+  only — the function is never directly reachable from the internet, and all public
+  traffic enters through the managed API Gateway front door. This is also
+  compatible with managed corporate accounts whose guardrails flag world-accessible
+  Function URLs. `app-lambda.yaml` (Function URL + CloudFront OAC) is kept as the
+  lighter variant for unrestricted accounts.
 - **M3 lifecycle** — DONE: `list.sh` / `persist.sh` / `detach_backend.py`, plus the
   **in-account scheduled reaper** (`install-reaper.sh` → EventBridge-timed Lambda;
   `templates/reaper.yaml` + `scripts/reaper_lambda/`) that deletes expired

--- a/src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
@@ -4,8 +4,8 @@
 Idempotently adds an origin for the backend + a '<slug>/api/*' cache behavior
 routing to it (no caching, all-viewer-except-host so the origin sees the right
 Host). Two origin flavors:
-  * API Gateway (default): plain HTTPS custom origin, no OAC. Guardrail-safe -
-    the Lambda behind it is not world-accessible.
+  * API Gateway (default): plain HTTPS custom origin, no OAC. The Lambda behind
+    it is not world-accessible - only API Gateway may invoke it.
   * Lambda Function URL (--oac): adds a Lambda OAC so CloudFront SigV4-signs the
     origin request (for AWS_IAM Function URLs in unrestricted accounts).
 

--- a/src/kiro_crew/deploy/skills/artifact-deploy/scripts/deploy-backend.sh
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/scripts/deploy-backend.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # KiroCrew One-Click Deploy - per-app backend (M2.2). API Gateway HTTP API ->
 # Lambda, fronted by the shared CloudFront distribution at /<slug>/api/*.
-# Guardrail-safe: the Lambda is invoked only by API Gateway (no world-accessible
-# Function URL). Pass --table to also provision a DynamoDB table (stateful apps).
+# The Lambda is invoked only by API Gateway, never through a world-accessible
+# Function URL. Pass --table to also provision a DynamoDB table (stateful apps).
 #
 # Usage:
 #   deploy-backend.sh <handler_dir> --slug NAME [--table] [--runtime python3.12] \
@@ -151,5 +151,5 @@ fi
 
 echo ""
 echo "✅ backend wired: https://$DOMAIN/$SLUG/api/"
-echo "   API Gateway origin; Lambda not world-accessible (guardrail-safe).$([[ $TABLE == 1 ]] && echo ' DynamoDB table: kirocrew-deploy-app-'$SLUG || true)"
+echo "   API Gateway origin; Lambda not world-accessible.$([[ $TABLE == 1 ]] && echo ' DynamoDB table: kirocrew-deploy-app-'$SLUG || true)"
 [[ "$WAIT" == "1" ]] || echo "   (CloudFront propagating ~3-5 min; pass --wait to block)"

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw-ddb.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw-ddb.yaml
@@ -1,9 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   KiroCrew One-Click Deploy - per-app STATEFUL backend (API Gateway HTTP API ->
-  Lambda -> DynamoDB). Guardrail-safe (Lambda invoked only by API Gateway; no
-  world-accessible Function URL). The Lambda role is least-privilege: CloudWatch
-  Logs + CRUD on ONLY its own table. One stack per slug.
+  Lambda -> DynamoDB). The Lambda is invoked only by API Gateway (scoped resource
+  policy), never through a world-accessible Function URL. The Lambda role is
+  least-privilege: CloudWatch Logs + CRUD on ONLY its own table. One stack per
+  slug.
 
 Parameters:
   Slug:

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw.yaml
@@ -1,10 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   KiroCrew One-Click Deploy - per-app backend (API Gateway HTTP API -> Lambda).
-  Guardrail-safe: the Lambda is invoked ONLY by API Gateway (scoped
-  apigateway.amazonaws.com permission), NOT via a world-accessible Function URL,
-  so the Lambda-world-accessible detector never fires. The public entry is the
-  shared CloudFront distribution at /<slug>/api/*. One stack per slug.
+  The Lambda is invoked ONLY by API Gateway (resource policy scoped to
+  apigateway.amazonaws.com), never through a Function URL, which would require a
+  Principal:"*" policy and make the function world-accessible. The public entry is
+  the shared CloudFront distribution at /<slug>/api/*. One stack per slug.
 
 Parameters:
   Slug:

--- a/src/kiro_crew/docs/deploy-web.md
+++ b/src/kiro_crew/docs/deploy-web.md
@@ -112,8 +112,11 @@ complete in seconds.
 | API | adds an API Gateway HTTP API to a Lambda at `/<slug>/api/*` | API-backed demo |
 | Stateful | adds a DynamoDB table | app that persists data |
 
-The Lambda is invoked only by API Gateway rather than exposed through a world-accessible Function
-URL, so accounts running automated guardrails against public Function URLs do not flag it.
+The Lambda is invoked only by API Gateway — its resource policy is scoped to
+`apigateway.amazonaws.com`, so the function is never directly reachable from the internet. A
+Function URL would instead require a `Principal:"*"` policy, making the Lambda itself
+world-accessible; this shape is therefore also fine in accounts running automated guardrails
+against public Function URLs.
 
 ---
 

--- a/test/test_deploy_apigw_rationale_docs.py
+++ b/test/test_deploy_apigw_rationale_docs.py
@@ -1,0 +1,168 @@
+"""The API-Gateway-over-Function-URL rationale is stated security-first.
+
+Issue #3475: the artifact-deploy docs argued the M2 backend shape backwards --
+as if API Gateway were chosen *so that* a corporate account's automated
+guardrails would not fire. The actual reason is the security property itself: a
+Function URL needs a ``Principal:"*"`` resource policy, so the Lambda becomes
+world-accessible, while an API Gateway HTTP API keeps the function's invoke
+permission scoped to the API Gateway service principal. Guardrail behaviour is a
+downstream consequence of that property, not the goal.
+
+The prose surfaces are ratcheted as prose: they fail if any of them reintroduces
+the guardrail-as-goal framing, or drops the property that makes the shape
+correct on its own merits. The templates are asserted structurally instead --
+every ``AWS::Lambda::Permission`` must name the API Gateway service principal by
+equality, which is what the prose is claiming and is stronger than finding the
+string somewhere in the file.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+from yaml_helpers import load_with
+
+_DEPLOY = Path(__file__).parent.parent / "src" / "kiro_crew" / "deploy"
+_SKILL = _DEPLOY / "skills" / "artifact-deploy"
+
+SKILL_MD = _SKILL / "SKILL.md"
+APIGW_TEMPLATE = _SKILL / "templates" / "app-apigw.yaml"
+APIGW_DDB_TEMPLATE = _SKILL / "templates" / "app-apigw-ddb.yaml"
+DEPLOY_BACKEND_SH = _SKILL / "scripts" / "deploy-backend.sh"
+ATTACH_BACKEND_PY = _SKILL / "scripts" / "attach_backend.py"
+DEPLOY_WEB_DOC = (
+    Path(__file__).parent.parent / "src" / "kiro_crew" / "docs" / "deploy-web.md"
+)
+
+#: Every surface that explains why the backend sits behind API Gateway. A new
+#: one must be added here, so the framing is pinned everywhere it is stated.
+RATIONALE_SURFACES = (
+    SKILL_MD,
+    APIGW_TEMPLATE,
+    APIGW_DDB_TEMPLATE,
+    DEPLOY_BACKEND_SH,
+    ATTACH_BACKEND_PY,
+    DEPLOY_WEB_DOC,
+)
+
+#: Phrasings that make "a guardrail does not fire" the purpose of the choice.
+#: "Guardrail-safe" is included because as a standalone label it names the
+#: account-policy outcome as the property being claimed.
+GUARDRAIL_AS_GOAL = (
+    re.compile(r"guardrail[- ]safe", re.IGNORECASE),
+    re.compile(r"auto[- ]mitigat", re.IGNORECASE),
+    re.compile(r"(?:so|thus)\b[^.]{0,80}\bdetector\b[^.]{0,40}\bfires?\b", re.I),
+    re.compile(r"\bno\b[^.]{0,40}\b(?:mitigation|detector)\b[^.]{0,20}\bfires?\b", re.I),
+)
+
+#: The service principal an API-Gateway-fronted Lambda scopes its invoke
+#: permission to.
+APIGW_SERVICE_PRINCIPAL = "apigateway.amazonaws.com"
+
+#: Prose must name the principal as *what the policy is scoped to*, not merely
+#: mention it. Matched as a phrase with escaped dots rather than by substring
+#: containment: a bare hostname in an ``in`` test is both the weaker assertion
+#: and, to CodeQL, indistinguishable from URL sanitization
+#: (py/incomplete-url-substring-sanitization).
+SCOPED_TO_APIGATEWAY = re.compile(
+    r"scoped\s+to\s+`?apigateway\.amazonaws\.com`?", re.IGNORECASE
+)
+
+#: A Function URL's world-accessible resource policy, in either spelling the
+#: prose may use.
+PRINCIPAL_STAR = re.compile(r"""Principal:\s*["']?\*["']?""")
+
+
+class _TagTolerantLoader(yaml.SafeLoader):
+    """SafeLoader that ignores CFN intrinsic tags (!Ref/!Sub/!If/!GetAtt...)."""
+
+
+def _construct_intrinsic(loader, tag_suffix, node):
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node, deep=True)
+    return loader.construct_mapping(node, deep=True)
+
+
+_TagTolerantLoader.add_multi_constructor(None, _construct_intrinsic)
+
+
+def _lambda_permissions(path: Path) -> dict[str, dict]:
+    """Every ``AWS::Lambda::Permission`` in a template, by logical id."""
+    doc = load_with(_TagTolerantLoader, path.read_text(encoding="utf-8"))
+    return {
+        name: res.get("Properties", {})
+        for name, res in doc.get("Resources", {}).items()
+        if res.get("Type") == "AWS::Lambda::Permission"
+    }
+
+
+class TestRationaleIsNotGuardrailEvasion:
+    """No surface presents guardrail behaviour as the reason for the design."""
+
+    def test_no_surface_frames_guardrails_as_the_goal(self):
+        offenders = []
+        for path in RATIONALE_SURFACES:
+            text = path.read_text(encoding="utf-8")
+            for pattern in GUARDRAIL_AS_GOAL:
+                match = pattern.search(text)
+                if match:
+                    offenders.append(f"{path.name}: {match.group(0)!r}")
+        assert not offenders, (
+            "guardrail-as-goal framing found (issue #3475): "
+            + "; ".join(offenders)
+            + " -- state the security property (a Function URL needs "
+            'Principal:"*"; API Gateway keeps the Lambda policy scoped) and let '
+            "guardrail compatibility be the consequence."
+        )
+
+
+class TestProseStatesTheSecurityProperty:
+    """The docs that argue the choice name the property that justifies it."""
+
+    def test_skill_md_names_principal_star_and_the_scoped_policy(self):
+        text = SKILL_MD.read_text(encoding="utf-8")
+        assert PRINCIPAL_STAR.search(text), (
+            "SKILL.md must say a Function URL requires a world-accessible "
+            'Principal:"*" resource policy'
+        )
+        assert SCOPED_TO_APIGATEWAY.search(text), (
+            "SKILL.md must say the Lambda's policy is scoped TO the API Gateway "
+            "service principal"
+        )
+        assert "app-lambda.yaml" in text, (
+            "SKILL.md must keep documenting the Function URL variant as the "
+            "lighter option for unrestricted accounts"
+        )
+
+    def test_deploy_web_doc_names_principal_star_and_the_scoped_policy(self):
+        text = DEPLOY_WEB_DOC.read_text(encoding="utf-8")
+        assert PRINCIPAL_STAR.search(text)
+        assert SCOPED_TO_APIGATEWAY.search(text)
+
+
+class TestTemplatesScopeTheInvokePermission:
+    """The claim the prose makes is true of the templates it describes."""
+
+    def test_every_lambda_permission_names_the_apigateway_principal(self):
+        for path in (APIGW_TEMPLATE, APIGW_DDB_TEMPLATE):
+            permissions = _lambda_permissions(path)
+            assert permissions, f"{path.name} declares no AWS::Lambda::Permission"
+            for name, props in permissions.items():
+                assert props.get("Principal") == APIGW_SERVICE_PRINCIPAL, (
+                    f"{path.name}:{name} must scope invoke to "
+                    f"{APIGW_SERVICE_PRINCIPAL}, got {props.get('Principal')!r} "
+                    "-- any other principal (notably '*') makes the function "
+                    "world-accessible, which is the shape these docs rule out"
+                )
+                assert props.get("Action") == "lambda:InvokeFunction", (
+                    f"{path.name}:{name} must grant only lambda:InvokeFunction"
+                )
+
+    def test_templates_still_say_the_lambda_is_not_world_accessible(self):
+        for path in (APIGW_TEMPLATE, APIGW_DDB_TEMPLATE):
+            text = path.read_text(encoding="utf-8")
+            assert "world-accessible" in text, (
+                f"{path.name} must still say the Lambda is not world-accessible"
+            )


### PR DESCRIPTION
## 1. What is the problem?

The `artifact-deploy` skill explained the M2 backend architecture backwards. `SKILL.md` said:

> Chosen over a raw Lambda Function URL because some managed corporate accounts run automated guardrails that auto-mitigate *world-accessible* Lambda Function URLs (`Principal:*`). API Gateway keeps the Lambda non-world-accessible (scoped `apigateway.amazonaws.com` invoke) so no auto-mitigation fires.

That reads as if API Gateway were chosen *so that* an account's guardrails would not fire — guardrail evasion as the objective. The same inverted framing had spread to five sibling surfaces, where "Guardrail-safe" was used as the label for the property being claimed:

- `templates/app-apigw.yaml` — "Guardrail-safe: … so the Lambda-world-accessible detector never fires"
- `templates/app-apigw-ddb.yaml` — "Guardrail-safe (Lambda invoked only by API Gateway …)"
- `scripts/deploy-backend.sh` — header comment, plus the post-deploy success line printed to the operator
- `scripts/attach_backend.py` — module docstring, "Guardrail-safe - the Lambda behind it is not world-accessible"
- `src/kiro_crew/docs/deploy-web.md` — "…so accounts running automated guardrails against public Function URLs do not flag it"

## 2. Why this issue matters to the user

These docs are the rationale an operator (and any future contributor changing the deploy topology) reads to decide whether the shape can be swapped. Stated as guardrail avoidance, the natural conclusion is "my account has no such guardrail, so a Function URL is fine here" — which trades away a real security property for nothing. The property is independent of any account policy: a Function URL requires a `Principal:"*"` resource policy, so the Lambda itself becomes world-accessible. `attach_backend.py` makes this concrete — its `--oac` flavor really does offer a Function URL origin, so the doc is guiding a live choice.

## 3. How our fix solves it

Symptom: the doc argues from guardrail behaviour. Root cause: the causal order is reversed — the security property is the reason, and guardrail compatibility is a downstream consequence of it. The fix restates the property first on every surface that argues the choice:

- **`SKILL.md`** takes the rewrite from the issue verbatim: a Function URL needs `Principal:"*"`; with API Gateway the Lambda's policy is scoped to `apigateway.amazonaws.com`, the function is never directly reachable from the internet, all public traffic enters through the managed front door. Corporate-guardrail compatibility is kept as a closing consequence, and `app-lambda.yaml` is still documented as the lighter variant for unrestricted accounts.
- **`docs/deploy-web.md`** gets the same property-first form, naming both `Principal:"*"` and the scoped policy.
- **Both CloudFormation `Description` blocks, `deploy-backend.sh` (header + success line), and `attach_backend.py` (docstring)** drop the "Guardrail-safe" label and state the invoke scope instead. Comment and description text only — no resource, property, or logic changed.
- **`test/test_deploy_apigw_rationale_docs.py`** pins the framing. One test asserts no surface reintroduces guardrail-as-goal phrasing (`guardrail-safe`, `auto-mitigat`, "…so the detector never fires"), the others assert the surfaces still name the property (`Principal:"*"`, `apigateway.amazonaws.com`) and that `app-lambda.yaml` stays documented. The surface list is a module constant, so adding a seventh place that argues the choice means adding it there too.

## 4. What tests we did

- New ratchet: 4 passed. Mutation-verified — reverting all six files to the pre-fix wording turns 3 of the 4 red (the fourth pins template content the base already satisfied).
- `pytest test/ -k deploy` → **650 passed, 1 skipped**.
- `cfn-lint src/kiro_crew/deploy/skills/artifact-deploy/templates/*.yaml` → clean (the CI step for these templates).
- `bash -n deploy-backend.sh`, `py_compile attach_backend.py` → clean.
- Brand Name Gate (diff-scoped, `--test` self-test first), Harness Parity Gate, `docs-lint.sh` (205 files), `scrub-lint.sh` → all pass. Inclusive Language: no hits on added lines.
- `isort --check-only` + `flake8` on the new test file → clean.

## 5. Any other suggestions on the work

The doc drift is worth noting as a pattern: the rationale was stated in six places and every copy inherited the same error, which is why this fixes all of them rather than only the two lines the issue quotes. The new test's surface list is the cheap guard against the seventh copy.

Closes #3475
