### PR TITLE
fix(agents): gate @server tool grants; warn on dangling refs (#3605)

### DIFF
--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -599,6 +599,48 @@ def _materialize_managed_refs(agent_data: dict[str, Any]) -> None:
     agent_data["mcpServers"] = servers
 
 
+def _unresolvable_tool_refs(agent_data: dict[str, Any]) -> list[str]:
+    """``@server``/``@server/tool`` grants whose server no config declares.
+
+    kiro-cli resolves a ``@`` tool reference against the agent's own
+    ``mcpServers`` plus the global ``mcp.json``; a name found in neither is
+    dropped SILENTLY at mount time — the agent simply loses the tool with no
+    exception and no log line anywhere. CI gates the shipped specs (see
+    ``test_pptx_maker_provision.py``), but a user-installed app whose server
+    failed to register is a runtime event CI cannot see, so the registration
+    path — the last point that holds both the grants and the merged server
+    map — reports it here.
+
+    Diagnostic only: the caller logs a warning and still registers the agent.
+    A dangling ref never mounts; it does not break the agent, so it must not
+    become fatal. The global config is read only when a candidate survives the
+    merged map (the common all-resolved case costs no I/O).
+    """
+    servers = agent_data.get("mcpServers")
+    known = set(servers) if isinstance(servers, dict) else set()
+    candidates: list[tuple[str, str]] = []
+    for entry in agent_data.get("tools") or []:
+        if not isinstance(entry, str) or not entry.startswith("@"):
+            continue
+        server = entry[1:].split("/", 1)[0]
+        if server not in known:
+            candidates.append((entry, server))
+    if not candidates:
+        return []
+    if agent_data.get("includeMcpJson") is False:
+        # The spec opts out of the global mcp.json, so kiro-cli will not
+        # consult it at mount time — an ambient entry cannot rescue these refs
+        # and treating it as resolvable would suppress the one signal that
+        # exists for exactly the specs (mochi's) that set this flag.
+        return [f"{entry} (server {server!r})" for entry, server in candidates]
+    ambient = set(_global_mcp_specs())
+    return [
+        f"{entry} (server {server!r})"
+        for entry, server in candidates
+        if server not in ambient
+    ]
+
+
 #: Keys the framework OWNS in a materialized app agent config: each is derived
 #: from the manifest, the per-app MCP policy, or the running install, so a stale
 #: value is a bug rather than a preference. Everything else a user hand-edits in
@@ -920,6 +962,20 @@ def _register_agents(app_name: str, manifest: AppManifest, app_root: Path) -> li
             _servers = merged.get("mcpServers")
             if isinstance(_servers, dict):
                 merged["mcpServers"] = _strip_ungoverned_auto_approve(_servers)
+            # The map above is FINAL — every source of servers has been merged —
+            # so this is the one point a dangling `@` grant is decidable. Warn,
+            # never reject: kiro-cli just skips the ref, so the agent works
+            # minus the tool, and the warning is the only signal that exists.
+            dangling = _unresolvable_tool_refs(merged)
+            if dangling:
+                logger.warning(
+                    "App %s: agent %r grants MCP tool ref(s) not found in this "
+                    "agent's merged mcpServers or the global mcp.json; kiro-cli "
+                    "will silently never mount them: %s",
+                    app_name,
+                    agent_name,
+                    ", ".join(dangling),
+                )
             atomic_write(link_path, json.dumps(merged, indent=2) + "\n")
             registered.append(_namespace(app_name, agent_name))
             # The DECLARED name only — kiro-cli enumerates agents by their

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -162,6 +162,129 @@ class TestAgentRegistration:
         assert removed == 1
         assert not (app_env["kiro_agents"] / "test-app--my-agent.json").exists()
 
+    def test_a_dangling_at_grant_logs_a_warning_and_still_registers(
+        self, tmp_path, app_env, monkeypatch, caplog
+    ):
+        """An ``@server`` grant no config declares must be LOUD at registration.
+
+        kiro-cli drops the reference silently at mount time — the agent works
+        minus the tool with no error anywhere — so this warning is the only
+        signal a user-installed app whose server failed to register ever gets
+        (CI's shipped-spec gate cannot see that runtime event). Warning only:
+        the agent must still register, a dangling ref is degradation, not a
+        broken agent.
+        """
+        from kiro_crew.apps import bridges as bridges_mod
+
+        # Deterministic ambient: the check falls back to the user's global
+        # mcp.json, and the developer's real one must not decide this test.
+        monkeypatch.setattr(bridges_mod, "_global_mcp_specs", lambda: {})
+        src = _make_app_source(tmp_path)
+        (src / "agents" / "my-agent.json").write_text(
+            json.dumps(
+                {"name": "my-agent", "model": "auto", "tools": ["fs_read", "@ghost/summon"]}
+            )
+        )
+        install_app(src)
+        manifest = AppManifest.from_json_file(
+            app_env["home"] / "apps" / "test-app" / APP_MANIFEST_FILENAME
+        )
+        app_root = app_env["home"] / "apps" / "test-app"
+
+        with caplog.at_level("WARNING", logger="kiro_crew.apps.bridges"):
+            registered = _register_agents("test-app", manifest, app_root)
+
+        assert "test-app/my-agent" in registered  # still registers
+        warning = "\n".join(
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        )
+        assert "silently never mount" in warning
+        assert "@ghost/summon" in warning
+        assert "my-agent" in warning
+
+    def test_resolvable_at_grants_log_no_dangling_warning(
+        self, tmp_path, app_env, monkeypatch, caplog
+    ):
+        """The four real resolution sources must not trip the diagnostic.
+
+        A spec-own server, a host-managed server (materialized by
+        ``_materialize_managed_refs``), the app's own namespaced server
+        (registered by ``_register_mcp_servers`` and injected back by
+        ``_own_mcp_servers``), and a global-``mcp.json`` server are each
+        resolvable at mount time; warning on any of them would train
+        operators to ignore the log line that matters.
+        """
+        from kiro_crew.apps import bridges as bridges_mod
+
+        monkeypatch.setattr(bridges_mod, "_global_mcp_specs", lambda: {"ambient-srv": {}})
+        src = _make_app_source(
+            tmp_path, mcpServers={"srv": {"command": "echo", "args": []}}
+        )
+        (src / "agents" / "my-agent.json").write_text(
+            json.dumps(
+                {
+                    "name": "my-agent",
+                    "model": "auto",
+                    "mcpServers": {"own-srv": {"command": "echo", "args": []}},
+                    "tools": [
+                        "@own-srv/do_thing",
+                        "@kirocrew-core",
+                        "@ambient-srv",
+                        "@test-app:srv",
+                    ],
+                }
+            )
+        )
+        install_app(src)
+        manifest = AppManifest.from_json_file(
+            app_env["home"] / "apps" / "test-app" / APP_MANIFEST_FILENAME
+        )
+        app_root = app_env["home"] / "apps" / "test-app"
+        # Register the app's own server first, mirroring register_app's order —
+        # _own_mcp_servers reads it back from the registered config.
+        _register_mcp_servers("test-app", manifest, live_port=None)
+
+        with caplog.at_level("WARNING", logger="kiro_crew.apps.bridges"):
+            _register_agents("test-app", manifest, app_root)
+
+        assert "silently never mount" not in caplog.text
+
+    def test_include_mcp_json_false_does_not_resolve_against_global_config(
+        self, tmp_path, app_env, monkeypatch, caplog
+    ):
+        """A spec that opts out of the global mcp.json gets no ambient rescue.
+
+        With ``includeMcpJson: false`` kiro-cli never consults the global
+        config at mount time, so a grant that only a global entry could
+        satisfy is dropped — treating the ambient entry as resolvable would
+        suppress the warning for exactly the specs that set this flag.
+        """
+        from kiro_crew.apps import bridges as bridges_mod
+
+        monkeypatch.setattr(bridges_mod, "_global_mcp_specs", lambda: {"ambient-srv": {}})
+        src = _make_app_source(tmp_path)
+        (src / "agents" / "my-agent.json").write_text(
+            json.dumps(
+                {
+                    "name": "my-agent",
+                    "model": "auto",
+                    "includeMcpJson": False,
+                    "tools": ["@ambient-srv"],
+                }
+            )
+        )
+        install_app(src)
+        manifest = AppManifest.from_json_file(
+            app_env["home"] / "apps" / "test-app" / APP_MANIFEST_FILENAME
+        )
+        app_root = app_env["home"] / "apps" / "test-app"
+
+        with caplog.at_level("WARNING", logger="kiro_crew.apps.bridges"):
+            _register_agents("test-app", manifest, app_root)
+
+        assert "silently never mount" in caplog.text
+        assert "@ambient-srv" in caplog.text
+
     def test_a_failed_rewrite_leaves_the_prior_config_intact(self, tmp_path, app_env, monkeypatch):
         """A rebuild must never destroy the working config before its replacement
         is durable.

--- a/test/test_pptx_maker_provision.py
+++ b/test/test_pptx_maker_provision.py
@@ -1046,3 +1046,77 @@ class TestShippedAgentsDoNotPreAuthorizeTools:
                 raw = raw.replace(placeholder, "/rendered")
             data = json.loads(raw)
             assert data.get("tools"), f"{path} lost its tools entirely"
+
+    def test_every_at_server_grant_resolves_to_a_declared_server(self) -> None:
+        """Every ``@server``/``@server/tool`` grant names a server something declares.
+
+        kiro-cli drops an unresolvable ``@`` reference SILENTLY at mount time:
+        the agent registers, mounts without the tool, and no exception or
+        warning appears anywhere — so a typo in a spec edit degrades an agent
+        with zero signal. This gate makes that failure loud in CI.
+
+        A shipped spec's ``@`` grant is resolvable when its server part names
+        one of the three sources registration actually merges (see
+        ``bridges._register_agents``):
+
+        - the spec's OWN ``mcpServers`` block (e.g. pptx-maker's ``sdpm``);
+        - a HOST-MANAGED server — read from ``agent._MANAGED_MCP_SERVERS``
+          itself, the registry ``bridges._materialize_managed_refs`` consults,
+          so a renamed managed server fails here instead of un-mounting. The
+          materializer keys on the WHOLE remainder after ``@`` (``t[1:]``), so
+          only the bare ``@server`` form resolves — ``@kirocrew-core/tool``
+          would never be copied into the spec's ``mcpServers`` and must FAIL
+          this gate;
+        - the owning app's NAMESPACED servers, ``<app>:<server>`` for every
+          key in the manifest's ``mcpServers`` (``bridges._own_mcp_servers``
+          injects these by prefix after ``_register_mcp_servers`` writes them).
+
+        Deliberately NOT validated: bare builtin names (kiro-cli checks those
+        at registration — re-listing its vocabulary here would rot) and the
+        ``/tool`` half of a reference (only the live server can enumerate its
+        tools; the server lookup is the part that fails silently).
+        """
+        import io
+
+        from kiro_crew.agent import _MANAGED_MCP_SERVERS
+
+        builtins_dir = provision._PACKAGE_ROOT.parent
+        templates = sorted(builtins_dir.glob("*/agents/*.json"))
+        assert templates, "no shipped agent templates found — did the path change?"
+        offenders: list[str] = []
+        grants_seen = 0
+        for path in templates:
+            raw = io.open(path, encoding="utf-8").read()
+            for placeholder in _declared_placeholders():
+                raw = raw.replace(placeholder, "/rendered")
+            data = json.loads(raw)
+            resolvable = set(data.get("mcpServers") or {})
+            manifest = json.loads(
+                (path.parent.parent / "app.json").read_text(encoding="utf-8")
+            )
+            app_name = manifest.get("name")
+            if isinstance(app_name, str) and app_name:
+                resolvable.update(
+                    f"{app_name}:{server}" for server in (manifest.get("mcpServers") or {})
+                )
+            for entry in data.get("tools") or []:
+                if not isinstance(entry, str) or not entry.startswith("@"):
+                    continue
+                grants_seen += 1
+                remainder = entry[1:]
+                server = remainder.split("/", 1)[0]
+                # Managed refs resolve on the WHOLE remainder (bare form only):
+                # _materialize_managed_refs matches `t[1:]` against the registry
+                # keys, so a per-tool managed ref never materializes.
+                if remainder in _MANAGED_MCP_SERVERS:
+                    continue
+                if server not in resolvable:
+                    offenders.append(f"{path}: {entry!r} (server {server!r})")
+        # The gate must not pass vacuously: shipped specs DO carry @ grants
+        # today, so finding none means the traversal or the spec format moved.
+        assert grants_seen, "no @server grants found in any shipped spec — did the format change?"
+        assert offenders == [], (
+            "these shipped agent specs grant tools on a server that nothing "
+            "declares — kiro-cli will silently drop them at mount time:\n  "
+            + "\n  ".join(offenders)
+        )


### PR DESCRIPTION
## What is the problem?

A shipped agent spec can grant a tool name that resolves to **nothing**, and the failure is silent: kiro-cli drops the unresolvable `@` reference at mount time — no exception, no warning, no log line anywhere. Verified latent, not live: every grant in every currently-shipped spec resolves today. The two routine events that would break this are a typo in a spec edit and an app whose MCP server fails to register.

## Why this issue matters to the user

The consequence lands on the user: an agent that silently lost a tool still believes it has the capability, offers to do the thing, and then does nothing — with no error anywhere to correlate. Because the failure is invisible, it can ship and stay shipped.

## How our fix solves it

Silent drop at mount → nothing gates the grant→server mapping → make the mapping checkable at the two points that can see it:

1. **CI gate (the deliverable).** Extends the existing shipped-spec scan (`TestShippedAgentsDoNotPreAuthorizeTools`, same traversal of `builtins/*/agents/*.json`) with a resolve gate: every `@server` / `@server/tool` grant must name a server declared by the spec's own `mcpServers`, the owning app manifest's namespaced `<app>:<server>` servers, or — **bare form only** — `agent._MANAGED_MCP_SERVERS`, read from the registry itself at test time (never a hand-written list). The bare-only rule for managed servers mirrors `bridges._materialize_managed_refs`, which matches the whole remainder after `@`: a per-tool managed ref (`@kirocrew-core/tool`) never materializes and therefore fails the gate. Bare builtin names are deliberately not re-validated (kiro-cli checks them at registration; duplicating its vocabulary would rot), and the `/tool` half is not resolved (only the live server can enumerate its tools; the server lookup is the part that fails silently).

2. **Mount-time warning (decided: yes, warning only).** CI covers shipped specs; a user-installed app whose server fails to register is a runtime event CI cannot see. `bridges._register_agents` now logs a warning for any `@` grant that neither the agent's final merged `mcpServers` nor the global `mcp.json` can satisfy — honoring `includeMcpJson: false` specs, for which the global config is never consulted at mount time and must not suppress the signal. Deliberately a warning, never fatal: a dangling ref just never mounts, so the agent still registers and works minus the tool. Zero I/O on the clean path (the global config is read lazily, only when a candidate survives the merged map).

## What tests we did

- New CI gate in `test/test_pptx_maker_provision.py`, mutation-verified in **both directions**: passes on the current tree unchanged; fails when a spec gains `@nonexistent/tool`; fails when a spec gains `@kirocrew-core/monitor_start` (the per-tool managed form the materializer cannot see). Also asserts at least one `@` grant was scanned so the gate can never pass vacuously.
- Three new tests in `test/test_app_bridges.py::TestAgentRegistration`: a dangling grant logs the warning and the agent still registers; all four real resolution sources (spec-own, managed, app-namespaced via the real `_register_mcp_servers` → `_own_mcp_servers` path, and global) stay silent; an `includeMcpJson: false` spec granting a global-only server still warns. The warning path and the `includeMcpJson` guard are each mutation-verified (disabling them fails the respective test).
- Local gates: `isort` / `flake8` / `mypy` clean; full pytest 52,652 passed (158 failures A/B-proven pre-existing host-sandbox artifacts — identical with the diff stashed; zero in changed files).

## Any other suggestions on the work

The gate encodes the materializer's bare-only matching for managed refs. If `_materialize_managed_refs` ever learns to split on `/`, the gate's managed rule should be relaxed in the same change — the test's docstring documents this coupling.

<!-- no-visual-delta -->
**Why no screenshot:** backend test + a log-line diagnostic; no rendered UI change.

Closes #3605
