### PR TITLE
refactor(mcp): delete the inert PoolKey.user_identity dimension (#3604)

### DIFF
--- a/src/kiro_crew/mcp_gateway/claim.py
+++ b/src/kiro_crew/mcp_gateway/claim.py
@@ -84,8 +84,8 @@ def build_claim_frame(pid: int, session_key: str, channel_id: Optional[str]) -> 
         "caller": {
             "session_key": session_key,
             "session_type": classify_session_type(session_key),
-            "principal_id": os.environ.get("KIROCREW_PRINCIPAL")
-            or os.environ.get("USER")
+            "principal_id": os.environ.get("USER")
+            or os.environ.get("USERNAME")
             or "",
             "channel_id": channel_id or "",
         },

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -2113,6 +2113,9 @@ async def _handle_connection(
                     session_key=resolved_session_key,
                     session_type="peer-resolved",
                     principal_id=str(
+                        # ``user_identity`` is the legacy spelling an older
+                        # stub may still send; the field was deleted from
+                        # PoolKey but stays honored here as a diagnostic.
                         register.get("principal_id") or register.get("user_identity") or ""
                     ),
                     channel_id=str(register.get("channel_id") or ""),

--- a/src/kiro_crew/mcp_gateway/pool.py
+++ b/src/kiro_crew/mcp_gateway/pool.py
@@ -4,12 +4,12 @@ Two sessions sharing a single backend MUST produce the same answers as if
 each had its own backend. Every attribute that changes backend behavior
 MUST be in :class:`PoolKey`, or two sessions can see cross-tenant state.
 
-The 13 dimensions captured below are the union of every spawn-time input
+The 12 dimensions captured below are the union of every spawn-time input
 that influences a Kiro MCP subprocess: identity (``server_name``,
 ``agent_name``), execution (``command_args_hash``, ``effective_env_hash``,
 ``work_dir``, ``binary_version``), security (``os_uid``, ``sandbox_mode``,
-``autoapprove_set_hash``, ``approval_mode``, ``trust_all_tools``,
-``user_identity``), and config drift (``config_snapshot_hash``).
+``autoapprove_set_hash``, ``approval_mode``, ``trust_all_tools``), and
+config drift (``config_snapshot_hash``).
 
 There is deliberately NO channel dimension. A channel is not a trust
 boundary and never was a usable proxy for one:
@@ -27,11 +27,17 @@ boundary and never was a usable proxy for one:
   onto every forwarded ``tools/call``, so a channel-aware backend learns the
   channel PER CALL and does not need a process to itself.
 
-The axis that genuinely expresses "a different person must not share a
-backend" is ``user_identity``. It is present above, and today it degrades to
-the OS user because nothing populates ``KIROCREW_PRINCIPAL`` — making that
-real is the prerequisite for a shared multi-principal gateway, and is
-tracked separately. Re-adding a channel dimension is not that fix.
+There is deliberately NO per-principal dimension either. Kiro Crew is
+single-operator: a Slack bot and a cron job are the same operator's
+automations, not separate principals, so a multi-principal shared gateway
+is not a supported deployment model. A ``user_identity`` field existed
+here historically, but nothing ever populated its ``KIROCREW_PRINCIPAL``
+source, so it always collapsed to the OS user and never isolated anything
+— it was deleted rather than kept as a misleading affordance. The
+cross-OS-user boundary that IS real is carried by ``os_uid``. If
+multi-principal isolation is ever wanted, it needs a real design (what
+counts as a principal on an unattended surface is the hard part);
+re-adding a key field would be the small part.
 
 Stable hashing uses SHA-256 over a JSON-serialized tuple with sorted keys.
 Python's built-in ``hash()`` is intentionally non-deterministic across
@@ -236,7 +242,6 @@ class PoolKey:
     autoapprove_set_hash: str
     approval_mode: str
     trust_all_tools: bool
-    user_identity: str
 
     # Config drift
     config_snapshot_hash: str
@@ -267,7 +272,9 @@ class PoolKey:
         # stub still reports it because gatewayd threads it into the per-call
         # caller identity (see ``_build_caller_block``), and an older stub
         # against a newer daemon must keep registering cleanly. It is simply
-        # not a pool dimension — see the module docstring.
+        # not a pool dimension — see the module docstring. The same applies
+        # to ``user_identity``, which older stubs still send: it was deleted
+        # as a pool dimension (it never isolated anything) and is ignored.
         # Security-boundary dims: type-check rather than coerce. bool("false")
         # is True and int() on a bool silently passes, so a stub sending a JSON
         # string/number for these could land in the wrong trust/uid partition.
@@ -292,7 +299,6 @@ class PoolKey:
                 autoapprove_set_hash=str(register["autoapprove_set_hash"]),
                 approval_mode=str(register["approval_mode"]),
                 trust_all_tools=trust_all_tools,
-                user_identity=str(register["user_identity"]),
                 config_snapshot_hash=str(register["config_snapshot_hash"]),
             )
         except (TypeError, ValueError) as exc:

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -354,8 +354,12 @@ def _build_caller_block(channel_id: Optional[str]) -> dict[str, str]:
     both ends of the wire in agreement. If the key is still unknown at register
     (claim hasn't happened yet), the recaller loop repairs it later."""
     session_key = CallerContext.from_env().session_key
+    # Diagnostic identity only — the OS user. USERNAME is the Windows spelling
+    # of USER; check both so this dimension is not empty on one platform.
+    # (A ``KIROCREW_PRINCIPAL`` override existed historically but nothing ever
+    # set it — Kiro Crew is single-operator, so it was deleted.)
     principal = (
-        os.environ.get("KIROCREW_PRINCIPAL") or os.environ.get("USER") or ""
+        os.environ.get("USER") or os.environ.get("USERNAME") or ""
     )
     if session_key.startswith("cron:"):
         session_type = "cron"
@@ -399,14 +403,6 @@ def build_register_payload(args: argparse.Namespace) -> dict:
         work_dir = str(args.work_dir)
 
     caller = _build_caller_block(channel_id)
-    # USERNAME is the Windows spelling of USER; check both so this diagnostic
-    # dimension is not empty on one platform.
-    user_identity = (
-        caller["principal_id"]
-        or os.environ.get("USER", "")
-        or os.environ.get("USERNAME", "")
-        or "unknown"
-    )
 
     return {
         "type": "register",
@@ -436,7 +432,15 @@ def build_register_payload(args: argparse.Namespace) -> dict:
         # per-connection backend exist without making every key
         # connection-private.
         "poolable": bool(args.poolable),
-        "user_identity": user_identity,
+        # Wire-compat ballast, NOT a pool dimension: an adopted daemon that
+        # outlived a package upgrade (the manager adopts anything answering
+        # ``pong`` with no version handshake — see gatewayd's capability
+        # comment) still runs a ``PoolKey.from_register`` that hard-requires
+        # ``user_identity``. Omitting the key would make that daemon reject
+        # every new stub's register as malformed, silently un-pooling the
+        # whole install until the daemon restarts. A current daemon ignores
+        # the key. Safe to drop once no pre-#3604 daemon can be adopted.
+        "user_identity": caller["principal_id"] or "unknown",
         "channel_id": channel_id,
         "config_snapshot_hash": _CONFIG_SNAPSHOT_PLACEHOLDER,
         "caller": caller,

--- a/test/test_gatewayd_more_coverage.py
+++ b/test/test_gatewayd_more_coverage.py
@@ -106,7 +106,6 @@ def _register_frame(**overrides: Any) -> dict[str, Any]:
         "autoapprove_set_hash": "b" * 8,
         "approval_mode": "reads",
         "trust_all_tools": False,
-        "user_identity": "cov",
         "config_snapshot_hash": "c" * 8,
         "session_key": "sess-cov",
         "session_type": "dashboard",

--- a/test/test_mcp_apps_call_endpoint.py
+++ b/test/test_mcp_apps_call_endpoint.py
@@ -64,7 +64,6 @@ def _pool_key(server: str = "fake-mcp-app") -> PoolKey:
         autoapprove_set_hash="ghi789",
         approval_mode="reads",
         trust_all_tools=False,
-        user_identity="testuser",
         config_snapshot_hash="jkl012",
     )
 

--- a/test/test_mcp_apps_e2e.py
+++ b/test/test_mcp_apps_e2e.py
@@ -68,7 +68,6 @@ def _pool_key() -> PoolKey:
         autoapprove_set_hash="ghi789",
         approval_mode="reads",
         trust_all_tools=False,
-        user_identity="testuser",
         config_snapshot_hash="jkl012",
     )
 

