### PR TITLE
fix(crew): dispatch the template a crew binds, not the crew's own name

### DIFF
--- a/src/kiro_crew/crew_chat.py
+++ b/src/kiro_crew/crew_chat.py
@@ -29,6 +29,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from kiro_crew.config.loader import KiroCrewConfig, resolve_agent_bindings
 from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import effective_session_key
@@ -993,6 +994,51 @@ class CrewOrchestrator:
         except Exception:
             logger.debug("crew: agent-cache warm failed", exc_info=True)
 
+    async def _dispatch_agent(self, slot: Any) -> str:
+        """The kiro-cli agent template this slot's crew dispatches as.
+
+        ``slot.agent`` names a KiroCrew CREW, but ``spawn(agent=)`` is validated
+        against the agent templates kiro-cli can load (``_validate_agent``), and
+        those are two namespaces, not one. They coincide for a crew whose
+        ``kiro_agent`` happens to be spelled like the crew itself — which is most
+        of them — so passing the crew name straight through worked by coincidence
+        until a crew disagreed with its template. ``default`` is exactly that
+        crew (it binds ``kirocrew``) and it is the one every session starts on, so
+        crew dispatch answered "Couldn't start that one" for an agent that exists.
+
+        A name that is NOT a configured crew is returned unchanged: it is then a
+        template or an app-materialized agent, and ``spawn()`` validates both
+        itself. Resolution deliberately does NOT pair with
+        ``_agent_prevalidated`` — mapping an alias proves the CREW exists, never
+        that its template does, so claiming prevalidation here would restore the
+        silent-fallback escalation ``_validate_agent`` refuses on purpose.
+
+        Loop-safe: an alias hit resolves from the config object alone, so the only
+        blocking step is loading the config, and that is awaited off-loop.
+        """
+        requested = str(getattr(slot, "agent", "") or "")
+        if not requested:
+            # An EMPTY name already means "use the default" everywhere below,
+            # and resolving it would name a template where none was asked for.
+            return ""
+        cfg = self._cfg
+        if cfg is None:
+            try:
+                cfg = await asyncio.to_thread(KiroCrewConfig.load)
+            except Exception:
+                logger.debug(
+                    "crew: config load failed; dispatching %r unresolved", requested, exc_info=True
+                )
+                return requested
+        if requested not in (getattr(cfg, "agents", None) or {}):
+            return requested
+        try:
+            resolved = str(resolve_agent_bindings(cfg, requested).kiro_agent or "")
+        except Exception:
+            logger.debug("crew: binding resolution failed for %r", requested, exc_info=True)
+            return requested
+        return resolved or requested
+
     async def _post_durable(self, slot: Any, content: str, kind: str = "crew") -> bool:
         """`_post`, then wait for the durable transcript row to actually land.
 
@@ -1390,6 +1436,10 @@ class CrewOrchestrator:
                 # leaked stored memory and lessons into every subagent it spawned.
                 no_reads = bool(getattr(slot, "blocks_reads", False))
                 await self._warm_agent_cache(slot)
+                # Resolved inside the barrier's try, so a failure reopens the
+                # entry like any other pre-spawn step rather than dispatching a
+                # name the validator will refuse.
+                dispatch_agent = await self._dispatch_agent(slot)
             except Exception:
                 e["state"] = prior_state or "pending"
                 e.pop("dispatch_id", None)
@@ -1414,7 +1464,7 @@ class CrewOrchestrator:
                 # subagent edits files, and without this it edited ANOTHER
                 # project's tree. Same value the warm above validated.
                 cwd=self._slot_cwd(slot),
-                agent=getattr(slot, "agent", "") or "",
+                agent=dispatch_agent,
                 keep=True,
                 _preassigned_id=dispatch_id,
                 include_memory=not no_reads,
@@ -1540,13 +1590,14 @@ class CrewOrchestrator:
         # id rather than a guess. Without this the continuation minted its id
         # inside the call, and a restart could neither adopt the started run nor
         # safely reopen the entry.
+        dispatch_agent = await self._dispatch_agent(slot)
         info = self._subagents.continue_conversation(
             t["topic_id"], e["text"] + _SUB_TASK_SUFFIX,
             # Same governance key as the spawn path: a continuation re-enters the
             # capability check, so keying it to the tab would let a resumed topic
             # run under a surface the linked session never granted.
             parent_session_key=effective_session_key(slot),
-            agent=getattr(slot, "agent", "") or "",
+            agent=dispatch_agent,
             # Same cwd as the spawn path. `spawn` resolves an empty cwd to the
             # pool project BEFORE validating the agent, so a project-local agent
             # was rejected here and the rejection fell through to a digest-only
@@ -1591,11 +1642,12 @@ class CrewOrchestrator:
                     raise
                 no_reads = bool(getattr(slot, "blocks_reads", False))
                 await self._warm_agent_cache(slot)
+                respawn_agent = await self._dispatch_agent(slot)
                 fresh = self._subagents.spawn(
                     seed + _SUB_TASK_SUFFIX,
                     parent_session_key=effective_session_key(slot),
                     cwd=self._slot_cwd(slot),
-                    agent=getattr(slot, "agent", "") or "", keep=True,
+                    agent=respawn_agent, keep=True,
                     _preassigned_id=respawn_id,
                     include_memory=not no_reads,
                     include_lessons=not no_reads,

--- a/test/test_crew_chat.py
+++ b/test/test_crew_chat.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import kiro_crew.crew_chat as crew_mod
+from kiro_crew.config.loader import KiroCrewAgentConfig, KiroCrewConfig
 from kiro_crew.crew_chat import CrewOrchestrator, CrewStore
 
 
@@ -55,11 +56,44 @@ def _spawn_info(run_id: str, done: bool = False, error: str = "", result: str = 
     return info
 
 
-def _orch(state: MagicMock | None = None, subagents: MagicMock | None = None) -> CrewOrchestrator:
+def _orch(state: MagicMock | None = None, subagents: MagicMock | None = None,
+          cfg: object | None = None) -> CrewOrchestrator:
     state = state or MagicMock()
     subagents = subagents or MagicMock()
     sessions = MagicMock()
-    return CrewOrchestrator(state=state, sessions=sessions, subagents=subagents)
+    return CrewOrchestrator(state=state, sessions=sessions, subagents=subagents, cfg=cfg)
+
+
+def _cfg(**crews: str) -> KiroCrewConfig:
+    """A config whose crews bind the given kiro-cli agent templates.
+
+    Spelled as ``crew_name=template_name`` because that distinction is the whole
+    point: production passes a CREW name where ``spawn()`` wants a template, and
+    a fixture that spelled both the same would hide the bug the same way the
+    ``agent="kirocrew"`` default in :func:`_slot` did.
+    """
+    cfg = KiroCrewConfig()
+    cfg.agents = {name: KiroCrewAgentConfig(kiro_agent=tpl) for name, tpl in crews.items()}
+    cfg.default_agent = next(iter(crews), "")
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def _no_real_config_read(monkeypatch):  # type: ignore[no-untyped-def]
+    """Keep dispatch resolution off this machine's real ``config.json``.
+
+    ``_dispatch_agent`` loads the config when the orchestrator holds none, which
+    is every orchestrator :func:`_orch` builds without an explicit one. Reading
+    the developer's file would let their crew names decide an assertion. The stub
+    config has no crews, so every name passes through unresolved — the behaviour
+    tests that do not care about resolution already expect.
+    """
+    class _Stub:
+        @staticmethod
+        def load() -> KiroCrewConfig:
+            return KiroCrewConfig()
+
+    monkeypatch.setattr(crew_mod, "KiroCrewConfig", _Stub)
 
 
 def _slot_save(side_effect: BaseException | None = None):
@@ -2603,3 +2637,98 @@ class TestGptRoundSixteen:
             "ingest returned without forcing the slot to disk — the echoed user "
             "message and the acknowledgement were memory-only"
         )
+
+
+# ── crew name vs kiro-cli template ──
+
+
+class TestDispatchAgent:
+    """``slot.agent`` names a CREW; ``spawn(agent=)`` wants a kiro-cli template.
+
+    The two coincide for a crew spelled like the template it binds, which is most
+    of them — so crew dispatch passing the crew name through worked by
+    coincidence. ``default`` binds ``kirocrew``, and every session starts on
+    ``default``, so the one crew that exposes the confusion is the common case.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_crew_resolves_to_the_template_it_binds(self) -> None:
+        orch = _orch(cfg=_cfg(default="kirocrew"))
+        assert await orch._dispatch_agent(_slot(agent="default")) == "kirocrew"
+
+    @pytest.mark.asyncio
+    async def test_a_crew_spelled_like_its_template_round_trips(self) -> None:
+        # The coincidence that hid the bug must keep working.
+        orch = _orch(cfg=_cfg(**{"deep-diver": "deep-diver"}))
+        assert await orch._dispatch_agent(_slot(agent="deep-diver")) == "deep-diver"
+
+    @pytest.mark.asyncio
+    async def test_an_empty_agent_stays_empty(self) -> None:
+        # Empty means "use the default" everywhere below. Naming a template here
+        # would dispatch one the caller never asked for.
+        orch = _orch(cfg=_cfg(default="kirocrew"))
+        assert await orch._dispatch_agent(_slot(agent="")) == ""
+
+    @pytest.mark.asyncio
+    async def test_a_name_that_is_not_a_crew_passes_through(self) -> None:
+        # Then it is a template or an app-materialized agent, both of which
+        # `spawn()` validates itself. Rewriting it to the default crew's template
+        # would silently run a different agent — the substitution `_validate_agent`
+        # refuses on purpose.
+        orch = _orch(cfg=_cfg(default="kirocrew"))
+        assert await orch._dispatch_agent(_slot(agent="some-app-agent")) == "some-app-agent"
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_config_dispatches_unresolved(self) -> None:
+        # Degrades to today's behaviour rather than inventing a template: the
+        # spawn may still be refused, but it is refused for the real reason.
+        class _Boom:
+            @staticmethod
+            def load() -> KiroCrewConfig:
+                raise RuntimeError("config unreadable")
+
+        orch = _orch()
+        with patch.object(crew_mod, "KiroCrewConfig", _Boom):
+            assert await orch._dispatch_agent(_slot(agent="default")) == "default"
+
+    @pytest.mark.asyncio
+    async def test_the_spawn_path_dispatches_the_template(self) -> None:
+        orch = _orch(cfg=_cfg(default="kirocrew"))
+        st = orch._store("s1")
+        e = st.add_msg("do the thing")
+        orch._subagents.spawn = MagicMock(return_value=_spawn_info("r1"))
+        await orch._apply(_slot(agent="default"), st,
+                          {"do": "spawn", "msg_id": e["msg_id"], "title": "t"})
+        kw = orch._subagents.spawn.call_args.kwargs
+        assert kw["agent"] == "kirocrew"
+        # Resolving an alias proves the CREW exists, never that its template
+        # does, so this path must still pay for on-loop validation.
+        assert not kw.get("_agent_prevalidated", False)
+
+    @pytest.mark.asyncio
+    async def test_the_continuation_path_dispatches_the_template(self) -> None:
+        orch = _orch(cfg=_cfg(default="kirocrew"))
+        st = orch._store("s1")
+        e = st.add_msg("follow up")
+        t = st.add_topic("t1", "r1", "the topic", e["msg_id"])
+        t["status"] = "idle"
+        orch._subagents.continue_conversation = MagicMock(
+            side_effect=lambda cid, task, **kw: _spawn_info(kw["_preassigned_id"]))
+        await orch._dispatch_continue(_slot(agent="default"), st, t, e)
+        assert orch._subagents.continue_conversation.call_args.kwargs["agent"] == "kirocrew"
+
+    @pytest.mark.asyncio
+    async def test_the_respawn_fallback_dispatches_the_template(self) -> None:
+        # conversation_gone respawns outright, and that spawn is validated the
+        # same way — a crew name there is refused exactly like the first one was.
+        orch = _orch(cfg=_cfg(default="kirocrew"))
+        st = orch._store("s1")
+        e = st.add_msg("do it")
+        t = st.add_topic("t1", "r1", "the topic", e["msg_id"])
+        t["status"] = "idle"
+        orch._subagents.continue_conversation = MagicMock(
+            return_value=_spawn_info("x", done=True, error="conversation_gone"))
+        orch._subagents.spawn = MagicMock(
+            side_effect=lambda task, **kw: _spawn_info(kw["_preassigned_id"]))
+        await orch._dispatch_continue(_slot(agent="default"), st, t, e)
+        assert orch._subagents.spawn.call_args.kwargs["agent"] == "kirocrew"


