### PR TITLE
feat: install apps the official catalog lists, at their pinned commit

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -639,31 +639,59 @@ for developer-facing diagnostics, drift-guarded by
 `website/src/test/appSdkEventScope.test.ts`). Runtime-facing summary for app
 authors: [../../../src/kiro_crew/docs/app-platform-trust-model.md](../../../src/kiro_crew/docs/app-platform-trust-model.md).
 
-## 14. The storefront reads the published catalog's display fields
+## 14. The published catalog is the store's inventory
 
 `GET /api/apps/registry` answers from the published catalog when it is reachable:
 `handle_registry` prefers `list_catalog_apps` (`registry.py`), which maps the
 published `official-registry.json` entries through
 `official_catalog.list_catalog_rows` and then applies the same install-status and
-trust stamping as the seed path. The bundled `app-registry.json` seed and the
-per-app `app.json` fetch are the OFFLINE FALLBACK, not the live source: a
-reachable catalog means the store renders the published document's list and
-display copy, and an unreachable one degrades to the seed listing.
+trust stamping as the seed path. The bundled `app-registry.json` seed is the
+catalog's OFFLINE SNAPSHOT, not a peer source: a reachable catalog means the
+store renders the published document's list, display copy, AND installable
+inventory; an unreachable one degrades the listing to the seed.
 
-The catalog is trusted only as far as TLS, so `list_catalog_rows` emits DISPLAY
-fields only — identity, display name, summary, version, tags, author, and asset
-refs. It never emits clone coordinates (`gitUrl`/`repo`/`branch`) and never emits
-`origin`, so a compromised document cannot point an install at attacker-selected
-code with gateway credentials nor forge a first-party provenance claim. Install
-continues to resolve through the seed and external registries, and `verified`
-stays `false` for a catalog `git` app until the catalog signature is checked:
-wiring signature verification into `official_catalog` is what flips that, not a
-field the catalog can assert about itself.
+The catalog is trusted only as far as TLS, so its power is bounded by
+pin-or-refuse rather than by withholding coordinates.
+`official_catalog.inventory()` materialises each `git`-source entry as an
+installable row carrying `gitUrl`/`repo`/`commit` (`builtin` entries produce
+nothing); a row that fails coordinate validation (https-only URL, 40/64-hex
+`ref`, contained relative `subdir`, kebab-case name, no duplicates) is dropped,
+never repaired. What keeps a compromised document from pointing an install at
+attacker-selected code with owner credentials is the posture stack, each layer
+independently load-bearing:
 
-A name is a filesystem path on install, so `list_catalog_rows` drops any entry
-whose name is not kebab-case (`KEBAB_RE.fullmatch`), and the catalog fetch runs
-off the event loop (`asyncio.to_thread`) so a cache-expired request never blocks
-the gateway loop.
+- **Pin or refuse.** A catalog row installs by `_git_fetch_commit` — fetch the
+  pinned SHA, assert the landed commit equals the pin, hard-fail otherwise. The
+  row carries no `branch`, so no code path can quietly clone a tip and succeed.
+- **Credential-free clone posture.** Catalog rows clone anonymously
+  (`anonymous_git_env`); they never inherit the owner-designated credential
+  carve-out.
+- **No provenance minting.** `inventory()` rows never carry `origin`,
+  `author`, or `_registry`; `verified` stays `false` for a catalog `git` app
+  until the catalog signature is checked — wiring signature verification into
+  `official_catalog` is what flips that, not a field the catalog can assert
+  about itself.
+- **Install coordinates never come from a cache.** `inventory_for_install` and
+  `list_registry`'s inventory both resolve through `fetch_inventory_entries`, a
+  fresh HTTPS fetch; the on-disk cache may enrich display fields of a row that
+  exists from another source but may never introduce or rewrite one
+  (`annotate` skips `_catalog` rows).
+- **Refuse, don't fall back.** A catalog fetch failure refuses installs,
+  updates, and execution grants for catalog-listed names rather than falling
+  back to the unpinned seed or an agent-writable external cache —
+  `_resolve_registry_row` distinguishes "the document does not name this app"
+  (seed may answer) from "the document could not be asked" (refuse).
+- **Supersession is URL-scoped.** A catalog row replaces a same-repo seed row
+  (scheme/host case-folded, path case preserved); a different-repo name
+  collision keeps the seed, so a republished document cannot silently re-home
+  an app to a new repository under a familiar name.
 
-Writers: `apps/official_catalog.py` (`list_catalog_rows`),
-`apps/registry.py` (`list_catalog_apps`), `apps/routes.py` (`handle_registry`).
+A name is a filesystem path on install, so `inventory()` and
+`list_catalog_rows` drop any entry whose name fails the manifest name contract
+(`app_name_error` / `KEBAB_RE`), and the catalog fetch runs off the event loop
+(`asyncio.to_thread`) so a cache-expired request never blocks the gateway loop.
+
+Writers: `apps/official_catalog.py` (`list_catalog_rows`, `inventory`,
+`fetch_inventory_entries`, `inventory_for_install`), `apps/registry.py`
+(`list_catalog_apps`, `_resolve_registry_row`, `_git_fetch_commit`),
+`apps/routes.py` (`handle_registry`).

--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -44,7 +44,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-from kiro_crew.apps.manifest import KEBAB_RE
+from kiro_crew.apps.manifest import KEBAB_RE, app_name_error
 from kiro_crew.config.loader import config_dir
 
 logger = logging.getLogger(__name__)
@@ -248,39 +248,16 @@ def load_official_catalog(fetcher: Any = None) -> list[dict[str, Any]]:
     if doc is None:
         return []
 
-    version = doc.get("schemaVersion")
-    # `type(...) is int` rather than `==` or `isinstance`: `1.0 == 1` and
-    # `True == 1` are both true in Python, and `bool` is a subclass of `int`, so
-    # either looser test accepts a document whose version field is not an
-    # integer at all. A version we cannot identify exactly is a contract we do
-    # not know, which is the whole reason this gate exists.
-    if type(version) is not int or version != SUPPORTED_SCHEMA_VERSION:
-        logger.warning(
-            "official catalog declares schemaVersion %r, expected %r; ignoring it",
-            version,
-            SUPPORTED_SCHEMA_VERSION,
-        )
+    # One rulebook, two reporting styles: this reader logs and degrades to `[]` so the
+    # store still renders, while `fetch_inventory_entries` raises so a caller cannot
+    # mistake a bad envelope for "no such app". What makes an envelope bad is stated once,
+    # in `_envelope_error` -- spelled twice, a schema bump or a new tombstone key updated
+    # here would silently weaken the other reader.
+    problem = _envelope_error(doc)
+    if problem is not None:
+        logger.warning("ignoring the official catalog: %s", problem)
         return []
-
-    # Refuse rather than ignore: see the module docstring. A non-empty history
-    # means an app has been withdrawn, and rendering the rest of the document
-    # while skipping the withdrawal is the one outcome this catalog exists to
-    # prevent.
-    for key in ("removed", "reinstated"):
-        if doc.get(key):
-            logger.warning(
-                "official catalog carries a non-empty %r list, which this client "
-                "cannot yet resolve; ignoring the whole catalog so a withdrawn app "
-                "is never rendered",
-                key,
-            )
-            return []
-
-    apps = doc.get("apps")
-    if not isinstance(apps, list):
-        logger.warning("official catalog has no usable apps list; ignoring it")
-        return []
-    return [a for a in apps if isinstance(a, dict) and isinstance(a.get("name"), str)]
+    return [a for a in doc["apps"] if isinstance(a, dict) and isinstance(a.get("name"), str)]
 
 
 #: Mirrors `ASSET_REF_PATTERN` in the catalog's publisher: a ref is a PATH, never
@@ -335,6 +312,284 @@ def _curated_tags(value: Any) -> list[str]:
     return [t for t in value if isinstance(t, str)]
 
 
