### PR TITLE
docs(ci): describe fork guard enforcement

### DIFF
--- a/.github/workflows/fork-workflow-guard.yml
+++ b/.github/workflows/fork-workflow-guard.yml
@@ -16,8 +16,9 @@ name: Fork Workflow-Change Guard
 #
 # OVERRIDE: a maintainer who has reviewed a legitimate workflow change applies
 # the `allow-fork-workflow-change` label; the guard then re-evaluates green.
-# Complements a CODEOWNERS rule on `.github/workflows/**` (which forces review;
-# this enforces it as a required, blocking check).
+# This check-run is advisory. Enforcement comes from GitHub's maintainer approval
+# requirement for fork workflow runs and the catch-all CODEOWNERS rule, which
+# requires a KiroCrew code-owner review for every change, including workflows.
 
 on:
   workflow_run:

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -598,7 +598,7 @@ Nothing the fork controls can influence these reviews:
   allowlist, plus short-lived Bedrock-only OIDC credentials, bound the blast radius
   of any prompt injection.
 
-**`fork-workflow-guard.yml`** blocks a fork PR that modifies anything under
+**`fork-workflow-guard.yml`** posts an advisory failure when a fork PR modifies anything under
 `.github/**`, the vector a fork would use to fake basic-CI results (rewrite `ci.yml`
 to pass) or tamper with CODEOWNERS. It is deterministic on purpose: "does the diff
 touch `.github/**`" is a file-path check, so a grep on the authentic changed-file
@@ -609,6 +609,11 @@ cannot disable it, and a fork's own `pull_request` runs have no `checks: write` 
 forge its verdict. A maintainer who has reviewed a legitimate workflow change applies
 the `allow-fork-workflow-change` label and the guard re-evaluates green; the label is
 stripped on a new revision, so the override cannot carry over.
+
+The guard is not a required status check and PR Readiness does not aggregate it.
+Merge enforcement instead comes from the maintainer-approval policy for fork
+workflow runs and the catch-all CODEOWNERS rule, which requires a code-owner review
+for workflow files just as it does for every other path.
 
 ## Over-engineering resistance
 

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -93,6 +93,16 @@ def _shell_function(script: str, function_name: str) -> str:
     return "\n".join(lines[start : end + 1])
 
 
+def test_fork_workflow_guard_describes_its_advisory_role() -> None:
+    guard = _workflow("fork-workflow-guard.yml")
+    codeowners = (ROOT / ".github" / "CODEOWNERS").read_text(encoding="utf-8")
+
+    assert "This check-run is advisory" in guard
+    assert "catch-all CODEOWNERS rule" in guard
+    assert "required, blocking check" not in guard
+    assert re.search(r"^\*\s+@kirodotdev/kirocrew-team$", codeowners, re.MULTILINE)
+
+
 class TestHumanOverrideHandler:
     def test_handler_runs_from_trusted_issue_comment_context(self) -> None:
         workflow = _workflow("ai-review-human-override.yml")


### PR DESCRIPTION
Closes #2878.

## Summary
- describe the fork workflow guard check-run as advisory
- identify fork-run approval and catch-all code-owner review as the actual enforcement
- add a regression test that pins the corrected contract

## Verification
- `pytest -q test/test_ai_review_workflows.py -k fork_workflow_guard_describes_its_advisory_role`
- `git diff --check`