### PR TITLE
fix(mcp-gateway): invalidate an observed hazard when the server changes

### DIFF
--- a/docs/system-specs/modules/mcp-shareability.md
+++ b/docs/system-specs/modules/mcp-shareability.md
@@ -59,8 +59,13 @@ process happened to start in.
 Path: `<records dir>/observed-hazards.json`, a sibling of `hot-keys.json`. Writer: gatewayd (`mcp_gateway/hazards.py`). Reader: the dashboard.
 
 ```json
-{"schema": 1, "servers": {"<name>": {"codes": ["..."], "count": 3, "lastSeen": 1.0}}}
+{"schema": 1, "servers": {"<name>": {
+  "identities": {"<hash>": {"codes": ["..."], "count": 3, "lastSeen": 1.0}},
+  "codes": ["..."], "count": 3, "lastSeen": 1.0
+}}}
 ```
+
+`identities` is the authoritative shape; the flat `codes`/`count`/`lastSeen` beside it are its union, written for a reader that predates the map. The version is deliberately NOT bumped: Make Live can put an earlier worktree back in front of the same data home, and a version-gated shape change would read as "future, ignore" there and silently drop every observation. Emitting both under one version costs a derived duplicate — built from the same records in the same payload, so the two cannot disagree — and keeps a downgrade readable. A reader that finds no `identities` treats the flat fields as one record under the empty identity, which is exactly how an older writer's file is absorbed.
 
 Codes are a closed vocabulary; an unknown code is refused on write and dropped on read, because a typo that silently became a permanent hazard would disqualify a server for ever with no way to read why:
 
@@ -70,6 +75,16 @@ Codes are a closed vocabulary; an unknown code is refused on write and dropped o
 Both are recorded ONLY for a shared backend (`exclusive_token` empty). A 1:1 backend legitimately owns its single client, so the same frame there proves nothing, and recording it would disqualify servers for behaviour that is correct when unshared.
 
 A missing, unreadable or future-schema file reads as "nothing observed" — never as "safe". Recording is in-memory and safe on the event loop; the flush is blocking IO and runs off-loop from the heartbeat sweep. Prior observations are reloaded when the sink is installed, so a daemon restart does not forget them.
+
+**Invalidation is tied to change, never to age.** Observations are stored per launch `identity` — the command/args, effective env and binary fingerprints the pool key already holds, so the recording site stamps one without doing IO on the loop. Each identity accumulates independently and nothing is ever moved or discarded across identities, because two backends for one NAME can be live at once: a blue/green drain keeps the outgoing build serving its attached stubs while the incoming one starts, so both can still record. A store that collapsed them into one row per name would let a late frame from the draining backend overwrite what the new build had already observed, and that reads as "nothing observed" for the build actually being kept — the permissive direction.
+
+Invalidation therefore happens on the READ: a launch whose identity has no record of its own reads as unobserved, so upgrading or reconfiguring a server clears its verdict without any write-side deletion. The identity deliberately excludes the pre-flight schema — a hazard is an observation of real traffic and stays true however the prober evolves, so folding that field in would let a schema bump erase evidence the gateway actually witnessed.
+
+There is no expiry by age, and that is a decision rather than an omission: a server that personalises state per caller does not become safe because a month passed, so ageing an observation out would manufacture a "safe to share" that nothing observed. The one case identity cannot cover is a frame THIS gateway misattributed — our own defect, which changes nothing about the server — so `clear(server_name)` is the explicit operator path for dropping evidence that is otherwise still current, and the only way to drop it.
+
+Row count is bounded by the number of distinct builds of a server that **actually misbehaved**: an identity appears only once a hazard is observed under it, so a well-behaved server never occupies space however often it is reconfigured. No cap is applied, deliberately — any age- or count-based eviction can evict the CURRENT build's record while a chatty outgoing one survives, which is the failure this shape exists to prevent.
+
+A file written **without** `identities` — by an older build, or by one this build later hands back to an older one — still loads. Its flat fields become one record under the empty identity: surfaced by the name-only read so the dashboard keeps showing the withdrawal, and matching no launch for the identity-checked read, which is the honest treatment of evidence that cannot be attributed. The name-only read (`codes_for_name`) unions across identities; that is a bounded difference in the safe direction — a row may show a withdrawal the next probe clears, never a recommendation the evidence contradicts.
 
 Because the flush runs off-loop while `record` keeps running ON it, an observation can land between building the payload and clearing the dirty flag. The generation counter is captured with the payload and dirty is cleared only if nothing moved in between: clearing unconditionally would drop that observation permanently, leaving the ledger looking clean while the file lacked the entry — a hazard the gateway actually saw that never withdraws a recommendation.
 