### PR DESCRIPTION
## What

Crew dispatch passed `slot.agent` straight into `spawn(agent=)`. Those are two
namespaces: `slot.agent` names a KiroCrew **crew**, while `spawn()` validates
against the agent **templates** kiro-cli can load. They coincide for a crew
spelled like the template it binds — most of them — so the layer confusion stayed
invisible until a crew disagreed with its template.

`default` is exactly that crew (it binds `kirocrew`), and it is the crew every
session starts on. So crew mode answered *"Couldn't start that one — say the word
and I'll retry."* three times and gave up, for an agent that exists:

```
WARNING kiro_crew.subagent: Agent 'default' not found; refusing spawn.
  Available: ['amzn-builder', ...]
```

`_validate_agent` refuses a named-but-unknown agent deliberately — a silent
fallback to the host default would be a privilege escalation — and its log line
subtracts `kirocrew` from the `Available:` list it prints, so the correct answer
was hidden from the error message.

## How

One accessor (`CrewOrchestrator._dispatch_agent`) resolves it for all three
dispatch sites — spawn, continuation, and the `conversation_gone` respawn — so
they cannot drift apart again.

- A configured crew resolves through `resolve_agent_bindings` to its `kiro_agent`.
- A name that is **not** a crew passes through unchanged: it is then a template or
  an app-materialized agent, and `spawn()` validates both itself. Rewriting it to
  the default crew's template would silently run a different agent.
