### PR TITLE
refactor: drop dead in-function imports, flatten nested ternaries

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1018,15 +1018,15 @@ _RE_5XX_NAMED = re.compile(
     r"|DispatchFailure|ConnectionReset(?:Error)?)\b"
 )
 _RE_5XX_STATUS = re.compile(r"(?:HTTP|status)\s*(?:code\s*)?(?:50[0234]|529)\b", re.IGNORECASE)
-# Genuine retry hint only. "response stream" USED TO BE matched here, which made
-# this branch a catch-all: kiro-cli wraps EVERY mid-stream provider failure as
-# "Encountered an error in the response stream: <real cause>", so the wrapper
-# prefix alone — present on quota exhaustion, validation errors, anything —
-# classified the error as a momentary 5xx, told the user to retry, and DISCARDED
-# the real cause. A monthly-usage-limit rejection surfaced as "The model backend
-# hit a transient error (HTTP 5xx)" and burned the retry ladder. The wrapper is
-# a transport envelope, not a signal about the failure inside it; classification
-# now reads the inner detail (see _provider_detail).
+# Genuine retry hint only. "response stream" is deliberately NOT matched here,
+# because that would make this branch a catch-all: kiro-cli wraps EVERY mid-stream
+# provider failure as "Encountered an error in the response stream: <real cause>",
+# so the wrapper prefix alone — present on quota exhaustion, validation errors,
+# anything — would classify the error as a momentary 5xx, tell the user to retry,
+# and DISCARD the real cause. A monthly-usage-limit rejection would surface as
+# "The model backend hit a transient error (HTTP 5xx)" and burn the retry ladder.
+# The wrapper is a transport envelope, not a signal about the failure inside it;
+# classification reads the inner detail (see _provider_detail).
 _RE_5XX_HINT = re.compile(r"(please try again)", re.IGNORECASE)
 # Session expiry, by HTTP status. An expired session is rejected with 401/403,
 # and nothing else in this module recognised those codes: the error fell through
@@ -1465,9 +1465,9 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
             # Unrecognised failure mode. Show the PROVIDER'S OWN message when
             # there is one — it is the true error, and the same words the CLI
             # prints, so the two surfaces agree. This is the path every provider
-            # failure without a curated branch above now takes; previously such
-            # errors were swallowed by an over-broad 5xx match and reported as a
-            # momentary blip, so the real cause never reached the user at all.
+            # failure without a curated branch above takes; an over-broad 5xx
+            # match would swallow such an error and report a momentary blip, so
+            # the real cause would never reach the user at all.
             #
             # Falls back to the raw dict only when there is no usable detail
             # (empty/odd data), so a genuinely opaque shape still loses nothing.
@@ -3365,15 +3365,15 @@ class AcpClient:
             return None
         except (ValueError, asyncio.LimitOverrunError) as exc:
             # A single JSON-RPC line exceeded the stdout StreamReader buffer
-            # (_STDOUT_BUFFER_LIMIT). This does NOT corrupt the stream, contrary
-            # to what this call site used to assume: before raising ValueError,
-            # readline() deletes the oversize line through its terminating
-            # newline when one is already buffered, else clears the buffer, then
-            # resumes the transport (CPython asyncio.streams.StreamReader
-            # .readline — its docstring states this). So drop the frame and let
-            # the caller read the next one, exactly like the blank-line and
-            # non-JSON paths below; raising AcpProcessDied here ended a healthy
-            # live turn over one unreadably large frame.
+            # (_STDOUT_BUFFER_LIMIT). This does NOT corrupt the stream: before
+            # raising ValueError, readline() deletes the oversize line through
+            # its terminating newline when one is already buffered, else clears
+            # the buffer, then resumes the transport (CPython
+            # asyncio.streams.StreamReader.readline — its docstring states this).
+            # So drop the frame and let the caller read the next one, exactly
+            # like the blank-line and non-JSON paths below; raising
+            # AcpProcessDied here would end a healthy live turn over one
+            # unreadably large frame.
             #
             # NOTE the deliberate asymmetry with AcpRuntime._reader_loop, which
             # additionally enforces a drain budget: that reader is a standalone
@@ -4415,9 +4415,8 @@ class AcpClient:
             raw = result.get("text", "") or result.get("message", "")
             if raw:
                 # Two-pass redaction (URLs + credentials) to match the shared
-                # AcpSessionHandle.send_command path; a URL-only pass previously
-                # leaked tokens/keys in slash-command output on the legacy path.
-                # (redact_* imported at module top.)
+                # AcpSessionHandle.send_command path: a URL-only pass leaves
+                # tokens/keys in slash-command output.
                 raw, _ = redact_exfiltration_urls(raw)
                 raw, _ = redact_credentials(raw)
             return raw
@@ -4987,6 +4986,9 @@ class AcpClient:
             "kiro-cli cancelled tool use(s) [site=%s session=%s]", site, self._session_id
         )
         try:
