### PR TITLE
perf(cli): defer heavy dispatch imports — −0.8s per CLI call, −58MB per MCP backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **`kirocrew` commands start up to ~0.8 s faster, and each MCP stdio server
+  drops ~58 MB of resident memory.** `cli.py` imported its full 132-subcommand
+  dispatch table at module scope — including the Slack gateway, the dashboard
+  state module and (through it) numpy — so every CLI invocation and every
+  long-lived MCP backend process (`mcp-core`, `mcp-cron`, `mcp-computer`) paid
+  ~1.3 s and ~112 MB for subcommands that never run. The four heavy import
+  statements now execute inside the one dispatch branch that uses each name,
+  cutting a fresh `import kiro_crew.cli` to ~0.5 s / ~54 MB. Each command now
+  pays only for the modules its own branch uses: the MCP stdio servers and
+  most verbs save the full ~0.8 s / ~58 MB, while commands that dispatch into
+  the deferred modules (e.g. `gateway`, `cron`) save the portion they don't
+  touch. A ratchet test keeps the deferred modules out of module scope and
+  verifies every deferred import still resolves. Behavior is unchanged: the
+  entry point, the fail-closed security prelude, and all subcommand dispatch
+  are untouched. (#3504)
+
 - **A lesson from a previous embedding-model generation could no longer get
   silently deleted or offered as a false contradiction.** `write_lesson`'s
   semantic dedup and `find_contradiction_candidates` compared raw embeddings

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -4,6 +4,27 @@
 
 The CLI module (`kiro_crew/cli.py`) provides the `kirocrew` command using stdlib `argparse`.
 
+## Import Weight Contract
+
+`cli.py` is the shared dispatcher for every subcommand — including the
+long-lived MCP stdio servers (`kirocrew mcp-core` / `mcp-cron` /
+`mcp-computer`), which hold its module-scope imports resident for their whole
+lifetime. Its module scope therefore stays light: `cli_commands`,
+`cli_server` (which pulls `slack.gateway`) and `dashboard.state` (which pulls
+`vector_memory` → `numpy`) are imported inside the one `main()` dispatch
+branch that uses each name, never at module scope. Deferring them cuts a
+fresh `import kiro_crew.cli` from ~1.3 s / ~112 MB to ~0.5 s / ~54 MB, paid
+per CLI invocation and per MCP backend process.
+`test/test_cli_lazy_imports.py` ratchets the contract: after
+`import kiro_crew.cli` in a fresh interpreter, none of those modules may be
+present in `sys.modules`, and every deferred dispatch import must resolve.
+
+The entry point itself is not negotiable: all invocation forms
+(`kirocrew <sub>`, `python -m kiro_crew <sub>`, and the frozen desktop
+binary) land in `cli.main()`, whose prelude runs `boot_platform()`
+(fail-closed for non-standalone profiles), sandbox env hygiene, and
+`KIROCREW_PROJECT_DIR` resolution before any dispatch.
+
 ## Source Checkout Launcher
 
 The POSIX wrapper at `bin/kirocrew` resolves symlinks to find the real checkout,

--- a/src/kiro_crew/__main__.py
+++ b/src/kiro_crew/__main__.py
@@ -1,8 +1,12 @@
 """Entry point for ``python -m kiro_crew``.
 
 ``_ensure_ssl_certs()`` MUST run before ``from kiro_crew.cli import main``
-because that import triggers ``aiohttp`` (via ``dashboard.origin`` →
-``dashboard.__init__`` → ``dashboard.server`` → ``from aiohttp import web``).
+because importing ``cli`` can still reach ``aiohttp`` transitively (e.g. via
+``cli_doctor`` → ``dashboard.crash_dump_store`` / ``dashboard.origin``).
+Issue #3504 deferred cli.py's heaviest aiohttp edges (``cli_server``,
+``dashboard.state``) to call time, which makes this ordering EASIER to hold —
+but any module-scope import that reaches aiohttp, now or later, must still
+execute after ``_ensure_ssl_certs()``, so the prelude stays mandatory.
 
 aiohttp caches its default SSL context at import time
 (``aiohttp.connector._SSL_CONTEXT_VERIFIED``).  On AL2 / dev-desktops the

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -48,8 +48,6 @@ from kiro_crew.config.loader import (
 from kiro_crew.config.paths import _default_home, _legacy_home
 from kiro_crew.constants import BANNER, MIN_NODE_MAJOR, env_flag_enabled
 from kiro_crew.crash_guard import install as _install_crash_guard
-from kiro_crew.dashboard.state import set_build_info
-from kiro_crew.dashboard.urls import parse_dashboard_url
 from kiro_crew.env import git_build_info
 from kiro_crew.gateway_lock import GatewayLock, GatewayLockError
 from kiro_crew.history import ConversationLog, HistoryConsolidator
@@ -560,6 +558,12 @@ def _diagnostic_port(gw_kwargs: dict) -> int | None:
     if override is not None:
         return None if str(override).lower() == "auto" else int(override)
     try:
+        # Deferred import: ``dashboard.urls`` is a stdlib-only leaf, but
+        # importing it executes ``dashboard/__init__`` — keep it out of
+        # cli.py's module scope so non-gateway commands and the MCP stdio
+        # servers never touch the dashboard package (see issue #3504).
+        from kiro_crew.dashboard.urls import parse_dashboard_url
+
         return parse_dashboard_url(KiroCrewConfig.load().dashboard.url)[1]
     except Exception:
         # Diagnosis only — never let it break the refusal path it decorates.
@@ -2199,6 +2203,13 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         # The asyncio loop handler is installed later inside run().
         _install_crash_guard()
         gw_kwargs = _resolve_gateway_args(args)
+        # Deferred imports (issue #3504): ``dashboard.state`` pulls
+        # vector_memory → numpy (~56 MB) and ``cli_server`` pulls
+        # slack.gateway (~549 ms) — only the gateway command needs either,
+        # so no other subcommand (and no MCP stdio server) pays for them.
+        from kiro_crew.cli_server import _gateway
+        from kiro_crew.dashboard.state import set_build_info
+
         # Resolve the running build's git branch+commit ONCE here in the sync
         # entrypoint: provably AFTER KIROCREW_PROJECT_DIR detection (top of main())
         # and BEFORE asyncio.run() starts the loop. Resolving it at state.py import
@@ -2237,16 +2248,28 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
             url=getattr(args, "url", False),
         )
     elif args.command == "cron":
+        from kiro_crew.cli_commands import _cron
+
         _cron(args)
     elif args.command == "spawn":
+        from kiro_crew.cli_commands import _spawn
+
         _spawn(args)
     elif args.command == "run":
+        from kiro_crew.cli_server import _run_task
+
         asyncio.run(_run_task(args))
     elif args.command == "learn":
+        from kiro_crew.cli_commands import _learn
+
         _learn(args)
     elif args.command == "artifact":
+        from kiro_crew.cli_commands import _artifact
+
         _artifact(args)
     elif args.command == "memory":
+        from kiro_crew.cli_commands import _memory_cmd
+
         _memory_cmd(args)
     elif args.command == "mcp-cron":
         from kiro_crew.mcp_cron import run_mcp_server as run_mcp_cron_server
@@ -2272,12 +2295,20 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
 
         run_computer(getattr(args, "computer_args", []))
     elif args.command == "eval":
+        from kiro_crew.cli_commands import _run_eval
+
         asyncio.run(_run_eval(args))
     elif args.command == "security":
+        from kiro_crew.cli_commands import _security
+
         _security(args)
     elif args.command == "tailnet":
+        from kiro_crew.cli_commands import _tailnet
+
         _tailnet(args)
     elif args.command == "telemetry":
+        from kiro_crew.cli_commands import _telemetry
+
         _telemetry(args)
     elif args.command == "policy":
         from kiro_crew.cli_commands import _policy
@@ -2286,26 +2317,46 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
     elif args.command == "knowledge":
         _knowledge(args)
     elif args.command == "pod":
+        from kiro_crew.cli_commands import _pod
+
         _pod(args)
     elif args.command == "update":
+        from kiro_crew.cli_server import _update
+
         _update()
     elif args.command == "stop":
+        from kiro_crew.cli_server import _stop
+
         _stop(args.port)
     elif args.command == "restart":
+        from kiro_crew.cli_server import _restart
+
         _restart(args.port)
     elif args.command == "service":
+        from kiro_crew.cli_server import _service_cmd
+
         sys.exit(_service_cmd(args))
     elif args.command == "sandbox":
+        from kiro_crew.cli_server import _sandbox_cmd
+
         sys.exit(_sandbox_cmd(args))
     elif args.command == "cloud":
         sys.exit(handle_cloud(args))
     elif args.command == "logs":
+        from kiro_crew.cli_server import _logs_cmd
+
         _logs_cmd(args)
     elif args.command == "token":
+        from kiro_crew.cli_server import _token
+
         _token(args)
     elif args.command == "logout":
+        from kiro_crew.cli_server import _logout, resolve_client_port
+
         _logout(resolve_client_port(args.port))
     elif args.command == "status":
+        from kiro_crew.cli_server import _status
+
         _status(args)
     elif args.command == "consolidate":
         _consolidate_cmd(args)
@@ -2336,10 +2387,16 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         if rc:
             raise SystemExit(rc)
     elif args.command == "agent":
+        from kiro_crew.cli_commands import _handle_agent
+
         _handle_agent(args)
     elif args.command == "workspace":
+        from kiro_crew.cli_commands import _handle_workspace
+
         _handle_workspace(args)
     elif args.command == "app":
+        from kiro_crew.cli_commands import _handle_app
+
         _handle_app(args)
     else:
         print(BANNER)
@@ -2349,43 +2406,22 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
 # ── Config ──
 
 
+# NOTE (issue #3504): ``cli_commands`` and ``cli_server`` are deliberately NOT
+# imported at module scope. ``cli_commands`` costs ~556 ms and ``cli_server``
+# ~549 ms (it pulls ``slack.gateway``), and the MCP stdio servers
+# (``kirocrew mcp-core`` / ``mcp-cron`` / ``mcp-computer``) — which dispatch
+# through this module and hold its imports RESIDENT for their whole lifetime —
+# need neither. Every name from those two modules is imported inside the one
+# ``main()`` dispatch branch that uses it. ``test_cli_lazy_imports.py`` ratchets
+# this: a new module-scope import that reaches them fails the suite.
 from kiro_crew.cli_bench import bench_cmd, register_bench_parser  # noqa: E402
 from kiro_crew.cli_chat import _run_chat  # noqa: E402
 from kiro_crew.cli_cloud import add_size_choices as _cloud_size_choices  # noqa: E402
 from kiro_crew.cli_cloud import handle_cloud  # noqa: E402
-from kiro_crew.cli_commands import (  # noqa: E402
-    _artifact,
-    _cron,
-    _handle_agent,
-    _handle_app,
-    _handle_workspace,
-    _learn,
-    _memory_cmd,
-    _pod,
-    _run_eval,
-    _security,
-    _spawn,
-    _tailnet,
-    _telemetry,
-)
 from kiro_crew.cli_config import _config_cmd  # noqa: E402
 from kiro_crew.cli_desktop import desktop_cmd, register_desktop_parser  # noqa: E402
 from kiro_crew.cli_doctor import _doctor  # noqa: E402
 from kiro_crew.cli_perf import perf_cmd, register_perf_parser  # noqa: E402
-from kiro_crew.cli_server import (  # noqa: E402
-    _gateway,
-    _logout,
-    _logs_cmd,
-    _restart,
-    _run_task,
-    _sandbox_cmd,
-    _service_cmd,
-    _status,
-    _stop,
-    _token,
-    _update,
-    resolve_client_port,
-)
 from kiro_crew.cli_setup import (  # noqa: E402, F401
     _fix_shell_profiles,
     _manifest,

--- a/test/test_app_cli.py
+++ b/test/test_app_cli.py
@@ -59,7 +59,7 @@ class TestHandleApp:
     def test_install_and_list(self, tmp_path, app_env):
         import argparse
 
-        from kiro_crew.cli import _handle_app
+        from kiro_crew.cli_commands import _handle_app
 
         src = _make_app_source(tmp_path)
 
@@ -76,7 +76,7 @@ class TestHandleApp:
     def test_enable_disable(self, tmp_path, app_env):
         import argparse
 
-        from kiro_crew.cli import _handle_app
+        from kiro_crew.cli_commands import _handle_app
 
         src = _make_app_source(tmp_path)
         install_app(src)
@@ -99,7 +99,7 @@ class TestHandleApp:
     def test_info(self, tmp_path, app_env, capsys):
         import argparse
 
-        from kiro_crew.cli import _handle_app
+        from kiro_crew.cli_commands import _handle_app
 
         src = _make_app_source(tmp_path)
         install_app(src)
@@ -114,7 +114,7 @@ class TestHandleApp:
     def test_uninstall_preserves_data_by_default(self, tmp_path, app_env):
         import argparse
 
-        from kiro_crew.cli import _handle_app
+        from kiro_crew.cli_commands import _handle_app
 
         src = _make_app_source(tmp_path)
         install_app(src)
@@ -134,7 +134,7 @@ class TestHandleApp:
     def test_uninstall_purge_data_requires_explicit_flag(self, tmp_path, app_env):
         import argparse
 
-        from kiro_crew.cli import _handle_app
+        from kiro_crew.cli_commands import _handle_app
 
         src = _make_app_source(tmp_path)
         install_app(src)
@@ -151,7 +151,7 @@ class TestHandleApp:
     def test_install_invalid_source(self, app_env):
         import argparse
 
-        from kiro_crew.cli import _handle_app
+        from kiro_crew.cli_commands import _handle_app
 
         ns = argparse.Namespace(app_action="install", source="/nonexistent")
         with pytest.raises(SystemExit):
@@ -160,7 +160,7 @@ class TestHandleApp:
     def test_no_action_prints_usage(self, app_env, capsys):
         import argparse
 
-        from kiro_crew.cli import _handle_app
+        from kiro_crew.cli_commands import _handle_app
 
         ns = argparse.Namespace(app_action=None)
         _handle_app(ns)
@@ -191,7 +191,7 @@ class TestEnableRegistersCrons:
     def _enable(self):
         import argparse
 
-        from kiro_crew.cli import _handle_app
+        from kiro_crew.cli_commands import _handle_app
 
         ns = argparse.Namespace(app_action="enable", name="cli-test-app")
         _handle_app(ns)
@@ -263,7 +263,7 @@ class TestEnableRegistersCrons:
     def test_disable_removes_registered_crons(self, tmp_path, app_env):
         import argparse
 
-        from kiro_crew.cli import _handle_app
+        from kiro_crew.cli_commands import _handle_app
 
         src = _make_app_source(tmp_path, crons=self.CRONS)
         install_app(src)

--- a/test/test_app_scaffold.py
+++ b/test/test_app_scaffold.py
@@ -80,7 +80,7 @@ class TestScaffold:
 
         import argparse
 
-        from kiro_crew.cli import _handle_app
+        from kiro_crew.cli_commands import _handle_app
         ns = argparse.Namespace(app_action="init", name="cli-scaffolded", dir=str(tmp_path), backend=False)
         _handle_app(ns)
         captured = capsys.readouterr()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -982,7 +982,7 @@ class TestCronCli:
             "--agent",
             "ea-briefing",
         ]
-        with patch.object(sys, "argv", argv), patch("kiro_crew.cli._cron") as mock_cron:
+        with patch.object(sys, "argv", argv), patch("kiro_crew.cli_commands._cron") as mock_cron:
             from kiro_crew.cli import main
 
             main()
@@ -1005,7 +1005,7 @@ class TestCronCli:
             "--every",
             "300",
         ]
-        with patch.object(sys, "argv", argv), patch("kiro_crew.cli._cron") as mock_cron:
+        with patch.object(sys, "argv", argv), patch("kiro_crew.cli_commands._cron") as mock_cron:
             from kiro_crew.cli import main
 
             main()
@@ -1024,7 +1024,7 @@ class TestCronCli:
             "--agent",
             "oncall-agent",
         ]
-        with patch.object(sys, "argv", argv), patch("kiro_crew.cli._cron") as mock_cron:
+        with patch.object(sys, "argv", argv), patch("kiro_crew.cli_commands._cron") as mock_cron:
             from kiro_crew.cli import main
 
             main()
@@ -1045,7 +1045,7 @@ class TestCronCli:
             "--name",
             "renamed",
         ]
-        with patch.object(sys, "argv", argv), patch("kiro_crew.cli._cron") as mock_cron:
+        with patch.object(sys, "argv", argv), patch("kiro_crew.cli_commands._cron") as mock_cron:
             from kiro_crew.cli import main
 
             main()
@@ -1073,7 +1073,7 @@ class TestPortEnvValidatedAtEntry:
             monkeypatch.setenv("KIROCREW_PORT", bad)
             dispatched = []
             with patch.object(sys, "argv", ["kirocrew", "cron", "list"]), patch(
-                "kiro_crew.cli._cron", lambda _ns: dispatched.append(True)
+                "kiro_crew.cli_commands._cron", lambda _ns: dispatched.append(True)
             ):
                 from kiro_crew.cli import main
 
@@ -1089,7 +1089,7 @@ class TestPortEnvValidatedAtEntry:
         monkeypatch.setenv("KIROCREW_PORT", "5477")
         dispatched = []
         with patch.object(sys, "argv", ["kirocrew", "cron", "list"]), patch(
-            "kiro_crew.cli._cron", lambda _ns: dispatched.append(True)
+            "kiro_crew.cli_commands._cron", lambda _ns: dispatched.append(True)
         ):
             from kiro_crew.cli import main
 
@@ -1125,7 +1125,7 @@ class TestSandboxActiveMarkerCleared:
             seen["marker"] = os.environ.get("KIROCREW_SANDBOX_ACTIVE")
             seen["level"] = os.environ.get("KIROCREW_SANDBOX_LEVEL")
 
-        with patch.object(sys, "argv", argv), patch("kiro_crew.cli._cron", _capture):
+        with patch.object(sys, "argv", argv), patch("kiro_crew.cli_commands._cron", _capture):
             from kiro_crew.cli import main
 
             main()
@@ -4104,7 +4104,7 @@ class TestSeedDispatch:
         mock_seed = MagicMock(return_value=0)
         with (
             patch("kiro_crew.cli.seed_cmd", mock_seed),
-            patch("kiro_crew.cli._gateway"),
+            patch("kiro_crew.cli_server._gateway"),
             patch("kiro_crew.cli.asyncio.run"),
         ):
             from kiro_crew.cli import main
@@ -4129,7 +4129,7 @@ class TestSeedDispatch:
         mock_seed = MagicMock()
         with (
             patch("kiro_crew.cli.seed_cmd", mock_seed),
-            patch("kiro_crew.cli._gateway"),
+            patch("kiro_crew.cli_server._gateway"),
             patch("asyncio.run"),
         ):
             from kiro_crew.cli import main
@@ -4147,7 +4147,7 @@ class TestSeedDispatch:
         mock_seed = MagicMock(return_value=0)
         with (
             patch("kiro_crew.cli.seed_cmd", mock_seed),
-            patch("kiro_crew.cli._gateway"),
+            patch("kiro_crew.cli_server._gateway"),
             patch("asyncio.run"),
         ):
             from kiro_crew.cli import main

--- a/test/test_cli_lazy_imports.py
+++ b/test/test_cli_lazy_imports.py
@@ -1,0 +1,228 @@
+"""Regression guards for issue #3504: cli.py's module-scope import weight.
+
+``cli.py`` used to import ``cli_commands`` (~556 ms), ``cli_server`` (~549 ms,
+pulling ``slack.gateway``) and ``dashboard.state`` (pulling ``vector_memory``
+→ ``numpy``, ~56 MB) at module scope, so every CLI invocation and — worse —
+every long-lived MCP stdio server (``kirocrew mcp-core`` / ``mcp-cron`` /
+``mcp-computer``) paid ~1.3 s and ~112 MB for subcommands that never run.
+Those imports were moved into the one ``main()`` dispatch branch that uses
+each name, cutting a fresh ``import kiro_crew.cli`` to ~0.5 s / ~54 MB.
+
+The tests here keep it that way:
+
+1. **Ratchet** — a fresh interpreter that imports ``kiro_crew.cli`` must not
+   end up with any of the heavy modules in ``sys.modules``.  Without this, the
+   next module-scope import silently undoes the win (the two historical
+   ``# noqa: E402`` blocks show that already happened once).
+2. **Dispatch integrity** — every function-local ``from kiro_crew.* import``
+   inside ``main()`` must resolve.  A typo in a moved import is otherwise only
+   discovered at runtime by the user who runs that one subcommand.
+3. **Stdio servers still serve** — ``mcp-core`` / ``mcp-cron`` answer
+   ``initialize`` + ``tools/list`` over stdio end-to-end through the real CLI
+   entry point.
+4. **Security prelude ordering** — ``boot_platform`` still runs before the
+   mcp-core dispatch branch, and a ``PlatformCompositionError`` still aborts
+   rather than downgrading.
+
+Fresh-interpreter checks run in subprocesses: the warm test process has long
+since imported the heavy modules, so an in-process ``sys.modules`` assertion
+would be vacuous.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import cli
+from kiro_crew.platform import PlatformCompositionError
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+_CLI_PY = _SRC / "kiro_crew" / "cli.py"
+
+#: Modules that must NOT load as a side effect of ``import kiro_crew.cli``.
+#: Each entry names a measured cost: cli_commands/cli_server are the two
+#: deferred dispatch-table modules (~1.1 s combined), slack.gateway is
+#: cli_server's heaviest edge, dashboard.state → vector_memory → numpy is the
+#: ~56 MB RSS chain.
+_BANNED_AFTER_CLI_IMPORT = (
+    "kiro_crew.cli_commands",
+    "kiro_crew.cli_server",
+    "kiro_crew.slack.gateway",
+    "kiro_crew.dashboard.state",
+    "kiro_crew.vector_memory",
+    "numpy",
+)
+
+
+def test_cli_import_does_not_load_heavy_modules() -> None:
+    """Ratchet: ``import kiro_crew.cli`` must stay free of the deferred modules.
+
+    If this fails, a module-scope import (direct or transitive) reached one of
+    the banned modules again — move it into the dispatch branch that needs it
+    instead of deleting it from the list.
+    """
+    code = (
+        "import sys; "
+        "import kiro_crew.cli; "
+        "banned = " + repr(list(_BANNED_AFTER_CLI_IMPORT)) + "; "
+        "present = [m for m in banned if m in sys.modules]; "
+        "print(repr(present))"
+    )
+    res = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=120
+    )
+    assert res.returncode == 0, f"import kiro_crew.cli failed:\n{res.stderr}"
+    present = ast.literal_eval(res.stdout.strip())
+    assert present == [], (
+        f"module-scope import of kiro_crew.cli loaded deferred modules: {present}. "
+        "A new (or moved-back) module-scope import reaches them — defer it into "
+        "the main() dispatch branch that uses it (see issue #3504)."
+    )
+
+
+def _local_imports_in_main() -> list[tuple[str, str]]:
+    """(module, name) for every function-local kiro_crew import inside main()."""
+    tree = ast.parse(_CLI_PY.read_text(encoding="utf-8"))
+    main_fn = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "main"
+    )
+    found: list[tuple[str, str]] = []
+    for node in ast.walk(main_fn):
+        if isinstance(node, ast.ImportFrom) and node.module and (
+            node.module == "kiro_crew" or node.module.startswith("kiro_crew.")
+        ):
+            for alias in node.names:
+                found.append((node.module, alias.name))
+    return found
+
+
+def test_main_contains_the_deferred_dispatch_imports() -> None:
+    """The dispatch imports really are function-local (not silently hoisted back)."""
+    local = _local_imports_in_main()
+    modules = {mod for mod, _ in local}
+    assert "kiro_crew.cli_commands" in modules
+    assert "kiro_crew.cli_server" in modules
+    assert "kiro_crew.dashboard.state" in modules
+    # Coherence check: the dispatch chain defers a substantial name set, not a remnant.
+    assert len(local) >= 25, f"expected >=25 deferred imports in main(), found {len(local)}"
+
+
+@pytest.mark.parametrize(
+    "module,name",
+    _local_imports_in_main(),
+    ids=lambda v: v if isinstance(v, str) else repr(v),
+)
+def test_every_deferred_dispatch_import_resolves(module: str, name: str) -> None:
+    """Each ``from <module> import <name>`` inside main() resolves.
+
+    This is the compile-time check the deferral gave up: a typo in a moved
+    import would otherwise surface only when a user runs that subcommand.
+    """
+    mod = importlib.import_module(module)
+    assert hasattr(mod, name), f"main() imports {name} from {module}, which lacks it"
+
+
+def _stdio_roundtrip(subcommand: str, tmp_path: Path) -> list[str]:
+    """Start ``kirocrew <subcommand>`` over stdio; return the tools/list names."""
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "kiro_crew", subcommand],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={
+            **os.environ,
+            "KIROCREW_HOME": str(tmp_path / "home"),
+        },
+    )
+    try:
+        init = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test-cli-lazy-imports", "version": "0"},
+            },
+        }
+        assert proc.stdin is not None and proc.stdout is not None
+        proc.stdin.write(json.dumps(init) + "\n")
+        proc.stdin.flush()
+        line = proc.stdout.readline()
+        assert line, f"{subcommand}: no initialize response (stderr: {proc.stderr.read()[:500]})"
+        resp = json.loads(line)
+        assert resp.get("id") == 1 and "result" in resp, f"bad initialize response: {resp}"
+        proc.stdin.write(json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n")
+        proc.stdin.write(json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}) + "\n")
+        proc.stdin.flush()
+        line2 = proc.stdout.readline()
+        assert line2, f"{subcommand}: no tools/list response"
+        resp2 = json.loads(line2)
+        assert resp2.get("id") == 2 and "result" in resp2, f"bad tools/list response: {resp2}"
+        return [t["name"] for t in resp2["result"]["tools"]]
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+@pytest.mark.parametrize("subcommand", ["mcp-core", "mcp-cron"])
+def test_mcp_stdio_server_answers_initialize_and_tools_list(
+    subcommand: str, tmp_path: Path
+) -> None:
+    """The stdio servers still boot and serve through the real CLI dispatch."""
+    tools = _stdio_roundtrip(subcommand, tmp_path)
+    assert len(tools) > 0, f"{subcommand} returned an empty tool table"
+
+
+def test_boot_platform_runs_before_mcp_core_dispatch(monkeypatch) -> None:
+    """Security prelude ordering survives the deferral.
+
+    ``boot_platform`` must fire before the mcp-core branch imports and starts
+    the server — the fail-closed contract is that a non-standalone profile
+    with no security overlay never reaches ``run_mcp_core_server``.
+    """
+    order: list[str] = []
+
+    monkeypatch.setattr(
+        cli, "boot_platform", lambda *_a, **_k: order.append("boot_platform")
+    )
+
+    fake_mcp_core = types.ModuleType("kiro_crew.mcp_core")
+    fake_mcp_core.run_mcp_core_server = lambda: order.append("dispatch")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kiro_crew.mcp_core", fake_mcp_core)
+
+    monkeypatch.setattr(cli.sys, "argv", ["kirocrew", "mcp-core"])
+    cli.main()
+
+    assert order == ["boot_platform", "dispatch"]
+
+
+def test_platform_composition_error_still_aborts_mcp_core(monkeypatch) -> None:
+    """A composition failure aborts BEFORE dispatch — no silent downgrade."""
+
+    def _raise(*_a, **_k):
+        raise PlatformCompositionError("companion missing")
+
+    monkeypatch.setattr(cli, "boot_platform", _raise)
+
+    dispatched: list[bool] = []
+    fake_mcp_core = types.ModuleType("kiro_crew.mcp_core")
+    fake_mcp_core.run_mcp_core_server = lambda: dispatched.append(True)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kiro_crew.mcp_core", fake_mcp_core)
+
+    monkeypatch.setattr(cli.sys, "argv", ["kirocrew", "mcp-core"])
+    with pytest.raises(PlatformCompositionError):
+        cli.main()
+    assert dispatched == [], "mcp-core dispatched despite a failed platform composition"

