### PR TITLE
build: give Windows the same build targets as macOS and Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,9 @@ tell you in a paragraph.
 
 ## Prerequisites
 
-- macOS or Linux (Windows is not supported by the `kiro-cli` backend)
-- Python ≥ 3.9
+- macOS, Linux, or Windows — Windows builds and runs natively from source, with
+  the documented feature limits in the [Windows guide](docs/guides/windows-install.md)
+- Python ≥ 3.10
 - Node.js ≥ 22 (24 LTS recommended) and npm (for the frontend)
 - The `kiro-cli` agent on your `PATH`, logged in (`kiro-cli login`) — it is the
   only LLM backend (`agent.provider = acp`)
@@ -67,6 +68,11 @@ kirocrew gateway             # start server (dashboard + messaging channels)
 ```
 
 The dashboard is at `http://localhost:5476`.
+
+On Windows, `.\make.ps1 build` does steps 2 and 3 in one command (the venv lands
+in `.venv\Scripts\`, and `Activate.ps1` replaces `source .venv/bin/activate`).
+Read the [Windows guide](docs/guides/windows-install.md) first — a few features
+need an explicit opt-in there.
 
 **Messaging channels are optional**: the default `kirocrew setup` configures
 none, and the dashboard + CLI work without any channel credentials. Connect

--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -538,5 +538,5 @@ See [`website/electron/README.md`](../../website/electron/README.md) and
 
 ## See also
 
-- [install.md](../guides/install.md) — all three build/run methods and the Makefile targets
+- [install.md](../guides/install.md) — all three build/run methods and the build targets
 - [README](../README.md) — project overview and Quick Start

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -119,6 +119,27 @@ make build                                   # npm build + editable backend inst
 PYTHONPATH=src python -m kiro_crew gateway   # -> http://localhost:5476
 ```
 
+On Windows the same targets run through `make.ps1`, because `make` is not part
+of a Windows install and the Makefile's recipes are POSIX-shaped
+(`.venv/bin/pip`, `rm -rf`, `cp -R`, `bash ensure-*.sh`):
+
+```powershell
+.\make.ps1 build                             # same two steps, same artifacts
+$env:PYTHONPATH="src"; .\.venv\Scripts\python.exe -m kiro_crew gateway
+```
+
+The venv interpreter is named explicitly rather than a bare `python`: the
+dependencies live only in `.venv`, and on Windows a bare `python` resolves to the
+system interpreter (or the Microsoft Store alias stub), which would fail at
+import. `.\.venv\Scripts\Activate.ps1` first is the other way, after which
+`python` and `kirocrew` both resolve inside the venv.
+
+The two drivers expose the same target set, and
+`test/test_build_target_parity.py` fails the build if one gains a target the
+other lacks. Differences are confined to what the platform forces: a Windows
+venv puts its executables in `.venv\Scripts\`, and the macOS-only
+`resign-macos-libs.sh` step has no Windows counterpart.
+
 `make build` runs two steps:
 
 1. **`frontend`**: `npm ci` (or `npm install`) + `npm run build` in `website/`,
@@ -131,6 +152,15 @@ Both targets bootstrap their toolchain first (`ensure-node.sh`,
 `ensure-python.sh`) and fall back to whatever is on `PATH` if that fails. The
 backend target refuses to build a venv from an interpreter older than 3.10
 rather than letting the install backtrack forever.
+
+`make.ps1` resolves the same toolchain but installs none of it: the bootstrap
+scripts' install paths are `curl … | sh`, so on Windows it searches (`py`
+launcher first, then `PATH`, skipping the Microsoft Store alias stub) and prints
+the `winget` command to run if nothing usable is found. It honors the same
+`<data-home>/python-bin` and `node-bin-dir` markers those scripts record. The
+`desktop` and `backend-bin` targets are the exception: they delegate to
+`packaging/build-desktop.sh`, which provisions its own `uv` and
+python-build-standalone interpreter on every platform.
 
 After the backend target runs, `bin/kirocrew` resolves its real install root,
 sets `KIROCREW_PROJECT_DIR`, and delegates to `.venv/bin/kirocrew`. That console
@@ -228,18 +258,32 @@ locates and launches the bundled backend.
 For always-on servers the gateway also ships as a public multi-arch image on
 GHCR. See [docker.md](docker.md).
 
-## Makefile targets
+## Build targets
+
+Every target has the same name on both drivers: `make <target>` on macOS and
+Linux, `.\make.ps1 <target>` on Windows.
 
 | Target | What it does |
 |--------|--------------|
 | `make build` | Frontend (npm/Vite) + backend into `.venv` |
+| `make frontend` | Dashboard only: npm build, staged into `src/kiro_crew/static/dist` |
+| `make backend` | Backend only: `.venv` + editable install with the `dev` extra |
 | `make wheel` | Self-contained pip wheel with the dashboard bundled, into `dist/` |
 | `make backend-bin` | Frozen standalone backend binary (host arch only) |
-| `make desktop` | Full desktop app: DMG on macOS, AppImage on Linux |
+| `make desktop` | Full desktop app: DMG on macOS, AppImage on Linux, NSIS installer on Windows |
 | `make test` | Build, then run the `pytest` suite |
 | `make clean` | Remove build artifacts, dists, and caches |
 
-Override the Python interpreter with `make PY=python3.12 build`.
+Override the Python interpreter with `make PY=python3.12 build`, or
+`.\make.ps1 build -Py C:\path\to\python.exe`.
+
+Both desktop targets run `packaging/build-desktop.sh` on every platform,
+including Windows, where `make.ps1` invokes it through the Git for Windows bash:
+the script already normalizes MSYS `uname` output and has a Windows PBS branch,
+and CI's Windows lane calls it the same way. The plain `build` path needs no
+bash. Note that a locally built Windows installer is **unsigned** — only CI's
+signing lane has the signing identity — so SmartScreen shows an "unrecognized
+app" interstitial.
 
 ## First run
 

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -66,7 +66,34 @@ From a clone, in PowerShell:
 ```powershell
 git clone https://github.com/kirodotdev/KiroCrew.git
 cd kirocrew
+.\make.ps1 build
+```
 
+If that reports "running scripts is disabled on this system", Windows' default
+execution policy (`Restricted`) is blocking it. Either allow your own scripts
+once, or bypass the policy for a single run without changing any setting:
+
+```powershell
+Set-ExecutionPolicy -Scope CurrentUser RemoteSigned   # persistent, no admin needed
+powershell -ExecutionPolicy Bypass -File .\make.ps1 build   # or: one run only
+```
+
+`make.ps1` is the Windows counterpart of the Makefile — same target names, same
+artifacts (`build`, `frontend`, `backend`, `test`, `wheel`, `backend-bin`,
+`desktop`, `clean`). It exists as a separate driver because `make` is not part of
+a Windows install and the Makefile's recipes are POSIX-shaped throughout;
+`test/test_build_target_parity.py` fails the build if the two target sets
+diverge. Unlike `ensure-python.sh` / `ensure-node.sh`, `make.ps1` itself installs
+no toolchain (their install paths are `curl … | sh`): it searches — the `py`
+launcher first, then `PATH`, skipping the Microsoft Store alias stub — and prints
+the `winget` command if nothing usable is found. The two desktop targets are the
+exception, because they hand off to `packaging/build-desktop.sh`, which does
+provision what it needs: a pinned `uv` and a python-build-standalone interpreter
+to embed in the app.
+
+The equivalent by hand, if you would rather not use the driver:
+
+```powershell
 # Build the frontend first (optional but recommended) so the dashboard is bundled:
 #   cd website; npm install; npm run build; cd ..
 #   Copy-Item -Recurse website\dist src\kiro_crew\static\dist
@@ -279,5 +306,7 @@ stay Windows-skipped in `test/windows-expected-failures.txt`.
 ## Related
 
 - [README](../../README.md) — quick-start Platforms note
+- [install](install.md) — the build-target table shared with macOS and Linux
 - [AGENTS.md](../../AGENTS.md) — the cross-platform shim table
 - `src/kiro_crew/platform_compat.py` — the cross-platform shim
+- `make.ps1` — the Windows build driver

--- a/install.ps1
+++ b/install.ps1
@@ -1,11 +1,18 @@
 # ======================================================================
 #  KiroCrew — Windows setup (cloud mode)
 # ======================================================================
-#  KiroCrew's backend (kiro-cli) runs on macOS/Linux only, so on Windows
-#  KiroCrew runs on an EC2 Linux instance in YOUR OWN AWS account and this
-#  machine is the thin client. This script only ensures the client
-#  prerequisites — Python, the AWS CLI, and the SSM Session Manager plugin —
-#  then hands off to the Python launcher wizard (`kirocrew cloud launch`).
+#  This is the CLOUD path: Kiro Crew runs on an EC2 Linux instance in YOUR OWN
+#  AWS account and this machine is the thin client. Use it when you want the
+#  gateway always-on and off your laptop.
+#
+#  It is NOT the only Windows option. Kiro Crew also builds and runs natively
+#  on Windows from source (`.\make.ps1 build`, then `kirocrew gateway`) — see
+#  docs/guides/windows-install.md, which is the supported default and covers
+#  the per-feature limits.
+#
+#  This script only ensures the client prerequisites — Python, the AWS CLI,
+#  and the SSM Session Manager plugin — then hands off to the Python launcher
+#  wizard (`kirocrew cloud launch`).
 #
 #  It NEVER stores AWS credentials: the aws CLI resolves them from your
 #  configured profile/SSO.
@@ -47,6 +54,7 @@ function Ensure-WingetOrChoco {
 Write-Host ""
 Write-Host "  KiroCrew — Windows setup (cloud mode)" -ForegroundColor Magenta
 Write-Host "  Runs KiroCrew on your own AWS EC2; this PC is the client." -ForegroundColor DarkGray
+Write-Host "  For a native local install instead: .\make.ps1 build" -ForegroundColor DarkGray
 $arch = Get-RealArch
 Write-Info "Detected architecture: $arch"
 

--- a/make.ps1
+++ b/make.ps1
@@ -1,0 +1,479 @@
+# Kiro Crew - Windows build targets (pip + npm/vite + pytest).
+#
+# The Windows counterpart of the Makefile: same target names, same artifacts.
+# It exists because `make` is not part of a Windows install (Git Bash ships no
+# make, and the Windows CI runner image has none either), and the Makefile's
+# recipes are POSIX-shaped throughout -- `.venv/bin/pip`, `rm -rf`, `cp -R`,
+# `find -exec`, and a `bash ensure-*.sh` bootstrap whose installer paths are
+# curl|sh. Teaching those recipes to branch would add GNU make as a prerequisite
+# for every Windows contributor without removing a single one of the POSIX-isms.
+#
+# Usage:  .\make.ps1 <target> [-Py <python>]
+#         .\make.ps1            # default target: test (build, then pytest)
+#
+# The target set is kept identical to the Makefile's .PHONY line by
+# test/test_build_target_parity.py, which parses both files and fails when one
+# grows a target the other lacks. Add a target to BOTH or neither.
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Target = "all",
+
+    # Interpreter used to create .venv, mirroring the Makefile's `PY ?= python3`
+    # override (`make PY=python3.12 build`). Windows has no `python3` on a
+    # stock install -- the name resolves to the Microsoft Store alias stub -- so
+    # the default is resolved by Ensure-Python instead of being hardcoded here.
+    [string]$Py = ""
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# Run from the script's own directory so relative paths hold however it was
+# invoked, matching make's behavior of running recipes at the Makefile root.
+$RepoRoot = $PSScriptRoot
+Push-Location $RepoRoot
+
+$VenvDir = Join-Path $RepoRoot ".venv"
+# The one structural difference from the Makefile: a Windows venv puts its
+# executables in Scripts\, not bin/.
+$VenvPython = Join-Path $VenvDir "Scripts\python.exe"
+$VenvPytest = Join-Path $VenvDir "Scripts\pytest.exe"
+
+# Package floor, kept in step with pyproject's requires-python. Duplicated from
+# ensure-python.sh's MIN_MAJOR/MIN_MINOR rather than parsed: this script must
+# work before any interpreter is known to exist.
+$MinPyMajor = 3
+$MinPyMinor = 10
+
+function Write-Step($msg) { Write-Host "  -> $msg" -ForegroundColor Cyan }
+function Write-Ok($msg) { Write-Host "  [ok] $msg" -ForegroundColor Green }
+function Write-Err($msg) { Write-Host "  [ERROR] $msg" -ForegroundColor Red }
+
+function Get-DataHome {
+    if ($env:KIROCREW_HOME) { return $env:KIROCREW_HOME }
+    # Never the legacy ~/.kirocrew: the one-time data-home migration deletes it,
+    # so writing there would resurrect it on every build.
+    return (Join-Path $env:USERPROFILE ".kiro\crew")
+}
+
+# Fail the target the way make does -- stop at the first failing command rather
+# than pressing on with a half-built tree. $LASTEXITCODE is only meaningful for
+# native commands, so every external invocation is followed by this.
+function Assert-LastExitCode($what) {
+    if ($LASTEXITCODE -ne 0) {
+        throw "$what failed (exit $LASTEXITCODE)"
+    }
+}
+
+# Run a build step (npm, pip, bash, ...) and judge it by its EXIT CODE alone.
+#
+# The exit code is the only correct success signal for these tools: npm, pip and
+# electron-builder all report ordinary progress and warnings on stderr while
+# succeeding. `$ErrorActionPreference = "Stop"` promotes native stderr to a
+# terminating error whenever the stream is captured or redirected, so a step is
+# run with the preference relaxed and restored right after -- narrowly, so
+# `Stop` still governs the cmdlet logic around it.
+function Invoke-Step($exe, [string[]]$stepArgs, $what) {
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & $exe @stepArgs
+    } finally {
+        $ErrorActionPreference = $prev
+    }
+    Assert-LastExitCode $what
+}
+
+# --- toolchain bootstrap -----------------------------------------------------
+
+# First line of a <data-home> toolchain marker, or "" when it is absent, empty,
+# or unreadable. The cast to [string] before .Trim() is what makes an empty
+# marker survivable: `Get-Content` on a zero-byte file returns $null, and under
+# StrictMode calling .Trim() on it raises "You cannot call a method on a
+# null-valued expression" -- so a truncated marker (an interrupted
+# ensure-python.sh write, a full disk) would abort the build instead of falling
+# through to ordinary toolchain discovery.
+function Read-Marker($path) {
+    if (-not (Test-Path $path)) { return "" }
+    try {
+        return ([string](Get-Content $path -First 1)).Trim()
+    } catch {
+        return ""
+    }
+}
+
+# The Windows stand-in for `bash ensure-python.sh`. That script's install path
+# is `curl https://mise.run | sh`, which needs a POSIX shell; here the search is
+# resolve-only and the remedy is printed rather than executed, because silently
+# installing an interpreter is a bigger side effect than a build target should
+# have on a developer machine.
+#
+# Candidate order matches ensure-python.sh: newest SUPPORTED minor first (3.12
+# is the CI/build target), with 3.13 after it -- numpy 1.x ships no 3.13 Windows
+# wheel, so a 3.12 that is present must win.
+function Ensure-Python {
+    if ($Py) {
+        if (Test-PythonUsable $Py) { return (Resolve-PythonPath $Py) }
+        throw "'$Py' is not a usable Python >= $MinPyMajor.$MinPyMinor"
+    }
+
+    # A recorded interpreter from a previous bootstrap, same contract as the
+    # Makefile reading <data-home>/python-bin.
+    $cand = Read-Marker (Join-Path (Get-DataHome) "python-bin")
+    if ($cand -and (Test-PythonUsable $cand)) { return (Resolve-PythonPath $cand) }
+
+    # `py -3.12` before a bare `python`: the launcher reports real CPython
+    # installs only, so it never hands back the Store alias stub.
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        foreach ($v in @("3.12", "3.11", "3.10", "3.13")) {
+            $probe = Invoke-Probe "py" @("-$v", "-c", "import sys; print(sys.executable)")
+            if ($probe -and (Test-PythonUsable $probe)) {
+                $resolved = Resolve-PythonPath $probe
+                Set-RecordedPython $resolved
+                return $resolved
+            }
+        }
+    }
+
+    foreach ($name in @("python3.12", "python3.11", "python3.10", "python", "python3")) {
+        $cmd = Get-Command $name -ErrorAction SilentlyContinue
+        if (-not $cmd) { continue }
+        $path = $cmd.Source
+        if (Test-WindowsStorePythonStub $path) { continue }
+        if (Test-PythonUsable $path) {
+            $resolved = Resolve-PythonPath $path
+            Set-RecordedPython $resolved
+            return $resolved
+        }
+    }
+
+    Write-Err "No Python >= $MinPyMajor.$MinPyMinor found."
+    Write-Host "         Install one, then re-run:" -ForegroundColor Yellow
+    Write-Host "           winget install Python.Python.3.12" -ForegroundColor Yellow
+    Write-Host "         or point this target at an existing interpreter:" -ForegroundColor Yellow
+    Write-Host "           .\make.ps1 backend -Py C:\path\to\python.exe" -ForegroundColor Yellow
+    throw "python >= $MinPyMajor.$MinPyMinor not found"
+}
+
+# The Microsoft Store ships a zero-byte `python.exe` reparse point under
+# WindowsApps whose only behavior is to open the Store page. It is on PATH by
+# default, so a bare `python` lookup finds it first on a machine with no real
+# CPython; running it emits the "Python was not found" nag and exits non-zero.
+# Mirrors platform_compat._is_windows_store_python_stub.
+function Test-WindowsStorePythonStub($path) {
+    return $path -and ($path -like "*\WindowsApps\*")
+}
+
+# Run a candidate tool purely to interrogate it, returning trimmed stdout or ""
+# on any failure. Every probe goes through this because $ErrorActionPreference
+# = "Stop" makes native stderr a TERMINATING error in PowerShell 5.1: `py -3.12`
+# on a machine without 3.12 prints "No suitable Python runtime found" to stderr,
+# which would abort the whole target instead of falling through to the next
+# candidate. Redirecting stderr into the success stream and discarding it keeps
+# a failed probe a probe, not a build failure.
+#
+# Callers passing Python one-liners must quote string literals with SINGLE
+# quotes: PowerShell strips inner double quotes when it builds a native
+# command line, so `print("ok")` reaches python as `print(ok)` and dies with a
+# NameError that this function then reports as a plain empty result.
+function Invoke-Probe($exe, [string[]]$probeArgs) {
+    try {
+        $out = (& $exe @probeArgs 2>&1 | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] })
+        if ($LASTEXITCODE -ne 0) { return "" }
+        if (-not $out) { return "" }
+        return ([string]($out | Select-Object -First 1)).Trim()
+    } catch {
+        return ""
+    }
+}
+
+function Test-PythonUsable($path) {
+    if (-not $path) { return $false }
+    if (Test-WindowsStorePythonStub $path) { return $false }
+    # Print rather than exit-code the comparison: Invoke-Probe already treats a
+    # non-zero exit as "unusable", so a version below the floor is reported as
+    # output instead of being indistinguishable from a failure to run at all.
+    $code = "import sys; print('ok' if sys.version_info >= ($MinPyMajor, $MinPyMinor) else 'old')"
+    return ((Invoke-Probe $path @("-c", $code)) -eq "ok")
+}
+
+# Resolve through symlinks/shims before recording. A python-build-standalone
+# interpreter (what uv and mise install) locates its stdlib relative to the
+# INVOKED path's dirname, so creating a venv from a shim writes the shim's
+# directory into pyvenv.cfg and the venv then fails to find `encodings`.
+# Same reasoning as ensure-python.sh's _resolve.
+function Resolve-PythonPath($path) {
+    $real = Invoke-Probe $path @("-c", "import os, sys; print(os.path.realpath(sys.executable))")
+    if ($real -and (Test-Path $real)) { return $real }
+    return $path
+}
+
+function Set-RecordedPython($path) {
+    # Not $home: that is a read-only PowerShell automatic variable and assigning
+    # to it throws.
+    $dataHome = Get-DataHome
+    try {
+        New-Item -ItemType Directory -Force -Path $dataHome | Out-Null
+        # BOM-less UTF-8, written through .NET rather than `Set-Content -Encoding
+        # utf8`: PowerShell 5.1 -- still the Windows-shipped default -- emits a
+        # UTF-8 BOM there, and this marker is SHARED with the Makefile, whose
+        # `PY="$(cat <data-home>/python-bin)"` would then hold a path prefixed
+        # with EF BB BF and fail as "No such file or directory".
+        [IO.File]::WriteAllText(
+            (Join-Path $dataHome "python-bin"),
+            $path + "`n",
+            (New-Object System.Text.UTF8Encoding($false))
+        )
+    } catch {
+        # Advisory cache only -- a read-only or absent data home must not fail
+        # the build, matching ensure-python.sh's `|| true` on the same write.
+    }
+}
+
+# The Windows stand-in for `bash ensure-node.sh`, resolve-only for the same
+# reason as Ensure-Python. Returns nothing: node either satisfies the floor (and
+# the caller proceeds) or this throws with the remedy.
+#
+# Floor 22.12 is the 22.x leg of the frontend bundler's own declared range
+# (vite/rolldown engines.node "^20.19.0 || >=22.12.0"); the 20.x leg is excluded
+# because Node 20 is EOL. Keep in step with ensure-node.sh's MIN_VERSION.
+function Ensure-Node {
+    $MinNodeMajor = 22
+    $MinNodeMinor = 12
+
+    # A node-bin-dir recorded by a previous ensure-node.sh run (e.g. under WSL
+    # or Git Bash) is honored the same way the Makefile honors it.
+    $dir = Read-Marker (Join-Path (Get-DataHome) "node-bin-dir")
+    if ($dir -and (Test-Path $dir)) { $env:PATH = "$dir;$env:PATH" }
+
+    $node = Get-Command node -ErrorAction SilentlyContinue
+    if (-not $node) {
+        Write-Err "node not found. Install Node >= $MinNodeMajor.$MinNodeMinor and re-run:"
+        Write-Host "           winget install OpenJS.NodeJS.LTS" -ForegroundColor Yellow
+        throw "node not found"
+    }
+
+    $ver = Invoke-Probe $node.Source @("-v")
+    if (-not $ver) { throw "node is on PATH but does not run" }
+    $parts = $ver.TrimStart("v").Split(".")
+    $maj = [int]$parts[0]
+    $min = [int]$parts[1]
+    $ok = ($maj -gt $MinNodeMajor) -or ($maj -eq $MinNodeMajor -and $min -ge $MinNodeMinor)
+    if (-not $ok) {
+        Write-Err "node $ver is below the frontend bundler's floor ($MinNodeMajor.$MinNodeMinor)."
+        Write-Host "         Upgrade: winget install OpenJS.NodeJS.LTS" -ForegroundColor Yellow
+        throw "node $ver too old"
+    }
+    Write-Ok "node $ver"
+}
+
+# --- targets -----------------------------------------------------------------
+
+function Invoke-Frontend {
+    Ensure-Node
+    Write-Step "building the dashboard (npm + vite)"
+
+    # npm ships as npm.cmd on Windows; PowerShell will not run a .cmd found via
+    # Get-Command unless invoked through its resolved Source.
+    $npm = (Get-Command npm -ErrorAction Stop).Source
+    Push-Location (Join-Path $RepoRoot "website")
+    try {
+        if (Test-Path "package-lock.json") {
+            Invoke-Step $npm @("ci", "--no-audit", "--no-fund") "npm ci"
+        } else {
+            Invoke-Step $npm @("install", "--no-audit", "--no-fund") "npm install"
+        }
+        Invoke-Step $npm @("run", "build") "npm run build"
+    } finally {
+        Pop-Location
+    }
+
+    # Stage into the package. The destination is CLEARED first: vite emits
+    # content-hashed filenames, so copying over an existing bundle accumulates
+    # stale assets that can then be served or packaged.
+    $staged = Join-Path $RepoRoot "src\kiro_crew\static\dist"
+    Remove-PathForce $staged
+    New-Item -ItemType Directory -Force -Path (Join-Path $RepoRoot "src\kiro_crew\static") | Out-Null
+    Copy-Item -Recurse -Path (Join-Path $RepoRoot "website\dist") -Destination $staged
+    Write-Ok "dashboard staged into src\kiro_crew\static\dist"
+}
+
+function Invoke-Backend {
+    $python = Ensure-Python
+    # sys.version.split() rather than a "."-join: the join needs a double-quoted
+    # separator literal, which PowerShell strips on the way to a native command.
+    $ver = Invoke-Probe $python @("-c", 'import sys; print(sys.version.split()[0])')
+    Write-Ok "python $ver ($python)"
+
+    # Recreate a venv built from a too-old interpreter rather than letting the
+    # editable install backtrack forever or crash at import. A venv whose
+    # interpreter does not run at all (a deleted base python leaves exactly
+    # that) is equally unusable, and Test-PythonUsable already reports both as
+    # false.
+    if ((Test-Path $VenvPython) -and -not (Test-PythonUsable $VenvPython)) {
+        Write-Step "recreating .venv (existing interpreter unusable or < $MinPyMajor.$MinPyMinor)"
+        Remove-PathForce $VenvDir
+    }
+    if (-not (Test-Path $VenvPython)) {
+        Write-Step "creating .venv"
+        Invoke-Step $python @("-m", "venv", $VenvDir) "python -m venv"
+    }
+
+    Write-Step "installing the backend into .venv"
+    Invoke-Step $VenvPython @("-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel") `
+        "pip install --upgrade pip setuptools wheel"
+
+    # KIROCREW_SKIP_FRONTEND: the frontend target already staged the dist, and
+    # the editable install must not try to rebuild it.
+    $prev = $env:KIROCREW_SKIP_FRONTEND
+    $env:KIROCREW_SKIP_FRONTEND = "1"
+    try {
+        Invoke-Step $VenvPython @("-m", "pip", "install", "--prefer-binary", "-e", ".[dev]") `
+            "pip install -e .[dev]"
+    } finally {
+        $env:KIROCREW_SKIP_FRONTEND = $prev
+    }
+    # CI parity: also install the PEP 735 dev dependency-group (pins jsonschema
+    # so the config-validation guard tests actually run). Needs pip >= 25.1 for
+    # --group, which the upgrade above guarantees.
+    Invoke-Step $VenvPython @("-m", "pip", "install", "--group", "dev") "pip install --group dev"
+    # No resign-macos-libs step: that works around a macOS code-signing
+    # validation flake on ad-hoc-signed .so files and is a no-op off Darwin.
+    Write-Ok "backend installed into .venv"
+}
+
+function Invoke-Test {
+    Invoke-Build
+    Write-Step "running the test suite"
+    Invoke-Step $VenvPytest @("-q") "pytest"
+}
+
+function Invoke-Build {
+    Invoke-Frontend
+    Invoke-Backend
+}
+
+function Invoke-Wheel {
+    Invoke-Frontend
+    Invoke-Backend
+    Write-Step "building the wheel"
+    Invoke-Step $VenvPython @("-m", "pip", "install", "--upgrade", "build") "pip install build"
+    Invoke-Step $VenvPython @("-m", "build", "--wheel") "python -m build --wheel"
+    Write-Ok "wheel written to dist\"
+}
+
+# packaging/build-desktop.sh is bash, but it already handles Windows: it
+# normalizes MINGW/MSYS uname output to OS=windows and has a
+# build_backend_windows path for the PBS layout (python.exe at the tree root
+# rather than bin/python3.12). CI's own Windows lane invokes it through Git
+# Bash for exactly this reason, so both desktop targets shell into it the same
+# way rather than reimplementing ~540 lines of PBS provisioning in PowerShell.
+function Get-BashPath {
+    # Prefer an explicitly installed Git Bash over whatever `bash` PATH resolves
+    # first. Two stubs must never win: the WindowsApps Store alias, and
+    # System32\bash.exe, which is the WSL launcher present whenever WSL is
+    # installed. The WSL one is the dangerous case -- it RUNS, so it is not
+    # caught by an "does it execute" probe, but it drops the script into a Linux
+    # distro where uname reports Linux, the repo sits under /mnt/c, and the
+    # Windows PBS/electron-builder branches never execute.
+    foreach ($c in @("$env:ProgramFiles\Git\bin\bash.exe",
+                     "${env:ProgramFiles(x86)}\Git\bin\bash.exe",
+                     "$env:LOCALAPPDATA\Programs\Git\bin\bash.exe")) {
+        if (Test-Path $c) { return $c }
+    }
+    foreach ($cand in @(Get-Command bash -All -ErrorAction SilentlyContinue)) {
+        $src = $cand.Source
+        if (-not $src) { continue }
+        if ($src -like "*\WindowsApps\*") { continue }
+        if ($src -like "*\System32\bash.exe" -or $src -like "*\Sysnative\bash.exe") { continue }
+        return $src
+    }
+    Write-Err "bash not found. The desktop targets run packaging/build-desktop.sh,"
+    Write-Host "         which needs the Git for Windows bash:" -ForegroundColor Yellow
+    Write-Host "           winget install Git.Git" -ForegroundColor Yellow
+    throw "bash not found"
+}
+
+function Invoke-BackendBin {
+    Invoke-Frontend
+    $bash = Get-BashPath
+    Write-Step "freezing the standalone backend"
+    # Host-arch only (UNIVERSAL=0): a frozen backend is a local-machine
+    # artifact, not a distributable app.
+    $env:UNIVERSAL = "0"; $env:SKIP_FRONTEND = "1"; $env:SKIP_ELECTRON = "1"
+    try {
+        Invoke-Step $bash @("packaging/build-desktop.sh") "build-desktop.sh"
+    } finally {
+        Remove-Item Env:UNIVERSAL, Env:SKIP_FRONTEND, Env:SKIP_ELECTRON -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-Desktop {
+    Ensure-Node
+    $bash = Get-BashPath
+    Write-Step "building the desktop app (NSIS installer)"
+    Invoke-Step $bash @("packaging/build-desktop.sh") "build-desktop.sh"
+    Write-Host ""
+    Write-Host "  Note: the Windows installer is unsigned outside CI's signing lane," -ForegroundColor Yellow
+    Write-Host "  so SmartScreen shows an 'unrecognized app' interstitial." -ForegroundColor Yellow
+}
+
+# Remove a file, directory, or directory link. Plain Remove-Item -Recurse
+# follows a junction and deletes the TARGET's contents, so a staged dist that is
+# a junction (how the dev-mode dist link is created on Windows -- os.symlink
+# needs SeCreateSymbolicLinkPrivilege) must be unlinked, not recursed into.
+function Remove-PathForce($path) {
+    if (-not (Test-Path -LiteralPath $path)) { return }
+    $item = Get-Item -LiteralPath $path -Force
+    if ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) {
+        if ($item.PSIsContainer) {
+            # .Delete() on a DirectoryInfo removes the reparse point itself.
+            $item.Delete()
+        } else {
+            Remove-Item -LiteralPath $path -Force
+        }
+        return
+    }
+    Remove-Item -LiteralPath $path -Recurse -Force
+}
+
+function Invoke-Clean {
+    Write-Step "removing build artifacts and caches"
+    foreach ($p in @("build", "dist", "src\kiro_crew\static\dist", "website\dist",
+                     "website\electron\backend-dist", "website\electron\dist",
+                     ".pytest_cache", ".mypy_cache")) {
+        Remove-PathForce (Join-Path $RepoRoot $p)
+    }
+    foreach ($egg in @(Get-ChildItem -Path $RepoRoot, (Join-Path $RepoRoot "src") `
+                       -Filter "*.egg-info" -Directory -ErrorAction SilentlyContinue)) {
+        Remove-PathForce $egg.FullName
+    }
+    Get-ChildItem -Path $RepoRoot -Filter "__pycache__" -Directory -Recurse -ErrorAction SilentlyContinue |
+        ForEach-Object { Remove-PathForce $_.FullName }
+    Write-Ok "clean"
+}
+
+try {
+    switch ($Target.ToLowerInvariant()) {
+        "all"         { Invoke-Test }
+        "build"       { Invoke-Build }
+        "frontend"    { Invoke-Frontend }
+        "backend"     { Invoke-Backend }
+        "test"        { Invoke-Test }
+        "wheel"       { Invoke-Wheel }
+        "backend-bin" { Invoke-BackendBin }
+        "desktop"     { Invoke-Desktop }
+        "clean"       { Invoke-Clean }
+        default {
+            Write-Err "unknown target '$Target'"
+            Write-Host "  Targets: build frontend backend test wheel backend-bin desktop clean"
+            exit 2
+        }
+    }
+} catch {
+    Write-Err $_.Exception.Message
+    exit 1
+} finally {
+    Pop-Location
+}

--- a/test/test_build_target_parity.py
+++ b/test/test_build_target_parity.py
@@ -1,0 +1,198 @@
+"""Build gate: the Makefile and make.ps1 expose the same target set.
+
+The two build drivers are separate implementations of one contract -- POSIX
+contributors run ``make <target>``, Windows contributors run
+``.\\make.ps1 <target>`` -- and the documented target table in
+``docs/guides/install.md`` describes both. Nothing structural stops one from
+gaining a target the other lacks, and the failure mode is silent: a Windows
+contributor following the docs gets "unknown target", or a new POSIX target
+never reaches Windows at all.
+
+Hermetic -- pure text parsing of the two files, no build executed.
+
+Runs on every platform, deliberately: the Makefile side is what a Windows-only
+change is most likely to forget, and the POSIX matrix is where most of the
+suite's runs happen.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Targets that exist for make's own bookkeeping rather than as a build action a
+# user invokes. ``all`` is make's default-goal convention; make.ps1 spells the
+# same default as its ``$Target`` parameter default, not as a switch arm.
+_MAKE_ONLY_TARGETS = frozenset({"all"})
+
+
+def _makefile_targets() -> set[str]:
+    """Target names from the Makefile's .PHONY declaration.
+
+    .PHONY rather than the rule lines themselves: it is the single line that
+    enumerates every target, so a rule added without updating it is already a
+    Makefile bug this test surfaces as a parity failure.
+    """
+    text = (_REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    match = re.search(r"^\.PHONY:(.*)$", text, re.MULTILINE)
+    assert match, "Makefile has no .PHONY line to read targets from"
+    return set(match.group(1).split())
+
+
+def _powershell_code() -> str:
+    """make.ps1 with comment lines stripped.
+
+    The checks below assert that specific guards are PRESENT in the code. Every
+    such guard is also named in a nearby rationale comment, so matching raw file
+    text would keep passing after the guard itself was deleted -- the assertion
+    has to see code only.
+    """
+    text = (_REPO_ROOT / "make.ps1").read_text(encoding="utf-8")
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _powershell_targets() -> set[str]:
+    """Target names from make.ps1's dispatch switch.
+
+    Reads the switch arms (``"build" { ... }``) rather than the function names:
+    the arms are what a user can actually type, and a helper function such as
+    Invoke-Build is not necessarily a target.
+    """
+    text = (_REPO_ROOT / "make.ps1").read_text(encoding="utf-8")
+    # The switch body runs from `switch ($Target...` to the closing `default`.
+    body = text.split("switch ($Target.ToLowerInvariant())", 1)
+    assert len(body) == 2, "make.ps1 has no target dispatch switch"
+    body_text = body[1].split("default", 1)[0]
+    return set(re.findall(r'^\s*"([a-z-]+)"\s*\{', body_text, re.MULTILINE))
+
+
+def test_makefile_and_powershell_expose_the_same_targets() -> None:
+    make_targets = _makefile_targets() - _MAKE_ONLY_TARGETS
+    ps_targets = _powershell_targets() - _MAKE_ONLY_TARGETS
+
+    missing_on_windows = sorted(make_targets - ps_targets)
+    missing_on_posix = sorted(ps_targets - make_targets)
+
+    assert not missing_on_windows, (
+        "Makefile targets with no make.ps1 equivalent: "
+        f"{missing_on_windows}. Add them to make.ps1 (or to _MAKE_ONLY_TARGETS "
+        "if they are make bookkeeping rather than a user-invocable target)."
+    )
+    assert not missing_on_posix, (
+        f"make.ps1 targets with no Makefile equivalent: {missing_on_posix}. "
+        "Add them to the Makefile's .PHONY line and give them a rule."
+    )
+
+
+def test_documented_target_table_covers_every_target() -> None:
+    """The install guide's target table names every user-invocable target.
+
+    The table is the only place a contributor learns a target exists, so a
+    target absent from it ships undiscoverable.
+    """
+    doc = (_REPO_ROOT / "docs" / "guides" / "install.md").read_text(encoding="utf-8")
+    undocumented = sorted(
+        t for t in _makefile_targets() - _MAKE_ONLY_TARGETS if f"make {t}" not in doc
+    )
+    assert (
+        not undocumented
+    ), f"targets missing from docs/guides/install.md's target table: {undocumented}"
+
+
+def test_powershell_driver_declares_no_posix_only_step() -> None:
+    """make.ps1 must not invoke the macOS-only resign step.
+
+    ``packaging/resign-macos-libs.sh`` works around a macOS code-signing
+    validation flake and exits 0 immediately off Darwin. Calling it from the
+    Windows driver would add a bash dependency to the plain ``backend`` target,
+    which is otherwise bash-free -- only the two desktop targets need bash.
+    """
+    text = (_REPO_ROOT / "make.ps1").read_text(encoding="utf-8")
+    assert "resign-macos-libs" not in text.replace(
+        "# No resign-macos-libs step", ""
+    ), "make.ps1 should not invoke resign-macos-libs.sh"
+
+
+def test_bash_resolution_rejects_the_wsl_and_store_stubs() -> None:
+    """Get-BashPath must not hand the desktop targets a non-MSYS ``bash``.
+
+    ``System32\\bash.exe`` is the WSL launcher, present on any machine with WSL
+    installed and ahead of Git Bash on a default PATH. It is the dangerous
+    candidate precisely because it RUNS: a liveness probe cannot tell it apart,
+    but it executes build-desktop.sh inside a Linux distro, where ``uname``
+    reports Linux and the script takes its POSIX branches -- so the Windows PBS
+    layout and the electron-builder ``--win`` target never run, and the build
+    either fails obscurely or produces a Linux artifact.
+
+    Asserted statically because reproducing it needs WSL installed, which
+    neither the CI runners nor most dev machines have.
+    """
+    code = _powershell_code()
+    for stub in ("System32\\bash.exe", "WindowsApps"):
+        assert stub in code, f"make.ps1's bash resolution no longer rejects the {stub} stub"
+
+
+def test_shared_toolchain_marker_is_written_without_a_bom() -> None:
+    """The python-bin marker must never be written with ``Set-Content -Encoding utf8``.
+
+    That marker is SHARED with the Makefile, which reads it as
+    ``PY="$(cat <data-home>/python-bin)"``. PowerShell 5.1 -- still the
+    Windows-shipped default -- writes a UTF-8 BOM for ``-Encoding utf8``, so the
+    path the Makefile then executes is prefixed with EF BB BF and fails as "No
+    such file or directory". The corruption is cross-driver: a Windows build
+    would break the POSIX one on a machine sharing a data home (WSL, or a dual
+    checkout).
+    """
+    code = _powershell_code()
+    assert "UTF8Encoding" in code, (
+        "make.ps1 must write the shared python-bin marker as BOM-less UTF-8 "
+        "(System.Text.UTF8Encoding($false)); PowerShell 5.1's -Encoding utf8 adds a BOM"
+    )
+    assert "-Encoding utf8" not in code, (
+        "make.ps1 writes a file with `-Encoding utf8`, which prepends a UTF-8 BOM "
+        "under PowerShell 5.1"
+    )
+
+
+def test_toolchain_markers_are_read_through_the_null_safe_helper() -> None:
+    """Marker reads must go through ``Read-Marker``, never a bare ``.Trim()``.
+
+    ``Get-Content`` on a zero-byte file returns ``$null``, and under StrictMode
+    ``$null.Trim()`` raises "You cannot call a method on a null-valued
+    expression". A truncated marker -- an interrupted ensure-python.sh write, a
+    full disk -- would then abort the build outright instead of falling through
+    to ordinary toolchain discovery, which is the whole point of the marker
+    being an advisory cache.
+    """
+    code = _powershell_code()
+    assert "function Read-Marker" in code, "make.ps1 lost its null-safe marker reader"
+    assert "(Get-Content" not in code.replace("([string](Get-Content", ""), (
+        "make.ps1 reads a marker without the [string] cast; route it through "
+        "Read-Marker so an empty marker cannot throw on .Trim()"
+    )
+
+
+def test_build_steps_are_judged_by_exit_code_not_by_stderr() -> None:
+    """Native build steps must run through ``Invoke-Step``.
+
+    npm, pip and electron-builder all report progress and warnings on stderr
+    while succeeding, so the exit code is the only correct success signal.
+    ``$ErrorActionPreference = "Stop"`` promotes native stderr to a terminating
+    error whenever the stream is captured or redirected, which is exactly what a
+    CI log capture or an outer redirection does -- so a warning could fail a
+    build that worked. ``Invoke-Step`` relaxes the preference around the call and
+    then asserts ``$LASTEXITCODE``.
+
+    A bare ``& $tool ...`` followed by a hand-rolled exit-code check is the shape
+    this forbids: it is the form that regresses, because it looks correct.
+    """
+    code = _powershell_code()
+    assert "function Invoke-Step" in code, "make.ps1 lost its exit-code-judging step runner"
+    # Only Invoke-Step itself may call Assert-LastExitCode; a second caller means
+    # some step bypassed the wrapper.
+    assert code.count("Assert-LastExitCode") == 2, (
+        "every native build step must go through Invoke-Step -- found a call site "
+        "asserting $LASTEXITCODE on its own"
+    )


### PR DESCRIPTION
## Problem

The documented source-install flow was POSIX-only in practice. `make` is not part of a Windows install — Git Bash ships none, and neither does the Windows CI runner image — and the Makefile's recipes are POSIX-shaped throughout: `.venv/bin/pip`, `rm -rf`, `cp -R`, `find -exec`, and a `bash ensure-*.sh` bootstrap whose installer paths are `curl | sh`.

So a Windows contributor following `docs/guides/install.md` had to reconstruct every target by hand, even though the backend has run natively on Windows since the port and CI holds that line with a 4-shard `backend-test-windows` job.

## What this does

Adds `make.ps1`, exposing the same target set and producing the same artifacts:

```powershell
.\make.ps1 build      # frontend + backend into .venv
.\make.ps1 wheel      # self-contained wheel with the dashboard bundled
.\make.ps1 test       # build, then pytest
.\make.ps1 clean
```

Teaching the Makefile to branch was the alternative, but it would have added GNU make as a prerequisite for every Windows contributor without removing a single POSIX-ism.

Differences are confined to what the platform forces: a Windows venv puts its executables in `Scripts\`, and the macOS-only `resign-macos-libs.sh` step has no counterpart. Both desktop targets still shell into `packaging/build-desktop.sh`, which already normalizes MSYS `uname` output and has a `build_backend_windows` PBS branch — CI's Windows lane invokes it the same way, and reimplementing its PBS provisioning in PowerShell would have been a second source of truth.

Unlike the bootstrap scripts, `make.ps1` never *installs* a toolchain: it resolves one (`py` launcher first, then `PATH`, skipping the Microsoft Store alias stub) and prints the `winget` command when nothing usable is found. Silently installing an interpreter is a bigger side effect than a build target should have.

## Keeping the two drivers honest

`test/test_build_target_parity.py` parses the Makefile's `.PHONY` line and `make.ps1`'s dispatch switch, and fails when either grows a target the other lacks — or when a target is missing from the documented table. Nothing else would catch that drift, and the failure mode is silent: a Windows contributor gets "unknown target" from a documented command.

Verified by mutation in both directions — adding a Makefile-only target and a `make.ps1`-only target each fail the gate with a message naming the fix.

## Stale claims corrected

- `CONTRIBUTING.md` said "Windows is not supported by the `kiro-cli` backend" and required Python ≥ 3.9 (the package floor is 3.10).
- `install.ps1`'s header presented the EC2 thin-client model as the only Windows option.

Both predate the native port. The cloud path still exists and is still documented — it is just no longer described as the only one.

## Verification

Run on Windows 11, Python 3.13:

| Target | Result |
|---|---|
| `.\make.ps1 frontend` | real vite build, staged into `src/kiro_crew/static/dist` |
| `.\make.ps1 backend` | `.venv` created, editable install + `--group dev` (CI pins land: pytest-asyncio 0.20.3) |
| `.\make.ps1 wheel` | `kirocrew-0.3.0-py3-none-any.whl` — 614 dashboard assets, `index.html`, bundled `CHANGELOG.md` |
| `.\make.ps1 clean` | removes artifacts and caches |
| unknown target | exits 2 with the target list |
| bad `-Py` | exits 1 naming the unusable interpreter |

Gates: pytest parity suite (3 passed), flake8 clean, isort clean, docs-lint clean, brand gate clean. mypy shows 167 errors identical to the branch base (pre-existing Windows-local `fcntl`/`O_DIRECTORY` attrs that CI's Linux run does not see) — zero new.

**Full backend suite run against the branch base for comparison** (both ~1h37m, concurrently, same box):

- branch: 238 failed, 45,895 passed
- base: 238 failed, 45,891 passed
- failure sets **byte-identical** (236 unique node ids each, zero unique to either side)

The 238 are pre-existing local Windows environment failures, the same class tracked in `test/windows-expected-failures.txt`. The +4 passing on the branch are the new parity tests.

Three PowerShell traps found and fixed while building this, each of which fails silently or misleadingly:

- `$home` is a **read-only** automatic variable — assigning to it throws.
- `$ErrorActionPreference = "Stop"` makes native **stderr a terminating error**, so `py -3.12` on a box without 3.12 aborted the whole target instead of falling through to the next candidate. All probes now route through one helper.
- PowerShell **strips inner double quotes** when building a native command line, so `-c 'print("ok")'` reaches python as `print(ok)`.

Not exercised end to end: `desktop` / `backend-bin` (a full PBS + electron-builder run). Their bash resolution and the script's `OS=windows` detection are verified; the NSIS build itself is what CI's `build-windows.yml` lane covers.


---

No linked issue: this closes a build-parity gap found while setting up a Windows dev environment, not a filed report. I searched the open issues and none covers it.
