### PR TITLE
feat: allocate a local tunnel port when the preferred one is taken

### DIFF
--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -131,7 +131,7 @@ Module responsibilities:
 | Module | Responsibility |
 |--------|----------------|
 | `registry.py` | Persistent list of configured instances (`~/.kiro/crew/instances.json`) + `last_active_id`. Light charset check on `ssh_host`/`remote_bin` (SSH) or `ssm_target`/`aws_profile`/`aws_region`/`ssm_run_as` (SSM) at add/update, per `connection_method`; every mutation re-reads the file and writes atomically, so a live gateway and a CLI edit cannot clobber each other. |
-| `port_allocator.py` | Probes for a free loopback port at or above `tunnel_base_port` (7778). The probe sets `SO_REUSEADDR` so a `TIME_WAIT` remnant from a just-closed forward is not a false "in use". |
+| `port_allocator.py` | Probes for a free loopback port at or above `tunnel_base_port` (7778). A port must be free on **every** loopback address (`127.0.0.1` and `::1`) to count as free. The probe sets `SO_REUSEADDR` so a `TIME_WAIT` remnant from a just-closed forward is not a false "in use". |
 | `token_mint.py` | Runs `kirocrew token --ttl --port --embed-parent-port` on the remote over SSH (run-marker first, then a bin-candidate ladder) and parses the JWT out of the printed URL. Token is returned in memory only, **never logged**. |
 | `ssm_token_mint.py` | The SSM sibling of `token_mint.py`: runs the same subcommand via `aws ssm send-command` through the launcher's `cloud.ssm` chokepoint, reusing the shared remote-command builders. Token in memory only, **never logged**. See §13. |
 | `validation.py` | The authoritative injection-safe guard on `ssh_host` / `remote_bin`, and on `ssm_target` / `aws_profile` / `aws_region` / `ssm_run_as`, applied immediately before any command line is built. See §11. |
@@ -140,16 +140,50 @@ Module responsibilities:
 | `diagnostics.py` | Dependency-ordered failure probes; reports the first broken link. `diagnose_instance` (SSH ladder) and `diagnose_instance_ssm` (SSM ladder). |
 | `handlers_instances.py` | Owner-only, enabled-gated, SEL-audited HTTP control plane. |
 
-**The local forward port mirrors the remote port.** `connect()` sets
-`local_port = inst.remote_port` rather than allocating a fresh one: the embedded
-iframe loads from `http://<host>:<local_port>`, and the remote gateway only
-trusts CSRF/WebSocket `Origin`s on its own configured port, so mirroring keeps
-the Origin valid with no per-instance allowlisting. The consequence is a hard
-constraint: **every simultaneously-connected instance must use a distinct remote
-port**, and a busy port is a clear connect error rather than a silent fallback
-(a different local port would leave the pane unable to stream or act). The
-`PortAllocator` is therefore constructed but not on the connect path today; the
-`tunnel_base_port` setting configures it.
+**The local forward port prefers — but no longer requires — the remote port.**
+`connect()` starts from `local_port = inst.remote_port`, because a stable,
+predictable port is worth keeping: the dashboard cookie is named
+`mc_token_<browser-facing port>`, so reconnecting on the same port reuses the
+same cookie rather than stranding one per attempt. When that port is
+unavailable — this host's own gateway owns it, an unrelated process holds it, or
+another instance already forwards the same remote port — `connect()` allocates a
+free loopback port from `PortAllocator` (based at `tunnel_base_port`, excluding
+ports committed to other instances) instead of failing the connect. Two remotes
+that both serve the same port can therefore be connected simultaneously through
+distinct forwards, and the remote keeps whatever port it runs on. The reservation
+lookup and the allocation go to `asyncio.to_thread` as a **single** callable: both
+are synchronous (a registry read, then a socket bind per candidate port), and one
+hop keeps the window between "what is reserved" and "what did we take" narrower
+than two hops would. `test/test_apps_instances_loop_offload.py` owns that
+convention and enforces it for this call site.
+
+A divergent local port is safe because every layer that sees the browser-facing
+port derives it **from the request** rather than assuming the remote gateway's
+own listen port: `check_origin` accepts a loopback `Origin` equal to the request
+`Host` (which is exactly what the embedded iframe sends), `build_allowed_hosts`
+compares hostname only, the parent's CSP `frame-src` admits `http://127.0.0.1:*`,
+`frame-ancestors` keys off the parent's `embed_parent_port`, and
+`_cookie_port_from_host` keys the cookie by the `Host` port. Connect fails only
+when no loopback port can be allocated at all.
+
+**A port counts as free only when it is free on every loopback address.**
+`_is_port_free` probes each of `127.0.0.1` and `::1` and requires all of them, so
+a port already held by a foreign listener on one family is never handed out.
+`ssh -L` binds a single address; leaving the other family to someone else would
+make `localhost:<port>` resolve to whichever socket the client's resolver and the
+platform's bind precedence happened to pick, which is not something the hub
+controls. Over-refusing costs the allocator one skipped candidate. A bind that
+fails with `EADDRNOTAVAIL` or `EAFNOSUPPORT` reads as *free*, not occupied —
+nothing can listen on an address the host cannot assign — so a host with IPv6
+disabled still allocates normally.
+
+**The port an instance last forwarded is reaped alongside the preferred one.**
+When the persisted `local_port` differs from the preferred port, the previous
+connect fell back to an allocated port; its orphan matches neither the preferred
+port's forward signature nor anything the allocator will reuse, since the
+allocator skips a still-bound port and climbs to the next one. Reaping both means
+a fallback instance reclaims its old port across unclean exits instead of
+stranding one forwarder and walking its port upward on every reconnect.
 
 **Platform note.** The hub side of this feature assumes a POSIX host with an
 OpenSSH `ssh` client on `PATH`. Two paths make that explicit: the
