### PR TITLE
Re-arm the cron timer when a job finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,21 @@ All notable changes to KiroCrew are documented in this file.
   recordings need it — is now flagged with its install command even while the
   status reads ready. (#3559)
 
+- **A cron job whose run eats most of its interval no longer waits an extra
+  ~30s past its next due time.** A running job is invisible to the
+  scheduler's wake calculation (it's excluded while `_executing`), so a
+  timer tick that fires mid-run only sees other jobs and can arm the full
+  `_TIMER_POLL_SECS` (30s) poll interval. Finishing a job never re-armed the
+  timer, so the service just waited out whatever wake was already
+  scheduled instead of the job's true (often much sooner) next-due delay —
+  measured on a live deployment at up to 20% of consecutive-run gaps ≥20s
+  for a job whose duration was 95% of its interval. Job completion now
+  re-arms the timer. Safe under the one real hazard this creates — a job
+  finishing while the timer's own tick is mid-dispatch (an
+  `asyncio.to_thread` await inside `_on_timer`) — by deferring to that
+  tick's own post-dispatch re-arm instead of cancelling it, so an in-flight
+  sweep can never lose a due job it hasn't spawned yet. (#3651)
+
 - **`kirocrew` commands start up to ~0.8 s faster, and each MCP stdio server
   drops ~58 MB of resident memory.** `cli.py` imported its full 132-subcommand
   dispatch table at module scope — including the Slack gateway, the dashboard

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -644,6 +644,14 @@ class CronService:
         self._on_job = on_job
         self._jobs: list[CronJob] = []
         self._timer_task: asyncio.Task[None] | None = None
+        # True only while _on_timer's due-scan + dispatch is actually running
+        # (set/cleared around that one await in _tick). A job finishing DURING
+        # that window must not cancel _timer_task via _arm_timer — see the
+        # guard in _arm_timer for why — so it re-arms itself for free once
+        # _on_timer returns instead: _tick's own finally already calls
+        # _arm_timer() there, by which point the finishing job is no longer in
+        # _executing, so that arm computes the job's true next-due delay.
+        self._on_timer_running = False
         self._running = False
         # The event loop this service is bound to, captured in create()/start()
         # (the gateway's loop). _arm_timer() uses it to re-arm the timer THREAD-
@@ -2315,6 +2323,19 @@ class CronService:
                 bound.call_soon_threadsafe(self._arm_timer)
             return
         current = asyncio.current_task()
+        if self._on_timer_running and self._timer_task is not current:
+            # A DIFFERENT task (e.g. a job's own completion, see
+            # _run_job_isolated) is asking to re-arm while the tick is mid
+            # `_on_timer` — a real interleave window, since `_on_timer` awaits
+            # `asyncio.to_thread` for its due-scan. Cancelling `_timer_task`
+            # here would fire a CancelledError into that await, aborting the
+            # in-flight dispatch and dropping any due jobs not yet spawned
+            # this sweep. Do nothing: `_tick`'s own `finally` calls
+            # `_arm_timer()` again the moment `_on_timer` returns, and by then
+            # the finishing job is out of `_executing`, so THAT arm computes
+            # its true next-due delay — the re-arm is deferred to a safe
+            # point, not lost.
+            return
         # Never cancel the timer task if we ARE that task. The tick's own
         # `finally` re-arms while the tick coroutine is still executing, so a
         # blind `self._timer_task.cancel()` there fires a CancelledError back
@@ -2339,11 +2360,13 @@ class CronService:
             except asyncio.TimeoutError:
                 pass  # normal wake-up
             if self._running:
+                self._on_timer_running = True
                 try:
                     await self._on_timer()
                 except Exception:
                     logger.exception("Cron timer error — will re-arm")
                 finally:
+                    self._on_timer_running = False
                     # Always re-arm, even after errors
                     if self._running:
                         self._arm_timer()
@@ -2546,6 +2569,17 @@ class CronService:
             self._cancelled_jobs.discard(job.id)
             self._executing.discard(job.id)
             self._running_tasks.pop(job.id, None)
+            # Re-arm now that this job is no longer invisible to the wake
+            # calculation (`_next_wake_secs` skips anything in `_executing`).
+            # Without this, a job whose run ate most of its interval has to
+            # wait for whatever wake was already armed while it was still
+            # running — up to `_TIMER_POLL_SECS` (30s) late — because
+            # finishing a job was never one of the mutations that re-arms the
+            # timer (#3651). Safe to call unconditionally: `_arm_timer`
+            # defers to the in-flight tick's own re-arm instead of cancelling
+            # it when `_on_timer` is mid-dispatch (see its guard), and is a
+            # no-op once the service has stopped running.
+            self._arm_timer()
             # Notify dashboard that the job has finished (clears the badge).
             try:
                 if self._push_refresh:

