### PR TITLE
refactor(dashboard): split status purpose from label

### DIFF
--- a/website/src/components/CommandPalette.test.tsx
+++ b/website/src/components/CommandPalette.test.tsx
@@ -34,7 +34,7 @@ const H = vi.hoisted(() => {
     chat: {
       slotStatusDetail: {} as Record<
         string,
-        { kind: string; text: string; ts: number; toolName?: string }
+        { kind: string; label: string; purpose?: string; ts: number }
       >,
     },
   }
@@ -442,7 +442,7 @@ describe('CommandPalette — render', () => {
     expect(H.recentsProvider.search).toHaveBeenCalledTimes(1)
 
     H.storeState.chat.slotStatusDetail = {
-      'chat-1': { kind: 'tool', text: 'Running: read /workspace/src/app.ts', ts: 1 },
+      'chat-1': { kind: 'tool', label: 'read /workspace/src/app.ts', purpose: 'Running: read /workspace/src/app.ts', ts: 1 },
     }
     rerender(<CommandPalette open onClose={vi.fn()} />)
 
@@ -457,7 +457,7 @@ describe('CommandPalette — render', () => {
       { key: 'chat-1', title: 'Live session', running: true, messages: 2 },
     ]
     H.storeState.chat.slotStatusDetail = {
-      'chat-1': { kind: 'tool', text: 'Reading the app entrypoint', ts: 1 },
+      'chat-1': { kind: 'tool', label: 'read /workspace/src/app.ts', purpose: 'Reading the app entrypoint', ts: 1 },
     }
     const { rerender } = render(<CommandPalette open onClose={vi.fn()} />, { wrapper })
     await screen.findByText('Recent Session')

--- a/website/src/components/CommandPalette.tsx
+++ b/website/src/components/CommandPalette.tsx
@@ -357,7 +357,9 @@ export default function CommandPalette({
                   s.pinned ? 1 : 0
                 }:${s.last_activity_ts ?? s.last_ts ?? ''}:${
                   slotStatusDetail[s.key]?.kind ?? ''
-                }:${slotStatusDetail[s.key]?.text ?? ''}:${slotStatusDetail[s.key]?.ts ?? ''}`,
+                }:${slotStatusDetail[s.key]?.label ?? ''}:${
+                  slotStatusDetail[s.key]?.purpose ?? ''
+                }:${slotStatusDetail[s.key]?.ts ?? ''}`,
             )
             .join('|') + `#${unreadSlots.join(',')}#${simplifiedToolNames ? 1 : 0}`
         : '',

--- a/website/src/components/commandPalette/providers/recentsProvider.test.ts
+++ b/website/src/components/commandPalette/providers/recentsProvider.test.ts
@@ -16,7 +16,7 @@ import {
 type MockState = {
   dashboard: { slots: ChatSlot[]; unreadSlots: string[] }
   chat: {
-    slotStatusDetail: Record<string, { kind?: string; text?: string; toolName?: string; ts?: number }>
+    slotStatusDetail: Record<string, { kind?: string; label?: string; purpose?: string; ts?: number }>
   }
 }
 
@@ -244,7 +244,7 @@ describe('sessionStatus — running detail', () => {
   it('surfaces the live tool call instead of the generic Thinking label', () => {
     expect(
       sessionStatus(slot({ running: true }), [], {
-        text: 'Running: read /workspace/src/app.ts',
+        label: 'Running: read /workspace/src/app.ts',
       }),
     ).toMatchObject({
       style: 'dot',
@@ -261,10 +261,19 @@ describe('sessionStatus — running detail', () => {
     })
   })
 
+  it('resolves fixed phase markers instead of rendering their stored label', () => {
+    expect(
+      sessionStatus(slot({ running: true }), [], { kind: 'thinking', label: 'stale locale text' }),
+    ).toMatchObject({ label: 'Thinking…' })
+    expect(
+      sessionStatus(slot({ running: true }), [], { kind: 'streaming', label: 'stale locale text' }),
+    ).toMatchObject({ label: 'Streaming' })
+  })
+
   it('shows the raw tool title when simplifiedToolNames is off', () => {
     // Same preference the inline tool pill obeys, so the palette row and the
     // transcript agree instead of the row always showing the purpose.
-    const detail = { kind: 'tool', text: 'Reading the app entrypoint', toolName: 'fs_read /workspace/src/app.ts' }
+    const detail = { kind: 'tool', purpose: 'Reading the app entrypoint', label: 'fs_read /workspace/src/app.ts' }
     expect(sessionStatus(slot({ running: true }), [], detail, false)).toMatchObject({
       label: 'fs_read /workspace/src/app.ts',
     })
@@ -291,7 +300,8 @@ describe('useRecentsProvider — live status bridge', () => {
     mocks.state.chat.slotStatusDetail = {
       dashboard_live: {
         kind: 'tool',
-        text: 'Running: read /workspace/src/app.ts',
+        label: 'read /workspace/src/app.ts',
+        purpose: 'Running: read /workspace/src/app.ts',
         ts: 123,
       },
     }
@@ -312,8 +322,8 @@ describe('useRecentsProvider — live status bridge', () => {
     mocks.state.chat.slotStatusDetail = {
       dashboard_live: {
         kind: 'tool',
-        text: 'Reading the app entrypoint',
-        toolName: 'fs_read /workspace/src/app.ts',
+        purpose: 'Reading the app entrypoint',
+        label: 'fs_read /workspace/src/app.ts',
         ts: 123,
       },
     }

--- a/website/src/components/commandPalette/providers/recentsProvider.ts
+++ b/website/src/components/commandPalette/providers/recentsProvider.ts
@@ -180,7 +180,7 @@ function shortMsg(slot: ChatSlot): string {
 export function sessionStatus(
   slot: ChatSlot,
   unread: string[],
-  statusDetail?: { kind?: string; text?: string; toolName?: string },
+  statusDetail?: { kind?: string; label?: string; purpose?: string },
   // Defaults to the ChatSettings default (on) so callers that don't care about
   // the preference keep the purpose-first behavior.
   simplifiedToolNames = true,
@@ -212,12 +212,17 @@ export function sessionStatus(
     }
   }
   if (slot.running) {
+    const fixedPhaseLabel = statusDetail?.kind === 'streaming'
+      ? i18nT('pages.chatSidebar.streaming')
+      : statusDetail?.kind === 'thinking'
+        ? i18nT('components.commandPalette.providers.recentsProvider.thinking')
+        : ''
     return {
       style: 'dot',
       colorVar: '--accent',
       pulse: true,
       label:
-        toolStatusLabel(statusDetail, simplifiedToolNames, i18next.language) ||
+        fixedPhaseLabel || toolStatusLabel(statusDetail, simplifiedToolNames, i18next.language) ||
         i18nT('components.commandPalette.providers.recentsProvider.thinking'),
     }
   }

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -1386,7 +1386,7 @@ export function useWebSocket() {
               voiceProgressRef.current = null
             }
             if (!isPassiveNote && data.slot && (data.role === 'user' || data.role === 'inject' || data.role === 'subagent')) {
-              dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'thinking', text: 'Thinking…', ts: Date.now() }))
+              dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'thinking', label: '', ts: Date.now() }))
             }
             break
           case 'chat_message_update':
@@ -1485,7 +1485,7 @@ export function useWebSocket() {
               entry.content += data.content ?? ''
               if (data.seq !== undefined) entry.lastSeq = data.seq
               if (store.getState().chat.slotStatusDetail[cs]?.kind !== 'streaming') {
-                dispatch(setSlotStatusDetail({ slot: cs, kind: 'streaming', text: 'Streaming', ts: Date.now() }))
+                dispatch(setSlotStatusDetail({ slot: cs, kind: 'streaming', label: '', ts: Date.now() }))
               }
               scheduleChunkFlush()
             }
@@ -1519,7 +1519,7 @@ export function useWebSocket() {
               const tcid = (data as Record<string, unknown>).tool_call_id as string | undefined
               const isUpdate = (data as Record<string, unknown>).is_update === true
               const purpose = sanitizeLlmOutput((data as Record<string, unknown>).purpose as string || '')
-              const toolName = sanitizeLlmOutput(data.tool || '')
+              const toolLabel = sanitizeLlmOutput(data.tool || '')
               const prev = store.getState().chat.slotStatusDetail[data.slot]
               const mergeInto = isUpdate && tcid && prev?.kind === 'tool' && prev.toolCallId === tcid
                 ? prev
@@ -1527,8 +1527,8 @@ export function useWebSocket() {
               dispatch(setSlotStatusDetail({
                 slot: data.slot,
                 kind: 'tool',
-                text: purpose || mergeInto?.text || '',
-                toolName: toolName || mergeInto?.toolName || '',
+                purpose: purpose || mergeInto?.purpose || '',
+                label: toolLabel || mergeInto?.label || '',
                 ...(tcid ? { toolCallId: tcid } : {}),
                 ts: Date.now(),
               }))
@@ -1782,7 +1782,7 @@ export function useWebSocket() {
             // made explicit.
             const detailKind = data.slot ? store.getState().chat.slotStatusDetail[data.slot]?.kind : undefined
             if (data.slot && detailKind !== 'streaming' && detailKind !== 'thinking') {
-              dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'thinking', text: 'Thinking…', ts: Date.now() }))
+              dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'thinking', label: '', ts: Date.now() }))
             }
             break
           }
@@ -1798,7 +1798,7 @@ export function useWebSocket() {
           }
           case 'chat_status':
             if (data.slot && data.status) {
-              dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'thinking', text: data.status, ts: Date.now() }))
+              dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'status', label: data.status, ts: Date.now() }))
             }
             break
           case 'chat_variant_switch':