--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -1220,16 +1220,26 @@ class Backend:
         stub attaches, and recording during that window would disqualify a
         server for behaviour that is correct.
 
-        Biased toward under-recording on purpose. A hazard is permanent and has
-        no redemption path, so a false one silently kills a server that is fine;
-        a missed one costs a withdrawal that the next observation makes again.
+        Biased toward under-recording on purpose. A false hazard withdraws a
+        recommendation for a server that is fine, so the bar is real traffic on a
+        genuinely shared backend; a missed one costs a withdrawal that the next
+        observation makes again.
+
+        The observation is stamped with what this backend actually launched, read
+        straight off the pool key, so upgrading or reconfiguring the server
+        invalidates it rather than holding the new version responsible for the
+        behaviour of the one it replaced.
 
         In-memory only — the flush is off-loop.
         """
         if self.exclusive_token or self.refcount <= 1:
             return
-        name = self.pool_key.server_name
-        if name and hazards.record_observed(name, code):
+        key = self.pool_key
+        name = key.server_name
+        identity = hazards.launch_identity(
+            key.command_args_hash, key.effective_env_hash, key.binary_version
+        )
+        if name and hazards.record_observed(name, code, identity):
             logger.warning(
                 "hazard: server %r first exhibited %s while shared; the "
                 "MCP page will withdraw its recommendation",

--- a/src/kiro_crew/mcp_gateway/hazards.py
+++ b/src/kiro_crew/mcp_gateway/hazards.py
@@ -23,9 +23,16 @@ Design constraints this shape satisfies
   off-loop. A hazard that is only in memory is still correct for the current
   process; losing the last flush costs a recommendation withdrawal, never
   correctness of routing.
-* **Monotonic, and bounded.** Hazards accumulate but the per-server record is
-  collapsed to a set of codes plus a count and a last-seen wall clock, so the
-  file cannot grow with traffic.
+* **Bounded, and invalidated by change rather than by age.** The per-server
+  record collapses to a set of codes plus a count and a last-seen wall clock, so
+  the file cannot grow with traffic. Each record is stamped with the launch
+  identity it was observed under, and observations made under a different
+  identity are discarded: upgrading or reconfiguring a server clears its
+  history, because the evidence described the program it replaced. Age alone
+  never clears anything — a server that personalises state per caller does not
+  become safe because time passed, so expiry would manufacture a safety nothing
+  observed. ``clear`` is the separate, explicit path for an observation this
+  gateway recorded in error.
 * **Never fabricates.** A missing or corrupt file reads as "no hazards
   observed", which is the truth: we have not seen one. It does NOT read as
   "safe" — safety is decided by ``shareability.assess``, which treats absence
@@ -58,7 +65,32 @@ _KNOWN_HAZARDS = frozenset(
     {HAZARD_UNROUTABLE_SERVER_REQUEST, HAZARD_UNATTRIBUTABLE_NOTIFICATION}
 )
 
+# Deliberately NOT bumped for the per-identity shape. A reader that does not know
+# ``identities`` must still see something, because this product can put an older
+# build back in front of the same data home — Make Live switches the gateway to
+# an arbitrary worktree, including an earlier one. A bumped schema would read as
+# "future, ignore" there and silently drop every observation, so the writer emits
+# BOTH shapes under one version instead: the nested map for readers that
+# understand it, plus the flat union a v1 reader already knows how to parse.
 _SCHEMA = 1
+
+
+def launch_identity(
+    command_args_hash: str, env_hash: str, binary_version: str
+) -> str:
+    """Stable string for what a launch actually ran.
+
+    Built from fields ``PoolKey`` already carries, so the recording site can
+    stamp an observation without doing any IO on the event loop.
+
+    Deliberately NOT ``verdict_cache.Identity.as_str()``, which folds in the
+    pre-flight schema. The two stores invalidate for different reasons: a
+    measurement is void when the way we measure changes, but a hazard is an
+    observation of real traffic that stays true however the prober evolves.
+    Sharing that field would let a pre-flight schema bump erase evidence the
+    gateway actually witnessed.
+    """
+    return "\u0000".join((command_args_hash, env_hash, binary_version))
 
 
 @dataclass
@@ -78,7 +110,14 @@ class HazardLedger:
 
     def __init__(self, path: Path) -> None:
         self._path = path
-        self._records: dict[str, _Record] = {}
+        # name -> launch identity -> record. Nested rather than one row per
+        # server because two backends for the same NAME can be live at once: a
+        # blue/green drain keeps the old build serving its attached stubs while
+        # the new one starts, so both can record. Collapsing them into one row
+        # let a late frame from the draining backend overwrite the new build's
+        # evidence, which reads as "nothing observed" for the build actually
+        # being kept — the permissive direction.
+        self._records: dict[str, dict[str, _Record]] = {}
         self._dirty = False
         # Bumped by every ``record``. ``flush`` captures it alongside the payload
         # so a concurrent observation cannot be marked persisted.
@@ -90,19 +129,30 @@ class HazardLedger:
 
     # -- writer side (gatewayd) ------------------------------------------
 
-    def record(self, server_name: str, code: str) -> bool:
-        """Note that *server_name* exhibited *code*. Returns True if new.
+    def record(self, server_name: str, code: str, identity: str = "") -> bool:
+        """Note that *server_name* exhibited *code* under *identity*. True if new.
 
         Unknown codes are refused rather than stored: the vocabulary is a
         contract with the UI, and a typo that silently became a permanent
         "hazard" would disqualify a server forever with no way to read why.
+
+        *identity* fingerprints what was actually launched, and each identity
+        accumulates independently. Observations are never moved or discarded
+        across identities: two backends for one NAME can be live at once during
+        a drain, so a write that replaced another identity's row would let a
+        late frame from the outgoing build erase what the incoming one observed.
+
+        Invalidation therefore happens on the READ, not here — a launch whose
+        identity has no record of its own reads as unobserved, which is what
+        makes an upgrade or a config edit clear the verdict.
         """
         if code not in _KNOWN_HAZARDS:
             logger.warning("hazards: refusing unknown code %r for %r", code, server_name)
             return False
         if not server_name:
             return False
