### PR TITLE
ci: make frontend shard failures name their reason in the job log (#3455)

### DIFF
--- a/.github/scripts/frontend-blob-reconcile.mjs
+++ b/.github/scripts/frontend-blob-reconcile.mjs
@@ -1,0 +1,189 @@
+// Reconcile the frontend shard verdicts against the merged blob reports.
+//
+// The sharded `vitest run --reporter=blob` jobs and the `--merge-reports` step
+// can exit non-zero without naming a failing test anywhere in the log: a blob
+// records `[version, files, unhandledErrors, coverage, executionTime,
+// environmentModules]` (flatted-encoded), and a worker that dies mid-run (see
+// the worker-OOM note in website/vite.config.ts) fails the job while every
+// test inside the blob still reads "pass". This script makes the reason
+// visible in one place: it decodes every blob, prints each failing test and
+// each unhandled runner error by name, and — when the shard job failed but no
+// test reported failing — states that contradiction explicitly instead of
+// leaving it to manual artifact probing.
+//
+// Usage (cwd must be website/ so `flatted` resolves from its node_modules):
+//   node ../.github/scripts/frontend-blob-reconcile.mjs [blob-dir]
+// Env:
+//   FRONTEND_TEST_RESULT  result of the frontend-test job (needs.*.result)
+//   MERGE_RESULT          outcome of the merge step (steps.<id>.outcome)
+//
+// Diagnostic only: always exits 0. The merge step's own exit code remains the
+// job verdict; this script never turns a red job green or a green job red.
+
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+// Resolve `flatted` from the invoking directory (website/), not from this
+// script's own location — .github/ has no node_modules.
+const require = createRequire(pathToFileURL(join(process.cwd(), 'noop.js')));
+
+function main() {
+  const blobDir = resolve(process.cwd(), process.argv[2] ?? '.vitest-reports');
+  const shardFailed = process.env.FRONTEND_TEST_RESULT === 'failure';
+  const mergeFailed = process.env.MERGE_RESULT === 'failure';
+
+  let parse;
+  try {
+    ({ parse } = require('flatted'));
+  } catch {
+    console.log(
+      '::warning::frontend-blob-reconcile: `flatted` is not resolvable from '
+      + `${process.cwd()} — run this from website/ after npm ci. Skipping.`,
+    );
+    return;
+  }
+
+  let entries;
+  try {
+    entries = readdirSync(blobDir).filter((f) => f.endsWith('.json'));
+  } catch {
+    console.log(`frontend-blob-reconcile: no blob directory at ${blobDir} — nothing to scan.`);
+    return;
+  }
+  if (entries.length === 0) {
+    console.log(`frontend-blob-reconcile: no blob files under ${blobDir} — nothing to scan.`);
+    return;
+  }
+
+  const failingTests = [];   // { name, message }
+  const fileErrors = [];     // files failing with no failing test inside (collection errors)
+  const unhandled = [];      // run-level errors (worker deaths land here)
+  const shardsSeen = [];     // [index, count] parsed from blob-<index>-<count>.json
+  let blobsRead = 0;
+
+  for (const entry of entries) {
+    const fullPath = join(blobDir, entry);
+    let files, errors;
+    try {
+      if (!statSync(fullPath).isFile()) continue;
+      [, files, errors] = parse(readFileSync(fullPath, 'utf-8'));
+    } catch (err) {
+      console.log(`::warning::frontend-blob-reconcile: could not read ${entry}: ${err?.message ?? err}`);
+      continue;
+    }
+    blobsRead += 1;
+    const m = /^blob-(\d+)-(\d+)\.json$/.exec(entry);
+    if (m) shardsSeen.push([Number(m[1]), Number(m[2])]);
+    for (const err of errors ?? []) {
+      unhandled.push(firstLine(err?.message ?? err?.stack ?? String(err)));
+    }
+    for (const file of files ?? []) {
+      const before = failingTests.length;
+      collectFailures(file, failingTests);
+      if (failingTests.length === before && file?.result?.state === 'fail') {
+        const msgs = (file.result.errors ?? []).map((e) => firstLine(e?.message ?? ''));
+        fileErrors.push({ name: file.name ?? file.filepath ?? '(unknown file)', message: msgs.join('; ') });
+      }
+    }
+  }
+
+  console.log(`frontend-blob-reconcile: scanned ${blobsRead} blob(s) under ${blobDir}.`);
+
+  // A shard killed before onTestRunEnd never writes its blob at all, so its
+  // absence -- not anything inside the surviving blobs -- is the failure's
+  // trace. The blob filename encodes blob-<index>-<count>, so the expected
+  // set is self-describing; no shard-count plumbing from the workflow needed.
+  // Disagreeing counts (blobs from different runs mixed into one dir) make
+  // the expected set undefined, so detection is skipped rather than guessed.
+  const counts = new Set(shardsSeen.map(([, c]) => c));
+  const expectedCount = counts.size === 1 ? [...counts][0] : 0;
+  const missingShards = [];
+  if (expectedCount > 0) {
+    const seen = new Set(shardsSeen.map(([i]) => i));
+    for (let i = 1; i <= expectedCount; i += 1) {
+      if (!seen.has(i)) missingShards.push(i);
+    }
+  }
+  if (missingShards.length > 0) {
+    console.log(
+      `\n::warning::Only ${shardsSeen.length} of ${expectedCount} shard blobs are present -- `
+      + `missing shard(s): ${missingShards.join(', ')}. A missing blob means that shard's vitest `
+      + 'process died before it could write its results (see the worker-OOM failure mode '
+      + 'documented in website/vite.config.ts); its verdict is not represented below.',
+    );
+  }
+
+  if (failingTests.length > 0) {
+    console.log(`\nFailing tests recorded in the merged shard results (${failingTests.length}):`);
+    for (const t of failingTests) {
+      console.log(`  FAIL ${t.name}${t.message ? ` — ${t.message}` : ''}`);
+    }
+  }
+  if (fileErrors.length > 0) {
+    console.log(`\nTest files that failed without a failing test inside (collection/setup errors, ${fileErrors.length}):`);
+    for (const f of fileErrors) {
+      console.log(`  FAIL ${f.name}${f.message ? ` — ${f.message}` : ''}`);
+    }
+  }
+  if (unhandled.length > 0) {
+    console.log(`\nUnhandled runner-level errors recorded in the blobs (${unhandled.length}):`);
+    for (const msg of unhandled) console.log(`  ERROR ${msg}`);
+  }
+
+  const nothingNamed = failingTests.length === 0 && fileErrors.length === 0;
+  if ((shardFailed || mergeFailed) && nothingNamed) {
+    const source = shardFailed ? 'a frontend-test shard' : 'the merge step';
+    if (unhandled.length > 0) {
+      const alsoMissing = missingShards.length > 0
+        ? ` Shard(s) ${missingShards.join(', ')} also never wrote a blob, so their verdicts may be an additional cause.`
+        : '';
+      console.log(
+        `\n::warning::No test in the merged shard results reported failing, but ${source} exited `
+        + `non-zero: the exit came from ${unhandled.length} unhandled runner error(s) listed above `
+        + '(e.g. a test worker dying mid-run), not a test assertion. See the documented worker-OOM '
+        + `failure mode in website/vite.config.ts.${alsoMissing}`,
+      );
+    } else if (missingShards.length > 0) {
+      console.log(
+        `\n::warning::No test in the present shard results reported failing, but ${source} exited `
+        + `non-zero: the likely reason is the missing shard blob(s) listed above -- that shard's `
+        + 'results were never written, so its failure cannot be named here.',
+      );
+    } else {
+      console.log(
+        `\n::warning::No test in the merged shard results reported failing and no unhandled error `
+        + `was recorded, but ${source} exited non-zero: the exit came from the runner itself, not `
+        + 'an assertion. See the documented worker-OOM failure mode in website/vite.config.ts.',
+      );
+    }
+  } else if (nothingNamed && unhandled.length === 0 && missingShards.length === 0) {
+    console.log('All tests in the merged shard results passed and no unhandled errors were recorded.');
+  }
+}
+
+function firstLine(text) {
+  return String(text ?? '').split('\n', 1)[0].slice(0, 300);
+}
+
+// Walk a task tree depth-first, collecting every leaf test whose recorded
+// state is "fail" with its full name and first error line.
+function collectFailures(task, out) {
+  if (!task || typeof task !== 'object') return;
+  if (task.type === 'test' && task.result?.state === 'fail') {
+    const msgs = (task.result.errors ?? []).map((e) => firstLine(e?.message ?? ''));
+    out.push({ name: task.fullName ?? task.name ?? '(unnamed test)', message: msgs.join('; ') });
+  }
+  for (const child of task.tasks ?? []) collectFailures(child, out);
+}
+
+// Diagnostic only, so a defect in this script must never become the failure it
+// exists to explain: an uncaught throw here would red a green merge job and --
+// because later steps default to `if: success()` -- block the coverage-frontend
+// upload the Coverage Gate consumes.
+try {
+  main();
+} catch (err) {
+  console.log(`::warning::frontend-blob-reconcile: reconciliation failed: ${err?.message ?? err}`);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1192,7 +1192,11 @@ jobs:
             # than SHARD_COUNT leaves some shards with no files, so
             # --passWithNoTests keeps an empty shard green (a legitimately empty
             # slice, not a lost suite).
-            npx vitest run --reporter=blob --passWithNoTests \
+            # blob alone prints no verdict (it only writes the artifact), so a
+            # failing shard's log would end at "exit code 1" with no FAIL line
+            # or summary; the second reporter keeps a human-readable verdict in
+            # this job's own log.
+            npx vitest run --reporter=blob --reporter=default --passWithNoTests \
               --shard=${{ matrix.shard }}/"$SHARD_COUNT" "${TARGETS[@]}"
           else
             # --reporter=blob stores results + per-shard coverage under
@@ -1200,7 +1204,11 @@ jobs:
             # the four shards back into one report and the merged cobertura the
             # Coverage Gate reads. Coverage is emitted per shard so the merge
             # can union it -- a single shard covers only the files it ran.
-            npx vitest run --coverage --reporter=blob \
+            # blob alone prints no verdict (it only writes the artifact), so a
+            # failing shard's log would end at "exit code 1" with no FAIL line
+            # or summary; the second reporter keeps a human-readable verdict in
+            # this job's own log.
+            npx vitest run --coverage --reporter=blob --reporter=default \
               --shard=${{ matrix.shard }}/"$SHARD_COUNT"
           fi
 
@@ -1250,6 +1258,7 @@ jobs:
           merge-multiple: true
 
       - name: Merge reports and coverage
+        id: merge
         working-directory: website
         # --merge-reports stitches the per-shard blobs back into one result set
         # WITHOUT re-running tests; --coverage unions the per-shard coverage and
@@ -1258,6 +1267,23 @@ jobs:
         # already consumes. A failed shard makes this exit non-zero, surfacing
         # the failure here too.
         run: npx vitest --merge-reports --coverage
+
+      - name: Reconcile shard verdicts against blob results
+        # Runs even when the merge step failed -- that is the case it exists
+        # for. A shard (or the merge) can exit non-zero without naming a
+        # failing test anywhere: a worker killed mid-run (the worker-OOM mode
+        # documented in website/vite.config.ts) fails the job while every test
+        # in the blob reads "pass". This step decodes the downloaded blobs,
+        # prints every failing test and unhandled runner error by name, and
+        # states the contradiction explicitly when a red verdict has no failing
+        # test behind it. Diagnostic only: it always exits 0 and never changes
+        # the job's verdict.
+        if: ${{ !cancelled() }}
+        working-directory: website
+        env:
+          FRONTEND_TEST_RESULT: ${{ needs.frontend-test.result }}
+          MERGE_RESULT: ${{ steps.merge.outcome }}
+        run: node "$GITHUB_WORKSPACE/.github/scripts/frontend-blob-reconcile.mjs" .vitest-reports
 
       - name: Upload merged coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/test/test_prepare_pr_profiles.py
+++ b/test/test_prepare_pr_profiles.py
@@ -287,6 +287,9 @@ def test_ci_blocking_scans_are_covered_by_the_floor():
         "python": "covered by the scripts/ scan and the pytest gate",
         "python3": "covered by the scripts/ scan and the pytest gate",
         "unshare": "namespace wrapper around the pytest gate",
+        # Diagnostic only: the blob-reconcile step in frontend-coverage-merge
+        # always exits 0 and never changes a job verdict, so it is not a gate.
+        "node": "runs the diagnostic frontend-blob-reconcile step, which never gates",
     }
     tools = set(re.findall(r"(?m)^\s*run: ([a-z][a-z0-9_-]+) ", run_text))
     tool_missing = sorted(


### PR DESCRIPTION
# ci: make frontend shard failures name their reason in the job log (#3455)

Closes #3455

## Problem

A failed frontend test shard reports no reason anywhere in CI. The sharded
`Frontend Tests` jobs run `npx vitest run --reporter=blob [--coverage]
--shard=N/4`, and the blob reporter prints no human-readable verdict — a
failing shard's log is a coverage table followed by `exit code 1`, with no
`FAIL` line, no test name, and no summary. The `Frontend Coverage Merge` job
that stitches the blobs has the same shape. In a real incident a shard exited
1 while its own blob artifact contained **zero** failing tests — the
documented worker-OOM failure mode in `website/vite.config.ts`, where an
unhandled worker death fails the job even though every test passed — and
diagnosing it took six manual artifact probes.

## Why it matters

Every red frontend shard currently sends the investigating human (or review
bot) into artifact archaeology: download blobs, decode them, diff verdict
against contents. The most common "red" (worker OOM with all tests passing)
is exactly the one the log says nothing about.

## Fix (symptom → root cause → change)

Symptom: red shard, silent log. Root cause: `--reporter=blob` replaces the
default reporter entirely and emits only the artifact file; nothing else in
the pipeline re-states the verdict. Change, two mechanical parts:

1. **Shard jobs** now run `--reporter=blob --reporter=default` (both
   branches: full suite and reduced backend-only scope). The blob artifact is
   unchanged for the merge job; the default reporter additionally prints
   `FAIL` lines, `Test Files` / `Tests` summaries in the shard's own log —
   even when a worker dies before the run-end banner.
2. **`Frontend Coverage Merge`** gains a diagnostic reconciliation step
   (`.github/scripts/frontend-blob-reconcile.mjs`, node + `flatted` from
   website's node_modules, no new dependency). After the merge it decodes
   every downloaded blob (`[version, files, unhandledErrors, …]`,
   flatted-encoded — a plain text scan cannot match `"state":"fail"`), prints
   every failing test and unhandled runner error by name, and — when the
   shard job or merge step reported failure but the scan finds zero failing
   tests — prints an explicit `::warning::` stating the exit came from the
   runner, not an assertion, pointing at vite.config.ts's worker-OOM note.
   The step is diagnostic only: always exits 0, runs under `!cancelled()` so
   it also runs when the merge fails (the case it exists for), and never
   changes any job's verdict.

Out of scope (per the issue): fixing the worker-OOM root cause itself.
This PR only makes the reason visible.

## Tests

- `--reporter=blob --reporter=default` verified locally on vitest 4.1.10:
  both the blob file and the human summary/`FAIL` lines are emitted.
- Reconcile script exercised against real blobs in all four branches:
  all-pass + green (silent OK line); all-pass + shard failure (explicit
  runner-exit warning); failing test + merge failure (test named with first
  error line); synthetic blob with a non-empty `unhandledErrors` array
  (error named + worker-death warning).

## Manual verification

`python -c "yaml.safe_load(...)"` on ci.yml passes; `node --check` on the new
script passes; `npx tsc -b` and the full `npx vitest run` suite pass in the
work tree. `actionlint` is not present in the repo. The changed workflow runs
on this PR itself, so the shard jobs in this PR's own checks demonstrate the
dual-reporter output.

## Screenshots

N/A — CI workflow/log change, no UI surface.
