### PR TITLE
fix(ci): require current-head advisory markers

### DIFF
--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -342,6 +342,10 @@ jobs:
           fi
           # Machine-parse the verdict header the prompt requires (case-insensitive).
           verdict="$(printf '%s\n' "$summary" | grep -iE '^Design-Verdict:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:lower:]' '[:upper:]')"
+          if ! grep -qF "[DESIGN-REVIEWED] $HEAD" <<<"$summary"; then
+            echo "verdict header present but the [DESIGN-REVIEWED] $HEAD marker is missing; treating as incomplete"
+            verdict=""
+          fi
           [ -z "$verdict" ] && verdict="UNKNOWN"
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
           MARKER="<!-- design-review -->"

--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -464,6 +464,7 @@ jobs:
         if: always()
         env:
           EXEC_FILE: ${{ steps.review.outputs.execution_file }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
           set -uo pipefail
           summary=""
@@ -477,6 +478,10 @@ jobs:
           verdict="UNKNOWN"
           if [ -s "$RUNNER_TEMP/design-review-output.md" ]; then
             v="$(printf '%s\n' "$summary" | grep -iE '^Design-Verdict:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:lower:]' '[:upper:]')"
+            if [ -n "$v" ] && ! grep -qF "[DESIGN-REVIEWED] $HEAD_SHA" <<<"$summary"; then
+              echo "verdict header present but the [DESIGN-REVIEWED] $HEAD_SHA marker is missing; treating as incomplete"
+              v=""
+            fi
             [ -n "$v" ] && verdict="$v"
           fi
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -660,6 +660,10 @@ jobs:
           fi
           # Machine-parse the verdict header the prompt requires (case-insensitive).
           verdict="$(printf '%s\n' "$summary" | grep -iE '^UX-Verdict:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:lower:]' '[:upper:]')"
+          if ! grep -qF "[UX-REVIEWED] $HEAD" <<<"$summary"; then
+            echo "verdict header present but the [UX-REVIEWED] $HEAD marker is missing; treating as incomplete"
+            verdict=""
+          fi
           [ -z "$verdict" ] && verdict="UNKNOWN"
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
           case "$verdict" in

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -476,6 +476,10 @@ jobs:
           fi
           # Machine-parse the verdict header the prompt requires (case-insensitive).
           verdict="$(printf '%s\n' "$summary" | grep -iE '^UX-Verdict:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:lower:]' '[:upper:]')"
+          if ! grep -qF "[UX-REVIEWED] $HEAD" <<<"$summary"; then
+            echo "verdict header present but the [UX-REVIEWED] $HEAD marker is missing; treating as incomplete"
+            verdict=""
+          fi
           [ -z "$verdict" ] && verdict="UNKNOWN"
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
           case "$verdict" in

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -242,6 +242,11 @@ design axis is **what each is allowed to read** (its prompt-injection surface) a
 | UX Review | `UX Review` | Agentic Fable 5, with the same fallback | Code plus committed screenshot PNGs, read directly | Does the shipped experience read correctly? | Advisory; red only on a genuine `BLOCK` |
 | First Principles | `First Principles Review` | Agentic Fable 5, same fallback, `--max-turns 120` (inventorying and counting is grep-heavy) | Code, the whole repository, and `gh pr view` | What is the author trying to do, and does each thing this ships *deserve to exist*, already exist, or only patch a symptom? | Advisory; red only on a genuine `BLOCK` |
 
+Each advisory reviewer must end its output with its lane-specific reviewed marker
+and the exact current head SHA. A verdict header without that current-head marker is
+treated as incomplete, so output from an earlier revision cannot be accepted after a
+push.
+
 ### Why a first-principles lane is not a second Design Review
 
 Design Review takes the PR's **stated problem as its frame** and judges the shape of

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -574,6 +574,19 @@ class TestFirstPrinciplesReview:
         assert 'v=""' in fork
         assert "HEAD_SHA: ${{ steps.pr.outputs.head_sha }}" in fork
 
+        expected = {
+            "design-review.yml": ("DESIGN-REVIEWED", "$HEAD"),
+            "fork-design-review.yml": ("DESIGN-REVIEWED", "$HEAD_SHA"),
+            "ux-review.yml": ("UX-REVIEWED", "$HEAD"),
+            "fork-ux-review.yml": ("UX-REVIEWED", "$HEAD"),
+        }
+        for name, (marker, head) in expected.items():
+            workflow = _workflow(name)
+            assert f'grep -qF "[{marker}] {head}" <<<"$summary"' in workflow
+            assert "treating as incomplete" in workflow
+
+        assert "HEAD_SHA: ${{ steps.pr.outputs.head_sha }}" in _workflow("fork-design-review.yml")
+
     def test_fork_lane_grants_no_shell_and_reads_intent_from_a_file(self) -> None:
         # `--allowedTools` Bash grants are PREFIX-matched, so `Bash(gh pr view:*)`
         # also admits `gh pr view ... > authentic.patch` -- an injected


### PR DESCRIPTION
Addresses #3447 (defect 2 of 3).

## Summary
- require Design and UX review output to carry the exact current-head marker
- degrade stale or missing markers to the existing non-blocking incomplete path
- cover same-repository and fork lanes and document the marker contract

## Verification
- `pytest -q test/test_ai_review_workflows.py` (112 passed)
- `git diff --check`