### PR TITLE
Fix: cancel the Notes autosave debounce on unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
+- **The Notes app's autosave debounce no longer outlives the page.** Editing
+  a note arms a 1000ms `window.setTimeout` that flushes the pending save;
+  nothing cancelled it on unmount, so navigating away (or, in tests,
+  unmounting) left the timer running. In production its callback could later
+  fire against an unmounted component; in the test suite the leaked callback
+  landed a `saveNote` call inside whichever unrelated test happened to be
+  running ~1s later, an intermittent cross-test failure. Unmount now cancels
+  the pending timer and, if there is a dirty edit, fires one best-effort save
+  directly (bypassing the state-setting flush path, which can no longer
+  safely run) — so a still-unsaved edit made just before navigating away is
+  preserved instead of silently lost. (#2984)
 
 - **Switching Kiro accounts mid-session no longer leaves the chat showing a raw
   `The bearer token included in the request is invalid.` with no way out.** A

--- a/website/src/apps/md-notebook/MdNotebookPage.tsx
+++ b/website/src/apps/md-notebook/MdNotebookPage.tsx
@@ -260,6 +260,37 @@ export default function MdNotebookPage() {
     dirtyRef.current = dirty
   }, [dirty])
 
+  // Cancel the autosave debounce on unmount (#2984). Without this the
+  // `window.setTimeout` armed in `edit` (below) outlives the component:
+  // React Router navigation (or, in tests, testing-library's unmount)
+  // removes this page but the timer keeps running, and its callback
+  // — `flushSave`, which calls `setDirty`/`setError`/`setFileConflict` — fires
+  // later against a component that no longer exists. In production that is a
+  // silent no-op write attempt racing whatever page replaced this one; in the
+  // test suite it is a cross-test `saveNote` call landing in whichever
+  // unrelated test happens to be running ~1s later.
+  //
+  // Clearing the timer alone would silently drop a still-unsaved edit made
+  // just before navigating away — the same edit `beforeunload` above warns
+  // about for a tab close. So on unmount, cancel the pending timer and, if
+  // there is a dirty note, fire one best-effort save directly at the API
+  // (never through `flushSave`, which sets state that can no longer safely
+  // be set here) using the current vault/path/content/mtime refs. Errors are
+  // swallowed: there is no component left to show them to, and retrying is
+  // not this effect's job — the note simply stays dirty for whichever
+  // surface opens it next to pick up.
+  useEffect(() => () => {
+    if (saveTimer.current) {
+      window.clearTimeout(saveTimer.current)
+      saveTimer.current = null
+    }
+    if (dirtyRef.current && pathRef.current) {
+      void notesApi
+        .saveNote(vaultRef.current, pathRef.current, contentRef.current, mtimeRef.current ?? undefined)
+        .catch(() => {})
+    }
+  }, [])
+
   // Warn on reload/close while an edit is still pending: the save is debounced,
   // so a reload within the debounce window would destroy the timer and lose the
   // latest content before it reaches disk.

--- a/website/src/test/MdNotebookPageCoverage.test.tsx
+++ b/website/src/test/MdNotebookPageCoverage.test.tsx
@@ -647,6 +647,50 @@ describe('MdNotebookPage — settings, guarded mutations and editor keys', () =>
     expect(api.saveNote).not.toHaveBeenCalled()
   })
 
+  // ── autosave debounce vs. unmount (#2984) ─────────────────────────────────
+
+  it('flushes a pending edit on unmount instead of losing it', async () => {
+    api.saveNote.mockResolvedValue({ mtime: 99 })
+    const { unmount } = await mountWithNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    // Fake timers only AFTER the userEvent interactions above: userEvent's own
+    // input simulation relies on real timers internally and hangs under fake
+    // ones (the established pattern a few tests up does the same).
+    vi.useFakeTimers()
+    fireEvent.change(rawEditor(), { target: { value: 'edited just before navigating away' } })
+    // Unmount well BEFORE the debounce would have fired on its own — this is
+    // the edit-loss case a bare clearTimeout (without a flush) would create.
+    unmount()
+    expect(api.saveNote).toHaveBeenCalledWith(
+      'v1', 'One.md', 'edited just before navigating away', expect.anything(),
+    )
+  })
+
+  it('does not leak the debounce timer past unmount', async () => {
+    api.saveNote.mockResolvedValue({ mtime: 99 })
+    const { unmount } = await mountWithNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    vi.useFakeTimers()
+    fireEvent.change(rawEditor(), { target: { value: 'edited just before navigating away' } })
+    unmount()
+    expect(api.saveNote).toHaveBeenCalledTimes(1)
+    // The ORIGINAL 1000ms debounce timer, if it survived unmount, would fire
+    // here — landing a second saveNote call against an unmounted page (or, in
+    // production, racing whatever page replaced it). This is the leak #2984
+    // reports: the callback firing later, during a DIFFERENT test/page.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS)
+    })
+    expect(api.saveNote).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not attempt a save on unmount when there is nothing dirty', async () => {
+    const { unmount } = await mountWithNote()
+    vi.useFakeTimers()
+    unmount()
+    expect(api.saveNote).not.toHaveBeenCalled()
+  })
+
   it('does not arm the reload warning for a block edit made mid-delete', async () => {
     api.deleteNote.mockReturnValue(pending())
     await mountWithNote()


### PR DESCRIPTION
## Summary

Fixes #2984. Note: PR #3101 already targets this issue — opening this as an independent implementation per maintainer discretion on which lands.

`MdNotebookPage` arms a 1000ms `window.setTimeout` (`SAVE_DEBOUNCE_MS`) on every edit, calling `flushSave()` when it fires. Nothing cancelled that timer on unmount: React Router navigation (or testing-library's `unmount()`) removes the page but the timer keeps running, and its callback — `flushSave`, which calls `setDirty`/`setError`/`setFileConflict` — fires later against a component that no longer exists.

Proven by instrumentation on PR #2964 (fixes #2914): a stack capture showed a second `saveNote` call arriving via `listOnTimeout` from a **prior test's unmounted component** — a cross-test race with a 1/5–1/15 repro rate under load-dependent timing drift.

## Fix

An unmount-only effect:
1. Cancels the pending debounce timer.
2. If there is a dirty note, fires **one** best-effort save directly at `notesApi.saveNote` (using the current vault/path/content/mtime refs) instead of losing the edit.

This deliberately does **not** go through `flushSave` — that function sets React state (`setDirty`/`setError`/`setFileConflict`), which can no longer safely run once the component is unmounting. Errors are swallowed: there is no component left to show them to, and the note simply stays dirty for whichever surface opens it next to pick up.

## Test plan

New tests in `MdNotebookPageCoverage.test.tsx`:
- [x] Unmounting a dirty page flushes the pending edit instead of losing it.
- [x] The debounce timer does not fire again after unmount — the core regression #2984 reports (advancing fake timers past `SAVE_DEBOUNCE_MS` post-unmount produces no second `saveNote` call).
- [x] Unmounting a clean page attempts no save at all.
- [x] `npx vitest run src/test/MdNotebookPageCoverage.test.tsx src/test/MdNotebookPage.coverage.test.tsx` — 112 passed
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — 0 errors (1 pre-existing unrelated warning elsewhere in the file)
- [x] `scripts/docs_lint.py` / `BRAND_BASE_REF=upstream/main scripts/check_brand_name.py` — clean