### PR TITLE
fix(chat): open native file picker on touch devices

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -467,6 +467,12 @@ service installer such as `cloudflared service install`).
 
 `kirocrew token` does the same thing from a shell on the gateway host.
 
+### Using Chat on a phone or tablet
+
+In the Chat composer, tap `+` to open the device's native Files picker and
+attach an image or a regular file. This direct touch path does not open the
+desktop-style command menu first.
+
 ### Session duration
 
 Three clocks. The first two are signed into the access token payload

--- a/src/kiro_crew/docs/dashboard.md
+++ b/src/kiro_crew/docs/dashboard.md
@@ -51,7 +51,10 @@ code blocks, Mermaid diagrams, and clickable file paths.
 - **Merge queued messages**: optionally merge queued messages into a single prompt
 - **Cooperative stop**: soft-stop sends cancel first, falls back to hard kill after budget (preserves session state)
 - **Tool input preview**: expandable tool input display in approval cards
-- **File upload**: drag-and-drop or paperclip upload for images and non-image files (.zip, .csv, .docx)
+- **File upload**: on desktop, use **Upload file** from the `+` menu or drop a
+  file into Chat. On a phone or other touch device, tap `+` to open the native
+  system Files picker directly. Both paths accept images and regular files such
+  as `.zip`, `.csv`, and `.docx`.
 - **Folder management**: create, rename, and organize sessions into sidebar folders with indent borders
 - **Per-channel session folders**: optional, off by default — each channel's settings panel (Slack, Discord, Telegram, Teams, Webex, WeCom, WeChat) can file conversations that start there into a named sidebar folder, marked with the channel's brand mark. Config key: `<channel>.session_folder` ("" = off). The folder is created when the setting is saved, so the surfacing path only ever reads the folder store; a configured folder that no longer exists (config.json hand-edited, or the folder deleted) leaves conversations unfiled until the next save recreates it. Filing applies as each conversation is first surfaced; a session moved by hand afterwards stays where it was put.
 - **Session colors**: per-session color picker for visual organization

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo, memo } from 'react'
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo, useId, memo } from 'react'
 import { ArrowUpFromLine, ArrowUp, Loader2, RotateCw, Plus, Crop, Bot, Mic, Square, BookOpen, X, ClipboardList, CheckCircle, Ban, Sparkles, Target, Lock, Folder, FolderOpen, FileText } from 'lucide-react'
 import CopyBranchButton from './CopyBranchButton'
 import { usePointerDrag } from '../hooks/usePointerDrag'
