### PR TITLE
feat(acp): KAS native sub-agent progress + steering display

### DIFF
--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -461,6 +461,9 @@ class AcpSessionHandle:
         # already-current mode does not surface a spurious agent-switch echo
         # (kiro-cli only emits on a real _kiro.dev/agent/switched). None = unseen.
         self._last_kas_mode_id: str | None = None
+        # KAS sub-agent roster keyed by agentSubtaskId. Each entry is shaped for
+        # EVENT_SUBAGENT_LIST consumption by _native_subagent_sync in chat_runner.
+        self._kas_subagent_roster: dict[str, dict[str, Any]] = {}
 
     @property
     def session_id(self) -> str:
@@ -553,6 +556,12 @@ class AcpSessionHandle:
         self._tool_call_mcp_server.clear()
         self._tool_call_tool_name.clear()
         self._permission_options.clear()
+        # Per-turn reset (parity with kiro-cli's authoritative full subagent_list
+        # each turn): otherwise a completed sub-agent from a prior turn stays in
+        # the roster and is re-emitted in the next turn's EVENT_SUBAGENT_LIST,
+        # which the fresh per-turn _native_tracker resurrects as a duplicate
+        # spawn/done card — and the roster would grow unbounded for the session.
+        self._kas_subagent_roster.clear()
 
         # Drain frames left over from a prior abandoned turn. The cancel-unacked
         # / stale / tool-stall / timeout paths synthesize a terminal
@@ -2179,7 +2188,9 @@ class AcpSessionHandle:
         methods: ``context_usage`` (the context meter) and ``turn_completion``
         (per-turn billing) together reconstruct the single ``_kiro.dev/metadata``
         frame, while the ``summarization_*`` kinds are KAS's compaction status
