### PR TITLE
feat(tips): curate tips for the features shipped this past month

### DIFF
--- a/src/kiro_crew/data/tips_curated.json
+++ b/src/kiro_crew/data/tips_curated.json
@@ -66,7 +66,7 @@
       "title": "Tune how many subagents run at once",
       "body": "`agent.max_subagents` caps concurrent subagents. **0 = auto-size** to your machine's memory and CPU; pin a number with `kirocrew config set agent.max_subagents 4`.",
       "why": "",
-      "doc": "dynamic-subagent-sizing.md",
+      "doc": "",
       "cta_prompt": "",
       "action": { "kind": "route", "label": "Open Subagent config", "route": "/settings?tab=overview" }
     },
@@ -85,7 +85,7 @@
       "title": "Run crons with no LLM",
       "body": "A scheduled job can run a shell `command` or a Python `script` directly — no model, zero tokens. Ideal for polling, cleanup, and health checks.",
       "why": "",
-      "doc": "cron-and-scheduling.md",
+      "doc": "",
       "cta_prompt": "",
       "action": { "kind": "route", "label": "New scheduled job", "route": "/schedule" }
     },
@@ -108,6 +108,106 @@
       "doc": "",
       "cta_prompt": "",
       "action": { "kind": "route", "label": "Open Apps", "route": "/apps" }
+    },
+    {
+      "id": "system-monitor",
+      "feature": "System Monitor",
+      "title": "See what each session is spending",
+      "body": "A task manager for your agent: live CPU and memory per session, credits spent, and a Storage screen for what each session holds on disk. Open **Developer › System** — turn on **Developer Mode** in **Settings › Developer** to keep it in the sidebar.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open System Monitor", "route": "/developer?tab=system" }
+    },
+    {
+      "id": "web-terminal",
+      "feature": "Built-in Terminal",
+      "title": "Run commands without leaving the dashboard",
+      "body": "Click the **Terminal** icon in the sidebar for a tabbed shell that opens in the selected session's project directory; select any output and **Send to chat**. Pick your shell, font, and size in **Settings › Display**.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Terminal settings", "route": "/settings?tab=display&highlight=key:dashboard.terminal.shell" }
+    },
+    {
+      "id": "artifacts-library",
+      "feature": "Artifacts",
+      "title": "Keep the UI the agent builds for you",
+      "body": "Widgets, generated images, and documents can be saved as **Artifacts** — each gets its own page, a version history, and a companion chat for iterating on it. Browse them under **Artifacts**.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Artifacts", "route": "/artifacts" }
+    },
+    {
+      "id": "language-picker",
+      "feature": "Dashboard Language",
+      "title": "Use the dashboard in your language",
+      "body": "Switch the whole dashboard to another language in **Settings › Display › Language**, or leave it on **Auto** to follow your browser and OS.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Language setting", "route": "/settings?tab=display&highlight=display.language" }
+    },
+    {
+      "id": "auto-skills",
+      "feature": "Auto-generated Skills",
+      "title": "Turn repeated work into a skill",
+      "body": "Let Kiro Crew draft a reusable skill whenever a finished session contains a multi-step procedure worth repeating. Enable **Auto-generate skills from sessions** in **Settings › Skills** — drafts wait in a review queue and never go live without your approval. Off by default.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Skills settings", "route": "/settings?tab=skills&highlight=key:skills.auto_create_from_sessions" }
+    },
+    {
+      "id": "role-models",
+      "feature": "Per-role Models",
+      "title": "Use a different model for background work",
+      "body": "Background jobs and sub-agents can run on their own model and reasoning effort, separate from your chat. Set **Background Model** in **Settings › Chat**; a role you leave unset stays on `auto`.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Background Model setting", "route": "/settings?tab=chat&highlight=chat.background-model" }
+    },
+    {
+      "id": "agent-browsing",
+      "feature": "Agent Browsing",
+      "title": "Let the agent use a real browser",
+      "body": "Install the **Playwright CLI** from **Settings › Browser** and the agent can open pages, read them, and fill forms — you watch, and can take over, in the chat's **Browser** panel.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Browser settings", "route": "/settings?tab=browser" }
+    },
+    {
+      "id": "computer-use",
+      "feature": "Computer Use",
+      "title": "Let the agent drive a desktop app",
+      "body": "On macOS, the agent can read a native app's window through accessibility and click, type, and scroll in it. Turn on **Enable computer use** in **Settings › Computer Use** — off until you do, and an agent cannot enable it itself.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Computer Use settings", "route": "/settings?tab=computer-use&highlight=computer-use.enable-computer-use" }
+    },
+    {
+      "id": "issue-radar",
+      "feature": "Issue Radar",
+      "title": "Triage GitHub and GitLab issues",
+      "body": "Enable the **Issue Radar** app under **Apps**, connect a repository, and triage issues and pull requests from the dashboard — what the agent finds stays on the issue's card. Off until you enable it.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Apps", "route": "/apps" }
+    },
+    {
+      "id": "remote-crew",
+      "feature": "Remote Crew",
+      "title": "Reach another machine's Kiro Crew",
+      "body": "Add another Kiro Crew gateway over SSH or AWS SSM in **Settings › Remote Crew**, then switch between instances from the header.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Remote Crew settings", "route": "/settings?tab=instances" }
     }
   ]
 }

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -10,6 +10,7 @@ import random
 import time
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -1625,6 +1626,86 @@ class TestCuratedTips:
         # Features with no in-dashboard destination render body only (no button).
         for tid in ("steer-or-queue", "local-telemetry"):
             assert "action" not in tips[tid], f"{tid} must not carry an action"
