### PR TITLE
feat(acp): make the session-start budget configurable

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -135,6 +135,9 @@ _REQUEST_TIMEOUT = 30.0
 # it (observed: remaining servers register within ~1s after the wait; a
 # 71-server agent with no pending OAuth completes in ~14s) — do NOT "tidy" it
 # back down to _REQUEST_TIMEOUT. See issue #2946.
+# This is the built-in default AND floor; ``agent.session_start_timeout_secs``
+# raises it for agents whose MCP fleet legitimately needs longer (see
+# _resolve_session_start_timeout below).
 _SESSION_NEW_TIMEOUT = 90.0
 _INIT_NOTIFICATION_BUFFER_LIMIT = 100
 # Teardown must be snappy: a session is usually terminated on a hot path
@@ -490,6 +493,29 @@ def _get_rss_tree_mb(pid: int) -> float | None:
     return total_kib / 1024.0
 
 
+def _resolve_session_start_timeout() -> float:
+    """Snapshot ``agent.session_start_timeout_secs`` from config.
+
+    Function-level import (mirrors ``_load_watchdog_settings`` in
+    session_handle.py) avoids the config -> dashboard -> acp import cycle;
+    any failure falls back to the built-in default rather than breaking a
+    runtime. The loader clamps the on-disk value to
+    [SESSION_START_TIMEOUT_MIN, SESSION_START_TIMEOUT_MAX]; the ``max`` here
+    is belt-and-braces so a degraded load can never shrink the budget below
+    the built-in floor — a session-start budget under the backend's 30s OAuth
+    wait recreates the race issue #2946 fixed.
+    """
+    try:
+        # circular import: config.loader -> dashboard -> session -> acp
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        cfg = KiroCrewConfig.load()
+        return max(_SESSION_NEW_TIMEOUT, float(cfg.agent.session_start_timeout_secs))
+    except Exception:
+        logger.debug("session-start timeout load failed — using default", exc_info=True)
+        return _SESSION_NEW_TIMEOUT
+
+
 class AcpRuntime:
     """Owns one kiro-cli acp subprocess with single-reader demux.
 
@@ -555,6 +581,13 @@ class AcpRuntime:
         # bound unbounded growth.
         self._max_age_secs = max_age_secs
         self._max_rss_mb = max_rss_mb
+
+        # session/new + session/load budget — resolved lazily on first use
+        # (never in __init__: KiroCrewConfig.load() is a synchronous disk
+        # read + schema validation on a cache miss, and runtimes are
+        # constructed on the event loop) and cached for the runtime's
+        # lifetime. See _session_start_budget().
+        self._session_start_timeout: float | None = None
 
         # Process state
         self._process: asyncio.subprocess.Process | None = None
@@ -1665,6 +1698,22 @@ class AcpRuntime:
                 ) from exc
         return None
 
+    async def _session_start_budget(self) -> float:
+        """The session/new + session/load budget, resolved lazily off-loop.
+
+        ``_resolve_session_start_timeout`` calls ``KiroCrewConfig.load()``,
+        which on a cache miss is a synchronous disk read + schema validation
+        — never run it on the event loop. Resolved once per runtime and
+        cached: the request paths must not re-read config per call, and a
+        changed config value applies to newly spawned runtimes (same
+        snapshot semantics as ``watchdog.*`` in session_handle.py).
+        """
+        if self._session_start_timeout is None:
+            self._session_start_timeout = await asyncio.to_thread(
+                _resolve_session_start_timeout
+            )
+        return self._session_start_timeout
+
     async def create_session(
         self,
         cwd: str | Path | None = None,
@@ -1700,11 +1749,12 @@ class AcpRuntime:
             kas_custom_agents=kas_agents,
         )
 
+        budget = await self._session_start_budget()
         self._session_inits_in_flight += 1
         session_id = ""
         try:
             resp = await self._send_and_await(
-                METHOD_SESSION_NEW, params, timeout=_SESSION_NEW_TIMEOUT
+                METHOD_SESSION_NEW, params, timeout=budget
             )
             session_id = str(resp.get("sessionId") or "")
             if not session_id:
@@ -1826,6 +1876,7 @@ class AcpRuntime:
             # the session itself from sessionId is called with an empty path, and
             # sending the field anyway would advertise a path that does not exist.
             load_params["_meta"] = {"_kiro.dev/session_file": session_file}
+        budget = await self._session_start_budget()
         self._session_inits_in_flight += 1
         loaded_session_id = ""
         try:
@@ -1837,7 +1888,7 @@ class AcpRuntime:
             # docs/system-specs/modules/acp-client.md "loading a session
             # triggers MCP re-initialization") — so it gets the same budget.
             resp = await self._send_and_await(
-                METHOD_SESSION_LOAD, load_params, timeout=_SESSION_NEW_TIMEOUT
+                METHOD_SESSION_LOAD, load_params, timeout=budget
             )
 
             # A genuine resume echoes "modes" in the response (same signal AcpClient

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1437,6 +1437,21 @@ class AgentConfig:
             "they end the turn between cycles and survive restarts.",
         ),
     )
+    session_start_timeout_secs: int = field(
+        default=90,
+        metadata=_meta(
+            "Session Start Timeout (secs)",
+            "Budget for ACP session/new and session/load on the shared "
+            "runtime. kiro-cli blocks the response while it initializes the "
+            "agent's MCP servers, so session start scales with server count "
+            "and per-server cold-start cost (sandboxed launchers, remote "
+            "servers, loaded hosts). Raise this when a large agent "
+            "legitimately needs longer than the 90s default. The floor is "
+            "the default itself: the budget must stay comfortably above the "
+            "backend's 30s OAuth authorization wait, so values below 90 are "
+            "clamped up.",
+        ),
+    )
     tool_approval_timeout_secs: int = field(
         default=600,
         metadata=_meta(
@@ -3390,6 +3405,21 @@ POOL_SIZE_MAX = 10  # session.pool_size — pre-warmed process pool
 CHAT_TURN_TIMEOUT_MIN = 300
 CHAT_TURN_TIMEOUT_MAX = 86400
 
+# agent.session_start_timeout_secs — budget for ACP session/new + session/load
+# on the shared runtime (acp/runtime.py ``_SESSION_NEW_TIMEOUT`` is the built-in
+# default). kiro-cli blocks the session/new response while it initializes the
+# session's MCP servers, so start time scales with the agent's server count and
+# per-server cold-start cost (observed: a 71-server agent with no pending OAuth
+# completes in ~14s; a 17-server agent behind a sandboxed per-server launcher on
+# a loaded host takes ~50s). The floor IS the default: the budget must stay
+# comfortably ABOVE the backend's 30s OAuth authorization wait (issue #2946) —
+# a lower value recreates the session-start race the dedicated budget exists to
+# prevent, so out-of-range values clamp UP to it. The max bounds a typo'd
+# value: a session start slower than 15 minutes is pathological and should
+# surface as a timeout, not wait forever.
+SESSION_START_TIMEOUT_MIN = 90
+SESSION_START_TIMEOUT_MAX = 900
+
 # agent.tool_approval_timeout_secs — how long a chat turn parks waiting for a
 # human to answer a tool-approval prompt. The floor keeps the window long enough
 # for a human who is actually present to reach the dashboard. The max is pinned
@@ -3445,6 +3475,12 @@ _SECURITY_BOUNDED_FIELDS: tuple[tuple[str, str, int, int], ...] = (
     ("agent", "max_subagents", 0, SUBAGENT_AUTO_MAX_CEILING),
     ("agent", "subagent_max_turns", 1, SUBAGENT_MAX_TURNS_CEILING),
     ("agent", "chat_turn_timeout_secs", CHAT_TURN_TIMEOUT_MIN, CHAT_TURN_TIMEOUT_MAX),
+    (
+        "agent",
+        "session_start_timeout_secs",
+        SESSION_START_TIMEOUT_MIN,
+        SESSION_START_TIMEOUT_MAX,
+    ),
     (
         "agent",
         "tool_approval_timeout_secs",
@@ -5775,6 +5811,12 @@ class KiroCrewConfig:
                     7200,
                     CHAT_TURN_TIMEOUT_MIN,
                     CHAT_TURN_TIMEOUT_MAX,
+                ),
+                session_start_timeout_secs=_safe_int(
+                    agent_data.get("session_start_timeout_secs", 90),
+                    90,
+                    SESSION_START_TIMEOUT_MIN,
+                    SESSION_START_TIMEOUT_MAX,
                 ),
                 tool_approval_timeout_secs=_safe_int(
                     agent_data.get("tool_approval_timeout_secs", 600),

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -5270,6 +5270,82 @@ async def test_session_load_call_site_passes_budget_above_request_timeout(monkey
 
 
 @pytest.mark.asyncio
+async def test_session_start_budget_follows_config(monkeypatch):
+    """agent.session_start_timeout_secs raises the session/new budget: the
+    configured value is resolved lazily (off-loop, on first session start —
+    never in __init__, where a config cache miss would block the event loop)
+    and handed to _send_and_await, so a large agent whose MCP fleet needs
+    longer than the 90s default (many servers, sandboxed per-server
+    launchers, loaded hosts) can extend the budget without patching the
+    constant. Resolved once per runtime and cached thereafter."""
+    from types import SimpleNamespace
+
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    fake_cfg = SimpleNamespace(agent=SimpleNamespace(session_start_timeout_secs=240))
+    monkeypatch.setattr(KiroCrewConfig, "load", classmethod(lambda cls: fake_cfg))
+
+    rt, _, _ = _make_runtime()
+    rt._expect_mcp_reports = False
+    # Lazy: construction must not have resolved (or read) config.
+    assert rt._session_start_timeout is None
+    seen: dict[str, object] = {}
+
+    async def _fake_send(method, params, timeout=None):
+        if method == METHOD_SESSION_NEW:
+            seen["timeout"] = timeout
+            return {"sessionId": "sid-cfg"}
+        return {}
+
+    monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+
+    await rt.create_session(cwd="/w", mcp_servers=[])
+
+    assert seen["timeout"] == 240.0
+    # Cached: later session starts on this runtime reuse the snapshot.
+    assert rt._session_start_timeout == 240.0
+    assert await rt._session_start_budget() == 240.0
+
+
+def test_runtime_construction_never_touches_config(monkeypatch):
+    """AcpRuntime.__init__ runs on the event loop; KiroCrewConfig.load() is a
+    synchronous disk read + schema validation on a cache miss, so the budget
+    must resolve lazily (off-loop) on first session start — never at
+    construction."""
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    def _boom(cls):
+        raise AssertionError("config must not be consulted at construction")
+
+    monkeypatch.setattr(KiroCrewConfig, "load", classmethod(_boom))
+    rt = AcpRuntime(work_dir="/tmp")
+    assert rt._session_start_timeout is None
+
+
+def test_resolve_session_start_timeout_floors_and_falls_back(monkeypatch):
+    """The resolver never returns below the built-in floor (a budget under the
+    backend's 30s OAuth wait recreates the #2946 race), and any config-load
+    failure degrades to the default instead of breaking runtime construction."""
+    from types import SimpleNamespace
+
+    from kiro_crew.acp.runtime import _resolve_session_start_timeout
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    # Below-floor value (belt-and-braces: the loader clamp already prevents
+    # this on disk, but a degraded load must not shrink the budget either).
+    low_cfg = SimpleNamespace(agent=SimpleNamespace(session_start_timeout_secs=10))
+    monkeypatch.setattr(KiroCrewConfig, "load", classmethod(lambda cls: low_cfg))
+    assert _resolve_session_start_timeout() == _SESSION_NEW_TIMEOUT
+
+    # Config load blowing up falls back to the default.
+    def _boom(cls):
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr(KiroCrewConfig, "load", classmethod(_boom))
+    assert _resolve_session_start_timeout() == _SESSION_NEW_TIMEOUT
+
+
+@pytest.mark.asyncio
 async def test_send_and_await_timeout_error_names_the_budget():
     """The timeout message must carry the budget that elapsed so a 90s
     session-start timeout is distinguishable from a generic 30s one. The

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -2686,6 +2686,33 @@ class TestSecurityBoundClamping:
             cfg = _load_from_dict({"session": {"pool_size": 1000}})
         assert cfg.session.pool_size == POOL_SIZE_MAX == 10
 
+    def test_session_start_timeout_default(self) -> None:
+        """Omitted from config.json, the budget is the built-in 90s default."""
+        cfg = _load_from_dict({})
+        assert cfg.agent.session_start_timeout_secs == 90
+
+    def test_session_start_timeout_custom_in_range(self) -> None:
+        """An in-range value from disk is preserved verbatim."""
+        cfg = _load_from_dict({"agent": {"session_start_timeout_secs": 240}})
+        assert cfg.agent.session_start_timeout_secs == 240
+
+    def test_session_start_timeout_floored_to_min(self) -> None:
+        """A value below the floor is clamped UP: a session-start budget under
+        the backend's 30s OAuth authorization wait recreates the race the
+        dedicated budget exists to prevent (issue #2946)."""
+        from kiro_crew.config.loader import SESSION_START_TIMEOUT_MIN
+
+        with unittest.mock.patch("kiro_crew.config.loader._log_config_clamp_event"):
+            cfg = _load_from_dict({"agent": {"session_start_timeout_secs": 10}})
+        assert cfg.agent.session_start_timeout_secs == SESSION_START_TIMEOUT_MIN == 90
+
+    def test_session_start_timeout_clamped_to_max(self) -> None:
+        with unittest.mock.patch("kiro_crew.config.loader._log_config_clamp_event"):
+            cfg = _load_from_dict({"agent": {"session_start_timeout_secs": 99999}})
+        from kiro_crew.config.loader import SESSION_START_TIMEOUT_MAX
+
+        assert cfg.agent.session_start_timeout_secs == SESSION_START_TIMEOUT_MAX == 900
+
     def test_full_pentest_reproduction_clamped(self) -> None:
         """The exact tester payload is clamped, and to_dict() (what the GET API
         serializes) reports the clamped values, not the inflated ones."""


### PR DESCRIPTION
## Problem

An agent whose MCP fleet needs more than 90s to initialize cannot create a session at all: `session/new` (and `session/load`, which shares the budget) times out with `AcpRuntimeError: Request session/new timed out`, and the budget — `_SESSION_NEW_TIMEOUT = 90.0` from #2946 / #3119 — is a module constant with no config override. Observed end-to-end at the ACP wire on a corporate Linux host: a 17-server agent behind per-server sandbox launchers completes `session/new` in ~50s warm; a cold start or one slow remote server pushes past 90s.

## Why it matters

When the budget is exceeded, every surface fails at once — dashboard (`Request session/new timed out`), channels and cron (`session/load timed out`) — because no path can create a fresh session. Warm pooled sessions mask the problem until a gateway restart clears them, so it presents as a sudden total outage. The only recourse today is patching source, which a `git pull` reverts.

## Fix (symptoms → root cause → change)

Symptom: session-start timeouts on large agents. Root cause: the session-start budget is sized to a fixed constant (90s, calibrated in #2946 around the backend's 30s OAuth wait plus a ~14s tail observed for a 71-server fast-path agent), but real per-server initialization cost is environment-dependent (sandboxed launchers, remote servers, host load) and can legitimately exceed any fixed number. Change: make the budget configurable while keeping 90s as both the default and the floor.

- `agent.session_start_timeout_secs` (default 90) added to `AgentConfig`, clamped at load to **[90, 900]** via `_SECURITY_BOUNDED_FIELDS` — the floor IS the current default, so the knob can only *extend* the budget; a lower value would recreate the session-start race #2946 fixed. Schema metadata makes it render in the dashboard config UI via the live `SCHEMA_REGISTRY` (the committed `config-baseline.json` snapshot is 41 entries stale on main already, so it is deliberately not regenerated here to keep the diff reviewable — regen tracked separately, see the disposition comments).
- `AcpRuntime` resolves the value **lazily on first session start, off the event loop** via `await asyncio.to_thread(_resolve_session_start_timeout)` in a new `_session_start_budget()` helper, then caches it for the runtime's lifetime. It is never read in `__init__` (a `KiroCrewConfig.load()` cache miss is a synchronous disk read + schema validation, and runtimes are constructed on the event loop — per GPT review round 1). The resolve happens before the `_session_inits_in_flight` bump in both paths so the thread hop cannot extend the init-frame staging window. Snapshot semantics match `watchdog.*` in `session_handle.py`: a changed config value applies to newly spawned runtimes. The resolver keeps the same function-level import (config → dashboard → acp cycle) and falls back to the built-in default on any load failure, with a belt-and-braces floor at `_SESSION_NEW_TIMEOUT` so a degraded load can never shrink the budget.
- Both call sites (`session/new` in `create_session`, `session/load` in `load_session`) pass the resolved budget. `_send_and_await`'s timeout error already formats the passed value, so a raised budget is named correctly in error messages with no further change.

## Tests

- `test_session_start_budget_follows_config` — a configured 240s resolves lazily (None at construction) and reaches the actual `_send_and_await` call site for `session/new`, then is cached for later session starts on the same runtime.
- `test_runtime_construction_never_touches_config` — `AcpRuntime.__init__` succeeds with `KiroCrewConfig.load` monkeypatched to raise, locking the no-config-on-the-event-loop-at-construction invariant.
- `test_resolve_session_start_timeout_floors_and_falls_back` — a below-floor value resolves to the 90s floor; a config-load exception degrades to the default instead of breaking session start.
- `test_session_start_timeout_default` / `_custom_in_range` / `_floored_to_min` / `_clamped_to_max` (config loader) — default, verbatim in-range persistence, and both clamp directions with the SEL clamp-event hook patched, matching the existing `TestSecurityBoundClamping` suite.
- The two existing #2946 call-site tests pass unchanged (default path still hands 90.0 to the wire).

Gates on macOS: full-file runs of `test_acp_runtime.py` + `test_config_loader.py` — 485 passed, 1 skipped; `isort` / `flake8` clean; `mypy` clean for the changed files (3 pre-existing `os.*xattr` errors in `hooks.py` reproduce identically on clean `origin/main` — Linux-only attrs invisible to macOS mypy). Full suite (round 1 head): 52,838 passed; all 135 shared failures reproduce on clean `origin/main` in the same environment (`AF_UNIX path too long` under a deep worktree path, pty/dyld host issues), and the 4 branch-only-in-full-run failures each pass in isolation (load flakes).

## Manual verification

Reproduced the failure and the fix shape in production before writing this: on the affected host, raising the runtime budget past the measured ~50s session start restored session creation on every surface (dashboard, Slack channel, cron) with no regression in warm-path latency. The 90s default path is additionally locked by the unchanged #2946 call-site tests.

## Issue link

Fixes #3642