### PR TITLE
fix(memory): guard _cosine_sim against mismatched dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **A lesson from a previous embedding-model generation could no longer get
+  silently deleted or offered as a false contradiction.** `write_lesson`'s
+  semantic dedup and `find_contradiction_candidates` compared raw embeddings
+  with a cosine helper that silently truncated a dimension mismatch to the
+  shorter vector instead of rejecting it, so a row embedded at a different
+  dimensionality (e.g. left over from an old embedding model) could score a
+  plausible-looking ~0.5 similarity against an unrelated new rule — landing
+  either past the 0.85 dedup line (deleting the old lesson as a "duplicate")
+  or inside the [0.4, 0.85) contradiction band (offered as a false
+  contradiction candidate). Both paths now converge onto the same
+  dimension-checked, float64-precision scorer the ranking paths already use,
+  which also removes a per-row query re-derivation from both loops. (#3466)
+
 - **Side-panel oversize-question refusal now reports an accurate character
   target for every script, not just emoji.** The refusal derived its
   character count from a fixed worst-case floor (4 bytes/char, the emoji

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -1129,7 +1129,11 @@ class VectorMemoryStore:
                 # population is real — legacy rows stay NULL until the backfill
                 # sweep or a re-write reaches them — so score them on the same
                 # weighted scale as embedded rows (see _hybrid_score).
-                vec_score = similarity(r)
+                # Clamped here (not inside the scorer): this caller passes
+                # query_has_vector=True below, so a negative raw cosine would
+                # otherwise reach _hybrid_score's weighted sum instead of the
+                # keyword-only floor a merely-dissimilar row should get.
+                vec_score = max(0.0, similarity(r))
 
                 score = _hybrid_score(
                     kw_score, vec_score, query_has_vector=query_embedding is not None
@@ -2193,6 +2197,10 @@ class VectorMemoryStore:
             matched = True
             break
 
+        # Built once for the whole scan (query-side vector + norm are the same
+        # for every row) rather than per candidate — see _stored_similarity_scorer.
+        similarity = self._stored_similarity_scorer(rule_emb) if rule_emb else None
+
         for existing in [] if matched else lesson_rows:
             existing_val = _as_text(existing)
             if existing_val is None:
@@ -2225,19 +2233,15 @@ class VectorMemoryStore:
                         continue
 
             # Semantic dedup via embeddings (use stored embedding when available)
-            if rule_emb:
+            if similarity is not None:
                 existing_emb_blob = existing.get("embedding")
+                row_blob: bytes | None = None
                 if (
                     existing_emb_blob
                     and isinstance(existing_emb_blob, bytes)
                     and len(existing_emb_blob) >= 4
                 ):
-                    try:
-                        existing_emb = list(
-                            struct.unpack(f"{len(existing_emb_blob) // 4}f", existing_emb_blob)
-                        )
-                    except struct.error:
-                        existing_emb = None
+                    row_blob = existing_emb_blob
                 elif self.embed_fn and backfills_done < _MAX_BACKFILLS_PER_CALL:
                     # Lazy backfill: compute embedding for legacy lessons (count even on failure)
                     # Sampled BEFORE the embed: _try_embed returns None when a swap
@@ -2247,15 +2251,13 @@ class VectorMemoryStore:
                     backfill_generation = self._space_generation
                     existing_emb = self._try_embed(existing_val, PRIORITY_BULK)
                     if existing_emb:
-                        blob = struct.pack(f"{len(existing_emb)}f", *existing_emb)
+                        row_blob = struct.pack(f"{len(existing_emb)}f", *existing_emb)
                         pending_backfills.append(
-                            (blob, existing["key"], backfill_generation)
+                            (row_blob, existing["key"], backfill_generation)
                         )
                     backfills_done += 1
-                else:
-                    existing_emb = None
-                if existing_emb:
-                    sim = self._cosine_sim(rule_emb, existing_emb)
+                if row_blob is not None:
+                    sim = similarity({"embedding": row_blob})
                     if sim > 0.85:
                         logger.info("Lesson semantic dedup: %.2f sim with %r", sim, existing["key"])
                         if len(rule) > len(existing_val):
@@ -2351,22 +2353,15 @@ class VectorMemoryStore:
             rule_emb = self._try_embed(rule) if self.embed_fn else None
         if not rule_emb:
             return []
+        # Builds the query-side work (vector + its norm) once for the whole scan,
+        # same reasoning as _rank_lessons / get_semantic_context. A row with no
+        # stored embedding, or one at a different dimensionality, scores 0.0 —
+        # which threshold_low's default of 0.4 already excludes without an
+        # explicit skip.
+        similarity = self._stored_similarity_scorer(rule_emb)
         candidates = []
         for existing in self.get_lessons():
-            existing_emb_blob = existing.get("embedding")
-            if (
-                not existing_emb_blob
-                or not isinstance(existing_emb_blob, bytes)
-                or len(existing_emb_blob) < 4
-            ):
-                continue
-            try:
-                existing_emb = list(
-                    struct.unpack(f"{len(existing_emb_blob) // 4}f", existing_emb_blob)
-                )
-            except struct.error:
-                continue
-            sim = self._cosine_sim(rule_emb, existing_emb)
+            sim = similarity(existing)
             if threshold_low <= sim < threshold_high:
                 existing_val = str(json.loads(existing["value_json"]))
                 candidates.append({"key": existing["key"], "rule": existing_val, "similarity": sim})
@@ -2505,6 +2500,18 @@ class VectorMemoryStore:
         A row whose vector has a different dimensionality is incomparable and
         scores 0.0 rather than being truncated against the query, matching
         ``_sqlite_vector_search`` and ``HybridRetriever._cosine_similarity``.
+
+        The raw (possibly negative) cosine value is returned uncapped — a
+        ranking caller that never distinguishes "no vector" (0.0) from
+        "opposite direction" (negative) should clamp at its own call site
+        (``max(0.0, ...)``); a threshold caller comparing the value against a
+        band that may include non-positive bounds needs the true value. The
+        numpy path promotes both operands to float64 before the norm and the
+        dot product: the stored blob is float32 on disk, and accumulating a
+        many-dimensional norm/dot in float32 lands ~1e-7 away from the plain
+        ``_cosine_sim`` this scorer replaces — irrelevant when only sorting,
+        not irrelevant when the value is compared against a fixed threshold
+        like the semantic-dedup line.
         """
         if not query_emb:
             return lambda row: 0.0
@@ -2512,7 +2519,7 @@ class VectorMemoryStore:
         q_bytes = q_len * 4
 
         if _HAS_NUMPY:
-            q_vec = np.asarray(query_emb, dtype=np.float32)
+            q_vec = np.asarray(query_emb, dtype=np.float64)
             q_norm = float(np.linalg.norm(q_vec))
             if not q_norm:
                 return lambda row: 0.0
@@ -2521,9 +2528,9 @@ class VectorMemoryStore:
                 blob = row.get("embedding")
                 if not isinstance(blob, bytes) or len(blob) != q_bytes:
                     return 0.0
-                vec = np.frombuffer(blob, dtype=np.float32)
+                vec = np.frombuffer(blob, dtype=np.float32).astype(np.float64)
                 denom = float(np.linalg.norm(vec)) * q_norm
-                return max(0.0, float(vec @ q_vec) / denom) if denom else 0.0
+                return float(vec @ q_vec) / denom if denom else 0.0
 
             return numpy_scorer
 
@@ -2539,7 +2546,7 @@ class VectorMemoryStore:
             denom = math.sqrt(sum(y * y for y in vec)) * q_norm_py
             if not denom:
                 return 0.0
-            return max(0.0, sum(x * y for x, y in zip(query_emb, vec)) / denom)
+            return sum(x * y for x, y in zip(query_emb, vec)) / denom
 
         return stdlib_scorer
 
@@ -2547,7 +2554,18 @@ class VectorMemoryStore:
 
     @staticmethod
     def _cosine_sim(a: list[float], b: list[float]) -> float:
-        """Cosine similarity between two vectors."""
+        """Cosine similarity between two vectors.
+
+        Vectors of different length are incomparable and score 0.0 rather
+        than being silently truncated to the shorter one by ``zip`` — a row
+        embedded at a different dimensionality (e.g. an old embedding-model
+        generation) would otherwise return a plausible-looking partial-overlap
+        score instead of being rejected. Matches the dimension guard already
+        enforced by ``_stored_similarity_scorer`` (byte-length check) and
+        ``HybridRetriever._cosine_similarity``.
+        """
+        if len(a) != len(b):
+            return 0.0
         dot = sum(x * y for x, y in zip(a, b))
         norm_a = math.sqrt(sum(x * x for x in a))
         norm_b = math.sqrt(sum(y * y for y in b))

--- a/test/test_lesson_contradiction.py
+++ b/test/test_lesson_contradiction.py
@@ -124,6 +124,57 @@ class TestFindContradictionCandidates:
         result = store.find_contradiction_candidates(query_text)
         assert len(result) == 5
 
+    def test_mismatched_dimension_row_is_never_a_candidate(self, tmp_path):
+        """Regression for #3466: a row embedded at a different dimensionality
+        (e.g. a leftover from a previous embedding-model generation) must score
+        0.0 -- not a plausible-looking partial-overlap value computed by
+        truncating against the shorter vector -- so it can never land inside
+        the contradiction band."""
+        import struct
+
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        store.embed_fn = _discriminating_embed
+        assert store.write_lesson("Use chronological order for release notes")
+        rows = store.db.execute("SELECT key FROM semantic_memory WHERE key LIKE 'lesson.%'").fetchall()
+        assert len(rows) == 1
+        key = rows[0]["key"]
+        # Overwrite the stored 384-float embedding with a 128-float one, as a
+        # row from an older embedding-model generation would carry.
+        stale_blob = struct.pack("128f", *([0.5] * 128))
+        store.db.execute(
+            "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (stale_blob, key)
+        )
+        store.db.commit()
+        result = store.find_contradiction_candidates("Use chronological order for release notes")
+        assert result == []
+
+    def test_dedup_never_matches_a_mismatched_dimension_row(self, tmp_path):
+        """The semantic-dedup path (write_lesson) shares the same guard: a
+        stale-dimension row must not be treated as a near-duplicate of a new
+        rule just because a truncated dot product happens to clear 0.85."""
+        import struct
+
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        store.embed_fn = _discriminating_embed
+        assert store.write_lesson("Always quote shell arguments in scripts")
+        rows = store.db.execute("SELECT key FROM semantic_memory WHERE key LIKE 'lesson.%'").fetchall()
+        key = rows[0]["key"]
+        stale_blob = struct.pack("128f", *([0.5] * 128))
+        store.db.execute(
+            "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (stale_blob, key)
+        )
+        store.db.commit()
+        # A genuinely different, word-disjoint rule must still be accepted as
+        # its own lesson rather than being silently dropped as a "duplicate"
+        # of the dimension-mismatched row.
+        assert store.write_lesson("Never hardcode credentials in config files")
+        remaining = store.db.execute(
+            "SELECT key FROM semantic_memory WHERE key LIKE 'lesson.%'"
+        ).fetchall()
+        assert len(remaining) == 2
+
 
 @pytest.mark.asyncio
 class TestResolveContradictions:

--- a/test/test_vector_memory_coverage.py
+++ b/test/test_vector_memory_coverage.py
@@ -609,6 +609,78 @@ class TestKeywordFallback:
         assert [h["text"] for h in hits] == ["A fragment about the nightly deployment pipeline"]
 
 
+class TestCosineSimDimensionGuard:
+    """Regression for #3466: `_cosine_sim` used to silently truncate a
+    dimension-mismatched pair via `zip` instead of rejecting it, so a row
+    embedded at a different dimensionality (e.g. a leftover from a previous
+    embedding-model generation) returned a plausible-looking partial-overlap
+    score instead of 0.0."""
+
+    def test_mismatched_length_scores_zero(self) -> None:
+        a = [1.0, 0.0, 0.0, 0.0]
+        b = [1.0, 0.0, 0.0]  # one dimension short
+        assert VectorMemoryStore._cosine_sim(a, b) == 0.0
+
+    def test_matching_length_is_unaffected(self) -> None:
+        a = [1.0, 0.0, 0.0, 0.0]
+        b = [1.0, 0.0, 0.0, 0.0]
+        assert VectorMemoryStore._cosine_sim(a, b) == pytest.approx(1.0)
+
+    def test_zero_vector_still_scores_zero_not_a_zerodivisionerror(self) -> None:
+        assert VectorMemoryStore._cosine_sim([0.0, 0.0], [1.0, 0.0]) == 0.0
+
+
+class TestStoredSimilarityScorer:
+    """Regression for #3466: the scorer built by `_stored_similarity_scorer`
+    backs the two threshold callers (semantic dedup, contradiction detection)
+    as well as the two ranking callers, so it must (1) reject a mismatched
+    dimension the same way `_cosine_sim` now does, (2) return the raw
+    (possibly negative) cosine value rather than clamping at 0.0 -- a
+    threshold caller comparing against a band that may include non-positive
+    bounds needs the true value, and (3) agree with `_cosine_sim` to float64
+    precision, not the ~1e-7 the numpy path's old float32 accumulation gave.
+    """
+
+    def _row(self, vec: list) -> dict:
+        import struct
+
+        return {"embedding": struct.pack(f"{len(vec)}f", *vec)}
+
+    @pytest.mark.parametrize("has_numpy", [True, False])
+    def test_mismatched_dimension_row_scores_zero(self, monkeypatch, has_numpy) -> None:
+        monkeypatch.setattr(vm, "_HAS_NUMPY", has_numpy and vm._HAS_NUMPY)
+        query = [1.0, 0.0, 0.0]
+        scorer = VectorMemoryStore._stored_similarity_scorer(query)
+        assert scorer(self._row([1.0, 0.0])) == 0.0  # one short
+        assert scorer(self._row([1.0, 0.0, 0.0, 0.0])) == 0.0  # one long
+
+    @pytest.mark.parametrize("has_numpy", [True, False])
+    def test_negative_cosine_is_returned_uncapped(self, monkeypatch, has_numpy) -> None:
+        monkeypatch.setattr(vm, "_HAS_NUMPY", has_numpy and vm._HAS_NUMPY)
+        query = [1.0, 0.0]
+        scorer = VectorMemoryStore._stored_similarity_scorer(query)
+        # Exactly opposite direction -> cosine == -1.0, not clamped to 0.0.
+        assert scorer(self._row([-1.0, 0.0])) == pytest.approx(-1.0)
+
+    @pytest.mark.parametrize("has_numpy", [True, False])
+    def test_agrees_with_cosine_sim_on_a_normal_pair(self, monkeypatch, has_numpy) -> None:
+        monkeypatch.setattr(vm, "_HAS_NUMPY", has_numpy and vm._HAS_NUMPY)
+        query = [0.37, -1.2, 0.05, 2.1, 0.0, -0.9]
+        row = [1.1, 0.3, -0.4, 0.02, 0.6, -1.5]
+        scorer = VectorMemoryStore._stored_similarity_scorer(query)
+        got = scorer(self._row(row))
+        want = VectorMemoryStore._cosine_sim(query, row)
+        # float32-stored row (as every scorer input is) vs the float64-list
+        # _cosine_sim compares against: agreement is bounded by the storage
+        # round-trip precision, not by the scorer's own arithmetic anymore.
+        assert got == pytest.approx(want, abs=1e-6)
+
+    def test_no_query_embedding_returns_a_constant_zero_scorer(self) -> None:
+        scorer = VectorMemoryStore._stored_similarity_scorer(None)
+        assert scorer(self._row([1.0, 0.0])) == 0.0
+        assert scorer({}) == 0.0
+
+
 class TestEpisodicPromotion:
     def test_promotion_without_an_embedder_is_skipped(self, tmp_path: Path) -> None:
         store = _store(tmp_path)


### PR DESCRIPTION
## Summary

Fixes #3466.

#3109 introduced `_stored_similarity_scorer` and wired it into the two ranking paths (`_rank_lessons`, `get_semantic_context`), deliberately leaving the two threshold callers — `write_lesson`'s semantic dedup and `find_contradiction_candidates` — on the older `_cosine_sim` helper. That helper has no dimension guard:

```python
dot = sum(x * y for x, y in zip(a, b))
```

`zip()` truncates the dot product to the shorter vector while both norms are still taken over their full length, so a row embedded at a different dimensionality (e.g. a leftover from a previous embedding-model generation) returns a plausible-looking partial-overlap score instead of being rejected. A 384-dim row against a 768-dim query returns roughly **0.50** — which sits squarely inside the `[0.4, 0.85)` contradiction band (offered as a false contradiction candidate) and is on the same scale as the `0.85` dedup line (a large enough partial overlap silently deletes a lesson as a "duplicate" of something unrelated).

## Fix, per the issue's proposed sequencing

1. **Dimension guard moved into `_cosine_sim` itself** (`return 0.0` on length mismatch), so every remaining caller of the raw helper gets it too.
2. **The scorer's numpy path promotes both operands to float64** before the norm and dot product — the stored blob is float32 on disk, and accumulating in float32 lands ~1e-7 away from the `_cosine_sim` it replaces. Irrelevant when only sorting; not irrelevant when the value is compared against a fixed threshold like the semantic-dedup line.
3. **The scorer no longer clamps at 0.0 internally** — the dedup and contradiction paths compare the raw value against thresholds that may be non-positive, where clamping changes which rows qualify. The clamp moves to `get_semantic_context`'s own call site (the one ranking caller that passes `query_has_vector=True` and therefore needs it); `_rank_lessons` needs no change, since it calls `_hybrid_score` without `query_has_vector` and a negative value there already degrades to the same keyword-only branch a clamped 0.0 would.
4. **`write_lesson`'s dedup loop and `find_contradiction_candidates` now build one scorer per call** (query vector + norm derived once, not once per lesson) instead of unpacking each stored blob into a list and calling `_cosine_sim` per row — the same hoisting `_stored_similarity_scorer` already does for the ranking paths. (The dedup loop's lazy-backfill branch, which computes a legacy lesson's embedding on the fly and previously held it only as an unpacked list, now packs it into bytes and routes it through the scorer like every other row — per the issue's own note that this branch "is not a pure drop-in.")

## Changes
- `src/kiro_crew/vector_memory.py`: the four points above.
- `test/test_vector_memory_coverage.py`: new `TestCosineSimDimensionGuard` + `TestStoredSimilarityScorer` (dimension mismatch → 0.0, uncapped negative cosine, float64 agreement with `_cosine_sim`, both numpy and stdlib paths via `_HAS_NUMPY` monkeypatch).
- `test/test_lesson_contradiction.py`: two regression tests — a stale-dimension row is never offered as a contradiction candidate, and never matches as a dedup duplicate either.
- `CHANGELOG.md`: entry under Unreleased.

## Test plan
- [x] `pytest test/test_vector_memory.py test/test_vector_memory_coverage.py test/test_lesson_contradiction.py test/test_lesson_ranking.py test/test_bench_ingest.py test/test_bench_retrieval_stats.py -q` — 463 passed, 10 skipped (pre-existing platform/numpy skips)
- [x] `flake8` / `isort --check` on changed files — clean
- [x] `mypy` on changed file — no new errors
- [x] `scripts/docs-lint.sh` — clean