### PR TITLE
Fix: gate kirocrew-computer spec emission on platform + keystone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **`kirocrew-computer` no longer spawns its ~109 MB backend process on
+  every chat process when the feature is disabled or unsupported on the
+  platform.** The managed MCP server was registered into the resolved agent
+  spec unconditionally; the keystone primary-enable and platform checks only
+  ran *inside* the already-running shim, after kiro-cli had already spawned
+  it. On a non-macOS host, or a macOS host that never enabled the feature,
+  every chat process — including every `spawn_run` subagent — paid that cost
+  for a capability it could never invoke. The managed-server entry now
+  carries a `spec_allowed_fn` gate (platform + keystone) consulted before the
+  entry is emitted into `mcpServers`, on both a fresh install and a refresh
+  of an existing config (which also drops a stale entry once the gate no
+  longer passes). The two in-process checks stay as defence in depth for a
+  mid-session disable. (#3482)
+
 - **Side-panel oversize-question refusal now reports an accurate character
   target for every script, not just emoji.** The refusal derived its
   character count from a fixed worst-case floor (4 bytes/char, the emoji

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -479,6 +479,25 @@ def _kirocrew_mcp_invocation(subcommand: str) -> tuple[str, list[str]]:
     return bin_path, [subcommand]
 
 
+def _computer_use_managed_server_allowed() -> bool:
+    """Whether ``kirocrew-computer`` may be emitted into the resolved agent spec.
+
+    Gates SPEC EMISSION, not just the in-process tool list (#3482). The shim's
+    own ``enable_state.is_enabled()`` checks (``mcp_computer.py``'s
+    ``_list_tools`` / ``_call_tool_inner``) only run once kiro-cli has already
+    spawned the ~109 MB backend process — so on a disabled install, or on any
+    platform other than macOS (this feature's only supported one), every chat
+    process paid that cost for a capability it could never invoke. Those two
+    in-process checks stay as defence in depth for a mid-session disable; this
+    is the first gate that stops the process from existing at all.
+    """
+    if not platform_compat.IS_MACOS:
+        return False
+    from kiro_crew.computer_use import enable_state
+
+    return enable_state.is_enabled()
+
+
 # ---------------------------------------------------------------------------
 # Managed MCP servers — single source of truth.
 #
@@ -489,10 +508,12 @@ def _kirocrew_mcp_invocation(subcommand: str) -> tuple[str, list[str]]:
 _MANAGED_MCP_SERVERS: dict[str, dict] = {
     "kirocrew-cron": {"invocation_fn": lambda: _kirocrew_mcp_invocation("mcp-cron")},
     "kirocrew-core": {"invocation_fn": lambda: _kirocrew_mcp_invocation("mcp-core")},
-    # Computer use (native desktop GUI automation).  Registered unconditionally —
-    # its stdio shim returns an EMPTY tools/list while the keystone primary enable
-    # is off, so a disabled feature costs the model no context and needs no
-    # per-server ``enabled_fn`` in this loop.
+    # Computer use (native desktop GUI automation). ``spec_allowed_fn`` gates
+    # whether this entry is emitted into the resolved spec at all (platform +
+    # keystone) — see _computer_use_managed_server_allowed. Its stdio shim
+    # ALSO returns an EMPTY tools/list while the keystone primary enable is
+    # off; that stays as defence in depth for a mid-session disable, not a
+    # substitute for this gate.
     #
     # DELIBERATELY NO ``autoApprove`` KEY, and none may ever be added: kiro-cli
     # approves an autoApproved MCP tool locally and emits no permission request,
@@ -500,7 +521,10 @@ _MANAGED_MCP_SERVERS: dict[str, dict] = {
     # floor, the sensitive-path check and the governance ceiling — is NEVER
     # reached for it. For a tool that can click in an already-authenticated
     # application that would be a complete gate bypass.
-    "kirocrew-computer": {"invocation_fn": lambda: _kirocrew_mcp_invocation("mcp-computer")},
+    "kirocrew-computer": {
+        "invocation_fn": lambda: _kirocrew_mcp_invocation("mcp-computer"),
+        "spec_allowed_fn": _computer_use_managed_server_allowed,
+    },
 }
 
 
@@ -1584,6 +1608,10 @@ def build_agent_config() -> dict:
     mcp = config.setdefault("mcpServers", {})
     registry_mode = _mcp_registry_mode()
     for name, spec in _MANAGED_MCP_SERVERS.items():
+        allowed_fn = spec.get("spec_allowed_fn")
+        if allowed_fn is not None and not allowed_fn():
+            mcp.pop(name, None)
+            continue
         if "invocation_fn" in spec:
             cmd, args = spec["invocation_fn"]()
         else:
@@ -1636,6 +1664,10 @@ def _refresh_dynamic_fields(config: dict) -> None:
     mcp = config.setdefault("mcpServers", {})
     registry_mode = _mcp_registry_mode()
     for name, spec in _MANAGED_MCP_SERVERS.items():
+        allowed_fn = spec.get("spec_allowed_fn")
+        if allowed_fn is not None and not allowed_fn():
+            mcp.pop(name, None)
+            continue
         is_new = name not in mcp
         entry = mcp.setdefault(name, {})
         if "invocation_fn" in spec:

--- a/test/test_computer_use_registration.py
+++ b/test/test_computer_use_registration.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import json
 from contextlib import ExitStack
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -216,6 +217,131 @@ def test_fresh_install_registers_the_server(tmp_path: Path):
     cfg_dir = _bundled_defaults(tmp_path)
     config = _installed(_run_install(tmp_path, cfg_dir))
     assert CU_SERVER in config["mcpServers"]
+
+
+# ── spec-emission gate (#3482): platform + keystone, using the REAL managed
+# dict (not the ``_MANAGED`` test fixture) so ``spec_allowed_fn`` is exercised.
+
+
+def _run_install_real_managed(tmp_path: Path, cfg_dir: Path, **kwargs) -> Path:
+    """Like ``_run_install``, but does NOT override ``_MANAGED_MCP_SERVERS``.
+
+    The gate under test (``spec_allowed_fn``) lives on the real
+    ``agent._MANAGED_MCP_SERVERS['kirocrew-computer']`` entry; the ``_MANAGED``
+    fixture used elsewhere in this file omits that key entirely, which is
+    exactly why those tests must not be the ones proving the gate works.
+    """
+    kiro_dir = tmp_path / "kiro_agents"
+    kiro_dir.mkdir(exist_ok=True)
+    mc_config = tmp_path / "mc_config.json"
+    if not mc_config.exists():
+        mc_config.write_text(json.dumps({"agent": {"kiro_hooks_autoimport": False}}))
+
+    patches = [
+        patch.multiple(
+            "kiro_crew.agent",
+            KIRO_AGENTS_DIR=kiro_dir,
+            _BUNDLED_CFG_DIR=cfg_dir,
+            _KIROCREW_BIN="/usr/bin/kirocrew",
+            _KIRO_MCP_JSON=tmp_path / "fake_kiro_mcp.json",
+            _CC_MCP_JSON=tmp_path / "fake_cc_mcp.json",
+        ),
+        patch("kiro_crew.agent._user_dir", lambda: tmp_path / "home"),
+        patch("kiro_crew.agent._prompt_path", return_value=cfg_dir / "prompt.md"),
+        patch("kiro_crew.agent._shipped_defaults", return_value=cfg_dir / "defaults.json"),
+        patch("kiro_crew.agent._project_dir", return_value=None),
+        patch("kiro_crew.agent._aim_skill_paths", return_value=[]),
+        patch("kiro_crew.agent.shutil.which", side_effect=lambda c, **kw: c),
+        patch("kiro_crew.agent._mc_config_path", return_value=mc_config),
+    ]
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        return install_agent(**kwargs)
+
+
+@pytest.fixture
+def cu_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``KIROCREW_HOME`` so the keystone read in the gate lands in a
+    tmp dir, never a developer's real ``~/.kiro/crew/computer_use.json``."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "cu_home"))
+    return tmp_path / "cu_home"
+
+
+def _write_keystone(cu_home: Path, **state: Any) -> None:
+    from kiro_crew.computer_use.types import STATE_FILE_NAME
+
+    cu_home.mkdir(parents=True, exist_ok=True)
+    (cu_home / STATE_FILE_NAME).write_text(json.dumps(state), encoding="utf-8")
+
+
+def test_non_darwin_spec_has_no_computer_entry_even_when_keystone_enabled(
+    tmp_path: Path, cu_home: Path
+):
+    """Non-macOS: no entry, no matter what the keystone says.
+
+    Computer use has no driver outside macOS, so a keystone left ``enabled``
+    from a config carried over between machines must not spawn a process that
+    can never do anything on this platform.
+    """
+    _write_keystone(cu_home, enabled=True)
+    cfg_dir = _bundled_defaults(tmp_path)
+    with patch("kiro_crew.agent.platform_compat.IS_MACOS", False):
+        config = _installed(_run_install_real_managed(tmp_path, cfg_dir))
+    # Asserted on the spec (mcpServers), not the tool list: the bundled
+    # defaults.json ships ``@kirocrew-computer`` in ``tools`` unconditionally
+    # (the shim's own empty tools/list already covers that layer). What must
+    # not happen is kiro-cli being told to SPAWN the process.
+    assert CU_SERVER not in config["mcpServers"]
+
+
+@pytest.mark.parametrize(
+    "keystone_state",
+    [
+        None,  # absent entirely
+        {},
+        {"enabled": False},
+        {"enabled": "false"},  # truthy non-True string
+        {"enabled": 1},  # truthy non-True int
+    ],
+)
+def test_darwin_spec_has_no_computer_entry_while_keystone_is_not_true(
+    tmp_path: Path, cu_home: Path, keystone_state
+):
+    """Darwin: still no entry unless the keystone spells ``"enabled": true``
+    exactly, mirroring the four keystone cases in ``test_mcp_computer.py``."""
+    if keystone_state is not None:
+        _write_keystone(cu_home, **keystone_state)
+    cfg_dir = _bundled_defaults(tmp_path)
+    with patch("kiro_crew.agent.platform_compat.IS_MACOS", True):
+        config = _installed(_run_install_real_managed(tmp_path, cfg_dir))
+    assert CU_SERVER not in config["mcpServers"]
+
+
+def test_darwin_with_keystone_enabled_emits_the_entry(tmp_path: Path, cu_home: Path):
+    """The one path that must work: darwin + ``{"enabled": true}`` -> emitted.
+
+    Guards against over-gating — a fix for #3482 that also silently disabled
+    the feature for its one supported, opted-in configuration would be worse
+    than the bug.
+    """
+    _write_keystone(cu_home, enabled=True)
+    cfg_dir = _bundled_defaults(tmp_path)
+    with patch("kiro_crew.agent.platform_compat.IS_MACOS", True):
+        config = _installed(_run_install_real_managed(tmp_path, cfg_dir))
+    assert CU_SERVER in config["mcpServers"]
+
+
+def test_refresh_drops_a_previously_emitted_entry_once_disallowed(tmp_path: Path, cu_home: Path):
+    """A gateway restart after the keystone flips off actually reclaims the
+    process — the refresh path must remove a stale entry, not just skip
+    re-adding one, or the ~109 MB process survives every disable until the
+    user edits ``kirocrew.json`` by hand."""
+    cfg_dir = _bundled_defaults(tmp_path)
+    _existing_config(tmp_path, {"command": "/usr/bin/kirocrew", "args": [CU_SUBCOMMAND]})
+    with patch("kiro_crew.agent.platform_compat.IS_MACOS", True):
+        config = _installed(_run_install_real_managed(tmp_path, cfg_dir))
+    assert CU_SERVER not in config["mcpServers"]
 
 
 # ── refresh of an existing config ──


### PR DESCRIPTION
## Summary

Fixes #3482.

`kirocrew-computer` was registered into the resolved agent spec unconditionally, so kiro-cli spawned its ~109 MB backend process for every chat process (including every `spawn_run` subagent) regardless of platform support or the keystone primary-enable. The two in-process enable checks in `mcp_computer.py` (`_list_tools` / `_call_tool_inner`) only run once that process already exists, so they hid the wasted `tools/list` surface but never stopped the process from existing.

- Added `_computer_use_managed_server_allowed()` in `src/kiro_crew/agent.py`: `platform_compat.IS_MACOS` AND `computer_use.enable_state.is_enabled()`.
- Wired it as a generic `spec_allowed_fn` hook on the `kirocrew-computer` entry in `_MANAGED_MCP_SERVERS` (not a server-specific branch), so a future gated managed server gets the same zero-cost-when-off property for free.
- Consulted in both `build_agent_config` (fresh install) and `_refresh_dynamic_fields` (existing config) before the entry is emitted — the refresh path also **pops** a stale entry once the gate no longer passes, so disabling the keystone actually reclaims the process on the next gateway start rather than persisting until a manual edit.
- Kept the two in-process checks as defence in depth for a mid-session disable, per the issue's proposed fix.
- Did not touch `tools`/`allowedTools` — the bundled `defaults.json` ships `@kirocrew-computer` there unconditionally by design (the shim's own empty `tools/list` already covers that layer); this fix is scoped to whether kiro-cli is told to spawn the process at all (`mcpServers`), per the issue's own test guidance ("assert on the spec, not on the tool list").

## Test plan

New tests in `test/test_computer_use_registration.py` exercise the REAL `agent._MANAGED_MCP_SERVERS` dict end to end — the existing suite's `_MANAGED` fixture intentionally omits `spec_allowed_fn`, so it could not have caught a regression in this gate:

- [x] Non-darwin with the keystone `{"enabled": true}` still emits no `kirocrew-computer` entry.
- [x] Darwin with the keystone absent / `{}` / `{"enabled": false}` / a truthy-non-`True` value (`"false"`, `1`) all emit nothing — mirrors the four keystone cases already covered in `test_mcp_computer.py`.
- [x] Darwin with `{"enabled": true}` **does** emit the entry (guards against over-gating the one path that must work).
- [x] A refresh of an existing config drops a previously-emitted entry once the gate no longer passes.
- [x] `pytest test/test_computer_use_registration.py test/test_mcp_computer.py test/test_agent.py -q` — 352 passed
- [x] `flake8` / `isort --check-only` — clean
- [x] `mypy src/kiro_crew/agent.py` — no new errors (3 pre-existing unrelated `hooks.py` xattr errors)
- [x] `scripts/docs_lint.py` — clean
- [x] `BRAND_BASE_REF=upstream/main scripts/check_brand_name.py` — clean