### PR TITLE
feat(skills): add module-simplification dev skill and AST detector

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/module-simplification/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/module-simplification/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: module-simplification
+description: "Refactor the Kiro Crew backend for readability ONE MODULE AT A TIME (one module = one branch = one commit = one PR), safely and in parallel across sessions. Carries the candidate classes worth sweeping, the three prohibitions that make a mechanical sweep safe (never delete an in-function `from X import Y`, never hoist a lazy import on the gateway boot path, never reshape a keystone security file), how to tell a real regression from this host's environmental test noise, and how several sessions share the work without colliding. Use when simplifying, tidying, de-duplicating, or flattening existing Kiro Crew backend code — not for feature work."
+triggers: kirocrew module simplification, kirocrew simplify module, kirocrew refactor module, kirocrew readability sweep, kirocrew dead imports, kirocrew chained ternary, kirocrew simplify backend, kirocrew source refactor
+repo_scope: src/kiro_crew
+---
+
+# Module-by-module simplification
+
+> **Scope guard: this skill applies ONLY when the working directory is the Kiro
+> Crew source repository (or a worktree of it).** Its rules are conventions of
+> this repo and are wrong elsewhere. Read
+> [`kirocrew-worktree-dev`](../kirocrew-worktree-dev/SKILL.md) first — every rule
+> there (worktree mandate, build gate, single commit) still applies. This skill
+> adds only what is specific to *behavior-preserving* refactoring.
+
+The whole point is **behavior preservation**. You are changing how code reads, never
+what it does. A simplification that alters behavior is not a simplification, it is an
+undocumented bug fix riding in a cleanup PR — the worst place to put one.
+
+## Rule 0 — One module, one branch, one commit, one PR
+
+```bash
+git worktree add ../kirocrew-wt-simplify-<module> -b refactor/simplify-<module> origin/main
+```
+
+Never batch modules. A 48-file mixed-class diff costs a reviewer far more than
+three narrow ones, and when a reviewer asks for one subtraction you re-run the
+whole gate cycle. One module also makes the parallel model in Rule 5 work.
+
+Name the branch **exactly** `refactor/simplify-<module>` — Rule 5 uses that
+pattern as the cross-session lock.
+
+## Rule 1 — What is in scope
+
+Run the bundled detector for the two mechanically decidable classes:
+
+```bash
+SKILL_DIR="${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/kirocrew-dev/module-simplification"
+python3 "$SKILL_DIR/scripts/scan_module.py"                      # queue: per-module counts
+python3 "$SKILL_DIR/scripts/scan_module.py" --module <module>     # site-level detail
+```
+
+It reports exactly two classes, and both are safe by construction:
+
+| Class | What it is | Why deleting/rewriting is safe |
+|---|---|---|
+| `shadow-import` | in-function `import X` where `X` is already imported at module scope in the same file | the inner statement re-binds the same `sys.modules` singleton, so it is a strict no-op |
+| `chained-ternary` | `a if c1 else b if c2 else d` (an `IfExp` whose `body`/`orelse` is an `IfExp`) | rewrite to `if`/`elif`/`else` preserving precedence, order and short-circuiting |
+
+The detector already excludes every false-positive class that has bitten this
+sweep before: `TYPE_CHECKING`-only module bindings (deleting the inner import
+would be a runtime `NameError`), `try/except ImportError` optional-dependency
+guards, `# circular import` markers **including one written inside a
+parenthesized form on the imported name's own line**, and ternaries that merely
+*contain* a ternary as a sub-expression of their result
+(`(a if c else b).method() if x else []` — that reads left-to-right and is out of
+scope). Trust its exclusions; do not re-derive them by eye.
+
+**A zero from the detector does not mean there is no work.** These two classes are
+finite and get consumed — one sweep took the whole tree from 98 actionable sites to
+0. When the scan comes back empty, the module's remaining simplification is entirely
+in the judgment classes below, which no detector decides for you. Re-run the scan
+anyway at the start of each module: the classes re-accumulate as new code lands, and
+Rule 6 explains why a rebase alone can put sites back.
+
+**Judgment classes** are also in scope, but only for the module you are already in,
+capped at a handful per file, and only when you are certain:
+
+- provably dead code — an unreachable branch, an unused local, a name nothing reads
+- a duplicated condition, or a branch that cannot differ from its sibling
+- logic re-implementing an existing helper — route it through the helper, after
+  verifying the semantics match **exactly** (a redaction helper that applies the
+  same two calls in the same order is a real dedup; one that reorders them is not)
+- nesting past three levels that flattens cleanly via an early return or `continue`
+- **comment hygiene**, per `AGENTS.md`: state current behavior in present tense,
+  drop task-log citations (PR/CR numbers, review-round markers, commit SHAs,
+  incident dates, milestone tags). Only in files you are already editing for a
+  structural reason, so comment churn rides along with substantive change instead
+  of becoming its own 200-file sweep.
+
+A comment you rewrite must be **true of the current code**. A stale comment flipped
+to confident present tense misleads the next reader worse than the stale one did —
+verify each claim against the adjacent lines before restating it.
+
+Two things look like this work and are not: chasing a coverage number, and
+"while I'm here" fixes. Both belong in their own PR.
+
+## Rule 2 — The three prohibitions
+
+These are not style preferences. Each one has already produced a defect here.
+
+### 2a — NEVER delete an in-function `from X import Y`
+
+An in-function `from X import Y` resolves `X.Y` at **call** time. A test that
+substitutes the attribute on the source module — `monkeypatch.setattr(mod, "Y", …)`
+or `patch("X.Y")` — is therefore observed by the function. The module-level binding
+captured the original object at import time and is **not**.
+
+Deleting one silently redirects the call to the real object. Measured: dropping a
+`KiroCrewConfig` shadow in `dashboard/handlers/memory.py` made the handler read the
+operator's real config instead of the test's mock, and only one assertion in the
+suite happened to notice.
+
+The asymmetry is what settles it. The gain is one dead-looking line; the loss is a
+test that keeps passing while verifying nothing — and several of these symbols are
+security controls (`is_sensitive_path`, `redact_credentials`,
+`redact_exfiltration_urls`, `sel`). Proving a deletion safe means enumerating every
+patch idiom across a 26k-test suite: dotted-string, module-object variable, module
+alias, and direct attribute assignment. One miss is invisible.
+
+So the detector never reports them, and neither do you.
+
+**A `# noqa: F811` on such an import is evidence somebody kept the shadow
+deliberately.** It is the opposite of a signal that the line is dead.
+
+### 2b — NEVER hoist a lazy import
+
+Deleting a shadow is safe because the module already loads at module scope.
+*Hoisting* a genuinely lazy import is a different act, and on the gateway boot path
+it violates the **blocking** AUTOSDE rule `no-new-work-on-gateway-boot-path`, which
+forbids eager import of an optional or feature-flagged subsystem. The detector flags
+those files `boot-path`, reading the rule's own `file-patterns` out of the checkout's
+`AUTOSDE.yaml` rather than carrying a copy — so widening that rule cannot leave the
+detector stale, and it exits nonzero if the rule is renamed. If a site is not in the
+detector's output, leave it.
+
+### 2c — NEVER reshape a keystone security file, and apply that consistently
+
+**The detector owns the keystone set** — it is `KEYSTONE_RELATIVE` in
+`scan_module.py`, which validates every entry against the checkout and exits nonzero
+if one no longer exists. Read it from there rather than from a list in prose; a
+second copy here is how the set goes stale. Files it covers are flagged `keystone`,
+and their chained ternaries are printed as `EXCLUDED` and not counted as work.
+
+That validation is one-directional, so note the gap: it catches a keystone file that
+was renamed or deleted, but **a newly added security-critical module is not detected
+and will be offered as ordinary work.** If you add one — a new matcher, guard, audit
+emitter, or policy evaluator — add it to `KEYSTONE_RELATIVE` in the same change.
+Nothing else will.
+
+Deleting a shadow-import in such a file is fine. Restructuring a sensitive-path
+matcher, a denied-command rule, a deny-by-default guard, an audit emit, a redaction
+call, or the governance intersection is not — even to "simplify" it. A verbose
+explicit guard stays verbose.
+
+**Consistency is the part that gets missed.** If you exclude one keystone file
+because "the value feeds only an audit label", that criterion covers *every*
+keystone audit label. Two reviewers caught exactly this drift on one PR: one hunk
+excluded in `safety_override.py` while the equivalent `Decision.layer` hunk in
+`platform/governance.py` landed. Decide the criterion once, then grep for every
+file it reaches before you push.
+
+## Rule 3 — The loop for one module
+
+1. **Scan** — `scan_module.py --module <module>`. Note `boot-path` / `keystone` flags.
+2. **Read before editing.** Open enough of each file to understand the surrounding
+   logic. Pattern-matching on a line number is how a `paused` hoist turns into an
+   `UnboundLocalError`: assigning a name inside a nested function makes it local for
+   that whole function, so a closure read elsewhere in it breaks. Check the
+   enclosing scope for the name you are about to bind.
+3. **Line numbers go stale the moment you edit.** Re-locate every subsequent site
+   in that file by its **text**, never by a number the scan printed earlier.
+4. **Prove each rewrite equivalent** before moving on: branch precedence; whether
+   the new form evaluates a call, property or subscript the original skipped (a
+   hoisted `dict.get` is unobservable, a hoisted property or anything that can raise
+   is not); `is not None` versus truthiness, which flips on `0`, `""`, `[]`, `False`;
+   whether a statement moved into or out of a `try`/`except`/`finally` or across an
+   `await`.
+5. **mypy infers a conditionally-assigned local from its FIRST assignment.** A chain
+   assigning `str` then `None` needs an explicit annotation
+   (`lock_reason: str | None`) or mypy rejects the `None`.
+6. **Gate** — Rule 4.
+7. **Review, then PR** — `prepare-pr` owns the commit→green loop.
+
+## Rule 4 — Gating, and attributing a test failure to the right cause
+
+`black --check` is **not** a CI gate here (deliberately disabled pending a bulk
+format pass), and flake8 ignores `E501`/`W503`. Do not reformat unrelated lines and
+do not report line length.
+
+Build the mypy/pytest venv on **Python 3.12** to match CI. A 3.14 venv invents a
+`asyncio.PidfdChildWatcher` error in `cli.py` (removed in 3.14), and never install
+`faiss` — it makes mypy stricter than CI, which sees a missing import.
+
+**Never conclude anything from the full suite's failure COUNT alone — on either
+side.** A count can be inflated by the machine, and a machine that inflates it will
+also hide a real regression inside the noise. Two causes seen on a development host,
+both of which red tests no diff touched:
+
+- **No usable OS-level sandbox.** `unshare(CLONE_NEWUSER)` returning `EINVAL` makes
+  anything that spawns a sandboxed subprocess raise `SandboxUnavailableError`.
+- **Memory pressure under `-n auto`.** Subagent spawns get refused for want of
+  several GB, reddening most of `test_subagent*` at once.
+
+On one such host `origin/main` itself failed 86 while a branch failed 123 — neither
+number said anything about the branch. Your host may be perfectly healthy and every
+failure real; that is exactly why the count is not the test. Attribute, don't assume:
+
+```bash
+# 1. Re-run just the failing files, in isolation, with nothing else heavy running.
+python -m pytest -q -p no:cacheprovider --override-ini="addopts=-n 4 --dist loadgroup" <files>
+
+# 2. If any still fail, build a PRISTINE baseline with its OWN venv and diff the
+#    failure SETS, not the counts. A shared venv is editable-installed against your
+#    branch worktree and would silently test the wrong source.
+git worktree add ../kirocrew-wt-baseline --detach origin/main
+```
+
+Everything environmental passes in isolation; a real regression still fails. That
+is exactly how one genuine regression was separated from 64 branch-only failures.
+CI is the authoritative suite signal — it has a working sandbox.
+
+**Check exit codes, never piped output.** `cmd | tail` makes `$?` tail's status, and
+a `grep -c` that finds nothing exits 1 and will short-circuit a `&&` chain, skipping
+the gate you thought ran. Redirect to a file and test `$?` on its own line.
+
+Two gate gotchas that cost a round each:
+
+- **`verify_vendor_manifest.py` fails after any test run**, because importing the
+  vendored tree leaves `__pycache__` under `src/kiro_crew/_vendor/`. It is gitignored
+  so `git status` looks clean. Clear it before pushing:
+  `find src/kiro_crew/_vendor -name __pycache__ -type d -exec rm -rf {} +`
+- **A backend-only diff narrows CI.** Touching nothing under `website/`,
+  `.github/` or `scripts/` makes the `changes` job report `only_backend=true`, so
+  the frontend suites cannot newly fail and you need not run them locally. Say so
+  in the PR body rather than leaving it unexplained.
+
+For the PR body: a backend-only sweep has no rendered delta, so it takes the
+`<!-- no-visual-delta -->` marker **plus** the required one-line justification.
+
+## Rule 5 — Several sessions at once
+
+The work parallelizes well because module file sets are disjoint. What does *not*
+parallelize is the push, so be precise about the mechanism.
+
+**The remote branch is the lock.** No claim file, no stale-lock cleanup, works
+across machines:
+
+```bash
+# See what is already claimed.
+git ls-remote --heads origin 'refactor/simplify-*'
+
+# Claim it, before editing anything. This is a CREATE-ONLY push: the empty lease
+# value asserts the remote ref does not exist yet, so exactly one session wins.
+git push --force-with-lease=refs/heads/refactor/simplify-<module>: -u origin refactor/simplify-<module>
+```
+
+A rejection (`! [rejected] ... (stale info)`) means another session got there first —
+take the next module off the queue.
+
+**Do not claim with a plain `git push -u`.** Two sessions that create the branch at
+the same commit — which is what a fresh worktree off `origin/main` gives you — both
+see the push succeed, so both believe they own the module and both start editing. The
+empty-lease form is what makes the claim exclusive rather than advisory.
+
+- **One session owns one module, start to merge.** Do not hand a half-finished
+  module to another session; the base will have moved and the second session cannot
+  tell your edits from the rebase's.
+- **Bound the in-flight count to about 2–4 PRs.** This repo already carries 200+
+  open PRs. A dozen simultaneous sweep PRs rebase into each other, and every rebase
+  can *add* new sites (Rule 6), so throughput goes down as concurrency goes up.
+- **Order the queue ascending by `actionable`.** Land the small modules first and
+  build reviewer trust before touching `dashboard/` and `slack/`, which hold most of
+  the sites and most of the risk.
+
+**Do NOT drive this from a cron job or a heartbeat task.** Both are structurally
+incapable of it and both fail while reporting success. A cron has no owning chat
+slot, so its tool calls land on a deny-by-default approval path and time out after
+180 seconds — and a denied tool inside a completed turn still records
+`last_status: ok`, so the registry looks healthy while nothing is pushed. Heartbeat
+runs under a strict name allowlist with no shell and no `git push`, so it cannot
+amend a commit at all. Use real interactive sessions, one per module; see
+[`babysit`](../babysit/SKILL.md) for the in-session monitoring loop that *can* push.
+
+## Rule 6 — The base moves under you, and it adds work
+
+`main` here can absorb dozens of commits while one PR is open — one measured PR
+rebased three times, once across 40 commits. Two consequences:
+
+- **Re-scan after every rebase.** A rebase does not just relocate your hunks, it can
+  introduce brand-new sites. One chained ternary appeared in `dashboard/state.py`
+  from a commit merged while the branch was open, which made a "the AST pass
+  enumerated everything" claim false through no fault of the pass.
+- **Re-run the gates after every rebase**, and let `push_guard.py` refuse the push
+  when `HEAD~1` is no longer `origin/main`. That refusal is the guard working.
+
+## Why these rules exist
+
+- Deleting an in-function `from X import Y` → a test's mock stops being observed →
+  a security control's test passes while verifying nothing (Rule 2a).
+- Hoisting a lazy import on the boot path → every user pays it on every launch, and
+  a blocking AUTOSDE rule rejects the diff (Rule 2b).
+- Reshaping a keystone guard for style → a reviewer must diff a security evaluator
+  to confirm a no-op; excluding one keystone file but not its twin gets caught and
+  costs a round (Rule 2c).
+- Trusting a stale line number → an edit lands in the wrong place, or a hoisted
+  local shadows a closure variable and raises `UnboundLocalError` (Rule 3).
+- Reading the full suite's failure count as signal → hours spent on failures
+  `origin/main` also has (Rule 4).
+- Batching modules → an unreviewable diff, and one requested subtraction re-runs the
+  whole gate cycle (Rule 0).
+- Driving the loop from cron → 100+ runs, zero pushes, a green-looking job registry
+  (Rule 5).

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/module-simplification/scripts/scan_module.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/module-simplification/scripts/scan_module.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Enumerate behavior-preserving simplification candidates in the Kiro Crew backend.
+
+Two candidate classes, both mechanically decidable:
+
+  shadow-import   an in-function ``import X`` whose every binding is ALREADY bound
+                  at module scope in the same file. The inner statement re-binds
+                  the same ``sys.modules`` singleton, so deleting it is a no-op.
+
+  chained-ternary an ``IfExp`` whose ``body`` or ``orelse`` is itself an ``IfExp``
+                  (``a if c1 else b if c2 else d``), where the reader has to unpack
+                  precedence to learn which branch wins.
+
+Deliberately NOT reported, because acting on them is unsafe or out of scope:
+
+  * ``from X import Y`` shadows. Such an import resolves ``X.Y`` at CALL time, so a
+    test substituting the attribute on the source module observes it while the
+    module-level binding (captured at import time) does not. Deleting one silently
+    breaks that test's mock, and several such symbols are security controls whose
+    tests would keep passing while verifying nothing.
+  * a name bound at module scope ONLY under ``if TYPE_CHECKING:`` — unbound at
+    runtime, so the in-function import is load-bearing and deleting it is a
+    NameError.
+  * an import inside ``try: ... except ImportError:`` (optional dependency).
+  * an import carrying a ``# circular import`` marker, including one written INSIDE
+    a parenthesized form on the imported name's own line.
+  * a ternary that merely CONTAINS a ternary as a sub-expression of its result
+    (``(a if c else b).method() if x else []``) — it reads left-to-right.
+  * a chained ternary in a keystone security file. Reshaping one keystone audit
+    label but not its twin is real, measured drift, so these are printed as
+    EXCLUDED and never counted as work.
+
+The boot-path set is READ FROM the scanned checkout's ``AUTOSDE.yaml`` rather than
+copied here, so a change to that rule's ``file-patterns`` cannot leave this script
+silently stale. Stdlib only, so it runs under any ``python3``.
+
+Run from the Kiro Crew worktree root:
+    scan_module.py                     # whole backend, per-module queue
+    scan_module.py --module dashboard  # one module, site-level detail
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# The AUTOSDE rule whose file set marks "an eager import here is a blocking
+# violation". Its patterns are read from the checkout, never restated here.
+BOOT_PATH_RULE_ID = "no-new-work-on-gateway-boot-path"
+
+# Keystone security files: a matcher or audit-label SHAPE here is not worth
+# churning for style. There is no machine-readable source for this set, so it is
+# curated -- and validated against the checkout on every run (see
+# _keystone_paths) so a rename or deletion fails loudly instead of quietly
+# un-protecting a file.
+KEYSTONE_RELATIVE = (
+    "src/kiro_crew/security.py",
+    "src/kiro_crew/hooks.py",
+    "src/kiro_crew/sel.py",
+    "src/kiro_crew/safety_override.py",
+    "src/kiro_crew/sandbox.py",
+    "src/kiro_crew/validation.py",
+    "src/kiro_crew/platform/governance.py",
+)
+
+CIRCULAR = re.compile(r"circular", re.I)
+
+
+def _boot_path_patterns(root: Path) -> list[str]:
+    """The boot-path rule's `file-patterns`, read from the checkout's AUTOSDE.yaml.
+
+    A tiny targeted reader rather than a YAML parse, to keep this script stdlib-only
+    so it runs under any `python3`. The shape it depends on is the rule list's:
+
+        - id: <rule-id>
+          file-patterns:
+            - "src/..."
+          rule: |
+
+    Exits nonzero if the rule or its patterns are absent, because falling back to a
+    hardcoded copy is exactly the silent staleness this function exists to remove.
+    """
+    autosde = root / "AUTOSDE.yaml"
+    if not autosde.is_file():
+        sys.exit(f"cannot read the boot-path rule: {autosde} is missing")
+    patterns: list[str] = []
+    in_rule = False
+    in_patterns = False
+    for raw in autosde.read_text(encoding="utf-8").splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("- id:"):
+            # A new rule entry ends the previous one.
+            in_rule = stripped.split(":", 1)[1].strip() == BOOT_PATH_RULE_ID
+            in_patterns = False
+            continue
+        if not in_rule:
+            continue
+        if stripped.startswith("file-patterns:"):
+            in_patterns = True
+            continue
+        if in_patterns:
+            if stripped.startswith("- "):
+                patterns.append(stripped[2:].strip().strip("\"'"))
+                continue
+            # Any other key at rule level ends the pattern list.
+            if stripped and not stripped.startswith("#"):
+                in_patterns = False
+    if not patterns:
+        sys.exit(
+            f"cannot read the boot-path rule: no `file-patterns` for "
+            f"{BOOT_PATH_RULE_ID!r} in {autosde}. The rule may have been renamed — "
+            "update BOOT_PATH_RULE_ID rather than hardcoding a file list."
+        )
+    return patterns
+
+
+def _keystone_paths(root: Path) -> list[str]:
+    """Curated keystone set, validated against the checkout.
+
+    A path that no longer exists means the set is stale and some file is now
+    unprotected, which is the failure this validation makes loud.
+    """
+    missing = [rel for rel in KEYSTONE_RELATIVE if not (root / rel).is_file()]
+    if missing:
+        sys.exit(
+            "keystone list is stale — these paths are not in the checkout: "
+            f"{missing}. Update KEYSTONE_RELATIVE; a renamed keystone file would "
+            "otherwise be silently reported as ordinary work."
+        )
+    return list(KEYSTONE_RELATIVE)
+
+
+def _is_test(path: Path) -> bool:
+    parts = path.parts
+    return (
+        "tests" in parts
+        or "_vendor" in parts
+        or path.name.startswith("test_")
+        or path.name == "conftest.py"
+    )
+
+
+def _bindings(node: ast.stmt) -> list[tuple[str, str]]:
+    """Normalized (source, bound_name) pairs for one import statement."""
+    out: list[tuple[str, str]] = []
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            out.append((alias.name, alias.asname or alias.name.split(".")[0]))
+    elif isinstance(node, ast.ImportFrom):
+        src = ("." * node.level) + (node.module or "")
+        for alias in node.names:
+            out.append((f"{src}.{alias.name}", alias.asname or alias.name))
+    return out
+
+
+class _ModuleScope(ast.NodeVisitor):
+    """Names an import UNCONDITIONALLY binds at module scope, and nothing else.
+
+    Does not descend into ``def``/``class`` bodies: a name bound only inside some
+    other function is not bound at module scope.
+
+    Only an import at the top level of the module counts. An import nested under ANY
+    ``if`` or ``try`` does NOT, because the name may be unbound at runtime:
+
+        if TYPE_CHECKING:            # never bound at runtime
+            from x import Y
+        if IS_POSIX:                 # unbound on Windows
+            import fcntl
+        try:                         # unbound, or bound to a stub, without the dep
+            import numpy as np
+        except ImportError:
+            np = None
+
+    Treating any of those as guaranteed would make an in-function re-import look
+    deletable, and deleting it is a NameError on the platform or install where the
+    guard is false. This repo ships macOS, Linux and Windows, so that is reachable.
+    The whole detector errs toward not reporting; this is where that starts.
+    """
+
+    def __init__(self) -> None:
+        self.runtime: set[tuple[str, str]] = set()
+        self._conditional = 0
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        return
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        return
+
+    def visit_If(self, node: ast.If) -> None:
+        self._conditional += 1
+        self.generic_visit(node)
+        self._conditional -= 1
+
+    def visit_Try(self, node: ast.Try) -> None:
+        self._conditional += 1
+        self.generic_visit(node)
+        self._conditional -= 1
+
+    def _record(self, node: ast.stmt) -> None:
+        if self._conditional:
+            return
+        self.runtime.update(_bindings(node))
+
+    def visit_Import(self, node: ast.Import) -> None:
+        self._record(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        self._record(node)
+
+
+class _Sites(ast.NodeVisitor):
+    def __init__(self, runtime: set[tuple[str, str]], source: str) -> None:
+        self.runtime = runtime
+        self.lines = source.splitlines()
+        self._fn = 0
+        self._guard: list[str] = []
+        self.shadow_plain: list[dict] = []
+        self.ternaries: list[dict] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._fn += 1
+        self.generic_visit(node)
+        self._fn -= 1
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_Try(self, node: ast.Try) -> None:
+        optional_dep = any(
+            (isinstance(h.type, ast.Name) and h.type.id in {"ImportError", "ModuleNotFoundError"})
+            or (
+                isinstance(h.type, ast.Tuple)
+                and any(
+                    isinstance(e, ast.Name) and e.id in {"ImportError", "ModuleNotFoundError"}
+                    for e in h.type.elts
+                )
+            )
+            or h.type is None
+            for h in node.handlers
+        )
+        self._guard.append("optional-dep" if optional_dep else "try")
+        self.generic_visit(node)
+        self._guard.pop()
+
+    def visit_IfExp(self, node: ast.IfExp) -> None:
+        if isinstance(node.body, ast.IfExp) or isinstance(node.orelse, ast.IfExp):
+            self.ternaries.append(
+                {"line": node.lineno, "text": self.lines[node.lineno - 1].strip()[:160]}
+            )
+        self.generic_visit(node)
+
+    def _marked_circular(self, node: ast.stmt) -> bool:
+        """A `# circular import` marker above the statement or inside its body.
+
+        The inside case matters: a parenthesized form often carries the marker on
+        the imported name's own line, e.g.
+            from kiro_crew.config.loader import (
+                KiroCrewConfig,  # circular import: loader imports apps/ ...
+            )
+        """
+        end = getattr(node, "end_lineno", node.lineno)
+        lo = max(0, node.lineno - 3)
+        return bool(CIRCULAR.search("\n".join(self.lines[lo:end])))
+
+    def visit_Import(self, node: ast.Import) -> None:
+        """Only a plain `import X` is ever reported (see the module docstring)."""
+        if not self._fn or "optional-dep" in self._guard:
+            return
+        pairs = _bindings(node)
+        if not pairs or self._marked_circular(node):
+            return
+        # Every binding must already exist at module scope AT RUNTIME. A partially
+        # redundant statement still needs its remaining names.
+        if not all(p in self.runtime for p in pairs):
+            return
+        end = getattr(node, "end_lineno", node.lineno)
+        self.shadow_plain.append(
+            {
+                "line": node.lineno,
+                "text": " ".join(x.strip() for x in self.lines[node.lineno - 1 : end])[:200],
+            }
+        )
+
+
+# Label for files directly under src/kiro_crew/. Deliberately shell-safe and
+# unquoted-friendly, because it is pasted straight into `--module <label>`; angle
+# brackets would be read as a redirection.
+TOPLEVEL_LABEL = "toplevel"
+
+
+def _module_of(rel_to_pkg: Path) -> str:
+    return rel_to_pkg.parts[0] if len(rel_to_pkg.parts) > 1 else TOPLEVEL_LABEL
+
+
+def _matches_boot_path(rel: str, patterns: list[str]) -> bool:
+    """True when `rel` is covered by any boot-path pattern.
+
+    ``fnmatch`` gives ``/`` no special meaning, so ``a/**/*.py`` compiles to a regex
+    that REQUIRES an intermediate directory and therefore misses ``a/core.py`` — the
+    direct children the rule most obviously covers. Each pattern is also tried with
+    ``/**/`` collapsed to ``/`` so zero-directory matches are caught. Under-matching
+    here would silently drop the `boot-path` flag from a file the blocking rule
+    protects, so this errs toward flagging.
+    """
+    for pattern in patterns:
+        if fnmatch.fnmatch(rel, pattern):
+            return True
+        if "/**/" in pattern and fnmatch.fnmatch(rel, pattern.replace("/**/", "/")):
+            return True
+    return False
+
+
+def scan(root: Path, boot_patterns: list[str], keystone: list[str]) -> dict[str, dict]:
+    pkg = root / "src" / "kiro_crew"
+    if not pkg.is_dir():
+        sys.exit(f"not a Kiro Crew checkout: {pkg} is missing")
+    found: dict[str, dict] = {}
+    pkg_resolved = pkg.resolve()
+    for path in sorted(pkg.rglob("*.py")):
+        if _is_test(path):
+            continue
+        # Read only regular files that really live inside the package. A symlink
+        # pointing outside it (or at a character device) is not source this scanner
+        # has any business reading, and an unbounded one would hang the scan.
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            if not path.resolve().is_relative_to(pkg_resolved):
+                continue
+        except OSError:
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            continue
+        scope = _ModuleScope()
+        scope.visit(tree)
+        sites = _Sites(scope.runtime, source)
+        sites.visit(tree)
+        if not (sites.shadow_plain or sites.ternaries):
+            continue
+        rel = path.relative_to(root).as_posix()
+        flags = []
+        if _matches_boot_path(rel, boot_patterns):
+            flags.append("boot-path")
+        if rel in keystone:
+            flags.append("keystone")
+        found[rel] = {
+            "module": _module_of(path.relative_to(pkg)),
+            "flags": flags,
+            "shadow_plain": sites.shadow_plain,
+            "chained_ternaries": sites.ternaries,
+        }
+    return found
+
+
+def _report_module(found: dict[str, dict], module: str) -> None:
+    actionable = 0
+    excluded = 0
+    for rel, info in sorted(found.items()):
+        keystone = "keystone" in info["flags"]
+        flags = f"  [{','.join(info['flags'])}]" if info["flags"] else ""
+        lines = [f"    shadow-import   :{s['line']:<5} {s['text']}" for s in info["shadow_plain"]]
+        for site in info["chained_ternaries"]:
+            if keystone:
+                lines.append(
+                    f"    ternary EXCLUDED (keystone) :{site['line']:<5} {site['text']}"
+                )
+            else:
+                lines.append(f"    chained-ternary :{site['line']:<5} {site['text']}")
+        actionable += len(info["shadow_plain"])
+        if keystone:
+            excluded += len(info["chained_ternaries"])
+        else:
+            actionable += len(info["chained_ternaries"])
+        print(f"{rel}{flags}")
+        print("\n".join(lines))
+    print(f"\nactionable sites in {module}: {actionable}")
+    if excluded:
+        print(
+            f"excluded as keystone (do NOT reshape): {excluded} — reshaping one "
+            "keystone audit label but not its twin is the drift this exclusion prevents"
+        )
+
+
+def _report_queue(found: dict[str, dict]) -> None:
+    tally: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for info in found.values():
+        row = tally[info["module"]]
+        row["files"] += 1
+        row["shadow"] += len(info["shadow_plain"])
+        # A keystone file's ternaries are excluded, so they must not be counted as
+        # work -- otherwise the queue invites the inconsistency the rule prevents.
+        if "keystone" in info["flags"]:
+            row["excluded"] += len(info["chained_ternaries"])
+        else:
+            row["ternary"] += len(info["chained_ternaries"])
+    header = f"{'module':22s} {'files':>6s} {'shadow':>7s} {'ternary':>8s} {'actionable':>11s}"
+    print(header)
+    print("-" * len(header))
+    # Ascending, so the queue reads in the order the skill says to work it: small
+    # modules first, dashboard/ and slack/ last.
+    rows = sorted(tally.items(), key=lambda kv: (kv[1]["shadow"] + kv[1]["ternary"]))
+    for module, row in rows:
+        act = row["shadow"] + row["ternary"]
+        print(f"{module:22s} {row['files']:6d} {row['shadow']:7d} {row['ternary']:8d} {act:11d}")
+    print("-" * len(header))
+    total = sum(r["shadow"] + r["ternary"] for r in tally.values())
+    print(
+        f"{'TOTAL':22s} {sum(r['files'] for r in tally.values()):6d} "
+        f"{sum(r['shadow'] for r in tally.values()):7d} "
+        f"{sum(r['ternary'] for r in tally.values()):8d} {total:11d}"
+    )
+    excluded = sum(r["excluded"] for r in tally.values())
+    if excluded:
+        print(f"(plus {excluded} keystone ternaries excluded, not counted as work)")
+    print("\nOne module per branch, per commit, per PR. Order by `actionable`, ascending,")
+    print("so small modules build reviewer trust before dashboard/ and slack/.")
+    if total == 0:
+        print("\nZero actionable sites does NOT mean zero work: these two classes are")
+        print("finite and get consumed. What remains is the judgment classes in the skill.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--module", help="restrict to one module dir under src/kiro_crew/")
+    args = parser.parse_args()
+
+    # Run from the worktree root. `cd` into another checkout to scan it.
+    root = Path.cwd().resolve()
+    boot_patterns = _boot_path_patterns(root)
+    keystone = _keystone_paths(root)
+
+    found = scan(root, boot_patterns, keystone)
+    if args.module:
+        found = {k: v for k, v in found.items() if v["module"] == args.module}
+        _report_module(found, args.module)
+    else:
+        _report_queue(found)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** adds a packaged agent skill and one stdlib script under
`src/kiro_crew/builtin_skills/`; nothing renders in the dashboard.

no linked issue: packages the method used in #3548 so the next sweep does not
re-derive it.

## Problem

Backend readability sweeps keep getting re-derived from scratch, and the parts that
are *unsafe* are invisible in the code. #3548 (61 dead-import deletions, 18 ternary
flattenings across 47 files) spent most of its cost discovering, not applying:

