### PR TITLE
feat: add slack.dm_single_session for one flat session per 1:1 DM

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -595,6 +595,8 @@ Session keys are namespaced as `f"{channel_type}:{conversation_id}"` (`session_k
 - `canonical_key(key)` — normalizes a bare legacy key to `slack:<thread>`; non-legacy keys (`dashboard:`, `channel:`, `slack:`, …) pass through unchanged. `SessionMap._load` (called from `__init__`) migrates bare keys and populates a Layer-3 `ChannelLink`; `get()`/`set()` re-canonicalize so a not-yet-updated caller passing a bare `thread_ts` still resolves.
 - `legacy_key(key)` — returns the bare `thread_ts` for a `slack:<thread>` key, else `None`.
 
+A Slack key's scope segment is not always a thread timestamp: with `slack.dm_single_session` on, a 1:1 DM is keyed `slack:<channel_id>` (`slack.transport_dispatch.flat_dm_session_key`) so the whole DM is one session. That is still the two-segment legacy shape — `is_legacy_slack_key` does not match a channel id, so `canonical_key` passes it through unchanged and `legacy_key` returns `None` for it, which is correct: there is no bare form to fold. It is deliberately NOT a `build_dm_session_key` bucket; see session.md for why the four-segment shape does not fit Slack.
+
 `ChannelLink(channel_type, channel_id=None, thread_id=None)` records the inbound channel a session belongs to (its **own** channel), with `to_dict()`/`from_dict()`. It is deliberately distinct from the dashboard→Slack *mirror* binding, which stays behind `SessionMap.get/set_slack_link` and is **not** modeled here (guardrail G3).
 
 ## Config flag & routing

--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -1126,6 +1126,15 @@ Legacy bare-thread Slack keys are unaffected — they keep the
 `canonical_key`/`legacy_key` shim. The DM channels are recent, so the key shape
 carries no prior persisted history to migrate.
 
+Slack does not use this key shape even for its own DMs. `slack.dm_single_session`
+gives a 1:1 DM one session by keying it `slack:<channel_id>`
+(`slack.transport_dispatch.flat_dm_session_key`) rather than by minting a
+four-segment bucket: a two-segment Slack key is what the existing thread keys
+already are, so the fold shim, the thread index and every caller that
+reverse-derives from a Slack key keep working unchanged. It carries no
+generation suffix, so the idle/daily rotation above does not apply — a flat DM
+relies on ordinary context compaction instead.
+
 ### Mid-turn messages (steer / queue)
 
 `SessionManager.is_busy(key)` reports whether a turn holds the session

--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -87,6 +87,55 @@ log, per-thread override maps, trust set). The canonical form is stable
 across all messages of a thread; the legacy bare form is folded onto the same
 live session by `SessionManager._fold_key` (see session.md).
 
+`slack.dm_single_session` (default off) splits those two for a 1:1 DM. A
+message in a `D…` channel runs under `slack:<channel_id>` —
+`flat_dm_session_key`, one session for the whole DM instead of one per
+message — and a top-level message posts at channel root, so `post_thread_ts` is
+`None` while `reply_ts` keeps its thread-index and reaction meaning. A THREADED
+reply in that DM joins the same session: in a 1:1 DM a thread is a layout habit
+rather than a new topic, so splitting it off would leave the branch without the
+conversation it answers. Only the session merges — the reply, the `!stop` ack and
+a privacy modifier's confirmation all still post where they were addressed, back
+inside the thread. The session is bound to
+the channel (`set_channel`) and NOT to a thread: a flat conversation has no
+thread for `set_slack_link` to claim, claiming one would give the dashboard
+mirror a thread to post into while the conversation itself is flat, and with
+several threads the scalar `slack_thread_ts` would flip to whichever spoke last.
+Routing needs no claim regardless: the flat key is DERIVED from the channel, so
+it is recomputed rather than looked up. That holds
+for every writer of the link, not just the turn's own self-link:
+`maybe_apply_privacy_modifiers` takes a separate `link_thread` flag, which is
+false in flat mode, so `!temporary` / `!incognito` register no thread while still
+confirming in place. A thread already claimed by its own per-thread session — the
+shape this feature replaces, e.g. from before the flag was on — is ignored so it
+cannot pull the turn back out of the merged conversation; any OTHER owner (a
+dashboard send-to-Slack) still wins.
+Group channels and group DMs (`mpim`) are excluded — a thread there is
+a deliberate scope boundary, and an `mpim` is shared with other people. The key
+keeps the two-segment `slack:<scope>` shape on purpose, so callers that treat a
+Slack key as opaque or reverse-derive from it are unaffected.
+
+One consumer needs the shape spelled out: `file_send`'s upload handler resolves
+its target from the session map, and its thread-first branch requires a thread
+before it will use the linked channel. A flat DM has a channel and no thread, so
+it fell through to the owner's DM — a file sent to a different conversation than
+the one that asked. The handler now also accepts "channel, no thread" when the
+session key IS that channel's key (`slack:<channel_id>`), delivering at the DM's
+root. Deliberately not broader: a thread-scoped or dashboard session that merely
+knows a channel keeps failing closed to the owner DM rather than broadcasting at
+the root of a channel it does not own.
+
+`_route_message` derives the same key for its busy/queue bookkeeping; keyed on
+the message ts instead, a second DM would read as not-busy, skip the queue and
+block inside `get_or_create` with none of the queued-message feedback. That
+derivation (`_dm_single_session_enabled`) additionally requires the turn to
+take the messaging-transport path, because only `handle_message_transport`
+honours the flat key: with `messaging.use_transport` off, or in a review-mode
+channel that `_route_message` deliberately keeps on native for its privacy
+gate, the turn runs under `canonical_key(msg_ts)` and the bookkeeping keys the
+same way. Both conditions live in that one helper so `!stop`, the queue check
+and `message_deleted` cannot disagree.
+
 1. Check hooks for auto-reply
 2. Check `status` keyword — reply with stats summary
 3. Check owner-only `!` commands (`!yolo`, `!agent`, `!ta`, `!allowlist`, `!dashboard`)

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3329,6 +3329,7 @@ class KiroCrewConfig:
                 reactions_enabled=bool(slack_data.get("reactions_enabled", True)),
                 use_tunnel_url=bool(slack_data.get("use_tunnel_url", False)),
                 show_thinking=bool(slack_data.get("show_thinking", True)),
+                dm_single_session=bool(slack_data.get("dm_single_session", False)),
                 home_tab_sessions_per_kind=_safe_int(
                     slack_data.get("home_tab_sessions_per_kind", 5), 5
                 ),

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -2050,6 +2050,18 @@ class SlackConfig:
             tags=["slack"],
         ),
     )
+    dm_single_session: bool = field(
+        default=False,
+        metadata=_meta(
+            "DM Single Session",
+            "Treat each 1:1 DM as one continuous conversation instead of starting "
+            "a new session per top-level message. Replies post at channel root "
+            "rather than in a thread. Threaded replies, group channels and group "
+            "DMs are unaffected. Off by default: turning it on routes the next DM "
+            "to a different session than the previous one.",
+            tags=["slack"],
+        ),
+    )
     home_tab_sessions_per_kind: int = field(
         default=5,
         metadata=_meta(

--- a/src/kiro_crew/dashboard/upload_destination.py
+++ b/src/kiro_crew/dashboard/upload_destination.py
@@ -266,6 +266,23 @@ async def resolve_slack(
             if not target_channel and link_ch:
                 target_channel = link_ch
                 channel_from_session_map = True
+        elif (
+            not link_ts
+            and link_ch
+            and not target_channel
+            and session_key == f"{SLACK_NAMESPACE}:{link_ch}"
+        ):
+            # A flat 1:1 DM (slack.dm_single_session) is keyed BY its channel and
+            # deliberately claims no thread, so the branch above finds a channel
+            # with no thread and would fall through to the owner's DM -- sending
+            # the file to a different conversation than the one that asked for
+            # it. Deliver at the root of that DM, which is where the flat
+            # conversation itself lives. Narrow on purpose: only when the key IS
+            # this channel's key, so a thread-scoped or dashboard session that
+            # merely knows a channel keeps failing closed to the owner DM rather
+            # than broadcasting at channel root.
+            target_channel = link_ch
+            channel_from_session_map = True
     channel = ""
     if target_channel:
         try:

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -266,6 +266,7 @@ Set via `kirocrew config set agent.acp_backend kas`.
 | `slack.command` | Slash-command name | `"kirocrew"` |
 | `slack.reactions` | Override phase reaction emojis (set a value to `null` to suppress that phase) | `{}` |
 | `slack.reactions_enabled` | Show phase reactions on Slack messages | `true` |
+| `slack.dm_single_session` | Treat each 1:1 DM as one continuous session, threaded replies included, instead of one per message | `false` |
 
 Only the owner (`KIROCREW_OWNER_ID`) is authorized to interact over Slack.
 Multi-user access and open channels are refused regardless of what these lists

--- a/src/kiro_crew/docs/slack-integration.md
+++ b/src/kiro_crew/docs/slack-integration.md
@@ -113,6 +113,22 @@ When the response finishes, the 👀 reaction swaps to 🦞.
 
 Slack ingests attachments on incoming messages and can upload local image references from completed replies. Outbound uploads are limited to 10 files, 10 MiB per file, and 25 MiB total per reply.
 
+## DM Sessions
+
+By default a session is scoped to a Slack **thread**, so every top-level message
+in a DM starts a fresh session and replies arrive as threaded replies. To keep
+one conversation, reply in the thread.
+
+Set `slack.dm_single_session` to `true` to treat each 1:1 DM as one continuous
+session instead: every message in that DM continues the same conversation, and a
+top-level reply posts at channel root so the DM reads as a normal chat. A
+threaded reply joins that same conversation too — in a 1:1 DM a thread is usually
+a layout choice, not a new topic — while the answer still lands inside the thread
+you asked in. Group channels and group DMs are unaffected.
+
+Off by default, because turning it on routes your next DM to a different session
+than the previous one. Existing threads keep working either way.
+
 ## OPTIONS Buttons
 
 When Kiro Crew presents choices, they render as interactive Block Kit buttons.

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -100,7 +100,7 @@ from kiro_crew.slack.sessions_view import (
     _build_sessions_blocks,
     _collect_recent_sessions_off_loop,
 )
-from kiro_crew.slack.transport_dispatch import handle_message_transport
+from kiro_crew.slack.transport_dispatch import flat_dm_session_key, handle_message_transport
 from kiro_crew.stats import Stats
 from kiro_crew.transcribe import is_available as stt_available
 from kiro_crew.transcribe import transcribe_audio
@@ -1678,6 +1678,26 @@ async def _transcribe_files(orch: "GatewayOrchestrator", files: list[dict]) -> l
 # ---------------------------------------------------------------------------
 
 
+def _dm_single_session_enabled(orch: GatewayOrchestrator, channel: str) -> bool:
+    """Whether a 1:1 DM in *channel* runs as one flat session.
+
+    Two conditions, because only ``handle_message_transport`` honours the flat
+    key. ``slack.dm_single_session`` alone is not enough: on the native path
+    (``messaging.use_transport`` off, or a review-mode channel that
+    ``_route_message`` deliberately keeps native) the turn runs under
+    ``canonical_key(msg_ts)``, so bookkeeping keyed by channel would address a
+    session that does not exist -- ``!stop`` pops the live task's entry, then
+    finds no session and answers "Nothing running." while the turn keeps going.
+    Deriving both conditions HERE keeps every call site in agreement instead of
+    each one re-deciding.
+    """
+    if getattr(getattr(orch._cfg, "slack", None), "dm_single_session", False) is not True:
+        return False
+    if getattr(getattr(orch._cfg, "messaging", None), "use_transport", False) is not True:
+        return False
+    return orch._cfg.channel_config(channel).activation != ACTIVATION_REVIEW
+
+
 async def _handle_message_deleted(orch: GatewayOrchestrator, event: dict) -> None:
     """Handle message_deleted subtype — cancel queued or in-flight messages."""
     deleted_ts = event.get("deleted_ts")
@@ -1685,7 +1705,12 @@ async def _handle_message_deleted(orch: GatewayOrchestrator, event: dict) -> Non
     _del_channel = event.get("channel", "")
     _del_user = event.get("previous_message", {}).get("user", "")
     if deleted_ts and _del_channel and is_allowed_user(_del_user):
-        _del_session_key = _del_thread_ts or deleted_ts
+        # Same key the turn was queued under, or the cancellation misses it: a
+        # deleted top-level message in a single-session DM belongs to the
+        # channel's session, not to its own timestamp.
+        _del_session_key = flat_dm_session_key(
+            _del_channel, _del_thread_ts, enabled=_dm_single_session_enabled(orch, _del_channel)
+        ) or (_del_thread_ts or deleted_ts)
         was_queued = False
         if orch.sessions:
             was_queued = orch.sessions.cancel_queued(_del_session_key, deleted_ts)
@@ -1793,6 +1818,7 @@ async def _dispatch_queued(
                 # Echo-loop guard travels with the queued turn (parity with the
                 # immediate dispatch above).
                 from_trusted_bot=bool(kwargs.get("from_trusted_bot", False)),
+                dm_single_session=KiroCrewConfig.load().slack.dm_single_session,
             )
             return
         await handle_message(
@@ -2520,7 +2546,16 @@ async def _route_message(
             if orch.slack:
                 await orch.slack.post_message(channel, "Nothing running.", thread_ts or msg_ts)
             return
-        session_key = thread_ts or msg_ts
+        _flat_stop_key = flat_dm_session_key(
+            channel, thread_ts, enabled=_dm_single_session_enabled(orch, channel)
+        )
+        session_key = _flat_stop_key or (thread_ts or msg_ts)
+        # Where the acknowledgements go. session_key is only a Slack timestamp
+        # while the session is thread-scoped; a single-session DM keys by channel,
+        # and passing that as thread_ts would be rejected. A flat DM therefore
+        # acks where the !stop was typed -- inside its thread if it had one, at
+        # channel root otherwise -- which is the same split the turn itself uses.
+        stop_post_ts: str | None = thread_ts if _flat_stop_key else session_key
         has_session = orch.sessions.has_session(session_key)
         active_task = orch._session_tasks.pop(session_key, None)
         if has_session or active_task:
@@ -2537,17 +2572,17 @@ async def _route_message(
                     sender_id,
                     "Stopping…",
                     blocks=build_stopping_blocks(session_key),
-                    thread_ts=session_key,
+                    thread_ts=stop_post_ts,
                 )
 
             async def _on_soft() -> None:
                 if orch.slack:
-                    await orch.slack.post_message(channel, "⏹ Execution stopped.", session_key)
+                    await orch.slack.post_message(channel, "⏹ Execution stopped.", stop_post_ts)
 
             async def _on_hard() -> None:
                 if orch.slack:
                     await orch.slack.post_message(
-                        channel, "⛔ Execution stopped — session reset.", session_key
+                        channel, "⛔ Execution stopped — session reset.", stop_post_ts
                     )
 
             outcome = await orch.sessions.stop_turn(session_key, on_soft=_on_soft, on_hard=_on_hard)
@@ -2556,7 +2591,7 @@ async def _route_message(
             # If stop_turn returned "idle" (no active turn), neither callback
             # fired — dismiss the stale "Stopping…" ephemeral explicitly.
             if outcome == "idle" and orch.slack:
-                await orch.slack.post_message(channel, "Nothing running.", session_key)
+                await orch.slack.post_message(channel, "Nothing running.", stop_post_ts)
             sel().log_tool_invocation(
                 session_key=session_key,
                 source="slack",
@@ -2618,7 +2653,14 @@ async def _route_message(
     )
 
     # ── Queue check: if session is busy, enqueue instead of blocking ──
-    session_key = thread_ts or msg_ts
+    # Keyed on the SAME session the turn will run under. A single-session DM keys
+    # by channel, so this has to derive it the same way the turn does -- keyed on
+    # the message ts instead, a second DM would read as not-busy, skip the queue,
+    # and block inside get_or_create with none of the queued-message feedback.
+    _dm_single_session = _dm_single_session_enabled(orch, channel)
+    session_key = (
+        flat_dm_session_key(channel, thread_ts, enabled=_dm_single_session) or thread_ts or msg_ts
+    )
     _task_busy = session_key in orch._session_tasks
     if _task_busy:
         # A task is already running for this session key.  Try the session-level
@@ -2760,6 +2802,7 @@ async def _route_message(
                 # messages (a reply is itself a bot-authored event the peer
                 # admits, so replying would ping-pong).
                 from_trusted_bot=from_trusted_bot,
+                dm_single_session=_dm_single_session,
             )
         )
         orch._session_tasks[session_key] = t

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -720,6 +720,7 @@ async def _apply_privacy_mode(
     slack: SlackClientOps,
     sessions: SessionManager,
     reply_ts: str,
+    link_thread: bool = True,
 ) -> None:
     """Mark a session as *mode* and notify the user (idempotent).
 
@@ -729,13 +730,20 @@ async def _apply_privacy_mode(
     """
 
     async def _notify(message: str) -> None:
-        await slack.post_message(channel, message, reply_ts)
+        await slack.post_message(channel, message, reply_ts or None)
 
     async def _on_applied(_mode: str) -> None:
         # Register thread so follow-up messages pass the in_active_thread
         # gate in mention/observe channels without needing another @mention.
         # reply_ts is the bare Slack thread_ts; session_key may be namespaced.
-        sessions.set_slack_link(session_key, reply_ts, channel)
+        # Skipped when there is no thread, and when the caller says this session
+        # is not thread-scoped at all (``link_thread=False`` -- a flat 1:1 DM,
+        # whose session is keyed by the channel): claiming a thread there would
+        # hand the dashboard mirror one branch to post into. Posting is a
+        # separate decision, so the confirmation still lands where the modifier
+        # was typed.
+        if reply_ts and link_thread:
+            sessions.set_slack_link(session_key, reply_ts, channel)
 
     await privacy_mode.apply_mode(
         mode,
@@ -756,10 +764,18 @@ async def _apply_temporary_modifier(
     slack: SlackClientOps,
     sessions: SessionManager,
     reply_ts: str,
+    link_thread: bool = True,
 ) -> None:
     """Mark a session as temporary and notify the user (idempotent)."""
     await _apply_privacy_mode(
-        privacy_mode.MODE_TEMPORARY, session_key, user_id, channel, slack, sessions, reply_ts
+        privacy_mode.MODE_TEMPORARY,
+        session_key,
+        user_id,
+        channel,
+        slack,
+        sessions,
+        reply_ts,
+        link_thread,
     )
 
 
@@ -770,10 +786,18 @@ async def _apply_incognito_modifier(
     slack: SlackClientOps,
     sessions: SessionManager,
     reply_ts: str,
+    link_thread: bool = True,
 ) -> None:
     """Mark a session as incognito and notify the user (idempotent)."""
     await _apply_privacy_mode(
-        privacy_mode.MODE_INCOGNITO, session_key, user_id, channel, slack, sessions, reply_ts
+        privacy_mode.MODE_INCOGNITO,
+        session_key,
+        user_id,
+        channel,
+        slack,
+        sessions,
+        reply_ts,
+        link_thread,
     )
 
 
@@ -786,6 +810,7 @@ async def maybe_apply_privacy_modifiers(
     slack: SlackClientOps,
     sessions: SessionManager,
     reply_ts: str,
+    link_thread: bool = True,
 ) -> tuple[str, str, bool]:
     """Strip and apply the ``!temporary`` / ``!incognito`` privacy modifiers.
 
@@ -814,7 +839,9 @@ async def maybe_apply_privacy_modifiers(
         cmd_stripped, had_mode = privacy_mode.strip_token(cmd_text, mode)
         if not had_mode:
             continue
-        await _apply_privacy_mode(mode, session_key, user_id, channel, slack, sessions, reply_ts)
+        await _apply_privacy_mode(
+            mode, session_key, user_id, channel, slack, sessions, reply_ts, link_thread
+        )
         cmd_text = cmd_stripped
         text = pattern.sub("", text)
         text = " ".join(text.split()) or text  # collapse whitespace

--- a/src/kiro_crew/slack/renderer.py
+++ b/src/kiro_crew/slack/renderer.py
@@ -415,9 +415,7 @@ class SlackRenderer(Renderer):
 
     async def _ensure_stream(self) -> str:
         if self._stream_ts is None:
-            ts = await self.slack.start_stream(
-                self.channel, self.thread_ts or "", user_id=self._user_id or None
-            )
+            ts = await self._start_stream_if_threaded()
             if ts:
                 self._stream_ts = ts
                 self._use_slack_stream = True
@@ -430,16 +428,29 @@ class SlackRenderer(Renderer):
                 )
         return self._stream_ts
 
+    async def _start_stream_if_threaded(self, *, initial_text: str | None = None) -> str | None:
+        """Start a Slack stream, unless this reply has no thread to stream into.
+
+        ``chat.startStream`` streams into a thread. A flat reply (``thread_ts``
+        None, as a single-session DM posts at channel root) has none, so calling
+        it would fail and log a warning on every turn for no gain. Returning None
+        routes the caller to the chat.update fallback, which still renders the
+        answer progressively.
+        """
+        if not self.thread_ts:
+            return None
+        return await self.slack.start_stream(
+            self.channel,
+            self.thread_ts,
+            initial_text=initial_text,
+            user_id=self._user_id or None,
+        )
+
     async def _rotate_stream(self) -> str | None:
         """Stop the dead stream and start a fresh one (native ``_rotate_stream``)."""
         if self._stream_ts:
             await self.slack.stop_stream(self.channel, self._stream_ts)
-        new_ts = await self.slack.start_stream(
-            self.channel,
-            self.thread_ts or "",
-            initial_text=_STREAM_CONTINUED,
-            user_id=self._user_id or None,
-        )
+        new_ts = await self._start_stream_if_threaded(initial_text=_STREAM_CONTINUED)
         if new_ts:
             self._stream_ts = new_ts
         else:

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -35,7 +35,7 @@ from kiro_crew.messaging import auto_title
 from kiro_crew.messaging.dispatch import build_directive_consumer
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
-from kiro_crew.messaging.link import canonical_key
+from kiro_crew.messaging.link import SLACK_NAMESPACE, canonical_key
 from kiro_crew.platform import current_context
 from kiro_crew.sel import sel
 from kiro_crew.session_allocation import SessionClosingError
@@ -115,6 +115,39 @@ async def _refresh_dashboard_tab(session_key: str) -> None:
         )
 
 
+def flat_dm_session_key(channel: str, thread_ts: str | None, *, enabled: bool) -> str | None:
+    """The channel-scoped session key a direct message belongs to.
+
+    Slack gives every top-level message its own timestamp, and the Slack session
+    key is derived from it, so each plain reply in a DM starts a session that has
+    none of the conversation's transcript. With ``slack.dm_single_session`` on, a
+    1:1 DM is instead treated as ONE flat conversation keyed by the channel:
+    ``slack:<channel_id>``.
+
+    A threaded reply inside that DM keys the same way, on purpose. In a 1:1 DM a
+    thread is a layout habit rather than a new topic, so splitting it off leaves
+    the branch with none of the conversation it is replying to. Only the SESSION
+    merges: the reply is still posted where it was addressed -- channel root for
+    a top-level message, back into the thread for a threaded one -- which is the
+    caller's ``post_thread_ts`` decision, not this key's.
+
+    Keeping the ``slack:`` namespace with a single scope segment is deliberate.
+    It is the same two-segment shape the thread keys already use, so everything
+    that treats a Slack key as opaque -- or that reverse-derives from it -- keeps
+    working; a four-segment DM bucket would not (``parse_session_key`` rejects
+    two-segment Slack keys by design, and callers rely on that).
+
+    Returns None -- meaning "key it by its own timestamp", the historical
+    behavior -- when the feature is off or the channel is not a 1:1 DM. Only
+    ``D`` ids qualify: a group channel's threads are a deliberate scope boundary,
+    and an ``mpim`` is shared with other people, so neither may collapse into one
+    conversation.
+    """
+    if not enabled or not channel.startswith("D"):
+        return None
+    return f"{SLACK_NAMESPACE}:{channel}"
+
+
 async def handle_message_transport(
     slack: SlackClientOps,
     sessions: SessionManager,
@@ -137,6 +170,7 @@ async def handle_message_transport(
     user_display_name: str | None = None,
     gateway: Any | None = None,
     from_trusted_bot: bool = False,
+    dm_single_session: bool = False,
 ) -> None:
     """Drive a Slack message through the new transport path end-to-end.
 
@@ -157,6 +191,20 @@ async def handle_message_transport(
     # shared with handler.py module dicts).
     reply_ts = thread_ts or msg_ts
     session_key = canonical_key(reply_ts)
+
+    # Where the CONVERSATION is posted, which a flat DM separates from reply_ts:
+    # None means channel root. reply_ts keeps its thread-index meaning either way
+    # (it is still a real Slack timestamp, and still what the reverse index and
+    # the reaction target are keyed by), so only the posting half moves.
+    post_thread_ts: str | None = reply_ts
+    _flat_key = flat_dm_session_key(channel, thread_ts, enabled=dm_single_session)
+    if _flat_key:
+        session_key = _flat_key
+        # Only a TOP-LEVEL message moves to channel root. A threaded reply keeps
+        # answering inside its thread -- the session merged, the layout did not,
+        # and answering at root would strand the reply away from the question.
+        if thread_ts is None:
+            post_thread_ts = None
 
     # ── Resolve the thread to its OWNING session (mirrors native handle_message) ──
     # canonical_key above is purely syntactic: it namespaces the bare thread ts
@@ -186,6 +234,14 @@ async def handle_message_transport(
         nonlocal session_key, linked_session_key
         owner = sessions.get_session_for_thread(reply_ts)
         if not owner:
+            return
+        if _flat_key and owner == canonical_key(reply_ts):
+            # A flat DM ignores a SELF-DERIVED owner: ``slack:<reply_ts>`` is the
+            # per-thread session this feature exists to stop splitting off, and a
+            # thread claimed before the flag was turned on would otherwise pull
+            # the turn back out of the merged conversation. Any OTHER owner is a
+            # real binding to somewhere else (a dashboard send-to-Slack), so it
+            # still wins below.
             return
         if owner != session_key:
             logger.info(
@@ -264,7 +320,7 @@ async def handle_message_transport(
     if context_builder:
         hook_result = context_builder.hooks.on_message(text)
         if hook_result.action == HOOK_REPLY:
-            await slack.post_message(channel, hook_result.text, reply_ts)
+            await slack.post_message(channel, hook_result.text, post_thread_ts)
             if conversation_log and not _is_slack_restricted(session_key):
                 await save_conversation_turn_off_loop(
                     conversation_log,
@@ -284,10 +340,10 @@ async def handle_message_transport(
         # importing the OSS SSO stub directly — keeps the CPP boundary intact
         # and returns the real SSO line under the enterprise companion context.
         mw = await current_context().identity.status_line(prefix=" · sso")
-        await slack.post_message(channel, Stats().summary() + mw, reply_ts)
+        await slack.post_message(channel, Stats().summary() + mw, post_thread_ts)
         return
     if _lower == "ping":
-        await slack.post_message(channel, "pong", reply_ts)
+        await slack.post_message(channel, "pong", post_thread_ts)
         return
 
     # ── !temporary / !incognito privacy modifiers (shared with native) ──
@@ -301,8 +357,20 @@ async def handle_message_transport(
     # created in that window and misroute every later reply in this thread.
     _resolve_thread_owner("pre-privacy")
     _cmd_text = re.sub(r"^<@[A-Z0-9]+(?:\|[^>]*)?>\s*", "", text.strip())
+    # post_thread_ts, not reply_ts: it is None for a top-level flat DM, so the
+    # confirmation lands where the modifier was typed. link_thread is separate --
+    # a flat DM's session is keyed by the channel, so it registers no thread even
+    # when the modifier arrives inside one.
     text, _cmd_text, _only_modifier = await maybe_apply_privacy_modifiers(
-        text, _cmd_text, session_key, user_id, channel, slack, sessions, reply_ts
+        text,
+        _cmd_text,
+        session_key,
+        user_id,
+        channel,
+        slack,
+        sessions,
+        post_thread_ts or "",
+        not _flat_key,
     )
     if _only_modifier:
         # Message was nothing but the modifier(s) — no LLM turn.
@@ -383,7 +451,7 @@ async def handle_message_transport(
         renderer = SlackRenderer(
             slack,
             channel,
-            reply_ts,
+            post_thread_ts,
             react_ts=msg_ts,
             reactions_enabled=reactions_enabled,
             show_thinking=show_thinking,
@@ -464,16 +532,29 @@ async def handle_message_transport(
         )
         if is_new:
             await sessions.set_channel(session_key, channel)
-        if not linked_session_key and not sessions.get_session_for_thread(reply_ts):
-            # Two conditions, deliberately. The first is the routing decision
-            # made at the top of this function. The second is a FRESH read,
-            # because that decision is many awaits old by now -- inbound
-            # governance, the hook path and session acquisition all yield -- and
-            # a dashboard send-to-Slack landing in that window would claim this
-            # thread after we looked. Self-linking on the stale value would
-            # overwrite that newer binding and send every later reply to the
-            # wrong session. Only claim a thread that is STILL unclaimed; the
-            # turn itself continues on the session we already acquired.
+        if (
+            not _flat_key
+            and not linked_session_key
+            and not sessions.get_session_for_thread(reply_ts)
+        ):
+            # Three conditions, deliberately. The first excludes a flat DM: its
+            # session is keyed by the channel, not by a thread, so binding it to
+            # a thread would hand the dashboard mirror one thread to post into
+            # while the conversation spans the whole DM -- and with several
+            # threads the scalar slack_thread_ts would just keep flipping to
+            # whichever spoke last. Routing needs no claim here anyway: the flat
+            # key is DERIVED from the channel, so it is recomputed rather than
+            # looked up. The channel binding it does need is set_channel above.
+            #
+            # The second is the routing decision made at the top of this
+            # function. The third is a FRESH read, because that decision is many
+            # awaits old by now -- inbound governance, the hook path and session
+            # acquisition all yield -- and a dashboard send-to-Slack landing in
+            # that window would claim this thread after we looked. Self-linking
+            # on the stale value would overwrite that newer binding and send
+            # every later reply to the wrong session. Only claim a thread that is
+            # STILL unclaimed; the turn itself continues on the session we
+            # already acquired.
             #
             # reply_ts (not session_key) is the true Slack timestamp -- storing
             # the namespaced key as slack_thread_ts would corrupt reply routing.
@@ -976,7 +1057,9 @@ async def handle_message_transport(
         else:
             try:
                 await slack.post_message(
-                    channel, "🔧 Something went wrong (transport path). Please try again.", reply_ts
+                    channel,
+                    "🔧 Something went wrong (transport path). Please try again.",
+                    post_thread_ts,
                 )
             except Exception:
                 pass

--- a/test/test_file_send_channel.py
+++ b/test/test_file_send_channel.py
@@ -457,6 +457,98 @@ class TestFileUploadSlotThreading:
                 assert call_args[0][1] == ""
 
     @pytest.mark.asyncio
+    async def test_flat_dm_session_uploads_into_that_dm(self, tmp_path):
+        """A flat 1:1 DM is keyed BY its channel and claims no thread.
+
+        The thread-first branch finds a channel with no thread, so without the
+        flat-DM case the file would land in the owner's DM instead of the
+        conversation that asked for it.
+        """
+        outbox = tmp_path / "outbox"
+        outbox.mkdir()
+        f = outbox / "report.txt"
+        f.write_text("data", encoding="utf-8")
+
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        slack.open_dm = AsyncMock(return_value="D_OWNER_DM")
+        state = self._make_state_with_link(slack, thread_ts="", channel="D_FLAT")
+        app = _make_app(slack, tmp_path, state=state)
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load"
+        ) as mock_cfg:
+            mock_cfg.return_value.load_credentials.return_value = {
+                "KIROCREW_OWNER_ID": "U_OWNER"
+            }
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/slack/upload-file",
+                    json={
+                        "file_path": str(f),
+                        "filename": "report.txt",
+                        "thread_ts": "",
+                        "channel": "",
+                    },
+                    headers={"X-Session-Key": "slack:D_FLAT"},
+                )
+                assert resp.status == 200
+                slack.upload_file.assert_called_once()
+                call_args = slack.upload_file.call_args
+                assert call_args[0][0] == "D_FLAT"
+                # Flat means channel root, not a thread.
+                assert call_args[0][1] == ""
+                slack.open_dm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_session_that_merely_knows_a_channel_still_uses_owner_dm(self, tmp_path):
+        """The flat-DM case is narrow: the key must BE that channel's key.
+
+        A thread-scoped or dashboard session carrying a channel but no thread
+        keeps failing closed to the owner DM rather than broadcasting at the
+        root of a channel it does not own.
+        """
+        outbox = tmp_path / "outbox"
+        outbox.mkdir()
+        f = outbox / "report.txt"
+        f.write_text("data", encoding="utf-8")
+
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        slack.open_dm = AsyncMock(return_value="D_OWNER_DM")
+        state = self._make_state_with_link(slack, thread_ts="", channel="D_FLAT")
+        app = _make_app(slack, tmp_path, state=state)
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load"
+        ) as mock_cfg:
+            mock_cfg.return_value.load_credentials.return_value = {
+                "KIROCREW_OWNER_ID": "U_OWNER"
+            }
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/slack/upload-file",
+                    json={
+                        "file_path": str(f),
+                        "filename": "report.txt",
+                        "thread_ts": "",
+                        "channel": "",
+                    },
+                    headers={"X-Session-Key": "dashboard:chat-1"},
+                )
+                assert resp.status == 200
+                call_args = slack.upload_file.call_args
+                assert call_args[0][0] == "D_OWNER_DM"
+
+    @pytest.mark.asyncio
     async def test_explicit_thread_ts_takes_priority_over_slot(self, tmp_path):
         """T3: Explicit thread_ts in body → takes priority over session map."""
         outbox = tmp_path / "outbox"

--- a/test/test_message_queue.py
+++ b/test/test_message_queue.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kiro_crew.config.loader import ACTIVATION_REVIEW
 from kiro_crew.session import SessionManager, _Session, unlink_queued_temp_paths
 
 # ── Unit tests for _Session queue fields ──
@@ -269,6 +270,75 @@ class TestHandleMessageDeleted:
              patch("kiro_crew.slack.events.sel"):
             await _handle_message_deleted(orch, event)
         # No thread_ts → session_key = deleted_ts
+        orch.sessions.cancel_queued.assert_called_once_with("ts_dm", "ts_dm")
+
+    @staticmethod
+    def _enable_flat_dm(orch):
+        """Both conditions the flat key needs: the flag AND the transport path."""
+        orch._cfg.slack.dm_single_session = True
+        orch._cfg.messaging.use_transport = True
+
+    @pytest.mark.asyncio
+    async def test_single_session_dm_cancels_under_the_channel_key(self):
+        """A flat DM queues under the channel key, so the cancel must use it too."""
+        from kiro_crew.slack.events import _handle_message_deleted
+
+        orch = self._make_orch()
+        self._enable_flat_dm(orch)
+        orch.sessions.cancel_queued.return_value = True
+        event = {"deleted_ts": "ts_dm", "channel": "D1", "previous_message": {"user": "U1"}}
+        with patch("kiro_crew.slack.events.is_allowed_user", return_value=True), \
+             patch("kiro_crew.slack.events.sel"):
+            await _handle_message_deleted(orch, event)
+        orch.sessions.cancel_queued.assert_called_once_with("slack:D1", "ts_dm")
+
+    @pytest.mark.asyncio
+    async def test_single_session_cancels_a_threaded_reply_under_the_channel_key(self):
+        """A threaded DM reply queues under the channel key too, so must cancel there."""
+        from kiro_crew.slack.events import _handle_message_deleted
+
+        orch = self._make_orch()
+        self._enable_flat_dm(orch)
+        orch.sessions.cancel_queued.return_value = True
+        event = self._make_event(channel="D1", thread_ts="thread1")
+        with patch("kiro_crew.slack.events.is_allowed_user", return_value=True), \
+             patch("kiro_crew.slack.events.sel"):
+            await _handle_message_deleted(orch, event)
+        orch.sessions.cancel_queued.assert_called_once_with("slack:D1", "ts_del")
+
+    @pytest.mark.asyncio
+    async def test_native_path_dm_keys_the_way_native_does(self):
+        """Only the transport path honours the flat key.
+
+        With ``messaging.use_transport`` off the turn runs under the message ts,
+        so cancelling under the channel key would miss it entirely.
+        """
+        from kiro_crew.slack.events import _handle_message_deleted
+
+        orch = self._make_orch()
+        orch._cfg.slack.dm_single_session = True
+        orch._cfg.messaging.use_transport = False
+        orch.sessions.cancel_queued.return_value = True
+        event = {"deleted_ts": "ts_dm", "channel": "D1", "previous_message": {"user": "U1"}}
+        with patch("kiro_crew.slack.events.is_allowed_user", return_value=True), \
+             patch("kiro_crew.slack.events.sel"):
+            await _handle_message_deleted(orch, event)
+        orch.sessions.cancel_queued.assert_called_once_with("ts_dm", "ts_dm")
+
+    @pytest.mark.asyncio
+    async def test_review_mode_dm_keys_the_way_native_does(self):
+        """_route_message keeps review-mode channels on native for the privacy
+        gate, so their bookkeeping must key like native too."""
+        from kiro_crew.slack.events import _handle_message_deleted
+
+        orch = self._make_orch()
+        self._enable_flat_dm(orch)
+        orch._cfg.channel_config.return_value.activation = ACTIVATION_REVIEW
+        orch.sessions.cancel_queued.return_value = True
+        event = {"deleted_ts": "ts_dm", "channel": "D1", "previous_message": {"user": "U1"}}
+        with patch("kiro_crew.slack.events.is_allowed_user", return_value=True), \
+             patch("kiro_crew.slack.events.sel"):
+            await _handle_message_deleted(orch, event)
         orch.sessions.cancel_queued.assert_called_once_with("ts_dm", "ts_dm")
 
     @pytest.mark.asyncio

--- a/test/test_slack_transport_dispatch.py
+++ b/test/test_slack_transport_dispatch.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import asyncio
 import importlib
 import sys
+from collections import OrderedDict
 from pathlib import Path
+
+import pytest
 
 from kiro_crew.acp.types import (
     EVENT_COMPLETE,
@@ -26,6 +29,8 @@ from kiro_crew.acp.types import (
     STOP_REASON_END_TURN,
 )
 from kiro_crew.messaging.link import canonical_key
+from kiro_crew.session import BACKGROUND_KEY
+from kiro_crew.slack import handler as slack_handler
 from kiro_crew.slack import transport_dispatch
 
 # Reuse the golden module's fakes without triggering the stdlib 'test' collision.
@@ -1495,3 +1500,303 @@ class TestTransportPartialProgressRescue:
         assistant = [r for r in rows if r.get("role") == "assistant"]
         assert len(assistant) == 1
         assert assistant[0].get("source_user") == "U_OWNER"
+
+
+class _LinkCapturingSessions(FakeSessions):
+    """FakeSessions that records acquired session keys and Slack link writes."""
+
+    def __init__(self, provider):
+        super().__init__(provider)
+        self.keys: list = []
+        self.links: list = []
+        # Who the thread index says owns this thread; None = unclaimed.
+        self.thread_owner: str | None = None
+
+    def get_session_for_thread(self, thread_ts):
+        return self.thread_owner
+
+    async def get_or_create(self, session_key, agent=None, channel_id=None):
+        self.keys.append(session_key)
+        return await super().get_or_create(session_key, agent=agent, channel_id=channel_id)
+
+    @property
+    def turn_keys(self) -> list:
+        """The keys real TURNS ran under.
+
+        The auto-title that follows a successful turn acquires the shared
+        ``BACKGROUND_KEY`` session to name the conversation. That is not a
+        routing decision this feature has any say over, so it is excluded here
+        rather than pinned into every assertion below.
+        """
+        return [k for k in self.keys if k != BACKGROUND_KEY]
+
+    def set_slack_link(self, key, thread_ts, channel_id):
+        # Deliberately NOT delegating to super(): the base fake stores links in a
+        # dict under this same attribute, so with the list used here a real link
+        # write raised TypeError and the assertions below failed for the wrong
+        # reason instead of showing the offending link.
+        self.links.append((key, thread_ts, channel_id))
+
+
+class TestFlatDmSessionKey:
+    """``slack.dm_single_session``: one session per 1:1 DM, replies at channel root."""
+
+    _DM = "D0AP0870FFH"
+
+    def test_disabled_keeps_the_per_message_key(self):
+        assert transport_dispatch.flat_dm_session_key(self._DM, None, enabled=False) is None
+
+    def test_top_level_dm_keys_by_channel(self):
+        assert (
+            transport_dispatch.flat_dm_session_key(self._DM, None, enabled=True)
+            == f"slack:{self._DM}"
+        )
+
+    def test_a_threaded_reply_in_a_dm_keys_by_channel_too(self):
+        # In a 1:1 DM a thread is a layout habit, not a new topic: splitting it
+        # off would leave the branch without the conversation it replies to.
+        assert (
+            transport_dispatch.flat_dm_session_key(self._DM, "1700000000.000001", enabled=True)
+            == f"slack:{self._DM}"
+        )
+
+    def test_a_group_channel_never_collapses(self):
+        assert transport_dispatch.flat_dm_session_key("C1", None, enabled=True) is None
+
+    def test_a_group_dm_never_collapses(self):
+        # An mpim is shared with other people, so it may not become one session.
+        assert transport_dispatch.flat_dm_session_key("G1", None, enabled=True) is None
+
+
+class TestFlatDmTransportWiring:
+    def _prep(self, monkeypatch):
+        monkeypatch.setattr(transport_dispatch, "_get_default_agent", lambda: "kirocrew")
+        monkeypatch.setattr(transport_dispatch, "_hydrate_thread_overrides", lambda *a, **k: None)
+        monkeypatch.setattr(transport_dispatch, "_hydrate_conv_flags", lambda *a, **k: None)
+        monkeypatch.setattr(transport_dispatch, "_thread_agents", {})
+
+    def _provider(self):
+        return ScriptedProvider(
+            [
+                make_event(EVENT_TEXT_CHUNK, text="hi"),
+                make_event(EVENT_COMPLETE, stop_reason=STOP_REASON_END_TURN),
+            ]
+        )
+
+    def _run(self, monkeypatch, *, channel, thread_ts, enabled, text="do it"):
+        self._prep(monkeypatch)
+        slack = RecordingSlackClient()
+        sessions = _LinkCapturingSessions(self._provider())
+        asyncio.run(
+            transport_dispatch.handle_message_transport(
+                slack=slack,
+                sessions=sessions,
+                channel=channel,
+                text=text,
+                thread_ts=thread_ts,
+                msg_ts=_MSG_TS,
+                user_id="U_OWNER",
+                context_builder=None,
+                conversation_log=None,
+                dm_single_session=enabled,
+            )
+        )
+        return slack, sessions
+
+    def test_dm_key_unchanged_when_disabled(self, monkeypatch):
+        # HARD INVARIANT: off by default, the DM key is byte-for-byte unchanged.
+        _slack, sessions = self._run(
+            monkeypatch, channel="D0AP0870FFH", thread_ts=None, enabled=False
+        )
+        assert sessions.turn_keys == [canonical_key(_MSG_TS)]
+
+    def test_enabled_runs_the_turn_under_the_channel_key(self, monkeypatch):
+        _slack, sessions = self._run(
+            monkeypatch, channel="D0AP0870FFH", thread_ts=None, enabled=True
+        )
+        assert sessions.turn_keys == ["slack:D0AP0870FFH"]
+
+    def test_enabled_posts_at_channel_root(self, monkeypatch):
+        slack, _sessions = self._run(
+            monkeypatch, channel="D0AP0870FFH", thread_ts=None, enabled=True
+        )
+        posted = [kw for m, kw in slack.transcript if m in ("post_message", "post_blocks")]
+        assert posted, "the turn posted nothing"
+        # Flat means no thread: a thread_ts here would bury the reply in a thread.
+        assert all(kw["thread_ts"] is None for kw in posted)
+
+    def test_enabled_does_not_claim_a_thread(self, monkeypatch):
+        # The session is keyed by the channel, so linking it to this message's ts
+        # would hand the dashboard mirror a thread to post into while the
+        # conversation itself is flat.
+        _slack, sessions = self._run(
+            monkeypatch, channel="D0AP0870FFH", thread_ts=None, enabled=True
+        )
+        assert sessions.links == []
+
+    def test_a_threaded_dm_reply_joins_the_same_session(self, monkeypatch):
+        _slack, sessions = self._run(
+            monkeypatch, channel="D0AP0870FFH", thread_ts="1700000000.000001", enabled=True
+        )
+        assert sessions.turn_keys == ["slack:D0AP0870FFH"]
+
+    def test_a_threaded_dm_reply_still_answers_inside_its_thread(self, monkeypatch):
+        # The session merged; the layout did not. Answering at channel root would
+        # strand the reply away from the question it answers.
+        thread_ts = "1700000000.000001"
+        slack, _sessions = self._run(
+            monkeypatch, channel="D0AP0870FFH", thread_ts=thread_ts, enabled=True
+        )
+        posted = [kw for m, kw in slack.transcript if m in ("post_message", "post_blocks")]
+        assert posted, "the turn posted nothing"
+        assert all(kw["thread_ts"] == thread_ts for kw in posted)
+
+    def test_a_threaded_dm_reply_claims_no_thread(self, monkeypatch):
+        # Several threads would each overwrite the session's scalar
+        # slack_thread_ts, so the dashboard mirror would follow whichever spoke
+        # last. Routing needs no claim: the flat key is derived from the channel.
+        _slack, sessions = self._run(
+            monkeypatch, channel="D0AP0870FFH", thread_ts="1700000000.000001", enabled=True
+        )
+        assert sessions.links == []
+
+    def test_a_group_channel_is_unaffected_when_enabled(self, monkeypatch):
+        _slack, sessions = self._run(monkeypatch, channel="C1", thread_ts=None, enabled=True)
+        assert sessions.turn_keys == [canonical_key(_MSG_TS)]
+
+    def test_a_thread_claimed_before_the_flag_does_not_split_the_dm(self, monkeypatch):
+        # A thread claimed by its own per-thread session (the shape this feature
+        # replaces, e.g. from before the flag was on) must not pull the turn back
+        # out of the merged conversation.
+        self._prep(monkeypatch)
+        thread_ts = "1700000000.000001"
+        slack = RecordingSlackClient()
+        sessions = _LinkCapturingSessions(self._provider())
+        sessions.thread_owner = canonical_key(thread_ts)
+        asyncio.run(
+            transport_dispatch.handle_message_transport(
+                slack=slack,
+                sessions=sessions,
+                channel="D0AP0870FFH",
+                text="do it",
+                thread_ts=thread_ts,
+                msg_ts=_MSG_TS,
+                user_id="U_OWNER",
+                context_builder=None,
+                conversation_log=None,
+                dm_single_session=True,
+            )
+        )
+        assert sessions.turn_keys == ["slack:D0AP0870FFH"]
+
+    def test_a_dashboard_linked_thread_still_wins(self, monkeypatch):
+        # Link-to-Dashboard is a real binding to somewhere else, not the shape
+        # this feature replaces, so it keeps ownership of its thread.
+        self._prep(monkeypatch)
+        thread_ts = "1700000000.000001"
+        slack = RecordingSlackClient()
+        sessions = _LinkCapturingSessions(self._provider())
+        sessions.thread_owner = "chat-7-1700000000"
+        asyncio.run(
+            transport_dispatch.handle_message_transport(
+                slack=slack,
+                sessions=sessions,
+                channel="D0AP0870FFH",
+                text="do it",
+                thread_ts=thread_ts,
+                msg_ts=_MSG_TS,
+                user_id="U_OWNER",
+                context_builder=None,
+                conversation_log=None,
+                dm_single_session=True,
+            )
+        )
+        assert sessions.turn_keys == ["chat-7-1700000000"]
+
+    def _clear_modifier_state(self, monkeypatch):
+        # Both modifiers are idempotent through module-level LRUs keyed by
+        # session_key, so a second test reusing the same DM would short-circuit
+        # before reaching the code under test.
+        monkeypatch.setattr(slack_handler, "_thread_temporary", OrderedDict())
+        monkeypatch.setattr(slack_handler, "_thread_incognito", OrderedDict())
+
+    @pytest.mark.parametrize("token", ["!incognito", "!temporary"])
+    def test_a_privacy_modifier_in_a_flat_dm_claims_no_thread(self, monkeypatch, token):
+        # The modifiers call set_slack_link themselves. Reached with this
+        # message's ts they bind the channel-keyed session to a thread, which
+        # reroutes later threaded replies into the flat session and hands the
+        # dashboard mirror a thread to post into -- the exact claim the
+        # self-link guard refuses for a flat DM.
+        self._clear_modifier_state(monkeypatch)
+        _slack, sessions = self._run(
+            monkeypatch,
+            channel="D0AP0870FFH",
+            thread_ts=None,
+            enabled=True,
+            text=f"{token} do it",
+        )
+        assert sessions.turn_keys == ["slack:D0AP0870FFH"]
+        assert sessions.links == []
+
+    @pytest.mark.parametrize("token", ["!incognito", "!temporary"])
+    def test_a_privacy_modifier_in_a_flat_dm_confirms_at_channel_root(self, monkeypatch, token):
+        self._clear_modifier_state(monkeypatch)
+        slack, _sessions = self._run(
+            monkeypatch,
+            channel="D0AP0870FFH",
+            thread_ts=None,
+            enabled=True,
+            text=f"{token} do it",
+        )
+        posted = [kw for m, kw in slack.transcript if m in ("post_message", "post_blocks")]
+        assert posted, "the turn posted nothing"
+        # Includes the modifier's own confirmation: a flat DM has no thread, and
+        # thread_ts="" would be forwarded to Slack verbatim rather than omitted.
+        assert all(kw["thread_ts"] is None for kw in posted)
+
+    @pytest.mark.parametrize("token", ["!incognito", "!temporary"])
+    def test_a_privacy_modifier_in_a_dm_thread_claims_no_thread_either(self, monkeypatch, token):
+        # The modifiers call set_slack_link themselves, so the flat session would
+        # get bound to whichever thread last carried a modifier.
+        self._clear_modifier_state(monkeypatch)
+        _slack, sessions = self._run(
+            monkeypatch,
+            channel="D0AP0870FFH",
+            thread_ts="1700000000.000001",
+            enabled=True,
+            text=f"{token} do it",
+        )
+        assert sessions.turn_keys == ["slack:D0AP0870FFH"]
+        assert sessions.links == []
+
+    @pytest.mark.parametrize("token", ["!incognito", "!temporary"])
+    def test_a_privacy_modifier_in_a_dm_thread_confirms_in_that_thread(self, monkeypatch, token):
+        self._clear_modifier_state(monkeypatch)
+        thread_ts = "1700000000.000001"
+        slack, _sessions = self._run(
+            monkeypatch,
+            channel="D0AP0870FFH",
+            thread_ts=thread_ts,
+            enabled=True,
+            text=f"{token} do it",
+        )
+        posted = [kw for m, kw in slack.transcript if m in ("post_message", "post_blocks")]
+        assert posted, "the turn posted nothing"
+        # Includes the modifier's own confirmation: not linking a thread must not
+        # cost us answering in it.
+        assert all(kw["thread_ts"] == thread_ts for kw in posted)
+
+    @pytest.mark.parametrize("token", ["!incognito", "!temporary"])
+    def test_a_privacy_modifier_claims_the_thread_when_the_flag_is_off(self, monkeypatch, token):
+        # Preserved behaviour: a thread-scoped session registers its thread so
+        # follow-ups pass the mention/observe in_active_thread gate.
+        self._clear_modifier_state(monkeypatch)
+        thread_ts = "1700000000.000001"
+        _slack, sessions = self._run(
+            monkeypatch,
+            channel="D0AP0870FFH",
+            thread_ts=thread_ts,
+            enabled=False,
+            text=f"{token} do it",
+        )
+        assert (canonical_key(thread_ts), thread_ts, "D0AP0870FFH") in sessions.links


### PR DESCRIPTION
Closes #3508.

A top-level Slack DM keys its session by its own message timestamp (`reply_ts = thread_ts or msg_ts` → `canonical_key`), so every plain reply in a DM starts a session holding none of the conversation's transcript. Continuing one requires remembering to use *Reply in thread* each time.

This adds `slack.dm_single_session` (**default off**). With it on, a 1:1 DM runs as ONE session keyed `slack:<channel_id>` and posts at channel root, so the DM reads as a normal chat.

## Why not the shape I proposed in the issue

I originally proposed keying Slack DMs through `build_dm_session_key` so they'd honour `messaging.dm_scope`. That is a fan-in — many thread timestamps to one session — and it is not representable: `session_map.py` stores `slack_thread_ts` as a **scalar** per entry, so each bind overwrites the previous and pops it from the reverse index. Making it N:1 would mean a `session_map.json` schema change plus migration, loosening `_evict_rival_claimants` (added in #2794 precisely "so a crash cannot persist a two-owner map"), overturning `test_session_map_unlink.py::test_same_key_new_thread_still_evicts_old_index`, satisfying a second 1:1 layer in the dashboard (`_slack_to_slot`), and answering which of N threads `chat_runner.py` should stream the dashboard mirror into.

Keying by channel avoids all of it. The key keeps the two-segment `slack:<scope>` shape the thread keys already use, so the binding stays 1:1, `_evict_rival_claimants` is untouched, and the callers that reverse-derive a thread from a Slack key (`_fire_slack_nudge`, the `_self_ref` guard in `state.py`) keep working. `parse_session_key` still rejects it, which `test_channel_registry.py` pins on purpose.

Full analysis in https://github.com/kirodotdev/KiroCrew/issues/3508#issuecomment-5290473624.

## Scope

- **1:1 DMs only** (`D…` ids). Threaded replies keep per-thread keying so a side conversation can still be branched deliberately; group channels and group DMs (`mpim`, shared with other people) never collapse. Detected on the channel id, not on `thread_ts is None` — a top-level message in a group channel also has no thread ts.
- **A flat DM claims no thread.** It binds its channel via `set_channel` but skips `set_slack_link`: handing the dashboard mirror a thread would post a mirrored turn into a thread while the conversation itself is flat.
- **`chat.startStream` requires a thread**, so a flat reply skips it and renders through the existing `chat.update` fallback (progressive edits) instead of failing and logging a warning every turn.

## A pre-existing key drift this had to fix

`events.py` derived its own session key three times as a bare `thread_ts or msg_ts`, never canonicalized, while `transport_dispatch.py` used `canonical_key`. `_fold_key` only folds bare ↔ `slack:<ts>`, so all three now derive the DM key the same way the turn does:

- `_route_message` busy/queue check — keyed on the message ts, a second DM reads as not-busy, skips the queue and blocks inside `get_or_create` with none of the ⏳ queued feedback.
- `!stop` — would miss the running turn entirely. This path was also using **one variable** as both the session key and the Slack `thread_ts` to post into; a channel-scoped key would have been sent to Slack as a thread ts, so the two are now separate.
- `message_deleted` — the undo-cancels-a-queued-turn path would miss it.

## Tests

13 new tests, all in existing files:

- `TestFlatDmSessionKey` — off / top-level DM / threaded DM reply / group channel / group DM.
- `TestFlatDmTransportWiring` — the turn runs under the channel key, posts with no `thread_ts`, claims no thread, and a threaded reply still keys by thread. Includes a **hard invariant** test that the DM key is byte-for-byte unchanged when the flag is off.
- `TestHandleMessageDeleted` — cancellation uses the channel key in flat mode, and still the thread key for a threaded reply.

Mutation-checked: forcing `flat_dm_session_key` to return None kills 4, restoring the threaded posting target kills 2, and reverting the `message_deleted` key kills 1.

Because the flag defaults off, **no existing test needed changing** — including the four that pin the current DM key derivation and the `inspect.getsource` assertion in `test_slack_options_lifecycle.py` (the DM key is resolved upstream into `session_key`, so that expression is untouched).

## Specs and docs

Updated in this commit per AGENTS.md: `session.md`, `messaging.md`, `slack-gateway.md`, plus user-facing `slack-integration.md` (new *DM Sessions* section) and the `configuration.md` table. `scripts/docs-lint.sh` passes.

## Deliberately out of scope

The flag is config-file only — not wired into the Slack settings panel, its TypeScript types, or the locale catalogs. Happy to add that here if you'd prefer it land together.

`config-baseline.json` is **not** regenerated. The committed file is already stale against `main`, and regenerating it pulls in ~670 lines of unrelated keys; `test_config_baseline.py` regenerates into a tmp dir and compares against the live registry, so it passes either way.

## Verification

`isort`, `flake8`, `docs-lint` and `check_harness_parity.py` clean. `mypy src/kiro_crew/` reports only 3 pre-existing errors in `hooks.py` (`os.listxattr`/`getxattr`/`setxattr` are Linux-only and this was run on macOS; that file is untouched). 1106 targeted tests pass across the Slack transport, message queue, session-map, config and channel-registry suites. No frontend change, so `tsc`/`vitest` were not run locally.
