### PR TITLE
fix: gate launchd logs branch on installed agent and non-empty log

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -760,7 +760,11 @@ source is most appropriate:
 1. systemd journal if the system service is installed on Linux. Tries
    unprivileged `journalctl` first; falls back to `sudo journalctl`
    only if the unprivileged probe returns no rows.
-2. launchd stdout file if a plist exists on macOS
+2. launchd stdout file if a plist exists on macOS and that file is
+   non-empty. Both conditions matter: the platform probe reports launchd
+   on any macOS host, and an install that never started the agent leaves
+   a 0-byte log behind, so either check alone would capture the command
+   and tail nothing.
 3. `~/.kiro/crew/gateway.log` for foreground gateways
 
 Uses `os.execvp` so signals (Ctrl+C) propagate naturally to the

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1661,7 +1661,21 @@ def _logs_cmd(args: argparse.Namespace) -> None:
             sudo_cmd.append("-f")
         os.execvp("sudo", sudo_cmd)
 
-    if plat == Platform.LAUNCHD and svc_macos.STDOUT_LOG.exists():
+    # Both guards mirror checks the systemd arm above already makes on its own
+    # branch. current_platform() returns LAUNCHD for any macOS host whether or
+    # not the agent is installed, so without PLIST_PATH this arm captures `logs`
+    # even when the gateway runs in the foreground; and a 0-byte STDOUT_LOG from
+    # an install that never started the agent still satisfies exists().
+    #
+    # Either miss is silent and total: this arm os.execvp()s, so there is no
+    # fall-through to the config_dir() log below and `kirocrew logs` exits 0
+    # having printed nothing.
+    if (
+        plat == Platform.LAUNCHD
+        and svc_macos.PLIST_PATH.exists()
+        and svc_macos.STDOUT_LOG.exists()
+        and svc_macos.STDOUT_LOG.stat().st_size > 0
+    ):
         cmd = ["tail", "-n", str(lines)]
         if follow:
             cmd.append("-f")

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -488,16 +488,53 @@ class TestLogsCmdSystemd:
 class TestLogsCmdOtherSources:
     """launchd stdout file, plain log file, and the "nothing to tail" refusal."""
 
-    def test_launchd_stdout_log_is_tailed(
-        self, monkeypatch, tmp_path, sel_rec, fake_execvp
-    ) -> None:
+    @pytest.fixture
+    def launchd(self, monkeypatch, tmp_path):
+        """An installed launchd agent: a plist on disk and a non-empty stdout log.
+
+        Both paths are patched even when a test only cares about one of them,
+        because the real ones are consulted otherwise and a CI runner has
+        neither.
+        """
+        plist = tmp_path / "crew.plist"
+        plist.write_text("<plist/>\n", encoding="utf-8", newline="\n")
         stdout_log = tmp_path / "launchd-gateway.log"
         stdout_log.write_text("x\n", encoding="utf-8", newline="\n")
         monkeypatch.setattr(cli_server, "current_platform", lambda: Platform.LAUNCHD)
+        monkeypatch.setattr(svc_macos, "PLIST_PATH", plist)
         monkeypatch.setattr(svc_macos, "STDOUT_LOG", stdout_log)
+        return types.SimpleNamespace(plist=plist, stdout_log=stdout_log)
+
+    def test_launchd_stdout_log_is_tailed(self, sel_rec, fake_execvp, launchd) -> None:
         with pytest.raises(_ExecCalled) as exc:
             cli_server._logs_cmd(argparse.Namespace(follow=True, lines=8))
