### PR TITLE
fix: preserve channel binding across context-overflow recycle

### DIFF
--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -3266,13 +3266,14 @@ class SessionManager:
 
         kiro-cli only: if the in-place ``/compact`` fails or times out, the
         session is recycled — killed so the next user message re-seeds context
-        via build_session_context(). The session_map entry is dropped so we
-        don't false-resume from stale state. That recycle happens inside
-        ``_compact_in_place``, under the turn semaphore it already holds, so no
-        queued turn can slip in between the failed compact and the kill. A
-        recycle is never forced through a live turn: if the turn semaphore
-        cannot be acquired within the budget, the attempt is skipped and the
-        next turn-end ``check_context_usage`` re-triggers it.
+        via build_session_context(). The session_map entry's resume sid is
+        cleared so we don't false-resume from stale state, while the entry
+        itself (and the channel bindings it carries) survives. That recycle
+        happens inside ``_compact_in_place``, under the turn semaphore it
+        already holds, so no queued turn can slip in between the failed compact
+        and the kill. A recycle is never forced through a live turn: if the turn
+        semaphore cannot be acquired within the budget, the attempt is skipped
+        and the next turn-end ``check_context_usage`` re-triggers it.
         """
         try:
             session = self._sessions.get(key)
@@ -3336,7 +3337,7 @@ class SessionManager:
             self._compacting.discard(key)
 
     async def _recycle_held(self, key: str, session: "_Session", pct: float) -> None:
-        """Recycle *session* — SIGKILL the provider and drop the map entry.
+        """Recycle *session* — SIGKILL the provider and clear its resume sid.
 
         The caller MUST already hold ``session.semaphore`` and is responsible
         for releasing it: this method neither acquires nor releases it, so the
@@ -3347,6 +3348,14 @@ class SessionManager:
         Operates strictly on the *session object passed in*: pop-by-identity
         means a fresh session registered by a racing cold-start is never
         popped or killed by mistake.
+
+        Housekeeping never removes a session's channel identity; only explicit
+        user actions do. The overflowed native conversation must not be resumed,
+        so this clears the sid (as :meth:`discard_conversation` does) instead of
+        deleting the session-map entry: the entry also carries the mirror
+        binding, the Slack thread/channel linkage and the durable flags, so a
+        full delete silently unlinks a mirrored session and forks its later
+        inbound messages into a new conversation.
         """
         self._recycling[key] = session
         try:
@@ -3362,9 +3371,9 @@ class SessionManager:
                 await session.provider.shutdown()
                 logger.info("Recycled session %s (context overflow; entry already replaced)", key)
             else:
-                self._session_map.delete(key)
+                self._session_map.clear_sid(key)
                 await popped.provider.shutdown()
-                logger.info("Recycled session %s (context overflow)", key)
+                logger.info("Recycled session %s (context overflow; sid cleared)", key)
             await self._fire_compact_callback(key, pct, success=True)
         finally:
             if self._recycling.get(key) is session:

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -12,6 +12,7 @@ import pytest
 
 from kiro_crew.acp.types import AcpPromptStats
 from kiro_crew.config import KiroCrewConfig
