### PR TITLE
fix(subagent): show the resolved turn cap in timeout errors, not 0

### DIFF
--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -24,7 +24,7 @@ Supports `on_tool_approval` callback for interactive tool approval (routed throu
 
 Priority (highest wins): **per-spawn `max_turns`** → **config `agent.subagent_max_turns`** → **hardcoded default (100)**
 
-A value of `0` means "not set" and falls through to the next level. Implemented as `info.max_turns or self._default_turn_limit or _TURN_LIMIT` in `_run_subagent()`.
+A value of `0` means "not set" and falls through to the next level. Implemented as `SubagentManager._effective_turn_limit()`, shared by the enforcement path in `_run_inner()` and the timeout/reap error strings (`_timeout_context()`).
 
 ### Concurrency Auto-Sizing — Memory Probe (per platform)
 

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -423,9 +423,16 @@ def _digest_hold_secs() -> float:
 DIGEST_HOLD_SECS = _digest_hold_secs()
 
 
-def _timeout_context(info: "SubagentInfo", *, include_elapsed: bool = True) -> str:
-    """Build a human-readable context string for timeout errors."""
-    parts = [f"turn {info.turns}/{info.max_turns}"]
+def _timeout_context(info: "SubagentInfo", *, include_elapsed: bool = True, turn_limit: int = 0) -> str:
+    """Build a human-readable context string for timeout errors.
+
+    ``turn_limit`` is the resolved effective turn cap (per-spawn override →
+    manager default → hardcoded). ``info.max_turns`` alone is only the raw
+    per-spawn override, which is 0 when unset and would render a misleading
+    ``turn N/0``. When no positive cap is known, the cap is omitted entirely.
+    """
+    limit = turn_limit or info.max_turns
+    parts = [f"turn {info.turns}/{limit}" if limit > 0 else f"turn {info.turns}"]
     if info.last_tool:
         parts.append(f"last tool: {_redact(info.last_tool)}")
     if include_elapsed:
@@ -1296,6 +1303,14 @@ class SubagentManager:
             )
         except Exception:
             self._spawn_stagger_secs = 2.0