@@ -1834,7 +1834,7 @@ export function useWebSocket() {
               dispatch(warmSlotCache(data.slot))
             }
             if (data.slot) {
-              dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'idle', text: 'Ready', ts: Date.now() }))
+              dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'idle', label: '', ts: Date.now() }))
             }
             if (data.slot) dispatch(refreshSlot(data.slot))
             if (data.slot) {

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -174,18 +174,17 @@ const ROW_ICON_PX = 10
  *  keeps one identity while the query has no data. */
 const NO_TAGS: ChatTag[] = []
 
-/** Translate a slot's running-status line. The status `text` is stored as a raw
- *  English literal by the websocket layer (a plain `.ts` module the i18n codemod
- *  never scans), so it must be localized at render time. The two fixed phases
- *  (`thinking`/`streaming`) map to catalog keys; a `tool` phase or a
- *  server-supplied status carries its own dynamic text and is passed through.
+/** Translate a slot's running-status line. Fixed phases are stored as
+ *  language-neutral `kind` markers and resolved here at render time, so a
+ *  language change updates an in-flight row immediately. A `tool` phase or a
+ *  server-supplied `status` carries dynamic text and is passed through.
  *
  *  A `tool` phase honors the user's `simplifiedToolNames` preference (purpose vs
  *  raw tool title) via toolStatusLabel, so the row agrees with the inline tool
  *  pill in the transcript rather than always showing the purpose. */
-function slotStatusText(detail: { kind?: string; text?: string; toolName?: string } | undefined, simplifiedToolNames: boolean, uiLang: string): string {
+function slotStatusText(detail: { kind?: string; label?: string; purpose?: string } | undefined, simplifiedToolNames: boolean, uiLang: string): string {
   if (detail?.kind === 'streaming') return i18nT('pages.chatSidebar.streaming')
-  if (detail?.kind === 'thinking' && detail.text === 'Thinking…') return i18nT('pages.chatSidebar.thinking')
+  if (detail?.kind === 'thinking') return i18nT('pages.chatSidebar.thinking')
   return toolStatusLabel(detail, simplifiedToolNames, uiLang) || i18nT('pages.chatSidebar.thinking')
 }
 

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -674,7 +674,7 @@ interface ChatState {
   slotRunning: boolean
   slotStopping: boolean
   slotState: SlotState
-  slotStatusDetail: Record<string, { kind: string; text: string; ts: number; toolName?: string; toolCallId?: string }>
+  slotStatusDetail: Record<string, { kind: string; label: string; purpose?: string; ts: number; toolCallId?: string }>
   slotHasMore: boolean
   slotOldestIndex: number
   /** Slot the cursor above describes. A switch moves activeSlot first, so
@@ -4023,7 +4023,7 @@ const chatSlice = createSlice({
      *  merged into it (see the `tool_call` case in useWebSocket) without a
      *  refinement of one call inheriting a sibling's purpose when tools run in
      *  parallel. */
-    setSlotStatusDetail(state, action: PayloadAction<{ slot: string; kind: string; text: string; ts: number; toolName?: string; toolCallId?: string }>) {
+    setSlotStatusDetail(state, action: PayloadAction<{ slot: string; kind: string; label: string; purpose?: string; ts: number; toolCallId?: string }>) {
       const { slot, ...detail } = action.payload
       if (isUnsafeKey(slot)) return
       state.slotStatusDetail[safeKey(slot)] = detail

--- a/website/src/test/ChatSidebar.goalLoop.test.tsx
+++ b/website/src/test/ChatSidebar.goalLoop.test.tsx
@@ -136,7 +136,7 @@ describe('chat sidebar — goal-loop progress subtitle', () => {
     const slots = [{ key: 'k', title: 'loop', running: true, messages: 5, last_message: 'stale' }]
     const { getByText, queryByText } = renderSidebar(
       slots,
-      { activeSlot: 'k', goalLoops: { k: { cycle_count: 3, max_cycles: 24 } }, slotStatusDetail: { k: { text: 'Reading gateway.log' } } },
+      { activeSlot: 'k', goalLoops: { k: { cycle_count: 3, max_cycles: 24 } }, slotStatusDetail: { k: { label: 'Reading gateway.log' } } },
       { activeSlotProp: 'k' },
     )
     expect(getByText('Loop 3/24')).toBeTruthy()

--- a/website/src/test/ChatSidebar.rowMemo.test.tsx
+++ b/website/src/test/ChatSidebar.rowMemo.test.tsx
@@ -204,7 +204,7 @@ describe('chat sidebar — session row memo boundary', () => {
       // (toolStatusLabel), so the assertion is independent of the
       // simplifiedToolNames preference.
       store.dispatch(setSlotStatusDetail({
-        slot: 'k-b', kind: 'status', text: 'Poking the build', ts: 1,
+        slot: 'k-b', kind: 'status', label: 'Poking the build', ts: 1,
       }))
     })
 

--- a/website/src/test/ChatSidebar.slotDerivation.test.tsx
+++ b/website/src/test/ChatSidebar.slotDerivation.test.tsx
@@ -190,7 +190,7 @@ describe('sidebar slot derivation — every derived value still reaches the row'
     const slots = [{ key: 'k', title: 'loop', running: false, messages: 5, last_message: 'cycle 7 output' }] as unknown as ChatSlot[]
     const { getByText, queryByText } = renderSidebar(
       slots,
-      { goalLoops: { k: { cycle_count: 7, max_cycles: 24 } }, slotStatusDetail: { k: { text: 'Reading gateway.log' } } },
+      { goalLoops: { k: { cycle_count: 7, max_cycles: 24 } }, slotStatusDetail: { k: { label: 'Reading gateway.log' } } },
     )
     expect(getByText('Loop 7/24')).toBeTruthy()
     expect(getByText(/cycle 7 output/)).toBeTruthy()
@@ -201,7 +201,7 @@ describe('sidebar slot derivation — every derived value still reaches the row'
     const slots = [{ key: 'k', title: 'loop', running: true, messages: 5, last_message: 'cycle 7 output' }] as unknown as ChatSlot[]
     const { getByText, queryByText } = renderSidebar(
       slots,
-      { activeSlot: 'k', goalLoops: { k: { cycle_count: 7, max_cycles: 24 } }, slotStatusDetail: { k: { text: 'Reading gateway.log' } } },
+      { activeSlot: 'k', goalLoops: { k: { cycle_count: 7, max_cycles: 24 } }, slotStatusDetail: { k: { label: 'Reading gateway.log' } } },
       { activeSlotProp: 'k' },
     )
     expect(getByText('Loop 7/24')).toBeTruthy()

--- a/website/src/test/ChatSidebar.toolStatusSetting.test.tsx
+++ b/website/src/test/ChatSidebar.toolStatusSetting.test.tsx
@@ -74,8 +74,8 @@ import type { ChatSlot } from '../types'
 
 const TOOL_DETAIL = {
   kind: 'tool',
-  text: 'Looking up the mic permission handler',
-  toolName: 'grep --include=*.ts setPermissionCheckHandler',
+  purpose: 'Looking up the mic permission handler',
+  label: 'grep --include=*.ts setPermissionCheckHandler',
   ts: 1,
 }
 
@@ -135,7 +135,7 @@ describe('chat sidebar — tool status honors simplifiedToolNames', () => {
     // going through the catalog rather than falling into the tool branch.
     cfg.value = { ...cfg.value, simplifiedToolNames: false }
     const { getByText } = renderSidebar(slots, {
-      slotStatusDetail: { k: { kind: 'thinking', text: 'Thinking…', ts: 1 } },
+      slotStatusDetail: { k: { kind: 'thinking', label: 'Thinking…', ts: 1 } },
     })
     expect(getByText(/Thinking…/)).toBeTruthy()
   })

--- a/website/src/test/ChatSliceCoverage.test.tsx
+++ b/website/src/test/ChatSliceCoverage.test.tsx
@@ -237,7 +237,7 @@ describe('chatSlice prototype-pollution guards', () => {
     store.dispatch(setActiveSlot('real'))
     for (const bad of POISON) {
       store.dispatch(setStopPressedAt({ slotId: bad, ts: 1 }))
-      store.dispatch(setSlotStatusDetail({ slot: bad, kind: 'tool', text: 't', ts: 1 }))
+      store.dispatch(setSlotStatusDetail({ slot: bad, kind: 'tool', label: 't', ts: 1 }))
       store.dispatch(sseContextUsage({ slot: bad, pct: 50, window_tokens: 100 }))
       store.dispatch(hydrateSlotMessages({ slot: bad, messages: [{ role: 'user', content: 'x' } as ChatMessage] }))
       store.dispatch(appendSlotMessage({ slot: bad, message: { role: 'user', content: 'x' } as ChatMessage }))

--- a/website/src/test/UseWebSocketCoverage.test.tsx
+++ b/website/src/test/UseWebSocketCoverage.test.tsx
@@ -547,7 +547,7 @@ describe('useWebSocket frame router', () => {
       })
     })
     expect(chat().slotStatusDetail[ACTIVE]?.kind).toBe('tool')
-    expect(chat().slotStatusDetail[ACTIVE]?.toolName).toBe('fs_read')
+    expect(chat().slotStatusDetail[ACTIVE]?.label).toBe('fs_read')
 
     act(() => {
       ws.simulateMessage({ type: 'tool_result', data: { slot: ACTIVE, output: '42 lines', tool_call_id: 'tc-9' } })
@@ -781,11 +781,12 @@ describe('useWebSocket frame router', () => {
       ws.simulateMessage({ type: 'chat_status', data: { slot: ACTIVE, status: 'Compacting…' } })
     })
     expect(chat().slotContextPct[ACTIVE]).toBe(42)
-    expect(chat().slotStatusDetail[ACTIVE]?.text).toBe('Compacting…')
+    expect(chat().slotStatusDetail[ACTIVE]?.kind).toBe('status')
+    expect(chat().slotStatusDetail[ACTIVE]?.label).toBe('Compacting…')
 
     // A status frame with no text is ignored rather than clearing the detail.
     act(() => { ws.simulateMessage({ type: 'chat_status', data: { slot: ACTIVE } }) })
-    expect(chat().slotStatusDetail[ACTIVE]?.text).toBe('Compacting…')
+    expect(chat().slotStatusDetail[ACTIVE]?.label).toBe('Compacting…')
   })
 
   it('re-reads the transcript when a variant switch names a slot', () => {

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -235,17 +235,17 @@ describe('chatSlice reducers', () => {
     })
   })
 
-  it('setSlotStatusDetail updates kind, text, and ts', () => {
+  it('setSlotStatusDetail keeps display labels separate from tool purposes', () => {
     const now = Date.now()
-    const state = reducer(initial, setSlotStatusDetail({ slot: 'test-slot', kind: 'thinking', text: 'Thinking…', ts: now }))
+    const state = reducer(initial, setSlotStatusDetail({ slot: 'test-slot', kind: 'thinking', label: 'Thinking…', ts: now }))
     expect(state.slotStatusDetail['test-slot'].kind).toBe('thinking')
-    expect(state.slotStatusDetail['test-slot'].text).toBe('Thinking…')
+    expect(state.slotStatusDetail['test-slot'].label).toBe('Thinking…')
     expect(state.slotStatusDetail['test-slot'].ts).toBe(now)
-    // Tool name optional
-    const state2 = reducer(state, setSlotStatusDetail({ slot: 'test-slot', kind: 'tool', text: 'Tool: read', toolName: 'read', ts: now }))
-    expect(state2.slotStatusDetail['test-slot'].toolName).toBe('read')
+    const state2 = reducer(state, setSlotStatusDetail({ slot: 'test-slot', kind: 'tool', label: 'read', purpose: 'Read the file', ts: now }))
+    expect(state2.slotStatusDetail['test-slot'].label).toBe('read')
+    expect(state2.slotStatusDetail['test-slot'].purpose).toBe('Read the file')
     // Idle clears
-    const state3 = reducer(state2, setSlotStatusDetail({ slot: 'test-slot', kind: 'idle', text: 'Ready', ts: now }))
+    const state3 = reducer(state2, setSlotStatusDetail({ slot: 'test-slot', kind: 'idle', label: 'Ready', ts: now }))
     expect(state3.slotStatusDetail['test-slot'].kind).toBe('idle')
   })
 
@@ -2001,7 +2001,7 @@ describe('slotHistory — session navigation stack', () => {
       loadingOlder: true,
       lastChunkSeq: 99,
       _wsChunkedDuringFetch: true,
-      slotStatusDetail: { x: { kind: 'tool', text: 'hi', ts: 1 } },
+      slotStatusDetail: { x: { kind: 'tool', label: 'hi', ts: 1 } },
       voicePlaying: true,
       voiceAudio: 'base64data',
     }

--- a/website/src/test/toolStatusLabel.test.ts
+++ b/website/src/test/toolStatusLabel.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect } from 'vitest'
 import { toolStatusLabel } from '../utils/toolStatusLabel'
 
 describe('toolStatusLabel', () => {
-  const toolDetail = { kind: 'tool', text: 'Looking up the mic permission handler', toolName: 'grep' }
+  const toolDetail = { kind: 'tool', purpose: 'Looking up the mic permission handler', label: 'grep' }
 
   it('returns the agent purpose when simplified names are on', () => {
     expect(toolStatusLabel(toolDetail, true)).toBe('Looking up the mic permission handler')
@@ -18,17 +18,17 @@ describe('toolStatusLabel', () => {
   })
 
   it('falls back to the purpose in raw mode when no tool title was recorded', () => {
-    // Details restored from before toolName was carried, or a status whose
+    // A malformed or legacy status whose
     // tool title was empty: showing the purpose beats blanking the row.
-    expect(toolStatusLabel({ kind: 'tool', text: 'Reading gateway.log' }, false)).toBe('Reading gateway.log')
+    expect(toolStatusLabel({ kind: 'tool', purpose: 'Reading gateway.log' }, false)).toBe('Reading gateway.log')
   })
 
   it('passes non-tool phases through unchanged in both modes', () => {
     for (const simplified of [true, false]) {
-      expect(toolStatusLabel({ kind: 'thinking', text: 'Thinking…' }, simplified)).toBe('Thinking…')
-      expect(toolStatusLabel({ kind: 'streaming', text: 'Streaming' }, simplified)).toBe('Streaming')
-      // Server-supplied chat_status carries only `text`, never a tool title.
-      expect(toolStatusLabel({ kind: 'thinking', text: 'Compacting…' }, simplified)).toBe('Compacting…')
+      expect(toolStatusLabel({ kind: 'thinking', label: 'Thinking…' }, simplified)).toBe('Thinking…')
+      expect(toolStatusLabel({ kind: 'streaming', label: 'Streaming' }, simplified)).toBe('Streaming')
+      // Server-supplied chat_status carries a display label, never a purpose.
+      expect(toolStatusLabel({ kind: 'thinking', label: 'Compacting…' }, simplified)).toBe('Compacting…')
     }
   })
 

--- a/website/src/test/useWebSocket.toolRefinementStatus.test.ts
+++ b/website/src/test/useWebSocket.toolRefinementStatus.test.ts
@@ -127,7 +127,7 @@ describe('useWebSocket tool-call refinement status detail', () => {
 
   const detail = () => globalStore.getState().chat.slotStatusDetail['slot-1']
   /** What the session-list row actually paints, under the default
-   *  `simplifiedToolNames` preference. The stored `text` is only half the input
+   *  `simplifiedToolNames` preference. The stored `purpose` is only half the input
    *  — toolStatusLabel owns the fallback from an absent purpose to the title —
    *  so the label is the assertion that matches what a user sees. */
   const label = () => toolStatusLabel(detail(), true, 'en')
@@ -140,10 +140,10 @@ describe('useWebSocket tool-call refinement status detail', () => {
     expect(label()).toBe('List the temp dir')
 
     act(() => { ws.simulateMessage(refinement()) })
-    // The purpose survives; the refined title still lands on toolName so raw
+    // The purpose survives; the refined title still lands on label so raw
     // mode (simplifiedToolNames off) shows the real command, not the stub.
     expect(label()).toBe('List the temp dir')
-    expect(detail().toolName).toBe('ls /tmp')
+    expect(detail().label).toBe('ls /tmp')
     expect(toolStatusLabel(detail(), false, 'en')).toBe('ls /tmp')
   })
 
@@ -160,7 +160,7 @@ describe('useWebSocket tool-call refinement status detail', () => {
 
     act(() => { ws.simulateMessage(refinement()) })
     expect(label()).toBe('ls /tmp')
-    expect(detail().text).toBe('')
+    expect(detail().purpose).toBe('')
   })
 
   it('adopts a purpose the refinement does supply', () => {
@@ -184,7 +184,7 @@ describe('useWebSocket tool-call refinement status detail', () => {
 
     // A kind-only refinement must not blank the row into an empty label.
     expect(label()).toBe('List the temp dir')
-    expect(detail().toolName).toBe('Terminal')
+    expect(detail().label).toBe('Terminal')
   })
 
   it('does not let a refinement inherit a parallel call\u2019s purpose', () => {
@@ -212,6 +212,6 @@ describe('useWebSocket tool-call refinement status detail', () => {
 
     // A fresh (non-update) frame is authoritative — no merge, no stale purpose.
     expect(label()).toBe('Find the caller')
-    expect(detail().toolName).toBe('grep')
+    expect(detail().label).toBe('grep')
   })
 })

--- a/website/src/utils/toolStatusLabel.ts
+++ b/website/src/utils/toolStatusLabel.ts
@@ -2,16 +2,16 @@ import { pickToolLabel } from './toolLabel'
 
 /** The pair of labels a live `tool` status carries — the same pair an inline
  *  tool pill chooses between (see ToolCallLine's `toolLabel`). */
-export type ToolStatusDetail = { kind?: string; text?: string; toolName?: string }
+export type ToolStatusDetail = { kind?: string; label?: string; purpose?: string }
 /**
  * Resolve a live session status to the label the user's `simplifiedToolNames`
  * preference asks for, so a session-list row agrees with the inline tool pill
  * instead of always showing the purpose.
  *
  * The websocket layer stores both forms on every `tool` status (see the
- * `tool_call` case in useWebSocket): `text` is the agent-written purpose — EMPTY
- * when the agent supplied none, because conflating the two upstream makes a
- * refinement unable to tell a real purpose from a stub title — and `toolName` is
+ * `tool_call` case in useWebSocket): `purpose` is the agent-written purpose —
+ * EMPTY when the agent supplied none, because conflating the two upstream makes
+ * a refinement unable to tell a real purpose from a stub title — and `label` is
  * the raw tool title. Falling back from an absent purpose to the title is
  * therefore this function's job. Non-tool phases — `thinking`, `streaming`, a
  * server-supplied `chat_status` — carry a single label and pass through
@@ -26,19 +26,19 @@ export function toolStatusLabel(
   uiLang = '',
 ): string {
   if (!detail) return ''
-  // Raw mode: prefer the tool title, but fall back to `text` for statuses that
-  // predate `toolName` (restored/legacy details) rather than blanking the row.
-  if (detail.kind === 'tool' && !simplifiedToolNames) return detail.toolName || detail.text || ''
-  // Simplified mode on a tool phase: `text` is the agent purpose. Guard it
+  // Raw mode prefers the tool title, but the purpose is still a safe fallback
+  // when a malformed or legacy frame omitted its label.
+  if (detail.kind === 'tool' && !simplifiedToolNames) return detail.label || detail.purpose || ''
+  // Simplified mode on a tool phase: `purpose` is the agent purpose. Guard it
   // against the active UI language (see pickToolLabel) so a purpose written in
   // another language falls back to the language-neutral tool title.
   if (detail.kind === 'tool') {
     return pickToolLabel({
       simplified: true,
-      purpose: detail.text,
-      rawLabel: detail.toolName || detail.text || '',
+      purpose: detail.purpose,
+      rawLabel: detail.label || '',
       uiLang,
     })
   }
-  return detail.text || ''
+  return detail.label || ''
 }


### PR DESCRIPTION
## Problem / Motivation

Live session status overloaded one `text` field with two different meanings: an agent-written tool purpose and the raw tool label. Consumers could not reliably honor the simplified-tool-name preference without guessing which value they had.

## Why it matters

The sidebar, recents list, and command palette should show the same meaningful status while preserving language changes during an active turn. Ambiguous stored data caused inconsistent labels and made localization easy to freeze in Redux state.

## What changed (motivation → approach → change)

The live status shape now carries explicit `label` and optional `purpose` fields. Tool display selection remains centralized in `toolStatusLabel`. Fixed thinking and streaming phases are stored as language-neutral `kind` markers and translated at render time, while server-supplied status text remains dynamic.

## Tests

- Focused Vitest suite: 391 tests passed on the maintainer-updated branch.
- Additional focused verification after the render-time localization correction: 140 tests passed.
- TypeScript typecheck, production frontend build, i18n gates, and changed-file ESLint passed on the prior reviewed head.

## Manual verification

N/A — reducer, websocket, resolver, sidebar, recents, and command-palette behavior is covered by focused automated tests.

<!-- no-visual-delta -->
**Why no screenshot:** The refactor preserves rendered English labels; its behavioral correction is that fixed phases retranslate when the active language changes.

## Related Issues

Closes #3429

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The repository's CLA placeholder remains pending OSPO wording.
