### PR TITLE
refactor: flatten and de-duplicate branch logic in the acp module

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1080,6 +1080,14 @@ _RE_USAGE_LIMIT = re.compile(
 # flipping an otherwise-terminal error.
 _RE_GENERATE_FAILED = re.compile(r"failed to generate a response", re.IGNORECASE)
 
+# kiro-cli's wording for a concurrent in-flight prompt on the session, read by
+# the user-facing formatter below and by `_raise_acp_error`'s AcpPromptBusy
+# classification. One pattern, but two haystacks: the formatter scopes to the
+# provider `data` field while the classifier also searches the JSON-RPC
+# `message`, so an echo carried only by `message` raises AcpPromptBusy under the
+# unrecognised-shape text.
+_PROMPT_BUSY_RE = re.compile(r"already in progress", re.IGNORECASE)
+
 # kiro-cli's envelope for a failure that happened mid-stream. The text after the
 # colon is the provider's own message — the same words the CLI prints in a
 # terminal — so it is what a user needs to see.
@@ -1452,7 +1460,7 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
                 "to a different model in the picker."
                 f"{req_id_suffix}"
             )
-        elif re.search(r"already in progress", data, re.IGNORECASE):
+        elif _PROMPT_BUSY_RE.search(data):
             # The backend still has an in-flight prompt on this session.
             # This means a previous turn didn't complete cleanly (tool stall,
             # timeout, or race between messages). The session will auto-recover
@@ -1509,9 +1517,6 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
 
 
 # ---------------------------------------------------------------------------
