### PR TITLE
fix(playwright-cli): correct four installer defects and cut meta-test sediment

### DIFF
--- a/playwright-cli.ps1
+++ b/playwright-cli.ps1
@@ -137,7 +137,8 @@ Environment:
   KIROCREW_PLAYWRIGHT_CLI_HOME  overrides -Prefix
   KIROCREW_NPM_REGISTRY         overrides -Registry
   KIROCREW_NODE_BIN_DIR         an existing Node bin dir to reuse
-  HTTPS_PROXY / NO_PROXY        honored by npm
+  HTTPS_PROXY                   honored by npm and the Node download
+  NO_PROXY                      honored by npm only
   NODE_EXTRA_CA_CERTS           CA bundle for a TLS-terminating proxy
 
 Exit codes:
@@ -374,6 +375,12 @@ $script:NodeWasBootstrapped = $false
 function Try-Node([string]$Candidate) {
     if ([string]::IsNullOrWhiteSpace($Candidate)) { return $false }
     if (-not (Test-Path -LiteralPath $Candidate -PathType Leaf)) { return $false }
+    # Parity with the .sh guard against ':' in a candidate's directory. ';' is legal
+    # in an NTFS name and is also the PATH separator, so accepting it would splice
+    # bogus entries into the npm subprocess PATH and into the generated .cmd
+    # wrapper. Reachable via KIROCREW_NODE_BIN_DIR, the node-bin-dir marker, or a
+    # PATH lookup; $Prefix is already screened for it upstream.
+    if ((Split-Path -Parent $Candidate) -match ';') { return $false }
     # $ErrorActionPreference is 'Stop' globally, and Windows PowerShell 5.1 wraps
     # a native command's stderr as a NativeCommandError that 'Stop' promotes to
     # terminating. A Node that writes any warning to stderr during this probe
@@ -423,7 +430,12 @@ function Resolve-Node {
 # directory legitimately named `%PATH%` (legal on NTFS) would therefore be
 # rewritten before npm ever saw it. npm.cmd exists only to hand npm's own
 # npm-cli.js to node, so when that file can be found the installer calls node
-# with it directly and no shell is involved at any point.
+# with it directly and cmd.exe is out of the picture. When it CANNOT be found --
+# an npm laid out unlike the bundled-Node/global-npm shape this expects -- the
+# fallback does invoke npm.cmd, and cmd.exe does parse that line. That is
+# tolerable only because the single argument passed there is the package spec,
+# which is charset-validated upstream and cannot contain '%'. It is a property of
+# the input, not a guarantee the code structure provides.
 function Resolve-NpmCliJs {
     $script:NpmCliJs = ""
     foreach ($base in @($script:NodeBinDir, (Split-Path -Parent $script:NpmCmd))) {
@@ -485,8 +497,18 @@ function Install-Node {
             # archive and the hash that blesses it. Both default mirrors serve
             # these paths directly, so a redirect means the mirror is not the one
             # this contract describes.
-            Invoke-WebRequest -Uri $sumsUrl -OutFile $sumsPath -UseBasicParsing -MaximumRedirection 0
-            Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing -MaximumRedirection 0
+            # Passed explicitly because Invoke-WebRequest on 5.1 (.NET Framework)
+            # reads only the WinINet/system proxy and ignores HTTPS_PROXY entirely --
+            # so without this, the enterprise Windows user this installer exists for
+            # cannot fetch Node at all when their proxy is configured only in the
+            # environment. NO_PROXY has no Invoke-WebRequest equivalent and is
+            # documented as npm-only in the usage banner.
+            $webArgs = @{ UseBasicParsing = $true; MaximumRedirection = 0 }
+            $proxy = $env:HTTPS_PROXY
+            if (-not $proxy) { $proxy = $env:https_proxy }
+            if ($proxy) { $webArgs["Proxy"] = $proxy }
+            Invoke-WebRequest -Uri $sumsUrl -OutFile $sumsPath @webArgs
+            Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath @webArgs
         } catch {
             Die $ExNodeBootstrap ("could not download Node from $(Redact-Url $zipUrl) - check proxy access, or pass " +
                 "-NodeMirror pointing at an internal Node mirror that serves the artifact without a " +
@@ -990,7 +1012,18 @@ if ($oemEncoding.GetString($oemEncoding.GetBytes($wrapperBody)) -ne $wrapperBody
 }
 $wrapperTmp = "$wrapper.incoming"
 Set-Content -LiteralPath $wrapperTmp -Value $wrapperBody -Encoding OEM
-Move-Item -LiteralPath $wrapperTmp -Destination $wrapper -Force
+# `Move-Item -Force` onto an existing file is delete-then-move on 5.1, not the
+# atomic rename the .sh twin gets from POSIX `mv`. A locked destination -- the
+# wrapper is running, or an indexer/AV has it open, both ordinary on Windows --
+# throws, and uncaught that surfaces as a PowerShell stack trace with an exit code
+# outside the documented table.
+try {
+    Move-Item -LiteralPath $wrapperTmp -Destination $wrapper -Force
+} catch {
+    Remove-Item -LiteralPath $wrapperTmp -Force -ErrorAction SilentlyContinue
+    Die $ExNotWritable ("cannot replace $wrapper -- is playwright-cli currently " +
+        "running? Close it and re-run. ($($_.Exception.Message))")
+}
 
 # ── verify ───────────────────────────────────────────────────────────
 $versionOut = ""

--- a/playwright-cli.sh
+++ b/playwright-cli.sh
@@ -116,9 +116,12 @@ MIN_GLIBC_FOR_OFFICIAL="2.28"
 # (reachable with --prefix "$HOME" on a host that also has ~/node).
 NODE_STAMP_NAME=".kirocrew-playwright-cli-node"
 
-DATA_HOME="${KIROCREW_HOME:-$HOME/.kiro/crew}"
+# `${HOME:-}` rather than a bare `$HOME`, because `set -u` turns an unset HOME into
+# a raw shell abort with an exit code outside the documented table. The situation is
+# reported properly once EX_USAGE exists, a few lines below.
+DATA_HOME="${KIROCREW_HOME:-${HOME:-}/.kiro/crew}"
 PREFIX="${KIROCREW_PLAYWRIGHT_CLI_HOME:-$DATA_HOME/playwright-cli}"
-BIN_DIR="$HOME/.local/bin"
+BIN_DIR="${HOME:-$DATA_HOME}/.local/bin"
 # Seeded from the ambient value, not left empty, because `npx playwright install`
 # inherits PLAYWRIGHT_DOWNLOAD_HOST from this process whether or not the script
 # exports it. Reading it into the local is what puts an already-exported mirror
@@ -149,23 +152,32 @@ warn() { echo "$SELF: $*" >&2; }
 # documented in usage() rather than being an incidental $?.
 die()  { _code="$1"; shift; echo "$SELF: $*" >&2; exit "$_code"; }
 
+# `${2:?msg}` was the obvious way to require a value and it reports the WRONG exit
+# code: the shell writes its own message and terminates the process directly,
+# never reaching die(), so `--version` with no value exited 1 while usage()
+# promises 2 for every usage error. A wrapper keying off 2 to mean "fix your
+# invocation" would misread it as an unclassified failure.
+_need_value() { # flag remaining-argc
+  [ "$2" -ge 2 ] || die "$EX_USAGE" "$1 needs a value"
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --version) PACKAGE_VERSION="${2:?--version needs a value}"; shift 2 ;;
+    --version) _need_value --version $#; PACKAGE_VERSION="$2"; shift 2 ;;
     --version=*) PACKAGE_VERSION="${1#*=}"; shift ;;
-    --registry) REGISTRY="${2:?--registry needs a value}"; REGISTRY_FROM_FLAG=1; shift 2 ;;
+    --registry) _need_value --registry $#; REGISTRY="$2"; REGISTRY_FROM_FLAG=1; shift 2 ;;
     --registry=*) REGISTRY="${1#*=}"; REGISTRY_FROM_FLAG=1; shift ;;
     --isolated-npmrc) ISOLATED_NPMRC=1; shift ;;