--- a/test/test_cron_resilience.py
+++ b/test/test_cron_resilience.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -133,6 +133,140 @@ class TestArmTimer:
         svc._arm_timer()
         assert svc._timer_task is not None
         assert not svc._timer_task.done()
+        await svc.stop()
+
+
+class TestJobCompletionRearms:
+    """A job finishing must re-arm the timer (#3651): a long-running job is
+    invisible to `_next_wake_secs` while `_executing`, so the wake computed
+    during its run can arm up to `_TIMER_POLL_SECS` (30s) out. Without a
+    re-arm on completion, the service waits for that stale wake instead of
+    the job's true (often much sooner) next-due delay.
+    """
+
+    @pytest.mark.asyncio
+    async def test_job_completion_calls_arm_timer(self, tmp_path: Path) -> None:
+        """Wiring guard: `_run_job_isolated`'s finally must call `_arm_timer`.
+        `wraps=` keeps the real re-arm behavior intact while tracking the call,
+        so this fails loudly (not just silently) if the call site is reverted."""
+        gate = asyncio.Event()
+
+        async def callback(job: CronJob) -> None:
+            await gate.wait()
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("j", "msg", every_secs=60)
+        svc._jobs[0].last_run_ts = time.time() - 120
+        job_id = svc._jobs[0].id
+
+        await svc._on_timer()
+        assert job_id in svc._executing
+
+        with patch.object(svc, "_arm_timer", wraps=svc._arm_timer) as mock_arm:
+            gate.set()
+            await svc._running_tasks[job_id]
+            assert mock_arm.called, "job completion must re-arm the timer"
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_arm_timer_does_not_cancel_an_in_flight_on_timer(self, tmp_path: Path) -> None:
+        """The hazard the naive fix has: `_on_timer` awaits `asyncio.to_thread`
+        for its due-scan, a real interleave window. A DIFFERENT task (a job
+        completing) calling `_arm_timer` during that window must not cancel
+        the in-flight tick -- that would drop any due jobs not yet dispatched
+        this sweep. Stands in for `_on_timer`'s one await point with a plain
+        gate so the interleave is deterministic rather than timing-dependent.
+        """
+        svc = CronService(base_dir=tmp_path)
+        svc._running = True
+        gate = asyncio.Event()
+
+        async def fake_tick() -> None:
+            svc._on_timer_running = True
+            try:
+                await gate.wait()
+            finally:
+                svc._on_timer_running = False
+
+        original_task = asyncio.create_task(fake_tick())
+        svc._timer_task = original_task
+        await asyncio.sleep(0)  # let fake_tick start and set the flag
+        assert svc._on_timer_running is True
+
+        svc._arm_timer()  # stands in for a job's completion re-arm
+
+        assert svc._timer_task is original_task
+        assert not svc._timer_task.cancelled()
+        assert not svc._timer_task.done()
+
+        gate.set()
+        await svc._timer_task  # must complete normally, no CancelledError
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_deferred_rearm_still_happens_once_on_timer_completes(
+        self, tmp_path: Path
+    ) -> None:
+        """The re-arm request skipped during the in-flight window above must
+        not be LOST -- `_tick`'s own finally re-arms unconditionally once
+        `_on_timer` returns, by which point a job that finished during the
+        window is out of `_executing`, so that arm reflects its true delay."""
+        svc = CronService(base_dir=tmp_path)
+        svc._running = True
+        gate = asyncio.Event()
+
+        async def fake_tick() -> None:
+            svc._on_timer_running = True
+            try:
+                await gate.wait()
+            finally:
+                svc._on_timer_running = False
+                svc._arm_timer()  # mirrors _tick's own post-_on_timer re-arm
+
+        original_task = asyncio.create_task(fake_tick())
+        svc._timer_task = original_task
+        await asyncio.sleep(0)
+
+        svc._arm_timer()  # deferred re-arm request, swallowed per the guard
+        assert not original_task.cancelled()
+
+        gate.set()
+        await original_task
+        await asyncio.sleep(0)  # let the finally's _arm_timer() install the new task
+        # A genuinely new timer task now exists -- the deferred request was
+        # honored once it was safe, not dropped on the floor.
+        assert svc._timer_task is not original_task
+        assert svc._timer_task is not None and not svc._timer_task.done()
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_on_timer_running_flag_true_only_during_dispatch(
+        self, tmp_path: Path
+    ) -> None:
+        """Confirms the flag is wired into the REAL `_tick`, not just the
+        `fake_tick` stand-ins above: true while `_on_timer` runs, false
+        immediately before and after."""
+        svc = CronService(base_dir=tmp_path)
+        svc._running = True
+        seen_during: list[bool] = []
+        real_on_timer = svc._on_timer
+
+        async def spy_on_timer() -> None:
+            seen_during.append(svc._on_timer_running)
+            await real_on_timer()
+
+        svc._on_timer = spy_on_timer  # type: ignore[method-assign]
+        svc._effective_delay = lambda: 0.01  # type: ignore[method-assign]
+
+        assert svc._on_timer_running is False
+        svc._arm_timer()
+        task = svc._timer_task
+        assert task is not None
+        await asyncio.wait_for(task, timeout=5)
+
+        assert seen_during == [True]
+        assert svc._on_timer_running is False
         await svc.stop()
 
 


