### PR TITLE
fix: prune repairs entries with channel bindings instead of deleting

### DIFF
--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -82,6 +82,19 @@ def _has_durable_flag(entry: dict) -> bool:
     return any(flags.get(name) for name in _DURABLE_FLAGS)
 
 
+def _survives_prune(entry: dict) -> bool:
+    """True iff *entry* holds state that must outlive its native session.
+
+    The ONE predicate behind every stale branch of :meth:`SessionMap.prune`, so
+    they cannot disagree about what a missing session file is allowed to take
+    with it. Two kinds of state qualify: a durable flag (a per-conversation
+    setting) and a channel binding — a Slack thread or a ``mirror`` — which is
+    the identity that routes a conversation back to its channel. Prune may clear
+    a stale ``sid`` on such an entry, but never discards the entry itself.
+    """
+    return bool(_has_durable_flag(entry) or entry.get("slack_thread_ts") or entry.get("mirror"))
+
+
 # Serializes every structural access to the map. MODULE-level, not per-instance,
 # because the instances are not the unit of exclusion: the read-only call sites
 # build their own throwaway ``SessionMap()`` (``handlers/session_storage.py``,
@@ -766,14 +779,20 @@ class SessionMap:
     def prune(self) -> int:
         """Remove entries whose session files no longer exist.
 
-        An entry carrying a DURABLE flag is never deleted, and when its ``sid``
-        has gone stale the ``sid`` is cleared instead. A durable flag is a
+        An entry carrying a DURABLE flag or a channel binding is never deleted,
+        and when its ``sid`` has gone stale the ``sid`` is cleared instead —
+        :func:`_survives_prune` is the single predicate both stale branches ask,
+        so neither can start discarding what the other keeps. A durable flag is a
         per-conversation SETTING, not session state: it can be written before the
         conversation has ever run a turn (``/unlink`` as the very first message
         leaves no ``sid``, no thread and no mirror), and it must outlive the
-        native session the conversation happened to be using. Deleting the entry
-        either way would silently revert the setting at the next restart, and the
-        user's next message would land on the default they had just turned off.
+        native session the conversation happened to be using. A channel binding
+        (``slack_thread_ts``, ``mirror``) is the conversation's identity: it is
+        what routes an inbound channel message back to this session. Deleting the
+        entry either way would silently revert user state at the next restart —
+        the setting returns to the default they had just turned off, or the next
+        message from the channel opens a fresh session instead of resuming the
+        one it is bound to.
 
         Session-SCOPED flags (a temporary or incognito thread) are deliberately
         NOT durable: they describe one session, so keeping their entries alive
@@ -792,19 +811,14 @@ class SessionMap:
             if (entry.get("provider") or PROVIDER_LABEL_DEFAULT) != PROVIDER_LABEL_DEFAULT:
                 continue
             sid = entry.get("sid")
-            durable = _has_durable_flag(entry)
+            survives = _survives_prune(entry)
             if sid and not (sessions_dir / f"{sid}.json").exists():
-                if durable:
+                if survives:
                     entry["sid"] = ""
                     repaired = True
                 else:
                     stale.append(key)
-            elif (
-                not sid
-                and not entry.get("slack_thread_ts")
-                and not entry.get("mirror")
-                and not durable
-            ):
+            elif not sid and not survives:
                 stale.append(key)
         for k in stale:
             del self._data[k]

--- a/test/test_session_map_mirror.py
+++ b/test/test_session_map_mirror.py
@@ -383,6 +383,71 @@ class TestPrunePreservesMirror:
             assert pruned == 0
             assert sm.get_mirror_link("dashboard:chat-1") is not None
 
+    def test_stale_sid_repairs_a_resume_binding_instead_of_dropping_it(self, tmp_path):
+        """A restart after kiro-cli collected the session file must not unlink.
+
+        The entry is stale by the ``sid`` predicate, but it carries the inbound
+        resume binding: delete it and the next message from that channel falls
+        back to the channel's own session instead of resuming the linked one.
+        """
+        key = "dashboard:chat-1"
+        link = ChannelLink(channel_type="discord", channel_id="dm-1")
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            sm = SessionMap()
+            sm.set(key, "sid-that-no-longer-exists")
+            sm.set_mirror_link(key, link, accepts_inbound=True)
+            assert sm.prune() == 0
+            assert sm.get_mirror_link(key) == link
+            assert sm.mirror_accepts_inbound(key) is True
+            assert (sm._data.get(key) or {}).get("sid") == ""
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            reloaded = SessionMap()
+        # The repair reached disk, so the next startup does not redo it.
+        assert reloaded.get_mirror_link(key) == link
+        assert reloaded.mirror_accepts_inbound(key) is True
+        assert not (reloaded._data.get(key) or {}).get("sid")
+
+    def test_stale_sid_repairs_a_slack_thread_binding(self, tmp_path):
+        """Same branch for Slack, whose binding lives in the dedicated fields.
+
+        The thread has to keep resolving to this session after the restart, or
+        the next reply in it starts a new conversation.
+        """
+        key = "dashboard:chat-1"
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            sm = SessionMap()
+            sm.set(key, "sid-that-no-longer-exists")
+            sm.set_slack_link(key, "1700000000.000100", "C123")
+            assert sm.prune() == 0
+            assert (sm._data.get(key) or {}).get("sid") == ""
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            reloaded = SessionMap()
+        assert reloaded.get_session_for_thread("1700000000.000100") == key
+        assert not (reloaded._data.get(key) or {}).get("sid")
+
+    def test_stale_sid_with_no_binding_is_still_collected(self, tmp_path):
+        """Repair is for entries that carry state; a bare stale row is garbage."""
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            sm = SessionMap()
+            sm.set("dashboard:chat-1", "sid-that-no-longer-exists")
+            assert sm.prune() == 1
+            assert "dashboard:chat-1" not in sm._data
+
+    def test_a_live_sid_with_a_mirror_is_left_alone(self, tmp_path):
+        """Prune only touches entries whose session file is gone."""
+        key = "dashboard:chat-1"
+        link = ChannelLink(channel_type="discord", channel_id="dm-1")
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            sm = SessionMap()
+            sm.set(key, "sid-alive")
+            sm.set_mirror_link(key, link, accepts_inbound=True)
+            with patch("kiro_crew.session_map._kiro_sessions_dir", return_value=tmp_path):
+                (tmp_path / "sid-alive.json").write_text("{}", encoding="utf-8")
+                assert sm.prune() == 0
+            assert (sm._data.get(key) or {}).get("sid") == "sid-alive"
+            assert sm.get_mirror_link(key) == link
+            assert sm.mirror_accepts_inbound(key) is True
+
 
 class TestPersistence:
     def test_inbound_resume_marker_round_trips_to_disk(self, tmp_path):


### PR DESCRIPTION
## Problem

`SessionMap.prune()` deletes an entry whose `sid` points at a session file that no longer exists — even when that entry carries a channel binding (`mirror` for Discord/Telegram, `slack_thread_ts` for Slack). kiro-cli garbage-collects its own session transcripts, so after a restart the map holds entries whose `sid` is stale but whose binding is still the live routing state for the conversation.

The two stale branches disagreed about what a missing session file may take with it:

- no `sid`: already preserved entries with `slack_thread_ts` or `mirror`
- stale `sid`: preserved only entries with a durable flag, and deleted everything else

So a restart after the native session files were cleaned silently unlinks a mirrored conversation. The next message from that channel no longer resolves to the bound session and falls back to the channel's own DM session, with no error and nothing in the logs.

## Fix

One preservation predicate, `_survives_prune()`, now governs both branches: an entry survives when it carries a durable flag, a `slack_thread_ts`, or a `mirror`. On a stale `sid` such an entry is repaired (`sid` cleared, persisted) instead of deleted. Prune may repair an entry but never discards channel identity.

Return-count semantics are unchanged — a `sid`-only reset is a repair, not a removal, so it is not counted. `_has_durable_flag` and the non-kiro-cli provider skip are untouched. The `prune()` docstring now states the rule for channel bindings alongside the durable-flag rule.

Net: 40 lines changed in `session_map.py` (most of it the docstring and the extracted predicate), 65 added in tests.

## Testing

- `test/test_session_map_mirror.py` — four new cases in `TestPrunePreservesMirror`: stale `sid` + inbound-accepting mirror survives with `sid` cleared and link plus `accepts_inbound` intact after reload; stale `sid` + `slack_thread_ts` survives and the thread still resolves after reload; stale `sid` with no binding is still collected; a live `sid` with a mirror is left alone. The two repair cases were confirmed to fail against the old behavior before the fix went in.
- Targeted suites green: session-map files (mirror, flush, locking, migration, unlink, conv_state, cwd), `test_sel.py`, `test_sel_prune_streaming.py`, plus the `test_security_posture.py` / `test_spawn_audit.py` drift guards — 344 passed.
- isort, flake8, mypy all clean. Full suite left to CI.
