### PR TITLE
test: replace wall-clock sync in the subagent reap-race test with events

### DIFF
--- a/test/test_subagent_reap_race.py
+++ b/test/test_subagent_reap_race.py
@@ -228,9 +228,19 @@ async def test_cancel_during_subagent_done_still_delivers_once():
     mgr._sessions.reset = _noop_reset
     delivered: list[str] = []
 
+    # Deterministic rendezvous instead of a wall-clock bet: `entered` tells the
+    # test exactly when the shielded report is in flight (so cancelling before
+    # that would race a step that hasn't started, and cancelling after it
+    # completes wouldn't be a cancel-mid-flight at all), and `release` lets the
+    # test decide exactly when the shielded report is allowed to finish, so its
+    # completion can be asserted separately from the awaiter's cancellation.
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
     async def _slow_event(name, _info, _payload=None):
         if name == "subagent_done":
-            await asyncio.sleep(0.05)
+            entered.set()
+            await release.wait()
 
     async def _record_delivery(_info):
         delivered.append("done")
@@ -241,12 +251,14 @@ async def test_cancel_during_subagent_done_still_delivers_once():
     task = asyncio.ensure_future(
         mgr._force_reap("a1b2c3d4", info, elapsed=1.0, reason="reaped")
     )
-    await asyncio.sleep(0.01)  # let it enter the shielded report
+    await asyncio.wait_for(entered.wait(), timeout=2)  # now inside the shielded report
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    # The shielded report survives its awaiter's cancellation.
+    # The shielded report survives its awaiter's cancellation -- release it
+    # and confirm it still completes delivery.
+    release.set()
     await asyncio.wait_for(
         asyncio.gather(*[t for t in mgr._report_tasks if not t.done()]), timeout=2
     )


### PR DESCRIPTION
## Summary

Fixes #3486.

`test/test_subagent_reap_race.py::test_cancel_during_subagent_done_still_delivers_once` fails intermittently in CI with `Failed: DID NOT RAISE <class 'asyncio.exceptions.CancelledError'>`.

Per the issue's root-cause analysis: the test synchronised with a wall-clock `await asyncio.sleep(0.01)`, betting that the claimer task had entered the shielded report but had not yet passed the point where cancellation is still observable to the awaiter. The stubbed `_fire_event` slept a further `0.05`s, so the intended window was ~40ms wide — but both sleeps are wall-clock, so under CI load or a slow scheduler tick the task can reach a state where `task.cancel()` no longer surfaces as `CancelledError` to the awaiter.

## Fix

Per the issue's suggested fix: replace the timing bet with a deterministic two-event rendezvous.

- `entered` — the stubbed `_fire_event` sets it immediately on being called for `subagent_done`. The test `await`s it (bounded by a real timeout, not a duration bet) before cancelling, so the cancel always lands at the same, known point inside the shielded report — never before it, never after it's moved on.
- `release` — the stub then blocks on it until the test explicitly lets it proceed, so the shielded report's *completion* can be asserted after the awaiter's cancellation is confirmed, rather than racing a fixed sleep duration to still be "in progress" when the assertion runs.

No wall-clock timing anywhere in the test now. The surrounding assertions (`delivered` reaching the parent, the shielded task surviving the awaiter's cancellation) are unchanged, matching the issue's note that they're "the valuable part."

## Test plan
- [x] `pytest test/test_subagent_reap_race.py -q` — 27 passed
- [x] `pytest test/test_subagent_reap_race.py -q -k test_cancel_during_subagent_done_still_delivers_once`, repeated 30x — 30/30 clean
- [x] `pytest test/test_subagent.py test/test_subagent_scale.py test/test_subagent_persistence.py test/test_subagent_cwd.py test/test_subagent_turn_resilience.py test/test_subagent_context_group_plumbing.py test/test_subagent_context_group_applied.py -q` — 255 passed
- [x] `flake8` — clean
- [ ] I did not reproduce the original CI flake locally — it depends on scheduler timing under load that isn't practical to force deterministically in a short local session. The fix removes the race condition at its root (wall-clock synchronization, replaced with event-based rendezvous) rather than tuning sleep durations, per the issue's own diagnosis.