-        assert exc.value.argv == ["tail", "-n", "8", "-f", str(stdout_log)]
+        assert exc.value.argv == ["tail", "-n", "8", "-f", str(launchd.stdout_log)]
+
+    def test_launchd_without_an_installed_plist_falls_through(
+        self, monkeypatch, tmp_path, sel_rec, fake_execvp, launchd
+    ) -> None:
+        """A foreground gateway on macOS reaches the config-dir log, not the agent's."""
+        launchd.plist.unlink()
+        fallback = tmp_path / "fallback" / "gateway.log"
+        fallback.parent.mkdir()
+        fallback.write_text("real\n", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(cli_server, "config_dir", lambda: fallback.parent)
+        with pytest.raises(_ExecCalled) as exc:
+            cli_server._logs_cmd(argparse.Namespace(follow=False, lines=4))
+        assert exc.value.argv == ["tail", "-n", "4", str(fallback)]
+
+    def test_launchd_with_an_empty_stdout_log_falls_through(
+        self, monkeypatch, tmp_path, sel_rec, fake_execvp, launchd
+    ) -> None:
+        """A 0-byte agent log satisfies exists(), so size is what gates the branch."""
+        launchd.stdout_log.write_text("", encoding="utf-8", newline="\n")
+        fallback = tmp_path / "fallback" / "gateway.log"
+        fallback.parent.mkdir()
+        fallback.write_text("real\n", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(cli_server, "config_dir", lambda: fallback.parent)
+        with pytest.raises(_ExecCalled) as exc:
+            cli_server._logs_cmd(argparse.Namespace(follow=False, lines=4))
+        assert exc.value.argv == ["tail", "-n", "4", str(fallback)]
 
     def test_no_log_source_at_all_exits_with_guidance(
         self, monkeypatch, tmp_path, sel_rec, capsys


### PR DESCRIPTION
## Problem / Motivation

On macOS, `kirocrew logs` can exit 0 having printed nothing at all, while the log
the user wanted sits untouched on disk.

`_logs_cmd` selects a log file to `tail`. The systemd arm guards on both the
platform **and** the unit file existing:

```python
if plat == Platform.SYSTEMD and svc_linux.UNIT_PATH.exists():
```

The launchd arm guarded only on the platform:

```python
if plat == Platform.LAUNCHD and svc_macos.STDOUT_LOG.exists():
```

That asymmetry produces two distinct misses:

1. **No agent installed.** `current_platform()` returns `LAUNCHD` for *any* macOS
   host, installed or not, so a gateway running in the foreground had its `logs`
   command captured by the agent branch.
2. **Agent installed but never started.** A 0-byte `STDOUT_LOG` still satisfies
   `exists()`, so the branch is taken and `tail` emits nothing.

## Why it matters

Both failures are silent and total, not partial. The branch ends in
`os.execvp()`, which replaces the process image — so there is **no fall-through**
to the `config_dir() / "gateway.log"` fallback immediately below it. The command
exits 0, prints nothing, and gives the user no signal that it looked in the wrong
place. Anyone running the gateway in the foreground on macOS — the normal
development and first-run path — cannot read their own logs, and the failure mode
actively misleads: exit 0 with empty output reads as "there are no logs yet"
rather than "I tailed the wrong file."

## What changed (motivation → approach → change)

**Symptom:** `kirocrew logs` silently prints nothing on macOS.

**Root cause:** the launchd branch is missing the installed-agent guard its
systemd sibling already has, and `exists()` is too weak a test for a log file
that an unstarted agent leaves at 0 bytes.

**Change:** bring the launchd arm up to parity with systemd by requiring the
plist to exist, and add a size check for the unstarted-agent case:

```python
if (
    plat == Platform.LAUNCHD
    and svc_macos.PLIST_PATH.exists()
    and svc_macos.STDOUT_LOG.exists()
    and svc_macos.STDOUT_LOG.stat().st_size > 0
):
```

Both conditions reference existing module constants (`svc_macos.PLIST_PATH`,
`svc_macos.STDOUT_LOG`) rather than literal paths, so there is no new hardcoded
location. When either guard fails, control now reaches the existing
`config_dir()` fallback — which is what the user wanted in both scenarios.

This is a spec-conformance fix, not a behavior proposal:
`docs/system-specs/modules/cli.md` **already documented** the resolution order as
"launchd stdout file **if a plist exists** on macOS". The code simply never
implemented that clause. The doc is updated in the same commit to also state the
non-empty condition and why each check is load-bearing.

## Tests

`test/test_cli_server_more_coverage.py`:

- **`test_launchd_stdout_log_is_tailed`** — pre-existing test, repaired. It
  patched `STDOUT_LOG` but not `PLIST_PATH`; once the plist guard exists it would
  consult the real `~/Library/LaunchAgents` and fail on any CI runner, which has
  no plist. Both paths now come from a shared `launchd` fixture that patches them
  together, with a docstring explaining why patching only one is a trap.
- **`test_launchd_without_an_installed_plist_falls_through`** (new) — locks in
  that a foreground gateway on macOS reaches the `config_dir()` log rather than
  the agent's.
- **`test_launchd_with_an_empty_stdout_log_falls_through`** (new) — locks in that
  a 0-byte agent log falls through, i.e. that size, not mere existence, gates the
  branch.

Both new tests were confirmed to **fail against the unfixed code** (they tail
`launchd-gateway.log` instead of `gateway.log`), so they genuinely pin the fix
rather than passing vacuously.

## Manual verification

N/A — unit coverage is sufficient. The change is a pure predicate on two
filesystem checks, and the tests exercise all three reachable outcomes
(both guards pass → agent log; plist missing → fallback; log empty → fallback)
by patching the module constants, which is how the surrounding suite already
tests this function.

Local gate results, with scope stated honestly:

- `test/test_cli_server_more_coverage.py` — 79/79 pass
- `flake8` — clean (the leading-`and` continuation style satisfies W504)
- `mypy` — `Success: no issues found in 1 source file`
- `scripts/scrub-lint.sh` — all checks passed
- `scripts/docs-lint.sh` and the brand-name check — pass

Not run locally: the full backend suite and the frontend gates. The only
interpreter available on my machine is Python 3.14, which is outside the
project's supported 3.10–3.13 range and disagrees with the pinned
`black==26.3.1` on files unrelated to this diff. Deferring both to CI.

## Related Issues

N/A — no tracking issue; found by reading the two service arms side by side and
noticing the guard asymmetry, then confirming against the existing spec text.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