--- a/test/test_mcp_gateway_apps_spool.py
+++ b/test/test_mcp_gateway_apps_spool.py
@@ -595,7 +595,6 @@ def _pool_key(server: str = "excalidraw-mcp") -> PoolKey:
         autoapprove_set_hash="ghi789",
         approval_mode="reads",
         trust_all_tools=False,
-        user_identity="testuser",
         config_snapshot_hash="jkl012",
     )
 

--- a/test/test_mcp_gateway_backend_coverage.py
+++ b/test/test_mcp_gateway_backend_coverage.py
@@ -92,7 +92,6 @@ def _pool_key(server: str = "example-mcp") -> PoolKey:
         autoapprove_set_hash="aah",
         approval_mode="reads",
         trust_all_tools=False,
-        user_identity="testuser",
         config_snapshot_hash="csh",
     )
 

--- a/test/test_mcp_gateway_bluegreen.py
+++ b/test/test_mcp_gateway_bluegreen.py
@@ -46,7 +46,6 @@ def _make_pool_key(server: str = "test-server", agent: str = "test-agent") -> Po
         autoapprove_set_hash="ghi789",
         approval_mode="reads",
         trust_all_tools=False,
-        user_identity="testuser",
         config_snapshot_hash="jkl012",
     )
 

--- a/test/test_mcp_gateway_claim.py
+++ b/test/test_mcp_gateway_claim.py
@@ -63,7 +63,6 @@ def _register(
         "autoapprove_set_hash": "2" * 64,
         "approval_mode": "interactive",
         "trust_all_tools": False,
-        "user_identity": "cp",
         "channel_id": "C_CP",
         "config_snapshot_hash": "3" * 64,
         "parent_pid": (ancestor_pids or _ANCESTORS)[0],  # legacy field, first ancestor
@@ -724,6 +723,23 @@ def test_stub_register_payload_carries_ancestor_pids() -> None:
     # Chain walks upward: on Linux the second entry (when present) must be
     # the parent of the first.
     assert len(set(chain)) == len(chain)  # no cycles
+
+
+def test_stub_register_payload_keeps_legacy_user_identity_key() -> None:
+    """Wire-compat ratchet (#3604): ``user_identity`` was deleted as a
+    PoolKey dimension, but the register payload must keep sending the key.
+    The manager adopts a running daemon with no version handshake, so a
+    daemon predating the deletion can serve new stubs — and its
+    ``PoolKey.from_register`` hard-requires the field, rejecting a payload
+    without it and silently un-pooling every session until the daemon
+    restarts. Drop this only when no pre-#3604 daemon can be adopted."""
+    args = stub_mod._parse_args(
+        ["--server", "echo-mcp", "--agent", "cp-agent",
+         "--target-command", "/bin/true", "--work-dir", "/tmp"]
+    )
+    payload = stub_mod.build_register_payload(args)
+    assert "user_identity" in payload
+    assert isinstance(payload["user_identity"], str) and payload["user_identity"]
 
 
 def test_classify_session_type() -> None:

--- a/test/test_mcp_gateway_cluster_fixes.py
+++ b/test/test_mcp_gateway_cluster_fixes.py
@@ -199,7 +199,6 @@ class TestNamingMigration:
             autoapprove_set_hash="a",
             approval_mode="interactive",
             trust_all_tools=False,
-            user_identity="test",
             config_snapshot_hash="c",
         )
         env_patch = {"MC_MCP_TARGET_TEST_SRV": "/usr/bin/test-srv --stdio"}
