### PR TITLE
fix(ci): replace single-user premise in four reviewer lanes with deployment-neutral framing (#3451)

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -141,12 +141,38 @@ jobs:
           REPO CONTEXT:
           KiroCrew is an open-source AI agent platform (Python backend + React/TS
           dashboard). It is a de-Amazoned public fork: do NOT flag the absence of
-          Brazil/AUTOSDE build tooling or internal-only infrastructure. It is a
-          single-user tool: every component runs as one OS user's own local
-          processes sharing that user's resources — the trust boundary is that OS
-          user (a team deployment stays per-user, same-UID), not a multi-tenant/
-          shared service. Keep review proportional to that shape. Follow the
-          conventions in CLAUDE.md and AGENTS.md (root and website/) when present.
+          Brazil/AUTOSDE build tooling or internal-only infrastructure.
+
+          DO NOT REASON FROM AN ASSUMED USER COUNT, in either direction. "It is
+          a single-user tool, so this guard is unnecessary" and "it will be
+          multi-user one day, so build the general case now" are both analogy
+          dressed as a requirement, and both are forbidden to you. Judge an item
+          by the harm it removes and the boundary it protects, counted the same
+          way as everything else.
+
+          The security boundaries this codebase actually has are real and
+          load-bearing, and each one gives a control a named cause, which makes
+          it DERIVED rather than speculative --
+            - the AGENT is untrusted with respect to its own governance
+              ceiling: it can neither read nor write security_policy.json,
+              profiles/, admission_policy.json or computer_use.json, and the
+              PreToolUse gate, the deny rules and the OS sandbox enforce that;
+            - an ENTERPRISE ADMINISTRATOR sits above the local user, composing
+              a policy ceiling tightest-wins that a running agent or app can
+              narrow but never loosen;
+            - the NETWORK is a boundary whenever the gateway is not on
+              loopback, where a dashboard requires token authentication;
+            - EXTERNAL CONTENT is untrusted input: fork pull-request diffs, web
+              pages, tool and command output, and messages arriving from any
+              connected channel;
+            - MULTIPLE HUMANS reach one gateway through the messaging surfaces,
+              admitted by allow-lists.
+          So a guard, permission check, redaction, or isolation step whose harm
+          is one of those boundaries has a named cause -- never report it as
+          speculative surface.
+
+          Follow the conventions in CLAUDE.md and AGENTS.md (root and
+          website/) when present.
 
           Start from the changes this branch introduces relative to the base:
               git diff ${{ github.event.pull_request.base.sha }}...HEAD

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -127,10 +127,35 @@ jobs:
             REPO CONTEXT: KiroCrew is an open-source AI agent platform (Python
             backend + React/TS dashboard), a de-Amazoned public fork. Do NOT flag
             the absence of Brazil/AUTOSDE build tooling or internal-only infra.
-            It is a single-user tool: every component runs as one OS user's own
-            local processes sharing that user's resources — the trust boundary is
-            that OS user (a team deployment stays per-user, same-UID), not a
-            multi-tenant/shared service. Keep review proportional to that shape.
+
+            DO NOT REASON FROM AN ASSUMED USER COUNT, in either direction. "It is
+            a single-user tool, so this guard is unnecessary" and "it will be
+            multi-user one day, so build the general case now" are both analogy
+            dressed as a requirement, and both are forbidden to you. Judge an item
+            by the harm it removes and the boundary it protects, counted the same
+            way as everything else.
+
+            The security boundaries this codebase actually has are real and
+            load-bearing, and each one gives a control a named cause, which makes
+            it DERIVED rather than speculative --
+              - the AGENT is untrusted with respect to its own governance
+                ceiling: it can neither read nor write security_policy.json,
+                profiles/, admission_policy.json or computer_use.json, and the
+                PreToolUse gate, the deny rules and the OS sandbox enforce that;
+              - an ENTERPRISE ADMINISTRATOR sits above the local user, composing
+                a policy ceiling tightest-wins that a running agent or app can
+                narrow but never loosen;
+              - the NETWORK is a boundary whenever the gateway is not on
+                loopback, where a dashboard requires token authentication;
+              - EXTERNAL CONTENT is untrusted input: fork pull-request diffs, web
+                pages, tool and command output, and messages arriving from any
+                connected channel;
+              - MULTIPLE HUMANS reach one gateway through the messaging surfaces,
+                admitted by allow-lists.
+            So a guard, permission check, redaction, or isolation step whose harm
+            is one of those boundaries has a named cause -- never report it as
+            speculative surface.
+
             CLAUDE.md and AGENTS.md (root and website/) hold the conventions.
 
             THIS IS A DESIGN REVIEW, NOT A LINE-LEVEL REVIEW. Two OTHER automated

--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -282,10 +282,35 @@ jobs:
             REPO CONTEXT: KiroCrew is an open-source AI agent platform (Python
             backend + React/TS dashboard), a de-Amazoned public fork. Do NOT flag
             the absence of Brazil/AUTOSDE build tooling or internal-only infra.
-            It is a single-user tool: every component runs as one OS user's own
-            local processes sharing that user's resources — the trust boundary is
-            that OS user (a team deployment stays per-user, same-UID), not a
-            multi-tenant/shared service. Keep review proportional to that shape.
+
+            DO NOT REASON FROM AN ASSUMED USER COUNT, in either direction. "It is
+            a single-user tool, so this guard is unnecessary" and "it will be
+            multi-user one day, so build the general case now" are both analogy
+            dressed as a requirement, and both are forbidden to you. Judge an item
+            by the harm it removes and the boundary it protects, counted the same
+            way as everything else.
+
+            The security boundaries this codebase actually has are real and
+            load-bearing, and each one gives a control a named cause, which makes
+            it DERIVED rather than speculative --
+              - the AGENT is untrusted with respect to its own governance
+                ceiling: it can neither read nor write security_policy.json,
+                profiles/, admission_policy.json or computer_use.json, and the
+                PreToolUse gate, the deny rules and the OS sandbox enforce that;
+              - an ENTERPRISE ADMINISTRATOR sits above the local user, composing
+                a policy ceiling tightest-wins that a running agent or app can
+                narrow but never loosen;
+              - the NETWORK is a boundary whenever the gateway is not on
+                loopback, where a dashboard requires token authentication;
+              - EXTERNAL CONTENT is untrusted input: fork pull-request diffs, web
+                pages, tool and command output, and messages arriving from any
+                connected channel;
+              - MULTIPLE HUMANS reach one gateway through the messaging surfaces,
+                admitted by allow-lists.
+            So a guard, permission check, redaction, or isolation step whose harm
+            is one of those boundaries has a named cause -- never report it as
+            speculative surface.
+
             CLAUDE.md and AGENTS.md (root and website/) hold the conventions.
 
             THIS IS A DESIGN REVIEW, NOT A LINE-LEVEL REVIEW. Two OTHER automated

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -339,12 +339,38 @@ jobs:
           REPO CONTEXT:
           Kiro Crew is an open-source AI agent platform (Python backend + React/TS
           dashboard). It is a de-Amazoned public fork: do NOT flag the absence of
-          Brazil/AUTOSDE build tooling or internal-only infrastructure. It is a
-          single-user tool: every component runs as one OS user's own local
-          processes sharing that user's resources — the trust boundary is that OS
-          user (a team deployment stays per-user, same-UID), not a multi-tenant/
-          shared service. Keep review proportional to that shape. Follow the
-          conventions in CLAUDE.md and AGENTS.md (root and website/) when present.
+          Brazil/AUTOSDE build tooling or internal-only infrastructure.
+
+          DO NOT REASON FROM AN ASSUMED USER COUNT, in either direction. "It is
+          a single-user tool, so this guard is unnecessary" and "it will be
+          multi-user one day, so build the general case now" are both analogy
+          dressed as a requirement, and both are forbidden to you. Judge an item
+          by the harm it removes and the boundary it protects, counted the same
+          way as everything else.
+
+          The security boundaries this codebase actually has are real and
+          load-bearing, and each one gives a control a named cause, which makes
+          it DERIVED rather than speculative --
+            - the AGENT is untrusted with respect to its own governance
+              ceiling: it can neither read nor write security_policy.json,
+              profiles/, admission_policy.json or computer_use.json, and the
+              PreToolUse gate, the deny rules and the OS sandbox enforce that;
+            - an ENTERPRISE ADMINISTRATOR sits above the local user, composing
+              a policy ceiling tightest-wins that a running agent or app can
+              narrow but never loosen;
+            - the NETWORK is a boundary whenever the gateway is not on
+              loopback, where a dashboard requires token authentication;
+            - EXTERNAL CONTENT is untrusted input: fork pull-request diffs, web
+              pages, tool and command output, and messages arriving from any
+              connected channel;
+            - MULTIPLE HUMANS reach one gateway through the messaging surfaces,
+              admitted by allow-lists.
+          So a guard, permission check, redaction, or isolation step whose harm
+          is one of those boundaries has a named cause -- never report it as
+          speculative surface.
+
+          Follow the conventions in CLAUDE.md and AGENTS.md (root and
+          website/) when present.
 
           The changes under review are the GitHub-authentic, SHA-pinned unified
           diff at: ${{ runner.temp }}/authentic.patch — read it (Read/Grep) as

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -822,3 +822,52 @@ class TestGptMediaFilterBehavior:
         assert len(raw) <= 8000
         # Must decode cleanly (no invalid trailing bytes) and drop the split char.
         assert raw.decode("utf-8") == "x" * 7999
+
+
+class TestDeploymentNeutralFramingParity:
+    """The four reviewer lanes carry an inlined copy of the deployment-neutral
+    framing (issue #3451). The copies are verbatim and unguarded by any shared
+    source file on main, so this asserts they stay byte-identical to EACH
+    OTHER after dedent -- an edit to one copy that does not touch the other
+    three recreates the cross-lane contradiction the swap removed."""
+
+    LANES = (
+        "design-review.yml",
+        "fork-design-review.yml",
+        "codex-review.yml",
+        "fork-gpt-review.yml",
+    )
+    FIRST = "DO NOT REASON FROM AN ASSUMED USER COUNT"
+    LAST = "speculative surface."
+
+    def _framing_block(self, workflow: str) -> str:
+        text = _workflow(workflow)
+        lines = text.splitlines()
+        start = next(
+            i for i, line in enumerate(lines) if self.FIRST in line
+        )
+        end = next(
+            i for i, line in enumerate(lines[start:], start)
+            if line.strip().endswith(self.LAST)
+        )
+        block = lines[start : end + 1]
+        indent = len(block[0]) - len(block[0].lstrip())
+        return "\n".join(
+            line[indent:] if line.strip() else "" for line in block
+        )
+
+    def test_all_four_lanes_carry_an_identical_framing_block(self):
+        blocks = {name: self._framing_block(name) for name in self.LANES}
+        reference = blocks[self.LANES[0]]
+        for name, block in blocks.items():
+            assert block == reference, (
+                f"{name} framing block drifted from {self.LANES[0]}; "
+                "the deployment-neutral framing must stay byte-identical "
+                "across all four reviewer lanes (issue #3451)"
+            )
+
+    def test_no_lane_reintroduces_the_single_user_premise(self):
+        for name in self.LANES + ("ux-review.yml", "fork-ux-review.yml"):
+            flat = _flat(_workflow(name))
+            assert "Keep review proportional to that shape" not in flat, name
+            assert "It is a single-user tool: every component" not in flat, name


### PR DESCRIPTION
Closes #3451

## What

The design-review, fork-design-review, codex-review, and fork-gpt-review lanes each told their model that Kiro Crew is a single-user tool and to keep review "proportional to that shape." That premise is increasingly false, and it directly contradicts the deployment-neutral framing the first-principles lane (#3436) introduces — one lane could score a guard *disproportionate* while another scores the same guard *derived*, on the same diff.

Mechanical swap: the single-user sentence is replaced in all four prompts with the framing copied **verbatim** from `.github/review-prompts/first-principles.md` on #3436's head branch — no assumed user count in either direction, plus the five named trust boundaries (agent vs its own governance ceiling, enterprise policy ceiling, network off loopback, untrusted external content, multiple humans via allow-lists). Nothing else in the prompts (rubrics, severity budgets, gating logic) is touched. The text is **inlined**, not referenced by path, so this PR has no ordering dependency on #3436.

## Scope checks the issue asked for

- `ux-review.yml` / `fork-ux-review.yml`: checked, do **not** carry the sentence — excluded.
- `.github/review-prompts/opus-validate.md` / `opus-discovery.md`: carry a variant but are outside this issue's named scope — follow-up filed as #3484.

## Verification

- YAML parse of all workflows; isort / flake8 / mypy clean (941 files)
- `test/test_ai_review_workflows.py` + `test/test_pr_quality_gates.py`: 79/79 pass (the design-lane contract assertions still hold)
- Full backend pytest: 50926 passed; 103 failures all pre-existing host-environment issues (missing `gh` in the sandboxed test env, sandbox backend unavailable), zero related — this diff touches no Python
- Two model-pinned pre-push reviewers: GPT (gpt-5.6-sol) NO FINDINGS; Opus (claude-opus-5) NO FINDINGS, byte-compared each inserted block against `first-principles.md` (exact match ×4) and confirmed exactly one changed scalar per file

## Reviewer advisory dispositions

1. *"DERIVED reads as a pointer to a rubric these prompts don't define."* Accepted as true, kept verbatim anyway: the issue explicitly instructs "use that file's existing wording verbatim rather than paraphrasing," and byte-identical copies are what makes a future parity gate possible. The sentence still lands directionally without the rubric.
2. *"Five unguarded copies of the same paragraph; opus prompts still carry the retired premise."* Follow-up #3484 covers both: updating the two `review-prompts/*.md` contracts and, once #3436 lands, a verbatim-parity assertion in `test_ai_review_workflows.py`.