### PR TITLE
fix(acp): re-declare pooled MCP stubs on session/load so resumed sessions stay pooled

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -184,9 +184,13 @@ attempts `session/load` instead of `session/new`:
 
 1. Check `agentCapabilities.loadSession` from `initialize` response
 2. Verify `~/.kiro/sessions/cli/{sid}.json` exists on disk
-3. Send `session/load` with `sessionId`, `cwd`, `mcpServers: []`, and
-   `_meta: {"_kiro.dev/session_file": "<path>"}` (required — without it kiro-cli
-   silently ignores the request)
+3. Send `session/load` with `sessionId`, `cwd`, `mcpServers` (the pooled
+   broker stubs, re-declared so the resumed session keeps talking to the
+   shared gateway — `session/load` re-initializes the session's MCP servers,
+   so an empty list would un-pool the session; `[]` only when the gateway is
+   disabled), and `_meta: {"_kiro.dev/session_file": "<path>"}` (required —
+   without it kiro-cli silently ignores the request). `AcpRuntime.load_session`
+   builds the same params for the multiplexed runtime.
 4. On success (response contains `modes`): set `_session_id`, `_resumed = True`
 5. On failure (JSON-RPC error, timeout, file missing): fall through to `session/new`
 

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -1805,21 +1805,33 @@ class AcpRuntime:
 
         Unlike create_session()+handle.load(), this issues session/load
         DIRECTLY (no session/new first), using the ORIGINAL sid as sessionId
-        and passing cwd + mcpServers:[] + the full transcript path, exactly as
-        AcpClient._initialize_session does. This avoids the double-session
-        footgun (fresh session/new context replayed on top of the loaded
-        transcript) that produced stopReason='refusal'. Raises on failure so
-        the caller can fall back to create_session().
+        and passing cwd + the pooled broker stubs + the full transcript path,
+        exactly as AcpClient._initialize_session does. This avoids the
+        double-session footgun (fresh session/new context replayed on top of
+        the loaded transcript) that produced stopReason='refusal'. Raises on
+        failure so the caller can fall back to create_session().
         """
         if not self._initialized:
             raise AcpRuntimeError("Runtime not initialized — call spawn() first")
         if not self._can_load_session:
             raise AcpRuntimeError("Backend does not advertise session/load support")
 
+        # Re-declare the pooled broker stubs so a resumed session keeps talking
+        # to the broker — same injection as create_session() and the AcpClient
+        # resume path (client.py). session/load re-initializes the session's MCP
+        # servers (see the budget note below), so an empty list here is APPLIED,
+        # not ignored: the stubs stop shadowing the agent spec's same-named
+        # entries and kiro-cli spawns its own copy of every pooled server,
+        # silently un-pooling the session for the rest of its life. Resolved off
+        # the event loop — the overlay lookup stats and reads files. Empty when
+        # the shared gateway is disabled, so non-pooled installs still send [].
+        mcp_servers = await asyncio.to_thread(
+            pooled_session_servers, self._mcp_gateway_overlay, agent or self._agent
+        )
         load_params: dict[str, Any] = {
             "sessionId": resume_sid,
             "cwd": str(cwd if cwd else self._work_dir),
-            "mcpServers": [],  # kiro-cli gets its servers via --agent
+            "mcpServers": mcp_servers,
         }
         if session_file:
             # Only kiro-cli is handed a transcript path. A backend that locates

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -3252,8 +3252,9 @@ class TestAcpRuntimePidTracking:
 class TestAcpRuntimeLoadSession:
     """load_session() must mirror AcpClient._initialize_session's resume path:
     issue session/load DIRECTLY (no session/new first) under the ORIGINAL sid,
-    with the same cwd + empty mcpServers + _kiro.dev/session_file _meta. The
-    double-session drift it replaces produced stopReason='refusal'."""
+    with the same cwd + mcpServers (pooled broker stubs re-declared; [] when no
+    overlay is configured) + _kiro.dev/session_file _meta. The double-session
+    drift it replaces produced stopReason='refusal'."""
 
     @pytest.mark.asyncio
     async def test_load_session_sends_direct_session_load_params(self, monkeypatch):
@@ -3287,6 +3288,8 @@ class TestAcpRuntimeLoadSession:
         assert load_params == {
             "sessionId": "sid-123",
             "cwd": "/work",
+            # [] because _make_runtime configures no MCP-gateway overlay — the
+            # non-pooled path is unchanged by the #3528 stub re-declaration.
             "mcpServers": [],
             "_meta": {"_kiro.dev/session_file": "/home/u/.kiro/sessions/cli/sid-123.json"},
         }
@@ -3339,6 +3342,8 @@ class TestAcpRuntimeLoadSession:
         await rt.load_session("/k/sid.json", "sid", cwd="/w", agent="kirocrew")
 
         # Mirror of AcpClient's kiro-branch load_params (client.py step 2).