- Deleting an in-function `from X import Y` looks identical to deleting
  `import X`. It is not, and the difference is silent.
- Four separate false-positive classes each looked like a real candidate until
  something failed or a reviewer objected.
- The dev host reds 90–120 tests for environmental reasons, so the suite's failure
  count carries no signal about the diff.
- Two reviewers independently caught the *same* inconsistency: a keystone-file
  exclusion applied to one file and not its twin.

None of that is written down anywhere, so the next sweep pays for it again.

## Why it matters

The expensive failure is not a rejected diff — it is a change that lands green and
wrong. An in-function `from X import Y` resolves `X.Y` at **call** time, so a test
that substitutes the attribute on the source module observes it, while the
module-level binding captured the original object at import time and does not.
Deleting one redirects the call to the real object with no error anywhere.

That is not hypothetical: it made `dashboard/handlers/memory.py` read the operator's
real config instead of the test's mock, and only one assertion in ~26k tests happened
to notice. Several symbols in that class are security controls
(`is_sensitive_path`, `redact_credentials`, `redact_exfiltration_urls`, `sel`), where
a mock that stops being observed leaves the test passing while verifying nothing.

## Fix (symptom → root cause → change)

**Symptom:** each sweep re-learns the same hazards, and one of them lands a silent
defect before it is learned.

