### PR TITLE
fix(instances): make token mint timeout user-configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **The instance token-mint timeout is now user-configurable.** The remote
+  `kirocrew token` mint ran with a hardcoded 30s budget, so a user behind a
+  slow ProxyCommand/jump host timed out in the mint step even when the ssh
+  forward itself came up (the connect flow spawns two proxy-bound ssh
+  children, and the mint is the second one). A new
+  `instances.mint_timeout_secs` (unset by default: SSH 30s, SSM 90s; clamped
+  to [10, 120]) now threads through the tunnel manager to both the SSH and
+  SSM mint paths; an explicit value applies to both transports, including a
+  value equal to either transport's default. (#3566)
+
 - **A Teams answer no longer gets silently truncated by a rate-limited
   chunk.** The Bot Framework Connector API enforces per-bot rate limits and
   can return HTTP 429, but the Teams outbound send raised immediately with

--- a/config-baseline.json
+++ b/config-baseline.json
@@ -2537,6 +2537,7 @@
         "warm_set_cap": 5,
         "tunnel_base_port": 7778,
         "ssh_compression": true,
+        "mint_timeout_secs": null,
         "max_recovery_attempts": 8,
         "recover_backoff_max_secs": 30.0,
         "probe_failure_threshold": 3
@@ -2597,6 +2598,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": true
+    },
+    {
+      "path": "instances.mint_timeout_secs",
+      "kind": "core",
+      "type": "number",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Mint Timeout (secs)",
+      "help": "How long to wait for the remote `kirocrew token` mint to return before failing a connect. When unset, SSH uses 30s and SSM uses 90s (its dispatch latency is higher). The mint runs over the same ssh transport as the tunnel, so a host behind a ProxyCommand or jump host pays the proxy handshake here too. An explicit value applies to both transports, so size it for the slowest transport you use. Clamped to [10, 120].",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": null
     },
     {
       "path": "instances.max_recovery_attempts",

--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -234,6 +234,7 @@ cannot drift.
 | `instances.tunnel_base_port` | `7778` | First local loopback port the allocator hands out. Out-of-range values fall back to the default. |
 | `instances.ssh_compression` | `true` | Add `-C` to the tunnel argv. See §5.2. |
 | `instances.connect_timeout_secs` | unset (SSH `15.0`, SSM `25.0`) | How long (secs) to wait for the local forward port to accept connections before declaring a connect attempt failed. Hosts behind a ProxyCommand or jump host need longer (the proxy handshake runs before ssh begins the forward). An explicit value applies to both transports, including a value equal to either transport's default. Values below 1 fall back to the transport defaults; values above 120 are clamped to 120. |
+| `instances.mint_timeout_secs` | unset (SSH `30.0`, SSM `90.0`) | How long (secs) to wait for the remote `kirocrew token` mint before failing a connect. The mint rides the same ssh transport as the tunnel, so a host behind a ProxyCommand or jump host pays the proxy handshake here too (the connect flow spawns two proxy-bound ssh children: `connect_timeout_secs` budgets the first, this budgets the second). An explicit value applies to both transports, including a value equal to either transport's default — size it for the slowest transport in use. Values below 10 fall back to the transport defaults; values above 120 are clamped with a warning. |
 | `instances.max_recovery_attempts` | `8` | Consecutive self-heal attempts before the tunnel is left disconnected. Below 1 falls back to the default; above `MAX_RECOVERY_ATTEMPTS_CEILING` (100) is clamped with a warning, so a pathological setting cannot turn bounded self-heal into a near-infinite retry loop. |
 | `instances.recover_backoff_max_secs` | `30.0` | Cap on the per-attempt backoff. Non-positive falls back to the default; above `RECOVER_BACKOFF_MAX_CEILING_SECS` (300) is clamped, bounding the worst-case wall-clock recovery window. |
 | `instances.probe_failure_threshold` | `3` | Consecutive health-probe failures before a non-forwarding tunnel is torn down. Below 1 falls back to the default. |
@@ -242,11 +243,11 @@ cannot drift.
 kirocrew config set instances.warm_set_cap 3
 kirocrew config set instances.ssh_compression false
 kirocrew config set instances.connect_timeout_secs 45
+kirocrew config set instances.mint_timeout_secs 60
 ```
 
 Constants that are **not** user-configurable: the probe interval (30s), the token
-refresh fraction (0.8), the stored-token probe timeout (2s), and the mint
-timeout (30s).
+refresh fraction (0.8), and the stored-token probe timeout (2s).
 
 ### 5.2 `instances.ssh_compression`
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -101,12 +101,15 @@ from kiro_crew.effort import EFFORT_LEVELS, is_valid_effort, model_supports_effo
 from kiro_crew.instances.constants import CONNECT_TIMEOUT_CEILING_SECS as _CONNECT_TIMEOUT_CEILING
 from kiro_crew.instances.constants import DEFAULT_CONNECT_TIMEOUT_SECS as _DEFAULT_CONNECT_TIMEOUT
 from kiro_crew.instances.constants import DEFAULT_MAX_RECOVERY_ATTEMPTS as _DEFAULT_MAX_RECOVERY
+from kiro_crew.instances.constants import DEFAULT_MINT_TIMEOUT_SECS as _DEFAULT_MINT_TIMEOUT
 from kiro_crew.instances.constants import DEFAULT_PROBE_FAILURE_THRESHOLD as _DEFAULT_PROBE_FAILS
 from kiro_crew.instances.constants import DEFAULT_RECOVER_BACKOFF_MAX_SECS as _DEFAULT_BACKOFF_MAX
 from kiro_crew.instances.constants import DEFAULT_SSH_COMPRESSION as _DEFAULT_SSH_COMPRESSION
 from kiro_crew.instances.constants import DEFAULT_TUNNEL_BASE_PORT as _DEFAULT_TUNNEL_BASE_PORT
 from kiro_crew.instances.constants import DEFAULT_WARM_SET_CAP as _DEFAULT_WARM_SET_CAP
 from kiro_crew.instances.constants import MAX_RECOVERY_ATTEMPTS_CEILING as _MAX_RECOVERY_CEILING
+from kiro_crew.instances.constants import MINT_TIMEOUT_CEILING_SECS as _MINT_TIMEOUT_CEILING
+from kiro_crew.instances.constants import MINT_TIMEOUT_FLOOR_SECS as _MINT_TIMEOUT_FLOOR
 from kiro_crew.instances.constants import (
     RECOVER_BACKOFF_MAX_CEILING_SECS as _RECOVER_BACKOFF_CEILING,
 )
@@ -4349,6 +4352,19 @@ class InstancesConfig:
             "An explicit value applies to both transports. Clamped to [1, 120].",
         ),
     )
+    mint_timeout_secs: float | None = field(
+        default=None,
+        metadata=_meta(
+            "Mint Timeout (secs)",
+            "How long to wait for the remote `kirocrew token` mint to return "
+            "before failing a connect. When unset, SSH uses 30s and SSM uses "
+            "90s (its dispatch latency is higher). The mint runs over the same "
+            "ssh transport as the tunnel, so a host behind a ProxyCommand or "
+            "jump host pays the proxy handshake here too. An explicit value "
+            "applies to both transports, so size it for the slowest transport "
+            "you use. Clamped to [10, 120].",
+        ),
+    )
     max_recovery_attempts: int = field(
         default=_DEFAULT_MAX_RECOVERY,
         metadata=_meta(
@@ -4405,6 +4421,24 @@ class InstancesConfig:
                 _CONNECT_TIMEOUT_CEILING,
             )
             object.__setattr__(self, "connect_timeout_secs", _CONNECT_TIMEOUT_CEILING)
+        if self.mint_timeout_secs is not None and self.mint_timeout_secs < _MINT_TIMEOUT_FLOOR:
+            logger.warning(
+                "instances.mint_timeout_secs %s < %s, using the transport default",
+                self.mint_timeout_secs,
+                _MINT_TIMEOUT_FLOOR,
+            )
+            object.__setattr__(self, "mint_timeout_secs", None)
+        elif (
+            self.mint_timeout_secs is not None
+            and self.mint_timeout_secs > _MINT_TIMEOUT_CEILING
+        ):
+            logger.warning(
+                "instances.mint_timeout_secs %s > %s, clamping to %s",
+                self.mint_timeout_secs,
+                _MINT_TIMEOUT_CEILING,
+                _MINT_TIMEOUT_CEILING,
+            )
+            object.__setattr__(self, "mint_timeout_secs", _MINT_TIMEOUT_CEILING)
         if self.max_recovery_attempts < 1:
             logger.warning(
                 "instances.max_recovery_attempts %d < 1, using %d",
@@ -5708,6 +5742,7 @@ class KiroCrewConfig:
         if not isinstance(instances_data, dict):
             instances_data = {}
         connect_timeout_raw = instances_data.get("connect_timeout_secs")
+        mint_timeout_raw = instances_data.get("mint_timeout_secs")
         mcp_gateway_data = data.get("mcp_gateway", {})
         if not isinstance(mcp_gateway_data, dict):
             mcp_gateway_data = {}
@@ -6459,6 +6494,11 @@ class KiroCrewConfig:
                 connect_timeout_secs=(
                     _safe_float(connect_timeout_raw, _DEFAULT_CONNECT_TIMEOUT)
                     if connect_timeout_raw is not None
+                    else None
+                ),
+                mint_timeout_secs=(
+                    _safe_float(mint_timeout_raw, _DEFAULT_MINT_TIMEOUT)
+                    if mint_timeout_raw is not None
                     else None
                 ),
                 max_recovery_attempts=_safe_int(

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1744,6 +1744,7 @@ def _register_instances_hooks(app: web.Application, state: DashboardState, port:
             base_port=_cfg.instances.tunnel_base_port,
             connect_timeout_secs=_cfg.instances.connect_timeout_secs,
             ssh_compression=_cfg.instances.ssh_compression,
+            mint_timeout_secs=_cfg.instances.mint_timeout_secs,
             max_recovery_attempts=_cfg.instances.max_recovery_attempts,
             recover_backoff_max_secs=_cfg.instances.recover_backoff_max_secs,
             probe_failure_threshold=_cfg.instances.probe_failure_threshold,

--- a/src/kiro_crew/instances/constants.py
+++ b/src/kiro_crew/instances/constants.py
@@ -88,6 +88,31 @@ DEFAULT_SSM_CONNECT_TIMEOUT_SECS: float = 25.0
 # generous enough for any realistic proxy chain while still bounding the wait.
 CONNECT_TIMEOUT_CEILING_SECS: float = 120.0
 
+# How long (secs) to wait for the remote `kirocrew token` to return before
+# giving up on a mint attempt. The mint runs over the same ssh transport as the
+# tunnel itself, so a host behind a ProxyCommand or jump host pays the proxy
+# handshake again here (the connect flow spawns two proxy-bound ssh children;
+# ``connect_timeout_secs`` above budgets the first, this budgets the second —
+# an operator who raised one typically needs to raise both). Exposed as a
+# user-tunable via ``kirocrew config set instances.mint_timeout_secs <value>``.
+DEFAULT_MINT_TIMEOUT_SECS: float = 30.0
+
+# The SSM mint dispatches ``aws ssm send-command`` and polls
+# ``get-command-invocation``: send-command has its own dispatch latency (agent
+# poll interval) on top of the remote command's runtime, so its default is
+# higher than the direct-ssh mint's. When the user supplies an explicit
+# (non-None) ``mint_timeout_secs`` override, it wins for both transports.
+DEFAULT_SSM_MINT_TIMEOUT_SECS: float = 90.0
+
+# Bounds on a user-configured instances.mint_timeout_secs. Below the floor
+# falls back to the default (a mint that can't finish in under 10s of budget
+# would fail every realistic proxy chain anyway, so a tiny value is a
+# misconfiguration, not a tuning choice); above the ceiling is clamped down
+# (with a warning) so a pathological value can't make a failed mint hang the
+# connect flow indefinitely.
+MINT_TIMEOUT_FLOOR_SECS: float = 10.0
+MINT_TIMEOUT_CEILING_SECS: float = 120.0
+
 # Proactively re-mint each instance's dashboard token at this fraction of its
 # TTL, before the 20h cap. 0.8 = refresh at 80% elapsed.
 DEFAULT_TOKEN_REFRESH_FRACTION: float = 0.8

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -69,6 +69,7 @@ from kiro_crew.instances.constants import (
     DEFAULT_CONNECT_TIMEOUT_SECS as _DEFAULT_CONNECT_TIMEOUT_SECS,
 )
 from kiro_crew.instances.constants import DEFAULT_MAX_RECOVERY_ATTEMPTS as _MAX_RECOVERY
+from kiro_crew.instances.constants import DEFAULT_MINT_TIMEOUT_SECS as _DEFAULT_MINT_TIMEOUT_SECS
 from kiro_crew.instances.constants import DEFAULT_PROBE_FAILURE_THRESHOLD as _PROBE_FAILS
 from kiro_crew.instances.constants import DEFAULT_PROBE_INTERVAL_SECS as _PROBE_INTERVAL
 from kiro_crew.instances.constants import (
@@ -77,6 +78,9 @@ from kiro_crew.instances.constants import (
 from kiro_crew.instances.constants import DEFAULT_SESSION_TRANSFER_TIMEOUT_SECS as _TRANSFER_TIMEOUT
 from kiro_crew.instances.constants import (
     DEFAULT_SSM_CONNECT_TIMEOUT_SECS as _DEFAULT_SSM_CONNECT_TIMEOUT_SECS,
+)
+from kiro_crew.instances.constants import (
+    DEFAULT_SSM_MINT_TIMEOUT_SECS as _DEFAULT_SSM_MINT_TIMEOUT_SECS,
 )
 from kiro_crew.instances.constants import DEFAULT_TOKEN_PROBE_TIMEOUT_SECS as _TOKEN_PROBE_TIMEOUT
 from kiro_crew.instances.constants import DEFAULT_TOKEN_REFRESH_FRACTION as _REFRESH_FRACTION
@@ -763,6 +767,7 @@ class SshTunnelManager:
         max_recovery_attempts: int = _MAX_RECOVERY,
         recover_backoff_max_secs: float = _RECOVER_BACKOFF_MAX_SECS,
         probe_failure_threshold: int = _PROBE_FAILS,
+        mint_timeout_secs: float | None = None,
         mint_token: Callable[..., Awaitable[str]] = mint_remote_token,
         tunnel_factory: Callable[..., _SshTunnel] | None = None,
         parent_port: int | None = None,
@@ -790,6 +795,7 @@ class SshTunnelManager:
         self._max_recovery = max_recovery_attempts
         self._recover_backoff_max = recover_backoff_max_secs
         self._probe_fails = probe_failure_threshold
+        self._mint_timeout = mint_timeout_secs
         self._mint_token = mint_token
         self._tunnel_factory = tunnel_factory or _SshTunnel
         # Only the real ssh path reaps OS-level orphans; injected fakes (tests)
@@ -888,6 +894,22 @@ class SshTunnelManager:
         if method == "ssm":
             return _DEFAULT_SSM_CONNECT_TIMEOUT_SECS
         return _DEFAULT_CONNECT_TIMEOUT_SECS
+
+    def _mint_timeout_for(self, method: str) -> float:
+        """Token-mint timeout for *method*, honoring an explicit override.
+
+        Mirrors :meth:`_connect_timeout_for`: the SSM mint dispatches
+        ``aws ssm send-command`` and polls ``get-command-invocation``, whose
+        dispatch latency (agent poll interval) makes its default higher. A
+        caller that passed an explicit ``mint_timeout_secs`` (config, tests)
+        wins for both transports — including a value equal to either
+        transport's default.
+        """
+        if self._mint_timeout is not None:
+            return self._mint_timeout  # explicit override
+        if method == "ssm":
+            return _DEFAULT_SSM_MINT_TIMEOUT_SECS
+        return _DEFAULT_MINT_TIMEOUT_SECS
 
     async def _ps_lines(self) -> list[str]:
         """Return ``<pid> <command>`` lines for all processes (portable ps).
@@ -992,6 +1014,7 @@ class SshTunnelManager:
                 ttl=inst.ttl,
                 remote_port=inst.remote_port,
                 embed_parent_port=self._parent_port,
+                timeout_secs=self._mint_timeout_for(params.method),
             )
         return await self._mint_token(
             params.ssh_host,
@@ -999,6 +1022,7 @@ class SshTunnelManager:
             ttl=inst.ttl,
             remote_port=inst.remote_port,
             embed_parent_port=self._parent_port,
+            timeout_secs=self._mint_timeout_for(params.method),
         )
 
     async def connect(self, instance_id: str) -> TunnelStatus:

--- a/src/kiro_crew/instances/ssm_token_mint.py
+++ b/src/kiro_crew/instances/ssm_token_mint.py
@@ -32,7 +32,7 @@ import logging
 import re
 
 from kiro_crew.cloud import ssm as cloud_ssm
-from kiro_crew.instances.constants import TTL_PATTERN
+from kiro_crew.instances.constants import DEFAULT_SSM_MINT_TIMEOUT_SECS, TTL_PATTERN
 from kiro_crew.instances.token_mint import (
     TokenMintError,
     build_remote_command,
@@ -51,8 +51,10 @@ logger = logging.getLogger(__name__)
 
 # How long to wait for the SSM send-command invocation to finish. Generous vs.
 # the SSH transport's 30s timeout: send-command has its own dispatch latency
-# (agent poll interval) on top of the remote command's own runtime.
-_DEFAULT_MINT_TIMEOUT_SECS = 90
+# (agent poll interval) on top of the remote command's own runtime. Canonical
+# default lives in instances.constants; an explicit user override of
+# ``instances.mint_timeout_secs`` wins for both transports.
+_DEFAULT_MINT_TIMEOUT_SECS = DEFAULT_SSM_MINT_TIMEOUT_SECS
 
 # Same ttl shape token_mint.py accepts (kept local rather than importing a
 # "private" helper cross-module — see module docstring).

--- a/src/kiro_crew/instances/token_mint.py
+++ b/src/kiro_crew/instances/token_mint.py
@@ -25,7 +25,7 @@ import logging
 import re
 
 from kiro_crew.config.paths import CONFIG_DIR_NAME, LEGACY_CONFIG_DIR_NAME
-from kiro_crew.instances.constants import TTL_PATTERN
+from kiro_crew.instances.constants import DEFAULT_MINT_TIMEOUT_SECS, TTL_PATTERN
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,9 @@ _CLIPPED_RUN_RE = re.compile(r"^[A-Za-z0-9_\-.=+/%%:?&]{%d,}" % _CLIPPED_RUN_MIN
 _CLIPPED_MARKER = "<clipped>"
 
 # How long to wait for the remote `kirocrew token` to return before giving up.
-_DEFAULT_MINT_TIMEOUT_SECS = 30.0
+# Canonical default lives in instances.constants (user-tunable via
+# ``instances.mint_timeout_secs``); aliased here for the local call sites.
+_DEFAULT_MINT_TIMEOUT_SECS = DEFAULT_MINT_TIMEOUT_SECS
 
 
 class TokenMintError(Exception):
@@ -322,19 +324,24 @@ def build_remote_token_command(
     )
 
 
-def _build_ssh_argv(ssh_host: str, remote_command: str) -> list[str]:
+def _build_ssh_argv(
+    ssh_host: str, remote_command: str, *, connect_timeout_secs: float = 10.0
+) -> list[str]:
     """Build the local ``ssh`` argv (no local shell) to run *remote_command*.
 
     ``BatchMode=yes`` fails fast instead of hanging on an interactive password
-    prompt; ``ConnectTimeout`` bounds the TCP connect. ``ssh_host`` is validated
-    by the caller (registry / tunnel manager) before reaching here.
+    prompt; ``ConnectTimeout`` bounds the TCP connect (and, on OpenSSH >= 8.6,
+    the banner/KEX exchange — which is where a slow ProxyCommand spends its
+    time, so the mint passes its own configurable budget here instead of the
+    10s fail-fast default). ``ssh_host`` is validated by the caller
+    (registry / tunnel manager) before reaching here.
     """
     return [
         "ssh",
         "-o",
         "BatchMode=yes",
         "-o",
-        "ConnectTimeout=10",
+        f"ConnectTimeout={max(1, round(connect_timeout_secs))}",
         "-o",
         "AddressFamily=inet",
         ssh_host,
@@ -416,7 +423,7 @@ async def mint_remote_token(
     remote_command = build_remote_token_command(
         remote_bin, ttl=ttl, port=remote_port, embed_parent_port=embed_parent_port
     )
-    argv = _build_ssh_argv(ssh_host, remote_command)
+    argv = _build_ssh_argv(ssh_host, remote_command, connect_timeout_secs=timeout_secs)
     logger.info("Minting token on %s (ttl=%s)", ssh_host, ttl)  # no token in logs
 
     try:

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -33,6 +33,7 @@ class TestConfig:
         from kiro_crew.config.loader import InstancesConfig
         from kiro_crew.instances.constants import (
             DEFAULT_CONNECT_TIMEOUT_SECS,
+            DEFAULT_MINT_TIMEOUT_SECS,
             DEFAULT_TUNNEL_BASE_PORT,
             DEFAULT_WARM_SET_CAP,
         )
@@ -43,6 +44,8 @@ class TestConfig:
         assert c.tunnel_base_port == DEFAULT_TUNNEL_BASE_PORT == 7778
         assert DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
         assert c.connect_timeout_secs is None
+        assert DEFAULT_MINT_TIMEOUT_SECS == 30.0
+        assert c.mint_timeout_secs is None
 
     def test_clamps_out_of_range(self):
         from kiro_crew.config.loader import InstancesConfig
@@ -62,6 +65,7 @@ class TestConfig:
             "tunnel_base_port": 7778,
             "ssh_compression": True,
             "connect_timeout_secs": None,
+            "mint_timeout_secs": None,
             "max_recovery_attempts": 8,
             "recover_backoff_max_secs": 30.0,
             "probe_failure_threshold": 3,
@@ -74,6 +78,7 @@ class TestConfig:
             "instances.tunnel_base_port",
             "instances.ssh_compression",
             "instances.connect_timeout_secs",
+            "instances.mint_timeout_secs",
             "instances.max_recovery_attempts",
             "instances.recover_backoff_max_secs",
             "instances.probe_failure_threshold",
@@ -213,6 +218,69 @@ class TestConfig:
         cfg_file.write_text(json.dumps({"instances": {"connect_timeout_secs": 15.0}}))
         cfg = KiroCrewConfig.load()
         assert cfg.instances.connect_timeout_secs == 15.0
+
+    def test_mint_timeout_default_and_clamps(self):
+        from kiro_crew.config.loader import InstancesConfig
+        from kiro_crew.instances.constants import (
+            DEFAULT_MINT_TIMEOUT_SECS,
+            MINT_TIMEOUT_CEILING_SECS,
+            MINT_TIMEOUT_FLOOR_SECS,
+        )
+
+        # Unset by default; the per-transport defaults live in constants.
+        c = InstancesConfig()
+        assert c.mint_timeout_secs is None
+        assert DEFAULT_MINT_TIMEOUT_SECS == 30.0
+
+        # Explicit override is honored — including the SSH-default value.
+        c = InstancesConfig(mint_timeout_secs=60.0)
+        assert c.mint_timeout_secs == 60.0
+        c = InstancesConfig(mint_timeout_secs=DEFAULT_MINT_TIMEOUT_SECS)
+        assert c.mint_timeout_secs == DEFAULT_MINT_TIMEOUT_SECS
+
+        # Below the floor falls back to unset (transport defaults).
+        assert MINT_TIMEOUT_FLOOR_SECS == 10.0
+        c = InstancesConfig(mint_timeout_secs=5.0)
+        assert c.mint_timeout_secs is None
+
+        c = InstancesConfig(mint_timeout_secs=-30.0)
+        assert c.mint_timeout_secs is None
+
+        # The floor value itself is left untouched.
+        c = InstancesConfig(mint_timeout_secs=MINT_TIMEOUT_FLOOR_SECS)
+        assert c.mint_timeout_secs == MINT_TIMEOUT_FLOOR_SECS
+
+        # Above the ceiling is clamped.
+        assert MINT_TIMEOUT_CEILING_SECS == 120.0
+        c = InstancesConfig(mint_timeout_secs=999.0)
+        assert c.mint_timeout_secs == MINT_TIMEOUT_CEILING_SECS
+
+        # Boundary value itself is left untouched.
+        c = InstancesConfig(mint_timeout_secs=MINT_TIMEOUT_CEILING_SECS)
+        assert c.mint_timeout_secs == MINT_TIMEOUT_CEILING_SECS
+
+    def test_mint_timeout_parses_from_config_file(self, tmp_path, monkeypatch):
+        import json
+
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({"instances": {"mint_timeout_secs": 60.0}}))
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg_file)
+        cfg = KiroCrewConfig.load()
+        assert cfg.instances.mint_timeout_secs == 60.0
+
+        cfg_file.write_text(json.dumps({"instances": {}}))
+        cfg = KiroCrewConfig.load()
+        assert cfg.instances.mint_timeout_secs is None
+
+        cfg_file.write_text(json.dumps({"instances": {"mint_timeout_secs": None}}))
+        cfg = KiroCrewConfig.load()
+        assert cfg.instances.mint_timeout_secs is None
+
+        cfg_file.write_text(json.dumps({"instances": {"mint_timeout_secs": 30.0}}))
+        cfg = KiroCrewConfig.load()
+        assert cfg.instances.mint_timeout_secs == 30.0
 
 
 # ── PortAllocator ───────────────────────────────────────────────────────────
@@ -376,6 +444,18 @@ class TestTokenMint:
         argv = _build_ssh_argv("cd-1", "echo hi")
         assert argv[0] == "ssh" and argv[-2] == "cd-1"
         assert "BatchMode=yes" in argv and "AddressFamily=inet" in argv
+        # Default fail-fast connect bound is preserved for callers that
+        # don't thread a budget (e.g. run_remote_kirocrew).
+        assert "ConnectTimeout=10" in argv
+        # The mint threads its configurable budget into ConnectTimeout so a
+        # slow ProxyCommand/banner exchange isn't killed at the 10s default
+        # before mint_timeout_secs can matter (OpenSSH >= 8.6 counts the
+        # banner/KEX exchange against ConnectTimeout).
+        argv = _build_ssh_argv("cd-1", "echo hi", connect_timeout_secs=60.0)
+        assert "ConnectTimeout=60" in argv and "ConnectTimeout=10" not in argv
+        # Sub-second values clamp up to ssh's integer floor of 1.
+        argv = _build_ssh_argv("cd-1", "echo hi", connect_timeout_secs=0.2)
+        assert "ConnectTimeout=1" in argv
 
     def test_mint_success_and_no_token_in_logs(self, monkeypatch, caplog):
         from kiro_crew.instances import token_mint as tm
@@ -1033,7 +1113,7 @@ class TestSshTunnelArgvCompression:
             return _FakeTunnel(*a, compression=compression, **k)
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             return "SECRET_TOK"
 
@@ -1231,7 +1311,7 @@ class TestSshTunnelManager:
         reg = InstancesRegistry(path=tmp_path / "instances.json")
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             return "SECRET_TOK"
 
@@ -1300,7 +1380,7 @@ class TestSshTunnelManager:
         from kiro_crew.instances.token_mint import TokenMintError
 
         async def bad_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             raise TokenMintError("nope")
 
@@ -2907,7 +2987,7 @@ class TestSelfHealRefreshRestart:
         reg = InstancesRegistry(path=tmp_path / "instances.json")
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             return "TOK"
 
@@ -3156,7 +3236,7 @@ class TestSelfHealRefreshRestart:
         release = asyncio.Event()
         minted = 0
 
-        async def slow_mint(host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None):
+        async def slow_mint(host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None):
             nonlocal minted
             minted += 1
             if arm.is_set():
@@ -3212,7 +3292,7 @@ class TestSelfHealRefreshRestart:
         seen: list = []
 
         async def capturing_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             seen.append(remote_port)
             return "TOK"
@@ -3419,7 +3499,7 @@ class TestPortMirror:
         monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": port_free)
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             return "TOK"
 
@@ -3507,7 +3587,7 @@ class TestLastError:
         reg = InstancesRegistry(path=tmp_path / "instances.json")
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             return "SECRET_TOK"
 
@@ -3542,7 +3622,7 @@ class TestLastError:
         from kiro_crew.instances.token_mint import TokenMintError
 
         async def bad_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             raise TokenMintError("nope")
 
@@ -3560,7 +3640,7 @@ class TestLastError:
         calls = {"n": 0}
 
         async def flaky_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             calls["n"] += 1
             if calls["n"] == 1:
@@ -3580,7 +3660,7 @@ class TestLastError:
         from kiro_crew.instances.token_mint import TokenMintError
 
         async def bad_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             raise TokenMintError("nope")
 
@@ -3609,7 +3689,7 @@ class TestStatusForRetainedError:
         reg = InstancesRegistry(path=tmp_path / "instances.json")
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             return "SECRET_TOK"
 
@@ -3625,7 +3705,7 @@ class TestStatusForRetainedError:
         from kiro_crew.instances.token_mint import TokenMintError
 
         async def bad_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             raise TokenMintError("nope")
 
@@ -3683,7 +3763,7 @@ class TestStartupRevive:
         reg = InstancesRegistry(path=tmp_path / "instances.json")
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             return "SECRET_TOK"
 
@@ -3716,7 +3796,7 @@ class TestStartupRevive:
         from kiro_crew.instances.ssh_tunnel_manager import TunnelState
         from kiro_crew.instances.token_mint import TokenMintError
 
-        async def mint(host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None):
+        async def mint(host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None):
             if "bad" in host:
                 raise TokenMintError("unreachable")
             return "SECRET_TOK"
@@ -3770,6 +3850,7 @@ class TestStartupRevive:
                 tunnel_base_port=53400,
                 ssh_compression=False,
                 connect_timeout_secs=15.0,
+                mint_timeout_secs=30.0,
                 max_recovery_attempts=8,
                 recover_backoff_max_secs=30.0,
                 probe_failure_threshold=3,
@@ -4189,7 +4270,7 @@ class TestSsmTransportSelection:
         from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
         ):
             return "SSH_TOKEN"
 
@@ -4286,6 +4367,81 @@ class TestSsmTransportSelection:
         assert seen["target"] == "i-0123456789abcdef0"
         assert seen["aws_profile"] == "dev" and seen["aws_region"] == "eu-west-2"
         await mgr.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_mint_timeout_threads_to_ssh_mint(self, tmp_path):
+        """A configured instances.mint_timeout_secs reaches the ssh mint call."""
+        from kiro_crew.instances.registry import InstancesRegistry
+        from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
+
+        seen = {}
+
+        async def capturing_mint(
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
+        ):
+            seen["timeout_secs"] = timeout_secs
+            return "TOK"
+
+        reg = InstancesRegistry(path=tmp_path / "instances.json")
+        mgr = SshTunnelManager(
+            reg,
+            base_port=53520,
+            mint_timeout_secs=77.0,
+            mint_token=capturing_mint,
+            tunnel_factory=_FakeTunnel,
+        )
+        reg.add(name="Dev", ssh_host="dev-1", instance_id="dev", remote_port=53521)
+        await mgr.connect("dev")
+        assert seen["timeout_secs"] == 77.0
+        await mgr.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_mint_timeout_ssm_default_and_override(self, tmp_path, monkeypatch):
+        """SSM mint keeps its higher default; an explicit override wins for it too."""
+        import kiro_crew.instances.ssh_tunnel_manager as mod
+        from kiro_crew.instances.constants import DEFAULT_SSM_MINT_TIMEOUT_SECS
+        from kiro_crew.instances.registry import InstancesRegistry
+        from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
+
+        seen = {}
+
+        async def fake_ssm_mint(target, **kwargs):
+            seen["timeout_secs"] = kwargs.get("timeout_secs")
+            return "SSM_TOKEN"
+
+        monkeypatch.setattr(mod, "mint_remote_token_ssm", fake_ssm_mint)
+        monkeypatch.setattr(
+            "kiro_crew.cloud.ssm.session_manager_plugin_installed", lambda: True
+        )
+
+        def add_ssm(reg, iid, port):
+            reg.add(
+                name=iid,
+                connection_method="ssm",
+                ssm_target="i-0123456789abcdef0",
+                aws_profile="dev",
+                aws_region="eu-west-2",
+                instance_id=iid,
+                remote_port=port,
+            )
+
+        # Default manager -> SSM mint gets the higher SSM default (90s).
+        reg = InstancesRegistry(path=tmp_path / "a.json")
+        mgr = SshTunnelManager(reg, base_port=53530, tunnel_factory=_FakeTunnel)
+        add_ssm(reg, "ec2a", 53531)
+        await mgr.connect("ec2a")
+        assert seen["timeout_secs"] == DEFAULT_SSM_MINT_TIMEOUT_SECS == 90.0
+        await mgr.shutdown()
+
+        # Explicit override wins for the SSM transport too.
+        reg2 = InstancesRegistry(path=tmp_path / "b.json")
+        mgr2 = SshTunnelManager(
+            reg2, base_port=53540, mint_timeout_secs=45.0, tunnel_factory=_FakeTunnel
+        )
+        add_ssm(reg2, "ec2b", 53541)
+        await mgr2.connect("ec2b")
+        assert seen["timeout_secs"] == 45.0
+        await mgr2.shutdown()
 
     @pytest.mark.asyncio
     async def test_ssm_connect_fails_clean_without_plugin(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

The remote `kirocrew token` mint runs with a hardcoded 30s budget
(`_DEFAULT_MINT_TIMEOUT_SECS` in `token_mint.py`). The instance connect flow
spawns two proxy-bound ssh children — the tunnel and the mint — and a user
behind a slow ProxyCommand/jump host whose proxy handshake needs more time has
no way to budget the second one: the forward comes up, then the connect fails
in the mint step with `timed out minting token`.

## Why it matters

Instances behind corporate proxies / jump hosts are exactly the deployment the
Instances feature targets. For those users a too-tight mint budget makes every
connect fail deterministically, with no workaround short of patching the
installed package.

## Fix (symptom → root cause → change)

Symptom: mint timeout on slow-proxy hosts. Root cause: the budget is a
module-private constant, not a config field. Change — mirror the established
pattern used by the other `instances.*` tunables (canonical default in
`instances/constants.py`, referenced from `InstancesConfig`, clamped in
`__post_init__`, parsed in `load()`, wired in `dashboard/server.py`):

- `instances.mint_timeout_secs` (unset by default: SSH 30s, SSM 90s; below 10
  falls back to the transport defaults, above 120 clamps with a warning).
- Threads through `SshTunnelManager` via a new `_mint_timeout_for(method)`
  that mirrors `_connect_timeout_for` (as reshaped by #3592): an explicit
  value wins for **both** transports — including a value equal to either
  transport's default; when unset, SSM keeps its higher 90s budget
  (`aws ssm send-command` dispatch latency — the SSM mint never invokes
  session-manager-plugin).
- The SSH (30s) and SSM (90s) defaults move to `instances/constants.py` so the
  constant and the config default cannot drift; `token_mint.py` /
  `ssm_token_mint.py` alias them.
- Spec table + not-user-configurable list updated; `config-baseline.json`
  regenerated **surgically** (only the new entry — a full regen carries ~650
  lines of pre-existing drift from other unregenerated PRs, left untouched).

Semantics note: earlier revisions used the in-band-sentinel convention
(explicit `30` indistinguishable from unset) to match the then-shipped
`_connect_timeout_for`. PR #3592 has since converted `connect_timeout_secs`
to an `Optional`/unset-by-default field where an explicit value always wins
(and fixed the `Optional` schema rendering that #3468 tracked), so this PR
now uses the same pattern: `mint_timeout_secs` is unset by default, and an
explicit value — including `30` on SSM — applies to both transports.

**Declared behavior change at default config:** the mint's ssh `ConnectTimeout`
now follows the mint budget (OpenSSH >= 8.6 counts the banner/KEX exchange
against `ConnectTimeout`, so without this the knob could not help the slow-proxy
user this PR exists for). Consequence: a dead-TCP host now stalls the mint step
~30s (the default budget) instead of ~10s before failing. The 10s fail-fast
default is preserved for `run_remote_kirocrew` (restart remote).

## Tests

- `test_mint_timeout_default_and_clamps` — unset by default, explicit override
  honored (including the SSH-default value), below-floor falls back to unset,
  floor boundary untouched, above-ceiling clamps, ceiling boundary untouched.
- `test_mint_timeout_parses_from_config_file` — config-file parse: explicit
  value, absent key, JSON `null`, and explicit-30 all round-trip correctly.
- `test_mint_timeout_threads_to_ssh_mint` — the configured value reaches the
  ssh mint call (wiring, not just storage).
- `test_mint_timeout_ssm_default_and_override` — SSM keeps 90s when unset; an
  explicit value wins for SSM too.
- Roundtrip/schema tests extended; startup wiring test extended; 16 existing
  fake-mint signatures widened to accept the new kwarg.

Local gates: isort, flake8, mypy, pytest (`test_instances.py` +
`test_config_loader.py`: 478 passed).

## Manual verification

N/A — unit coverage exercises the full config→manager→mint-call chain; no
live ssh host in the loop adds signal beyond the seam tests.

<!-- no-visual-delta -->
**Why no screenshot:** backend/config/docs only — the Settings UI renders the
new field from the existing schema machinery; no frontend file touched.

Closes #3566



