### PR TITLE
fix(dashboard): reject unknown theme-pack font role at install

### DIFF
--- a/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
+++ b/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
@@ -63,8 +63,11 @@ a level-0 pack shipping a font is refused.
   are rejected at install and dropped at runtime (CSS-escape evasions included).
   A `font-family` on ONE allowlisted surface (e.g. `.topbar`) is fine.
 - Ship the font's license file in the pack source (OFL/Apache/MIT).
-- KNOWN TRAP: a wrong role *string* (e.g. `"monospace"`) silently coerces to
-  `sans` — the mono face lands on the Sans option.
+- Only `"sans"` and `"mono"` are valid; a wrong role *string* (e.g. the CSS
+  keyword `"monospace"`) is **rejected at install** with an error naming the
+  font and the bad value. An already-installed pack whose role predates this
+  check keeps loading — the coercion-to-`sans` behavior only remains on that
+  read path, never on a fresh install.
 
 ## variables.json — the palette
 

--- a/src/kiro_crew/dashboard/theme_validate.py
+++ b/src/kiro_crew/dashboard/theme_validate.py
@@ -1111,11 +1111,13 @@ def _validate_theme_dir(
     ``_validate_theme_data`` for the colour values so the 43-var allowlist and
     per-value CSS sanitisation match editor-created themes.
 
-    ``installing`` marks the install path, where a pack may still be REFUSED for
-    pinning the UI font in ``overrides.css``. This function also runs when an
-    already-installed pack is re-read (the theme-detail route), and a pack that
-    predates that rule must keep loading there — so the font-pin layer is opt-in
-    rather than applied to every read. See ``_validate_overrides_css``.
+    ``installing`` marks the install path, where a pack may still be REFUSED
+    for pinning the UI font in ``overrides.css``, or for a ``fonts`` entry
+    declaring an unrecognised ``role``. This function also runs when an
+    already-installed pack is re-read (the theme-detail route), and a pack
+    that predates either rule must keep loading there — so both layers are
+    opt-in rather than applied to every read. See ``_validate_overrides_css``
+    and ``_theme_asset_descriptor``.
     """
     if not path.is_dir() or path.is_symlink():
         return None, "theme path is not a directory"
@@ -1160,6 +1162,42 @@ def _validate_theme_dir(
     emoji = manifest.get("emoji", _THEME_DEFAULT_EMOJI)
     if not isinstance(emoji, str):
         return None, "theme.json 'emoji' must be a string"
+
+    # Font role: reject an unrecognised value at INSTALL time only. The read
+    # path (`_theme_asset_descriptor`, which this function also feeds when an
+    # already-installed pack is re-read by the theme-detail route) stays
+    # lenient and coerces an unknown role to "sans" -- only an absent `role`
+    # is the deliberate default case; an explicit ``null`` is rejected.
+    # Rejecting it only at install
+    # keeps a pack that predates this rule loading, matching the font-pin
+    # check below. "monospace" (the CSS keyword) is the likeliest typo for
+    # exactly the role most likely to be mistyped, and the failure is
+    # otherwise silent: the mono face quietly renders as Sans while Mono keeps
+    # the built-in JetBrains Mono (#2750).
+    if installing:
+        fonts_manifest = manifest.get("fonts")
+        if isinstance(fonts_manifest, list):
+            for f in fonts_manifest:
+                if not isinstance(f, dict):
+                    continue
+                # Skip only a genuinely ABSENT role (the deliberate
+                # default case). An explicit JSON `null` is a present,
+                # non-string value and falls through to rejection like any
+                # other bad role, instead of silently coercing to "sans".
+                if "role" not in f:
+                    continue
+                role = f["role"]
+                # isinstance FIRST, same as the read path: `role in
+                # _THEME_FONT_ROLES` against an unhashable value (a list, a
+                # dict) raises TypeError before the membership test runs.
+                if isinstance(role, str) and role in _THEME_FONT_ROLES:
+                    continue
+                fam = f.get("family")
+                fam_label = fam if isinstance(fam, str) and fam else "<unnamed>"
+                return None, (
+                    f"font entry '{fam_label}' has role {role!r}; "
+                    "valid roles are 'sans' and 'mono'"
+                )
 
     max_entries = _THEME_ENTRIES_BY_LEVEL.get(level, 160)
     max_total = _THEME_TOTAL_BYTES_BY_LEVEL.get(level, 5 * 1024 * 1024)

--- a/test/test_theme_install.py
+++ b/test/test_theme_install.py
@@ -1386,6 +1386,100 @@ class TestFontRoles:
         assert len(_theme_asset_descriptor(d, manifest, 1)["fonts"]) == 6
 
 
+class TestFontRoleRejectedAtInstall:
+    """A `fonts` entry whose `role` is neither "sans" nor "mono" is REFUSED at
+    install (`installing=True`) instead of silently coercing to "sans".
+    "monospace" (the CSS keyword) is the likeliest typo for exactly the role
+    most likely to be mistyped, and `_theme_asset_descriptor`'s lenient
+    coercion (covered by `TestFontRoles` above, which must keep passing
+    unchanged) made the failure silent: the mono face renders as Sans while
+    Mono keeps the built-in JetBrains Mono (#2750). Unlike that read path,
+    `_validate_theme_dir` reads `theme.json` from disk, so these build a real
+    on-disk pack rather than passing an in-memory manifest."""
+
+    def _pack_with_font_role(self, tmp_path: Path, role: object) -> Path:
+        d = tmp_path / "role-pack"
+        d.mkdir(parents=True, exist_ok=True)
+        _write(
+            d / "theme.json",
+            {
+                "slug": "role-pack",
+                "name": "Role Pack",
+                "emoji": "🎨",
+                "level": 1,
+                "formatVersion": 1,
+                "fonts": [{"family": "Manrope", "file": "sans.ttf", "role": role}],
+            },
+        )
+        _write(d / "variables.json", _VALID_VARS)
+        (d / "styles" / "fonts").mkdir(parents=True, exist_ok=True)
+        (d / "styles" / "fonts" / "sans.ttf").write_bytes(_TTF)
+        return d
+
+    def test_unknown_role_rejected_at_install(self, tmp_path: Path) -> None:
+        d = self._pack_with_font_role(tmp_path, "monospace")
+        summary, err = _validate_theme_dir(d, installing=True)
+        assert summary is None
+        assert err is not None
+        assert "Manrope" in err
+        assert "monospace" in err
+        assert "'sans' and 'mono'" in err
+
+    def test_unknown_role_tolerated_on_re_read(self, tmp_path: Path) -> None:
+        # The theme-detail route re-runs this validator for every installed
+        # pack on read (installing=False, the default). A pack that predates
+        # this rule -- or installed before a narrower rule existed -- must
+        # keep loading there rather than 500ing and dropping out of the theme
+        # map, mirroring the font-pin rule's own install-only enforcement.
+        d = self._pack_with_font_role(tmp_path, "monospace")
+        summary, err = _validate_theme_dir(d)
+        assert err is None, err
+        assert summary is not None
+
+    @pytest.mark.parametrize("role", ["sans", "mono"])
+    def test_valid_roles_accepted_at_install(self, tmp_path: Path, role: str) -> None:
+        d = self._pack_with_font_role(tmp_path, role)
+        summary, err = _validate_theme_dir(d, installing=True)
+        assert err is None, err
+
+    def test_absent_role_still_accepted_at_install(self, tmp_path: Path) -> None:
+        # Absent is the deliberate default case (coerces to sans on read) --
+        # not what this rule targets.
+        d = tmp_path / "no-role-pack"
+        d.mkdir()
+        _write(
+            d / "theme.json",
+            {
+                "slug": "no-role-pack",
+                "name": "No Role",
+                "emoji": "🎨",
+                "level": 1,
+                "formatVersion": 1,
+                "fonts": [{"family": "Manrope", "file": "sans.ttf"}],
+            },
+        )
+        _write(d / "variables.json", _VALID_VARS)
+        (d / "styles" / "fonts").mkdir(parents=True)
+        (d / "styles" / "fonts" / "sans.ttf").write_bytes(_TTF)
+        summary, err = _validate_theme_dir(d, installing=True)
+        assert err is None, err
+
+    @pytest.mark.parametrize("bad_role", [[], {}, 7, True, ["sans"], None])
+    def test_non_string_role_rejected_at_install_without_crashing(
+        self, tmp_path: Path, bad_role: object
+    ) -> None:
+        # `role` is untrusted manifest JSON. Membership-testing an unhashable
+        # value (a list, a dict) against the frozenset raises TypeError if the
+        # isinstance guard is dropped -- this must return a clean error
+        # instead of crashing the install handler. An explicit JSON `null`
+        # (None) is a PRESENT non-string value: it is rejected like any other
+        # bad role, distinct from the absent-role default case above.
+        d = self._pack_with_font_role(tmp_path, bad_role)
+        summary, err = _validate_theme_dir(d, installing=True)
+        assert summary is None
+        assert err is not None
+
+
 class TestOverridesFontPin:
     """overrides.css must not pin the UI font: a pin lands below where the Font
     Family preference is applied, so Mono/System would stop working with nothing


### PR DESCRIPTION
## Problem / Motivation

In `_theme_asset_descriptor` (`src/kiro_crew/dashboard/theme_validate.py`), a font entry whose `role` is neither `"sans"` nor `"mono"` silently coerces to `"sans"`. A pack author who writes the plausible-but-wrong `"role": "monospace"` (the CSS keyword, instead of `"mono"`) gets their monospace face routed to the **Sans** option, while the Mono option keeps the built-in JetBrains Mono — and nothing anywhere reports it, not at install, not at runtime.

## Why it matters

A pack author who mistypes the role gets no error and no warning: the theme installs "successfully" but silently mis-renders, and the only way to discover the mistake is to notice the wrong font showing up in the wrong UI slot. The typo (`"monospace"` for `"mono"`) is the natural one to make since it's the CSS keyword, so this is a likely failure mode for real pack authors, not a hypothetical edge case.

## What changed (motivation → approach → change)

Symptom → root cause → fix: a pack author's mistyped `role` renders silently wrong (symptom) because the read path (`_theme_asset_descriptor`) treats any unrecognised `role` as "absent" and defaults it to `sans` with no reporting anywhere in the install flow (root cause). Per the issue's (#2750) suggested fix shape, this adds an install-only check rather than tightening the read path:

- Added an install-only check (`_validate_theme_dir(..., installing=True)`) that walks the manifest's `fonts` array and rejects an unrecognised `role`, with the same actionable-message style as the existing `_overrides_font_violation` (overrides.css font-pin) check: `"font entry 'Manrope' has role 'monospace'; valid roles are 'sans' and 'mono'"`.
- The **read path stays lenient, unchanged** — `_theme_asset_descriptor` still coerces to `sans`, and `_validate_theme_dir` without `installing=True` (the theme-detail route's re-validation of an already-installed pack) still accepts it. This mirrors why the font-pin rule is itself install-only: a stricter read path would 500 an already-installed pack that predates the rule instead of warning its author.
- Guarded `role`'s type before the frozenset membership test (matching the read path's existing guard) — an unhashable `role` (a list, a dict) raises `TypeError` against `in _THEME_FONT_ROLES` otherwise, which would crash the install handler instead of returning a clean error.
- Updated the `theme-pack-authoring` skill doc, which previously documented the silent-coercion behavior as a "KNOWN TRAP" — now describes the install-time rejection.
- An explicit JSON `"role": null` is **rejected at install** like any other non-string role (the check skips only a genuinely *absent* `role`, via `"role" not in f`). This makes install slightly stricter than the read path, which cannot distinguish absent from `null` (`f.get("role")`) and coerces both to `sans` — deliberate: `null` is a present, authored value, and silently coercing it is the same class of silent mis-render this PR exists to stop. The read path is unchanged.

## Tests

- New `TestFontRoleRejectedAtInstall` class in `test/test_theme_install.py`: rejects `"monospace"` at install with the expected message; tolerates it on re-read (`installing=False`); accepts both valid roles; accepts an absent role (the deliberate default case); and rejects a non-string role without crashing (parametrized over `[]`, `{}`, `7`, `True`, `["sans"]`, `None` — the last locks in the explicit-`null` rejection).
- Verified all 6 new rejection-path tests fail against the pre-fix code (`git stash` the production change, re-run — 6 fail as expected, the 4 "accepted"/tolerated tests still pass; restored after).
- The existing `test_unknown_role_falls_back_to_sans` (exercises `_theme_asset_descriptor` directly, the read path) is untouched and still passes — confirms the read path's leniency is preserved.
- `pytest test/test_theme_install.py test/test_dashboard_themes_coverage.py test/test_theme_css_security.py test/test_theme_authoring_skill.py` — 415 passed.
- `flake8` / `isort --check-only` / `mypy` on the changed source file — clean (3 pre-existing, unrelated `os.xattr` errors in `hooks.py` reproduce identically on unmodified `main`).

## Manual verification

N/A — unit coverage sufficient; this is a backend validation-path change with no UI surface, and the new tests exercise both the install-time rejection and the unchanged read-path leniency directly against the validator functions.

## Related Issues

Fixes #2750

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