@@ -230,7 +229,6 @@ class TestNamingMigration:
             autoapprove_set_hash="a",
             approval_mode="interactive",
             trust_all_tools=False,
-            user_identity="test",
             config_snapshot_hash="c",
         )
         env_patch = {

--- a/test/test_mcp_gateway_exclusive_backend.py
+++ b/test/test_mcp_gateway_exclusive_backend.py
@@ -40,7 +40,6 @@ def _make_pool_key(server: str = "srv", agent: str = "agent") -> PoolKey:
         autoapprove_set_hash="ghi789",
         approval_mode="reads",
         trust_all_tools=False,
-        user_identity="testuser",
         config_snapshot_hash="jkl012",
     )
 
@@ -337,7 +336,6 @@ def _register_frame(*, poolable: bool) -> dict[str, Any]:
         "approval_mode": "interactive",
         "trust_all_tools": False,
         "poolable": poolable,
-        "user_identity": "ex",
         "channel_id": "C_EX",
         "config_snapshot_hash": "3" * 64,
         "session_key": "dashboard:chat-EX-1",

--- a/test/test_mcp_gateway_poolkey.py
+++ b/test/test_mcp_gateway_poolkey.py
@@ -25,10 +25,37 @@ _VALID = {
     "autoapprove_set_hash": "h3",
     "approval_mode": "interactive",
     "trust_all_tools": False,
-    "user_identity": "u",
     "channel_id": None,
     "config_snapshot_hash": "h4",
 }
