### PR TITLE
fix(cloud): install voice dependencies during provisioning

### DIFF
--- a/cloud-install.sh
+++ b/cloud-install.sh
@@ -11,7 +11,7 @@
 #  the Python `kiro_crew.cloud` module (testable, cross-platform). It NEVER
 #  stores AWS credentials — the aws CLI resolves them from your profile/SSO.
 #
-#  Usage (from a clone):   bash cloud-install.sh [--size <tier>] [--non-interactive]
+#  Usage (from a clone):   bash cloud-install.sh [--size <tier>] [--non-interactive] [--voice]
 # ======================================================================
 set -euo pipefail
 
@@ -24,6 +24,7 @@ unset PYTHONPATH PYTHONHOME
 
 SIZE=""
 NONINTERACTIVE=0
+WITH_VOICE=0
 # while+shift (not `for arg in "$@"`): the space-separated `--size <tier>`
 # form needs to consume the following word, which a for-loop can't do.
 while [ $# -gt 0 ]; do
@@ -31,6 +32,7 @@ while [ $# -gt 0 ]; do
         --size) shift; SIZE="${1:-}";;
         --size=*) SIZE="${1#*=}";;
         --non-interactive) NONINTERACTIVE=1;;
+        --voice) WITH_VOICE=1;;
         *) ;;
     esac
     shift || true
@@ -151,7 +153,12 @@ info "Installing the KiroCrew client (pip, editable)…"
 _venv="$REPO_ROOT/.venv"
 [ -x "$_venv/bin/python" ] || "$PY" -m venv "$_venv"
 "$_venv/bin/pip" install --upgrade pip -q 2>/dev/null || true
-KIROCREW_SKIP_FRONTEND=1 "$_venv/bin/pip" install -e "$REPO_ROOT" -q && ok "KiroCrew client installed" || { warn "pip install failed"; exit 1; }
+_pip_target="$REPO_ROOT"
+if [ "$WITH_VOICE" -eq 1 ]; then
+    _pip_target="${REPO_ROOT}[voice]"
+    info "Including voice extras (.[voice])"
+fi
+KIROCREW_SKIP_FRONTEND=1 "$_venv/bin/pip" install -e "$_pip_target" -q && ok "Kiro Crew client installed" || { warn "pip install failed"; exit 1; }
 mkdir -p "$HOME/.local/bin"
 ln -sf "$_venv/bin/kirocrew" "$HOME/.local/bin/kirocrew"
 KC="$_venv/bin/kirocrew"

--- a/docs/system-specs/modules/cloud.md
+++ b/docs/system-specs/modules/cloud.md
@@ -87,6 +87,11 @@ rollback, one-command `delete-stack` teardown. AMI resolves from the public
 failed bootstrap folds the on-box setup-log tail into the signal reason so the
 cause survives the rollback.
 
+The instance bootstrap runs `install.sh --voice` on both its initial attempt and
+retry. This installs the existing `voice` extra (`boto3` and
+`amazon-transcribe`) before the gateway first imports its Transcribe provider;
+installing those SDKs after startup would otherwise require a gateway restart.
+
 Because the public repo is private, the box can't `git clone` it: the launcher
 packages the local checkout and uploads it to a launcher-owned bucket
 (`kirocrew-src-<account>-<region>`); the instance downloads it with its own IAM
@@ -366,6 +371,9 @@ exits non-zero.
 `aws` CLI + `session-manager-plugin` + Python are present, then hand off to
 `kirocrew cloud launch`. They install *client* prerequisites only — the gateway
 always runs on the Linux EC2 box, never on Windows.
+`cloud-install.sh --voice` additionally installs the existing `voice` extra in
+the launcher's managed client venv; the EC2 bootstrap includes that extra by
+default regardless of this client-side flag.
 
 `kirocrew cloud launch` runs `python -m kiro_crew`, which imports the whole CLI —
 including gateway/cron/session modules (plus `apps/bridges` and the PTY

--- a/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
+++ b/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
@@ -535,10 +535,10 @@ Resources:
           export KIROCREW_REQUIRE_FRONTEND=1
           # One retry: first-boot contention can signal-kill the first build;
           # the warm re-run reliably succeeds (see "Source fetch" above).
-          if ! bash install.sh; then
+          if ! bash install.sh --voice; then
             echo "install.sh failed on first attempt - settling then retrying once"
             sleep 20
-            bash install.sh
+            bash install.sh --voice
           fi
           KCFETCH
           chmod +x /tmp/kcfetch.sh

--- a/test/test_cloud_ec2.py
+++ b/test/test_cloud_ec2.py
@@ -260,6 +260,12 @@ class TestTemplate:
         text = ec2.load_template()
         assert "KIROCREW_REQUIRE_FRONTEND=1" in text
 
+    def test_bootstrap_installs_voice_extra_before_gateway_boot(self):
+        # Remote instances need the Transcribe SDK in their venv before the
+        # gateway imports boto3. Keep both the first attempt and retry aligned.
+        text = ec2.load_template()
+        assert text.count("bash install.sh --voice") == 2
+
     def test_instance_enforces_imdsv2(self):
         text = ec2.load_template()
         assert "MetadataOptions" in text

--- a/test/test_cloud_install.py
+++ b/test/test_cloud_install.py
@@ -1,0 +1,14 @@
+"""Contract tests for the macOS/Linux cloud launcher bootstrap."""
+
+from pathlib import Path
+
+CLOUD_INSTALL_SH = Path(__file__).resolve().parents[1] / "cloud-install.sh"
+
+
+def test_voice_flag_selects_extra() -> None:
+    """``--voice`` must flow through to the editable pip target."""
+    script = CLOUD_INSTALL_SH.read_text()
+
+    assert "--voice) WITH_VOICE=1;;" in script
+    assert '_pip_target="${REPO_ROOT}[voice]"' in script
+    assert 'pip" install -e "$_pip_target"' in script


### PR DESCRIPTION
## Problem / Motivation

Remote instances provisioned through the app UI install only the base Python
package. AWS Transcribe therefore reports "Not installed" because the gateway
venv lacks `boto3` and `amazon-transcribe`.

The EC2 bootstrap called `install.sh` without its existing `--voice` flag.
Installing the SDKs after startup is also insufficient until restart because
the Transcribe module resolves `boto3` at import time.

## Why it matters

Whisper is impractical on the smaller CPU-only remote tiers, so Transcribe is
the useful voice provider there. Provisioned crews should have that supported
provider available on their first gateway boot.

## What changed (motivation → approach → change)

- pass `--voice` to both the initial EC2 install attempt and its retry
- add a matching `cloud-install.sh --voice` path that selects the existing
  editable `[voice]` extra
- document the remote bootstrap and client-side flag contracts
- add regression coverage for both EC2 install attempts and the launcher
  flag-to-pip wiring

This reuses the existing optional extra; it does not add or widen dependency
versions.

## Tests

- fail-before: both new regression nodes failed against the original wiring
- `pytest -q test/test_cloud_install.py test/test_cloud_ec2.py` — 91 passed
- `bash -n cloud-install.sh` and `bash -n install.sh`
- Black, isort, and Flake8 on the changed Python test surface
- `python scripts/docs_lint.py`
- brand-name diff gate
- `git diff --check`

## Manual verification

N/A — no live AWS resources were provisioned; the CloudFormation template,
expanded UserData size, and shell argument wiring are covered by focused
contract tests.

## Related Issues

Fixes #3560

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template does not yet provide contributor CLA wording.