+        # mcpServers is [] on BOTH paths here because no overlay is configured;
+        # the pooled case is covered by test_load_session_redeclares_pooled_stubs.
         expected = {
             "sessionId": "sid",
             "cwd": "/w",
@@ -3372,6 +3377,140 @@ class TestAcpRuntimeLoadSession:
             await rt.load_session("/k/sid.json", "sid-z", cwd="/w", agent="kirocrew")
         assert METHOD_SESSION_TERMINATE in methods
         assert "sid-z" not in rt._session_queues
+
+    @pytest.mark.asyncio
+    async def test_load_session_redeclares_pooled_stubs(self, tmp_path, monkeypatch):
+        """#3528 regression: a resumed session must re-declare the pooled broker
+        stubs. session/load re-initializes the session's MCP servers, so the []
+        this path used to send was APPLIED — the stubs stopped shadowing the
+        agent spec's same-named entries and kiro-cli spawned its own copy of
+        every pooled server, silently un-pooling the session for life.
+
+        Asserts on the EMITTED mcpServers of both requests: load_session must
+        carry exactly the entries create_session injects for the same agent +
+        overlay. Mutating the fix back to [] fails the first assert."""
+        from kiro_crew.mcp_gateway.rewriter import _WRAPPER_MARKER
+
+        overlay = tmp_path / "agents"
+        overlay.mkdir()
+        (overlay / "kirocrew.json").write_text(
+            json.dumps({"name": "kirocrew", "mcpServers": {"builder-mcp": {
+                _WRAPPER_MARKER: True,
+                "command": "/data/mcp-gateway/stubs/mc-mcp-stub-wrapper.sh",
+                "args": ["--target-command=builder-mcp"],
+                "env": {},
+            }}}),
+            encoding="utf-8",
+        )
+        rt, _, _ = _make_runtime()
+        rt._can_load_session = True
+        rt._mcp_gateway_overlay = str(overlay)
+
+        sent: list[tuple[str, dict]] = []
+
+        async def _fake_send(method, params, timeout=None):
+            sent.append((method, params))
+            if method == METHOD_SESSION_LOAD:
+                return {"modes": {}, "models": []}
+            if method == METHOD_SESSION_NEW:
+                return {"sessionId": "sid-new"}
+            return {}
+
+        monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+
+        await rt.load_session("/k/sid.json", "sid-r", cwd="/w", agent="kirocrew")
+        load_params = next(p for m, p in sent if m == METHOD_SESSION_LOAD)
+        assert [e["name"] for e in load_params["mcpServers"]] == ["builder-mcp"]
+
+        # Parity with create_session for the same agent + overlay: the two
+        # injection paths must never diverge.
+        await rt.create_session(cwd="/w", agent="kirocrew")
+        new_params = next(p for m, p in sent if m == METHOD_SESSION_NEW)
+        assert load_params["mcpServers"] == new_params["mcpServers"]
+
+    @pytest.mark.asyncio
+    async def test_load_session_resolves_stubs_off_the_event_loop(self, monkeypatch):
+        """The overlay lookup stats and reads files; like create_session it must
+        run via asyncio.to_thread, not on the loop thread."""
+        import threading
+
+        import kiro_crew.acp.runtime as rt_mod
+
+        rt, _, _ = _make_runtime()
+        rt._can_load_session = True
+        rt._mcp_gateway_overlay = "/nonexistent-overlay"
+
+        loop_thread = threading.current_thread()
+        seen: list[threading.Thread] = []
+
+        def _recording_pooled(overlay_dir, agent, channel_id=None):
+            seen.append(threading.current_thread())
+            return []
+
+        monkeypatch.setattr(rt_mod, "pooled_session_servers", _recording_pooled)
+
+        async def _fake_send(method, params, timeout=None):
+            if method == METHOD_SESSION_LOAD:
+                return {"modes": {}, "models": []}
+            return {}
+
+        monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+        await rt.load_session("/k/sid.json", "sid-t", cwd="/w", agent="kirocrew")
+
+        assert seen, "load_session never consulted pooled_session_servers"
+        assert all(t is not loop_thread for t in seen)
+
+    def test_every_session_request_builder_consults_pooled_servers(self):
+        """#3528 guard: the stub injection now lives at multiple call sites in
+        two files, and this bug was exactly one of them silently sending [].
+        Enumerate every function that issues session/new or session/load and
+        assert each one consults the pooled-stub resolution (either
+        pooled_session_servers directly or the _pooled_mcp_servers hook), so a
+        fourth builder — or a regression in an existing one — fails here
+        instead of shipping another silent un-pooling path."""
+        import ast
+        import inspect
+
+        import kiro_crew.acp.client as client_mod
+        import kiro_crew.acp.runtime as rt_mod
+
+        _SEND_FUNCS = {"_send_request", "_send_and_await"}
+        _SESSION_METHODS = {"METHOD_SESSION_NEW", "METHOD_SESSION_LOAD"}
+
+        def _builders(module) -> dict[str, str]:
+            src = inspect.getsource(module)
+            out: dict[str, str] = {}
+            for node in ast.walk(ast.parse(src)):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for call in ast.walk(node):
+                    if (
+                        isinstance(call, ast.Call)
+                        and isinstance(call.func, ast.Attribute)
+                        and call.func.attr in _SEND_FUNCS
+                        and call.args
+                        and isinstance(call.args[0], ast.Name)
+                        and call.args[0].id in _SESSION_METHODS
+                    ):
+                        out[node.name] = ast.get_source_segment(src, node) or ""
+                        break
+            return out
+
+        builders = {**_builders(rt_mod), **_builders(client_mod)}
+        # The four known builders; a new one is included automatically.
+        assert {
+            "create_session",
+            "load_session",
+            "_new_session_following_substitution",
+            "_initialize_session",
+        } <= builders.keys(), f"expected builders missing from scan: {sorted(builders)}"
+        for name, body in builders.items():
+            assert (
+                "pooled_session_servers" in body or "_pooled_mcp_servers" in body
+            ), (
+                f"{name} issues session/new or session/load but never consults "
+                "the pooled broker stubs — it would un-pool its sessions (#3528)"
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What is the problem?

`AcpRuntime.load_session` — the `session/load` resume path — sent an empty `mcpServers` array:

```python
"mcpServers": [],  # kiro-cli gets its servers via --agent
```

The empty list is not inert. `session/load` is gated by the same MCP (re-)initialization as `session/new`, so `[]` is applied: the pooled broker stubs stop shadowing the agent spec's same-named entries, and kiro-cli spawns its own copy of every pooled server. The stale comment was true before session-injected stubs existed; it is now exactly the assumption that breaks pooling.

The injection existed on two of three paths and was missing on the third:

| Path | Injects pooled stubs? |
|---|---|
| `AcpRuntime.create_session` (`pooled_session_servers(...)`) | yes |
| `AcpClient` `session/load` (`client.py`, "re-declared" comment) | yes |
| `AcpRuntime.load_session` | **no — sent `[]`** |

# Why this matters to the user

Resume is not rare — it happens on gateway restart, on the runtime's idle recycle, and on transparent respawn after a runtime death (`providers/acp.py:566` is the live dashboard-session path). Each resume silently and permanently un-pooled that session, so an instance drifts one-directionally toward unpooled over time. On a live host, resumed sessions showed **0 MCP stubs / 30 processes / ~2.9× the memory** of pooled siblings — the smoking gun being a 2-minute process uptime carrying 25 turns. Nothing reported the degradation.

# How our fix solves it

Chain from symptom to root cause: resumed sessions spawn private MCP copies → because kiro-cli re-initializes servers from the `session/load` params → because `load_session` sends `[]` where its two sibling paths send the pooled stub list.

The fix re-declares the stubs exactly as the siblings do:

- Resolve the stub list the same way `create_session` does — `pooled_session_servers(self._mcp_gateway_overlay, agent or self._agent)`, wrapped in `asyncio.to_thread` because the overlay lookup stats and reads files.
- Replace the stale comment with one that states why an empty list is destructive here.
- `pooled_session_servers` returns `[]` when the shared gateway is disabled, so non-pooled installs still send `[]` — the change is additive, not a behaviour flip.
- Updated `docs/system-specs/modules/acp-client.md` resume step 3, which still documented `mcpServers: []` (stale even for the client path, which has injected since the pooling feature landed).

# What tests we did

New tests in `test/test_acp_runtime.py` (all four from the issue's test plan):

1. **Injection parity**: `load_session` emits exactly the stub entries `create_session` injects for the same agent + overlay — asserted on the emitted `mcpServers` of both requests, not on a mock's call count.
2. **Non-pooled path unchanged**: the existing params-shape tests run with no overlay configured and still assert `mcpServers: []` (now annotated as the no-overlay case).
3. **Off-loop resolution**: `pooled_session_servers` runs on a `to_thread` worker, never the event-loop thread.
4. **Regression guard** (the issue's "cannot silently regress a third time" suggestion): a source-scan test enumerates every function in `runtime.py` + `client.py` that issues `session/new` or `session/load` and asserts each one consults the pooled-stub resolution. A fourth builder is included automatically.

Verification:

- Targeted mutation check: 3 mutants (send `[]`; skip resolution; resolve on-loop) — **3/3 killed**, each by a real assertion failure.
- `pytest test/test_acp_runtime.py test/test_acp_provider.py test/test_acp_client.py test/test_mcp_gateway_session_inject.py test/test_mcp_gateway_cluster_fixes.py` — **800 passed**, including the real-kiro-cli session-injection precedence anti-drift guard.
- `isort --check-only`, `flake8`, `mypy` clean on changed files.

# Any other suggestions

Degradation observability (a session that loses pooling is visible only as a memory/proc delta in the dashboard table; `stub_fallback.jsonl` cannot cover it because no stub ever starts) remains out of scope here, as the issue proposed.

Fixes #3528