@@ -163,7 +197,7 @@ direct `os.kill(pid, signal.SIGTERM)` rather than going through
 ## 4. The connect → warm → self-heal lifecycle
 
 1. **Connect.** `POST /api/instances/{id}/connect` validates the ssh inputs,
-   reaps any orphaned forwarder still holding the mirrored port, starts
+   reaps any orphaned forwarder still holding the preferred port, starts
    `ssh -N -L`, waits until the local forward accepts a TCP connection, mints a
    dashboard token on the remote over SSH, and returns the live status plus the
    token. Connect is **idempotent**: an already-connected instance returns its
@@ -738,7 +772,7 @@ whose current variable parts are all charset-bound literals.
 | Iframe is blank or black | The pane's embedded SPA never announced readiness within 15s, so the error panel with **Retry** appears (Retry force-reloads even an identical src). An iframe reports no load error to its parent, so this watchdog is the only signal. |
 | Connect fails with an SSH auth error | Refresh your SSH credentials (re-add the key to `ssh-agent`); `BatchMode` never prompts, so a missing credential is an immediate failure. Tunnels self-heal once auth is restored. |
 | Connect fails for another reason | Use **Diagnose**. The ladder reports the first broken link: `ssh_unreachable` (check SSH access or the host alias), `remote_down` (remote gateway not listening), `not_connected` (SSH and remote are fine, this instance has no tunnel yet: click Connect), or `tunnel_down` (reconnect). |
-| "local port N is already in use" | The forward mirrors the remote port, so two instances cannot share one. Change this instance's remote port (and the remote gateway's own port to match), or stop whatever holds the port. |
+| "local port N is in use and no free loopback port could be allocated" | The preferred port is taken *and* the allocator found nothing free from `tunnel_base_port` upward — every candidate was either bound on a loopback address or committed to another instance. Disconnect instances that no longer need to be live, or lower `instances.tunnel_base_port` to open up range below the crowded band. |
 | Instance keeps dropping | The health probe plus 2-tier self-heal retry over roughly a two-minute window (8 attempts, capped-exponential backoff). Tune `instances.max_recovery_attempts` / `recover_backoff_max_secs` / `probe_failure_threshold`; both recovery values are clamped so they cannot loop indefinitely. If self-heal gives up, diagnosis runs automatically. Check the remote gateway and SSH stability. |
 | A pane vanished from the warm set but its switcher entry is still there | It was LRU-evicted (warm set full). The tunnel is untouched: selecting the crew re-warms it. Raise `instances.warm_set_cap` if you want more panes resident. |
 | Every token mint fails on one remote, though its gateway is healthy | The remote's `~/.local/bin/kirocrew` probably points at an uninstalled checkout. See §12: the run-marker is what makes mint follow the *running* gateway's install. |

--- a/src/kiro_crew/cloud/launch_engine.py
+++ b/src/kiro_crew/cloud/launch_engine.py
@@ -114,13 +114,16 @@ class RealLaunchEngine:
     def _allocate_port(self) -> int:
         """Pick a gateway port this crew can actually be reached on.
 
-        The tunnel forces ``local_port == remote_port`` so the embedded dashboard's
-        Origin matches what the remote gateway trusts, and it hard-fails rather than
-        falling back when that port is busy. Registering every crew on the default
-        5476 therefore produced a crew that could never be connected: the operator's
-        own gateway usually owns 5476, and a second crew would collide with the
-        first. Allocate deterministically upward from the tunnel base, skipping every
-        port the registry already hands out.
+        The tunnel PREFERS ``local_port == remote_port`` so the embedded dashboard's
+        Origin matches what the remote gateway trusts, falling back to an allocated
+        loopback port only when the mirrored one is already bound locally. Handing
+        every crew the default 5476 would therefore still be wrong, just quietly:
+        the operator's own gateway usually owns 5476 and a second crew would collide
+        with the first, so every such crew would connect on a fallback port instead
+        of the one it registered. Allocating a distinct port up front keeps the
+        registered port and the live forward the same in the common case. Allocate
+        deterministically upward from the tunnel base, skipping every port the
+        registry already hands out.
         """
         if self._port:
             return self._port

--- a/src/kiro_crew/instances/port_allocator.py
+++ b/src/kiro_crew/instances/port_allocator.py
@@ -6,15 +6,16 @@ its SSH forward. This allocator hands out the first free port at or above a base
 already bound on the loopback interface or reserved by a caller (e.g. ports the
 registry has already assigned to other instances).
 