-        rec = self._records.setdefault(server_name, _Record())
+        per_identity = self._records.setdefault(server_name, {})
+        rec = per_identity.setdefault(identity, _Record())
         is_new = code not in rec.codes
         rec.codes.add(code)
         rec.count += 1
@@ -110,6 +160,28 @@ class HazardLedger:
         self._dirty = True
         self._generation += 1
         return is_new
+
+    def clear(self, server_name: str) -> bool:
+        """Forget every observation for *server_name*. True if anything went.
+
+        The identity check on read cannot cover one case: an observation this
+        gateway recorded in error. A misattributed frame is a defect on OUR side,
+        so fixing it changes nothing about the server's identity and the evidence
+        would otherwise stand for ever against a server that never misbehaved.
+        This is the deliberate operator escape hatch for that, and the only way
+        to drop evidence that is still current.
+
+        Note what is NOT offered: expiry by age. A server that personalises
+        state per caller does not become safe because a month passed, so ageing
+        an observation out would manufacture a "safe to share" that nothing
+        observed. Every invalidation here is tied to something real changing —
+        the program, or a human saying the record is wrong.
+        """
+        if self._records.pop(server_name, None) is None:
+            return False
+        self._dirty = True
+        self._generation += 1
+        return True
 
     def flush(self) -> None:
         """Persist if anything changed. Safe to call often; cheap when clean.
@@ -137,11 +209,29 @@ class HazardLedger:
                 "schema": _SCHEMA,
                 "servers": {
                     name: {
-                        "codes": sorted(rec.codes),
-                        "count": rec.count,
-                        "lastSeen": rec.last_seen,
+                        "identities": {
+                            identity: {
+                                "codes": sorted(rec.codes),
+                                "count": rec.count,
+                                "lastSeen": rec.last_seen,
+                            }
+                            for identity, rec in sorted(per_identity.items())
+                        },
+                        # Flat union of the same records, for a reader that
+                        # predates ``identities``. Derived here from the very
+                        # records above, in the same payload, so the two cannot
+                        # disagree; a reader that understands ``identities``
+                        # ignores these three.
+                        "codes": sorted(
+                            {c for rec in per_identity.values() for c in rec.codes}
+                        ),
+                        "count": sum(rec.count for rec in per_identity.values()),
+                        "lastSeen": max(
+                            (rec.last_seen for rec in per_identity.values()),
+                            default=0.0,
+                        ),
                     }
-                    for name, rec in sorted(self._records.items())
+                    for name, per_identity in sorted(self._records.items())
                 },
             }
             try:
@@ -180,27 +270,72 @@ class HazardLedger:
         for name, entry in servers.items():
             if not isinstance(name, str) or not isinstance(entry, dict):
                 continue
-            codes = entry.get("codes")
-            if not isinstance(codes, list):
-                continue
-            kept = {c for c in codes if isinstance(c, str) and c in _KNOWN_HAZARDS}
-            if not kept:
-                continue
-            count = entry.get("count")
-            last = entry.get("lastSeen")
-            self._records[name] = _Record(
-                codes=kept,
-                count=count if isinstance(count, int) and count >= 0 else len(kept),
-                last_seen=finite_float(last),
-            )
+            # ``identities`` is the authoritative shape. Its absence means a
+            # writer that predates it — including an older build put back in
+            # front of this data home — so the flat fields are all there is, and
+            # they land under the empty identity: still visible to the name-only
+            # read, matching no launch for the identity-checked one, which is the
+            # honest reading of evidence that cannot be attributed.
+            raw_identities = entry.get("identities")
+            if not isinstance(raw_identities, dict):
+                raw_identities = {"": entry}
+            per_identity: dict[str, _Record] = {}
+            for identity, sub in raw_identities.items():
+                if not isinstance(identity, str) or not isinstance(sub, dict):
+                    continue
+                codes = sub.get("codes")
+                if not isinstance(codes, list):
+                    continue
+                kept = {c for c in codes if isinstance(c, str) and c in _KNOWN_HAZARDS}
+                if not kept:
+                    continue
+                count = sub.get("count")
+                per_identity[identity] = _Record(
+                    codes=kept,
+                    count=count if isinstance(count, int) and count >= 0 else len(kept),
+                    last_seen=finite_float(sub.get("lastSeen")),
+                )
+            if per_identity:
+                self._records[name] = per_identity
 
-    def codes_for(self, server_name: str) -> tuple[str, ...]:
-        """Hazard codes observed for *server_name*, oldest-agnostic, sorted."""
-        rec = self._records.get(server_name)
+    def codes_for(self, server_name: str, identity: str) -> tuple[str, ...]:
+        """Hazard codes observed for *server_name* under *identity*, sorted.
+
+        Returns empty when this identity has no record of its own, which reads as
+        "nothing observed about THIS program" rather than "safe": absence of
+        hazards is absence of evidence, and ``shareability.assess`` treats it
+        that way. Another identity's record is never consulted, so a hazard on
+        the build being replaced cannot answer for the build replacing it.
+
+        This is the read a caller that acts on the verdict wants — refusing to
+        pool, most of all — because it is the one that cannot strand a server on
+        evidence about a version it no longer runs.
+        """
+        rec = self._records.get(server_name, {}).get(identity)
         return tuple(sorted(rec.codes)) if rec else ()
 
+    def codes_for_name(self, server_name: str) -> tuple[str, ...]:
+        """Every code stored under *server_name*, across all identities, sorted.
+
+        For the dashboard row builder, which knows a name and deliberately does
+        no IO, so it cannot fingerprint a binary to compare identities. The
+        consequence is bounded and in the safe direction: a row can show a
+        withdrawal that the next probe clears, never a recommendation that the
+        evidence contradicts.
+        """
+        codes: set[str] = set()
+        for rec in self._records.get(server_name, {}).values():
+            codes |= rec.codes
+        return tuple(sorted(codes))
+
     def as_dict(self) -> dict[str, tuple[str, ...]]:
-        return {name: tuple(sorted(rec.codes)) for name, rec in self._records.items()}
+        """Every stored code by name, identity-blind like ``codes_for_name``.
+
+        The dashboard's bulk read. Not identity-checked, for the same reason:
+        resolving an identity means fingerprinting a binary, which this caller
+        deliberately does not do.
+        """
+        return {name: self.codes_for_name(name) for name in self._records}
 
 
 def ledger_path(runtime_dir: Path) -> Path:
@@ -234,17 +369,30 @@ def install_sink(runtime_dir: Path) -> HazardLedger:
     return _sink
 
 
-def record_observed(server_name: str, code: str) -> bool:
+def record_observed(server_name: str, code: str, identity: str = "") -> bool:
     """Note a hazard on the process sink. In-memory only; never touches disk.
 
     Safe to call from the event loop precisely because it does no IO — the
