### PR TITLE
fix: audit and notify when an inbound session binding is cleared

### DIFF
--- a/src/kiro_crew/dashboard/chat_mirror.py
+++ b/src/kiro_crew/dashboard/chat_mirror.py
@@ -35,7 +35,12 @@ from kiro_crew.dashboard.chat_runner import _resolve_channel_target, _resolve_mi
 from kiro_crew.dashboard.chat_slack import list_slack_channels
 from kiro_crew.dashboard.chat_utils import effective_session_key
 from kiro_crew.dashboard.state import DashboardState
-from kiro_crew.messaging.link import SLACK_NAMESPACE, ChannelLink, is_channel_session_key
+from kiro_crew.messaging.link import (
+    SLACK_NAMESPACE,
+    UNBIND_REASON_DASHBOARD_UNLINK,
+    ChannelLink,
+    is_channel_session_key,
+)
 from kiro_crew.messaging.renderer import chunk_text
 from kiro_crew.platform.context import redact_via_context
 from kiro_crew.platform.governance_profiles import vet_and_audit
@@ -637,7 +642,9 @@ async def api_chat_slot_mirror_unlink(request: web.Request) -> web.Response:
         return web.json_response({"error": "not found"}, status=404)
 
     session_key = effective_session_key(slot)
-    cleared = state.sessions.clear_mirror_link(session_key)
+    cleared = state.sessions.clear_mirror_link(
+        session_key, reason=UNBIND_REASON_DASHBOARD_UNLINK
+    )
     state.push_slots_update()
     sel().log_api_access(
         caller="dashboard",

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2334,6 +2334,8 @@ async def start_dashboard(
     state.wire_session_compact_callback()
     # Visible notice when the watchdog recycles a dashboard session (e.g. RSS)
     state.wire_session_recycle_callback()
+    # Visible notice in a channel that just lost its session-resume binding
+    state.wire_session_unbind_listener()
 
     app = web.Application(
         client_max_size=60 * 1024 * 1024
@@ -3288,6 +3290,8 @@ async def start_api_server(
     state.wire_session_compact_callback()
     # Visible notice when the watchdog recycles a dashboard session (e.g. RSS)
     state.wire_session_recycle_callback()
+    # Visible notice in a channel that just lost its session-resume binding
+    state.wire_session_unbind_listener()
 
     app = web.Application(
         client_max_size=60 * 1024 * 1024

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -35,10 +35,17 @@ from kiro_crew.history import latest_transcript_ts, monotonic_transcript_ts
 from kiro_crew.knowledge.store import KnowledgeStore
 from kiro_crew.messaging.link import (
     SLACK_NAMESPACE,
+    UNBIND_REASON_DASHBOARD_UNLINK,
+    UNBIND_REASON_ENTRY_DELETED,
+    UNBIND_REASON_ORIGIN_REBIND,
+    UNBIND_REASON_SESSION_DESTROYED,
+    UNBIND_REASON_UNSPECIFIED,
+    UNBIND_REASON_USER_UNLINK,
     ChannelLink,
     channel_namespace_of,
     is_channel_session_key,
 )
+from kiro_crew.messaging.renderer import display_safe
 from kiro_crew.notifications.bus import (
     NotificationBus,
     NotificationValidationError,
@@ -442,6 +449,30 @@ _SESSION_RECYCLED_NOTICE = (
     "♻️ This session was recycled by the watchdog ({reason}). "
     "Conversation history is preserved — your next message starts a fresh process."
 )
+#: Sent to a conversation that just lost its inbound resume binding, so the next
+#: message landing in a brand-new session is explained rather than mysterious.
+#: ``!sessions`` is Discord's command and Discord is the only transport that binds
+#: inbound, so the instruction is reachable wherever this notice can arrive.
+_INBOUND_UNBIND_NOTICE = (
+    '🔗 This conversation was detached from session "{title}" — {why}. '
+    "Run `!sessions` to reattach."
+)
+
+#: Human phrasing per audited reason, so the notice never shows an audit token.
+#: The two vocabularies stay separate on purpose: a reason can be renamed or split
+#: without rewriting user copy, and this copy can be reworded without touching the
+#: trail. An unmapped reason falls back to the generic phrase rather than leaking
+#: through as a raw token.
+_INBOUND_UNBIND_WHY: dict[str, str] = {
+    UNBIND_REASON_DASHBOARD_UNLINK: "someone unlinked it from the dashboard",
+    UNBIND_REASON_ORIGIN_REBIND: "this conversation was relinked to a new session",
+    UNBIND_REASON_SESSION_DESTROYED: "that session was deleted",
+    UNBIND_REASON_ENTRY_DELETED: "that session's record was removed",
+    UNBIND_REASON_UNSPECIFIED: "the link was cleared",
+}
+_INBOUND_UNBIND_WHY_DEFAULT = "the link was cleared"
+
+
 #: Shown when the out-of-band watchdog finds a turn whose consumer stopped
 #: pulling events. Deliberately describes the observation rather than promising a
 #: remedy: nothing is cancelled or retried, because what the turn is blocked on
@@ -2617,6 +2648,119 @@ class DashboardState:
             logging.getLogger(__name__).exception(
                 "Failed to deliver channel compact notice for %s", key
             )
+
+    def wire_session_unbind_listener(self) -> None:
+        """Register the channel notice for a removed inbound resume binding.
+
+        The session map audits every removal itself; what it cannot do is reach
+        the conversation, because that means resolving a transport. This is where
+        those halves meet. Called from async gateway startup, which is what makes
+        the loop capture below correct: the listener itself runs on whatever thread
+        performed the clear, so the loop has to be bound here.
+        """
+        loop = asyncio.get_event_loop()
+
+        def _on_unbind(key: str, link: ChannelLink, reason: str) -> None:
+            if reason == UNBIND_REASON_USER_UNLINK:
+                # The in-channel unlink command has already replied in this very
+                # conversation, so a notice here would be an echo of it.
+                return
+            if loop.is_closed():
+                # The gateway is shutting down; there is nothing left to deliver
+                # on. The SEL event already recorded the removal.
+                logger.debug("Gateway loop closed; dropping inbound-unbind notice for %s", key)
+                return
+            try:
+                # ``call_soon_threadsafe`` rather than a call-time
+                # ``get_running_loop``: SessionMap is synchronous and a clear can
+                # arrive on a worker thread, where there is no running loop and the
+                # notice would be dropped. The loop captured at wire time is the
+                # gateway's own. Stays SYNC and returns at once — the map holds its
+                # lock across this call.
+                loop.call_soon_threadsafe(self._spawn_unbind_notice, key, link, reason)
+            except RuntimeError:
+                # Raced a shutdown between the is_closed check and the call.
+                logger.debug("Gateway loop gone; dropping inbound-unbind notice for %s", key)
+
+        self.sessions.set_unbind_listener(_on_unbind)
+
+    def _spawn_unbind_notice(self, key: str, link: ChannelLink, reason: str) -> None:
+        """Start the notice task on the gateway loop, retaining a strong reference.
+
+        Runs ON the loop (``call_soon_threadsafe`` target), so creating the task is
+        safe here. Tracked in ``_background_tasks`` for the same reason
+        :meth:`_spawn_ws_send` does it: the loop holds only a weak reference, so an
+        untracked task can be collected mid-send and the notice silently vanishes.
+        """
+        task = asyncio.ensure_future(self._notify_inbound_unbind(key, link, reason))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._on_unbind_notice_done)
+
+    def _on_unbind_notice_done(self, task: "asyncio.Task") -> None:  # type: ignore[type-arg]
+        """Release the finished notice task and consume any exception it stored.
+
+        ``_notify_inbound_unbind`` swallows its own delivery failures, so an
+        exception here is unexpected; reading it keeps asyncio from logging a bare
+        "exception was never retrieved" at GC time.
+        """
+        self._background_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.debug("inbound-unbind notice task failed: %s", exc)
+
+    async def _notify_inbound_unbind(self, key: str, link: ChannelLink, reason: str) -> None:
+        """Tell the conversation behind *link* that it is no longer attached.
+
+        Rides the governed cross-surface ladder rather than the transport directly,
+        so the send is capability-checked and governance-vetted like every other
+        outbound notice. Best-effort: the binding is already gone and audited, so an
+        unreachable, ungoverned or unregistered channel is logged and dropped
+        rather than raised on a background task.
+        """
+        # Lazy: chat_runner imports this module at scope, so a top-level import
+        # here would close the cycle.
+        from kiro_crew.dashboard.chat_runner import _resolve_channel_target
+
+        try:
+            # Off-loop: the ladder's governance gate walks the profile directory,
+            # which is unbounded on slow storage.
+            target = await asyncio.to_thread(_resolve_channel_target, self, key, link)
+            if target is None:
+                return
+            resolved, transport = target
+            notice = _INBOUND_UNBIND_NOTICE.format(
+                title=self._unbind_notice_title(key),
+                why=_INBOUND_UNBIND_WHY.get(reason, _INBOUND_UNBIND_WHY_DEFAULT),
+            )
+            # The title is user-controlled (a rename, or an LLM-authored one), so
+            # the rendered notice goes through the SHARED outbound display sink —
+            # display canonicalization, exfiltration URLs, credentials, then
+            # mention defang — rather than a second copy of that order here.
+            await transport.send_message(
+                resolved.channel_id,
+                display_safe(notice),
+                thread_id=resolved.thread_id,
+            )
+        except Exception:
+            logging.getLogger(__name__).warning(
+                "Failed to deliver inbound-unbind notice for %s", key, exc_info=True
+            )
+
+    def _unbind_notice_title(self, key: str) -> str:
+        """Name the detached session the way the user saw it, falling back to *key*.
+
+        A title only exists while a slot is displaying the session; the raw key
+        still identifies it, so nothing beyond the in-memory slot is worth a lookup.
+        """
+        from kiro_crew.dashboard.chat_utils import dashboard_slot_key
+
+        slot_key = dashboard_slot_key(key)
+        slot = self.get_slot(slot_key) if slot_key else None
+        if slot is None:
+            return key
+        return slot.display_title or key
 
     def wire_session_recycle_callback(self) -> None:
         """Register the dashboard's recycle-notification callback.

--- a/src/kiro_crew/discord/session_resume.py
+++ b/src/kiro_crew/discord/session_resume.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 from kiro_crew.history import is_incognito_transcript
 from kiro_crew.messaging.driver import sanitize_channel_replay_text
-from kiro_crew.messaging.link import ChannelLink
+from kiro_crew.messaging.link import UNBIND_REASON_USER_UNLINK, ChannelLink
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.session_map import ConversationOwnershipConflict
@@ -155,7 +155,9 @@ class DiscordSessionResume:
             # the dispatcher's own sweep — clearing only *key* here would leave
             # that mirror occupying the location and reproduce the "already
             # attached" refusal after an apparently successful unlink.
-            cleared = self.sessions.clear_mirror_links_at(self.link_for(channel_id))
+            cleared = self.sessions.clear_mirror_links_at(
+                self.link_for(channel_id), reason=UNBIND_REASON_USER_UNLINK
+            )
             logger.info(
                 "discord: released resumed session %s (cleared bindings: %s)",
                 key,

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -48,6 +48,7 @@ from kiro_crew.messaging.dispatch import delivery_is_muted
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import (
+    UNBIND_REASON_ORIGIN_REBIND,
     ChannelLink,
     bind_origin_mirror,
     build_dm_session_key,
@@ -1006,12 +1007,18 @@ class DiscordDispatcher:
             # it mutates anything, so ordering it first leaves the batch clean
             # and nothing is written.
             with self.sessions.batched_save():
-                self.sessions.set_mirror_link(key, self._origin_mirror_link(channel_id))
+                self.sessions.set_mirror_link(
+                    key,
+                    self._origin_mirror_link(channel_id),
+                    reason=UNBIND_REASON_ORIGIN_REBIND,
+                )
                 self.sessions.set_mirror_opt_out(key, False)
                 # Drop any pre-unification row so a stale binding cannot outlive
                 # the rebind (reads prefer the channel key, but a leftover row
                 # would still answer a clear).
-                self.sessions.clear_mirror_link(legacy_dashboard_mirror_key(key))
+                self.sessions.clear_mirror_link(
+                    legacy_dashboard_mirror_key(key), reason=UNBIND_REASON_ORIGIN_REBIND
+                )
         except ConversationOwnershipConflict:
             # Reachable past the resumed-session check above because that check
             # fails CLOSED on duplicate inbound bindings: with two of them at this

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -187,6 +187,52 @@ def session_key(channel_type: str, conversation_id: str) -> str:
     return f"{channel_type}:{conversation_id}"
 
 
+# ── Why an inbound resume binding was removed ────────────────────────────────
+# The audited vocabulary, kept in this leaf module because both sides need it:
+# ``SessionMap`` stamps it on the audit event and normalizes to it, and the
+# transports that clear a binding pass it. Every clearing call site names one of
+# these constants — a bare literal grows a spelling the audit cannot group by, so
+# ``UNBIND_REASONS`` below is the closed set.
+
+# No caller named a reason. Its appearance in the trail is itself the finding: it
+# names a clearing path that has not been threaded yet.
+UNBIND_REASON_UNSPECIFIED = "unspecified"
+
+# The user asked for it in the conversation and got a reply there, so a notice
+# would be an echo. The audit still happens; only the announcement is suppressed,
+# and the suppressing side is the listener rather than the map.
+UNBIND_REASON_USER_UNLINK = "user_unlink"
+
+# The dashboard's mirror-unlink endpoint. The click happens on a surface the bound
+# channel cannot see, so this is the reason the notice exists for.
+UNBIND_REASON_DASHBOARD_UNLINK = "dashboard_unlink"
+
+# A transport re-binding the conversation it is being read in as its own origin
+# mirror, which displaces whatever binding that key held.
+UNBIND_REASON_ORIGIN_REBIND = "origin_rebind"
+
+# An explicit, irreversible session teardown; the entry and every binding on it go.
+UNBIND_REASON_SESSION_DESTROYED = "session_destroyed"
+
+# A whole-entry delete whose caller named no motive — the shape of the removal
+# rather than its cause.
+UNBIND_REASON_ENTRY_DELETED = "entry_deleted"
+
+#: The closed vocabulary. A reason outside this set is normalized to
+#: ``unspecified`` at the map's choke point, so it can neither fragment the audit
+#: trail nor reach the channel notice's phrasing map as a miss.
+UNBIND_REASONS: frozenset[str] = frozenset(
+    {
+        UNBIND_REASON_UNSPECIFIED,
+        UNBIND_REASON_USER_UNLINK,
+        UNBIND_REASON_DASHBOARD_UNLINK,
+        UNBIND_REASON_ORIGIN_REBIND,
+        UNBIND_REASON_SESSION_DESTROYED,
+        UNBIND_REASON_ENTRY_DELETED,
+    }
+)
+
+
 # ── Canonical address parsing (RFC §9 rule 4: exactly ONE parser module) ──
 
 
@@ -424,9 +470,13 @@ def release_conversation_location(
     the opt-out write) still gets a single write.
     """
     with sessions.batched_save():
-        cleared = int(sessions.clear_mirror_link(key))
-        cleared += int(sessions.clear_mirror_link(legacy_dashboard_mirror_key(key)))
-        swept = sessions.clear_mirror_links_at(location)
+        cleared = int(sessions.clear_mirror_link(key, reason=UNBIND_REASON_USER_UNLINK))
+        cleared += int(
+            sessions.clear_mirror_link(
+                legacy_dashboard_mirror_key(key), reason=UNBIND_REASON_USER_UNLINK
+            )
+        )
+        swept = sessions.clear_mirror_links_at(location, reason=UNBIND_REASON_USER_UNLINK)
     if swept:
         logger.info(
             "%s: unlink swept %d mirror binding(s) at this conversation: %s",

--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -115,16 +115,25 @@ def _default_redactor(text: str) -> str:
     return out
 
 
-def _display_safe(choice: str) -> str:
-    """Redact *choice* against what the platform will SHOW, then defang mentions.
+def display_safe(text: str) -> str:
+    """Redact *text* against what the platform will SHOW, then defang mentions.
+
+    The shared outbound display sink: every surface that renders untrusted text
+    into a channel message goes through here, so one text cannot be sanitized two
+    ways. Used by this module's overflow list and by the dashboard's channel
+    notices.
 
     Order matters. Redaction runs FIRST, on the canonical display form, because
     the ZWSP insertion below is itself a transformation applied after the scan
     -- exactly the class of reassembly hazard the display redactor exists to
     close, and inserting the ZWSP first could split a key so the regex stops
     matching it while the platform still renders it whole.
+
+    The defang covers both mention grammars because the callers are
+    channel-neutral: ``@`` for Discord/Telegram users and ``@everyone``, ``<!``
+    for Slack's ``<!channel>``.
     """
-    safe, _ = redact_for_display(choice or "", _default_redactor)
+    safe, _ = redact_for_display(text or "", _default_redactor)
     return safe.replace("@", "@\u200b").replace("<!", "<\u200b!")
 
 
@@ -155,7 +164,7 @@ def format_overflow(overflow: list[str], start: int) -> str:
       breaks slack broadcast ranges (``<!channel>``, ``<!here>``,
       ``<!everyone>``).
     """
-    return "\n".join(f"{start + i + 1}. {_display_safe(c)}" for i, c in enumerate(overflow))
+    return "\n".join(f"{start + i + 1}. {display_safe(c)}" for i, c in enumerate(overflow))
 
 
 def apply_options_cap(

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -370,6 +370,14 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "to the browser.",
     ),
     (
+        "Session detach notice",
+        "dashboard/state.py",
+        "The notice sent to a channel whose session-resume binding was cleared — a "
+        "separate egress boundary from the browser payload, and its session title is "
+        "user-controlled, so the rendered notice is re-scanned through the shared "
+        "display_safe sink before it reaches the transport.",
+    ),
+    (
         "Channel session surfacing",
         "dashboard/channel_slots.py",
         "Titles and hydrated transcript of a Slack/Discord/Teams conversation as it is "

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -110,6 +110,8 @@ from kiro_crew.constants import COMPACT_WAIT_TIMEOUT_SECS
 from kiro_crew.executors import maintenance_executor, subprocess_executor
 from kiro_crew.mcp_gateway.abort import schedule_abort
 from kiro_crew.messaging.link import (
+    UNBIND_REASON_SESSION_DESTROYED,
+    UNBIND_REASON_UNSPECIFIED,
     ChannelLink,
     canonical_key,
     legacy_key,
@@ -122,6 +124,7 @@ from kiro_crew.sel import sel
 from kiro_crew.session_map import _kiro_sessions_dir  # noqa: F401
 from kiro_crew.session_map import MIRROR_OPT_OUT_FLAG
 from kiro_crew.session_map import SessionMap as SessionMap  # noqa: F401
+from kiro_crew.session_map import UnbindListener, set_unbind_listener
 from kiro_crew.session_pid import (
     _build_child_map,
     _cleanup_orphaned_mcp_servers,
@@ -3582,7 +3585,7 @@ class SessionManager:
             # Reap any companion subagent runtime keyed by this parent (see remove()).
             await self.release_subagent_runtime(key)
         finally:
-            self._session_map.delete(key)
+            self._session_map.delete(key, reason=UNBIND_REASON_SESSION_DESTROYED)
             logger.info("Destroyed session (map deleted): %s", key)
 
     async def discard_conversation(self, key: str) -> None:
@@ -4259,17 +4262,20 @@ class SessionManager:
         link: ChannelLink | None,
         *,
         accepts_inbound: bool = False,
+        reason: str = UNBIND_REASON_UNSPECIFIED,
     ) -> None:
         """Bind (or clear) a session's channel-neutral mirror target.
 
         ``accepts_inbound`` upgrades a non-Slack outbound mirror into a
         persisted session-resume binding. Slack owns its dedicated reverse
-        index; other channels use :meth:`find_mirror_sessions`.
+        index; other channels use :meth:`find_mirror_sessions`. ``reason`` is
+        recorded when this call ends an existing inbound binding.
         """
         self._session_map.set_mirror_link(
             key,
             link,
             accepts_inbound=accepts_inbound,
+            reason=reason,
         )
 
     def get_mirror_link(self, key: str) -> ChannelLink | None:
@@ -4391,13 +4397,24 @@ class SessionManager:
         """Sessions that must stop *key* from binding *link*, or [] if it is free."""
         return self._session_map.mirror_claim_blockers(key, link, accepts_inbound=accepts_inbound)
 
-    def clear_mirror_link(self, key: str) -> bool:
+    def clear_mirror_link(self, key: str, *, reason: str = UNBIND_REASON_UNSPECIFIED) -> bool:
         """Remove a session's outbound mirror binding. Returns True iff present."""
-        return self._session_map.clear_mirror_link(key)
+        return self._session_map.clear_mirror_link(key, reason=reason)
 
-    def clear_mirror_links_at(self, link: ChannelLink) -> list[str]:
+    def clear_mirror_links_at(
+        self, link: ChannelLink, *, reason: str = UNBIND_REASON_UNSPECIFIED
+    ) -> list[str]:
         """Clear every session mirroring to an exact location; return cleared keys."""
-        return self._session_map.clear_mirror_links_at(link)
+        return self._session_map.clear_mirror_links_at(link, reason=reason)
+
+    @staticmethod
+    def set_unbind_listener(callback: UnbindListener | None) -> None:
+        """Register the sink notified when an inbound resume binding is removed.
+
+        The registry it writes is the session map's, shared by every instance, so
+        a removal performed through a throwaway map is announced too.
+        """
+        set_unbind_listener(callback)
 
     def set_mirror_paused(self, key: str, paused: bool, *, origin: bool = False) -> bool:
         """Set whether turns reach one non-Slack delivery; return the prior state.

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -23,11 +23,15 @@ from kiro_crew.acp.types import PROVIDER_LABEL_DEFAULT
 from kiro_crew.config.paths import config_dir, kiro_sessions_dir
 from kiro_crew.messaging.link import (
     SLACK_NAMESPACE,
+    UNBIND_REASON_ENTRY_DELETED,
+    UNBIND_REASON_UNSPECIFIED,
+    UNBIND_REASONS,
     ChannelLink,
     canonical_key,
     is_channel_session_key,
     legacy_dashboard_mirror_key,
 )
+from kiro_crew.sel import _infer_source, sel
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +97,50 @@ def _survives_prune(entry: dict) -> bool:
     a stale ``sid`` on such an entry, but never discards the entry itself.
     """
     return bool(_has_durable_flag(entry) or entry.get("slack_thread_ts") or entry.get("mirror"))
+
+
+# The callable shape a lost-binding announcement is delivered through:
+# ``(session_key, link, reason)``.
+UnbindListener = Callable[[str, ChannelLink, str], None]
+
+# Announces a lost inbound binding to the channel that lost it. Registered by the
+# gateway, because reaching a channel means resolving a transport and SessionMap is
+# the synchronous store every surface sits on. MODULE-level for the same reason as
+# :data:`_MAP_LOCK`: a clearing call site may hold a throwaway ``SessionMap()``, and
+# a per-instance listener would leave those removals unannounced.
+_UNBIND_LISTENER: UnbindListener | None = None
+
+
+def _normalize_unbind_reason(reason: str) -> str:
+    """Constrain *reason* to the audited vocabulary.
+
+    The runtime guard behind :data:`~kiro_crew.messaging.link.UNBIND_REASONS`. An
+    unexpected value would add an unbounded SEL dimension and reach the notice's
+    phrasing map as a miss, so it is recorded as ``unspecified`` and the WARNING
+    names the call site that needs threading.
+    """
+    if reason in UNBIND_REASONS:
+        return reason
+    logger.warning(
+        "unknown inbound-unbind reason %r; recording as %r",
+        reason,
+        UNBIND_REASON_UNSPECIFIED,
+    )
+    return UNBIND_REASON_UNSPECIFIED
+
+
+def set_unbind_listener(callback: UnbindListener | None) -> None:
+    """Register (or clear, with None) the sink for inbound-binding removals.
+
+    Invoked as ``callback(session_key, link, reason)`` after the binding is gone
+    and persisted, so the callback observes a committed removal. Best-effort by
+    contract: it is called inside the map lock on a synchronous path, so it must
+    not block, and an exception it raises is swallowed — a broken notifier cannot
+    fail the unlink that provoked it. Suppression by reason belongs to the
+    callback, since only it knows what the user has already been told.
+    """
+    global _UNBIND_LISTENER
+    _UNBIND_LISTENER = callback
 
 
 # Serializes every structural access to the map. MODULE-level, not per-instance,
@@ -230,6 +278,9 @@ class SessionMap:
         self._thread_to_session: dict[str, str] = {}  # slack_thread_ts → session_key
         self._batch_depth = 0
         self._batch_dirty = False
+        # Strong references to in-flight audit writes, so an executor Future is not
+        # collected before its result is consumed. Discarded on completion.
+        self._audit_futures: set["asyncio.Future[None]"] = set()
         # Deferred-flush state (all mutated under _MAP_LOCK). ``_dirty`` records
         # that in-memory state is ahead of the file; ``_flush_task`` is the one
         # loop task owed for it. ``_snapshot_seq`` tickets each serialized
@@ -683,12 +734,32 @@ class SessionMap:
                 jsonl_size = 0
             if jsonl_size < 10:
                 logger.info("Session %s has empty JSONL — pruning stale entry for %s", sid, key)
-                self._remove_entry(matched_key)
+                self._repair_or_remove_stale(matched_key)
                 return None
             return sid
         if sid:
-            self._remove_entry(matched_key)
+            self._repair_or_remove_stale(matched_key)
         return None
+
+    @_guarded
+    def _repair_or_remove_stale(self, key: str) -> None:
+        """Drop a stale entry, or clear only its ``sid`` when state must outlive it.
+
+        Asks :func:`_survives_prune`, the same predicate :meth:`prune` uses, so
+        the two stale paths cannot disagree: an entry carrying a channel binding
+        or a durable flag keeps the entry and loses only the dead ``sid``. The
+        binding is the conversation's identity — deleting it here would strand the
+        channel. No inbound-unbind audit or notice fires on the repair branch,
+        because no binding was removed; the removal branch reaches an entry that
+        holds none.
+        """
+        entry = self._data.get(key)
+        if entry is not None and _survives_prune(entry):
+            if entry.get("sid"):
+                entry["sid"] = ""
+                self._save()
+            return
+        self._remove_entry(key, reason=UNBIND_REASON_ENTRY_DELETED)
 
     def has_hint(self, key: str) -> bool:
         """Read-only, in-memory probe: does an entry exist for *key*?
@@ -703,15 +774,113 @@ class SessionMap:
         """
         return self._resolve_alias(key)[1] is not None
 
+    @staticmethod
+    def _inbound_binding(entry: dict) -> ChannelLink | None:
+        """The inbound resume binding *entry* holds, or None when it holds none.
+
+        The single definition of "losing this strands a conversation", so every
+        removal path announces the same thing. An entry flagged inbound whose
+        ``mirror`` is missing or unparsable routes nothing already, so it is no loss.
+        """
+        if not entry.get("mirror_accepts_inbound"):
+            return None
+        raw = entry.get("mirror")
+        if not isinstance(raw, dict):
+            return None
+        try:
+            return ChannelLink.from_dict(raw)
+        except (TypeError, ValueError):
+            return None
+
+    def _note_inbound_unbind(self, key: str, link: ChannelLink, reason: str) -> None:
+        """Audit and announce the removal of one inbound resume binding.
+
+        The choke point every removal path funnels through, so a binding cannot
+        die traceless: the SEL event is the durable record (lifecycle logs are
+        INFO and a production gateway logs WARNING and above), and the listener is
+        what reaches the channel that just lost its way back. Called after the
+        removal is persisted, so the audit describes something that happened, and
+        both legs are best-effort — a broken sink or notifier must not turn an
+        unlink, or a teardown reaching here from a ``finally``, into a raise.
+
+        The reason is normalized HERE rather than trusted from the caller: this is
+        the only place that sees every removal.
+        """
+        reason = _normalize_unbind_reason(reason)
+        target = f"{link.channel_type}:{link.channel_id or ''}"
+        if link.thread_id:
+            target = f"{target}/{link.thread_id}"
+        self._emit_unbind_audit(key, target, reason)
+        listener = _UNBIND_LISTENER
+        if listener is None:
+            return
+        try:
+            listener(key, link, reason)
+        except Exception:
+            logger.warning("inbound-unbind listener failed for %s", key, exc_info=True)
+
+    def _emit_unbind_audit(self, key: str, target: str, reason: str) -> None:
+        """Write the removal's SEL event without blocking a caller on the loop.
+
+        ``sel()`` does real filesystem work on its first call — it resolves the
+        data home, creates the log and mints the HMAC trust root — and every write
+        appends. This is reached from synchronous ``SessionMap`` calls a coroutine
+        makes inline, so doing it here stalls the gateway for the disk I/O. The
+        WHOLE closure, ``sel()`` included, therefore runs in the running loop's
+        executor, with the Future retained and its result consumed so a failure
+        logs instead of vanishing. Off the loop there is nothing to protect, so it
+        runs inline — same single event either way, no thread per event.
+        """
+
+        def _emit() -> None:
+            sel().log_api_access(
+                caller="kirocrew",
+                operation="session.inbound_unbind",
+                outcome="success",
+                # ``_infer_source`` is the canonical key->surface classifier, so
+                # this event's surface cannot drift from the rest of the trail.
+                source=_infer_source(key),
+                resources=f"{key} -> {target} ({reason})",
+            )
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                _emit()
+            except Exception:
+                logger.warning("inbound-unbind audit failed for %s", key, exc_info=True)
+            return
+        future = loop.run_in_executor(None, _emit)
+        self._audit_futures.add(future)
+
+        def _consume(done: "asyncio.Future[None]") -> None:
+            self._audit_futures.discard(done)
+            if done.cancelled():
+                return
+            exc = done.exception()
+            if exc is not None:
+                logger.warning("inbound-unbind audit failed for %s: %s", key, exc)
+
+        future.add_done_callback(_consume)
+
     @_guarded
-    def _remove_entry(self, key: str) -> None:
-        """Remove an entry and update reverse index."""
+    def _remove_entry(self, key: str, *, reason: str = UNBIND_REASON_UNSPECIFIED) -> None:
+        """Remove an entry and update reverse index.
+
+        A dying entry takes any inbound binding it held with it, so the removal
+        is announced here rather than at each caller — this is the only path by
+        which a whole entry leaves the map.
+        """
         entry = self._data.pop(key, None)
         if entry:
+            inbound = self._inbound_binding(entry)
             ts = entry.get("slack_thread_ts")
             if ts and self._thread_to_session.get(ts) == key:
                 del self._thread_to_session[ts]
             self._save()
+            if inbound is not None:
+                self._note_inbound_unbind(key, inbound, reason)
 
     @_guarded
     def set(self, key: str, sid: str, *, provider: str = "", cwd: str = "") -> None:
@@ -771,9 +940,14 @@ class SessionMap:
         return entry.get("discarded_sid", "")
 
     @_guarded
-    def delete(self, key: str) -> None:
-        """Remove mapping and persist."""
-        self._remove_entry(canonical_key(key))
+    def delete(self, key: str, *, reason: str = UNBIND_REASON_ENTRY_DELETED) -> None:
+        """Remove mapping and persist.
+
+        The catch-all reason names the shape of the removal rather than its
+        motive: a caller that knows why (a session teardown, a recycle) passes
+        its own so the audit says which one happened.
+        """
+        self._remove_entry(canonical_key(key), reason=reason)
 
     @_guarded
     def prune(self) -> int:
@@ -1053,6 +1227,7 @@ class SessionMap:
         link: ChannelLink | None,
         *,
         accepts_inbound: bool = False,
+        reason: str = UNBIND_REASON_UNSPECIFIED,
     ) -> None:
         """Bind (or clear, when *link* is None) a session's mirror target.
 
@@ -1060,6 +1235,11 @@ class SessionMap:
         messages arriving from that exact channel location may be routed back to
         *key*. Ordinary dashboard mirrors remain outbound-only. Slack keeps its
         dedicated reverse index and therefore ignores this flag.
+
+        ``reason`` describes the removal this call performs, if any: a None
+        *link*, or an overwrite that displaces an inbound binding — rebinding to
+        another location, or to the same one as outbound-only, both end a session
+        resume as thoroughly as an unlink does.
 
         Raises :class:`ConversationOwnershipConflict` when another session already
         holds this exact location AND the conversation is inbound-committed —
@@ -1069,7 +1249,7 @@ class SessionMap:
         conversation stay as permitted as they were before this rule.
         """
         if link is None:
-            self.clear_mirror_link(key)
+            self.clear_mirror_link(key, reason=reason)
             return
         if link.channel_type == SLACK_NAMESPACE:
             self.set_slack_link(key, link.thread_id or "", link.channel_id)
@@ -1082,6 +1262,7 @@ class SessionMap:
                 f"{len(rivals)} other session(s)"
             )
         entry = self._ensure_entry(key)
+        displaced = self._inbound_binding(entry)
         entry["mirror"] = link.to_dict()
         if accepts_inbound:
             entry["mirror_accepts_inbound"] = True
@@ -1091,6 +1272,8 @@ class SessionMap:
         # as the Slack path: a marker outliving its binding re-mutes the next one.
         entry.pop("mirror_paused", None)
         self._save()
+        if displaced is not None and (displaced != link or not accepts_inbound):
+            self._note_inbound_unbind(key, displaced, reason)
 
     @_guarded
     def mirror_claim_blockers(
@@ -1246,7 +1429,9 @@ class SessionMap:
         return matches
 
     @_guarded
-    def clear_mirror_links_at(self, link: ChannelLink) -> list[str]:
+    def clear_mirror_links_at(
+        self, link: ChannelLink, *, reason: str = UNBIND_REASON_UNSPECIFIED
+    ) -> list[str]:
         """Clear EVERY session whose mirror targets an exact non-Slack location.
 
         The write counterpart of :meth:`find_mirror_sessions`. An in-channel
@@ -1264,20 +1449,28 @@ class SessionMap:
         exactly as in :meth:`find_mirror_sessions`.
         """
         cleared: list[str] = []
+        lost: list[tuple[str, ChannelLink]] = []
         for key in self.find_mirror_sessions(link):
             entry = self._data.get(key)
             if entry is None:  # pragma: no cover - keys come from _data itself
                 continue
+            inbound = self._inbound_binding(entry)
             entry.pop("mirror", None)
             entry.pop("mirror_accepts_inbound", None)
             entry.pop("mirror_paused", None)
             cleared.append(key)
+            if inbound is not None:
+                lost.append((key, inbound))
         if cleared:
             self._save()
+        # A sweep can clear several sessions at one location; each one lost its
+        # own way back, so each is audited and announced separately.
+        for key, inbound in lost:
+            self._note_inbound_unbind(key, inbound, reason)
         return cleared
 
     @_guarded
-    def clear_mirror_link(self, key: str) -> bool:
+    def clear_mirror_link(self, key: str, *, reason: str = UNBIND_REASON_UNSPECIFIED) -> bool:
         """Remove a session's outbound mirror binding; return True iff one existed.
 
         A non-Slack ``mirror`` field is dropped directly; a Slack binding is
@@ -1291,10 +1484,13 @@ class SessionMap:
         if not entry:
             return False
         if entry.get("mirror") is not None:
+            inbound = self._inbound_binding(entry)
             entry.pop("mirror", None)
             entry.pop("mirror_accepts_inbound", None)
             entry.pop("mirror_paused", None)
             self._save()
+            if inbound is not None:
+                self._note_inbound_unbind(mkey, inbound, reason)
             return True
         if entry.get("slack_thread_ts") or entry.get("slack_channel_id"):
             return self.clear_slack_link(mkey)

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -41,6 +41,7 @@ from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn
 from kiro_crew.messaging.link import (
     CHAT_TYPE_DIRECT,
     CHAT_TYPE_FORUM,
+    UNBIND_REASON_ORIGIN_REBIND,
     ChannelLink,
     bind_origin_mirror,
     build_dm_session_key,
@@ -1414,11 +1415,17 @@ class TelegramDispatcher:
         # for what is one user-visible action.
         with self.sessions.batched_save():
             self.sessions.set_mirror_opt_out(key, False)
-            self.sessions.set_mirror_link(key, self._origin_mirror_link(route, chat_id))
+            self.sessions.set_mirror_link(
+                key,
+                self._origin_mirror_link(route, chat_id),
+                reason=UNBIND_REASON_ORIGIN_REBIND,
+            )
             # Drop any pre-unification row so a stale binding cannot outlive the
             # rebind (reads prefer the channel key, but a leftover row would still
             # answer a clear).
-            self.sessions.clear_mirror_link(legacy_dashboard_mirror_key(key))
+            self.sessions.clear_mirror_link(
+                legacy_dashboard_mirror_key(key), reason=UNBIND_REASON_ORIGIN_REBIND
+            )
         await self._reply(
             chat_id,
             "✅ Linked. Replies from the dashboard for this conversation will "

--- a/test/test_chat_mirror.py
+++ b/test/test_chat_mirror.py
@@ -317,6 +317,51 @@ class TestMirrorUnlink:
             assert resp.status == 200
             assert (await resp.json())["was_linked"] is False
 
+    @pytest.mark.asyncio
+    async def test_unlink_names_the_dashboard_as_the_reason(self, tmp_path, monkeypatch):
+        """The audit has to say which surface cleared the binding.
+
+        A dashboard click is invisible to the bound channel, so it is the reason
+        the notice exists for — an unattributed clear would land in the trail as
+        ``unspecified`` and read as a path nobody threaded.
+        """
+        from kiro_crew.messaging.link import UNBIND_REASON_DASHBOARD_UNLINK
+
+        state = _prep(tmp_path, monkeypatch)
+        state.sessions.clear_mirror_link = MagicMock(return_value=True)
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/mirror-unlink")
+            assert resp.status == 200
+
+        assert state.sessions.clear_mirror_link.call_args.kwargs["reason"] == (
+            UNBIND_REASON_DASHBOARD_UNLINK
+        )
+
+    @pytest.mark.asyncio
+    async def test_link_reports_a_conversation_claimed_mid_flight(self, tmp_path, monkeypatch):
+        """The genuine race: the precheck passed, then someone else claimed it.
+
+        Reported as the same 409 conflict rather than a 500, so the client offers
+        "unlink there first" instead of inviting a retry of a request that is
+        behaving correctly.
+        """
+        from kiro_crew.session_map import ConversationOwnershipConflict
+
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("telegram")
+        state.register_channel_transport(transport)
+        state.sessions.mirror_claim_blockers = MagicMock(return_value=[])
+        state.sessions.set_mirror_link = MagicMock(
+            side_effect=ConversationOwnershipConflict("claimed")
+        )
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "conversation_occupied"
+
 
 class TestMirrorReminder:
     @pytest.mark.asyncio

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -57,7 +57,11 @@ from kiro_crew.discord.transport_dispatch import (
     DiscordDispatcher,
 )
 from kiro_crew.messaging.attachments import cleanup
-from kiro_crew.messaging.link import ChannelLink, legacy_dashboard_mirror_key
+from kiro_crew.messaging.link import (
+    UNBIND_REASON_UNSPECIFIED,
+    ChannelLink,
+    legacy_dashboard_mirror_key,
+)
 from kiro_crew.messaging.queue_receipt import receipt_text as _receipt_text
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.session import _opt_out_key
@@ -265,6 +269,7 @@ class FakeSessions:
         link: Any,
         *,
         accepts_inbound: bool = False,
+        reason: str = UNBIND_REASON_UNSPECIFIED,
     ) -> None:
         # Interface parity with the real SessionMap: a conversation is exclusive
         # once it is inbound-committed — this claim is inbound-capable, or an
@@ -323,13 +328,15 @@ class FakeSessions:
             if candidate == link and (not inbound_only or key in self.inbound_mirror_keys)
         ]
 
-    def clear_mirror_link(self, key: str) -> bool:
+    def clear_mirror_link(self, key: str, *, reason: str = UNBIND_REASON_UNSPECIFIED) -> bool:
         self.batched_writes.append(self.batch_depth > 0)
         self.inbound_mirror_keys.discard(key)
         self.batched_writes.append(self.batch_depth > 0)
         return self.mirror_links.pop(key, None) is not None
 
-    def clear_mirror_links_at(self, link: Any) -> list[str]:
+    def clear_mirror_links_at(
+        self, link: Any, *, reason: str = UNBIND_REASON_UNSPECIFIED
+    ) -> list[str]:
         self.batched_writes.append(self.batch_depth > 0)
         cleared = self.find_mirror_sessions(link)
         for key in cleared:

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -9,7 +9,7 @@ import pytest
 from kiro_crew.discord.client import DiscordInteraction
 from kiro_crew.discord.commands import parse_command, parse_command_argument
 from kiro_crew.discord.transport_dispatch import DiscordDispatcher
-from kiro_crew.messaging.link import ChannelLink
+from kiro_crew.messaging.link import UNBIND_REASON_UNSPECIFIED, ChannelLink
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.session import _opt_out_key
 from kiro_crew.session_map import ConversationOwnershipConflict
@@ -96,6 +96,9 @@ class _Sessions:
         self.origin_links: dict[str, ChannelLink] = {}
         self.inbound_keys: set[str] = set()
         self.mirror_opt_outs: set[str] = set()
+        # Every reason a clear was made with, so a test can assert the in-channel
+        # unlink is attributed rather than landing as unattributed in the audit.
+        self.unbind_reasons: list[str] = []
         self.last_key = ""
         self.provider = _Provider()
 
@@ -105,6 +108,7 @@ class _Sessions:
         link: ChannelLink,
         *,
         accepts_inbound: bool = False,
+        reason: str = UNBIND_REASON_UNSPECIFIED,
     ) -> None:
         # Interface parity with the real SessionMap: a conversation is exclusive
         # once it is inbound-committed — this claim is inbound-capable, or an
@@ -160,11 +164,15 @@ class _Sessions:
             if candidate == link and (not inbound_only or key in self.inbound_keys)
         ]
 
-    def clear_mirror_link(self, key: str) -> bool:
+    def clear_mirror_link(self, key: str, *, reason: str = UNBIND_REASON_UNSPECIFIED) -> bool:
+        self.unbind_reasons.append(reason)
         self.inbound_keys.discard(key)
         return self.mirror_links.pop(key, None) is not None
 
-    def clear_mirror_links_at(self, link: ChannelLink) -> list[str]:
+    def clear_mirror_links_at(
+        self, link: ChannelLink, *, reason: str = UNBIND_REASON_UNSPECIFIED
+    ) -> list[str]:
+        self.unbind_reasons.append(reason)
         cleared = self.find_mirror_sessions(link)
         for key in cleared:
             self.inbound_keys.discard(key)

--- a/test/test_inbound_unbind_notice.py
+++ b/test/test_inbound_unbind_notice.py
@@ -1,0 +1,361 @@
+"""The channel notice for a removed inbound session-resume binding.
+
+``SessionMap`` audits every removal itself but cannot reach the conversation —
+that needs a transport, which the gateway owns. These pin the other half: the
+listener ``DashboardState`` registers, which reason it stays quiet for, and the
+delivery it performs through the governed cross-surface ladder.
+
+All against fakes — no real transport, session manager, or network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.messaging.link import ChannelLink
+
+LINK = ChannelLink(channel_type="discord", channel_id="chan-1")
+KEY = "discord:kirocrew:direct:42"
+
+
+def _has_running_loop() -> bool:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+class _Transport:
+    def __init__(self, fail: bool = False, proactive: bool = True) -> None:
+        self.sent: list[tuple[str, str, str | None]] = []
+        self.fail = fail
+        self.capabilities = SimpleNamespace(
+            supports_proactive_send=proactive, max_message_chars=2000
+        )
+
+    async def send_message(
+        self, conversation_id: str, content: str, thread_id: str | None = None
+    ) -> str:
+        if self.fail:
+            raise RuntimeError("discord down")
+        self.sent.append((conversation_id, content, thread_id))
+        return "mid-1"
+
+
+@pytest.fixture()
+def state(monkeypatch, tmp_path):
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    return DashboardState(
+        sessions=MagicMock(count=0),
+        crons=MagicMock(),
+        lessons=MagicMock(),
+        start_time=0.0,
+    )
+
+
+@contextmanager
+def _permit_governance():
+    """Permit the ladder's governance gate, which it imports at call time."""
+    with patch(
+        "kiro_crew.platform.governance_profiles.vet_and_audit",
+        return_value=SimpleNamespace(permitted=True),
+    ):
+        yield
+
+
+def _listener(state: DashboardState):
+    """Install the listener and return the closure handed to the session map."""
+    state.wire_session_unbind_listener()
+    state.sessions.set_unbind_listener.assert_called_once()
+    return state.sessions.set_unbind_listener.call_args[0][0]
+
+
+async def _sent(
+    state: DashboardState,
+    *,
+    title: str | None = None,
+    reason: str = "dashboard_unlink",
+) -> str:
+    """Deliver one notice through a fake transport and return the text it got."""
+    transport = _Transport()
+    state.channel_transports["discord"] = transport
+    title_patch = (
+        patch.object(state, "_unbind_notice_title", return_value=title)
+        if title is not None
+        else nullcontext()
+    )
+    with title_patch, _permit_governance():
+        await state._notify_inbound_unbind(KEY, LINK, reason)
+    assert len(transport.sent) == 1
+    assert transport.sent[0][0] == "chan-1"
+    return transport.sent[0][1]
+
+
+class TestWiring:
+    @pytest.mark.parametrize(
+        "reason, loop_closed, scheduled",
+        [
+            ("dashboard_unlink", False, True),
+            # The in-channel command already replied there, so a notice would echo.
+            ("user_unlink", False, False),
+            # A shutdown race must not raise out of a synchronous map callback.
+            ("entry_deleted", True, False),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_a_removal_schedules_the_notice_unless_suppressed(
+        self, state: DashboardState, reason: str, loop_closed: bool, scheduled: bool
+    ) -> None:
+        listener = _listener(state)
+        closed_patch = (
+            patch.object(asyncio.get_running_loop(), "is_closed", return_value=True)
+            if loop_closed
+            else nullcontext()
+        )
+        with patch.object(state, "_notify_inbound_unbind", AsyncMock()) as notify:
+            with closed_patch:
+                listener(KEY, LINK, reason)
+            # Two hops: call_soon_threadsafe lands the callback, which creates
+            # the task, which then runs.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        if scheduled:
+            notify.assert_awaited_once_with(KEY, LINK, reason)
+        else:
+            notify.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_notice_task_is_tracked_until_it_finishes(
+        self, state: DashboardState
+    ) -> None:
+        """An untracked task can be collected mid-send, silently losing the notice."""
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _slow(key: str, link: ChannelLink, reason: str) -> None:
+            started.set()
+            await release.wait()
+
+        with patch.object(state, "_notify_inbound_unbind", _slow):
+            _listener(state)(KEY, LINK, "dashboard_unlink")
+            await asyncio.wait_for(started.wait(), timeout=5)
+            # A strong reference is held for the task's whole lifetime.
+            assert len(state._background_tasks) == 1
+            task = next(iter(state._background_tasks))
+            release.set()
+            await asyncio.wait_for(task, timeout=5)
+
+        # Released on completion, so the set does not grow without bound.
+        assert state._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_notice_task_is_reaped_and_its_error_consumed(
+        self, state: DashboardState
+    ) -> None:
+        async def _boom(key: str, link: ChannelLink, reason: str) -> None:
+            raise RuntimeError("notice exploded")
+
+        with patch.object(state, "_notify_inbound_unbind", _boom):
+            _listener(state)(KEY, LINK, "entry_deleted")
+            for _ in range(20):
+                await asyncio.sleep(0)
+                if not state._background_tasks:
+                    break
+
+        assert state._background_tasks == set()
+
+
+class TestWorkerThreadDelivery:
+    """A clear on a worker thread must still reach the channel.
+
+    ``SessionMap`` is synchronous and reachable from ``asyncio.to_thread``, so a
+    listener that looked up the running loop at call time found none and dropped
+    the notice. The loop captured at wire time plus ``call_soon_threadsafe`` closes
+    that gap — and since the map holds its lock across the callback, the callback
+    must also return without waiting on the delivery.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_clear_from_a_worker_thread_is_delivered_without_blocking_it(
+        self, state: DashboardState
+    ) -> None:
+        transport = _Transport()
+        state.channel_transports["discord"] = transport
+        listener = _listener(state)
+        returned = threading.Event()
+
+        def _worker() -> None:
+            # No running loop on this thread — the exact condition that used to
+            # drop the notice.
+            assert not _has_running_loop()
+            listener(KEY, LINK, "dashboard_unlink")
+            # Set only after the callback returned, so waiting on it proves the
+            # callback did not block on the delivery it queued.
+            returned.set()
+
+        with _permit_governance():
+            thread = threading.Thread(target=_worker)
+            thread.start()
+            assert await asyncio.to_thread(returned.wait, 5) is True
+            thread.join(5)
+            # Drain the scheduled callback and the task it creates.
+            for _ in range(200):
+                if transport.sent:
+                    break
+                await asyncio.sleep(0.01)
+
+        assert len(transport.sent) == 1
+        assert "detached" in transport.sent[0][1]
+
+
+class TestDelivery:
+    @pytest.mark.asyncio
+    async def test_notice_names_the_session_by_key_without_a_tab(
+        self, state: DashboardState
+    ) -> None:
+        """No slot displays the session, so the key is what identifies it."""
+        assert KEY in await _sent(state, reason="session_destroyed")
+
+    @pytest.mark.parametrize(
+        "transport, permit",
+        [
+            (None, True),  # nothing registered for this channel
+            (_Transport(proactive=False), True),  # channel cannot be pushed to
+            (_Transport(fail=True), True),  # send raised
+            (_Transport(), False),  # governance denied
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_an_undeliverable_notice_is_a_silent_noop(
+        self, state: DashboardState, transport, permit: bool
+    ) -> None:
+        """The binding is already gone and audited; a failed notice adds nothing."""
+        state.channel_transports["discord"] = transport or _Transport(proactive=False)
+
+        with patch(
+            "kiro_crew.platform.governance_profiles.vet_and_audit",
+            return_value=SimpleNamespace(permitted=permit),
+        ):
+            await state._notify_inbound_unbind(KEY, LINK, "entry_deleted")
+
+        assert state.channel_transports["discord"].sent == []
+
+
+class TestNoticeIsSafeAndHuman:
+    """A user-controlled title must not carry secrets, pings or audit tokens out.
+
+    The title comes from a rename or an LLM, and the reason is an internal audit
+    dimension. Both reach a channel through this one notice, so both are sanitized
+    at the same boundary: the shared display sink, then a human phrase per reason
+    with a generic fallback.
+    """
+
+    # Split literals so this file carries no scannable secret in one token; both
+    # fixtures are ones the redactors are already pinned against in
+    # test_security.py. A well-formed S3 presigned URL is deliberately exempt
+    # (``_is_safe_presigned``), so the URL below carries a fixed credential in its
+    # query instead — the shape ``_exfil_url_warning`` classifies unconditionally.
+    AWS_KEY_ID = "AKIA" "IOSFODNN7EXAMPLE"
+    EXFIL_URL = "https://evil.example.com/collect?t=" + "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef12"
+    ZWSP = "\u200b"
+
+    @pytest.mark.parametrize(
+        "title, banned, expected",
+        [
+            # Credentials: plain, split by markup the channel renders away (the
+            # sink scans the CANONICAL display form), and adjacent to an @ so the
+            # defang's ZWSP cannot break the scan.
+            (f"deploy {AWS_KEY_ID} run", AWS_KEY_ID, None),
+            (f"**{AWS_KEY_ID[:4]}**{AWS_KEY_ID[4:]}", AWS_KEY_ID, None),
+            (f"@ops {AWS_KEY_ID}", AWS_KEY_ID, None),
+            (f"upload to {EXFIL_URL}", "evil.example.com/collect", None),
+            # Mentions, in both channel grammars, defanged but still readable.
+            ("ping <@1234567890>", "<@1234567890>", "@\u200b1234567890"),
+            ("@everyone look", "@everyone", "@\u200beveryone"),
+            ("see <!channel> now", "<!channel>", "<\u200b!channel>"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_a_dangerous_title_never_reaches_the_transport(
+        self, state: DashboardState, title: str, banned: str, expected: str | None
+    ) -> None:
+        text = await _sent(state, title=title)
+
+        assert banned not in text
+        if expected is not None:
+            assert expected in text
+        # The notice still goes out and still explains itself.
+        assert "detached" in text
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_title_passes_through_untouched(
+        self, state: DashboardState
+    ) -> None:
+        """Sanitization is not allowed to mangle the common case."""
+        text = await _sent(state, title="Refactor the billing importer")
+
+        assert "Refactor the billing importer" in text
+        assert "someone unlinked it from the dashboard" in text
+        assert "!sessions" in text
+        assert self.ZWSP not in text
+
+    @pytest.mark.parametrize(
+        "reason, banned",
+        [
+            ("dashboard_unlink", "dashboard_unlink"),
+            ("origin_rebind", "origin_rebind"),
+            ("session_destroyed", "session_destroyed"),
+            ("entry_deleted", "entry_deleted"),
+            ("unspecified", "unspecified"),
+            # An unmapped reason must not surface as itself either.
+            ("some_future_reason", "some_future_reason"),
+            # The reason slot is scanned too, not just the title.
+            (f"unlink {AWS_KEY_ID}", AWS_KEY_ID),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_no_audit_token_reaches_the_channel(
+        self, state: DashboardState, reason: str, banned: str
+    ) -> None:
+        text = await _sent(state, reason=reason)
+
+        assert banned not in text
+        assert "detached" in text
+
+    @pytest.mark.asyncio
+    async def test_an_unmapped_reason_falls_back_to_generic_copy(
+        self, state: DashboardState
+    ) -> None:
+        assert "the link was cleared" in await _sent(state, reason="some_future_reason")
+
+    def test_every_audited_reason_has_a_phrase(self) -> None:
+        """A new reason constant without copy would fall back silently."""
+        from kiro_crew.dashboard.state import _INBOUND_UNBIND_WHY
+        from kiro_crew.messaging.link import UNBIND_REASON_USER_UNLINK, UNBIND_REASONS
+
+        # user_unlink is never announced (the in-channel command already replied),
+        # so it is the one reason that needs no phrase.
+        assert UNBIND_REASONS - {UNBIND_REASON_USER_UNLINK} <= set(_INBOUND_UNBIND_WHY)
+
+    @pytest.mark.asyncio
+    async def test_a_delivery_failure_logs_at_warning(
+        self, state: DashboardState, caplog
+    ) -> None:
+        """A production gateway logs WARNING and above, so DEBUG is invisible."""
+        state.channel_transports["discord"] = _Transport(fail=True)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.dashboard.state"):
+            with _permit_governance():
+                await state._notify_inbound_unbind(KEY, LINK, "dashboard_unlink")
+
+        assert any("inbound-unbind notice" in r.message for r in caplog.records)

--- a/test/test_messaging_link.py
+++ b/test/test_messaging_link.py
@@ -283,3 +283,74 @@ class TestBindOriginMirror:
     def test_no_exception_from_the_claim_escapes(self) -> None:
         sess = _Sessions(raise_on_set=RuntimeError("session map on fire"))
         assert bind_origin_mirror(sess, key="k", location=_HERE) is False
+
+
+class TestUnbindReasonVocabulary:
+    """The audited reason strings are a closed set with one home.
+
+    A call site that invents a spelling fragments the audit trail into groups
+    nothing can join, and a duplicate value makes two causes indistinguishable in
+    it. Both are cheap to pin and impossible to notice by reading a diff.
+    """
+
+    def test_the_vocabulary_is_closed_and_unambiguous(self) -> None:
+        from kiro_crew.messaging import link as link_mod
+
+        declared = [
+            value
+            for name, value in vars(link_mod).items()
+            if name.startswith("UNBIND_REASON_") and isinstance(value, str)
+        ]
+        # Closed set, and no two causes share a spelling — a duplicate would make
+        # them indistinguishable in the audit.
+        assert set(declared) == set(link_mod.UNBIND_REASONS)
+        assert len(declared) == len(set(declared))
+
+    def test_no_call_site_passes_a_bare_reason_literal(self) -> None:
+        """A literal at a binding call site bypasses the vocabulary entirely.
+
+        Scoped by AST to the methods that actually carry an unbind reason —
+        ``reason=`` is an ordinary kwarg name elsewhere in the package (autonudge
+        stop reasons, history archive reasons), and a text scan would flag those.
+        The planted sample proves the scanner fires at all.
+        """
+        import ast
+        from pathlib import Path
+
+        import kiro_crew
+
+        binding_calls = {
+            "clear_mirror_link",
+            "clear_mirror_links_at",
+            "set_mirror_link",
+            "delete",
+        }
+
+        def _bare_reasons(tree: ast.AST) -> list[int]:
+            hits = []
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+                if name not in binding_calls:
+                    continue
+                for kw in node.keywords:
+                    if kw.arg == "reason" and isinstance(kw.value, ast.Constant):
+                        hits.append(kw.value.lineno)
+            return hits
+
+        planted = ast.parse('s.clear_mirror_link(key, reason="made_up")\n')
+        assert len(_bare_reasons(planted)) == 1, "the scanner does not fire"
+
+        pkg = Path(kiro_crew.__file__).resolve().parent
+        offenders = [
+            f"{path.relative_to(pkg)}:{line}"
+            for path in pkg.rglob("*.py")
+            if "_vendor" not in path.parts
+            for line in _bare_reasons(ast.parse(path.read_text(encoding="utf-8")))
+        ]
+        assert not offenders, (
+            "unbind reasons must come from messaging.link's UNBIND_REASON_* "
+            f"constants, not bare literals: {offenders}"
+        )

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -691,9 +691,18 @@ class TestRedactionSinkRegistry:
         # Wrappers that run BOTH scanners internally, so a sink using one is fully
         # covered: StreamRedactor (rolling dual-pass), redact() (the dual-pass
         # helper), redact_and_truncate() (redact-then-slice, so a credential cannot
-        # straddle the truncation boundary), and redact_via_context() (routes to
-        # CredentialPolicy.redact, whose Default delegates to security.redact).
-        dual_pass = ("StreamRedactor", "redact(", "redact_tree", "redact_and_truncate", "redact_via_context")
+        # straddle the truncation boundary), redact_via_context() (routes to
+        # CredentialPolicy.redact, whose Default delegates to security.redact), and
+        # display_safe() (redact_for_display with the exfil+credential redactor,
+        # then the mention defang).
+        dual_pass = (
+            "StreamRedactor",
+            "redact(",
+            "redact_tree",
+            "redact_and_truncate",
+            "redact_via_context",
+            "display_safe",
+        )
         for label, module, detail in security_posture._REDACTION_SINKS:
             text = (pkg / module).read_text(encoding="utf-8")
             full = any(w in text for w in dual_pass) or (
@@ -724,6 +733,7 @@ class TestRedactionSinkRegistry:
             "streamredactor": "StreamRedactor",
             "redact_and_truncate": "redact_and_truncate",
             "redact_via_context": "redact_via_context",
+            "display_safe": "display_safe",
             "exfiltration-url scanning only": "redact_exfiltration_urls",
         }
         for label, module, detail in security_posture._REDACTION_SINKS:

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -2016,7 +2016,9 @@ class TestDestroy:
         with patch.object(mgr._session_map, "delete") as mock_delete:
             await mgr.destroy("k1")
         provider.shutdown.assert_awaited_once()
-        mock_delete.assert_called_once_with("k1")
+        # The reason is part of the call: a destroyed session takes any inbound
+        # resume binding with it, and the map audits the removal under this name.
+        mock_delete.assert_called_once_with("k1", reason="session_destroyed")
         assert not mgr.has_session("k1")
 
     @pytest.mark.asyncio
@@ -2024,7 +2026,7 @@ class TestDestroy:
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
         with patch.object(mgr._session_map, "delete") as mock_delete:
             await mgr.destroy("nonexistent")
-        mock_delete.assert_called_once_with("nonexistent")
+        mock_delete.assert_called_once_with("nonexistent", reason="session_destroyed")
 
     @pytest.mark.asyncio
     async def test_destroy_shutdown_exception_still_deletes_map(self, cfg):
@@ -2036,7 +2038,7 @@ class TestDestroy:
             with pytest.raises(RuntimeError, match="boom"):
                 await mgr.destroy("k1")
         # finally block still runs
-        mock_delete.assert_called_once_with("k1")
+        mock_delete.assert_called_once_with("k1", reason="session_destroyed")
 
 
 class TestDiscardConversation:

--- a/test/test_session_map_mirror.py
+++ b/test/test_session_map_mirror.py
@@ -9,17 +9,27 @@ Slack ``ChannelLink`` without needing migration.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import asyncio
+import logging
+import threading
+import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from kiro_crew.messaging.link import (
+    UNBIND_REASON_UNSPECIFIED,
     ChannelLink,
     legacy_dashboard_mirror_key,
     release_conversation_location,
 )
 from kiro_crew.session import SessionManager, _opt_out_key
-from kiro_crew.session_map import MIRROR_OPT_OUT_FLAG, ConversationOwnershipConflict, SessionMap
+from kiro_crew.session_map import (
+    MIRROR_OPT_OUT_FLAG,
+    ConversationOwnershipConflict,
+    SessionMap,
+    set_unbind_listener,
+)
 
 
 @pytest.fixture()
@@ -871,3 +881,379 @@ class TestAutomaticMirrorOptOut:
         # The repair reached disk, so the next startup does not redo it.
         assert reloaded.get_flag(key, MIRROR_OPT_OUT_FLAG) is True
         assert not (reloaded._data.get(key) or {}).get("sid")
+
+
+INBOUND_LINK = ChannelLink(channel_type="discord", channel_id="chan-1")
+
+
+@pytest.fixture()
+def unbind_calls():
+    """Capture ``(key, link, reason)`` per announced removal, then unregister.
+
+    The listener registry is module-level (a removal performed through a
+    throwaway map must still be announced), so it is restored unconditionally —
+    a leaked listener would fire on every later test in this worker.
+    """
+    calls: list[tuple[str, ChannelLink, str]] = []
+    set_unbind_listener(lambda key, link, reason: calls.append((key, link, reason)))
+    try:
+        yield calls
+    finally:
+        set_unbind_listener(None)
+
+
+@pytest.fixture()
+def sel_events():
+    """Capture every SEL event the map emits during a removal."""
+    with patch("kiro_crew.session_map.sel") as fake_sel:
+        fake_sel.return_value.log_api_access = MagicMock()
+        yield fake_sel.return_value.log_api_access
+
+
+def _inbound_audits(log_api_access):
+    """The inbound-unbind events among everything captured."""
+    return [
+        call.kwargs
+        for call in log_api_access.call_args_list
+        if call.kwargs.get("operation") == "session.inbound_unbind"
+    ]
+
+
+class TestInboundUnbindIsLoud:
+    """Every removal of an inbound resume binding is audited and announced.
+
+    The binding is what routes a channel message back to an existing session, so
+    losing it silently strands the conversation and nothing in the trail says which
+    removal did it. These pin the choke point rather than the call sites, so a
+    future caller inherits the behavior instead of having to remember it.
+    """
+
+    def test_clear_mirror_link_audits_and_announces(
+        self, session_map, unbind_calls, sel_events
+    ):
+        session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+        assert session_map.clear_mirror_link("dashboard:chat-1", reason="dashboard_unlink")
+
+        assert unbind_calls == [("dashboard:chat-1", INBOUND_LINK, "dashboard_unlink")]
+        audits = _inbound_audits(sel_events)
+        assert len(audits) == 1
+        assert "dashboard:chat-1" in audits[0]["resources"]
+        assert "discord:chan-1" in audits[0]["resources"]
+        assert "dashboard_unlink" in audits[0]["resources"]
+
+    def test_clear_mirror_links_at_announces_each_loser(
+        self, session_map, unbind_calls, sel_events
+    ):
+        """A location sweep can clear several sessions; each lost its own way back."""
+        plant_binding(session_map, "dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+        plant_binding(session_map, "dashboard:chat-2", INBOUND_LINK, accepts_inbound=True)
+
+        cleared = session_map.clear_mirror_links_at(INBOUND_LINK, reason="user_unlink")
+
+        assert sorted(cleared) == ["dashboard:chat-1", "dashboard:chat-2"]
+        assert sorted(key for key, _, _ in unbind_calls) == [
+            "dashboard:chat-1",
+            "dashboard:chat-2",
+        ]
+        assert {reason for _, _, reason in unbind_calls} == {"user_unlink"}
+        assert len(_inbound_audits(sel_events)) == 2
+
+    @pytest.mark.parametrize(
+        "removal, reason",
+        [
+            # An explicit clear through set_mirror_link(None).
+            (lambda m, k: m.set_mirror_link(k, None, reason="dashboard_unlink"),
+             "dashboard_unlink"),
+            # An overwrite onto another location ends the old resume as thoroughly.
+            (lambda m, k: m.set_mirror_link(
+                k,
+                ChannelLink(channel_type="discord", channel_id="chan-2"),
+                accepts_inbound=True,
+                reason="origin_rebind",
+            ), "origin_rebind"),
+            # Same location, inbound flag dropped: no longer resumable.
+            (lambda m, k: m.set_mirror_link(k, INBOUND_LINK, reason="origin_rebind"),
+             "origin_rebind"),
+            # A whole-entry delete carrying its caller's reason.
+            (lambda m, k: m.delete(k, reason="session_destroyed"), "session_destroyed"),
+            # A caller that names none is recorded as unattributed, not skipped.
+            (lambda m, k: m.clear_mirror_link(k), UNBIND_REASON_UNSPECIFIED),
+        ],
+    )
+    def test_every_removal_shape_announces_with_its_reason(
+        self, session_map, unbind_calls, removal, reason
+    ):
+        session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+        removal(session_map, "dashboard:chat-1")
+
+        assert unbind_calls == [("dashboard:chat-1", INBOUND_LINK, reason)]
+
+    def test_rebinding_the_same_inbound_binding_is_not_a_removal(
+        self, session_map, unbind_calls
+    ):
+        session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+        session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+
+        assert unbind_calls == []
+
+    def test_deleting_the_whole_entry_announces(self, session_map, unbind_calls, sel_events):
+        """A dying entry takes its binding with it, so the entry path announces too."""
+        session_map.set("dashboard:chat-1", "sid-1")
+        session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+
+        session_map.delete("dashboard:chat-1")
+
+        assert unbind_calls == [("dashboard:chat-1", INBOUND_LINK, "entry_deleted")]
+        assert len(_inbound_audits(sel_events)) == 1
+
+    def test_prune_repairs_a_bound_entry_without_unbinding_it(self, session_map, unbind_calls):
+        """A stale sid on a bound entry clears the sid; the binding is not a casualty.
+
+        ``_survives_prune`` keeps any entry carrying a channel binding, so prune
+        cannot reach an inbound binding at all — nothing is removed, so nothing is
+        announced.
+        """
+        session_map.set("dashboard:chat-1", "sid-that-no-longer-exists")
+        session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+
+        assert session_map.prune() == 0
+        assert session_map.get_mirror_link("dashboard:chat-1") == INBOUND_LINK
+        assert session_map.mirror_accepts_inbound("dashboard:chat-1") is True
+        assert unbind_calls == []
+
+
+class TestOutboundOnlyStaysQuiet:
+    """An outbound-only mirror routes nothing back, so losing it strands nobody."""
+
+    @pytest.mark.parametrize(
+        "setup, remove",
+        [
+            # An outbound-only mirror, cleared by key and deleted with its entry;
+            # a Slack binding (its own reverse index); and an inbound flag with no
+            # mirror, which routes nothing and so is no loss.
+            (lambda m: m.set_mirror_link("dashboard:chat-1", INBOUND_LINK),
+             lambda m: m.clear_mirror_link("dashboard:chat-1")),
+            (lambda m: m.set_mirror_link("dashboard:chat-1", INBOUND_LINK),
+             lambda m: m.delete("dashboard:chat-1")),
+            (lambda m: m.set_mirror_link(
+                "dashboard:chat-1",
+                ChannelLink(channel_type="slack", channel_id="C1", thread_id="ts-1"),
+             ),
+             lambda m: m.clear_mirror_link("dashboard:chat-1")),
+            (lambda m: (m._ensure_entry("dashboard:chat-1").update(
+                {"mirror_accepts_inbound": True}), m._save()),
+             lambda m: m.delete("dashboard:chat-1")),
+        ],
+    )
+    def test_losing_it_announces_nothing(
+        self, session_map, unbind_calls, sel_events, setup, remove
+    ):
+        setup(session_map)
+        remove(session_map)
+
+        assert unbind_calls == []
+        assert _inbound_audits(sel_events) == []
+
+    def test_sweeping_outbound_mirrors_does_not_announce(self, session_map, unbind_calls):
+        plant_binding(session_map, "dashboard:chat-1", INBOUND_LINK)
+        plant_binding(session_map, "dashboard:chat-2", INBOUND_LINK)
+
+        assert len(session_map.clear_mirror_links_at(INBOUND_LINK)) == 2
+        assert unbind_calls == []
+
+
+class TestAnnouncementIsBestEffort:
+    """A broken notifier or audit sink cannot fail the removal that provoked it."""
+
+    def test_listener_exception_is_swallowed_and_logged_at_warning(
+        self, session_map, caplog
+    ):
+        def _explode(key, link, reason):
+            raise RuntimeError("notifier down")
+
+        set_unbind_listener(_explode)
+        try:
+            with caplog.at_level(logging.WARNING, logger="kiro_crew.session_map"):
+                session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+                assert session_map.clear_mirror_link("dashboard:chat-1") is True
+        finally:
+            set_unbind_listener(None)
+        # The removal still committed, and the failure is visible in production.
+        assert session_map.get_mirror_link("dashboard:chat-1") is None
+        assert any("listener failed" in r.message for r in caplog.records)
+
+    def test_manager_registers_on_the_shared_registry(self, session_map, tmp_path):
+        """A removal through a DIFFERENT map instance is announced too."""
+        calls: list[str] = []
+        _manager_over(session_map).set_unbind_listener(
+            lambda key, link, reason: calls.append(key)
+        )
+        try:
+            session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+            with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+                other = SessionMap()
+            other.clear_mirror_link("dashboard:chat-1")
+        finally:
+            set_unbind_listener(None)
+
+        assert calls == ["dashboard:chat-1"]
+
+
+class TestAuditDoesNotBlockTheLoop:
+    """The SEL write, ``sel()`` resolution included, must leave the loop free.
+
+    ``sel()`` resolves the data home, creates the log and mints the HMAC trust root
+    on its first call, and every write appends. ``SessionMap`` is called
+    synchronously from coroutines, so doing that inline stalls the gateway.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_loop_keeps_beating_while_the_audit_runs(
+        self, session_map, unbind_calls
+    ):
+        """The clear must RETURN while the sink is still blocked.
+
+        Timing the synchronous call is the only assertion that fails when ``sel()``
+        is resolved on the caller's thread: a heartbeat measured after the call
+        returns cannot tell a stall from a slow sink.
+        """
+        entered = threading.Event()
+        release = threading.Event()
+
+        def _blocking_sel():
+            entered.set()
+            # Long enough that an inline resolution cannot finish inside the
+            # assertion below; released in the finally so nothing hangs.
+            release.wait(30)
+            return MagicMock()
+
+        session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+        try:
+            with patch("kiro_crew.session_map.sel", _blocking_sel):
+                started = time.monotonic()
+                session_map.clear_mirror_link("dashboard:chat-1", reason="dashboard_unlink")
+                elapsed = time.monotonic() - started
+                # The audit is in flight on the executor...
+                assert await asyncio.to_thread(entered.wait, 10) is True
+                # ...and the loop-side caller did not wait for it.
+                assert elapsed < 1.0, f"clear blocked the caller for {elapsed:.1f}s"
+                # The loop is still able to run work.
+                beats = 0
+                for _ in range(5):
+                    await asyncio.sleep(0)
+                    beats += 1
+                assert beats == 5
+        finally:
+            release.set()
+
+    @pytest.mark.asyncio
+    async def test_an_audit_failure_is_isolated_and_logged_at_warning(
+        self, session_map, caplog
+    ):
+        session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_map"):
+            with patch("kiro_crew.session_map.sel", side_effect=RuntimeError("sel down")):
+                # The removal still commits despite the broken sink.
+                assert session_map.clear_mirror_link("dashboard:chat-1") is True
+                for _ in range(200):
+                    if any("audit failed" in r.message for r in caplog.records):
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert session_map.get_mirror_link("dashboard:chat-1") is None
+        assert any("audit failed" in r.message for r in caplog.records)
+
+    def test_off_loop_the_audit_runs_inline_exactly_once(self, session_map):
+        """With no loop to protect there is nothing to offload to."""
+        calls: list[dict] = []
+        fake = MagicMock()
+        fake.log_api_access = lambda **kw: calls.append(kw)
+
+        session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+        with patch("kiro_crew.session_map.sel", return_value=fake):
+            session_map.clear_mirror_link("dashboard:chat-1", reason="dashboard_unlink")
+
+        assert len(calls) == 1
+        assert calls[0]["operation"] == "session.inbound_unbind"
+        assert "dashboard_unlink" in calls[0]["resources"]
+
+
+class TestReasonIsNormalizedAtTheChokePoint:
+    """An unexpected reason must not reach SEL or the notice copy."""
+
+    def test_an_unknown_reason_is_normalized_and_warned(
+        self, session_map, unbind_calls, caplog
+    ):
+        session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_map"):
+            session_map.clear_mirror_link("dashboard:chat-1", reason="totally_made_up")
+
+        assert unbind_calls == [
+            ("dashboard:chat-1", INBOUND_LINK, UNBIND_REASON_UNSPECIFIED)
+        ]
+        assert any("totally_made_up" in r.getMessage() for r in caplog.records)
+
+
+class TestGetRepairsRatherThanUnbinds:
+    """``get()``'s stale-entry path must not delete a bound conversation.
+
+    Same hazard prune was corrected for: a garbage-collected session file leaves a
+    stale ``sid``, and deleting the whole entry takes the channel binding with it.
+    """
+
+    @pytest.mark.parametrize(
+        "plant, verify",
+        [
+            # A mirror binding (the inbound resume identity), a Slack thread, and a
+            # durable per-conversation SETTING — each must outlive the session.
+            (
+                lambda m, k: m.set_mirror_link(k, INBOUND_LINK, accepts_inbound=True),
+                lambda m, k: m.get_mirror_link(k) == INBOUND_LINK
+                and m.mirror_accepts_inbound(k) is True,
+            ),
+            (
+                lambda m, k: m.set_slack_link(k, "ts-1", "C1"),
+                lambda m, k: m.get_slack_link(k) == ("ts-1", "C1"),
+            ),
+            (
+                lambda m, k: m.set_flag(k, MIRROR_OPT_OUT_FLAG, True),
+                lambda m, k: m.get_flag(k, MIRROR_OPT_OUT_FLAG) is True,
+            ),
+        ],
+    )
+    def test_state_that_must_outlive_the_session_survives(
+        self, session_map, unbind_calls, plant, verify
+    ):
+        key = "dashboard:chat-1"
+        session_map.set(key, "sid-that-no-longer-exists")
+        plant(session_map, key)
+
+        assert session_map.get(key) is None
+        assert key in session_map._data
+        assert not session_map._data[key]["sid"]
+        assert verify(session_map, key)
+        # Nothing was unbound, so nothing is audited or announced.
+        assert unbind_calls == []
+
+    def test_the_repair_reaches_disk(self, session_map, unbind_calls, tmp_path):
+        key = "dashboard:chat-1"
+        session_map.set(key, "sid-that-no-longer-exists")
+        session_map.set_mirror_link(key, INBOUND_LINK, accepts_inbound=True)
+        assert session_map.get(key) is None
+
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            reloaded = SessionMap()
+
+        assert reloaded.get_mirror_link(key) == INBOUND_LINK
+        assert unbind_calls == []
+
+    def test_a_truly_unbound_stale_entry_is_still_collected(
+        self, session_map, unbind_calls
+    ):
+        key = "dashboard:chat-1"
+        session_map.set(key, "sid-gone")
+
+        assert session_map.get(key) is None
+        assert key not in session_map._data
+        # It held no binding, so there is nothing to announce.
+        assert unbind_calls == []

--- a/test/test_session_more_coverage.py
+++ b/test/test_session_more_coverage.py
@@ -39,7 +39,7 @@ import pytest
 
 from kiro_crew import platform_compat
 from kiro_crew.config import KiroCrewConfig
-from kiro_crew.messaging.link import ChannelLink
+from kiro_crew.messaging.link import UNBIND_REASON_UNSPECIFIED, ChannelLink
 from kiro_crew.session import (
     BACKGROUND_KEY,
     SessionManager,
@@ -151,8 +151,18 @@ class TestSessionMapDelegation:
     def test_set_mirror_link_forwards_accepts_inbound_as_a_keyword(self, mgr, smap) -> None:
         link = ChannelLink(channel_type="discord", channel_id="C9")
         mgr.set_mirror_link("dashboard:a", link, accepts_inbound=True)
+        # The unbind reason rides along on the same call: a rebind through this
+        # wrapper can displace an inbound binding, and the map's audit is what
+        # records which caller did it.
         smap.set_mirror_link.assert_called_once_with(
-            "dashboard:a", link, accepts_inbound=True
+            "dashboard:a", link, accepts_inbound=True, reason=UNBIND_REASON_UNSPECIFIED
+        )
+
+    def test_set_mirror_link_forwards_a_callers_reason(self, mgr, smap) -> None:
+        link = ChannelLink(channel_type="discord", channel_id="C9")
+        mgr.set_mirror_link("dashboard:a", link, reason="origin_rebind")
+        smap.set_mirror_link.assert_called_once_with(
+            "dashboard:a", link, accepts_inbound=False, reason="origin_rebind"
         )
 
     def test_get_mirror_link_returns_the_stored_link(self, mgr, smap) -> None:

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -19,7 +19,11 @@ from unittest.mock import patch
 
 from kiro_crew.acp.client import AcpError
 from kiro_crew.acp.types import EVENT_COMPACTION_STATUS, EVENT_COMPLETE, EVENT_TEXT_CHUNK
-from kiro_crew.messaging.link import ChannelLink, legacy_dashboard_mirror_key
+from kiro_crew.messaging.link import (
+    UNBIND_REASON_UNSPECIFIED,
+    ChannelLink,
+    legacy_dashboard_mirror_key,
+)
 from kiro_crew.messaging.renderer import (
     DONE,
     STEER_CONSUMED,
@@ -319,7 +323,9 @@ class FakeSessions:
     def max_generation(self, bucket: str) -> int:
         return -1
 
-    def set_mirror_link(self, key: str, link: Any) -> None:
+    def set_mirror_link(
+        self, key: str, link: Any, *, reason: str = UNBIND_REASON_UNSPECIFIED
+    ) -> None:
         self.batched_writes.append(self.batch_depth > 0)
         self.mirror_links[key] = link
 
@@ -344,11 +350,13 @@ class FakeSessions:
     def mirror_opt_out(self, key: str) -> bool:
         return _opt_out_key(key) in self.mirror_opt_outs
 
-    def clear_mirror_link(self, key: str) -> bool:
+    def clear_mirror_link(self, key: str, *, reason: str = UNBIND_REASON_UNSPECIFIED) -> bool:
         self.batched_writes.append(self.batch_depth > 0)
         return self.mirror_links.pop(key, None) is not None
 
-    def clear_mirror_links_at(self, link: Any) -> list[str]:
+    def clear_mirror_links_at(
+        self, link: Any, *, reason: str = UNBIND_REASON_UNSPECIFIED
+    ) -> list[str]:
         cleared = [key for key, candidate in self.mirror_links.items() if candidate == link]
         for key in cleared:
             self.mirror_links.pop(key, None)


### PR DESCRIPTION
## Problem

An inbound resume binding (a `SessionMap` entry with `mirror` plus
`mirror_accepts_inbound`) is what routes a channel message back into an existing
session. When it is removed, the conversation is stranded: the user's next
message silently starts a brand-new session, with no notice in the channel and
nothing in the trail saying which removal did it.

Four paths can remove one, and only one of them said anything at all:

- the dashboard `mirror-unlink` endpoint SEL-logs the click, but never tells the
  bound channel — a Discord DM was detached this way with zero notice
- `clear_mirror_link`, `clear_mirror_links_at`, `set_mirror_link(None)` or an
  overwrite, and whole-entry `delete()` were all completely silent

The lifecycle log lines that exist are INFO, and a production gateway logs
WARNING and above, so those removals left no trace anywhere.

## Why it matters

The user is left with a conversation that looks connected and is not. Their next
message opens a fresh session, the history they were working in is not there, and
nothing anywhere says why. On the operator side there is no record of which
removal did it, so the state cannot be reconstructed after the fact.

## Fix (symptom → root cause → change)

The symptom is "the reply started a new session"; the root cause is that binding
removal had no single choke point, so each call path decided on its own whether to
say anything, and all but one said nothing.

So the fix is one choke point in `SessionMap` — `_note_inbound_unbind` — with one
predicate, `_inbound_binding`, deciding what counts as an inbound binding. Every
removal path funnels through it, so a new call site inherits the behavior instead
of having to remember it:

- `clear_mirror_link`
- `clear_mirror_links_at` (each swept session announced separately)
- `set_mirror_link(None)`, and an overwrite that displaces an inbound binding —
  rebinding to another location, or to the same one as outbound-only
- `_remove_entry` / `delete()`, the only path a whole entry leaves the map by

Three housekeeping paths deliberately do **not** appear, because none of them
removes a binding:

| path | what it does instead |
| --- | --- |
| context-overflow recycle | clears the `sid`, keeps the entry |
| `prune()` | keeps any entry `_survives_prune` matches, repairs its stale `sid` |
| `get()`'s stale-entry repair | same predicate as `prune` — repairs a bound entry, only removes a truly unbound one |

`get()` is included in this PR because it had the same hazard `prune` was
corrected for: it deleted the whole entry on a stale `sid`, taking the channel
binding with it, and sent an unattributed notice for a removal the user never
asked for. It now asks `_survives_prune` and repairs.

## The audit write is off the event loop

The hook emits a SEL `api_access` event, `operation="session.inbound_unbind"`,
with the key, the bound location and the reason in `resources`.

`sel()` does real filesystem work on its first call — it resolves the data home,
creates the log and mints the HMAC trust root — and every write appends.
`SessionMap` is synchronous and called inline from coroutines, so doing that work
on the caller's thread stalls the gateway for the duration of the disk I/O. The
**whole closure, `sel()` resolution included**, therefore runs in the running
loop's executor, with the Future retained in `_audit_futures` and its result
consumed so a failure logs instead of vanishing. Off the loop (a worker thread,
the CLI, a test) there is nothing to protect and it runs inline — exactly one
event either way, and no thread spawned per event.

## Reason vocabulary, normalized at the choke point

The public clearing methods take a keyword-only `reason` drawn from a closed
vocabulary in `messaging/link.py` (`UNBIND_REASONS`), threaded from the call
sites and **normalized in the map**: an unexpected value is logged at WARNING and
recorded as `unspecified`, so it can neither inflate SEL cardinality nor reach
user-facing copy.

| call site | reason |
| --- | --- |
| `dashboard/chat_mirror.py` mirror-unlink endpoint | `dashboard_unlink` |
| `messaging/link.py` `release_conversation_location` (in-channel unlink) | `user_unlink` |
| `discord/session_resume.py` `leave_resumed_session` | `user_unlink` |
| `discord/transport_dispatch.py` origin-mirror link | `origin_rebind` |
| `telegram/transport_dispatch.py` `_handle_link` | `origin_rebind` |
| `SessionManager.destroy()` | `session_destroyed` |
| `delete()` with no reason given | `entry_deleted` |
| anything not yet threaded | `unspecified` |

Call sites import the constants; a test walks the package's AST and fails on a
bare `reason="..."` literal at any binding call, so the vocabulary cannot
fragment.

## Notification

`SessionMap` is the synchronous store every surface sits on, so it must not
import transports. It exposes `set_unbind_listener(cb(key, link, reason))`
instead, registered by the gateway at startup (`DashboardState.
wire_session_unbind_listener`, alongside the existing compact and recycle
callbacks). Wiring runs on the gateway's event loop and captures it, so a clear
arriving on a worker thread — where there is no running loop — still queues the
send via `call_soon_threadsafe`. The callback stays synchronous and returns
immediately, because the map holds its lock across it. The scheduled task is kept
in `_background_tasks` and discarded on completion, the same strong-reference
pattern `_spawn_ws_send` uses, so it cannot be collected mid-send.

The notice:

> 🔗 This conversation was detached from session "&lt;title&gt;" — someone unlinked
> it from the dashboard. Run `!sessions` to reattach.

Each audited reason maps to a human phrase at the notice boundary, so no audit
token reaches the channel and the two vocabularies evolve independently; an
unmapped reason falls back to generic safe copy rather than surfacing as itself.

Delivery rides the governed cross-surface ladder (`_resolve_channel_target`), so
it is capability-checked and governance-vetted like every other outbound notice.
The title is user-controlled, so the rendered notice goes through the **shared**
`messaging.renderer.display_safe` sink — display canonicalization, exfiltration
URLs, credentials, then mention defang (`@` → `@\u200b`, `<!` → `<\u200b!`).
Redaction runs first on purpose: the zero-width space is a transformation applied
after the scan, and inserting it first could split a credential so the regex stops
matching while the channel still renders it whole. Promoting the renderer's own
helper rather than adding a second copy is what keeps one text from being
sanitized two ways.

`user_unlink` is audited but **not** announced: the in-channel unlink command
already replied in that same conversation, so a notice would be an echo.
Suppression lives in the listener, not the map — the map audits unconditionally,
and only the listener knows what the user has already been told.

Every leg is best-effort, and every swallowed failure logs at **WARNING** rather
than DEBUG, because a production gateway logs WARNING and above: a listener
exception, a broken audit sink, or a closed loop must not fail a session teardown
that reaches this code from a `finally`, but it must not be invisible either.

## Scope

Inbound bindings only. Outbound-only mirrors route nothing back, so clearing one
strands nobody and stays silent. Slack's `slack_thread_ts` / `slack_channel_id`
fields and its own reverse index are untouched — Slack never sets this flag, and
**Slack reverse-link removal is explicitly deferred**: it routes inbound through a
separate index with its own lifecycle, and folding it in would widen this PR past
its purpose.

No new endpoints, no sweeps, no persistence.

## Tests

Targeted files, all passing (1193 tests):

- `test/test_session_map_mirror.py` — every removal shape announces once with its
  reason and emits one SEL event; outbound-only clears, Slack clears, and an
  inbound flag with no mirror stay silent; a same-location same-flag rebind is not
  a removal; `prune()` and `get()` both repair a bound entry's stale sid without
  unbinding it, while a truly unbound stale entry is still collected; the audit
  leaves the loop free while a blocked sink is in flight (timed, so an inline
  `sel()` fails it), lands exactly once, and isolates its failures at WARNING; an
  unknown reason is normalized with a WARNING
- `test/test_inbound_unbind_notice.py` — the wiring, `user_unlink` suppression and
  closed-loop skip; delivery to a fake transport; the sanitization matrix
  (credential plain, markdown-split, and adjacent to `@`; exfiltration URL;
  `<@id>`, `@everyone`, `<!channel>`) with an ordinary title left untouched and no
  stray zero-width space; every reason's human phrasing plus the unmapped
  fallback; WARNING-level delivery-failure log; task tracking, release and error
  consumption; and delivery from a real worker thread synchronized on an event
  rather than a sleep, which also proves the callback does not block it
- `test/test_messaging_link.py` — the reason vocabulary is closed and unambiguous,
  and no binding call site passes a bare literal (with a planted sample proving
  the scanner fires)
- `test/test_security_posture.py` + `test/test_spawn_audit.py` — the SEL/spawn
  drift guards, with the detach-notice sink row naming the shared `display_safe`
  sink so the guard proves the real one
- `test/test_session.py`, `test/test_chat_mirror.py`, `test/test_discord.py`,
  `test/test_discord_sessions.py`, `test/test_telegram.py`,
  `test/test_slack_mirror_unlink.py`, `test/test_dashboard_state_ws.py`,
  `test/test_session_more_coverage.py`, `test/test_session_map_locking.py`,
  `test/test_options_cap_contract.py`, `test/test_slack_render_pipeline.py`,
  `test/test_channel_connect_row.py`, `test/test_capability_ledger.py`

Mutation-checked: resolving `sel()` outside the offloaded closure, deleting a
bound entry in `get()`, and dropping the reason normalizer each fail their
matching test.

`isort`, `flake8` and CI-parity `mypy` (967 files) are clean.
`chat_mirror.py` coverage is **82%** (194/238), above the 80% floor. The full
suite is left to CI.

## Manual verification

N/A — unit coverage is sufficient. Every path is exercised against a fake
transport, including the worker-thread, blocked-sink and closed-loop cases that a
manual click cannot reach.

<!-- no-visual-delta -->
**Why no screenshot:** backend only — no dashboard component, layout or string
changes; the one user-visible string is a channel message asserted in tests.

no linked issue: found while reviewing the mirror-binding lifecycle, not filed
separately.
