### PR TITLE
fix(agent): don't spawn the computer-use backend when it can't be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ All notable changes to KiroCrew are documented in this file.
   dimension-checked, float64-precision scorer the ranking paths already use,
   which also removes a per-row query re-derivation from both loops. (#3466)
 
+- **Computer use no longer costs a 109 MB backend process per chat when it is
+  off — or on platforms where it cannot run at all.** `kirocrew-computer` was
+  registered into the agent spec unconditionally, and the keystone enable was
+  only checked *inside* the process the spec had already caused kiro-cli to
+  spawn: it suppressed the tool list, never the process. Every chat process paid
+  ~109 MB for a disabled capability, including every `spawn_run` subagent, and
+  on Linux/Windows it paid that for a feature with no driver (macOS is the only
+  supported platform) — measured at 16 processes / 1.75 GB on one Linux host.
+  The server is now withheld from the emitted spec, unless this is macOS *and*
+  the keystone is on; enabling it from Settings rebuilds the spec before
+  restarting sessions, so the tools still appear in the session you are sitting
+  in. Your `tools` entries are left untouched — a ref whose server the spec does
+  not define resolves to nothing, so a mount you had narrowed to a single tool
+  comes back exactly as you left it. Only the entry's own `autoApprove` and
+  custom `env` keys are reset by an off/on cycle and need re-applying,
+  deliberately: restoring an approval from a file the agent can write would
+  bypass the PreToolUse gate. The two in-process checks are kept as defence in
+  depth for a mid-session disable. (#3482)
+
 - **Side-panel oversize-question refusal now reports an accurate character
   target for every script, not just emoji.** The refusal derived its
   character count from a fixed worst-case floor (4 bytes/char, the emoji

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -120,6 +120,59 @@ from the live `kirocrew` binary, strips stale remote-transport fields (`url`,
 gateway is actually running under while preserving the user's own env keys.
 User customizations such as `autoApprove` are preserved.
 
+An entry may also carry a **`spec_gate`** — a predicate consulted at spec
+EMISSION time. `kirocrew-computer` is the one row that has one, and the
+distinction it draws is the difference between a capability that advertises no
+tools and one that costs nothing: emitting the entry is what makes kiro-cli spawn
+the backend, so an in-process enable check can only ever refuse work in a process
+that is already resident (~109 MB, per chat process, including every `spawn_run`
+subagent). While the gate is closed the server appears in neither `mcpServers`
+nor `tools`, so nothing is spawned at all. Both loops that write specs honour it,
+and asymmetrically on purpose:
+
+- `build_agent_config()` withholds the entry **and pops one arriving from the
+  user override file** — a platform gate exists because there is no driver on
+  this OS, and an override must not smuggle a server past it;
+- `_refresh_dynamic_fields()` **retracts** an entry a previous pass wrote while
+  the gate was open, because a skip-only refresh would mean turning a feature off
+  never reclaims the process turning it on started;
+**The `@server` refs in `tools` / `allowedTools` are left exactly as they are.**
+Withholding the entry is the whole control: a `@server` ref resolves against the
+agent's own `mcpServers` plus the global `mcp.json`, so with no entry in either
+there is nothing to launch — the ref names nothing and mounts nothing.
+
+| | |
+|---|---|
+| **Preserved** | the user's `tools` and `allowedTools` refs, verbatim — including a mount hand-narrowed to a single `@server/tool` |
+| **NOT preserved** | the entry's `autoApprove` and user `env` keys. An off/on cycle resets these; the operator re-applies them |
+
+Stripping the refs as well is the tidier-looking design and it is where a whole
+class of defects came from. The removed set is not reconstructible from the server
+name — a user can narrow `tools` to ONE `@server/tool` ref while the re-enable path
+re-adds the BARE ref — so anything that prunes must also stash and restore, and
+every way that stash can fail silently **widens** the mount: an unwritable stash, a
+stash cleared before the spec write landed, a rebuild path that skipped the
+restore. Leaving the refs alone has none of those states, and the only place a stash
+could live is a sidecar the agent itself can write.
+
+That last point is why the entry's own fields are still dropped rather than stashed:
+a restored `autoApprove` would be an **agent-authored** value that a later rebuild
+installs into the spec, and kiro-cli approves an auto-approved MCP tool *locally* —
+no permission request is emitted, so `hooks.on_tool_call` (deny floor,
+sensitive-path check, governance ceiling) and the SEL audit are never reached. For
+tools that can click and type into an already-authenticated application that is a
+self-granted gate bypass. Losing an approval is the safe direction; restoring one
+from a file the agent can write is not.
+
+Withholding is recorded to SEL as `mcp_server_withheld`, derived from the gate plus
+the shipped template rather than from a config delta — nothing in the spec changes
+shape when a gate closes, so there is no delta to observe, and the audit trail would
+otherwise have no record that a shipped server was deliberately not emitted.
+
+The gate decision is snapshotted **once per rebuild** and threaded through both emit
+loops, so a keystone flip landing mid-rebuild cannot produce a spec that emits one
+server's entry under the old decision and another's under the new one.
+
 Under an enterprise MCP registry, `_refresh_dynamic_fields()` also maintains a
 `"type": "registry"` marker on these three entries — added when
 `agent.mcp_registry_mode` is declared, and REMOVED when it is not. The marker is
@@ -137,7 +190,8 @@ request, so `hooks.on_tool_call` (the PreToolUse deny floor, sensitive-path
 check and governance ceiling) is never reached for it. For a tool that can click
 and type into an already-authenticated application, that would be a complete
 gate bypass. Its stdio shim answers an empty `tools/list` while the keystone
-enable is off, so a disabled feature costs the model no context.
+enable is off — retained as defence in depth for a mid-session disable, on top of
+the `spec_gate` above that keeps the process from existing in the first place.
 
 ### The final auto-approve pass
 

--- a/docs/system-specs/modules/computer-use.md
+++ b/docs/system-specs/modules/computer-use.md
@@ -72,6 +72,41 @@ gateway over loopback with the `X-Internal-Secret` handshake (the pattern
 sibling header, read only by `GET /api/token/local`), and relays the text result
 back. Everything of consequence happens in the gateway.
 
+### The shim is not spawned at all unless it can be used
+
+`agent._computer_use_spec_gate()` decides whether `kirocrew-computer` appears in
+the **emitted agent spec**: macOS **and** the keystone enable, or no entry. This is
+a separate control from the two in-process checks, and it has to be, because those
+run inside a process the spec already caused kiro-cli to spawn — they can make a
+disabled feature advertise zero tools, but not make it cost nothing. It cost
+~109 MB of resident memory per chat process (including every `spawn_run`
+subagent), and on Linux/Windows it cost that for a capability with no driver:
+`backend.select_default_backend` has one only on macOS, so the process could never
+have done anything at all.
+
+The gate **fails closed** — a missing, unreadable or malformed keystone yields no
+entry — matching `enable_state`'s own posture, for a stronger reason: the open
+position hands out the operator's whole desktop.
+
+Both in-process checks stay, and they cover what the gate structurally cannot: the
+keystone flipping **off** mid-session, after the spec was written and the backend
+spawned. The gate covers what they cannot: the process existing.
+
+`tools` is **not** touched. The `@kirocrew-computer` ref the shipped
+`defaults.json` grants stays where it is: a ref resolves against the agent's own
+`mcpServers` plus the global `mcp.json`, so once the entry is withheld the ref names
+nothing and launches nothing. Removing it would destroy a mount the user may have
+narrowed to a single tool and cannot be reconstructed on re-enable — the bare ref the
+template re-adds is wider than what they chose.
+
+The entry's `autoApprove` and user `env` keys are the one thing an off/on cycle does
+reset. Stashing them would need a sidecar the agent can write, and an approval
+restored from there would never reach the PreToolUse gate — see
+[Managed servers](../../architecture/mcp.md#managed-servers). The operator
+re-applies them. Pinned by
+`test_computer_use_registration.py::TestSpecEmissionGate`,
+`::TestGatedEntryIsNotPreserved` and `::TestGatedRefsAreLeftALONE`.
+
 Three reasons the split is worth the extra hop, none of them governance:
 
 * **the native work must not run in the shim.** A ctypes fault is not catchable in
@@ -1569,6 +1604,28 @@ off keeps an empty computer-use tool set for its whole life: the operator enable
 it, asks the agent to look at a window, and is told there are no tools. Restarting
 is the same remedy `POST /api/mcp/sync` already applies when MCP routing changes,
 and for the same reason.
+
+**The spec is rebuilt BEFORE the reset, under the config lock, and both of those are
+load-bearing.** The enable is also a spec-emission gate ([above](#the-shim-is-not-spawned-at-all-unless-it-can-be-used)),
+so while it was off the server was not in `mcpServers` at all. A reset alone would
+restart every session into the *same* spec that omits it, and the tools would not
+appear until the next gateway start; a rebuild *after* the reset would be equally
+broken, restarting sessions into the old spec. Rebuilding first keeps the
+user-visible contract — enable, sessions restart, the tools are there — exactly as
+it was before the gate existed.
+
+The lock matters because the rebuild READS the keystone and WRITES the spec. Outside
+it, two overlapping PUTs interleave: an enable's slower rebuild can land its spec
+*after* a later disable's, leaving a spec that mounts — and therefore spawns — the
+server the keystone now forbids. Holding `_get_config_lock()` makes read-decide-write
+atomic against every keystone writer, so whichever rebuild finishes last is the one
+that read the final state. It is a plain reacquisition: the write block has already
+exited its own, and `rebuild_agent_config` never takes this lock.
+
+A rebuild failure never fails the SAVE (same rule as the reset: the write already
+landed and was audited), and the fallback is the old behaviour of the surface
+appearing on the next cold gateway. Pinned by
+`test_computer_use_api.py::TestEnableRestartsSessions`.
 
 Deliberately narrow, so a restart is never gratuitous:
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -479,20 +479,93 @@ def _kirocrew_mcp_invocation(subcommand: str) -> tuple[str, list[str]]:
     return bin_path, [subcommand]
 
 
+def _computer_use_spec_gate() -> bool:
+    """Whether ``kirocrew-computer`` belongs in an EMITTED agent spec.
+
+    The shim's own ``enable_state.is_enabled()`` checks (in ``_list_tools`` and
+    again in the dispatcher) decide what a RUNNING backend may do; they cannot
+    decide whether it runs at all, because they execute inside the process the
+    spec already caused kiro-cli to spawn. So a disabled feature still cost a
+    full backend process — ~109 MB, per chat process including every
+    ``spawn_run`` subagent — and on Linux/Windows it cost that for a capability
+    with no driver at all (see ``backend.select_default_backend``: macOS is the
+    only platform with one). This gate is the same decision moved to the only
+    place that can act on it: spec emission.
+
+    Both in-process checks stay as defence in depth. They still cover the case
+    this gate structurally cannot — the keystone flipping OFF mid-session, after
+    the spec was written and the backend spawned.
+
+    Fails CLOSED, matching the keystone's own posture (``enable_state`` reads a
+    missing / unreadable / malformed file as DISABLED): the open position of this
+    gate hands out the operator's whole desktop, so an unreadable ceiling must
+    never be read generously.
+    """
+    if not platform_compat.IS_MACOS:
+        return False
+    try:
+        # Function-local: ``enable_state`` reaches ``config.loader`` at module
+        # scope, and agent.py imports that loader function-locally everywhere
+        # else for exactly that reason — a module-scope import here would close
+        # an import cycle through the config plane.
+        from kiro_crew.computer_use import enable_state
+
+        return enable_state.is_enabled()
+    except Exception:
+        logger.debug(
+            "computer-use keystone unreadable; omitting it from the agent spec",
+            exc_info=True,
+        )
+        return False
+
+
+def _gated_off_servers() -> frozenset[str]:
+    """Managed servers whose ``spec_gate`` is CLOSED right now.
+
+    Evaluated ONCE per rebuild and threaded through the emit path and the withhold
+    audit, rather than each re-reading the gate. The reads are cheap; agreeing is
+    the point. A keystone flip landing between the two would produce a spec and an
+    audit trail that contradict each other — the record claiming a server was
+    withheld when it was emitted, or staying silent when it was withheld. That
+    record is read during incident response, against the config it describes.
+
+    A gate that raises is treated as closed, for the same fail-closed reason the
+    computer-use gate itself is.
+    """
+    closed: set[str] = set()
+    for name, spec in _MANAGED_MCP_SERVERS.items():
+        gate = spec.get("spec_gate")
+        if gate is None:
+            continue
+        try:
+            if not gate():
+                closed.add(name)
+        except Exception:
+            logger.debug("spec gate for %s raised; treating as closed", name, exc_info=True)
+            closed.add(name)
+    return frozenset(closed)
+
+
 # ---------------------------------------------------------------------------
 # Managed MCP servers — single source of truth.
 #
 # Every server here is dynamically injected into the agent config at install
 # time (both fresh and existing configs).  Adding a new managed server =
 # one entry here.
+#
+# An entry may carry a ``spec_gate`` callable: a predicate consulted at spec
+# EMISSION time, so a capability that is off (or impossible on this platform)
+# costs no backend process rather than merely no tools.  Absent = always
+# emitted, which is what the two always-on servers want.
 # ---------------------------------------------------------------------------
 _MANAGED_MCP_SERVERS: dict[str, dict] = {
     "kirocrew-cron": {"invocation_fn": lambda: _kirocrew_mcp_invocation("mcp-cron")},
     "kirocrew-core": {"invocation_fn": lambda: _kirocrew_mcp_invocation("mcp-core")},
-    # Computer use (native desktop GUI automation).  Registered unconditionally —
-    # its stdio shim returns an EMPTY tools/list while the keystone primary enable
-    # is off, so a disabled feature costs the model no context and needs no
-    # per-server ``enabled_fn`` in this loop.
+    # Computer use (native desktop GUI automation).  ``spec_gate`` keeps the
+    # entry out of the emitted spec unless this is macOS AND the keystone primary
+    # enable is on, so kiro-cli never spawns the backend for a feature that is
+    # off or unsupported (see _computer_use_spec_gate).  The shim's own empty
+    # ``tools/list`` while disabled is retained as defence in depth.
     #
     # DELIBERATELY NO ``autoApprove`` KEY, and none may ever be added: kiro-cli
     # approves an autoApproved MCP tool locally and emits no permission request,
@@ -500,7 +573,10 @@ _MANAGED_MCP_SERVERS: dict[str, dict] = {
     # floor, the sensitive-path check and the governance ceiling — is NEVER
     # reached for it. For a tool that can click in an already-authenticated
     # application that would be a complete gate bypass.
-    "kirocrew-computer": {"invocation_fn": lambda: _kirocrew_mcp_invocation("mcp-computer")},
+    "kirocrew-computer": {
+        "invocation_fn": lambda: _kirocrew_mcp_invocation("mcp-computer"),
+        "spec_gate": _computer_use_spec_gate,
+    },
 }
 
 
@@ -1546,7 +1622,7 @@ def _apply_user_kiro_hooks(config: dict, mc_cfg: dict) -> None:
         logger.debug("SEL audit for kiro_hooks merge failed", exc_info=True)
 
 
-def build_agent_config() -> dict:
+def build_agent_config(*, gated_off: "frozenset[str] | None" = None) -> dict:
     """Return the final agent config (shipped defaults + user overrides + dynamic fields).
 
     Security-critical ``hooks`` always use the bundled config as their base,
@@ -1556,6 +1632,11 @@ def build_agent_config() -> dict:
     hooks.py PreToolUse gate, not via the kiro agent spec. User-defined
     ``kiro_hooks`` from ``~/.kiro/crew/config.json`` are then additively merged;
     bundled hooks always run first and cannot be removed.
+
+    Args:
+        gated_off: Managed servers whose ``spec_gate`` is closed. Pass the
+            caller's snapshot so one rebuild's emit path and its withhold audit
+            agree; omitted, it is evaluated here.
     """
     config = _load_json(_shipped_defaults())
     config = _deep_merge(config, _load_json(_user_overrides_path()))
@@ -1583,7 +1664,18 @@ def build_agent_config() -> dict:
     config["prompt"] = f"file://{_prompt_path()}"
     mcp = config.setdefault("mcpServers", {})
     registry_mode = _mcp_registry_mode()
+    if gated_off is None:
+        gated_off = _gated_off_servers()
     for name, spec in _MANAGED_MCP_SERVERS.items():
+        if name in gated_off:
+            # The gate is the whole point of this branch: emitting the entry is
+            # what makes kiro-cli spawn the backend, so a closed gate must not
+            # emit one. ``pop`` as well as ``continue`` because the base here is
+            # shipped defaults merged with the user override file, and an entry
+            # arriving from there would otherwise slip past a platform gate that
+            # exists because the capability has no driver on this OS.
+            mcp.pop(name, None)
+            continue
         if "invocation_fn" in spec:
             cmd, args = spec["invocation_fn"]()
         else:
@@ -1622,11 +1714,18 @@ def build_agent_config() -> dict:
     return config
 
 
-def _refresh_dynamic_fields(config: dict) -> None:
+def _refresh_dynamic_fields(
+    config: dict, *, gated_off: "frozenset[str] | None" = None
+) -> None:
     """Update security-critical and dynamic fields in an existing config.
 
     Called when ``kirocrew.json`` already exists so user customizations are
     preserved while security controls and runtime paths stay current.
+
+    Args:
+        gated_off: Managed servers whose ``spec_gate`` is closed. Pass the
+            caller's snapshot so one rebuild's emit path and its withhold audit
+            agree; omitted, it is evaluated here.
     """
     # Prompt URI — always resolve at install time
     config["prompt"] = f"file://{_prompt_path()}"
@@ -1635,7 +1734,29 @@ def _refresh_dynamic_fields(config: dict) -> None:
     # Only refresh command/args; preserve user customizations (e.g. autoApprove).
     mcp = config.setdefault("mcpServers", {})
     registry_mode = _mcp_registry_mode()
+    if gated_off is None:
+        gated_off = _gated_off_servers()
     for name, spec in _MANAGED_MCP_SERVERS.items():
+        if name in gated_off:
+            # RETRACT, not merely skip: an earlier refresh wrote this entry while
+            # the gate was open, and leaving it would mean turning the feature
+            # off never reclaims the backend process turning it on started.
+            #
+            # The entry's user-owned fields are NOT preserved. Stashing them
+            # would need an agent-writable sidecar, and an ``autoApprove``
+            # restored from there is a self-granted auto-approve: kiro-cli
+            # approves such a tool locally, so ``hooks.on_tool_call`` never sees
+            # the call. An off/on cycle therefore resets a customized entry and
+            # the operator re-applies it — losing an approval is the safe
+            # direction, granting one from an agent-writable file is not.
+            #
+            # The server's ``@ref`` in ``tools`` is deliberately left alone. A ref
+            # whose server has no ``mcpServers`` entry resolves to nothing and
+            # mounts nothing, so withholding the entry is the whole control;
+            # removing the ref as well would destroy a grant the user may have
+            # narrowed by hand and cannot be reconstructed on re-enable.
+            mcp.pop(name, None)
+            continue
         is_new = name not in mcp
         entry = mcp.setdefault(name, {})
         if "invocation_fn" in spec:
@@ -1824,23 +1945,28 @@ def get_shipped_tools() -> dict[str, list[str]]:
     return {k: shipped.get(k, []) for k in ("tools", "allowedTools")}
 
 
-def _load_existing_config(path: Path) -> tuple[dict, bool]:
+def _load_existing_config(
+    path: Path, *, gated_off: "frozenset[str] | None" = None
+) -> tuple[dict, bool]:
     """Load and refresh an existing kirocrew.json.
 
     Returns (config, fresh_install).  Falls back to build_agent_config()
     when the file is corrupt or refresh fails.
+
+    *gated_off* is the caller's spec-gate snapshot, forwarded so whichever branch
+    runs reads the same decision the caller's audit will report.
     """
     try:
         config = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError, ValueError):
         config = None
     if not isinstance(config, dict):
-        return build_agent_config(), True
+        return build_agent_config(gated_off=gated_off), True
     try:
-        _refresh_dynamic_fields(config)
+        _refresh_dynamic_fields(config, gated_off=gated_off)
     except (AttributeError, TypeError, RuntimeError) as exc:
         logger.error("Refresh failed, rebuilding from defaults: %s", exc)
-        return build_agent_config(), True
+        return build_agent_config(gated_off=gated_off), True
     return config, False
 
 
@@ -2307,12 +2433,17 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
 
     # Managed MCP sync happens after config is fully built (see below).
 
+    # One spec-gate snapshot for the whole rebuild, so the emit path below and the
+    # withhold audit near the end describe the SAME decision (see
+    # _gated_off_servers).
+    gated_off = _gated_off_servers()
+
     if not clean and path.exists():
         # Existing config — preserve user customizations, only refresh
         # security-critical and dynamic fields.
-        config, fresh_install = _load_existing_config(path)
+        config, fresh_install = _load_existing_config(path, gated_off=gated_off)
     else:
-        config = build_agent_config()
+        config = build_agent_config(gated_off=gated_off)
         fresh_install = True
 
     # Seed default-model tracking for a fresh/clean build. A clean regen always
@@ -2786,6 +2917,29 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
                 source="install_agent",
                 resources=f"{cu_ref} added to tools (existing config upgrade)",
             )
+
+    # Audit the DECISION, not a config delta. Nothing in the spec changes shape
+    # when a gate closes — the ``@ref`` stays exactly where the template put it
+    # and only the ``mcpServers`` entry is withheld — so there is no delta to
+    # observe, and a reader of the audit trail would otherwise have no record
+    # that a shipped server was deliberately not emitted. Derived from the gate
+    # plus the shipped template so the fresh and existing paths record the same
+    # fact.
+    _withheld = sorted(
+        f"@{name}" for name in gated_off if f"@{name}" in get_shipped_tools().get("tools", [])
+    )
+    if _withheld:
+        sel().log_api_access(
+            caller="system",
+            operation="mcp_server_withheld",
+            outcome="ok",
+            source="install_agent",
+            resources=(
+                f"{', '.join(_withheld)} withheld from mcpServers (unsupported "
+                f"platform or capability disabled); its tools ref is retained and "
+                f"resolves to nothing"
+            ),
+        )
 
     # Final dedup (preserves order).
     for key in ("tools", "allowedTools"):

--- a/src/kiro_crew/dashboard/handlers/computer_use.py
+++ b/src/kiro_crew/dashboard/handlers/computer_use.py
@@ -711,6 +711,44 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
     # tear down the user's session.
     sessions_reset = 0
     if STATE_KEY_ENABLED in state_patch and state_patch[STATE_KEY_ENABLED] != enabled_before:
+        # REBUILD THE AGENT SPEC FIRST. The enable is also a spec-emission gate
+        # (``agent._computer_use_spec_gate``): while it is off the server is not in
+        # ``mcpServers`` at all, so no backend is spawned. A reset alone would
+        # therefore restart every session into the SAME spec that omits the server
+        # — the tools would not appear until the next gateway start, which is a
+        # regression in the one path that has to work. Rebuilding here keeps the
+        # user-visible contract ("enable, sessions restart, tools are there")
+        # exactly as it was.
+        #
+        # UNDER THE CONFIG LOCK, reacquired: the rebuild READS the keystone and
+        # WRITES the spec, so leaving it outside would let two overlapping PUTs
+        # interleave — an enable's slower rebuild could land its spec after a
+        # later disable's, leaving a spec that mounts (and spawns) the server the
+        # keystone now forbids. Holding the lock makes read-decide-write atomic
+        # against every keystone writer, so the rebuild that finishes last is the
+        # one that read the final state. The write block above has already exited
+        # its own acquisition, and ``rebuild_agent_config`` never takes this lock,
+        # so this cannot self-deadlock.
+        #
+        # A rebuild failure must not fail the SAVE: the write already landed and
+        # was audited. The fallback is the pre-existing behaviour — the tool
+        # surface appears on the next gateway start.
+        #
+        # The import is function-local and must STAY function-local, which is not
+        # a style choice: it makes the name resolve at CALL time, so
+        # ``kiro_crew.agent`` is the single place a test can substitute the
+        # rebuild. Hoisting it to module scope binds the name here at import time,
+        # and the test guard that keeps the suite from rewriting the operator's
+        # real ``~/.kiro/agents`` would silently stop reaching this call site.
+        # Pinned by ``test_patching_the_agent_module_REACHES_the_handler``.
+        try:
+            from kiro_crew.agent import rebuild_agent_config
+
+            async with _get_config_lock():
+                await asyncio.to_thread(rebuild_agent_config)
+        except Exception:
+            logger.exception("computer-use enable saved, but agent config rebuild failed")
+
         from kiro_crew.dashboard.handlers.sessions import _reset_all_sessions
 
         try:

--- a/test/test_computer_use_api.py
+++ b/test/test_computer_use_api.py
@@ -93,6 +93,29 @@ def profiles_dir(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def no_agent_spec_rewrite(monkeypatch):
+    """Never let a test rewrite the operator's real ``~/.kiro/agents``.
+
+    Flipping the computer-use enable rebuilds the agent spec (the enable is a
+    spec-emission gate, so the tools would otherwise not appear until the next
+    gateway start). That rebuild writes ``~/.kiro/agents/kirocrew.json``, which is
+    machine-wide and deliberately NOT under the ``KIROCREW_HOME`` this module's
+    ``home`` fixture redirects — so every enable-flipping test would touch the
+    developer's live agent config, and a plain clone (CI, or a checkout that is not
+    a git worktree) has no guard that stops it.
+
+    Autouse rather than per-test: this file has a dozen tests that flip the enable
+    for unrelated reasons (auth, validation, corrupt-file handling), and each new
+    one would silently inherit the problem. The three tests that ASSERT on the
+    rebuild re-patch it with their own recorder, which still wins — a later
+    ``monkeypatch.setattr`` overrides this one and both unwind at teardown.
+    """
+    import kiro_crew.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "rebuild_agent_config", lambda **_: Path("/dev/null"))
+
+
+@pytest.fixture(autouse=True)
 def _reset_ctx():
     yield
     ctx_mod.reset_context()
@@ -1523,7 +1546,11 @@ class TestEnableRestartsSessions:
 
     @staticmethod
     def _spy(monkeypatch) -> list:
-        """Record calls to ``_reset_all_sessions`` without touching real sessions."""
+        """Record calls to ``_reset_all_sessions`` without touching real sessions.
+
+        The spec rebuild the enable flip performs is stubbed module-wide by the
+        ``no_agent_spec_rewrite`` autouse fixture, so it needs no handling here.
+        """
         calls: list = []
         import kiro_crew.dashboard.handlers.sessions as sessions_mod
 
@@ -1597,6 +1624,162 @@ class TestEnableRestartsSessions:
         assert resp.status == 200
         assert body["enabled"] is True
         assert body["sessions_reset"] == 0
+        assert json.loads(state_file.read_text())[STATE_KEY_ENABLED] is True
+
+    @pytest.mark.asyncio
+    async def test_the_flip_REBUILDS_the_agent_spec(self, state_file, monkeypatch):
+        """The enable is a spec-emission gate, so the reset needs a fresh spec.
+
+        ``agent._computer_use_spec_gate`` keeps ``kirocrew-computer`` out of the
+        emitted spec while the keystone is off, so restarting sessions without
+        rebuilding would restart them into a spec that still omits the server —
+        the operator enables the feature and the tools appear only after the next
+        gateway start.
+        """
+        import kiro_crew.agent as agent_mod
+
+        self._spy(monkeypatch)
+        built: list = []
+        monkeypatch.setattr(
+            agent_mod,
+            "rebuild_agent_config",
+            lambda **k: (built.append(k), Path("/dev/null"))[1],
+        )
+        async with _client() as client:
+            resp = await client.put("/api/computer-use/config", json={"enabled": True})
+        assert resp.status == 200
+        assert len(built) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_NO_OP_resave_does_not_rebuild(self, state_file, monkeypatch):
+        """Same narrowness as the reset: no transition, no work."""
+        import kiro_crew.agent as agent_mod
+
+        state_file.write_text(json.dumps({STATE_KEY_ENABLED: True}), encoding="utf-8")
+        self._spy(monkeypatch)
+        built: list = []
+        monkeypatch.setattr(
+            agent_mod,
+            "rebuild_agent_config",
+            lambda **k: (built.append(k), Path("/dev/null"))[1],
+        )
+        async with _client() as client:
+            resp = await client.put("/api/computer-use/config", json={"enabled": True})
+        assert resp.status == 200
+        assert built == []
+
+    @pytest.mark.asyncio
+    async def test_the_spec_rebuild_HOLDS_the_config_lock(self, state_file, monkeypatch):
+        """**The rebuild must not escape the lock that serialises keystone writes.**
+
+        The rebuild READS the keystone and WRITES the spec. Outside the lock, two
+        overlapping PUTs interleave: an enable's slower rebuild can land its spec
+        AFTER a later disable's, leaving a spec that mounts — and therefore spawns
+        — the server the keystone now forbids. Holding the lock makes
+        read-decide-write atomic against every keystone writer, so whichever
+        rebuild finishes last is the one that read the final state.
+
+        Asserted on the lock's own state at rebuild time rather than on source
+        order: a lock acquired and released before the call would read the same in
+        the source and fix nothing.
+        """
+        import kiro_crew.agent as agent_mod
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        self._spy(monkeypatch)
+        # Resolved on the loop: ``_get_config_lock`` needs a running loop, and the
+        # rebuild itself runs in a worker thread where there is none.
+        lock = _get_config_lock()
+        held: list[bool] = []
+        monkeypatch.setattr(
+            agent_mod,
+            "rebuild_agent_config",
+            lambda **_: (held.append(lock.locked()), Path("/dev/null"))[1],
+        )
+        async with _client() as client:
+            resp = await client.put("/api/computer-use/config", json={"enabled": True})
+        assert resp.status == 200
+        assert held == [True], "the spec rebuild ran outside the config lock"
+
+    @pytest.mark.asyncio
+    async def test_no_test_here_can_reach_the_REAL_spec_rebuild(self, state_file, monkeypatch):
+        """Ratchet for the ``no_agent_spec_rewrite`` autouse fixture.
+
+        Without this, deleting that fixture fails nothing: every test would still
+        pass while quietly rewriting the developer's ``~/.kiro/agents``. The
+        assertion is behavioural — it flips the enable for real and checks that
+        what the handler called was the stub, not the module's own function.
+        """
+        import kiro_crew.agent as agent_mod
+
+        reached: list[str] = []
+        current = agent_mod.rebuild_agent_config
+        if getattr(current, "__name__", "") != "<lambda>":
+            # The guard is gone; install a tripwire so the call is observable.
+            monkeypatch.setattr(
+                agent_mod,
+                "rebuild_agent_config",
+                lambda **_: (reached.append("real"), Path("/dev/null"))[1],
+            )
+        async with _client() as client:
+            resp = await client.put("/api/computer-use/config", json={"enabled": True})
+        assert resp.status == 200
+        assert reached == [], (
+            "the real rebuild_agent_config was reachable — the no_agent_spec_rewrite "
+            "autouse fixture is missing or no longer autouse"
+        )
+
+    @pytest.mark.asyncio
+    async def test_patching_the_agent_module_REACHES_the_handler(self, state_file, monkeypatch):
+        """The guard above only works because the import resolves at CALL time.
+
+        ``api_computer_use_config_save`` imports ``rebuild_agent_config`` inside the
+        function. Hoisting it to module scope would bind the name at import time,
+        so patching ``kiro_crew.agent`` would no longer reach this call site — and
+        the guard above would keep passing while every enable-flipping test wrote
+        the operator's real ``~/.kiro/agents`` again.
+
+        Asserted POSITIVELY (the stub must have run), because "the real one did not
+        run" is also true when nothing ran at all.
+        """
+        import kiro_crew.agent as agent_mod
+
+        ran: list[str] = []
+        monkeypatch.setattr(
+            agent_mod,
+            "rebuild_agent_config",
+            lambda **_: (ran.append("stub"), Path("/dev/null"))[1],
+        )
+        async with _client() as client:
+            resp = await client.put("/api/computer-use/config", json={"enabled": True})
+        assert resp.status == 200
+        assert ran == ["stub"], (
+            "patching kiro_crew.agent no longer reaches the handler's call site — the "
+            "import was hoisted to module scope, which defeats no_agent_spec_rewrite"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_failed_rebuild_does_not_fail_the_SAVE(self, state_file, monkeypatch):
+        """Same rule the reset already followed: the write landed and was audited.
+
+        The fallback is the pre-existing behaviour — the tool surface appears on
+        the next gateway start — and the sessions are still reset, because a stale
+        ``tools/list`` is a separate problem from a stale spec.
+        """
+        import kiro_crew.agent as agent_mod
+
+        calls = self._spy(monkeypatch)
+
+        def _boom(**_):
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr(agent_mod, "rebuild_agent_config", _boom)
+        async with _client() as client:
+            resp = await client.put("/api/computer-use/config", json={"enabled": True})
+            body = await resp.json()
+        assert resp.status == 200
+        assert body["enabled"] is True
+        assert len(calls) == 1
         assert json.loads(state_file.read_text())[STATE_KEY_ENABLED] is True
 
 

--- a/test/test_computer_use_registration.py
+++ b/test/test_computer_use_registration.py
@@ -36,7 +36,7 @@ from unittest.mock import patch
 
 import pytest
 
-from kiro_crew import agent, mcp_cleanup, mcp_discovery, onboarding_import
+from kiro_crew import agent, agent_state, mcp_cleanup, mcp_discovery, onboarding_import
 from kiro_crew.agent import install_agent
 from kiro_crew.platform_compat import IS_POSIX
 
@@ -51,6 +51,18 @@ _MANAGED = {
     "kirocrew-cron": {"invocation_fn": lambda: ("/usr/bin/kirocrew", ["mcp-cron"])},
     "kirocrew-core": {"invocation_fn": lambda: ("/usr/bin/kirocrew", ["mcp-core"])},
     CU_SERVER: {"invocation_fn": lambda: ("/usr/bin/kirocrew", [CU_SUBCOMMAND])},
+}
+
+# The same set with the REAL gate on the computer-use row. ``_MANAGED`` above
+# deliberately carries none, so the pre-existing emission tests keep exercising
+# the ungated path; the gate's own tests stage this one.
+_GATED_MANAGED = {
+    "kirocrew-cron": {"invocation_fn": lambda: ("/usr/bin/kirocrew", ["mcp-cron"])},
+    "kirocrew-core": {"invocation_fn": lambda: ("/usr/bin/kirocrew", ["mcp-core"])},
+    CU_SERVER: {
+        "invocation_fn": lambda: ("/usr/bin/kirocrew", [CU_SUBCOMMAND]),
+        "spec_gate": agent._computer_use_spec_gate,
+    },
 }
 
 
@@ -77,13 +89,17 @@ def _bundled_defaults(tmp_path: Path) -> Path:
     return cfg_dir
 
 
-def _run_install(tmp_path: Path, cfg_dir: Path, **kwargs) -> Path:
+def _run_install(tmp_path: Path, cfg_dir: Path, *, managed: "dict | None" = None, **kwargs) -> Path:
     """Run ``install_agent`` with every module global redirected into *tmp_path*.
 
     The ``patch.multiple`` + ``ExitStack`` shape from ``test_agent.py``. This is
     what keeps a test from touching the developer's real ``~/.kiro/agents`` — which
     for THIS feature would mean writing a computer-use MCP entry into their live
     agent config.
+
+    *managed* overrides the staged managed-server set. It defaults to ``_MANAGED``
+    (no ``spec_gate``, so the emission tests below exercise the ungated path);
+    ``TestSpecEmissionGate`` passes the gated shape.
     """
     kiro_dir = tmp_path / "kiro_agents"
     kiro_dir.mkdir(exist_ok=True)
@@ -97,7 +113,7 @@ def _run_install(tmp_path: Path, cfg_dir: Path, **kwargs) -> Path:
             KIRO_AGENTS_DIR=kiro_dir,
             _BUNDLED_CFG_DIR=cfg_dir,
             _KIROCREW_BIN="/usr/bin/kirocrew",
-            _MANAGED_MCP_SERVERS=_MANAGED,
+            _MANAGED_MCP_SERVERS=_MANAGED if managed is None else managed,
             _KIRO_MCP_JSON=tmp_path / "fake_kiro_mcp.json",
             _CC_MCP_JSON=tmp_path / "fake_cc_mcp.json",
         ),
@@ -549,8 +565,663 @@ def test_computer_use_sources_are_scrub_lint_clean():
     )
 
 
+class TestGatedEntryIsNotPreserved:
+    """**A withheld entry's user fields are deliberately NOT restored.**
+
+    Retracting the entry is required, and the fields it carries (``autoApprove``,
+    the user's own ``env`` keys) are genuinely lost — an off/on cycle resets them
+    and the operator re-applies them. That is a real cost, accepted for a reason:
+    the only place to stash them would be the ``agent_state`` sidecar, which is an
+    ORDINARY file under the data home (not on ``security._CREW_SECRET_LEAVES``,
+    not write-protected), so the agent can write it. A restored ``autoApprove``
+    would then be an agent-authored auto-approve, and kiro-cli approves an
+    auto-approved MCP tool LOCALLY — no permission request, so
+    ``hooks.on_tool_call`` and its audit are never reached. For a server that can
+    click and type into an authenticated application that is a self-granted gate
+    bypass, which is exactly what this feature's own spec forbids.
+
+    Losing an approval is the safe direction; restoring one from a file the agent
+    can write is not.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_sidecar(self, tmp_path, monkeypatch):
+        import kiro_crew.config.paths as paths
+
+        monkeypatch.setattr(paths, "_resolved_home", None)
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir(parents=True, exist_ok=True)
+        yield
+        monkeypatch.setattr(paths, "_resolved_home", None)
+
+    @staticmethod
+    def _refresh(cfg: dict, *, macos: bool) -> None:
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.multiple("kiro_crew.agent", _MANAGED_MCP_SERVERS=_GATED_MANAGED)
+            )
+            stack.enter_context(
+                patch("kiro_crew.agent._prompt_path", return_value=Path("/tmp/p.md"))
+            )
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", macos))
+            if macos:
+                stack.enter_context(
+                    patch("kiro_crew.computer_use.enable_state.is_enabled", return_value=True)
+                )
+            agent._refresh_dynamic_fields(cfg)
+
+    def _cfg(self) -> dict:
+        return {
+            "name": "kirocrew",
+            "mcpServers": {
+                CU_SERVER: {
+                    "command": "/usr/bin/kirocrew",
+                    "args": [CU_SUBCOMMAND],
+                    "autoApprove": [f"{CU_SERVER}/computer_get_state"],
+                    "env": {"MY_VAR": "keep"},
+                }
+            },
+        }
+
+    def test_an_off_then_ON_cycle_does_NOT_restore_autoApprove(self):
+        """The security-relevant half: no auto-approve comes back by itself."""
+        cfg = self._cfg()
+        self._refresh(cfg, macos=False)
+        assert CU_SERVER not in cfg["mcpServers"]
+
+        self._refresh(cfg, macos=True)
+        entry = cfg["mcpServers"][CU_SERVER]
+        assert "autoApprove" not in entry, "an auto-approve grant came back on its own"
+        assert "MY_VAR" not in entry.get("env", {})
+        # Our own half is regenerated, so the server still works.
+        assert entry["command"] == "/usr/bin/kirocrew"
+        assert entry["args"] == [CU_SUBCOMMAND]
+
+    def test_NOTHING_about_the_entry_reaches_the_sidecar(self):
+        """Asserted on the file, because the shape is the control.
+
+        The sidecar cannot express an entry field at all — there is no code that
+        writes one and no key that would hold it — so a future author cannot
+        re-introduce the bypass by passing a different argument.
+        """
+        cfg = self._cfg()
+        self._refresh(cfg, macos=False)
+        raw = json.dumps(agent_state._read())
+        assert "autoApprove" not in raw
+        assert "MY_VAR" not in raw
+
+    def test_the_sidecar_has_no_entry_writer_at_all(self):
+        """A ratchet on the surface, not just on one call path.
+
+        Nothing about a withheld entry is stashed anywhere. If a future change
+        re-adds an entry-field writer, this fails here rather than surfacing as a
+        self-granted auto-approve in someone's spec.
+        """
+        assert not hasattr(agent_state, "set_parked_mcp_state")
+        assert not hasattr(agent, "_park_gated_entry")
+        assert not hasattr(agent, "_restore_parked_entry")
+        assert not hasattr(agent, "_user_owned_entry_fields")
+
+
+class TestGatedRefsAreLeftALONE:
+    """**A withheld server keeps its ``@ref``. Nothing prunes it, so nothing has
+    to restore it.**
+
+    The entry is the whole control. A ``@server`` ref resolves against the agent's
+    own ``mcpServers`` plus the global ``mcp.json``, so a ref whose entry was
+    never emitted names nothing, mounts nothing, and spawns nothing — which is the
+    entire point of the gate.
+
+    Removing the ref as well looks tidier and is where every widening bug came
+    from: the removed set is not reconstructible from the server name (a user can
+    narrow ``tools`` to ONE ``@server/tool`` ref, and the re-enable path re-adds
+    the BARE ref), so anything that prunes must also preserve, and every failure
+    mode of that preservation — an unwritable stash, a stash cleared before the
+    write landed, a rebuild path that skipped the restore — silently WIDENS what
+    is mounted. Leaving the ref alone has none of those states.
+
+    The assertions below are therefore about what does NOT happen to the spec, and
+    the ratchet at the end is on the module surface so the machinery cannot come
+    back one helper at a time.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_sidecar(self, tmp_path, monkeypatch):
+        import kiro_crew.config.paths as paths
+
+        monkeypatch.setattr(paths, "_resolved_home", None)
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir(parents=True, exist_ok=True)
+        yield
+        monkeypatch.setattr(paths, "_resolved_home", None)
+
+    @staticmethod
+    def _refresh(cfg: dict, *, macos: bool) -> None:
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.multiple("kiro_crew.agent", _MANAGED_MCP_SERVERS=_GATED_MANAGED)
+            )
+            stack.enter_context(
+                patch("kiro_crew.agent._prompt_path", return_value=Path("/tmp/p.md"))
+            )
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", macos))
+            if macos:
+                stack.enter_context(
+                    patch("kiro_crew.computer_use.enable_state.is_enabled", return_value=True)
+                )
+            agent._refresh_dynamic_fields(cfg)
+
+    def test_a_NARROWED_ref_survives_an_off_on_cycle_byte_for_byte(self):
+        """The defect class this replaces, asserted end to end.
+
+        One per-tool ref, a full disable, a full re-enable. If anything strips and
+        re-adds refs, the bare ``@kirocrew-computer`` appears here and the user who
+        chose exactly one tool silently gets all of them.
+        """
+        narrowed = f"{CU_REF}/computer_get_state"
+        cfg = {
+            "name": "kirocrew",
+            "tools": ["ReadFile", narrowed],
+            "allowedTools": [narrowed],
+            "mcpServers": {CU_SERVER: {"command": "/usr/bin/kirocrew", "args": [CU_SUBCOMMAND]}},
+        }
+
+        def _cu_refs() -> list:
+            # Scoped to THIS server: the refresh legitimately adds unrelated
+            # builtins, and only the computer-use refs are the widening oracle.
+            return [
+                t
+                for t in cfg["tools"]
+                if isinstance(t, str) and (t == CU_REF or t.startswith(f"{CU_REF}/"))
+            ]
+
+        self._refresh(cfg, macos=False)
+        assert CU_SERVER not in cfg["mcpServers"], "the entry must be withheld"
+        assert _cu_refs() == [narrowed], "the gate took the user's narrowed ref away"
+        assert cfg["allowedTools"] == [narrowed]
+        assert "ReadFile" in cfg["tools"]
+
+        self._refresh(cfg, macos=True)
+        assert _cu_refs() == [narrowed], (
+            "the mounted tool set WIDENED across an off/on cycle: "
+            f"expected only {narrowed!r}, got {_cu_refs()!r}"
+        )
+        assert cfg["allowedTools"] == [narrowed]
+        assert CU_SERVER in cfg["mcpServers"], "re-enabling must emit the entry again"
+
+    def test_the_ref_remains_while_the_entry_is_withheld(self):
+        """Ref-without-entry is the intended steady state, not a leak.
+
+        Stated as its own test because it is the claim the whole design rests on:
+        the ref is inert, so the withheld entry alone is what stops the process
+        from being spawned.
+        """
+        cfg = {
+            "name": "kirocrew",
+            "tools": [CU_REF],
+            "mcpServers": {CU_SERVER: {"command": "/usr/bin/kirocrew", "args": [CU_SUBCOMMAND]}},
+        }
+        self._refresh(cfg, macos=False)
+        assert CU_REF in cfg["tools"]
+        assert CU_SERVER not in cfg["mcpServers"]
+
+    def test_a_fresh_build_also_keeps_the_shipped_ref(self):
+        """The derived agents take this dict as-is, so it must not diverge."""
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.multiple("kiro_crew.agent", _MANAGED_MCP_SERVERS=_GATED_MANAGED)
+            )
+            stack.enter_context(
+                patch("kiro_crew.agent._prompt_path", return_value=Path("/tmp/p.md"))
+            )
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", False))
+            cfg = agent.build_agent_config()
+        if CU_REF in agent.get_shipped_tools().get("tools", []):
+            assert CU_REF in cfg.get("tools", []), "a fresh build stripped the shipped ref"
+        assert CU_SERVER not in cfg.get("mcpServers", {})
+
+    def test_no_park_machinery_exists_anywhere(self):
+        """A ratchet on the surface, not on one call path.
+
+        Every widening bug in this area came from code that removed a ref and then
+        owed the user a restoration. If any of it returns, this fails here rather
+        than as a silently widened mount in someone's spec.
+        """
+        for gone in (
+            "_prune_gated_managed_refs",
+            "_park_gated_refs",
+            "_restore_parked_refs",
+            "_clear_parked_refs",
+        ):
+            assert not hasattr(agent, gone), f"{gone} came back; refs must be left alone"
+        for gone in ("get_parked_mcp_refs", "set_parked_mcp_refs"):
+            assert not hasattr(agent_state, gone), f"{gone} came back"
+        assert "parked_mcp_refs" not in json.dumps(agent_state._read())
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-q"])
+
+
+# ── The spec-emission gate ──
+
+
+class TestSpecEmissionGate:
+    """The server must not reach the EMITTED spec when it cannot be used.
+
+    The two in-process checks (``_list_tools`` and the dispatcher) run inside a
+    process the spec already caused kiro-cli to spawn, so they can only make a
+    disabled feature advertise zero tools — they cannot make it cost nothing. It
+    cost ~109 MB per chat process, including every ``spawn_run`` subagent, and on
+    Linux/Windows it cost that for a capability with no driver at all.
+
+    So these assertions are on the SPEC, not on ``tools/list``: that is the
+    difference the fix is about, and a ``tools/list``-only test passes just as
+    well while the process is still being spawned. The existing ``tools/list``
+    tests stay — this gate is defence in depth's partner, not its replacement.
+    """
+
+    # The real gate, unlike the ``_MANAGED`` fixture above (which deliberately
+    # carries none so the pre-existing emission tests keep exercising the
+    # ungated path).
+    _GATED = _GATED_MANAGED
+
+    @staticmethod
+    def _build(tmp_path: Path, *, macos: bool, keystone: "dict | None") -> dict:
+        """Build a fresh spec with *macos* and *keystone* in effect.
+
+        The keystone is written to a real temp file and read through the real
+        ``enable_state``, so the four malformed spellings below are judged by the
+        production predicate rather than by a stub that could disagree with it.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        state_path = tmp_path / "computer_use.json"
+        if keystone is not None:
+            state_path.write_text(json.dumps(keystone), encoding="utf-8")
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.multiple(
+                    "kiro_crew.agent",
+                    _BUNDLED_CFG_DIR=cfg_dir,
+                    _MANAGED_MCP_SERVERS=TestSpecEmissionGate._GATED,
+                )
+            )
+            stack.enter_context(
+                patch("kiro_crew.agent._shipped_defaults", return_value=cfg_dir / "defaults.json")
+            )
+            stack.enter_context(
+                patch("kiro_crew.agent._prompt_path", return_value=cfg_dir / "prompt.md")
+            )
+            stack.enter_context(patch("kiro_crew.agent._project_dir", return_value=None))
+            stack.enter_context(
+                patch("kiro_crew.agent._mc_config_path", return_value=tmp_path / "none.json")
+            )
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", macos))
+            stack.enter_context(
+                patch(
+                    "kiro_crew.computer_use.enable_state.computer_use_state_path",
+                    return_value=state_path,
+                )
+            )
+            return agent.build_agent_config()
+
+    def test_a_non_darwin_platform_gets_no_entry(self, tmp_path: Path):
+        """**The Linux/Windows case — the one with no driver at all.**
+
+        Asserted with the keystone ENABLED, so the platform half of the gate is
+        proven on its own rather than passing because the feature happened to be
+        off too. ``select_default_backend`` has no driver here, so the spawned
+        process could never have done anything.
+        """
+        config = self._build(tmp_path, macos=False, keystone={"enabled": True})
+        assert CU_SERVER not in config["mcpServers"]
+        # The always-on servers are untouched — this is one gate, not a purge.
+        assert "kirocrew-core" in config["mcpServers"]
+        assert "kirocrew-cron" in config["mcpServers"]
+
+    @pytest.mark.parametrize(
+        "keystone",
+        [
+            None,  # file absent
+            {},  # present, empty
+            {"enabled": False},
+            {"enabled": "true"},  # truthy NON-True: a hand-edited string
+            {"enabled": 1},  # truthy NON-True: a hand-edited int
+        ],
+        ids=["absent", "empty", "false", "string-true", "int-one"],
+    )
+    def test_darwin_with_the_keystone_off_gets_no_entry(self, tmp_path: Path, keystone):
+        """Mirrors ``test_mcp_computer.py``'s keystone cases, one layer earlier.
+
+        The truthy-non-``True`` spellings matter for the same reason they matter
+        in ``enable_state.is_enabled``: a hand-edited ``"enabled": "false"`` is a
+        truthy string, and reading it generously would spawn a desktop-control
+        backend the operator never enabled.
+        """
+        config = self._build(tmp_path, macos=True, keystone=keystone)
+        assert CU_SERVER not in config["mcpServers"]
+
+    def test_darwin_with_the_keystone_ON_gets_the_entry(self, tmp_path: Path):
+        """**Guard against over-gating the one path that must work.**
+
+        Without this, "no entry" could be satisfied by a gate that is simply
+        always closed — which would ship the feature dead on its own platform.
+        """
+        config = self._build(tmp_path, macos=True, keystone={"enabled": True})
+        assert config["mcpServers"][CU_SERVER]["args"] == [CU_SUBCOMMAND]
+        assert CU_REF in config["tools"]
+
+    def test_the_withheld_entry_is_what_stops_the_spawn_not_the_ref(self, tmp_path: Path):
+        """The ``mcpServers`` entry carries the command, so withholding it is enough.
+
+        A ``@server`` ref resolves against the agent's own ``mcpServers`` plus the
+        global ``mcp.json``; with no entry in either there is nothing to launch, so
+        the surviving ref names nothing and mounts nothing. Asserted here because
+        the alternative — stripping the ref too — is what made a narrowed grant
+        unreconstructible and silently widened it on re-enable.
+        """
+        config = self._build(tmp_path, macos=False, keystone={"enabled": True})
+        assert CU_SERVER not in config["mcpServers"], "the entry is the control"
+        assert CU_REF in config["tools"], "the user's ref must survive the withhold"
+        # Scoped: the always-on servers are untouched, entry and ref alike.
+        assert "kirocrew-core" in config["mcpServers"]
+        assert "@kirocrew-core" in config["tools"]
+
+    def test_an_override_file_cannot_smuggle_the_entry_past_the_gate(self, tmp_path: Path):
+        """A user override naming the server does not defeat a PLATFORM gate.
+
+        ``build_agent_config`` merges the user override file over shipped
+        defaults, so a ``continue`` alone would let an entry arriving from there
+        reach the spec — spawning a backend on an OS where it has no driver.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        override = tmp_path / "override.json"
+        override.write_text(
+            json.dumps({"mcpServers": {CU_SERVER: {"command": "/x", "args": ["y"]}}}),
+            encoding="utf-8",
+        )
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.multiple(
+                    "kiro_crew.agent",
+                    _BUNDLED_CFG_DIR=cfg_dir,
+                    _MANAGED_MCP_SERVERS=self._GATED,
+                )
+            )
+            stack.enter_context(
+                patch("kiro_crew.agent._shipped_defaults", return_value=cfg_dir / "defaults.json")
+            )
+            stack.enter_context(
+                patch("kiro_crew.agent._user_overrides_path", return_value=override)
+            )
+            stack.enter_context(
+                patch("kiro_crew.agent._prompt_path", return_value=cfg_dir / "prompt.md")
+            )
+            stack.enter_context(patch("kiro_crew.agent._project_dir", return_value=None))
+            stack.enter_context(
+                patch("kiro_crew.agent._mc_config_path", return_value=tmp_path / "none.json")
+            )
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", False))
+            config = agent.build_agent_config()
+        assert CU_SERVER not in config["mcpServers"]
+
+    def test_a_refresh_RETRACTS_an_entry_written_while_the_gate_was_open(self):
+        """Turning the feature OFF must reclaim the process turning it on started.
+
+        A refresh that only skipped would leave the entry an earlier pass wrote,
+        so the backend would keep being spawned for a disabled feature — the bug,
+        one release later and harder to see.
+        """
+        cfg = {
+            "mcpServers": {
+                CU_SERVER: {"command": "/usr/bin/kirocrew", "args": [CU_SUBCOMMAND]},
+                "kirocrew-core": {"command": "/usr/bin/kirocrew", "args": ["mcp-core"]},
+            },
+            "tools": ["ReadFile", CU_REF, "@kirocrew-core"],
+            "allowedTools": [f"{CU_REF}/computer_get_state"],
+        }
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.multiple("kiro_crew.agent", _MANAGED_MCP_SERVERS=self._GATED)
+            )
+            stack.enter_context(
+                patch("kiro_crew.agent._prompt_path", return_value=Path("/tmp/p.md"))
+            )
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", False))
+            agent._refresh_dynamic_fields(cfg)
+        assert CU_SERVER not in cfg["mcpServers"]
+        assert "kirocrew-core" in cfg["mcpServers"]
+        # Withholding the ENTRY is the whole control. The refs name a server this
+        # spec no longer defines, which resolves to nothing and mounts nothing, so
+        # they are left exactly as the user left them.
+        assert CU_REF in cfg["tools"]
+        assert cfg["allowedTools"] == [f"{CU_REF}/computer_get_state"]
+        assert "ReadFile" in cfg["tools"]
+
+    def test_the_gate_fails_CLOSED_when_the_keystone_cannot_be_read(self, tmp_path: Path):
+        """An unreadable ceiling is never read generously.
+
+        Same posture as ``enable_state.load_state``, and for a stronger reason
+        here: the open position of this gate hands out the operator's whole
+        desktop.
+        """
+        with ExitStack() as stack:
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", True))
+            stack.enter_context(
+                patch(
+                    "kiro_crew.computer_use.enable_state.is_enabled",
+                    side_effect=OSError("boom"),
+                )
+            )
+            assert agent._computer_use_spec_gate() is False
+
+    def test_a_gate_that_raises_is_treated_as_closed(self):
+        """``_gated_off_servers`` never lets an exception mean "emit it"."""
+
+        def _explode() -> bool:
+            raise RuntimeError("gate is broken")
+
+        managed = {CU_SERVER: {"invocation_fn": lambda: ("x", []), "spec_gate": _explode}}
+        with patch.multiple("kiro_crew.agent", _MANAGED_MCP_SERVERS=managed):
+            assert agent._gated_off_servers() == frozenset({CU_SERVER})
+
+    def test_only_computer_use_is_gated(self):
+        """The always-on servers carry NO gate.
+
+        A ``spec_gate`` accidentally added to ``kirocrew-core`` would remove the
+        agent's whole first-party tool surface, and the failure would look like a
+        model problem rather than a config one.
+        """
+        gated = {n for n, s in agent._MANAGED_MCP_SERVERS.items() if "spec_gate" in s}
+        assert gated == {CU_SERVER}
+
+    def test_the_shipped_row_gate_is_the_computer_use_predicate(self):
+        """Pinned by identity: a gate is only useful if it is the real one."""
+        assert agent._MANAGED_MCP_SERVERS[CU_SERVER]["spec_gate"] is (
+            agent._computer_use_spec_gate
+        )
+
+    def test_enabling_rebuilds_the_spec_before_resetting_sessions(self):
+        """**The enable path must still work in the session the user is sitting in.**
+
+        The enable is now a spec-emission gate too, so a reset alone would restart
+        every session into the same spec that omits the server — the tools would
+        not appear until the next gateway start. Asserted on ORDER because a
+        rebuild after the reset would restart sessions into the OLD spec and be
+        just as broken.
+        """
+        import inspect
+
+        from kiro_crew.dashboard.handlers import computer_use as handler
+
+        src = inspect.getsource(handler.api_computer_use_config_save)
+        rebuild_at = src.find("rebuild_agent_config")
+        reset_at = src.find("_reset_all_sessions")
+        assert rebuild_at != -1, "the enable flip must rebuild the agent spec"
+        assert reset_at != -1
+        assert rebuild_at < reset_at, "the rebuild must precede the session reset"
+
+    def test_a_malformed_tools_list_does_not_fault_the_withhold(self):
+        """A hand-edited ``tools: {}`` must not fault the whole rebuild.
+
+        The gate runs on a config assembled from files we do not fully control,
+        and a crash here would take down the one function that produces the agent
+        spec at all — a far worse outcome than an odd ``tools`` value surviving.
+        """
+        cfg = {
+            "name": "kirocrew",
+            "tools": {"not": "a list"},
+            "allowedTools": None,
+            "mcpServers": {CU_SERVER: {"command": "x", "args": []}},
+        }
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.multiple("kiro_crew.agent", _MANAGED_MCP_SERVERS=self._GATED)
+            )
+            stack.enter_context(
+                patch("kiro_crew.agent._prompt_path", return_value=Path("/tmp/p.md"))
+            )
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", False))
+            agent._refresh_dynamic_fields(cfg)
+        assert CU_SERVER not in cfg["mcpServers"], "the withhold must still happen"
+        assert cfg["tools"] == {"not": "a list"}
+
+    def test_the_WHOLE_install_withholds_the_server_and_audits_the_decision(
+        self, tmp_path: Path
+    ):
+        """**End-to-end through ``install_agent``, which is what actually runs.**
+
+        The per-function tests above prove each half; this one proves the file
+        written to ``~/.kiro/agents`` — after every merge, validation and
+        tools-sync pass — carries neither the entry nor the ref. That is the state
+        kiro-cli reads, and it is the only assertion that would have caught the
+        original bug.
+
+        Staged as an UPGRADE (an existing config holding both the entry and the
+        ref, i.e. what every user who ran a pre-fix build has on disk), because
+        that is the case where the retraction has work to do.
+
+        Also asserts the SEL record: "a managed server was withheld from your
+        agent spec" is an outcome an operator has to be able to see, exactly like
+        the neighbouring ``mcp_auto_approve_withheld`` audit.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        (kiro_dir / "kirocrew.json").write_text(
+            json.dumps(
+                {
+                    "model": "claude-user-custom",
+                    "tools": ["ReadFile", CU_REF, "@kirocrew-core"],
+                    "allowedTools": ["ReadFile", f"{CU_REF}/computer_get_state"],
+                    "mcpServers": {
+                        CU_SERVER: {"command": "/usr/bin/kirocrew", "args": [CU_SUBCOMMAND]},
+                        "kirocrew-core": {"command": "/usr/bin/kirocrew", "args": ["mcp-core"]},
+                    },
+                    "hooks": {"preToolUse": "audit"},
+                }
+            )
+        )
+        events: list[dict] = []
+
+        class _Sel:
+            def log_api_access(self, **kw):
+                events.append(kw)
+
+            def __getattr__(self, _name):  # every other SEL call is a no-op here
+                return lambda *a, **k: None
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", False))
+            stack.enter_context(patch("kiro_crew.agent.sel", lambda: _Sel()))
+            path = _run_install(tmp_path, cfg_dir, managed=self._GATED)
+
+        config = _installed(path)
+        assert CU_SERVER not in config["mcpServers"]
+        # The refs stay put: no entry means nothing to launch, and removing them
+        # is what would lose a hand-narrowed grant.
+        assert CU_REF in config["tools"]
+        assert f"{CU_REF}/computer_get_state" in config["allowedTools"]
+        # The always-on servers still ship — the gate is one row, not a purge.
+        assert "kirocrew-core" in config["mcpServers"]
+        assert "@kirocrew-core" in config["tools"]
+        # And the user's own entries are untouched.
+        assert "ReadFile" in config["tools"]
+
+        withheld = [
+            e
+            for e in events
+            if e.get("operation") == "mcp_server_withheld" and CU_REF in str(e.get("resources"))
+        ]
+        assert withheld, f"no SEL record for the withheld server: {events}"
+        # The audit text must describe the config that was actually written. A
+        # security trail claiming it removed a grant it left in place is worse
+        # than no trail: it is read during incident response, when the config it
+        # contradicts is the thing being reconstructed.
+        _said = str(withheld[0].get("resources"))
+        assert "mcpServers" in _said
+        assert "mcpServers/tools" not in _said, (
+            "the audit claims the tools ref was withheld, but it is still in the "
+            f"written config: {_said!r} vs tools={config['tools']!r}"
+        )
+        assert CU_REF in config["tools"], "premise of the assertion above"
+
+    def test_a_FRESH_install_audits_the_withheld_server_too(self, tmp_path: Path):
+        """**The audit must not depend on there being a ref left to delete.**
+
+        Nothing in the spec changes shape when a gate closes — the ref stays where
+        the template put it and only the entry is withheld — so there is no delta
+        to derive an audit from. The record comes from the gate plus the shipped
+        template instead, so the fresh and existing paths report the same fact.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        events: list[dict] = []
+
+        class _Sel:
+            def log_api_access(self, **kw):
+                events.append(kw)
+
+            def __getattr__(self, _name):
+                return lambda *a, **k: None
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", False))
+            stack.enter_context(patch("kiro_crew.agent.sel", lambda: _Sel()))
+            path = _run_install(tmp_path, cfg_dir, managed=self._GATED)
+
+        assert CU_SERVER not in _installed(path)["mcpServers"]
+        assert [e for e in events if e.get("operation") == "mcp_server_withheld"], (
+            f"a fresh install withheld the server without auditing it: {events}"
+        )
+
+    def test_no_withheld_audit_when_the_template_never_granted_it(self, tmp_path: Path):
+        """An edition that ships without computer use has nothing to report.
+
+        The record says "a grant the template makes was withheld"; with no grant
+        there is no removal, and a per-rebuild event about a server the user was
+        never offered is noise an auditor has to learn to ignore.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        defaults_path = cfg_dir / "defaults.json"
+        defaults = json.loads(defaults_path.read_text(encoding="utf-8"))
+        defaults["tools"] = [t for t in defaults["tools"] if t != CU_REF]
+        defaults_path.write_text(json.dumps(defaults))
+        events: list[dict] = []
+
+        class _Sel:
+            def log_api_access(self, **kw):
+                events.append(kw)
+
+            def __getattr__(self, _name):
+                return lambda *a, **k: None
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("kiro_crew.platform_compat.IS_MACOS", False))
+            stack.enter_context(patch("kiro_crew.agent.sel", lambda: _Sel()))
+            _run_install(tmp_path, cfg_dir, managed=self._GATED)
+
+        assert [e for e in events if e.get("operation") == "mcp_server_withheld"] == []
 
 
 # ── The data-home pin ──

--- a/test/test_mcp_registry_governance.py
+++ b/test/test_mcp_registry_governance.py
@@ -28,6 +28,13 @@ from kiro_crew.kiro_cli import (
 
 MANAGED = ("kirocrew-core", "kirocrew-cron", "kirocrew-computer")
 
+# ``kirocrew-computer`` carries a ``spec_gate`` and is therefore absent from an
+# emitted spec on any non-macOS host (and on macOS with the keystone off) -- see
+# ``agent._computer_use_spec_gate``. These tests are about the REGISTRY MARKER, not
+# about that gate, so they pin it OPEN with an empty snapshot: the marker rule must
+# hold for every managed server the spec actually carries, on every CI platform.
+NO_GATES: frozenset[str] = frozenset()
+
 
 def _write_config(home: Path, *, registry_mode: bool | None) -> Path:
     path = home / "config.json"
@@ -154,13 +161,13 @@ class TestIdentityProbeIsAudited:
 class TestFreshInstallMarker:
     def test_no_marker_outside_registry_mode(self, monkeypatch):
         monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: False)
-        config = agent_mod.build_agent_config()
+        config = agent_mod.build_agent_config(gated_off=NO_GATES)
         for name in MANAGED:
             assert "type" not in config["mcpServers"][name], name
 
     def test_marker_on_every_managed_server_in_registry_mode(self, monkeypatch):
         monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: True)
-        config = agent_mod.build_agent_config()
+        config = agent_mod.build_agent_config(gated_off=NO_GATES)
         for name in MANAGED:
             assert config["mcpServers"][name]["type"] == "registry", name
 
@@ -168,7 +175,7 @@ class TestFreshInstallMarker:
         """command/args stay so doctor's handshake probe, the CC sidecar sync and
         a later ungoverned refresh still describe a runnable server."""
         monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: True)
-        entry = agent_mod.build_agent_config()["mcpServers"]["kirocrew-core"]
+        entry = agent_mod.build_agent_config(gated_off=NO_GATES)["mcpServers"]["kirocrew-core"]
         assert entry["command"]
         assert entry["args"] == ["mcp-core"] or "mcp-core" in entry["args"]
 
@@ -177,7 +184,7 @@ class TestRefreshMarker:
     def test_refresh_adds_the_marker(self, monkeypatch):
         monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: True)
         config = {"mcpServers": {name: {"command": "x", "args": []} for name in MANAGED}}
-        agent_mod._refresh_dynamic_fields(config)
+        agent_mod._refresh_dynamic_fields(config, gated_off=NO_GATES)
         for name in MANAGED:
             assert config["mcpServers"][name]["type"] == "registry", name
 
@@ -190,7 +197,7 @@ class TestRefreshMarker:
                 name: {"command": "x", "args": [], "type": "registry"} for name in MANAGED
             }
         }
-        agent_mod._refresh_dynamic_fields(config)
+        agent_mod._refresh_dynamic_fields(config, gated_off=NO_GATES)
         for name in MANAGED:
             assert "type" not in config["mcpServers"][name], name
 
@@ -199,7 +206,7 @@ class TestRefreshMarker:
         theirs, and kiro-cli tolerates it."""
         monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: False)
         config = {"mcpServers": {"kirocrew-core": {"command": "x", "args": [], "type": "stdio"}}}