+
+    def test_curated_tips_do_not_claim_a_catalog_doc(self) -> None:
+        """A curated tip must not carry a `doc` the docs catalog also owns.
+
+        Dismissing a tip appends its `doc` to `dismissed_docs`, and
+        `_is_eligible` then refuses EVERY tip carrying that doc. So a curated
+        tip that names an allowlisted doc silently takes the catalog's tip for
+        the same doc down with it — one dismissal, two features permanently
+        unmentionable. Doc-level dismissal exists to keep identity stable for
+        LLM-generated tips whose ids churn between regenerations; a curated tip
+        has a hand-authored, permanent id and does not need it.
+        """
+        from kiro_crew.tips import _load_curated_tips
+        from kiro_crew.tips_allowlist import TIP_DOC_ALLOWLIST
+
+        collisions = {
+            t["id"]: t["doc"] for t in _load_curated_tips()
+            if t.get("doc") in TIP_DOC_ALLOWLIST
+        }
+        assert not collisions, (
+            "curated tips claiming a catalog doc (dismissing one would also "
+            f"suppress the catalog tip for that doc): {collisions}"
+        )
+
+    def test_curated_highlight_anchors_exist_in_settings_registry(self) -> None:
+        """A tip's `highlight=` names a control the settings registry owns.
+
+        Two forms reach the same highlight. `key:<configKey>` finds the control
+        by a `data-setting-key` attribute, so it survives translation;
+        `<tab>.<kebab-label>` resolves the registry's ENGLISH label and matches
+        it against the rendered DOM label, which cannot match once the
+        dashboard is translated (the button still opens the right tab, and the
+        highlight is simply skipped). Prefer `key:` wherever the registry
+        carries a configKey; only 6 of 97 entries do today.
+
+        Either way the registry is generated from the panels, so a renamed or
+        deleted control silently turns the button into a navigation that
+        highlights nothing. Pin the two together.
+        """
+        from kiro_crew.tips import _load_curated_tips
+
+        registry_file = (
+            Path(__file__).resolve().parents[1]
+            / "website/src/components/commandPalette/settingsRegistry.gen.ts"
+        )
+        if not registry_file.is_file():  # packaged install carries no website/ tree
+            pytest.skip("settings registry not present in this tree")
+        source = registry_file.read_text(encoding="utf-8")
+        entries = json.loads(source[source.index("[\n  {"):source.rindex("]") + 1])
+        by_id = {e["id"]: e for e in entries}
+        by_config_key = {e["configKey"]: e for e in entries if e.get("configKey")}
+
+        for tip in _load_curated_tips():
+            route = tip.get("action", {}).get("route", "")
+            query = parse_qs(urlparse(route).query)
+            if "highlight" not in query:
+                continue
+            anchor = query["highlight"][0]
+            if anchor.startswith("key:"):
+                entry = by_config_key.get(anchor[len("key:"):])
+                assert entry is not None, (
+                    f"{tip['id']} highlights unknown config key {anchor!r}"
+                )
+            else:
+                entry = by_id.get(anchor)
+                assert entry is not None, (
+                    f"{tip['id']} highlights unknown control {anchor!r}"
+                )
+                # An id-form anchor whose control HAS a configKey is a missed
+                # chance at the translation-proof form.
+                assert not entry.get("configKey"), (
+                    f"{tip['id']} uses the label-derived id {anchor!r} while "
+                    f"the control exposes configKey {entry['configKey']!r} — "
+                    f"use highlight=key:{entry['configKey']} so the highlight "
+                    f"survives a translated dashboard"
+                )
+            assert query["tab"][0] == entry["tab"], (
+                f"{tip['id']} highlights {anchor!r}, which lives on the "
+                f"{entry['tab']!r} tab, not {query['tab'][0]!r}"
+            )
 
     @pytest.mark.asyncio
     async def test_curated_action_survives_serve(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## 1. What is the problem?

The feature-tips card can only surface a feature that lives in one of two pools: the docs catalog (`src/kiro_crew/docs/*.md` filtered by `TIP_DOC_ALLOWLIST`) or the hand-authored curated pool (`src/kiro_crew/data/tips_curated.json`).

The curated pool held 11 tips, and its newest entry predates roughly a month of shipped, user-visible surfaces. None of those surfaces has a `docs/*.md` entry either, so the discovery mechanism structurally could not mention any of them:

System Monitor, the built-in terminal, the Artifacts library, the dashboard language picker, auto-generated skills, per-role models, agent browsing, Computer Use, Issue Radar, Remote Crew.

A second gap surfaced while checking the existing entries: a curated tip's button navigates to a hard-coded path whose `highlight=<id>` fragment names a control id owned by the generated settings registry, and nothing pinned the two together.

## 2. Why this issue matters to the user

Most of the missing features are off by default behind a Settings control the user has no reason to visit — `skills.auto-generate-skills-from-sessions`, `computer-use.enable-computer-use`, Issue Radar's `defaultEnabled: false`. A tip is the only in-product prompt for that shape of feature, so with no tip the feature ships and is never seen, while the eligible pool keeps re-offering the same eleven items.

On the anchor gap: renaming or deleting a settings control leaves a tip's button landing on the correct tab and highlighting nothing. The button still "works", so the breakage is invisible.

## 3. How our fix solves it

**Ten curated tips**, one per feature, each written action-first in the pool's existing voice and each ending at the exact control or page:

| id | destination |
|---|---|
| `system-monitor` | `/developer?tab=system` |
| `web-terminal` | `key:dashboard.terminal.shell` |
| `artifacts-library` | `/artifacts` |
| `language-picker` | `display.language` |
| `auto-skills` | `key:skills.auto_create_from_sessions` |
| `role-models` | `chat.background-model` |
| `agent-browsing` | `/settings?tab=browser` |
| `computer-use` | `computer-use.enable-computer-use` |
| `issue-radar` | `/apps` |
| `remote-crew` | `/settings?tab=instances` |

A `key:` destination resolves the control by its `data-setting-key` attribute and survives a translated dashboard; a bare `<tab>.<label>` id resolves the registry's English label, which cannot match once the UI is translated (the button still opens the right tab, the highlight is just skipped). Only 6 of 97 registry entries expose a `configKey`, so `key:` is used wherever it is available — see #3520.

Every route was read out of `website/src/App.tsx` and every anchor out of `settingsRegistry.gen.ts` rather than written from memory, which changed three of them:

- **System Monitor has no `/system` route.** The page renders only as a tab of the Developer page, so the tip points at `/developer?tab=system` and names the Developer Mode toggle that puts it in the sidebar. The route itself is not gated, so the button works whether or not that toggle is on.
- **Issue Radar ships `defaultEnabled: false`**, so `/issue-radar` is not reachable for a user who has never enabled it. The button goes to `/apps`, where enabling happens.
- **Remote Crew has no registry anchor**, so that tip carries a bare `?tab=instances` rather than a `highlight=` that would silently no-op.

Two features were deliberately not given a tip. **Notifications** is almost entirely on by default (bell feed, chime, dock badge), so it is not discovery. **Crews** still labels its workspace and memory bindings a preview, and a tip would have to gloss over that; Artifacts took the slot instead.

Computer Use is worded "On macOS" because the driver is macOS-only and the tip pool is served to every platform.

**Behaviour change to two tips that already ship — read this even if you skim the rest.** Dismissing a tip appends its `doc` to `dismissed_docs` (`tips.py:1003`), and `_is_eligible` then refuses **every** tip carrying that doc (`tips.py:698`). Three curated tips named a doc the catalog also owns, so dismissing one silently suppressed a second, unrelated tip. All three are now `"doc": ""`:

| tip | claimed doc | status |
|---|---|---|
| `auto-skills` | `skills.md` | added by this PR |
| `subagent-parallelism` | `dynamic-subagent-sizing.md` | **already shipping** |
| `zero-token-cron` | `cron-and-scheduling.md` | **already shipping** |

The two shipping tips therefore change in two ways: dismissing them no longer suppresses the catalog tip for the same doc (the fix), and they lose their "learn more" doc link, because `doc` renders that link as well as carrying the dismissal identity (`TipCard.tsx:98`). I widened the fix past the reported line because a ratchet that skips those two rows is a half-guard when the invariant is identical for all three. #3524 tracks splitting the field so the links can come back.

**Anchor ratchet.** `test_curated_highlight_anchors_exist_in_settings_registry` parses the generated registry and asserts every curated `highlight=` names a control that exists *and* sits on the tab the route names. It skips cleanly in a packaged install, where the `website/` tree is absent.

**Doc-collision ratchet.** `test_curated_tips_do_not_claim_a_catalog_doc` fails any curated tip whose `doc` is in `TIP_DOC_ALLOWLIST`.

## 4. What tests we did

- `test/test_tips.py` — 121 passed, including the 13 curated-pool tests.
- Both new ratchets mutation-verified. Anchors: misspelling one (`display.langauge`) fails with "highlights unknown control"; moving a valid anchor to the wrong tab fails with "lives on the 'display' tab, not 'chat'". Doc collision: restoring `skills.md` fails with `{'auto-skills': 'skills.md'}`.
- `test/test_brand_name_gate.py` — 85 passed.
- `isort --check-only` and `flake8` clean on the changed test file.

No visual delta: this PR adds data rows to a pool the tip card already renders, and no component changed.

## 5. Any other suggestions on the work

Three follow-ups worth their own issues, deliberately not bundled here:

- `agent-questions.md`, `followup-suggestions.md` and `inbound-webhooks.md` exist in `src/kiro_crew/docs/` but are missing from `TIP_DOC_ALLOWLIST`, so those docs can never surface as a tip either. That is a one-line allowlist change plus a catalog regeneration.
- Nothing checks that a curated tip's `route` resolves to a real SPA path — only the `highlight` half is now pinned. A route ratchet needs the router's path list reachable from Python, which is a bigger change than this PR.
- `tips_catalog.json` carries a `generated_at` of 2026-08-04; worth confirming the release-time regeneration step still runs.

Closes #3517

