### PR TITLE
docs: correct why the catalog adds no inventory

### DIFF
--- a/docs/request-for-change/rfc-appstore-official-registry.md
+++ b/docs/request-for-change/rfc-appstore-official-registry.md
@@ -189,6 +189,18 @@ Amazon/Brazil constructs.
 
 ### 3.1 Entry shape — tagged `source` union
 
+> **Amended: `source` is AUTHORED input only and is not published.** This section
+> describes the authored catalog, where it still holds in full. The published
+> document dropped the block entirely (`KiroCrewApps` PR #17) because nothing read
+> it: the client resolves inventory from its own bundled seed, keyed `branch`, and
+> detects an update by comparing the version at that branch's tip against the
+> installed one — it never reads install coordinates from the served document.
+> Publishing them advertised a contract nothing honoured. The four `reserved`
+> transports below (`archive`, `bundle`, `oci`, `s3`) existed only in the published
+> schema and had no authored counterpart, so they could be validated but never
+> written; they are gone. Re-publishing a coordinate is a live decision again the
+> day inventory migrates to the catalog, and §3.1's rules are what it should follow.
+
 Where an app's bytes come from is a **discriminated union** under `source`, not a
 set of flat sibling URL fields. Only `type: "git"` is defined in v1; the
 discriminator exists from day one so a second transport is additive:

--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -22,10 +22,14 @@ instead of degrading silently:
   withdrawn app must never be rendered because we skipped the mechanism that
   withdraws it.
 - **No new inventory.** Every entry annotates a row that already exists (a
-  built-in discovered from disk, or a seed-index row). A published ``git`` source
-  is pinned to a COMMIT, and the install path clones with ``--branch``, which a
-  commit id is not -- so adding installable entries needs that path changed
-  first. An entry matching nothing is ignored.
+  built-in discovered from disk, or a seed-index row); an entry matching nothing
+  is ignored. The catalog is a PRESENTATION document and carries no fetch
+  coordinates at all, so there is nothing here to install from. Inventory is
+  resolved from the bundled seed, whose rows are keyed by ``branch``, and an
+  update is detected by comparing the version at that branch's tip against the
+  installed one. Adding installable entries means writing that read path first,
+  and choosing the key it reads -- which is where a coordinate would have to be
+  published again.
 """
 
 from __future__ import annotations

--- a/test/test_official_catalog.py
+++ b/test/test_official_catalog.py
@@ -201,9 +201,8 @@ class TestAnnotate:
         assert "_index_author" not in rows[0]
 
     def test_an_entry_matching_no_row_is_ignored(self):
-        """Annotate-only: a published git source is pinned to a COMMIT and the
-        install path clones with --branch, so new inventory needs that path
-        changed first."""
+        """Annotate-only: the catalog carries no fetch coordinates, so an entry
+        that matches no existing row has nothing to install from."""
         rows = self.rows()
         oc.annotate(rows, [{"name": "not-listed", "displayName": "Ghost"}])
         assert [r["name"] for r in rows] == ["demo-app", "other-app"]


### PR DESCRIPTION
## What

Docs only. Corrects why the official catalog adds no inventory, in the module
docstring that states it and in the RFC section it points back to.

## The wrong reason

`official_catalog.py` said:

> A published `git` source is pinned to a COMMIT, and the install path clones with
> `--branch`, which a commit id is not -- so adding installable entries needs that
> path changed first.

That describes a failure **that is not reachable**, because no client code reads
install coordinates from the served document:

| Check | Result |
|---|---|
| `official_catalog.py` reads `"source"` | **0** (one docstring mention, now this text) |
| `registry.py` reads `get("ref")` | **0** |
| `registry.py` reads `get("branch")` | 3 |

The real reason is that the read path does not exist. The commit/branch mismatch
would only matter after someone wrote it — and writing it is where the field name
and value shape get decided.

## And it is now impossible

[KiroCrewApps#17](https://github.com/kirodotdev/KiroCrewApps/pull/17) removes the
`source` block from the published document, so there are no coordinates to be
pinned to anything. Inventory comes from the bundled seed, keyed `branch`, and
`updateAvailable` is computed by comparing the version at that branch's tip
against the installed one (`registry.py`'s `_resolve_manifest` → `_version_newer`;
`annotate` writes `version` zero times, deliberately). That is also why pinning a
commit and detecting updates cannot both live at that layer.

## RFC

§3.1 gets an amendment note, not a rewrite. The tagged `source` union it specifies
still governs **authored** input, and stays the rule to follow the day inventory
migrates to the catalog and a coordinate is published again. The note also records
that the four `reserved` transports (`archive`, `bundle`, `oci`, `s3`) existed only
in the published schema with no authored counterpart — validatable but never
writable — and are gone.

## Verified

`pytest test/test_official_catalog.py` 104 passed; `isort`, `flake8`, `mypy` (968
files), `docs-lint`, `check_brand_name` all exit 0. No runtime code changed.