**Root cause:** the safe subset is mechanically decidable, but nothing encodes it —
so the decision is made per-site, by eye, under time pressure.

**Change:** a packaged skill plus the detector it depends on.

`scripts/scan_module.py` (stdlib, no deps) reports exactly two classes and excludes
the rest by construction:

| Reported | Why it is safe |
|---|---|
| `shadow-import` — in-function `import X`, module already imported at module scope | inner statement re-binds the same `sys.modules` singleton; deletion is a no-op |
| `chained-ternary` — `IfExp` whose `body`/`orelse` is an `IfExp` | rewrite preserving precedence, order, short-circuiting |

Excluded, each because it already cost something: `TYPE_CHECKING`-only module
bindings (deleting the inner import is a runtime `NameError`); `try/except
ImportError` optional-dependency guards; `# circular import` markers **including
one written inside a parenthesized form on the imported name's own line** (this one
hid real circular-import guards in `apps/registry.py` from an earlier scan); and a
ternary that merely *contains* a ternary in its result
(`(a if c else b).method() if x else []`), which reads left-to-right.

`from X import Y` shadows are never reported at all. The plain-vs-`from` split
exists internally so the exclusion is correct, not as a reporting mode — surfacing a
class the skill forbids acting on would invite the mistake.

Two lists that could go stale are handled rather than copied. The boot-path set is
**read from the scanned checkout's `AUTOSDE.yaml`** (`no-new-work-on-gateway-boot-path`'s
own `file-patterns`), and the script exits nonzero if that rule is renamed instead of
falling back to a hardcoded copy. The keystone set has no machine-readable source, so
it stays curated but is validated against the checkout on every run: a renamed or
deleted keystone file fails loudly instead of being silently reported as ordinary work.