- Resolution deliberately does **not** pair with `_agent_prevalidated`. Mapping an
  alias proves the CREW exists, never that its template does, so claiming
  prevalidation would restore the escalation `_validate_agent` exists to refuse.
- Loop-safe: an alias hit resolves from the config object alone, and the config
  load is awaited off-loop.

`chat_orchestrator.py` reads `slot.agent` eleven times and is deliberately
untouched: every one is a `SecurityEvent(agent=...)` audit field, where the crew
the user picked is the right thing to record.

## Evidence

No UI in this change, so there is no screenshot to show. The discriminating fact
is which names resolve, probed against a real `config.json` (13 crews):

```
crews: 13   templates: 14
crew != template: 1
  'default' -> 'kirocrew'   template_known=True   crewname_known=False
crews whose template kiro-cli does NOT have: []
```

`crewname_known=False` is the bug — the name being dispatched today is not one
kiro-cli has — and `template_known=True` is the fix landing on something real.
After the change all 13 crews dispatch a template kiro-cli can load.

## Tests

8 new in `test/test_crew_chat.py` (`TestDispatchAgent`): crew → template,
same-name crew round-trip, empty stays empty, non-crew name passes through,
unreadable config degrades unresolved, and all three dispatch paths asserted to
send the template with `_agent_prevalidated` still off.

`_slot()`'s `agent="kirocrew"` default was a *template* name where production
passes a *crew* name, which is how the suite missed this — so the new fixtures
spell crews as `crew_name=template_name`, and an autouse fixture keeps resolution
off the developer's real `config.json`.

Local gates: `244 passed` (`test_crew_chat.py` 157, plus `test_crew_http.py`,
`test_native_subagent_spawn.py`, `test_kiro_crew.py`), isort / flake8 / mypy clean
on both touched files.

## Not in scope

- `_dispatch_continue` has no `_warm_agent_cache`, so a crew bound to a
  project-local agent is still refused on the continuation path. Separate bug.
- A crew's `model` binding is still not threaded into `spawn(model=)`. That is a
  behaviour change, not a refusal fix.
