### PR TITLE
test: wait on the SSE signal watchdog tests actually assert on

### DIFF
--- a/test/test_auto_research_handlers_coverage.py
+++ b/test/test_auto_research_handlers_coverage.py
@@ -626,7 +626,12 @@ class TestWatchdogLoop:
         slot = SimpleNamespace(_trust=True, running=False)
         state = SimpleNamespace(_slots={f"research-{cid}": slot})
         assert await _drive_watchdog(
-            {"state": state}, lambda: _status(cid) == h.CampaignStatus.NEEDS_INPUT
+            {"state": state},
+            # Wait on BOTH the status commit and the independently-scheduled SSE
+            # emit (see test_new_verified_finding_completes_the_campaign) -- the
+            # assertion below reads sse.types(), so the SSE half must be observed
+            # before _drive_watchdog's finally cancels the loop.
+            lambda: _status(cid) == h.CampaignStatus.NEEDS_INPUT and "needs_input" in sse.types(),
         )
         assert slot._trust is False
         question = json.loads((h._campaign_dir(cid) / "questions.json").read_text())
@@ -658,7 +663,8 @@ class TestWatchdogLoop:
         _running(cid)
         (h._campaign_dir(cid) / "questions.json").write_text('{"question": "Which DB?"}')
         assert await _drive_watchdog(
-            {"state": None}, lambda: _status(cid) == h.CampaignStatus.NEEDS_INPUT
+            {"state": None},
+            lambda: _status(cid) == h.CampaignStatus.NEEDS_INPUT and "needs_input" in sse.types(),
         )
         assert "needs_input" in sse.types()
 
@@ -678,6 +684,13 @@ class TestWatchdogLoop:
             assert await _await_until(lambda: polls["n"] >= 1)  # baseline count recorded
             _write_finding(cid, 2, verification={"passed": True})
             assert await _await_until(lambda: _status(cid) == h.CampaignStatus.COMPLETE)
+            # The status commit (worker thread) and the SSE emit (call_soon_threadsafe
+            # from _sse_from_thread's on_commit hook) are two separate scheduling
+            # events, not one step — waiting on status alone proves the commit
+            # happened, not that the loop has drained the queued SSE callback yet.
+            # Wait on the SIGNAL THIS TEST ASSERTS ON, or task.cancel() below can win
+            # the race and the "complete" event goes missing from sse.types().
+            assert await _await_until(lambda: "complete" in sse.types())
         finally:
             task.cancel()
             try:
@@ -701,6 +714,11 @@ class TestWatchdogLoop:
             assert await _await_until(lambda: polls["n"] >= 1)
             _write_finding(cid, 2)  # unverified, but hits max_cycles
             assert await _await_until(lambda: _status(cid) == h.CampaignStatus.COMPLETE)
+            # See test_new_verified_finding_completes_the_campaign: the status commit
+            # and the SSE emit are scheduled independently, so wait on the SSE signal
+            # this test actually asserts on rather than relying on task.cancel()'s
+            # timing to have let the queued callback run first.
+            assert await _await_until(lambda: "complete" in sse.types())
         finally:
             task.cancel()
             try:
@@ -722,6 +740,10 @@ class TestWatchdogLoop:
             assert await _await_until(lambda: polls["n"] >= 1)
             _write_finding(cid, 6, new_findings_count=0)
             assert await _await_until(lambda: _status(cid) == h.CampaignStatus.STAGNANT)
+            # See test_new_verified_finding_completes_the_campaign: status commit and
+            # SSE emit are scheduled independently, so wait on the SSE signal this
+            # test actually asserts on.
+            assert await _await_until(lambda: "stagnant" in sse.types())
         finally:
             task.cancel()
             try:
@@ -746,7 +768,12 @@ class TestWatchdogLoop:
         _running(cid)
         _write_finding(cid, 1)
         assert await _drive_watchdog(
-            {"state": None}, lambda: _status(cid) == h.CampaignStatus.FAILED
+            {"state": None},
+            # Wait on BOTH the status commit and the independently-scheduled SSE
+            # emit (see test_new_verified_finding_completes_the_campaign) — the
+            # assertion below reads sse.types(), so the SSE half must be observed
+            # before _drive_watchdog's finally cancels the loop.
+            lambda: _status(cid) == h.CampaignStatus.FAILED and "failed" in sse.types(),
         )
         assert "stalled" in (h.get_campaign(cid) or {})["error_message"]
         svc.update.assert_awaited_once_with(terminating_loop.id, active=False)


### PR DESCRIPTION
## Summary

Fixes #3472.

`test_auto_research_handlers_coverage.py::TestWatchdogLoop::test_new_verified_finding_completes_the_campaign` fails intermittently in CI with `assert ['new_finding'] == ['new_finding', 'complete']`. Per the issue's root-cause analysis: the test waits on one signal (the campaign's DB status) and asserts on a different one (the SSE events emitted) — no longer one step since #3198 took the campaigns DB off the event loop.

`_guarded_transition` commits the status **in a worker thread** and delivers the SSE through its `on_commit` hook via `loop.call_soon_threadsafe(_emit_sse, event)`, which **schedules** the emit rather than running it inline. Real ordering:

1. status commits in the worker thread → the status wait is now satisfiable
2. `call_soon_threadsafe` queues `_emit_sse` on the loop
3. the test's wait returns, `finally:` cancels the watchdog task
4. `sse.types()` is read

If the loop hasn't drained the queued callback from step 2 before step 4, the event is missing — intermittently, since `task.cancel()` racing the queued callback is a scheduling window, not a constant failure.

## Fix

Wait on the SSE signal the test actually asserts on (in addition to the status wait, which still proves the DB transition happened), per the issue's suggested fix. Applied to the reported test plus every sibling in the same class with the identical wait-on-status/assert-on-SSE shape, found per the issue's own suggestion to check for the pattern elsewhere:

- `test_new_verified_finding_completes_the_campaign` (reported)
- `test_reaching_the_cycle_cap_completes_the_campaign`
- `test_repeated_empty_cycles_mark_the_campaign_stagnant`
- `test_idle_deadline_settles_the_campaign_and_tears_the_loop_down`
- `test_expired_trust_forces_reauthorization`
- `test_pending_question_pauses_an_attended_campaign`

(`test_add_question_appends_and_rewrites_the_brief`'s `sse.types()` assertion was **not** touched — it calls the handler directly with no watchdog polling/threaded commit involved, so it isn't the same race.)

## Test plan
- [x] `pytest test/test_auto_research_handlers_coverage.py -q` — 195 passed
- [x] `pytest test/test_auto_research_handlers_coverage.py -q -k TestWatchdogLoop`, repeated 20x — 20/20 clean
- [x] `flake8` — clean
- [ ] I did not reproduce the original CI flake locally — it depends on the specific worker-thread scheduling timing under CI's environment, which isn't practical to force deterministically in a short local session. The fix targets the issue's confirmed root cause (independent thread-commit vs. `call_soon_threadsafe` scheduling — the ordering was traced, not guessed) rather than a hypothesized one.