### PR TITLE
fix(instances): preserve explicit connect timeout

### DIFF
--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -223,8 +223,9 @@ why it is down.
 
 ### 5.1 `instances.*` config keys
 
-Defaults live in `kiro_crew.instances.constants` and are referenced from the
-`InstancesConfig` dataclass, so the constant and the config default cannot drift.
+Transport defaults and bounds live in `kiro_crew.instances.constants` and are
+referenced from `InstancesConfig`, so the documented values and runtime policy
+cannot drift.
 
 | Key | Default | Meaning |
 |-----|---------|---------|
@@ -232,7 +233,7 @@ Defaults live in `kiro_crew.instances.constants` and are referenced from the
 | `instances.warm_set_cap` | `5` | Max instances kept warm at once (bounds memory/sockets; each warm instance is a full dashboard SPA). Clamped up to 1. |
 | `instances.tunnel_base_port` | `7778` | First local loopback port the allocator hands out. Out-of-range values fall back to the default. |
 | `instances.ssh_compression` | `true` | Add `-C` to the tunnel argv. See §5.2. |
-| `instances.connect_timeout_secs` | `15.0` | How long (secs) to wait for the local forward port to accept connections before declaring a connect attempt failed. Hosts behind a ProxyCommand or jump host need longer (the proxy handshake runs before ssh begins the forward). The SSM transport uses its own higher default (25s) unless this value is explicitly set. Clamped to [1, 120]. |
+| `instances.connect_timeout_secs` | unset (SSH `15.0`, SSM `25.0`) | How long (secs) to wait for the local forward port to accept connections before declaring a connect attempt failed. Hosts behind a ProxyCommand or jump host need longer (the proxy handshake runs before ssh begins the forward). An explicit value applies to both transports, including a value equal to either transport's default. Values below 1 fall back to the transport defaults; values above 120 are clamped to 120. |
 | `instances.max_recovery_attempts` | `8` | Consecutive self-heal attempts before the tunnel is left disconnected. Below 1 falls back to the default; above `MAX_RECOVERY_ATTEMPTS_CEILING` (100) is clamped with a warning, so a pathological setting cannot turn bounded self-heal into a near-infinite retry loop. |
 | `instances.recover_backoff_max_secs` | `30.0` | Cap on the per-attempt backoff. Non-positive falls back to the default; above `RECOVER_BACKOFF_MAX_CEILING_SECS` (300) is clamped, bounding the worst-case wall-clock recovery window. |
 | `instances.probe_failure_threshold` | `3` | Consecutive health-probe failures before a non-forwarding tunnel is torn down. Below 1 falls back to the default. |

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -4217,9 +4217,9 @@ class InstancesConfig:
     since enabling it allows the gateway to open SSH ``-L`` forwards and relaxes
     the dashboard CSP ``frame-src`` for the active loopback tunnel ports.
 