-The "in use" probe binds ``127.0.0.1:<port>`` momentarily; a successful bind
-means the port is free. This is advisory — there is an inherent TOCTOU window
-between probing and the tunnel actually binding — so callers should treat a
-returned port as a best-effort suggestion and handle a late bind failure by
-re-allocating.
+The "in use" probe binds the port on every loopback address momentarily; a
+successful bind on all of them means the port is free. This is advisory — there
+is an inherent TOCTOU window between probing and the tunnel actually binding —
+so callers should treat a returned port as a best-effort suggestion and handle a
+late bind failure by re-allocating.
 """
 
 from __future__ import annotations
 
+import errno
 import logging
 import socket
 from collections.abc import Iterable
@@ -27,9 +28,29 @@ logger = logging.getLogger(__name__)
 # and we should fail loudly rather than wander into them.
 _MAX_PORT = 65535
 
+# Loopback addresses a listener on this host can bind independently of each
+# other. A port counts as free only when it is free on ALL of them: ``ssh -L``
+# binds one address, so a process holding the same port on another loopback
+# family leaves ``localhost:<port>`` ambiguous — which socket serves a given
+# connection then depends on name resolution order and on platform bind
+# precedence rather than on anything this process controls. Refusing such a port
+# keeps the forward the only listener reachable at that port.
+_LOOPBACK_PROBE_HOSTS: tuple[str, ...] = ("127.0.0.1", "::1")
 
-def _is_port_free(port: int, host: str = "127.0.0.1") -> bool:
-    """Return True if *port* can be bound on *host* (i.e. it is free).
+# Bind errors that mean "this address does not exist here" rather than "occupied"
+# — a family compiled in but not configured (no ::1), or not supported at all.
+# Nothing can be listening on an address the host cannot assign, so these read as
+# free instead of in use; treating them as in use would refuse every port on a
+# host with IPv6 disabled.
+_ADDRESS_UNUSABLE = frozenset({errno.EADDRNOTAVAIL, errno.EAFNOSUPPORT})
+
+
+def _is_addr_free(port: int, host: str) -> bool:
+    """Return True if *port* can be bound on *host* (i.e. nothing holds it there).
+
+    Single-address primitive behind :func:`_is_port_free`. The socket family is
+    inferred from *host*, so this probes the same address a listener would
+    actually bind rather than assuming IPv4.
 
     Sets ``SO_REUSEADDR`` before probing so this check mirrors what the SSH
     forward listener actually does at bind time — OpenSSH sets ``SO_REUSEADDR``
@@ -48,17 +69,37 @@ def _is_port_free(port: int, host: str = "127.0.0.1") -> bool:
     connected instances) still fails to bind and is correctly reported in use
     (``SO_REUSEADDR`` exempts ``TIME_WAIT`` only, never an active ``LISTEN``).
 
-    A bind failure (``OSError``) is interpreted as "in use / unavailable".
+    A bind failure (``OSError``) is interpreted as "in use / unavailable", except
+    for the errnos in :data:`_ADDRESS_UNUSABLE`, which mean the address itself is
+    not assignable on this host and therefore cannot be occupied.
     """
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    try:
+        sock = socket.socket(family, socket.SOCK_STREAM)
+    except OSError:  # family unsupported: nothing can be listening on it
+        return True
     try:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.bind((host, port))
         return True
-    except OSError:
-        return False
+    except OSError as e:
+        return e.errno in _ADDRESS_UNUSABLE
     finally:
         sock.close()
+
+
+def _is_port_free(port: int, host: str | None = None) -> bool:
+    """Return True if *port* is free on every loopback address, or on *host* alone.
+
+    With no *host* this probes all of :data:`_LOOPBACK_PROBE_HOSTS` and requires
+    every one of them to be free — stricter than a single-family probe on purpose:
+    a port that is free on ``127.0.0.1`` but held on ``::1`` is not safely ours,
+    so it is reported in use. Over-refusing costs the allocator one skipped
+    candidate; under-refusing hands out a port whose traffic can land in another
+    process. Pass *host* to probe one address only.
+    """
+    hosts = _LOOPBACK_PROBE_HOSTS if host is None else (host,)
+    return all(_is_addr_free(port, h) for h in hosts)
 
 
 class PortAllocator:

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -878,14 +878,6 @@ class SshTunnelManager:
         if cancelled is not None:
             raise cancelled
 
-    def _reserved_ports(self) -> set[int]:
-        """Ports already taken: live tunnels + local_port set on any instance."""
-        reserved: set[int] = {t.status.local_port for t in self._tunnels.values()}
-        for inst in self._registry.list():
-            if inst.local_port:
-                reserved.add(inst.local_port)
-        return reserved
-
     def _connect_timeout_for(self, method: str) -> float:
         """Readiness timeout for *method*, honoring an explicit caller override.
 
@@ -935,6 +927,45 @@ class SshTunnelManager:
         except Exception:
             return []
         return out.decode("utf-8", "replace").splitlines()
+
+    def _reserved_ports(self, except_id: str = "") -> set[int]:
+        """Ports already taken: live tunnels + local_port set on any instance.
+
+        Two sources, unioned because neither alone is sufficient: the live tunnels
+        (authoritative for what is bound right now) and the registry's persisted
+        ``local_port`` hints (which cover an instance whose tunnel is momentarily
+        down but which will reclaim its port on reconnect).
+
+        *except_id* omits one instance's own reservation, so a reconnecting
+        instance can reclaim the port it previously held instead of stepping past
+        it. Omitting the argument reserves every port, which is what a caller
+        asking "what is taken?" without a subject wants.
+
+        Feeds :meth:`PortAllocator.allocate`'s ``exclude``. A stale hint naming a
+        now-free port only costs the allocator one skipped candidate, so erring
+        toward exclusion is the safe direction. Registry failure is likewise
+        non-fatal: fewer exclusions is recoverable (the allocator still probes
+        each candidate), while refusing to connect is not.
+
+        Synchronous on purpose, and therefore a frame the loop-offload ratchet in
+        ``test_apps_instances_loop_offload.py`` does not scan: callers on an async
+        path must hand it to ``asyncio.to_thread`` along with the allocation it
+        feeds, because it reads the registry.
+        """
+        reserved: set[int] = set()
+        for inst_id, tunnel in self._tunnels.items():
+            if inst_id == except_id:
+                continue
+            port = getattr(tunnel.status, "local_port", 0)
+            if port:
+                reserved.add(int(port))
+        try:
+            for inst in self._registry.list():
+                if inst.id != except_id and inst.local_port:
+                    reserved.add(int(inst.local_port))
+        except Exception:  # a registry read failure must not block connecting
+            logger.debug("could not read registry for port exclusion", exc_info=True)
+        return reserved
 
     async def _reap_orphan_forwarder(self, local_port: int) -> int:
         """SIGTERM any stale ssh forwarder still holding *local_port*.
