### PR TITLE
ci: dispatch stuck PR Readiness recomputes oldest-first

### DIFF
--- a/.github/workflows/pr-readiness-sweep.yml
+++ b/.github/workflows/pr-readiness-sweep.yml
@@ -66,7 +66,9 @@ jobs:
   sweep:
     name: Nudge stuck PR Readiness statuses
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Headroom for the larger dispatch volume: a real backlog can now be drained
+    # in a single sweep (see MAX_DISPATCH), so the job may fire many recomputes.
+    timeout-minutes: 15
     steps:
       - name: Re-fire readiness for stale pull requests
         env:
@@ -76,10 +78,13 @@ jobs:
           # A `pending` status older than this (minutes) is considered a
           # dropped-event freeze rather than an in-flight fan-out.
           STALE_MINUTES: "15"
-          # Runaway backstop: never dispatch more than this many recomputes in
-          # a single sweep. Anything beyond the cap is left for the next sweep
-          # (it stays stale, so it is picked up again).
-          MAX_DISPATCH: "10"
+          # Runaway backstop ONLY -- not a fairness throttle. Dispatch is
+          # oldest-stale-first (see the sort in the second pass), so the cap can
+          # never perpetually starve a low-numbered PR the way the old small,
+          # PR-number-ordered cap did. It is sized to cover the entire open-PR
+          # set in a single sweep, so a genuine backlog drains in one pass; it
+          # exists only to bound a single sweep against a pathological run.
+          MAX_DISPATCH: "200"
         run: |
           set -euo pipefail
 
@@ -93,8 +98,12 @@ jobs:
           total="$(jq 'length' <<<"$prs")"
           echo "Scanning $total open pull request(s) for stale PR Readiness."
 
-          dispatched=0
-          skipped_cap=0
+          # First pass: COLLECT every stale PR; do NOT dispatch inline. Inline
+          # dispatch in `gh pr list` order plus a cap starves whichever stale PRs
+          # land past the cap on every sweep -- in practice the oldest,
+          # lowest-numbered ones, since the list is newest-first. Gather them all
+          # here, then dispatch oldest-first in the second pass below.
+          stale_file="$(mktemp)"
 
           while read -r row; do
             [ -n "$row" ] || continue
@@ -171,11 +180,28 @@ jobs:
                 ;;
             esac
 
+            # Record as "staleness_epoch<TAB>number<TAB>sha<TAB>reason". The
+            # staleness epoch is the status's own updated_at, so a numeric sort
+            # ascending on column 1 orders by HOW LONG each PR has been frozen.
+            printf '%s\t%s\t%s\t%s\n' "$updated_epoch" "$number" "$sha" "$reason" >>"$stale_file"
+          done < <(jq -c '.[]' <<<"$prs")
+
+          stale_total=0
+          [ -s "$stale_file" ] && stale_total="$(wc -l <"$stale_file" | tr -d ' ')"
+          echo "Found $stale_total stale PR Readiness status(es); dispatching oldest-first."
+
+          dispatched=0
+          skipped_cap=0
+
+          # Second pass: dispatch OLDEST-stale-first (numeric sort ascending on
+          # the staleness epoch in column 1). The longest-frozen PR is always
+          # served first, so nothing can be perpetually deferred by the cap.
+          while IFS=$'\t' read -r s_epoch number sha reason; do
+            [ -n "$number" ] || continue
             if [ "$dispatched" -ge "$MAX_DISPATCH" ]; then
               skipped_cap=$(( skipped_cap + 1 ))
               continue
             fi
-
             echo "PR #$number: PR Readiness $reason at $sha -> re-firing recompute."
             if gh workflow run pr-readiness.yml --repo "$REPO" \
                 -f pr="$number" -f sha="$sha" >/dev/null 2>&1; then
@@ -183,6 +209,8 @@ jobs:
             else
               echo "PR #$number: failed to dispatch pr-readiness.yml (will retry next sweep)."
             fi
