### PR TITLE
fix(cloud): clone public source from packaged installs

### DIFF
--- a/docs/system-specs/modules/cloud.md
+++ b/docs/system-specs/modules/cloud.md
@@ -3,9 +3,10 @@
 ## Overview
 
 `src/kiro_crew/cloud/` runs KiroCrew on the user's **own** AWS EC2 instance with a
-single command. It provisions a CloudFormation stack, ships the local source,
-signs `kiro-cli` in over SSM, and opens the dashboard through an SSM
-port-forward. Command surface (wired in `cli_cloud.py`, invoked via
+single command. It provisions a CloudFormation stack, ships an available local
+checkout (or clones the public repo from packaged installs), signs `kiro-cli` in
+over SSM, and opens the dashboard through an SSM port-forward. Command surface
+(wired in `cli_cloud.py`, invoked via
 `kirocrew cloud <action>`):
 
 ```
@@ -72,7 +73,7 @@ claim that a hostile in-process agent is fully contained.
 | `ssm.py` | SSM `send-command` run-and-poll (base64-wrapped remote scripts) + `start-session` port-forward; `port_is_free` / `wait_for_local_port`. |
 | `login.py` | `kiro-cli` device-code / social sign-in on the box over SSM. |
 | `connect.py` | SSM port-forward + token mint + open browser; Instances-registry integration; `redact_token`. |
-| `source.py` | Package the local checkout (`git archive`, tarfile fallback) and upload to a per-account S3 bucket; secret-excluding filter shared by both paths. Also **`ensure_instance_boundary`** — creates the shared, immutable `kirocrew-ec2-boundary` managed policy once (create-if-not-exists, never re-versioned) and returns its ARN; `delete_instance_boundary` for admin cleanup. |
+| `source.py` | Detect and package an editable local checkout (`git archive`, tarfile fallback) and upload it to a per-account S3 bucket; packaged installs instead use the template's public-repo clone fallback. The secret-excluding filter is shared by both packaging paths. Also **`ensure_instance_boundary`** — creates the shared, immutable `kirocrew-ec2-boundary` managed policy once (create-if-not-exists, never re-versioned) and returns its ARN; `delete_instance_boundary` for admin cleanup. |
 | `config.py` | Persisted profile / region / tag (**never credentials**); `load()` tolerates a hand-edited/corrupt `cloud.json` — bad JSON *or* a non-object shape falls back to defaults rather than crashing every cloud command. |
 | `sizes.py` | arm64/Graviton size tiers (16 GB default `t4g.xlarge`). |
 | `ui.py` / `wizard.py` | Terminal UI + the interactive launch flow. `_deploy_with_progress` runs the blocking deploy on a daemon thread and captures the `aws cloudformation deploy` child via a `proc_sink`, so a Ctrl+C on the main (poll) thread terminates it instead of orphaning it (~1800s). An unknown `--size`/`size_key` on the public `launch()` entrypoint yields a clean rc=1 + message, not an uncaught `KeyError`. Resuming a saved stack (`launch` after `stop`) first calls `_ensure_running_and_ssm_ready` — starts a `stopped` instance and waits for SSM `Online` before sign-in/tunnel (which are SSM-only and would otherwise fail); a `terminated` instance fails clean pointing at `--new`. `last_tag` is persisted (`cfg.save()`) **only after** a deploy confirms healthy — a failed first launch leaves no saved pointer, so the next `launch` retries clean instead of resuming a rolled-back/instance-less stack; `_saved_launch_is_usable` additionally ignores a stale saved tag (from an older build) whose stack is in a `_FAILED_STATES` status or has no instance. |
@@ -92,11 +93,14 @@ retry. This installs the existing `voice` extra (`boto3` and
 `amazon-transcribe`) before the gateway first imports its Transcribe provider;
 installing those SDKs after startup would otherwise require a gateway restart.
 
-Because the public repo is private, the box can't `git clone` it: the launcher
-packages the local checkout and uploads it to a launcher-owned bucket
+When the installed module belongs to a valid source checkout, the launcher
+packages that checkout and uploads it to a launcher-owned bucket
 (`kirocrew-src-<account>-<region>`); the instance downloads it with its own IAM
-role (`s3:GetObject` scoped to the single object). A public `git clone` remains
-a fallback when no `SourceBucket` is passed.
+role (`s3:GetObject` scoped to the single object). Wheel and desktop installs
+have no checkout to package, so `ec2.deploy` omits `SourceBucket` by default and
+the template clones the public repository/ref instead. An explicit
+`ship_source=True` remains fail-closed rather than packaging an unrelated
+`site-packages` ancestor.
 
 `discover_network` is **egress-kind-aware**, not just "has a default route":
 `_subnet_egress_kinds` classifies each subnet's effective route table (explicit

--- a/src/kiro_crew/cloud/ec2.py
+++ b/src/kiro_crew/cloud/ec2.py
@@ -492,7 +492,7 @@ def deploy(
     repo: str = "",
     ref: str = "",
     allow_ssh_cidr: str = "",
-    ship_source: bool = True,
+    ship_source: Optional[bool] = None,
     dashboard_port: int = 0,
     disable_rollback: bool = False,
     dry_run: bool = False,
@@ -500,9 +500,10 @@ def deploy(
 ) -> DeployResult:
     """Provision (or update) the KiroCrew stack. Idempotent by stack name.
 
-    When ``ship_source`` (default) the local source is packaged and uploaded to
-    S3 so the instance installs from it (private-repo safe) instead of cloning
-    GitHub. ``subnet_id`` pins the launch to an explicit subnet (validated by
+    By default the local source is packaged and uploaded only when Kiro Crew is
+    running from a checkout; packaged installs use the template's public-repo
+    clone path. Explicit ``ship_source=True`` remains fail-closed when no checkout
+    exists. ``subnet_id`` pins the launch to an explicit subnet (validated by
     :func:`resolve_explicit_subnet`) instead of auto-discovery. ``dry_run``
     returns the exact argv without calling AWS. ``proc_sink`` is forwarded to
     :func:`aws.run_aws` for the (long) deploy call so a caller running deploy on
@@ -521,6 +522,13 @@ def deploy(
         repo = validate_field(repo, _REPO_SPEC) or ""
     if ref:
         ref = validate_field(ref, _REF_SPEC) or ""
+
+    from kiro_crew.cloud import source as source_mod
+
+    if ship_source is None:
+        ship_source = source_mod.find_repo_root() is not None
+        if not ship_source:
+            logger.info("no checkout found; the instance will clone the public repo")
 
     if dry_run:
         # For the dry run we can't hit AWS for the VPC or account id, so show
@@ -551,8 +559,6 @@ def deploy(
 
     existing = find_stack(tag, profile, region)
     reused = existing is not None
-
-    from kiro_crew.cloud import source as source_mod
 
     # Ensure the SHARED, immutable instance permissions boundary exists (created
     # once by launcher code, not per-launch CFN — see source.ensure_instance_boundary

--- a/src/kiro_crew/cloud/launch_engine.py
+++ b/src/kiro_crew/cloud/launch_engine.py
@@ -15,7 +15,6 @@ import threading
 
 from kiro_crew.cloud import connect as connect_mod
 from kiro_crew.cloud import ec2, iam, login, sizes
-from kiro_crew.cloud import source as source_mod
 from kiro_crew.cloud.aws import AWSError
 from kiro_crew.instances.port_allocator import PortAllocator
 from kiro_crew.instances.registry import InstancesRegistry
@@ -145,21 +144,11 @@ class RealLaunchEngine:
 
     def provision(self, *, tag: str, size_key: str, profile: str, region: str) -> str:
         tier = sizes.get_tier(size_key)
-        # Ship the local source only when this really is a checkout. The dashboard
-        # runs from a wheel/app install for most users, where `source.repo_root()`
-        # fails closed by design (it must not tar up site-packages) — and with
-        # ship_source left at its default that raised mid-provision, making
-        # one-click setup impossible for anyone who did not install from git. With
-        # no checkout the instance installs from the template's public-repo clone
-        # instead, which is the fallback the template already carries.
-        ship_source = source_mod.find_repo_root() is not None
-        if not ship_source:
-            logger.info(
-                "no local checkout found; the instance will install by cloning the "
-                "public repo instead of shipping local source"
-            )
         result = ec2.deploy(
-            tag=tag, tier=tier, profile=profile, region=region, ship_source=ship_source,
+            tag=tag,
+            tier=tier,
+            profile=profile,
+            region=region,
             dashboard_port=self._allocate_port(),
         )
         return result.instance_id

--- a/test/test_cloud_ec2.py
+++ b/test/test_cloud_ec2.py
@@ -466,7 +466,10 @@ class TestBuildDeployArgv:
 
 class TestDeployDryRun:
     def test_dry_run_returns_argv_without_aws(self, monkeypatch):
+        import kiro_crew.cloud.source as source_mod
+
         # If run_aws is called during a dry run, fail loudly.
+        monkeypatch.setattr(source_mod, "find_repo_root", lambda: object())
         monkeypatch.setattr(aws, "run_aws", lambda *a, **k: pytest.fail("dry run must not hit AWS"))
         r = ec2.deploy(
             tag="t1", tier=sizes.default_tier(), profile="dev", region="us-east-1", dry_run=True
@@ -501,6 +504,16 @@ class TestDeployDryRun:
             ship_source=False,
             dry_run=True,
         )
+        assert not any(a.startswith("SourceBucket=") for a in r.argv)
+
+    def test_dry_run_defaults_to_public_clone_without_checkout(self, monkeypatch):
+        import kiro_crew.cloud.source as source_mod
+
+        monkeypatch.setattr(source_mod, "find_repo_root", lambda: None)
+        monkeypatch.setattr(aws, "run_aws", lambda *a, **k: pytest.fail("dry run must not hit AWS"))
+
+        r = ec2.deploy(tag="t1", tier=sizes.default_tier(), dry_run=True)
+
         assert not any(a.startswith("SourceBucket=") for a in r.argv)
 
 

--- a/test/test_cloud_launch_job.py
+++ b/test/test_cloud_launch_job.py
@@ -380,7 +380,6 @@ class TestRealEngineGatewayPort:
         monkeypatch.setattr(le.ec2, "deploy", lambda **kw: (
             seen.update(kw) or SimpleNamespace(instance_id="i-0abc")))
         monkeypatch.setattr(le.sizes, "get_tier", lambda k: SimpleNamespace(key=k))
-        monkeypatch.setattr(le.source_mod, "find_repo_root", lambda: None)
         monkeypatch.setattr(
             le.connect_mod, "register_instance",
             lambda iid, **kw: seen.update({"reg": kw}) or "inst-1",
@@ -439,45 +438,46 @@ class TestRealEngineGatewayPort:
         assert seen["dashboard_port"] == 5600
 
 
-class TestRealEngineProvisionSourceMode:
-    """One-click setup must work from a wheel/app install. `source.repo_root()` fails
-    closed there by design (it must never tar up site-packages), so leaving
-    ship_source at its default made provisioning raise for every user who did not
-    install from git."""
+class TestRealEnginePreflight:
+    """The credentials gate that runs immediately before `provision`.
 
-    def _deploy_spy(self, monkeypatch):
+    `iam.reachability_check` reports failure in-band rather than raising, so a
+    preflight that only inspected `reachable` truthily — or that let an
+    unreachable account through — would surface as a confusing mid-provision
+    CloudFormation error instead of "your AWS credentials did not resolve".
+    """
+
+    def _engine(self, monkeypatch, reach):
         from kiro_crew.cloud import launch_engine as le
 
-        seen = {}
+        monkeypatch.setattr(le.iam, "reachability_check", lambda profile, region: reach)
+        return le.RealLaunchEngine()
 
-        def _fake_deploy(**kw):
-            seen.update(kw)
-            return SimpleNamespace(instance_id="i-0abc")
+    def test_a_reachable_account_passes(self, monkeypatch):
+        engine = self._engine(monkeypatch, {"reachable": True})
+        assert engine.preflight("default", "us-east-1") is None
 
-        monkeypatch.setattr(le.ec2, "deploy", _fake_deploy)
-        monkeypatch.setattr(le.sizes, "get_tier", lambda k: SimpleNamespace(key=k))
-        return le, seen
+    def test_an_unreachable_account_raises_with_the_reported_detail(self, monkeypatch):
+        from kiro_crew.cloud.aws import AWSError
 
-    def test_without_a_checkout_it_clones_instead_of_failing(self, monkeypatch):
-        le, seen = self._deploy_spy(monkeypatch)
-        monkeypatch.setattr(le.source_mod, "find_repo_root", lambda: None)
-
-        got = le.RealLaunchEngine().provision(
-            tag="kc-1", size_key="balanced", profile="", region="us-east-1"
+        engine = self._engine(
+            monkeypatch, {"reachable": False, "detail": "ExpiredToken: session expired"}
         )
+        with pytest.raises(AWSError, match="ExpiredToken: session expired"):
+            engine.preflight("default", "us-east-1")
 
-        assert got == "i-0abc"
-        assert seen["ship_source"] is False
+    def test_it_falls_back_to_note_then_to_a_generic_reason(self, monkeypatch):
+        """`detail` is not guaranteed: the probe reports some failures as `note`,
+        and a bare `{"reachable": False}` must still name a cause."""
+        from kiro_crew.cloud.aws import AWSError
 
-    def test_with_a_checkout_it_still_ships_local_source(self, monkeypatch, tmp_path):
-        le, seen = self._deploy_spy(monkeypatch)
-        monkeypatch.setattr(le.source_mod, "find_repo_root", lambda: tmp_path)
+        engine = self._engine(monkeypatch, {"reachable": False, "note": "no such profile"})
+        with pytest.raises(AWSError, match="no such profile"):
+            engine.preflight("default", "us-east-1")
 
-        le.RealLaunchEngine().provision(
-            tag="kc-1", size_key="balanced", profile="", region="us-east-1"
-        )
-
-        assert seen["ship_source"] is True
+        engine = self._engine(monkeypatch, {"reachable": False})
+        with pytest.raises(AWSError, match="AWS credentials did not resolve"):
+            engine.preflight("default", "us-east-1")
 
 
 class TestRealEngineRegistration:


### PR DESCRIPTION
## Problem / Motivation

`kirocrew cloud launch` cannot provision from a packaged install. `ec2.deploy()`
defaulted `ship_source=True`, and from a wheel or the Desktop app source
discovery correctly refuses to treat `site-packages` as a checkout, so the upload
raised before CloudFormation was ever called.

The Dashboard launch engine had worked around the default with its own
checkout probe. The CLI wizard calls `deploy()` directly, so it inherited the
broken default — two callers, two behaviours, one of them fatal.

## Why it matters

This is every user who did not install from git, which is the normal case: the
macOS app and the PyPI wheel both hit it. One-click cloud setup fails outright,
and the error names a missing source root rather than anything the user can act
on. A contributor running from a checkout never sees it, which is why it survived.

## What changed

- auto-detect source-checkout availability at the shared `ec2.deploy()` boundary,
  so every caller — CLI wizard and Dashboard alike — gets one behaviour
- with no checkout, omit `SourceBucket` and let the CloudFormation template's
  existing public-repo clone path provision the instance
- keep an explicit `ship_source=True` fail-closed, so a caller that means it still
  gets a hard error rather than a silent downgrade
- delete the now-duplicated Dashboard-only selection logic
- document both provisioning modes in the cloud system spec

## Tests

- fail-before/pass-after regression:
  `TestDeployDryRun::test_dry_run_defaults_to_public_clone_without_checkout`
- `TestRealEnginePreflight` — new coverage for the credentials gate that runs
  immediately before `provision`; `iam.reachability_check` reports failure in-band
  rather than raising, so `detail`, the `note` fallback, and a bare
  `{"reachable": False}` are each pinned to name a cause
- `181 passed, 3 skipped` across `test_cloud_ec2.py`, `test_cloud_source.py`,
  `test_cloud_wizard.py`, `test_cloud_launch_job.py`
- flake8, isort, mypy (`--follow-imports=skip`), docs lint (207 files),
  `git diff --check`: all clean

## Manual verification

N/A — unit coverage sufficient. The dry-run path asserts the exact argv handed to
CloudFormation, which is the contract that broke.

## Related Issues

Fixes #2382
