### PR TITLE
feat(desktop): add macOS New Window command

### DIFF
--- a/website/electron/README.md
+++ b/website/electron/README.md
@@ -197,6 +197,7 @@ each launch to get a fresh JWT — no manual paste required.
 
 | Location | Item | Action |
 |----------|------|--------|
+| Connection menu (macOS) | New Window (⌘⇧N) | Open another dashboard window with a new blank session on the existing local gateway |
 | Tab menu / tab bar right-click | Set Remote Host… | Configure hostname for the **focused tab's** port |
 | Tab menu / tab bar right-click | Refresh Token (⌘⇧T) | Fetch a fresh token for the **focused tab** |
 | Tab menu / tray | Open Config File | Open `config.json` in default editor |
@@ -242,6 +243,10 @@ Open via **Tab menu → Open Config File** or tray menu.
 
 ## Notes
 
+- On macOS, **Connection → New Window** (⌘⇧N) opens an independent
+  dashboard window and creates a blank session. It shares the running local
+  gateway and authentication origin, but does not copy the current session,
+  project, draft, or context.
 - Closing the window hides to tray — right-click the tray icon or Cmd+Q to quit
 - External links open in your default browser
 - Desktop leaves the child `PATH` unchanged; the gateway-side prerequisite

--- a/website/electron/app-menu.js
+++ b/website/electron/app-menu.js
@@ -28,6 +28,7 @@ function buildMenuTemplate(deps) {
     zoomOut,
     alwaysOnTop, // initial checked state for Keep on Top (restored preference)
     toggleAlwaysOnTop,
+    openNewSessionWindow,
     openNewConnectionWindow,
     renameCurrentWindow,
     promptRemoteHost,
@@ -110,6 +111,12 @@ function buildMenuTemplate(deps) {
       id: "connection-menu",
       label: "Connection",
       submenu: [
+        ...(isMac
+          ? [
+              { label: "New Window", accelerator: "Cmd+Shift+N", click: openNewSessionWindow },
+              { type: "separator" },
+            ]
+          : []),
         { label: "New Connection Window…", accelerator: "CmdOrCtrl+N", click: openNewConnectionWindow },
         // No accelerator: Cmd+Shift+R is Force Reload (platform standard).
         { label: "Rename Window…", click: renameCurrentWindow },

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -17,7 +17,7 @@ const {
   SPAWN_MARKER,
 } = require("./bundle-integrity");
 const { findConfiguredDashboardPort } = require("./data-home");
-const { createTokenRetryHandler } = require("./token-retry");
+const { createTokenRetryHandler, dashboardRetryPath } = require("./token-retry");
 const { createRendererRecovery } = require("./renderer-recovery");
 const { classifyAuthBlock, defaultedPort } = require("./gateway-auth-hint");
 const { exitImmersiveModes } = require("./blocking-prompt");
@@ -3076,7 +3076,17 @@ async function showUnrecoverableGatewayError(win, port, options = {}) {
   if (win === mainWindow) { isQuitting = true; app.quit(); } else { win.destroy(); }
 }
 
-async function showLoadingThenConnect(win, backendUrl = BACKEND_URL, { reconnect = false } = {}) {
+function dashboardEntryUrl(backendUrl, initialPath = "", token = "") {
+  const target = initialPath ? new URL(initialPath, backendUrl) : new URL(backendUrl);
+  if (token) target.searchParams.set("token", token);
+  return target.toString();
+}
+
+async function showLoadingThenConnect(
+  win,
+  backendUrl = BACKEND_URL,
+  { reconnect = false, initialPath = "" } = {},
+) {
   const healthUrl = `${backendUrl}/api/status`;
   const wc = win.webContents;
   // Paint the splash in the user's chosen accent (persisted from a prior session
@@ -3109,8 +3119,8 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL, { reconnect
         // gateway is ready, then fade out and hand off to the dashboard.
         await fadeLoadingScreen(wc);
         if (win.isDestroyed()) return;
-        wc.loadURL(`${backendUrl}?token=${token}`);
-        if (backendUrl === BACKEND_URL) startLivenessMonitor(win);
+        wc.loadURL(dashboardEntryUrl(backendUrl, initialPath, token));
+        if (backendUrl === BACKEND_URL && win === mainWindow) startLivenessMonitor(win);
         return;
       }
 
@@ -3125,8 +3135,8 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL, { reconnect
 
       if (status !== 403) {
         // Not an auth block — the gateway serves without a token.
-        wc.loadURL(backendUrl);
-        if (backendUrl === BACKEND_URL) startLivenessMonitor(win);
+        wc.loadURL(dashboardEntryUrl(backendUrl, initialPath));
+        if (backendUrl === BACKEND_URL && win === mainWindow) startLivenessMonitor(win);
         return;
       }
 
@@ -3314,7 +3324,7 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL, { reconnect
         // Deliberately NOT flagged as a reconnect: every path here goes through a
         // dialog button the user just clicked, so the re-entry may raise (#6373).
         if (win.isDestroyed()) return;
-        return showLoadingThenConnect(win, backendUrl);
+        return showLoadingThenConnect(win, backendUrl, { initialPath });
       }
       // Quit
       if (win === mainWindow) {
@@ -3326,6 +3336,69 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL, { reconnect
       return;
     }
   }
+}
+
+// ── Standalone dashboard windows ──
+
+function createConnectionWindow(backendUrl, port, initialPath = "") {
+  const connOpts = {
+    width: 1280,
+    height: 860,
+    minWidth: 550,
+    minHeight: 600,
+    backgroundColor: "#0f1117",
+  };
+  // Same platform-conditional chrome as the main window (see createWindow):
+  // frameless + inset traffic lights on macOS, titleBarOverlay on Windows,
+  // frame:false on CSD-preferring Linux desktops, native frame elsewhere.
+  if (IS_MAC) connOpts.titleBarStyle = "hidden";
+  if (IS_MAC) connOpts.trafficLightPosition = trafficLightPositionForZoom(1);
+  if (IS_WINDOWS) {
+    connOpts.titleBarStyle = "hidden";
+    connOpts.autoHideMenuBar = true;
+    connOpts.titleBarOverlay = {
+      color: WINDOWS_TITLEBAR_BACKGROUND,
+      symbolColor: nativeTheme.shouldUseDarkColors
+        ? WINDOWS_TITLEBAR_SYMBOL_DARK
+        : WINDOWS_TITLEBAR_SYMBOL_LIGHT,
+      height: HEADER_CSS_PX,
+    };
+  }
+  if (LINUX_FRAMELESS) {
+    connOpts.frame = false;
+    connOpts.autoHideMenuBar = true; // same rationale as createWindow
+  }
+  const connWin = new BaseWindow(connOpts);
+  if (IS_WINDOWS && typeof connWin.setMenuBarVisibility === "function") {
+    connWin.setMenuBarVisibility(false);
+  }
+
+  setupWindowContents(connWin, backendUrl);
+
+  // `initialPath` may carry a one-shot intent ("/chat?new=1" mints a blank
+  // session), so the 403 retry must re-request where the window ACTUALLY is --
+  // replaying a consumed intent would mint a second session over the one on
+  // screen. Updated before onNavigate runs, so a 403 uses the URL that failed.
+  let retryTarget = initialPath;
+  const onNavigate = createTokenRetryHandler(async () => {
+    let token = await fetchLocalToken(backendUrl);
+    if (!token) ({ token } = await fetchRemoteToken(port));
+    if (token && !connWin.isDestroyed()) {
+      connWin.webContents.loadURL(dashboardEntryUrl(backendUrl, retryTarget, token));
+    }
+  });
+  connWin.webContents.on("did-navigate", (_e, url, httpCode) => {
+    retryTarget = dashboardRetryPath(url, backendUrl, retryTarget);
+    onNavigate(httpCode).catch((err) => console.error("Token retry failed:", err));
+  });
+
+  return connWin;
+}
+
+async function openNewSessionWindow() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  const win = createConnectionWindow(BACKEND_URL, PORT, "/chat?new=1");
+  await showLoadingThenConnect(win, BACKEND_URL, { initialPath: "/chat?new=1" });
 }
 
 // ── New Connection Window ──
@@ -3368,51 +3441,7 @@ async function openNewConnectionWindow() {
     if (!mainWindow || mainWindow.isDestroyed()) return;
 
     const backendUrl = `http://localhost:${port}`;
-    const connOpts = {
-      width: 1280,
-      height: 860,
-      minWidth: 550,
-      minHeight: 600,
-      backgroundColor: "#0f1117",
-    };
-    // Same platform-conditional chrome as the main window (see createWindow):
-    // frameless + inset traffic lights on macOS, titleBarOverlay on Windows,
-    // frame:false on CSD-preferring Linux desktops, native frame elsewhere.
-    if (IS_MAC) connOpts.titleBarStyle = "hidden";
-    if (IS_MAC) connOpts.trafficLightPosition = trafficLightPositionForZoom(1);
-    if (IS_WINDOWS) {
-      connOpts.titleBarStyle = "hidden";
-      connOpts.autoHideMenuBar = true;
-      connOpts.titleBarOverlay = {
-        color: WINDOWS_TITLEBAR_BACKGROUND,
-        symbolColor: nativeTheme.shouldUseDarkColors
-          ? WINDOWS_TITLEBAR_SYMBOL_DARK
-          : WINDOWS_TITLEBAR_SYMBOL_LIGHT,
-        height: HEADER_CSS_PX,
-      };
-    }
-    if (LINUX_FRAMELESS) {
-      connOpts.frame = false;
-      connOpts.autoHideMenuBar = true; // same rationale as createWindow
-    }
-    const connWin = new BaseWindow(connOpts);
-    if (IS_WINDOWS && typeof connWin.setMenuBarVisibility === "function") {
-      connWin.setMenuBarVisibility(false);
-    }
-
-    setupWindowContents(connWin, backendUrl);
-
-    const onNavigate = createTokenRetryHandler(async () => {
-      let token = await fetchLocalToken(backendUrl);
-      if (!token) ({ token } = await fetchRemoteToken(port));
-      if (token && !connWin.isDestroyed()) {
-        connWin.webContents.loadURL(`${backendUrl}?token=${token}`);
-      }
-    });
-    connWin.webContents.on("did-navigate", (_e, _url, httpCode) => {
-      onNavigate(httpCode).catch((err) => console.error("Token retry failed:", err));
-    });
-
+    const connWin = createConnectionWindow(backendUrl, port);
     // Every connection is a standalone window (tracked for menu actions).
     await showLoadingThenConnect(connWin, backendUrl);
   });
@@ -3676,6 +3705,7 @@ app.whenReady().then(async () => {
       // same persisted state createWindow() restores from.
       alwaysOnTop: !!(store.get("windowState") || {}).alwaysOnTop,
       toggleAlwaysOnTop,
+      openNewSessionWindow: () => openNewSessionWindow(),
       openNewConnectionWindow: () => openNewConnectionWindow(),
       renameCurrentWindow: () => renameCurrentWindow(),
       promptRemoteHost: () => promptRemoteHost(),

--- a/website/electron/test/app-menu.test.js
+++ b/website/electron/test/app-menu.test.js
@@ -19,6 +19,7 @@ function makeDeps(overrides = {}) {
     zoomOut: record("zoomOut"),
     alwaysOnTop: false,
     toggleAlwaysOnTop: record("toggleAlwaysOnTop"),
+    openNewSessionWindow: record("openNewSessionWindow"),
     openNewConnectionWindow: record("openNewConnectionWindow"),
     renameCurrentWindow: record("renameCurrentWindow"),
     promptRemoteHost: record("promptRemoteHost"),
@@ -71,6 +72,15 @@ test("mac: no File or Help menus (their items live in the app menu)", () => {
   assert.ok(!labels.includes("Help"));
 });
 
+test("mac: Connection exposes New Window on Cmd+Shift+N", () => {
+  const { deps, calls } = makeDeps({ isMac: true });
+  const item = findItem(buildMenuTemplate(deps), (i) => i.label === "New Window");
+  assert.ok(item, "New Window present on macOS");
+  assert.strictEqual(item.accelerator, "Cmd+Shift+N");
+  item.click();
+  assert.deepStrictEqual(calls, ["openNewSessionWindow"]);
+});
+
 // ── Windows/Linux shape ──
 
 test("win/linux: File menu is first with Settings… and quit", () => {
@@ -107,6 +117,14 @@ test("win/linux: no macOS-only roles anywhere in the template", () => {
   for (const role of ["appMenu", "services", "hide", "hideOthers", "unhide"]) {
     assert.strictEqual(findItem(template, (i) => i.role === role), null, `no ${role} off darwin`);
   }
+});
+
+test("win/linux: New Window stays macOS-only", () => {
+  const { deps } = makeDeps({ isMac: false });
+  assert.strictEqual(
+    findItem(buildMenuTemplate(deps), (i) => i.label === "New Window"),
+    null,
+  );
 });
 
 // ── shared structure (both platforms) ──

--- a/website/electron/test/reconnect-focus.test.js
+++ b/website/electron/test/reconnect-focus.test.js
@@ -104,7 +104,10 @@ describe("main.js wiring (source pins)", () => {
 
   it("showLoadingThenConnect routes its initial reveal through the helper", () => {
     const body = fnBody("showLoadingThenConnect");
-    assert.match(body, /async function showLoadingThenConnect\(win, backendUrl = BACKEND_URL, \{ reconnect = false \} = \{\}\)/);
+    assert.match(
+      body,
+      /async function showLoadingThenConnect\([\s\S]*?\{ reconnect = false, initialPath = "" \} = \{\},[\s\S]*?\)/,
+    );
     assert.match(body, /revealWindowForConnect\(win, \{ reconnect \}\)/);
   });
 

--- a/website/electron/test/shell-contract.test.js
+++ b/website/electron/test/shell-contract.test.js
@@ -20,6 +20,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const ROOT = path.join(__dirname, "..");
+const MAIN_SOURCE = fs.readFileSync(path.join(ROOT, "main.js"), "utf-8");
 
 /** Every shipped .js under electron/ (tests and deps excluded). */
 function sourceFiles() {
@@ -70,6 +71,24 @@ test("packaging allowlist has no stale entries", () => {
     [],
     `listed in build.files but does not exist (left behind by a rename?): ${stale.join(", ")}`,
   );
+});
+
+test("macOS New Window opens the blank-session route on the existing gateway", () => {
+  assert.match(
+    MAIN_SOURCE,
+    /createConnectionWindow\(BACKEND_URL, PORT, "\/chat\?new=1"\)/,
+  );
+  assert.match(
+    MAIN_SOURCE,
+    /showLoadingThenConnect\(win, BACKEND_URL, \{ initialPath: "\/chat\?new=1" \}\)/,
+  );
+});
+
+test("only the primary local window owns the gateway liveness monitor", () => {
+  const guardedStarts = MAIN_SOURCE.match(
+    /backendUrl === BACKEND_URL && win === mainWindow\) startLivenessMonitor\(win\)/g,
+  ) || [];
+  assert.strictEqual(guardedStarts.length, 2, "authenticated and unauthenticated handoffs stay guarded");
 });
 
 // ── IPC channel contract ──────────────────────────────────────────────────

--- a/website/electron/test/token-retry.test.js
+++ b/website/electron/test/token-retry.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
-const { createTokenRetryHandler } = require("../token-retry");
+const { createTokenRetryHandler, dashboardRetryPath } = require("../token-retry");
 
 describe("createTokenRetryHandler", () => {
   it("calls refreshFn on 403", async () => {
@@ -53,5 +53,42 @@ describe("createTokenRetryHandler", () => {
     await handler(404);
     await handler(500);
     assert.equal(called, 0);
+  });
+});
+
+describe("dashboardRetryPath", () => {
+  const BACKEND = "http://localhost:3113";
+
+  it("follows the window past a consumed ?new=1 intent", () => {
+    // The SPA replaced /chat?new=1 with the slot it minted. A retry must not
+    // re-run the intent, or it mints a second session over this one.
+    assert.equal(
+      dashboardRetryPath(`${BACKEND}/chat?sid=slot-abc&token=stale`, BACKEND, "/chat?new=1"),
+      "/chat?sid=slot-abc",
+    );
+  });
+
+  it("keeps an entry intent that has not been consumed yet", () => {
+    assert.equal(
+      dashboardRetryPath(`${BACKEND}/chat?new=1&token=stale`, BACKEND, "/chat?new=1"),
+      "/chat?new=1",
+    );
+  });
+
+  it("drops the stale token so the caller can append a fresh one", () => {
+    assert.equal(dashboardRetryPath(`${BACKEND}/?token=stale`, BACKEND, ""), "/");
+  });
+
+  it("keeps the fallback for a URL this gateway does not serve", () => {
+    // The splash screen is a local file:// load, and a second connection window
+    // points at a different port — neither should retarget this window.
+    assert.equal(dashboardRetryPath("file:///app/loading.html", BACKEND, "/chat?new=1"), "/chat?new=1");
+    assert.equal(dashboardRetryPath("about:blank", BACKEND, "/chat?new=1"), "/chat?new=1");
+    assert.equal(dashboardRetryPath("http://localhost:9999/chat", BACKEND, "/chat?new=1"), "/chat?new=1");
+  });
+
+  it("keeps the fallback for an unparseable URL", () => {
+    assert.equal(dashboardRetryPath("", BACKEND, "/chat?new=1"), "/chat?new=1");
+    assert.equal(dashboardRetryPath(undefined, BACKEND, "/chat?new=1"), "/chat?new=1");
   });
 });

--- a/website/electron/token-retry.js
+++ b/website/electron/token-retry.js
@@ -14,4 +14,31 @@ function createTokenRetryHandler(refreshFn, maxRetries = 2) {
   };
 }
 
-module.exports = { createTokenRetryHandler };
+/**
+ * The path+query a 403 retry should re-request, derived from the URL that
+ * actually failed rather than from the window's entry path.
+ *
+ * A window's entry path can carry a ONE-SHOT intent -- "/chat?new=1" mints a
+ * blank session and the SPA immediately replaces the URL with "?sid=<slot>".
+ * Replaying the entry path on a later 403 would mint a SECOND session and swap
+ * out the one the user is looking at, so the retry has to follow the window.
+ *
+ * The stale `token` is dropped: the caller appends a freshly fetched one.
+ * A URL this gateway does not serve (the local splash `file://`, `about:blank`)
+ * leaves `fallback` standing, so the entry intent survives until the dashboard
+ * itself has navigated.
+ */
+function dashboardRetryPath(navigatedUrl, backendUrl, fallback = "") {
+  let target;
+  try {
+    target = new URL(navigatedUrl);
+    if (target.origin !== new URL(backendUrl).origin) return fallback;
+  } catch {
+    return fallback;
+  }
+  target.searchParams.delete("token");
+  const query = target.searchParams.toString();
+  return `${target.pathname}${query ? `?${query}` : ""}`;
+}
+
+module.exports = { createTokenRetryHandler, dashboardRetryPath };

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -3695,19 +3695,46 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // still stuck at 'POP'.
   const lastLocKeyRef = useRef<string | null>(null)
   const [sidError, setSidError] = useState('')
+  const [newSlotFailed, setNewSlotFailed] = useState(false)
   const [highlightTs, setHighlightTs] = useState<string | null>(null)
-  // Embed ?new=1: create a new chat slot and navigate to it
-  const embedNewSlotMutation = useMutation({
+  // ?new=1: create a blank slot for an embed or a fresh desktop window.
+  const newSlotMutation = useMutation({
     mutationFn: () => dispatch(createSlot({ mode })).unwrap(),
     onSuccess: (slot) => {
-      if (slot?.key) navigate(`/embed/chat/${slot.key}`, { replace: true })
+      newSessionRef.current = false
+      setNewSlotFailed(false)
+      setSidError('')
+      if (!slot?.key) return
+      navigate(
+        embedMode ? `/embed/chat/${slot.key}` : `/chat?sid=${encodeURIComponent(slot.key)}`,
+        { replace: true },
+      )
+    },
+    onError: () => {
+      // Keep the failed window on its blank-session surface. Clearing only the
+      // ref lets the auto-select effect silently fall back to an older session,
+      // which makes a failed "New Window" look as if it copied that session.
+      newSessionRef.current = false
+      setNewSlotFailed(true)
+      setSidError(i18nT('pages.chatPage.could_not_start_a_new_session'))
     },
   })
   useEffect(() => {
-    if (!initialNewRef.current || !embedMode) return
+    if (!initialNewRef.current || (embedded && !embedMode) || popout) return
     initialNewRef.current = false
-    embedNewSlotMutation.mutate()
+    newSessionRef.current = true
+    setNewSlotFailed(false)
+    setSidError('')
+    if (!embedMode) dispatch(setActiveSlot(null))
+    newSlotMutation.mutate()
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  // Choosing a real session explicitly abandons a failed blank-window intent;
+  // its banner must not follow the user into the selected conversation.
+  useEffect(() => {
+    if (!activeSlot || !newSlotFailed) return
+    setNewSlotFailed(false)
+    setSidError('')
+  }, [activeSlot, newSlotFailed])
   // On mount, URL ?sid= drives which session is active (URL wins over localStorage)
   useEffect(() => {
     if (embedded && !embedMode) return
@@ -3937,6 +3964,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // is still creating + slack-linking its session; otherwise we'd switch to
     // a different slot and orphan the linked one (breaking Slack mirroring).
     if (tokenConsumingRef.current) return
+    if (newSessionRef.current || newSlotFailed) return
     if (searchParams.get('slot') || searchParams.get('sid') || initialSidRef.current) return
     if (filteredSlots.length > 0) {
       const saved = localStorage.getItem(slotStorageKey)
@@ -3947,7 +3975,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       autoCreatedRef.current = true
       dispatch(createSlot({ agent: defaultAgent || undefined, mode }))
     }
-  }, [activeSlot, filteredSlots, searchParams, dispatch, slotStorageKey, connected, slotsLoaded, defaultAgent, mode])
+  }, [activeSlot, filteredSlots, searchParams, dispatch, slotStorageKey, connected, slotsLoaded, defaultAgent, mode, newSlotFailed])
 
   // Slot switch: the virtualizer (keyed on sessionId = activeSlot) force-pins
   // to the true bottom itself in a layout effect. Here we just re-arm the
@@ -7086,7 +7114,23 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         ) : !activeSlot ? (
           <div className="flex-1 flex flex-col items-center justify-center gap-4 px-8">
             <EmptyState icon={<MessageSquare className="lucide-inline" />} title={i18nT('pages.chatPage.what_can_i_do_for_you')} subtitle={i18nT('pages.chatPage.start_a_new_chat_to_begin')} />
-            <Btn primary onClick={() => dispatch(createSlot({ agent: pendingAgent || defaultAgent || undefined, model: pendingModel || undefined, mode }))}>{i18nT('pages.chatPage.start_a_new_chat')}</Btn>
+            <Btn
+              primary
+              disabled={newSlotMutation.isPending}
+              onClick={() => {
+                if (newSlotFailed) {
+                  // Re-arm before state updates can let auto-selection run.
+                  newSessionRef.current = true
+                  setNewSlotFailed(false)
+                  setSidError('')
+                  newSlotMutation.mutate()
+                  return
+                }
+                dispatch(createSlot({ agent: pendingAgent || defaultAgent || undefined, model: pendingModel || undefined, mode }))
+              }}
+            >
+              {i18nT('pages.chatPage.start_a_new_chat')}
+            </Btn>
           </div>
         ) : (
           <SearchHighlightContext.Provider value={searchCtxValue}>
@@ -8129,4 +8173,3 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     </RowDisclosureProvider>
   )
 }
-

--- a/website/src/test/ChatPageSendCreateFailure.test.tsx
+++ b/website/src/test/ChatPageSendCreateFailure.test.tsx
@@ -67,7 +67,7 @@ Object.defineProperty(window, 'matchMedia', {
 
 import ChatPage from '../pages/ChatPage'
 
-function makeStore(pendingInput = 'do not lose me') {
+function makeStore(pendingInput: string | null = 'do not lose me') {
   return configureStore({
     reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
     preloadedState: {
@@ -106,6 +106,21 @@ function makeSlotlessStore(pendingInput = 'do not lose me') {
       dashboard: { ...state.dashboard, slots: [], slotsLoaded: false } as unknown as RootState['dashboard'],
       chat: { ...state.chat, activeSlot: null, pendingInput } as unknown as RootState['chat'],
       notifications: { items: [] } as unknown as RootState['notifications'],
+    },
+  })
+}
+
+/** A new renderer with known sessions but no selected session. This is the
+ *  exact state where a failed `?new=1` intent can race the auto-select effect. */
+function makeInactiveStore() {
+  const store = makeStore(null)
+  const state = store.getState()
+  return configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+    preloadedState: {
+      dashboard: state.dashboard,
+      chat: { ...state.chat, activeSlot: null } as unknown as RootState['chat'],
+      notifications: state.notifications,
     },
   })
 }
@@ -447,5 +462,48 @@ describe('send() when creating the session fails', { timeout: 20_000 }, () => {
     expect(createChatSlot).toHaveBeenCalledTimes(2)
     // NOT 'slot-a' — that session has nothing to do with this message.
     expect(sendChat.mock.calls[0][1]).toBe('slot-z')
+  })
+})
+
+describe('full-dashboard new-window intent', () => {
+  it('creates a blank slot without copying or sending the current session', async () => {
+    createChatSlot.mockResolvedValue({
+      key: 'slot-new', title: 'slot-new', messages: 0, running: false,
+    })
+    const store = makeInactiveStore()
+
+    await renderSlotless(store, '/chat?new=1')
+
+    await waitFor(() => expect(createChatSlot).toHaveBeenCalledTimes(1))
+    expect(sendChat).not.toHaveBeenCalled()
+    expect(store.getState().chat.activeSlot).toBe('slot-new')
+  })
+
+  it('keeps a failed blank window from falling back to an existing session and retries explicitly', async () => {
+    let resolveRetry!: (slot: { key: string; title: string; messages: number; running: boolean }) => void
+    createChatSlot.mockRejectedValueOnce(new Error('gateway unavailable'))
+    createChatSlot.mockImplementationOnce(() => new Promise((resolve) => { resolveRetry = resolve }))
+    const store = makeInactiveStore()
+
+    await renderSlotless(store, '/chat?new=1')
+
+    await waitFor(() => expect(createChatSlot).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.getByText('Could not start a new session')).toBeTruthy())
+    expect(store.getState().chat.activeSlot).toBeNull()
+    expect(sendChat).not.toHaveBeenCalled()
+
+    const retry = screen.getByRole('button', { name: 'Start a new chat' })
+    fireEvent.click(retry)
+
+    await waitFor(() => expect(createChatSlot).toHaveBeenCalledTimes(2))
+    expect(retry).toBeDisabled()
+    fireEvent.click(retry)
+    expect(createChatSlot).toHaveBeenCalledTimes(2)
+    act(() => resolveRetry({
+      key: 'slot-retry', title: 'slot-retry', messages: 0, running: false,
+    }))
+    await waitFor(() => expect(store.getState().chat.activeSlot).toBe('slot-retry'))
+    expect(screen.queryByText('Could not start a new session')).toBeNull()
+    expect(sendChat).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Problem / Motivation

The macOS desktop shell has no native way to open a second independent window for a fresh session. Users must leave the session they are viewing, while the existing New Connection Window action targets a different gateway.

## Why it matters

A user should be able to keep a long-running conversation visible and start an unrelated session beside it, with no project, draft, or context leaking from the current session.

## What changed

- add a macOS-only **Connection -> New Window** command on `Cmd+Shift+N`
- open the blank-session dashboard route on the already-running local gateway
- preserve the new-session route intent across token acquisition and token retry
- create exactly one blank slot even if the user double-clicks while creation is pending
- keep gateway liveness ownership on the primary window
- reuse the standalone connection-window factory instead of re-entering primary-window creation

Windows and Linux menus are unchanged.

## Conflict resolution

Rebased the original single commit onto current `main` and reconciled the newer ChatPage session-creation flow as a whole. The retry button is disabled for the entire pending mutation, preventing duplicate slots without changing existing error recovery. The larger overlapping #6856 remains deferred so this smaller PR can establish the base behavior first.

## Tests

- `node --test test/app-menu.test.js test/reconnect-focus.test.js test/shell-contract.test.js test/token-retry.test.js`: 52 passed
- `npx vitest run src/test/ChatPageSendCreateFailure.test.tsx --coverage.enabled=false`: 14 passed
- `npm run typecheck`
- changed-file ESLint: 0 errors
- production Vite build
- full Electron suite: 1,436 passed, 2 skipped
- `git diff --check` and clean merge-tree validation

## Screenshot evidence

This changes a visible macOS native menu. The conflict-resolution environment is Windows and cannot produce truthful macOS menu evidence; a macOS capture is still required from the PR owner or maintainer. No no-visual waiver is claimed.

Closes #3610