The detector also enforces the consistency half of the keystone rule rather than
leaving it to prose: a chained ternary in `security.py`, `hooks.py`, `sel.py`,
`safety_override.py`, `sandbox.py`, `platform/governance.py` or `validation.py` is
printed as `EXCLUDED by Rule 2c` and **not counted as work**. That is what drops
`platform` from 2 actionable sites to 0, and it is the drift both reviewers caught on
#3548.

`SKILL.md` carries the loop (one module = one branch = one commit = one PR), the
three prohibitions, the equivalence checks a rewrite must survive, how to attribute
a failure on a sandbox-less host, and how several sessions share the queue using the
remote branch as the lock.

## Tests

No new tests. The change adds a `SKILL.md` and one script that is not part of the
importable `kiro_crew` module tree, and the existing guards already cover what can
regress here:

- `test/test_builtin_skill_packaging.py` — passes. It enforces that a packaged
  skill never points at an unpackaged one; this skill's only cross-references are
  `kirocrew-worktree-dev` and `babysit`, both packaged siblings.
- `test/test_skills.py`, `test/test_agent_template_skills.py` — pass, so the loader
  reads the new skill directory and its frontmatter.
- `setup.cfg`'s `builtin_skills/**/*` glob already ships it; no packaging change.

## Manual verification