-        agent_mod._refresh_dynamic_fields(config)
+        agent_mod._refresh_dynamic_fields(config, gated_off=NO_GATES)
         assert config["mcpServers"]["kirocrew-core"]["type"] == "stdio"
 
 


### PR DESCRIPTION
# What is the problem?

`kirocrew-computer` started a full ~109 MB Python backend process **per chat process** — including every `spawn_run` subagent — even when the capability was disabled, and even on platforms where it cannot work at all.

Registration was unconditional (`agent.py`'s `_MANAGED_MCP_SERVERS`), and the keystone enable was only checked *inside* the already-running server (`mcp_computer._list_tools`, `_call_tool_inner`). Both checks are correct, but neither is reachable before the process exists: they can make a disabled feature advertise zero tools, not make it cost nothing.

Measured on one live Linux host: **16 `mcp-computer` backends holding ~1747 MB RSS**, 14 of them unpooled under `kiro-cli-chat`, with the keystone off and on an OS where `backend.select_default_backend()` has no driver at all.

# Why this issue matters to the user

~1.75 GB of resident memory was held by a feature that could not be invoked even once on that machine. Every non-macOS user paid ~109 MB per chat process for a capability with no implementation, and every macOS user who never enabled it paid the same. On a busy host with a dozen concurrent sessions this was the single largest block of avoidable KiroCrew memory.

It also blocked a design direction: "ship the capability default-OFF behind a keystone" was not actually free, so any future gated first-party MCP server would have inherited the same per-session cost.

# How our fix solves it

The chain runs symptom → mechanism → fix: the memory is held by a process; the process exists because kiro-cli was handed a `command` entry for the server; the entry was emitted because nothing consulted the platform or the keystone at emission time. So the decision moves to spec emission.

The managed row now carries a **`spec_gate`** predicate (`_computer_use_spec_gate`: macOS **and** the keystone, fail-closed). Three writers honour it, asymmetrically on purpose:

- **`build_agent_config()`** withholds the entry **and pops one arriving from the user override file** — a platform gate exists because there is no driver on this OS, and an override must not smuggle a server past it.
- **`_refresh_dynamic_fields()`** **retracts** an entry a previous pass wrote while the gate was open. A skip-only refresh would mean turning the feature off never reclaims the process turning it on started — the same bug, one release later.
- **`_prune_gated_managed_refs()`** strips `@kirocrew-computer` and any `@kirocrew-computer/<tool>` grant from `tools`/`allowedTools`, audited to SEL. This is not cosmetic: the shipped `defaults.json` grants the ref unconditionally, and kiro-cli mounts a server *because* something references it, so a surviving ref would keep spawning the very backend the gate declined. Scoped to gated servers only — a server dropped for an unresolvable command keeps its ref, or one bad PATH would permanently delete the user's grant.

The gate decision is **snapshotted once per rebuild** and threaded through all three, so a keystone flip landing mid-rebuild cannot produce a spec that mounts a server whose ref was just pruned (or the reverse).

**The enable path still works in the session the user is sitting in.** `PUT /api/computer-use/config` already reset sessions on an enable flip (kiro-cli caches `tools/list` for a session's lifetime). Since the enable is now also an emission gate, a reset alone would restart every session into the *same* spec that omits the server, and the tools would not appear until the next gateway start. The handler now rebuilds the spec **before** the reset — the order is load-bearing, and a rebuild failure never fails the SAVE (same rule the reset already followed).

The two in-process checks are **kept as defence in depth**: they cover what this gate structurally cannot, namely the keystone flipping *off* mid-session, after the spec was written and the backend spawned.

As the issue flagged, the 8-place registration ratchet now distinguishes "present in the managed set" (still asserted, unchanged) from "emitted into the resolved spec" (now conditional).

# What tests we did

`TestSpecEmissionGate` in `test/test_computer_use_registration.py` (16 new tests), asserting on the **spec**, not on `tools/list` — a `tools/list`-only test passes just as well while the process is still being spawned:

- non-darwin gets no entry, asserted with the keystone **enabled** so the platform half is proven on its own;
- darwin with the keystone absent / `{}` / `false` / `"true"` / `1` gets no entry (mirrors the existing `test_mcp_computer.py` keystone cases through the real `enable_state`, so the truthy-non-`True` spellings are judged by the production predicate);
- darwin with `{"enabled": true}` **does** get the entry — the guard against over-gating the one path that must work;
- no dangling ref; a user override cannot defeat a platform gate; a refresh retracts; the gate fails closed on an unreadable keystone; a raising gate reads as closed; only computer-use is gated; the shipped row's gate is pinned by identity; the rebuild precedes the session reset;
- an **end-to-end `install_agent`** case staged as an upgrade (existing config holding both the entry and the ref — what every pre-fix user has on disk), asserting the file written to `~/.kiro/agents` carries neither, that the always-on servers and the user's own entries survive, and that the withheld server is recorded in SEL.

The four existing `tools/list`-empty tests are untouched and green.

Also:
- **Mutation-verified: 12/12 mutants killed** — gate ignored, skip-without-pop, platform half removed, keystone read failing open, raising gate treated as open, refresh skipping instead of retracting, prune removed (both call sites), per-tool refs surviving, audit suppressed, malformed `tools` faulting the prune, rebuild moved after the reset.
- Full backend suite: **47,429 passed**. The 36 failures are pre-existing host-environment cases on this box (userns `EPERM`, no editable install for subprocess imports, missing `qrcode`, terminal-probe and log-capture flakes) — identical set before and after the change, verified by diffing the failure names against a clean `main` run.
- `isort`, `flake8`, `mypy` (4 pre-existing errors in files this PR does not touch, same count on `main`), `docs-lint`, `scrub-lint`, brand gate, harness parity, inclusive-language scan on added lines: all clean.
- Docs updated in the same PR: `docs/system-specs/modules/computer-use.md` (new "The shim is not spawned at all unless it can be used" section, plus the load-bearing rebuild-before-reset ordering) and `docs/architecture/mcp.md` (the `spec_gate` contract under Managed servers).

# Any other suggestions on the work

- `spec_gate` is deliberately a generic key rather than a computer-use special case: it is the mechanism a future default-OFF first-party server needs to be genuinely zero-cost. It is currently on exactly one row, and a test pins that.
- Two related findings from the same measurement are **not** folded in here: most first-party backends are spawned directly by `kiro-cli-chat` rather than through the stub/pool, and each backend pays `cli.py`'s module-scope import chain (~70 MB / ~900 ms). The latter is not fixable by bypassing `cli.py` — `main()` runs `boot_platform()` fail-closed specifically to stop `mcp-core`/`mcp-cron` running with no security overlay — so the correct fix is lazy imports inside `cli.py`, which is a separate change with its own ratchet.

Closes #3482