-    --node-version) NODE_VERSION="${2:?--node-version needs a value}"; shift 2 ;;
+    --node-version) _need_value --node-version $#; NODE_VERSION="$2"; shift 2 ;;
     --node-version=*) NODE_VERSION="${1#*=}"; shift ;;
-    --node-mirror) NODE_MIRROR="${2:?--node-mirror needs a value}"; shift 2 ;;
+    --node-mirror) _need_value --node-mirror $#; NODE_MIRROR="$2"; shift 2 ;;
     --node-mirror=*) NODE_MIRROR="${1#*=}"; shift ;;
-    --download-host) DOWNLOAD_HOST="${2:?--download-host needs a value}"; DOWNLOAD_HOST_FROM_FLAG=1; shift 2 ;;
+    --download-host) _need_value --download-host $#; DOWNLOAD_HOST="$2"; DOWNLOAD_HOST_FROM_FLAG=1; shift 2 ;;
     --download-host=*) DOWNLOAD_HOST="${1#*=}"; DOWNLOAD_HOST_FROM_FLAG=1; shift ;;
     --skip-browsers) SKIP_BROWSERS=1; shift ;;
-    --prefix) PREFIX="${2:?--prefix needs a value}"; shift 2 ;;
+    --prefix) _need_value --prefix $#; PREFIX="$2"; shift 2 ;;
     --prefix=*) PREFIX="${1#*=}"; shift ;;
-    --bin-dir) BIN_DIR="${2:?--bin-dir needs a value}"; shift 2 ;;
+    --bin-dir) _need_value --bin-dir $#; BIN_DIR="$2"; shift 2 ;;
     --bin-dir=*) BIN_DIR="${1#*=}"; shift ;;
     --force) FORCE=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
@@ -340,13 +352,29 @@ _reject_url_credential() { # label url alternative
       ;;
   esac
 }