-          done < <(jq -c '.[]' <<<"$prs")
+          done < <(sort -n -k1,1 "$stale_file")
+
+          rm -f "$stale_file"
 
           echo "Re-fired $dispatched recompute(s); $skipped_cap stale PR(s) deferred to next sweep by MAX_DISPATCH=$MAX_DISPATCH."

--- a/test/test_pr_readiness_sweep.py
+++ b/test/test_pr_readiness_sweep.py
@@ -303,6 +303,94 @@ def test_max_dispatch_caps_the_sweep(runner: Runner) -> None:
     )
 
 
+# ── Fairness: oldest-stale-first, never PR-list order ────────────────────────
+
+# A `gh` stub that serves per-SHA readiness statuses, so several PRs can be
+# frozen for different lengths of time in one sweep. The base stub keys statuses
+# only on the subcommand (one fixture for all PRs), which cannot express "PR A is
+# staler than PR B" -- the exact thing this ordering test must vary.
+GH_STUB_PER_SHA = r"""#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1 ${2:-}" = "pr list" ]; then
+  cat "$FIXTURES/prs.json"; exit 0
+fi
+if [ "$1 ${2:-}" = "workflow run" ]; then
+  printf '%s\n' "$*" >> "$FIXTURES/dispatched.txt"; exit 0
+fi
+if [ "$1" = "api" ]; then
+  case "${2:-}" in
+    *"/check-runs") echo '{"check_runs":[]}'; exit 0 ;;
+    *"/commits/"*"/statuses")
+      sha="${2#*/commits/}"; sha="${sha%%/statuses}"
+      cat "$FIXTURES/status_${sha}.json"; exit 0 ;;
+  esac
+fi
+echo "gh stub: unhandled: $*" >&2
+exit 90
+"""
+
+
+def test_dispatch_is_oldest_stale_first(tmp_path: Path, script: str) -> None:
+    """The longest-frozen PR is dispatched first, regardless of PR-list order.
+
+    This is the anti-starvation property: with a per-sweep cap, dispatching in
+    `gh pr list` order (newest-first) permanently defers the oldest, lowest-
+    numbered frozen PRs. Ordering by how long each PR has been stale fixes that.
+    """
+    fixtures = tmp_path / "fixtures"
+    work = tmp_path / "work"
+    bindir = tmp_path / "bin"
+    for d in (fixtures, work, bindir):
+        d.mkdir(parents=True)
+    stub = bindir / "gh"
+    stub.write_text(GH_STUB_PER_SHA)
+    stub.chmod(0o755)
+
+    # PRs as `gh pr list` returns them (newest-numbered first), each frozen for a
+    # DIFFERENT length of time. Staleness order (oldest first) is 3120, 3400, 3612
+    # -- the opposite of the list order for the newest entry.
+    prs = [
+        {"number": 3612, "headRefOid": "aaa"},
+        {"number": 3120, "headRefOid": "bbb"},
+        {"number": 3400, "headRefOid": "ccc"},
+    ]
+    (fixtures / "prs.json").write_text(json.dumps(prs))
+    ages = {
+        "aaa": "2020-01-01T00:00:03Z",  # least stale
+        "bbb": "2020-01-01T00:00:01Z",  # most stale -> first
+        "ccc": "2020-01-01T00:00:02Z",
+    }
+    for sha, at in ages.items():
+        (fixtures / f"status_{sha}.json").write_text(
+            json.dumps([{"context": "PR Readiness", "state": "pending", "updated_at": at}])
+        )
+
+    proc = subprocess.run(  # noqa: S603 - fixed argv, test-local stub
+        ["bash", "-c", script],
+        cwd=work,
+        env={
+            **os.environ,
+            "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+            "FIXTURES": str(fixtures),
+            "REPO": "kirodotdev/KiroCrew",
+            "STATUS_CONTEXT": "PR Readiness",
+            "STALE_MINUTES": "15",
+            "MAX_DISPATCH": "200",
+        },
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    dispatched = (fixtures / "dispatched.txt").read_text().splitlines()
+    order = []
+    for line in dispatched:
+        for tok in line.split():
+            if tok.startswith("pr="):
+                order.append(int(tok.split("=", 1)[1]))
+    assert order == [3120, 3400, 3612], f"expected oldest-first, got {order}"
+
+
 def test_the_sweep_never_recomputes_a_verdict_itself(script: str) -> None:
     """It may only nudge the authoritative workflow.
 


### PR DESCRIPTION
## Problem

The PR Readiness Self-Heal Sweep (`.github/workflows/pr-readiness-sweep.yml`) is supposed to unstick PRs whose `PR Readiness` status froze at `pending` after GitHub dropped a `workflow_run` event. In practice, old low-numbered PRs stay frozen for hours despite the sweep running every 15 minutes.

A live sweep run showed why:

```
Scanning 212 open pull request(s) for stale PR Readiness.
PR #3612: ... -> re-firing recompute.
PR #3611: ...
... (8 more, all high-numbered)
Re-fired 10 recompute(s); 64 stale PR(s) deferred to next sweep by MAX_DISPATCH=10.
```

74 of 212 open PRs were stale, but the sweep dispatched only 10 per cycle **in `gh pr list` order (newest-numbered first)**, deferring 64. A low-numbered PR (e.g. #3120) sits at the back of that order every single sweep and is never reached before the cap — permanent starvation.

## Why it matters

`PR Readiness` is a required, merge-blocking status. A PR whose every check is green but whose aggregate is frozen `pending` **cannot merge**, and the very mechanism built to rescue it structurally skips it forever. The freeze is systemic (35% of open PRs), so this is not an edge case.

## Fix

- **Symptom:** oldest / lowest-numbered frozen PRs never get a recompute dispatched.
- **Root cause:** the sweep dispatched inline while iterating `gh pr list` (newest-first) and stopped at `MAX_DISPATCH=10`; with a backlog larger than the cap, entries past the cap are re-deferred in the same order every cycle, so the tail starves.
- **Change:**
  1. **Two-pass, oldest-stale-first.** The first pass only *collects* every stale PR as `staleness_epoch<TAB>number<TAB>sha<TAB>reason`. The second pass dispatches after `sort -n -k1,1`, so the **longest-frozen** PR is always served first. Ordering is now by how long a PR has been stuck, never by PR number — nothing can be perpetually deferred.
  2. **`MAX_DISPATCH` 10 → 200**, and redefined as a pure runaway backstop rather than a fairness throttle. It now covers the entire realistic open-PR set, so a genuine backlog drains in a single sweep; combined with oldest-first ordering, raising the cap can't starve newly-stale PRs either.
  3. **`timeout-minutes` 10 → 15** for headroom against the larger dispatch volume.

The re-fire *conditions* (stale-`pending`-past-threshold, and `failure`-with-newer-check-evidence) and the "nudge only, never publish a verdict" invariant are unchanged.

## Tests

`test/test_pr_readiness_sweep.py` (extracts the real `run:` block and executes it against a `gh` stub):

- New `test_dispatch_is_oldest_stale_first`: three PRs frozen for different durations, listed newest-first; asserts dispatch order is oldest-first (`[3120, 3400, 3612]`), the opposite of list order. Uses a per-SHA status stub so PRs can differ in staleness.
- All existing condition/anti-storm/cap tests retained and still pass.

## Manual verification

- `python3 -c yaml.safe_load(...)` → YAML valid; `timeout=15`, `MAX_DISPATCH=200`.
- `bash -n` on the extracted `run:` script → clean.
- Standalone smoke test of the `sort -n -k1,1` + `IFS=$'\t' read` path with three fake rows → dispatch order `3120, 3400, 3612` (oldest-first) confirmed.
- `py_compile` on the test file → clean.
- The behavioural pytest module is GNU-`date -d` gated, so it skips on macOS and runs for real on the Linux CI leg.