-        (kiro-cli: ``_kiro.dev/compaction/status``).
+        (kiro-cli: ``_kiro.dev/compaction/status``) and the ``steering_*`` kinds
+        are KAS's mid-turn steer echo (kiro-cli: ``session/update`` steer
+        discriminants, handled by the "steer" action).
         """
         meta = update.get("_meta")
         kiro = meta.get("kiro") if isinstance(meta, dict) else None
@@ -2205,7 +2216,141 @@ class AcpSessionHandle:
             # reaches the dashboard — redact exfil URLs/credentials first.
             summary = redact_text(str(kiro.get("conversationSummary", "") or ""))
             return [AcpEvent(kind=EVENT_COMPACTION_STATUS, text=status_type, title=summary)]
+        if kind in ("steering_queued", "steering_injected", "steering_cleared"):
+            # KAS mid-turn steer echo. kiro-cli sends these as `session/update`
+            # discriminants (handled by the "steer" action); KAS instead puts the
+            # kind under `_meta.kiro`, so route it here. `injected` is the
+            # settling signal (→ EVENT_STEER_CONSUMED, which _settle_consumed_steers
+            # consumes); queued/cleared mirror the kiro path. Never trust
+            # backend-echoed steer text — redact before it reaches any surface.
+            if kind == "steering_cleared":
+                return [AcpEvent(kind=EVENT_STEER_CLEARED)]
+            text = redact_text(str(kiro.get("content") or ""))
+            steer_kind = EVENT_STEER_CONSUMED if kind == "steering_injected" else EVENT_STEER_QUEUED
+            return [AcpEvent(kind=steer_kind, text=text)]
         return []
+
+    def _handle_kas_subagent(self, update: dict) -> list[AcpEvent] | None:
+        """Route KAS PARENT sub-agent frames to EVENT_SUBAGENT_LIST.
+
+        Returns a list of events when the frame is a PARENT sub-agent lifecycle
+        frame (``kind:"agent-subtask"`` or ``pipeline``), or ``None`` when it is
+        a child nested tool or an ordinary frame that should fall through to the
+        shared parser (so caches populate and tool events render).
+        """
+        meta = update.get("_meta")
+        kiro = meta.get("kiro") if isinstance(meta, dict) else None
+        if not isinstance(kiro, dict):
+            return None
+
+        agent_subtask_id = kiro.get("agentSubtaskId")
+        pipeline = kiro.get("pipeline")
+
+        if not agent_subtask_id and not pipeline:
+            return None
+
+        # Pipeline frame: one entry per stage.
+        if isinstance(pipeline, dict):
+            stages = pipeline.get("stages")
+            if isinstance(stages, list):
+                for stage in stages:
+                    if not isinstance(stage, dict):
+                        continue
+                    s_id = stage.get("agentSubtaskId")
+                    if not isinstance(s_id, str) or not s_id:
+                        continue
+                    s_status = str(stage.get("status") or "in_progress")
+                    s_name = str(stage.get("name") or stage.get("role") or "")
+                    self._kas_subagent_roster[s_id] = {
+                        "sessionId": s_id,
+                        "sessionName": s_name,
+                        "agentName": s_name,
+                        "initialQuery": s_name,
+                        "status": {"type": s_status, "message": ""},
+                    }
+            return [AcpEvent(
+                kind=EVENT_SUBAGENT_LIST,
+                subagents=list(self._kas_subagent_roster.values()),
+            )]
+
+        # Individual agent-subtask frame (kind == "agent-subtask") → PARENT.
+        is_parent = kiro.get("kind") == "agent-subtask"
+
+        if is_parent:
+            subtask_id = str(agent_subtask_id)
+            status = str(update.get("status") or "in_progress")
+            title = str(update.get("title") or "")
+            name = title.replace("Sub-agent: ", "") if title.startswith("Sub-agent: ") else title
+            self._kas_subagent_roster[subtask_id] = {
+                "sessionId": subtask_id,
+                "sessionName": title,
+                "agentName": name,
+                "initialQuery": title,
+                "status": {"type": status, "message": ""},
+            }
+            return [AcpEvent(
+                kind=EVENT_SUBAGENT_LIST,
+                subagents=list(self._kas_subagent_roster.values()),
+            )]
+
+        # Child nested tool_call/tool_call_update (has agentSubtaskId but NOT
+        # kind:"agent-subtask" or pipeline) → return None so the caller falls
+        # through to parse_session_update (populates caches + renders tool
+        # events). The caller prepends the activity prefix separately.
+        return None
+
+    def _handle_kas_subagent_chunk(self, update: dict) -> list[AcpEvent] | None:
+        """Route KAS agent_message_chunk with agentSubtaskId to activity.
+
+        Returns a list when the chunk belongs to a child sub-agent, else None
+        (fall through to normal chunk handling).
+        """
+        meta = update.get("_meta")
+        kiro = meta.get("kiro") if isinstance(meta, dict) else None
+        if not isinstance(kiro, dict):
+            return None
+        subtask_id = kiro.get("agentSubtaskId")
+        if not isinstance(subtask_id, str) or not subtask_id:
+            return None
+        # Must NOT have kind:"agent-subtask" or pipeline — those are parent frames
+        if kiro.get("kind") == "agent-subtask" or kiro.get("pipeline"):
+            return None
+        text, _thinking = parse_text_chunk(update)
+        if not text or _thinking:
+            # A child's private reasoning (thinking/reasoning content) must not
+            # surface as visible sub-agent activity — parity with the kiro native
+            # subagent path, which only forwards non-thinking agent_message_chunk.
+            return []
+        return [AcpEvent(
+            kind=EVENT_SUBAGENT_ACTIVITY,
+            sub_session_id=subtask_id,
+            text=redact_text(text),
+        )]
+
+    def _build_child_tool_activity_prefix(self, update: dict) -> list[AcpEvent]:
+        """Build an EVENT_SUBAGENT_ACTIVITY prefix for a child nested tool frame.
+
+        Called when ``_handle_kas_subagent`` returns None (child tool) so the
+        activity attribution is emitted BEFORE the tool events from
+        ``parse_session_update``.
+        """
+        meta = update.get("_meta")
+        kiro = meta.get("kiro") if isinstance(meta, dict) else None
+        if not isinstance(kiro, dict):
+            return []
+        subtask_id = kiro.get("agentSubtaskId")
+        if not isinstance(subtask_id, str) or not subtask_id:
+            return []
+        tool_call_id = str(update.get("toolCallId") or "")
+        if not tool_call_id:
+            return []
+        title = redact_text(str(update.get("title") or ""))
+        return [AcpEvent(
+            kind=EVENT_SUBAGENT_ACTIVITY,
+            sub_session_id=subtask_id,
+            tool_call_id=tool_call_id,
+            title=title,
+        )]
 
     def _apply_kas_context_pct(self, pct: object) -> None:
         """Apply a KAS ``context_usage`` percentage to the context meter.
