### PR TITLE
fix(dashboard): preserve auto-speak tails across segments

### DIFF
--- a/docs/system-specs/features/voice-streaming.md
+++ b/docs/system-specs/features/voice-streaming.md
@@ -30,14 +30,14 @@ Piper:  POST /api/voice/synthesize → synthesize_speech() one WAV
 
 ## Streaming Auto-Speak Flow
 
-1. User sends a message; `spokenLenRef` resets to 0
+1. User sends a message; `voiceProgressRef` clears its prior message identity
 2. Backend streams `chat_chunk` events via WebSocket
 3. Frontend accumulates text in a `streaming` message in Redux
 4. On each chunk, regex scans for sentence boundaries (`[.!?]` followed by whitespace)
 5. New complete sentences (≥10 chars) are sent to `POST /api/voice/synthesize`
 6. Backend calls Polly per sentence, broadcasts `voice_chunk` (base64 MP3) via WS
 7. Frontend decodes chunks into blob URLs, queues them, plays sequentially
-8. On `chat_done`, any remaining unspoken tail text is synthesized
+8. On `chat_segment` or `chat_done`, any remaining unspoken tail text is synthesized before finalization
 9. `voice_complete` event carries the stitched full MP3 for replay
 
 ## Interrupt Mechanism
@@ -49,7 +49,7 @@ Sending a new message while voice is playing triggers an interrupt:
 3. `stopVoice()` pauses the active `Audio` element, clears the queue, and sets `voiceMutedRef = true`
 4. Incoming `voice_chunk` events from the old response are dropped while muted
 5. `chat_done` for the old response skips remaining-text synthesis when muted
-6. When the new response's first sentence is detected (`spokenLenRef === 0`), `voiceMutedRef` resets to `false`
+6. When a new response message identity is observed, `voiceMutedRef` resets to `false`
 
 The DOM event pattern avoids prop drilling between `ChatPage` (where send lives) and `useWebSocket` (where audio state lives, called from `App.tsx`).
 
@@ -154,9 +154,12 @@ placeholders so listeners know content exists without hearing raw syntax.
 When the assistant calls a tool mid-response, the backend emits a `chat_segment`
 event that finalizes the current streaming message and starts a new one.
 
-The frontend resets `spokenLenRef` to 0 on `chat_segment` so the new segment's
-text is spoken from the beginning. Without this reset, the offset from segment 1
-would cause segment 2 to be skipped until its length exceeded the old offset.
+The frontend keys `voiceProgressRef` by `{slot, messageId}`. Before
+`chat_segment` finalizes the current streaming message, it synthesizes any
+unspoken tail of at least 10 characters and marks that message consumed. The
+next segment receives a new message identity and therefore starts at offset 0.
+This also prevents a background slot's segment event from resetting speech
+progress for the active slot.
 
 ## Synthesize Serialization
 
@@ -194,7 +197,7 @@ async pipeline: markdown strip → SSML → Polly → Slack file upload.
 | `voicePlayingRef` | `boolean` | True while an Audio element is playing |
 | `activeAudioRef` | `HTMLAudioElement` | Currently playing audio (for pause on interrupt) |
 | `autoSpeakRef` | `boolean` | Cached auto-speak preference from server |
-| `spokenLenRef` | `number` | Character offset of text already sent to TTS |
+| `voiceProgressRef` | `{ slot, messageId, spokenLen }` | Message-scoped character offset already sent to TTS |
 | `voiceMutedRef` | `boolean` | Suppresses incoming voice chunks after interrupt |
 | `synthChainRef` | `Promise` | Serializes synthesize calls to prevent out-of-order audio |
 

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -14,10 +14,24 @@ import { TAB_ID } from '../api/tabId'
 import { api } from '../api/client'
 import { sanitizeLlmOutput } from '../utils/sanitize'
 import { applyStatusDelta, parseStatusDelta } from '../utils/pullRequestStatusDelta'
-import type { StatusData, ChatSlot, Notification, PullRequestStatusBatch, TodoList } from '../types'
+import type { StatusData, ChatMessage, ChatSlot, Notification, PullRequestStatusBatch, TodoList } from '../types'
 import { i18nT } from '../i18n/t'
 
 type LogCallback = ((data: { level: string; msg: string }) => void) | null