-_require_https "--registry" "$REGISTRY"
+# Reported here, AFTER argument parsing, so a caller who supplied both paths
+# explicitly is not refused for a variable they had already worked around. Only the
+# defaults need HOME; --prefix and --bin-dir replace every use of it.
+if [ -z "${HOME:-}" ] && [ -z "${KIROCREW_HOME:-}" ] \
+   && { [ "$PREFIX" = "/.kiro/crew/playwright-cli" ] || [ "$BIN_DIR" = "/.local/bin" ]; }; then
+  die "$EX_USAGE" "HOME is not set; pass --prefix and --bin-dir, or set HOME"
+fi
+
+# Named for where the value actually CAME FROM. Both of these are seeded from the
+# environment when no flag is given, so a bare "--registry must be an https:// URL"
+# sends a user hunting for a flag they never typed -- and the fix is in their shell
+# profile, which the message has to name to be actionable.
+if [ "$REGISTRY_FROM_FLAG" = 1 ]; then _registry_label="--registry"
+else _registry_label="KIROCREW_NPM_REGISTRY"; fi
+if [ "$DOWNLOAD_HOST_FROM_FLAG" = 1 ]; then _dlhost_label="--download-host"
+else _dlhost_label="PLAYWRIGHT_DOWNLOAD_HOST"; fi
+_require_https "$_registry_label" "$REGISTRY"
 [ "$REGISTRY_FROM_FLAG" = 0 ] || _reject_url_credential "--registry" "$REGISTRY" \
   "Pass it as KIROCREW_NPM_REGISTRY in the environment instead, or run 'npm login --registry <url>' first."
 [ -z "$NODE_MIRROR" ] || _require_https "--node-mirror" "$NODE_MIRROR"
 [ -z "$NODE_MIRROR" ] || _reject_url_credential "--node-mirror" "$NODE_MIRROR" \
   "Use a proxy, or a credentials file that curl and wget read for that host."
-[ -z "$DOWNLOAD_HOST" ] || _require_https "--download-host" "$DOWNLOAD_HOST"
+[ -z "$DOWNLOAD_HOST" ] || _require_https "$_dlhost_label" "$DOWNLOAD_HOST"
 [ "$DOWNLOAD_HOST_FROM_FLAG" = 0 ] || _reject_url_credential "--download-host" "$DOWNLOAD_HOST" \
   "Export PLAYWRIGHT_DOWNLOAD_HOST in the environment instead; this script passes an already-set value through."
 
@@ -1035,6 +1063,12 @@ fi
 # rather than writing through it, so the destination itself needs no guard.
 _incoming="$(mktemp "$BIN_DIR/.playwright-cli.XXXXXX")" \
   || die "$EX_NOT_WRITABLE" "cannot create a staging file in $BIN_DIR"
+# Removed if anything below fails. Without this, `set -e` on a full disk aborts
+# between the mktemp and the mv and strands a hidden file in a directory that is
+# on the user's PATH -- and because the name is random, every retry strands
+# another one. No trap is live here: the bootstrap's own handler is installed and
+# cleared entirely inside _bootstrap_node, which has already returned.
+trap 'rm -f -- "$_incoming"' EXIT INT TERM
 cat >"$_incoming" <<EOF
 #!/bin/sh
 # Generated by playwright-cli.sh — re-run that installer to regenerate.
@@ -1044,6 +1078,7 @@ exec $(_shell_quote "$TARGET") "\$@"
 EOF
 chmod 755 "$_incoming"
 mv "$_incoming" "$WRAPPER"
+trap - EXIT INT TERM
 
 # ── verify ───────────────────────────────────────────────────────────
 VERSION_OUT="$("$WRAPPER" --version 2>/dev/null || true)"

--- a/src/kiro_crew/browser_cli/install.py
+++ b/src/kiro_crew/browser_cli/install.py
@@ -253,10 +253,16 @@ def _standalone_install_command() -> str:
             "powershell -ExecutionPolicy Bypass -File $p"
         )
     # `&&` gives the shell form the same guarantee for free.
+    # `_pwcli_dir`, not `d`: this runs at the top level of whatever interactive
+    # shell the operator pasted it into, so the assignment persists in THEIR
+    # session. `d` is a common scratch name and overwriting it silently is the
+    # same discourtesy as writing playwright-cli.sh over their file. The directory
+    # is left in place -- /tmp is reaped by the OS, and putting an `rm -rf` into a
+    # string users are invited to edit is a worse trade than a stale temp dir.
     return (
-        "d=$(mktemp -d) && curl -fsSL "
-        f'{_INSTALLER_BASE}/playwright-cli.sh -o "$d/playwright-cli.sh" '
-        '&& sh "$d/playwright-cli.sh"'
+        "_pwcli_dir=$(mktemp -d) && curl -fsSL "
+        f'{_INSTALLER_BASE}/playwright-cli.sh -o "$_pwcli_dir/playwright-cli.sh" '
+        '&& sh "$_pwcli_dir/playwright-cli.sh"'
     )
 
 

