### PR TITLE
fix(dashboard): stop the topbar capsule overlapping the centered search

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -171,12 +171,35 @@ export function metricColor(pct: number): string {
 }
 export const memColorClass = metricColor
 
+// Geometry for the centered top-bar search overlay. It is absolutely
+// positioned and centered on the VIEWPORT (left: 50vw), not flowed between the
+// brand and actions clusters, so it cannot be squeezed by its siblings — this
+// function has to keep it inside the gutter instead.
+//
+// Both inputs are the space a cluster CONSUMES from its side of the viewport
+// (`brand.right`, and `viewportWidth - actions.left`), not the cluster's bare
+// width: the header has its own horizontal padding, so measuring width alone
+// under-counts the occupied space and ate the whole TOPBAR_SEARCH_GAP.
+//   - `gutter` is the reserved space on EACH side (the larger of the two
+//     clusters plus the gap, mirrored because the overlay is center-anchored).
+//   - `width` is the resolved px width: a third of the viewport, but never
+//     wider than the space the clusters leave. It used to be a fixed
+//     `33.3333vw - 40px` in CSS, which sat UNDER a wide actions cluster
+//     (metrics capsule + usage pill) on narrower windows.
+//   - `visible` is only the floor: below TOPBAR_SEARCH_MIN_WIDTH the overlay is
+//     dropped rather than shrunk further, so `width` is never below the floor
+//     while the overlay is on screen.
 const TOPBAR_SEARCH_GAP = 12
 const TOPBAR_SEARCH_MIN_WIDTH = 240
+// Actions-cluster reach assumed for the first paint, before the clusters have
+// been measured. Chosen to reproduce the long-standing 360px initial gutter.
+const TOPBAR_SEARCH_ASSUMED_ACTIONS = 348
 
-export function calculateTopbarSearchLayout(brandWidth: number, actionsWidth: number, viewportWidth: number) {
-  const gutter = Math.ceil(Math.max(brandWidth, actionsWidth)) + TOPBAR_SEARCH_GAP
-  return { gutter, visible: viewportWidth - (gutter * 2) >= TOPBAR_SEARCH_MIN_WIDTH }
+export function calculateTopbarSearchLayout(brandEdge: number, actionsEdge: number, viewportWidth: number) {
+  const gutter = Math.ceil(Math.max(brandEdge, actionsEdge)) + TOPBAR_SEARCH_GAP
+  const available = viewportWidth - (gutter * 2)
+  const width = Math.max(TOPBAR_SEARCH_MIN_WIDTH, Math.min(Math.round(viewportWidth / 3) - 40, available))
+  return { gutter, width, visible: available >= TOPBAR_SEARCH_MIN_WIDTH }
 }
 
 // Apps-nav fetch resilience (see refreshAppNav). The dashboard loads
@@ -1677,18 +1700,26 @@ export default function App() {
   }, [isMobile, effectiveCollapsed])
   const topbarBrandRef = useRef<HTMLDivElement>(null)
   const topbarActionsRef = useRef<HTMLDivElement>(null)