+
+type VoiceProgress = {
+  slot: string
+  messageId: string
+  spokenLen: number
+}
+
+function voiceMessageId(message: ChatMessage): string {
+  const clientId = message.meta?.clientTs
+  if (typeof clientId === 'string' && clientId) return clientId
+  if (message.ts) return message.ts
+  const serverId = message.meta?.mid
+  return typeof serverId === 'string' ? serverId : ''
+}
 
 /** Single multiplexed WebSocket replacing all SSE + polling connections. */
 /** The server-side IDENTITY of a held card: a blocking ask's `ask_id`, or a
@@ -188,12 +202,10 @@ export function useWebSocket() {
   const voicePlayingRef = useRef(false)
   const activeAudioRef = useRef<HTMLAudioElement | null>(null)
   const autoSpeakRef = useRef(false)
-  const spokenLenRef = useRef(0)  // chars already sent to TTS during streaming
-  // Whether the streaming path synthesized anything this turn. chat_segment
-  // resets spokenLenRef to 0, so the completion pass cannot tell "nothing
-  // spoken yet" (speak the whole reply) from "spoken, then segment-reset"
-  // (speaking from 0 repeats the entire reply) without this.
-  const spokeThisTurnRef = useRef(false)
+  // Speech offsets belong to one concrete message. A segment for another slot
+  // must not reset the active message, and a new post-tool segment must start
+  // from zero even while the previous message remains in the transcript.
+  const voiceProgressRef = useRef<VoiceProgress | null>(null)
   const voiceMutedRef = useRef(false)  // suppress incoming chunks after interrupt
   const synthChainRef = useRef<Promise<unknown>>(Promise.resolve())  // serialize TTS calls
   // #1 streaming-chunk coalescing: accumulate per-slot chunk text and flush
@@ -224,6 +236,35 @@ export function useWebSocket() {
     voicePlayingRef.current = false
     dispatch(setVoicePlaying(false))
   }, [dispatch])
+
+  const voiceProgressFor = useCallback((slot: string, message: ChatMessage): VoiceProgress | null => {
+    const messageId = voiceMessageId(message)
+    if (!messageId) return null
+    const current = voiceProgressRef.current
+    if (!current || current.slot !== slot || current.messageId !== messageId) {
+      const next = { slot, messageId, spokenLen: 0 }
+      voiceProgressRef.current = next
+      voiceMutedRef.current = false
+      return next
+    }
+    return current
+  }, [])
+
+  const enqueueVoiceSynthesis = useCallback((slot: string, text: string) => {
+    synthChainRef.current = synthChainRef.current
+      .then(() => api.voiceSynthesize(slot, text))
+      .catch(() => {})
+  }, [])
+
+  const flushVoiceTail = useCallback((slot: string, message: ChatMessage) => {
+    const progress = voiceProgressFor(slot, message)
+    if (!progress) return
+    const remaining = message.content.slice(progress.spokenLen).trim()
+    // Mark the whole message consumed even when its tail is below the speech
+    // floor, so a later completion event cannot reconsider or repeat it.
+    progress.spokenLen = message.content.length
+    if (remaining.length >= 10) enqueueVoiceSynthesis(slot, remaining)
+  }, [enqueueVoiceSynthesis, voiceProgressFor])
 
   const playNextVoiceChunk = useCallback(() => {
     if (voicePlayingRef.current || voiceQueueRef.current.length === 0) return
@@ -404,35 +445,28 @@ export function useWebSocket() {
     // after the batched content has landed in the store. (Moved here from the
     // per-chunk path so it reads the post-dispatch streaming content.)
     if (dispatchedActive && autoSpeakRef.current && activeSlot) {
-      if (spokenLenRef.current === 0) voiceMutedRef.current = false
       const msgs = store.getState().chat.messages
       const streaming = [...msgs].reverse().find(m => m.role === 'streaming')
       if (streaming) {
+        const progress = voiceProgressFor(activeSlot, streaming)
+        if (!progress) return
         const full = streaming.content
-        // The counter is 0 with the spoke-flag still set only right after a
-        // chat_segment reset. New streaming content in that state is a fresh
-        // post-segment block — the trailing message is no longer the
-        // already-spoken one, so the completion pass must not skip it.
-        if (spokenLenRef.current === 0 && full.length > 0) spokeThisTurnRef.current = false
         let lastBound = -1
         const re = /[.!?](?:\s|$)/g
         let match
         while ((match = re.exec(full)) !== null) {
-          if (match.index + 1 > spokenLenRef.current) lastBound = match.index + 1
+          if (match.index + 1 > progress.spokenLen) lastBound = match.index + 1
         }
-        if (lastBound > spokenLenRef.current) {
-          const newText = full.slice(spokenLenRef.current, lastBound).trim()
+        if (lastBound > progress.spokenLen) {
+          const newText = full.slice(progress.spokenLen, lastBound).trim()
           if (newText.length >= 10) {
-            spokenLenRef.current = lastBound
-            spokeThisTurnRef.current = true
-            synthChainRef.current = synthChainRef.current
-              .then(() => api.voiceSynthesize(activeSlot, newText))
-              .catch(() => {})
+            progress.spokenLen = lastBound
+            enqueueVoiceSynthesis(activeSlot, newText)
           }
         }
       }
     }
-  }, [dispatch])
+  }, [dispatch, enqueueVoiceSynthesis, voiceProgressFor])
 
   const scheduleChunkFlush = useCallback(() => {
     if (chunkFlushScheduledRef.current) return
@@ -859,7 +893,7 @@ export function useWebSocket() {
             // trigger (no-op unless an L2 theme with that manifest sound is
             // active + unmuted). User/tool messages don't chime.
             if (data.role === 'assistant') emitThemeSound('message-received')
-            if (data.role === 'user' || data.role === 'inject' || data.role === 'subagent') { stopVoice(); spokenLenRef.current = 0; spokeThisTurnRef.current = false; synthChainRef.current = Promise.resolve() }
+            if (data.role === 'user' || data.role === 'inject' || data.role === 'subagent') { stopVoice(); voiceProgressRef.current = null; synthChainRef.current = Promise.resolve() }
             if (data.slot && (data.role === 'user' || data.role === 'inject' || data.role === 'subagent')) {
               dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'thinking', text: 'Thinking…', ts: Date.now() }))
             }
@@ -1170,11 +1204,16 @@ export function useWebSocket() {
             }
             break
           }
-          case 'chat_segment':
+          case 'chat_segment': {
             flushChunks()
+            const segmentSlot = data.slot as string
+            if (autoSpeakRef.current && !voiceMutedRef.current && segmentSlot === store.getState().chat.activeSlot) {
+              const streaming = [...store.getState().chat.messages].reverse().find(m => m.role === 'streaming')
+              if (streaming) flushVoiceTail(segmentSlot, streaming)
+            }
             dispatch(sseChatMessage({ ...data, role: '_segment' }))
-            spokenLenRef.current = 0
             break
+          }
           case 'chat_status':
             if (data.slot && data.status) {
               dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'thinking', text: data.status, ts: Date.now() }))
@@ -1186,6 +1225,14 @@ export function useWebSocket() {
           case 'chat_done':
             flushChunks()
             if (data.slot) chunkBufRef.current.delete(data.slot)
+            // Consume the tail while the streaming row still carries the same
+            // identity used by sentence-boundary progress tracking.
+            if (autoSpeakRef.current && !voiceMutedRef.current && data.slot === store.getState().chat.activeSlot) {
+              const msgs = store.getState().chat.messages
+              const last = [...msgs].reverse().find(m => m.role === 'streaming')
+                ?? [...msgs].reverse().find(m => m.role === 'assistant')
+              if (last) flushVoiceTail(data.slot, last)
+            }
             dispatch(sseChatMessage({ ...data, role: '_done' }))
             // Turn-complete chime: sound-only (no feed entry, no toast).
             // Plays on every real turn completion — active or background
@@ -1229,25 +1276,7 @@ export function useWebSocket() {
               queryClient.invalidateQueries({ queryKey: ['pull-request-source'], refetchType })
               queryClient.invalidateQueries({ queryKey: ['pull-request-statuses'], refetchType })
             }
-            // Auto-speak: speak any remaining unspoken text from streaming
-            if (autoSpeakRef.current && !voiceMutedRef.current && data.slot === store.getState().chat.activeSlot) {
-              const msgs = store.getState().chat.messages
-              const last = [...msgs].reverse().find(m => m.role === 'assistant')
-              if (last) {
-                const remaining = last.content.slice(spokenLenRef.current).trim()
-                // spokenLen 0 after streaming spoke means chat_segment reset
-                // the counter — "remaining" would then be the whole reply,
-                // repeating everything already spoken.
-                const segmentReset = spokeThisTurnRef.current && spokenLenRef.current === 0
-                if (remaining.length >= 10 && !segmentReset) {
-                  synthChainRef.current = synthChainRef.current
-                    .then(() => api.voiceSynthesize(data.slot, remaining))
-                    .catch(() => {})
-                }
-              }
-              spokenLenRef.current = 0
-              spokeThisTurnRef.current = false
-            } else if (data.slot === store.getState().chat.activeSlot) {
+            if ((!autoSpeakRef.current || voiceMutedRef.current) && data.slot === store.getState().chat.activeSlot) {
               // Re-check config in case it changed
               api.voiceConfig().then(c => { autoSpeakRef.current = !!c.autoSpeak }).catch(() => {})
             }

--- a/website/src/test/useWebSocket.autoSpeakSegmentReset.test.ts
+++ b/website/src/test/useWebSocket.autoSpeakSegmentReset.test.ts
@@ -4,8 +4,9 @@
  * spoken-length counter to 0, so after a segment the completion pass would
  * slice the finished reply from 0 and speak EVERYTHING a second time.
  *
- * These tests pin both sides: a segment-reset turn is not re-spoken, and a
- * reply that never streamed through the sentence path is still spoken in full.
+ * These tests pin the message-scoped progress contract: segment tails are
+ * flushed once, unrelated slots cannot reset the offset, and non-streamed
+ * replies still get their completion-only synthesis.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
@@ -106,6 +107,48 @@ describe('useWebSocket auto-speak after a segment reset', () => {
     act(() => { ws.simulateMessage({ type: 'chat_done', data: { slot: 'slot-1' } }) })
     await act(async () => {})
     expect(api.voiceSynthesize).toHaveBeenCalledTimes(1)
+
+    hook.unmount()
+  })
+
+  it('flushes an unspoken tail before chat_segment finalizes it', async () => {
+    const { hook, ws } = await mount()
+    const tail = 'An unpunctuated segment tail that still needs speech'
+
+    act(() => {
+      ws.simulateMessage({ type: 'chat_chunk', data: { slot: 'slot-1', content: tail, seq: 1 } })
+      ws.simulateMessage({ type: 'chat_segment', data: { slot: 'slot-1' } })
+    })
+    await act(async () => {})
+
+    expect(api.voiceSynthesize).toHaveBeenCalledTimes(1)
+    expect(api.voiceSynthesize).toHaveBeenCalledWith('slot-1', tail)
+
+    hook.unmount()
+  })
+
+  it('does not let a background segment reset active-slot speech progress', async () => {
+    const { hook, ws } = await mount()
+    const tail = 'an unpunctuated continuation after the sentence'
+
+    act(() => {
+      ws.simulateMessage({ type: 'chat_chunk', data: { slot: 'slot-1', content: SENTENCE, seq: 1 } })
+      // A segment for another slot synchronously flushes the active chunk, but
+      // must not reset the active message's already-spoken offset.
+      ws.simulateMessage({ type: 'chat_segment', data: { slot: 'slot-2' } })
+    })
+    await act(async () => {})
+    expect(api.voiceSynthesize).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      ws.simulateMessage({ type: 'chat_chunk', data: { slot: 'slot-1', content: tail, seq: 2 } })
+      ws.simulateMessage({ type: 'chat_done', data: { slot: 'slot-1' } })
+    })
+    await act(async () => {})
+
+    expect(api.voiceSynthesize).toHaveBeenCalledTimes(2)
+    expect(api.voiceSynthesize).toHaveBeenNthCalledWith(1, 'slot-1', SENTENCE.trim())
+    expect(api.voiceSynthesize).toHaveBeenNthCalledWith(2, 'slot-1', tail)
 
     hook.unmount()
   })


### PR DESCRIPTION
Fixes #3421

## Problem

Auto-speak tracked one turn-wide character offset. A `chat_segment` reset that
offset without speaking an unpunctuated tail, so the tail was lost forever. The
same unscoped reset also let a background slot make the active reply repeat text
that had already been synthesized.

## Change

- track speech progress by `{slot, messageId, spokenLen}`
- flush a segment's remaining tail before the reducer finalizes its streaming row
- preserve the 10-character speech floor and serialized synthesis order
- document the message-scoped segment contract
- cover both the lost-tail case and cross-slot reset isolation

## Validation

- fail-before: the new tail test observed 0 syntheses; the cross-slot test observed
  3 calls instead of 2
- `npx vitest run useWebSocket --reporter=dot` (18 files, 189 tests passed)
- `npx tsc -b`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- `python scripts/docs_lint.py`
- `BRAND_BASE_REF=origin/main python scripts/check_brand_name.py`

No visual changes; screenshots are not applicable.