+
+
+def test_pool_key_field_set_is_exactly_the_twelve_dimensions() -> None:
+    """The key's field set is asserted EXPLICITLY so adding or removing a
+    pool dimension has to be a deliberate test change, never a silent one.
+    ``user_identity`` was deleted (issue #3604): nothing ever populated its
+    ``KIROCREW_PRINCIPAL`` source, so it always collapsed to the OS user and
+    never isolated anything — re-adding it must come with a real
+    multi-principal design, not just a field.
+    """
+    assert set(PoolKey.__dataclass_fields__) == {
+        # identity
+        "server_name",
+        "agent_name",
+        # execution shape
+        "command_args_hash",
+        "effective_env_hash",
+        "work_dir",
+        "binary_version",
+        # security boundary
+        "os_uid",
+        "sandbox_mode",
+        "autoapprove_set_hash",
+        "approval_mode",
+        "trust_all_tools",
+        # config drift
+        "config_snapshot_hash",
+    }
 
 
 def test_valid_register_roundtrips() -> None:
@@ -93,12 +120,23 @@ class TestChannelIsNotAPoolDimension:
     def test_channel_absent_from_repr(self) -> None:
         assert "chan=" not in str(PoolKey.from_register({**_VALID, "channel_id": "C_X"}))
 
+    def test_legacy_user_identity_is_not_a_pool_dimension(self) -> None:
+        """An older stub still sends ``user_identity`` in its register
+        payload. The field was deleted from the key (it never isolated
+        anything — nothing populated ``KIROCREW_PRINCIPAL``, so it always
+        collapsed to the OS user), so the payload key must be ignored, not
+        rejected, and must not partition the pool."""
+        base = PoolKey.from_register(dict(_VALID))
+        for legacy in ("someone-else", "", "unknown"):
+            variant = PoolKey.from_register({**_VALID, "user_identity": legacy})
+            assert variant.stable_hash() == base.stable_hash()
+            assert variant == base
+
     def test_security_dimensions_still_partition(self) -> None:
         """Negative control: dropping the channel dimension must not have made
         the key permissive — the real boundaries still split."""
         base = PoolKey.from_register(dict(_VALID))
         for field, other in (
-            ("user_identity", "someone-else"),
             ("os_uid", 1001),
             ("sandbox_mode", "none"),
             ("effective_env_hash", "different"),

--- a/test/test_mcp_gateway_prewarm.py
+++ b/test/test_mcp_gateway_prewarm.py
@@ -38,7 +38,6 @@ def _register(server: str = "test-mcp") -> dict[str, object]:
         "autoapprove_set_hash": "c" * 64,
         "approval_mode": "interactive",
         "trust_all_tools": False,
-        "user_identity": "test-user",
         "config_snapshot_hash": "d" * 64,
     }
 

--- a/test/test_mcp_gateway_prewarm_cov80.py
+++ b/test/test_mcp_gateway_prewarm_cov80.py
@@ -58,7 +58,6 @@ def _register(server: str = "test-mcp", agent: str = "test-agent") -> dict[str, 
         "autoapprove_set_hash": "c" * 64,
         "approval_mode": "interactive",
         "trust_all_tools": False,
-        "user_identity": "test-user",
         "config_snapshot_hash": "d" * 64,
     }
 

--- a/test/test_mcp_gateway_recaller.py
+++ b/test/test_mcp_gateway_recaller.py
@@ -42,7 +42,6 @@ def _register(session_key: str) -> dict[str, Any]:
         "autoapprove_set_hash": "2" * 64,
         "approval_mode": "interactive",
         "trust_all_tools": False,
-        "user_identity": "rc",
         "channel_id": "C_RC",
         "config_snapshot_hash": "3" * 64,
         "session_key": session_key,

--- a/test/test_mcp_gateway_shutdown_and_env.py
+++ b/test/test_mcp_gateway_shutdown_and_env.py
@@ -58,7 +58,6 @@ def _pool_key(
         autoapprove_set_hash="ghi789",
         approval_mode="reads",
         trust_all_tools=False,
-        user_identity="testuser",
         config_snapshot_hash="jkl012",
     )
 

--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -98,7 +98,6 @@ def _pool_key(server: str = "demo-mcp", agent: str = "cov-agent", env_hash: str 
         autoapprove_set_hash="b" * 8,
         approval_mode="reads",
         trust_all_tools=False,
-        user_identity="cov",
         config_snapshot_hash="c" * 8,
     )
 

--- a/test/test_stop_kill_cancel.py
+++ b/test/test_stop_kill_cancel.py
@@ -44,7 +44,6 @@ def _make_pool_key(server: str = "test-mcp") -> PoolKey:
         "autoapprove_set_hash": "c" * 64,
         "approval_mode": "interactive",
         "trust_all_tools": False,