-    flush is a separate, off-loop step. Returns True when this is the first
-    time *code* was seen for *server_name*, so a caller can log it once at a
-    louder level than the per-occurrence debug line.
+    flush is a separate, off-loop step, and *identity* is read off the pool key
+    the caller already holds rather than computed here. Returns True when this
+    is the first time *code* was seen for *server_name*, so a caller can log it
+    once at a louder level than the per-occurrence debug line.
     """
     if _sink is None:
         return False
-    return _sink.record(server_name, code)
+    return _sink.record(server_name, code, identity)
+
+
+def clear_observed(server_name: str) -> bool:
+    """Drop every observation for *server_name* from the process sink.
+
+    In-memory like ``record_observed``; the caller flushes. Returns False when
+    there was nothing to forget, so an operator surface can say so instead of
+    reporting a clear that changed nothing.
+    """
+    if _sink is None:
+        return False
+    return _sink.clear(server_name)
 
 
 def flush_sink() -> None:

--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -512,7 +512,7 @@ class TestHeartbeatSweeper:
             task.cancel()
             await asyncio.wait_for(task, timeout=5)
 
-            assert hazards.load_ledger(tmp_path).codes_for("srv") == (
+            assert hazards.load_ledger(tmp_path).codes_for_name("srv") == (
                 hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
             )
         finally:

--- a/test/test_mcp_preflight.py
+++ b/test/test_mcp_preflight.py
@@ -124,7 +124,7 @@ class TestCacheDegradesSafely:
             b'{"schema": 1, "servers": {"a\xff\xfe": {}}}'
         )
         ledger = hazards.load_ledger(tmp_path)
-        assert ledger.codes_for("a") == ()
+        assert ledger.codes_for_name("a") == ()
 
     def test_entry_that_cannot_say_whether_it_ran_is_dropped(self, tmp_path) -> None:
         vc.cache_path(tmp_path).write_text(

--- a/test/test_mcp_shareability.py
+++ b/test/test_mcp_shareability.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -271,14 +272,14 @@ class TestHazardLedger:
         led.flush()
 
         fresh = hazards.load_ledger(tmp_path)
-        assert fresh.codes_for("srv") == (hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,)
-        assert fresh.codes_for("other") == ()
+        assert fresh.codes_for_name("srv") == (hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,)
+        assert fresh.codes_for_name("other") == ()
 
     def test_unknown_code_is_refused(self, tmp_path) -> None:
         """The vocabulary is a UI contract; a typo must not disqualify forever."""
         led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
         assert led.record("srv", "made_up") is False
-        assert led.codes_for("srv") == ()
+        assert led.codes_for_name("srv") == ()
         led.flush()
         assert not hazards.ledger_path(tmp_path).exists()
 
@@ -310,8 +311,8 @@ class TestHazardLedger:
             encoding="utf-8",
         )
         led = hazards.load_ledger(tmp_path)
-        assert led.codes_for("a") == ()
-        assert led.codes_for("b") == (hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,)
+        assert led.codes_for_name("a") == ()
+        assert led.codes_for_name("b") == (hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,)
 
     def test_flush_is_a_no_op_when_clean(self, tmp_path) -> None:
         led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
@@ -343,7 +344,7 @@ class TestHazardLedger:
 
         assert led._dirty is True, "the concurrent observation was marked persisted"
         led.flush()
-        assert hazards.load_ledger(tmp_path).codes_for("other") == (
+        assert hazards.load_ledger(tmp_path).codes_for_name("other") == (
             hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,
         )
 
@@ -399,7 +400,7 @@ class TestHazardLedger:
         led.record("srv", hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION)
         led.flush()
 
-        observed = hazards.load_ledger(tmp_path).codes_for("srv")
+        observed = hazards.load_ledger(tmp_path).codes_for_name("srv")
         verdict = assess(
             ShareEvidence(
                 name="srv", probe_ok=True, capabilities={}, observed_hazards=observed
@@ -448,7 +449,7 @@ class TestHostileRecordNumbers:
 
         led = hazards.load_ledger(tmp_path)
 
-        assert led.codes_for("srv") == (hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,)
+        assert led.codes_for_name("srv") == (hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,)
 
     def test_a_huge_timestamp_does_not_take_the_verdict_cache_down(self, tmp_path) -> None:
         vc.cache_path(tmp_path).write_text(
@@ -779,7 +780,206 @@ class TestNoBlockingRecordIoOnTheLoop:
         assert cache.server_names() == {"a", "b"}
 
 
+class TestHazardInvalidation:
+    """A hazard must survive what does not change the program, and only that.
+
+    The ledger's neighbour — the pre-flight cache — re-measures when a server's
+    launch identity changes. Without the same rule here a single observation
+    disqualifies a server for ever, so wiring a pooling refusal to this ledger
+    would strand a server on evidence about a version it no longer runs.
+    """
+
+    @staticmethod
+    def _ident(binary: str = "v1") -> str:
+        return hazards.launch_identity("cmd1", "env1", binary)
+
+    def test_an_upgrade_discards_the_prior_observation(self, tmp_path) -> None:
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST, self._ident("v1"))
+        assert led.codes_for("srv", self._ident("v1")) != ()
+
+        # Same path, same args, new bytes: the evidence described the old build.
+        assert led.codes_for("srv", self._ident("v2")) == ()
+
+    def test_the_discard_is_a_replacement_not_an_accumulation(self, tmp_path) -> None:
+        """A new identity starts clean — it does not inherit the old codes.
+
+        Inheriting would make an upgrade look like it exhibited behaviour it
+        never showed, which is the same permanence bug wearing a new identity.
+        """
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST, self._ident("v1"))
+        led.record("srv", hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION, self._ident("v2"))
+
+        assert led.codes_for("srv", self._ident("v2")) == (
+            hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,
+        )
+
+    def test_a_draining_backend_cannot_erase_the_new_builds_evidence(
+        self, tmp_path
+    ) -> None:
+        """Two identities are live at once during a blue/green drain.
+
+        The pool keeps the outgoing build serving its attached stubs while the
+        incoming one starts, so BOTH can still record. Collapsing them into one
+        row per name let a late frame from the draining backend overwrite what
+        the new build had already observed — and that reads as "nothing observed"
+        for the build actually being kept, the permissive direction.
+        """
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        new = self._ident("v2")
+        old = self._ident("v1")
+
+        led.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST, new)
+        # The outgoing backend emits one more frame AFTER the new build recorded.
+        led.record("srv", hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION, old)
+
+        assert led.codes_for("srv", new) == (
+            hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
+        ), "the new build's evidence survived a late frame from the old one"
+        assert led.codes_for("srv", old) == (
+            hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,
+        ), "each identity keeps its own observations"
+
+        led.flush()
+        reloaded = hazards.load_ledger(tmp_path)
+        assert reloaded.codes_for("srv", new) == (
+            hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
+        )
+
+    def test_an_unchanged_server_keeps_its_hazard(self, tmp_path) -> None:
+        """The direction that must NOT clear — otherwise the ledger is useless.
+
+        Two codes under ONE identity, because a single observation cannot tell a
+        correct implementation from one that resets on every record: both would
+        end up holding exactly the code just written.
+        """
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST, self._ident())
+        led.record("srv", hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION, self._ident())
+        led.flush()
+
+        reloaded = hazards.load_ledger(tmp_path)
+        assert reloaded.codes_for("srv", self._ident()) == (
+            hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,
+            hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
+        ), "observations under one identity accumulate, they do not replace"
+
+    def test_identity_is_not_the_preflight_identity(self) -> None:
+        """The two stores must not share an invalidation trigger.
+
+        ``verdict_cache.Identity`` folds in the pre-flight schema, because a
+        measurement is void when the way we measure changes. A hazard is an
+        observation of real traffic and stays true however the prober evolves, so
+        sharing that field would let a schema bump erase witnessed evidence.
+        """
+        launch = hazards.launch_identity("cmd1", "env1", "1.0.0")
+        preflight = vc.Identity("cmd1", "env1", "1.0.0").as_str()
+        assert launch != preflight
+        assert str(vc.SCHEMA) not in launch.split("\u0000")
+
+    def test_a_legacy_row_reads_as_unobserved_but_still_shows(self, tmp_path) -> None:
+        """A v1 file still loads; its rows just cannot be attributed.
+
+        They must not be deleted — that would discard real evidence to add a
+        field — and must not be trusted for a launch either, so they land under
+        the empty identity: invisible to the checked read, still surfaced by the
+        name-only one so the dashboard keeps showing the withdrawal.
+        """
+        (tmp_path / hazards.HAZARDS_FILENAME).write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "servers": {
+                        "srv": {
+                            "codes": [hazards.HAZARD_UNROUTABLE_SERVER_REQUEST],
+                            "count": 1,
+                            "lastSeen": 1.0,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        led = hazards.load_ledger(tmp_path)
+        assert led.codes_for("srv", self._ident()) == ()
+        assert led.codes_for_name("srv") == (
+            hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
+        )
+
+    def test_an_older_reader_still_sees_the_evidence(self, tmp_path) -> None:
+        """The written file must not lock out a build that predates identities.
+
+        Make Live can put an earlier worktree back in front of the same data
+        home, so a version-gated shape change would read as "future, ignore"
+        there and silently drop every observation. The writer therefore keeps the
+        schema and emits the flat union alongside the nested map.
+        """
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST, self._ident("v1"))
+        led.record("srv", hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION, self._ident("v2"))
+        led.flush()
+
+        raw = json.loads((tmp_path / hazards.HAZARDS_FILENAME).read_text())
+        assert raw["schema"] == 1, "a bump would make an older reader ignore the file"
+        entry = raw["servers"]["srv"]
+        # What a reader that knows nothing about identities parses:
+        assert entry["codes"] == [
+            hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,
+            hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
+        ], "the flat union carries every code an older reader would need"
+        # ...and the shape this build actually reads, unaffected by it:
+        assert set(entry["identities"]) == {self._ident("v1"), self._ident("v2")}
+
+    def test_clear_drops_evidence_that_is_still_current(self, tmp_path) -> None:
+        """The escape hatch identity cannot provide.
+
+        A frame this gateway misattributed is our defect; fixing it changes
+        nothing about the server, so without an explicit clear the record would
+        stand for ever against a server that never misbehaved.
+        """
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST, self._ident())
+        led.flush()
+
+        assert led.clear("srv") is True
+        assert led.clear("srv") is False, "a second clear reports nothing to forget"
+        led.flush()
+        assert hazards.load_ledger(tmp_path).codes_for_name("srv") == ()
+
+    def test_nothing_expires_by_age(self, tmp_path) -> None:
+        """Ageing an observation out would manufacture a safety nothing observed.
+
+        A server that personalises state per caller does not become safe because
+        time passed, so a very old hazard on an UNCHANGED identity still stands.
+        """
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST, self._ident())
+        # Backdate well past any plausible expiry window.
+        led._records["srv"][self._ident()].last_seen = 1.0
+        led.flush()
+
+        assert hazards.load_ledger(tmp_path).codes_for("srv", self._ident()) == (
+            hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
+        )
+
+    def test_the_recording_site_stamps_the_pool_key(self) -> None:
+        """The identity must come from the launch, with no IO on the loop.
+
+        ``PoolKey`` already carries the three fingerprints, which is what makes
+        stamping free at a site that runs on the event loop.
+        """
+        from kiro_crew.mcp_gateway import backend as backend_mod
+
+        src = inspect.getsource(backend_mod.Backend._record_hazard)
+        assert "launch_identity" in src
+        assert "key.command_args_hash" in src and "key.binary_version" in src
+        for forbidden in ("open(", "read_bytes", "sha256", "to_thread"):
+            assert forbidden not in src, f"{forbidden} would put IO on the loop"
+
+
 class TestRecordsDirIsNotGatedOnABroker:
+
     """A machine that never enabled stubbing must still get verdicts.
 
     Deriving the records directory from ``mcp_gateway.socket_path`` made the
