### PR TITLE
Fix: telemetry.beacon_enabled resolves to a settings deep link, not a CLI popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
+- **`<SettingRef configKey="telemetry.beacon_enabled" />` now resolves to a
+  real deep link into Settings → Privacy instead of a copyable CLI command.**
+  The heartbeat opt-out toggle previously rendered only inside
+  `PrivacyDisclosure.tsx` — shared with the onboarding privacy step — which
+  the settings-registry extractor never scans (it only reads
+  `SettingsToggle` elements whose source text is literally inside a
+  `pages/settings/*` panel file). `PrivacyPanel.tsx` now also renders a
+  registry-visible toggle for the same key, mirroring the fix #2651 already
+  shipped for `telemetry.enabled`. The onboarding flow keeps using the
+  original shared component unchanged. (#2689)
 
 - **Switching Kiro accounts mid-session no longer leaves the chat showing a raw
   `The bearer token included in the request is invalid.` with no way out.** A

--- a/website/src/components/PrivacyDisclosure.tsx
+++ b/website/src/components/PrivacyDisclosure.tsx
@@ -42,7 +42,10 @@ export const SHELL_COMMANDS = [
  * diagnostic onto the user's screen. `reason` stays in the payload for bug
  * reports and logs.
  */
-const NOT_SENDING_KEY = {
+/** Exported so `pages/settings/PrivacyPanel.tsx`'s registry-visible
+ *  `BeaconToggle` (#2689) can reuse the same reason-code -> copy mapping
+ *  instead of drifting a second copy out of sync with this one. */
+export const NOT_SENDING_KEY = {
   already_sent_today: 'privacyDisclosure.notSendingAlreadySentToday',
   awaiting_privacy_ack: 'privacyDisclosure.notSendingAwaitingAck',
   ci: 'privacyDisclosure.notSendingCi',

--- a/website/src/components/commandPalette/providers/settingsRegistry.test.ts
+++ b/website/src/components/commandPalette/providers/settingsRegistry.test.ts
@@ -52,4 +52,16 @@ describe('settingsRegistry.gen.ts — anti-stale guard', () => {
     const ids = SETTINGS_REGISTRY.map(e => e.id)
     expect(new Set(ids).size).toBe(ids.length)
   })
+
+  it('telemetry.beacon_enabled resolves to a settings tab (#2689)', () => {
+    // The beacon toggle used to render ONLY inside PrivacyDisclosure.tsx,
+    // shared with onboarding and never scanned by the extractor -- so a
+    // <SettingRef configKey="telemetry.beacon_enabled" /> fell through to
+    // the copyable-CLI-command fallback instead of a deep link. PrivacyPanel
+    // now also renders a registry-visible SettingsToggle for the same key.
+    const entry = SETTINGS_REGISTRY.find(e => e.configKey === 'telemetry.beacon_enabled')
+    expect(entry).toBeDefined()
+    expect(entry?.tab).toBe('privacy')
+    expect(entry?.type).toBe('toggle')
+  })
 })

--- a/website/src/components/commandPalette/settingsRegistry.gen.ts
+++ b/website/src/components/commandPalette/settingsRegistry.gen.ts
@@ -653,6 +653,15 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "configKey": "telemetry.enabled"
   },
   {
+    "id": "privacy.send-anonymous-usage-heartbeat",
+    "label": "Send anonymous usage heartbeat",
+    "description": "Saved for future launches.",
+    "tab": "privacy",
+    "type": "toggle",
+    "occurrence": 1,
+    "configKey": "telemetry.beacon_enabled"
+  },
+  {
     "id": "security.trust-every-third-party-app",
     "label": "Trust every third-party app",
     "labelKey": "pages.settings.securityPanel.trustedApps.allow_all_label",

--- a/website/src/pages/settings/PrivacyPanel.tsx
+++ b/website/src/pages/settings/PrivacyPanel.tsx
@@ -1,12 +1,15 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { SlidersHorizontal } from 'lucide-react'
+import { Trans } from 'react-i18next'
 import { api, ApiError } from '../../api/client'
 import { Card, CardTitle } from '../../components/ui'
 import { SettingsToggle } from '../../components/settings'
+import { SettingRef } from '../../components/settingRef/SettingRef'
 import {
+  NOT_SENDING_KEY,
   PrivacyCommandList,
   PrivacyDisclosureSections,
-  TelemetryToggle,
+  type BeaconStatus,
 } from '../../components/PrivacyDisclosure'
 import { i18nT } from '../../i18n/t'
 
@@ -41,6 +44,107 @@ interface CollectionStatus {
 /** A 409 from the config route is the egress refusal, not a transient failure. */
 function isEgressRefusal(err: unknown): boolean {
   return err instanceof ApiError && err.status === 409
+}
+
+/**
+ * The heartbeat opt-out control, registry-visible (#2689).
+ *
+ * `PrivacyDisclosure.tsx`'s `TelemetryToggle` renders the identical control —
+ * same query, same mutation, same override precedence — but as a bare
+ * `<Toggle>`, and it stays that way: it is shared with the onboarding privacy
+ * step (`PrivacyChapter.tsx`), which is not a `pages/settings/*` panel and
+ * has no config-key concept of its own. The settings-registry extractor
+ * (`settingsExtract.ts`) only finds a `<SettingsToggle configKey=…>` element
+ * whose SOURCE TEXT is literally inside a `PANEL_TAB_MAP`-mapped file — it
+ * does not follow into an imported component's own JSX — so `<SettingRef
+ * configKey="telemetry.beacon_enabled" />` could never resolve to a deep link
+ * while the only rendering of this control lived in `PrivacyDisclosure.tsx`.
+ * This duplicates the toggle's state/logic (accepted cost, per the issue) so
+ * this file's own JSX carries a `SettingsToggle` the extractor can see.
+ */
+function BeaconToggle() {
+  const qc = useQueryClient()
+  const statusQ = useQuery<BeaconStatus>({
+    queryKey: ['beaconStatus'],
+    queryFn: () => api.beaconStatus(),
+  })
+
+  const enabled = statusQ.data?.enabled ?? false
+  const envOverride = statusQ.data?.env_override ?? false
+  const overlayOverride = statusQ.data?.overlay_override ?? false
+  const govOverride = statusQ.data?.governance_override ?? false
+  const pinned = govOverride || envOverride || overlayOverride
+  const shadowed = enabled && !statusQ.data?.would_send && !statusQ.isLoading
+
+  const toggleMut = useMutation({
+    mutationFn: (value: boolean) => api.patchConfig('telemetry.beacon_enabled', value),
+    onMutate: async (value: boolean) => {
+      await qc.cancelQueries({ queryKey: ['beaconStatus'] })
+      const prev = qc.getQueryData<BeaconStatus>(['beaconStatus'])
+      qc.setQueryData<BeaconStatus>(['beaconStatus'], old => ({ ...(old ?? {}), enabled: value }))
+      return { prev }
+    },
+    onError: (_err, _value, ctx) => {
+      if (ctx?.prev) qc.setQueryData(['beaconStatus'], ctx.prev)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['beaconStatus'] })
+      qc.invalidateQueries({ queryKey: ['kirocrewConfig'] })
+    },
+  })
+
+  const NOTE_ID = 'beacon-toggle-note'
+  const showNote = pinned || (!pinned && shadowed)
+
+  return (
+    <div>
+      <SettingsToggle
+        label={i18nT('privacyDisclosure.toggleLabel')}
+        description={i18nT('privacyDisclosure.toggleDescription')}
+        checked={enabled}
+        onChange={v => toggleMut.mutate(v)}
+        disabled={statusQ.isLoading || toggleMut.isPending || pinned}
+        configKey="telemetry.beacon_enabled"
+        describedBy={showNote ? NOTE_ID : undefined}
+      />
+      {toggleMut.isError && (
+        <p role="alert" className="text-[12px] text-danger mt-1">
+          {i18nT('privacyDisclosure.toggleSaveFailed')}
+        </p>
+      )}
+      {/* Precedence mirrors TelemetryToggle: an admin pin outranks the env
+          var, which outranks the overlay; only shown at all when nothing
+          pins it does the "not sending" note apply. */}
+      {govOverride && (
+        <p id={NOTE_ID} className="text-[12px] text-muted mt-1">
+          {i18nT('privacyDisclosure.governanceOverrideNote')}
+        </p>
+      )}
+      {!govOverride && envOverride && (
+        <p id={NOTE_ID} className="text-[12px] text-muted mt-1">
+          <Trans
+            i18nKey="privacyDisclosure.envOverrideWithSettingRef"
+            components={{
+              settingRef: <SettingRef kind="env" configKey={statusQ.data?.env_var ?? 'KIROCREW_TELEMETRY_DISABLED'} envIntent="unset" />,
+            }}
+          />
+        </p>
+      )}
+      {!govOverride && !envOverride && overlayOverride && (
+        <p id={NOTE_ID} className="text-[12px] text-muted mt-1">
+          {i18nT('privacyDisclosure.overlayOverrideNote')}
+        </p>
+      )}
+      {!pinned && shadowed && (
+        <p id={NOTE_ID} className="text-[12px] text-muted mt-1">
+          {i18nT(
+            NOT_SENDING_KEY[statusQ.data?.reason_code as keyof typeof NOT_SENDING_KEY]
+            ?? 'privacyDisclosure.notSendingGeneric',
+          )}
+        </p>
+      )}
+    </div>
+  )
 }
 
 function MetricRecordingToggle() {
@@ -165,7 +269,7 @@ export function PrivacyPanel() {
           <SlidersHorizontal className="lucide-inline" aria-hidden="true" />
           {i18nT('privacyDisclosure.controlsTitle')}
         </CardTitle>
-        <TelemetryToggle />
+        <BeaconToggle />
         {/* Recording is a separate decision from the heartbeat: this one never
             leaves the machine, so it sits below the egress control rather than
             being folded into it. */}

--- a/website/src/test/PrivacyPanel.test.tsx
+++ b/website/src/test/PrivacyPanel.test.tsx
@@ -181,6 +181,21 @@ describe('PrivacyPanel', () => {
       expect(patchConfig).toHaveBeenCalledWith('telemetry.beacon_enabled', false))
   })
 
+  it('carries the configKey the settings registry needs to resolve a deep link (#2689)', async () => {
+    // <SettingRef configKey="telemetry.beacon_enabled" /> resolved to a copyable
+    // CLI popover instead of a real deep link because the only rendering of
+    // this control lived in PrivacyDisclosure.tsx (shared with onboarding),
+    // which settingsExtract.ts never scans -- it only reads SettingsToggle
+    // elements whose source text is literally inside a pages/settings/* panel
+    // file. SettingsToggle stamps `data-setting-key` from `configKey`, so
+    // asserting on that attribute here is the same check the extractor's
+    // static scan is doing against this file's own JSX.
+    renderWithProviders(<PrivacyPanel />)
+    const toggle = await screen.findByRole('switch', { name: TOGGLE_LABEL })
+    const row = toggle.closest('[data-setting-key]')
+    expect(row).toHaveAttribute('data-setting-key', 'telemetry.beacon_enabled')
+  })
+
   it('surfaces a save failure and restores the previous state', async () => {
     patchConfig.mockRejectedValue(new Error('nope'))
     renderWithProviders(<PrivacyPanel />)


### PR DESCRIPTION
## Summary

Fixes #2689.

`<SettingRef configKey="telemetry.beacon_enabled" />` rendered as a copyable CLI command instead of a deep link into Settings → Privacy, even though the dashboard has a working beacon toggle. The settings-registry extractor (`settingsExtract.ts`) statically scans each file under `pages/settings/*` for a literal `<SettingsToggle configKey=...>` element in **that file's own source text** — it does not follow into an imported component's JSX. The beacon toggle (`TelemetryToggle`) lives in `components/PrivacyDisclosure.tsx`, shared with the onboarding privacy step, and renders a bare `<Toggle>` with no `configKey` at all, so it was invisible to the extractor regardless of which page imported and rendered it.

This is the same reachability gap PR #2651 already fixed for `telemetry.enabled` (`MetricRecordingToggle` in `PrivacyPanel.tsx`) — and the fix is the same shape (**Option 1** from the issue): `PrivacyPanel.tsx` now also renders `BeaconToggle`, a registry-visible `SettingsToggle` wired to the same `telemetry.beacon_enabled` key, with the same query/mutation/override-precedence logic as `TelemetryToggle`. `PrivacyDisclosure.tsx`'s `TelemetryToggle` is **untouched** and still used by the onboarding flow (`PrivacyChapter.tsx`), which is not a `pages/settings/*` panel and has no config-key concept. **Option 2** from the issue (teach the extractor to follow shared components) was explicitly flagged there as a bigger, more general fix — left for a future issue if more settings end up in shared components.

`NOT_SENDING_KEY` is exported from `PrivacyDisclosure.tsx` so `BeaconToggle` reuses the same reason-code → copy mapping instead of drifting a second one out of sync.

Regenerated `settingsRegistry.gen.ts` via `npm run gen:settings` (9-line addition: `telemetry.beacon_enabled` now resolves under the `privacy` tab).

## Test plan

- [x] All 17 existing `PrivacyPanel.test.tsx` beacon-toggle tests pass unchanged against the new component (same DOM text, same mutation calls) — confirms full behavioral parity with the old `TelemetryToggle` rendering.
- [x] New test: the rendered toggle carries `data-setting-key="telemetry.beacon_enabled"` (what `SettingsToggle` stamps from `configKey`, and what makes it extractor-visible).
- [x] New test in `settingsRegistry.test.ts`: `telemetry.beacon_enabled` resolves under the `privacy` tab as a `toggle` in the real generated registry.
- [x] `PrivacyChapter.test.tsx` (onboarding) — 7 passed, unaffected since `TelemetryToggle` itself is untouched.
- [x] `npx vitest run src/test/PrivacyPanel.test.tsx src/components/commandPalette/providers/settingsRegistry.test.ts src/components/settingRef/resolveSettingRef.test.ts src/components/PrivacyChapter.test.tsx` — 47 passed
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — 0 errors, 0 warnings
- [x] `node scripts/i18n-check.mjs` — all 16 checks pass (no new i18n keys — reused the existing `privacyDisclosure.*` strings `TelemetryToggle` already uses)
- [x] `scripts/docs_lint.py` / `BRAND_BASE_REF=upstream/main scripts/check_brand_name.py` — clean