### PR TITLE
Make an explicit connect_timeout_secs of 15 apply to SSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **An explicit `instances.connect_timeout_secs` of exactly 15 (the SSH
+  default) now actually applies to the SSM transport.** `_connect_timeout_for`
+  detected "the user explicitly set this" by comparing the configured value
+  against the SSH default, so a value equal to that default was
+  indistinguishable from never having been set — SSM silently kept its own
+  25s default instead of the user's explicit 15s. The field is now `None` by
+  default (an explicit unset sentinel) rather than pre-filled with the SSH
+  default, so any explicit value, including one that happens to equal a
+  transport's own default, is honored by both transports. (#3542)
+
 - **`kirocrew` commands start up to ~0.8 s faster, and each MCP stdio server
   drops ~58 MB of resident memory.** `cli.py` imported its full 132-subcommand
   dispatch table at module scope — including the Slack gateway, the dashboard

--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -223,8 +223,9 @@ why it is down.
 
 ### 5.1 `instances.*` config keys
 
-Defaults live in `kiro_crew.instances.constants` and are referenced from the
-`InstancesConfig` dataclass, so the constant and the config default cannot drift.
+Transport defaults and bounds live in `kiro_crew.instances.constants` and are
+referenced from the `InstancesConfig` dataclass, so the documented values and
+runtime policy cannot drift.
 
 | Key | Default | Meaning |
 |-----|---------|---------|
@@ -232,7 +233,7 @@ Defaults live in `kiro_crew.instances.constants` and are referenced from the
 | `instances.warm_set_cap` | `5` | Max instances kept warm at once (bounds memory/sockets; each warm instance is a full dashboard SPA). Clamped up to 1. |
 | `instances.tunnel_base_port` | `7778` | First local loopback port the allocator hands out. Out-of-range values fall back to the default. |
 | `instances.ssh_compression` | `true` | Add `-C` to the tunnel argv. See §5.2. |
-| `instances.connect_timeout_secs` | `15.0` | How long (secs) to wait for the local forward port to accept connections before declaring a connect attempt failed. Hosts behind a ProxyCommand or jump host need longer (the proxy handshake runs before ssh begins the forward). The SSM transport uses its own higher default (25s) unless this value is explicitly set. Clamped to [1, 120]. |
+| `instances.connect_timeout_secs` | unset (SSH `15.0`, SSM `25.0`) | How long (secs) to wait for the local forward port to accept connections before declaring a connect attempt failed. Hosts behind a ProxyCommand or jump host need longer (the proxy handshake runs before ssh begins the forward). An explicit value applies to BOTH transports, including one that happens to equal a transport's own default — unset is the only value read as "no override". Values below 1 fall back to unset (transport-default) semantics; values above 120 are clamped to 120. |
 | `instances.max_recovery_attempts` | `8` | Consecutive self-heal attempts before the tunnel is left disconnected. Below 1 falls back to the default; above `MAX_RECOVERY_ATTEMPTS_CEILING` (100) is clamped with a warning, so a pathological setting cannot turn bounded self-heal into a near-infinite retry loop. |
 | `instances.recover_backoff_max_secs` | `30.0` | Cap on the per-attempt backoff. Non-positive falls back to the default; above `RECOVER_BACKOFF_MAX_CEILING_SECS` (300) is clamped, bounding the worst-case wall-clock recovery window. |
 | `instances.probe_failure_threshold` | `3` | Consecutive health-probe failures before a non-forwarding tunnel is torn down. Below 1 falls back to the default. |

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -4261,18 +4261,20 @@ class InstancesConfig:
             "on a fast/local link where compression CPU outweighs the bandwidth win.",
         ),
     )