@@ -856,12 +1056,15 @@ class TestBackendRecordsHazards:
 
     @staticmethod
     def _backend(server_name: str, *, exclusive_token: str = "", refcount: int = 2) -> object:
-        """A Backend-shaped stand-in for the three fields ``_record_hazard`` reads.
+        """A Backend-shaped stand-in for the fields ``_record_hazard`` reads.
 
         Deliberately not a MagicMock: the point is to pin that the method reads
-        ``pool_key.server_name``, ``exclusive_token`` and ``refcount`` — the REAL
-        field names on ``Backend`` — so a rename cannot leave this passing
-        against a mock that would answer to anything.
+        ``pool_key.server_name``, the three launch fingerprints,
+        ``exclusive_token`` and ``refcount`` — the REAL field names on
+        ``Backend`` and ``PoolKey`` — so a rename cannot leave this passing
+        against a mock that would answer to anything. That the fingerprints are
+        already ON the pool key is what lets the recording site stamp an identity
+        without doing IO on the event loop.
 
         ``refcount`` defaults to 2 because that is the only state in which a
         hazard means anything: two clients attached, so an unattributable frame
@@ -870,7 +1073,12 @@ class TestBackendRecordsHazards:
         from kiro_crew.mcp_gateway.backend import Backend
 
         obj = object.__new__(Backend)
