### PR TITLE
fix(ci): reconcile stranded fork review checks

### DIFF
--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -159,10 +159,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="Design Review" -f head_sha="$HEAD" -f status="in_progress" \
+            -f external_id="design-review-pr-$PR" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -557,6 +559,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
           CHECK_ID: ${{ steps.check.outputs.id }}
           VERDICT: ${{ steps.verdict.outputs.verdict }}
         run: |
@@ -567,15 +570,38 @@ jobs:
             BLOCK)    conclusion="failure"; title="BLOCK — design concern (advisory)" ;;
             *)        conclusion="neutral"; title="review incomplete (advisory)" ;;
           esac
+          summary="Advisory fork design review for $HEAD. See the PR comment for details."
+          complete() {
+            for attempt in 1 2; do
+              if gh api --method PATCH "repos/$REPO/check-runs/$1" \
+                -f status="completed" -f conclusion="$2" \
+                -f "output[title]=Design Review — $3" \
+                -f "output[summary]=$summary" >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::warning::could not complete check-run $1 for $HEAD"
+            return 1
+          }
           if [ -n "${CHECK_ID:-}" ]; then
-            gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-              -f status="completed" -f conclusion="$conclusion" \
-              -f "output[title]=Design Review — $title" \
-              -f "output[summary]=Advisory fork design review for $HEAD. See the PR comment for details." >/dev/null || true
+            complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="Design Review" -f head_sha="$HEAD" \
               -f status="completed" -f conclusion="neutral" \
               -f "output[title]=Design Review — could not run (advisory)" \
               -f "output[summary]=The fork design review job failed before producing a verdict; re-run it. Advisory — does not block merge." >/dev/null || true
