### PR TITLE
fix(test): poll for thread death in sandboxed cron cancel test (#3570)

### DIFF
--- a/test/test_cron_cancel.py
+++ b/test/test_cron_cancel.py
@@ -228,9 +228,20 @@ class TestSubprocessRegistry:
             assert "cancelme" in _RUNNING_PROCS
             started = time.time()
             assert kill_running_process("cancelme") is True
-            t.join(timeout=10)
-        assert not t.is_alive()
-        assert time.time() - started < 10  # died well before the 30s sleep
+            # Poll for thread death (same pattern as the registration wait
+            # above) instead of one fixed-budget join: an instantaneous
+            # is_alive() read behind a single join can report a still-dying
+            # thread on a loaded runner even when SIGTERM worked. The 20s
+            # deadline stays comfortably below the child's 30s sleep, so
+            # passing still proves death-by-cancellation, not natural expiry.
+            deadline = started + 20
+            while time.time() < deadline and t.is_alive():
+                t.join(timeout=0.1)
+        assert not t.is_alive(), "thread still alive 20s after SIGTERM"
+        # 25, not 20: the final join may return ~0.1s past the poll deadline
+        # with the thread already dead; the headroom keeps that success from
+        # failing here while staying well below the 30s natural expiry.
+        assert time.time() - started < 25  # died well before the 30s sleep
         assert result["status"] == "cancelled"
         assert "cancelme" not in _RUNNING_PROCS
         assert "cancelme" not in _CANCELLED_PROC_JOBS  # flag consumed


### PR DESCRIPTION
## Problem

`test/test_cron_cancel.py::TestSubprocessRegistry::test_run_command_sandboxed_can_be_cancelled_mid_run` flaked on a CI Linux shard (Backend Tests 3.10, shard 1) with `assert not True` on the thread-liveness check, while passing locally and on recent `main` runs. Because Coverage Combine skips when a shard fails, the single flake surfaced as two red checks and blocked PR Readiness on unrelated PRs.

## Why it matters

A flaky required check taxes every open PR: contributors pay re-run round-trips for a failure they did not cause, and a red Coverage Gate hides real coverage regressions behind noise.

## Fix (symptom → root cause → change)

The failing assertion was `assert not t.is_alive()` immediately after a single `t.join(timeout=10)` — an instantaneous liveness read behind a fixed budget. On a loaded shard, the 10s join can expire while the SIGTERMed child is still being reaped, so the test fails even though the registry/cancel mechanics under test worked. (The shard's `unshare(CLONE_NEWNS) EPERM` userns-probe noise is a red herring for this test: it already patches `wrap_argv`/`cgroup_scope_argv` to identity and pins the shell, precisely because CI runners lack the namespace sandbox.)

The change replaces the fixed join with a polled wait — the same poll-over-sleep shape the repo's determinism guidance prescribes and that this test already uses while waiting for registration: loop `t.join(0.1)` under a 20s deadline, exiting as soon as the thread dies. The 20s deadline stays well below the child's 30s sleep, so a pass still proves death-by-cancellation rather than natural expiry. The elapsed-time assertion gets 25s of headroom (the final join can return ~0.1s past the poll deadline with the thread already dead) and a diagnostic message. All post-conditions are unchanged: `status == "cancelled"`, registry entry removed, cancelled-flag consumed.

Test-only change; no `src/` code is touched. No userns skip guard is added — that would silently remove the registry/cancel coverage this test exists to provide.

## Tests

- `test/test_cron_cancel.py` — the modified test itself locks in the polled-wait shape; full file passes 12/12 locally.
- Full backend gate run locally: isort, flake8, mypy clean; pytest failure set is byte-identical to pristine `main` on the same host (zero regressions).

## Manual verification

N/A — unit coverage sufficient: the change is confined to the wait/assert shape of one test, and the test exercises it directly.

## Local pre-push review

Two model-pinned read-only reviewers ran against the diff before push:

- **GPT lane** (codex-review contract): PASS, no findings.
- **Opus lane** (claude-review + AUTOSDE contract): PASS, no blocking findings; the one matching blocking rule (`no-test-side-effects`) is not hit. Three advisories, dispositioned:
  1. Poll-deadline/elapsed-assert collision window (~0.1s false-failure) — **fixed**: elapsed bound raised to 25s with a comment naming the reason.
  2. `time.time()` is NTP-steppable; guidance example uses `time.monotonic()` — **accepted-and-deferred**: every one of the file's 10 clock reads is `time.time()` (including the adjacent registration wait), so a correct conversion is file-wide, not local to this fix. Deferred to keep this PR minimal; happy to file a follow-up.
  3. Bare liveness assert carried no diagnostic — **fixed**: failure message added.

Closes #3570