-        obj.pool_key = SimpleNamespace(server_name=server_name)  # type: ignore[attr-defined]
+        obj.pool_key = SimpleNamespace(  # type: ignore[attr-defined]
+            server_name=server_name,
+            command_args_hash="cmd1",
+            effective_env_hash="env1",
+            binary_version="v1",
+        )
         obj.exclusive_token = exclusive_token  # type: ignore[attr-defined]
         obj.refcount = refcount  # type: ignore[attr-defined]
         return obj
@@ -880,7 +1088,7 @@ class TestBackendRecordsHazards:
         backend = self._backend("srv")
         backend._record_hazard(hazards.HAZARD_UNROUTABLE_SERVER_REQUEST)  # type: ignore[attr-defined]
         hazards.flush_sink()
-        assert hazards.load_ledger(tmp_path).codes_for("srv") == (
+        assert hazards.load_ledger(tmp_path).codes_for_name("srv") == (
             hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
         )
 


### PR DESCRIPTION
## 1. What is the problem?

An observed hazard was permanent. Once gatewayd saw a server behave per-client while its backend was shared, that record stood for ever — no upgrade, no reconfiguration, and no operator action could clear it.

This is asymmetric with the pre-flight cache sitting in the same directory, which re-measures whenever a server's launch identity changes. The ledger had no equivalent, so the two stores disagreed about what "this server changed" means.

## 2. Why this issue matters to the user

Today the ledger is only read by the MCP page, so a stale record costs a withdrawn recommendation. That changes the moment anything acts on it.

The intended next step for this feature is a pooling refusal: gatewayd declines to share a backend for a `refuted` server. With a permanent record, one observation — including one this gateway misattributed — would un-pool that server for the life of the install. The user would see a server that never pools again, with no way to find out why and no way to clear it, even after upgrading to a build that fixed the behaviour.

Fixing the invalidation path first means the refusal can never strand a server.

## 3. How our fix solves it

Chain from symptom to root cause:

- **Symptom**: a hazard never clears.
- **Cause**: the record stores only `codes`, `count` and `lastSeen` — nothing that says *what program* was observed. With no way to tell the old build from the new one, the only safe reading of a stored code is "still applies".
- **Fix**: stamp each record with the launch identity it was observed under, and treat a different identity as "nothing observed about this program".

`identity` is built from the command/args, effective-env and binary fingerprints that `PoolKey` **already carries**, which is what makes stamping free at a recording site that runs on the event loop — no hashing, no file reads, no `to_thread`. A test pins that the site reads those pool-key fields and contains none of `open(` / `read_bytes` / `sha256` / `to_thread`.

An observation under a new identity **replaces** rather than accumulates: carrying the old codes forward would make an upgrade look like it exhibited behaviour it never showed — the same permanence bug wearing a new identity.

Three decisions worth stating explicitly, because each has a plausible-looking wrong answer:

**No expiry by age.** A server that personalises state per caller does not become safe because a month passed, so ageing an observation out would manufacture a "safe to share" that nothing observed. Every invalidation here is tied to something real changing: the program, or a human saying the record is wrong. A mutant that adds a 30-day expiry is killed by a test.

**The identity is deliberately NOT `verdict_cache.Identity.as_str()`**, which folds in the pre-flight schema. The two stores invalidate for different reasons: a measurement is void when the way we measure changes, but a hazard is an observation of real traffic that stays true however the prober evolves. Sharing that field would let a pre-flight schema bump erase evidence the gateway actually witnessed.

**The file schema is unchanged at v1.** `identity` is optional in both directions — an older reader ignores it, and a record written before it existed loads as empty, which matches no launch, so the identity-checked read treats the server as unobserved. Bumping the schema instead would make `load()` discard the whole file on upgrade, throwing away real evidence in order to add a field.

Reads are split so an identity-blind caller has to say so: `codes_for(name, identity)` is the checked read for anything acting on the verdict, and `codes_for_name(name)` is for the dashboard row builder, which does no IO and therefore cannot fingerprint a binary. That difference is bounded and in the safe direction — a row may show a withdrawal the next probe clears, never a recommendation the evidence contradicts.

Finally, identity cannot cover a frame **this gateway** misattributed: that is our defect, and fixing it changes nothing about the server. `clear(server_name)` is the explicit path for dropping evidence that is otherwise still current.

## 4. What tests we did

- **236 targeted tests** green (`test_mcp_shareability.py`, `test_mcp_preflight.py`, `test_mcp_gatewayd_coverage.py`), including 8 new tests for the invalidation path.
- **Mutation-verified 8/8**, deliberately including both over-correction directions:
  - identity ignored on read (stale hazard applies to a new build) — caught
  - new identity inherits the old codes — caught
  - *over-correction*: every record resets, so a hazard never persists — caught
  - *over-correction*: age-based expiry manufactures safety — caught
  - identity shared with the pre-flight cache — caught
  - legacy empty identity matches anything — caught
  - `clear` does not persist — caught
  - recording site does IO on the loop — caught
- The mutation run found a **vacuous assertion in my own new test**: "an unchanged server keeps its hazard" recorded only once, and a single observation cannot distinguish correct behaviour from an implementation that resets on every record. Rewritten to record two codes under one identity, which is what actually pins accumulation.
- Wider slice `-k "mcp or gateway"`: **4436 passed**. One unrelated failure, `test_gateway_lock_diagnosis.py::test_flock_is_held_by_a_fork_orphan` (`assert 7447 == 1`), diagnosed rather than waved off: that file imports only stdlib and pytest and references neither `hazards` nor `mcp_gateway.backend`, so no import path exists from it to this change. The PID-shaped number is this host's leftover orphan gateway processes making the lock-diagnosis test count several holders instead of one.
- Blocking gates: isort, flake8, mypy (967 files), docs_lint, brand — all clean, re-run after rebasing onto current main.

## 5. Any other suggestions on the work

**`clear()` has no operator surface yet.** It is reachable as an API and via `clear_observed` on the process sink, but nothing in the dashboard or CLI calls it. That is deliberate scope: this PR makes the invalidation *possible* and correct, and the surface belongs with whichever consumer lands first. Worth deciding together with the pooling refusal, so the affordance appears next to the thing it corrects rather than as a bare button.

**The dashboard row builder stays identity-blind.** Making it checked would mean fingerprinting binaries inside a request path that is deliberately IO-free. If that ever becomes wanted, the honest way is for the probe pass to write the resolved identity where the row builder can read it, not to add IO to the handler.

**This does not make the feature live.** No UI consumes `recommendation`, `seed.py` still has no production call site, and a `refuted` server is still pooled. This removes the blocker in front of the refusal; it does not implement it.

Closes #3289
