### PR TITLE
feat(cli): surface the built-in denied-command catalog in policy show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,17 @@ All notable changes to KiroCrew are documented in this file.
   writes still audit as `dashboard`; the caller header alone grants nothing.
   (#3503)
 
+- **`kirocrew policy show` no longer hides the 139 built-in denied-command
+  rules from the agent.** The rules are visible and configurable to the
+  user (Settings → Security), but the agent's only way to discover them was
+  to attempt a command and be refused — so it could plan multi-step work
+  that turned out to be impossible from the first step, walking the user
+  through setup effort (e.g. exporting AWS credentials) for a task a
+  hard-denied command would block later anyway. `policy show` now prints
+  the rule count grouped by category on every install, enterprise policy or
+  not; `--ids` lists each category's rule ids for citing a specific rule
+  when relaying a refusal. (#3454)
+
 - **Side-panel oversize-question refusal now reports an accurate character
   target for every script, not just emoji.** The refusal derived its
   character count from a fixed worst-case floor (4 bytes/char, the emoji

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -132,7 +132,7 @@ This allows `kirocrew` to find project-level agent config and skills from any di
 | `kirocrew config edit` | Open config in `$EDITOR` |
 | `kirocrew memory list/search/stats/audit` | Inspect vector memory (entries, semantic search, counts, suspicious-content scan) |
 | `kirocrew memory export/import/migrate` | Export memory to JSON, import it back, or migrate legacy markdown memory into the vector store |
-| `kirocrew policy show/validate/explain/profile` | Inspect the effective enterprise security policy, load-check it and all profiles, explain one tool/scope decision for a surface, or print a profile |
+| `kirocrew policy show/validate/explain/profile` | Inspect the effective enterprise security policy, load-check it and all profiles, explain one tool/scope decision for a surface, or print a profile. `show` also summarizes the built-in denied-command catalog as grouped counts (`--ids` lists each category's rule ids), on every install regardless of whether an enterprise policy is active — the one place an agent can learn a class of work is hard-denied before planning around it. |
 | `kirocrew pod up/down/ls/status/token/url/logs/exec/install/provision` | Isolated worktree test gateways (**Linux `systemd --user` only** — every systemd-touching verb refuses with a one-line message on macOS/Windows). See `src/kiro_crew/pod/README.md`. |
 | `kirocrew knowledge dedup [--apply]` | Collapse cross-source duplicate knowledge documents (dry-run unless `--apply`) |
 | `kirocrew cron preview <script>` | Run a script cron locally with real MCP tools; notifications are captured and printed instead of delivered |

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1366,7 +1366,18 @@ Examples:
         "policy", help="Inspect the governance security policy + profiles"
     )
     policy_sub = policy_parser.add_subparsers(dest="policy_action")
-    policy_sub.add_parser("show", help="Show the effective enterprise security policy")
+    policy_show = policy_sub.add_parser("show", help="Show the effective enterprise security policy")
+    policy_show.add_argument(
+        "--ids",
+        action="store_true",
+        # NOT named --verbose: the top-level parser already defines --verbose/-v
+        # as an int `count` (log level). A same-named store_true on this
+        # subparser would collide in the merged Namespace via argparse's
+        # parent/subparser default-override gotcha (see the --no-jail comment
+        # above) -- whichever parser's default applies last silently
+        # overwrites the other's value.
+        help="List each denied-command category's rule ids (default: counts only)",
+    )
     policy_sub.add_parser("validate", help="Validate the policy + all profiles (load-check)")
     explain_parser = policy_sub.add_parser(
         "explain", help="Explain a tool/scope decision for a surface"

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -18,6 +18,7 @@ import traceback
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -64,6 +65,7 @@ from kiro_crew.hooks import safe_read_file
 from kiro_crew.learn import Lesson, LessonStore
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.security import (
+    BUILTIN_DENIED_RULES,
     BUILTIN_DENY_PATTERNS,
     is_sensitive_path,
     redact,
@@ -1166,6 +1168,40 @@ def _security(args: argparse.Namespace) -> None:
         print("Usage: kirocrew security {audit|deny-list|events|verify}")
 
 
+def _print_denied_command_summary(*, ids: bool) -> None:
+    """Print the built-in denied-command catalog as grouped counts (or, with
+    ``--ids``, each category's rule ids).
+
+    The 139 built-in rules are visible and configurable to the USER (Settings
+    → Security renders them in category accordions, backed by
+    ``GET /api/security/denied-commands``) but were invisible to the AGENT --
+    ``policy show`` reported everything except them, so an agent planning a
+    multi-step task had no way to learn a class of work is hard-denied before
+    committing to a plan that turns out to be impossible. See issue #3454.
+
+    Deliberately just counts + ids, not the full 139 regex patterns: enough
+    for planning ("this class of work is blocked") and for citing a rule id
+    when relaying a refusal, without bloating the output the way dumping
+    every pattern would.
+    """
+    by_category: dict[str, list] = {}
+    for rule in BUILTIN_DENIED_RULES:
+        by_category.setdefault(rule.category, []).append(rule)
+    counts = Counter({cat: len(rules) for cat, rules in by_category.items()})
+    print(
+        f"   • commands.denied: {len(BUILTIN_DENIED_RULES)} rules "
+        f"in {len(by_category)} categories"
+    )
+    if ids:
+        for cat, rules in sorted(by_category.items(), key=lambda kv: -len(kv[1])):
+            rule_ids = ", ".join(r.id for r in rules)
+            print(f"       {cat}({len(rules)}): {rule_ids}")
+    else:
+        summary = " ".join(f"{cat}({n})" for cat, n in counts.most_common())
+        print(f"       {summary}")
+        print("     (add --ids for rule ids, or see Settings → Security)")
+
+
 def _policy(args: argparse.Namespace) -> None:
     """Governance policy + profile inspection (read-only; safe to expose to LLM).
 
@@ -1191,6 +1227,7 @@ def _policy(args: argparse.Namespace) -> None:
     if action == "show":
         if ceiling is None:
             print("No enterprise security policy is active (editable secure-defaults).")
+            _print_denied_command_summary(ids=getattr(args, "ids", False))
             return
         # Report the PROVEN provenance, not the claimed one: printing a bare
         # issuer implied a trust decision nothing had made.  signature_summary()
@@ -1206,6 +1243,7 @@ def _policy(args: argparse.Namespace) -> None:
             print("   (no governed scopes)")
         for scope in sorted(ceiling.controls):
             print(f"   • {scope}: {ceiling.controls[scope]}")
+        _print_denied_command_summary(ids=getattr(args, "ids", False))
 
     elif action == "validate":
         ok = True

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -971,6 +971,51 @@ class TestPolicyCli:
         assert "require_sandbox=True" in out
         assert "capabilities.telemetry: off" in out
 
+    def test_show_without_policy_includes_denied_command_summary(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Regression for #3454: an agent's only prior discovery mechanism for
+        the 139 built-in denied-command rules was to attempt one and be
+        refused. `policy show` must surface them even on a standalone
+        (non-enterprise) install, which is the common case the early-return
+        branch serves."""
+        with patch(
+            "kiro_crew.platform.context.current_context",
+            return_value=SimpleNamespace(governance=None),
+        ):
+            cc._policy(_ns(policy_action="show"))
+        out = capsys.readouterr().out
+        assert "commands.denied: 139 rules in 10 categories" in out
+        assert "aws-destructive(47)" in out
+        # Counts only by default -- rule ids are the --ids opt-in.
+        assert "aws-destructive-ec2-terminate-instances" not in out
+
+    def test_show_with_policy_also_includes_denied_command_summary(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch(
+            "kiro_crew.platform.context.current_context",
+            return_value=SimpleNamespace(governance=_fake_ceiling()),
+        ):
+            cc._policy(_ns(policy_action="show"))
+        assert "commands.denied:" in capsys.readouterr().out
+
+    def test_show_ids_lists_rule_ids_per_category(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Named --ids, not --verbose: the top-level parser already defines
+        # --verbose/-v as an int `count` (log level); a same-named store_true
+        # on this subparser would collide via argparse's parent/subparser
+        # default-override gotcha.
+        with patch(
+            "kiro_crew.platform.context.current_context",
+            return_value=SimpleNamespace(governance=None),
+        ):
+            cc._policy(_ns(policy_action="show", ids=True))
+        out = capsys.readouterr().out
+        assert "aws-destructive-ec2-terminate-instances" in out
+        assert "reverse-shell-nc" in out
+
     def test_show_with_no_governed_scopes(self, capsys: pytest.CaptureFixture[str]) -> None:
         ceiling = _fake_ceiling()
         ceiling.controls = {}


### PR DESCRIPTION
## Summary

Fixes #3454.

The 139 built-in denied-command rules are visible and configurable to the **user** (Settings → Security renders them in category accordions, backed by `GET /api/security/denied-commands`) but invisible to the **agent**: `kirocrew policy show` — the one surface an agent can query — reported everything except them.

An agent plans a multi-step task before executing it. With no way to enumerate the denies, it commits to plans that are impossible from the first step, and the user pays for the detour. The issue's concrete example: a session where the agent walked the user through exporting temporary AWS credentials, verified identity, chose a subnet/AMI, and wrote an API key into an SSM parameter — all permitted — before the actual `RunInstances` launch hit a hard deny that made the task impossible from message one.

## Approach

Implements the issue's **option 1** (the smaller of the proposals — option 3, injecting a summary into agent context the way memory/lessons already are, is noted as "higher leverage" but a separate, larger change, left as a natural follow-up):

> Include the denied-command rules in `kirocrew policy show`. Grouped counts plus rule ids is enough to change agent planning; the full 139 patterns would bloat the output.

`policy show` now prints the catalog as grouped category counts **unconditionally** — including on a standalone install with no enterprise policy active, which is the common case the handler's early-return branch previously skipped entirely (nothing after `if ceiling is None: return` ever ran):

```
   • commands.denied: 139 rules in 10 categories
       aws-destructive(47) sensitive-file-read(27) credential-exfil(21)
       local-destructive(18) git-publish(7) self-protection(6)
       iac-teardown(4) sql(4) pipe-to-shell(3) reverse-shell(2)
     (add --ids for rule ids, or see Settings → Security)
```

`--ids` lists each category's rule ids, for citing a specific rule when relaying a refusal.

**Naming note:** the issue's own example sketches `--verbose`, but the top-level parser already defines `--verbose`/`-v` as an int `count` (log level). A same-named `store_true` on the `policy show` subparser would silently corrupt that value in the merged `Namespace` via argparse's parent/subparser default-override behavior (verified directly — see test plan). Named it `--ids` instead.

## Changes
- `src/kiro_crew/cli_commands.py`: `_print_denied_command_summary()`, called from both branches of `policy show`.
- `src/kiro_crew/cli.py`: `--ids` flag on the `policy show` subparser.
- `test/test_cli_commands_coverage.py`: 3 new tests (summary present with no policy, summary present with a policy, `--ids` lists rule ids).
- `docs/system-specs/modules/cli.md`: updated the `policy show` table entry.
- `CHANGELOG.md`: entry under Unreleased.

## Test plan
- [x] `pytest test/test_cli_commands_coverage.py test/test_security.py test/test_denied_commands_api.py test/test_denied_commands_hooks.py -q` — 784 passed, 3 skipped
- [x] Manually verified the argparse merge behavior directly: `verbose` (count) and `ids` (bool) coexist with no collision in any argument order (`-v policy show`, `policy show --ids`, `-v policy show --ids`)
- [x] `flake8` / `isort --check` on changed files — clean
- [x] `mypy` on changed files — no new errors
- [x] `scripts/docs-lint.sh` — clean