-_PROMPT_BUSY_RE = re.compile(r"already in progress", re.IGNORECASE)
-
-
 def _rejected_model_from_error(error: object) -> str | None:
     """Return the model id a prompt-time error reports as invalid/unavailable.
 
@@ -5320,34 +5325,37 @@ class AcpClient:
                         entry = json.loads(line)
                     except json.JSONDecodeError:
                         continue
-                    if entry.get("kind") == "ToolResults":
-                        for c in entry.get("data", {}).get("content", []):
-                            if c.get("kind") == "toolResult":
-                                tr = c.get("data")
-                                if not isinstance(tr, dict):
-                                    continue
-                                tool_use_id = tr.get("toolUseId", "")
-                                output_parts: list[str] = []
-                                for rc in tr.get("content", []):
-                                    if isinstance(rc, dict):
-                                        if rc.get("kind") == "json":
-                                            d = rc.get("data", {})
-                                            if isinstance(d, dict) and "stdout" in d:
-                                                out = d.get("stdout", "")
-                                                if out:
-                                                    output_parts.append(out[:4000])
-                                            else:
-                                                output_parts.append(json.dumps(d, indent=2)[:4000])
-                                        elif rc.get("kind") == "text":
-                                            output_parts.append(str(rc.get("data", ""))[:4000])
-                                if output_parts:
-                                    results.append(
-                                        AcpEvent(
-                                            kind=EVENT_TOOL_RESULT,
-                                            tool_call_id=tool_use_id,
-                                            tool_output="\n".join(output_parts)[:8000],
-                                        )
-                                    )
+                    if entry.get("kind") != "ToolResults":
+                        continue
+                    for c in entry.get("data", {}).get("content", []):
+                        if c.get("kind") != "toolResult":
+                            continue
+                        tr = c.get("data")
+                        if not isinstance(tr, dict):
+                            continue
+                        tool_use_id = tr.get("toolUseId", "")
+                        output_parts: list[str] = []
+                        for rc in tr.get("content", []):
+                            if not isinstance(rc, dict):
+                                continue
+                            if rc.get("kind") == "json":
+                                d = rc.get("data", {})
+                                if isinstance(d, dict) and "stdout" in d:
+                                    out = d.get("stdout", "")
+                                    if out:
+                                        output_parts.append(out[:4000])
+                                else:
+                                    output_parts.append(json.dumps(d, indent=2)[:4000])
+                            elif rc.get("kind") == "text":
+                                output_parts.append(str(rc.get("data", ""))[:4000])
+                        if output_parts:
+                            results.append(
+                                AcpEvent(
+                                    kind=EVENT_TOOL_RESULT,
+                                    tool_call_id=tool_use_id,
+                                    tool_output="\n".join(output_parts)[:8000],
+                                )
+                            )
         except Exception:
             logger.debug("Failed to read JSONL for tool results", exc_info=True)
         if results:

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -2198,9 +2198,11 @@ class AcpSessionHandle:
                 # them so the meter resets and fresh telemetry re-derives real
                 # numbers (parity with the kiro-cli compaction handler).
                 self.last_prompt_stats.reset_after_compaction()
-            status_type = "completed" if kind == "summarization_completed" else (
-                "failed" if kind == "summarization_failed" else "started"
-            )
+                status_type = "completed"
+            elif kind == "summarization_failed":
+                status_type = "failed"
+            else:
+                status_type = "started"
             # conversationSummary is backend-echoed, LLM-influenced text that
             # reaches the dashboard — redact exfil URLs/credentials first.
             summary = redact_text(str(kiro.get("conversationSummary", "") or ""))


### PR DESCRIPTION
<!-- no-visual-delta -->
Backend-only diff (two files under `src/kiro_crew/acp/`); nothing under `website/`
changes, so there is no rendered surface to screenshot.

## Problem

Three readability defects in the `acp` module, all found by the module-simplification
detector plus its judgment classes:

1. `session_handle.py::_handle_kas_session_info` derived a compaction `status_type`
   from a **chained ternary** whose first arm re-tested `kind ==
   "summarization_completed"` — a condition the enclosing block had already branched
   on immediately above. One predicate, two spellings, five lines apart.
2. `client.py::_format_acp_error` re-wrote the prompt-busy pattern inline as
   `re.search(r"already in progress", data, re.IGNORECASE)`, while
   `client.py::_raise_acp_error` matched the **identical** pattern through the
   precompiled `_PROMPT_BUSY_RE`. One literal, two copies — and the constant was
   defined *below* its first reader, under an orphaned section separator.
3. `client.py::_read_new_tool_results_sync` nested **eleven** levels deep, because
   three enclosing conditions each wrapped an entire loop body rather than guarding
   it.

## Why it matters

Every one of these makes the next reader do work the code should have done. A
duplicated predicate is a place where a future edit can change one copy and not the
other; a duplicated regex literal is the same hazard with a security-adjacent
classifier attached (the pattern decides whether a user sees "still processing" or a
raw provider error, and whether `AcpPromptBusy` is raised); and eleven levels of
nesting hides which condition actually governs a statement. This module is the ACP
transport every session runs through, so it is read often and under pressure.

## Fix (symptoms → root cause → change)

The root cause in all three cases is the same: a condition expressed in a shape that
buries it. So each is re-expressed in the shape that surfaces it, with no change to
what runs.

- **`session_handle.py:2196`** — fold the ternary into the `if` that already tested
  its first arm: `if kind == "summarization_completed": … status_type = "completed"` /
  `elif kind == "summarization_failed":` / `else:`. The enclosing
  `if kind in (started, completed, failed)` guard makes the chain total, so
  `status_type` is bound on every path. `reset_after_compaction()` keeps exactly its
  old guard and position; only a literal assignment is appended after it, and the
  comment explaining the reset still sits on the statement it explains.
- **`client.py:1083`** — move `_PROMPT_BUSY_RE` up beside the sibling `_RE_*` error
  matchers it is read with, and route both call sites through it. **The two call
  sites deliberately search different haystacks** — the formatter scopes to the
  provider `data` field, the classifier also searches the JSON-RPC `message`. That
  divergence is *documented in the constant's comment and left exactly as it is*;
  unifying it would be a behavior change, which this PR is not.
- **`client.py:5322`** — invert the three enclosing conditions into early `continue`
  guards. Each wrapped the whole remainder of its loop iteration with no `else` arm
  and nothing following it, so `continue` is equivalent to falling off the end. The
  deepest arm drops from eleven levels to eight. Every moved line stays inside the
  same `try:`/`with open(...)`, and the `self._jsonl_pos` bookkeeping is untouched.

No API, schema, or documented behavior changes, so no spec update is required.
`docs/system-specs/modules/acp-client.md` names `_PROMPT_BUSY_RE` and the
`summarization_*` mapping but quotes neither code shape; both sentences stay true.

## Tests

No new tests: this is behavior-preserving by contract, and the existing suite already
pins all three arms of the compaction branch
(`test/test_kas_display_mapping.py` — `started`, `completed` + reset, `failed`
without reset). Adding tests here would lock in the *shape* rather than the behavior.

Ran on the Python 3.12 CI-parity venv, all exit 0:

- `flake8`, `isort --check-only`, `mypy src/kiro_crew` (967 files, clean)
- `check_brand_name.py`, `check_harness_parity.py`, `docs_lint.py --test`,
  `docs-lint.sh`, `check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
  `scrub-lint.sh --no-history`
- `pytest -k "acp or session_handle or compaction or kas"` → **1700 passed, 1 skipped**
- Re-ran every gate after rebasing onto `79416b25`, and re-ran the detector: the
  module reports **0 actionable sites**, and no new site appeared from the rebase.

## Manual verification

N/A — unit coverage is sufficient. The change alters no runtime behavior, and the
one path a unit test cannot easily reach (`_read_new_tool_results_sync`'s JSONL
fallback) was verified by differential execution instead: the pre- and post-diff
control flow were transcribed and run over ~500k randomized entry trees
(non-dict `tr`/`rc`/`c`, absent vs falsy `stdout`, oversize strings exercising the
`[:4000]`/`[:8000]` caps), comparing both the returned event list and the raised
exception type — zero mismatches.

## Pre-review fleet

Five read-only reviewers ran before this PR opened, each on a distinct lens:
AUTOSDE blocking rules + the deterministic `code-review.yml` greps; behavior
preservation; module-scope binding and test patchability; the security keystone and
boot path; comment accuracy and spec sync.

**Three findings, all confirmed against the code and all acted on:**

1. *(fixed)* The comment I added above `_PROMPT_BUSY_RE` claimed that routing both
   sites through one constant meant "the message a user sees and the exception class
   raised are decided from one pattern". False — they share the pattern but not the
   haystack (`data` vs `data + message`). The comment now records the divergence
   instead of papering over it.
2. *(fixed)* The commit message said the duplicated predicate sat "three lines
   above"; it is five. Reworded to "immediately above".
3. *(out of scope — see below)* A **pre-existing** redaction gap, unrelated to this
   diff.

**Refuted / dropped:** one reviewer flagged the section separator at `client.py:1516`
now reading as a header for `_rejected_model_from_error`. Dropped — that is what the
separator does in this file, `flake8` is clean on it, and changing it would be churn.
Nothing else survived.

## Deliberately NOT in this PR

`_read_new_tool_results_sync` emits `tool_output` **without redaction**, while both
sibling builders of the same `EVENT_TOOL_RESULT` do redact
(`client.py::_extract_tool_result` → `redact_exfiltration_urls` +
`redact_credentials`; `_dispatch.py::_build_tool_result_event` → `_redact`). This is
**pre-existing** — the line is byte-identical to the base — and this diff neither
added nor removed it; the flatten only reshaped the surrounding `if` nesting.

It is left out on purpose: it is a security behavior change, and landing one inside a
commit whose whole contract is "no behavior change" is the worst place to put it.
**It wants its own PR and a maintainer's judgment on whether the JSONL fallback path
is reachable with attacker-influenced content.**