-    connect_timeout_secs: float = field(
-        default=_DEFAULT_CONNECT_TIMEOUT,
+    connect_timeout_secs: float | None = field(
+        default=None,
         metadata=_meta(
             "Connect Timeout (secs)",
             "How long to wait for the local forward port to accept connections "
-            "before declaring a connect attempt failed. The default (15s) is "
-            "sufficient for a direct ssh TCP connect, but hosts behind a "
-            "ProxyCommand or jump host routinely need longer (the proxy handshake "
-            "runs before ssh begins the forward). Raise this if connecting a "
-            "remote instance times out while the same ssh forward succeeds by hand. "
-            "The SSM transport uses its own higher default (25s) unless this value "
-            "is explicitly set. Clamped to [1, 120].",
+            "before declaring a connect attempt failed. Unset by default: SSH uses "
+            "15s and SSM uses its own higher 25s (session-manager-plugin's "
+            "WebSocket handshake routinely takes longer than a direct ssh TCP "
+            "connect). An explicit value applies to BOTH transports, including a "
+            "value that happens to equal one transport's default -- unlike the "
+            "unset state, it is no longer distinguishable from 'no override'. "
+            "Raise this if connecting a remote instance times out while the same "
+            "ssh forward succeeds by hand (hosts behind a ProxyCommand or jump "
+            "host routinely need longer). Clamped to [1, 120].",
         ),
     )
     max_recovery_attempts: int = field(
@@ -4314,14 +4316,16 @@ class InstancesConfig:
                 _DEFAULT_TUNNEL_BASE_PORT,
             )
             object.__setattr__(self, "tunnel_base_port", _DEFAULT_TUNNEL_BASE_PORT)
-        if self.connect_timeout_secs < 1.0:
+        if self.connect_timeout_secs is not None and self.connect_timeout_secs < 1.0:
             logger.warning(
-                "instances.connect_timeout_secs %s < 1, using %s",
+                "instances.connect_timeout_secs %s < 1, using the transport default",
                 self.connect_timeout_secs,
-                _DEFAULT_CONNECT_TIMEOUT,
             )
-            object.__setattr__(self, "connect_timeout_secs", _DEFAULT_CONNECT_TIMEOUT)
-        elif self.connect_timeout_secs > _CONNECT_TIMEOUT_CEILING:
+            object.__setattr__(self, "connect_timeout_secs", None)
+        elif (
+            self.connect_timeout_secs is not None
+            and self.connect_timeout_secs > _CONNECT_TIMEOUT_CEILING
+        ):
             logger.warning(
                 "instances.connect_timeout_secs %s > %s, clamping to %s",
                 self.connect_timeout_secs,
@@ -5631,6 +5635,12 @@ class KiroCrewConfig:
         instances_data = data.get("instances", {})
         if not isinstance(instances_data, dict):
             instances_data = {}
+        # Read raw (not defaulted) so an ABSENT key stays None -- the unset
+        # sentinel that lets each transport fall back to its own default --
+        # while an explicitly configured value, including one that happens to
+        # equal a transport default, is parsed and passed through as an
+        # override.
+        _connect_timeout_raw = instances_data.get("connect_timeout_secs")
         mcp_gateway_data = data.get("mcp_gateway", {})
         if not isinstance(mcp_gateway_data, dict):
             mcp_gateway_data = {}
@@ -6361,9 +6371,10 @@ class KiroCrewConfig:
                 ssh_compression=bool(
                     instances_data.get("ssh_compression", _DEFAULT_SSH_COMPRESSION)
                 ),
-                connect_timeout_secs=_safe_float(
-                    instances_data.get("connect_timeout_secs", _DEFAULT_CONNECT_TIMEOUT),
-                    _DEFAULT_CONNECT_TIMEOUT,
+                connect_timeout_secs=(
+                    _safe_float(_connect_timeout_raw, _DEFAULT_CONNECT_TIMEOUT)
+                    if _connect_timeout_raw is not None
+                    else None
                 ),
                 max_recovery_attempts=_safe_int(
                     instances_data.get("max_recovery_attempts", _DEFAULT_MAX_RECOVERY),

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -758,7 +758,7 @@ class SshTunnelManager:
         registry: InstancesRegistry,
         *,
         base_port: int = DEFAULT_TUNNEL_BASE_PORT,
-        connect_timeout_secs: float = _DEFAULT_CONNECT_TIMEOUT_SECS,
+        connect_timeout_secs: float | None = None,
         ssh_compression: bool = True,
         max_recovery_attempts: int = _MAX_RECOVERY,
         recover_backoff_max_secs: float = _RECOVER_BACKOFF_MAX_SECS,
@@ -881,13 +881,15 @@ class SshTunnelManager:
         with the SSM service before it binds the local port, which routinely
         takes longer than a direct ssh TCP connect — so the SSM default is
         higher. A caller that passed an explicit ``connect_timeout_secs``
-        (tests, tuning) wins for both transports.
+        (tests, tuning) wins for both transports — ``None`` (unset) is the only
+        value that defers to a transport default, so an explicit value equal to
+        one transport's default is no longer mistaken for "no override".
         """
-        if self._connect_timeout != _DEFAULT_CONNECT_TIMEOUT_SECS:
+        if self._connect_timeout is not None:
             return self._connect_timeout  # explicit override
         if method == "ssm":
             return _DEFAULT_SSM_CONNECT_TIMEOUT_SECS
-        return self._connect_timeout
+        return _DEFAULT_CONNECT_TIMEOUT_SECS
 
     async def _ps_lines(self) -> list[str]:
         """Return ``<pid> <command>`` lines for all processes (portable ps).

--- a/test/test_config_schema.py
+++ b/test/test_config_schema.py
@@ -306,6 +306,14 @@ class TestConfigSchemaProperties:
         all_fields = _all_fields_recursive(KiroCrewConfig)
         for path, f in all_fields:
             tp = _resolve_type(f)
+            # Unwrap ``X | None`` to X before mapping: the real registry entry
+            # (built via schema.py's own `_optional_inner`) resolves the inner
+            # type, e.g. `float | None` -> "number". Without this unwrap here
+            # too, the union itself falls through `_EXPECTED_TYPE_MAP` to the
+            # "string" catch-all and this test's expectation disagrees with
+            # the registry it's supposed to be checking (#3542, the first
+            # field in the tree to use this shape).
+            tp, _ = _schema_module._optional_inner(tp)
             origin = typing.get_origin(tp)
 
             # Determine expected JSON Schema type

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -41,7 +41,12 @@ class TestConfig:
         assert c.enabled is False
         assert c.warm_set_cap == DEFAULT_WARM_SET_CAP == 5
         assert c.tunnel_base_port == DEFAULT_TUNNEL_BASE_PORT == 7778
-        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
+        # Unset by default (None), not the SSH default value -- the field is a
+        # tri-state "no override" sentinel now, not a pre-filled 15.0 that an
+        # explicit 15.0 could never be told apart from. See
+        # test_connect_timeout_default_and_clamps.
+        assert c.connect_timeout_secs is None
+        assert DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
 
     def test_clamps_out_of_range(self):
         from kiro_crew.config.loader import InstancesConfig
@@ -60,7 +65,7 @@ class TestConfig:
             "warm_set_cap": 5,
             "tunnel_base_port": 7778,
             "ssh_compression": True,
-            "connect_timeout_secs": 15.0,
+            "connect_timeout_secs": None,
             "max_recovery_attempts": 8,
             "recover_backoff_max_secs": 30.0,
             "probe_failure_threshold": 3,
@@ -153,20 +158,27 @@ class TestConfig:
             DEFAULT_CONNECT_TIMEOUT_SECS,
         )
 
-        # Default value matches the constant.
+        # Unset by default -- the sentinel that lets each transport fall back
+        # to its own default (SSH 15s / SSM 25s in ssh_tunnel_manager.py).
         c = InstancesConfig()
-        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
+        assert c.connect_timeout_secs is None
 
-        # Explicit override is honored.
+        # Explicit override is honored, INCLUDING a value equal to the SSH
+        # default -- the whole point of the None sentinel is that this no
+        # longer collapses into "unset" the way it did when 15.0 played both
+        # roles (#3542).
         c = InstancesConfig(connect_timeout_secs=45.0)
         assert c.connect_timeout_secs == 45.0
+        c = InstancesConfig(connect_timeout_secs=DEFAULT_CONNECT_TIMEOUT_SECS)
+        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
 
-        # Below 1 falls back to the default.
+        # Below 1 falls back to unset (transport-default) semantics, not a
+        # hardcoded float -- so a too-low SSM override still gets 25s, not 15s.
         c = InstancesConfig(connect_timeout_secs=0.5)
-        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS
+        assert c.connect_timeout_secs is None
 
         c = InstancesConfig(connect_timeout_secs=-10.0)
-        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS
+        assert c.connect_timeout_secs is None
 
         # Above the ceiling is clamped.
         assert CONNECT_TIMEOUT_CEILING_SECS == 120.0
@@ -1213,6 +1225,46 @@ class TestSshTunnelManager:
         return reg, SshTunnelManager(
             reg, base_port=53400, mint_token=mint or ok_mint, tunnel_factory=factory
         )
+
+    def test_connect_timeout_for_unset_uses_per_transport_default(self, tmp_path):
+        """No explicit override (the manager's default) -- SSH and SSM each get
+        their own default, not the SSH one applied to both (#3542)."""
+        from kiro_crew.instances.constants import (
+            DEFAULT_CONNECT_TIMEOUT_SECS,
+            DEFAULT_SSM_CONNECT_TIMEOUT_SECS,
+        )
+
+        assert DEFAULT_SSM_CONNECT_TIMEOUT_SECS != DEFAULT_CONNECT_TIMEOUT_SECS
+        _reg, mgr = self._mgr(tmp_path)
+        assert mgr._connect_timeout_for("ssh") == DEFAULT_CONNECT_TIMEOUT_SECS
+        assert mgr._connect_timeout_for("ssm") == DEFAULT_SSM_CONNECT_TIMEOUT_SECS
+
+    def test_connect_timeout_for_explicit_value_wins_for_both_transports(self, tmp_path):
+        """An explicit override applies to SSM too, EVEN WHEN it is exactly the
+        SSH default (15.0) -- the bug this issue reports. Before the None
+        sentinel, `_connect_timeout != _DEFAULT_CONNECT_TIMEOUT_SECS` was false
+        for exactly this value, so SSM silently got its own 25s default
+        instead of the user's explicit 15s."""
+        from kiro_crew.instances.constants import (
+            DEFAULT_CONNECT_TIMEOUT_SECS,
+            DEFAULT_SSM_CONNECT_TIMEOUT_SECS,
+        )
+        from kiro_crew.instances.registry import InstancesRegistry
+        from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
+
+        reg = InstancesRegistry(path=tmp_path / "instances.json")
+        mgr = SshTunnelManager(
+            reg, base_port=53400, connect_timeout_secs=DEFAULT_CONNECT_TIMEOUT_SECS
+        )
+        assert mgr._connect_timeout_for("ssh") == DEFAULT_CONNECT_TIMEOUT_SECS
+        assert mgr._connect_timeout_for("ssm") == DEFAULT_CONNECT_TIMEOUT_SECS
+        assert mgr._connect_timeout_for("ssm") != DEFAULT_SSM_CONNECT_TIMEOUT_SECS
+
+        # A genuinely different override still applies to both, as before.
+        reg2 = InstancesRegistry(path=tmp_path / "instances2.json")
+        mgr2 = SshTunnelManager(reg2, base_port=53401, connect_timeout_secs=45.0)
+        assert mgr2._connect_timeout_for("ssh") == 45.0
+        assert mgr2._connect_timeout_for("ssm") == 45.0
 
     @pytest.mark.asyncio
     async def test_connect_persists_and_idempotent(self, tmp_path):


### PR DESCRIPTION
## Summary

Fixes #3542. `instances.connect_timeout_secs` used 15.0 (the SSH default) as both the field's default value AND the sentinel `_connect_timeout_for()` used to detect "the caller explicitly overrode this":

```python
if self._connect_timeout != _DEFAULT_CONNECT_TIMEOUT_SECS:
    return self._connect_timeout  # explicit override
if method == "ssm":
    return _DEFAULT_SSM_CONNECT_TIMEOUT_SECS
```

A user who ran `kirocrew config set instances.connect_timeout_secs 15` was therefore indistinguishable from one who never set it at all: for the SSM transport, the readiness timeout silently resolved to 25s instead of the configured 15s.

- `InstancesConfig.connect_timeout_secs` is now `float | None`, defaulting to `None` — an explicit "unset" sentinel rather than a pre-filled value that collides with a real user setting.
- `SshTunnelManager`'s own `connect_timeout_secs` param follows the same `float | None = None` shape, and `_connect_timeout_for` now checks `is not None` instead of comparing against the default constant.
- A below-floor override (`< 1`) now falls back to unset (transport-default) semantics instead of a hardcoded SSH-shaped float, so a too-low override on SSM still gets SSM's own 25s default rather than SSH's 15s.
- Updated `docs/system-specs/modules/instances.md`'s config table and the CHANGELOG.
- `test/test_config_schema.py`'s ad-hoc Python→JSON-schema type-mapping helper didn't unwrap `X | None`, so it fell through to `"string"` for the first real Optional field in the config tree — fixed by reusing `config/schema.py`'s own `_optional_inner` unwrap (the real schema registry already handles this correctly, per `TestOptionalFieldMapping`).

## Test plan

- [x] `pytest test/test_instances.py test/test_config_schema.py test/test_config_loader.py` — 496 passed, 6 skipped (pre-existing skips), including two new regression tests exercising `SshTunnelManager._connect_timeout_for` directly for the SSH/SSM default split and the exact reported bug (an explicit 15.0 reaching SSM)
- [x] `mypy` on both changed source files — clean (3 pre-existing, unrelated `os.xattr` errors in `hooks.py` reproduce identically on unmodified `main`)
- [x] `flake8` / `isort --check-only` on all changed files — clean