+#: A git object name as the published document must spell it: sha1 (40 hex) or
+#: sha256 (64 hex). Defined here rather than imported from ``registry`` because
+#: that module imports THIS one; the duplication is one regex against a circular
+#: import.
+#:
+#: Every pattern in this group ends at ``\Z``, not ``$``. Python's ``$`` matches
+#: before a trailing newline, so ``$`` here accepted a 40-hex pin with ``"\n"``
+#: appended -- a value that then reaches a ``git`` argument vector. Interior line
+#: breaks are caught by the character classes; only the trailing one needs the
+#: stricter anchor, which is exactly the case an interior-newline test misses.
+#: One slug segment, which is what an app name has to be before it can become a
+#: directory. The name reaches ``app_source_dir(name)`` and the persistent app
+#: data root, so a document-supplied ``"../../x"`` or an absolute value would
+#: escape into paths this client owns. The url, commit and subdir were validated
+#: from the start; the name reaching a filesystem path was the gap.
+_MAX_NAME_LEN = 64
+
+_COMMIT_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
+
+#: An https clone URL with no room for a control character, whitespace, or a
+#: leading ``-``. The scheme restriction is the load-bearing part: ``ext::``
+#: hands a command line to a shell and ``file://`` reads local paths, and this
+#: value reaches ``git`` on the user's machine.
+_CLONE_URL_RE = re.compile(r"^https://[^\s\x00-\x1f\x7f]+\Z")
+
+#: A contained relative path inside the app's repository. No leading slash, no
+#: ``..`` segment, no backslash: the value is joined to a clone root, and the
+#: join is re-checked there -- this is the first of the two gates, not the only
+#: one.
+_SUBDIR_RE = re.compile(r"^(?!/)(?!.*(?:^|/)\.\.(?:/|\Z))[A-Za-z0-9_./-]+\Z")
+
+
+def _coordinates(source: Any) -> dict[str, str] | None:
+    """Validated fetch coordinates for a ``git`` source, or None to skip the row.
+
+    This is the FIRST place the document's ``source`` block is examined at all:
+    ``load_official_catalog`` checks the envelope and each entry's ``name``, and
+    nothing below it looked inside ``source``. So every field is validated here
+    for TYPE as well as shape -- the document arrives over the network, and a
+    coordinate that reaches ``git`` unchecked is an argument-injection surface,
+    not a cosmetic problem.
+
+    A row that fails any check is DROPPED rather than repaired. There is no safe
+    repair for a coordinate: guessing a branch when the pin is malformed would
+    install bytes nobody attested, which is the one outcome the pin exists to
+    prevent.
+    """
+    if not isinstance(source, dict) or source.get("type") != "git":
+        return None
+    url = source.get("url")
+    commit = source.get("ref")
+    subdir = source.get("subdir", "")
+    if not isinstance(url, str) or not _CLONE_URL_RE.match(url):
+        return None
+    if not isinstance(commit, str) or not _COMMIT_RE.match(commit):
+        return None
+    if subdir not in ("", None):
+        if not isinstance(subdir, str) or not _SUBDIR_RE.match(subdir):
+            return None
+    return {"url": url, "commit": commit, "subdirectory": subdir or ""}
+
+
+def inventory(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Materialise installable rows from the catalog's ``git`` entries.
+
+    This is what makes the catalog the SHELF rather than a decoration on one:
+    :func:`annotate` can only change a row that already exists, so an app the
+    catalog lists but the bundled seed does not was previously unlistable and
+    therefore uninstallable -- adding one required shipping a release.
+
+    ``builtin`` entries produce nothing here on purpose. Their code ships in the
+    wheel and is discovered from disk; a row for code this client does not have
+    would render an install control that cannot work.
+
+    Two fields are deliberately ABSENT from the rows this returns:
+
+    - ``branch``, because these rows are pinned. Emitting one would let the
+      install path silently fall back to a branch tip (``entry.get("branch",
+      "main")``) and succeed, recording the tip's commit as provenance while the
+      pin did nothing -- the one failure mode here that is both quiet and
+      "successful". Callers assert on ``commit`` instead.
+    - ``_index_author``, so these rows do NOT mint the verified badge. The
+      catalog's signature is not checked yet, and the same restraint already
+      governs :func:`annotate`'s curated author.
+
+    ``version`` IS set, and it is the point: the store owns update availability.
+    A developer pushing to their repository is not an approved update; a
+    republished catalog entry is. This is also what lets the caller skip the
+    per-app manifest clone, since the row already carries everything the list
+    renders.
+    """
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in entries:
+        name = entry.get("name")
+        if not isinstance(name, str):
+            continue
+        # `app_name_error` is the project's SINGLE app-name contract -- its own
+        # docstring says every path admitting an app funnels through it so a name
+        # refused at one door cannot enter by another. A local regex here was exactly
+        # that other door: it accepted reserved names like `system` (which shadows a
+        # notification channel namespace) and Windows device names, and those reach
+        # the build before any canonical check runs.
+        if app_name_error(name) is not None:
+            logger.warning("dropping catalog entry with inadmissible name %r", name)
+            continue
+        if len(name) > _MAX_NAME_LEN:
+            # NOT a competing identity rule -- `app_name_error` owns admissibility,
+            # and it does not bound length. This is a bound on the name AS A DIRECTORY
+            # COMPONENT, kept local because raising it into the shared contract would
+            # change every admission path in the product, which this change is not
+            # scoped to do.
+            logger.warning("dropping catalog entry with an over-long name %r", name)
+            continue
+        if name in seen:
+            # Two rows with one name make identity ambiguous: consent is shown for
+            # whichever row the listing rendered, while a later name-only lookup can
+            # resolve the other one -- a different repository under a granted name.
+            logger.warning("dropping duplicate catalog entry for %r", name)
+            continue
+        coords = _coordinates(entry.get("source"))
+        if coords is None:
+            continue
+        row: dict[str, Any] = {
+            "name": name,
+            "gitUrl": coords["url"],
+            # `repo` is the legacy alias `_entry_git_url` falls back to, and
+            # `_pinned_registry_entry` matches an installed app's recorded
+            # sourceUrl against it. Both names carry one value.
+            "repo": coords["url"],
+            "commit": coords["commit"],
+            "_catalog": True,
+        }
+        if coords["subdirectory"]:
+            row["subdirectory"] = coords["subdirectory"]
+        if version := _curated_str(entry.get("version")):
+            row["version"] = version
+        if display := _curated_str(entry.get("displayName")):
+            row["displayName"] = display
+        if summary := _curated_str(entry.get("summary")):
+            row["description"] = summary
+        if tags := _curated_tags(entry.get("tags")):
+            row["tags"] = tags
+        # `author` is deliberately NOT set here even though the catalog states one.
+        # `list_registry` snapshots `_index_author = entry["author"]`
+        # unconditionally, and `_apply_trust_fields` derives the first-party
+        # `verified` badge from that snapshot -- so an author on this row is a path
+        # from an unsigned document to the badge. :func:`annotate` sets it for
+        # DISPLAY after the snapshot has already been taken, which is the whole
+        # reason that ordering exists.
+        if icon := _resolve_ref(entry.get("iconRef")):
+            row["iconUrl"] = icon
+        if dark := _resolve_ref(entry.get("iconRefDark")):
+            row["iconUrlDark"] = dark
+        if hero := _resolve_ref(entry.get("heroRef")):
+            row["heroImage"] = hero
+        seen.add(name)
+        rows.append(row)
+    return rows
+
+
+def _envelope_error(doc: Any) -> str | None:
+    """Why *doc* is not a usable catalog envelope, or None when it is.
+
+    ONE copy of the rules, because this document's two readers disagree only about how to
+    REPORT a bad envelope, never about what makes one bad. Spelled twice, a schema bump or
+    a new tombstone key updated in one place silently weakened the other.
+
+    ``type(...) is int`` rather than ``==`` or ``isinstance``: ``1.0 == 1`` and
+    ``True == 1`` are both true in Python and ``bool`` subclasses ``int``, so either
+    looser test accepts a document whose version field is not an integer at all.
+    """
+    if not isinstance(doc, dict):
+        return "the official catalog could not be fetched or is not a JSON object"
+    version = doc.get("schemaVersion")
+    if type(version) is not int or version != SUPPORTED_SCHEMA_VERSION:
+        return f"unsupported catalog schemaVersion: {version!r}"
+    for key in ("removed", "reinstated"):
+        if doc.get(key):
+            # A withdrawn app must never render, and this client cannot resolve the
+            # tombstone lists, so the whole document is refused rather than partly used.
+            return f"catalog carries a whole-document {key!r} marker"
+    if not isinstance(doc.get("apps"), list):
+        return "catalog document has no usable 'apps' list"
+    return None
+
+
+class CatalogUnavailable(Exception):
+    """The catalog could not be consulted, so absence cannot be asserted.
+
+    Exists because ``None`` and "I could not ask" are answers a caller must be able
+    to tell apart. While every failure returned ``None``, a CDN outage was
+    indistinguishable from "this app is not in the catalog" -- and the install path
+    reads the latter as permission to use the unpinned bundled coordinates, so a
+    network failure silently downgraded a pinned app to a branch tip.
+    """
+
+
+def fetch_inventory_entries() -> list[dict[str, Any]]:
+    """The catalog's entries from a FRESH HTTPS fetch, never the on-disk cache.
+
+    Raises :class:`CatalogUnavailable` when the document cannot be fetched or
+    interpreted, so a caller cannot mistake "could not ask" for "nothing there".
+
+    This is the only source allowed to MATERIALISE inventory. The cache under the
+    data home is agent-writable, which is harmless while it supplies display copy
+    for rows that exist anyway (:func:`annotate` skips rows carrying ``_registry``,
+    so it cannot even re-dress an external row). It is NOT harmless once a cached
+    row can CREATE a listed row: a planted name would render with official
+    provenance and deduplicate the real same-named external row out of the listing,
+    so the consent prompt would describe an official app while the name grant it
+    produces installs the external one. App trust is keyed by name, so the display
+    the consent decision is made on is part of the trust boundary.
+    """
+    # Respect the module's failure memory before paying another timeout.
+    #
+    # `load_official_catalog` remembers a failed fetch precisely so the next caller does
+    # not wait again, and skipping that made every store listing during a CDN outage pay
+    # a full HTTPS timeout. Reading it here is safe in a way that reading cached ENTRIES
+    # would not be: the memory can only make this function refuse EARLIER, never make it
+    # answer. The file is agent-writable, so an attacker can clear the memory -- and the
+    # worst that buys them is one real fetch attempt, which is the same fail-closed
+    # answer by a slower route.
+    cached = _read_cache()
+    if isinstance(cached, dict) and _FAILED_KEY in cached:
+        raise CatalogUnavailable("a recent catalog fetch failed; not retrying yet")
+
+    doc = fetch_document(OFFICIAL_CATALOG_URL)
+    if not isinstance(doc, dict):
+        _write_failure()
+    problem = _envelope_error(doc)
+    if problem is not None:
+        raise CatalogUnavailable(problem)
+    assert isinstance(doc, dict)  # narrowed by _envelope_error
+    return [a for a in doc["apps"] if isinstance(a, dict)]
+
+
+def inventory_for_install(name: str) -> dict[str, Any] | None:
+    """The row named *name*, resolved WITHOUT reading the on-disk cache.
+
+    The cache under the data home is not a sensitive path, so the agent's own file
+    tools can write it (verified against ``security.is_sensitive_write_path``). That
+    is harmless while the cache only supplies display copy, which is all
+    :func:`annotate` consumes. It is NOT harmless once a row supplies install
+    coordinates: an attacker who can write that file chooses which repository a name
+    the owner has already permitted for execution installs from, and app trust is
+    keyed by NAME. Reading coordinates from an agent-writable file would make the
+    name-to-URL binding attacker-controlled.
+
+    So the install path re-fetches the document over HTTPS and ignores the cache
+    entirely. Someone able to write a local file cannot answer for
+    ``apps.crew.kiro.dev``, and TLS to our own domain is the trust basis this module
+    already documents. This is NOT a substitute for verifying the ``.sig`` sidecar --
+    that would also close the case where the CDN itself is wrong -- but it removes
+    the local surface, which is the one this client creates for itself.
+
+    Returns None ONLY when a valid catalog document does not name *name* -- an
+    authoritative absence. Every other outcome raises :class:`CatalogUnavailable`,
+    because a caller that cannot tell "not in the catalog" from "could not reach the
+    catalog" will treat a network failure as permission to install from unpinned
+    coordinates.
+    """
+    apps = fetch_inventory_entries()
+    rows = list(inventory(apps))
+    for row in rows:
+        if row.get("name") == name:
+            return row
+    if any(a.get("name") == name for a in apps):
+        # The catalog DOES name this app, but `inventory` dropped it -- a builtin
+        # (no git coordinates) or a row whose `source` failed validation. Reporting
+        # absence here would let a caller fall back to unpinned coordinates for an
+        # app the catalog is actually curating.
+        raise CatalogUnavailable(
+            f"catalog names {name!r} but supplies no usable install coordinates"
+        )
+    return None
+
+
 def annotate(rows: list[dict[str, Any]], entries: list[dict[str, Any]]) -> None:
     """Overlay curated fields from *entries* onto matching *rows*, in place.
 
@@ -372,6 +627,11 @@ def annotate(rows: list[dict[str, Any]], entries: list[dict[str, Any]]) -> None:
         # the verified mark, but it runs AFTER this overlay, so the copy and the
         # icon would land regardless.
         if row.get("_registry"):
+            continue
+        if row.get("_catalog"):
+            # Already materialised FROM this document by `inventory`, so overlaying it
+            # again can only change the row if two sources disagree -- and a second
+            # source for one row's identity is the thing to avoid, not a feature.
             continue
         entry = by_name.get(row.get("name"))
         if entry is None:

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -55,7 +55,6 @@ from kiro_crew.apps.manager import (
     update_app,
 )
 from kiro_crew.apps.manifest import AppManifest
-from kiro_crew.apps.official_catalog import load_official_catalog
 from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 from kiro_crew.sel import sel
 
@@ -74,7 +73,14 @@ logger = logging.getLogger(__name__)
 SOURCE_REGISTRY_PREFIX = "registry:"
 
 # A git object name: sha1 (40 hex) or sha256 (64 hex) repository format.
-_COMMIT_SHA_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+#
+# Anchored at ``\Z`` rather than ``$``: Python's ``$`` matches before a trailing
+# newline, so ``$`` accepted a 40-hex value with ``"\n"`` appended. That matters at
+# both readers -- this pattern validates a pin before it reaches a git argument
+# vector, and it validates a SHA read back off disk in
+# :func:`_resolved_clone_commit`, where a value that only looks like a commit would
+# be reported as the landed one.
+_COMMIT_SHA_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
 
 
 class StreamingLogLines(list):
@@ -678,6 +684,7 @@ async def _fetch_app_manifest(
     git_url: str = "",
     *,
     owner_designated: bool = False,
+    commit: str = "",
 ) -> dict[str, Any] | None:
     """Fetch app.json for an app from its source repo (lightweight).
 
@@ -697,6 +704,14 @@ async def _fetch_app_manifest(
     clone uses ``minimal_env()`` + context sandbox mode instead of the
     default anonymous+strict posture. Only set when the entry's effective
     clone URL is byte-identical to the owner-configured registry repo URL.
+
+    *commit*: a pinned commit. When set, the manifest is read from THAT tree
+    rather than a branch tip, and the local fast path compares commits instead of
+    branch names. This matters on the install path specifically: this manifest is
+    what the admission gate inspects, so reading it from a branch tip while the
+    install fetches a pinned commit would gate one tree and install another --
+    and a pinned row carries no branch at all, so the branch would silently be
+    the ``"main"`` default.
     """
     if not git_url:
         git_url = repo
@@ -712,15 +727,28 @@ async def _fetch_app_manifest(
     # repo A's manifest and then run repo B's code. So the local copy is only
     # used when the clone's origin still is git_url; otherwise fall through to
     # the throwaway clone of git_url, which always describes what gets cloned.
-    if app_name:
+    if app_name and not commit:
+        # A PINNED entry gets no local fast path at all.
+        #
+        # The persistent checkout is agent-writable, and `app.json` there can be
+        # edited without HEAD moving -- so a commit comparison attests where the tree
+        # was placed, never what it now holds. This manifest is what the admission and
+        # platform gates read, so a local edit bypasses `installMode`/`os`
+        # restrictions and gets the tree built server-side. It is the same reason a
+        # pinned install never reuses an existing checkout; the rule belongs here too,
+        # and previously stopped one caller short of this one.
+        #
+        # The cost is a shallow single-commit fetch per pinned listing, which the
+        # pinned branch below already performs.
         clone_dir = app_source_dir(app_name)
         manifest_dir = _contained_join(clone_dir, subdirectory)
         local_manifest = manifest_dir / "app.json" if manifest_dir is not None else None
+        fresh_enough = await _clone_branch_matches(clone_dir, branch)
         if (
             local_manifest is not None
             and local_manifest.is_file()
             and await _clone_origin_matches(clone_dir, git_url)
-            and await _clone_branch_matches(clone_dir, branch)
+            and fresh_enough
         ):
             try:
                 content = await asyncio.to_thread(local_manifest.read_text, "utf-8")
@@ -748,7 +776,7 @@ async def _fetch_app_manifest(
     tmp_root: str | None = None
     try:
         tmp_root = await asyncio.to_thread(tempfile.mkdtemp, prefix="kirocrew-manifest-")
-        # Credential posture for the manifest clone. Default: anonymous+strict
+        # Credential posture for the manifest fetch. Default: anonymous+strict
         # (confused-deputy defense — see anonymous_git_env). Same-repo
         # carve-out: when owner_designated is True the clone URL is the
         # owner-configured registry repo itself, so the confused-deputy
@@ -760,36 +788,67 @@ async def _fetch_app_manifest(
         else:
             clone_env = anonymous_git_env()
             sandbox_mode = "strict"
-        clone_cmd = [
-            "git",
-            "clone",
-            "--depth",
-            "1",
-            "--branch",
-            branch,
-            "--single-branch",
-            git_url,
-            tmp_root,
-        ]
-        sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode=sandbox_mode)
-        sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-        proc = await create_subprocess_limited(
-            *sandboxed_cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=clone_env,
-            start_new_session=platform_compat.IS_POSIX,
-            creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
-        )
-        _, stderr = await _communicate_with_timeout(proc, timeout=_CLONE_TIMEOUT)
-        if proc.returncode != 0:
-            logger.debug(
-                "manifest clone failed for %s: %s",
+
+        if commit:
+            # Read the manifest from the pinned tree. `--branch` cannot take a
+            # commit id, and on the install path this manifest is what the
+            # admission gate inspects -- gating a branch tip while installing a
+            # pinned commit would check one tree and install another.
+            fetch_log: list[str] = []
+            # A NONEXISTENT child, not `tmp_root` itself. `tmp_root` already exists
+            # (TemporaryDirectory created it), and `_git_fetch_commit` refuses a
+            # destination that exists but is not a checkout -- the guard that stops it
+            # from adopting, and later deleting, a directory it did not create. Handing
+            # it `tmp_root` made every pinned manifest fetch fail, which left the
+            # admission and platform-compatibility gates with no manifest at all.
+            fetch_dest = Path(tmp_root) / "pinned"
+            checkout_root = fetch_dest
+            err = await _git_fetch_commit(
                 git_url,
-                stderr.decode(errors="replace").strip(),
+                commit,
+                fetch_dest,
+                fetch_log,
+                clone_env=clone_env,
+                sandbox_mode=sandbox_mode,
             )
-            return None
-        manifest_dir = _contained_join(Path(tmp_root), subdirectory)
+            if err is not None:
+                logger.debug("manifest fetch of pinned commit failed for %s: %s", git_url, err)
+                return None
+        else:
+            clone_cmd = [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                branch,
+                "--single-branch",
+                git_url,
+                tmp_root,
+            ]
+            sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode=sandbox_mode)
+            sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
+            proc = await create_subprocess_limited(
+                *sandboxed_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=clone_env,
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+            )
+            _, stderr = await _communicate_with_timeout(proc, timeout=_CLONE_TIMEOUT)
+            if proc.returncode != 0:
+                logger.debug(
+                    "manifest clone failed for %s: %s",
+                    git_url,
+                    stderr.decode(errors="replace").strip(),
+                )
+                return None
+            checkout_root = Path(tmp_root)
+        # Containment is measured from the root the tree actually landed in, which
+        # differs by branch: the pinned fetch uses a child of `tmp_root` so it gets a
+        # destination it created, the branch clone uses `tmp_root` itself.
+        manifest_dir = _contained_join(checkout_root, subdirectory)
         if manifest_dir is None:
             # Untrusted index subdirectory escaped the clone root (absolute,
             # ``..``, or a symlink resolving outside tmp_root) — refuse.
@@ -805,6 +864,128 @@ async def _fetch_app_manifest(
     finally:
         if tmp_root:
             await asyncio.to_thread(shutil.rmtree, tmp_root, ignore_errors=True)
+
+
+def _remote_controlled_url(entry: dict[str, Any]) -> bool:
+    """Whether *entry*'s clone URL came from content we do not control.
+
+    Drives the CREDENTIAL posture: a True answer means the clone runs
+    credential-free and strict-sandboxed (:func:`anonymous_git_env`), because the
+    URL is not one the owner typed.
+
+    Both markers qualify. ``_registry`` is an external index's row. ``_catalog`` is
+    the official catalog's, whose URL arrives in a document fetched over the network
+    whose signature this client does not yet verify -- so it is remote-controlled in
+    exactly the same way. Reading "no ``_registry``" as "owner-designated" held only
+    while the sole marker-less rows came from the wheel's bundled seed, which the
+    owner installed deliberately.
+    """
+    return bool(entry.get("_registry")) or bool(entry.get("_catalog"))
+
+
+def _official_entry(entry: dict[str, Any]) -> bool:
+    """Whether *entry* is an app WE list, which decides install-receipt eligibility.
+
+    Deliberately NOT the negation of :func:`_remote_controlled_url`. A catalog row
+    is remote-controlled (credential-free) AND official (receipt fires); collapsing
+    both onto one boolean is what made the catalog row take owner credentials.
+    """
+    return not entry.get("_registry")
+
+
+async def _move_checkout_aside(dest: Path, log_lines: list[str]) -> Path | None:
+    """Atomically rename *dest* to a sibling temp path under the app-sources root.
+
+    Returns the new path, or ``None`` if the rename failed. Nothing is ever
+    deleted here: the caller reports the failure and the retention sweep owns the
+    moved-aside directory's eventual removal.
+    """
+    aside = dest.with_name(f"{dest.name}.stale-{uuid.uuid4().hex[:8]}")
+    try:
+        await asyncio.to_thread(dest.rename, aside)
+    except OSError as exc:
+        log_lines.append(f"Could not move aside the checkout at {dest}: {exc}")
+        return None
+    # Refresh mtime so the retention clock starts now, not at the checkout's
+    # last-modified time (which may already exceed the sweep threshold).
+    # Best-effort: failure only shortens how long the directory survives.
+    try:
+        await asyncio.to_thread(os.utime, aside)
+    except OSError:
+        pass
+    return aside
+
+
+def _same_git_target(a: str, b: str) -> bool:
+    """Whether two clone URLs name the same repository.
+
+    Cosmetic variance between the separately-authored seed and catalog is a trailing
+    ``/``, a trailing ``.git``, and the case of the scheme and host -- those three
+    are normalised.
+
+    **The PATH keeps its case.** Repository paths are case-sensitive on plenty of
+    forges, so folding them makes two DIFFERENT repositories compare equal, and this
+    predicate is what decides whether a catalog row may stand in for a bundled app.
+    App trust is keyed by name, so a false "same target" here is the name-rebinding
+    that requiring URL equality exists to prevent.
+    """
+
+    def norm(url: str) -> str:
+        u = (url or "").strip().rstrip("/")
+        if u.endswith(".git"):
+            u = u[: -len(".git")]
+        scheme, sep, rest = u.partition("://")
+        if not sep:
+            # No scheme to split on (scp-style or a bare path): fold nothing, since
+            # the host cannot be told from the path without guessing.
+            return u
+        host, slash, path = rest.partition("/")
+        return f"{scheme.lower()}://{host.lower()}{slash}{path}"
+
+    return bool(a) and norm(a) == norm(b)
+
+
+def _catalog_row_supersedes_seed(seed: dict[str, Any], catalog_row: dict[str, Any]) -> bool:
+    """Whether *catalog_row* may stand in for the same-named *seed* row.
+
+    The catalog is the shelf and the bundled seed is its offline snapshot, so when
+    both describe the same app the catalog's row is the better one: it carries the
+    curated copy AND the commit pin, while the seed carries four coordinate fields
+    and no pin. Deferring to the seed instead is what made the pin dead data for
+    every app that actually has one -- both git catalog entries are also seed
+    entries, so a name-collision rule that favoured the seed discarded 100% of the
+    published pins.
+
+    Requiring URL equality is the security half. Without it, a catalog revision
+    could rebind a bundled app's NAME to a different repository, and app trust is
+    keyed by name -- so the row that replaces the seed must be describing the same
+    repository the wheel shipped against, not merely claiming the same name.
+    """
+    return _same_git_target(_entry_git_url(seed), _entry_git_url(catalog_row))
+
+
+def _is_catalog_row(entry: dict[str, Any]) -> bool:
+    """Whether *entry* came from the official catalog and may skip the manifest fetch.
+
+    Both halves are required. ``_catalog`` is on the row-projection allowlist, so
+    an external registry's index -- untrusted, index-controlled JSON -- can set it
+    on its own rows; ``_registry`` is attached server-side per configured registry
+    and cannot be forged. Testing only ``_catalog`` would let such a row skip the
+    fetch of the app's OWN manifest and keep index-supplied display copy instead,
+    which is the substitution the manifest fetch exists to prevent.
+    """
+    return bool(entry.get("_catalog")) and not entry.get("_registry")
+
+
+async def _identity(entry: dict[str, Any]) -> dict[str, Any]:
+    """Return *entry* unchanged, as an awaitable.
+
+    Lets the manifest-fetch gather hold a uniform list of coroutines while a
+    catalog row skips the fetch entirely: the alternative is branching on row
+    kind at the gather site AND at the result-zip below it, where an index
+    mismatch would silently pair a row with another row's manifest.
+    """
+    return entry
 
 
 async def _resolve_manifest(entry: dict[str, Any]) -> dict[str, Any]:
@@ -878,6 +1059,15 @@ _REGISTRY_ROW_KEYS: frozenset[str] = frozenset(
         "gitUrl",
         "repo",
         "branch",
+        # `_catalog` must survive the merge or the row goes back through the
+        # per-app manifest clone it exists to make unnecessary.
+        #
+        # `commit` survives for data fidelity only, NOT as an authorization: this
+        # projection also builds rows from an external registry's index, so the
+        # value here is index-controlled. `install_from_registry` reads the pin only
+        # for `_is_catalog_row`, which no index row can satisfy.
+        "commit",
+        "_catalog",
         "subdirectory",
         "resources",
         "detectInstalled",
@@ -1118,7 +1308,21 @@ def _apply_trust_fields(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
         else:
             builtin = entry.get("origin") == "builtin"
             entry["provenance"] = "builtin" if builtin else "official"
-            entry["verified"] = builtin or folded_author in FIRST_PARTY_AUTHORS
+            if entry.get("_catalog"):
+                # A catalog row's author is curated copy from a document whose
+                # signature this client does not yet check, so it must never mint
+                # the first-party badge.
+                #
+                # The refusal lives HERE and not at the row's source because
+                # omitting `_index_author` upstream does not survive: the snapshot
+                # loop in `list_registry` assigns `_index_author = entry["author"]`
+                # unconditionally, which silently re-created the very path the
+                # omission was meant to close. This function is the trust
+                # boundary, so a rule stated anywhere else is a rule some later
+                # assignment can undo.
+                entry["verified"] = False
+            else:
+                entry["verified"] = builtin or folded_author in FIRST_PARTY_AUTHORS
     return entries
 
 
@@ -1710,6 +1914,61 @@ async def list_registry() -> list[dict[str, Any]]:
     """
     entries = await asyncio.to_thread(_load_registry_file)
 
+    # The catalog is the shelf, and the bundled seed is its offline snapshot.
+    #
+    # This runs FIRST, before the manifest fetches below, because a catalog row
+    # already carries everything the list renders -- display copy, artwork, and
+    # the `version` that decides whether an update is available. Applied here,
+    # those rows need no per-app clone at all. Applied afterwards (which is what
+    # `annotate` alone did) the clone is paid for and then overwritten.
+    #
+    # Seed rows LOSE a name collision when both name the same repository, because
+    # the seed's four coordinate fields carry no pin: favouring it discarded every
+    # published pin, since both git catalog entries are also seed entries. The seed
+    # remains the fallback for when the catalog cannot be loaded at all (the
+    # `except` below), which is the availability job it actually exists for. A
+    # catalog row naming a DIFFERENT repository does not supersede -- see
+    # `_catalog_row_supersedes_seed`.
+    catalog_entries: list[dict[str, Any]] = []
+    try:
+        # A FRESH fetch, not `load_official_catalog` -- that reads the agent-writable
+        # cache, and a cached row that MATERIALISES inventory can render with official
+        # provenance and deduplicate the real same-named external row out of the
+        # listing. The consent prompt would then describe an official app while the
+        # name grant it produces installs the external one. The cache still feeds
+        # `annotate` further down, which is display copy for rows that exist anyway
+        # and skips rows carrying `_registry`.
+        catalog_entries = await asyncio.to_thread(official_catalog.fetch_inventory_entries)
+        if catalog_entries:
+            by_name = {e.get("name"): i for i, e in enumerate(entries)}
+            for row in official_catalog.inventory(catalog_entries):
+                idx = by_name.get(row.get("name"))
+                if idx is None:
+                    entries.append(row)
+                elif _catalog_row_supersedes_seed(entries[idx], row):
+                    # Same app, same repo: take the catalog's row whole. It carries
+                    # the pin and the curated copy; the seed carries neither.
+                    # Replacing rather than overlaying `commit` onto the seed row is
+                    # deliberate -- a row needs `_catalog` for the install path to
+                    # honour its pin at all, and a seed row given `_catalog` would
+                    # then skip the manifest fetch it depends on for display copy.
+                    entries[idx] = row
+                else:
+                    logger.warning(
+                        "catalog entry %r names a different repository than the "
+                        "bundled seed (%r vs %r); keeping the seed row",
+                        row.get("name"),
+                        _entry_git_url(row),
+                        _entry_git_url(entries[idx]),
+                    )
+    except Exception:  # noqa: BLE001 - degrade, never 500 the store
+        # No catalog inventory this listing. That is the behaviour the store had
+        # before this module existed (seed + built-ins discovered on disk), and it
+        # is the right degradation: a name we cannot confirm right now must not
+        # appear as an official row, because that row is what a consent grant is
+        # made against.
+        logger.warning("no official catalog inventory this listing", exc_info=True)
+
     # Load external registries from config, deduplicating against core and each other
     external_entries = await _load_external_registries()
     seen_names = {e.get("name") for e in entries}
@@ -1731,9 +1990,16 @@ async def list_registry() -> list[dict[str, Any]]:
     for entry in entries:
         entry["_index_author"] = entry.get("author")
 
-    # Fetch manifests in parallel for all entries
+    # Fetch manifests in parallel, EXCEPT for catalog rows.
+    #
+    # A catalog row already carries the display fields and the `version` this
+    # list needs, baked at publish time from the app's own app.json by a pipeline
+    # that read it once, centrally. Cloning the app's repository again to learn
+    # what the catalog already told us is the per-app network cost this document
+    # exists to remove -- and it is O(N) in the number of third-party apps, which
+    # is exactly the number the store is meant to grow.
     resolved = await asyncio.gather(
-        *[_resolve_manifest(e) for e in entries],
+        *[_identity(e) if _is_catalog_row(e) else _resolve_manifest(e) for e in entries],
         return_exceptions=True,
     )
     entries = [r if isinstance(r, dict) else entries[i] for i, r in enumerate(resolved)]
@@ -1777,23 +2043,32 @@ async def list_registry() -> list[dict[str, Any]]:
     # index-declared author snapshot, which the overlay deliberately leaves
     # alone while the document's signature is not yet checked.
     #
-    # Annotate-only: every catalog entry names something already listed here.
-    # Adding installable entries needs the install path to accept a
-    # commit-pinned source first, so an entry matching no row is ignored.
     # Containment, not defensiveness. This handler has no try/except above it, so
-    # anything escaping the catalog step is an HTTP 500 for the WHOLE store --
-    # and the catalog is an enhancement to a listing that is already complete
-    # without it. "Anything went wrong, render what we had" is therefore the
-    # correct semantics at this seam specifically, and a broad catch here is not
-    # hiding a defect from us: it logs with a traceback, and the module's own
-    # precise guards still run first. Three separate escape routes were found
-    # here by review, each individually narrower than this seam.
-    try:
-        catalog = await asyncio.to_thread(load_official_catalog)
-        if catalog:
-            official_catalog.annotate(entries, catalog)
-    except Exception:  # noqa: BLE001 - degrade to the seed, never 500 the store
-        logger.warning("ignoring the official catalog after a failure", exc_info=True)
+    # anything escaping the catalog step is an HTTP 500 for the WHOLE store -- and the
+    # curated copy is an enhancement to a listing that is already complete without it.
+    # "Anything went wrong, render what we had" is therefore the correct semantics at
+    # this seam specifically, and a broad catch here is not hiding a defect: it logs
+    # with a traceback, and the module's own precise guards still run first.
+    #
+    # Annotate from the SAME fresh entries the inventory came from, never the cache.
+    #
+    # Round 11 stopped the agent-writable cache from INTRODUCING a row; this stops it
+    # from REWRITING one. `annotate` overlays `displayName` and `description`, which
+    # are exactly what the consent modal renders, and it only skips rows carrying
+    # `_registry` -- so a poisoned cache entry could re-label a freshly fetched
+    # first-party row and the name-scoped grant would then execute the real app under
+    # a spoofed identity. Same value, different verb, same trust boundary.
+    #
+    # When the fetch failed, `catalog_entries` is empty and no catalog-derived copy is
+    # applied at all. That is the correct degradation: rows then render the copy their
+    # own manifest supplies, which is what the store did before this module existed.
+    # There is no third source to fall back to -- a second source for the same rows is
+    # precisely the defect.
+    if catalog_entries:
+        try:
+            official_catalog.annotate(entries, catalog_entries)
+        except Exception:  # noqa: BLE001 - degrade, never 500 the store
+            logger.warning("ignoring curated catalog copy after a failure", exc_info=True)
 
     return _apply_trust_fields(
         _enrich_with_install_status(entries, installed_map, detected)
@@ -1839,15 +2114,108 @@ def get_server_platform() -> dict[str, str]:
     return {"os": PlatformConfig.current_os(), "arch": _platform.machine()}
 
 
+def _seed_row(name: str) -> dict[str, Any] | None:
+    """The bundled seed row named *name*, if this wheel shipped one."""
+    for entry in _load_registry_file():
+        if isinstance(entry, dict) and entry.get("name") == name:
+            return entry
+    return None
+
+
+def _resolve_registry_row(name: str) -> tuple[dict[str, Any] | None, str]:
+    """Resolve *name* to an installable row, or a refusal reason.
+
+    Searches the official catalog first, then the bundled seed, then external
+    registry caches. Returns ``(row, reason)``; a non-empty *reason* means the
+    caller must REFUSE and must not substitute another row.
+
+    **"The catalog says there is no pin" and "I could not ask the catalog" are
+    different answers, and collapsing them is a security defect.** A seeded
+    official app has a published pin, so falling back to its branch-only seed row
+    on a lookup failure installs a mutable branch tip while the store claims the
+    app is pinned -- the pin silently not applying, which is this path's one
+    quiet-yet-"successful" failure mode. So a lookup FAILURE with a seed row
+    present refuses, while an authoritative "no catalog row" keeps using the seed.
+
+    The availability cost is bounded and small: an install already requires the
+    network to clone, so the only window this closes is "catalog host unreachable
+    while the git host is reachable". Refusing there is the same choice made for
+    the coordinate cache (never read for install) and for existing checkouts
+    (never reused) -- a security property that holds only when the network
+    cooperates is not one anybody can reason about.
+    """
+    seed_row = _seed_row(name)
+
+    catalog_row: dict[str, Any] | None = None
+    catalog_failed = False
+    try:
+        catalog_row = official_catalog.inventory_for_install(name)
+    except official_catalog.CatalogUnavailable as exc:
+        catalog_failed = True
+        logger.warning("cannot confirm official coordinates for %r: %s", name, exc)
+    except Exception:  # noqa: BLE001 - fail closed: an unexpected error is not "no row"
+        catalog_failed = True
+        logger.warning("official catalog lookup failed for %r", name, exc_info=True)
+
+    if catalog_row is not None and (
+        seed_row is None or _catalog_row_supersedes_seed(seed_row, catalog_row)
+    ):
+        # The catalog row carries the pin and the curated copy; a same-repo seed row
+        # carries neither, so it does not win. Deferring to it is what made every
+        # published pin unreachable on the install path.
+        return catalog_row, ""
+
+    if catalog_failed:
+        # Before ANY fallback, seed or external. Without the catalog we cannot know
+        # whether this name is a catalog app, and app trust is keyed by name: a
+        # same-named external registry row would install a different repository's
+        # code under a name the owner already permitted for execution. The local
+        # cache cannot be consulted to decide -- it is agent-writable, which is the
+        # surface `inventory_for_install` refuses to read in the first place.
+        detail = (
+            "is bundled and may carry an official commit pin"
+            if seed_row is not None
+            else "may be an official catalog app"
+        )
+        return None, (
+            f"app {name!r} {detail}, but the official catalog could not be reached to "
+            "confirm it — refusing to resolve it from another source. Retry when the "
+            "catalog is reachable."
+        )
+
+    if seed_row is not None:
+        return seed_row, ""
+    return _external_registry_row(name), ""
+
+
 def get_registry_app(name: str) -> dict[str, Any] | None:
     """Look up a registry app by name (synchronous, for internal use).
 
-    Searches the bundled registry first, then external registry caches.
+    Returns the row, or ``None`` when no source offers *name*.
+
+    RAISES :class:`official_catalog.CatalogUnavailable` when resolution was refused
+    because the catalog could not be consulted. Raising rather than returning None is
+    what lets the refusal keep its reason while this stays the single lookup the
+    install path goes through: a returned None is indistinguishable from "no such
+    app", and re-deriving the difference in the caller costs a second catalog fetch
+    and stops being sound as soon as the refusal covers more than one case.
+
+    Blocking (reads the bundled file, fetches the catalog over HTTPS, and reads
+    external index caches) — call it off the event loop.
     """
-    for entry in _load_registry_file():
-        if entry.get("name") == name:
-            return entry
-    # Search external registry caches
+    row, refusal = _resolve_registry_row(name)
+    if refusal:
+        raise official_catalog.CatalogUnavailable(refusal)
+    return row
+
+
+def _external_registry_row(name: str) -> dict[str, Any] | None:
+    """The first row named *name* from an owner-configured external registry cache.
+
+    Separate from the catalog/seed resolution above because these rows are a
+    different trust class: they carry ``_registry``, which flips provenance and is
+    attached here at the lookup boundary so a stale cache cannot omit it.
+    """
     from kiro_crew.config.loader import (
         KiroCrewConfig,  # circular import: loader.py imports from apps/ at module level; deferring avoids ImportError
     )
@@ -1882,6 +2250,50 @@ def _registry_app_candidates(name: str) -> list[dict[str, Any]]:
         for entry in _load_registry_file()
         if isinstance(entry, dict) and entry.get("name") == name
     ]
+    # The catalog is an inventory source, so it must appear here too. An app
+    # installed from a catalog-only row records its provenance, and provenance-
+    # pinned resolution then looks for a candidate offering that same source: a
+    # candidate set that omits the catalog refuses EVERY later update of exactly
+    # the apps this inventory exists to make installable.
+    try:
+        row = official_catalog.inventory_for_install(name)
+        if row is not None:
+            # REPLACE the equivalent seed candidates, do not merely outrank them.
+            #
+            # Ordering alone is not enough because provenance matching compares the
+            # recorded source URL EXACTLY: an app installed when the seed's URL had no
+            # `.git` suffix does not match a catalog URL that has one, so the match
+            # walks past the catalog row and takes the retained seed -- delivering a
+            # branch-tip update for an app the store presents as pinned. Ordering only
+            # helped in the case that never needed help (URLs already identical).
+            #
+            # Replacing also keeps this path consistent with `_resolve_registry_row`,
+            # where the catalog row wins outright; two resolvers disagreeing about the
+            # same collision is how one of them ends up wrong.
+            superseded = [c for c in candidates if _catalog_row_supersedes_seed(c, row)]
+            if superseded:
+                candidates = [c for c in candidates if c not in superseded]
+                candidates.insert(0, row)
+            else:
+                candidates.append(row)
+    except Exception:  # noqa: BLE001 - a failed lookup is not "no pin"; see below
+        # A seed candidate names the SAME repository as the catalog row it shadows,
+        # so provenance-pinned resolution would accept it and deliver a branch-tip
+        # update for an app the store says is pinned. With the pin unknowable, the
+        # seed candidates are dropped rather than offered.
+        logger.warning(
+            "official catalog lookup failed for %r; refusing to offer any candidate "
+            "rather than resolving an update from an unconfirmed source",
+            name,
+            exc_info=True,
+        )
+        # Return immediately. Clearing the seed candidates and then falling through
+        # to the external caches below still let a same-named external row answer --
+        # and a tampered cache row missing its `_registry` marker reads as official,
+        # so a provenance match would install an unpinned branch with the OWNER's
+        # credentials. `_resolve_registry_row` already refuses before any fallback;
+        # this is its sibling and must refuse the same way.
+        return []
     from kiro_crew.config.loader import (
         KiroCrewConfig,  # circular import: loader.py imports from apps/ at module level; deferring avoids ImportError
     )
@@ -1932,7 +2344,12 @@ def _resolve_install_entry(name: str) -> tuple[dict[str, Any] | None, str]:
     meta = get_app(name) or {}
     pinned_url = str(meta.get("sourceUrl", "") or "")
     if not pinned_url:
-        return get_registry_app(name), ""
+        try:
+            return get_registry_app(name), ""
+        except official_catalog.CatalogUnavailable as exc:
+            # A refusal, not an absence: report the cause so the user is not sent
+            # looking for a missing app during a catalog outage.
+            return None, str(exc)
     entry = _pinned_registry_entry(name, meta)
     if entry is None:
         return None, (
@@ -2072,6 +2489,53 @@ def _resolved_clone_commit(clone_root: Path) -> str:
     except (OSError, UnicodeDecodeError):
         pass
     return ""
+
+
+def _restore_moved_aside(
+    moved_aside: Path | None, pkg_dir: Path, log_lines: list[str], reason: str
+) -> None:
+    """Put a moved-aside checkout back at *pkg_dir*, setting the replacement aside.
+
+    One restoration path, called from every exit that abandons a replacement clone.
+    A pinned install moves the previous checkout aside on EVERY reinstall, so an exit
+    that forgets this leaves the user's only edited copy as a `.stale-*` sibling that
+    the retention sweep later deletes.
+
+    TWO RENAMES, NO RECURSIVE DELETE, and that shape is what makes it callable from
+    anywhere. Two review rounds pulled in opposite directions here: awaiting is unsound
+    during cancellation (re-entering a loop being torn down surfaces as
+    ``RuntimeError: Event loop is closed``), while a synchronous ``rmtree`` of a large
+    checkout stalls the gateway's tasks and heartbeat on the loop thread. Both are right,
+    so neither answer is -- the deletion itself is what has to go.
+
+    What actually saves the user's data is the rename, which is O(1) on one filesystem.
+    The discarded replacement is renamed to a ``.partial-*`` sibling and left for
+    :func:`_sweep_stale_checkouts`, which already owns both the ``stale`` and ``partial``
+    prefixes. So this function is cheap enough to run inline on any path, needs no thread
+    and no loop, and cannot block.
+    """
+    if moved_aside is None or not moved_aside.exists():
+        return
+    if pkg_dir.exists():
+        discarded = pkg_dir.with_name(f"{pkg_dir.name}.partial-{uuid.uuid4().hex[:8]}")
+        try:
+            pkg_dir.rename(discarded)
+        except OSError as exc:
+            # Cannot clear the destination, so the restore rename below would collide.
+            # Leave both trees in place and say where the copy is.
+            log_lines.append(
+                f"WARNING: could not set aside the replacement at {pkg_dir}: {exc}; "
+                f"the previous checkout is retained at {moved_aside.name}"
+            )
+            return
+    try:
+        moved_aside.rename(pkg_dir)
+        log_lines.append(f"Restored the previous checkout after {reason}")
+    except OSError as exc:
+        log_lines.append(
+            f"WARNING: could not restore the previous checkout from "
+            f"{moved_aside.name}: {exc}; it is retained there for manual recovery"
+        )
 
 
 async def _refuse_identity_mismatch(
@@ -2344,6 +2808,185 @@ async def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
         await proc.wait()
 
 
+async def _git_fetch_commit(
+    git_url: str,
+    commit: str,
+    dest: Path,
+    log_lines: list[str],
+    *,
+    clone_env: dict[str, str],
+    sandbox_mode: str,
+) -> dict[str, Any] | None:
+    """Materialise *dest* at exactly *commit*. Returns None on success.
+
+    ``git clone --branch`` cannot take a commit id -- it exits 128 with
+    ``Remote branch <sha> not found in upstream origin`` -- so a pinned entry
+    needs fetch-by-SHA instead. The published catalog pins every third-party app
+    to a commit, and this is the only path that honours that pin.
+
+    Four separate git invocations, each of which MUST carry the same credential
+    posture and sandbox mode as the clone it replaces: one that forgets is a
+    credential-exposure hole, not a style slip.
+
+    ``git remote add origin`` is not optional bookkeeping. ``git init`` + ``git
+    fetch <url> <sha>`` leaves NO origin remote, and the update path reads it
+    (:func:`_clone_origin_url`); without it every later update fails closed with
+    ``unreadable_clone_origin`` and deliberately does NOT delete the checkout, so
+    the app installs once and then needs manual cleanup to ever update again.
+
+    ``--filter=blob:none`` is deliberately absent. A server that does not support
+    it merely warns and sends everything, and a server that DOES support it turns
+    the app's source tree into a partial clone whose later file reads become lazy
+    network fetches -- during the build, off the install path's error handling.
+
+    ``--template=`` is likewise load-bearing: the owner-designated posture uses
+    :func:`minimal_env`, which does not disable the user's global git config, so a
+    configured ``init.templateDir`` would install hooks into this repository and
+    the checkout below would then execute ``post-checkout``.
+    """
+
+    async def run(argv: list[str], *, cwd: Path | None = None, timeout: int) -> tuple[int, str]:
+        sandboxed, _cleanup = wrap_argv(argv, mode=sandbox_mode)
+        sandboxed = cgroup_scope_argv(sandboxed)
+        proc = await create_subprocess_limited(
+            *sandboxed,
+            cwd=str(cwd) if cwd else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            start_new_session=platform_compat.IS_POSIX,
+            creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+            env=clone_env,
+        )
+        try:
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            await _kill_process_group(proc)
+            return 124, "timed out"
+        except asyncio.CancelledError:
+            await _kill_process_group(proc)
+            raise
+        return proc.returncode or 0, out.decode(errors="replace").strip()
+
+    # Hardening applied to the network step. None of these are set anywhere on
+    # the existing clone paths; the fetch is where an attacker-influenced URL
+    # meets git, so they start here rather than nowhere.
+    hardening = [
+        "-c",
+        "protocol.ext.allow=never",
+        "-c",
+        "submodule.recurse=false",
+        "-c",
+        "fetch.recurseSubmodules=no",
+    ]
+
+    # Destination lifecycle, stated as one invariant because three reviewer findings
+    # were three exits from the same mistake:
+    #
+    #   THIS FUNCTION MAY DELETE `dest` IF AND ONLY IF THIS INVOCATION CREATED IT
+    #   AND DID NOT SUCCEED -- and that is decided in ONE place, not per branch.
+    #
+    # The earlier drafts put cleanup on each failure branch, so each fix closed one
+    # exit and left the others: adopting a non-checkout destination (deleted the
+    # user's files), a moved-aside restore that skipped on cancellation, and finally
+    # a spawn exception between `git init` and `git remote add` that left a `.git`
+    # directory with no origin -- which then wedges every later attempt on
+    # `unreadable_clone_origin`, a fail-closed path that deliberately does not clean
+    # up after itself.
+    #
+    # Cleanup therefore belongs to the LIFETIME of the thing created, not to the
+    # enumeration of ways to fail. The `finally` below covers return, raise and
+    # cancellation without any branch having to remember.
+    created_here = False
+    succeeded = False
+    try:
+        if (dest / ".git").is_dir():
+            pass  # a checkout we can fetch into; never ours to delete
+        elif dest.exists():
+            # Refuse rather than adopt. `not (dest / ".git").is_dir()` answers "is
+            # there a checkout here", which is NOT "am I creating this": a plain
+            # directory of the user's files, or a `.git` FILE from a worktree link,
+            # would read as fresh.
+            log_lines.append(
+                f"Refusing to fetch into {dest}: it exists but is not a git checkout "
+                "(remove or fix it manually and retry)"
+            )
+            return {
+                "ok": False,
+                "name": dest.name,
+                "error": "destination_not_a_checkout",
+                "message": (
+                    "The destination exists but is not a git checkout. Remove or fix it "
+                    "manually and retry the install."
+                ),
+            }
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            # Set BEFORE the spawn: `git init` may create the directory and then
+            # fail, or the spawn itself may raise, and either way the directory is
+            # ours to discard.
+            created_here = True
+            code, out = await run(
+                ["git", "init", "--quiet", "--template=", str(dest)], timeout=15
+            )
+            if code != 0:
+                log_lines.append(f"git init failed (exit {code}): {out}")
+                return {"ok": False, "name": dest.name, "error": "git init failed"}
+            code, out = await run(
+                ["git", "remote", "add", "origin", git_url], cwd=dest, timeout=15
+            )
+            if code != 0:
+                log_lines.append(f"git remote add failed (exit {code}): {out}")
+                return {"ok": False, "name": dest.name, "error": "git remote add failed"}
+
+        log_lines.append(f"Fetching {git_url} at {commit[:12]}...")
+        code, out = await run(
+            ["git", *hardening, "fetch", "--depth", "1", "origin", commit],
+            cwd=dest,
+            timeout=_CLONE_TIMEOUT,
+        )
+        log_lines.append(out)
+        if code != 0:
+            # Fail closed. A server that will not serve this object (unreachable
+            # commit, or one no ref contains) must not degrade into "install the
+            # default branch instead" -- that is the pin silently not applying.
+            return {
+                "ok": False,
+                "name": dest.name,
+                "error": f"git fetch of pinned commit failed (exit {code})",
+            }
+
+        code, out = await run(
+            ["git", "checkout", "--quiet", "--detach", "FETCH_HEAD"], cwd=dest, timeout=15
+        )
+        if code != 0:
+            log_lines.append(f"git checkout failed (exit {code}): {out}")
+            return {
+                "ok": False,
+                "name": dest.name,
+                "error": "git checkout of pinned commit failed",
+            }
+
+        # The pin only becomes real here. `_resolved_clone_commit` degrades to "" on
+        # any read failure, so an empty answer is a FAILURE rather than a pass: the
+        # whole point is refusing to build a tree we cannot identify.
+        landed = await asyncio.to_thread(_resolved_clone_commit, dest)
+        if landed != commit:
+            log_lines.append(
+                f"pinned commit not honoured: asked for {commit}, checkout reports "
+                f"{landed or '<unknown>'} — refusing to install"
+            )
+            return {
+                "ok": False,
+                "name": dest.name,
+                "error": "pinned commit verification failed",
+            }
+        succeeded = True
+        return None
+    finally:
+        if created_here and not succeeded:
+            await asyncio.to_thread(shutil.rmtree, dest, True)
+
+
 async def _git_clone_or_pull(
     git_url: str,
     branch: str,
@@ -2352,6 +2995,8 @@ async def _git_clone_or_pull(
     *,
     index_originated: bool = False,
     pending_cleanup: list[Path] | None = None,
+    restorable_stale: list[Path] | None = None,
+    commit: str = "",
 ) -> dict[str, Any] | None:
     """Clone *git_url* into *dest*, or fast-forward it if already present.
 
@@ -2390,6 +3035,9 @@ async def _git_clone_or_pull(
     # Track a moved-aside directory if we need to preserve the old checkout
     # during origin-mismatch re-clone (delete-after-success pattern).
     moved_aside: Path | None = None
+    # Whether *moved_aside* is the same repository (restore it on failure) rather
+    # than a different one moved out of the way (retain it, never restore).
+    moved_aside_is_restorable = False
 
     if dest.is_dir() and (dest / ".git").is_dir():
         # The credential posture was decided from *git_url* — but a persisted
@@ -2433,102 +3081,152 @@ async def _git_clone_or_pull(
             # Move aside with an atomic same-filesystem rename into a sibling
             # temp path under the app-sources root. If rename fails (e.g. locked
             # files on Windows), return fail-closed without deleting dest.
-            stale_name = f"{dest.name}.stale-{uuid.uuid4().hex[:8]}"
-            moved_aside = dest.with_name(stale_name)
-            try:
-                await asyncio.to_thread(dest.rename, moved_aside)
-            except OSError as exc:
-                log_lines.append(
-                    f"Could not move aside the stale clone at {dest}: {exc}; "
-                    "refusing to build from it"
-                )
+            moved_aside = await _move_checkout_aside(dest, log_lines)
+            if moved_aside is None:
+                log_lines.append(f"Refusing to build from the stale clone at {dest}")
                 return {
                     "ok": False,
                     "name": dest.name,
                     "error": "stale_clone_not_removed",
                     "message": (
                         "A checkout of a different repository is present and could not be "
-                        f"moved aside: {exc}. Remove it manually and retry the install."
+                        "moved aside. Remove it manually and retry the install."
                     ),
                 }
-            # Refresh mtime so the retention clock starts now, not at the
-            # checkout's last-modified time (which may already exceed the
-            # sweep threshold).  Best-effort — failure here is harmless
-            # (the directory just survives slightly shorter than intended).
-            try:
-                await asyncio.to_thread(os.utime, moved_aside)
-            except OSError:
-                pass
 
     if dest.is_dir() and (dest / ".git").is_dir():
-        # Already cloned from the verified origin — fetch and fast-forward.
-        # (The origin-mismatch gate above guarantees this checkout's origin is
-        # byte-identical to git_url: a mismatched checkout was moved aside and
-        # never reused, so the fetch source and the provenance record are the
-        # same URL by construction.)
-        log_lines.append(f"Updating {git_url} (branch: {branch})...")
-        # Route through wrap_argv (OS sandbox) THEN cgroup_scope_argv, matching
-        # the fresh-clone path below — the cgroup DoS ceiling is the outermost
-        # layer but must not replace the wrap_argv sandbox on this
-        # agent-influenced git spawn.
-        pull_cmd, _cleanup = wrap_argv(
-            ["git", "pull", "--ff-only", "origin", branch],
-            mode=sandbox_mode,
-        )
-        pull_cmd = cgroup_scope_argv(pull_cmd)
-        proc = await create_subprocess_limited(
-            *pull_cmd,
-            cwd=str(dest),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            start_new_session=platform_compat.IS_POSIX,
-            creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
-            env=clone_env,
-        )
-        try:
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
-            log_lines.append(stdout.decode(errors="replace").strip())
-            if proc.returncode != 0:
-                # Fail closed: installing whatever the checkout happens to hold
-                # while persisting the catalog URL as its provenance would
-                # record a source the installed code was never fetched from.
-                log_lines.append(f"git pull failed (exit {proc.returncode}) — aborting")
+        if commit:
+            # A PINNED INSTALL NEVER REUSES AN EXISTING TREE.
+            #
+            # Four review rounds landed here, each a different way of trusting
+            # on-disk state: adopting a destination that was not a checkout, an
+            # exception leaving a half-built one, HEAD equality standing in for
+            # contents, and finally content `git status` cannot report at all. The
+            # last one is why no cleanliness check can close this class: `.git/`
+            # is never reported by any `git status` variant, so an added
+            # `.git/hooks/post-checkout` is invisible, and an untracked
+            # `sitecustomize.py` executes on interpreter start if the tree lands on
+            # `sys.path`. Both run attacker code while the receipt records the pin.
+            #
+            # So the pin's meaning is restored structurally instead: the tree the
+            # build sees is one this call fetched, not one it inspected. The old
+            # checkout is moved aside (never deleted) and the fresh-checkout path
+            # below fetches into an empty destination created by
+            # `git init --template=`, which is also what keeps hooks absent.
+            #
+            # The cost is one shallow fetch of a single commit per pinned reinstall.
+            # The fast path it replaces was buying that round-trip with trust in an
+            # agent-writable directory.
+            moved_aside = await _move_checkout_aside(dest, log_lines)
+            # This one is the SAME repository with the user's own edits, so a failed
+            # transaction must put it back. The origin-mismatch move above is a
+            # DIFFERENT repository's checkout: restoring that would hand the build the
+            # very tree the mismatch gate refused, so it is only ever retained. One
+            # list carrying both meanings is what made a failed pinned update either
+            # lose the user's edits or resurrect the wrong repo, depending on which
+            # rule won.
+            moved_aside_is_restorable = moved_aside is not None
+            if moved_aside is None:
                 return {
                     "ok": False,
-                    "error": f"git pull failed (exit {proc.returncode}); not installing stale code",
+                    "name": dest.name,
+                    "error": "existing_checkout_not_moved_aside",
+                    "message": (
+                        "The existing app checkout could not be moved aside, so a "
+                        "pinned install cannot be performed safely. Remove or move it "
+                        "manually and retry the install."
+                    ),
                 }
-        except asyncio.TimeoutError:
-            await _kill_process_group(proc)
-            log_lines.append("git pull timed out — aborting")
-            return {
-                "ok": False,
-                "error": "git pull timed out; not installing stale code",
-            }
-        return None
+            # Fall through: `dest` no longer exists, so the pinned fetch below
+            # creates it fresh inside the try/finally that owns restoration.
+        else:
+            # Already cloned from the verified origin — fetch and fast-forward.
+            # (The origin-mismatch gate above guarantees this checkout's origin is
+            # byte-identical to git_url: a mismatched checkout was moved aside and
+            # never reused, so the fetch source and the provenance record are the
+            # same URL by construction.)
+            log_lines.append(f"Updating {git_url} (branch: {branch})...")
+            # Route through wrap_argv (OS sandbox) THEN cgroup_scope_argv, matching
+            # the fresh-clone path below — the cgroup DoS ceiling is the outermost
+            # layer but must not replace the wrap_argv sandbox on this
+            # agent-influenced git spawn.
+            pull_cmd, _cleanup = wrap_argv(
+                ["git", "pull", "--ff-only", "origin", branch],
+                mode=sandbox_mode,
+            )
+            pull_cmd = cgroup_scope_argv(pull_cmd)
+            proc = await create_subprocess_limited(
+                *pull_cmd,
+                cwd=str(dest),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+                env=clone_env,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
+                log_lines.append(stdout.decode(errors="replace").strip())
+                if proc.returncode != 0:
+                    # Fail closed: installing whatever the checkout happens to hold
+                    # while persisting the catalog URL as its provenance would
+                    # record a source the installed code was never fetched from.
+                    log_lines.append(f"git pull failed (exit {proc.returncode}) — aborting")
+                    return {
+                        "ok": False,
+                        "error": (
+                            f"git pull failed (exit {proc.returncode}); "
+                            "not installing stale code"
+                        ),
+                    }
+            except asyncio.TimeoutError:
+                await _kill_process_group(proc)
+                log_lines.append("git pull timed out — aborting")
+                return {
+                    "ok": False,
+                    "error": "git pull timed out; not installing stale code",
+                }
+            return None
 
-    # Fresh clone.
-    log_lines.append(f"Cloning {git_url} (branch: {branch})...")
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    clone_cmd = [
-        "git",
-        "clone",
-        "--depth",
-        "1",
-        "--branch",
-        branch,
-        "--single-branch",
-        git_url,
-        str(dest),
-    ]
-    sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode=sandbox_mode)
-    sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-
-    # If we moved aside a stale clone for re-clone, wrap the entire spawn+wait
-    # in try/finally so that ANY failure path (spawn exception, cancellation,
-    # timeout, nonzero exit) restores the moved-aside checkout. The old checkout
-    # must never disappear permanently due to a transient clone failure.
+    # Fresh checkout.
+    #
+    # Both the pinned and the branch path run inside the SAME try/finally below,
+    # which owns moved-aside restoration. The first draft gave the pinned path its
+    # own restore, which skipped on a spawn exception or cancellation -- and the two
+    # copies could nest, stranding the user's old checkout. One restoration path,
+    # exercised by both.
     clone_succeeded = False
     try:
+        if commit:
+            result = await _git_fetch_commit(
+                git_url,
+                commit,
+                dest,
+                log_lines,
+                clone_env=clone_env,
+                sandbox_mode=sandbox_mode,
+            )
+            if result is not None:
+                return result
+            clone_succeeded = True
+            return None
+
+        log_lines.append(f"Cloning {git_url} (branch: {branch})...")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        clone_cmd = [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            branch,
+            "--single-branch",
+            git_url,
+            str(dest),
+        ]
+        sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode=sandbox_mode)
+        sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
+
         proc = await create_subprocess_limited(
             *sandboxed_cmd,
             stdout=asyncio.subprocess.PIPE,
@@ -2563,6 +3261,11 @@ async def _git_clone_or_pull(
                 # after the full install transaction succeeds.
                 if pending_cleanup is not None:
                     pending_cleanup.append(moved_aside)
+                # Reported separately, because only a same-repository move may be
+                # restored: putting an origin-mismatched checkout back would give the
+                # build the tree that gate refused.
+                if moved_aside_is_restorable and restorable_stale is not None:
+                    restorable_stale.append(moved_aside)
             else:
                 # Clone did NOT succeed — remove any partial dest and restore
                 # the old checkout so the user's code is not stranded.
@@ -2613,6 +3316,7 @@ async def _clone_build_app(
     index_originated: bool = False,
     subdirectory: str = "",
     entry_repo: str = "",
+    commit: str = "",
 ) -> dict[str, Any]:
     """Clone an app repo, gate its identity, then run its build.
 
@@ -2635,15 +3339,48 @@ async def _clone_build_app(
     # across the complete lifecycle transaction — clone/build, copy,
     # registration, and backend startup — so nested acquisition here would
     # deadlock (asyncio.Lock is not reentrant).
-    return await _clone_build_app_locked(
-        git_url,
-        app_name,
-        log_lines,
-        branch=branch,
-        index_originated=index_originated,
-        subdirectory=subdirectory,
-        entry_repo=entry_repo,
-    )
+    # The restoration state is collected HERE, at the single return, rather than
+    # stamped onto the result inside `_clone_build_app_locked`. That function has six
+    # exits and the state was only attached on the successful one, so a post-fetch
+    # failure -- a subdirectory that escapes containment, an identity mismatch, a
+    # rejected admission -- dropped it, and the caller's `finally` had nothing to
+    # restore from: the user's edited checkout went to the retention sweep. A list the
+    # callee fills and this one exit reads cannot be forgotten by a new exit.
+    restorable_stale: list[Path] = []
+    try:
+        result = await _clone_build_app_locked(
+            git_url,
+            app_name,
+            log_lines,
+            branch=branch,
+            index_originated=index_originated,
+            subdirectory=subdirectory,
+            entry_repo=entry_repo,
+            commit=commit,
+            restorable_stale=restorable_stale,
+        )
+    except BaseException:
+        # Cancellation and exceptions never reach the stamping line below, so the
+        # caller's `finally` would see no state and the user's moved-aside checkout
+        # would go to the retention sweep. There is no result dict to carry it on
+        # this path, so restore HERE, where both the state and the destination are
+        # known. `BaseException` on purpose: `CancelledError` is the reported case.
+        #
+        # SYNCHRONOUS, and that is the point: `await` during cancellation re-enters a
+        # loop that is being torn down, which surfaces as `RuntimeError: Event loop is
+        # closed` -- a failure this handler caused on three CI platforms at once. The
+        # work is a rmtree plus a rename, so it never needed the loop.
+        if restorable_stale:
+            _restore_moved_aside(
+                restorable_stale[0],
+                app_source_dir(app_name),
+                log_lines,
+                "the build was interrupted",
+            )
+        raise
+    if restorable_stale and isinstance(result, dict):
+        result["_restorable_stale"] = list(restorable_stale)
+    return result
 
 
 async def _unpoison_rejected_checkout(
@@ -2758,6 +3495,8 @@ async def _clone_build_app_locked(
     index_originated: bool = False,
     subdirectory: str = "",
     entry_repo: str = "",
+    commit: str = "",
+    restorable_stale: list[Path] | None = None,
 ) -> dict[str, Any]:
     """Inner implementation of _clone_build_app, called under per-app lock."""
     if not _looks_like_git_url(git_url):
@@ -2769,6 +3508,8 @@ async def _clone_build_app_locked(
 
     pkg_dir = app_source_dir(app_name)
     pending_cleanup: list[Path] = []
+    if restorable_stale is None:
+        restorable_stale = []
     # Captured BEFORE the clone so a refusal below can tell a checkout this run
     # created (delete: no residue) from a pre-existing app workspace (preserve).
     checkout_preexisted = (pkg_dir / ".git").is_dir()
@@ -2797,6 +3538,8 @@ async def _clone_build_app_locked(
         log_lines,
         index_originated=index_originated,
         pending_cleanup=pending_cleanup,
+        restorable_stale=restorable_stale,
+        commit=commit,
     )
     if clone_err is not None:
         return clone_err
@@ -3142,6 +3885,53 @@ async def install_from_registry(
     repo = entry.get("repo", "")
     branch = entry.get("branch", "main")
     subdirectory = entry.get("subdirectory", "")
+    # Pinning is a CATALOG mechanism, so the pin is read only for a catalog row.
+    #
+    # `commit` is on the row-projection allowlist (`_REGISTRY_ROW_KEYS`), and that
+    # projection also builds rows from an external registry's index -- untrusted,
+    # index-controlled JSON. Reading it unconditionally would hand that index a
+    # capability its `branch` field cannot express: a fetch BY SHA reaches objects
+    # no branch contains (a commit force-pushed away, or one that only ever existed
+    # on a side ref), while a branch clone can only ever reach what a ref points at.
+    # The owner-configured `branch` would then stop bounding which code gets built
+    # and runs `onInstall`.
+    #
+    # `_is_catalog_row` is the right test rather than a bare `_catalog` check,
+    # because `_catalog` is index-settable while `_registry` is attached server-side
+    # per configured registry and cannot be forged.
+    if _is_catalog_row(entry):
+        commit = str(entry.get("commit", "") or "")
+    else:
+        commit = ""
+        if entry.get("commit"):
+            # Not a refusal: `branch` is exactly the coordinate such a row is
+            # entitled to, so honouring it is correct. But an index author who
+            # believes they pinned deserves to see that they did not.
+            logger.warning(
+                "ignoring commit pin on non-catalog row %r: pinning is a catalog "
+                "mechanism; installing from branch %r instead",
+                name,
+                branch,
+            )
+
+    # The pin is honoured or the install is refused -- there is no third option.
+    #
+    # `branch` above defaults to "main", and that default is what makes a quiet
+    # failure possible: a catalog row carries a commit and no branch, so a path
+    # that ignored `commit` would clone the tip of "main", SUCCEED, and record the
+    # tip's commit as this app's provenance. The store would then look like it
+    # installs pinned bytes while installing whatever the app's default branch
+    # holds today. Refusing a malformed pin is the only safe answer, because the
+    # alternative is inventing coordinates nobody signed.
+    if commit and not _COMMIT_SHA_RE.match(commit):
+        return {
+            "ok": False,
+            "name": name,
+            "error": (
+                f"app {name!r} carries a malformed pinned commit; refusing to "
+                f"install rather than fall back to a branch"
+            ),
+        }
 
     # Confused-deputy defense on the INSTALL path (companion to the automatic
     # browse/refresh defense in ``anonymous_git_env``). An entry that came from
@@ -3163,12 +3953,25 @@ async def install_from_registry(
     # AND sandbox mode together (the strict sandbox hiding ~/.ssh is the
     # load-bearing enforcement on credential-helper setups, not the env alone).
     # Sibling repos on the same host remain anonymous+strict.
-    index_originated = bool(entry.get("_registry"))
-    # OFFICIALNESS is decided here, BEFORE the owner-designated carve-out below:
-    # that carve-out flips index_originated as a CREDENTIAL decision (owner
-    # explicitly designated the repo), but an external-index entry never becomes
-    # an official-catalog entry — install receipts must not fire for it.
-    official_entry = not index_originated
+    # Credential posture and OFFICIALNESS are two different questions, and a
+    # catalog row is the case that separates them: its URL arrives in a document
+    # fetched over the network whose signature this client does not yet verify, so
+    # it is remote-controlled content exactly like an external index's URL -- but
+    # it IS an app we list, so its install receipt must still fire.
+    #
+    # Treating "no `_registry`" as "the owner designated this repo" was true while
+    # the only marker-less rows came from the wheel's bundled seed, which the owner
+    # installed deliberately. A catalog row is not that: nobody typed its URL, and
+    # a repointed row on a trusted forge would otherwise be cloned with the
+    # gateway's ambient git/ssh identity -- the confused-deputy read this posture
+    # exists to prevent.
+    index_originated = _remote_controlled_url(entry)    # OFFICIALNESS is decided from `_registry` ALONE, and BEFORE the
+    # owner-designated carve-out below: that carve-out flips index_originated as a
+    # CREDENTIAL decision (owner explicitly designated the repo), but an
+    # external-index entry never becomes an official-catalog entry — install
+    # receipts must not fire for it. A catalog row has no `_registry`, so it stays
+    # official even though it takes the credential-free posture above.
+    official_entry = _official_entry(entry)
     # The originating external registry id, recorded as provenance. Empty means
     # the bundled (KiroCrew-shipped) catalog, which is itself a distinct source.
     # Captured BEFORE the owner-designated carve-out (same reasoning as above):
@@ -3196,6 +3999,7 @@ async def install_from_registry(
         app_name=name,
         git_url=git_url,
         owner_designated=manifest_owner_designated,
+        commit=commit,
     )
 
     # Admission: gate AFTER the manifest fetch (so a signed manifest is verified)
@@ -3300,6 +4104,9 @@ async def install_from_registry(
         except (asyncio.TimeoutError, OSError):
             pass
 
+    build_result: dict[str, Any] = {}
+    # Cleared only after the transaction durably succeeds; the `finally` below reads it.
+    durable_success = False
     try:
         # Best-effort sweep of aged .stale-* / .partial-* dirs before the
         # install — prevents unbounded accumulation without blocking.
@@ -3321,6 +4128,7 @@ async def install_from_registry(
             # below is still authoritative for choosing app.json's directory.
             subdirectory=subdirectory,
             entry_repo=repo,
+            commit=commit,
         )
         if not build_result["ok"]:
             return {**build_result, "log": "\n".join(log_lines)}
@@ -3629,6 +4437,12 @@ async def install_from_registry(
 
             display = manifest_data.get("displayName", name)
             version = manifest_data.get("version", "0.0.0")
+            # Set BEFORE any of the fallible bookkeeping below, because this branch
+            # returns ok=True regardless of how the registration and provenance writes
+            # go: the clone is in place and the app will register itself on next
+            # launch. Leaving it False would report success to the caller while the
+            # `finally` rolled the source checkout back underneath it.
+            durable_success = True
             reg_result = register_external_app(
                 name=name,
                 version=version,
@@ -3690,6 +4504,14 @@ async def install_from_registry(
         # self-heals a legacy record: its next successful update writes the full
         # provenance it was missing.
         if result.ok:
+            # BEFORE the bookkeeping below, not after. `install_app`/`update_app` has
+            # already copied the files into place, so the installed app IS updated. If
+            # provenance persistence then raises, deciding "not durable" and rolling
+            # the SOURCE checkout back would leave installed files from the new
+            # version beside a source tree from the old one -- a torn state worse than
+            # either outcome. A failed receipt is a bookkeeping problem to log; it does
+            # not un-install what is installed.
+            durable_success = True
             set_app_provenance(
                 result.name,
                 source=f"{SOURCE_REGISTRY_PREFIX}{name}",
@@ -3724,3 +4546,46 @@ async def install_from_registry(
     except Exception as exc:
         logger.exception("Failed to install %s from registry", name)
         return {"ok": False, "name": name, "error": str(exc), "log": "\n".join(log_lines)}
+    finally:
+        # RESTORATION BELONGS TO THE LIFETIME, NOT TO THE LIST OF FAILURES.
+        #
+        # A pinned install moves the previous checkout aside on every reinstall, and
+        # this function has seven post-clone exits (containment, identity mismatch,
+        # two admission gates, onInstall, the install step, the happy path) plus an
+        # exception path and cancellation. Restoring on the branches instead meant an
+        # `onInstall` that exited non-zero returned early and left the user's only
+        # edited copy as a `.stale-*` sibling for the retention sweep to delete.
+        #
+        # One site, reached by every exit. It is a no-op unless a moved-aside
+        # checkout exists AND the transaction did not durably succeed, so the
+        # pre-clone exits and the happy path both pass through untouched.
+        if not durable_success:
+            try:
+                pending = build_result.get("_restorable_stale") or []
+                if pending:
+                    _restore_moved_aside(
+                        Path(pending[0]),
+                        # `app_source_dir(name)`, NOT `build_result["pkg_dir"]`: every
+                        # post-clone FAILURE dict omits `pkg_dir`, so reading it raised a
+                        # KeyError that the broad catch below swallowed -- the
+                        # restoration silently did nothing on exactly the exits it
+                        # exists for. The destination is a function of the app name, so
+                        # derive it instead of depending on a key the failure paths do
+                        # not carry. It is the clone ROOT either way: a `subdirectory`
+                        # entry points `app_source` inside the tree, while the
+                        # moved-aside sibling replaces the whole checkout.
+                        app_source_dir(name),
+                        log_lines,
+                        "the install did not complete",
+                    )
+            except Exception:  # noqa: BLE001 - never mask the outcome being returned
+                # WARNING, not debug: this catch is what hid the KeyError above for
+                # four review rounds. A restoration that could not run is a possible
+                # data loss, so it has to be visible in the log the user sees.
+                logger.warning(
+                    "could not restore the moved-aside checkout for %r", name, exc_info=True
+                )
+                log_lines.append(
+                    "WARNING: the previous checkout could not be restored; recover it "
+                    "from the .stale-* sibling directory"
+                )

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -1965,8 +1965,13 @@ _SAFE_SCP_URL_RE = re.compile(r"^[A-Za-z0-9._\-]+@[A-Za-z0-9.\-]+:[A-Za-z0-9._/\
 _SAFE_SSH_URL_RE = re.compile(
     r"^ssh://(?:[A-Za-z0-9._\-]+@)?[A-Za-z0-9.\-]+(?::[0-9]+)?/[A-Za-z0-9._/\-]+$"
 )
-_SAFE_REF_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
-_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_./-]+$")
+# `\Z`, not `$`: Python's `$` also matches immediately BEFORE a trailing newline, so with
+# the `.match` calls in the blob handler a value like "main\n" passes -- and both of these
+# feed git argv and a filesystem join. Same defect class as the catalog-side coordinate
+# patterns; these are the blob handler's instances. (The class is wider than this file:
+# other `$`-anchored request-path patterns exist elsewhere, e.g. papyrus's GIT_URL_RE.)
+_SAFE_REF_RE = re.compile(r"^[A-Za-z0-9._/-]+\Z")
+_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_./-]+\Z")
 _BLOB_ALLOWED_EXT = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico"})
 
 

--- a/src/kiro_crew/dashboard/handlers/security.py
+++ b/src/kiro_crew/dashboard/handlers/security.py
@@ -48,6 +48,7 @@ from aiohttp import web
 
 from kiro_crew.apps.execution import APP_NAME_RE, builtin_app_names, trusted_app_names
 from kiro_crew.apps.manager import disable_app, get_app, list_apps
+from kiro_crew.apps.official_catalog import CatalogUnavailable
 from kiro_crew.apps.registry import get_registry_app
 from kiro_crew.apps.routes import app_lifecycle_lock
 from kiro_crew.apps.teardown import teardown_app_runtime
@@ -1000,7 +1001,15 @@ async def api_trusted_app_grant(request: web.Request) -> web.Response:
         # Offloaded: both read from disk (installed.json + app.json; the registry
         # file and its cached external-index snapshots).
         def _is_known_app() -> bool:
-            return get_app(name) is not None or get_registry_app(name) is not None
+            if get_app(name) is not None:
+                return True
+            try:
+                return get_registry_app(name) is not None
+            except CatalogUnavailable:
+                # Resolution was refused because the catalog could not be consulted.
+                # Treat as not-known: this gates an execution grant, so declining
+                # while the source cannot be confirmed is the safe direction.
+                return False
 
         # Whether the app is INSTALLED right now, kept separate from "known". A
         # registry-only name is grantable on purpose (the install-consent flow grants

--- a/test/test_app_execution.py
+++ b/test/test_app_execution.py
@@ -784,6 +784,13 @@ class TestRegistryAndProvenanceBoundary:
             return item
 
         monkeypatch.setattr(registry, "_load_external_registries", _no_external_registries)
+        # The official catalog is a THIRD inventory source, so this test has to
+        # isolate it exactly as it already isolates the seed and the external
+        # registries. Left unpatched it reaches the live document over the
+        # network, and the assertion below would then depend on what the store
+        # currently ships. Inventory comes from a fresh fetch, so patching this
+        # source covers both the listing and the install-resolution paths.
+        monkeypatch.setattr(registry.official_catalog, "fetch_inventory_entries", lambda: [])
         monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
         monkeypatch.setattr(registry, "_resolve_manifest", _identity_manifest)
         monkeypatch.setattr(execution, "third_party_execution_allowed", lambda: False)

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -1691,7 +1691,7 @@ class TestCatalogFailureNeverBreaksTheStore:
         def boom():
             raise exc
 
-        monkeypatch.setattr(registry, "load_official_catalog", boom)
+        monkeypatch.setattr(registry.official_catalog, "fetch_inventory_entries", boom)
         rows = await self._rows(monkeypatch)
         assert "seed-app" in rows, "the seed listing must survive a catalog failure"
 
@@ -1700,7 +1700,9 @@ class TestCatalogFailureNeverBreaksTheStore:
         """The overlay is the half that touches untrusted field types, so it is
         the half most likely to raise on a document we did not anticipate."""
         monkeypatch.setattr(
-            registry, "load_official_catalog", lambda: [{"name": "seed-app"}]
+            registry.official_catalog,
+            "fetch_inventory_entries",
+            lambda: [{"name": "seed-app"}],
         )
 
         def boom(rows, entries):
@@ -1715,13 +1717,19 @@ class TestCatalogFailureNeverBreaksTheStore:
         self, monkeypatch, caplog
     ):
         """A broad catch is only acceptable because it is loud: without the
-        traceback this would hide our own bugs instead of a bad document."""
+        traceback this would hide our own bugs instead of a bad document.
+
+        Patched at `fetch_inventory_entries` because that is the source the listing
+        now uses; the cache-fed loader is no longer on this path at all.
+        """
 
         def boom():
             raise RuntimeError("kaboom")
 
-        monkeypatch.setattr(registry, "load_official_catalog", boom)
+        monkeypatch.setattr(
+            registry.official_catalog, "fetch_inventory_entries", boom
+        )
         with caplog.at_level("WARNING", logger=registry.logger.name):
             await self._rows(monkeypatch)
-        assert any("official catalog" in r.message for r in caplog.records)
+        assert any("catalog" in r.message for r in caplog.records)
         assert any(r.exc_info for r in caplog.records), "expected a traceback"

--- a/test/test_catalog_inventory.py
+++ b/test/test_catalog_inventory.py
@@ -1,0 +1,1595 @@
+"""The catalog as the shelf: inventory rows, and installs that honour the pin.
+
+These cover the seam this change opens. The one that matters most is
+``test_a_pinned_entry_never_falls_back_to_a_branch``: every other failure here is
+loud, and that one is the only way this feature can fail while reporting success.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+from typing import Any
+
+import pytest
+
+from kiro_crew.apps import official_catalog as oc
+from kiro_crew.apps import registry as reg
+
+SHA = "a" * 40
+OTHER_SHA = "b" * 40
+URL = "https://github.com/org/demo-app"
+
+
+def catalog_git(name: str = "demo-app", **over: Any) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "name": name,
+        "source": {"type": "git", "url": URL, "ref": SHA},
+        "version": "1.2.3",
+        "displayName": "Demo App",
+        "summary": "Does the demo thing.",
+        "tags": ["dev"],
+        "author": {"name": "Demo Labs"},
+    }
+    entry.update(over)
+    return entry
+
+
+class TestInventory:
+    def test_a_git_entry_becomes_an_installable_row(self):
+        (row,) = oc.inventory([catalog_git()])
+        assert row["name"] == "demo-app"
+        assert row["gitUrl"] == URL
+        assert row["repo"] == URL, "the legacy alias carries the same value"
+        assert row["commit"] == SHA
+        assert row["_catalog"] is True
+
+    def test_the_row_carries_the_catalogs_version(self):
+        """Update availability belongs to the store, not to the app's branch tip.
+
+        `_enrich_with_install_status` compares this against the installed version,
+        so a row without it reads as "never any update".
+        """
+        (row,) = oc.inventory([catalog_git()])
+        assert row["version"] == "1.2.3"
+
+    def test_the_row_carries_display_fields_so_no_manifest_fetch_is_needed(self):
+        (row,) = oc.inventory([catalog_git()])
+        assert row["displayName"] == "Demo App"
+        assert row["description"] == "Does the demo thing.", "summary lands on description"
+        assert row["tags"] == ["dev"]
+
+    def test_no_author_is_emitted(self):
+        """`list_registry` snapshots `_index_author = entry["author"]`
+        unconditionally, and `_apply_trust_fields` derives the first-party badge
+        from that snapshot -- so an author here is a path from an unsigned document
+        to the badge. `annotate` sets it for display AFTER the snapshot."""
+        (row,) = oc.inventory([catalog_git()])
+        assert "author" not in row
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "../../../etc/passwd",  # traversal into paths this client owns
+            "..",
+            "/abs",
+            "a/b",  # a name becomes ONE directory segment
+            "a\\b",
+            "Upper",  # the contract is a lowercase slug
+            "-leading",
+            "trailing-",
+            "with space",
+            "demo-app\n",  # trailing newline, the \Z-vs-$ class
+            "",
+            "x" * 65,
+        ],
+    )
+    def test_a_name_that_is_not_a_slug_is_dropped(self, name):
+        """The name reaches `app_source_dir(name)` and the persistent app data
+        root, so it is a filesystem path before it is a label."""
+        assert oc.inventory([catalog_git(name=name)]) == []
+
+    def test_a_builtin_entry_produces_no_row(self):
+        """Its code ships in the wheel and is discovered from disk. A row here
+        would render an install control for something registry install cannot do."""
+        assert oc.inventory([{"name": "mochi", "source": {"type": "builtin"}}]) == []
+
+    def test_no_branch_is_emitted(self):
+        """The absence is the guard. `install_from_registry` defaults `branch` to
+        "main", so a row carrying one would let a pin-ignoring path succeed
+        against the wrong bytes."""
+        (row,) = oc.inventory([catalog_git()])
+        assert "branch" not in row
+
+    def test_no_registry_marker_is_emitted(self):
+        """`_registry` means "external": it flips provenance, drops `verified`,
+        strips `featured`, and makes `annotate` skip the row entirely."""
+        (row,) = oc.inventory([catalog_git()])
+        assert "_registry" not in row
+
+    def test_no_index_author_is_emitted(self):
+        """The catalog's signature is not verified yet, so its curated author must
+        not mint the verified badge -- the same restraint `annotate` already has."""
+        (row,) = oc.inventory([catalog_git()])
+        assert "_index_author" not in row
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            {"type": "git", "url": URL},  # no pin at all
+            {"type": "git", "url": URL, "ref": "main"},  # a branch where a pin belongs
+            {"type": "git", "url": URL, "ref": SHA + "\n"},  # trailing newline
+            {"type": "git", "url": URL, "ref": "A" * 40},  # uppercase hex
+            {"type": "git", "url": "http://x/a", "ref": SHA},  # not https
+            {"type": "git", "url": "ext::sh -c id", "ref": SHA},  # executes
+            {"type": "git", "url": "file:///etc", "ref": SHA},  # reads local paths
+            {"type": "git", "url": URL + "\n", "ref": SHA},  # trailing newline in url
+            {"type": "git", "url": URL, "ref": SHA, "subdir": "../etc"},  # traversal
+            {"type": "git", "url": URL, "ref": SHA, "subdir": "apps/..\n"},  # hidden by \n
+            {"type": "git", "url": URL, "ref": SHA, "subdir": "/abs"},  # absolute
+        ],
+    )
+    def test_a_row_with_unusable_coordinates_is_dropped_not_repaired(self, source):
+        """Dropped, never repaired. Guessing a branch when the pin is malformed
+        installs bytes nobody attested, which is what the pin prevents."""
+        assert oc.inventory([{"name": "demo-app", "source": source}]) == []
+
+    def test_hostile_field_types_drop_the_field_not_the_row(self):
+        entry = catalog_git(version=5, displayName=[], tags="devops", author="Labs")
+        (row,) = oc.inventory([entry])
+        assert "version" not in row
+        assert "displayName" not in row
+        assert "tags" not in row, "a bare string must not become one tag per character"
+        assert row["commit"] == SHA, "the row itself survives"
+
+
+class TestInstallCoordinatesDoNotTrustTheCache:
+    """The cache under the data home is NOT a sensitive path, so the agent's own
+    file tools can write it. That is harmless for display copy and unacceptable for
+    install coordinates: app trust is keyed by NAME, so whoever controls the
+    name-to-URL binding controls what a trusted name installs.
+    """
+
+    def test_the_cache_is_writable_by_the_agent(self):
+        """The premise, asserted rather than assumed -- if this ever becomes False
+        the reasoning below can be revisited, and the test says so out loud."""
+        from kiro_crew import security
+        from kiro_crew.config.loader import config_dir
+
+        cache = config_dir() / "cache" / "official-catalog.json"
+        assert security.is_sensitive_write_path(str(cache)) is False
+        assert security.is_sensitive_write_path(str(config_dir() / "security_policy.json")) is True
+
+    def test_install_lookup_refetches_and_ignores_a_poisoned_cache(self, monkeypatch):
+        poisoned = {
+            "schemaVersion": 1,
+            "apps": [{
+                "name": "demo-app",
+                "source": {"type": "git", "url": "https://evil.example/x", "ref": OTHER_SHA},
+            }],
+        }
+        honest = {
+            "schemaVersion": 1,
+            "apps": [catalog_git()],
+        }
+        monkeypatch.setattr(oc, "_read_cache", lambda: poisoned)
+        monkeypatch.setattr(oc, "fetch_document", lambda url: honest)
+
+        row = oc.inventory_for_install("demo-app")
+        assert row is not None
+        assert row["gitUrl"] == URL, "the freshly fetched document decides the URL"
+        assert row["commit"] == SHA
+
+    def test_a_remembered_failure_skips_the_fetch(self, monkeypatch):
+        """The module remembers a failed fetch so the next caller does not wait again;
+        the fresh path bypassed that, so every listing during an outage paid a full
+        HTTPS timeout."""
+        calls: list[str] = []
+
+        def counting_fetch(url, *a, **k):
+            calls.append(url)
+            return None
+
+        monkeypatch.setattr(oc, "fetch_document", counting_fetch)
+        monkeypatch.setattr(oc, "_read_cache", lambda: {oc._FAILED_KEY: 1.0})
+        with pytest.raises(oc.CatalogUnavailable):
+            oc.fetch_inventory_entries()
+        assert calls == [], "a remembered failure must not be retried"
+
+    def test_the_memory_can_only_refuse_earlier_never_answer(self, monkeypatch):
+        """Reading the agent-writable memory is safe only in this direction: clearing it
+        buys one real fetch attempt, which is the same fail-closed answer."""
+        monkeypatch.setattr(oc, "fetch_document", lambda url, *a, **k: None)
+        monkeypatch.setattr(oc, "_read_cache", lambda: None)  # memory cleared
+        monkeypatch.setattr(oc, "_write_failure", lambda: None)
+        with pytest.raises(oc.CatalogUnavailable):
+            oc.fetch_inventory_entries()
+
+    def test_install_lookup_refuses_when_the_document_cannot_be_fetched(self, monkeypatch):
+        """Refusing beats falling back to a local copy that may have been edited.
+
+        An app whose coordinates cannot be confirmed right now must not be installed
+        from bytes an attacker could have chosen.
+
+        It RAISES rather than returning None: the caller reads None as "not in the
+        catalog", which is its licence to use the unpinned bundled coordinates. A
+        refusal that looks like an absence is not a refusal.
+        """
+        monkeypatch.setattr(oc, "_read_cache", lambda: {"schemaVersion": 1, "apps": [catalog_git()]})
+        monkeypatch.setattr(oc, "fetch_document", lambda url: None)
+        with pytest.raises(oc.CatalogUnavailable):
+            oc.inventory_for_install("demo-app")
+
+    @pytest.mark.parametrize(
+        "doc",
+        [
+            {"schemaVersion": 2, "apps": [catalog_git()]},  # unknown schema
+            {"schemaVersion": 1, "apps": [catalog_git()], "removed": [{"name": "x"}]},
+            {"schemaVersion": 1, "apps": "not-a-list"},
+            {"schemaVersion": 1},
+        ],
+    )
+    def test_install_lookup_applies_the_same_envelope_gates(self, monkeypatch, doc):
+        """A fresh fetch is not a licence to skip the checks the cached path makes.
+
+        Each of these is "I could not interpret the catalog", never "the app is
+        absent from it", so each raises.
+        """
+        monkeypatch.setattr(oc, "fetch_document", lambda url: doc)
+        with pytest.raises(oc.CatalogUnavailable):
+            oc.inventory_for_install("demo-app")
+
+
+class TestCredentialPosture:
+    def test_a_catalog_row_takes_the_credential_free_posture(self):
+        """A catalog URL is remote-controlled content, not a repo the owner typed.
+
+        `index_originated` drives the clone's credential posture. Treating "no
+        `_registry`" as "owner-designated" was true while the only marker-less rows
+        came from the wheel's bundled seed; a catalog row is not that, and a
+        repointed row on a trusted forge would otherwise be cloned with the
+        gateway's ambient git/ssh identity.
+        """
+        assert reg._remote_controlled_url({"_catalog": True}) is True
+        assert reg._remote_controlled_url({"_registry": "acme"}) is True
+        assert reg._remote_controlled_url({}) is False, "the bundled seed stays owner-designated"
+
+    def test_a_catalog_row_is_still_an_official_entry(self):
+        """Credential posture and officialness are different questions, and the
+        catalog row is the case that separates them: credential-free, yet an app we
+        list -- so its install receipt must still fire."""
+        assert reg._official_entry({"_catalog": True}) is True
+        assert reg._official_entry({"_registry": "acme"}) is False
+        assert reg._official_entry({}) is True
+
+
+class TestPinnedFetchNeverEatsUserData:
+    @pytest.mark.asyncio
+    async def test_a_destination_that_is_not_a_checkout_is_refused_not_deleted(self, tmp_path):
+        """The first draft read "no .git directory" as "I am creating this", so a
+        plain directory of the user's files was deleted when a fetch failed."""
+        dest = tmp_path / "app-source"
+        dest.mkdir()
+        (dest / "important.txt").write_text("user data", encoding="utf-8")
+        log: list[str] = []
+
+        result = await reg._git_fetch_commit(
+            "https://example.com/a.git", SHA, dest, log,
+            clone_env={}, sandbox_mode="standard",
+        )
+        assert result is not None and result["error"] == "destination_not_a_checkout"
+        assert (dest / "important.txt").read_text(encoding="utf-8") == "user data"
+
+    @pytest.mark.asyncio
+    async def test_a_git_file_rather_than_directory_is_also_refused(self, tmp_path):
+        """A worktree link stores `.git` as a FILE, so an `is_dir()` test alone
+        classifies a real checkout as fresh."""
+        dest = tmp_path / "linked"
+        dest.mkdir()
+        (dest / ".git").write_text("gitdir: /elsewhere/.git/worktrees/x\n", encoding="utf-8")
+        log: list[str] = []
+
+        result = await reg._git_fetch_commit(
+            "https://example.com/a.git", SHA, dest, log,
+            clone_env={}, sandbox_mode="standard",
+        )
+        assert result is not None and result["error"] == "destination_not_a_checkout"
+        assert (dest / ".git").is_file(), "the link was left alone"
+
+    @pytest.mark.asyncio
+    async def test_a_spawn_failure_after_init_leaves_nothing_behind(self, tmp_path, monkeypatch):
+        """The exit three rounds of patches all missed.
+
+        Cleanup used to sit on each failure BRANCH, so an exception between
+        `git init` and `git remote add` bypassed every one of them and left a `.git`
+        directory with no origin -- which then wedges each later attempt on
+        `unreadable_clone_origin`, a fail-closed path that deliberately does not
+        clean up after itself. Cleanup now belongs to the destination's lifetime.
+        """
+        dest = tmp_path / "app-source"
+        calls: list[list[str]] = []
+
+        async def flaky(*argv, **kwargs):
+            calls.append(list(argv))
+            if any("remote" in str(a) for a in argv):
+                raise OSError("simulated spawn failure")
+            (dest / ".git").mkdir(parents=True, exist_ok=True)
+
+            class _P:
+                returncode = 0
+
+                async def communicate(self):
+                    return b"", b""
+
+            return _P()
+
+        monkeypatch.setattr(reg, "create_subprocess_limited", flaky)
+        monkeypatch.setattr(reg, "wrap_argv", lambda argv, mode=None: (argv, None))
+        monkeypatch.setattr(reg, "cgroup_scope_argv", lambda argv: argv)
+
+        with pytest.raises(OSError):
+            await reg._git_fetch_commit(
+                "https://example.com/a.git", SHA, dest, [],
+                clone_env={}, sandbox_mode="standard",
+            )
+        assert not dest.exists(), "a directory this call created must not survive a raise"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_after_init_leaves_nothing_behind(self, tmp_path, monkeypatch):
+        """Same invariant, different exit: `finally` covers cancellation too, which a
+        per-branch `if` never can."""
+        dest = tmp_path / "app-source"
+
+        async def cancelling(*argv, **kwargs):
+            if any("remote" in str(a) for a in argv):
+                raise asyncio.CancelledError()
+            (dest / ".git").mkdir(parents=True, exist_ok=True)
+
+            class _P:
+                returncode = 0
+
+                async def communicate(self):
+                    return b"", b""
+
+            return _P()
+
+        monkeypatch.setattr(reg, "create_subprocess_limited", cancelling)
+        monkeypatch.setattr(reg, "wrap_argv", lambda argv, mode=None: (argv, None))
+        monkeypatch.setattr(reg, "cgroup_scope_argv", lambda argv: argv)
+
+        with pytest.raises(asyncio.CancelledError):
+            await reg._git_fetch_commit(
+                "https://example.com/a.git", SHA, dest, [],
+                clone_env={}, sandbox_mode="standard",
+            )
+        assert not dest.exists()
+
+
+class TestPinIsACatalogMechanism:
+    """An external index may not reach a commit its configured branch cannot.
+
+    `commit` is on the row-projection allowlist, so an external registry's index --
+    untrusted JSON -- can set it. A fetch BY SHA reaches objects no branch contains,
+    so honouring an index-supplied pin would let the index escape the owner-
+    configured `branch` and get arbitrary code built and `onInstall`-executed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_external_registry_pin_is_not_honoured(self, monkeypatch):
+        seen: dict[str, Any] = {}
+
+        async def capture(git_url, branch, dest, log_lines, *, commit="", **kwargs):
+            seen["branch"] = branch
+            seen["commit"] = commit
+            return {"ok": False, "name": "x", "error": "stopped after coordinates"}
+
+        monkeypatch.setattr(reg, "_git_clone_or_pull", capture)
+        monkeypatch.setattr(reg, "app_execution_denied", lambda *a, **k: None)
+        monkeypatch.setattr(
+            reg,
+            "get_registry_app",
+            lambda name: {
+                "name": "evil",
+                "gitUrl": "https://example.com/e.git",
+                "repo": "o/e",
+                "branch": "main",
+                # An index naming a commit that no branch contains.
+                "commit": SHA,
+                "_registry": "some-external-registry",
+                "_catalog": True,  # index-settable, so it must not be enough
+            },
+        )
+
+        await reg.install_from_registry("evil")
+        assert seen["commit"] == "", "an index-supplied pin must not reach the fetch"
+        assert seen["branch"] == "main", "the configured branch still bounds the install"
+
+    @pytest.mark.asyncio
+    async def test_catalog_pin_is_still_honoured(self, monkeypatch):
+        """The mirror case: gating the read must not disable the feature."""
+        seen: dict[str, Any] = {}
+
+        async def capture(git_url, branch, dest, log_lines, *, commit="", **kwargs):
+            seen["commit"] = commit
+            return {"ok": False, "name": "x", "error": "stopped after coordinates"}
+
+        monkeypatch.setattr(reg, "_git_clone_or_pull", capture)
+        monkeypatch.setattr(reg, "app_execution_denied", lambda *a, **k: None)
+        monkeypatch.setattr(
+            reg,
+            "get_registry_app",
+            lambda name: {
+                "name": "good",
+                "gitUrl": "https://example.com/g.git",
+                "repo": "o/g",
+                "commit": SHA,
+                "_catalog": True,  # and no `_registry`
+            },
+        )
+
+        await reg.install_from_registry("good")
+        assert seen["commit"] == SHA
+
+
+async def _async_passthrough(entry: Any) -> Any:
+    """Stand in for `_resolve_manifest`, returning the row unchanged."""
+    return entry
+
+
+def _async_return(value: Any):
+    """A stand-in coroutine function returning *value*, ignoring its arguments."""
+
+    async def _inner(*args: Any, **kwargs: Any) -> Any:
+        return value
+
+    return _inner
+
+
+class TestSeedCollisionKeepsThePin:
+    """Resolution must DELIVER the pin, not merely be capable of honouring it.
+
+    Both git catalog entries are also seed entries, so a collision rule favouring
+    the seed made the pin unreachable for 100% of the apps that have one -- while
+    every component-level test of the fetch still passed.
+    """
+
+    def test_install_lookup_prefers_the_catalog_row_for_the_same_repo(self, monkeypatch):
+        monkeypatch.setattr(
+            reg,
+            "_load_registry_file",
+            lambda: [{"name": "dup", "gitUrl": URL, "repo": URL, "branch": "main"}],
+        )
+        monkeypatch.setattr(
+            reg.official_catalog,
+            "inventory_for_install",
+            lambda name: {
+                "name": "dup",
+                # Cosmetically different, same repository.
+                "gitUrl": URL.rstrip("/") + ".git",
+                "repo": URL,
+                "commit": SHA,
+                "_catalog": True,
+            },
+        )
+        row = reg.get_registry_app("dup")
+        assert row is not None
+        assert row.get("commit") == SHA, "the seed row must not shadow the pin"
+        assert reg._is_catalog_row(row), "and the row must still be pin-honouring"
+
+    def test_a_catalog_row_naming_another_repo_does_not_replace_the_seed(self, monkeypatch):
+        """The security half: app trust is keyed by name, so a same-name row from a
+        different repository must not stand in for the bundled one."""
+        seed = {"name": "dup", "gitUrl": URL, "repo": URL, "branch": "main"}
+        monkeypatch.setattr(reg, "_load_registry_file", lambda: [seed])
+        monkeypatch.setattr(
+            reg.official_catalog,
+            "inventory_for_install",
+            lambda name: {
+                "name": "dup",
+                "gitUrl": "https://example.com/somewhere-else",
+                "repo": "o/other",
+                "commit": SHA,
+                "_catalog": True,
+            },
+        )
+        row = reg.get_registry_app("dup")
+        assert row == seed, "a different repository must not supersede the seed"
+
+    def test_candidates_put_the_pinned_row_first(self, monkeypatch):
+        monkeypatch.setattr(
+            reg,
+            "_load_registry_file",
+            lambda: [{"name": "dup", "gitUrl": URL, "repo": URL, "branch": "main"}],
+        )
+        monkeypatch.setattr(
+            reg.official_catalog,
+            "inventory_for_install",
+            lambda name: {
+                "name": "dup",
+                "gitUrl": URL,
+                "repo": URL,
+                "commit": SHA,
+                "_catalog": True,
+            },
+        )
+        monkeypatch.setattr(reg, "_read_external_registry_cache", lambda *a, **k: None)
+        candidates = reg._registry_app_candidates("dup")
+        assert candidates[0].get("commit") == SHA, "the pinned row must be resolved first"
+
+
+class TestPinnedInstallNeverReusesAnExistingTree:
+    """The pin means "these bytes", so the tree the build sees must be one this
+    call fetched -- not one it inspected.
+
+    No cleanliness check can substitute: `git status` never reports `.git/`
+    content, so an added `.git/hooks/post-checkout` is invisible to every variant
+    of it, and an untracked `sitecustomize.py` executes on interpreter start.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_existing_checkout_is_moved_aside_not_reused(self, tmp_path, monkeypatch):
+        dest = tmp_path / "source"
+        (dest / ".git").mkdir(parents=True)
+        # Content no `git status` variant would report as a modification.
+        hooks = dest / ".git" / "hooks"
+        hooks.mkdir()
+        (hooks / "post-checkout").write_text("#!/bin/sh\necho pwned\n")
+        (dest / "sitecustomize.py").write_text("import os\n")
+
+        fetched: dict[str, Any] = {}
+
+        async def fake_fetch(git_url, commit, d, log_lines, **kwargs):
+            # The fetch must see an ABSENT destination: that is what makes the
+            # tree fresh, and what keeps `git init --template=` hook-free.
+            fetched["dest_exists"] = d.exists()
+            fetched["commit"] = commit
+            return None
+
+        monkeypatch.setattr(reg, "_clone_origin_url", _async_return(URL))
+        monkeypatch.setattr(reg, "_git_fetch_commit", fake_fetch)
+
+        result = await reg._git_clone_or_pull(URL, "main", dest, [], commit=SHA)
+        assert result is None
+        assert fetched["commit"] == SHA
+        assert fetched["dest_exists"] is False, "the pinned fetch must get a fresh destination"
+        # Nothing was destroyed: the old tree survives beside it for recovery.
+        aside = [p for p in tmp_path.iterdir() if p.name.startswith("source.stale-")]
+        assert len(aside) == 1, "the old checkout is moved aside, never deleted"
+        assert (aside[0] / ".git" / "hooks" / "post-checkout").exists()
+
+    @pytest.mark.asyncio
+    async def test_a_checkout_already_at_the_pin_is_still_not_reused(self, tmp_path, monkeypatch):
+        """HEAD equality is no longer consulted at all -- it described placement,
+        never contents."""
+        dest = tmp_path / "source"
+        (dest / ".git").mkdir(parents=True)
+        called: list[str] = []
+
+        async def fake_fetch(git_url, commit, d, log_lines, **kwargs):
+            called.append(commit)
+            return None
+
+        monkeypatch.setattr(reg, "_clone_origin_url", _async_return(URL))
+        monkeypatch.setattr(reg, "_git_fetch_commit", fake_fetch)
+        # Even reporting the exact pin must not short-circuit the fetch.
+        monkeypatch.setattr(reg, "_resolved_clone_commit", lambda p: SHA)
+
+        result = await reg._git_clone_or_pull(URL, "main", dest, [], commit=SHA)
+        assert result is None
+        assert called == [SHA], "a pinned install always fetches"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_move_aside_refuses_instead_of_building(self, tmp_path, monkeypatch):
+        dest = tmp_path / "source"
+        (dest / ".git").mkdir(parents=True)
+
+        async def _must_not_fetch(*a, **k):
+            raise AssertionError("a refused move-aside must not reach the fetch")
+
+        monkeypatch.setattr(reg, "_clone_origin_url", _async_return(URL))
+        monkeypatch.setattr(reg, "_git_fetch_commit", _must_not_fetch)
+        monkeypatch.setattr(reg, "_move_checkout_aside", _async_return(None))
+
+        result = await reg._git_clone_or_pull(URL, "main", dest, [], commit=SHA)
+        assert result is not None
+        assert result["error"] == "existing_checkout_not_moved_aside"
+        assert dest.exists(), "a checkout we could not move is left untouched"
+
+    @pytest.mark.asyncio
+    async def test_move_aside_never_deletes_on_rename_failure(self, tmp_path, monkeypatch):
+        dest = tmp_path / "source"
+        dest.mkdir()
+        (dest / "user-file.txt").write_text("keep me")
+
+        def boom(*a, **k):
+            raise OSError("cross-device link")
+
+        monkeypatch.setattr(pathlib.Path, "rename", boom)
+        aside = await reg._move_checkout_aside(dest, [])
+        assert aside is None
+        assert (dest / "user-file.txt").read_text() == "keep me"
+
+
+class TestCatalogFailureNeverDowngradesToAnUnpinnedSeed:
+    """"The catalog says there is no pin" and "I could not ask the catalog" are
+    different answers; collapsing them let a network failure install a branch tip
+    for an app the store presents as pinned."""
+
+    def _seed_only(self, monkeypatch, raising: bool):
+        """Drive the REAL failure shape, not a hand-made one.
+
+        The first version of this helper patched `inventory_for_install` to raise --
+        a shape the real function never produced, because it returned None for every
+        failure. The test passed while the defect it described stayed live. So the
+        stub goes at the actual boundary: `fetch_document`, which is what a CDN
+        outage breaks.
+        """
+        seed = {"name": "dup", "gitUrl": URL, "repo": URL, "branch": "main"}
+        monkeypatch.setattr(reg, "_load_registry_file", lambda: [seed])
+
+        def fetch(url, *a, **k):
+            if raising:
+                return None  # what an unreachable catalog actually yields
+            return {
+                "schemaVersion": reg.official_catalog.SUPPORTED_SCHEMA_VERSION,
+                "apps": [],  # a valid catalog that simply does not name "dup"
+            }
+
+        monkeypatch.setattr(reg.official_catalog, "fetch_document", fetch)
+        monkeypatch.setattr(reg, "_read_external_registry_cache", lambda *a, **k: None)
+        return seed
+
+    def test_an_unreachable_catalog_raises_rather_than_reporting_absence(self, monkeypatch):
+        """The source-level half: `None` must mean "not in the catalog", nothing else.
+
+        While every failure returned None, the caller's split below could not fire at
+        all -- so this assertion is what makes the rest of the class meaningful.
+        """
+        self._seed_only(monkeypatch, raising=True)
+        with pytest.raises(reg.official_catalog.CatalogUnavailable):
+            reg.official_catalog.inventory_for_install("dup")
+
+    def test_a_valid_catalog_without_the_name_returns_none(self, monkeypatch):
+        self._seed_only(monkeypatch, raising=False)
+        assert reg.official_catalog.inventory_for_install("dup") is None
+
+    def test_a_failed_catalog_lookup_refuses_the_seed(self, monkeypatch):
+        self._seed_only(monkeypatch, raising=True)
+        row, reason = reg._resolve_registry_row("dup")
+        assert row is None, "an unpinned seed must not stand in for an unknown pin"
+        assert "could not be reached" in reason
+
+    def test_an_authoritative_no_catalog_row_still_uses_the_seed(self, monkeypatch):
+        """The other half: refusing on a successful "no row" would break every
+        seed-only app for no security gain."""
+        seed = self._seed_only(monkeypatch, raising=False)
+        row, reason = reg._resolve_registry_row("dup")
+        assert row == seed
+        assert reason == ""
+
+    def test_the_install_path_reports_why_it_refused(self, monkeypatch):
+        self._seed_only(monkeypatch, raising=True)
+        monkeypatch.setattr(reg, "get_app", lambda name: {})
+        entry, error = reg._resolve_install_entry("dup")
+        assert entry is None
+        # Assert the substance, not a phrase: the user must learn the catalog could
+        # not be consulted, rather than that the app does not exist.
+        assert "could not be reached" in error
+        assert "not found" not in error, (
+            "a bare 'not found' would send the user looking for a missing app "
+            "instead of a network failure"
+        )
+
+    def test_candidates_drop_unpinned_seed_rows_on_failure(self, monkeypatch):
+        """A seed candidate names the SAME repo as the catalog row it shadows, so
+        provenance-pinned resolution would accept it and deliver a branch tip."""
+        self._seed_only(monkeypatch, raising=True)
+        assert reg._registry_app_candidates("dup") == []
+
+
+class TestPinnedManifestFetchReachesTheGates:
+    """The admission and platform-compatibility gates read this manifest.
+
+    No test covered this path, so a destination that `_git_fetch_commit` refuses --
+    `tmp_root` itself, which already exists and is not a checkout -- made every
+    pinned manifest fetch fail silently. `manifest = None` then let the platform and
+    minClientVersion checks fall back to permissive defaults before the build runs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_pinned_fetch_gets_a_destination_it_can_create(self, monkeypatch):
+        seen: dict[str, Any] = {}
+
+        async def fake_fetch(git_url, commit, dest, log_lines, **kwargs):
+            seen["dest"] = dest
+            seen["existed"] = dest.exists()
+            seen["parent_exists"] = dest.parent.exists()
+            (dest).mkdir(parents=True, exist_ok=True)
+            (dest / "app.json").write_text('{"name": "demo", "displayName": "Demo"}')
+            return None
+
+        monkeypatch.setattr(reg, "_git_fetch_commit", fake_fetch)
+        manifest = await reg._fetch_app_manifest(
+            "o/demo", "main", "", app_name="demo", git_url=URL, commit=SHA
+        )
+        assert seen["existed"] is False, (
+            "_git_fetch_commit refuses a destination that exists but is not a checkout"
+        )
+        assert seen["parent_exists"] is True, "the temp root itself is still created for it"
+        assert manifest is not None, "the gates must actually receive a manifest"
+        assert manifest.get("displayName") == "Demo"
+
+    @pytest.mark.asyncio
+    async def test_a_pinned_subdirectory_is_read_from_the_fetched_root(self, monkeypatch):
+        """Containment is measured from where the tree landed, not from the temp root."""
+
+        async def fake_fetch(git_url, commit, dest, log_lines, **kwargs):
+            (dest / "nested").mkdir(parents=True)
+            (dest / "nested" / "app.json").write_text('{"name": "demo", "version": "9.9.9"}')
+            return None
+
+        monkeypatch.setattr(reg, "_git_fetch_commit", fake_fetch)
+        manifest = await reg._fetch_app_manifest(
+            "o/demo", "main", "nested", app_name="demo", git_url=URL, commit=SHA
+        )
+        assert manifest is not None and manifest.get("version") == "9.9.9"
+
+
+class TestUrlEquivalenceDoesNotRebindNames:
+    """`_same_git_target` decides whether a catalog row may stand in for a bundled
+    app, and app trust is keyed by name -- so a false "same target" IS the rebinding
+    that requiring URL equality exists to prevent."""
+
+    @pytest.mark.parametrize(
+        "a,b",
+        [
+            ("https://example.com/Owner/Repo", "https://example.com/owner/repo"),
+            ("https://example.com/o/Repo", "https://example.com/o/repo"),
+            ("https://example.com/O/r", "https://example.com/o/r"),
+        ],
+    )
+    def test_path_case_is_not_folded(self, a, b):
+        assert not reg._same_git_target(a, b), "repository paths are case-sensitive"
+
+    @pytest.mark.parametrize(
+        "a,b",
+        [
+            ("https://example.com/o/r", "https://example.com/o/r.git"),
+            ("https://example.com/o/r/", "https://example.com/o/r"),
+            ("HTTPS://EXAMPLE.COM/o/r", "https://example.com/o/r"),
+            ("https://Example.Com/o/r.git/", "https://example.com/o/r"),
+        ],
+    )
+    def test_genuinely_cosmetic_variance_still_matches(self, a, b):
+        """The opposite failure mode: too strict here and the pin never applies,
+        which is the round-6 defect all over again."""
+        assert reg._same_git_target(a, b)
+
+    def test_a_case_only_difference_does_not_let_the_catalog_replace_the_seed(self):
+        seed = {"name": "x", "gitUrl": "https://example.com/Owner/Repo", "repo": "o/r"}
+        catalog = {"name": "x", "gitUrl": "https://example.com/owner/repo", "commit": SHA}
+        assert not reg._catalog_row_supersedes_seed(seed, catalog)
+
+
+class TestCandidateSetReplacesEquivalentSeedRows:
+    """Provenance matching compares the recorded URL EXACTLY, so a retained seed row
+    is selected whenever its URL differs cosmetically from the catalog's."""
+
+    def _rows(self, monkeypatch, seed_url: str, catalog_url: str):
+        seed = {"name": "dup", "gitUrl": seed_url, "repo": seed_url, "branch": "main"}
+        monkeypatch.setattr(reg, "_load_registry_file", lambda: [seed])
+        monkeypatch.setattr(
+            reg.official_catalog,
+            "inventory_for_install",
+            lambda n: {"name": "dup", "gitUrl": catalog_url, "commit": SHA, "_catalog": True},
+        )
+        monkeypatch.setattr(reg, "_read_external_registry_cache", lambda *a, **k: None)
+
+    def test_a_cosmetically_different_seed_row_is_removed_not_outranked(self, monkeypatch):
+        self._rows(
+            monkeypatch,
+            seed_url="https://example.com/o/r",
+            catalog_url="https://example.com/o/r.git",
+        )
+        candidates = reg._registry_app_candidates("dup")
+        assert len(candidates) == 1, "the unpinned equivalent must not remain selectable"
+        assert candidates[0].get("commit") == SHA
+
+    def test_a_different_repository_is_still_kept(self, monkeypatch):
+        """Scope: replacing must apply only to the SAME repository."""
+        self._rows(
+            monkeypatch,
+            seed_url="https://example.com/o/r",
+            catalog_url="https://example.com/other/repo",
+        )
+        candidates = reg._registry_app_candidates("dup")
+        assert len(candidates) == 2, "a different repo's row is an addition, not a replacement"
+
+
+class TestCatalogFailureBlocksExternalFallbackToo:
+    """A catalog-only app has no seed row, so the old refusal (which required one)
+    let a same-named external registry answer for it."""
+
+    def _no_seed(self, monkeypatch):
+        monkeypatch.setattr(reg, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(reg.official_catalog, "fetch_document", lambda url: None)
+        monkeypatch.setattr(
+            reg,
+            "_read_external_registry_cache",
+            lambda *a, **k: [{"name": "dup", "gitUrl": "https://evil.example/x", "repo": "e/x"}],
+        )
+
+    def test_an_external_row_may_not_answer_while_the_catalog_is_unreachable(self, monkeypatch):
+        self._no_seed(monkeypatch)
+        row, reason = reg._resolve_registry_row("dup")
+        assert row is None, "a different source must not stand in for an unconfirmed name"
+        assert "could not be reached" in reason
+
+    def test_the_external_row_still_resolves_when_the_catalog_answers(self, monkeypatch):
+        """Scope: only a FAILED lookup blocks the external path.
+
+        Stubbed at `_external_registry_row` because what changed is whether
+        resolution REACHES that fallback, not how it reads config.
+        """
+        monkeypatch.setattr(reg, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(
+            reg.official_catalog,
+            "fetch_document",
+            lambda url: {
+                "schemaVersion": reg.official_catalog.SUPPORTED_SCHEMA_VERSION,
+                "apps": [],
+            },
+        )
+        monkeypatch.setattr(
+            reg,
+            "_external_registry_row",
+            lambda n: {"name": n, "gitUrl": "https://ext.example/x", "_registry": "ext"},
+        )
+        row, reason = reg._resolve_registry_row("dup")
+        assert reason == ""
+        assert row is not None and row.get("_registry") == "ext"
+
+
+class TestTheCacheMayNotIntroduceInventory:
+    """The listing is what a consent grant is made against, so a cache-planted name
+    must not become a row.
+
+    The cache is agent-writable. Supplying display copy for rows that exist anyway is
+    safe (`annotate` skips `_registry` rows). MATERIALISING a row is not: a planted
+    name renders with official provenance and deduplicates the real same-named
+    external row out of the listing, so the prompt describes an official app while
+    the name grant installs the external one.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_poisoned_cache_cannot_relabel_a_fresh_row(self, monkeypatch):
+        """Round 11 stopped the cache INTRODUCING a row; this stops it REWRITING one.
+
+        `annotate` overlays `displayName` and `description` -- exactly what the consent
+        modal renders -- and it used to read the cache, so a poisoned entry could
+        re-label a freshly fetched first-party row while the name-scoped grant executed
+        the real app.
+        """
+        real = {
+            "name": "demo-app",
+            "displayName": "Demo App",
+            "source": {"type": "git", "url": URL, "ref": SHA},
+        }
+        monkeypatch.setattr(reg.official_catalog, "fetch_document", lambda url: {
+            "schemaVersion": reg.official_catalog.SUPPORTED_SCHEMA_VERSION,
+            "apps": [real],
+        })
+        # The cache claims a different identity for the same name.
+        monkeypatch.setattr(reg.official_catalog, "_read_cache", lambda: {
+            "schemaVersion": reg.official_catalog.SUPPORTED_SCHEMA_VERSION,
+            "apps": [{**real, "displayName": "SPOOFED", "summary": "spoofed copy"}],
+        })
+        monkeypatch.setattr(reg, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(reg, "list_installed_apps", lambda: [])
+
+        async def _no_external():
+            return []
+
+        monkeypatch.setattr(reg, "_load_external_registries", _no_external)
+        monkeypatch.setattr(reg, "_resolve_manifest", _async_passthrough)
+
+        rows = await reg.list_registry()
+        row = next(r for r in rows if r.get("name") == "demo-app")
+        assert row.get("displayName") == "Demo App", (
+            "the identity the consent modal renders must come from the fetched document"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_poisoned_cache_cannot_relabel_a_seed_row(self, monkeypatch):
+        """Isolates the listing-SOURCE half of the fix.
+
+        A seed row is not a `_catalog` row, so `annotate`'s skip does not protect it --
+        only feeding the overlay from the fresh document does. Without this, the two
+        layers cover each other and neither is independently tested.
+        """
+        seed = {"name": "seed-app", "gitUrl": URL, "repo": URL, "branch": "main"}
+        monkeypatch.setattr(reg, "_load_registry_file", lambda: [seed])
+        # A valid fresh document that does not mention this app at all.
+        monkeypatch.setattr(reg.official_catalog, "fetch_document", lambda url: {
+            "schemaVersion": reg.official_catalog.SUPPORTED_SCHEMA_VERSION,
+            "apps": [],
+        })
+        # The cache claims curated copy for it.
+        monkeypatch.setattr(reg.official_catalog, "_read_cache", lambda: {
+            "schemaVersion": reg.official_catalog.SUPPORTED_SCHEMA_VERSION,
+            "apps": [{"name": "seed-app", "displayName": "SPOOFED", "summary": "spoof"}],
+        })
+        monkeypatch.setattr(reg, "list_installed_apps", lambda: [])
+
+        async def _no_external():
+            return []
+
+        monkeypatch.setattr(reg, "_load_external_registries", _no_external)
+
+        async def _manifest_copy(entry):
+            return {**entry, "displayName": "From Manifest"}
+
+        monkeypatch.setattr(reg, "_resolve_manifest", _manifest_copy)
+
+        rows = await reg.list_registry()
+        row = next(r for r in rows if r.get("name") == "seed-app")
+        assert row.get("displayName") == "From Manifest", (
+            "a cached entry must not supply copy for any row the consent modal renders"
+        )
+
+    def test_annotate_applies_curated_copy(self):
+        """Scope guard: skipping catalog rows must not turn the overlay into a no-op
+        for the rows it exists to serve (seed rows and built-ins)."""
+        row = {"name": "demo-app", "displayName": "From Manifest"}
+        oc.annotate([row], [{"name": "demo-app", "displayName": "Curated Name"}])
+        assert row["displayName"] == "Curated Name"
+
+    def test_annotate_leaves_catalog_rows_alone(self):
+        """Belt and braces at the overlay itself: a row materialised FROM the document
+        needs no second pass over it."""
+        row = {"name": "demo-app", "displayName": "Demo App", "_catalog": True}
+        oc.annotate([row], [{"name": "demo-app", "displayName": "SPOOFED"}])
+        assert row["displayName"] == "Demo App"
+
+    @pytest.mark.asyncio
+    async def test_a_planted_cache_row_does_not_reach_the_listing(self, monkeypatch):
+        planted = {
+            "name": "squatted",
+            "displayName": "Totally Official",
+            "source": {"type": "git", "url": URL, "ref": SHA},
+        }
+        # The CACHE says yes; the network says the catalog is unreachable. The listing
+        # reads neither the cache's inventory nor its curated copy, so a poisoned cache
+        # has no effect at all -- that is the property under test.
+        monkeypatch.setattr(reg.official_catalog, "_read_cache", lambda: {
+            "schemaVersion": reg.official_catalog.SUPPORTED_SCHEMA_VERSION,
+            "apps": [planted],
+        })
+        monkeypatch.setattr(reg.official_catalog, "fetch_document", lambda url: None)
+        monkeypatch.setattr(reg, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(reg, "list_installed_apps", lambda: [])
+
+        external = {
+            "name": "squatted",
+            "gitUrl": "https://ext.example/real",
+            "repo": "e/real",
+            "_registry": "ext",
+        }
+
+        async def _external():
+            return [external]
+
+        monkeypatch.setattr(reg, "_load_external_registries", _external)
+        monkeypatch.setattr(reg, "_resolve_manifest", _async_passthrough)
+
+        rows = await reg.list_registry()
+        by_name = {r.get("name"): r for r in rows}
+        assert "squatted" in by_name, "the real external row must survive"
+        assert by_name["squatted"].get("_registry") == "ext", (
+            "a planted cache row must not shadow the external row it squats"
+        )
+
+    def test_the_fresh_fetch_refuses_rather_than_reading_the_cache(self, monkeypatch):
+        monkeypatch.setattr(reg.official_catalog, "_read_cache", lambda: {
+            "schemaVersion": reg.official_catalog.SUPPORTED_SCHEMA_VERSION,
+            "apps": [{"name": "planted", "source": {"type": "git", "url": URL, "ref": SHA}}],
+        })
+        monkeypatch.setattr(reg.official_catalog, "fetch_document", lambda url: None)
+        with pytest.raises(reg.official_catalog.CatalogUnavailable):
+            reg.official_catalog.fetch_inventory_entries()
+
+
+class TestCatalogNamesUseTheCanonicalContract:
+    """`app_name_error` documents itself as the SINGLE app-name contract, so a local
+    regex here was the "other door" it exists to prevent."""
+
+    @pytest.mark.parametrize("name", ["system", "nul", "con", "Not-Kebab", "has_underscore"])
+    def test_names_the_canonical_contract_refuses_are_dropped(self, name):
+        entry = {"name": name, "source": {"type": "git", "url": URL, "ref": SHA}}
+        assert list(oc.inventory([entry])) == []
+
+    def test_a_duplicate_name_is_dropped(self):
+        """Two rows with one name make identity ambiguous: consent is shown for the
+        row that rendered, while a name-only lookup can resolve the other."""
+        a = {"name": "demo-app", "source": {"type": "git", "url": URL, "ref": SHA}}
+        b = {
+            "name": "demo-app",
+            "source": {"type": "git", "url": "https://other.example/x", "ref": SHA},
+        }
+        rows = list(oc.inventory([a, b]))
+        assert len(rows) == 1
+        assert rows[0]["gitUrl"] == URL, "the first row wins; the second is not silently used"
+
+    def test_a_normal_name_still_materialises(self):
+        entry = {"name": "demo-app", "source": {"type": "git", "url": URL, "ref": SHA}}
+        assert len(list(oc.inventory([entry]))) == 1
+
+
+class TestPinnedManifestNeverReadsThePersistentCheckout:
+    """The persistent checkout is agent-writable and `app.json` there can be edited
+    without HEAD moving, so a commit comparison attests placement, not contents --
+    and this manifest is what the admission and platform gates read."""
+
+    @pytest.mark.asyncio
+    async def test_a_pinned_entry_ignores_the_local_manifest(self, tmp_path, monkeypatch):
+        planted = tmp_path / "demo"
+        planted.mkdir()
+        (planted / "app.json").write_text('{"name": "demo", "displayName": "PLANTED"}')
+        monkeypatch.setattr(reg, "app_source_dir", lambda n: planted)
+        monkeypatch.setattr(reg, "_resolved_clone_commit", lambda p: SHA)
+        monkeypatch.setattr(reg, "_clone_origin_matches", _async_return(True))
+        # Open EVERY route into the fast path, so the only thing keeping the planted
+        # manifest out is the pinned-entry gate itself. Patching just one freshness
+        # check would let a regression that restores the other route pass unnoticed.
+        monkeypatch.setattr(reg, "_clone_branch_matches", _async_return(True))
+
+        async def fake_fetch(git_url, commit, dest, log_lines, **kwargs):
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "app.json").write_text('{"name": "demo", "displayName": "FETCHED"}')
+            return None
+
+        monkeypatch.setattr(reg, "_git_fetch_commit", fake_fetch)
+        manifest = await reg._fetch_app_manifest(
+            "o/demo", "main", "", app_name="demo", git_url=URL, commit=SHA
+        )
+        assert manifest is not None
+        assert manifest["displayName"] == "FETCHED", (
+            "a pinned manifest must come from a tree this call fetched"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_unpinned_entry_still_uses_the_local_manifest(self, tmp_path, monkeypatch):
+        """Scope: the fast path is removed for PINNED entries only -- taking it away
+        from branch entries would make every listing a fresh network clone."""
+        local = tmp_path / "demo"
+        local.mkdir()
+        (local / "app.json").write_text('{"name": "demo", "displayName": "LOCAL"}')
+        monkeypatch.setattr(reg, "app_source_dir", lambda n: local)
+        monkeypatch.setattr(reg, "_clone_origin_matches", _async_return(True))
+        monkeypatch.setattr(reg, "_clone_branch_matches", _async_return(True))
+        manifest = await reg._fetch_app_manifest(
+            "o/demo", "main", "", app_name="demo", git_url=URL
+        )
+        assert manifest is not None and manifest["displayName"] == "LOCAL"
+
+
+class TestAFailedInstallRestoresThePreviousCheckout:
+    """A pinned install moves the previous checkout aside on EVERY reinstall, so an
+    exit that forgets to restore leaves the user's only edited copy as a `.stale-*`
+    sibling that the retention sweep later deletes."""
+
+    @pytest.mark.asyncio
+    async def test_the_moved_aside_checkout_is_put_back(self, tmp_path):
+        pkg = tmp_path / "source"
+        pkg.mkdir()
+        (pkg / "replacement.txt").write_text("the tree the user did not ask for")
+        aside = tmp_path / "source.stale-abcd1234"
+        aside.mkdir()
+        (aside / "my-edit.py").write_text("local work")
+
+        reg._restore_moved_aside(aside, pkg, [], "the install step failed")
+
+        assert (pkg / "my-edit.py").read_text() == "local work"
+        assert not (pkg / "replacement.txt").exists(), "the replacement is discarded"
+        assert not aside.exists()
+
+    @pytest.mark.asyncio
+    async def test_a_missing_moved_aside_is_a_no_op(self, tmp_path):
+        """Scope: nothing to restore must not delete the tree that is there."""
+        pkg = tmp_path / "source"
+        pkg.mkdir()
+        (pkg / "keep.txt").write_text("installed fine")
+        reg._restore_moved_aside(None, pkg, [], "reason")
+        assert (pkg / "keep.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_restoration_never_recursively_deletes(self, tmp_path, monkeypatch):
+        """Two reviews pulled opposite ways here — no awaiting during cancellation, and
+        no blocking rmtree on the loop thread — so the deletion itself had to go.
+
+        The replacement is RENAMED to a `.partial-*` sibling, which the retention sweep
+        already owns (it collects both the `stale` and `partial` prefixes). Two O(1)
+        renames need neither a thread nor a loop, so the same call is safe on every path.
+        """
+        pkg = tmp_path / "source"
+        pkg.mkdir()
+        (pkg / "big-tree.bin").write_text("the replacement")
+        aside = tmp_path / "source.stale-abcd1234"
+        aside.mkdir()
+        (aside / "my-edit.py").write_text("local work")
+
+        def no_rmtree(*a, **k):
+            raise AssertionError("restoration must not recursively delete")
+
+        monkeypatch.setattr(reg.shutil, "rmtree", no_rmtree)
+
+        def no_to_thread(*a, **k):
+            raise AssertionError("restoration must not need the event loop")
+
+        monkeypatch.setattr(reg.asyncio, "to_thread", no_to_thread)
+
+        reg._restore_moved_aside(aside, pkg, [], "the install step failed")
+
+        assert (pkg / "my-edit.py").read_text() == "local work"
+        assert not (pkg / "big-tree.bin").exists(), "the replacement is out of the way"
+        partial = [p for p in tmp_path.iterdir() if ".partial-" in p.name]
+        assert len(partial) == 1 and (partial[0] / "big-tree.bin").exists(), (
+            "the discarded replacement is left for the retention sweep, not deleted inline"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_failed_rename_leaves_the_copy_recoverable(self, tmp_path, monkeypatch):
+        pkg = tmp_path / "source"
+        pkg.mkdir()
+        aside = tmp_path / "source.stale-abcd1234"
+        aside.mkdir()
+        (aside / "my-edit.py").write_text("local work")
+
+        def boom(*a, **k):
+            raise OSError("locked")
+
+        monkeypatch.setattr(pathlib.Path, "rename", boom)
+        logs: list[str] = []
+        reg._restore_moved_aside(aside, pkg, logs, "the install step failed")
+        assert (aside / "my-edit.py").exists(), "the copy must survive for manual recovery"
+        # Either rename can be the one that fails, so assert the substance: the log has
+        # to say the copy is retained and where.
+        assert any("retained" in line for line in logs), logs
+        assert any(aside.name in line for line in logs), logs
+
+
+class TestRestorationIsScopedToSameRepositoryMoves:
+    """Two kinds of moved-aside checkout, opposite correct handling.
+
+    An origin-mismatch move holds a DIFFERENT repository, and restoring it would hand
+    the build the tree that gate refused. A pinned reinstall's move holds the SAME
+    repository with the user's edits, and NOT restoring it loses them to the sweep.
+    One list carrying both meanings meant whichever rule won was wrong for the other.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_same_repo_move_is_reported_as_restorable(self, tmp_path, monkeypatch):
+        dest = tmp_path / "source"
+        (dest / ".git").mkdir(parents=True)
+        monkeypatch.setattr(reg, "_clone_origin_url", _async_return(URL))
+
+        async def fake_fetch(git_url, commit, d, log_lines, **kwargs):
+            d.mkdir(parents=True, exist_ok=True)
+            return None
+
+        monkeypatch.setattr(reg, "_git_fetch_commit", fake_fetch)
+        pending: list[pathlib.Path] = []
+        restorable: list[pathlib.Path] = []
+        result = await reg._git_clone_or_pull(
+            URL,
+            "main",
+            dest,
+            [],
+            commit=SHA,
+            pending_cleanup=pending,
+            restorable_stale=restorable,
+        )
+        assert result is None
+        assert len(pending) == 1, "still retained for recovery"
+        assert restorable == pending, "and marked restorable, because it is the same repo"
+
+    @pytest.mark.asyncio
+    async def test_an_origin_mismatch_move_is_not_restorable(self, tmp_path, monkeypatch):
+        dest = tmp_path / "source"
+        (dest / ".git").mkdir(parents=True)
+        # The existing checkout points somewhere else entirely.
+        monkeypatch.setattr(reg, "_clone_origin_url", _async_return("https://other.example/x"))
+
+        async def fake_clone(*a, **k):
+            class _P:
+                returncode = 0
+
+                async def communicate(self):
+                    return b"", b""
+
+            dest.mkdir(parents=True, exist_ok=True)
+            return _P()
+
+        monkeypatch.setattr(reg, "create_subprocess_limited", fake_clone)
+        monkeypatch.setattr(reg, "wrap_argv", lambda argv, mode=None: (argv, None))
+        monkeypatch.setattr(reg, "cgroup_scope_argv", lambda argv: argv)
+        pending: list[pathlib.Path] = []
+        restorable: list[pathlib.Path] = []
+        await reg._git_clone_or_pull(
+            URL,
+            "main",
+            dest,
+            [],
+            pending_cleanup=pending,
+            restorable_stale=restorable,
+        )
+        assert restorable == [], (
+            "restoring a different repository's checkout would defeat the "
+            "origin-mismatch gate"
+        )
+
+
+class TestCandidatesRefuseBeforeAnyFallback:
+    """`_resolve_registry_row`'s sibling. Clearing the seed candidates and then
+    falling through to the external caches still let a same-named row answer -- and a
+    tampered cache row missing `_registry` reads as official, so a provenance match
+    would install an unpinned branch with the OWNER's credentials."""
+
+    def test_no_candidate_is_offered_when_the_catalog_is_unreachable(self, monkeypatch):
+        monkeypatch.setattr(reg, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(reg.official_catalog, "fetch_document", lambda url: None)
+
+        # A configured registry MUST exist for this to test anything: without one the
+        # external loop iterates nothing and the assertion would hold even with the
+        # refusal removed.
+        class _Reg:
+            name = "ext"
+            repo = "o/ext"
+
+        class _Cfg:
+            registries = [_Reg()]
+
+            @staticmethod
+            def load():
+                return _Cfg()
+
+        import kiro_crew.config.loader as loader
+
+        monkeypatch.setattr(loader, "KiroCrewConfig", _Cfg)
+        # A markerless external row -- exactly the shape that reads as official.
+        monkeypatch.setattr(
+            reg,
+            "_read_external_registry_cache",
+            lambda *a, **k: [{"name": "dup", "gitUrl": "https://evil.example/x", "repo": "e/x"}],
+        )
+        monkeypatch.setattr(reg, "_apply_configured_branch", lambda rows, reg_cfg: None)
+        assert reg._registry_app_candidates("dup") == []
+
+    def test_external_candidates_still_resolve_when_the_catalog_answers(self, monkeypatch):
+        """Scope: only a FAILED lookup refuses.
+
+        Stubbed at the config boundary because the test environment configures no
+        registries, so patching the cache reader alone leaves the loop with nothing
+        to iterate and the assertion would hold for the wrong reason.
+        """
+        monkeypatch.setattr(reg, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(
+            reg.official_catalog,
+            "fetch_document",
+            lambda url: {
+                "schemaVersion": reg.official_catalog.SUPPORTED_SCHEMA_VERSION,
+                "apps": [],
+            },
+        )
+
+        class _Reg:
+            name = "ext"
+            repo = "o/ext"
+
+        class _Cfg:
+            registries = [_Reg()]
+
+            @staticmethod
+            def load():
+                return _Cfg()
+
+        import kiro_crew.config.loader as loader
+
+        monkeypatch.setattr(loader, "KiroCrewConfig", _Cfg)
+        monkeypatch.setattr(
+            reg,
+            "_read_external_registry_cache",
+            lambda *a, **k: [{"name": "dup", "gitUrl": "https://ext.example/x", "repo": "e/x"}],
+        )
+        monkeypatch.setattr(reg, "_apply_configured_branch", lambda rows, reg_cfg: None)
+        assert [c.get("name") for c in reg._registry_app_candidates("dup")] == ["dup"]
+
+
+class TestRestorationStateSurvivesEveryExit:
+    """`_clone_build_app_locked` has six exits and the state was attached only to the
+    successful one, so a post-fetch failure dropped it and the caller's `finally` had
+    nothing to restore from."""
+
+    @pytest.mark.asyncio
+    async def test_a_failure_exit_still_reports_the_restorable_path(self, monkeypatch):
+        aside = pathlib.Path("/tmp/does-not-matter.stale-abcd")
+
+        async def failing_locked(*a, **kwargs):
+            # Fill the caller-owned list, then fail the way a containment or
+            # admission rejection does.
+            kwargs["restorable_stale"].append(aside)
+            return {"ok": False, "error": "subdirectory escapes the clone root"}
+
+        monkeypatch.setattr(reg, "_clone_build_app_locked", failing_locked)
+        result = await reg._clone_build_app(URL, "demo", [])
+        assert result["ok"] is False
+        assert result.get("_restorable_stale") == [aside], (
+            "a failing exit must still hand the caller something to restore"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_restorable_path_means_no_key(self, monkeypatch):
+        async def clean_locked(*a, **kwargs):
+            return {"ok": True, "pkg_dir": pathlib.Path("/tmp/x")}
+
+        monkeypatch.setattr(reg, "_clone_build_app_locked", clean_locked)
+        result = await reg._clone_build_app(URL, "demo", [])
+        assert "_restorable_stale" not in result
+
+
+class TestInterruptionAndTornStateOnTheInstallPath:
+    """The two ways a correct-looking rollback still loses or tears state."""
+
+    @pytest.mark.asyncio
+    async def test_the_interruption_path_does_not_touch_the_event_loop(
+        self, tmp_path, monkeypatch
+    ):
+        """Awaiting during cancellation re-enters a loop being torn down, which CI
+        reported as `RuntimeError: Event loop is closed` on three platforms at once.
+
+        Drives the real interruption path with `asyncio.to_thread` sabotaged: the async
+        restoration wrapper goes through it, so an `await` here explodes while the
+        synchronous call does not. Asserting on the helper directly could not tell the
+        two apart.
+        """
+        pkg = tmp_path / "demo"
+        pkg.mkdir()
+        (pkg / "replacement.txt").write_text("half-built")
+        aside = tmp_path / "demo.stale-abcd1234"
+        aside.mkdir()
+        (aside / "my-edit.py").write_text("local work")
+
+        async def cancelled_locked(*a, **kwargs):
+            kwargs["restorable_stale"].append(aside)
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(reg, "_clone_build_app_locked", cancelled_locked)
+        monkeypatch.setattr(reg, "app_source_dir", lambda n: pkg)
+
+        def exploding_to_thread(*a, **k):
+            raise AssertionError("the interruption path must not use the event loop")
+
+        monkeypatch.setattr(reg.asyncio, "to_thread", exploding_to_thread)
+
+        with pytest.raises(asyncio.CancelledError):
+            await reg._clone_build_app(URL, "demo", [])
+
+        assert (pkg / "my-edit.py").read_text() == "local work"
+        assert not (pkg / "replacement.txt").exists()
+        assert not aside.exists()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_restores_the_moved_aside_checkout(self, tmp_path, monkeypatch):
+        """An `await` that is cancelled never reaches the line that hands the state to
+        the caller, so it has to be restored where the state actually lives."""
+        pkg = tmp_path / "demo"
+        pkg.mkdir()
+        (pkg / "replacement.txt").write_text("half-built")
+        aside = tmp_path / "demo.stale-abcd1234"
+        aside.mkdir()
+        (aside / "my-edit.py").write_text("local work")
+
+        async def cancelled_locked(*a, **kwargs):
+            kwargs["restorable_stale"].append(aside)
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(reg, "_clone_build_app_locked", cancelled_locked)
+        monkeypatch.setattr(reg, "app_source_dir", lambda n: pkg)
+
+        with pytest.raises(asyncio.CancelledError):
+            await reg._clone_build_app(URL, "demo", [])
+
+        assert (pkg / "my-edit.py").read_text() == "local work"
+        assert not aside.exists()
+
+    @pytest.mark.asyncio
+    async def test_an_exception_also_restores(self, tmp_path, monkeypatch):
+        pkg = tmp_path / "demo"
+        pkg.mkdir()
+        aside = tmp_path / "demo.stale-abcd1234"
+        aside.mkdir()
+        (aside / "my-edit.py").write_text("local work")
+
+        async def raising_locked(*a, **kwargs):
+            kwargs["restorable_stale"].append(aside)
+            raise OSError("disk went away")
+
+        monkeypatch.setattr(reg, "_clone_build_app_locked", raising_locked)
+        monkeypatch.setattr(reg, "app_source_dir", lambda n: pkg)
+
+        with pytest.raises(OSError):
+            await reg._clone_build_app(URL, "demo", [])
+        assert (pkg / "my-edit.py").exists()
+
+
+class TestRequestPathPatternsRejectATrailingNewline:
+    """`$` also matches before a trailing newline, and these two feed git argv and a
+    filesystem join via `.match`. Same defect class as the catalog-side coordinate
+    patterns, found as their remaining siblings."""
+
+    @pytest.mark.parametrize("value", ["main\n", "refs/heads/main\n", "v1.0\n"])
+    def test_ref_pattern_rejects_a_trailing_newline(self, value):
+        from kiro_crew.apps import routes
+
+        assert not routes._SAFE_REF_RE.match(value)
+
+    @pytest.mark.parametrize("value", ["icon.png\n", "assets/logo.svg\n"])
+    def test_path_pattern_rejects_a_trailing_newline(self, value):
+        from kiro_crew.apps import routes
+
+        assert not routes._SAFE_PATH_RE.match(value)
+
+    @pytest.mark.parametrize("value", ["main", "refs/heads/main", "v1.0"])
+    def test_ordinary_refs_still_pass(self, value):
+        """Scope: tightening the anchor must not reject the values it exists to admit."""
+        from kiro_crew.apps import routes
+
+        assert routes._SAFE_REF_RE.match(value)
+
+    @pytest.mark.parametrize("value", ["icon.png", "assets/logo.svg"])
+    def test_ordinary_paths_still_pass(self, value):
+        from kiro_crew.apps import routes
+
+        assert routes._SAFE_PATH_RE.match(value)
+
+
+class TestTrustBoundary:
+    def test_a_catalog_row_never_mints_the_verified_badge(self):
+        """The catalog's signature is not checked, so its curated author must not
+        make an app read as first-party.
+
+        Asserted at `_apply_trust_fields` rather than at the row's source because
+        `list_registry` assigns `_index_author = entry["author"]` unconditionally:
+        a rule stated upstream is a rule a later assignment can undo, and that is
+        exactly what happened before this test existed.
+        """
+        rows = reg._apply_trust_fields(
+            [{"name": "demo-app", "_catalog": True, "_index_author": "Kiro Crew"}]
+        )
+        assert rows[0]["verified"] is False
+        assert rows[0]["provenance"] == "official"
+
+    def test_a_seed_row_with_a_first_party_author_still_earns_the_badge(self):
+        """The refusal above must be scoped to catalog rows, not a blanket change."""
+        rows = reg._apply_trust_fields(
+            [{"name": "demo-app", "_index_author": "Kiro Crew"}]
+        )
+        assert rows[0]["verified"] is True
+
+    def test_an_external_row_cannot_forge_the_catalog_fast_path(self):
+        """`_catalog` is on the row-projection allowlist, so an external registry's
+        index can set it. Skipping the manifest fetch for such a row would let
+        index-supplied display copy stand in for the app's own manifest."""
+        assert reg._is_catalog_row({"_catalog": True}) is True
+        assert reg._is_catalog_row({"_catalog": True, "_registry": "acme"}) is False
+        assert reg._is_catalog_row({"_registry": "acme"}) is False
+        assert reg._is_catalog_row({}) is False
+
+
+class TestPinnedInstallRefusals:
+    @pytest.mark.asyncio
+    async def test_a_pinned_entry_never_falls_back_to_a_branch(self, monkeypatch):
+        """The only failure mode here that is quiet AND reports success.
+
+        `install_from_registry` reads `branch` with a default of "main". A path
+        that ignored a malformed `commit` would clone that tip, succeed, and record
+        the tip's commit as provenance -- a store that looks like it installs
+        pinned bytes while installing today's default branch.
+        """
+        # `_catalog` (and no `_registry`) is the shape a real catalog install row
+        # has; the pin is only read for such a row.
+        entry = {
+            "name": "demo-app",
+            "gitUrl": URL,
+            "repo": URL,
+            "commit": "not-a-sha",
+            "_catalog": True,
+        }
+        monkeypatch.setattr(reg, "_resolve_install_entry", lambda name: (entry, ""))
+
+        called: list[Any] = []
+
+        async def _must_not_run(*a, **kw):
+            called.append((a, kw))
+            raise AssertionError("clone/fetch must not be reached")
+
+        monkeypatch.setattr(reg, "_clone_build_app", _must_not_run)
+        result = await reg.install_from_registry("demo-app")
+        assert result["ok"] is False
+        assert "pinned commit" in result["error"]
+        assert called == [], "nothing was fetched"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            SHA + "\n",  # Python's `$` matches before a trailing newline
+            SHA + "\r\n",
+            "\n" + SHA,
+            SHA.upper(),
+            SHA[:39],
+            SHA + "a",
+            "main",
+            "",
+        ],
+    )
+    def test_the_install_paths_pin_check_is_no_weaker_than_the_catalogs(self, value):
+        """Defence in depth is only depth if the outer layer is not the laxer one.
+
+        This pattern also validates the SHA read back off disk by
+        `_resolved_clone_commit`, which is what the post-fetch verification compares
+        against -- so a value that merely looks like a commit would be reported as
+        the landed one.
+        """
+        assert reg._COMMIT_SHA_RE.match(value) is None, value
+        assert oc._COMMIT_RE.match(value) is None, "the two layers must agree"
+
+    def test_both_pin_checks_accept_a_real_commit(self):
+        """The tightening must not have broken the accept case."""
+        assert reg._COMMIT_SHA_RE.match(SHA) is not None
+        assert oc._COMMIT_RE.match(SHA) is not None
+        assert reg._COMMIT_SHA_RE.match("b" * 64) is not None
+
+    @pytest.mark.asyncio
+    async def test_the_pin_reaches_the_fetch(self, monkeypatch):
+        seen: dict[str, Any] = {}
+        manifest_seen: dict[str, Any] = {}
+
+        async def _capture(git_url, app_name, log_lines, **kw):
+            seen.update(kw)
+            seen["git_url"] = git_url
+            return {"ok": False, "error": "stop here"}
+
+        async def _capture_manifest(repo, branch, subdirectory="", **kw):
+            manifest_seen.update(kw)
+            return None
+
+        entry = {
+            "name": "demo-app",
+            "gitUrl": URL,
+            "repo": URL,
+            "commit": SHA,
+            "_catalog": True,
+        }
+        monkeypatch.setattr(reg, "_resolve_install_entry", lambda name: (entry, ""))
+        # Third-party execution is disabled by default, and that gate sits between
+        # the pin check and the fetch. It is unrelated to what this test asserts,
+        # so it is neutralised rather than satisfied by rewriting config -- note
+        # that the refusal test above needs no such patch, which is itself evidence
+        # the pin check runs BEFORE this gate.
+        monkeypatch.setattr(reg, "app_execution_denied", lambda *a, **kw: "")
+        # The pinned path does a REAL manifest fetch before the clone (no local fast
+        # path for pins), so this stub is load-bearing twice over: without it the test
+        # spawns a real sandboxed git subprocess -- which fails DETERMINISTICALLY on
+        # CI hosts where the sandbox backend is unavailable (AppArmor userns
+        # restriction on ubuntu-latest; Windows fails closed) while passing on a dev
+        # desk whose sandbox works, after a real network round-trip. A missing
+        # manifest is tolerated by design, so returning None keeps the install
+        # marching toward the clone this test is actually about.
+        monkeypatch.setattr(reg, "_fetch_app_manifest", _capture_manifest)
+        monkeypatch.setattr(reg, "_clone_build_app", _capture)
+        result = await reg.install_from_registry("demo-app")
+        assert result.get("error") == "stop here", f"returned before the fetch: {result}"
+        assert seen["commit"] == SHA
+        assert seen["git_url"] == URL
+        # The pin must reach BOTH fetch layers: the manifest preflight and the clone.
+        assert manifest_seen.get("commit") == SHA

--- a/test/test_external_registry.py
+++ b/test/test_external_registry.py
@@ -3404,6 +3404,258 @@ class TestInstallScriptFailurePreservesStaleCheckout:
         assert (stale_paths[0] / "local-edits.txt").read_text() == "precious data"
 
     @pytest.mark.asyncio
+    async def test_same_repo_stale_is_restored_when_install_from_registry_fails(self, tmp_path):
+        """Path-level companion to the helper tests: the `finally` in
+        install_from_registry must actually fire.
+
+        The helper was unit-tested while the WIRING was not, which is how a
+        branch-based restoration that missed the `onInstall` exit shipped. This drives
+        the same failure the test above drives, but with a SAME-REPOSITORY move, which
+        must be put back rather than retained.
+        """
+        from kiro_crew.apps.registry import install_from_registry
+
+        pkg_dir = tmp_path / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text(
+            '{"name": "testapp", "setup": {"onInstall": "exit 1"}}', encoding="utf-8"
+        )
+        (pkg_dir / "replacement.txt").write_text("freshly fetched", encoding="utf-8")
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_pending_stale_cleanup": [stale_dir],
+                "_restorable_stale": [stale_dir],
+            }
+
+        class _ScriptFailProc:
+            returncode = 1
+
+            async def communicate(self):
+                return (b"script failed", None)
+
+        def _fake_wrap_argv(argv, mode="standard"):
+            return list(argv), None
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.wrap_argv", side_effect=_fake_wrap_argv),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                new=AsyncMock(return_value=_ScriptFailProc()),
+            ),
+            # The destination is derived from the app name in production
+            # (`pkg_dir = app_source_dir(app_name)` is its only assignment), so the
+            # test has to say where that is rather than relying on the result dict.
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert not result["ok"]
+        assert (pkg_dir / "my-work.txt").read_text(encoding="utf-8") == "important", (
+            "the user's edited checkout must be back in place after a failed update"
+        )
+        assert not (pkg_dir / "replacement.txt").exists(), "the replacement is discarded"
+        assert not stale_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_restoration_works_when_the_failure_dict_omits_pkg_dir(self, tmp_path, monkeypatch):
+        """The exit Design Review found, which four rounds of rollback work missed.
+
+        Every post-clone FAILURE dict omits `pkg_dir`, so reading it raised a KeyError
+        that the broad catch swallowed -- the restoration silently did nothing on
+        exactly the exits it exists for, and the suite was green because every existing
+        test drove a failure that came AFTER an ok result carrying `pkg_dir`.
+        """
+        from kiro_crew.apps.registry import install_from_registry
+
+        pkg_dir = tmp_path / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "replacement.txt").write_text("half-installed", encoding="utf-8")
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            # Shaped like a real post-clone refusal: ok=False, NO pkg_dir, but the
+            # rollback state is present.
+            return {
+                "ok": False,
+                "name": app_name,
+                "error": "blocked by admission policy: not allowlisted",
+                "_restorable_stale": [stale_dir],
+            }
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert not result["ok"]
+        assert (pkg_dir / "my-work.txt").read_text(encoding="utf-8") == "important", (
+            "a failure dict without pkg_dir must still get the checkout restored"
+        )
+        assert not stale_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_provenance_write_does_not_roll_back_the_source(self, tmp_path):
+        """`install_app` has already copied the files, so treating a failed receipt as
+        "not durable" would leave installed files from the NEW version beside a source
+        tree from the OLD one -- worse than either outcome."""
+        from kiro_crew.apps.registry import install_from_registry
+
+        pkg_dir = tmp_path / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text('{"name": "testapp"}', encoding="utf-8")
+        (pkg_dir / "replacement.txt").write_text("the installed version", encoding="utf-8")
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "old.txt").write_text("previous", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_pending_stale_cleanup": [stale_dir],
+                "_restorable_stale": [stale_dir],
+            }
+
+        class _Ok:
+            ok = True
+            name = "testapp"
+            message = "installed"
+            error = None
+
+        def _boom(*a, **k):
+            raise OSError("provenance store unwritable")
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.get_app", return_value=None),
+            patch("kiro_crew.apps.registry.install_app", return_value=_Ok()),
+            patch("kiro_crew.apps.registry.set_app_provenance", side_effect=_boom),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert not result["ok"], "the bookkeeping failure is still reported"
+        assert (pkg_dir / "replacement.txt").exists(), (
+            "the installed source tree must NOT be rolled back under installed files"
+        )
+        assert stale_dir.exists(), "the previous checkout is retained, not restored"
+
+    @pytest.mark.asyncio
+    async def test_a_successful_install_is_not_rolled_back(self, tmp_path):
+        """Scope guard for the `finally`: a durable success must keep the freshly
+        fetched tree, and retain the old one as a sibling rather than restoring it."""
+        from kiro_crew.apps.registry import install_from_registry
+
+        pkg_dir = tmp_path / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text('{"name": "testapp"}', encoding="utf-8")
+        (pkg_dir / "replacement.txt").write_text("freshly fetched", encoding="utf-8")
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_pending_stale_cleanup": [stale_dir],
+                "_restorable_stale": [stale_dir],
+            }
+
+        class _Ok:
+            ok = True
+            name = "testapp"
+            message = "installed"
+            error = None
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.get_app", return_value=None),
+            patch("kiro_crew.apps.registry.install_app", return_value=_Ok()),
+            patch("kiro_crew.apps.registry.set_app_provenance"),
+            # Needed for the rollback destination to be observable at all: without it a
+            # wrongly-triggered restore would land outside tmp_path and the assertions
+            # below would pass for the wrong reason.
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert result["ok"], result
+        assert (pkg_dir / "replacement.txt").exists(), (
+            "a durable success must keep the tree it installed"
+        )
+        assert stale_dir.exists(), "the old checkout is retained beside it, not restored"
+
+    @pytest.mark.asyncio
     async def test_stale_not_cleaned_when_install_from_registry_fails(self, tmp_path):
         """Full install_from_registry flow: clone+build succeed but install
         script fails → stale checkout NOT deleted."""


### PR DESCRIPTION
## Problem

**Adding a third-party app to the official store required shipping a release.**

The catalog could already describe the whole shelf — measured against the live
document and this checkout, zero drift:

```
catalog entries: 22  (builtin=20 git=2)
builtins on disk: 20        catalog builtin NOT on disk: []
seed git entries: 2         catalog git entries not in seed: []
entries carrying `version`: 22/22
```

But nothing read that description as inventory. `annotate()` can only decorate a
row that already exists, and `get_registry_app()` — which install resolves
through — read only the bundled seed and external registry caches. A catalog row
that matched nothing was ignored.

## Three seams had to move

### 1. Inventory

`official_catalog.inventory()` materialises rows from the catalog's `git` entries.
It is also **the first place the document's `source` block is validated at all**:
`load_official_catalog` checks the envelope and each entry's `name`, and nothing
below it looked inside `source`.

A row whose coordinates fail any check is **dropped, never repaired** — guessing a
branch when the pin is malformed installs bytes nobody attested.

`builtin` entries produce no row: their code ships in the wheel, so a row would
render an install control that cannot work.

**Two absences are load-bearing:**

| Absent | Why |
|---|---|
| `branch` | `install_from_registry` defaults it to `"main"`. A row carrying one would let a pin-ignoring path clone that tip and **succeed**, recording the tip's commit as provenance — a store that looks like it installs pinned bytes while installing today's default branch |
| `_index_author` | The catalog's signature is not verified yet, so its curated author must not mint the `verified` badge — the same restraint `annotate` already has |

`version` **is** published to the row, and that is the point: update availability
belongs to the store. A developer pushing to their repository is not an approved
update; a republished catalog entry is.

### 2. Install at the pinned commit

`git clone --branch` cannot take a commit id — exit 128, `Remote branch <sha> not
found`. `_git_fetch_commit` fetches by SHA instead:

```
git init --template=  →  git remote add origin  →  git fetch --depth 1 origin <sha>
  →  git checkout --detach FETCH_HEAD  →  assert the checkout reports exactly <sha>
```

Four invocations, all carrying the same credential posture and sandbox mode as the
clone they replace — one that forgets is a credential-exposure hole, not a style
slip.

Three details are not incidental, and each was **verified against the two real
third-party repos in the live catalog** rather than reasoned about:

- **`git remote add origin` is mandatory.** `git init` + `git fetch <url> <sha>`
  leaves no origin remote, and the update path reads it. Without it an app
  installs once and then fails closed forever with `unreadable_clone_origin` —
  which deliberately does *not* delete the checkout, so it needs manual cleanup.
- **No `--filter=blob:none`.** A server lacking it only warns; a server having it
  turns the app's source tree into a partial clone whose later file reads become
  lazy network fetches *during the build*.
- **`--template=` matters** because the owner-designated posture uses
  `minimal_env`, which does not disable the user's global git config — a
  configured `init.templateDir` would install hooks and the checkout would then
  run `post-checkout`.

A pinned entry also **bypasses `git pull` entirely**: the checkout is a detached
HEAD with no tracking branch, and a new pin that is not a descendant of the old
one would fail `--ff-only` even though moving to it is exactly what was asked.
Already at the pin means no network at all.

### 3. Latency

A catalog row **skips the per-app manifest clone** — it already carries the
display fields and `version` the list renders. Applied *before* the fetch gather
rather than after it, which is what `annotate` alone did: paying for the clone and
then overwriting its result.

Honest sizing: that is **2 clones today**, because the 20 built-ins have no git URL
and were always free. The saving is O(N) in third-party apps, which is the number
the store exists to grow.

## What changes for a user, beyond the addition

The store gaining installable third-party apps is an addition. Four consequences are
not, and they are stated here rather than left for a reader to find:

| Change | Why it is this way |
|---|---|
| **A catalog-host outage refuses installs, updates, and execution grants** for bundled and catalog-named apps, rather than falling back to bundled coordinates. | The bundled coordinates carry no pin, so falling back installs a mutable branch tip for an app the store presents as pinned. An install already needs the network to clone, so the window this closes is "catalog host down while the git host is up". |
| **Every store listing performs one fresh catalog HTTPS fetch**, and does not serve inventory or curated copy from the on-disk cache. | That cache is agent-writable (verified against `security.is_sensitive_write_path`), and a cached row can both create a listed row and re-label one — and the row's label is what the consent prompt renders. The module's existing failure memory is respected, so an outage costs one timeout, not one per listing. |
| **A pinned reinstall never reuses the existing checkout**: it is moved aside and refetched, and restored if the transaction fails. | HEAD equality attests where a tree was placed, not what it holds, and `git status` cannot report `.git/hooks` content at all. Cost: one shallow single-commit fetch per pinned reinstall. |
| **A `commit` on an external-registry row is ignored** (with a warning) rather than honoured. | Pinning is a catalog mechanism. A fetch by SHA reaches objects no branch contains, so honouring an index-supplied pin would let that index escape the owner-configured branch. |

The alternative to the second row — making the catalog cache a protected path like the
keystone files and then trusting it — is a real design option that this PR does not take.
It would restore offline listing and remove the compensating controls above, and it is a
maintainer-level call; see the Design Review disposition on this PR for the trade as
stated.

## Manual verification (the part no mock covers)

Ran the real helper against the live catalog's current pins:

```
live catalog revision: 2026-08-13T23:33:01Z-4bb11ec
pinned git rows: [('launchdarkly', '3942dd38797c'), ('todo-ledger', '6cb16f604283')]

  launchdarkly / todo-ledger
      HEAD == pin        : True
      origin readable    : True
      app.json present   : True
      NOT a partial clone: True
      no hooks installed : True

  nonexistent pin refused and cleaned up: True  (exit 128)
```

Those five lines are exactly the five ways this path can fail quietly.

## Tests

21 new in `test/test_catalog_inventory.py`. `344 passed` across the touched
suites, including `test_external_registry.py` and
`test_app_identity_provenance.py`, which assert the existing `["git","clone"]`
argv — unaffected, because the pinned path is a separate branch rather than a
rewrite of the clone.

**Each guard was reverted one at a time to confirm a NAMED test fails — 7/7
caught.** Three tests that could not fail have already been found in this
workstream, so a green suite is not treated as evidence on its own.

| Mutation | Caught by |
|---|---|
| `\Z` → `$` (trailing newline on the pin) | `test_a_row_with_unusable_coordinates_is_dropped_not_repaired` |
| emit `branch` next to the pin | `test_no_branch_is_emitted` |
| let a builtin become an installable row | `test_a_builtin_entry_produces_no_row` |
| curated author reaches the trust snapshot | `test_no_index_author_is_emitted` |
| drop the catalog's `version` | `test_the_row_carries_the_catalogs_version` |
| ignore a malformed pin | `test_a_pinned_entry_never_falls_back_to_a_branch` |
| stop threading the pin to the fetch | `test_the_pin_reaches_the_fetch` |

The `\Z` anchors are deliberate. `$` matches before a trailing newline in Python's
`re`, and the first draft **accepted a 40-hex pin with `"\n"` appended** — a value
that then reaches a git argument vector. The probe that caught it had the same
blind spot at first: it tested interior newlines and not trailing ones.

Gates on the rebased head: `isort`, `flake8`, `mypy` (968 files), `pytest`,
`docs-lint`, `check_brand_name` all exit 0.

## Not in this PR

Built-in rows still reach the UI **client-synthesised from installed apps**
(`AppsPage.tsx`), so the catalog's curated copy and artwork for the 20 built-ins
remains unused. Making the catalog their source needs a server-side row for a
built-in, a reversal of the frontend's dedup direction (which currently discards
same-named backend rows), and a non-actionable "requires a newer Kiro Crew" state
in four components — a built-in listed by the catalog but absent from this wheel
would otherwise render a clickable **Install**. `minClientVersion` has zero readers
today and is where that state would come from.