--- a/test/test_cron_approval_mode.py
+++ b/test/test_cron_approval_mode.py
@@ -774,7 +774,7 @@ class TestNoCronsFlag:
         with patch.object(sys, "argv", ["kirocrew", "gateway", "--no-crons"]):
             from kiro_crew.cli import main
 
-            with patch("kiro_crew.cli._gateway", new_callable=AsyncMock) as mock_gw, patch(
+            with patch("kiro_crew.cli_server._gateway", new_callable=AsyncMock) as mock_gw, patch(
                 "kiro_crew.cli.asyncio"
             ) as mock_asyncio:
                 mock_asyncio.run = MagicMock()

--- a/test/test_workspace_crud_cli.py
+++ b/test/test_workspace_crud_cli.py
@@ -185,7 +185,7 @@ class TestWorkspaceDispatch:
         with (
             unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
             unittest.mock.patch("sys.argv", ["kirocrew", "workspace", "list"]),
-            unittest.mock.patch("kiro_crew.cli._handle_workspace") as mock_handler,
+            unittest.mock.patch("kiro_crew.cli_commands._handle_workspace") as mock_handler,
         ):
             main()
         mock_handler.assert_called_once()


### PR DESCRIPTION
# What is the problem?

`cli.py` imports the dashboard, the full 132-subcommand dispatch surface and the Slack gateway at **module scope**, so every consumer pays for all of it regardless of which subcommand runs:

- the long-lived MCP stdio servers (`kirocrew mcp-core` / `mcp-cron` / `mcp-computer`) hold the cost **resident** for their whole lifetime, multiplied per session that runs its own backend;
- every interactive `kirocrew <verb>` invocation pays it as startup latency;
- every script cron pays it per run.

Measured on one host (fresh interpreter, warm page cache): `import kiro_crew.cli` = **~1.3 s / ~112 MB peak RSS**, vs the 40.6 MB an MCP server actually needs. `-X importtime` attribution: `cli_commands` 556 ms, `cli_server` 549 ms (→ `slack.gateway` 230 ms), `dashboard.state` 183 ms (→ `vector_memory` → `numpy`, ~56 MB).

# Why this matters to the user

A stdio MCP server is a thin JSON-RPC loop; holding ~58 MB of Slack gateway, dashboard state and numpy resident per backend process is pure loss that compounds with every session. Interactively, ~0.8 s of every `kirocrew <anything>` is imports for subcommands that will not run.

# How our fix solves it

**The entry point does not change.** All invocation forms (`kirocrew <sub>`, `python -m kiro_crew <sub>`, the frozen desktop binary where `sys.executable` *is* the CLI) land in `cli.main()`, whose mandatory prelude — `boot_platform()` fail-closed for non-standalone profiles, sandbox env hygiene, `KIROCREW_PROJECT_DIR` resolution — runs before any dispatch. That stays exactly as is.

What moves is the cost: the four heavy module-scope import statements (`dashboard.state`, `dashboard.urls`, `cli_commands`, `cli_server`) now execute inside the one `main()` dispatch branch that uses each name — the same pattern the `computer`, `policy` and `snapshot` branches already used, for the same reason. An AST pass confirmed this is mechanical: all 27 moved names are referenced exactly once each, inside `main()`'s dispatch chain or `_diagnostic_port`; none is a default argument, decorator, base class or module-level constant.

Measured on the branch (fresh interpreter, 3 runs each):

| | wall | peak RSS |
|---|---|---|
| main | 0.99–1.02 s | 106–111 MB |
| this branch | 0.37–0.48 s | 54–55 MB |

**−~0.6 s and −~55 MB**, per MCP backend process and per CLI invocation. The whole `vector_memory` → `numpy` chain no longer loads.

Known residual (out of scope per the issue): `cli_doctor` → `dashboard.crash_dump_store` / `dashboard.origin` still pulls ~13 MB of the dashboard package transitively. The `__main__.py` SSL-ordering comment is updated accordingly — deferring these edges makes the `_ensure_ssl_certs()`-before-aiohttp invariant *easier* to hold, and the prelude stays mandatory.

Test monkeypatches on the moved names (`kiro_crew.cli._cron` / `._gateway` / `._handle_workspace` / `._handle_app`) were retargeted to their defining modules (`kiro_crew.cli_commands.*` / `kiro_crew.cli_server.*`), which call-time imports resolve against.

# What tests we did

New `test/test_cli_lazy_imports.py` (40 tests):

1. **Ratchet** — fresh-interpreter subprocess imports `kiro_crew.cli` and asserts `sys.modules` contains none of `numpy`, `kiro_crew.slack.gateway`, `kiro_crew.dashboard.state`, `kiro_crew.vector_memory`, `kiro_crew.cli_server`, `kiro_crew.cli_commands`. Without it the next module-scope import silently undoes the win — the two historical `# noqa: E402` blocks show that already happened once.
2. **Dispatch integrity** — AST-driven parametrization over every function-local `from kiro_crew.* import` inside `main()`: each import must resolve, restoring the compile-time check the deferral gave up (a typo in a moved import would otherwise surface only at runtime for the user running that subcommand).
3. **Stdio servers still serve** — `mcp-core` and `mcp-cron` answer `initialize` + `tools/list` over stdio end-to-end through the real `python -m kiro_crew` entry point.
4. **Security prelude ordering** — `boot_platform` runs before the mcp-core branch dispatches, and a `PlatformCompositionError` still aborts before the server can start (no silent downgrade).

Local gates: full backend pytest (51k+ tests; the only failures are pre-existing environmental ones — no `gh` CLI in the sandbox, userns uid-mapping, agent-session env leakage — reproduced identically on unmodified main), isort/flake8/mypy clean on all touched files, Inclusive Language diff scan clean, docs spec (`docs/system-specs/modules/cli.md`) updated with the new Import Weight Contract section, CHANGELOG entry added.

# Any other suggestions

- The residual ~13 MB `cli_doctor` → dashboard edge is deliberately not folded in; the mechanical 55 MB lands first with the ratchet in place, per the issue.
- The memory half of the payoff compounds with #3495 (stub pool fallback): every backend that currently falls back to a private process pays this cost today.

Closes #3504