-    The numeric tunables default to constants defined in
-    ``kiro_crew.instances.constants`` so the canonical default lives in one
-    place and cannot drift from this dataclass.
+    Numeric transport defaults and bounds live in
+    ``kiro_crew.instances.constants`` so their canonical values cannot drift
+    from this dataclass.
     """
 
     enabled: bool = field(
@@ -4261,18 +4261,18 @@ class InstancesConfig:
             "on a fast/local link where compression CPU outweighs the bandwidth win.",
         ),
     )
-    connect_timeout_secs: float = field(
-        default=_DEFAULT_CONNECT_TIMEOUT,
+    connect_timeout_secs: float | None = field(
+        default=None,
         metadata=_meta(
             "Connect Timeout (secs)",
             "How long to wait for the local forward port to accept connections "
-            "before declaring a connect attempt failed. The default (15s) is "
-            "sufficient for a direct ssh TCP connect, but hosts behind a "
+            "before declaring a connect attempt failed. When unset, SSH uses "
+            "15s and SSM uses 25s. Fifteen seconds is sufficient for a direct "
+            "ssh TCP connect, but hosts behind a "
             "ProxyCommand or jump host routinely need longer (the proxy handshake "
             "runs before ssh begins the forward). Raise this if connecting a "
             "remote instance times out while the same ssh forward succeeds by hand. "
-            "The SSM transport uses its own higher default (25s) unless this value "
-            "is explicitly set. Clamped to [1, 120].",
+            "An explicit value applies to both transports. Clamped to [1, 120].",
         ),
     )
     max_recovery_attempts: int = field(
@@ -4314,14 +4314,16 @@ class InstancesConfig:
                 _DEFAULT_TUNNEL_BASE_PORT,
             )
             object.__setattr__(self, "tunnel_base_port", _DEFAULT_TUNNEL_BASE_PORT)
-        if self.connect_timeout_secs < 1.0:
+        if self.connect_timeout_secs is not None and self.connect_timeout_secs < 1.0:
             logger.warning(
-                "instances.connect_timeout_secs %s < 1, using %s",
+                "instances.connect_timeout_secs %s < 1, using the transport default",
                 self.connect_timeout_secs,
-                _DEFAULT_CONNECT_TIMEOUT,
             )
-            object.__setattr__(self, "connect_timeout_secs", _DEFAULT_CONNECT_TIMEOUT)
-        elif self.connect_timeout_secs > _CONNECT_TIMEOUT_CEILING:
+            object.__setattr__(self, "connect_timeout_secs", None)
+        elif (
+            self.connect_timeout_secs is not None
+            and self.connect_timeout_secs > _CONNECT_TIMEOUT_CEILING
+        ):
             logger.warning(
                 "instances.connect_timeout_secs %s > %s, clamping to %s",
                 self.connect_timeout_secs,
@@ -5631,6 +5633,7 @@ class KiroCrewConfig:
         instances_data = data.get("instances", {})
         if not isinstance(instances_data, dict):
             instances_data = {}
+        connect_timeout_raw = instances_data.get("connect_timeout_secs")
         mcp_gateway_data = data.get("mcp_gateway", {})
         if not isinstance(mcp_gateway_data, dict):
             mcp_gateway_data = {}
@@ -6361,9 +6364,10 @@ class KiroCrewConfig:
                 ssh_compression=bool(
                     instances_data.get("ssh_compression", _DEFAULT_SSH_COMPRESSION)
                 ),
-                connect_timeout_secs=_safe_float(
-                    instances_data.get("connect_timeout_secs", _DEFAULT_CONNECT_TIMEOUT),
-                    _DEFAULT_CONNECT_TIMEOUT,
+                connect_timeout_secs=(
+                    _safe_float(connect_timeout_raw, _DEFAULT_CONNECT_TIMEOUT)
+                    if connect_timeout_raw is not None
+                    else None
                 ),
                 max_recovery_attempts=_safe_int(
                     instances_data.get("max_recovery_attempts", _DEFAULT_MAX_RECOVERY),

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -758,7 +758,7 @@ class SshTunnelManager:
         registry: InstancesRegistry,
         *,
         base_port: int = DEFAULT_TUNNEL_BASE_PORT,
-        connect_timeout_secs: float = _DEFAULT_CONNECT_TIMEOUT_SECS,
+        connect_timeout_secs: float | None = None,
         ssh_compression: bool = True,
         max_recovery_attempts: int = _MAX_RECOVERY,
         recover_backoff_max_secs: float = _RECOVER_BACKOFF_MAX_SECS,
@@ -883,11 +883,11 @@ class SshTunnelManager:
         higher. A caller that passed an explicit ``connect_timeout_secs``
         (tests, tuning) wins for both transports.
         """
-        if self._connect_timeout != _DEFAULT_CONNECT_TIMEOUT_SECS:
+        if self._connect_timeout is not None:
             return self._connect_timeout  # explicit override
         if method == "ssm":
             return _DEFAULT_SSM_CONNECT_TIMEOUT_SECS