### PR DESCRIPTION
## Summary

Fixes #3651. A cron job whose run eats most of its interval could be dispatched up to ~30s late. Three things combine:

1. `_next_wake_secs` skips any job currently in `_executing` — a running job is invisible to the wake calculation.
2. `_effective_delay` caps the armed sleep at `_TIMER_POLL_SECS` (30s).
3. Finishing a job never re-armed the timer — every existing `_arm_timer` call site is either a job-**set** mutation (add/update/remove/pause/resume/reload) or the timer's own post-dispatch re-arm; a job *finishing* changes one job's due-ness, not the set, so it fell outside that invariant.

So a tick that fires while a long-running job is mid-execution only sees the *other* jobs and can arm up to 30s out. When the job finishes, nothing re-arms, so the service waits out that stale wake instead of the job's true (often much sooner) next-due delay. The issue includes live-deployment evidence: a 60s-interval job with a 56.9s median run duration saw 22 of 109 consecutive-run gaps ≥20s (97% of gaps ≤30s — the `_TIMER_POLL_SECS` signature).

## Fix

`_run_job_isolated`'s `finally` now calls `_arm_timer()` right after clearing `_executing`, so the next arm reflects the job's fresh next-due delay.

The issue itself flagged why this isn't safe unconditionally, and asked for a second opinion on the deferral approach before anyone pushed a concurrency change: `_arm_timer` cancels the current timer task, and `_on_timer` (which the timer task runs) awaits `asyncio.to_thread` for its due-scan — a real interleave window. A job finishing during that window and cancelling the in-flight tick there would drop any due jobs the scan already found but hadn't spawned yet that sweep.

Guarded with a new `self._on_timer_running` flag, set/cleared around that one `await self._on_timer()` in `_tick`:
- A re-arm request from a **different** task (a job completing) while the flag is true is a no-op — it defers entirely to `_tick`'s own `finally`, which unconditionally re-arms the moment `_on_timer` returns. By then the finishing job is already out of `_executing`, so *that* arm computes its true delay. Deferred, never lost.
- The existing self-referential guard (never cancel `_timer_task` if we *are* that task, covering the tick's own end-of-dispatch re-arm) is unchanged.

## Test plan

New `TestJobCompletionRearms` class in `test/test_cron_resilience.py`:
- `test_job_completion_calls_arm_timer` — wiring guard (real job execution via the `on_job` callback, gated by an `asyncio.Event`), `_arm_timer` patched with `wraps=` so real behavior stays intact while tracking the call.
- `test_arm_timer_does_not_cancel_an_in_flight_on_timer` — reproduces the exact hazard: a `fake_tick` standing in for `_on_timer`'s one await point, a re-arm request from a different task while it's "mid-dispatch" must not cancel it.
- `test_deferred_rearm_still_happens_once_on_timer_completes` — closes the loop: the deferred request isn't lost, a genuinely new timer task exists once the in-flight tick's own `finally` runs.
- `test_on_timer_running_flag_true_only_during_dispatch` — confirms the flag is wired into the **real** `_tick`, not just the `fake_tick` stand-ins above.

- [x] **Verified all 4 new tests fail against the pre-fix code** (`git stash` the production change, re-run — 4/4 fail, including a real `CancelledError` reproduction in the in-flight-cancellation test; restored after)
- [x] Full sweep of every test file importing `kiro_crew.cron` (55 files) — 2312 passed, 3 skipped (pre-existing skips)
- [x] `flake8` / `isort --check-only` / `mypy` on the changed source file — clean (3 pre-existing, unrelated `os.xattr` errors in `hooks.py` reproduce identically on unmodified `main`)