### PR TITLE
Fix: AttributeError on Windows opening files in the dashboard file viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **Fixed a Windows-only crash opening any file in the dashboard file
+  viewer.** `dashboard/handlers/files.py` referenced `os.O_NOFOLLOW` bare in
+  two places — a flag that does not exist on Windows' `os` module — so every
+  call to `/api/file-download` and `/api/file-raw` raised `AttributeError`
+  instead of serving the file, symlinked or not. Now uses
+  `getattr(os, "O_NOFOLLOW", 0)`, the pattern already used in 15+ other
+  places in the codebase for the same reason. (#3164)
+
 - **Side-panel oversize-question refusal now reports an accurate character
   target for every script, not just emoji.** The refusal derived its
   character count from a fixed worst-case floor (4 bytes/char, the emoji

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -1642,7 +1642,7 @@ async def api_file_download(request: web.Request) -> web.Response:
 
     # Read raw bytes via O_NOFOLLOW to atomically reject symlinks (no TOCTOU race).
     try:
-        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
         with os.fdopen(fd, "rb") as f:
             st = os.fstat(f.fileno())
             if st.st_size > _MAX_UPLOAD_BYTES:
@@ -1739,7 +1739,7 @@ async def api_file_raw(request: web.Request) -> web.Response:
     # Open with O_NOFOLLOW to atomically reject symlinks (no TOCTOU race).
     # Read header + full content through the same fd to avoid re-opening.
     try:
-        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
         with os.fdopen(fd, "rb") as f:
             st = os.fstat(f.fileno())
             if st.st_size > _MAX_UPLOAD_BYTES:

--- a/test/test_file_download.py
+++ b/test/test_file_download.py
@@ -188,6 +188,23 @@ async def test_symlink_rejected(tmp_path, mock_sel):
 
 
 @pytest.mark.asyncio
+async def test_downloads_without_crashing_on_a_platform_with_no_o_nofollow(tmp_path, mock_sel, monkeypatch):
+    """#3164: Windows' ``os`` module has no ``O_NOFOLLOW`` attribute, so a bare
+    ``os.O_NOFOLLOW`` reference raised ``AttributeError`` on every download,
+    not just a symlinked one. ``getattr(os, "O_NOFOLLOW", 0)`` is the fix --
+    simulated here by removing the attribute rather than by actually running
+    on Windows."""
+    monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+    f = tmp_path / "plain.docx"
+    f.write_bytes(_DOCX_LIKE_BYTES)
+    with patch("kiro_crew.dashboard.handlers._validate_dashboard_path", return_value=str(f)):
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"/api/file-download?path={f}")
+            assert resp.status == 200
+            assert await resp.read() == _DOCX_LIKE_BYTES
+
+
+@pytest.mark.asyncio
 async def test_oversize_file_rejected(tmp_path, mock_sel):
     """Files larger than _MAX_UPLOAD_BYTES (50 MB) must be rejected with 413
     before the body is buffered. We simulate via stat patching to avoid

--- a/test/test_file_raw.py
+++ b/test/test_file_raw.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -124,6 +125,21 @@ async def test_rejects_symlink(tmp_path, mock_sel):
             resp = await client.get(f"/api/file-raw?path={link}")
             assert resp.status == 403
             assert "symlink" in (await resp.json())["error"]
+
+
+@pytest.mark.asyncio
+async def test_serves_without_crashing_on_a_platform_with_no_o_nofollow(tmp_path, mock_sel, monkeypatch):
+    """#3164: Windows' ``os`` module has no ``O_NOFOLLOW`` attribute, so a bare
+    ``os.O_NOFOLLOW`` reference raised ``AttributeError`` on every file-viewer
+    open, not just a symlinked one. Simulated here by removing the attribute
+    rather than by actually running on Windows."""
+    monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+    f = tmp_path / "test.png"
+    f.write_bytes(_PNG_HEADER)
+    with patch("kiro_crew.dashboard.handlers._validate_dashboard_path", return_value=str(f)):
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"/api/file-raw?path={f}")
+            assert resp.status == 200
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #3164. Note: PR #3165 already targets this issue — opening this as an independent implementation per maintainer discretion on which lands.

`dashboard/handlers/files.py` referenced `os.O_NOFOLLOW` bare in two places (`api_file_download` and `api_file_raw`), a flag that does not exist on Windows' `os` module. Every call to `/api/file-download` or `/api/file-raw` on Windows raised `AttributeError` — not just for symlinked paths, the file viewer was entirely broken on that platform.

Fixed with `getattr(os, "O_NOFOLLOW", 0)`, the pattern already used in 15+ other places in this codebase (`hooks.py`, `steering.py`, `apps/manager.py`) for the identical reason. The `O_NOFOLLOW` protection itself (TOCTOU defense against a symlink swap) degrades to a no-op on Windows, same as everywhere else that already uses this pattern — this is not a new security gap, it matches the existing accepted posture.

## Test plan

- [x] New regression tests in `test_file_download.py` and `test_file_raw.py`: remove `os.O_NOFOLLOW` via `monkeypatch.delattr` to simulate the Windows condition, verify a plain (non-symlinked) file still downloads/serves successfully instead of raising `AttributeError`.
- [x] `pytest test/test_file_download.py test/test_file_raw.py test/test_dashboard_files_coverage.py -q` — 115 passed
- [x] `flake8` / `isort --check-only` — clean
- [x] `mypy src/kiro_crew/dashboard/handlers/files.py` — no new errors (3 pre-existing unrelated `hooks.py` xattr errors)
- [x] `scripts/docs_lint.py` / `BRAND_BASE_REF=upstream/main scripts/check_brand_name.py` — clean