### PR TITLE
ci(pr-readiness): echo lane state to the job log, not just the step summary

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -708,6 +708,15 @@ jobs:
             description="Eligible automated validation passed for this revision"
           fi
 
+          # Diagnostic-only: the lane arrays are only ever readable from
+          # $GITHUB_STEP_SUMMARY, which `gh run view --log` cannot query --
+          # so a run that publishes a wrong pending/failed verdict (e.g. a
+          # lane invisible under GITHUB_TOKEN but visible under a user token)
+          # can only be diagnosed by opening the summary UI by hand (#3550).
+          # Plain `echo` here lands in the job's own log instead, so
+          # `gh run view --log | grep 'pr-readiness: lane state'` finds it.
+          echo "pr-readiness: lane state -- passed=[${passed[*]:-}] pending=[${pending[*]:-}] failed=[${failed[*]:-}] skipped=[${skipped[*]:-}]"
+
           {
             echo "state=$state"
             echo "label=$label"

--- a/test/test_pr_readiness_evaluate.py
+++ b/test/test_pr_readiness_evaluate.py
@@ -479,3 +479,42 @@ class TestGenuineFailureStaysRed:
         # say so instead of presenting itself as a complete evaluation.
         summary = (runner.temp / "pr-readiness-summary.md").read_text()
         assert "truncated" in summary
+
+
+class TestLaneStateIsLoggedNotOnlySummarized:
+    """#3550: a run that publishes a wrong verdict (e.g. a lane invisible
+    under GITHUB_TOKEN but visible under a user token) could previously only
+    be diagnosed by opening the $GITHUB_STEP_SUMMARY UI by hand --
+    `gh run view --log` cannot query it. The evaluate step must also echo the
+    lane arrays to the job's own stdout log."""
+
+    def test_all_green_run_logs_every_lane_as_passed(self, runner: Runner):
+        proc, outputs = runner.evaluate()
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "success"
+        log_line = next(
+            line for line in proc.stdout.splitlines() if line.startswith("pr-readiness: lane state")
+        )
+        assert "pending=[]" in log_line
+        assert "failed=[]" in log_line
+        # Real lane labels, not just a non-empty bucket -- proves the log line
+        # carries the SAME names the summary does, not a placeholder.
+        assert "CI" in log_line
+        assert "Opus 4.8 Review" in log_line
+
+    def test_a_stuck_lane_is_named_in_the_log_line(self, runner: Runner):
+        # The exact #3550 shape: one lane never completes (still queued),
+        # everything else green. The diagnostic line must name it so a
+        # stuck-pending PR is diagnosable from `gh run view --log` alone,
+        # without opening the step-summary UI.
+        (runner.fixtures / "codeql_runs.json").write_text(
+            _run_json("codeql", status="queued", conclusion="")
+        )
+        proc, outputs = runner.evaluate()
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "pending"
+        log_line = next(
+            line for line in proc.stdout.splitlines() if line.startswith("pr-readiness: lane state")
+        )
+        assert "CodeQL" in log_line
+        assert "pending=[CodeQL" in log_line


### PR DESCRIPTION
## Summary

Fixes #3550 (the "small, do first" diagnosability item — the deeper `GITHUB_TOKEN`-vs-user-token visibility hypothesis needs a live repro this environment can't reproduce, and is left for a follow-up if the log line doesn't already answer it next time).

The evaluate step's `passed[]`/`pending[]`/`failed[]` lane arrays were only ever written to `$GITHUB_STEP_SUMMARY` — readable in the Actions UI, but not queryable via `gh run view --log`. When the evaluator publishes a wrong verdict (e.g. "1 pending" on a head where every lane is verifiably green), the only way to see which lane it thought was pending was to open the step-summary UI by hand — across 6+ evaluations over an hour, per the reported case.

Adds one plain `echo "pr-readiness: lane state -- passed=[...] pending=[...] failed=[...] skipped=[...]"` right after the lane arrays are finalized, so the same information lands in the job's own stdout log and `gh run view --log | grep 'pr-readiness: lane state'` finds it in seconds.

## Test plan

- [x] New tests in `test_pr_readiness_evaluate.py` execute the real extracted script against a stubbed `gh` (the existing harness for this file) and assert the log line appears with the real lane labels: an all-green run (`passed=[...]` with CI/Opus 4.8 Review/etc, `pending=[] failed=[]`), and a run with one lane still queued (`pending=[CodeQL...]`).
- [x] YAML syntax validated (`yaml.safe_load`).
- [x] `flake8` / `isort --check-only` on the test file — clean.
- [x] `scripts/docs_lint.py` / `BRAND_BASE_REF=upstream/main scripts/check_brand_name.py` — clean.
- [x] Full `test_pr_readiness_evaluate.py` (18 tests, including the 2 new ones) — pass. **Note for reviewers**: this file's tests need GNU `timeout` (via `gh-retry.sh`), which is absent on plain macOS. Confirmed this is a pre-existing local-environment gap — 11 tests in this file already fail here without it, unrelated to this change — by verifying with a temporary `timeout` shim that all 18 pass once it's present. CI's Linux runners have the real GNU `timeout`, so this should be a non-issue there.
- [x] Broader regression sweep: `test_pr_readiness_publish.py`, `test_pr_readiness_sweep.py`, `test_ai_review_workflows.py`, `test_workflow_permissions.py` — 130 passed, 12 skipped (unrelated).

No CHANGELOG entry — this is CI-tooling-only, matching the established convention for pure test/CI-infra changes.