### PR TITLE
refactor(deploy): drop a shadow import and route redaction through one helper

### DIFF
--- a/src/kiro_crew/deploy/handlers.py
+++ b/src/kiro_crew/deploy/handlers.py
@@ -105,10 +105,10 @@ def _sanitize_response(payload: Any) -> Any:
     """Recursively apply credential + exfiltration redaction to all str values in a response payload.
 
     Deploy handler error responses echo LLM-controlled values (local_dir,
-    site_id, profile) without BOTH redaction passes. This helper walks dict/list
-    structures and applies _redact_text to every str leaf. Applied at the three
-    chokepoint handlers (_handle_deploy, _handle_recall, _handle_destroy) so
-    ALL paths through _do_* are covered in one place.
+    site_id, profile), which need BOTH redaction passes. This helper walks
+    dict/list structures and applies _redact_text to every str leaf. Applied at
+    the three chokepoint handlers (_handle_deploy, _handle_recall,
+    _handle_destroy) so ALL paths through _do_* are covered in one place.
     """
     if isinstance(payload, str):
         return _redact_text(payload)
@@ -130,8 +130,7 @@ def _redact_profile_fields(profiles: list[dict[str, Any]]) -> list[dict[str, Any
         entry: dict[str, Any] = {}
         for k, v in p.items():
             if isinstance(v, str) and v:
-                v, _ = redact_credentials(v)
-                v, _ = redact_exfiltration_urls(v)
+                v = _redact_text(v)
             entry[k] = v
         out.append(entry)
     return out
@@ -210,10 +209,7 @@ def _safe_err(exc: BaseException) -> str:
     AWS CLI stderr can contain credential fragments (access key ids, session
     tokens, etc.) — never surface the raw exception in response payloads.
     """
-    msg = str(exc)
-    msg, _ = redact_credentials(msg)
-    msg, _ = redact_exfiltration_urls(msg)
-    return msg
+    return _redact_text(str(exc))
 
 
 # --- local_dir input validation (security-controls) ------------
@@ -303,7 +299,7 @@ def _allowed_local_roots() -> list[Path]:
                 pass
     except Exception:
         pass
-    # Always allow the deploy staging dir (for artifact staging, F2/F3).
+    # Always allow the deploy staging dir, where artifacts are staged for publish.
     try:
         sr = _staging_root()
         roots.append(sr.resolve())
@@ -1307,8 +1303,6 @@ def _internal_denied(func):  # type: ignore[no-untyped-def]
     A new handler without this decorator (and not in the allowlist) will trip the
     registration-time assertion in register_routes.
     """
-    import functools
-
     @functools.wraps(func)
     async def _wrapper(request: web.Request) -> web.Response:
         if _is_internal_secret_request(request):


### PR DESCRIPTION
<!-- no-visual-delta -->
Backend-only diff: one file under `src/kiro_crew/deploy/`, nothing under `website/`,
`.github/` or `scripts/`, so there is no rendered surface to screenshot and CI's
`changes` job reports `only_backend=true`.

## Problem

Four readability defects in `src/kiro_crew/deploy/handlers.py`, found by the
module-simplification detector plus a judgment pass over the same file:

1. `_internal_denied` runs `import functools` inside the function body while the
   module already imports `functools` at module scope (line 18). The inner
   statement re-binds the same `sys.modules` singleton — a strict no-op that
   reads as though the import were deliberately deferred.
2. `_redact_profile_fields` and `_safe_err` each inline `redact_credentials`
   followed by `redact_exfiltration_urls` — the same two calls, in the same
   order, that the file's own `_redact_text` helper already wraps. Three copies
   of one redaction pipeline in one file.
3. A comment on the deploy staging root carries a task-log marker (`F2/F3`)
   instead of the rationale, which `AGENTS.md` forbids in code comments.
4. `_sanitize_response`'s docstring asserts that "Deploy handler error responses
   echo LLM-controlled values … **without** BOTH redaction passes" — a
   present-tense claim about current behavior that is false, since this helper is
   applied at the three chokepoint handlers precisely so both passes run.

## Why it matters

Item 2 is the one with a maintenance cost beyond reading: the credential /
exfiltration redaction pipeline for deploy responses is defined in three places
in one file. A future change to that pipeline — adding a third pass, reordering,
or fixing one of the two matchers' call contract — has to find all three, and the
two inlined copies are the ones a reader greps past because they don't mention
`_redact_text`. Item 4 is worse than a stale comment: a reader who trusts it
concludes the deploy error path is missing a redaction pass and may "fix" a
non-bug.

## Fix (symptoms → root cause → change)

- **Symptom:** a lazy-looking `import functools` in a security decorator.
  **Root cause:** a leftover shadow of the module-scope import.
  **Change:** delete the inner statement. `functools` now resolves to the module
  global — the same object, since both bindings come from `sys.modules`. This is
  an `import X` shadow, not a `from X import Y` shadow, so no test-mock
  observability changes (there is no per-attribute binding to substitute).
- **Symptom:** the redaction pair inlined twice.
  **Root cause:** `_redact_text` was introduced after the two call sites.
  **Change:** route both through `_redact_text`. Equivalence: `_redact_text` is
  exactly `redact_credentials` then `redact_exfiltration_urls`, discarding the
  same second tuple element, so each rewrite is a token-for-token substitution.
  Both call sites keep their existing guards (`isinstance(v, str) and v`, and
  `str(exc)`), so no value reaches the pipeline that did not before. Both still
  resolve `redact_credentials` / `redact_exfiltration_urls` through the same
  module-level names, so a test patching either on `kiro_crew.deploy.handlers`
  observes them identically.
- **Symptoms 3 and 4:** comment defects.
  **Change:** replace the `F2/F3` marker with what the line is actually for, and
  correct the docstring sentence to state the requirement ("which need BOTH
  redaction passes") rather than a false claim about current behavior.

**Deliberately out of scope**, so the exclusion is uniform rather than
case-by-case:

- The same inline redaction pair in `deploy/profiles.py:283`, `deploy/iam.py:671`
  and `deploy/scan.py:221` is **left alone**. `_redact_text` is private to
  `handlers.py`; reaching it from a sibling module would mean importing a private
  name across modules, and the alternative — promoting the helper into
  `security.py` — is a wider change than a readability sweep should carry. The
  criterion applied is "dedup only within the file that owns the helper", and it
  is applied to every such site, not just some.
- `deploy/scan.py:210`'s in-function `from kiro_crew.security import …` is
  untouched: an in-function `from X import Y` resolves at call time and a test may
  substitute the attribute on the source module, so removing one can silently
  redirect a security control past a mock.
- `_do_deploy` and `_allowed_local_roots` nest past three levels but are left as
  they are. `_allowed_local_roots` computes the path allowlist that confines a
  request-supplied `local_dir`; restructuring a path guard for style is not a
  simplification, it is asking a reviewer to diff a security boundary to confirm
  a no-op.

## Tests

No new tests — the change is behavior-preserving by construction, so there is no
new behavior to lock in, and adding a test that asserts the source text of a
refactor is how the `test_deploy_round*_fixes.py` files became brittle. The
existing suite is the check that matters here, and it already covers each edited
symbol:

- `_internal_denied` — `test_deploy_web_handlers.py::test_internal_secret_teardown_denied_403`,
  `::test_internal_secret_list_allowed`, `::test_internal_secret_profiles_post_denied`
- `_redact_profile_fields` — `test_deploy_handlers_coverage.py::test_redact_profile_fields_keeps_non_strings`
- `_redact_text` — `test_deploy_round6_fixes.py` (redaction + clean-passthrough)

## Manual verification

N/A — unit coverage sufficient. Every edit is a local substitution whose
equivalence is decidable by reading the two forms, and the covering tests above
exercise the deny path and the redaction path directly.

Gates run locally on the Python 3.12 CI-parity venv: `isort --check-only`,
`flake8`, `mypy src/kiro_crew/` (968 files, clean), `check_brand_name.py`,
`check_harness_parity.py`, `docs-lint.sh`, `scrub-lint.sh --no-history` (the form
CI runs), `verify_vendor_manifest.py` — all exit 0. Tests: 696 passed / 1 skipped
for `-k deploy`, plus 216 passed across the four non-deploy-named files that
import `deploy.handlers` (`test_artifacts_handlers.py`,
`test_cse_2026_08_07_fixes.py`, `test_external_access_seam.py`,
`test_publish_providers.py`).

Note on `scrub-lint.sh` without `--no-history`: it fails on this checkout with
1117 pre-existing commits flagged by author email. Pristine `origin/main` fails
it identically with the same 1117 commits, and CI invokes it as `--no-history`,
so it is unrelated to this diff.

## Screenshots

N/A — no user-visible UI change (see the no-visual-delta note above).
