### PR TITLE
fix(tests): rewrite three cov80 test files against the shipped components

### DIFF
--- a/website/src/components/InboundLinkChip.cov80.test.tsx
+++ b/website/src/components/InboundLinkChip.cov80.test.tsx
@@ -1,39 +1,48 @@
-import { screen, fireEvent, waitFor } from '@testing-library/react'
+// InboundLinkChip — the information-only header chip for a session driven from
+// another channel. Only a `direction: 'both'` link earns the chip; it carries
+// no action (connect/disconnect lives in the session menu), and it stays
+// visible even when the channel is disconnected, because inbound delivery
+// keeps working either way.
+import { screen } from '@testing-library/react'
 import { createTestStore, renderWithProviders } from '../test/helpers'
 import InboundLinkChip from './InboundLinkChip'
 import { sseSlots } from '../store/dashboardSlice'
-import { api } from '../api/client'
+import { i18nT } from '../i18n/t'
 import type { ChatSlot, SessionLink } from '../types'
-
-vi.mock('../api/client', async importOriginal => {
-  const mod = await importOriginal<typeof import('../api/client')>()
-  return { ...mod, api: { ...mod.api, unlinkMirror: vi.fn() } }
-})
-
-const unlinkMirror = vi.mocked(api.unlinkMirror)
 
 function link(over: Partial<SessionLink> = {}): SessionLink {
   return { channel: 'slack', label: 'zzq-chan', target: 'C1', direction: 'both', live: true, ...over }
 }
 