-        return self._connect_timeout
+        return _DEFAULT_CONNECT_TIMEOUT_SECS
 
     async def _ps_lines(self) -> list[str]:
         """Return ``<pid> <command>`` lines for all processes (portable ps).

--- a/test/test_config_schema.py
+++ b/test/test_config_schema.py
@@ -306,6 +306,9 @@ class TestConfigSchemaProperties:
         all_fields = _all_fields_recursive(KiroCrewConfig)
         for path, f in all_fields:
             tp = _resolve_type(f)
+            optional_args = typing.get_args(tp)
+            if len(optional_args) == 2 and type(None) in optional_args:
+                tp = next(arg for arg in optional_args if arg is not type(None))
             origin = typing.get_origin(tp)
 
             # Determine expected JSON Schema type

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -41,7 +41,8 @@ class TestConfig:
         assert c.enabled is False
         assert c.warm_set_cap == DEFAULT_WARM_SET_CAP == 5
         assert c.tunnel_base_port == DEFAULT_TUNNEL_BASE_PORT == 7778
-        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
+        assert DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
+        assert c.connect_timeout_secs is None
 
     def test_clamps_out_of_range(self):
         from kiro_crew.config.loader import InstancesConfig
@@ -60,7 +61,7 @@ class TestConfig:
             "warm_set_cap": 5,
             "tunnel_base_port": 7778,
             "ssh_compression": True,
-            "connect_timeout_secs": 15.0,
+            "connect_timeout_secs": None,
             "max_recovery_attempts": 8,
             "recover_backoff_max_secs": 30.0,
             "probe_failure_threshold": 3,
@@ -78,6 +79,12 @@ class TestConfig:
             "instances.probe_failure_threshold",
         ):
             assert p in paths
+        timeout_entry = next(
+            e for e in SCHEMA_REGISTRY if e.path == "instances.connect_timeout_secs"
+        )
+        assert timeout_entry.type == "number"
+        assert timeout_entry.nullable is True
+        assert timeout_entry.default_value is None
 
     def test_recovery_knobs_parse_from_config_file(self, tmp_path, monkeypatch):
         import json
@@ -153,20 +160,25 @@ class TestConfig:
             DEFAULT_CONNECT_TIMEOUT_SECS,
         )
 
-        # Default value matches the constant.
+        # Unset remains distinguishable from an explicit value equal to the SSH
+        # default, so the manager can select the transport-specific default.
         c = InstancesConfig()
-        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
+        assert DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
+        assert c.connect_timeout_secs is None
+
+        c = InstancesConfig(connect_timeout_secs=DEFAULT_CONNECT_TIMEOUT_SECS)
+        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS
 
         # Explicit override is honored.
         c = InstancesConfig(connect_timeout_secs=45.0)
         assert c.connect_timeout_secs == 45.0
 
-        # Below 1 falls back to the default.
+        # Below 1 falls back to the transport-specific defaults.
         c = InstancesConfig(connect_timeout_secs=0.5)
-        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS
+        assert c.connect_timeout_secs is None
 
         c = InstancesConfig(connect_timeout_secs=-10.0)
-        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS
+        assert c.connect_timeout_secs is None
 
         # Above the ceiling is clamped.
         assert CONNECT_TIMEOUT_CEILING_SECS == 120.0
@@ -189,6 +201,18 @@ class TestConfig:
         monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg_file)
         cfg = KiroCrewConfig.load()
         assert cfg.instances.connect_timeout_secs == 45.0
+
+        cfg_file.write_text(json.dumps({"instances": {}}))
+        cfg = KiroCrewConfig.load()
+        assert cfg.instances.connect_timeout_secs is None
+
+        cfg_file.write_text(json.dumps({"instances": {"connect_timeout_secs": None}}))
+        cfg = KiroCrewConfig.load()
+        assert cfg.instances.connect_timeout_secs is None
+
+        cfg_file.write_text(json.dumps({"instances": {"connect_timeout_secs": 15.0}}))
+        cfg = KiroCrewConfig.load()
+        assert cfg.instances.connect_timeout_secs == 15.0
 
 
 # ── PortAllocator ───────────────────────────────────────────────────────────
@@ -955,6 +979,7 @@ class _FakeTunnel:
         self.aws_profile = aws_profile
         self.aws_region = aws_region
         self.ssh_host = ssh_host
+        self.connect_timeout_secs = connect_timeout_secs
         self.status = TunnelStatus(instance_id=iid, local_port=lp, remote_port=rp)
 
     async def start(self):
@@ -4159,7 +4184,7 @@ class TestSsmTransportSelection:
 
         monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
 
-    def _mgr(self, tmp_path, *, mint=None):
+    def _mgr(self, tmp_path, *, mint=None, connect_timeout_secs=None):
         from kiro_crew.instances.registry import InstancesRegistry
         from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
 
@@ -4169,12 +4194,48 @@ class TestSsmTransportSelection:
             return "SSH_TOKEN"
 
         reg = InstancesRegistry(path=tmp_path / "instances.json")
+        manager_kwargs = {}
+        if connect_timeout_secs is not None:
+            manager_kwargs["connect_timeout_secs"] = connect_timeout_secs
         return reg, SshTunnelManager(
             reg,
             base_port=53500,
             mint_token=mint or ok_mint,
             tunnel_factory=_FakeTunnel,
+            **manager_kwargs,
         )
+
+    @pytest.mark.parametrize(
+        ("configured", "ssh_expected", "ssm_expected"),
+        [
+            (None, 15.0, 25.0),
+            (15.0, 15.0, 15.0),
+            (45.0, 45.0, 45.0),
+            (0.0, 15.0, 25.0),
+            (200.0, 120.0, 120.0),
+        ],
+    )
+    def test_connect_timeout_matrix(
+        self, tmp_path, configured, ssh_expected, ssm_expected
+    ):
+        from kiro_crew.config.loader import InstancesConfig
+        from kiro_crew.instances.constants import (
+            CONNECT_TIMEOUT_CEILING_SECS,
+            DEFAULT_CONNECT_TIMEOUT_SECS,
+            DEFAULT_SSM_CONNECT_TIMEOUT_SECS,
+        )
+
+        assert DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
+        assert DEFAULT_SSM_CONNECT_TIMEOUT_SECS == 25.0
+        assert CONNECT_TIMEOUT_CEILING_SECS == 120.0
+
+        config = InstancesConfig(connect_timeout_secs=configured)
+        _, mgr = self._mgr(
+            tmp_path,
+            connect_timeout_secs=config.connect_timeout_secs,
+        )
+        assert mgr._connect_timeout_for("ssh") == ssh_expected
+        assert mgr._connect_timeout_for("ssm") == ssm_expected
 
     @pytest.mark.asyncio
     async def test_ssh_instance_uses_ssh_transport(self, tmp_path):
@@ -4190,6 +4251,7 @@ class TestSsmTransportSelection:
     @pytest.mark.asyncio
     async def test_ssm_instance_uses_ssm_transport_and_ssm_mint(self, tmp_path, monkeypatch):
         import kiro_crew.instances.ssh_tunnel_manager as mod
+        from kiro_crew.instances.constants import DEFAULT_SSM_CONNECT_TIMEOUT_SECS
 
         seen = {}
 
@@ -4218,6 +4280,7 @@ class TestSsmTransportSelection:
         assert tunnel.transport == "ssm"
         assert tunnel.ssm_target == "i-0123456789abcdef0"
         assert tunnel.aws_profile == "dev" and tunnel.aws_region == "eu-west-2"
+        assert tunnel.connect_timeout_secs == DEFAULT_SSM_CONNECT_TIMEOUT_SECS == 25.0
         # Token came from the SSM mint (NOT the ssh mint seam).
         assert mgr.get_token("ec2") == "SSM_TOKEN"
         assert seen["target"] == "i-0123456789abcdef0"


### PR DESCRIPTION
## Problem

`instances.connect_timeout_secs` uses 15.0 as both the SSH default and the
sentinel for "no explicit override".

That makes an explicitly configured value of 15.0 indistinguishable from
an unset value. For SSM, `_connect_timeout_for()` therefore replaces the
user's explicit 15s value with the transport default of 25s.

## Fix

- represent an unset connect timeout as `None`
- preserve transport defaults when unset: SSH 15s, SSM 25s
- treat every non-None value, including exactly 15.0, as an explicit override
- make below-floor values fall back to transport-default semantics
- expose the config field as a nullable number
- preserve upper-bound clamping
- update the Instances specification and Optional-schema regression coverage

Behavior:

| Configuration | SSH | SSM |
|---|---:|---:|
| unset / null | 15s | 25s |
| explicit 15 | 15s | 15s |
| explicit 45 | 45s | 45s |
| invalid below 1 | 15s | 25s |
| above 120 | 120s | 120s |

## Testing

- `test/test_instances.py`: 201 passed, 2 skipped
- config/schema adjacent suites: 331 passed, 3 skipped
- focused timeout matrix and schema regressions: 9 passed
- flake8
- isort
- mypy on affected production modules
- docs lint
- brand gate
- `git diff --check`

Closes #3542
