### PR TITLE
fix(browser): adapt the browser install to non-apt Linux and token paste

### DIFF
--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -323,9 +323,16 @@ running `playwright-cli` commands, so it needs Node.js 20 or newer:
 
 ```bash
 npm install -g @playwright/cli@latest
-playwright-cli install-browser              # add --with-deps on Linux
+playwright-cli install-browser              # --with-deps on Debian/Ubuntu only
 playwright-cli install --skills agents --global
 ```
+
+`--with-deps` installs OS libraries through `apt` and needs root. Playwright
+implements it for apt alone, so on Fedora, RHEL, CentOS or Amazon Linux it
+misfires against Ubuntu package names; install the libraries with your own
+package manager instead. The Settings → Browser install button adapts to the
+host and reports the command to run when it needs root — see
+[the browser module spec](../system-specs/modules/browser.md#os-dependencies).
 
 The dashboard's **Browser** panel embeds the CLI's own dashboard over loopback,
 which shows the live session and lets you take over with real mouse and keyboard.

--- a/docs/system-specs/modules/browser.md
+++ b/docs/system-specs/modules/browser.md
@@ -88,10 +88,11 @@ once, at install, so registry auth applies at install time only.
 
 1. Detect `playwright-cli` on PATH and Node.js 20 or newer.
 2. Install when absent: `npm install -g @playwright/cli@latest`.
-3. `playwright-cli install-browser` for the browser binary (`--with-deps` on
-   Linux). The CLI downloads one on first use regardless, so the explicit step
-   exists to give the operator a progress surface and a visible failure rather
-   than a stall inside the first browse.
+3. `playwright-cli install-browser` for the browser binary. The CLI downloads one
+   on first use regardless, so the explicit step exists to give the operator a
+   progress surface and a visible failure rather than a stall inside the first
+   browse. `--with-deps` is appended only on an apt host, and a refusal there is
+   retried without it — see [OS dependencies](#os-dependencies).
 4. `playwright-cli install --skills agents --global` so the command reference is
    discoverable from the skill file rather than occupying the system prompt.
    `--skills` accepts `claude` (default) or `agents`; `--global` targets the home
@@ -135,6 +136,30 @@ is what the [accepted risk](#accepted-risk) above is about.
 
 State files hold live session credentials and are written with owner-only
 permissions.
+
+**The attach token.** `attach --extension` works without one: the extension
+answers a tokenless handshake by asking the human to approve the connection in the
+browser. Setting `PLAYWRIGHT_MCP_EXTENSION_TOKEN` removes that one click and
+nothing else, so it is opt-in and absent by default. `browser_cli/token.py` stores
+it owner-only behind `security._CREW_SECRET_LEAVES` — the agent inherits it through
+the environment and can never open the file — and no status surface returns the
+value, only whether one exists.
+
+The extension presents the token as a shell assignment, so the settings field
+accepts either form and stores the same token:
+
+```
+PLAYWRIGHT_MCP_EXTENSION_TOKEN=<value>
+<value>
+```
+
+`normalize_paste` strips the prefix only when the text left of the **first** `=`
+is exactly the variable name. That condition is a safety property rather than a
+nicety: these tokens are base64url and can legitimately contain `=`, so a looser
+rule would corrupt a bare token. `export`/`set` keywords and a matched pair of
+surrounding quotes are removed for the same reason. Normalization also runs on
+read, so a stored value holding the whole assignment repairs itself instead of
+reporting "stored" while the extension keeps prompting.
 
 ### Snapshot retention
 
@@ -191,8 +216,58 @@ exposes an interactive takeover surface to the network.
 |---|---|
 | Node.js | 20 or newer |
 | Install | `npm install -g @playwright/cli@latest` |
-| Browser binary | `install-browser`, with `--with-deps` on Linux |
+| Browser binary | `install-browser`; `--with-deps` on an apt host only |
 | Attach | Chromium-family only, since Playwright ships an attach extension for that family alone |
+
+### OS dependencies
+
+Playwright's `--with-deps` implementation is **apt-only**. On a distribution it
+does not recognize it does not decline — it selects its nearest Ubuntu package
+set and runs `apt-get` as root anyway. On an rpm host that is wrong twice: the
+package names do not exist, and the command needs a privilege a managed
+workstation withholds. Because the flag and the browser download are one CLI
+invocation, that refusal also took the download down, which is what made a
+missing OS library present as a sudo policy error quoting a 60-package `apt-get`
+line the user never typed.
+
+`browser_cli/os_deps.py` resolves the host family from `/etc/os-release`
+(`ID` plus `ID_LIKE`, so derivatives resolve through their base) and the browser
+step adapts:
+
+| Family | `--with-deps` | On failure |
+|---|---|---|
+| debian / ubuntu | passed | retried without the flag, so the download still lands |
+| rpm (rhel, fedora, centos, amzn, rocky, alma, suse) | never passed | failure detail carries a `sudo dnf install` line naming the rpm packages |
+| unrecognized Linux | never passed | no remedy offered — a guessed package manager fails on its own first argument and reads as the product being broken |
+| macOS / Windows | not applicable | the browser download alone is sufficient |
+
+The remedy is a command for a human to run, appended to the failing step's
+`stderr` (which the settings panel already renders verbatim) rather than a new UI
+state. Nothing in this path elevates or runs a package manager. The rpm list
+covers Chromium alone: it is the engine `attach` supports and the one `browser_ok`
+gates on, so it is what "browsing works" means.
+
+**A zero exit is not a verdict.** MEASURED on Amazon Linux 2023: with libraries
+missing, `install-browser` prints
+
+```
+Playwright Host validation warning:
+║ Host system is missing dependencies to run browsers. ║
+```
+
+and **exits 0**, leaving the browser directories in the cache. Playwright
+classifies it as a warning. Reading the exit code alone therefore reports a
+browser that cannot launch as installed — the panel goes green, `browser_ok`
+turns true because the build is genuinely on disk, and the real error arrives at
+the user's first browse as an opaque stack trace. Every browser step is judged on
+its output as well as its exit code (`os_deps.host_deps_unsatisfied`, matched
+against the header and the message body so a reworded box still trips one), and a
+match fails the step and carries the remedy.
+
+`browser_ok` keeps meaning "a build is downloaded", which stays literally true on
+such a host; the install error is what carries the truth that it cannot run.
+Making `browser_ok` mean "and it can launch" would need a validation probe on
+every settings poll.
 
 ### Standalone enterprise installer
 

--- a/src/kiro_crew/browser_cli/__init__.py
+++ b/src/kiro_crew/browser_cli/__init__.py
@@ -5,6 +5,9 @@ Three concerns, one per module, with no shared mutable state:
 - :mod:`kiro_crew.browser_cli.install` — detection, installation, and the
   capability gate. Presence of ``playwright-cli`` is the gate; there is no
   toggle, flag, or consent file anywhere in this package.
+- :mod:`kiro_crew.browser_cli.os_deps` — which Linux hosts the browser download's
+  ``--with-deps`` flag can serve, and the command handed to the operator on the
+  ones it cannot. Reads ``/etc/os-release``; never runs a package manager.
 - :mod:`kiro_crew.browser_cli.view` — supervises ``playwright-cli show``, the
   CLI's own dashboard, as a long-lived loopback-only child process.
 - :mod:`kiro_crew.browser_cli.snapshots` — retention for the timestamped YAML

--- a/src/kiro_crew/browser_cli/install.py
+++ b/src/kiro_crew/browser_cli/install.py
@@ -27,10 +27,12 @@ import logging
 import os
 import re
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 from kiro_crew import platform_compat
+from kiro_crew.browser_cli import os_deps
 from kiro_crew.env import augmented_path, find_node_tool, node_augmented_path
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -377,7 +379,13 @@ def _redact(text: str) -> str:
     return text
 
 
-def _step(name: str, argv: list[str], timeout: float) -> dict[str, Any]:
+def _step(
+    name: str,
+    argv: list[str],
+    timeout: float,
+    hint: str = "",
+    failure_signal: Callable[[str], bool] | None = None,
+) -> dict[str, Any]:
     """Run one install step and describe its outcome.
 
     stderr is carried only on failure: a successful ``npm install`` writes
@@ -390,9 +398,21 @@ def _step(name: str, argv: list[str], timeout: float) -> dict[str, Any]:
     and the log is the longer-lived of the two surfaces: `kirocrew logs` output
     gets pasted into bug reports. Redacting at the boundary would have left the
     secret in the log file, which is the copy that outlives the session.
+
+    *failure_signal* inspects the child's output for a failure the exit code does
+    NOT report. A zero exit is otherwise taken at face value, which is wrong for
+    exactly one case -- see :func:`os_deps.host_deps_unsatisfied`.
+
+    *hint* is our own trusted remediation line, appended AFTER the cap so a long
+    stderr cannot push the actionable part out of the operator's view. It is not
+    redacted because it is a constant composed here, never external output.
     """
-    rc, _out, err = _run(argv, timeout)
+    rc, out, err = _run(argv, timeout)
     ok = rc == 0
+    # Both streams: the diagnostic is on stderr today, and a step that starts
+    # printing it to stdout must not silently reopen the bug this guards.
+    if ok and failure_signal is not None and failure_signal(f"{err}\n{out}"):
+        ok = False
     # Redact BEFORE truncating: a credential straddling the truncation
     # boundary no longer matches its regex (e.g. the trailing ``@`` in a
     # ``://user:pass@host`` URL is past the cap), so truncating first can
@@ -401,15 +421,57 @@ def _step(name: str, argv: list[str], timeout: float) -> dict[str, Any]:
     # alternation with no nested quantifiers, so redacting the full
     # stderr is linear in input length — measured at <200 ms on 50 KB of
     # adversarial input, well below the subprocess timeout.
-    detail = "" if ok else _redact(err.strip())[:_STDERR_CAP]
+    detail = "" if ok else _redact((err.strip() or out.strip()))[:_STDERR_CAP]
     if not ok:
         logger.warning("playwright-cli install step %s failed (rc=%d): %s", name, rc, detail)
+        if hint:
+            detail = f"{detail}\n\n{hint}" if detail else hint
     return {
         "name": name,
         "ok": ok,
         "returncode": rc,
         "stderr": detail,
     }
+
+
+def _download_browser(path: str, engine: str | None = None) -> list[dict[str, Any]]:
+    """Download a browser build, adapting to what this host's OS allows.
+
+    Shared by :func:`install` and :func:`install_browser` so the two cannot
+    disagree about a host: they answer different product questions but face the
+    same package manager.
+
+    ``--with-deps`` is passed only where Playwright can honour it (see
+    :mod:`kiro_crew.browser_cli.os_deps`), and even there a refusal is not fatal.
+    Installing OS packages needs root, a managed workstation often withholds it,
+    and the download itself needs no privilege at all -- so the flag is dropped
+    and the download retried rather than losing the browser over a permission the
+    operator may never have. Returns every attempt, so the panel shows what was
+    tried instead of only the last verdict.
+
+    Every attempt is judged on its output as well as its exit code: a build whose
+    libraries are missing downloads "successfully" and cannot launch.
+    """
+    base = [path, "install-browser"] + ([engine] if engine else [])
+    suffix = f"-{engine}" if engine else ""
+    hint = os_deps.missing_deps_hint()
+
+    def attempt(step_name: str, argv: list[str], with_hint: bool) -> dict[str, Any]:
+        return _step(
+            step_name,
+            argv,
+            _BROWSER_INSTALL_TIMEOUT_S,
+            hint=hint if with_hint else "",
+            failure_signal=os_deps.host_deps_unsatisfied,
+        )
+
+    if not os_deps.with_deps_supported():
+        return [attempt(f"install-browser{suffix}", base, True)]
+
+    first = attempt(f"install-browser{suffix}", base + ["--with-deps"], False)
+    if first["ok"]:
+        return [first]
+    return [first, attempt(f"install-browser{suffix}-no-deps", base, True)]
 
 
 def install() -> dict[str, Any]:
@@ -420,9 +482,8 @@ def install() -> dict[str, Any]:
     step installs. The result carries every step attempted so an operator sees
     which one failed rather than only that something did.
 
-    ``--with-deps`` is Linux-only. It installs OS packages through the system
-    package manager, which needs privileges and has no meaning on macOS or
-    Windows, where the browser download alone is sufficient.
+    The browser step adapts to the host's package manager; see
+    :func:`_download_browser`.
     """
     steps: list[dict[str, Any]] = []
 
@@ -458,10 +519,7 @@ def install() -> dict[str, Any]:
         )
         return {"ok": False, "steps": steps}
 
-    browser_argv = [path, "install-browser"]
-    if platform_compat.IS_LINUX:
-        browser_argv.append("--with-deps")
-    steps.append(_step("install-browser", browser_argv, _BROWSER_INSTALL_TIMEOUT_S))
+    steps.extend(_download_browser(path))
     if not steps[-1]["ok"]:
         return {"ok": False, "steps": steps}
 
@@ -472,7 +530,11 @@ def install() -> dict[str, Any]:
             _SKILLS_INSTALL_TIMEOUT_S,
         )
     )
-    return {"ok": all(s["ok"] for s in steps), "steps": steps}
+    # The LAST step decides, not every step: a recovered ``--with-deps`` refusal
+    # leaves its failed attempt in the list for the operator to see, and that
+    # entry must not veto an install the retry actually completed. Every earlier
+    # gate has already returned on a real failure, so only this step is undecided.
+    return {"ok": steps[-1]["ok"], "steps": steps}
 
 
 def install_browser(engine: str) -> dict[str, Any]:
@@ -513,8 +575,5 @@ def install_browser(engine: str) -> dict[str, Any]:
                 }
             ],
         }
-    argv = [path, "install-browser", engine]
-    if platform_compat.IS_LINUX:
-        argv.append("--with-deps")
-    step = _step(f"install-browser-{engine}", argv, _BROWSER_INSTALL_TIMEOUT_S)
-    return {"ok": step["ok"], "steps": [step]}
+    steps = _download_browser(path, engine)
+    return {"ok": steps[-1]["ok"], "steps": steps}

--- a/src/kiro_crew/browser_cli/os_deps.py
+++ b/src/kiro_crew/browser_cli/os_deps.py
@@ -1,0 +1,239 @@
+"""Which Linux hosts ``install-browser --with-deps`` can actually serve.
+
+Playwright's OS-dependency installer is **apt-only**. On a distribution it does
+not recognize it does not decline -- it picks its nearest Ubuntu package set and
+runs ``apt-get`` anyway, as root. On an rpm host that is wrong twice over: the
+package names do not exist, and the command needs a privilege the operator of a
+managed workstation usually does not have. The observed shape on Amazon Linux
+2023 is a sudo policy refusal quoting a 60-package ``apt-get`` line the user
+never typed, and because the flag and the browser download are one CLI
+invocation, that refusal takes the download down with it.
+
+So the flag is offered only where it means something, and everywhere else the
+operator is handed the one command that does work on their distribution. The
+package list is the remedy for a failure they must fix with root; nothing here
+elevates, and nothing here runs a package manager.
+
+The read blocks (the os-release file), so a caller on the event loop offloads
+them -- the same contract as the rest of this package.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+from functools import lru_cache
+
+from kiro_crew import platform_compat
+
+logger = logging.getLogger(__name__)
+
+#: Family names this module reports. Not free-form strings: callers branch on
+#: them, so they are named here and nowhere else.
+FAMILY_DEBIAN = "debian"
+FAMILY_RPM = "rpm"
+FAMILY_UNKNOWN = "unknown"
+
+#: ``ID``/``ID_LIKE`` tokens that mean apt. Matched against both fields because a
+#: derivative (Linux Mint, Pop!_OS, elementary) names itself in ``ID`` and its
+#: base only in ``ID_LIKE``.
+_DEBIAN_IDS = frozenset({"debian", "ubuntu"})
+
+#: ``ID``/``ID_LIKE`` tokens that mean dnf/yum. ``amzn`` reports
+#: ``ID_LIKE=fedora``, so the ``ID_LIKE`` scan covers Amazon Linux without
+#: naming it, but it is listed anyway: Amazon Linux 2 omits ``ID_LIKE``.
+_RPM_IDS = frozenset(
+    {
+        "rhel",
+        "fedora",
+        "centos",
+        "amzn",
+        "rocky",
+        "almalinux",
+        "ol",
+        "opensuse",
+        "sles",
+        "suse",
+    }
+)
+
+#: Chromium's shared-library dependencies as rpm package names.
+#:
+#: Chromium alone, not all three engines: it is the engine ``attach`` supports
+#: and the one ``browser_ok`` gates on, so it is what "browsing works" means. A
+#: list covering Firefox and WebKit too would be longer, would ask for more root,
+#: and would still not be what the blocked operator needs first.
+#:
+#: These are NOT a translation of Playwright's Debian list. rpm splits and names
+#: the same libraries differently (``mesa-libgbm`` for ``libgbm1``, ``cups-libs``
+#: for ``libcups2``), so a mechanically mapped list fails on the first package
+#: and teaches the operator that the remedy is broken.
+_RPM_CHROMIUM_PACKAGES: tuple[str, ...] = (
+    "alsa-lib",
+    "at-spi2-atk",
+    "at-spi2-core",
+    "atk",
+    "cairo",
+    "cups-libs",
+    "dbus-libs",
+    "expat",
+    "fontconfig",
+    "freetype",
+    "gdk-pixbuf2",
+    "glib2",
+    "gtk3",
+    "lcms2",
+    "libX11",
+    "libXcomposite",
+    "libXcursor",
+    "libXdamage",
+    "libXext",
+    "libXfixes",
+    "libXi",
+    "libXrandr",
+    "libXrender",
+    "libdrm",
+    "libjpeg-turbo",
+    "libpng",
+    "libwebp",
+    "libxcb",
+    "libxkbcommon",
+    "libxml2",
+    "libxslt",
+    "mesa-libgbm",
+    "nspr",
+    "nss",
+    "pango",
+)
+
+
+#: Remedy for the apt family. Deliberately not a package list: Playwright installs
+#: its own, correct, per-version set there, and a copy here would go stale against
+#: the CLI the user actually has.
+_APT_DEPS_COMMAND = "sudo npx playwright install-deps chromium"
+
+#: Remedy for the rpm family, completed with :data:`_RPM_CHROMIUM_PACKAGES`.
+_DNF_DEPS_COMMAND_PREFIX = "sudo dnf install -y "
+
+#: What a blocked operator is told. One sentence of cause, then the command, so the
+#: actionable part is last and survives being appended after a truncated stderr.
+_MISSING_DEPS_HINT = (
+    "The browser needs OS libraries that only root can install. "
+    "Run this yourself, then retry the install:\n{command}"
+)
+
+
+def _os_release_ids() -> set[str]:
+    """Lowercased ``ID`` and ``ID_LIKE`` tokens identifying this distribution.
+
+    Read through :func:`platform.freedesktop_os_release` rather than opening
+    ``/etc/os-release`` directly. The stdlib consults BOTH locations the
+    freedesktop specification defines -- a minimal or immutable image may ship
+    only ``/usr/lib/os-release`` -- and it applies the spec's shell-style
+    unquoting, so a hand-rolled parser here would be a less correct copy of it.
+
+    An absent or unreadable file yields an empty set, which reports as
+    :data:`FAMILY_UNKNOWN` -- the conservative answer, since that is the family
+    for which no package manager is assumed.
+    """
+    try:
+        release = platform.freedesktop_os_release()
+    except OSError:
+        logger.debug("no freedesktop os-release on this host", exc_info=True)
+        return set()
+    # ``ID`` is single-valued; ``ID_LIKE`` is a space-separated list naming the
+    # bases a derivative inherits from. Both are scanned so a derivative that
+    # names itself in ``ID`` still resolves through its base.
+    ids: set[str] = set()
+    for key in ("ID", "ID_LIKE"):
+        ids.update(token for token in release.get(key, "").lower().split() if token)
+    return ids
+
+
+@lru_cache(maxsize=1)
+def linux_family() -> str:
+    """Package-manager family of this host.
+
+    Cached because a distribution does not change under a running process, and
+    every browser install attempt asks twice (once for the flag, once for the
+    remedy). Tests that fake the os-release data call
+    ``linux_family.cache_clear()``.
+    """
+    if not platform_compat.IS_LINUX:
+        return FAMILY_UNKNOWN
+    ids = _os_release_ids()
+    # Debian first: a Debian derivative never claims an rpm ID, but checking rpm
+    # first would let a host listing both resolve to the manager it lacks.
+    if ids & _DEBIAN_IDS:
+        return FAMILY_DEBIAN
+    if ids & _RPM_IDS:
+        return FAMILY_RPM
+    return FAMILY_UNKNOWN
+
+
+def with_deps_supported() -> bool:
+    """Whether ``--with-deps`` can install this host's OS packages.
+
+    True only on the apt family. Elsewhere the flag does not decline, it
+    mis-fires -- see the module docstring -- and takes the browser download with
+    it, so it is not passed at all.
+    """
+    return linux_family() == FAMILY_DEBIAN
+
+
+def manual_deps_command() -> str | None:
+    """The command the operator can run with root to install the OS libraries.
+
+    ``None`` off Linux, where the browser download alone is sufficient and there
+    is nothing to install. On an unknown Linux the return is also ``None``: a
+    guessed package manager is worse than silence, because a command that fails
+    on its own first argument reads as the product being broken rather than as
+    the host being unrecognized.
+    """
+    family = linux_family()
+    if family == FAMILY_DEBIAN:
+        return _APT_DEPS_COMMAND
+    if family == FAMILY_RPM:
+        return _DNF_DEPS_COMMAND_PREFIX + " ".join(_RPM_CHROMIUM_PACKAGES)
+    return None
+
+
+def missing_deps_hint() -> str:
+    """One line for a failed browser step, or ``""`` when there is nothing to add.
+
+    Appended to a step's failure detail rather than raised as its own state: the
+    settings panel already shows that detail verbatim, so this turns an opaque
+    package-manager refusal into the command that resolves it without adding a
+    surface to the UI or a string to the translation catalogs.
+    """
+    command = manual_deps_command()
+    if command is None:
+        return ""
+    return _MISSING_DEPS_HINT.format(command=command)
+
+
+#: How Playwright announces that the browser it just downloaded cannot run.
+#:
+#: MEASURED on Amazon Linux 2023: with libraries missing, ``install-browser``
+#: prints this block and **exits 0**. Playwright classifies it as a warning, so
+#: the exit code alone reports a browser that cannot launch as installed --
+#: the panel goes green, and the real error arrives at the user's first browse
+#: as an opaque stack trace instead. The output is therefore the only signal.
+#:
+#: Two markers rather than one: the header and the message body are emitted by
+#: different call sites, so a reworded box still trips the other. Matched
+#: case-insensitively on a substring, never parsed -- the box is decoration.
+_HOST_VALIDATION_MARKERS = (
+    "host validation warning",
+    "missing dependencies to run browsers",
+)
+
+
+def host_deps_unsatisfied(text: str) -> bool:
+    """Whether *text* carries Playwright's missing-library host validation.
+
+    Read the exit code AND this, never the exit code alone -- see
+    :data:`_HOST_VALIDATION_MARKERS` for the measurement.
+    """
+    lowered = (text or "").lower()
+    return any(marker in lowered for marker in _HOST_VALIDATION_MARKERS)

--- a/src/kiro_crew/browser_cli/token.py
+++ b/src/kiro_crew/browser_cli/token.py
@@ -38,6 +38,51 @@ TOKEN_ENV = "PLAYWRIGHT_MCP_EXTENSION_TOKEN"
 
 _TOKEN_FILE = "playwright-extension-token"
 
+#: Shell keywords a pasted assignment may carry. The extension's setup text is a
+#: shell line, and a user copying it takes the whole line.
+_ASSIGNMENT_PREFIXES = ("export ", "set ", "setx ")
+
+
+def normalize_paste(raw: str) -> str:
+    """The token value out of whatever the user pasted.
+
+    The extension presents the token as a shell assignment, so both of these are
+    what a user reasonably pastes into one field, and both mean the same token::
+
+        PLAYWRIGHT_MCP_EXTENSION_TOKEN=<value>
+        <value>
+
+    Accepting only the bare form stores the variable name as part of the
+    credential, and the failure is silent and far away: the token is written, the
+    panel says "stored", and the extension simply keeps asking for approval as
+    though none were set.
+
+    The prefix is stripped only when the text left of the FIRST ``=`` is exactly
+    :data:`TOKEN_ENV`. That condition is the safety property, not a nicety --
+    these tokens are base64url and can legitimately contain ``=`` padding, so a
+    rule like "take everything after the last ``=``" would corrupt a bare token
+    that this function must pass through untouched.
+    """
+    text = (raw or "").strip()
+    lowered = text.lower()
+    for prefix in _ASSIGNMENT_PREFIXES:
+        if lowered.startswith(prefix):
+            text = text[len(prefix) :].strip()
+            break
+    name, sep, value = text.partition("=")
+    # Case-insensitive on the NAME only: it is a label the user transcribed, while
+    # the value is a credential and stays byte-exact.
+    if sep and name.strip().upper() == TOKEN_ENV:
+        text = value.strip()
+    # Quotes come from the shell form (`NAME="value"`), where they are syntax
+    # rather than token bytes. Stripped as a matched pair only, so a token that
+    # legitimately begins or ends with a quote is not silently shortened.
+    for quote in ('"', "'"):
+        if len(text) >= 2 and text.startswith(quote) and text.endswith(quote):
+            text = text[1:-1]
+            break
+    return text.strip()
+
 
 def token_path() -> Path:
     """Where the token is stored.
@@ -52,11 +97,15 @@ def token_path() -> Path:
 def read_token() -> str | None:
     """The stored token, or ``None`` when none is set.
 
-    Whitespace is stripped because the value is pasted from a browser UI, where a
-    trailing newline is the norm and would otherwise be sent as part of the token.
+    Normalized on the way out as well as in, via :func:`normalize_paste`: a stored
+    value can hold the whole pasted assignment rather than the token alone, and the
+    resulting failure is invisible (the panel reports "stored" while the extension
+    keeps prompting). Repairing it on read costs the user nothing, where noticing
+    and re-pasting costs them the diagnosis first. The call is idempotent, so a
+    value that is already clean passes through byte-exact.
     """
     try:
-        raw = token_path().read_text(encoding="utf-8").strip()
+        raw = normalize_paste(token_path().read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError):
         return None
     return raw or None
@@ -75,12 +124,16 @@ def has_token() -> bool:
 def set_token(value: str) -> None:
     """Store *value*, or clear the token when it is blank.
 
+    The input is whatever the user pasted, so it goes through
+    :func:`normalize_paste` first: a copied shell assignment stores the same token
+    as the bare value rather than the variable name plus the token.
+
     Written owner-only via ``restrict_to_owner`` and atomically, so a concurrent
     read never sees a half-written token, a later reader cannot pick up a truncated
     one, and the file is never world-readable — even on Windows where a numeric
     mode is silently ignored.
     """
-    cleaned = (value or "").strip()
+    cleaned = normalize_paste(value)
     if not cleaned:
         clear_token()
         return

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -1958,7 +1958,22 @@ async def api_browser_install_start(request: web.Request) -> web.Response:
             state._browser_install_error = None
             try:
                 result = await asyncio.to_thread(browser_cli_install.install)
-                failed = [s for s in result.get("steps", []) if not s.get("ok")]
+                # The LAST step, not the first failed one. Two reasons, both of
+                # them cases this string is the only cure for:
+                #   * A step can fail and be RECOVERED -- a refused
+                #     ``--with-deps`` is retried without the flag
+                #     (browser_cli.os_deps) and its failed attempt stays in
+                #     ``steps`` so the operator can see what was tried. Reporting
+                #     "any failed step" would raise a permanent banner quoting a
+                #     sudo refusal on a host where browsing works.
+                #   * When the install really did fail, the FIRST failed step may
+                #     be that same recovered one, which would mask the step that
+                #     actually decided the outcome and drop the remedy it carries.
+                # ``install`` returns ``ok`` from its last step and every earlier
+                # gate returns on a real failure, so the last step is always the
+                # decisive one.
+                steps = result.get("steps") or []
+                failed = [] if result.get("ok") or not steps else steps[-1:]
                 if failed:
                     first = failed[0]
                     # `stderr`, not `error`: install steps only ever carry
@@ -2034,7 +2049,11 @@ async def api_browser_engine_install(request: web.Request) -> web.Response:
         state._browser_install_error = None
         try:
             result = await asyncio.to_thread(browser_cli_install.install_browser, engine)
-            failed = [s for s in result.get("steps", []) if not s.get("ok")]
+            # The decisive step, not the first failed one: see the CLI install
+            # path above for why a recovered attempt must neither raise a banner
+            # nor mask the step that actually decided the outcome.
+            steps = result.get("steps") or []
+            failed = [] if result.get("ok") or not steps else steps[-1:]
             if failed:
                 first = failed[0]
                 state._browser_install_error = _redact(

--- a/src/kiro_crew/docs/getting-started.md
+++ b/src/kiro_crew/docs/getting-started.md
@@ -93,9 +93,15 @@ To browse, install the Playwright agent CLI (needs Node.js 20 or newer):
 
 ```bash
 npm install -g @playwright/cli@latest
-playwright-cli install-browser              # add --with-deps on Linux
+playwright-cli install-browser              # --with-deps on Debian/Ubuntu only
 playwright-cli install --skills agents --global
 ```
+
+`--with-deps` installs OS libraries through `apt` and needs root. Playwright
+implements it for apt alone, so on Fedora, RHEL, CentOS or Amazon Linux it
+misfires against Ubuntu package names; install the libraries with your own
+package manager instead. The Settings → Browser install button handles this
+per-distribution and prints the command to run when it needs root.
 
 Having `playwright-cli` on your `PATH` is what makes browsing available, so
 uninstalling it is how you take the capability away. Note that it covers

--- a/test/test_browser_cli_install.py
+++ b/test/test_browser_cli_install.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-from kiro_crew import platform_compat
 from kiro_crew.browser_cli import install as mod
 
 
@@ -18,6 +17,19 @@ def isolated_browser_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> P
     cache.mkdir()
     monkeypatch.setattr(mod, "_browsers_cache_dir", lambda: cache)
     return cache
+
+
+@pytest.fixture(autouse=True)
+def _default_no_os_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every test to a host with no OS-package step.
+
+    The browser step now asks :mod:`kiro_crew.browser_cli.os_deps` what this host
+    allows, and the answer is read from the DEVELOPER's ``/etc/os-release``
+    otherwise -- which would make the argv assertions here pass on macOS and fail
+    on Ubuntu. Tests that care about the flag opt in explicitly.
+    """
+    monkeypatch.setattr(mod.os_deps, "with_deps_supported", lambda: False)
+    monkeypatch.setattr(mod.os_deps, "missing_deps_hint", lambda: "")
 
 
 def _wire(
@@ -164,7 +176,6 @@ def test_install_aborts_when_npm_is_missing(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_install_runs_all_three_steps_in_order(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(platform_compat, "IS_LINUX", False)
     calls = _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/playwright-cli"})
 
     result = mod.install()
@@ -186,18 +197,226 @@ def test_install_runs_all_three_steps_in_order(monkeypatch: pytest.MonkeyPatch) 
     ]
 
 
-def test_install_adds_with_deps_on_linux_only(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``--with-deps`` drives the system package manager, so it is Linux-only."""
-    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
-    linux_calls = _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/pw"})
+def test_install_adds_with_deps_only_where_the_host_honours_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--with-deps`` drives the system package manager, and Playwright's
+    implementation of it is apt-only, so the flag is gated on the host family
+    rather than on "is Linux"."""
+    monkeypatch.setattr(mod.os_deps, "with_deps_supported", lambda: True)
+    apt_calls = _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/pw"})
     mod.install()
-    assert ["/n/pw", "install-browser", "--with-deps"] in linux_calls
+    assert ["/n/pw", "install-browser", "--with-deps"] in apt_calls
 
-    monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+    monkeypatch.setattr(mod.os_deps, "with_deps_supported", lambda: False)
     other_calls = _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/pw"})
     mod.install()
     assert ["/n/pw", "install-browser"] in other_calls
     assert all("--with-deps" not in argv for argv in other_calls)
+
+
+def test_install_falls_back_without_deps_when_the_package_step_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refused ``apt-get`` must not cost the operator the browser.
+
+    Regression for a real dev-desktop failure: ``--with-deps`` shells out to
+    ``apt-get`` as root, sudo policy refuses it, and because the flag and the
+    download are one CLI invocation the download failed too -- even though it
+    needs no privilege at all.
+    """
+    monkeypatch.setattr(mod.os_deps, "with_deps_supported", lambda: True)
+    monkeypatch.setattr(mod.os_deps, "missing_deps_hint", lambda: "run this: sudo apt-get ...")
+    calls = _wire(
+        monkeypatch,
+        {"npm": "/n/npm", "playwright-cli": "/n/pw"},
+        # Keyed on argv[0], so this fails BOTH browser attempts and the skills
+        # step too; the with-deps branch is distinguished below by argv content.
+    )
+
+    def fake_run(argv: list[str], timeout: float) -> tuple[int, str, str]:
+        calls.append(list(argv))
+        if "--with-deps" in argv:
+            return (
+                1,
+                "",
+                "Sorry, user bolichen is not allowed to execute "
+                "'/bin/sh -c apt-get update' as root on dev-dsk-example.",
+            )
+        return (0, "", "")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    result = mod.install()
+
+    assert result["ok"] is True
+    assert [s["name"] for s in result["steps"]] == [
+        "npm-install-global",
+        "install-browser",
+        "install-browser-no-deps",
+        "install-skills",
+    ]
+    # The refused attempt stays visible rather than being swallowed...
+    assert result["steps"][1]["ok"] is False
+    # ...but it must not veto an install the retry completed.
+    assert result["steps"][2]["ok"] is True
+    assert ["/n/pw", "install-browser", "--with-deps"] in calls
+    assert ["/n/pw", "install-browser"] in calls
+
+
+def test_a_zero_exit_carrying_the_host_validation_warning_is_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MEASURED: ``install-browser`` exits 0 when the host is missing libraries.
+
+    Playwright classifies it as a warning, so trusting the exit code reports a
+    browser that cannot launch as installed -- the panel goes green and the real
+    error arrives at the user's first browse as an opaque stack trace. The step
+    must fail, and must carry the remedy.
+    """
+    monkeypatch.setattr(mod.os_deps, "missing_deps_hint", lambda: "sudo dnf install -y nss")
+    warning = (
+        "Playwright Host validation warning: \n"
+        "Host system is missing dependencies to run browsers.\n"
+        "Missing libraries:\n    libgtk-4.so.1\n"
+    )
+    _wire(
+        monkeypatch,
+        {"npm": "/n/npm", "playwright-cli": "/n/pw"},
+        {"/n/pw": (0, "", warning)},
+    )
+
+    result = mod.install()
+
+    assert result["ok"] is False
+    browser_step = result["steps"][1]
+    assert browser_step["name"] == "install-browser"
+    assert browser_step["ok"] is False
+    # rc stays 0 -- the exit code is honestly reported, it is just not the verdict.
+    assert browser_step["returncode"] == 0
+    assert "missing dependencies" in browser_step["stderr"]
+    assert "sudo dnf install -y nss" in browser_step["stderr"]
+    # The skills step never runs behind a browser that cannot launch.
+    assert [s["name"] for s in result["steps"]] == ["npm-install-global", "install-browser"]
+
+
+def test_the_host_validation_warning_is_caught_on_stdout_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The diagnostic is on stderr today; a version that moves it to stdout must
+    not silently reopen the bug."""
+    _wire(
+        monkeypatch,
+        {"npm": "/n/npm", "playwright-cli": "/n/pw"},
+        {"/n/pw": (0, "Host system is missing dependencies to run browsers.", "")},
+    )
+
+    result = mod.install()
+
+    assert result["ok"] is False
+    assert result["steps"][1]["ok"] is False
+    assert "missing dependencies" in result["steps"][1]["stderr"]
+
+
+def test_an_ordinary_zero_exit_browser_step_still_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The signal must not fail an install that actually worked: Playwright writes
+    progress and download notices to stderr on a healthy run."""
+    _wire(
+        monkeypatch,
+        {"npm": "/n/npm", "playwright-cli": "/n/pw"},
+        {"/n/pw": (0, "", "Downloading Chromium 141.0 (playwright build v1237)")},
+    )
+
+    result = mod.install()
+
+    assert result["ok"] is True
+    assert [s["name"] for s in result["steps"]] == [
+        "npm-install-global",
+        "install-browser",
+        "install-skills",
+    ]
+
+
+def test_install_still_fails_when_the_no_deps_retry_also_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fallback is a retry, not a guarantee: a real download failure stays fatal.
+
+    Also pins WHERE the remedy lands. It belongs on the retry, which is the
+    attempt that actually ran without the package step; putting it on the
+    with-deps attempt would hang a remediation command on a failure the retry may
+    well have recovered from.
+    """
+    monkeypatch.setattr(mod.os_deps, "with_deps_supported", lambda: True)
+    monkeypatch.setattr(mod.os_deps, "missing_deps_hint", lambda: "sudo dnf install -y nss")
+    calls = _wire(
+        monkeypatch,
+        {"npm": "/n/npm", "playwright-cli": "/n/pw"},
+        {"/n/pw": (1, "", "network unreachable")},
+    )
+
+    result = mod.install()
+
+    assert result["ok"] is False
+    assert [s["name"] for s in result["steps"]] == [
+        "npm-install-global",
+        "install-browser",
+        "install-browser-no-deps",
+    ]
+    assert "sudo dnf install -y nss" not in result["steps"][1]["stderr"]
+    assert "sudo dnf install -y nss" in result["steps"][2]["stderr"]
+    assert all("--skills" not in argv for argv in calls)
+
+
+def test_a_failed_browser_step_carries_the_manual_remedy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a host whose libraries only root can install, the failure detail must
+    carry the command that resolves it -- the settings panel shows that detail
+    verbatim, so this is the whole remediation surface."""
+    monkeypatch.setattr(mod.os_deps, "missing_deps_hint", lambda: "sudo dnf install -y nss")
+    _wire(
+        monkeypatch,
+        {"npm": "/n/npm", "playwright-cli": "/n/pw"},
+        {"/n/pw": (1, "", "Host system is missing dependencies!")},
+    )
+
+    result = mod.install()
+
+    assert result["ok"] is False
+    detail = result["steps"][-1]["stderr"]
+    assert "Host system is missing dependencies!" in detail
+    assert "sudo dnf install -y nss" in detail
+
+
+def test_the_remedy_survives_a_stderr_long_enough_to_hit_the_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hint is appended AFTER truncation. Appending before it would let a
+    verbose package manager push the one actionable line out of view."""
+    monkeypatch.setattr(mod.os_deps, "missing_deps_hint", lambda: "sudo dnf install -y nss")
+    _wire(
+        monkeypatch,
+        {"npm": "/n/npm", "playwright-cli": "/n/pw"},
+        {"/n/pw": (1, "", "x" * 50_000)},
+    )
+
+    result = mod.install()
+
+    assert "sudo dnf install -y nss" in result["steps"][-1]["stderr"]
+
+
+def test_a_successful_step_carries_no_remedy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The hint is failure-only: on a green install it would read as a warning."""
+    monkeypatch.setattr(mod.os_deps, "missing_deps_hint", lambda: "sudo dnf install -y nss")
+    _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/pw"})
+
+    result = mod.install()
+
+    assert result["ok"] is True
+    assert all(s["stderr"] == "" for s in result["steps"])
 
 
 def test_install_stops_at_the_first_failure(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -233,7 +452,6 @@ def test_install_reports_binary_unresolvable_after_npm_success(
 
 
 def test_install_browser_failure_skips_skills(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(platform_compat, "IS_LINUX", False)
     calls = _wire(
         monkeypatch,
         {"npm": "/n/npm", "playwright-cli": "/n/pw"},
@@ -346,10 +564,10 @@ class TestPerEngineDownloads:
     def test_a_known_engine_is_passed_through(self, monkeypatch, tmp_path):
         fake_cli = tmp_path / "playwright-cli"
         fake_cli.write_text("")
-        monkeypatch.setattr(mod, "cli_path", lambda: fake_cli)
+        monkeypatch.setattr(mod, "cli_path", lambda: str(fake_cli))
         seen: list[list[str]] = []
 
-        def _fake_step(name, argv, timeout):
+        def _fake_step(name, argv, timeout, hint="", failure_signal=None):
             seen.append(argv)
             return {"name": name, "ok": True, "returncode": 0}
 
@@ -365,6 +583,51 @@ class TestPerEngineDownloads:
         result = mod.install_browser("chromium")
         assert result["ok"] is False
         assert result["steps"][0]["name"] == "resolve-binary"
+
+    def test_a_refused_package_step_falls_back_to_a_plain_retry(self, monkeypatch, tmp_path):
+        """The per-engine path shares `_download_browser` with `install()`, so a
+        host that refuses the package manager must not cost it the download here
+        either."""
+        monkeypatch.setattr(mod.os_deps, "with_deps_supported", lambda: True)
+        fake_cli = tmp_path / "playwright-cli"
+        fake_cli.write_text("")
+        monkeypatch.setattr(mod, "cli_path", lambda: str(fake_cli))
+
+        seen: list[list[str]] = []
+
+        def fake_run(argv, timeout):
+            seen.append(list(argv))
+            if "--with-deps" in argv:
+                return (1, "", "not allowed to execute ... as root")
+            return (0, "", "")
+
+        monkeypatch.setattr(mod, "_run", fake_run)
+
+        result = mod.install_browser("firefox")
+
+        assert result["ok"] is True
+        assert [s["name"] for s in result["steps"]] == [
+            "install-browser-firefox",
+            "install-browser-firefox-no-deps",
+        ]
+        assert [str(fake_cli), "install-browser", "firefox", "--with-deps"] in seen
+        assert [str(fake_cli), "install-browser", "firefox"] in seen
+
+    def test_the_engine_still_reaches_argv_once_on_a_host_without_the_flag(
+        self, monkeypatch, tmp_path
+    ):
+        """The no-flag path must keep the engine argument: dropping it would
+        silently download Chromium while reporting the engine the user asked for."""
+        fake_cli = tmp_path / "playwright-cli"
+        fake_cli.write_text("")
+        monkeypatch.setattr(mod, "cli_path", lambda: str(fake_cli))
+        seen: list[list[str]] = []
+        monkeypatch.setattr(mod, "_run", lambda argv, t: (seen.append(list(argv)), (0, "", ""))[1])
+
+        result = mod.install_browser("webkit")
+
+        assert result["ok"] is True
+        assert seen == [[str(fake_cli), "install-browser", "webkit"]]
 
 
 class TestFailureDetailIsRedactedAtTheSource:

--- a/test/test_browser_cli_journeys.py
+++ b/test/test_browser_cli_journeys.py
@@ -523,6 +523,147 @@ class TestOneInstallSlotIsNotAFoldedLie:
         assert _json.loads(resp.text)["code"] == "install_already_running"
 
 
+class TestARecoveredStepIsNotReportedAsAnError:
+    """A step can fail and be RECOVERED, so "any step failed" is not the verdict.
+
+    ``--with-deps`` is refused by sudo policy on a managed workstation; the
+    browser download is then retried without it and succeeds. That first attempt
+    stays in ``steps`` so the operator can see what was tried, which means
+    scanning every step for ``ok=False`` raises a permanent error banner quoting
+    a sudo refusal on a host where browsing now works. The panel renders
+    ``last_error`` with no gate of its own, so the verdict is made here.
+    """
+
+    #: What ``install()`` returns once a refused package step has been recovered.
+    _RECOVERED = {
+        "ok": True,
+        "steps": [
+            {"name": "npm-install-global", "ok": True, "returncode": 0, "stderr": ""},
+            {
+                "name": "install-browser",
+                "ok": False,
+                "returncode": 1,
+                "stderr": "not allowed to execute '/bin/sh -c apt-get update' as root",
+            },
+            {
+                "name": "install-browser-no-deps",
+                "ok": True,
+                "returncode": 0,
+                "stderr": "",
+            },
+            {"name": "install-skills", "ok": True, "returncode": 0, "stderr": ""},
+        ],
+    }
+
+    def _owner_request(self, state):
+        from unittest.mock import MagicMock
+
+        req = MagicMock()
+        req.path = "/api/browser/install"
+        _claims = {"app": "", "user": "the-owner"}
+        req.get = lambda key, default=None: _claims.get(key, default)
+        req.__contains__ = lambda self_inner, key: key in _claims
+        req.__getitem__ = lambda self_inner, key: _claims[key]
+
+        async def _json():
+            return {}
+
+        req.json = _json
+        req.app = {"state": state}
+        return req
+
+    def _last_error(self, monkeypatch, result):
+        import asyncio
+
+        from kiro_crew.dashboard.handlers import messaging as msg
+
+        monkeypatch.setattr(msg.browser_cli_install, "install", lambda: result)
+        monkeypatch.setattr(
+            msg.browser_cli_install, "detect", lambda: {"installed": True}
+        )
+        monkeypatch.setattr(msg.browser_cli_token, "has_token", lambda: False)
+
+        async def _go():
+            state = type("S", (), {})()
+            state.owner_id = "the-owner"
+            state._browser_install_task = None
+            state._browser_install_error = None
+            await msg.api_browser_install_start(self._owner_request(state))
+            task = state._browser_install_task
+            if task is not None:
+                await task
+            return state._browser_install_error
+
+        return asyncio.run(_go())
+
+    def test_a_recovered_with_deps_refusal_leaves_no_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        assert self._last_error(monkeypatch, self._RECOVERED) is None
+
+    def test_a_recovered_failure_does_not_mask_the_step_that_decided_the_outcome(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The FIRST failed step can be the recovered one, so reporting it would
+        hide the real failure and drop the remedy the operator needs."""
+        masked = {
+            "ok": False,
+            "steps": [
+                {
+                    "name": "npm-install-global",
+                    "ok": True,
+                    "returncode": 0,
+                    "stderr": "",
+                },
+                {
+                    "name": "install-browser",
+                    "ok": False,
+                    "returncode": 1,
+                    "stderr": "not allowed to execute '/bin/sh -c apt-get update' as root",
+                },
+                {
+                    "name": "install-browser-no-deps",
+                    "ok": False,
+                    "returncode": 0,
+                    "stderr": "Host system is missing dependencies!\nsudo dnf install -y nss",
+                },
+            ],
+        }
+        error = self._last_error(monkeypatch, masked)
+        assert error is not None
+        # The decisive step and ITS remedy, not the recovered sudo refusal.
+        assert "install-browser-no-deps" in error
+        assert "sudo dnf install -y nss" in error
+        assert "apt-get update" not in error
+
+    def test_a_genuine_failure_still_reports_its_detail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The gate must not swallow a real failure: the remedy the operator
+        needs travels in exactly this string."""
+        failed = {
+            "ok": False,
+            "steps": [
+                {
+                    "name": "npm-install-global",
+                    "ok": True,
+                    "returncode": 0,
+                    "stderr": "",
+                },
+                {
+                    "name": "install-browser",
+                    "ok": False,
+                    "returncode": 1,
+                    "stderr": "Host system is missing dependencies!\nsudo dnf install -y nss",
+                },
+            ],
+        }
+        error = self._last_error(monkeypatch, failed)
+        assert error is not None
+        assert "install-browser" in error
+        assert "sudo dnf install -y nss" in error
+
+
 def test_non_object_json_is_a_validation_error_not_a_500():
     """`body.get()` on valid-but-non-object JSON raises AttributeError.
 

--- a/test/test_browser_cli_os_deps.py
+++ b/test/test_browser_cli_os_deps.py
@@ -1,0 +1,207 @@
+"""Which Linux hosts ``--with-deps`` is offered on, and what the others are told."""
+
+from __future__ import annotations
+
+import platform
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.browser_cli import os_deps as mod
+
+
+@pytest.fixture(autouse=True)
+def _clear_family_cache():
+    """``linux_family`` memoizes a value that cannot change under a real process."""
+    mod.linux_family.cache_clear()
+    yield
+    mod.linux_family.cache_clear()
+
+
+def _os_release(monkeypatch: pytest.MonkeyPatch, fields: dict[str, str]) -> None:
+    """Make the host report *fields* as its freedesktop os-release.
+
+    The stdlib reader is stubbed rather than a temp file written, because
+    :func:`platform.freedesktop_os_release` memoizes its own result -- a real file
+    would be read once and then shadow every later test in the worker.
+    """
+    monkeypatch.setattr(platform, "freedesktop_os_release", lambda: dict(fields))
+    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+
+
+def _no_os_release(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the host report no os-release at all, the way the stdlib does."""
+
+    def _raise() -> dict[str, str]:
+        raise OSError("no os-release on this host")
+
+    monkeypatch.setattr(platform, "freedesktop_os_release", _raise)
+    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+
+
+class TestFamilyDetection:
+    @pytest.mark.parametrize(
+        ("fields", "expected"),
+        [
+            ({"ID": "ubuntu", "ID_LIKE": "debian"}, mod.FAMILY_DEBIAN),
+            ({"ID": "debian"}, mod.FAMILY_DEBIAN),
+            # A derivative names itself in ID and its base only in ID_LIKE.
+            ({"ID": "linuxmint", "ID_LIKE": "ubuntu debian"}, mod.FAMILY_DEBIAN),
+            # Amazon Linux 2023: the host this whole module exists for.
+            ({"ID": "amzn", "ID_LIKE": "fedora", "VERSION_ID": "2023"}, mod.FAMILY_RPM),
+            # Amazon Linux 2 omits ID_LIKE, so ID alone must resolve it.
+            ({"ID": "amzn", "VERSION_ID": "2"}, mod.FAMILY_RPM),
+            ({"ID": "centos", "ID_LIKE": "rhel fedora"}, mod.FAMILY_RPM),
+            ({"ID": "fedora"}, mod.FAMILY_RPM),
+            ({"ID": "alpine"}, mod.FAMILY_UNKNOWN),
+            ({"PRETTY_NAME": "something"}, mod.FAMILY_UNKNOWN),
+            # Extra whitespace in the ID_LIKE list must still tokenize.
+            ({"ID": "pop", "ID_LIKE": "  ubuntu   debian "}, mod.FAMILY_DEBIAN),
+            # The spec says lowercase; reality varies, so it is normalized.
+            ({"ID": "Fedora"}, mod.FAMILY_RPM),
+        ],
+    )
+    def test_it_reads_id_and_id_like(self, monkeypatch, fields, expected):
+        _os_release(monkeypatch, fields)
+        assert mod.linux_family() == expected
+
+    def test_an_absent_os_release_is_unknown_rather_than_a_guess(self, monkeypatch):
+        _no_os_release(monkeypatch)
+        assert mod.linux_family() == mod.FAMILY_UNKNOWN
+
+    def test_non_linux_never_reads_the_file(self, monkeypatch):
+        """macOS and Windows have no OS-package step, so the read is skipped."""
+        monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+        monkeypatch.setattr(
+            mod, "_os_release_ids", lambda: pytest.fail("must not read os-release off Linux")
+        )
+        assert mod.linux_family() == mod.FAMILY_UNKNOWN
+
+
+class TestWithDepsIsOfferedOnlyWherePlaywrightHonoursIt:
+    def test_apt_family_gets_the_flag(self, monkeypatch):
+        _os_release(monkeypatch, {"ID": "ubuntu"})
+        assert mod.with_deps_supported() is True
+
+    def test_rpm_family_does_not(self, monkeypatch):
+        """Playwright has no rpm path: it picks Ubuntu package names and runs
+        ``apt-get`` anyway, which fails on both the names and the privilege -- and
+        because the flag and the download are one invocation, takes the download
+        with it."""
+        _os_release(monkeypatch, {"ID": "amzn", "ID_LIKE": "fedora"})
+        assert mod.with_deps_supported() is False
+
+    def test_unknown_linux_does_not(self, monkeypatch):
+        _os_release(monkeypatch, {"ID": "alpine"})
+        assert mod.with_deps_supported() is False
+
+    def test_non_linux_does_not(self, monkeypatch):
+        monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+        assert mod.with_deps_supported() is False
+
+
+class TestTheManualRemedy:
+    def test_rpm_family_names_dnf_and_rpm_package_names(self, monkeypatch):
+        _os_release(monkeypatch, {"ID": "amzn", "ID_LIKE": "fedora"})
+        command = mod.manual_deps_command()
+        assert command is not None
+        assert command.startswith("sudo dnf install -y ")
+        # rpm names, not a mechanical mapping of Playwright's Debian list: a
+        # command that fails on its own first package teaches the operator that
+        # the remedy is broken.
+        assert "mesa-libgbm" in command
+        assert "cups-libs" in command
+        assert "libgbm1" not in command
+        assert "libcups2" not in command
+
+    def test_apt_family_defers_to_playwright_rather_than_pinning_a_list(self, monkeypatch):
+        """On apt Playwright installs its own per-version set; a copy here goes
+        stale against the CLI the user actually has."""
+        _os_release(monkeypatch, {"ID": "ubuntu"})
+        command = mod.manual_deps_command()
+        assert command == "sudo npx playwright install-deps chromium"
+
+    def test_unknown_linux_offers_nothing(self, monkeypatch):
+        _os_release(monkeypatch, {"ID": "alpine"})
+        assert mod.manual_deps_command() is None
+        assert mod.missing_deps_hint() == ""
+
+    def test_non_linux_offers_nothing(self, monkeypatch):
+        monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+        assert mod.manual_deps_command() is None
+        assert mod.missing_deps_hint() == ""
+
+    def test_the_hint_carries_the_command_and_says_root_is_needed(self, monkeypatch):
+        _os_release(monkeypatch, {"ID": "amzn", "ID_LIKE": "fedora"})
+        command = mod.manual_deps_command()
+        hint = mod.missing_deps_hint()
+        assert command is not None
+        assert "root" in hint
+        assert command in hint
+
+    def test_nothing_here_runs_a_package_manager(self, monkeypatch):
+        """This module composes a command for a human; it never elevates itself."""
+        _os_release(monkeypatch, {"ID": "amzn", "ID_LIKE": "fedora"})
+        import subprocess
+
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: pytest.fail("os_deps must not spawn")
+        )
+        mod.linux_family()
+        mod.with_deps_supported()
+        mod.manual_deps_command()
+        mod.missing_deps_hint()
+
+
+class TestTheHostValidationWarningIsAFailure:
+    """Playwright reports a browser that cannot launch as a WARNING, and exits 0.
+
+    MEASURED on Amazon Linux 2023: with libraries missing, ``install-browser``
+    prints the box below and exits 0. Reading the exit code alone reports the
+    install as green and defers the real error to the user's first browse.
+    """
+
+    #: The real output, trimmed. Kept verbatim so a reworded box is caught here.
+    _REAL = (
+        "Playwright Host validation warning: \n"
+        "╔══════════════════════════════════════════════════════╗\n"
+        "║ Host system is missing dependencies to run browsers. ║\n"
+        "║ Missing libraries:                                   ║\n"
+        "║     libgtk-4.so.1                                    ║\n"
+        "╚══════════════════════════════════════════════════════╝\n"
+        "    at validateDependenciesLinux (/n/coreBundle.js:32000:9)\n"
+    )
+
+    def test_the_real_output_is_detected(self):
+        assert mod.host_deps_unsatisfied(self._REAL) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Playwright Host validation warning:",
+            "HOST SYSTEM IS MISSING DEPENDENCIES TO RUN BROWSERS.",
+            "host validation warning",
+        ],
+        ids=["header-only", "message-shouted", "already-lowercase"],
+    )
+    def test_either_marker_alone_is_enough_and_case_does_not_matter(self, text):
+        """Header and message come from different call sites, so one reworded box
+        still trips the other."""
+        assert mod.host_deps_unsatisfied(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "Downloading Chromium 141.0 (playwright build v1237)",
+            "chromium 141.0 downloaded to /home/u/.cache/ms-playwright/chromium-1237",
+            "npm warn deprecated foo@1.0.0",
+        ],
+        ids=["empty", "progress", "success", "npm-noise"],
+    )
+    def test_ordinary_output_is_not_a_failure(self, text):
+        """A false positive here fails an install that actually worked."""
+        assert mod.host_deps_unsatisfied(text) is False
+
+    def test_none_is_tolerated(self):
+        assert mod.host_deps_unsatisfied(None) is False  # type: ignore[arg-type]

--- a/test/test_browser_cli_token.py
+++ b/test/test_browser_cli_token.py
@@ -53,6 +53,96 @@ class TestStorage:
         assert mod.read_token() is None
 
 
+class TestPasteNormalization:
+    """The extension shows the token as a shell assignment, so both forms arrive.
+
+    Storing the variable name as part of the credential fails silently and far
+    away: the panel reports "stored" while the extension keeps prompting.
+    """
+
+    @pytest.mark.parametrize(
+        "pasted",
+        [
+            "tok-value",
+            "PLAYWRIGHT_MCP_EXTENSION_TOKEN=tok-value",
+            "  PLAYWRIGHT_MCP_EXTENSION_TOKEN=tok-value\n",
+            "export PLAYWRIGHT_MCP_EXTENSION_TOKEN=tok-value",
+            "EXPORT PLAYWRIGHT_MCP_EXTENSION_TOKEN=tok-value",
+            'PLAYWRIGHT_MCP_EXTENSION_TOKEN="tok-value"',
+            "PLAYWRIGHT_MCP_EXTENSION_TOKEN='tok-value'",
+            "set PLAYWRIGHT_MCP_EXTENSION_TOKEN=tok-value",
+            "setx PLAYWRIGHT_MCP_EXTENSION_TOKEN=tok-value",
+            # A name transcribed in the wrong case is still the name.
+            "playwright_mcp_extension_token=tok-value",
+        ],
+        ids=[
+            "bare",
+            "assignment",
+            "assignment-padded",
+            "export",
+            "export-caps",
+            "double-quoted",
+            "single-quoted",
+            "set",
+            "setx",
+            "lowercase-name",
+        ],
+    )
+    def test_every_reasonable_paste_yields_the_same_token(self, home: Path, pasted: str):
+        mod.set_token(pasted)
+        assert mod.read_token() == "tok-value"
+        assert mod.cli_env_overrides() == {mod.TOKEN_ENV: "tok-value"}
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            # base64url padding: these tokens legitimately end in '='.
+            "abc123==",
+            "a=b",
+            "-ZpIqE3oycOCoseznXbu-bwUpP6Bw-u5MpO52f0n_dA",
+            # A name that is NOT ours must not be treated as a prefix to strip.
+            "SOME_OTHER_VAR=abc123",
+        ],
+        ids=["padding", "inner-equals", "urlsafe", "foreign-assignment"],
+    )
+    def test_a_bare_token_containing_equals_is_passed_through_byte_exact(
+        self, home: Path, value: str
+    ):
+        """The prefix is stripped only when the text left of the FIRST '=' is
+        exactly our variable name. Any looser rule (split on the last '=', strip
+        anything before an '=') corrupts these."""
+        mod.set_token(value)
+        assert mod.read_token() == value
+
+    @pytest.mark.parametrize("value", ['"abc123', 'abc123"', "'abc123", "abc123'"])
+    def test_a_token_wrapped_in_unmatched_quotes_keeps_them(self, home: Path, value: str):
+        """Quotes are stripped as a matched pair only, so a token that genuinely
+        starts or ends with one is not silently shortened. Both ends are covered:
+        the guard is an ``and`` of startswith/endswith, and an ``or`` would eat
+        half of these."""
+        mod.set_token(value)
+        assert mod.read_token() == value
+
+    def test_an_assignment_with_an_empty_value_clears_rather_than_storing_the_name(
+        self, home: Path
+    ):
+        mod.set_token("tok-value")
+        mod.set_token("PLAYWRIGHT_MCP_EXTENSION_TOKEN=")
+        assert mod.has_token() is False
+
+    def test_a_token_already_stored_in_the_assignment_form_repairs_itself_on_read(self, home: Path):
+        """An install that stored the pasted assignment before this normalization
+        existed holds a token that cannot work and reports as configured. Reading
+        repairs it, so the user does not have to notice and re-paste."""
+        mod.token_path().write_text(f"{mod.TOKEN_ENV}=legacy-value\n", encoding="utf-8")
+        assert mod.read_token() == "legacy-value"
+        assert mod.cli_env_overrides() == {mod.TOKEN_ENV: "legacy-value"}
+
+    def test_normalization_is_idempotent(self, home: Path):
+        once = mod.normalize_paste(f"{mod.TOKEN_ENV}=tok-value")
+        assert mod.normalize_paste(once) == once
+
+
 class TestItIsRegisteredAsACredential:
     def test_the_file_is_a_known_secret_leaf(self):
         # The agent inherits the token through the environment and never needs to


### PR DESCRIPTION
# Problem

Pressing **Install** in Settings → Browser fails on Amazon Linux 2023 with a wall
of Debian package names and a sudo refusal the operator cannot act on:

```
BEWARE: your OS is not officially supported by Playwright;
        installing dependencies for ubuntu24.04-arm64 as a fallback.
Sorry, user <user> is not allowed to execute '/bin/sh -c apt-get update&& apt-get
install -y --no-install-recommends libasound2t64 libatk-bridge2.0-0t64 …' as root
```

Two independent things are wrong in that one message. The package manager is not
this host's (`apt-get` does not exist on an rpm distribution, so the command would
fail even *with* root), and the command needs a privilege a managed workstation
withholds. Browsing is left completely unavailable, not degraded: the browser
download never runs.

# Why it matters

The operator this hits hardest is the one the standalone-installer work exists to
serve: a machine without administrator rights. The step that actually grants the
capability — downloading a browser into the user's own Playwright cache — needs no
privilege at all, and it was being killed by an optional step that does.

# Fix (symptom → root cause → change)

`install()` and `install_browser()` both appended `--with-deps` whenever the host
was Linux. Playwright implements that flag for **apt only**; on a distribution it
does not recognize it selects its nearest Ubuntu package set and shells out to
`apt-get` as root anyway. Because the flag and the browser download are one CLI
invocation, the refusal failed the download too, and `install-skills` was skipped
behind it.

**1. The flag is now gated on the host, and a refusal is not fatal.** New
`browser_cli/os_deps.py` resolves the family from the host's freedesktop
os-release data via `platform.freedesktop_os_release()`, reading `ID` plus
`ID_LIKE` so a derivative resolves through its base. The stdlib reader is used
rather than opening a path directly: it consults both locations the
freedesktop spec defines (a minimal or immutable image may ship only the
`/usr/lib` one), it applies the spec's shell-style unquoting, and it keeps this
module free of an absolute POSIX path literal that has no meaning on Windows.

| Family | `--with-deps` | On failure |
|---|---|---|
| debian / ubuntu | passed | retried without the flag, so the download still lands |
| rpm (rhel, fedora, centos, amzn, rocky, alma, suse) | never passed | detail carries a `sudo dnf install` line with rpm package names |
| unrecognized Linux | never passed | no remedy offered — a guessed package manager fails on its own first argument and reads as the product being broken |
| macOS / Windows | not applicable | the browser download alone is sufficient |

The remedy rides in the failing step's existing `stderr` field, which the panel
already renders verbatim, so there is **no new UI state and no new catalog string**.
Nothing here elevates or runs a package manager.

**2. A zero exit is not the verdict.** Measured on this host, with libraries
missing:

```
$ playwright-cli install-browser ; echo "exit=$?"
Playwright Host validation warning:
║ Host system is missing dependencies to run browsers. ║
║     libgtk-4.so.1  libicuuc.so.74  libflite.so.1 …   ║
exit=0
```

Playwright classifies it as a **warning** and still leaves the browser directories
in the cache. Trusting the exit code therefore reports a browser that cannot launch
as installed: the panel goes green, `browser_ok` turns true because the build
genuinely is on disk, and the real error reaches the user at their first browse as
an opaque stack trace. Every browser step is now judged on its output as well as
its exit code (`os_deps.host_deps_unsatisfied`, matching the header and the message
body so a reworded box still trips one), and a match fails the step and carries the
remedy. `browser_ok` keeps meaning "a build is downloaded", which stays literally
true on such a host; the install error carries the rest.

**3. The reported error is the step that decided the outcome.** `install()` now
returns the verdict of its last step rather than `all(steps)`, so a recovered
`--with-deps` refusal stays visible in `steps` without vetoing an install the retry
completed. The two handlers that derive `last_error` report that same decisive
step. Scanning for *any* failed step was wrong twice over: on a recovered refusal
it raised a permanent error banner on a host where browsing works, and on a genuine
failure it surfaced the recovered refusal instead of the step that actually failed,
dropping that step's remedy with it.

**4. The extension token accepts either paste form.** The extension presents the
token as a shell assignment, so both of these now store the same token:

```
PLAYWRIGHT_MCP_EXTENSION_TOKEN=<value>
<value>
```

The prefix is stripped **only** when the text left of the *first* `=` is exactly
the variable name. That condition is a safety property, not a convenience: these
tokens are base64url and can legitimately contain `=`, so a looser rule ("take
everything after the last `=`") would corrupt a bare token. `export`/`set`/`setx`
keywords and a matched pair of surrounding quotes are removed for the same reason —
none of those characters exist in the token alphabet, so the match is structurally
impossible against a real token. Normalization also runs on **read**, so a stored
value holding the whole assignment repairs itself instead of reporting "stored"
while the extension keeps prompting.

**On commit scope:** this carries two concerns (host OS deps, token paste). They
are kept together because they are one user-facing goal — making the browser
capability usable on a non-apt host by an operator who pastes a token from the
extension — and the token half is confined to `token.py` plus its test. Happy to
split on request; the token change lifts out cleanly.

# Tests

- `test/test_browser_cli_os_deps.py` (new) — family detection across ubuntu,
  debian, a derivative naming its base only in `ID_LIKE`, amzn 2023 (`ID_LIKE=fedora`)
  and amzn 2 (no `ID_LIKE`), centos, fedora, alpine, an unreadable file and a
  non-Linux host; that `--with-deps` is offered only on apt; that the rpm remedy
  uses rpm names (`mesa-libgbm`, `cups-libs`) and not a mechanical mapping of
  Playwright's Debian list; that the apt remedy defers to Playwright instead of
  pinning a stale list; that an unrecognized Linux is offered nothing; that the
  module never spawns a package manager; and that the real host-validation output
  is detected while ordinary progress and download notices are not.
- `test/test_browser_cli_install.py` — the flag is gated on the host family, not on
  `IS_LINUX`; a refused package step falls back to a plain retry and the install
  still reports success; a genuine download failure stays fatal; the remedy lands
  on the retry and not on the recovered attempt; the remedy survives a stderr long
  enough to hit the truncation cap; a successful step carries no remedy; a zero exit
  carrying the host-validation warning fails the step, on stderr **and** on stdout;
  ordinary stderr output on a healthy run still succeeds; and the engine positional
  survives on every branch.
- `test/test_browser_cli_journeys.py` — a recovered refusal leaves `last_error`
  unset; a recovered failure does not mask the step that decided the outcome; a
  genuine failure still reports its detail and remedy.
- `test/test_browser_cli_token.py` — nine paste forms normalize to one token;
  values containing `=` (base64url padding, an inner `=`, a foreign
  `OTHER_VAR=` assignment) pass through byte-exact; unmatched quotes at either end
  are preserved; an assignment with an empty value clears rather than storing the
  name; a stored assignment repairs itself on read; normalization is idempotent.

Each of the three defect fixes was fail-before verified by reverting only that
change and confirming the new test fails on the precise symptom.

# Manual verification

Verified on the affected host (Amazon Linux 2023, aarch64): `linux_family()` →
`rpm`, `with_deps_supported()` → `False`, and the remedy renders as a `sudo dnf
install -y …` line, so `apt-get` is never invoked. The zero-exit measurement above
was taken with a clean `PLAYWRIGHT_BROWSERS_PATH` and the raw exit code captured
without a pipe. Token normalization checked against both paste forms using a
shape-alike placeholder.

<!-- no-visual-delta -->
**Why no screenshot:** no frontend file is touched — the remedy is delivered
through the existing backend `stderr` field that Settings → Browser already
renders, so there is no new component, layout, string, or rendered state.

no linked issue: found and diagnosed from a live install failure rather than a
filed report.