-function slot(links: SessionLink[]): ChatSlot {
+function slot(links?: SessionLink[]): ChatSlot {
   return { key: 'zzq-slot', messages: 0, running: false, links } as ChatSlot
 }
 
-function storeWith(links: SessionLink[]) {
+function storeWith(links?: SessionLink[]) {
   const store = createTestStore()
   store.dispatch(sseSlots([slot(links)]))
   return store
 }
 
-describe('InboundLinkChip', () => {
-  beforeEach(() => {
-    unlinkMirror.mockReset()
-    unlinkMirror.mockResolvedValue(undefined as never)
-  })
+const drivenFrom = (label: string) => i18nT('components.inboundLinkChip.driven_from', { label })
 
+describe('InboundLinkChip', () => {
   it('renders nothing without a slotKey', () => {
     const { container } = renderWithProviders(<InboundLinkChip />, { store: storeWith([link()]) })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing for an unknown slot', () => {
+    const { container } = renderWithProviders(<InboundLinkChip slotKey="zzq-missing" />, {
+      store: storeWith([link()]),
+    })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when the slot has no links at all', () => {
+    const { container } = renderWithProviders(<InboundLinkChip slotKey="zzq-slot" />, {
+      store: storeWith(undefined),
+    })
     expect(container.firstChild).toBeNull()
   })
 
@@ -44,48 +53,32 @@ describe('InboundLinkChip', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('renders the chip for a two-way link', () => {
+  it('renders the chip for a two-way link, with no action attached', () => {
     renderWithProviders(<InboundLinkChip slotKey="zzq-slot" />, { store: storeWith([link()]) })
-    expect(screen.getByText(/zzq-chan/)).toBeInTheDocument()
-    expect(screen.getByRole('button')).toBeEnabled()
+    expect(screen.getByText(drivenFrom('zzq-chan'))).toBeInTheDocument()
+    // Information only: disconnecting happens in the session menu, so the chip
+    // must not offer a second, contradictory control.
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('a declined confirm leaves the link alone', () => {
-    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
-    renderWithProviders(<InboundLinkChip slotKey="zzq-slot" />, { store: storeWith([link()]) })
-    fireEvent.click(screen.getByRole('button'))
-    expect(confirm).toHaveBeenCalled()
-    expect(unlinkMirror).not.toHaveBeenCalled()
-    confirm.mockRestore()
-  })
-
-  it('a confirmed release calls the API, drops the link and notifies', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
-    const store = storeWith([link(), link({ direction: 'origin', label: 'zzq-keep' })])
-    renderWithProviders(<InboundLinkChip slotKey="zzq-slot" />, { store })
-
-    fireEvent.click(screen.getByRole('button'))
-    await waitFor(() => expect(unlinkMirror).toHaveBeenCalledWith('zzq-slot'))
-
-    await waitFor(() => {
-      const links = store.getState().dashboard.slots[0].links ?? []
-      expect(links.map(l => l.direction)).toEqual(['origin'])
+  it('stays visible when the channel is disconnected', () => {
+    // A disconnect stops outbound delivery only — messages from the channel
+    // still land here, which is exactly what the chip claims.
+    renderWithProviders(<InboundLinkChip slotKey="zzq-slot" />, {
+      store: storeWith([link({ live: false })]),
     })
-    const notes = store.getState().notifications.items ?? []
-    expect(notes.some(n => n.kind === 'success')).toBe(true)
+    expect(screen.getByText(drivenFrom('zzq-chan'))).toBeInTheDocument()
   })
 
-  it('a failed release notifies with the error reason and keeps the link', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
-    unlinkMirror.mockRejectedValue(new Error('zzq-unlink-broke'))
-    const store = storeWith([link()])
-    renderWithProviders(<InboundLinkChip slotKey="zzq-slot" />, { store })
-
-    fireEvent.click(screen.getByRole('button'))
-    await waitFor(() => {
-      const notes = store.getState().notifications.items ?? []
-      expect(notes.some(n => n.kind === 'error' && n.title.includes('zzq-unlink-broke'))).toBe(true)
+  it('surfaces the first two-way link when the slot carries several', () => {
+    renderWithProviders(<InboundLinkChip slotKey="zzq-slot" />, {
+      store: storeWith([
+        link({ direction: 'out', label: 'zzq-skip' }),
+        link({ label: 'zzq-first' }),
+        link({ label: 'zzq-second' }),
+      ]),
     })
-    expect(store.getState().dashboard.slots[0].links).toHaveLength(1)
+    expect(screen.getByText(drivenFrom('zzq-first'))).toBeInTheDocument()
+    expect(screen.queryByText(drivenFrom('zzq-second'))).not.toBeInTheDocument()
   })
 })

--- a/website/src/components/LinkedSurfacesSection.cov80.test.tsx
+++ b/website/src/components/LinkedSurfacesSection.cov80.test.tsx
@@ -2,7 +2,7 @@ import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders, createTestStore } from '../test/helpers'
 import LinkedSurfacesSection from './LinkedSurfacesSection'
 import { addSlotOptimistic } from '../store/dashboardSlice'
-import { api } from '../api/client'
+import { ApiError, api } from '../api/client'
 import { i18nT } from '../i18n/t'
 import type { ChatSlot, ConfiguredChannelTarget, SessionLink } from '../types'
 
@@ -14,10 +14,9 @@ vi.mock('../api/client', async importOriginal => {
       ...mod.api,
       channelTargets: vi.fn(),
       slackLink: vi.fn(),
-      unlinkSlack: vi.fn(),
       linkMirror: vi.fn(),
-      remindMirror: vi.fn(),
-      unlinkMirror: vi.fn(),
+      pauseSlack: vi.fn(),
+      pauseMirror: vi.fn(),
     },
   }
 })
@@ -25,18 +24,24 @@ vi.mock('../api/client', async importOriginal => {
 /**
  * happy-dom cannot drive a real Radix menu open (no PointerEvent), so both
  * menu families collapse to plain buttons. `onSelect` gets a cancelable Event
- * so the unavailable-target branch can really call `preventDefault()`.
+ * so the row's `preventDefault()` (keep the menu open) can really run, and the
+ * aria/tooltip attributes are forwarded because the disabled and in-flight
+ * assertions read them off the rendered row.
  */
 function stubItem(prefix: string) {
-  const Item = ({ children, onSelect, ...rest }: {
+  const Item = ({ children, onSelect, title, ...rest }: {
     children?: React.ReactNode
     onSelect?: (e: Event) => void
+    title?: string
     'aria-disabled'?: boolean
+    'aria-busy'?: boolean
     className?: string
   }) => (
     <button
       type="button"
       aria-disabled={rest['aria-disabled']}
+      aria-busy={rest['aria-busy']}
+      title={title}
       className={rest.className}
       onClick={() => onSelect?.(new Event('select', { cancelable: true }))}
     >
@@ -57,10 +62,9 @@ vi.mock('./ui/context-menu', async importOriginal => ({
 
 const channelTargets = vi.mocked(api.channelTargets)
 const slackLink = vi.mocked(api.slackLink)
-const unlinkSlack = vi.mocked(api.unlinkSlack)
 const linkMirror = vi.mocked(api.linkMirror)
-const remindMirror = vi.mocked(api.remindMirror)
-const unlinkMirror = vi.mocked(api.unlinkMirror)
+const pauseSlack = vi.mocked(api.pauseSlack)
+const pauseMirror = vi.mocked(api.pauseMirror)
 
 const SLOT = 'zzq-slot'
 const L = (k: string, vars?: Record<string, unknown>) =>
@@ -99,217 +103,279 @@ const notifications = (store: ReturnType<typeof createTestStore>) =>
 const slotOf = (store: ReturnType<typeof createTestStore>) =>
   store.getState().dashboard.slots.find(s => s.key === SLOT)!
 
+const rowOf = (store: ReturnType<typeof createTestStore>, channel: string, origin = false) =>
+  slotOf(store).links!.find(l => l.channel === channel && (l.direction === 'origin') === origin)
+
 describe('LinkedSurfacesSection', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     channelTargets.mockResolvedValue([] as never)
     slackLink.mockResolvedValue({ ok: true, channel: 'C-zzq', thread_ts: '1.2' } as never)
-    unlinkSlack.mockResolvedValue({ ok: true } as never)
     linkMirror.mockResolvedValue({ ok: true, conversation_id: 'conv-zzq' } as never)
-    remindMirror.mockResolvedValue({ ok: true } as never)
-    unlinkMirror.mockResolvedValue({ ok: true } as never)
+    pauseSlack.mockResolvedValue({ ok: true } as never)
+    pauseMirror.mockResolvedValue({ ok: true } as never)
   })
 
-  describe('ConnectedBadge', () => {
-    it('labels an origin link Origin and offers no actions', async () => {
-      mount({ links: [link({ direction: 'origin' })] })
-      expect(await screen.findByRole('status')).toHaveTextContent(
-        L('connected', { label: 'zzq-guild' }),
-      )
-      expect(screen.getByRole('status')).toHaveTextContent(L('origin'))
-      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  describe('one row per channel — the label is the action', () => {
+    it('disconnects a connected Slack channel and flips the verb in place', async () => {
+      const { store } = mount({ links: [link({ channel: 'slack', label: 'Slack' })] })
+      fireEvent.click(await screen.findByText(L('disconnect_from', { label: 'Slack' })))
+      await waitFor(() => expect(pauseSlack).toHaveBeenCalledWith(SLOT, true))
+      // The row is patched in place: the binding is retained, never dropped.
+      await waitFor(() => expect(rowOf(store, 'slack')?.paused).toBe(true))
+      expect(slotOf(store).links).toHaveLength(1)
+      expect(screen.getByText(L('connect_to', { label: 'Slack' }))).toBeInTheDocument()
     })
 
-    it('labels a two-way link Two-way', async () => {
-      mount({ links: [link({ direction: 'both' })] })
-      expect(await screen.findByRole('status')).toHaveTextContent(L('two_way'))
+    it('reconnects a disconnected Slack channel on the same single row', async () => {
+      const { store } = mount({ links: [link({ channel: 'slack', label: 'Slack', paused: true })] })
+      expect(screen.queryByText(L('disconnect_from', { label: 'Slack' }))).not.toBeInTheDocument()
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'Slack' })))
+      await waitFor(() => expect(pauseSlack).toHaveBeenCalledWith(SLOT, false))
+      await waitFor(() => expect(rowOf(store, 'slack')?.paused).toBe(false))
     })
 
-    it('appends Offline to a dead mirror and hides the reminder action', async () => {
-      mount({ links: [link({ live: false })] })
-      const badge = await screen.findByRole('status')
-      expect(badge).toHaveTextContent(`${L('mirror')} · ${L('offline')}`)
-      expect(screen.queryByText(L('post_reminder', { label: 'zzq-guild' }))).not.toBeInTheDocument()
-      // The release action survives, so a dead link can still be let go.
-      expect(screen.getByText(L('stop_mirroring', { label: 'zzq-guild' }))).toBeInTheDocument()
+    it('a failed Slack disconnect notifies and keeps the row connected', async () => {
+      pauseSlack.mockRejectedValue(new Error('zzq-pause-refused'))
+      const { store } = mount({ links: [link({ channel: 'slack', label: 'Slack' })] })
+      fireEvent.click(await screen.findByText(L('disconnect_from', { label: 'Slack' })))
+      await waitFor(() => expect(notifications(store)).toEqual([
+        `error:${L('disconnect_failed', { label: 'Slack', reason: 'zzq-pause-refused' })}`,
+      ]))
+      expect(rowOf(store, 'slack')?.paused).toBeUndefined()
+      expect(screen.getByText(L('disconnect_from', { label: 'Slack' }))).toBeInTheDocument()
     })
 
-    it('an offline origin link keeps its role and is never marked Offline', async () => {
-      mount({ links: [link({ direction: 'origin', live: false })] })
-      expect(await screen.findByRole('status')).toHaveTextContent(L('origin'))
-      expect(screen.getByRole('status')).not.toHaveTextContent(L('offline'))
+    it('a non-Error Slack reconnect failure falls back to the generic reason', async () => {
+      pauseSlack.mockRejectedValue('zzq-not-an-error')
+      const { store } = mount({ links: [link({ channel: 'slack', label: 'Slack', paused: true })] })
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'Slack' })))
+      await waitFor(() => expect(notifications(store)).toEqual([
+        `error:${L('connect_failed', { label: 'Slack', reason: L('unknown_error') })}`,
+      ]))
     })
-  })
 
-  describe('legacy slack_linked slot', () => {
-    it('synthesises a Slack link row with both Slack actions', async () => {
-      mount({ slack_linked: true })
-      expect(await screen.findByRole('status')).toHaveTextContent(
-        L('connected', { label: 'Slack' }),
-      )
-      expect(screen.getByText(i18nT('components.slackLinkSection.post_reminder_in_slack')))
+    it('disconnects a mirror through the channel-neutral endpoint and patches its row', async () => {
+      const { store } = mount({ links: [link()] })
+      fireEvent.click(await screen.findByText(L('disconnect_from', { label: 'Discord' })))
+      await waitFor(() => expect(pauseMirror).toHaveBeenCalledWith(SLOT, true, false))
+      await waitFor(() => expect(rowOf(store, 'discord')?.paused).toBe(true))
+    })
+
+    it('marks the born-in conversation as origin when disconnecting it', async () => {
+      const { store } = mount({ links: [link({ direction: 'origin' })] })
+      fireEvent.click(await screen.findByText(L('disconnect_from', { label: 'Discord' })))
+      await waitFor(() => expect(pauseMirror).toHaveBeenCalledWith(SLOT, true, true))
+      await waitFor(() => expect(rowOf(store, 'discord', true)?.paused).toBe(true))
+    })
+
+    it('a failed mirror disconnect notifies and leaves the delivery flowing', async () => {
+      pauseMirror.mockRejectedValue(new Error('zzq-mirror-refused'))
+      const { store } = mount({ links: [link()] })
+      fireEvent.click(await screen.findByText(L('disconnect_from', { label: 'Discord' })))
+      await waitFor(() => expect(notifications(store)).toEqual([
+        `error:${L('disconnect_failed', { label: 'Discord', reason: 'zzq-mirror-refused' })}`,
+      ]))
+      expect(rowOf(store, 'discord')?.paused).toBeUndefined()
+    })
+
+    it('a failed mirror reconnect reports the connect direction', async () => {
+      pauseMirror.mockRejectedValue(new Error('zzq-resume-refused'))
+      const { store } = mount({ links: [link({ paused: true })] })
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'Discord' })))
+      await waitFor(() => expect(notifications(store)).toEqual([
+        `error:${L('connect_failed', { label: 'Discord', reason: 'zzq-resume-refused' })}`,
+      ]))
+    })
+
+    it('renders ONE row when the wire reports a channel twice, and acts on both deliveries', async () => {
+      // A session born in Discord and then mirrored to Discord carries two links
+      // for the one channel: an origin fact and a mirror fact with separate
+      // paused flags. One row, and its click covers the whole group — acting on
+      // only one delivery left the other muted with no control on screen.
+      const { store } = mount({
+        links: [
+          link({ direction: 'origin' }),
+          link({ direction: 'out', target: 't-2' }),
+        ],
+      })
+      expect(await screen.findAllByText(L('disconnect_from', { label: 'Discord' }))).toHaveLength(1)
+      fireEvent.click(screen.getByText(L('disconnect_from', { label: 'Discord' })))
+      await waitFor(() => expect(pauseMirror).toHaveBeenCalledTimes(2))
+      // One call per delivery, addressed by role, all of them disconnects.
+      const calls = pauseMirror.mock.calls
+      expect(calls.map(call => call[2]).sort()).toEqual([false, true])
+      expect(calls.every(call => call[1] === true)).toBe(true)
+      await waitFor(() => expect(slotOf(store).links!.every(l => l.paused === true)).toBe(true))
+    })
+
+    it('reads as connected while ANY delivery in the group is still live', async () => {
+      // Under "all" a partially-failed group would read Connect while messages
+      // were still arriving; under "any" one click stops the remainder.
+      mount({
+        links: [
+          link({ direction: 'origin', paused: true }),
+          link({ direction: 'out', target: 't-2' }),
+        ],
+      })
+      expect(await screen.findByText(L('disconnect_from', { label: 'Discord' }))).toBeInTheDocument()
+      expect(screen.queryByText(L('connect_to', { label: 'Discord' }))).not.toBeInTheDocument()
+    })
+
+    it('falls back to the wire label for a channel with no brand name', async () => {
+      mount({ links: [link({ channel: 'zzq-chan', label: 'zzq-row-label' })] })
+      expect(await screen.findByText(L('disconnect_from', { label: 'zzq-row-label' })))
         .toBeInTheDocument()
     })
+  })
 
-    it('posting a Slack reminder sends no explicit channel', async () => {
-      mount({ slack_linked: true })
-      fireEvent.click(
-        await screen.findByText(i18nT('components.slackLinkSection.post_reminder_in_slack')),
-      )
-      await waitFor(() => expect(slackLink).toHaveBeenCalledWith(SLOT, undefined))
+  describe('in-flight guard — per row, not per menu', () => {
+    it('shows the spinner on the busy row and swallows a second click', async () => {
+      let release: (v: unknown) => void = () => {}
+      pauseSlack.mockReturnValue(new Promise(r => { release = r }) as never)
+      mount({ links: [link({ channel: 'slack', label: 'Slack' })] })
+      const row = await screen.findByText(L('disconnect_from', { label: 'Slack' }))
+      fireEvent.click(row)
+      await waitFor(() => expect(row.closest('button')).toHaveAttribute('aria-busy', 'true'))
+      fireEvent.click(row)
+      expect(pauseSlack).toHaveBeenCalledTimes(1)
+      release({ ok: true })
+      // The verb flip is the confirmation — no success toast.
+      expect(await screen.findByText(L('connect_to', { label: 'Slack' }))).toBeInTheDocument()
     })
 
-    it('a successful re-link stores the returned channel and thread', async () => {
-      const { store } = mount({ slack_linked: true })
-      fireEvent.click(
-        await screen.findByText(i18nT('components.slackLinkSection.post_reminder_in_slack')),
-      )
-      await waitFor(() => expect(slotOf(store).slack_channel).toBe('C-zzq'))
+    it('guards an offer row while its connect is in flight', async () => {
+      channelTargets.mockResolvedValue([target()] as never)
+      let release: (v: unknown) => void = () => {}
+      linkMirror.mockReturnValue(new Promise(r => { release = r }) as never)
+      mount()
+      const row = await screen.findByText(L('connect_to', { label: 'zzq-target-label' }))
+      fireEvent.click(row)
+      await waitFor(() => expect(row.closest('button')).toHaveAttribute('aria-busy', 'true'))
+      fireEvent.click(row)
+      expect(linkMirror).toHaveBeenCalledTimes(1)
+      release({ ok: true })
+    })
+  })
+
+  describe('offers — channels the session does not hold', () => {
+    it('connects an offered mirror target, named by destination', async () => {
+      channelTargets.mockResolvedValue([target()] as never)
+      mount()
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'zzq-target-label' })))
+      await waitFor(() => expect(linkMirror).toHaveBeenCalledWith(SLOT, 'discord', 'zzq-target'))
+    })
+
+    it('routes a Slack offer through the slack-link path and stores the binding', async () => {
+      channelTargets.mockResolvedValue([
+        target({ channel_type: 'slack', target_id: 'dm', label: 'Slack · Direct Message' }),
+      ] as never)
+      const { store } = mount()
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'Slack · Direct Message' })))
+      await waitFor(() => expect(slackLink).toHaveBeenCalledWith(SLOT, 'dm'))
+      expect(linkMirror).not.toHaveBeenCalled()
+      await waitFor(() => expect(slotOf(store).slack_linked).toBe(true))
+      expect(slotOf(store).slack_channel).toBe('C-zzq')
       expect(slotOf(store).slack_thread_ts).toBe('1.2')
     })
 
     it('a not-ok Slack response leaves the slot untouched', async () => {
+      channelTargets.mockResolvedValue([
+        target({ channel_type: 'slack', target_id: 'dm', label: 'Slack · Direct Message' }),
+      ] as never)
       slackLink.mockResolvedValue({ ok: false } as never)
-      const { store } = mount({ slack_linked: true })
-      fireEvent.click(
-        await screen.findByText(i18nT('components.slackLinkSection.post_reminder_in_slack')),
-      )
+      const { store } = mount()
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'Slack · Direct Message' })))
       await waitFor(() => expect(slackLink).toHaveBeenCalled())
+      expect(slotOf(store).slack_linked).toBeUndefined()
       expect(slotOf(store).slack_channel).toBeUndefined()
     })
 
-    it('unlinking clears the Slack fields and drops the link', async () => {
-      const { store } = mount({ slack_linked: true, links: [link({ channel: 'slack' })] })
-      fireEvent.click(
-        await screen.findByText(i18nT('components.slackLinkSection.unlink_from_slack')),
+    it('a failed Slack connect is reported in the notification feed', async () => {
+      channelTargets.mockResolvedValue([
+        target({ channel_type: 'slack', target_id: 'dm', label: 'Slack · Direct Message' }),
+      ] as never)
+      slackLink.mockRejectedValue(new Error('zzq-slack-refused'))
+      const { store } = mount()
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'Slack · Direct Message' })))
+      await waitFor(() => expect(notifications(store)).toEqual([
+        `error:${L('connect_failed', { label: 'Slack', reason: 'zzq-slack-refused' })}`,
+      ]))
+    })
+
+    it('reports a conversation held by another session as in use, not as an error', async () => {
+      channelTargets.mockResolvedValue([target()] as never)
+      linkMirror.mockRejectedValue(
+        new ApiError(409, 'conflict', JSON.stringify({ code: 'conversation_occupied' })),
       )
-      await waitFor(() => expect(slotOf(store).slack_linked).toBe(false))
-      expect(slotOf(store).links).toEqual([])
-      expect(slotOf(store).slack_channel).toBeUndefined()
+      const { store } = mount()
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'zzq-target-label' })))
+      await waitFor(() => expect(notifications(store)).toEqual([
+        `error:${L('held_elsewhere', { label: 'zzq-target-label' })}`,
+      ]))
     })
 
-    it('a failed unlink warns and keeps the session linked', async () => {
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      unlinkSlack.mockRejectedValue(new Error('zzq-unlink-failed'))
-      const { store } = mount({ slack_linked: true })
-      fireEvent.click(
-        await screen.findByText(i18nT('components.slackLinkSection.unlink_from_slack')),
+    it('a 409 with a different code stays a plain connect failure', async () => {
+      // The endpoint answers 409 for an unavailable target too — the status alone
+      // must not be read as occupied.
+      channelTargets.mockResolvedValue([target()] as never)
+      linkMirror.mockRejectedValue(
+        new ApiError(409, 'zzq-target-down', JSON.stringify({ code: 'configured_target_unavailable' })),
       )
-      await waitFor(() => expect(warn).toHaveBeenCalledWith(
-        'unlinkSlack failed; session stays linked', expect.any(Error),
-      ))
-      expect(slotOf(store).slack_linked).toBe(true)
-      warn.mockRestore()
-    })
-
-    it('a failed link warns without clearing anything', async () => {
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      slackLink.mockRejectedValue(new Error('zzq-link-failed'))
-      mount({ slack_linked: true })
-      fireEvent.click(
-        await screen.findByText(i18nT('components.slackLinkSection.post_reminder_in_slack')),
-      )
-      await waitFor(() => expect(warn).toHaveBeenCalledWith(
-        'slackLink failed', expect.any(Error),
-      ))
-      warn.mockRestore()
-    })
-  })
-
-  describe('mirror reminder', () => {
-    it('a delivered reminder is reported in the notification feed', async () => {
-      const { store } = mount({ links: [link()] })
-      fireEvent.click(await screen.findByText(L('post_reminder', { label: 'zzq-guild' })))
+      const { store } = mount()
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'zzq-target-label' })))
       await waitFor(() => expect(notifications(store)).toEqual([
-        `success:${L('reminder_sent', { label: 'zzq-guild' })}`,
-      ]))
-      expect(remindMirror).toHaveBeenCalledWith(SLOT)
-    })
-
-    it("a rejected reminder surfaces the backend's own reason", async () => {
-      remindMirror.mockRejectedValue(new Error('zzq-503-not-live'))
-      const { store } = mount({ links: [link()] })
-      fireEvent.click(await screen.findByText(L('post_reminder', { label: 'zzq-guild' })))
-      await waitFor(() => expect(notifications(store)).toEqual([
-        `error:${L('reminder_failed', { reason: 'zzq-503-not-live' })}`,
+        `error:${L('connect_failed', { label: 'zzq-target-label', reason: 'zzq-target-down' })}`,
       ]))
     })
 
-    it('a non-Error rejection falls back to the generic reason', async () => {
-      remindMirror.mockRejectedValue('zzq-not-an-error')
-      const { store } = mount({ links: [link()] })
-      fireEvent.click(await screen.findByText(L('post_reminder', { label: 'zzq-guild' })))
+    it('a non-Error connect failure falls back to the generic reason', async () => {
+      channelTargets.mockResolvedValue([target()] as never)
+      linkMirror.mockRejectedValue('zzq-not-an-error')
+      const { store } = mount()
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'zzq-target-label' })))
       await waitFor(() => expect(notifications(store)).toEqual([
-        `error:${L('reminder_failed', { reason: 'unknown error' })}`,
+        `error:${L('connect_failed', { label: 'zzq-target-label', reason: L('unknown_error') })}`,
       ]))
     })
-  })
 
-  describe('stopping a mirror', () => {
-    it('a declined confirm leaves the link in place', async () => {
-      const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
-      const { store } = mount({ links: [link()] })
-      fireEvent.click(await screen.findByText(L('stop_mirroring', { label: 'zzq-guild' })))
-      expect(confirm).toHaveBeenCalledWith(L('confirm_stop_mirroring', { label: 'zzq-guild' }))
-      expect(unlinkMirror).not.toHaveBeenCalled()
-      expect(slotOf(store).links).toHaveLength(1)
-      confirm.mockRestore()
+    it('an unavailable target explains itself visibly and refuses the click', async () => {
+      channelTargets.mockResolvedValue([
+        target({ available: false, unavailable_reason: 'zzq-transport-absent' }),
+      ] as never)
+      const { store } = mount()
+      const row = await screen.findByText(L('connect_to', { label: 'zzq-target-label' }))
+      // The reason is visible text, not tooltip-only — a keyboard or touch user
+      // never sees a title attribute.
+      expect(screen.getByText('zzq-transport-absent')).toBeInTheDocument()
+      const button = row.closest('button')!
+      expect(button).toHaveAttribute('aria-disabled', 'true')
+      expect(button).toHaveAttribute('title', 'zzq-transport-absent')
+      fireEvent.click(row)
+      await waitFor(() => expect(notifications(store)).toEqual(['error:zzq-transport-absent']))
+      expect(linkMirror).not.toHaveBeenCalled()
     })
 
-    it('a one-way mirror is stopped, not released', async () => {
-      const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
-      const { store } = mount({ links: [link()] })
-      fireEvent.click(await screen.findByText(L('stop_mirroring', { label: 'zzq-guild' })))
-      await waitFor(() => expect(slotOf(store).links).toEqual([]))
-      expect(notifications(store)).toEqual([
-        `success:${L('mirror_stopped', { label: 'zzq-guild' })}`,
-      ])
-      confirm.mockRestore()
+    it('an unavailable target with no reason uses the generic explanation', async () => {
+      channelTargets.mockResolvedValue([target({ available: false })] as never)
+      const { store } = mount()
+      fireEvent.click(await screen.findByText(L('connect_to', { label: 'zzq-target-label' })))
+      await waitFor(() => expect(notifications(store)).toEqual([`error:${L('unavailable')}`]))
     })
 
-    it('a two-way binding is released, with the release confirm and message', async () => {
-      const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
-      const { store } = mount({ links: [link({ direction: 'both' })] })
-      fireEvent.click(await screen.findByText(L('release', { label: 'zzq-guild' })))
-      expect(confirm).toHaveBeenCalledWith(L('confirm_release', { label: 'zzq-guild' }))
-      await waitFor(() => expect(notifications(store)).toEqual([
-        `success:${L('released', { label: 'zzq-guild' })}`,
-      ]))
-      confirm.mockRestore()
+    it('an offer with no label of its own falls back to the brand label', async () => {
+      channelTargets.mockResolvedValue([target({ label: '' })] as never)
+      mount()
+      expect(await screen.findByText(L('connect_to', { label: 'Discord' }))).toBeInTheDocument()
     })
 
-    it('a failed stop is reported and the link stays', async () => {
-      const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
-      unlinkMirror.mockRejectedValue(new Error('zzq-stop-failed'))
-      const { store } = mount({ links: [link()] })
-      fireEvent.click(await screen.findByText(L('stop_mirroring', { label: 'zzq-guild' })))
-      await waitFor(() => expect(notifications(store)).toEqual([
-        `error:${L('stop_failed', { reason: 'zzq-stop-failed' })}`,
-      ]))
-      expect(slotOf(store).links).toHaveLength(1)
-      confirm.mockRestore()
-    })
-
-    it('a non-Error stop failure falls back to the generic reason', async () => {
-      const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
-      unlinkMirror.mockRejectedValue('zzq-not-an-error')
-      const { store } = mount({ links: [link()] })
-      fireEvent.click(await screen.findByText(L('stop_mirroring', { label: 'zzq-guild' })))
-      await waitFor(() => expect(notifications(store)).toEqual([
-        `error:${L('stop_failed', { reason: 'unknown error' })}`,
-      ]))
-      confirm.mockRestore()
-    })
-  })
-
-  describe('configured-target picker', () => {
-    it('renders nothing while the target list has not resolved', async () => {
-      let release: (v: unknown) => void = () => {}
-      channelTargets.mockReturnValue(new Promise(r => { release = r }) as never)
-      const { container } = mount()
+    it('does not offer a second conversation on a channel the session already holds', async () => {
+      channelTargets.mockResolvedValue([target()] as never)
+      mount({ links: [link()] })
       await waitFor(() => expect(channelTargets).toHaveBeenCalled())
-      expect(container.textContent).toBe('')
-      release([])
+      expect(screen.queryByText(L('connect_to', { label: 'zzq-target-label' })))
+        .not.toBeInTheDocument()
+      expect(screen.getByText(L('disconnect_from', { label: 'Discord' }))).toBeInTheDocument()
     })
 
     it('a non-array payload degrades to an empty picker instead of throwing', async () => {
@@ -319,107 +385,28 @@ describe('LinkedSurfacesSection', () => {
       expect(container.querySelectorAll('button')).toHaveLength(0)
     })
 
-    it('links an available target and keeps any origin link', async () => {
-      channelTargets.mockResolvedValue([target()] as never)
-      const { store } = mount()
-      fireEvent.click(await screen.findByText('zzq-target-label'))
-      await waitFor(() => expect(linkMirror).toHaveBeenCalledWith(SLOT, 'discord', 'zzq-target'))
-      await waitFor(() => expect(slotOf(store).links).toEqual([{
-        channel: 'discord', label: 'zzq-target-label', target: 'conv-zzq',
-        direction: 'out', live: true,
-      }]))
-    })
-
-    it('falls back to the configured target id when no conversation is returned', async () => {
-      channelTargets.mockResolvedValue([target()] as never)
-      linkMirror.mockResolvedValue({ ok: true } as never)
-      const { store } = mount()
-      fireEvent.click(await screen.findByText('zzq-target-label'))
-      await waitFor(() => expect(slotOf(store).links?.[0].target).toBe('zzq-target'))
-    })
-
-    it('a not-ok link response writes no link', async () => {
-      channelTargets.mockResolvedValue([target()] as never)
-      linkMirror.mockResolvedValue({ ok: false } as never)
-      const { store } = mount()
-      fireEvent.click(await screen.findByText('zzq-target-label'))
-      await waitFor(() => expect(linkMirror).toHaveBeenCalled())
-      expect(slotOf(store).links).toBeUndefined()
-    })
-
-    it('a failed link is reported in the notification feed', async () => {
-      channelTargets.mockResolvedValue([target()] as never)
-      linkMirror.mockRejectedValue(new Error('zzq-link-refused'))
-      const { store } = mount()
-      fireEvent.click(await screen.findByText('zzq-target-label'))
-      await waitFor(() => expect(notifications(store)).toEqual([
-        `error:${L('link_failed', { reason: 'zzq-link-refused' })}`,
-      ]))
-    })
-
-    it('a non-Error link failure falls back to the generic reason', async () => {
-      channelTargets.mockResolvedValue([target()] as never)
-      linkMirror.mockRejectedValue('zzq-not-an-error')
-      const { store } = mount()
-      fireEvent.click(await screen.findByText('zzq-target-label'))
-      await waitFor(() => expect(notifications(store)).toEqual([
-        `error:${L('link_failed', { reason: 'unknown error' })}`,
-      ]))
-    })
-
-    it('a slack target routes through the slack-link path, not the mirror path', async () => {
-      channelTargets.mockResolvedValue([
-        target({ channel_type: 'slack', target_id: 'dm', label: 'zzq-unused' }),
-      ] as never)
-      mount()
-      fireEvent.click(
-        await screen.findByText(i18nT('components.slackLinkSection.send_to_slack')),
-      )
-      await waitFor(() => expect(slackLink).toHaveBeenCalledWith(SLOT, 'dm'))
-      expect(linkMirror).not.toHaveBeenCalled()
-    })
-
-    it('a non-dm slack target keeps its own label', async () => {
-      channelTargets.mockResolvedValue([
-        target({ channel_type: 'slack', target_id: 'C-zzq', label: 'zzq-chan' }),
-      ] as never)
-      mount()
-      fireEvent.click(await screen.findByText('zzq-chan'))
-      await waitFor(() => expect(slackLink).toHaveBeenCalledWith(SLOT, 'C-zzq'))
-    })
-
-    it('an unavailable target explains itself and refuses the click', async () => {
-      channelTargets.mockResolvedValue([
-        target({ available: false, unavailable_reason: 'zzq-transport-absent' }),
-      ] as never)
-      const { store } = mount()
-      const row = await screen.findByText('zzq-target-label')
-      expect(screen.getByText('zzq-transport-absent')).toBeInTheDocument()
-      expect(row.closest('button')).toHaveAttribute('aria-disabled', 'true')
-      fireEvent.click(row)
-      await waitFor(() => expect(notifications(store)).toEqual(['error:zzq-transport-absent']))
-      expect(linkMirror).not.toHaveBeenCalled()
-    })
-
-    it('an unavailable target with no reason uses the generic explanation', async () => {
-      channelTargets.mockResolvedValue([target({ available: false })] as never)
-      const { store } = mount()
-      fireEvent.click(await screen.findByText('zzq-target-label'))
-      await waitFor(() => expect(notifications(store)).toEqual([`error:${L('unavailable')}`]))
-    })
-
-    it('the picker is hidden once a mirror exists', async () => {
-      channelTargets.mockResolvedValue([target()] as never)
-      mount({ links: [link()] })
+    it('renders nothing while the target list has not resolved', async () => {
+      let release: (v: unknown) => void = () => {}
+      channelTargets.mockReturnValue(new Promise(r => { release = r }) as never)
+      const { container } = mount()
       await waitFor(() => expect(channelTargets).toHaveBeenCalled())
-      expect(screen.queryByText('zzq-target-label')).not.toBeInTheDocument()
+      expect(container.textContent).toBe('')
+      release([])
     })
+  })
+
+  it('never invents a row from slack_linked alone — rows come from the wire', async () => {
+    // An invented row cannot know `paused`, which is how a disconnected thread
+    // once rendered as connected.
+    const { container } = mount({ slack_linked: true })
+    await waitFor(() => expect(channelTargets).toHaveBeenCalled())
+    expect(container.textContent).toBe('')
   })
 
   it('behaves identically inside the context-menu family', async () => {
     channelTargets.mockResolvedValue([target()] as never)
     mount({}, 'context')
-    fireEvent.click(await screen.findByText('zzq-target-label'))
+    fireEvent.click(await screen.findByText(L('connect_to', { label: 'zzq-target-label' })))
     await waitFor(() => expect(linkMirror).toHaveBeenCalledWith(SLOT, 'discord', 'zzq-target'))
   })
 

--- a/website/src/test/SpecBuilderSpecStatePanelCov80.test.tsx
+++ b/website/src/test/SpecBuilderSpecStatePanelCov80.test.tsx
@@ -1,6 +1,8 @@
 // SpecStatePanel — the structured state card under the docs pane. Decisions are
-// clickable until answered, answering posts a chat message through the parent's
-// mutation, and the CONTEXT table only lists the rows the payload actually has.
+// clickable until answered; a clicked decision collapses to its chosen option
+// immediately (marked "sending…" until the agent writes the real answer back),
+// answering posts a chat message through the parent's mutation, and the CONTEXT
+// table only lists the rows the payload actually has.
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import type { SpecDetail } from '../apps/spec-builder/api'
@@ -81,7 +83,7 @@ describe('SpecStatePanel', () => {
     expect(sent.endsWith(': zz-opt-a')).toBe(true)
   })
 
-  it('blocks a second answer while one is in flight, then re-enables', async () => {
+  it('collapses the clicked decision to "sending…" and blocks the others while in flight', async () => {
     let release: (() => void) | undefined
     const sendMessage = vi.fn(() => new Promise<void>(res => { release = () => res() }))
     render(
@@ -98,18 +100,22 @@ describe('SpecStatePanel', () => {
       />,
     )
     fireEvent.click(screen.getByText('zz-opt-a'))
-    fireEvent.click(screen.getByText('zz-opt-b'))
+    // The clicked decision collapses to its chosen option right away — the
+    // sibling option is gone, and the badge shows the send is under way.
+    expect(screen.queryByText('zz-opt-b')).not.toBeInTheDocument()
+    expect(screen.getByText('→ zz-opt-a')).toBeInTheDocument()
+    expect(screen.getByText('sending…')).toBeInTheDocument()
+    // The unrelated decision is dimmed and inert while another one is answering.
+    expect(screen.getByText('zz-opt-c').closest('[aria-label]')).toHaveStyle({ opacity: '0.5' })
     fireEvent.click(screen.getByText('zz-opt-c'))
     expect(sendMessage).toHaveBeenCalledTimes(1)
-    // The unrelated decision is dimmed while another one is answering.
-    expect(screen.getByText('zz-opt-c').closest('[aria-label]')).toHaveStyle({ opacity: '0.5' })
     release?.()
     await waitFor(() => expect(screen.getByText('zz-opt-c').closest('[aria-label]')).toHaveStyle({ opacity: '1' }))
     fireEvent.click(screen.getByText('zz-opt-c'))
     expect(sendMessage).toHaveBeenCalledTimes(2)
   })
 
-  it('swallows a send failure and re-enables the options', async () => {
+  it('a send failure reopens the decision so it can be answered again', async () => {
     const sendMessage = vi.fn().mockRejectedValue(new Error('zz-send-failed'))
     render(
       <SpecStatePanel
@@ -118,7 +124,56 @@ describe('SpecStatePanel', () => {
       />,
     )
     fireEvent.click(screen.getByText('zz-opt-a'))
-    await waitFor(() => expect(screen.getByText('zz-opt-a').closest('[aria-label]')).toHaveStyle({ opacity: '1' }))
+    // The instruction never reached the agent, so the local mark is dropped and
+    // the option comes back clickable instead of sitting on a false "sending…".
+    await waitFor(() => expect(screen.getByText('zz-opt-a')).toBeInTheDocument())
+    expect(screen.queryByText('sending…')).not.toBeInTheDocument()
+    expect(screen.getByText('pending')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('zz-opt-a'))
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it('the server answer wins over the local sending mark', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined)
+    const { rerender } = render(
+      <SpecStatePanel
+        detail={detail({ state: { decisions: [{ id: 'd1', title: 'zz-one', options: ['zz-opt-a', 'zz-opt-b'] }] } })}
+        sendMessage={sendMessage}
+      />,
+    )
+    fireEvent.click(screen.getByText('zz-opt-a'))
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1))
+    rerender(
+      <SpecStatePanel
+        detail={detail({ state: { decisions: [{ id: 'd1', title: 'zz-one', options: ['zz-opt-a', 'zz-opt-b'], answer: 'zz-opt-b' }] } })}
+        sendMessage={sendMessage}
+      />,
+    )
+    expect(screen.getByText('answered')).toBeInTheDocument()
+    expect(screen.getByText('→ zz-opt-b')).toBeInTheDocument()
+  })
+
+  it('an id that comes back carrying a different question is open again', async () => {
+    // The agent rewrites .spec-state.json wholesale, so the same id can return
+    // with a new question; the local mark is keyed on id+title and must not
+    // claim the new question was already answered.
+    const sendMessage = vi.fn().mockResolvedValue(undefined)
+    const { rerender } = render(
+      <SpecStatePanel
+        detail={detail({ state: { decisions: [{ id: 'd1', title: 'zz-one', options: ['zz-opt-a'] }] } })}
+        sendMessage={sendMessage}
+      />,
+    )
+    fireEvent.click(screen.getByText('zz-opt-a'))
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1))
+    rerender(
+      <SpecStatePanel
+        detail={detail({ state: { decisions: [{ id: 'd1', title: 'zz-other-question', options: ['zz-opt-z'] }] } })}
+        sendMessage={sendMessage}
+      />,
+    )
+    expect(screen.getByText('pending')).toBeInTheDocument()
+    expect(screen.getByText('zz-opt-z')).toBeInTheDocument()
   })
 
   it('surfaces a blocking note on its own', () => {


### PR DESCRIPTION
## Problem

`main` CI is red: three test files fail deterministically, taking Frontend Tests shards 1–2, Coverage Merge, and Coverage Gate down with them. Every open PR inherits the failures through the merge ref.

- `website/src/components/LinkedSurfacesSection.cov80.test.tsx` — 29/33 fail (`Unable to find ... components.slackLinkSection.unlink_from_slack`)
- `website/src/components/InboundLinkChip.cov80.test.tsx` — 2 fail (same removed API)
- `website/src/test/SpecBuilderSpecStatePanelCov80.test.tsx` — 5 fail (`Unable to find ... zz-opt-b`)

All three reproduced failing at pristine `origin/main` (`659cab000`) in a clean worktree.

## Why it matters

Nothing can pass CI against the current base — fork PRs and same-repo branches alike show red frontend shards on code they never touched.

## Fix (symptoms → root cause → change)

PR #3476 (`ca66a1233`) added 188 coverage-floor test files in one batch; three were authored against components that sibling PRs rewrote minutes before the batch merged, and the combination never ran CI together:

- #3006 (`3e07eff83`, merged 00:18) rewrote `LinkedSurfacesSection.tsx` and `InboundLinkChip.tsx` to the per-channel connect/disconnect row model — the old `slackLinkSection.*` menu items and their i18n keys no longer exist, so the tests' `i18nT(...)` calls render raw keys.
- #3402 (`a9c802b8f`) changed the Spec Builder decision tray's rendering, breaking the panel test's option-row expectations.
- #3476 (`ca66a1233`, merged 00:23) added the three test files written against the pre-rewrite components.

The test files are the only artifacts asserting the removed APIs, so the fix rewrites them against the shipped components. Kept scenarios re-expressed where equivalents exist (link/unlink → connect/disconnect flows, failure paths keeping state, in-flight answer blocking); dropped scenarios whose UI is gone (reminder posting, confirm-based mirror release); added coverage for the new models (per-row in-flight guards, 409 `conversation_occupied` discrimination, label fallbacks, the wire-trust rule, immediate-approval rendering).

## Tests

- `LinkedSurfacesSection.cov80.test.tsx`: 29/29 pass (was 4/33), 100% lines / 97.18% branches on the component
- `InboundLinkChip.cov80.test.tsx`: 7/7 pass, 100% lines on the component
- `SpecBuilderSpecStatePanelCov80.test.tsx`: 13/13 pass, 100% lines on the panel
- Full frontend suite at this base: **1222 files, 19,851 tests, 0 failures** — no other file from the #3476 batch is broken
- `tsc -b` clean

## Manual verification

N/A — test-only change; no component code touched.

## Screenshots

N/A — no user-visible UI change.