-        "user_identity": "test-user",
         "config_snapshot_hash": "d" * 64,
     })
 
@@ -527,7 +526,6 @@ class TestDetachOnCancelFailure:
             "autoapprove_set_hash": "2" * 64,
             "approval_mode": "interactive",
             "trust_all_tools": False,
-            "user_identity": "leak",
             "channel_id": "C_LEAK",
             "config_snapshot_hash": "3" * 64,
             "session_key": "dashboard:chat-leak",


### PR DESCRIPTION
## What is the problem?

`PoolKey.user_identity` exists to isolate pooled MCP backends per principal, but nothing ever populates it. It reads `KIROCREW_PRINCIPAL` with a fallback to `USER`, and there is no write site for that variable anywhere in `src/` — `pool.py` documented this itself. On a single-operator install the field always collapses to the OS user, so it carries one constant value and never isolates anything.

## Why this issue matters to the user

The field implies a capability that does not exist. A reader of `PoolKey` reasonably concludes that pooled backends are isolated per principal and that setting `KIROCREW_PRINCIPAL` would achieve that. Neither is true, and someone will eventually build on that assumption. The direction is settled: Kiro Crew is single-operator — a Slack bot and a cron job are the same operator's automations, not separate principals — so multi-principal shared gateways are not a supported deployment model and there is nothing for this field to grow into.

## How our fix solves it

This is a deletion, not a redesign: the misleading affordance is removed rather than implemented.

- `PoolKey` drops `user_identity` (13 → 12 dimensions); `from_register` no longer requires it. A payload still carrying the key (older stub) is ignored, exactly like the pre-existing `channel_id` handling. The module docstring is rewritten to record the single-operator decision; the real cross-user boundary remains `os_uid`.
- The `KIROCREW_PRINCIPAL` env reads are deleted from `stub.py` (`_build_caller_block`) and `claim.py`. The diagnostic `principal_id` now derives from `USER`/`USERNAME` (the `USERNAME` fallback preserves the Windows diagnostic value the deleted field used to carry).
- **Version-skew guard (found by pre-push review):** the register payload deliberately KEEPS sending a `user_identity` key as wire-compat ballast. The manager adopts a running gatewayd with no version handshake, so a daemon that outlived a package upgrade still runs a `from_register` that hard-requires the field — omitting the key would make that daemon reject every new stub's register, silently un-pooling the whole install until the daemon restarts. A current daemon ignores the key. A ratchet test pins the key in place with the removal condition documented.
- `gatewayd`'s `register.get("user_identity")` diagnostic fallback is kept (annotated as legacy) so an old stub's caller identity still resolves.
- No persisted-store impact: the prewarm hot-set recomputes digests from stored registers at load (self-healing across the key-shape change), and the rewriter fingerprint / shareability entry key never embedded `user_identity`.

Grep confirms no docs or config schema reference `KIROCREW_PRINCIPAL`; the only remaining mentions are code comments explaining the deletion.

## What tests we did

- `test_mcp_gateway_poolkey.py`: new explicit field-set assertion (all 12 dimensions enumerated) so re-adding a pool dimension must be a deliberate test change; new `test_legacy_user_identity_is_not_a_pool_dimension` proving an old stub's payload is accepted and does not partition the pool.
- `test_mcp_gateway_claim.py`: new `test_stub_register_payload_keeps_legacy_user_identity_key` wire-compat ratchet.
- 15 test files updated to drop the deleted field from `PoolKey(...)` constructions and register fixtures.
- Local gates: isort / flake8 / mypy clean on all changed files; 718 targeted tests across every touched module pass (poolkey, claim, prewarm, recaller, stub admission/recaller, gatewayd coverage, exclusive backend, bluegreen, apps spool/e2e/call-endpoint, stop-kill-cancel, identity topology).
- Pre-push review: GPT (gpt-5.6-sol) found the adopted-daemon skew as BLOCKING — fixed with the wire-compat key + ratchet test; Opus (claude-opus-5) reported NO BLOCKING, independently confirmed the same skew and its fix, verified no real security partition weakened (`user_identity` was same-uid env data; the socket peer-cred check already confines connections to one uid), and verified the docstring's 12-dimension enumeration matches the dataclass exactly.

## Manual verification

N/A — unit coverage sufficient: the change is a field deletion plus env-read removal, fully exercised by the register/pool-key unit tests; no UI or runtime-config surface changed.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (MCP gateway pool identity); no frontend files touched, no rendered delta.

Closes #3604
