### PR TITLE
fix(ci): make UX scope detection pipe-safe

### DIFF
--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -249,7 +249,7 @@ jobs:
           changed="$( { grep -E '^\+\+\+ b/' "$PATCH" | sed 's#^+++ b/##'; \
                         grep -E '^--- a/' "$PATCH" | sed 's#^--- a/##'; } \
                       2>/dev/null | grep -v '^/dev/null$' | sort -u || true )"
-          if printf '%s\n' "$changed" | grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)'; then
+          if grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)' <<<"$changed"; then
             echo "ui=true" >> "$GITHUB_OUTPUT"
             echo "UI-relevant changes detected; running UX review."
           else

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           set -euo pipefail
           changed="$(git diff --name-only "$BASE_SHA"...HEAD)"
-          if printf '%s\n' "$changed" | grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)'; then
+          if grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)' <<<"$changed"; then
             echo "ui=true" >> "$GITHUB_OUTPUT"
             echo "UI-relevant changes detected; running UX review."
           else

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -452,6 +452,10 @@ and grounds visual findings in them, and it is instructed to treat screenshot co
 as untrusted (a screenshot, title, commit message or filename attempting to grant
 leniency is ignored, and screenshot polish never waives a lens).
 
+The scope gate passes the complete changed-file list to `grep` through a here-string.
+This avoids the `SIGPIPE` false-negative that a `printf | grep -q` pipeline can
+produce under `pipefail` when an early match closes the pipe.
+
 ### Human override
 
 `ai-review-human-override.yml` lets a repository **writer** record a judgment with:

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -559,6 +559,11 @@ class TestFirstPrinciplesReview:
             assert '<<<"$touched"' in script
             assert "printf '%s\\n' \"$touched\" \\" not in script
 
+        for name in ("ux-review.yml", "fork-ux-review.yml"):
+            script = _step_script(_workflow(name), "Detect UI-relevant changes")
+            assert '<<<"$changed"' in script
+            assert "printf '%s\\n' \"$changed\" |" not in script
+
     def test_verdict_requires_the_current_head_marker(self) -> None:
         # Without this the [FIRST-PRINCIPLES-REVIEWED] marker is decorative: a
         # reply carrying the verdict header but a stale/rewritten marker was


### PR DESCRIPTION
Addresses #3447 (defect 3 of 3).

## Summary
- replace the `printf | grep -q` UX scope pipelines with here-strings
- cover both same-repository and fork review lanes
- add a regression test and document why the pipe-safe form is required

## Verification
- `.venv/bin/pytest -q test/test_ai_review_workflows.py -k scope_gate_cannot_be_defeated_by_pipe_timing`
- `git diff --check`