### PR TITLE
fix: interrupt 'run this next' promotes the clicked queued message

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -1930,10 +1930,13 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
         raise
     queue_id = body.get("queue_id")
     if queue_id:
-        for i, item in enumerate(slot._queue):
-            if item.get("queue_id") == queue_id:
-                slot._queue.insert(0, slot._queue.pop(i))
-                break
+        # Wire-side field is `queue_id`; stored items carry `id` (the key
+        # queue_append/queue_insert write and every *_by_id helper matches).
+        # The previous inline loop compared item.get("queue_id"), which is
+        # None on every production item — a silent no-op that made the
+        # "run this next" click land on whatever happened to be at the
+        # front of the queue instead of the selected message.
+        slot.queue_promote_by_id(queue_id)
 
     # Stop current turn but preserve the queue so dequeue loop fires
     # (soft_pending already claimed above, before the request-body await)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1760,6 +1760,21 @@ class _ChatSlot:
                 return True
         return False
 
+    def queue_promote_by_id(self, queue_id: str) -> bool:
+        """Move a queue item to the front by ID. Returns True if found.
+
+        Used by the interrupt endpoint's "run this next" path: the promoted
+        item is what the dequeue loop picks up after the current turn stops.
+        Like every ``*_by_id`` helper, this matches the storage key (``id``)
+        that :meth:`queue_append` / :meth:`queue_insert` write — callers
+        translate the wire-side ``queue_id`` field to it at the boundary.
+        """
+        for i, item in enumerate(self._queue):
+            if item["id"] == queue_id:
+                self._queue.insert(0, self._queue.pop(i))
+                return True
+        return False
+
     @property
     def running(self) -> bool:
         return self.task is not None and not self.task.done()

--- a/test/test_chat_slot_interrupt.py
+++ b/test/test_chat_slot_interrupt.py
@@ -92,7 +92,7 @@ class TestChatSlotInterrupt:
         mock_task = MagicMock()
         mock_task.done.return_value = False
         slot.task = mock_task
-        slot._queue = [{"queue_id": "q1", "content": "hello"}]
+        slot.queue_append("hello")
         state = _mock_state(slot)
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
@@ -115,22 +115,43 @@ class TestChatSlotInterrupt:
         mock_task = MagicMock()
         mock_task.done.return_value = False
         slot.task = mock_task
-        slot._queue = [
-            {"queue_id": "q1", "content": "first"},
-            {"queue_id": "q2", "content": "second"},
-            {"queue_id": "q3", "content": "third"},
-        ]
+        # Seed through the REAL production path (queue_append -> {"id": ...}),
+        # not a hand-built dict. The original fixture used {"queue_id": ...},
+        # a shape that never occurs in production, which let the handler's
+        # wrong-key match (item.get("queue_id")) pass this test while being a
+        # silent no-op on real queues.
+        q1 = slot.queue_append("first")
+        q2 = slot.queue_append("second")
+        q3 = slot.queue_append("third")
         state = _mock_state(slot)
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
                 "/api/chat/slots/test/interrupt",
-                json={"queue_id": "q2"},
+                json={"queue_id": q2},
             )
             assert resp.status == 200
             # q2 should now be at front
-            assert slot._queue[0]["queue_id"] == "q2"
-            assert slot._queue[1]["queue_id"] == "q1"
-            assert slot._queue[2]["queue_id"] == "q3"
+            assert slot._queue[0]["id"] == q2
+            assert slot._queue[1]["id"] == q1
+            assert slot._queue[2]["id"] == q3
+
+    @pytest.mark.asyncio
+    async def test_interrupt_with_unknown_queue_id_preserves_order(self, _patch_sel):
+        """An unknown queue_id must not reorder anything (and must not 500)."""
+        slot = _ChatSlot("test")
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        slot.task = mock_task
+        q1 = slot.queue_append("first")
+        q2 = slot.queue_append("second")
+        state = _mock_state(slot)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/interrupt",
+                json={"queue_id": "does-not-exist"},
+            )
+            assert resp.status == 200
+            assert [i["id"] for i in slot._queue] == [q1, q2]
 
     @pytest.mark.asyncio
     async def test_interrupt_sets_stop_state_to_soft_pending(self, _patch_sel):
@@ -138,7 +159,7 @@ class TestChatSlotInterrupt:
         mock_task = MagicMock()
         mock_task.done.return_value = False
         slot.task = mock_task