@@ -1070,34 +1101,81 @@ class SshTunnelManager:
                 if not cloud_ssm.session_manager_plugin_installed():
                     return self._error_status(inst, cloud_ssm.session_manager_plugin_install_hint())
 
-            # Mirror the local forward port to the remote (configured)
-            # port. The embedded dashboard runs in an iframe at
-            # http://127.0.0.1:<local_port>, and the remote gateway only trusts
-            # CSRF/WebSocket Origins on its own configured port. Forcing
-            # local_port == remote_port keeps the Origin valid without per-instance
-            # allow-listing. Each simultaneously-connected instance must therefore
-            # use a distinct remote port (a local port cannot be bound twice).
+            # The local forward port PREFERS the remote (configured) port, because
+            # a stable, predictable port is worth keeping: the dashboard cookie is
+            # named ``mc_token_<browser-facing port>``, so reconnecting on the same
+            # port reuses the same cookie instead of stranding one per attempt.
+            #
+            # It is a preference, not an invariant. Every layer that sees the
+            # browser-facing port derives it FROM THE REQUEST rather than assuming
+            # the remote gateway's own listen port, so a divergent local port is
+            # already safe end to end:
+            #   * ``check_origin`` accepts a loopback Origin equal to the request
+            #     Host — which is what the embedded iframe sends (it is served at
+            #     the forward's port and opens its WebSocket to that same host);
+            #   * ``build_allowed_hosts`` compares hostname only, port-independent;
+            #   * the parent's CSP ``frame-src`` admits ``http://127.0.0.1:*``;
+            #   * ``frame-ancestors`` keys off ``embed_parent_port`` (the PARENT's
+            #     port), which this does not change;
+            #   * ``_cookie_port_from_host`` keys the cookie by the Host port.
+            # So when the preferred port is unavailable we allocate a free one
+            # rather than refuse the connection: the remote keeps whatever port it
+            # runs on, and two remotes that both serve the same port can be
+            # connected simultaneously through distinct forwards.
             local_port = inst.remote_port
 
             # Clear any orphaned forwarder still holding this port from an
             # unclean prior exit (hard kill bypasses graceful shutdown; macOS has no
-            # parent-death signal) so the new tunnel can bind it.
+            # parent-death signal) so the new tunnel can bind it. Done BEFORE the
+            # free probe so a reclaimable port is still preferred over a new one.
+            #
+            # The port this instance last forwarded is reaped alongside it when it
+            # differs, i.e. when the previous connect fell back to an allocated
+            # port. Its orphan is invisible to the reap above (that one matches the
+            # preferred port's forward signature) and to the allocator, which skips
+            # the still-bound port and climbs to the next one — so without this the
+            # instance strands one forwarder per unclean exit and its port walks
+            # upward on every reconnect.
             if self._reaps_orphans:
                 await self._reap_orphan_forwarder(local_port)
+                previous = int(inst.local_port or 0)
+                if previous and previous != local_port:
+                    await self._reap_orphan_forwarder(previous)
 
-            # Hard-fail with a clear message if the mirrored port is still occupied
-            # (e.g. another instance on the same remote port, or the local gateway).
-            # No dynamic fallback — a different local port would break the
-            # origin match and leave the embedded dashboard unable to stream/act.
             if not _is_port_free(local_port):