@@ -2301,6 +2446,41 @@ class AcpSessionHandle:
             kas_events = self._handle_kas_update(session_update, update)
             if kas_events is not None:
                 return kas_events
+
+        # KAS sub-agent progress: tool_call/tool_call_update frames carrying
+        # _meta.kiro.agentSubtaskId or _meta.kiro.pipeline are sub-agent
+        # lifecycle frames — intercept PARENT frames and route to the native
+        # sub-agent WS path (EVENT_SUBAGENT_LIST) instead of rendering them as
+        # ordinary tool calls. CHILD nested tool frames (agentSubtaskId present,
+        # but not a parent) emit an activity prefix AND fall through to the
+        # shared parser (caches populate + tool events render).
+        # Positive KAS gate (H5).
+        if self._runtime.acp_backend == ACP_BACKEND_KAS:
+            if session_update in ("tool_call", "tool_call_update"):
+                kas_sub_events = self._handle_kas_subagent(update)
+                if kas_sub_events is not None:
+                    return kas_sub_events
+                _child_prefix = self._build_child_tool_activity_prefix(update)
+                if _child_prefix:
+                    # Child nested tool: run the shared parser for its cache
+                    # SIDE EFFECTS ONLY — the trusted _tool_call_is_shell signal
+                    # + redacted input that a later permission/result reads — but
+                    # return ONLY the activity. Surfacing the tool events would
+                    # render the child tool as a top-level tool; the sub-agent
+                    # card is fed by the roster + activity, not the raw frame.
+                    parse_session_update(
+                        update,
+                        tool_input_cache=self._tool_call_inputs,
+                        shell_cache=self._tool_call_is_shell,
+                        raw_params_cache=self._tool_call_raw_params,
+                        mcp_server_name_cache=self._tool_call_mcp_server,
+                        tool_name_cache=self._tool_call_tool_name,
+                    )
+                    return _child_prefix
+            if session_update == "agent_message_chunk":
+                kas_chunk_events = self._handle_kas_subagent_chunk(update)
+                if kas_chunk_events is not None:
+                    return kas_chunk_events
 
         # All other session/update kinds go through the single shared parser so
         # AcpRuntime and AcpClient cannot drift on frame shape or redaction. The

--- a/test/test_kas_display_mapping.py
+++ b/test/test_kas_display_mapping.py
@@ -19,6 +19,9 @@ from kiro_crew.acp.types import (
     ACP_BACKEND_KIRO,
     EVENT_AGENT_SWITCHED,
     EVENT_COMPACTION_STATUS,
+    EVENT_STEER_CLEARED,
+    EVENT_STEER_CONSUMED,
+    EVENT_STEER_QUEUED,
     EVENT_TEXT_CHUNK,
     JsonRpcMessage,
 )
@@ -314,3 +317,56 @@ def test_context_usage_not_applied_on_kiro_backend() -> None:
         {"sessionUpdate": "session_info_update", "_meta": {"kiro": {"kind": "context_usage", "usagePercentage": 42.5}}},
     )
     assert handle.last_prompt_stats.context_pct != 42.5
+
+
+# ── session_info_update / steering_* → steer events ──────────────────────────
+
+
+def test_steering_injected_maps_to_consumed() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(
+        handle,
+        {
+            "sessionUpdate": "session_info_update",
+            "_meta": {"kiro": {"kind": "steering_injected", "messageId": "m1", "content": "focus on tests"}},
+        },
+    )
+    # injected is the settling signal that _settle_consumed_steers consumes.
+    assert len(events) == 1
+    assert events[0].kind == EVENT_STEER_CONSUMED
+    assert events[0].text == "focus on tests"
+
+
+def test_steering_queued_maps_to_queued() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(
+        handle,
+        {
+            "sessionUpdate": "session_info_update",
+            "_meta": {"kiro": {"kind": "steering_queued", "messageId": "m1", "content": "also update docs"}},
+        },
+    )
+    assert len(events) == 1
+    assert events[0].kind == EVENT_STEER_QUEUED
+    assert events[0].text == "also update docs"
+
+
+def test_steering_cleared_maps_to_cleared_no_text() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(
+        handle,
+        {"sessionUpdate": "session_info_update", "_meta": {"kiro": {"kind": "steering_cleared", "messageIds": ["m1"]}}},
+    )
+    assert len(events) == 1
+    assert events[0].kind == EVENT_STEER_CLEARED
+
+
+def test_steering_not_routed_on_kiro_backend() -> None:
+    handle = _handle(ACP_BACKEND_KIRO)
+    # kiro-cli delivers steer as session/update discriminants (the "steer"
+    # action), never as a session_info_update _meta.kiro kind, so this KAS-shaped
+    # frame must NOT produce a steer event on the kiro path.
+    assert _update(
+        handle,
+        {"sessionUpdate": "session_info_update", "_meta": {"kiro": {"kind": "steering_injected", "content": "x"}}},
+    ) == []