+          fi
+          if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
+            enc="$(jq -rn '\"Design Review\" | @uri')"
+            stranded="$(gh api --method GET \
+              "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
+              --jq ".check_runs[]
+                    | select(.status != \"completed\")
+                    | select(.external_id == \"design-review-pr-$PR\")
+                    | .id" 2>/dev/null || true)"
+            for id in $stranded; do
+              complete "$id" "neutral" "review incomplete (advisory)" || true
+            done
           fi

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -159,10 +159,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="GPT 5.6 Review" -f head_sha="$HEAD" -f status="in_progress" \
+            -f external_id="gpt-review-pr-$PR" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -712,6 +714,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
           CHECK_ID: ${{ steps.check.outputs.id }}
         run: |
           set -uo pipefail
@@ -723,15 +726,38 @@ jobs:
               conclusion="success"; title="no blocking findings"
             fi
           fi
+          summary="Fork AI review for $HEAD. See the PR comment for details."
+          complete() {
+            for attempt in 1 2; do
+              if gh api --method PATCH "repos/$REPO/check-runs/$1" \
+                -f status="completed" -f conclusion="$2" \
+                -f "output[title]=GPT 5.6 Review — $3" \
+                -f "output[summary]=$summary" >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::warning::could not complete check-run $1 for $HEAD"
+            return 1
+          }
           if [ -n "${CHECK_ID:-}" ]; then
-            gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-              -f status="completed" -f conclusion="$conclusion" \
-              -f "output[title]=GPT 5.6 Review — $title" \
-              -f "output[summary]=Fork AI review for $HEAD. See the PR comment for details." >/dev/null || true
+            complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="GPT 5.6 Review" -f head_sha="$HEAD" \
               -f status="completed" -f conclusion="failure" \
               -f "output[title]=GPT 5.6 Review — could not run" \
               -f "output[summary]=The fork GPT review job failed before producing a verdict; re-run it." >/dev/null || true
+          fi
+          if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
+            enc="$(jq -rn '\"GPT 5.6 Review\" | @uri')"
+            stranded="$(gh api --method GET \
+              "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
+              --jq ".check_runs[]
+                    | select(.status != \"completed\")
+                    | select(.external_id == \"gpt-review-pr-$PR\")
+                    | .id" 2>/dev/null || true)"
+            for id in $stranded; do
+              complete "$id" "failure" "review incomplete" || true
+            done
           fi

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -163,10 +163,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="Opus 4.8 Review" -f head_sha="$HEAD" -f status="in_progress" \
+            -f external_id="opus-review-pr-$PR" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -447,6 +449,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
           CHECK_ID: ${{ steps.check.outputs.id }}
         run: |
           set -uo pipefail
@@ -458,15 +461,38 @@ jobs:
               conclusion="success"; title="no blocking findings"
             fi
           fi
+          summary="Fork AI review for $HEAD. See the PR comment for details."
+          complete() {
+            for attempt in 1 2; do
+              if gh api --method PATCH "repos/$REPO/check-runs/$1" \
+                -f status="completed" -f conclusion="$2" \
+                -f "output[title]=Opus 4.8 Review — $3" \
+                -f "output[summary]=$summary" >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::warning::could not complete check-run $1 for $HEAD"
+            return 1
+          }
           if [ -n "${CHECK_ID:-}" ]; then
-            gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-              -f status="completed" -f conclusion="$conclusion" \
-              -f "output[title]=Opus 4.8 Review — $title" \
-              -f "output[summary]=Fork AI review for $HEAD. See the PR comment for details." >/dev/null || true
+            complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="Opus 4.8 Review" -f head_sha="$HEAD" \
               -f status="completed" -f conclusion="failure" \
               -f "output[title]=Opus 4.8 Review — could not run" \
               -f "output[summary]=The fork Opus review job failed before producing a verdict; re-run it." >/dev/null || true
+          fi
+          if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
+            enc="$(jq -rn '\"Opus 4.8 Review\" | @uri')"
+            stranded="$(gh api --method GET \
+              "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
+              --jq ".check_runs[]
+                    | select(.status != \"completed\")
+                    | select(.external_id == \"opus-review-pr-$PR\")
+                    | .id" 2>/dev/null || true)"
+            for id in $stranded; do
+              complete "$id" "failure" "review incomplete" || true
+            done
           fi

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -158,10 +158,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="UX Review" -f head_sha="$HEAD" -f status="in_progress" \
+            -f external_id="ux-review-pr-$PR" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -721,6 +723,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
           CHECK_ID: ${{ steps.check.outputs.id }}
           VERDICT: ${{ steps.post.outputs.verdict }}
         run: |
@@ -737,15 +740,38 @@ jobs:
             *)
               conclusion="neutral"; title="review incomplete (advisory)" ;;
           esac
+          summary="Advisory fork UX review for $HEAD. See the PR comment for details."
+          complete() {
+            for attempt in 1 2; do
+              if gh api --method PATCH "repos/$REPO/check-runs/$1" \
+                -f status="completed" -f conclusion="$2" \
+                -f "output[title]=UX Review — $3" \
+                -f "output[summary]=$summary" >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::warning::could not complete check-run $1 for $HEAD"
+            return 1
+          }
           if [ -n "${CHECK_ID:-}" ]; then
-            gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-              -f status="completed" -f conclusion="$conclusion" \
-              -f "output[title]=UX Review — $title" \
-              -f "output[summary]=Advisory fork UX review for $HEAD. See the PR comment for details." >/dev/null || true
+            complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="UX Review" -f head_sha="$HEAD" \
               -f status="completed" -f conclusion="neutral" \
               -f "output[title]=UX Review — could not run (advisory)" \
               -f "output[summary]=The fork UX review job failed before producing a verdict; advisory, does not block merge." >/dev/null || true
+          fi
+          if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
+            enc="$(jq -rn '\"UX Review\" | @uri')"
+            stranded="$(gh api --method GET \
+              "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
+              --jq ".check_runs[]
+                    | select(.status != \"completed\")
+                    | select(.external_id == \"ux-review-pr-$PR\")
+                    | .id" 2>/dev/null || true)"
+            for id in $stranded; do
+              complete "$id" "neutral" "review incomplete (advisory)" || true
+            done
           fi

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -582,6 +582,11 @@ named exactly like its same-repo twin (`Opus 4.8 Review`, `GPT 5.6 Review`,
 it opens that check-run as early as possible keyed to `head_sha` so a job that dies
 still leaves a fail-closed result.
 
+Every fork check-run is also tagged with the originating PR number. Finalization
+retries once, then reconciles any incomplete run for that same head and PR. This
+keeps a transient Checks API failure from leaving PR Readiness permanently pending,
+without completing a sibling PR's review when two PRs share a commit.
+
 Nothing the fork controls can influence these reviews:
 
 - `workflow_run` **always** runs the workflow definition from the **default branch**,

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -596,28 +596,43 @@ class TestFirstPrinciplesReview:
         # pr-readiness.yml counts ANY non-completed check-run of this name as
         # pending, so one swallowed finalize error would wedge the PR at
         # `checking` with no later event able to clear it.
-        finalize = _step_script(
-            _workflow("fork-first-principles-review.yml"), "Finalize check-run (advisory)"
-        )
-
-        assert "for attempt in 1 2; do" in finalize
-        assert "completing stranded check-run" in finalize
-        assert "::warning::could not complete check-run" in finalize
+        lanes = {
+            "fork-opus-review.yml": "Finalize check-run (fail closed)",
+            "fork-gpt-review.yml": "Finalize check-run (fail closed)",
+            "fork-design-review.yml": "Finalize check-run (advisory)",
+            "fork-ux-review.yml": "Finalize check-run (advisory)",
+            "fork-first-principles-review.yml": "Finalize check-run (advisory)",
+        }
+        for name, step in lanes.items():
+            finalize = _step_script(_workflow(name), step)
+            assert "for attempt in 1 2; do" in finalize
+            assert "check-runs?check_name=$enc&per_page=100" in finalize
+            assert "::warning::could not complete check-run" in finalize
 
     def test_sweep_only_completes_check_runs_this_pr_created(self) -> None:
         # Two open PRs can share a head commit, so a check-run of this name on this
         # head may belong to a DIFFERENT pull request -- completing it would publish
         # a verdict computed from another diff. The wedge fix is therefore scoped by
         # external_id, so it can never reach a sibling's review.
-        workflow = _workflow("fork-first-principles-review.yml")
-        opened = _step_script(workflow, "Open check-run (in progress)")
-        finalize = _step_script(workflow, "Finalize check-run (advisory)")
+        lanes = {
+            "fork-opus-review.yml": ("Finalize check-run (fail closed)", "opus-review-pr-$PR"),
+            "fork-gpt-review.yml": ("Finalize check-run (fail closed)", "gpt-review-pr-$PR"),
+            "fork-design-review.yml": ("Finalize check-run (advisory)", "design-review-pr-$PR"),
+            "fork-ux-review.yml": ("Finalize check-run (advisory)", "ux-review-pr-$PR"),
+            "fork-first-principles-review.yml": (
+                "Finalize check-run (advisory)",
+                "first-principles-pr-$PR",
+            ),
+        }
+        for name, (step, external_id) in lanes.items():
+            workflow = _workflow(name)
+            opened = _step_script(workflow, "Open check-run (in progress)")
+            finalize = _step_script(workflow, step)
 
-        assert '-f external_id="first-principles-pr-$PR"' in opened
-        assert 'select(.external_id == \\"first-principles-pr-$PR\\")' in finalize
-        assert '[ -n "${PR:-}" ]' in finalize
-        # An unscoped sweep must not come back.
-        assert 'select(.status != "completed") | .id' not in finalize
+            assert f'-f external_id="{external_id}"' in opened
+            assert f'select(.external_id == \\"{external_id}\\")' in finalize
+            assert '[ -n "${PR:-}" ]' in finalize
+            assert 'select(.status != "completed") | .id' not in finalize
 
     def test_review_text_is_gated_on_credential_shapes(self) -> None:
         # The reviewer has read-only tools, no shell and no network, so the review


### PR DESCRIPTION
Addresses #3447 (defect 1 of 3).

## Summary
- retry failed check-run finalization in all four fork review lanes
- tag opened checks with the originating PR and sweep only matching incomplete runs
- preserve fail-closed conclusions for blocking lanes and neutral incompletion for advisory lanes
- extend regression coverage and document the reconciliation contract

## Verification
- `pytest -q test/test_ai_review_workflows.py` (112 passed)
- `git diff --check`