### PR TITLE
feat: preview notification sound on per-category dropdown change

### DIFF
--- a/website/src/pages/settings/NotificationsPanel.tsx
+++ b/website/src/pages/settings/NotificationsPanel.tsx
@@ -278,8 +278,13 @@ export function NotificationsPanel() {
                     options={opts}
                     optionLabels={optLabels}
                     onChange={v => {
-                      if (v === DEFAULT_SENTINEL) clearCategoryOverride(cat)
-                      else setCategoryPreset(cat, v as SoundPreset)
+                      if (v === DEFAULT_SENTINEL) {
+                        clearCategoryOverride(cat)
+                        if (fallback !== 'none') playPreset(fallback, settings.volume)
+                      } else {
+                        setCategoryPreset(cat, v as SoundPreset)
+                        if (v !== 'none') playPreset(v as SoundPreset, settings.volume)
+                      }
                     }}
                     disabled={!settings.enabled}
                   />


### PR DESCRIPTION
## Problem

When choosing a notification sound from the per-category dropdown in Settings > Notifications, there is no audio feedback. The user has to trigger an actual notification to hear what they selected, turning sound configuration into a guessing game.

## Why it matters

Users who want to differentiate notification categories by sound have no way to audition the options without waiting for a real notification to fire. This makes the feature feel broken on first use.

## Fix

The `onChange` handler for each per-category `SettingsSelect` now also calls `playPreset()` with the newly selected sound at the current volume level. Selecting "Use default" plays the fallback sound (so you hear what that category will actually use), and selecting "None" stays silent. The existing Test button remains as an explicit replay option.

The `playPreset` function was already imported and wired to the Test button; this change reuses it inline in the dropdown handler.

## Tests

- All 13 NotificationsPanel tests pass (7 main + 6 channels)
- TypeScript compilation passes

## Manual verification

1. Open Settings > Notifications > Per-category sounds
2. Change any dropdown (e.g. Turn complete from Chime to Ding)
3. Hear the Ding sound play immediately on selection
4. Change to "None" -- silence
5. Change to "Use default" -- hear the fallback sound