### PR TITLE
fix(build): retry electron-builder on transient network failures, not just ENOTEMPTY

### DIFF
--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -173,6 +173,69 @@ rm_rf_resilient() {
   done
 }
 
+# Invoke electron-builder. Split into its own function purely so a test can
+# shadow it with a stub -- CSC_IDENTITY_AUTO_DISCOVERY=false disables macOS
+# codesign identity auto-discovery for local/CI builds.
+_eb_invoke() {
+  CSC_IDENTITY_AUTO_DISCOVERY=false ./node_modules/.bin/electron-builder "$@"
+}
+
+# Run electron-builder (EB_ARGS as "$@"), retrying a bounded number of times
+# on two transient failure classes -- and still failing the build on anything
+# else, or once the retry budget is exhausted:
+#
+#   - macOS .DS_Store/ENOTEMPTY temp-dir race (electron-userland/electron-builder#6890):
+#     the universal build's lipo-merge stage removes dist/mac-universal-<arch>-temp
+#     dirs with a recursive fs.rm that has no retries of its own, and Desktop
+#     Services (Finder/Spotlight) can drop a fresh .DS_Store into one mid-removal.
+#   - transient network/TLS failures in electron-builder's OWN mid-build
+#     fetches: the AppImage and NSIS/Squirrel targets pull their own tooling
+#     through `got` AFTER the electron zip has already reported
+#     progress=100%. A dropped connection ("socket hang up") or a
+#     TLS-intercepted response ("self-signed certificate") aborts the whole
+#     build there. These are per-execution network events, not build errors --
+#     the same commit passes on a plain re-run, and one matrix leg can fail
+#     while its siblings go green in the same attempt (#3088).
+#
+# Split out of the packaging step (rather than left inline) so the
+# retry/classification logic is testable in isolation, mirroring
+# rm_rf_resilient above: a test extracts this function's body, shadows
+# _eb_invoke with a stub that fails N times, and asserts the real retry/
+# classification logic here recovers (or correctly gives up).
+run_electron_builder_with_retry() {
+  local attempt=1 max_attempts=3 eb_log eb_transient eb_backoff
+  while : ; do
+    eb_log="$(mktemp "${TMPDIR:-/tmp}/kc-eb.XXXXXX")"
+    if _eb_invoke "$@" 2>&1 | tee "$eb_log"; then
+      rm -f "$eb_log"; return 0
+    fi
+    # Classify the failure before deciding: each transient class needs its
+    # own cleanup, and anything unrecognised must still abort on the first
+    # failure.
+    eb_transient=""
+    if grep -q "ENOTEMPTY" "$eb_log"; then
+      eb_transient="ds_store"
+    elif grep -qE "socket hang up|self[- ]signed certificate|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND" "$eb_log"; then
+      eb_transient="network"
+    fi
+    if [ -n "$eb_transient" ] && [ "$attempt" -lt "$max_attempts" ]; then
+      if [ "$eb_transient" = "ds_store" ]; then
+        echo "  ⚠ macOS .DS_Store/ENOTEMPTY temp-dir race (attempt $attempt/$max_attempts); sweeping .DS_Store and retrying…" >&2
+        find dist -name .DS_Store -delete 2>/dev/null || true
+        rm -rf dist/*-temp 2>/dev/null || true
+        eb_backoff=2
+      else
+        echo "  ⚠ transient network/TLS failure in an electron-builder fetch (attempt $attempt/$max_attempts); retrying…" >&2
+        eb_backoff=$((attempt * 10))
+      fi
+      rm -f "$eb_log"; attempt=$((attempt + 1)); sleep "$eb_backoff"; continue
+    fi
+    rm -f "$eb_log"
+    echo "❌ electron-builder failed (not a known transient class, or retries exhausted)." >&2
+    return 1
+  done
+}
+
 # --- 1. Frontend ------------------------------------------------------------
 if [ "${SKIP_FRONTEND:-0}" != "1" ]; then
   log "Building dashboard (npm)…"
@@ -614,40 +677,18 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
   # per target, and clearing between them would delete the previous artifact.
   rm_rf_resilient dist
 
-  # One electron-builder invocation, with the macOS .DS_Store/ENOTEMPTY retry:
-  # electron-builder's universal step stages each arch into
-  # dist/mac-universal-<arch>-temp, lipo-merges them, then removes the temp
-  # dirs with a recursive fs.rm. If macOS Desktop Services (Finder/Spotlight)
-  # drops a .DS_Store into a temp dir *during* that removal, Node's fs.rm --
-  # which performs no retries -- fails the final rmdir with ENOTEMPTY and the
-  # whole build aborts (electron-userland/electron-builder#6890). It is a
-  # transient race, so retry from a swept, clean dir a bounded number of times.
-  eb_run() {
-    local attempt=1 max_attempts=3 eb_log
-    while : ; do
-      eb_log="$(mktemp "${TMPDIR:-/tmp}/kc-eb.XXXXXX")"
-      if CSC_IDENTITY_AUTO_DISCOVERY=false ./node_modules/.bin/electron-builder "$@" 2>&1 | tee "$eb_log"; then
-        rm -f "$eb_log"; return 0
-      fi
-      if grep -q "ENOTEMPTY" "$eb_log" && [ "$attempt" -lt "$max_attempts" ]; then
-        echo "  ⚠ macOS .DS_Store/ENOTEMPTY temp-dir race (attempt $attempt/$max_attempts); sweeping .DS_Store and retrying…" >&2
-        find dist -name .DS_Store -delete 2>/dev/null || true
-        rm -rf dist/*-temp 2>/dev/null || true
-        rm -f "$eb_log"; attempt=$((attempt + 1)); sleep 2; continue
-      fi
-      rm -f "$eb_log"
-      echo "❌ electron-builder failed (not the .DS_Store race, or retries exhausted)." >&2
-      exit 1
-    done
-  }
-
+  # Each electron-builder invocation below goes through
+  # run_electron_builder_with_retry (defined above, alongside rm_rf_resilient)
+  # so the macOS .DS_Store/ENOTEMPTY race AND transient network/TLS failures
+  # in electron-builder's own mid-build fetches are both retried, not just
+  # the former.
   if [ "$OS" = "darwin" ]; then
     EB_ARGS+=( --mac )
     [ "$UNIVERSAL" = "1" ] && EB_ARGS+=( --universal )
-    eb_run "${EB_ARGS[@]}"
+    run_electron_builder_with_retry "${EB_ARGS[@]}"
   elif [ "$OS" = "windows" ]; then
     EB_ARGS+=( --win )
-    eb_run "${EB_ARGS[@]}"
+    run_electron_builder_with_retry "${EB_ARGS[@]}"
   else
     # One invocation PER FORMAT, each preceded by its own beacon stamp, so the
     # AppImage and the deb do not both claim the label of whichever was built
@@ -658,7 +699,7 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
       target="${pair%%:*}"; dist="${pair##*:}"
       log "Packaging Linux ${target} (dist=${dist})…"
       restamp_backends "$dist"
-      eb_run "${EB_ARGS[@]}" --linux "$target"
+      run_electron_builder_with_retry "${EB_ARGS[@]}" --linux "$target"
     done
   fi
 )

--- a/test/test_build_desktop_electron_retry.py
+++ b/test/test_build_desktop_electron_retry.py
@@ -1,0 +1,182 @@
+"""Regression guard for the electron-builder retry loop in
+``packaging/build-desktop.sh`` (#3088).
+
+Background
+----------
+``Build Desktop`` used to abort on the FIRST failure of any kind unless the
+electron-builder log matched the literal string ``ENOTEMPTY`` (the macOS
+``.DS_Store`` temp-dir race, electron-builder#6890). Every other transient,
+per-execution failure — a dropped connection ("socket hang up") or a
+TLS-intercepted response ("self-signed certificate") from electron-builder's
+own mid-build fetches (the AppImage/NSIS/Squirrel tooling, pulled AFTER the
+electron zip itself has already downloaded) — fell straight through to
+``exit 1`` with zero retries, even though the same commit reliably passed on
+a plain re-run.
+
+``run_electron_builder_with_retry`` classifies a failure into one of two
+transient classes (each with its own cleanup/backoff) or "unknown", and only
+the two known classes get a bounded retry; anything else — or the budget
+being exhausted — still fails the build, exactly as before.
+
+Why this test exists
+---------------------
+The real failures are per-execution network/TLS events and can't be
+reproduced deterministically. What CAN be tested deterministically is the
+retry/classification logic itself: shadow ``_eb_invoke`` (the sole point
+where the real ``electron-builder`` binary is invoked) with a stub that fails
+N times with a chosen error string, and assert the real loop above it
+retries the right number of times and reaches the right outcome.
+
+The function body is extracted from the shipped script (not copied), so the
+test tracks the real source of truth, mirroring
+``test_build_desktop_rm_resilient.py``'s approach to ``rm_rf_resilient``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="run_electron_builder_with_retry is a POSIX bash helper"
+)
+
+SCRIPT = Path(__file__).parent.parent / "packaging" / "build-desktop.sh"
+
+
+def _extract_function(name: str) -> str:
+    text = SCRIPT.read_text()
+    m = re.search(rf"^{re.escape(name)}\(\) \{{.*?^\}}", text, re.DOTALL | re.MULTILINE)
+    assert m, f"{name}() not found in packaging/build-desktop.sh"
+    return m.group(0)
+
+
+def _run(stub_calls: str, harness: str, tmp_path: Path) -> subprocess.CompletedProcess:
+    """Run a bash snippet with a stubbed ``_eb_invoke`` and the real retry
+    function sourced above it. ``sleep`` is a no-op so the real backoff
+    (``attempt * 10`` seconds for the network class) doesn't slow the suite.
+    """
+    script = (
+        "set -uo pipefail\n"  # not -e: the harness itself checks $? after the call
+        "sleep() { :; }\n"
+        f"{stub_calls}\n"
+        f"{_extract_function('run_electron_builder_with_retry')}\n"
+        f"{harness}"
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        # The child is the bash snippet assembled above, so its output encoding
+        # is ours to know: pin UTF-8 rather than inheriting the locale (the
+        # Windows ANSI code page) via bare text=True.
+        encoding="utf-8",
+        timeout=30,
+    )
+
+
+def _counting_stub(tmp_path: Path, fail_times: int, error_line: str) -> tuple[str, Path]:
+    """A ``_eb_invoke`` stub that fails ``fail_times`` times with
+    ``error_line`` on stderr, then succeeds."""
+    counter = tmp_path / "calls"
+    counter.write_text("")
+    stub = f"""
+_eb_invoke() {{
+  printf 'x' >> "{counter}"
+  n=$(wc -c < "{counter}" | tr -d ' ')
+  if [ "$n" -le {fail_times} ]; then
+    echo "{error_line}" >&2
+    return 1
+  fi
+  return 0
+}}
+"""
+    return stub, counter
+
+
+class TestElectronBuilderRetryWiring:
+    def test_packaging_step_calls_the_retry_function(self) -> None:
+        """A revert to a bare/inline electron-builder invocation must fail
+        here, not just silently drop the retry+classification logic."""
+        text = SCRIPT.read_text()
+        assert "run_electron_builder_with_retry() {" in text
+        assert re.search(
+            r'(?m)^\s*run_electron_builder_with_retry\s+"\$\{EB_ARGS\[@\]\}"\s*$', text
+        ), "packaging step must call run_electron_builder_with_retry with EB_ARGS"
+        # And the old bare-loop call site must be gone.
+        assert './node_modules/.bin/electron-builder "${EB_ARGS[@]}" 2>&1 | tee' not in text
+
+
+class TestTransientClassesRetry:
+    def test_retries_on_ds_store_enotempty(self, tmp_path: Path) -> None:
+        (tmp_path / "dist").mkdir()
+        stub, counter = _counting_stub(
+            tmp_path, fail_times=1, error_line="Error: ENOTEMPTY: directory not empty"
+        )
+        proc = _run(stub, 'run_electron_builder_with_retry; echo "EXIT=$?"', tmp_path)
+        assert "EXIT=0" in proc.stdout, proc.stdout + proc.stderr
+        assert len(counter.read_text()) == 2, "must retry exactly once then succeed"
+
+    @pytest.mark.parametrize(
+        "error_line",
+        [
+            "RequestError: socket hang up",
+            "self-signed certificate; if the root CA is installed locally, try running Node.js with --use-system-ca",
+            "Error: connect ECONNRESET",
+            "Error: connect ETIMEDOUT",
+        ],
+    )
+    def test_retries_on_transient_network_failure(self, tmp_path: Path, error_line: str) -> None:
+        (tmp_path / "dist").mkdir()
+        stub, counter = _counting_stub(tmp_path, fail_times=1, error_line=error_line)
+        proc = _run(stub, 'run_electron_builder_with_retry; echo "EXIT=$?"', tmp_path)
+        assert "EXIT=0" in proc.stdout, proc.stdout + proc.stderr
+        assert len(counter.read_text()) == 2
+
+    def test_gives_up_after_max_attempts_on_known_transient_class(self, tmp_path: Path) -> None:
+        """A PERSISTENT outage (every attempt fails) must still fail the
+        build once the retry budget (3 attempts) is exhausted -- this is not
+        a mask, only a bounded number of extra tries."""
+        (tmp_path / "dist").mkdir()
+        stub, counter = _counting_stub(
+            tmp_path, fail_times=99, error_line="RequestError: socket hang up"
+        )
+        proc = _run(stub, 'run_electron_builder_with_retry; echo "EXIT=$?"', tmp_path)
+        assert "EXIT=1" in proc.stdout, proc.stdout + proc.stderr
+        assert len(counter.read_text()) == 3, "must stop at max_attempts, not retry forever"
+
+    def test_does_not_retry_an_unrecognised_failure(self, tmp_path: Path) -> None:
+        """A genuine build error (e.g. a real packaging/config mistake) must
+        abort on its FIRST occurrence with no retries -- only the two known
+        transient classes get a second chance."""
+        (tmp_path / "dist").mkdir()
+        stub, counter = _counting_stub(
+            tmp_path, fail_times=99, error_line="Error: Cannot find module 'some-broken-config-key'"
+        )
+        proc = _run(stub, 'run_electron_builder_with_retry; echo "EXIT=$?"', tmp_path)
+        assert "EXIT=1" in proc.stdout, proc.stdout + proc.stderr
+        assert len(counter.read_text()) == 1, "an unrecognised error must not be retried at all"
+
+    def test_forwards_eb_args_to_the_real_invocation(self, tmp_path: Path) -> None:
+        """EB_ARGS must reach electron-builder unmangled through the retry
+        wrapper."""
+        seen = tmp_path / "seen_args"
+        stub = f"""
+_eb_invoke() {{
+  printf '%s\\n' "$@" > "{seen}"
+  return 0
+}}
+"""
+        (tmp_path / "dist").mkdir()
+        proc = _run(
+            stub,
+            'run_electron_builder_with_retry --mac "-c.extraMetadata.version=1.2.3"; echo "EXIT=$?"',
+            tmp_path,
+        )
+        assert "EXIT=0" in proc.stdout, proc.stdout + proc.stderr
+        assert seen.read_text().splitlines() == ["--mac", "-c.extraMetadata.version=1.2.3"]


### PR DESCRIPTION
## Problem / Motivation

`Build Desktop` is a required check on every PR, and it aborts on the **first**
transient network failure with zero retries.

`packaging/build-desktop.sh` already had a bounded retry loop around
`electron-builder`, but its predicate was a single literal `grep -q "ENOTEMPTY"`
— it recognised exactly one transient class, the macOS `.DS_Store`/`ENOTEMPTY`
temp-dir race ([electron-builder#6890](https://github.com/electron-userland/electron-builder/issues/6890)).
Every other per-execution failure fell straight through to `exit 1`.

The observable symptom, as reported in #3088: the **same commit** goes red and
then green with no code change, and a single matrix leg fails while its siblings
pass **in the same attempt**. Both are signatures of a per-execution event, not a
build error.

## Why it matters

A dropped connection during CI reds a required check on an otherwise-good
commit. Because the failure is per-execution, the only remedy today is for a
contributor (or a maintainer) to re-run the job until it happens to pass.

The cost is repo-wide, not per-PR:

- Contributors learn to re-run a red `Build Desktop` reflexively, which is
  exactly the habit that lets a *real* packaging regression slide by as "just
  another flake".
- Every re-run repeats a full desktop build (~8 minutes per leg), so the CI
  minutes are spent re-doing work that already succeeded.
- Fork PRs pay double: their runs need maintainer approval, so each re-run costs
  a human round-trip too.

## What changed (motivation → approach → change)

**Symptom → root cause.** `electron-builder` fetches more than the Electron zip.
The AppImage and NSIS/Squirrel targets pull their own tooling through `got`
*after* the Electron download has already reported `progress=100%`. A dropped
connection (`socket hang up`) or a TLS-intercepted response
(`self-signed certificate`) at that point aborts the whole build. So the failure
lands in a code path the existing retry loop deliberately did not cover: the
predicate was written for a macOS filesystem race and never widened when the
network-fetch stages were added.

**Approach.** Two deliberate choices, both following what this file already does:

1. **Extract, don't extend inline.** The retry loop was a nested `eb_run()`
   defined inside the packaging step's subshell, so it was unreachable from a
   test. It is now `run_electron_builder_with_retry()` at file scope, next to the
   existing `rm_rf_resilient()` helper — the same pattern this script already
   uses for "bounded retry around a flaky operation", and the reason
   `rm_rf_resilient` has unit tests while `eb_run` had none.
2. **Classify, then decide.** Rather than widening one regex into a catch-all,
   the failure is classified first and each class carries its own cleanup and
   backoff. A catch-all would have made "unrecognised error" unreachable, which
   is the branch that keeps this from being a mask.

**Change.**

- Added `run_electron_builder_with_retry()`, which classifies a failure into
  `ds_store` (`ENOTEMPTY`) or `network` (`socket hang up`,
  `self-signed certificate`, `ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`,
  `ENOTFOUND`), then:
  - `ds_store` — sweeps `.DS_Store` and `dist/*-temp`, flat 2s backoff (unchanged
    from before).
  - `network` — no cleanup needed, `attempt * 10`s backoff, because a network
    blip needs time to clear where a filesystem race does not.
  - anything else — **returns 1 on the first failure, with zero retries.**
- Both classes share the pre-existing bounded budget of **3 attempts**; once it
  is exhausted the build fails.
- Split the real invocation into `_eb_invoke()` purely so a test can shadow it.
- Repointed all three call sites (macOS, Windows, and the per-format Linux loop)
  at the new helper and deleted the old inline loop.

**This is not a threshold widen or a mask.** A genuine build error still fails on
its first occurrence with no retries; a persistent outage still fails once the
budget is spent. And the retry cannot hide a corrupted or tampered download:

- It wraps the **entire** `electron-builder` invocation, so whatever integrity
  verification `electron-builder` performs on its own downloads re-runs in full
  on every attempt. Nothing is skipped, cached past verification, or reused from
  the aborted attempt.
- A checksum/integrity error matches **neither** transient class, so it takes the
  unrecognised-error branch and fails closed on attempt 1.
- No TLS verification is weakened anywhere: the diff adds no
  `NODE_TLS_REJECT_UNAUTHORIZED`, no `--insecure`, no `strict-ssl=false`.
  Retrying `self-signed certificate` re-validates the certificate on each
  attempt — a persistent interception exhausts the budget and fails the build.

`set -euo pipefail` is in force, so `_eb_invoke "$@" 2>&1 | tee "$eb_log"`
propagates `electron-builder`'s exit status rather than `tee`'s.

## Tests

`test/test_build_desktop_electron_retry.py` — 9 tests. Real network failures are
per-execution and cannot be reproduced deterministically, but the
retry/classification logic can be: the test **extracts the function body from the
shipped script** (rather than copying it) and shadows `_eb_invoke` with a stub
that fails N times with a chosen error string, so the assertions run against the
real logic and cannot drift from it.

What each locks in:

| Test | Behavior |
|---|---|
| `test_packaging_step_calls_the_retry_function` | The packaging step calls the helper with `EB_ARGS`, and the old bare inline loop is gone |
| `test_retries_on_ds_store_enotempty` | The pre-existing `ENOTEMPTY` class still retries and recovers |
| `test_retries_on_transient_network_failure` (×4) | Recovers on `socket hang up`, `self-signed certificate`, `ECONNRESET`, `ETIMEDOUT` |
| `test_gives_up_after_max_attempts_on_known_transient_class` | A *persistent* transient error stops at exactly 3 attempts and still fails the build |
| `test_does_not_retry_an_unrecognised_failure` | An unrecognised error fails on attempt 1 with **zero** retries |
| `test_forwards_eb_args_to_the_real_invocation` | `EB_ARGS` pass through the wrapper unmangled |

**Mutation-verified in both directions**, so these tests are known to fail when
the fix is absent:

- Against the pre-fix script (`packaging/build-desktop.sh` from `main`): **9/9
  fail**.
- Against a targeted mutant that narrows only the network regex back to matching
  nothing: **exactly the 5 network-class tests fail**, while the `ENOTEMPTY`,
  unrecognised-error, `EB_ARGS`, and wiring tests still pass — confirming the
  suite locks in the classification widening specifically, not merely the rename.

Also run: `pytest test/test_build_desktop_electron_retry.py
test/test_build_desktop_rm_resilient.py
test/test_build_desktop_launcher_symlink.py test/test_build_target_parity.py` —
**27 passed**. `bash -n packaging/build-desktop.sh` clean;
`black` / `flake8` / `isort` / `mypy` clean on the new test file.

## Manual verification

N/A for the failure itself — a transient network fault is per-execution and
cannot be induced on demand, which is why the logic is covered by the stubbed
unit tests above rather than by a manual repro.

The unchanged happy path *is* covered end-to-end by CI: `Build Desktop`
(`ubuntu-22.04` and `ubuntu-22.04-arm`) and `Linux Packaging (build +
smoke-install)` run the real `electron-builder` through the new helper on every
attempt, so a regression in the wrapper's argument forwarding or exit-status
handling would fail those checks rather than passing silently.

## Related Issues

Fixes #3088

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, the helper is documented in-file where the previous inline loop was
- [x] No secrets, credentials, or internal references in the diff