-        slot._queue = [{"queue_id": "q1", "content": "msg"}]
+        slot.queue_append("msg")
         state = _mock_state(slot)
         async with TestClient(TestServer(_make_app(state))) as client:
             await client.post(
@@ -159,7 +180,7 @@ class TestChatSlotInterrupt:
         mock_task = MagicMock()
         mock_task.done.return_value = False
         slot.task = mock_task
-        slot._queue = [{"queue_id": "q1", "content": "msg"}]
+        slot.queue_append("msg")
 
         # Simulate a pending approval future (agent waiting for permission)
         loop = asyncio.get_running_loop()

--- a/test/test_spec_builder_routes_coverage.py
+++ b/test/test_spec_builder_routes_coverage.py
@@ -2088,7 +2088,7 @@ class TestTeardownWorkerSlot:
     @pytest.mark.asyncio
     async def test_the_slot_is_popped_queued_work_dropped_and_the_turn_cancelled(self):
         slot = _Slot("spec-builder-demo", running=True)
-        slot._queue = ["next prompt"]
+        slot._queue = [{"id": "q1", "content": "next prompt"}]
         slot._pending_synthesis = True
         task = mock.Mock()
         task.cancel = mock.Mock()
@@ -2167,7 +2167,7 @@ class TestHaltActiveTurn:
     @pytest.mark.asyncio
     async def test_the_turn_is_stopped_cooperatively_then_cancelled(self):
         slot = _Slot("spec-builder-demo", running=True)
-        slot._queue = ["next"]
+        slot._queue = [{"id": "q1", "content": "next"}]
         task = mock.Mock()
         task.done.return_value = False
         slot.task = task  # type: ignore[assignment]

--- a/test/test_stop_handler_idempotent.py
+++ b/test/test_stop_handler_idempotent.py
@@ -141,7 +141,7 @@ class TestInterruptHandlerIdempotent:
         slot._stop_state = "soft_pending"
         slot._stop_event_id = "stop-xyz"
         slot.running = True
-        slot._queue = [{"queue_id": "q1", "content": "hello"}]
+        slot._queue = [{"id": "q1", "content": "hello"}]
 
         state = _FakeState(slot)
         app = web.Application()
@@ -502,7 +502,7 @@ class TestStopCancelsTheSessionTheTurnRunsOn:
         slot = _FakeSlot()
         slot.linked_session_key = "slack:1786000000.1"
         # /interrupt is only reachable with something queued to promote.
-        slot._queue = [{"queue_id": "q1", "content": "next"}]
+        slot._queue = [{"id": "q1", "content": "next"}]
         state = _FakeState(slot)
 
         request = self._request(state)


### PR DESCRIPTION
## What

The interrupt endpoint's "run this next" promotion silently ignored the clicked queued message. Clicking the lightning button on a specific card stopped the current turn, but the queue drained in its prior order - the selection had no effect. Invisible until queue reorder (#2241 / v0.2.0) made display order diverge from insertion order.

Closes #3589

## Why

`api_chat_slot_interrupt` matched `item.get("queue_id")` on stored queue items, but `queue_append` / `queue_insert` write the storage key `"id"`. The match was `None` for every production item, so the promotion loop never fired - a silent no-op behind a 200 response and a SEL audit entry that recorded the `queue_id` as handled. Every other queue endpoint (cancel, edit, reorder) already translates the wire field `queue_id` to the storage key `id` correctly; this was the single site reading the wire key on a storage item.

## How

- `state.py`: new `_ChatSlot.queue_promote_by_id(queue_id)` helper next to its sibling `queue_remove_by_id` / `queue_edit_by_id` (all keyed on the storage `"id"`), so the handler no longer manipulates `_queue` inline - the inline manipulation is what let the key drift in unnoticed.
- `chat_handlers.py`: the promotion block calls the helper.
- `test_chat_slot_interrupt.py`: the existing promotion test passed against the broken handler because its fixture hand-seeded `{"queue_id": ...}` items - the same wrong key the handler read, a shape that never occurs in production. All fixtures in the file now seed through the real `queue_append` path. The promotion test asserts on the storage key and was verified to FAIL against the old handler (red) before the fix (green). A new regression covers the unknown-id case: order preserved, no 500.

## Testing

- Red phase proven: with fixtures on the production schema and the old handler, the promotion test fails with `assert '1f8205b2...' == '0134b6f7...'` (front item is not the clicked one).
- Green: `test_chat_slot_interrupt.py` 10/10.
- Adjacent surface: `test_queue_cancel.py`, `test_queue_edit.py`, `test_queue_reorder.py`, `test_stop_handler_idempotent.py` - 67/67 total.
- Gates: isort clean, flake8 clean, mypy clean on both touched source files.

## Screenshots / video

Backend-only change (`src/kiro_crew/` + `test/`): no frontend files touched, no pixels changed. The frontend already sends the correct `queue_id` on both call sites (ChatPane and ChatPage); this fix makes the backend honor it.

## Notes

The fixture sweep is included: an audit of every hand-seeded `slot._queue` fixture suite-wide found two more drifted files, both fixed here. `test_stop_handler_idempotent.py` carried the same wrong `{"queue_id": ...}` shape (one of its tests exercises this very endpoint), and `test_spec_builder_routes_coverage.py` seeded bare strings instead of dicts. All other `_ChatSlot` queue fixtures already match the production schema; `SubagentManager._queue` is a different queue with its own schema and was deliberately left untouched. Both swept files re-run green (the one failure in `test_spec_builder_routes_coverage.py`, `TestHandleSettings::test_a_usable_base_path_is_stored_fully_resolved`, is pre-existing on clean `main` and unrelated - path resolution, macOS environment).

