### PR TITLE
fix(browser-cli): let mise reshim find mise during playwright-cli install

### DIFF
--- a/src/kiro_crew/browser_cli/install.py
+++ b/src/kiro_crew/browser_cli/install.py
@@ -73,9 +73,27 @@ def cli_env() -> dict[str, str]:
     in a version-manager-owned bin directory that the gateway process may never
     have had on PATH, so a child that inherits it unchanged cannot find the
     binary that was just installed.
+
+    Two layers, node bins outermost so they win:
+
+    1. :func:`node_augmented_path` prepends the Node bin dirs, so ``npm``/``node``
+       resolve to the managed toolchain.
+    2. :func:`augmented_path` (the inner layer) contributes the broad non-login
+       PATH -- ``~/.local/bin``, ``/opt/homebrew/bin``, the mise shims -- because
+       the mise-managed per-version ``npm`` is itself a wrapper script that runs
+       ``mise reshim`` after a global install. That hook needs the ``mise``
+       binary itself on PATH, and mise installs to ``~/.local/bin`` (or
+       Homebrew's bin), NOT to any Node bin dir. A GUI- or daemon-launched
+       gateway inherits a minimal PATH lacking those dirs, so without this layer
+       the wrapper dies ``mise: command not found`` and, under its
+       ``set -euo pipefail``, fails the whole ``npm install -g`` with rc 127.
+
+    This also aligns the exec env with discovery: :func:`cli_path` already
+    searches over ``node_augmented_path(augmented_path(PATH))``, so the child's
+    PATH now matches the path the binary was resolved on.
     """
     env = dict(os.environ)
-    env["PATH"] = node_augmented_path(env.get("PATH", ""))
+    env["PATH"] = node_augmented_path(augmented_path(env.get("PATH", "")))
     return env
 
 

--- a/test/test_browser_cli_install.py
+++ b/test/test_browser_cli_install.py
@@ -261,12 +261,49 @@ def test_step_success_does_not_surface_stderr(monkeypatch: pytest.MonkeyPatch) -
     assert result["steps"][0]["stderr"] == ""
 
 
-def test_cli_env_puts_node_dirs_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A global npm bin dir the gateway never had on PATH must still be found."""
+def test_cli_env_layers_node_dirs_over_the_broad_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Node bins win, and the broad non-login PATH is layered under them.
+
+    A global npm bin dir the gateway never had on PATH must still be found
+    (node layer, outermost). The broad layer under it carries ``~/.local/bin`` /
+    Homebrew's bin so a mise-managed npm's post-install ``mise reshim`` hook can
+    find the ``mise`` binary instead of dying ``mise: command not found``.
+    """
+    monkeypatch.setattr(mod, "augmented_path", lambda base: f"/home/.local/bin:{base}")
     monkeypatch.setattr(mod, "node_augmented_path", lambda base: f"/node/bin:{base}")
     monkeypatch.setenv("PATH", "/usr/bin")
 
-    assert mod.cli_env()["PATH"] == "/node/bin:/usr/bin"
+    assert mod.cli_env()["PATH"] == "/node/bin:/home/.local/bin:/usr/bin"
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX ~ expansion and the ~/.local/bin (mise) layout; Windows uses a different PATH set",
+)
+def test_cli_env_integration_puts_mise_home_bin_on_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The REAL (unstubbed) broad layer must contribute ``~/.local/bin``.
+
+    The stubbed unit tests above lock only the composition order. This one runs
+    the real ``augmented_path`` so it fails if a refactor drops ``~/.local/bin``
+    from the broad PATH -- the dir where the ``mise`` binary lives, without which
+    the post-install ``mise reshim`` hook dies ``mise: command not found`` and
+    ``npm install -g`` fails rc 127. That regression would otherwise be invisible
+    to this suite.
+    """
+    home = tmp_path / "home"
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    # Isolate mise's data dir so the assertion does not depend on the host's.
+    monkeypatch.delenv("MISE_DATA_DIR", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    path_entries = mod.cli_env()["PATH"].split(os.pathsep)
+
+    assert str(local_bin) in path_entries
 
 
 class TestPerEngineDownloads:
@@ -463,6 +500,7 @@ class TestCliEnvIsPublic:
     def test_cli_env_augments_path_from_node_augmented_path(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.setattr(mod, "augmented_path", lambda base: base)
         monkeypatch.setattr(mod, "node_augmented_path", lambda base: f"/nvm/bin:{base}")
         monkeypatch.setenv("PATH", "/usr/local/bin")
 


### PR DESCRIPTION
## Problem

Installing `playwright-cli` (browser features) fails in the dashboard with:

```
npm-install-global: Reshimming mise 24...
/Users/<user>/.local/share/mise/installs/node/24/bin/npm: line 76: mise: command not found
```

The `npm install -g @playwright/cli@latest` step exits rc 127, so browsing never becomes available.

## Why it matters

This blocks the entire browser-CLI install on any machine whose Node is managed by **mise** and whose gateway was launched from the GUI (Finder/Dock) or as a daemon — i.e. the common macOS install. The failure is opaque (an npm shim line number) and there is no fallback, so the user simply has no working browser tooling.

## Fix (symptoms → root cause → change)

- **Symptom:** `mise: command not found` from inside the mise-managed `npm`, failing the global install.
- **Root cause:** the per-version `npm` that mise installs (`.../installs/node/<v>/bin/npm`) is itself a wrapper script with `set -euo pipefail` that runs **`mise reshim`** after any global install. `cli_env()` built the child's PATH with `node_augmented_path()` only — the *narrow* Node-toolchain dir list. That puts `node`/`npm` on PATH but **not** `mise`'s own bin dir (`~/.local/bin`, or Homebrew's). A GUI/daemon-launched gateway inherits a minimal PATH lacking those dirs too, so the reshim hook can't find `mise`, dies, and `pipefail` turns that into rc 127 for the whole step.
- **Change:** layer the broad `augmented_path()` **under** the Node dirs in `cli_env()`:
  `node_augmented_path(augmented_path(env["PATH"]))`. `augmented_path` contributes `~/.local/bin` / `/opt/homebrew/bin` / the mise shims, so `mise` is discoverable, while `node_augmented_path` still prepends the Node bin dirs so `node`/`npm` resolve to the managed toolchain first. This also aligns the exec env with discovery: `cli_path()` already searches over `node_augmented_path(augmented_path(PATH))`, so the install child now runs on the same PATH the binary was resolved on.

## Tests

- `test_cli_env_layers_node_dirs_over_the_broad_path` — locks the composition order (Node dirs outermost, broad layer under them) with both helpers stubbed.
- `test_cli_env_augments_path_from_node_augmented_path` — updated to stub the new inner `augmented_path` layer as identity.
- `test_cli_env_integration_puts_mise_home_bin_on_path` (new) — runs the **real** `augmented_path` against a temp `$HOME` and asserts `~/.local/bin` (where `mise` lives) is on the resulting PATH. This guards the actual bug: a future refactor dropping `~/.local/bin` from the broad layer would fail here instead of silently re-breaking the reshim hook.

## Manual verification

N/A beyond unit coverage — the failure is a PATH-composition gap fully reproduced by `test_cli_env_integration_puts_mise_home_bin_on_path`. Empirically confirmed on the reporting machine that the mise per-version `npm` is a `mise reshim` wrapper and that `mise` resolves at `~/.local/bin/mise`, which `augmented_path` now contributes.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (`browser_cli/install.py` + its test); no rendered UI is affected.

no linked issue: surfaced from a live dashboard error report, no tracked issue filed.