--- a/test/test_kas_subagent_progress.py
+++ b/test/test_kas_subagent_progress.py
@@ -1,0 +1,306 @@
+"""KAS native sub-agent progress (Group B).
+
+KAS delivers sub-agent lifecycle as ``session/update`` discriminants carrying
+``_meta.kiro.agentSubtaskId`` (individual) or ``_meta.kiro.pipeline`` (pipeline).
+These tests pin that the KAS-gated interception in
+``AcpSessionHandle._handle_update`` routes them to EVENT_SUBAGENT_LIST /
+EVENT_SUBAGENT_ACTIVITY, and that the kiro path is untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from kiro_crew.acp.session_handle import AcpSessionHandle
+from kiro_crew.acp.types import (
+    ACP_BACKEND_KAS,
+    ACP_BACKEND_KIRO,
+    EVENT_SUBAGENT_ACTIVITY,
+    EVENT_SUBAGENT_LIST,
+    EVENT_TEXT_CHUNK,
+    JsonRpcMessage,
+)
+
+
+def _handle(backend: str) -> AcpSessionHandle:
+    """A handle over a fake runtime pinned to the given backend."""
+    rt = MagicMock()
+    rt.acp_backend = backend
+    rt.pid = None
+    rt.is_alive = MagicMock(return_value=True)
+    rt.send_notification = AsyncMock()
+    return AcpSessionHandle("sB", asyncio.Queue(), rt)
+
+
+def _update(handle: AcpSessionHandle, update: dict) -> list:
+    return handle._handle_update(
+        JsonRpcMessage(method="session/update", params={"update": update})
+    )
+
+
+# ── Individual agent-subtask spawn → EVENT_SUBAGENT_LIST ─────────────────────
+
+
+def test_individual_agent_subtask_emits_subagent_list() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(handle, {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc1",
+        "title": "Sub-agent: researcher",
+        "status": "in_progress",
+        "_meta": {"kiro": {"kind": "agent-subtask", "agentSubtaskId": "sa-1"}},
+    })
+    assert len(events) == 1
+    assert events[0].kind == EVENT_SUBAGENT_LIST
+    assert events[0].subagents is not None
+    assert len(events[0].subagents) == 1
+    entry = events[0].subagents[0]
+    assert entry["sessionId"] == "sa-1"
+    assert entry["sessionName"] == "Sub-agent: researcher"
+    assert entry["agentName"] == "researcher"
+    assert entry["initialQuery"] == "Sub-agent: researcher"
+    assert entry["status"]["type"] == "in_progress"
+
+
+# ── Completed frame → entry completed ────────────────────────────────────────
+
+
+def test_completed_agent_subtask_updates_roster() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    # Spawn
+    _update(handle, {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc1",
+        "title": "Sub-agent: coder",
+        "status": "in_progress",
+        "_meta": {"kiro": {"kind": "agent-subtask", "agentSubtaskId": "sa-2"}},
+    })
+    # Complete
+    events = _update(handle, {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc1",
+        "title": "Sub-agent: coder",
+        "status": "completed",
+        "_meta": {"kiro": {"kind": "agent-subtask", "agentSubtaskId": "sa-2"}},
+    })
+    assert len(events) == 1
+    assert events[0].kind == EVENT_SUBAGENT_LIST
+    entry = events[0].subagents[0]
+    assert entry["sessionId"] == "sa-2"
+    assert entry["status"]["type"] == "completed"
+
+
+# ── Pipeline frame → one entry per stage ─────────────────────────────────────
+
+
+def test_pipeline_frame_creates_entries_per_stage() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(handle, {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc-pipe",
+        "title": "Pipeline",
+        "_meta": {"kiro": {"pipeline": {
+            "groupId": "g1",
+            "stages": [
+                {"name": "research", "role": "researcher", "status": "in_progress",
+                 "dependsOn": [], "agentSubtaskId": "ps-1"},
+                {"name": "code", "role": "coder", "status": "pending",
+                 "dependsOn": ["ps-1"], "agentSubtaskId": "ps-2"},
+            ],
+        }}},
+    })
+    assert len(events) == 1
+    assert events[0].kind == EVENT_SUBAGENT_LIST
+    assert len(events[0].subagents) == 2
+    ids = {e["sessionId"] for e in events[0].subagents}
+    assert ids == {"ps-1", "ps-2"}
+    statuses = {e["sessionId"]: e["status"]["type"] for e in events[0].subagents}
+    assert statuses["ps-1"] == "in_progress"
+    assert statuses["ps-2"] == "pending"
+
+
+# ── Child nested tool_call → activity prefix + cache populated + tool event ──
+
+
+def test_child_nested_tool_call_emits_activity() -> None:
+    """A child nested tool_call emits ONLY activity (not a top-level tool event)
+    yet still populates the security caches via a side-effect parser call."""
+    from kiro_crew.acp.types import EVENT_TOOL_CALL
+
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(handle, {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "child-tc-1",
+        "title": "read_file src/main.py",
+        "status": "in_progress",
+        "_meta": {"kiro": {"agentSubtaskId": "sa-1"}},
+    })
+    # Activity only — the tool must NOT surface as a top-level tool call.
+    activity_events = [e for e in events if e.kind == EVENT_SUBAGENT_ACTIVITY]
+    tool_events = [e for e in events if e.kind == EVENT_TOOL_CALL]
+    assert len(activity_events) == 1
+    assert activity_events[0].sub_session_id == "sa-1"
+    assert activity_events[0].tool_call_id == "child-tc-1"
+    assert activity_events[0].title == "read_file src/main.py"
+    assert tool_events == []
+    # But the security cache IS populated (side-effect parse), so a later
+    # permission/result for this child tool has the trusted shell signal.
+    assert "child-tc-1" in handle._tool_call_is_shell
+
+
+# ── Child agent_message_chunk → EVENT_SUBAGENT_ACTIVITY w/ redacted text ─────
+
+
+def test_child_agent_message_chunk_emits_activity() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(handle, {
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "Working on the fix..."},
+        "_meta": {"kiro": {"agentSubtaskId": "sa-1"}},
+    })
+    assert len(events) == 1
+    assert events[0].kind == EVENT_SUBAGENT_ACTIVITY
+    assert events[0].sub_session_id == "sa-1"
+    assert events[0].text == "Working on the fix..."
+
+
+# ── Kiro-backend parity: KAS-shaped frame NOT intercepted on kiro ────────────
+
+
+def test_kas_subagent_frame_not_intercepted_on_kiro_backend() -> None:
+    handle = _handle(ACP_BACKEND_KIRO)
+    # On kiro, a tool_call with _meta.kiro.agentSubtaskId falls through to the
+    # shared parser (no EVENT_SUBAGENT_LIST, just a normal tool_call event).
+    events = _update(handle, {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc1",
+        "title": "Sub-agent: researcher",
+        "status": "in_progress",
+        "_meta": {"kiro": {"kind": "agent-subtask", "agentSubtaskId": "sa-1"}},
+    })
+    # Should NOT produce EVENT_SUBAGENT_LIST — kiro path processes it as a
+    # normal tool call.
+    subagent_events = [e for e in events if e.kind == EVENT_SUBAGENT_LIST]
+    assert subagent_events == []
+
+
+def test_kas_subagent_chunk_not_intercepted_on_kiro_backend() -> None:
+    handle = _handle(ACP_BACKEND_KIRO)
+    events = _update(handle, {
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "hello"},
+        "_meta": {"kiro": {"agentSubtaskId": "sa-1"}},
+    })
+    # On kiro, this is just a regular text chunk, NOT subagent activity.
+    assert len(events) == 1
+    assert events[0].kind == EVENT_TEXT_CHUNK
+    assert events[0].text == "hello"
+
+
+# ── Failed status in roster ──────────────────────────────────────────────────
+
+
+def test_failed_agent_subtask_updates_roster() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    _update(handle, {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc1",
+        "title": "Sub-agent: builder",
+        "status": "in_progress",
+        "_meta": {"kiro": {"kind": "agent-subtask", "agentSubtaskId": "sa-3"}},
+    })
+    events = _update(handle, {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc1",
+        "title": "Sub-agent: builder",
+        "status": "failed",
+        "_meta": {"kiro": {"kind": "agent-subtask", "agentSubtaskId": "sa-3"}},
+    })
+    assert events[0].subagents[0]["status"]["type"] == "failed"
+
+
+# ── No agentSubtaskId → normal tool_call pass-through ────────────────────────
+
+
+def test_normal_tool_call_not_intercepted_on_kas() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(handle, {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc-normal",
+        "title": "read_file",
+        "status": "in_progress",
+        "_meta": {"kiro": {}},
+    })
+    # Falls through to parse_session_update → normal EVENT_TOOL_CALL
+    from kiro_crew.acp.types import EVENT_TOOL_CALL
+    assert any(e.kind == EVENT_TOOL_CALL for e in events)
+
+
+# ── Regression: roster reset per turn (BLOCKER) ──────────────────────────────
+
+
+def _status_of(events: list, sid: str) -> str | None:
+    for ev in events:
+        for entry in (ev.subagents or []):
+            if entry.get("sessionId") == sid:
+                return entry["status"]["type"]
+    return None
+
+
+def test_roster_cleared_between_turns_excludes_prior_completed() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    # Turn 1: sub-agent A spawns then completes.
+    _update(handle, {"sessionUpdate": "tool_call", "toolCallId": "tcA", "title": "Sub-agent: A",
+                     "status": "in_progress", "_meta": {"kiro": {"kind": "agent-subtask", "agentSubtaskId": "A"}}})
+    _update(handle, {"sessionUpdate": "tool_call_update", "toolCallId": "tcA", "title": "Sub-agent: A",
+                     "status": "completed", "_meta": {"kiro": {"kind": "agent-subtask", "agentSubtaskId": "A"}}})
+    assert "A" in handle._kas_subagent_roster
+    # Turn boundary: prompt()'s per-turn reset block clears the roster (parity
+    # with kiro-cli's authoritative full list each turn).
+    handle._kas_subagent_roster.clear()
+    # Turn 2: a new sub-agent B — its LIST must NOT resurrect the completed A.
+    events = _update(handle, {"sessionUpdate": "tool_call", "toolCallId": "tcB", "title": "Sub-agent: B",
+                              "status": "in_progress", "_meta": {"kiro": {"kind": "agent-subtask", "agentSubtaskId": "B"}}})
+    ids = {e.get("sessionId") for ev in events for e in (ev.subagents or [])}
+    assert ids == {"B"}
+
+
+# ── Regression: child thinking chunk not surfaced (BLOCKER) ──────────────────
+
+
+def test_child_thinking_chunk_not_surfaced() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(handle, {"sessionUpdate": "agent_message_chunk",
+                              "_meta": {"kiro": {"agentSubtaskId": "c1"}},
+                              "content": {"type": "thinking", "text": "private reasoning"}})
+    assert events == []
+
+
+def test_child_text_chunk_is_surfaced() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(handle, {"sessionUpdate": "agent_message_chunk",
+                              "_meta": {"kiro": {"agentSubtaskId": "c1"}},
+                              "content": {"type": "text", "text": "hello from child"}})
+    assert len(events) == 1
+    assert events[0].kind == EVENT_SUBAGENT_ACTIVITY
+    assert events[0].sub_session_id == "c1"
+    assert events[0].text == "hello from child"
+
+
+# ── Pipeline stage status transition reflected in the list ───────────────────
+
+
+def test_pipeline_stage_status_transition() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    stage_running = {"name": "s1", "role": "r1", "status": "in_progress", "agentSubtaskId": "st1"}
+    stage_done = {"name": "s1", "role": "r1", "status": "completed", "agentSubtaskId": "st1"}
+    _update(handle, {
+        "sessionUpdate": "tool_call", "toolCallId": "tcP", "title": "Orchestrate Sub-agent",
+        "_meta": {"kiro": {"pipeline": {"groupId": "g1", "stages": [stage_running]}}},
+    })
+    events = _update(handle, {
+        "sessionUpdate": "tool_call_update", "toolCallId": "tcP",
+        "_meta": {"kiro": {"pipeline": {"groupId": "g1", "stages": [stage_done]}}},
+    })
+    assert _status_of(events, "st1") == "completed"


### PR DESCRIPTION
## Problem

On the `kas` ACP backend, two display capabilities were missing:
- **Sub-agent progress**: KAS emits sub-agents as ordinary `tool_call`/`tool_call_update` frames tagged `_meta.kiro.agentSubtaskId` (individual) or `_meta.kiro.pipeline` (orchestrate), with the child's own frames repeating the same id. There is no aggregated `list_update` like kiro-cli's, so Crew rendered them as confusing top-level tool calls in the main transcript instead of the sub-agent progress UI.
- **Steering**: KAS reports mid-turn steer as `session_info_update` with `_meta.kiro.kind` in {`steering_queued`,`steering_injected`,`steering_cleared`}. The existing "steer" classifier keys on `update.sessionUpdate` (always `"session_info_update"` for KAS), so it never fired — queued steers never settled in the UI.

## Why it matters

These make KAS look half-broken: sub-agents cluttered the main transcript with no roster/progress, and steering appeared stuck. This is the demo-facing completion of KAS display parity.

## Fix (symptom → root cause → change)

Both are KAS-gated (`self._runtime.acp_backend == ACP_BACKEND_KAS`, positive check) so the kiro-cli path is byte-for-byte untouched (harness parity), and both reuse existing downstream consumers so no `chat_runner`/frontend change is needed.

- **Sub-agent progress:** a KAS-gated interception in `_handle_update` (before the shared parser) reconstructs a per-session roster from the per-frame `agentSubtaskId`/`pipeline` events and emits the existing `EVENT_SUBAGENT_LIST` (full roster, in the kiro-cli list shape `_native_subagent_sync` already diffs into WS `subagent_spawn/tool/done`). A child's streamed text → `EVENT_SUBAGENT_ACTIVITY`. Status maps in_progress/pending/completed/failed; terminal frames flip the entry so the diff emits `subagent_done`. **The roster is cleared in the per-turn reset** so it stays authoritative per turn like kiro-cli's list (no resurrecting completed prior-turn agents, no unbounded growth). Child **thinking/reasoning** chunks are suppressed (not surfaced as visible activity), matching the kiro native-subagent path.
- **Steering:** the KAS `steering_*` kinds are routed through `_handle_kas_session_info` → `EVENT_STEER_QUEUED/CONSUMED/CLEARED` (injected → CONSUMED, the signal `_settle_consumed_steers` acts on), redacting backend-echoed text.

## Tests

`test/test_kas_subagent_progress.py`: individual spawn/complete → `EVENT_SUBAGENT_LIST`; pipeline stages (incl. a status transition on `tool_call_update`); child tool → activity; child text → activity; child **thinking** chunk → suppressed; **cross-turn roster isolation** (turn 2 list excludes a prior completed agent); kiro-backend parity (not intercepted). Steering cases added to `test/test_kas_display_mapping.py`. 40 tests pass; flake8 + mypy + harness-parity green.

## Manual verification

N/A for the mapping logic — unit tests pin every frame shape against the pulled KAS source. A real-KAS spot check (spawn a sub-agent → watch the roster cards; trigger a steer → watch it settle) is worth doing but needs KAS running with auth.

## Known limitations (deferred, display-only)

- A child's *nested tool call* is pulled out of the main transcript (attribution only) and not yet rendered on the sub-agent card.
- If a child activity/text frame arrives *before* its parent `agent-subtask` frame, it is dropped (KAS establishes no ordering guarantee; unlikely given KAS pre-generates the subtask id before the child runs).
- Intra-turn pipeline stage *removal* (a regrouped/cancelled plan) is not pruned within a turn (the per-turn reset clears it across turns).

<!-- no-visual-delta -->
**Why no screenshot:** backend dispatch + tests only; no frontend render change (the sub-agent cards and steer indicator are existing UI surfaces, now merely fed on KAS).

no linked issue: incremental KAS-roadmap work (Group B + steering), tracked in team notes.