+
+    def _effective_turn_limit(self, info: SubagentInfo) -> int:
+        """Resolved turn cap for a run: per-spawn ``max_turns`` → config
+        default (``agent.subagent_max_turns``) → hardcoded ``_TURN_LIMIT``.
+
+        ``0`` at any level means "not set" and falls through to the next.
+        """
+        return info.max_turns or self._default_turn_limit or _TURN_LIMIT
 
     def update_completion_keep(self, mode: str, max_chars: int) -> None:
         """Update the live completion-keep mode and char budget.
@@ -2300,9 +2315,9 @@ class SubagentManager:
             if not info.error and not info.user_stopped:
                 # A user stop is neutral — never synthesize a reap error for it.
                 if reason == "startup_timeout":
-                    info.error = f"Failed to start within {self._startup_deadline}s (no runtime launched, no turn produced) [{_timeout_context(info, include_elapsed=False)}]"
+                    info.error = f"Failed to start within {self._startup_deadline}s (no runtime launched, no turn produced) [{_timeout_context(info, include_elapsed=False, turn_limit=self._effective_turn_limit(info))}]"
                 else:
-                    info.error = f"Reaped after {int(elapsed)}s (exceeded {self._default_timeout}s deadline) [{_timeout_context(info, include_elapsed=False)}]"
+                    info.error = f"Reaped after {int(elapsed)}s (exceeded {self._default_timeout}s deadline) [{_timeout_context(info, include_elapsed=False, turn_limit=self._effective_turn_limit(info))}]"
             if not info.user_stopped:
                 # A user-initiated stop is a neutral outcome, not a failure.
                 Stats().inc_subagent_failed()
@@ -4314,7 +4329,7 @@ class SubagentManager:
             )
         except asyncio.TimeoutError:
             if not info.reaped:
-                info.error = f"Timed out after {self._default_timeout // 60} minutes [{_timeout_context(info)}]"
+                info.error = f"Timed out after {self._default_timeout // 60} minutes [{_timeout_context(info, turn_limit=self._effective_turn_limit(info))}]"
                 info.done = True
                 Stats().inc_subagent_failed()
                 self._write_tombstone(info, "timeout")
@@ -4926,7 +4941,7 @@ class SubagentManager:
 
         result_text = ""
         turns = 0
-        turn_limit = info.max_turns or self._default_turn_limit or _TURN_LIMIT
+        turn_limit = self._effective_turn_limit(info)
         # Reports inherited agent (not just info.agent) so telemetry shows
         # the actual agent used for this subagent session.
         await self._fire_event(

--- a/test/test_stop_kill_cancel.py
+++ b/test/test_stop_kill_cancel.py
@@ -654,6 +654,7 @@ class TestConservativeShutdown:
         mgr._queue = []
         mgr._running_count = 1
         mgr._default_timeout = 300
+        mgr._default_turn_limit = 100
         mgr._write_tombstone = MagicMock()
         mgr._record_cost = MagicMock()
         mgr._on_event = None
@@ -717,6 +718,7 @@ class TestConservativeShutdown:
         mgr._queue = []
         mgr._running_count = 2
         mgr._default_timeout = 300
+        mgr._default_turn_limit = 100
         mgr._write_tombstone = MagicMock()
         mgr._record_cost = MagicMock()
         mgr._on_event = None

--- a/test/test_subagent.py
+++ b/test/test_subagent.py
@@ -1311,6 +1311,55 @@ class TestTimeoutContext:
         mock_redact.assert_called_once_with("some_tool")
         assert "last tool: [REDACTED]" in ctx
 
+    def test_unset_cap_omitted_not_slash_zero(self) -> None:
+        """max_turns=0 (no per-spawn cap) must not render a misleading 'turn N/0'."""
+        from kiro_crew.subagent import SubagentInfo, _timeout_context
+
+        info = SubagentInfo(id="t1", task="test", turns=41, max_turns=0, started=time.time() - 10)
+        ctx = _timeout_context(info)
+        assert "turn 41" in ctx
+        assert "turn 41/" not in ctx
+
+    def test_resolved_turn_limit_used_over_raw_zero(self) -> None:
+        """The caller-resolved effective cap is shown when the raw override is unset."""
+        from kiro_crew.subagent import SubagentInfo, _timeout_context
+
+        info = SubagentInfo(id="t1", task="test", turns=41, max_turns=0, started=time.time() - 10)
+        ctx = _timeout_context(info, turn_limit=100)
+        assert "turn 41/100" in ctx
+
+
+class TestEffectiveTurnLimit:
+    """Resolution chain: per-spawn max_turns → manager default → hardcoded."""
+
+    def _manager(self, default_turn_limit: int) -> "SubagentManager":
+        return SubagentManager(
+            sessions=_mock_sessions(),
+            ctx_builder=None,
+            default_turn_limit=default_turn_limit,
+        )
+
+    def test_per_spawn_override_wins(self) -> None:
+        from kiro_crew.subagent import SubagentInfo
+
+        manager = self._manager(default_turn_limit=50)
+        info = SubagentInfo(id="t1", task="test", max_turns=30)
+        assert manager._effective_turn_limit(info) == 30
+
+    def test_falls_back_to_manager_default(self) -> None:
+        from kiro_crew.subagent import SubagentInfo
+
+        manager = self._manager(default_turn_limit=50)
+        info = SubagentInfo(id="t1", task="test", max_turns=0)
+        assert manager._effective_turn_limit(info) == 50
+
+    def test_falls_back_to_hardcoded_limit(self) -> None:
+        from kiro_crew.subagent import _TURN_LIMIT, SubagentInfo
+
+        manager = self._manager(default_turn_limit=0)
+        info = SubagentInfo(id="t1", task="test", max_turns=0)
+        assert manager._effective_turn_limit(info) == _TURN_LIMIT
+
 
 class TestAgentInheritance:
     """Agent name is inherited from parent session when not explicitly specified."""


### PR DESCRIPTION
## Problem / Motivation

I got a subagent timeout tonight whose error read `Timed out after 30 minutes [turn 41/0 | last tool: ...]`. The `turn 41/0` is nonsense to a reader: it looks like "turn 41 of a 0-turn budget". The context string prints the raw per-spawn `max_turns` override, which is `0` whenever no override was passed — while the cap actually enforced on the run falls back to the config default (`agent.subagent_max_turns`) and then the hardcoded limit (100).

## Why it matters

Timeout/reap errors are exactly the moment a user is trying to understand what their subagent was doing; a `/0` cap actively misleads (it suggests a broken or zero budget) and generates support questions instead of answering them.

## What changed (motivation → approach → change)

Symptom: `turn N/0` in timeout, startup-timeout, and reap error strings. Root cause: `_timeout_context()` only receives `SubagentInfo` and prints `info.max_turns` verbatim, but `max_turns == 0` means "not set" in the resolution chain (per-spawn → config default → hardcoded, as documented in `docs/system-specs/modules/subagent.md`). Change: the resolution chain now lives in one `SubagentManager._effective_turn_limit()` helper, used both by the enforcement path in `_run_inner` (same value as before, no behavior change) and by the three error-string call sites, which pass the resolved cap into `_timeout_context(..., turn_limit=...)`. If no positive cap is known, the cap is omitted (`turn 41`) rather than rendering `/0`.

## Tests

- `test_unset_cap_omitted_not_slash_zero` — locks in that `max_turns=0` never renders `turn N/0`.
- `test_resolved_turn_limit_used_over_raw_zero` — the resolved cap passed by the caller is what renders (`turn 41/100`).
- `TestEffectiveTurnLimit` (3 tests) — the resolution chain: per-spawn override wins, falls back to the manager default, then to the hardcoded limit.
- Existing `TestTimeoutContext` tests pass unchanged (explicit `max_turns` still renders `turn 5/30`).
- `test_stop_kill_cancel.py`'s two skeleton-manager fixtures (built via `SubagentManager.__new__`) gained a `_default_turn_limit` attribute, since the reap error path now reads it.

Full local gate: full pytest suite run — the only failures are environment-specific and byte-identical on a clean `origin/main` checkout (e.g. `AF_UNIX path too long` from a long worktree path); `test/test_subagent.py` + `test/test_stop_kill_cancel.py` 121/121 green; isort, flake8 clean; mypy's 3 errors are pre-existing on main (Linux-only `os.*xattr` on a macOS host).

## Manual verification

N/A — unit coverage sufficient: the change is a pure string-composition fix plus an identical-value refactor of the limit resolution, both fully exercised by the tests above.

## Related Issues

None filed; observed live on a timed-out subagent run.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the spec documents the resolution chain, which is unchanged
- [x] No secrets, credentials, or internal references in the diff