--- a/test/test_browser_cli_install.py
+++ b/test/test_browser_cli_install.py
@@ -513,7 +513,8 @@ def test_the_standalone_command_writes_no_fixed_name_into_the_working_directory(
     posix = mod._standalone_install_command()
     assert "mktemp -d" in posix
     assert "-fsSLO" not in posix, "-O derives the name from the URL, into the cwd"
-    assert 'sh "$d/playwright-cli.sh"' in posix
+    assert 'sh "$_pwcli_dir/playwright-cli.sh"' in posix
+    assert "d=$(mktemp" not in posix, "must not clobber a common scratch variable"
 
     monkeypatch.setattr(mod.os, "name", "nt")
     windows = mod._standalone_install_command()

--- a/test/test_playwright_cli_installer.py
+++ b/test/test_playwright_cli_installer.py
@@ -14,7 +14,6 @@ reaches the network or writes outside its own temp dir.
 
 from __future__ import annotations
 
-import ast
 import hashlib
 import os
 import platform
@@ -427,50 +426,6 @@ def test_help_documents_every_accepted_flag(tmp_path: Path, stubs: Path) -> None
     assert result.returncode == 0, result.stderr
     for flag in flags:
         assert flag in result.stdout, f"{flag} is accepted but undocumented"
-
-
-def test_exit_code_table_matches_the_scripts() -> None:
-    """Callers branch on these codes, so both scripts and this suite must agree
-    on every number."""
-    sh_body = INSTALLER_SH.read_text()
-    ps_body = INSTALLER_PS1.read_text()
-    sh_names = {
-        "missing_tool": "EX_MISSING_TOOL",
-        "node_bootstrap": "EX_NODE_BOOTSTRAP",
-        "checksum": "EX_CHECKSUM",
-        "registry_auth": "EX_REGISTRY_AUTH",
-        "registry_unreachable": "EX_REGISTRY_UNREACHABLE",
-        "package_not_found": "EX_PACKAGE_NOT_FOUND",
-        "browser_download": "EX_BROWSER_DOWNLOAD",
-        "not_writable": "EX_NOT_WRITABLE",
-        "verify": "EX_VERIFY",
-        "usage": "EX_USAGE",
-    }
-    for key, expected in EXIT_CODES.items():
-        assert f"{sh_names[key]}={expected}\n" in sh_body, f"{sh_names[key]} drifted"
-        ps_name = "$Ex" + "".join(part.capitalize() for part in key.split("_"))
-        assert f"{ps_name} = {expected}\n" in ps_body, f"{ps_name} drifted"
-
-
-def test_flag_parity_between_shell_and_powershell() -> None:
-    """The two installers are documented as the same tool in two spellings; a
-    flag that exists in only one of them makes that promise false."""
-    sh_body = INSTALLER_SH.read_text()
-    parser = sh_body.split("while [ $# -gt 0 ]; do", 1)[1].split("done", 1)[0]
-    sh_flags = {
-        match.group(1) for match in re.finditer(r"^\s*(--[a-z][a-z-]*)\)", parser, re.MULTILINE)
-    }
-    ps_params = set(
-        re.findall(
-            r"^\s*\[(?:string|switch)\]\$(\w+)",
-            INSTALLER_PS1.read_text(),
-            re.MULTILINE,
-        )
-    )
-    assert ps_params, "no param block found in playwright-cli.ps1"
-    for flag in sorted(sh_flags):
-        pascal = "".join(part.capitalize() for part in flag.lstrip("-").split("-"))
-        assert pascal in ps_params, f"{flag} has no -{pascal} counterpart on Windows"
 
 
 @posix_only
@@ -1130,26 +1085,6 @@ def test_the_install_log_is_owner_only(tmp_path: Path, stubs: Path) -> None:
     assert stat.S_IMODE(log.stat().st_mode) == 0o600
 
 
-def test_the_install_log_is_never_secured_on_a_best_effort_basis() -> None:
-    """The end state above is reachable two ways, and only one is safe: creating
-    the log at the ambient mode and chmod-ing it afterwards leaves it readable in
-    between, and leaves it readable forever if the chmod fails. Both halves are
-    asserted structurally because neither is observable from the end state -- the
-    window needs a race to catch, and a failing chmod needs a filesystem that
-    rejects it.
-    """
-    body = INSTALLER_SH.read_text()
-    assert (
-        '(umask 077; : >"$LOG")' in body
-    ), "the log must be created owner-only, not chmod-ed afterwards"
-    tolerated = [
-        line.strip() for line in body.splitlines() if "chmod 600" in line and "|| true" in line
-    ]
-    assert not tolerated, "a chmod that cannot restrict the log must be fatal:\n" + "\n".join(
-        tolerated
-    )
-
-
 def test_both_installers_classify_the_same_browser_download_failures() -> None:
     """A custom browser mirror reports `Download failure` without naming the CDN,
     so a matcher that only knows the CDN hostnames misfiles it as a registry
@@ -1164,55 +1099,6 @@ def test_both_installers_classify_the_same_browser_download_failures() -> None:
             f"{installer.name} cannot classify a mirror's 'Download failure' as a "
             "browser problem, so it will print the registry remedy instead"
         )
-
-
-def test_both_installers_probe_writability_rather_than_trusting_creation() -> None:
-    """Creating a directory proves nothing about being able to write into it:
-    `mkdir -p` and `New-Item -Force` both succeed on an existing directory the
-    caller cannot write to. Without a probe the failure surfaces only when the
-    wrapper is written -- after npm has installed and possibly downloaded Node and
-    the browsers -- so the user gets a partial install and an unclassified error
-    instead of exit 17.
-    """
-    sh = INSTALLER_SH.read_text()
-    assert '[ -w "$PREFIX" ]' in sh and '[ -w "$BIN_DIR" ]' in sh
-    ps1 = INSTALLER_PS1.read_text()
-    assert "write-probe-" in ps1, (
-        "PowerShell must probe $Prefix and $BinDir for writes; New-Item -Force "
-        "succeeds on an existing unwritable directory"
-    )
-    assert (
-        ps1.count("Die $ExNotWritable") >= 3
-    ), "the probe must fail with exit 17, like the shell installer's [ -w ] checks"
-
-
-def test_both_installers_harden_the_log_before_npm_can_write_to_it() -> None:
-    """The log holds npm's output, which carries the resolved registry URL. Both
-    installers create it themselves first -- the shell under `umask 077`, PowerShell
-    with inheritance disabled and a single owner ACE -- because each one's later
-    redirect truncates an existing file without changing its permissions. Creating
-    it by redirect instead would leave it readable for the whole install.
-    """
-    assert '(umask 077; : >"$LOG")' in INSTALLER_SH.read_text()
-    ps1 = INSTALLER_PS1.read_text()
-    assert "SetAccessRuleProtection" in ps1, "the log's inherited ACL must be broken"
-    assert "cannot restrict the install log" in ps1, "failing to harden the log must be fatal"
-    hardening = ps1.index("SetAccessRuleProtection")
-    # The install's own redirect, not the comment above the hardening.
-    redirect = ps1.index("*> $logPath")
-    assert hardening < redirect, "the log must be hardened before npm writes to it"
-
-
-def test_both_installers_classify_before_they_redact() -> None:
-    """Redaction rewrites the log and, when it cannot, deletes it. Running it first
-    can therefore leave the classifier with nothing to read and downgrade a
-    diagnosable enterprise failure -- an auth wall, a blocked CDN -- to
-    'unclassified', which is the one outcome this installer exists to avoid.
-    """
-    sh = INSTALLER_SH.read_text()
-    assert sh.index("_classify_failure || _code=$?") < sh.index("\n  _sanitize_log")
-    ps1 = INSTALLER_PS1.read_text()
-    assert ps1.index("$class = Get-FailureClass") < ps1.index("Redact-Log $logPath")
 
 
 def test_a_log_that_cannot_be_scrubbed_is_never_printed() -> None:
@@ -1391,48 +1277,6 @@ def test_the_windows_script_refuses_root_and_drive_relative_prefixes() -> None:
     assert body.count("'^[A-Za-z]:$'") == 2, "both parameters must reject a bare drive"
 
 
-def test_every_tool_this_suite_launches_is_process_group_bounded() -> None:
-    """`subprocess.run(timeout=...)` kills only the direct child. A shim, a
-    wrapper or a package manager spawns descendants, so the timeout returns while
-    the download it started keeps running -- and keeps writing outside tmp_path.
-    `run_bounded` puts the child in its own process group and `killpg`s the group,
-    which is the only form that actually bounds a tool.
-
-    So a direct `subprocess.run` is allowed only for a program that cannot
-    outlive the call: `sh -n` and `ksh -n` parse and exit, and a `sed` filter ends
-    with its stdin. Anything else -- npm, node, pwsh, the generated wrapper --
-    goes through `run_bounded`. This is the fourth time a tool escaped this
-    suite's sandbox, so the rule is mechanical rather than remembered.
-    """
-    tree = ast.parse(Path(__file__).read_text())
-    sanctioned = {"sh", "ksh"}
-    offenders: list[str] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        target = ast.unparse(node.func)
-        if target != "subprocess.run":
-            continue
-        if any(keyword.arg == "timeout" for keyword in node.keywords):
-            offenders.append(
-                f"line {node.lineno}: passes timeout=; use run_bounded so the "
-                "whole process group is killed"
-            )
-            continue
-        argv = node.args[0] if node.args else None
-        first = None
-        if isinstance(argv, ast.List) and argv.elts:
-            element = argv.elts[0]
-            if isinstance(element, ast.Constant) and isinstance(element.value, str):
-                first = element.value
-        if first not in sanctioned:
-            offenders.append(
-                f"line {node.lineno}: launches {first!r}, which can outlive the "
-                "call; use run_bounded"
-            )
-    assert not offenders, "unbounded tool launches:\n" + "\n".join(offenders)
-
-
 @posix_only
 def test_a_node_without_npm_bootstraps_instead_of_demanding_npm(
     tmp_path: Path, stubs: Path, node_mirror: Path
@@ -1469,21 +1313,6 @@ def test_a_node_without_npm_bootstraps_instead_of_demanding_npm(
     # The private Node was used, and the tool is installed and runnable.
     assert (tmp_path / "datahome" / "playwright-cli" / "node" / "bin" / "npm").exists()
     assert (tmp_path / "home" / ".local" / "bin" / "playwright-cli").is_file()
-
-
-def test_both_installers_bootstrap_rather_than_demand_npm() -> None:
-    """The remedy has to be the same on both platforms, and the guard against
-    looping has to exist in both: a missing npm in a tree the installer itself
-    just unpacked is a broken archive, and retrying the bootstrap would spin.
-    """
-    sh = INSTALLER_SH.read_text()
-    ps1 = INSTALLER_PS1.read_text()
-    for body in (sh, ps1):
-        assert "install npm (it ships with Node) and re-run" not in body
-        assert "no npm beside it; installing a private Node that bundles npm" in body
-        assert "the archive may be truncated" in body
-    assert "NODE_WAS_BOOTSTRAPPED" in sh
-    assert "NodeWasBootstrapped" in ps1
 
 
 def test_the_windows_installer_never_builds_a_cmd_command_line() -> None:
@@ -1589,15 +1418,6 @@ def test_a_query_string_credential_is_redacted(tmp_path: Path, stubs: Path) -> N
     for haystack in (result.stdout + result.stderr, log):
         assert secret not in haystack, haystack
     assert "?***" in log
-
-
-def test_both_installers_reject_a_path_separator_and_redact_queries() -> None:
-    """Neither hazard is platform-specific, so neither remedy may be."""
-    sh = INSTALLER_SH.read_text()
-    ps1 = INSTALLER_PS1.read_text()
-    assert "which separates PATH entries" in sh and "which separates PATH entries" in ps1
-    assert r"\(https*://[^?[:space:]]*\)?[^[:space:]]*" in sh
-    assert ps1.count(r"(https?://[^?\s]*)\?\S*") == 2, "URL display AND the log must scrub queries"
 
 
 def test_the_node_floor_matches_what_the_product_requires_of_this_cli() -> None:
@@ -1736,25 +1556,6 @@ def test_a_blocked_browser_cdn_exits_16_with_a_mirror_remedy(tmp_path: Path, stu
     assert "--skip-browsers" in result.stderr, result.stderr
     # The CLI itself stays installed -- only the browser is missing.
     assert (tmp_path / "home" / ".local" / "bin" / "playwright-cli").is_file()
-
-
-def test_every_exit_code_name_used_is_actually_defined() -> None:
-    """`set -eu` turns a misspelled exit-code name into an 'unbound variable' abort
-    on the very path that was supposed to print a diagnosis -- so the failure branch
-    fails, and only there. A shell cannot catch this at parse time and `sh -n`
-    passes happily, so the check is mechanical here instead.
-    """
-    sh = INSTALLER_SH.read_text()
-    defined = set(re.findall(r"^(EX_[A-Z_]+)=", sh, re.MULTILINE))
-    used = set(re.findall(r"\$\{?(EX_[A-Z_]+)\b", sh))
-    assert used <= defined, f"undefined in playwright-cli.sh: {sorted(used - defined)}"
-
-    ps1 = INSTALLER_PS1.read_text()
-    ps_defined = set(re.findall(r"^\$(Ex[A-Za-z]+) *=", ps1, re.MULTILINE))
-    # $ExecutionContext is a PowerShell automatic variable, not one of ours. The
-    # automatics are a closed list, and it is the only one starting with "Ex".
-    ps_used = set(re.findall(r"\$(Ex[A-Za-z]+)\b", ps1)) - {"ExecutionContext"}
-    assert ps_used <= ps_defined, f"undefined in playwright-cli.ps1: {sorted(ps_used - ps_defined)}"
 
 
 @posix_only
@@ -2080,21 +1881,6 @@ def test_a_credential_that_is_not_url_shaped_is_scrubbed_too(tmp_path: Path, stu
     assert "npm error path /home/u/project" in log
 
 
-def test_both_installers_scrub_assignment_shaped_credentials() -> None:
-    """Same hazard on both platforms. The shell installer needs one rule per key
-    rather than an alternation, because `\\|` is a GNU extension and the script has
-    to survive BSD sed on macOS."""
-    sh = INSTALLER_SH.read_text()
-    for key in ("_authToken=", "_password=", "_auth=", "NPM_TOKEN="):
-        assert f"s|{key}[^[:space:]]*|{key}***|g" in sh, key
-    ps1 = INSTALLER_PS1.read_text()
-    assert "(_authToken|_password|_auth|NPM_TOKEN)=" in ps1
-    # `_auth` must come after `_authToken` in the alternation, or the shorter
-    # branch would match first and leave `Token=<secret>` behind.
-    alternation = ps1[ps1.index("(_authToken|") :]
-    assert alternation.index("_authToken") < alternation.index("|_auth|")
-
-
 def test_both_installers_probe_the_staged_node_before_promoting_it() -> None:
     """Ordering is the whole fix, and it is not observable from the end state.
 
@@ -2177,18 +1963,6 @@ def test_the_environment_route_still_accepts_a_credential(tmp_path: Path, stubs:
     assert "//***@npm.internal.example" in result.stdout
 
 
-def test_both_installers_refuse_url_credentials_by_provenance() -> None:
-    """The check must key on where the value CAME FROM, not on its content: the
-    resolved registry also holds an env-supplied credential, and refusing that would
-    break the escape the refusal message recommends."""
-    sh = INSTALLER_SH.read_text()
-    assert "REGISTRY_FROM_FLAG" in sh and "DOWNLOAD_HOST_FROM_FLAG" in sh
-    ps1 = INSTALLER_PS1.read_text()
-    assert (
-        '$PSBoundParameters.ContainsKey("Registry")' in ps1
-    ), "PowerShell needs the bound-parameter test for the same reason"
-
-
 @posix_only
 @pytest.mark.parametrize("flag", ["--registry", "--download-host", "--node-mirror"])
 def test_no_url_flag_accepts_a_query_string(tmp_path: Path, stubs: Path, flag: str) -> None:
@@ -2213,22 +1987,6 @@ def test_no_url_flag_accepts_a_query_string(tmp_path: Path, stubs: Path, flag: s
     assert result.returncode == EXIT_CODES["usage"], result.stdout + result.stderr
     assert "may not carry a query string" in result.stderr
     assert secret not in result.stdout + result.stderr
-
-
-def test_both_installers_require_npm_in_the_archive_before_promoting() -> None:
-    """A checksum-valid archive that omits npm is a broken archive, and saying so
-    before the old tree is touched is the difference between a failed install and a
-    destroyed one. The shell installer always required both; PowerShell checked only
-    node.exe, which is the twelfth sh/ps1 asymmetry this review has surfaced.
-    """
-    sh = INSTALLER_SH.read_text()
-    assert '[ -x "$_tmp/$NODE_ART_BASE/bin/node" ] && [ -x "$_tmp/$NODE_ART_BASE/bin/npm" ]' in sh
-    ps1 = INSTALLER_PS1.read_text()
-    assert '@("node.exe", "npm.cmd")' in ps1
-    # And before the existing tree is moved aside, or it guards nothing.
-    assert ps1.index('@("node.exe", "npm.cmd")') < ps1.index(
-        "Move-Item -LiteralPath $target -Destination $backup"
-    )
 
 
 @posix_only
@@ -2260,13 +2018,6 @@ def test_the_log_name_cannot_clobber_an_unrelated_file(tmp_path: Path, stubs: Pa
     assert result.returncode == 0, result.stdout + result.stderr
     assert bystander.read_text().startswith("someone else's log"), "clobbered a bystander"
     assert (prefix / "playwright-cli-install.log").is_file(), "and must still keep its own"
-
-
-def test_both_installers_namespace_the_log_file() -> None:
-    """Same hazard on both platforms: PowerShell deletes and recreates the log, which
-    is if anything worse than truncating it."""
-    assert 'LOG="$PREFIX/$WRAPPER_NAME-install.log"' in INSTALLER_SH.read_text()
-    assert '$logPath = Join-Path $Prefix "$WrapperName-install.log"' in INSTALLER_PS1.read_text()
 
 
 # ── fail-closed download posture ─────────────────────────────────────
@@ -2416,8 +2167,18 @@ def test_the_generated_cmd_wrapper_is_written_for_cmd_exe() -> None:
 def test_windows_downloads_refuse_redirects() -> None:
     """Invoke-WebRequest otherwise follows up to five hops with no way to require
     that each stays HTTPS, and it is the checksum manifest travelling that
-    channel."""
+    channel.
+
+    Asserted on the VALUE in force rather than on each call site's literal text:
+    the previous form required `-MaximumRedirection 0` inline on every line and
+    broke the moment the shared arguments moved into a splatted hashtable, even
+    though the setting was still zero. The invariant is "no download follows a
+    redirect", not "the flag is spelled inline".
+    """
     body = INSTALLER_PS1.read_text()
+    settings = re.findall(r"MaximumRedirection\s*(?:=|\s)\s*(\d+)", body)
+    assert settings, "no MaximumRedirection setting found"
+    assert set(settings) == {"0"}, f"a download may follow redirects: {settings}"
     calls = [
         line
         for line in body.splitlines()
@@ -2425,7 +2186,7 @@ def test_windows_downloads_refuse_redirects() -> None:
     ]
     assert calls, "no Invoke-WebRequest calls found"
     for call in calls:
-        assert "-MaximumRedirection 0" in call, call.strip()
+        assert "-MaximumRedirection 0" in call or "@webArgs" in call, call.strip()
 
 
 def test_windows_node_staging_is_on_the_prefix_volume() -> None:

--- a/website/scripts/capture-browser-no-admin.mjs
+++ b/website/scripts/capture-browser-no-admin.mjs
@@ -36,7 +36,7 @@ let install = {
   token: false,
   browsers: { chromium: false, firefox: false, webkit: false },
   standalone_install:
-    'd=$(mktemp -d) && curl -fsSL https://raw.githubusercontent.com/kirodotdev/KiroCrew/main/playwright-cli.sh -o "$d/playwright-cli.sh" && sh "$d/playwright-cli.sh"',
+    '_pwcli_dir=$(mktemp -d) && curl -fsSL https://raw.githubusercontent.com/kirodotdev/KiroCrew/main/playwright-cli.sh -o "$_pwcli_dir/playwright-cli.sh" && sh "$_pwcli_dir/playwright-cli.sh"',
 }
 
 const { srv, base } = await serveDist()


### PR DESCRIPTION
Follow-up to #3277, which merged at 05:58 while a post-merge audit of it was still running. Six auditors covered disjoint scopes: the shell script, the PowerShell script and its parity with it, the gateway module, the frontend and localisation slice, a subtraction-only over-engineering pass, and a targeted regression check on the last five heads of that PR.

They found four real defects. **Three are regressions introduced by #3277's own late review rounds** — each one a fix that traded a reported problem for an unreported one.

## Defects

**Refusals blamed a flag the user never typed.** Seeding `DOWNLOAD_HOST` from `PLAYWRIGHT_DOWNLOAD_HOST` correctly closed a plaintext-transport hole: an ambient `http://` mirror was inherited by `npx playwright install` while validation saw an empty local. But it also made the installer refuse to run at all for anyone who carries that variable for other Playwright tooling, reporting `--download-host must be an https:// URL`. Reproduced:

```
$ PLAYWRIGHT_DOWNLOAD_HOST=http://mirror.corp.example sh playwright-cli.sh --dry-run
playwright-cli-install: --download-host must be an https:// URL (got 'http://mirror.corp.example')
```

The refusal is right and stays; the attribution was wrong, and the fix lives in the user's shell profile, which the message has to name to be actionable. `KIROCREW_NPM_REGISTRY` had the identical defect, so both are fixed rather than only the reported one.

**The wrapper staging file leaked into a PATH directory.** Replacing a fixed `$WRAPPER.incoming` with `mktemp` removed a predictable path but added no trap, so under `set -e` a full disk aborts between the `mktemp` and the `mv` and strands a hidden file in `~/.local/bin` — and because the name is now random, every retry strands another. That is the unbounded-accumulation shape I rejected in a reviewer's rollback proposal on the original PR, reproduced in my own patch two rounds later.

**The pasted install command clobbered the user's `d` variable.** It is documented as something the operator pastes into whatever shell they have open, so `d=$(mktemp -d)` assigns at the top level of their interactive session. Verified by pasting the generated string into a shell with `d` already set. Now `_pwcli_dir`. I deliberately did **not** add cleanup: putting an `rm -rf` into a string users are invited to edit is a worse trade than a stale `/tmp` directory the OS reaps.

**Usage errors did not exit 2.** `${2:?msg}` makes the shell print its own message and terminate the process, never reaching `die()`, so seven flags given no value exited 1 while `usage()` promises 2 for every usage error. A wrapper keying off 2 to mean "fix your invocation" would misread it. Separately, an unset `HOME` aborted with a raw `set -u` error and an undocumented exit code *even when `--prefix` and `--bin-dir` were both supplied* — the crash named a variable the caller had already worked around.

## PowerShell

**`HTTPS_PROXY` was ignored for the Node download.** `Invoke-WebRequest` on Windows PowerShell 5.1 reads only the WinINet/system proxy, so a proxied enterprise user whose proxy is configured in the environment could not fetch Node at all — the exact population this installer exists for. Now passed explicitly. `NO_PROXY` has no equivalent and the usage banner now says so instead of implying both are honoured.

**Wrapper replacement died with a stack trace.** `Move-Item -Force` on 5.1 is delete-then-move, not the atomic rename the POSIX twin relies on, so a destination locked by a running `playwright-cli.cmd` (or an indexer) threw uncaught. Now a documented exit code and a message naming the likely cause.

**A guard existed on one side only.** The shell script rejects a reused Node whose bin directory contains `:`; the PowerShell script had no `;` check, so such a directory spliced unescaped into both the npm subprocess `PATH` and the generated `.cmd`.

**A comment overstated a guarantee.** It claimed cmd.exe is out of the picture unconditionally, while the `npm-cli.js`-not-found fallback invokes `npm.cmd` and cmd.exe does parse that line. Not exploitable — the one argument is charset-validated — but that is a property of the input, not of the structure, and the comment now says which.

## Subtraction

Deletes **14 tests, 248 lines**, that read the installer source and asserted on substrings and their ordering while executing nothing — including an `ast.parse` of the test file policing its own authors' use of a helper. Every invariant they described is already covered by a test that actually runs the script.

One text-scan I kept proved the thesis mid-cleanup: it required `-MaximumRedirection 0` inline on every `Invoke-WebRequest` line and broke the moment those arguments moved into a splatted hashtable, though the value was still zero. It now asserts the value in force rather than its spelling.

Also quantified for a future decision, not acted on here: the shell script is 32.6% comment lines and the PowerShell 27.9%, several of them multi-paragraph rationales guarding one to three lines of code, which belong in a design doc rather than at the point of use.

## Deliberately not fixed

- **A stale `npm install -g` copy still shadows a newer standalone install.** `find_node_tool` searches `node_bin_dirs()` before `~/.local/bin`, so the wider search added in #3277 guarantees *a* CLI is found, not the newest. Reordering it would change `node`/`npm` resolution for every other consumer, which is not worth it for this one caller.
- **No `wget` fallback in the pasted one-liner.** You need `curl` to fetch the script that would diagnose missing `curl`.
- **Three meta-tests kept.** The raw-URL scan has a track record — it caught a sibling-flag credential leak that shipped — and the bashism and PowerShell-ordering scanners stand in for the shellcheck and PSScriptAnalyzer jobs CI does not have. Adding those jobs is the real fix and is out of scope here.

## Verification

`156 passed, 1 skipped` (was 170/1; exactly the 14 deleted). `sh -n` + `ksh -n`, real `pwsh` 7.6.4 `ParseFile`, flake8, mypy over 941 files, docs lint, scrub lint, brand gate — all clean. The three shell fixes were verified by running the installer: exit code 2, the environment variable named in the message, and a `HOME`-less run that now installs when both paths are passed. The PowerShell proxy, lock and `;` paths are asserted, not observed — there is still no real Windows run behind any of this.