+from kiro_crew.messaging.link import ChannelLink
 from kiro_crew.session import (
     _BG_BLIND_RECYCLE_PROMPTS,
     BACKGROUND_KEY,
@@ -146,6 +147,57 @@ class TestSessionManager:
             replacement.needs_context_reinjection is False
         ), "a recycle must not flag the fresh replacement session"
         assert mgr.consume_needs_reinjection("thread1") is False
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_overflow_recycle_preserves_channel_binding(self, cfg):
+        """A context-overflow recycle is housekeeping, so it must not unlink.
+
+        Dropping the whole session-map entry takes the mirror binding with it: a
+        Discord conversation resumed into that session loses its binding, and
+        later inbound messages from that channel fork into a new conversation.
+        Only the resume sid may go — the overflowed native conversation must not
+        be resumed.
+        """
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("dashboard:chat-1")
+        key = mgr._fold_key("dashboard:chat-1")
+        session = mgr._sessions[key]
+        mgr._session_map.set(key, "sid-overflowed")
+        mgr.set_mirror_link(
+            key,
+            ChannelLink(channel_type="discord", channel_id="C1"),
+            accepts_inbound=True,
+        )
+
+        await mgr._recycle_held(key, session, 95.0)
+
+        link = mgr.get_mirror_link(key)
+        assert link is not None
+        assert (link.channel_type, link.channel_id) == ("discord", "C1")
+        assert mgr.mirror_accepts_inbound(key) is True
+        # The overflowed conversation stays unresumable...
+        assert not mgr._session_map.get(key)
+        # ...and the entry was repaired, not deleted, so the dropped sid is
+        # still diagnosable.
+        assert mgr._session_map.get_discarded_sid(key) == "sid-overflowed"
+        assert not mgr.has_session(key)
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_overflow_recycle_clears_sid_instead_of_deleting_entry(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("thread1")
+        key = mgr._fold_key("thread1")
+        session = mgr._sessions[key]
+        with (
+            patch.object(mgr._session_map, "clear_sid") as mock_clear,
+            patch.object(mgr._session_map, "delete") as mock_delete,
+        ):
+            await mgr._recycle_held(key, session, 95.0)
+        provider.shutdown.assert_awaited_once()
+        mock_clear.assert_called_once_with(key)
+        mock_delete.assert_not_called()
         await mgr.close_all()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A context-overflow recycle destroys the session channel binding. `_recycle_held` called `session_map.delete(key)`, which removes the entire session-map entry -- not just the stale resume sid, but the mirror binding (`mirror`, `mirror_accepts_inbound`), the Slack thread/channel linkage, and the durable flags.

## Why it matters

A Discord DM resumed into a session via `!session` silently loses its binding the moment that session hits the context ceiling and the in-place `/compact` fails. Later Discord messages no longer route to the bound session -- they fall back to the DM own session, forking the conversation. Telegram mirrors and Slack thread links are lost the same way. Hit repeatedly in production on 2026-08-13.

## Invariant

Housekeeping never removes a session channel identity; only explicit user actions do. After an overflow recycle the overflowed native conversation must not be resumed, but the entry bindings and flags survive.

## Fix

Replace the `delete(key)` with `clear_sid(key)` -- exactly the semantics `discard_conversation` already uses for the poisoned-conversation escalation, whose docstring spells out why a full delete "would silently unlink a mirrored session". `clear_sid` drops the sid (so the next turn cold-starts instead of `session/load`-ing the overflowed conversation) and stashes it as `discarded_sid`, leaving the entry and its bindings in place.

Docstrings on `_recycle_held` and `_compact_session` now state the current behavior and the invariant. `destroy()` and `forget_conversation()` are untouched -- their full deletes are intentional.

## Tests

Two tests next to the existing recycle coverage in `test/test_session.py`:

- `test_overflow_recycle_preserves_channel_binding` -- a session with a sid and an inbound-capable Discord mirror runs through the recycle; asserts the mirror link and `mirror_accepts_inbound` survive, the sid is cleared, and the entry was repaired rather than deleted (`get_discarded_sid` still returns it).
- `test_overflow_recycle_clears_sid_instead_of_deleting_entry` -- asserts `clear_sid` is called and `delete` never is, so a future change cannot quietly reintroduce the delete.

Both fail against the pre-fix code (verified by reverting the one-line change) and pass with it.

## Manual verification

N/A -- the failure is a session-map state transition, fully covered by the two unit tests above.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no frontend paths touched.

## Gates

Targeted `test/test_session.py` plus the `test_security_posture.py` / `test_spawn_audit.py` drift guards (295 passed), isort, flake8, and mypy (941 files, clean) all green locally. Full suite left to CI.
