### PR TITLE
fix(sel): folder-write audit names the internal caller, not a blanket mcp label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ All notable changes to KiroCrew are documented in this file.
   dimension-checked, float64-precision scorer the ranking paths already use,
   which also removes a per-row query re-derivation from both loops. (#3466)
 
+- **Folder-write audit lines now name the internal component that made the
+  write, instead of inferring the caller's identity from the internal secret's
+  presence.** Every MCP stdio server now declares its component name on
+  loopback gateway requests (`X-Internal-Caller`, attached centrally by the
+  shared request helpers), and the folder endpoints validate it against a
+  known-caller set before trusting it into the security event log's `caller`
+  field — `source` stays in SEL's interface vocabulary (`mcp`), so operator
+  queries over `source == "mcp"` keep matching folder writes. The old
+  inference was correct only while exactly one internal caller existed — a
+  second internal caller would have silently inherited the same label. An
+  authenticated internal write with a missing or unrecognized caller name is
+  audited as `caller="unknown-internal"` with a warning, so a new caller shows
+  up loudly until it is added to the known set alongside its own test. Browser
+  writes still audit as `dashboard`; the caller header alone grants nothing.
+  (#3503)
+
 - **Side-panel oversize-question refusal now reports an accurate character
   target for every script, not just emoji.** The refusal derived its
   character count from a fixed worst-case floor (4 bytes/char, the emoji

--- a/docs/system-specs/modules/sel.md
+++ b/docs/system-specs/modules/sel.md
@@ -17,9 +17,9 @@ Each entry records:
 | `event_id` | Unique 16-char hex identifier |
 | `timestamp` | ISO 8601 UTC |
 | `event_type` | `tool_invocation`, `api_access`, `config_bounds_clamped`, `governance_decision`, `governance_degraded` |
-| `caller_identity` | Session key (e.g. `dashboard:abc`, `cron:xyz`, `subagent:123`) |
+| `caller_identity` | Session key (e.g. `dashboard:abc`, `cron:xyz`, `subagent:123`). API-access events from mixed-internal endpoints that validate `X-Internal-Caller` (the chat folder writes) carry the internal caller's declared **component name** here — e.g. `kirocrew-dashboard`, or `unknown-internal` for an authenticated internal caller that declared no recognized name (a defined, warned state, not log corruption); `source` stays in the interface vocabulary (`mcp`) for those events |
 | `agent` | Agent name (`kirocrew`, custom agent name) |
-| `source` | Interface: `slack`, `dashboard`, `cli`, `cron`, `subagent`, `taskrunner`, `mcp`, `background`, `acp` (ACP-transport events, e.g. `tool_interrupted`), `token_auth` / `refresh_tokens` (dashboard auth), `host` (the `_host` sentinel — an in-process host action like app activation / workspace admission), `unknown` (empty/unrecognized session key, which must NOT be mis-tagged `slack`) |
+| `source` | Interface: `slack`, `dashboard`, `cli`, `cron`, `subagent`, `taskrunner`, `mcp`, `background`, `acp` (ACP-transport events, e.g. `tool_interrupted`), `token_auth` / `refresh_tokens` (dashboard auth), `host` (the `_host` sentinel — an in-process host action like app activation / workspace admission), `unknown` (empty/unrecognized session key, which must NOT be mis-tagged `slack`). This is a closed interface vocabulary — component attribution does not extend it; see `caller` below |
 | `operation` | Tool name or `METHOD /api/path` |
 | `tool_kind` | Tool category (`execute_bash`, `fs_write`, `mcp_core`, `mcp_cron`, etc.) |
 | `outcome` | `invoked`, `auto_approved`, `approved`, `rejected`, `denied`, `completed`, `failed`, `clamped`, `degraded` (a governance chokepoint failed OPEN) |

--- a/src/kiro_crew/dashboard/chat_folders.py
+++ b/src/kiro_crew/dashboard/chat_folders.py
@@ -185,18 +185,53 @@ async def _unhide_folder(state: DashboardState, folder_id: str) -> bool:
     return await state.mutate_folders(_clear)
 
 
-def _audit_origin(request: web.Request) -> str:
-    """SEL ``source`` for a folder mutation: ``"mcp"`` for a tool, else ``"dashboard"``.
+# The internal callers this module recognizes on ``X-Internal-Caller``.
+# Exact-listed and ratcheted in ``test_chat_folder_audit_origin.py``: adding a
+# caller here must be a conscious edit paired with a test, never a silent
+# widen — the point of the header is that a NEW internal caller surfaces as
+# ``unknown-internal`` in the audit until someone decides what to call it,
+# instead of silently inheriting another component's label (#3503).
+_KNOWN_INTERNAL_CALLERS = frozenset({"kirocrew-dashboard"})
 
-    These endpoints are now driven by BOTH the browser and the
-    ``chat_folder_*`` MCP tools (``/api/chat`` is a mixed-internal path), and an
-    audit line that labels every write ``dashboard`` cannot answer "did I move
-    that session, or did the agent?". Same header test as
-    ``handlers/artifacts.py`` uses for artifact lifecycle events — the header is
-    already validated by the token-auth middleware, so its presence is a
-    trustworthy origin marker rather than a claim from the body.
+
+def _audit_origin(request: web.Request) -> tuple[str, str]:
+    """SEL ``(source, caller)`` for a folder mutation.
+
+    ``source`` stays in SEL's documented *interface* vocabulary (``dashboard``,
+    ``mcp``, ...) so operator queries like ``source == "mcp"`` keep matching
+    every MCP-driven event uniformly; the validated component identity rides
+    in ``caller``, which SEL already carries for exactly this purpose.
+
+    These endpoints are driven by BOTH the browser and the ``chat_folder_*``
+    MCP tools (``/api/chat`` is a mixed-internal path). A request without
+    ``X-Internal-Secret`` is the browser: ``("dashboard", "dashboard")``. An
+    internal request names its component in ``X-Internal-Caller`` (attached by
+    the MCP stdio servers' shared loopback request helpers — see
+    ``mcp_shared.set_internal_caller``), validated against
+    ``_KNOWN_INTERNAL_CALLERS``. Inferring the identity from the secret alone
+    was correct only while exactly one internal caller existed, and would
+    silently mislabel every write the moment a second one is added.
+
+    Trust model: the secret is verified by the token-auth middleware before
+    this handler runs, so authentication is settled here. The caller header is
+    ATTRIBUTION on top of that — it grants nothing (a browser sending the
+    header without the secret still audits as ``dashboard``), and an
+    unrecognized or missing value on an authenticated internal request is
+    recorded as ``caller="unknown-internal"`` with a warning rather than
+    trusted into the audit log.
     """
-    return "mcp" if request.headers.get("X-Internal-Secret") is not None else "dashboard"
+    if request.headers.get("X-Internal-Secret") is None:
+        return "dashboard", "dashboard"
+    caller = (request.headers.get("X-Internal-Caller") or "").strip()
+    if caller in _KNOWN_INTERNAL_CALLERS:
+        return "mcp", caller
+    logger.warning(
+        "internal folder write without a recognized X-Internal-Caller (got %r) — "
+        "audited as unknown-internal; a new internal caller must be added to "
+        "_KNOWN_INTERNAL_CALLERS alongside its ratchet test",
+        caller[:64],
+    )
+    return "mcp", "unknown-internal"
 
 
 async def api_chat_folders(request: web.Request) -> web.Response:
@@ -309,9 +344,10 @@ async def api_chat_folder_create(request: web.Request) -> web.Response:
             status=400,
         )
     state.push_slots_update()
+    source, caller = _audit_origin(request)
     sel().log_api_access(
-        caller=_audit_origin(request), operation="chat.folder_create",
-        outcome="allowed", source=_audit_origin(request), resources=str(folder["id"]),
+        caller=caller, operation="chat.folder_create",
+        outcome="allowed", source=source, resources=str(folder["id"]),
     )
     return web.json_response(folder, status=201)
 
@@ -438,9 +474,10 @@ async def api_chat_folder_update(request: web.Request) -> web.Response:
             status=409,
         )
     state.push_slots_update()
+    source, caller = _audit_origin(request)
     sel().log_api_access(
-        caller=_audit_origin(request), operation="chat.folder_update",
-        outcome="allowed", source=_audit_origin(request), resources=fid,
+        caller=caller, operation="chat.folder_update",
+        outcome="allowed", source=source, resources=fid,
     )
     return web.json_response(folder)
 
@@ -499,9 +536,10 @@ async def api_chat_folder_delete(request: web.Request) -> web.Response:
         state.push_slots_update()
         raise
     state.push_slots_update()
+    source, caller = _audit_origin(request)
     sel().log_api_access(
-        caller=_audit_origin(request), operation="chat.folder_delete",
-        outcome="allowed", source=_audit_origin(request), resources=fid,
+        caller=caller, operation="chat.folder_delete",
+        outcome="allowed", source=source, resources=fid,
     )
     return web.json_response({"ok": True})
 
@@ -537,9 +575,10 @@ async def api_chat_slot_folder(request: web.Request) -> web.Response:
         )
     await save_slot_off_loop(state, slot, force=True)
     state.push_slots_update()
+    source, caller = _audit_origin(request)
     sel().log_api_access(
-        caller=_audit_origin(request), operation="chat.slot_folder",
-        outcome="allowed", source=_audit_origin(request), resources=name,
+        caller=caller, operation="chat.slot_folder",
+        outcome="allowed", source=source, resources=name,
     )
     return web.json_response({"ok": True, "folder_id": slot.folder_id})
 

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -53,6 +53,7 @@ from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.mcp_caller import current_caller
 from kiro_crew.mcp_shared import (
     call_tool_with_logging,
+    internal_caller,
     run_mcp_stdio_loop,
 )
 from kiro_crew.mcp_tools import build_tool_list, dispatch
@@ -828,9 +829,30 @@ def _session_key_header_error(sk: str) -> str | None:
         )
 
 
+def _caller_header() -> dict[str, str]:
+    """``X-Internal-Caller`` for this process, when it has declared one.
+
+    MCP stdio servers declare their component name via
+    ``mcp_shared.set_internal_caller`` (done centrally in
+    ``run_mcp_stdio_loop``), and every loopback request from these helpers
+    carries it so the gateway's audit log can attribute an internal write to
+    the actual component instead of inferring "some internal caller" from the
+    secret's mere presence (#3503). Attribution only — the gateway
+    authenticates on ``X-Internal-Secret`` and validates this name against a
+    known set before trusting it into an audit line. Processes that never
+    declared an identity (CLI, tests) send no header rather than a guess.
+    """
+    name = internal_caller()
+    return {"X-Internal-Caller": name} if name else {}
+
+
 def _post(path: str, body: dict | None = None, *, timeout: float = 30) -> dict:
     data = json.dumps(body or {}).encode()
-    headers = {"Content-Type": "application/json", "X-Internal-Secret": _internal_secret()}
+    headers = {
+        "Content-Type": "application/json",
+        "X-Internal-Secret": _internal_secret(),
+        **_caller_header(),
+    }
     sk = _resolve_session_key()
     _sk_err = _session_key_header_error(sk)
     if _sk_err:
@@ -920,7 +942,7 @@ def _get(path: str, session_key: str | None = None) -> dict:
     session. Passing the verified key makes the value that was checked the value
     that is used. It is still validated by ``_session_key_header_error``.
     """
-    headers = {"X-Internal-Secret": _internal_secret()}
+    headers = {"X-Internal-Secret": _internal_secret(), **_caller_header()}
     sk = _resolve_session_key() if session_key is None else session_key
     _sk_err = _session_key_header_error(sk)
     if _sk_err:
@@ -942,7 +964,11 @@ def _get(path: str, session_key: str | None = None) -> dict:
 
 def _patch(path: str, body: dict | None = None) -> dict:
     data = json.dumps(body or {}).encode()
-    headers = {"Content-Type": "application/json", "X-Internal-Secret": _internal_secret()}
+    headers = {
+        "Content-Type": "application/json",
+        "X-Internal-Secret": _internal_secret(),
+        **_caller_header(),
+    }
     sk = _resolve_session_key()
     _sk_err = _session_key_header_error(sk)
     if _sk_err:
@@ -980,7 +1006,11 @@ def _put(path: str, body: dict | None = None, session_key: str | None = None) ->
     this path means writing another crew's work item and public ledger.
     """
     data = json.dumps(body or {}).encode()
-    headers = {"Content-Type": "application/json", "X-Internal-Secret": _internal_secret()}
+    headers = {
+        "Content-Type": "application/json",
+        "X-Internal-Secret": _internal_secret(),
+        **_caller_header(),
+    }
     sk = _resolve_session_key() if session_key is None else session_key
     _sk_err = _session_key_header_error(sk)
     if _sk_err:
@@ -1006,7 +1036,7 @@ def _put(path: str, body: dict | None = None, session_key: str | None = None) ->
 
 def _delete(path: str, body: dict | None = None) -> dict:
     data = json.dumps(body or {}).encode() if body else None
-    headers = {"X-Internal-Secret": _internal_secret()}
+    headers = {"X-Internal-Secret": _internal_secret(), **_caller_header()}
     sk = _resolve_session_key()
     _sk_err = _session_key_header_error(sk)
     if _sk_err:

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -23,8 +23,12 @@ folder, reparent a folder, and file a live session into one. Create and move
 only — no delete and no rename, so nothing here can lose a conversation. Every
 tool is a thin proxy over the dashboard's existing endpoints (loopback +
 ``X-Internal-Secret``); the endpoints keep owning every tree invariant, and the
-gateway audits each write with ``source=mcp`` so the log can tell an agent's
-move from the user's own.
+gateway audits each write with the caller's declared component name — this
+server's requests carry ``X-Internal-Caller: kirocrew-dashboard`` (attached
+centrally by ``run_mcp_stdio_loop`` + the ``mcp_core`` request helpers), which
+``chat_folders._audit_origin`` validates against its known-caller set — so the
+log can tell an agent's move from the user's own, and from any future internal
+caller's.
 
 Why the set needs no second gate behind the assignment: these tools grant no
 read the agent does not already have (``list_sessions`` in ``kirocrew-core`` is

--- a/src/kiro_crew/mcp_shared.py
+++ b/src/kiro_crew/mcp_shared.py
@@ -38,6 +38,35 @@ from kiro_crew.validation import (
 
 logger = logging.getLogger(__name__)
 
+# The component name this PROCESS presents on loopback gateway requests as
+# ``X-Internal-Caller``. Set exactly once by ``run_mcp_stdio_loop`` from the
+# server name it is handed, BEFORE any request is served — so every MCP stdio
+# server (kirocrew-core, kirocrew-dashboard, kirocrew-cron, kirocrew-computer)
+# self-identifies without per-server wiring, and a future server gets it for
+# free. ``None`` outside an MCP server process (CLI, tests), in which case the
+# request helpers send no caller header at all rather than inventing an
+# identity. The header is ATTRIBUTION for the gateway's audit log (SEL
+# ``source`` — see ``chat_folders._audit_origin``), never authorization: the
+# ``X-Internal-Secret`` handshake alone authenticates the request (#3503).
+_internal_caller_name: str | None = None
+
+
+def set_internal_caller(name: str | None) -> None:
+    """Declare this process's component identity for internal HTTP requests.
+
+    ``None`` un-declares it — used by ``run_mcp_stdio_loop``'s teardown to
+    restore the prior value, so repeated loops in one process (the test
+    suite) cannot leak one server's identity into the next test's requests.
+    """
+    global _internal_caller_name
+    _internal_caller_name = name
+
+
+def internal_caller() -> str | None:
+    """The declared component identity for internal HTTP requests, if any."""
+    return _internal_caller_name
+
+
 # Max tools/call requests buffered while a tool worker is busy.
 # Overflow gets an immediate JSON-RPC busy error instead of silence.
 PENDING_CALLS_MAX = 32
@@ -710,6 +739,14 @@ def run_mcp_stdio_loop(
     ``dup2`` on fd 1 — see the ``_stdout_fd`` comment block. It is released on
     exit so repeated loops in one process (the test suite) cannot leak fds.
     """
+    # Declare this process's identity for loopback requests FIRST — tool calls
+    # dispatched below reach the gateway through mcp_core's request helpers,
+    # which attach it as ``X-Internal-Caller`` so the audit log can name the
+    # component (not just "an internal caller") behind each write. Restored on
+    # exit, like the fd snapshot below, so repeated loops in one process (the
+    # test suite) cannot leak one server's identity into later requests.
+    _prior_caller = internal_caller()
+    set_internal_caller(server_name)
     snapshot_stdout_fd()
     try:
         _run_stdio_dispatch_loop(
@@ -720,6 +757,7 @@ def run_mcp_stdio_loop(
             advertise_caller_identity=advertise_caller_identity,
         )
     finally:
+        set_internal_caller(_prior_caller)
         release_stdout_fd()
 
 

--- a/test/test_chat_folder_audit_origin.py
+++ b/test/test_chat_folder_audit_origin.py
@@ -1,18 +1,33 @@
 """The folder endpoints must audit WHO moved a session — agent or human.
 
-``/api/chat/folders`` and ``/api/chat/slots/{slot}/folder`` are now driven by
-both the browser and the ``chat_folder_*`` MCP tools. An audit line that labels
+``/api/chat/folders`` and ``/api/chat/slots/{slot}/folder`` are driven by both
+the browser and the ``chat_folder_*`` MCP tools. An audit line that labels
 every write ``dashboard`` cannot answer "did I file that session, or did the
 agent?", which is the whole point of auditing a mutation.
+
+Since #3503 the audit splits interface from identity: ``source`` stays in
+SEL's closed interface vocabulary (``dashboard`` / ``mcp``) so operator
+queries like ``source == "mcp"`` keep matching every MCP-driven event
+uniformly, while ``caller`` carries the internal caller's own declared
+identity (``X-Internal-Caller``, validated against
+``_KNOWN_INTERNAL_CALLERS``) rather than a value inferred from the secret's
+presence — inferring from the secret was correct only while exactly one
+internal caller existed, and would silently mislabel writes the moment a
+second one is added. An authenticated internal request with a missing or
+unrecognized caller header audits as ``caller="unknown-internal"`` with a
+warning: loud, attributable, and never trusted verbatim into the log.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
 from aiohttp.test_utils import TestClient, TestServer
 from chat_test_helpers import _make_folder_app, _make_state
+
+from kiro_crew.dashboard.chat_folders import _KNOWN_INTERNAL_CALLERS
 
 
 class _RecordingSel:
@@ -57,7 +72,34 @@ class TestFolderAuditOrigin:
         assert event["caller"] == "dashboard"
 
     @pytest.mark.asyncio
-    async def test_mcp_create_is_audited_as_mcp(
+    async def test_caller_header_without_secret_is_still_dashboard(
+        self, tmp_path: Any, monkeypatch: Any, recorded: _RecordingSel
+    ) -> None:
+        """The caller header alone grants nothing — attribution, not authorization.
+
+        A browser (or anything else that never presented ``X-Internal-Secret``)
+        cannot promote its own audit label to an internal component's by naming
+        one: the secret check runs first, and this request audits exactly like
+        any other browser write.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        client = await _client(state)
+        try:
+            resp = await client.post(
+                "/api/chat/folders",
+                json={"name": "Sneaky"},
+                headers={"X-Internal-Caller": "kirocrew-dashboard"},
+            )
+            assert resp.status == 201
+        finally:
+            await client.close()
+        event = next(e for e in recorded.events if e["operation"] == "chat.folder_create")
+        assert event["source"] == "dashboard"
+        assert event["caller"] == "dashboard"
+
+    @pytest.mark.asyncio
+    async def test_mcp_create_is_audited_as_declared_caller(
         self, tmp_path: Any, monkeypatch: Any, recorded: _RecordingSel
     ) -> None:
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
@@ -67,17 +109,20 @@ class TestFolderAuditOrigin:
             resp = await client.post(
                 "/api/chat/folders",
                 json={"name": "Agent"},
-                headers={"X-Internal-Secret": "s3cret"},
+                headers={
+                    "X-Internal-Secret": "s3cret",
+                    "X-Internal-Caller": "kirocrew-dashboard",
+                },
             )
             assert resp.status == 201
         finally:
             await client.close()
         event = next(e for e in recorded.events if e["operation"] == "chat.folder_create")
         assert event["source"] == "mcp"
-        assert event["caller"] == "mcp"
+        assert event["caller"] == "kirocrew-dashboard"
 
     @pytest.mark.asyncio
-    async def test_mcp_session_move_is_audited_as_mcp(
+    async def test_mcp_session_move_is_audited_as_declared_caller(
         self, tmp_path: Any, monkeypatch: Any, recorded: _RecordingSel
     ) -> None:
         """The mutation Raymond most needs attributed: who re-filed the session."""
@@ -94,12 +139,92 @@ class TestFolderAuditOrigin:
             resp = await client.patch(
                 "/api/chat/slots/myslot/folder",
                 json={"folder_id": "f1"},
-                headers={"X-Internal-Secret": "s3cret"},
+                headers={
+                    "X-Internal-Secret": "s3cret",
+                    "X-Internal-Caller": "kirocrew-dashboard",
+                },
             )
             assert resp.status == 200
         finally:
             await client.close()
         event = next(e for e in recorded.events if e["operation"] == "chat.slot_folder")
         assert event["source"] == "mcp"
-        assert event["caller"] == "mcp"
+        assert event["caller"] == "kirocrew-dashboard"
         assert event["resources"] == "myslot"
+
+    @pytest.mark.asyncio
+    async def test_internal_write_without_caller_header_is_unknown_internal(
+        self, tmp_path: Any, monkeypatch: Any, recorded: _RecordingSel, caplog: Any
+    ) -> None:
+        """Secret present, no caller header: audit loudly, never guess.
+
+        This is the exact latent bug of #3503 made visible — an internal
+        caller that never declared itself used to inherit the ``mcp`` label
+        silently; now it shows up as ``unknown-internal`` plus a warning that
+        names the fix (add the caller to the known set, with a test).
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        client = await _client(state)
+        try:
+            with caplog.at_level(logging.WARNING, logger="kiro_crew.dashboard.chat_folders"):
+                resp = await client.post(
+                    "/api/chat/folders",
+                    json={"name": "Mystery"},
+                    headers={"X-Internal-Secret": "s3cret"},
+                )
+                assert resp.status == 201
+        finally:
+            await client.close()
+        event = next(e for e in recorded.events if e["operation"] == "chat.folder_create")
+        assert event["source"] == "mcp"
+        assert event["caller"] == "unknown-internal"
+        assert any("X-Internal-Caller" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_internal_write_with_unrecognized_caller_is_unknown_internal(
+        self, tmp_path: Any, monkeypatch: Any, recorded: _RecordingSel, caplog: Any
+    ) -> None:
+        """An arbitrary caller string is never trusted verbatim into the audit log."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        client = await _client(state)
+        try:
+            with caplog.at_level(logging.WARNING, logger="kiro_crew.dashboard.chat_folders"):
+                resp = await client.post(
+                    "/api/chat/folders",
+                    json={"name": "Rogue"},
+                    headers={
+                        "X-Internal-Secret": "s3cret",
+                        "X-Internal-Caller": "not-a-known-component",
+                    },
+                )
+                assert resp.status == 201
+        finally:
+            await client.close()
+        event = next(e for e in recorded.events if e["operation"] == "chat.folder_create")
+        assert event["source"] == "mcp"
+        assert event["caller"] == "unknown-internal"
+        assert any("not-a-known-component" in r.getMessage() for r in caplog.records)
+
+
+class TestKnownCallerRatchet:
+    def test_known_internal_callers_exact_list(self) -> None:
+        """RATCHET: adding an internal caller is a conscious, reviewed edit.
+
+        The known set is the entire defense #3503 asks for — a second internal
+        caller must fail loudly (``unknown-internal`` + warning) until someone
+        adds it HERE, alongside its own audit test. Widening this assertion is
+        that conscious edit.
+        """
+        assert _KNOWN_INTERNAL_CALLERS == frozenset({"kirocrew-dashboard"})
+
+    def test_dashboard_server_name_is_a_known_caller(self) -> None:
+        """The cross-module contract pin: the name the dashboard MCP server
+        declares (via ``run_mcp_stdio_loop`` → ``X-Internal-Caller``) must be a
+        name ``_audit_origin`` recognizes — renaming either side without the
+        other silently downgrades every agent folder write to
+        ``unknown-internal``."""
+        from kiro_crew.mcp_dashboard import SERVER_NAME
+
+        assert SERVER_NAME in _KNOWN_INTERNAL_CALLERS

--- a/test/test_mcp_internal_caller.py
+++ b/test/test_mcp_internal_caller.py
@@ -1,0 +1,141 @@
+"""Every MCP stdio server must NAME ITSELF on loopback gateway requests.
+
+#3503: the gateway's folder-audit path used to infer ``source=mcp`` from the
+mere presence of ``X-Internal-Secret`` — correct only while exactly one
+internal caller existed. The fix has two halves, and this file pins the
+sending half: ``run_mcp_stdio_loop`` declares the server's component name
+(``mcp_shared.set_internal_caller``) before any tool is dispatched, and the
+``mcp_core`` request helpers attach it to every request as
+``X-Internal-Caller``. The receiving half (validation against a known set,
+``unknown-internal`` fallback) is pinned in ``test_chat_folder_audit_origin.py``.
+
+A process that never declared an identity (CLI, tests) must send NO caller
+header rather than a guessed one — absence is what the receiving side turns
+into a loud ``unknown-internal`` audit, while a wrong guess would be trusted.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+import pytest
+
+from kiro_crew import mcp_core, mcp_shared
+
+
+@pytest.fixture(autouse=True)
+def _isolated_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test starts undeclared, however earlier tests left the global."""
+    monkeypatch.setattr(mcp_shared, "_internal_caller_name", None)
+
+
+class _CapturedRequest:
+    def __init__(self) -> None:
+        self.req: Any = None
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch) -> _CapturedRequest:
+    """Route the mcp_core helpers' urlopen into a recorder returning ``{}``."""
+    cap = _CapturedRequest()
+
+    class _Resp(io.BytesIO):
+        def __enter__(self) -> "_Resp":
+            return self
+
+        def __exit__(self, *a: Any) -> None:
+            self.close()
+
+    def _fake_urlopen(req: Any, timeout: float = 0) -> _Resp:
+        cap.req = req
+        return _Resp(json.dumps({}).encode())
+
+    monkeypatch.setattr(mcp_core, "_api_urlopen", _fake_urlopen)
+    monkeypatch.setattr(mcp_core, "_internal_secret", lambda: "sekrit")
+    monkeypatch.setattr(mcp_core, "_resolve_session_key", lambda: "")
+    monkeypatch.setattr(mcp_core, "_api_base", lambda: "http://127.0.0.1:1")
+    return cap
+
+
+def _headers(cap: _CapturedRequest) -> dict[str, str]:
+    return {k.lower(): v for k, v in cap.req.header_items()}
+
+
+class TestCallerHeaderAttachment:
+    def test_post_carries_declared_caller(self, captured: _CapturedRequest) -> None:
+        mcp_shared.set_internal_caller("kirocrew-dashboard")
+        mcp_core._post("/api/chat/folders", {"name": "x"})
+        headers = _headers(captured)
+        assert headers["x-internal-caller"] == "kirocrew-dashboard"
+        assert headers["x-internal-secret"] == "sekrit"
+
+    def test_get_carries_declared_caller(self, captured: _CapturedRequest) -> None:
+        mcp_shared.set_internal_caller("kirocrew-dashboard")
+        mcp_core._get("/api/chat/folders")
+        assert _headers(captured)["x-internal-caller"] == "kirocrew-dashboard"
+
+    def test_patch_carries_declared_caller(self, captured: _CapturedRequest) -> None:
+        mcp_shared.set_internal_caller("kirocrew-dashboard")
+        mcp_core._patch("/api/chat/folders/f1", {"parent_id": ""})
+        assert _headers(captured)["x-internal-caller"] == "kirocrew-dashboard"
+
+    def test_put_carries_declared_caller(self, captured: _CapturedRequest) -> None:
+        mcp_shared.set_internal_caller("kirocrew-dashboard")
+        mcp_core._put("/api/thing", {})
+        assert _headers(captured)["x-internal-caller"] == "kirocrew-dashboard"
+
+    def test_delete_carries_declared_caller(self, captured: _CapturedRequest) -> None:
+        """DELETE is the one verb that destroys data — the case the audit
+        exists for — so it must be attributable like the other four."""
+        mcp_shared.set_internal_caller("kirocrew-dashboard")
+        mcp_core._delete("/api/thing")
+        assert _headers(captured)["x-internal-caller"] == "kirocrew-dashboard"
+
+    def test_undeclared_process_sends_no_caller_header(
+        self, captured: _CapturedRequest
+    ) -> None:
+        """No identity declared → no header. Absence is the honest signal the
+        receiving side converts to ``unknown-internal``; a fabricated default
+        would instead be trusted as a real component name."""
+        mcp_core._post("/api/chat/folders", {"name": "x"})
+        headers = _headers(captured)
+        assert "x-internal-caller" not in headers
+        assert headers["x-internal-secret"] == "sekrit"
+
+
+class TestStdioLoopDeclaresIdentity:
+    def test_loop_declares_server_name_before_dispatch_and_restores_after(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The declaration is centralized in ``run_mcp_stdio_loop`` — every
+        current and FUTURE stdio server self-identifies without per-server
+        wiring — and it must land before the dispatch loop serves anything,
+        or the first tool call of a session would go out anonymous. On exit
+        the prior value is restored (like the fd snapshot), so repeated loops
+        in one process cannot leak one server's identity into later requests."""
+        seen_at_dispatch: list[str | None] = []
+
+        def _fake_dispatch(*a: Any, **k: Any) -> None:
+            seen_at_dispatch.append(mcp_shared.internal_caller())
+
+        monkeypatch.setattr(mcp_shared, "_run_stdio_dispatch_loop", _fake_dispatch)
+        mcp_shared.run_mcp_stdio_loop(
+            "test-server", "0.0", lambda: [], lambda _n, _a: ""
+        )
+        assert seen_at_dispatch == ["test-server"]
+        assert mcp_shared.internal_caller() is None
+
+    def test_loop_restores_identity_even_when_dispatch_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(*a: Any, **k: Any) -> None:
+            raise RuntimeError("dispatch died")
+
+        monkeypatch.setattr(mcp_shared, "_run_stdio_dispatch_loop", _boom)
+        with pytest.raises(RuntimeError):
+            mcp_shared.run_mcp_stdio_loop(
+                "test-server", "0.0", lambda: [], lambda _n, _a: ""
+            )
+        assert mcp_shared.internal_caller() is None


### PR DESCRIPTION
# What is the problem?

`_audit_origin` in `src/kiro_crew/dashboard/chat_folders.py` decides the SEL `source` for every folder mutation by checking whether `X-Internal-Secret` is present: secret ⇒ `mcp`, no secret ⇒ `dashboard`. That inference is correct today only because exactly one internal caller (the `kirocrew-dashboard` MCP server) drives these endpoints. The moment a second internal caller is added, its writes silently inherit the `mcp` label — the audit line can no longer answer "which component moved that session?", which is the whole reason the audit exists. Latent-correctness issue introduced by #3473.

# Why this issue matters to the user

The folder audit exists to answer one question: *did I move that session, or did the agent?* An audit that labels every future internal caller identically fails silently — nobody notices until the day an operator needs the log to attribute a mutation and it can't. Worse, the failure mode is invisible: nothing errors, the log just tells a subtly wrong story.

# How our fix solves it

Symptom → root cause → change:

- **Root cause**: origin was *inferred from a side effect of authentication* (secret presence) instead of *declared by the caller*.
- **Change, sending side**: every MCP stdio server now declares its component name once, centrally — `run_mcp_stdio_loop` calls the new `mcp_shared.set_internal_caller(server_name)` before dispatching anything (and restores the prior value on exit, like the fd snapshot next to it, so repeated loops in one process cannot leak identity). The `mcp_core` loopback request helpers (`_post`/`_get`/`_patch`/`_put`/`_delete`) attach it to every request as `X-Internal-Caller`. A process that never declared an identity (CLI, tests) sends **no** header rather than a guess — absence is the honest signal the receiving side turns into a loud audit state, while a fabricated default would be trusted.
- **Change, receiving side**: `_audit_origin` validates the header against an exact-listed known set (`_KNOWN_INTERNAL_CALLERS = {"kirocrew-dashboard"}`) and uses the validated name as the SEL `source`. Secret present but header missing/unrecognized ⇒ `source=unknown-internal` plus a warning naming the remedy — so a new internal caller shows up loudly until it is added to the known set alongside its own test. Browser requests (no secret) still audit as `dashboard`.
- **Trust model unchanged**: the header is attribution, never authorization. Authentication still rides entirely on the middleware-verified `X-Internal-Secret`; the caller header alone grants nothing (a browser sending it without the secret still audits as `dashboard` — pinned by test).
- The four audit call sites now compute the origin once per request, so the missing-header warning fires once per mutation, not twice.

# What tests we did

- `test/test_chat_folder_audit_origin.py` (rewritten): browser ⇒ `dashboard`; caller header without secret ⇒ still `dashboard` (attribution-not-authorization pin); declared caller ⇒ `kirocrew-dashboard` on create and session-move; secret with missing header ⇒ `unknown-internal` + warning; secret with unrecognized header ⇒ `unknown-internal` + warning naming the rejected value. **Ratchets**: exact-list assertion on `_KNOWN_INTERNAL_CALLERS`, and the cross-module pin `mcp_dashboard.SERVER_NAME ∈ _KNOWN_INTERNAL_CALLERS` (renaming either side without the other fails the suite instead of silently downgrading every agent write to `unknown-internal`).
- `test/test_mcp_internal_caller.py` (new): all five request helpers carry the declared name; an undeclared process sends no header; `run_mcp_stdio_loop` declares the server name before dispatch and restores the prior value after, including when dispatch raises.
- Mutation verification: 7/7 mutants killed (empty known set; revert to secret-presence inference; unknown-caller falls through to `dashboard`; header attachment dropped; loop never declares; `_delete` loses the header; `finally` doesn't restore).
- Local gates: isort / flake8 / mypy clean; new + neighboring suites green (`test_mcp_shared.py`, `test_mcp_dashboard_folders.py`, `test_mcp_dashboard_registration.py`, `test_dashboard_chat.py -k folder`, `test_channel_folders.py`, `test_issue_radar_crew_mcp_tools.py`).
- Pre-push model reviews: GPT (`gpt-5.6-sol`, codex-review contract) — zero findings; Opus (`claude-opus-5`, claude-review + AUTOSDE contract) — zero blocking, 3 advisories, **all three fixed** (`_delete` header coverage, `docs/system-specs/modules/sel.md` source vocabulary updated, loop identity restore).

# Manual verification

N/A — unit coverage sufficient: the full chain (server name → header → validated SEL source) is pinned end-to-end by the cross-module ratchet plus the helper and endpoint tests, and the change has no rendered surface.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (SEL audit attribution + internal HTTP header); no frontend file touched and no pixel changes.

# Any other suggestions on the work

`handlers/artifacts.py` and `deploy/handlers.py` still infer MCP-origin from secret presence for their own audit/gating. Same latent shape, deliberately out of scope here (issue #3503 names the folder writes); worth a follow-up issue if a second internal caller for those surfaces ever lands. Note this PR is based on `feat/dashboard-control-mcp` (PR #3473) because `_audit_origin` only exists there; it should be retargeted/rebased onto `main` when #3473 merges.

Closes #3503