-  const [topbarSearchLayout, setTopbarSearchLayout] = useState({ gutter: 360, visible: true })
+  const [topbarSearchLayout, setTopbarSearchLayout] = useState(() =>
+    calculateTopbarSearchLayout(0, TOPBAR_SEARCH_ASSUMED_ACTIONS, typeof window === 'undefined' ? 1440 : window.innerWidth))
   useEffect(() => {
     if (isMobile) return
     const brand = topbarBrandRef.current
     const actions = topbarActionsRef.current
     if (!brand || !actions) return
     const update = () => {
-      const brandWidth = brand.getBoundingClientRect().width
-      const actionsWidth = actions.getBoundingClientRect().width
-      if (brandWidth <= 0 || actionsWidth <= 0) return
-      const next = calculateTopbarSearchLayout(brandWidth, actionsWidth, window.innerWidth)
-      setTopbarSearchLayout(current => current.gutter === next.gutter && current.visible === next.visible ? current : next)
+      const brandRect = brand.getBoundingClientRect()
+      const actionsRect = actions.getBoundingClientRect()
+      // Only the actions cluster proves layout has happened. The brand cluster
+      // is LEGITIMATELY 0-wide in the common single-instance desktop case —
+      // InstanceTabBar renders nothing without a remote instance and the brand
+      // itself moved to the sidebar — so bailing on `brandWidth <= 0` skipped
+      // every measurement, froze this state on its optimistic initial value,
+      // and let the centered search overlay run under the capsule. The actions
+      // cluster always holds at least the capsule's connection dot.
+      if (actionsRect.width <= 0) return
+      const next = calculateTopbarSearchLayout(brandRect.right, window.innerWidth - actionsRect.left, window.innerWidth)
+      setTopbarSearchLayout(current => current.gutter === next.gutter && current.width === next.width && current.visible === next.visible ? current : next)
     }
     update()
     const observer = new ResizeObserver(update)
@@ -1831,7 +1862,7 @@ export default function App() {
             data-topbar-overlay
             onClick={commandPalette.openPalette}
             className="absolute h-7 px-3 rounded-md border border-border bg-card text-muted hover:text-text hover:border-border-hover transition-colors flex items-center justify-center gap-2 cursor-pointer shadow-none"
-            style={{ left: '50vw', transform: 'translateX(-50%)', width: 'calc(33.3333vw - 40px)', minWidth: TOPBAR_SEARCH_MIN_WIDTH }}
+            style={{ left: '50vw', transform: 'translateX(-50%)', width: topbarSearchLayout.width }}
             aria-label={i18nT('app.search_sessions_files_and_commands')}
             title={i18nT('app.search_everywhere_k')}
           >

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -715,9 +715,63 @@ describe('App routing', () => {
   })
 
   it('reserves the larger topbar cluster before showing the centered search', () => {
-    expect(calculateTopbarSearchLayout(330, 180, 1200)).toEqual({ gutter: 342, visible: true })
-    expect(calculateTopbarSearchLayout(180, 505, 1570)).toEqual({ gutter: 517, visible: true })
-    expect(calculateTopbarSearchLayout(330, 180, 900)).toEqual({ gutter: 342, visible: false })
+    expect(calculateTopbarSearchLayout(330, 180, 1200)).toEqual({ gutter: 342, width: 360, visible: true })
+    expect(calculateTopbarSearchLayout(180, 505, 1570)).toEqual({ gutter: 517, width: 483, visible: true })
+    expect(calculateTopbarSearchLayout(330, 180, 900)).toEqual({ gutter: 342, width: 240, visible: false })
+  })
+
+  it('caps the centered search at the measured gutter instead of a fixed third of the viewport', () => {
+    // Regression: `visible` is only a floor gate (does 240px still fit?), while
+    // the overlay rendered at a fixed 33.3333vw - 40px. Between those two
+    // numbers sits an overlap band where the gate says "show it" and the box is
+    // nonetheless wider than the space the actions cluster leaves, so it ran
+    // underneath the metrics capsule. Measured at 1400x820 with a 552px-reach
+    // capsule the overlay used to run 77px under it. A wide actions cluster
+    // must shrink the overlay, not be covered by it.
+    const wide = calculateTopbarSearchLayout(12, 460, 1300)
+    expect(wide.visible).toBe(true)
+    expect(wide.width).toBe(1300 - wide.gutter * 2)            // clamped to the gutter
+    expect(wide.width).toBeLessThan(Math.round(1300 / 3) - 40) // ...below the old fixed third
+    // A narrow actions cluster leaves the third of the viewport untouched.
+    expect(calculateTopbarSearchLayout(12, 180, 1300).width).toBe(Math.round(1300 / 3) - 40)
+  })
+
+  it('keeps a real gap between the centered search and the clusters that bound it', () => {
+    // The gutter is built from how far each cluster REACHES in from its side of
+    // the viewport, not its bare width. Measuring width alone ignored the
+    // header's own px-3 padding, so the whole TOPBAR_SEARCH_GAP was swallowed
+    // and the overlay's border ended up flush against the capsule (measured:
+    // 0px clearance). With reaches as inputs the clearance is the full gap.
+    const viewport = 1500
+    const actionsReach = 500                     // viewport - actions.left
+    const { width, visible } = calculateTopbarSearchLayout(12, actionsReach, viewport)
+    expect(visible).toBe(true)
+    // The overlay is centered, so its right edge sits at (viewport + width) / 2.
+    const clearance = (viewport - actionsReach) - (viewport + width) / 2
+    expect(clearance).toBeGreaterThanOrEqual(12)
+  })
+
+  it('measures the topbar clusters even when the brand cluster is empty', () => {
+    // Regression: the brand cluster is legitimately 0-wide on a single-instance
+    // desktop (the brand lives in the sidebar and InstanceTabBar renders
+    // nothing without a remote instance), but `update` bailed on
+    // `brandWidth <= 0`. The measurement therefore never ran in the common
+    // case, the state stayed frozen on its optimistic initial value, and the
+    // overlay kept its full width no matter how wide the capsule grew.
+    const rect = (left: number, width: number) => ({ width, height: 40, top: 0, left, right: left + width, bottom: 40, x: left, y: 0, toJSON: () => ({}) }) as DOMRect
+    // jsdom viewport is 1024 wide. Actions cluster reaches 370px in from the
+    // right (left edge at 654), the brand cluster is empty at the px-3 edge.
+    const spy = vi.spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: Element) { return this.classList.contains('ml-auto') ? rect(654, 370) : rect(12, 0) })
+    try {
+      renderWithProviders(<App />, { route: '/chat' })
+      const trigger = screen.getByRole('button', { name: 'Search sessions, files, and commands' })
+      // gutter = 370 + 12 = 382, so the overlay is capped at 1024 - 764 = 260px,
+      // below the unclamped 301px a fixed third of the viewport would have given.
+      expect(trigger.style.width).toBe('260px')
+    } finally {
+      spy.mockRestore()
+    }
   })
 
   it('resizes the sidebar and main body together with a quick shell transition', () => {


### PR DESCRIPTION
## Problem

On narrower desktop windows the centered **Search for anything** overlay runs
underneath the readout capsule, so the CPU/MEM/DSK metrics render on top of the
search field's border and background.

Measured in chromium (820px tall, capsule carrying the metrics segment, 552px
reach): the overlay ran **117px** under the capsule at a 1280px viewport, 111px
at 1300px, and 77px at 1400px.

## Root cause

Three defects in the topbar geometry stacked up.

**1. The measurement never ran in the common case.** `update()` bailed on
`brandWidth <= 0`, but the left brand cluster is legitimately 0-wide on a
single-instance desktop — the brand moved to the sidebar and `InstanceTabBar`
renders nothing without a remote instance. The layout state therefore stayed
frozen on its optimistic initial value and never reacted to the capsule's width
at all. Readiness now keys off the actions cluster, which always holds at least
the connection dot.

**2. The overlay's width ignored the measurement even when it did run.**
`calculateTopbarSearchLayout` returned a `gutter` that nothing consumed:
`visible` gated only the 240px floor, while the box rendered at a fixed
`33.3333vw - 40px`. Between those two numbers sits an overlap band where the gate
says "show it" and the box is nonetheless wider than the space the clusters
leave. The function now resolves the final width and clamps it to the gutter.

**3. The gutter under-counted the space each cluster occupies**, taking the
cluster's bare width rather than how far it reaches in from its side of the
viewport. The header's own `px-3` padding then swallowed the whole
`TOPBAR_SEARCH_GAP`, leaving the overlay flush against the capsule (measured 0px
clearance once defect 2 was fixed).

## Behaviour change

Below the existing 240px floor the overlay is **dropped rather than shrunk** —
that floor is pre-existing policy, it was just unreachable while the measurement
was frozen. With a metrics-bearing capsule that threshold lands around a 1300px
viewport; the capsule's own collapse toggle (click the connection dot) frees the
space and brings the search back. ⌘K is unaffected either way.

## Verification

Before / after at a 1400px viewport — note the search field's right border and
background running under the capsule in the first frame:

| before | after |
|---|---|
| search 427px wide, 77px under the capsule | search 248px wide, 12px clear |

- Browser A/B against a real gateway at 1280 / 1300 / 1400 / 1500px: overlap
  117 / 111 / 77 / 0px before, clearance 12px (or overlay dropped) after.
- 3 new regression tests, each **revert-verified** against its own defect
  (patch the fix out, confirm that test fails).
- `vitest run` full suite: 1222 files, 19850 passed, 0 failed.
- `tsc --noEmit` clean, `npm run lint` 0 errors.
- `I18N_BASE_REF=origin/main npm run i18n:check` ok; render gate exit 0.

No backend changes.