@@ -917,6 +917,7 @@ function ChatInput({
   // when the caret enters a token — the AT half of the paste-preview a11y fix.
   const [pastePreviewPanelId, setPastePreviewPanelId] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const fileInputId = useId()
   // "+" drop-up menu (upload file / image + browse toggle).
   const [plusOpen, setPlusOpen] = useState(false)
   const [ctxPopoverOpen, setCtxPopoverOpen] = useState(false)
@@ -1066,6 +1067,7 @@ function ChatInput({
   }, [disabled, onFollowUpSend])
   const { botName } = useBranding()
   const isMobile = useIsMobile()
+  const directFilePicker = isMobile || isTouchDevice()
   const [attachControlRow, controlRowEdges, remeasureControlRow] = useScrollEdges<HTMLDivElement>()
   // The control row's chips are prop-driven (the auto-nudge loop chip, the
   // approval-mode picker) and appear or change label while the row keeps its
@@ -2407,7 +2409,7 @@ function ChatInput({
         </div>
       )}
 
-      <input ref={fileInputRef} type="file" aria-label={i18nT('components.chatInput.attach_files')} multiple accept={FILE_ACCEPT} className="hidden" onChange={handleFileInputChange} />
+      <input id={fileInputId} ref={fileInputRef} type="file" aria-label={i18nT('components.chatInput.attach_files')} multiple accept={FILE_ACCEPT} className="sr-only" onChange={handleFileInputChange} />
 
       <SlashCommandMenu input={value} anchorRef={inputRef as React.RefObject<HTMLElement>} open={slashMenuOpen} onSelect={cmd => { onChange(cmd); setSlashMenuOpen(false) }} onClose={() => setSlashMenuOpen(false)} />
 
@@ -2547,19 +2549,31 @@ function ChatInput({
           <div className="flex items-center gap-0.5 min-w-0">
             {onUploadFiles && (
               <div className="relative shrink-0" ref={plusWrapRef}>
-                <button
-                  ref={plusBtnRef}
-                  className={`w-8 h-8 rounded-lg flex items-center justify-center cursor-pointer transition-all disabled:opacity-30 bg-transparent border-none ${plusOpen ? 'text-text bg-bg-hover' : 'text-muted hover:text-text hover:bg-bg-hover'}`}
-                  onClick={togglePlus}
-                  disabled={uploading}
-                  aria-haspopup="menu"
-                  aria-expanded={plusOpen}
-                  aria-label={i18nT('components.chatInput.add_files_options')}
-                  title={i18nT('components.chatInput.add_files_options')}
-                >
-                  {uploading ? <Loader2 size={18} className="animate-spin" /> : <Plus size={18} className={`transition-transform ${plusOpen ? 'rotate-45' : ''}`} />}
-                </button>
-                {plusOpen && plusRect && createPortal(
+                {directFilePicker ? (
+                  <label
+                    htmlFor={uploading ? undefined : fileInputId}
+                    aria-disabled={uploading || undefined}
+                    className={`w-8 h-8 rounded-lg flex items-center justify-center transition-all bg-transparent ${uploading ? 'opacity-30 cursor-default' : 'cursor-pointer text-muted hover:text-text hover:bg-bg-hover'}`}
+                    aria-label={i18nT('components.chatInput.attach_files')}
+                    title={i18nT('components.chatInput.attach_files')}
+                  >
+                    {uploading ? <Loader2 size={18} className="animate-spin" /> : <Plus size={18} />}
+                  </label>
+                ) : (
+                  <button
+                    ref={plusBtnRef}
+                    className={`w-8 h-8 rounded-lg flex items-center justify-center cursor-pointer transition-all disabled:opacity-30 bg-transparent border-none ${plusOpen ? 'text-text bg-bg-hover' : 'text-muted hover:text-text hover:bg-bg-hover'}`}
+                    onClick={togglePlus}
+                    disabled={uploading}
+                    aria-haspopup="menu"
+                    aria-expanded={plusOpen}
+                    aria-label={i18nT('components.chatInput.add_files_options')}
+                    title={i18nT('components.chatInput.add_files_options')}
+                  >
+                    {uploading ? <Loader2 size={18} className="animate-spin" /> : <Plus size={18} className={`transition-transform ${plusOpen ? 'rotate-45' : ''}`} />}
+                  </button>
+                )}
+                {!directFilePicker && plusOpen && plusRect && createPortal(
                   <div
                     ref={plusMenuRef}
                     className="fixed w-[260px] rounded-xl bg-bg-elevated border border-border shadow-xl p-2 animate-slide-up z-[60]"

--- a/website/src/test/ChatInput.snip.test.tsx
+++ b/website/src/test/ChatInput.snip.test.tsx
@@ -2,26 +2,33 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
 
-// Toggle capture-support + mobile per test.
-const h = vi.hoisted(() => ({ supported: true, mobile: false }))
+// Toggle capture support and input capability per test.
+const h = vi.hoisted(() => ({ supported: true, mobile: false, touch: false }))
 vi.mock('../hooks/useScreenSnip', () => ({ isScreenSnipSupported: () => h.supported }))
 vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => h.mobile }))
+vi.mock('../utils/isTouchDevice', () => ({ isTouchDevice: () => h.touch }))
 vi.mock('../api/client', () => ({ api: new Proxy({}, { get: () => vi.fn() }) }))
 
 import ChatInput from '../components/ChatInput'
 
-// Screenshot lives inside the "+" drop-up menu ("Add files & options"),
-// which renders only when onUploadFiles is provided (ChatPage always passes both).
 const base = { value: '', onChange: vi.fn(), onSend: vi.fn(), onUploadFiles: vi.fn() }
 const openPlusMenu = () => fireEvent.click(screen.getByTitle('Add files & options'))
 const snipItem = () => screen.queryByRole('button', { name: /screenshot/i })
 
+function expectDirectFilePicker(container: HTMLElement) {
+  const fileInput = screen.getByLabelText('Attach files', { selector: 'input[type="file"]' })
+  const picker = container.querySelector('label[aria-label="Attach files"]')
+  expect(picker).toHaveAttribute('for', fileInput.id)
+  expect(container.querySelector('button[title="Add files & options"]')).toBeNull()
+}
+
 beforeEach(() => {
   h.supported = true
   h.mobile = false
+  h.touch = false
 })
 
-describe('ChatInput screenshot action (in + menu)', () => {
+describe('ChatInput screenshot action', () => {
   it('shows Screenshot in the + menu and fires onScreenshot when screen capture is supported', () => {
     const onScreenshot = vi.fn()
     renderWithProviders(<ChatInput {...base} onScreenshot={onScreenshot} isMac={false} />)
@@ -46,10 +53,17 @@ describe('ChatInput screenshot action (in + menu)', () => {
     expect(snipItem()).toBeNull()
   })
 
-  it('hides Screenshot on mobile even when capture is supported', () => {
+  it('uses the accessible direct file picker on mobile instead of Screenshot', () => {
     h.mobile = true
-    renderWithProviders(<ChatInput {...base} onScreenshot={vi.fn()} isMac={true} />)
-    openPlusMenu()
+    const { container } = renderWithProviders(<ChatInput {...base} onScreenshot={vi.fn()} isMac={true} />)
+    expectDirectFilePicker(container)
+    expect(snipItem()).toBeNull()
+  })
+
+  it('uses the accessible direct file picker on touch devices', () => {
+    h.touch = true
+    const { container } = renderWithProviders(<ChatInput {...base} onScreenshot={vi.fn()} isMac={true} />)
+    expectDirectFilePicker(container)
     expect(snipItem()).toBeNull()
   })
 })

--- a/website/src/test/ChatInput.test.tsx
+++ b/website/src/test/ChatInput.test.tsx
@@ -13,6 +13,9 @@ import type { PasteBlock } from '../utils/pasteTokens'
 const touchEnv = vi.hoisted(() => ({ touch: false }))
 vi.mock('../utils/isTouchDevice', () => ({ isTouchDevice: () => touchEnv.touch }))
 
+const mobileEnv = vi.hoisted(() => ({ mobile: false }))
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => mobileEnv.mobile }))
+
 const defaultProps = {
   value: '',
   onChange: vi.fn(),
@@ -23,6 +26,7 @@ beforeEach(() => {
   vi.restoreAllMocks()
   localStorage.clear()
   touchEnv.touch = false
+  mobileEnv.mobile = false
 })
 
 describe('ChatInput', () => {
@@ -55,6 +59,18 @@ describe('ChatInput', () => {
     it('shows offline placeholder when connected=false', () => {
       renderWithProviders(<ChatInput {...defaultProps} connected={false} />)
       expect(screen.getByPlaceholderText(/Gateway offline/)).toBeInTheDocument()
+    })
+
+    it('makes the touch-device + control open the native file picker directly in a wide viewport', () => {
+      touchEnv.touch = true
+      renderWithProviders(<ChatInput {...defaultProps} onUploadFiles={vi.fn()} />)
+
+      const input = screen.getAllByLabelText('Attach files').find((element) => element.tagName === 'INPUT')
+      const mobilePlus = screen.getByTitle('Attach files').closest('label')
+      expect(input).toBeDefined()
+      expect(mobilePlus).toHaveAttribute('for', input?.id)
+      expect(screen.queryByRole('button', { name: 'Add files & options' })).not.toBeInTheDocument()
+      expect(screen.queryByText('Upload file')).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Problem / Motivation

On phones and touch PWAs, opening the Chat composer’s plus menu adds an unnecessary intermediate action before the system Files picker appears. Desktop users still need the existing plus-menu workflow.

## Why it matters

Touch upload should behave like a native mobile affordance: one tap opens the platform picker, while desktop behavior remains predictable and unchanged.

## What changed

- Bind the touch/mobile composer control directly to the hidden file input.
- Preserve the desktop plus-menu workflow.
- Document both upload paths.

## Tests

- Focused ChatInput Vitest suite (137 tests)
- TypeScript production build
- Documentation lint
- isort and flake8

## Scope

No backend or upload-protocol changes.