-                return self._error_status(
-                    inst,
-                    f"local port {local_port} is already in use. Each connected "
-                    f"instance must use a distinct remote port — change this "
-                    f"instance's remote port (and set that same port on the remote "
-                    f"host's dashboard.url), or disconnect whatever is holding "
-                    f"port {local_port}.",
+                # Occupied by something we do not own (this host's own gateway, an
+                # unrelated process, or another instance forwarding the same remote
+                # port). Fall back to an allocated loopback port, excluding ports
+                # already committed to other instances so two connects cannot race
+                # onto one port.
+                #
+                # Offloaded as ONE callable: the reservation lookup reads the
+                # instances registry and the allocation probes candidate ports with
+                # a socket bind apiece, both synchronous filesystem/syscall work
+                # that the repo keeps off the event loop (see
+                # test_apps_instances_loop_offload.py). Splitting them into two
+                # to_thread hops would also widen the TOCTOU window between
+                # "what is reserved" and "what did we take".
+                try:
+                    allocated = await asyncio.to_thread(
+                        lambda: self._allocator.allocate(
+                            exclude=self._reserved_ports(except_id=inst.id)
+                        )
+                    )
+                except RuntimeError as e:
+                    return self._error_status(
+                        inst,
+                        f"local port {local_port} is in use and no free loopback "
+                        f"port could be allocated: {e}",
+                    )
+                logger.info(
+                    "Instance %s: local port %d unavailable; forwarding %d -> remote %d",
+                    inst.id,
+                    inst.remote_port,
+                    allocated,
+                    inst.remote_port,
                 )
+                local_port = allocated
 
             # Open the tunnel first so the forward is live.
             tunnel = self._tunnel_factory(

--- a/test/test_apps_instances_loop_offload.py
+++ b/test/test_apps_instances_loop_offload.py
@@ -403,3 +403,64 @@ def test_no_direct_registry_call_in_instances_handler_async_frames() -> None:
         if is_reg_name or is_registry_call:
             offenders.append(f"{owner}:{call.lineno} calls registry .{func.attr}() on the loop")
     assert not offenders, "direct registry call on the event loop:\n" + "\n".join(offenders)
+
+
+@pytest.mark.asyncio
+async def test_connect_fallback_allocation_runs_off_the_loop_thread(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The busy-preferred-port fallback allocates on a worker thread.
+
+    When the mirrored port is taken, connect() reserves-and-allocates: a registry
+    read plus one socket bind per candidate port. Both are synchronous, so the
+    whole expression is handed to ``asyncio.to_thread`` as a single callable.
+    Reverting that offload makes the recorded probe thread the loop thread.
+    """
+    import kiro_crew.instances.port_allocator as pa
+    import kiro_crew.instances.ssh_tunnel_manager as stm
+    from kiro_crew.instances.registry import InstancesRegistry
+    from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager, TunnelState
+
+    loop_thread = threading.current_thread()
+    probe_threads: list[threading.Thread] = []
+
+    # The preferred (mirrored) port reads as busy so connect takes the fallback;
+    # every candidate the allocator probes reads as free, and records its thread.
+    monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": False)
+
+    def _recording_probe(port: int, host: str = "127.0.0.1") -> bool:
+        probe_threads.append(threading.current_thread())
+        return True
+
+    monkeypatch.setattr(pa, "_is_port_free", _recording_probe)
+
+    async def _mint(host: str, **_kw: object) -> str:
+        return "TOK"
+
+    class _FakeTunnel:
+        def __init__(self, iid: str, ssh_host: str, lp: int, rp: int, **_kw: object) -> None:
+            from kiro_crew.instances.ssh_tunnel_manager import TunnelStatus
+
+            self.status = TunnelStatus(instance_id=iid, local_port=lp, remote_port=rp)
+
+        async def start(self) -> bool:
+            self.status.state = TunnelState.CONNECTED
+            return True
+
+        async def stop(self) -> None:
+            self.status.state = TunnelState.STOPPED
+
+    reg = InstancesRegistry(path=tmp_path / "instances.json")
+    reg.add(name="CD", ssh_host="cd-1-alias", remote_port=5476, instance_id="cd-1")
+    mgr = SshTunnelManager(
+        reg, base_port=53400, mint_token=_mint, tunnel_factory=_FakeTunnel  # type: ignore[arg-type]
+    )
+
+    status = await mgr.connect("cd-1")
+
+    assert status.state == TunnelState.CONNECTED
+    assert status.local_port == 53400, "the fallback allocation did not happen"
+    assert probe_threads, "the allocator never probed a candidate port"
+    assert all(t is not loop_thread for t in probe_threads), (
+        "the fallback port allocation ran synchronously on the event loop thread"
+    )

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -13,6 +13,7 @@ suite needs no asyncio pytest plugin.
 from __future__ import annotations
 
 import asyncio
+import errno
 import json
 import logging
 import os
@@ -343,6 +344,80 @@ class TestPortAllocator:
         port = s.getsockname()[1]
         s.close()
         assert _is_port_free(port) is True
+
+    @pytest.mark.skipif(not socket.has_ipv6, reason="host has no IPv6 support")
+    def test_is_port_free_rejects_port_held_on_ipv6_loopback_only(self):
+        """A port free on 127.0.0.1 but LISTENing on ::1 counts as in use.
+
+        The forward binds one address, so leaving the other loopback family to a
+        foreign listener makes `localhost:<port>` resolve to whichever socket the
+        client's resolver and the platform's bind precedence pick. The probe must
+        therefore clear every loopback address, not just IPv4.
+        """
+        from kiro_crew.instances.port_allocator import _is_port_free
+
+        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        try:
+            s.bind(("::1", 0))
+        except OSError:  # ::1 not configured on this host
+            s.close()
+            pytest.skip("::1 is not assignable here")
+        s.listen(1)
+        port = s.getsockname()[1]
+        try:
+            # Quick check: the IPv4 half really is free, so only the ::1 half can be
+            # what makes the aggregate probe say "in use".
+            assert _is_port_free(port, "127.0.0.1") is True
+            assert _is_port_free(port) is False
+        finally:
+            s.close()
+
+    def test_is_port_free_treats_unassignable_address_as_free(self, monkeypatch):
+        """EADDRNOTAVAIL means the address does not exist, not that it is taken.
+
+        Without this, a host with IPv6 compiled in but ::1 not configured would
+        see every candidate port as occupied and connect would never allocate one.
+        """
+        import kiro_crew.instances.port_allocator as pa
+
+        real_socket = socket.socket
+
+        def fake_socket(family, type_):
+            sock = real_socket(family, type_)
+            if family == socket.AF_INET6:
+                sock.close()
+
+                class _Unassignable:
+                    def setsockopt(self, *a):
+                        pass
+
+                    def bind(self, *a):
+                        raise OSError(errno.EADDRNOTAVAIL, "Cannot assign address")
+
+                    def close(self):
+                        pass
+
+                return _Unassignable()
+            return sock
+
+        monkeypatch.setattr(pa.socket, "socket", fake_socket)
+
+        s = real_socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        s.close()
+        assert pa._is_port_free(port) is True
+
+    def test_allocate_skips_port_held_on_one_loopback_family(self, monkeypatch):
+        """The allocator climbs past a port the aggregate probe rejects."""
+        import kiro_crew.instances.port_allocator as pa
+
+        base = 41000
+        monkeypatch.setattr(
+            pa, "_is_addr_free", lambda port, host: not (port == base and host == "::1")
+        )
+        assert pa.PortAllocator(base_port=base).allocate() == base + 1
 
 
 # ── token mint ──────────────────────────────────────────────────────────────
@@ -1305,8 +1380,10 @@ Host {host}
 class TestSshTunnelManager:
     @pytest.fixture(autouse=True)
     def _free_ports(self, monkeypatch):
-        # Connect now probes _is_port_free (CSE SEC-016 mirror conflict check).
-        # Keep these unit tests hermetic / independent of the host's real ports.
+        # Connect probes _is_port_free for the preferred (remote) port. Keep these
+        # unit tests hermetic / independent of the host's real ports; the
+        # busy-port fallback path has its own coverage in
+        # TestConnectLocalPortAllocation.
         import kiro_crew.instances.ssh_tunnel_manager as stm
 
         monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
@@ -3585,10 +3662,11 @@ class TestInstancesStartupHooks:
 
 
 class TestPortMirror:
-    """CSE SEC-016: the SSH tunnel's local port mirrors the remote (configured)
-    port so the embedded dashboard's Origin (http://127.0.0.1:<port>) matches the
-    remote gateway's trusted port. Each connected instance must use a distinct
-    remote port; a local bind conflict hard-fails (no dynamic fallback)."""
+    """The SSH tunnel's local port PREFERS the remote (configured) port, so the
+    embedded dashboard keeps a stable, predictable origin (and reuses its
+    `mc_token_<port>` cookie) across reconnects. It is a preference, not an
+    invariant: when the preferred port is already bound locally, connect
+    allocates a free loopback port instead of refusing."""
 
     @staticmethod
     def _mgr(reg, factory, monkeypatch, *, port_free=True):
@@ -3647,26 +3725,37 @@ class TestPortMirror:
         assert reg.get("cd-1").local_port == 7900
 
     @pytest.mark.asyncio
-    async def test_port_conflict_hard_fails(self, tmp_path, monkeypatch):
+    async def test_port_conflict_falls_back_to_allocated_port(self, tmp_path, monkeypatch):
+        """A locally-bound preferred port yields an allocated local port, not an error.
+
+        The forward's REMOTE end is unchanged — only the local end moves — so the
+        remote gateway keeps serving whatever port it was configured for.
+        """
+        import kiro_crew.instances.port_allocator as pa
+        from kiro_crew.instances.constants import DEFAULT_TUNNEL_BASE_PORT
         from kiro_crew.instances.registry import InstancesRegistry
         from kiro_crew.instances.ssh_tunnel_manager import TunnelState
 
         captured: dict = {}
 
         def factory(iid, ssh_host, lp, rp, **k):
-            captured["called"] = True
+            captured["lp"], captured["rp"] = lp, rp
             return _FakeTunnel(iid, ssh_host, lp, rp, **k)
+
+        # Every candidate the allocator probes is free; only the preferred port
+        # (patched via _mgr's port_free=False) is taken.
+        monkeypatch.setattr(pa, "_is_port_free", lambda port, host="127.0.0.1": True)
 
         reg = InstancesRegistry(path=tmp_path / "instances.json")
         reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1", remote_port=7900)
         mgr = self._mgr(reg, factory, monkeypatch, port_free=False)
 
         status = await mgr.connect("cd-1")
-        assert status.state == TunnelState.ERROR
-        assert "already in use" in (status.error or "")
-        assert "distinct remote port" in (status.error or "")
-        # We fail before opening the tunnel — factory never invoked.
-        assert "called" not in captured
+
+        assert status.state == TunnelState.CONNECTED
+        assert captured["lp"] == DEFAULT_TUNNEL_BASE_PORT
+        assert captured["rp"] == 7900
+        assert reg.get("cd-1").local_port == DEFAULT_TUNNEL_BASE_PORT
 
 
 class TestLastError:
@@ -4682,3 +4771,173 @@ class TestSsmExitErrorClassification:
         t = _SshTunnel("dev", "dev-1", 7777, 7777)
         t._stderr_buf = "Permission denied (publickey)."
         assert "ssh auth failed" in t._exit_error(255)
+
+
+class TestConnectLocalPortAllocation:
+    """`connect()` prefers the remote port but falls back to an allocated one.
+
+    The two `_is_port_free` references are deliberately patched INDEPENDENTLY:
+    `ssh_tunnel_manager`'s copy gates the preflight on the preferred port, while
+    `port_allocator`'s copy decides what the fallback allocation finds free. A
+    test that patched only one would not be able to express "preferred port busy,
+    other ports free".
+    """
+
+    def _mgr(self, tmp_path, *, base_port=53400):
+        from kiro_crew.instances.registry import InstancesRegistry
+        from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
+
+        reg = InstancesRegistry(path=tmp_path / "instances.json")
+
+        async def ok_mint(
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
+        ):
+            return "SECRET_TOK"
+
+        captured: list = []
+
+        def factory(iid, ssh_host, lp, rp, **kw):
+            tunnel = _FakeTunnel(iid, ssh_host, lp, rp, **kw)
+            captured.append(tunnel)
+            return tunnel
+
+        mgr = SshTunnelManager(
+            reg, base_port=base_port, mint_token=ok_mint, tunnel_factory=factory
+        )
+        return reg, mgr, captured
+
+    @staticmethod
+    def _patch_ports(monkeypatch, *, busy=(), allocator_free=True):
+        """Mark *busy* ports unavailable to the preflight; set allocator freedom."""
+        import kiro_crew.instances.port_allocator as pa
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+
+        monkeypatch.setattr(
+            stm, "_is_port_free", lambda port, host="127.0.0.1": port not in set(busy)
+        )
+        monkeypatch.setattr(
+            pa, "_is_port_free", lambda port, host="127.0.0.1": bool(allocator_free)
+        )
+
+    @pytest.mark.asyncio
+    async def test_prefers_remote_port_when_free(self, tmp_path, monkeypatch):
+        """A free preferred port is still mirrored — no gratuitous port churn."""
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        self._patch_ports(monkeypatch)
+        reg, mgr, captured = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", remote_port=5476, instance_id="cd-1")
+
+        st = await mgr.connect("cd-1")
+
+        assert st.state == TunnelState.CONNECTED
+        assert st.local_port == 5476
+        assert reg.get("cd-1").local_port == 5476
+
+    @pytest.mark.asyncio
+    async def test_allocates_when_preferred_port_busy(self, tmp_path, monkeypatch):
+        """The local gateway owning the remote port no longer blocks the connect.
+
+        This is the regression this class exists for: a hub whose own dashboard
+        is on 5476 connecting to a remote that also serves 5476.
+        """
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        self._patch_ports(monkeypatch, busy=(5476,))
+        reg, mgr, captured = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", remote_port=5476, instance_id="cd-1")
+
+        st = await mgr.connect("cd-1")
+
+        assert st.state == TunnelState.CONNECTED
+        assert st.local_port == 53400
+        # The forward still targets the remote's real port; only the local end moved.
+        assert captured[0].status.remote_port == 5476
+        assert reg.get("cd-1").local_port == 53400
+
+    @pytest.mark.asyncio
+    async def test_allocation_skips_ports_held_by_other_instances(
+        self, tmp_path, monkeypatch
+    ):
+        """Two instances on the same remote port get DIFFERENT local ports."""
+        self._patch_ports(monkeypatch, busy=(5476,))
+        reg, mgr, _captured = self._mgr(tmp_path)
+        # A sibling already committed the allocator's base port.
+        reg.add(name="Other", ssh_host="other-alias", remote_port=5476, instance_id="other")
+        reg.update("other", local_port=53400)
+        reg.add(name="CD", ssh_host="cd-1-alias", remote_port=5476, instance_id="cd-1")
+
+        st = await mgr.connect("cd-1")
+
+        assert st.local_port == 53401
+
+    @pytest.mark.asyncio
+    async def test_errors_when_no_port_can_be_allocated(self, tmp_path, monkeypatch):
+        """Exhaustion is a clean connect error, not an exception out of connect()."""
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        self._patch_ports(monkeypatch, busy=(5476,), allocator_free=False)
+        reg, mgr, captured = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", remote_port=5476, instance_id="cd-1")
+
+        st = await mgr.connect("cd-1")
+
+        assert st.state == TunnelState.ERROR
+        assert "no free loopback" in st.error
+        # No tunnel was ever spawned for a connect that could not get a port.
+        assert captured == []
+
+    @staticmethod
+    def _record_reaps(mgr):
+        """Enable reaping and capture the ports it is asked to clear.
+
+        The manager only reaps when it owns tunnel spawning (`tunnel_factory is
+        None`), which this class's fake factory disables, so the flag is set back
+        on explicitly to exercise the path.
+        """
+        reaped: list[int] = []
+
+        async def fake_reap(port: int) -> int:
+            reaped.append(int(port))
+            return 0
+
+        mgr._reaps_orphans = True
+        mgr._reap_orphan_forwarder = fake_reap  # type: ignore[method-assign]
+        return reaped
+
+    @pytest.mark.asyncio
+    async def test_reaps_previously_allocated_port_so_it_can_be_reclaimed(
+        self, tmp_path, monkeypatch
+    ):
+        """An orphan on the port this instance last used is cleared too.
+
+        Reaping only the preferred port leaves the previous fallback's forwarder
+        alive; the allocator then finds that port bound, climbs past it, and the
+        instance strands one forwarder and one port per unclean exit.
+        """
+        self._patch_ports(monkeypatch, busy=(5476,))
+        reg, mgr, _captured = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", remote_port=5476, instance_id="cd-1")
+        # A prior connect fell back to 53400 and exited uncleanly.
+        reg.update("cd-1", local_port=53400)
+        reaped = self._record_reaps(mgr)
+
+        st = await mgr.connect("cd-1")
+
+        assert reaped == [5476, 53400]
+        # With the orphan cleared the instance reclaims its old port instead of
+        # creeping to the next one.
+        assert st.local_port == 53400
+
+    @pytest.mark.asyncio
+    async def test_does_not_reap_the_preferred_port_twice(self, tmp_path, monkeypatch):
+        """No redundant reap when the persisted port IS the preferred one."""
+        self._patch_ports(monkeypatch)
+        reg, mgr, _captured = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", remote_port=5476, instance_id="cd-1")
+        reg.update("cd-1", local_port=5476)
+        reaped = self._record_reaps(mgr)
+
+        await mgr.connect("cd-1")
+
+        assert reaped == [5476]


### PR DESCRIPTION
## Problem / Motivation

Instance connect set `local_port = inst.remote_port` unconditionally and refused to connect when that port was already bound locally:

```
local port 5476 is already in use. Each connected instance must use a distinct
remote port — change this instance's remote port (and set that same port on the
remote host's dashboard.url), or disconnect whatever is holding port 5476.
```

Both ends default to 5476, so the out-of-the-box case is a hub whose **own** gateway owns the port it needs for the remote. Two remotes serving the same port could also never be connected at the same time.

## Why it matters

The only workaround was to change the **remote's** port to resolve a purely **local** conflict — reconfiguring and restarting a gateway on another host, then keeping `dashboard.url` in sync with it. Anyone connecting their first instance with both sides on the default port hits this, and the error text sends them to fix the wrong machine.

## What changed (motivation → approach → change)

Goal: a local bind conflict should be resolved locally, without touching the remote.

Approach: keep mirroring as a *preference* rather than an invariant. Mirroring is worth preferring — the dashboard cookie is `mc_token_<browser-facing port>`, so a stable port reuses one cookie instead of stranding one per attempt — but it is not load-bearing for correctness, because every layer that sees the browser-facing port already derives it **from the request** rather than from the remote gateway's listen port:

| Layer | Why a divergent local port is already safe |
|---|---|
| `check_origin` | Accepts a loopback `Origin` equal to the request `Host` — exactly what the embedded iframe sends |
| `build_allowed_hosts` | Compares hostname only; port-independent by design |
| CSP `frame-src` | Admits `http://127.0.0.1:*` |
| CSP `frame-ancestors` | Keys off `embed_parent_port` (the *parent's* port), untouched here |
| Session cookie | `_cookie_port_from_host` keys by the `Host` port — its docstring already cites SSH tunnels as the reason |

Change: when the preferred port is unavailable, `connect()` allocates a free loopback port from the existing `PortAllocator` (based at `instances.tunnel_base_port`) instead of failing, excluding ports already committed to other instances so two connects cannot race onto one port. Connect now fails only when no loopback port can be allocated at all. This also puts `PortAllocator` on the connect path — it was previously constructed but never used, leaving `instances.tunnel_base_port` configuring nothing.

Two review findings from the first revision are folded in:

- **Reservation lookup and allocation are offloaded together** via `asyncio.to_thread` as a single callable. Both are synchronous (a registry read, then a socket bind per candidate port), and `test/test_apps_instances_loop_offload.py` establishes that this class of work is kept off the event loop as a house convention. One hop rather than two also keeps the window between "what is reserved" and "what did we take" as narrow as possible.
- **No duplicate helper.** The lookup reuses the existing `_reserved_ports`, which had no production caller, rather than adding a second spelling of it; it gains an `except_id` filter so a reconnecting instance can reclaim the port it previously held. `launch_engine._allocate_port`'s docstring documented the old hard-fail-only behaviour and is corrected in the same commit.

No token claim, no new config key, no env var, and no widening of any allowlist.

## Tests

- `test/test_instances.py` — `TestConnectLocalPortAllocation` covers the preferred port being used when free, allocation when it is busy, allocation skipping ports held by other instances, and a clean error with no tunnel spawned when allocation is exhausted. The two `_is_port_free` references are patched independently so "preferred busy, others free" is expressible.
- `TestPortMirror::test_port_conflict_hard_fails` pinned the old contract and is replaced by `test_port_conflict_falls_back_to_allocated_port`, which also asserts the forward's **remote** end is unchanged.
- `test/test_apps_instances_loop_offload.py` — new `test_connect_fallback_allocation_runs_off_the_loop_thread` records the thread each candidate-port probe runs on and asserts none is the loop thread, so reverting the offload fails the test. It sits in the file that owns that convention rather than in a new place.
- **5130 passed / 30 skipped** across the 67 test files referencing instances, ssh_tunnel_manager or launch_engine. isort, flake8 and `scripts/docs-lint.sh` clean; mypy clean for changed files (the 3 remaining errors are pre-existing `os.getxattr`/`setxattr` calls in untouched `hooks.py`, Linux-only APIs flagged on macOS).

## Manual verification

Verified end-to-end against a real remote before and after: hub gateway on 5476, remote gateway on 5476, instance `remote_port: 5476`. Previously the hard error above. Now the forward comes up on the allocated port, the gateway logs `local port 5476 unavailable; forwarding <allocated> -> remote 5476`, and the embedded pane loads and streams — which is what actually exercises the origin, Host, cookie and CSP layers rather than only my reading of them.

## Related Issues

None filed — reported and reproduced directly.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Placeholder in the repository template pending OSPO/Legal wording; nothing to sign here yet. I agree to whatever CLA is published for this repository.
