### PR TITLE
fix(i18n): preserve cross-tab choice over stale boot

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -917,6 +917,11 @@ Auto option writes `""` to clear a previous explicit choice. An explicit choice
 always outranks detection, so a user who selects English on a zh-CN machine is
 not re-detected back to Chinese on the next load.
 
+A cross-tab `storage` event is also an explicit user choice. Once one arrives,
+`LanguageProvider` refuses to adopt the older `/api/theme/boot` response that may
+still be in flight, so the UI, local mirror, and workspace write cannot diverge
+because of response ordering.
+
 The picker's Auto row is labelled plain **"Auto"**, not "Auto (follow browser)".
 The desktop app has no browser preference to follow — its locale comes from the
 OS — so naming the browser was wrong on that surface. The row annotates itself

--- a/website/src/i18n/LanguageProvider.test.tsx
+++ b/website/src/i18n/LanguageProvider.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
@@ -249,5 +249,40 @@ describe('LanguageProvider — an empty server value must not erase a local choi
     wrap(<Probe />, { language: '' })
     await waitFor(() => expect(screen.getByTestId('resolved')).toHaveTextContent('en'))
     expect(screen.getByTestId('choice')).toHaveTextContent('(auto)')
+  })
+})
+
+describe('LanguageProvider cross-tab boot ordering', () => {
+  it('keeps a cross-tab choice when an older boot response arrives later', async () => {
+    let resolveBoot!: (value: { language: string }) => void
+    const bootPromise = new Promise<{ language: string }>((resolve) => {
+      resolveBoot = resolve
+    })
+    vi.spyOn(api, 'themeBoot').mockReturnValue(bootPromise as never)
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <LanguageProvider><Probe /></LanguageProvider>
+      </QueryClientProvider>,
+    )
+
+    localStorage.setItem(LANG_STORAGE_KEY, 'zh-CN')
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: LANG_STORAGE_KEY,
+        newValue: 'zh-CN',
+        storageArea: localStorage,
+      }))
+    })
+    await waitFor(() => expect(screen.getByTestId('choice')).toHaveTextContent('zh-CN'))
+
+    resolveBoot({ language: 'en' })
+    await waitFor(() => {
+      expect(qc.getQueryData(['theme-boot'])).toEqual({ language: 'en' })
+    })
+
+    expect(screen.getByTestId('choice')).toHaveTextContent('zh-CN')
+    expect(localStorage.getItem(LANG_STORAGE_KEY)).toBe('zh-CN')
   })
 })

--- a/website/src/i18n/LanguageProvider.tsx
+++ b/website/src/i18n/LanguageProvider.tsx
@@ -260,10 +260,13 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   }, [])
 
   // Cross-tab sync: switching language in one tab updates the others without a
-  // reload. Same StorageEvent pattern as useUIMode.
+  // reload. A storage event represents an explicit choice in another tab, so it
+  // must also outrank any server value that was already in flight at boot.
+  // Same StorageEvent pattern as useUIMode.
   useEffect(() => {
     const onStorage = (e: StorageEvent) => {
       if (e.key !== LANG_STORAGE_KEY) return
+      userChose.current = true
       setLanguageState(e.newValue ?? AUTO_LANGUAGE)
     }
     window.addEventListener('storage', onStorage)


### PR DESCRIPTION
## Summary

- treat a cross-tab language storage event as an explicit user choice before updating provider state
- prevent an older in-flight `/api/theme/boot` response from reverting that newer choice
- add a deterministic deferred-response regression test and document the ordering contract

## Scope

This deliberately addresses **Finding 1 only** from #727, matching the maintainer triage recommendation to split the mechanical boot race from the memoized-subtree design decision. Finding 2 remains open and unchanged.

## Root cause

Local picker changes set `userChose.current`, which blocks adoption of a stale boot response. The cross-tab `storage` handler updated `language` without setting the same latch. If the initial boot request completed after another tab selected a language, the provider adopted the older server value and rewrote both the UI and local mirror.

The storage event now closes the latch before applying its value, giving all explicit user choices the same ordering guarantee.

## Testing

- fail-before: the new deferred-boot probe failed with `Expected zh-CN, received en`
- pass-after: `LanguageProvider.test.tsx` — 23 passed
- `npx tsc -b` — passed after rebase onto latest main
- changed-file ESLint — passed
- docs lint — all 207 Markdown files passed
- i18n diff gates — all 6 branch-owned checks passed
- `git diff --check` — passed

## Baseline note

The whole-repo i18n runner still reports the pre-existing stale `en-XA.json` hard-zero failure. This branch changes no catalog file (`git diff origin/main -- website/src/i18n/locales` is empty), so it does not regenerate or absorb that unrelated baseline.

Addresses the cross-tab boot race in #727.