+            # Re-imported at call time on purpose: the module-level binding is
+            # captured at import time, so only this rebind resolves the CURRENT
+            # ``kiro_crew.sel.sel`` and lets a substituted emitter be observed.
             from kiro_crew.sel import sel
 
             sel().log_tool_invocation(

--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -97,19 +97,19 @@ def _fence_untrusted(text: str) -> str:
 # Resolved per call, never captured at import: an import-time binding freezes
 # the data home and defeats pod isolation, the lazy legacy-home migration and
 # test isolation. The name below is an opt-in override (None = live home) so
-# existing monkeypatch call sites keep working. See config.md "Data Home" and
-# issue #874; dashboard/handlers/usage.py is the reference implementation.
+# existing monkeypatch call sites keep working. See config.md "Data Home";
+# dashboard/handlers/usage.py is the reference implementation.
 RESEARCH_DIR: Path | None = None
 DB_PATH: Path | None = None
 
 
 def research_dir() -> Path:
-    """Research workspace dir, resolved against the live data home (issue #874)."""
+    """Research workspace dir, resolved against the live data home."""
     return RESEARCH_DIR if RESEARCH_DIR is not None else data_home() / "workspace" / "research"
 
 
 def db_path() -> Path:
-    """Campaigns sqlite DB path, resolved against the live data home (issue #874)."""
+    """Campaigns sqlite DB path, resolved against the live data home."""
     return (
         DB_PATH if DB_PATH is not None else data_home() / "apps" / "auto-research" / "campaigns.db"
     )
@@ -1808,11 +1808,12 @@ def _write_brief(cid: str, row: Any) -> None:
         for s in subs:
             text = s.get("text", "") if isinstance(s, dict) else str(s)
             origin = s.get("origin", "grill") if isinstance(s, dict) else "grill"
-            tag = (
-                " _(emergent)_"
-                if origin == "emergent"
-                else " _(user guidance)_" if origin == "manual" else ""
-            )
+            if origin == "emergent":
+                tag = " _(emergent)_"
+            elif origin == "manual":
+                tag = " _(user guidance)_"
+            else:
+                tag = ""
             lines.append(f"- {text}{tag}")
     else:
         lines.append(

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/report.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/report.py
@@ -498,9 +498,12 @@ def _detail_html(r: dict) -> str:
     label = (f"Design reasoning + {n} finding{'s' if n != 1 else ''}"
              if n else "Design reasoning")
     verdict = html.escape(r["gate_verdict"])
-    vc, vbg = (_SEV_COLORS["red"] if verdict == "BLOCK"
-               else _SEV_COLORS["yellow"] if verdict == "CONCERNS"
-               else _SEV_COLORS["green"])
+    if verdict == "BLOCK":
+        vc, vbg = _SEV_COLORS["red"]
+    elif verdict == "CONCERNS":
+        vc, vbg = _SEV_COLORS["yellow"]
+    else:
+        vc, vbg = _SEV_COLORS["green"]
     body = ""
     if design:
         body += (

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/demo_harness.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/demo_harness.py
@@ -172,7 +172,6 @@ class Demo:
         if main:
             with self._safe_open(f"{self.out}/MAIN_WEBM", workdir=self.out) as f:
                 f.write(main)
-        import json
         rec_ms = int((time.time() - (self._t_video0 or time.time())) * 1000)
         with self._safe_open(f"{self.out}/events.json", workdir=self.out) as f:
             json.dump({"viewport": {"width": self.width, "height": self.height},

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
@@ -2626,8 +2626,6 @@ async def _handle_generate_recommendations(request: web.Request) -> web.Response
             status=502,
         )
 
-    import time
-
     generated_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     payload = {"recommendations": result["recommendations"], "generated_at": generated_at}
     await _st(key, store.write_recommendations_cache, owner, repo, payload)
@@ -2831,10 +2829,10 @@ async def _handle_get_tagging(request: web.Request) -> web.Response:
     untagged = [r["number"] for r in rows]
 
     # Per-label OPEN-issue counts and open-issue titles, derived from the same
-    # set this route already loaded. Both used to be read from the shared issue
-    # list, which follows the user's open/closed filter — so entering Tagging
-    # from a Closed filter reported closed counts as open ones and lost the
-    # example titles. Serving them here makes the dashboard filter-independent.
+    # set this route already loaded rather than from the shared issue list: that
+    # list follows the user's open/closed filter, so entering Tagging from a
+    # Closed filter would report closed counts as open ones and lose the example
+    # titles. Serving them here makes the dashboard filter-independent.
     label_counts: dict[str, int] = {}
     for iss in issues:
         if not isinstance(iss, dict):

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/datadog.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/datadog.py
@@ -123,11 +123,10 @@ _STATE_SEVERITY: dict[str, str] = {
 _METRIC_LOOKBACK_SECS = 3600
 
 #: Datadog's mute endpoint takes an optional ``end`` epoch and treats its ABSENCE as
-#: "mute forever" — so posting ``body={}`` (what this adapter used to do) silenced a
-#: production monitor indefinitely, and the only way back was a human noticing and
-#: unmuting by hand. The window is now always sent, bounded by the shared
-#: ``resolve_silence_secs`` so every provider's suppression obeys one ceiling rather
-#: than each adapter inventing its own.
+#: "mute forever", so posting ``body={}`` silences a production monitor indefinitely
+#: and the only way back is a human noticing and unmuting by hand. The window is
+#: therefore always sent, bounded by the shared ``resolve_silence_secs`` so every
+#: provider's suppression obeys one ceiling rather than each adapter inventing its own.
 
 
 def _api_base() -> str:
@@ -305,8 +304,6 @@ class DatadogEvidenceSource:
         return await asyncio.to_thread(self._gather_sync, signal, budget)
 
     def _gather_sync(self, signal: Signal, budget: EvidenceBudget) -> list[Evidence]:
-        import time
-
         monitor_id = signal.labels.get("dd_monitor_id", "")
         if not monitor_id:
             return []

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/store.py
@@ -413,9 +413,9 @@ def update_fields(incident_id: str, **updates: Any) -> Incident:
 
     Passes ``_KEEP_STATUS`` rather than reading the status here and handing it back: a read
     outside the lock is stale by the time the locked write runs, so on a mutually-legal
-    transition pair (`investigating` <-> `needs_human`) that stale value silently reverted a
-    concurrent change — the incident-index sibling of the proposal races. The status is now
-    only ever read INSIDE the lock, so a field edit cannot move it.
+    transition pair (`investigating` <-> `needs_human`) that stale value would silently revert
+    a concurrent change — the incident-index sibling of the proposal races. The status is only
+    ever read INSIDE the lock, so a field edit cannot move it.
     """
     return transition(incident_id, _KEEP_STATUS, **updates)
 

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -1115,11 +1115,9 @@ def _app_activation_denied(name: str) -> str | None:
     session key (surface ``host``): app activation is an operator/host action, so
     it is governed by the policy ceiling AND any ``bind: {type: surface, id:
     host}`` profile — an honest, stable bind target.  (It must NOT use an empty
-    key, which would classify to surface ``unknown`` and silently match nothing;
-    an empty key previously mis-classified to ``slack`` and accidentally picked up
-    slack-bound profiles.)  Best-effort beyond the always-on
-    checks: a ``PlatformCompositionError`` propagates (fail-closed CPP); any other
-    error degrades to "no opinion" (None).
+    key, which classifies to surface ``unknown`` and silently matches nothing.)
+    Best-effort beyond the always-on checks: a ``PlatformCompositionError``
+    propagates (fail-closed CPP); any other error degrades to "no opinion" (None).
     """
     from kiro_crew.platform.context import PlatformCompositionError
 

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -764,29 +764,28 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
     except Exception:
         pass
 
-    # Per-app lifecycle lock, WIDENED to wrap the ENTIRE uninstall sequence:
+    # Per-app lifecycle lock, wrapping the ENTIRE uninstall sequence:
     # cron-cleanup precondition → onUninstall script → backend stop →
-    # deregistration → dependency cleanup → file removal. Previously the lock
-    # was taken only AFTER the onUninstall script had already run. It is now
-    # taken FIRST, deliberately, because:
+    # deregistration → dependency cleanup → file removal. The lock is taken
+    # FIRST, deliberately, because:
     #   (a) the cron-cleanup precondition below must be able to abort BEFORE
     #       any destructive action (see its comment), which requires it — and
     #       therefore the lock — to precede the onUninstall script; and
     #   (b) the onUninstall script may itself be destructive (it can wipe app
     #       data), so holding the lock across it stops a racing enable/update
     #       of the same app from starting a backend mid-teardown.
-    # Cost: a concurrent same-app lifecycle op now waits up to the onUninstall
+    # Cost: a concurrent same-app lifecycle op waits up to the onUninstall
     # timeout — acceptable, since those ops genuinely conflict and the lock is
     # per-app (other apps are unaffected).
     async with app_lifecycle_lock(name):
         # Step 0: the execution grant must be removable before anything is
         # destroyed. A grant is keyed on the app NAME alone, so one left behind
         # admits a DIFFERENT app later installed under this name — code execution
-        # with no consent prompt. That check used to live inside uninstall_app
-        # (Step 5), which made it unreachable as an abort: by then the cron
-        # manifest, the onUninstall script, the backend and the dependencies had
-        # all already been torn down, so the refusal stranded a half-removed app
-        # and every retry re-ran the non-idempotent script. Asking here keeps the
+        # with no consent prompt. Checking it inside uninstall_app (Step 5)
+        # instead would make it unreachable as an abort: by then the cron
+        # manifest, the onUninstall script, the backend and the dependencies have
+        # all already been torn down, so the refusal strands a half-removed app
+        # and every retry re-runs the non-idempotent script. Asking here keeps the
         # refusal free and the retry safe, exactly like the cron precondition.
         # Offloaded: the precondition reads config.json and config.local.json from
         # disk, and this is an async handler — the same reason `uninstall_app` below
@@ -1273,11 +1272,11 @@ async def handle_disable_app(request: web.Request) -> web.Response:
     # resources — must not interleave with a concurrent install/update/
     # uninstall/enable of the same app.
     async with app_lifecycle_lock(name):
-        # `onDisable` is NOT run here any more: it moved INTO
-        # `teardown_app_runtime` below, so that revoking an app's execution grant
-        # runs it too. It used to be handler-only, which made revoke weaker than
-        # disable — see the ordering rationale in apps/teardown.py. Running it here
-        # as well would run the app's script twice per disable.
+        # `onDisable` is NOT run here: it runs inside `teardown_app_runtime`
+        # below, so that revoking an app's execution grant runs it too. Keeping it
+        # handler-only would make revoke weaker than disable — see the ordering
+        # rationale in apps/teardown.py. Running it here as well would run the
+        # app's script twice per disable.
         #
         # Invoke Python lifecycle hooks, stop the backend PROCESS, and deregister
         # resources through the ONE shared teardown that revoking an app's
@@ -1804,8 +1803,8 @@ async def handle_app_ui_file(request: web.Request) -> web.Response:
     # revalidate each load. FileResponse answers conditional requests
     # (If-Modified-Since / If-None-Match from its Last-Modified/ETag) with a
     # body-less 304, so unchanged files stay cheap while app updates are picked
-    # up on a plain refresh. The previous public,max-age=3600 served every
-    # app's UI stale for up to an hour after an update.
+    # up on a plain refresh. A long ``public,max-age=...`` instead would serve an
+    # app's UI stale for that whole window after an update.
     from kiro_crew.apps.dev_mode import is_dev_mode_cached
 
     cache = "no-store" if is_dev_mode_cached(name) else "no-cache"

--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -469,9 +469,9 @@ class Artifact:
     #: the live read of it FAILED — the file was deleted or moved, is no longer
     #: readable, or resolves outside the roots that authorize it. The store
     #: falls back to the last snapshot in that case so the artifact stays
-    #: viewable, which used to make a dead pointer indistinguishable from a
-    #: healthy one (``live_dirty`` was computed against the fallback and so
-    #: read "in sync"). This field is the signal that the pointer is dead.
+    #: viewable, which on its own makes a dead pointer indistinguishable from a
+    #: healthy one (``live_dirty`` is computed against the fallback and so
+    #: reads "in sync"). This field is the signal that the pointer is dead.
     #: Not persisted; set by ``get()`` — same contract as ``live_dirty``.
     source_missing: bool = False
     #: Structured metadata for ``kind="webapp"`` artifacts — a deployed application
@@ -838,12 +838,12 @@ def _validate_description(description: str | None) -> str:
 def _validate_source_path(value: str | None, field_name: str = "source_path") -> str:
     """Validate a filesystem-pointer field (``source_path`` / ``source_root``).
 
-    REJECTS an over-long value instead of truncating it. Truncation used to be
-    silent (``source_path[:512]``), which turned a too-long-but-valid path into
-    a shorter path that points somewhere else — practically always somewhere
-    that doesn't exist. The artifact then looked file-backed while its live read
-    could never succeed. Failing the save is the honest outcome: the caller
-    learns immediately instead of the user discovering a hollow artifact later.
+    REJECTS an over-long value instead of truncating it. Silent truncation
+    (``source_path[:512]``) turns a too-long-but-valid path into a shorter path
+    that points somewhere else — practically always somewhere that doesn't
+    exist. The artifact then looks file-backed while its live read can never
+    succeed. Failing the save is the honest outcome: the caller learns
+    immediately instead of the user discovering a hollow artifact later.
     """
     if value is None:
         return ""
@@ -1366,8 +1366,8 @@ class ArtifactStore:
                 else:
                     # Fall through to the snapshot fallback — file moved /
                     # deleted / unreadable / outside the authorized root. Flag
-                    # it: the fallback keeps the artifact viewable, which
-                    # previously made a dead pointer look completely healthy.
+                    # it: the fallback keeps the artifact viewable, which on its
+                    # own makes a dead pointer look completely healthy.
                     meta.source_missing = True
                     meta.content = self._read_text(self._artifact_dir(slug) / "current.html")
             else:
@@ -1499,12 +1499,11 @@ class ArtifactStore:
                 return None
             # Bound the read at the FILE level, not after-the-fact: read
             # MAX_CONTENT_BYTES+1 bytes from disk, decode (errors='replace'
-            # for invalid sequences). Previously called
-            # p.read_text() which loads the entire file into memory before
-            # the size check — a multi-GB file pointed to by source_path
-            # would exhaust memory before truncation triggered. Bounding
-            # the read caps memory at MAX_CONTENT_BYTES+1 regardless of
-            # file size.
+            # for invalid sequences). p.read_text() would load the entire
+            # file into memory before the size check — a multi-GB file
+            # pointed to by source_path would exhaust memory before
+            # truncation triggered. Bounding the read caps memory at
+            # MAX_CONTENT_BYTES+1 regardless of file size.
             # Read through the descriptor-pinned helper rather than by name.
             # The containment check above is on a RESOLVED path, which still
             # leaves a check-to-use window: the final component, or an ancestor
@@ -1780,11 +1779,12 @@ class ArtifactStore:
                     # Lifecycle event. Caller-specified event_type wins
                     # (revert flow uses 'reverted'); otherwise actor-based
                     # default: agent → iterated, user → edited.
-                    resolved_event_type = (
-                        event_type
-                        if event_type is not None
-                        else ("iterated" if actor == "agent" else "edited")
-                    )
+                    if event_type is not None:
+                        resolved_event_type = event_type
+                    elif actor == "agent":
+                        resolved_event_type = "iterated"
+                    else:
+                        resolved_event_type = "edited"
                     self._append_event(
                         art,
                         type=resolved_event_type,

--- a/src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
+++ b/src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
@@ -131,9 +131,12 @@ def main(argv: list[str] | None = None) -> int:
     if not re.fullmatch(r"[A-Za-z0-9._-]{1,64}", args.name):
         _fail("--name must be a plain filename fragment (letters, digits, . _ -)")
 
-    project = Path(args.project).resolve() if args.project else (
-        scenario.parent if scenario else Path.cwd()
-    )
+    if args.project:
+        project = Path(args.project).resolve()
+    elif scenario:
+        project = scenario.parent
+    else:
+        project = Path.cwd()
     node = _probe_node()
     _probe_playwright(project)
 

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -130,7 +130,7 @@ def _token(args: argparse.Namespace) -> None:
     runs this over SSH and regex-extracts the JWT from stdout, so mixing error
     prose into stdout both violates the Unix convention and hides the reason
     from any caller that only captures stderr (which is how a failed remote
-    mint used to surface as a useless ``<no stderr>``).
+    mint surfaces as a useless ``<no stderr>``).
     """
     # Seam-supplied pre-launch checks (CPP IdentityProvider seam) — e.g. a
     # companion SSO-session freshness prompt before minting a token. Public
@@ -326,8 +326,8 @@ def _stop(cli_port: int | None = None) -> None:
         return
 
     # Cross-platform port -> listening PID lookup (lsof on POSIX, netstat -ano
-    # on Windows — there is no lsof there, which previously made `kirocrew stop`
-    # a no-op on Windows).
+    # on Windows — there is no lsof there, so an lsof-only lookup makes
+    # `kirocrew stop` a no-op on Windows).
     pids = platform_compat.find_listening_pids(port)
 
     if not pids:
@@ -898,7 +898,7 @@ def _restart(cli_port: int | None = None) -> None:
     pid = proc.pid
     # A pid is not a running gateway. The replacement can be refused by the
     # ownership guard, crash on a bad config, or hang before it binds — all of
-    # which used to print the success line below and exit 0 with nothing serving.
+    # which would print the success line below and exit 0 with nothing serving.
     # Report success only once the NEW gateway answers, and audit what happened.
     verdict, exit_status = _wait_gateway_ready(proc, port, prior_marker_pid, _RESTART_READY_TIMEOUT)
     if verdict != _READY_OK:
@@ -1130,9 +1130,7 @@ def _update_wheel(layout) -> None:
     the standard state for ``curl | sh`` installs where the venv at
     ``~/.kiro/crew-venv`` has no source tree.
     """
-    import json
     import re
-    import urllib.request
 
     from kiro_crew import __version__ as local_version
     from kiro_crew.platform.update_governance import update_blocked_reason

--- a/src/kiro_crew/computer_use/cursor_motion.py
+++ b/src/kiro_crew/computer_use/cursor_motion.py
@@ -162,11 +162,11 @@ class CursorPath:
         EXACTLY (not evaluated) so ``point_at(0)``/``point_at(1)`` are bit-equal
         to ``start``/``end`` and cannot drift by a float epsilon.
         """
-        clamped = 0.0 if t < 0.0 else (1.0 if t > 1.0 else float(t))
-        if clamped <= 0.0:
+        if t <= 0.0:
             return self.start
-        if clamped >= 1.0:
+        if t >= 1.0:
             return self.end
+        clamped = float(t)
         omt = 1.0 - clamped
         a = omt * omt * omt
         b = 3.0 * omt * omt * clamped

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -1363,7 +1363,12 @@ class CronService:
         if timeout_secs and not 1 <= int(timeout_secs) <= 86400:
             raise ValueError(f"timeout_secs must be within 1..86400, got {timeout_secs}")
         if timeout_secs and (command or script):
-            _eff_sub = int(timeout) if timeout else (30 if script else 300)
+            if timeout:
+                _eff_sub = int(timeout)
+            elif script:
+                _eff_sub = 30
+            else:
+                _eff_sub = 300
             if int(timeout_secs) < _eff_sub + _SUBPROC_CLEANUP_ALLOWANCE_SECS:
                 raise ValueError(
                     "timeout_secs (wake budget) must cover the command/script "
@@ -1615,9 +1620,9 @@ class CronService:
                         raise ValueError(
                             f"timeout_secs must be within 1..86400, got {_tsecs}"
                         )
-                # Script/command subprocess timeout. MCP cron_update has passed
-                # this since the field existed, but no branch consumed it — the
-                # update was accepted and silently dropped.
+                # Script/command subprocess timeout. MCP cron_update passes this
+                # field, so a branch has to consume it here — otherwise the
+                # update is accepted and silently dropped.
                 _tsub: int | None = None
                 if "timeout" in kwargs and kwargs["timeout"] is not None:
                     try:
@@ -1634,11 +1639,12 @@ class CronService:
                 if job.command or job.script:
                     _eff_secs = _tsecs if _tsecs is not None else job.timeout_secs
                     _eff_sub_new = _tsub if _tsub is not None else job.timeout
-                    _eff_sub = (
-                        int(_eff_sub_new)
-                        if _eff_sub_new
-                        else (30 if job.script else 300)
-                    )
+                    if _eff_sub_new:
+                        _eff_sub = int(_eff_sub_new)
+                    elif job.script:
+                        _eff_sub = 30
+                    else:
+                        _eff_sub = 300
                     if (_tsecs is not None or _tsub is not None) and _eff_secs < (
                         _eff_sub + _SUBPROC_CLEANUP_ALLOWANCE_SECS
                     ):

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -2583,10 +2583,16 @@ async def api_chat_slots_cleanup(request: web.Request) -> web.Response:
         _sync_dashboard_slots(state)
         state.push_slots_update()
         state.push_refresh("history")
+    if not failed:
+        cleanup_outcome = "ok"
+    elif archived:
+        cleanup_outcome = "partial"
+    else:
+        cleanup_outcome = "error"
     sel().log_api_access(
         caller="dashboard",
         operation="chat.slots_cleanup",
-        outcome="ok" if not failed else ("partial" if archived else "error"),
+        outcome=cleanup_outcome,
         source="dashboard",
         resources=f"archived={len(archived)} failed={len(failed)} threshold={max_days}d keys={','.join(archived[:10])}",
     )

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3389,7 +3389,7 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     cron_label, _ = redact_credentials(cron_label)
     # Structured completion facts stamped at enqueue time (gateway _subagent_done)
     # ride through to the row so the card reads them instead of re-parsing the
-    # header prose (#1792). Only a single, un-merged system injection carries
+    # header prose. Only a single, un-merged system injection carries
     # them: a merge concatenates several entries under one synthetic header, for
     # which per-entry facts are meaningless — subagent completions never merge
     # (they drain one at a time and break any user-message merge), so this only
@@ -3400,14 +3400,24 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     # the synthesis turn).
     if is_subagent and slot._pending_synthesis and isinstance(_row_meta, dict):
         _row_meta = {**_row_meta, "synthesisPending": True}
+    if is_subagent:
+        row_role = "subagent"
+    elif is_cron or is_recovery:
+        row_role = "inject"
+    else:
+        row_role = "user"
+    if is_cron:
+        # A cron row's `cls` slot carries a JSON payload, not a CSS class name:
+        # `cronLabel` is structured data the frontend reads off the row.
+        row_cls = json.dumps({"cronLabel": cron_label})
+    elif is_recovery:
+        row_cls = "msg msg-inject"
+    else:
+        row_cls = "msg msg-u"
     slot.append(
-        "subagent" if is_subagent else "inject" if (is_cron or is_recovery) else "user",
+        row_role,
         next_msg,
-        (
-            json.dumps({"cronLabel": cron_label})
-            if is_cron
-            else "msg msg-inject" if is_recovery else "msg msg-u"
-        ),
+        row_cls,
         meta=_row_meta if isinstance(_row_meta, dict) else None,
     )
 
@@ -3524,8 +3534,9 @@ def _emit_ttft_metric(t0: float, session_key: str, *, is_new: bool, resumed: boo
     read side by side.
     """
     try:
-        # circular import: metrics.provider -> config.loader -> ... (same
-        # reason _emit_kiro_startup_metric imports lazily).
+        # Re-read at call time even though the module also imports it at the
+        # top: the rebind is what lets a test patching
+        # ``kiro_crew.metrics.provider.get_recorder`` reach this emit.
         from kiro_crew.metrics.provider import get_recorder
 
         get_recorder().histogram(

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1146,6 +1146,9 @@ _STARTUP_READ_AGENT_KEYS = frozenset(
 
 async def api_kirocrew_config(request: web.Request) -> web.Response:
     """GET/PUT /api/config/kirocrew — read or update KiroCrew config."""
+    # Re-imported at call time (not reused from the module-level binding) so a
+    # test that redirects ``kiro_crew.config.loader.config_path`` at a temp path
+    # is observed by this handler.
     from kiro_crew.config.loader import config_path  # noqa: F811
 
     if request.method == "PUT":
@@ -1310,7 +1313,7 @@ def _agent_values() -> set[str]:
 def _active_advertised_ids(request: web.Request) -> list[str] | None:
     """Advertised model ids from the first active provider, or None if unknown.
 
-    Uses the shared :func:`advertised_model_ids` shape parser (#1596) so this
+    Uses the shared :func:`advertised_model_ids` shape parser so this
     validation sees exactly what the session-init withhold check sees. Returns
     ``None`` when no session has initialized / nothing was advertised, so callers
     treat entitlement as UNKNOWN rather than denying on no evidence.
@@ -2036,8 +2039,6 @@ async def api_session_agent_stream(request: web.Request) -> web.StreamResponse:
     await resp.prepare(request)
 
     last_pos = 0
-    import asyncio  # noqa: F811
-
     from kiro_crew.security import redact_credentials, redact_exfiltration_urls  # noqa: F811
 
     for _ in range(1200):  # 20 min max

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -279,8 +279,6 @@ async def api_outbox_notify(request: web.Request) -> web.Response:
 
 async def api_outbox_download(request: web.Request) -> web.StreamResponse:
     """GET /api/outbox/{filename} — download a file from the outbox."""
-    import urllib.parse  # noqa: F811
-
     from kiro_crew.config.loader import outbox_dir  # noqa: F811
     from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes  # noqa: F811
 
@@ -1084,7 +1082,6 @@ async def api_workspaces(request: web.Request) -> web.Response:
 
 async def api_workspaces_create(request: web.Request) -> web.Response:
     """POST /api/workspaces — create a new workspace."""
-    import asyncio  # noqa: F811
     import shutil  # noqa: F811
 
     from kiro_crew.validation import WORKSPACE_NAME_RE  # noqa: F811
@@ -1449,9 +1446,6 @@ async def api_file_watch(request: web.Request) -> web.StreamResponse:
 
 async def api_file_read(request: web.Request) -> web.Response:
     """GET /api/file-read?path=... — read file content for the markdown panel."""
-    import logging  # noqa: F811
-    import os  # noqa: F811
-
     from kiro_crew.validation import (  # noqa: F811
         FILE_READ_SCHEMA,
         ValidationError,
@@ -1715,8 +1709,6 @@ async def api_file_download(request: web.Request) -> web.Response:
 
 async def api_file_raw(request: web.Request) -> web.Response:
     """GET /api/file-raw?path=... — serve a file with its native content type (images, etc.)."""
-    import os  # noqa: F811
-
     import kiro_crew.dashboard.handlers as _h  # noqa: F811
 
     def _log(outcome: str, res: str) -> None:
@@ -1796,9 +1788,6 @@ async def api_file_raw(request: web.Request) -> web.Response:
 
 async def api_file_write(request: web.Request) -> web.Response:
     """POST /api/file-write — write file content from the markdown panel."""
-    import logging  # noqa: F811
-    import os  # noqa: F811
-
     from kiro_crew.validation import (  # noqa: F811
         FILE_WRITE_SCHEMA,
         ValidationError,
@@ -1841,7 +1830,6 @@ async def api_file_write(request: web.Request) -> web.Response:
         )
         return web.json_response({"error": "not found"}, status=404)
     try:
-        import os  # noqa: F811
         import shutil  # noqa: F811
         import tempfile  # noqa: F811
 
@@ -1928,9 +1916,9 @@ def _fuzzy_score(q: str, name: str, rel: str) -> float:
 
 async def api_file_search(request: web.Request) -> web.Response:
     """GET /api/file-search?q=... — fuzzy filename search for the @-mention file picker."""
-    import os  # noqa: F811
-    import time  # noqa: F811
-
+    # Re-imported at call time (not reused from the module-level binding) so a
+    # test that stubs ``kiro_crew.security.is_sensitive_path`` is observed by the
+    # project-root rejection below.
     from kiro_crew.security import is_sensitive_path  # noqa: F811
 
     caller = request.get("user", "dashboard")
@@ -2246,8 +2234,6 @@ def _browse_files_sync(base: str, skip: set[str]) -> tuple[list[dict], list[dict
 
 async def api_browse_dirs(request: web.Request) -> web.Response:
     """GET /api/browse-dirs?path=... — list subdirectories for directory browser."""
-    import os  # noqa: F811
-
     from kiro_crew.security import is_sensitive_path  # noqa: F811
 
     caller = request.get("user", "dashboard")
@@ -2529,9 +2515,9 @@ async def api_dashboard_config(request: web.Request) -> web.Response:
     from kiro_crew.config.loader import KiroCrewConfig  # noqa: F811
 
     # Offloaded: KiroCrewConfig.load() stats, reads, parses, and validates config
-    # files. The client now polls this endpoint on an interval to pick up
-    # externally edited dashboard.gitlab_hosts, so a slow or network-backed config
-    # directory would otherwise stall the sole event loop on every poll.
+    # files. The client polls this endpoint on an interval to pick up externally
+    # edited dashboard.gitlab_hosts, so a slow or network-backed config directory
+    # would otherwise stall the sole event loop on every poll.
     try:
         cfg = await asyncio.to_thread(KiroCrewConfig.load)
     except asyncio.CancelledError:

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -586,8 +586,14 @@ async def source_counts(request: web.Request) -> web.Response:
     # holds documents -- which the list view filters out, hiding a source the user
     # cannot then see or delete. The union is over item ids, so a document held both
     # ways counts once per source and never twice.
-    where_sl = [w.replace("source_id", "i.source_id") if "source_id" in w else f"i.{w}"
-                if w != "1=1" else w for w in where]
+    where_sl: list[str] = []
+    for w in where:
+        if "source_id" in w:
+            where_sl.append(w.replace("source_id", "i.source_id"))
+        elif w == "1=1":
+            where_sl.append(w)  # the constant-true clause takes no table alias
+        else:
+            where_sl.append(f"i.{w}")
     sql = (
         f"SELECT COALESCE(NULLIF(sid, ''), '{_NO_SOURCE}') AS sid, "  # noqa: S608
         "COUNT(DISTINCT item_id) AS cnt FROM ("

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -185,6 +185,11 @@ def _get_vector_store(state: DashboardState):
         return mem.vector_store
     # Fallback: create standalone
     if not hasattr(state, "_standalone_vector"):
+        # Both imports resolve their target at CALL time, which is what lets a test
+        # substitute the attribute on the source module and have this function
+        # observe it. ``KiroCrewConfig`` deliberately shadows this module's own
+        # top-level binding: that binding captured the original object at import
+        # time and would not see such a substitution.
         from kiro_crew.config.loader import KiroCrewConfig  # noqa: F811
         from kiro_crew.vector_memory import VectorMemoryStore  # noqa: F811
 
@@ -1069,9 +1074,11 @@ async def api_memory_episodic_delete(request: web.Request) -> web.Response:
 async def api_memory_stats(request: web.Request) -> web.Response:
     """GET /api/memory/stats — memory system statistics."""
     store = _get_vector_store(request.app["state"])
-    # Offload: serializes on _db_lock (#1947) — see api_memory_semantic.
+    # Offload: serializes on _db_lock — see api_memory_semantic.
     stats = await asyncio.to_thread(store.memory_stats)
-    # Add embedding status
+    # Add embedding status. The shadowing import is deliberate: resolving
+    # ``KiroCrewConfig`` at call time is what lets a test substitute it on the
+    # source module.
     from kiro_crew.config.loader import KiroCrewConfig  # noqa: F811
 
     cfg = KiroCrewConfig.load()

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -1414,20 +1414,25 @@ async def api_send_message(request: web.Request) -> web.Response:
             thread_hint = " threaded=1" if thread_ts else ""
             if reply_broadcast:
                 thread_hint += " broadcast=1"
-            base_res = (
-                f"target_channel={target_channel} target_user={target_user}"
-                if (target_channel or target_user)
-                else ("session=origin" if sent_session else "fallback=owner_dm")
-            )
+            if target_channel or target_user:
+                base_res = f"target_channel={target_channel} target_user={target_user}"
+            elif sent_session:
+                base_res = "session=origin"
+            else:
+                base_res = "fallback=owner_dm"
+            if sent_session:
+                downstream_service = "session"
+            elif sent_slack:
+                downstream_service = "slack"
+            else:
+                downstream_service = "dashboard"
             _sel().log_tool_invocation(
                 session_key="dashboard",
                 tool_name="send_message",
                 outcome=(
                     "completed" if sent_slack or sent_session or not slack_attempted else "error"
                 ),
-                downstream_service=(
-                    "session" if sent_session else ("slack" if sent_slack else "dashboard")
-                ),
+                downstream_service=downstream_service,
                 resources=base_res + thread_hint,
             )
         except Exception:
@@ -1439,9 +1444,9 @@ async def api_send_message(request: web.Request) -> web.Response:
             {"ok": False, "error": f"Slack delivery failed: {safe_error}", "slack": False},
             status=502,
         )
-    # A: report the actual delivery channel so callers (and the read-back
+    # Report the actual delivery channel so callers (and the read-back
     # steering) can distinguish a real Slack post from a notification-only
-    # send. "ok: true" alone previously masked notification-only outcomes.
+    # send; "ok: true" alone masks that difference.
     if sent_session:
         delivered_to = "session"
     elif sent_slack:
@@ -1689,8 +1694,6 @@ def _missing_scope_message(needed: str) -> str:
 
 async def api_slack_profile(request: web.Request) -> web.Response:
     """POST /api/slack-profile — read a Slack user's profile."""
-    import time  # noqa: F811
-
     from kiro_crew.security import redact_credentials, redact_exfiltration_urls  # noqa: F811
     from kiro_crew.validation import USER_ID_RE  # noqa: F811
 

--- a/src/kiro_crew/dashboard/handlers/security.py
+++ b/src/kiro_crew/dashboard/handlers/security.py
@@ -268,7 +268,13 @@ def build_denied_commands_snapshot() -> dict:
         enabled = is_pinned or is_floor or (not disable_all and rid not in disabled_ids)
         # "floor" wins over "policy": the floor holds even if every governance
         # pin were removed, so it is the stronger (and always-true) reason.
-        lock_reason = "floor" if is_floor else ("policy" if is_pinned else None)
+        lock_reason: str | None
+        if is_floor:
+            lock_reason = "floor"
+        elif is_pinned:
+            lock_reason = "policy"
+        else:
+            lock_reason = None
         builtins.append(
             {
                 "id": rid,

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -1692,8 +1692,6 @@ async def _reset_all_sessions(request: web.Request) -> int:
         if providers:
 
             async def _safe_shutdown(p: LLMProvider) -> None:
-                import kiro_crew.dashboard.handlers as _h  # noqa: F811
-
                 _timeout = _SHUTDOWN_TIMEOUT_SECS
                 try:
                     await asyncio.wait_for(p.shutdown(), timeout=_timeout)

--- a/src/kiro_crew/dashboard/handlers/skill_budget.py
+++ b/src/kiro_crew/dashboard/handlers/skill_budget.py
@@ -143,9 +143,10 @@ def _compute_budget(
                     if alias_entry is not None:
                         total_hits += alias_entry[0]
                         latest_seen = max(latest_seen, alias_entry[1])
-                deliveries = total_hits if total_hits > 0 else (
-                    0 if (own_entry is not None or alias_keys) else None
-                )
+                # This branch already established that the skill IS tracked, so a
+                # zero total reads as "tracked, never delivered" (0) rather than
+                # "untracked" (None, set in the else branch below).
+                deliveries = max(total_hits, 0)
                 # idle_days: days since last_seen
                 if latest_seen > 0:
                     idle_days = (now - latest_seen) / 86400.0

--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -1659,15 +1659,14 @@ async def _fetch_gitlab(ref: SourceRef) -> dict[str, Any]:
         _mark_partial(partial_sections, "files")
     normalized_files = []
     for item in change_rows:
-        status = (
-            "deleted"
-            if item.get("deleted_file")
-            else (
-                "added"
-                if item.get("new_file")
-                else "renamed" if item.get("renamed_file") else "modified"
-            )
-        )
+        if item.get("deleted_file"):
+            status = "deleted"
+        elif item.get("new_file"):
+            status = "added"
+        elif item.get("renamed_file"):
+            status = "renamed"
+        else:
+            status = "modified"
         patch = item.get("diff") or ""
         normalized_files.append(
             {

--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -420,15 +420,14 @@ async def api_taskrunner_to_chat(request: web.Request) -> web.Response:
     lines.append(run.spec_content[:3000] if run.spec_content else "(no spec)")
     lines.append("\n## Step Results\n")
     for s in run.tasks:
-        icon = (
-            "✅"
-            if s.status == TaskStatus.PASSED
-            else (
-                "❌"
-                if s.status == TaskStatus.FAILED
-                else "🔄" if s.status in (TaskStatus.IN_PROGRESS, TaskStatus.REVIEWING) else "⏭"
-            )
-        )
+        if s.status == TaskStatus.PASSED:
+            icon = "✅"
+        elif s.status == TaskStatus.FAILED:
+            icon = "❌"
+        elif s.status in (TaskStatus.IN_PROGRESS, TaskStatus.REVIEWING):
+            icon = "🔄"
+        else:
+            icon = "⏭"
         lines.append(f"{icon} **Step {s.index}: {s.title}**")
         if s.error:
             lines.append(f"  Error: {s.error[:300]}")

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2199,7 +2199,7 @@ async def start_dashboard(
     except Exception:
         logger.debug("Could not register pending-skill staged hook", exc_info=True)
 
-    # --- Dynamic Workflows (M6) ---
+    # --- Dynamic Workflows ---
     try:
         from kiro_crew.dashboard.handlers import workflows as wf_handlers
         from kiro_crew.dashboard.workflow_inject import inject_workflow_result

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3864,6 +3864,12 @@ class DashboardState:
                     done_at = float(info.get("done_at") or 0.0)
                     if done_at and (now - done_at) > ttl_secs:
                         continue
+                    if info.get("stopped"):
+                        outcome = "stopped"
+                    elif info.get("error"):
+                        outcome = "failed"
+                    else:
+                        outcome = "completed"
                     done.append(
                         {
                             **base,
@@ -3871,11 +3877,7 @@ class DashboardState:
                             "elapsed": float(info.get("elapsed") or 0.0),
                             "error": info.get("error"),
                             "stopped": bool(info.get("stopped")),
-                            "outcome": (
-                                "stopped"
-                                if info.get("stopped")
-                                else ("failed" if info.get("error") else "completed")
-                            ),
+                            "outcome": outcome,
                             "result": str(info.get("result") or ""),
                             "done_at": done_at,
                         }
@@ -4967,6 +4969,21 @@ class DashboardState:
             if nested and nested[0] == channel_type:
                 channel_id = nested[1]
             normalized = ChannelLink(channel_type, channel_id, link.thread_id)
+            # Real on EVERY row, origin included: the conversation a session was
+            # born in can be disconnected too, so it stops syndicating there and
+            # the session carries on in the dashboard. `direction` still records
+            # the provenance the sidebar mark needs; it no longer decides whether
+            # the row has a control.
+            #
+            # Keyed to the row's SOURCE, not just its channel: a session born in
+            # Discord that also mirrors to Telegram draws two non-Slack rows, and
+            # while both read one value, muting either silently muted the other.
+            if channel_type == SLACK_NAMESPACE:
+                paused = slack_paused
+            elif direction == "origin":
+                paused = origin_paused
+            else:
+                paused = mirror_paused
             links.append(
                 {
                     "channel": channel_type,
@@ -4974,22 +4991,7 @@ class DashboardState:
                     "target": _redacted_link_target(channel_id),
                     "direction": direction,
                     "live": self._channel_link_is_live(normalized),
-                    # Real on EVERY row, origin included: the conversation a
-                    # session was born in can be disconnected too, so it stops
-                    # syndicating there and the session carries on in the
-                    # dashboard. `direction` still records the provenance the
-                    # sidebar mark needs; it no longer decides whether the row
-                    # has a control.
-                    #
-                    # Keyed to the row's SOURCE, not just its channel: a session
-                    # born in Discord that also mirrors to Telegram draws two
-                    # non-Slack rows, and while both read one value, muting
-                    # either silently muted the other.
-                    "paused": (
-                        slack_paused
-                        if channel_type == SLACK_NAMESPACE
-                        else origin_paused if direction == "origin" else mirror_paused
-                    ),
+                    "paused": paused,
                 }
             )
 

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -419,6 +419,14 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                             try:
                                 if native.get("done"):
                                     _err = native.get("error")
+                                    # Same precedence the producer uses, for a
+                                    # snapshot that carries no outcome of its own.
+                                    if native.get("stopped"):
+                                        _outcome = "stopped"
+                                    elif _err:
+                                        _outcome = "failed"
+                                    else:
+                                        _outcome = "completed"
                                     _replay.append(
                                         {
                                             "type": "subagent_done",
@@ -428,18 +436,7 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                                                 "elapsed": native["elapsed"],
                                                 "error": _r(str(_err)) if _err else None,
                                                 "stopped": bool(native.get("stopped")),
-                                                "outcome": str(
-                                                    native.get("outcome")
-                                                    or (
-                                                        "stopped"
-                                                        if native.get("stopped")
-                                                        else (
-                                                            "failed"
-                                                            if native.get("error")
-                                                            else "completed"
-                                                        )
-                                                    )
-                                                ),
+                                                "outcome": str(native.get("outcome") or _outcome),
                                                 "task": _r(str(native["task"])),
                                                 "agent": _r(str(native["agent"])),
                                                 "result": _r(str(native["result"])),

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -834,7 +834,6 @@ def _cleanup_old_archives(retention_days: int | None = None, base: Path | None =
     entirely — the user manages archive deletion manually.
     """
     global _last_cleanup
-    import time as _time
 
     # Explicit negative disables cleanup immediately (no config read needed).
     if retention_days is not None and retention_days < 0:
@@ -848,8 +847,7 @@ def _cleanup_old_archives(retention_days: int | None = None, base: Path | None =
     # Past the throttle window: stamp _last_cleanup NOW, before resolving
     # retention. Otherwise a config-resolved "disabled" (negative) would return
     # without updating the window, so every subsequent archive write would
-    # re-run the expensive KiroCrewConfig.load() — reintroducing the
-    # regression for the disabled case.
+    # re-run the expensive KiroCrewConfig.load().
     _last_cleanup = now
     # Resolve retention from config if not given, honoring a config-resolved
     # negative as the disable signal too.
@@ -1085,12 +1083,12 @@ def latest_transcript_ts(*candidates: str | None) -> str | None:
 
 
 #: Default upper bound on the number of distinct session keys held in the
-#: in-memory transcript / metadata caches.  The previous implementation used
-#: plain ``dict`` caches that grew one entry per session key touched and never
-#: evicted — on a gateway serving thousands of sessions the parsed message
-#: lists (each up to ~200 messages / 2 MB of source JSONL) accumulated in RAM
-#: for the lifetime of the process.  A bounded LRU keeps hot sessions resident
-#: while giving the working set a deterministic ceiling.
+#: in-memory transcript / metadata caches.  Unbounded ``dict`` caches grow one
+#: entry per session key touched and never evict — on a gateway serving
+#: thousands of sessions the parsed message lists (each up to ~200 messages /
+#: 2 MB of source JSONL) accumulate in RAM for the lifetime of the process.  A
+#: bounded LRU keeps hot sessions resident while giving the working set a
+#: deterministic ceiling.
 _TRANSCRIPT_CACHE_MAX = 256
 
 # Metadata reads retry briefly before reporting "no metadata": on Windows a

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -1572,8 +1572,6 @@ def validate_file_path(raw: str) -> str | None:
     Enforces: is_sensitive_path(), realpath canonicalization.
     Returns the canonical path or None if rejected.
     """
-    import os
-
     if not raw:
         return None
     path = os.path.realpath(os.path.expanduser(raw))
@@ -1597,9 +1595,6 @@ def safe_read_file(path: str) -> str:
     detected. Other read errors (missing file, permission denied) propagate
     unchanged so callers surface accurate messages.
     """
-    import errno
-    import os
-
     resolved = os.path.realpath(os.path.expanduser(path))
     if is_sensitive_path(resolved):
         raise PermissionError(f"Blocked: access to sensitive path: {resolved}")
@@ -1634,8 +1629,6 @@ def safe_read_file_bytes(raw: str) -> bytes | None:
 
     Returns file content as bytes, or None if path is rejected or unreadable.
     """
-    import os
-
     path = validate_file_path(raw)
     if path is None:
         return None
@@ -1675,9 +1668,6 @@ def safe_read_file_bytes_with_identity(
     exceeds ``MAX_FILE_BYTES``. Returns ``None`` when the path is rejected by
     :func:`validate_file_path` or is otherwise unreadable.
     """
-    import errno
-    import os
-
     path = validate_file_path(raw)
     if path is None:
         return None
@@ -1713,8 +1703,6 @@ def stat_identity(raw: str) -> tuple[int, int] | None:
 
     Returns ``(dev, ino)`` or ``None`` if the path is rejected or unstattable.
     """
-    import os
-
     path = validate_file_path(raw)
     if path is None:
         return None
@@ -1727,8 +1715,6 @@ def stat_identity(raw: str) -> tuple[int, int] | None:
 
 def _fd_real_path(fd: int) -> str | None:
     """Real filesystem path of an OPEN descriptor."""
-    import os
-
     if os.name == "nt":
         try:
             import ctypes
@@ -1808,9 +1794,6 @@ def safe_read_file_bytes_nolink(
     Returns file content as bytes, or None if the path is rejected,
     hardlinked, non-regular, escaping ``within_root``, or unreadable.
     """
-    import os
-    import stat as _stat
-
     # Callers that pass an explicit limit own the higher-level bound (for
     # example, the importer's trusted 64 MiB SQLite snapshot cap). Keep the
     # default cap for general reads, but do not silently narrow a documented
@@ -2253,8 +2236,6 @@ def safe_copy_file_nolink(raw: str, dest_dir: str) -> str | None:
     the inode actually opened and copied, so no check-to-use window remains.
     If the fd's real path cannot be determined, fail closed.
     """
-    import os
-    import stat as _stat
     import tempfile
 
     path = validate_file_path(raw)
@@ -2320,8 +2301,6 @@ def safe_read_prefix(raw: str, n: int) -> bytes | None:
 
     Returns up to *n* bytes, or None if the path is rejected or unreadable.
     """
-    import os
-
     if n <= 0:
         return b""
     path = validate_file_path(raw)
@@ -2480,7 +2459,6 @@ def safe_read_file_internal(read_id: str) -> bytes | None:
     # refused, binding the read to the real allowlisted file rather than a
     # redirected target. Check + read share ONE descriptor (TOCTOU-safe), and
     # fstat confirms a regular file before reading.
-    import os
     import stat
 
     try:
@@ -2751,8 +2729,6 @@ async def run_script_hook(
 
     Passes hook event as JSON via STDIN (Kiro CLI compatible).
     """
-    import os
-
     start = time.monotonic()
     # Governance: the ``capabilities.script_hooks`` gate (default OFF) may forbid
     # running script hooks for the active surface. Checked before the subprocess
@@ -2868,7 +2844,12 @@ async def run_script_hook(
         elapsed = int((time.monotonic() - start) * 1000)
         exit_code = proc.returncode or 0
         hook.last_run = time.time()
-        hook.last_status = "blocked" if exit_code == 2 else ("ok" if exit_code == 0 else "error")
+        if exit_code == 2:
+            hook.last_status = "blocked"
+        elif exit_code == 0:
+            hook.last_status = "ok"
+        else:
+            hook.last_status = "error"
         hook.run_count += 1
         return ScriptHookResult(
             hook_id=hook.id,
@@ -3098,8 +3079,6 @@ class ScriptHookStore:
         ``run_script_hook`` (ARG_MAX safety), so a hook keying on the tail of the
         segment reads it from stdin JSON rather than the truncated env var.
         """
-        import os
-
         results = []
         # Build base hook event (Kiro CLI format)
         hook_event: dict = {"hook_event_name": event, "cwd": os.getcwd()}

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -2041,11 +2041,17 @@ class KiroPrerequisiteService:
                 "probe execution failed",
             )
             return ProcessResult(ok=False, error="Kiro CLI probe could not run")
+        if result.ok:
+            audit_detail = ""
+        elif result.timed_out:
+            audit_detail = "timeout"
+        else:
+            audit_detail = "nonzero exit"
         await self._set_terminal_audit(
             action,
             "completed" if result.ok else "failed",
             "gateway-status",
-            "" if result.ok else ("timeout" if result.timed_out else "nonzero exit"),
+            audit_detail,
         )
         return result
 
@@ -2192,11 +2198,17 @@ class KiroPrerequisiteService:
                 "probe execution failed",
             )
             return ProcessResult(ok=False, error="Kiro identity probe could not run")
+        if result.ok:
+            audit_detail = ""
+        elif result.timed_out:
+            audit_detail = "timeout"
+        else:
+            audit_detail = "nonzero exit"
         await self._set_terminal_audit(
             action,
             "completed" if result.ok else "failed",
             "gateway-status",
-            "" if result.ok else ("timeout" if result.timed_out else "nonzero exit"),
+            audit_detail,
         )
         return result
 

--- a/src/kiro_crew/link_unfurl.py
+++ b/src/kiro_crew/link_unfurl.py
@@ -264,7 +264,11 @@ def vet_unfurl_url(
         raise UnfurlRejected("invalid_url") from None
     if explicit_port is not None and explicit_port not in ALLOWED_PORTS:
         raise UnfurlRejected("blocked_url")
-    port = explicit_port if explicit_port is not None else (443 if scheme == "https" else 80)
+    if explicit_port is not None:
+        port = explicit_port
+    else:
+        # ALLOWED_SCHEMES is http/https only, so these two defaults cover it.
+        port = 443 if scheme == "https" else 80
 
     # 5. suffixes that cannot name a public host
     for suffix in BLOCKED_HOST_SUFFIXES:

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -579,6 +579,8 @@ def _deny_channel_agent_messaging(caller_session: str, tool_name: str) -> str | 
     if not caller_session.startswith("channel:"):
         return None
     try:
+        # Resolved from ``kiro_crew.sel`` at call time, not through the
+        # module-level binding, so a substituted SEL factory is observed.
         from kiro_crew.sel import sel
 
         sel().log_tool_invocation(
@@ -729,6 +731,8 @@ def _audit_governance_deny(session_key: str, tool_name: str, scope: str, decisio
     """Best-effort SEL audit of a governance denial (writes to the JSONL file,
     NOT stdout — safe in the stdio MCP server). Never raises."""
     try:
+        # Resolved from ``kiro_crew.sel`` at call time, not through the
+        # module-level binding, so a substituted SEL factory is observed.
         from kiro_crew.sel import sel
 
         sel().log_governance_decision(

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -450,6 +450,8 @@ def _audit_governance_deny(session_key: str, tool_name: str, scope: str, decisio
     trail. Never raises (audit must not wedge the deny path).
     """
     try:
+        # Resolved from ``kiro_crew.sel`` at call time, not through the
+        # module-level binding, so a substituted SEL factory is observed.
         from kiro_crew.sel import sel
 
         sel().log_governance_decision(

--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -173,8 +173,8 @@ def apply_options_cap(
     * ``len(choices) <= max_buttons`` — byte-identical pass-through.
     * overflow — the first ``max_buttons`` choices are kept for the widget;
       the remainder is appended to ``body`` as a numbered text list
-      (numbering continues after the widget slots). Previously overflow was
-      silently dropped: the user never learned those choices existed.
+      (numbering continues after the widget slots) rather than dropped, so
+      the user still learns those choices exist.
     * ``max_buttons <= 0`` — returns ``(body, [])``; zero-widget channels
       own their trailer handling (today: strip).
     """
@@ -184,7 +184,12 @@ def apply_options_cap(
     if not overflow:
         return body, kept
     lines = format_overflow(overflow, start=len(kept))
-    sep = "\n\n" if body and not body.endswith("\n") else "\n" if body else ""
+    if not body:
+        sep = ""
+    elif body.endswith("\n"):
+        sep = "\n"
+    else:
+        sep = "\n\n"
     return f"{body}{sep}{lines}", kept
 
 

--- a/src/kiro_crew/onboarding_import.py
+++ b/src/kiro_crew/onboarding_import.py
@@ -1725,7 +1725,10 @@ def _schedule_from_record(record: Any, scan: _Scan) -> dict[str, Any] | None:
             scan.diagnostic("schedules", "ambiguous_schedule_trigger", unsupported=True)
             return None
         family = next(iter(trigger_families))
-        expected_kind = "cron" if family == "cron" else "at" if family == "at" else "every"
+        # Exactly one family here (guarded above), drawn from the three literals
+        # added while scanning the schedule dict. The cron store spells the
+        # interval family "every".
+        expected_kind = {"cron": "cron", "at": "at", "interval": "every"}[family]
         allowed_kinds = {
             "cron": {"cron"},
             "interval": {"every", "interval"},
@@ -3517,11 +3520,12 @@ def _write_workspace(
 
     canonical = str(workspace)
     for existing in workspaces.values():
-        existing_dir = (
-            existing.get("dir")
-            if isinstance(existing, dict)
-            else existing if isinstance(existing, str) else None
-        )
+        if isinstance(existing, dict):
+            existing_dir = existing.get("dir")
+        elif isinstance(existing, str):
+            existing_dir = existing
+        else:
+            existing_dir = None
         if not isinstance(existing_dir, str):
             continue
         try:

--- a/src/kiro_crew/publish_sync.py
+++ b/src/kiro_crew/publish_sync.py
@@ -1071,8 +1071,15 @@ async def pull_upstream(
     except Exception as exc:  # pragma: no cover — pull must not 500
         logger.warning("pull_upstream: write-back failed for %s: %s", slug, exc)
         return {"pulled": False, "reason": "write-back failed", "source": source}
+    # Prefer the version the fetch reported, fall back to the pre-pull remote
+    # state, and 0 when neither carries an integer version.
     pcv = pulled.get("current_version")
-    cloud_dest_v = pcv if isinstance(pcv, int) else (cur_v if isinstance(cur_v, int) else 0)
+    if isinstance(pcv, int):
+        cloud_dest_v = pcv
+    elif isinstance(cur_v, int):
+        cloud_dest_v = cur_v
+    else:
+        cloud_dest_v = 0
     if is_pub and updated.publication is not None:
         upub = updated.publication
         version_map = dict(upub.version_map)

--- a/src/kiro_crew/skill_providers/skillsh.py
+++ b/src/kiro_crew/skill_providers/skillsh.py
@@ -83,9 +83,7 @@ class SkillsShProvider:
         # {"skills": null} yields a non-list -> items[:limit] raises TypeError.
         # Either way ProviderRegistry.search would swallow it and silently zero
         # ALL skillsh results. Coerce anything that isn't a list to [] instead.
-        raw_items = data if isinstance(data, list) else (
-            data.get("skills") if isinstance(data, dict) else None
-        )
+        raw_items = data.get("skills") if isinstance(data, dict) else data
         items: list[Any] = raw_items if isinstance(raw_items, list) else []
         results: list[SkillSearchResult] = []
         for item in items[:limit]:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -1289,14 +1289,12 @@ class GatewayOrchestrator:
                     # implicit trust path here: an unowned background command
                     # always prompts.
                     #
-                    # This used to consult an "all open conversations are
-                    # trusted" rule, which was narrower than the heuristic it
-                    # replaced but still reproduced the exact harm this change
-                    # exists to remove. For a single-user dashboard with one
-                    # trusted chat open -- the typical state -- `all()` is
-                    # trivially satisfied, so a cron's command was silently
-                    # auto-approved with no prompt: privilege the job was never
-                    # granted, justified by trust the user granted to a
+                    # An "all open conversations are trusted" rule does not
+                    # narrow this enough to be safe: for a single-user dashboard
+                    # with one trusted chat open -- the typical state -- `all()`
+                    # is trivially satisfied, so a cron's command would be
+                    # silently auto-approved with no prompt: privilege the job
+                    # was never granted, justified by trust the user granted to a
                     # conversation the job has nothing to do with.
                     #
                     # Session trust means "auto-approve tools for THIS chat
@@ -4410,6 +4408,10 @@ class GatewayOrchestrator:
                 return
             slot._recovery_retrigger_count += 1
             slot._recovery_chat_triggered = True
+            # Bound here rather than at module scope: this reads ``_run_chat`` from
+            # ``dashboard.chat``, a different module than the top-level
+            # ``chat_runner`` import, and resolving it per call is what lets a test
+            # patch ``dashboard.chat._run_chat`` and have this path observe it.
             from kiro_crew.dashboard.chat import _run_chat
 
             failures = slot._pending_subagent_failures[:]
@@ -4745,11 +4747,16 @@ class GatewayOrchestrator:
                 # digest — held members return before the announce is sent, so
                 # without accumulation only the last member's guard_msg would
                 # survive and a mid-wave "you MUST ask the user" ceiling would
-                # be silently dropped (Opus MEDIUM / Arbiter item 3).
+                # be silently dropped.
                 if guard_msg:
                     bp["guard_msgs"].append(guard_msg)
                 _oc = info.outcome
-                bp["stopped" if _oc == "stopped" else "err" if _oc == "failed" else "ok"] += 1
+                if _oc == "stopped":
+                    bp["stopped"] += 1
+                elif _oc == "failed":
+                    bp["err"] += 1
+                else:
+                    bp["ok"] += 1
                 # Exception-first digest content: failures/stops carry detail,
                 # successes are one pointer line (full output stays on disk).
                 if _oc == "completed":
@@ -4770,7 +4777,7 @@ class GatewayOrchestrator:
                     # members only (running OR still queued behind the
                     # stagger gate) — an unrelated agent under the same
                     # parent must neither hold the digest hostage nor
-                    # release it early (GPT 5.6 round-1 HIGH).
+                    # release it early.
                     try:
                         _last = bool(
                             self.subagent_mgr
@@ -4781,7 +4788,7 @@ class GatewayOrchestrator:
                 if _last:
                     self._batch_progress.pop(_batch_id, None)
                     # Prune per-wave bookkeeping for ALL wave sizes (bounds
-                    # _seen_batches / _batch_submitted growth — Opus LOW).
+                    # _seen_batches / _batch_submitted growth).
                     try:
                         if self.subagent_mgr:
                             self.subagent_mgr.finalize_batch(_batch_id)
@@ -4829,14 +4836,14 @@ class GatewayOrchestrator:
                         # Held for the next chunk — the terminal WS event,
                         # tracker accounting, and stats above already ran;
                         # only the per-agent injection turn is suppressed.
-                        # Restart safety (Arbiter item 1): flag the member so
-                        # the run loop SKIPS mark_delivered — its result is
-                        # not in the parent's context yet, and a "delivered"
-                        # tombstone would hide it from orphan reconciliation.
-                        # If the gateway restarts mid-chunk, PR #298's orphan
-                        # path finds these undelivered results and delivers a
-                        # recovery digest; in normal operation they are marked
-                        # delivered when their chunk flushes.
+                        # Restart safety: flag the member so the run loop SKIPS
+                        # mark_delivered — its result is not in the parent's
+                        # context yet, and a "delivered" tombstone would hide it
+                        # from orphan reconciliation. If the gateway restarts
+                        # mid-chunk, the orphan path finds these undelivered
+                        # results and delivers a recovery digest; in normal
+                        # operation they are marked delivered when their chunk
+                        # flushes.
                         info._digest_held = True
                         # Hold clock for the reaper's hold-deadline sweep. Kept
                         # separate from _digest_held (the restart-safety flag the
@@ -4873,7 +4880,7 @@ class GatewayOrchestrator:
                     if len(_digest_body) > 60_000:
                         _digest_body = _digest_body[:60_000] + "\n…(digest truncated)"
                     # Deduped union of this chunk's members' escalation
-                    # guards — not just the flushing member's (Arbiter item 3).
+                    # guards — not just the flushing member's.
                     _guards = "".join(dict.fromkeys(bp.get("guard_msgs", [])))
                     bp["chunks"] += 1
                     bp["flushed"] = bp["done"]
@@ -5505,7 +5512,6 @@ class GatewayOrchestrator:
                     body = f"{body}\n\n{cron_response}"
                     logger.info("Subagent %s → cron session %s", info.id, parent_key)
                     # also deliver the synthesized response to Slack.
-                    # Previously it only reached the dashboard notification body.
                     # honor the parent cron job's silent flag too —
                     # info.silent is never set from the cron's silent setting for
                     # spawn_run sub-agents, so a silent cron would otherwise still

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -2129,11 +2129,14 @@ def build_timing_footer(
     if client is not None:
         try:
             ctx_pct = round(client.context_usage_pct())
-            ctx_icon = (
-                "🔴"
-                if ctx_pct >= 70
-                else "🟠" if ctx_pct >= 50 else "🟡" if ctx_pct >= 30 else "🟢"
-            )
+            if ctx_pct >= 70:
+                ctx_icon = "🔴"
+            elif ctx_pct >= 50:
+                ctx_icon = "🟠"
+            elif ctx_pct >= 30:
+                ctx_icon = "🟡"
+            else:
+                ctx_icon = "🟢"
             footer_text = f"Finished in {duration} · {ctx_icon} ctx {ctx_pct}%"
         except Exception:
             logger.debug("Failed to retrieve context usage", exc_info=True)
@@ -4490,6 +4493,9 @@ async def handle_interaction(
                     error="not_thread_owner",
                 )
                 return None
+            # Imported at call time on purpose: tests patch
+            # ``kiro_crew.session.SessionMap`` to drive the fail-closed path, and
+            # only a call-time rebind observes that patch.
             from kiro_crew.session import SessionMap
 
             session_key = thread_ts

--- a/src/kiro_crew/slack/interactions.py
+++ b/src/kiro_crew/slack/interactions.py
@@ -289,8 +289,6 @@ async def ack_button(payload: dict, channel: str, msg_ts: str) -> None:
 
     updated = False
     if response_url:
-        import aiohttp
-
         try:
             async with aiohttp.ClientSession() as sess:
                 resp = await sess.post(
@@ -739,8 +737,6 @@ async def dispatch(payload: dict) -> None:
         url = action.get("value", "")
         response_url = payload.get("response_url", "")
         if response_url and url:
-            import aiohttp
-
             async with aiohttp.ClientSession() as sess:
                 await sess.post(
                     response_url,
@@ -825,8 +821,6 @@ async def dispatch(payload: dict) -> None:
             )
             response_url = payload.get("response_url", "")
             if response_url and response_url.startswith("https://hooks.slack.com/"):
-                import aiohttp
-
                 async with aiohttp.ClientSession() as sess:
                     await sess.post(
                         response_url,
@@ -849,8 +843,6 @@ async def dispatch(payload: dict) -> None:
         # Replace the button with confirmation
         response_url = payload.get("response_url", "")
         if response_url and response_url.startswith("https://hooks.slack.com/"):
-            import aiohttp
-
             async with aiohttp.ClientSession() as sess:
                 await sess.post(
                     response_url,
@@ -1007,22 +999,22 @@ async def dispatch(payload: dict) -> None:
             sess_key = SlackApprovalDecider.session_for(approval_key)
             add_trusted_session(sess_key, _orch.sessions if _orch else None)
         resolved = SlackApprovalDecider.resolve_global(approval_key, approved)
-        if resolved:
-            label = (
-                "🔓 Trusted this session — tools auto-approved"
-                if is_trust
-                else ("✅ Approved" if approved else "🚫 Denied")
-            )
-        else:
+        if not resolved:
             label = "⏱ This approval already expired."
+            outcome = "expired"
+        elif is_trust:
+            label = "🔓 Trusted this session — tools auto-approved"
+            outcome = "trusted"
+        elif approved:
+            label = "✅ Approved"
+            outcome = "approved"
+        else:
+            label = "🚫 Denied"
+            outcome = "denied"
         sel().log_api_access(
             caller=user_id,
             operation="slack.transport_tool_approval",
-            outcome=(
-                ("trusted" if is_trust else ("approved" if approved else "denied"))
-                if resolved
-                else "expired"
-            ),
+            outcome=outcome,
             source="slack",
             resources=f"approval_key={approval_key}",
         )
@@ -2267,8 +2259,6 @@ async def _handle_agent_select(
 
     response_url = payload.get("response_url", "")
     if response_url:
-        import aiohttp
-
         try:
             async with aiohttp.ClientSession() as sess:
                 await sess.post(
@@ -2290,6 +2280,8 @@ async def _handle_users_select(
     payload: dict, action: dict, channel: str, msg_ts: str, user_id: str
 ) -> None:
     """Handle multi_users_select — update allowlist."""
+    # Imported at call time on purpose: tests patch ``handler.is_owner`` to drive
+    # the non-owner rejection, and only a call-time rebind observes that patch.
     from kiro_crew.slack.handler import is_owner, set_allowed_users
 
     if not is_owner(user_id):
@@ -2337,6 +2329,8 @@ async def _handle_channels_select(
     payload: dict, action: dict, channel: str, msg_ts: str, user_id: str
 ) -> None:
     """Handle multi_channels_select — update tracked channels."""
+    # Imported at call time on purpose: tests patch ``handler.is_owner`` to drive
+    # the non-owner rejection, and only a call-time rebind observes that patch.
     from kiro_crew.slack.handler import is_owner, set_tracking_channels
 
     if not is_owner(user_id):
@@ -2415,8 +2409,6 @@ async def _handle_stop_confirm(payload: dict, channel: str, msg_ts: str, user_id
 
         async def _update_ephemeral(blocks: list[dict], text: str) -> None:
             if response_url:
-                import aiohttp
-
                 try:
                     async with aiohttp.ClientSession() as sess:
                         await sess.post(
@@ -2462,8 +2454,6 @@ async def _handle_stop_confirm(payload: dict, channel: str, msg_ts: str, user_id
         response_url = payload.get("response_url", "")
         label = "Nothing running."
         if response_url:
-            import aiohttp
-
             try:
                 async with aiohttp.ClientSession() as sess:
                     await sess.post(
@@ -2483,8 +2473,6 @@ async def _handle_stop_cancel(payload: dict, channel: str, msg_ts: str) -> None:
     """Delete the ephemeral stop confirmation message on cancel."""
     response_url = payload.get("response_url", "")
     if response_url:
-        import aiohttp
-
         try:
             async with aiohttp.ClientSession() as sess:
                 await sess.post(
@@ -2534,8 +2522,6 @@ async def _handle_stop_kill_now(
         from kiro_crew.slack.blocks import build_stop_failed_blocks
 
         if response_url:
-            import aiohttp
-
             try:
                 async with aiohttp.ClientSession() as sess:
                     await sess.post(
@@ -2591,8 +2577,6 @@ async def _handle_allowlist_remove(
 
     response_url = payload.get("response_url", "")
     if response_url:
-        import aiohttp
-
         try:
             async with aiohttp.ClientSession() as sess:
                 await sess.post(
@@ -2632,8 +2616,6 @@ async def _handle_channel_remove(
 
     response_url = payload.get("response_url", "")
     if response_url:
-        import aiohttp
-
         try:
             async with aiohttp.ClientSession() as sess:
                 await sess.post(
@@ -2660,8 +2642,6 @@ async def _handle_session_resume(
     payload: dict, action: dict, channel: str, msg_ts: str, user_id: str
 ) -> None:
     """Show choice buttons for how to resume a session."""
-    import json
-
     if not is_owner(user_id):
         logger.warning("session_resume rejected: non-owner %s", user_id)
         sel().log_api_access(
@@ -2785,8 +2765,6 @@ async def _handle_resume_choice(
     mode: str,
 ) -> None:
     """Dispatch session resume to thread or DM based on user choice."""
-    import json
-
     if not is_owner(user_id):
         logger.warning("resume_choice rejected: non-owner %s", user_id)
         sel().log_api_access(
@@ -2834,8 +2812,6 @@ async def _handle_resume_choice(
             label = f"\U0001f9f5 Already active: <{link}|Go to conversation>"
             response_url = payload.get("response_url", "")
             if response_url:
-                import aiohttp
-
                 try:
                     async with aiohttp.ClientSession() as sess:
                         await sess.post(
@@ -2952,8 +2928,6 @@ async def _handle_resume_choice(
         # Update the choice message
         response_url = payload.get("response_url", "")
         if response_url:
-            import aiohttp
-
             try:
                 async with aiohttp.ClientSession() as sess:
                     await sess.post(
@@ -3014,8 +2988,6 @@ async def _handle_session_end(
     response_url = payload.get("response_url", "")
     label = f"🛑 Session `{session_id[:12]}…` ended."
     if response_url:
-        import aiohttp
-
         try:
             async with aiohttp.ClientSession() as sess:
                 await sess.post(response_url, json={"replace_original": True, "text": label})
@@ -3130,8 +3102,6 @@ async def _handle_session_new(
     response_url = payload.get("response_url", "")
     label = "✨ New session created."
     if response_url:
-        import aiohttp
-
         try:
             async with aiohttp.ClientSession() as sess:
                 await sess.post(response_url, json={"replace_original": False, "text": label})
@@ -3219,8 +3189,6 @@ async def _post_review_auth_error(response_url: str) -> None:
     if not response_url:
         return
     try:
-        import aiohttp
-
         async with aiohttp.ClientSession() as sess:
             await sess.post(
                 response_url,
@@ -3284,8 +3252,6 @@ async def _handle_review_approve(payload: dict, action: dict) -> None:
     response_url = payload.get("response_url", "")
     if response_url:
         try:
-            import aiohttp
-
             async with aiohttp.ClientSession() as sess:
                 await sess.post(response_url, json={"delete_original": True})
         except Exception:
@@ -3337,8 +3303,6 @@ async def _handle_review_edit(payload: dict, action: dict) -> None:
     response_url = payload.get("response_url", "")
     if response_url:
         try:
-            import aiohttp
-
             async with aiohttp.ClientSession() as sess:
                 await sess.post(response_url, json={"delete_original": True})
         except Exception:
@@ -3382,8 +3346,6 @@ async def _handle_review_cancel(payload: dict, action: dict) -> None:
     response_url = payload.get("response_url", "")
     if response_url:
         try:
-            import aiohttp
-
             async with aiohttp.ClientSession() as sess:
                 await sess.post(response_url, json={"delete_original": True})
         except Exception:
@@ -3488,8 +3450,6 @@ async def _handle_review_revise(payload: dict, action: dict) -> None:
     response_url = payload.get("response_url", "")
     if response_url:
         try:
-            import aiohttp
-
             async with aiohttp.ClientSession() as sess:
                 await sess.post(response_url, json={"delete_original": True})
         except Exception:

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -345,10 +345,10 @@ def _subagent_default_model() -> str:
     """Explicit sub-agent model pin (``agent.role_models['subagent']``), or ``""``.
 
     Returns ``""`` when the sub-agent role is unpinned so the caller OMITS the
-    model kwarg and keeps deferring to the provider's configured default exactly
-    as before this knob existed — rather than forcing the chat default on as an
-    explicit override (which also breaks callers/mocks that don't expect the
-    kwarg). Only a deliberate pin overrides. Never raises.
+    model kwarg and keeps deferring to the provider's configured default —
+    rather than forcing the chat default on as an explicit override (which also
+    breaks callers/mocks that don't expect the kwarg). Only a deliberate pin
+    overrides. Never raises.
     """
     try:
         from kiro_crew.config.loader import KiroCrewConfig, normalize_agent_model
@@ -362,8 +362,8 @@ def _subagent_default_effort() -> str:
     """Explicit sub-agent effort pin (``agent.role_efforts['subagent']``), or ``""``.
 
     Returns ``""`` when unpinned so the caller omits ``reasoning_effort_override``
-    and the factory's default effort applies — the prior behavior. Only a
-    deliberate pin overrides. Never raises.
+    and the factory's default effort applies. Only a deliberate pin overrides.
+    Never raises.
     """
     try:
         from kiro_crew.config.loader import KiroCrewConfig
@@ -2579,17 +2579,11 @@ class SubagentManager:
         measurement divided by the number of concurrently-live sharing sessions
         on the same pid, i.e. an average share, not an exclusive figure.
         """
-
-        def _r(s: str) -> str:
-            s, _ = redact_exfiltration_urls(s)
-            s, _ = redact_credentials(s)
-            return s
-
         return [
             {
                 "id": a.id,
-                "task": _r(a.task[:80]),
-                "agent": _r(a.agent),
+                "task": _redact(a.task[:80]),
+                "agent": _redact(a.agent),
                 "parent": a.parent_session_key,
                 "rss_mb": round(a.last_rss_gb * 1024, 1),
                 "peak_rss_mb": round(a.peak_rss_gb * 1024, 1),
@@ -3930,8 +3924,8 @@ class SubagentManager:
             # A user Stop funnels into `_force_reap` and can land while this
             # approval is still pending (a human prompt has no deadline), and
             # `_force_reap` releases the slot and reports. A bare decrement here
-            # then double-released — driving `_running_count` negative — and the
-            # announce below double-reported the completion.
+            # would double-release — driving `_running_count` negative — and the
+            # announce below would double-report the completion.
             if self._release_slot(info):
                 self._running_count -= 1
                 self._drain_queue()

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -1054,6 +1054,8 @@ class TaskRunner:
         self._stall_cancelled_ids.discard(task_id)
         await self._apersist_runs()
         try:
+            # Resolved from ``kiro_crew.sel`` at call time, not through the
+            # module-level binding, so a substituted SEL factory is observed.
             from kiro_crew.sel import sel
 
             sel().log_tool_invocation(

--- a/src/kiro_crew/testing/fake_channel_wire.py
+++ b/src/kiro_crew/testing/fake_channel_wire.py
@@ -284,7 +284,12 @@ class FakeWireSession:
         Webex's ``_api`` drives every verb through this one call, so a fake
         lacking it would make those clients untestable at the wire layer.
         """
-        body = data if data is not None else (_dumps(json) if json is not None else None)
+        if data is not None:
+            body = data
+        elif json is not None:
+            body = _dumps(json)
+        else:
+            body = None
         return self._dispatch(method.upper(), url, headers, body, params)
 
     def post(
@@ -296,7 +301,12 @@ class FakeWireSession:
         headers: Optional[Dict[str, str]] = None,
         **_kw: Any,
     ) -> _FakeResponseCM:
-        body = data if data is not None else (_dumps(json) if json is not None else None)
+        if data is not None:
+            body = data
+        elif json is not None:
+            body = _dumps(json)
+        else:
+            body = None
         return self._dispatch("POST", url, headers, body, None)
 
     def get(

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -1098,7 +1098,7 @@ class VectorMemoryStore:
             # Context assembly runs on executor threads (subagent context builds,
             # run_in_embed_pool) concurrent with writers on worker threads, and
             # context.py does not guard this call — an unserialized fetch here
-            # used to kill the whole subagent run (see the locked-fetch helper
+            # kills the whole subagent run (see the locked-fetch helper
             # contract). The helper materializes the rows.
             all_rows = self._fetch_all_locked(
                 "SELECT key, value_json, updated_at, embedding FROM semantic_memory "
@@ -1397,8 +1397,6 @@ class VectorMemoryStore:
 
         embedding_blob: bytes | None = None
         if embedding is not None:
-            import struct
-
             if _HAS_NUMPY:
                 vec = np.array(embedding, dtype=np.float32)
                 norm = np.linalg.norm(vec)
@@ -1743,15 +1741,13 @@ class VectorMemoryStore:
         relevance_filter: bool = False,
     ) -> list[dict]:
         """Cosine similarity search using embeddings stored in SQLite (stdlib only)."""
-        import struct
-
         # Normalize query
         norm = math.sqrt(sum(x * x for x in query_embedding))
         q = [x / norm for x in query_embedding] if norm > 0 else query_embedding
         q_len = len(q)
 
         # Serialized via the locked helper — two threads running a statement at
-        # the same time used to corrupt each other's row iteration (observed as
+        # the same time corrupt each other's row iteration (surfacing as
         # DatabaseError("another row available") and, on Windows CI, a NULL
         # value for a column the WHERE clause excludes). Only the fetch is
         # locked: the scoring loop below works on materialized rows.

--- a/src/kiro_crew/voice_reply.py
+++ b/src/kiro_crew/voice_reply.py
@@ -587,16 +587,14 @@ def split_sentences(text: str) -> list[str]:
 async def stitch_mp3s(paths: list[str], output: str | None = None) -> str | None:
     """Concatenate MP3 files into a single file using ffmpeg.
 
-    Windows: ffmpeg is not guaranteed on PATH (the dashboard-streaming stitch
-    path then fails); should be made optional + warn. The Slack thread-upload
-    path is unaffected. Tracked as follow-on work.
+    Windows: ffmpeg is not guaranteed on PATH, so the dashboard-streaming stitch
+    path fails there; making it optional with a warning is a known gap. The
+    Slack thread-upload path is unaffected.
     """
     if not paths:
         return None
     if len(paths) == 1:
         if output:
-            import shutil
-
             shutil.copy2(paths[0], output)
             return output
         return paths[0]


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only change under `src/kiro_crew/`; no file under a
watched frontend path is touched and nothing renders differently.

no linked issue: this is a self-directed readability sweep, not a tracked defect.

## Problem

Three readability defects had accumulated across the backend, each one a violation
of a rule this repo has already written down:

1. **Dead in-function imports.** 61 functions re-imported a module that the same
   file already imports at module scope. `AUTOSDE.yaml`'s `top-level-imports` rule
   exists precisely because in-function imports "make dependencies hard to trace,
   break IDE navigation, hide circular-import issues until runtime" — and these
   particular ones buy nothing, because the module object is already loaded.
2. **Nested ternaries.** 19 sites chained a ternary inside a ternary, so the reader
   has to unpack operator precedence to learn which branch wins. Several spanned
   multiple lines with the conditions separated from their results.
3. **Comments that narrate history instead of stating behavior.** Comments carrying
   `previously…` / `used to…` / `we now…`, plus task-log citations (`PR #`,
   `Opus MEDIUM`, `Arbiter item 3`, `GPT 5.6 round-1 HIGH`, `M6`) that `AGENTS.md`
   explicitly bans: "No PR/CR numbers, review-round markers, incident dates,
   milestone tags, or commit SHAs. That history lives in git."

## Why it matters

None of these change runtime behavior, which is exactly why they persist — nothing
fails, so nobody fixes them, and each one taxes every future reader of a hot file.
The comment class is the most actively harmful: a comment that describes code that
no longer exists sends the next reader (or agent) looking for a code path that
isn't there, and `used to`/`previously` phrasing makes it impossible to tell what
is true *now* without re-deriving it from the code. `dashboard/` and `slack/` carry
most of the affected files, and those are the files changed most often.

## Fix (symptom → root cause → change)

**Symptom:** the same three shapes recur in ~50 files, so spot-fixing them during
feature work never converges.

**Root cause:** each is mechanically detectable but no gate detects it —
`top-level-imports` is `blocking: false`, and nothing lints comment tense at all.

**Change:** an AST pass enumerated candidate sites, then each was applied and
verified per module. Three classes landed:

- **61 in-function `import X` deletions.** Restricted to statements whose *every*
  binding is already bound at module scope in the same file. For a plain
  `import X` the inner statement re-binds the same `sys.modules` singleton, so
  deleting it is a strict no-op.
- **18 nested ternaries → `if`/`elif`/`else`.** Branch precedence, evaluation
  order and short-circuiting preserved at every site. One needed an explicit
  `lock_reason: str | None` annotation because mypy infers a conditionally
  assigned local from its first assignment. The targeted shape is the *chained*
  ternary — an `IfExp` whose `body` or `orelse` is itself an `IfExp`, where the
  reader has to unpack precedence. A ternary that merely *contains* one as a
  sub-expression of its result (`(a if c else b).method() if x else []`, as in
  `acp/client.py` and `acp/_dispatch.py`) is a different shape and is out of
  scope.
- **Comment hygiene**, only in files already touched for one of the above, so the
  comment work rides along with substantive change instead of forming its own
  200-file sweep.

Plus one dedup: `subagent.py`'s `task_memory_rows` called a local closure identical
to the module-level `_redact`; it now calls `_redact` directly (same two redactions
in the same order — and `_redact` is what the tests already patch).

### What was deliberately NOT done

- **In-function `from X import Y` deletions are excluded, by design.** Such an
  import resolves `X.Y` at *call* time, so a test that substitutes the attribute on
  the source module is observed by the function, whereas the module-level binding
  captured the original object at import time. Deleting one therefore can change
  which object is called. This was not theoretical: an early revision dropped a
  `KiroCrewConfig` shadow in `dashboard/handlers/memory.py`, and
  `test_dashboard_fallback_passes_embedding_dim` began reading the real config
  instead of the test's mock. Proving the class safe would mean enumerating every
  patch idiom across a 26k-test suite (dotted string, module-object variable,
  module alias, attribute assignment), and several of the symbols are security
  controls (`is_sensitive_path`, `redact_credentials`, `redact_exfiltration_urls`,
  `sel`) where a silently-broken patch stops a test from verifying a guarantee
  without going red. The value is small and the risk is asymmetric, so all 35 such
  deletions were reverted. **46 name-redundant `from` imports remain in the tree on
  purpose** — a `# noqa: F811` on one is evidence somebody kept the shadow
  deliberately, not evidence of dead code.
- **`safety_override.py` and `platform/governance.py` are not touched at all.**
  One exclusion covers both: the file is keystone, and the value a nested ternary
  computes there feeds only an audit label (`safety_override`'s SEL `resources=`
  string; `governance`'s `Decision.layer`, which names the levels that govern a
  scope and does not affect the permit). A style-only rewrite is not worth making
  the next reviewer of `resolve()` diff a security evaluator. Earlier revisions
  flattened one ternary in each file, contradicting this very criterion — First
  Principles Review caught `safety_override`, Design Review caught that the same
  criterion covers `governance`, and both hunks were dropped. Those files are now
  byte-identical to `main`.
- No security-check shape changed: no sensitive-path matcher, denied-command rule,
  deny-by-default guard, audit emit, redaction call, or governance intersection was
  restructured. The one keystone-adjacent rewrite that remains is `hooks.py`'s
  `hook.last_status`, a reporting field derived from a script hook's exit code.

## Tests

No test changes. This diff is behavior-preserving, so the existing suite is the
assertion: the ~50 modified files are covered by tests that already pin the
behavior each rewrite had to keep, and a semantics slip in any ternary or a
`NameError` from any deleted import surfaces as a failure.

That is not just an argument — it caught the one real defect in this change. The
`memory.py` regression above was found by the suite, not by review, and closing it
is what motivated dropping the entire `from`-import class.

## Manual verification

Gates run locally on a **CI-parity venv** (Python 3.12.13, the dependency-group
pins, deliberately without `faiss` so mypy sees the same missing import CI does):

| Gate | Result |
|---|---|
| `flake8 src/kiro_crew test` | clean |
| `isort --check-only src/kiro_crew test` | clean |
| `mypy src/kiro_crew/` | `Success: no issues found in 967 source files` |
| `check_brand_name.py` (`--test` + diff vs merge-base) | pass |
| `check_harness_parity.py` (`--test` + diff vs merge-base) | pass |
| `docs_lint.py --test` / `docs-lint.sh` | pass |
| `check_per_file_coverage.py --test` | pass |
| `verify_vendor_manifest.py` | pass |
| `scrub-lint.sh --no-history` | pass |
| `pytest` (full) | see note |

**Note on the full suite.** Every test that this branch touches passes. The dev
host has no usable OS-level sandbox (`unshare(CLONE_NEWUSER)` returns `EINVAL`), so
any test spawning a sandboxed subprocess fails here regardless of branch — 108 of
123 failures in the branch run raise `SandboxUnavailableError`, and a full run of
pristine `origin/main` on the same host fails 86. The rest are resource-pressure
artifacts of a 16-worker run (subagent spawns refused for want of 4 GB; the
`is_denied` ReDoS test asserts a timing ratio). Re-run in isolation on this branch:
all 288 `test_subagent*` tests pass, `test_denied_commands_security.py`,
`test_dev_fleet_app.py`, `test_slack_gateway_more_coverage.py` and
`test_vector_memory.py` pass (1016 passed), and the one `test_ledger_sync_git.py`
case passes. No failure is attributable to this diff.

Frontend gates were not run: the diff touches no path under `website/`, `.github/`
or `scripts/`, so CI's `changes` job resolves `only_backend=true` and the frontend
suites cannot newly fail.
