### PR TITLE
fix(dashboard): redact non-user content on the WS broadcast path (#1713)

### DIFF
--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -698,9 +698,10 @@ def _rehydrate_slot_from_history(
                 cls,
                 ts=m.get("ts", ""),
                 # broadcast=False: replaying history must not emit N `chat_message`
-                # events. _broadcast_chat_message ships content verbatim, and this
+                # events. _broadcast_chat_message redacts non-user content (parity
+                # with _prepare_messages) but deliberately not meta, and this
                 # helper also runs for on-demand cold-slot rehydrates while clients
-                # ARE connected, so broadcasting here would push unredacted history
+                # ARE connected, so broadcasting here would push unredacted meta
                 # straight to them. Clients get the transcript from the slot detail
                 # endpoint (redacted) and the sidebar from the coalesced slots push.
                 broadcast=False,

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -4259,11 +4259,24 @@ class DashboardState:
 
     def _broadcast_chat_message(self, slot_key: str, msg: dict) -> None:
         """Push a chat message to all SSE clients via the global stream."""
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        # Mirror the display-time redaction gate _prepare_messages applies on
+        # the HTTP history path, so a row's *content* leaves the backend in one
+        # byte form regardless of which consumer receives it. Scope: content
+        # only — `cls` / `meta` and the live `chat_chunk` stream are
+        # deliberately not covered (see the direct_meta comment below). Gate is
+        # `!= "user"` for the same reason as there: every non-user role can
+        # carry model/tool output, and user-authored content stays raw (the
+        # user typed it and is the only one who sees it back).
+        if role != "user" and isinstance(content, str) and content:
+            content, _ = redact_exfiltration_urls(content)
+            content, _ = redact_credentials(content)
         payload: dict[str, Any] = {
             "_type": "chat_message",
             "slot": slot_key,
-            "role": msg.get("role", ""),
-            "content": msg.get("content", ""),
+            "role": role,
+            "content": content,
             "ts": msg.get("ts", ""),
         }
         # Include cls for backward compatibility

--- a/test/test_display_time_redaction.py
+++ b/test/test_display_time_redaction.py
@@ -228,11 +228,13 @@ def test_restore_recent_sessions_does_not_broadcast_either(tmp_path, monkeypatch
 
 
 def test_rehydrate_does_not_broadcast_replayed_messages(tmp_path, monkeypatch) -> None:
-    """_broadcast_chat_message ships content verbatim.
+    """Replayed history must not be broadcast even though content is now redacted.
 
+    _broadcast_chat_message redacts non-user *content* (parity with
+    _prepare_messages, #1713) but deliberately not *meta* — so replaying history
+    through it would still push unredacted meta straight to connected clients.
     This helper also runs for on-demand cold-slot rehydrates, i.e. while clients
-    are connected — so replaying history through it would push unredacted content
-    straight to them.
+    are connected.
     """
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     state = _make_state(tmp_path / "sessions")
@@ -515,3 +517,45 @@ def test_oauth_completion_preserves_a_legitimate_url() -> None:
     meta = sent[0]["payload"]["meta"]
     assert meta.get("oauth_url") == legit, "a legitimate consent URL was blanked"
     assert meta.get("completed") is True
+
+
+# ── 7. WS broadcast redaction parity with the HTTP history path (#1713) ──────
+#
+# _prepare_messages (HTTP history) redacts non-user content at display time;
+# _broadcast_chat_message (live WS push) used to ship the same row verbatim, so
+# one chat row left the backend in two different byte forms depending on which
+# consumer received it. These pin the parity on both sides of the role gate.
+
+
+def test_ws_broadcast_redacts_assistant_content(tmp_path, monkeypatch) -> None:
+    """An assistant row carrying a credential comes out redacted on the WS path."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    sent: list[dict] = []
+    monkeypatch.setattr(state, "_broadcast", lambda payload: sent.append(payload))
+
+    state._broadcast_chat_message(
+        "chat-1-wsred", {"role": "assistant", "content": f"key {SECRET}", "ts": "1"}
+    )
+
+    assert len(sent) == 1, "precondition: exactly one payload was broadcast"
+    assert SECRET not in sent[0]["content"], "WS payload leaked an unredacted credential"
+    assert sent[0]["role"] == "assistant"
+
+
+def test_ws_broadcast_leaves_user_content_raw(tmp_path, monkeypatch) -> None:
+    """A user row is left alone — the same carve-out as _prepare_messages.
+
+    The user typed it and is the only one who sees it back; redacting it here
+    would diverge from the HTTP path in the other direction.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    sent: list[dict] = []
+    monkeypatch.setattr(state, "_broadcast", lambda payload: sent.append(payload))
+
+    text = f"my note contains {SECRET}"
+    state._broadcast_chat_message("chat-1-wsraw", {"role": "user", "content": text, "ts": "1"})
+
+    assert len(sent) == 1, "precondition: exactly one payload was broadcast"
+    assert sent[0]["content"] == text, "user-authored content must survive verbatim"


### PR DESCRIPTION
## Problem

The same chat row can leave the backend in two different byte forms. The HTTP history path (`chat_utils._prepare_messages`) redacts non-user content at display time, but the live WebSocket broadcast path (`state._broadcast_chat_message`) assigned `payload["content"]` straight from the message with no redaction. A credential or exfiltration URL in assistant output was therefore scrubbed for the HTTP consumer and delivered verbatim to WS clients.

## Why it matters

Any SSE/WS client connected during a live turn receives unredacted credential-shaped strings and exfiltration URLs that every other egress surface (slot detail endpoint, history prefix, stage capture) already scrubs. The redaction boundary is only as strong as its leakiest path.

## Fix (symptoms → root cause → change)

- **Symptom**: one row, two byte forms — redacted over HTTP, verbatim over WS.
- **Root cause**: `_broadcast_chat_message` never applied the display-time redaction gate that `_prepare_messages` applies; the two paths were written independently.
- **Change**: mirror the same role gate on the broadcast path — when `role != "user"` and content is a non-empty string, pass it through `redact_exfiltration_urls` then `redact_credentials` before building the payload. User-authored content stays raw (same carve-out as the HTTP path). No new imports: `state.py` already imports both redactors at module scope. Scope is content only: `cls` / `meta` / `direct_meta` handling is deliberately untouched — direct meta is the live OAuth banner's egress path and is documented in place; redacting it would blank genuine consent URLs.

Two stale comments that documented the old verbatim behavior (in `chat_persistence.py` and the rehydrate test docstring) are updated to match.

**Out of scope** (per issue triage): the issue's secondary suggestion of a stable per-row id instead of ts+content identity is not done here — it is a separate concern (and largely addressed by `meta.mid` from #1706).

## Tests

- `test_ws_broadcast_redacts_assistant_content` — an assistant row carrying a credential-shaped string comes out redacted in the WS payload. **Proven to fail on base** (verified by stashing the fix: `AssertionError: WS payload leaked an unredacted credential`).
- `test_ws_broadcast_leaves_user_content_raw` — a user row survives verbatim, pinning the carve-out so the WS path cannot silently diverge in the other direction.

Both live in `test/test_display_time_redaction.py` alongside the existing display-time redaction pins (all 24 pass).

## Manual verification

N/A — unit coverage exercises the exact changed function through the same `_broadcast` seam production uses; no UI or protocol shape changed.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; the WS payload shape is unchanged, only credential bytes inside `content` are masked.

## Local gates

isort / flake8 / mypy green. Backend pytest: 52,825 passed; the failing tests on this host are pre-existing environment issues (sandbox backend unavailable) — verified identical failure set on clean `main` in the same environment.

Closes #1713