Gates on a CI-parity venv (Python 3.12.13, dependency-group pins, no `faiss`):

| Gate | Result |
|---|---|
| `flake8 src/kiro_crew test` | clean |
| `isort --check-only src/kiro_crew test` | clean |
| `mypy src/kiro_crew/` | `Success: no issues found in 969 source files` |
| `check_brand_name.py` (`--test` + diff vs merge-base) | pass |
| `check_harness_parity.py` (diff vs merge-base) | pass |
| `docs-lint.sh` | pass |
| `scrub-lint.sh --no-history` | pass |
| `verify_vendor_manifest.py` | pass |
| `test_builtin_skill_packaging.py` | pass |
| `test_skills.py` + `test_agent_template_skills.py` | pass |

Detector exercised against this checkout: 39 files, 61 `shadow-import`, 38
`chained-ternary` after the keystone exclusion (99 actionable, plus 6 keystone
ternaries excluded and not counted). `--module platform` correctly prints 0
actionable with 2 excluded, confirming the Rule-2c enforcement; `session.py`'s
`TYPE_CHECKING`-shadowed import is correctly not reported; and it runs under bare
`python3` outside the venv, confirming stdlib-only.

Frontend gates were not run: the diff touches nothing under `website/`, `.github/`
or `scripts/`, so CI's `changes` job reports `only_backend=true`.
