### PR TITLE
fix(dev-fleet): persist provision failure dismissal

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -135,6 +135,7 @@ verification. Route names below are relative to that prefix.
 | `/apps/dev-fleet/api/pod/restart` | `{name}` | Stop then start pod |
 | `/apps/dev-fleet/api/pod/token` | `{name}` | Mint a dashboard token for the pod |
 | `/apps/dev-fleet/api/pod/provision` | `{name}` | Start async venv+dist build (returns `{run_id}`) |
+| `/apps/dev-fleet/api/pod/provision/dismiss` | `{name, run_id}` | Forget a terminal provision failure when the run id still matches |
 | `/apps/dev-fleet/api/rebase` | `{name}` | Rebase worktree onto origin/main |
 | `/apps/dev-fleet/api/restart-gateway` | — | Restart the live gateway through its service-manager backend; returns the pre-restart `start_id` for the restart handshake |
 | `/apps/dev-fleet/api/make-live` | `{path, dry_run?}` | Repoint the live gateway at another worktree (see Make Live); a real cutover returns `start_id` for the restart handshake |
@@ -471,10 +472,10 @@ running run resumes polling into the stepper (accumulating the log window as
 usual), and a failed run restores the persisted red failure state with its log
 auto-expanded. Reattached and locally-started runs are deduped by run id, so a
 fleet refetch never starts a second poll loop for a run already being tracked.
-The dismiss `×` is client-side only: a failed run's id keeps being exposed
-until a newer provision for that checkout replaces it, the run is evicted from
-the bounded registry, or the gateway restarts — so a reload after dismissing
-re-shows the failure. Server-side dismissal is deliberately out of scope here.
+The dismiss `×` posts the worktree name and run id to the server before clearing
+the local strip. The server removes the persisted id only when it still matches
+that terminal run; a stale dismiss cannot clear a newer provision, and a running
+provision cannot be dismissed. A successful response therefore survives reload.
 
 ## Action narration (restart + sync feedback)
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -2256,10 +2256,11 @@ async def _provision_reattach_ids() -> dict[str, str]:
 
     A run id is exposed while the run is still executing, or when it finished
     unsuccessfully (the failed stepper + log must survive a reload). A failed
-    id persists until a newer provision for the same checkout overwrites it,
-    the run is evicted from the bounded registry, or the gateway restarts —
-    the UI dismiss is client-side only, so a reload after dismissing re-shows
-    the failure. Successful runs are omitted: the refreshed fleet row already
+    id persists until the UI dismisses it (POST /api/pod/provision/dismiss
+    forgets the id server-side, so a reload after dismissing does NOT re-show
+    the failure), a newer provision for the same checkout overwrites it, the
+    run is evicted from the bounded registry, or the gateway restarts.
+    Successful runs are omitted: the refreshed fleet row already
     reports the built state, so there is nothing to reattach to. Run ids
     evicted from the bounded run registry are omitted too — the UI could not
     fetch their output anyway.
@@ -2976,6 +2977,18 @@ async def _pod_provision(name: str) -> dict:
         )
         _PROVISION_INFLIGHT[name] = rid
     return {"ok": True, "run_id": rid}
+
+
+async def _pod_provision_dismiss(name: str, run_id: str) -> dict:
+    """Forget one terminal provision run without racing a replacement run."""
+    async with _PROVISION_LOCK:
+        if _PROVISION_INFLIGHT.get(name) != run_id:
+            return {"ok": True, "dismissed": False}
+        async with _RUNS_LOCK:
+            if _RUNS.get(run_id, {}).get("status") == "running":
+                return {"ok": False, "error": "cannot dismiss a running provision"}
+        _PROVISION_INFLIGHT.pop(name, None)
+    return {"ok": True, "dismissed": True}
 
 
 # --- disk aggregation ---
@@ -4558,13 +4571,28 @@ async def api_dev_fleet_sync(request: web.Request) -> web.Response:
     return web.json_response(result, status=code)
 
 
-async def _json_body(request: web.Request) -> tuple[dict | None, web.Response | None]:
-    """Parse a JSON object body; (body, None) on success, (None, 400) otherwise."""
+async def _json_body(
+    request: web.Request, *, code: str | None = None
+) -> tuple[dict | None, web.Response | None]:
+    """Parse a JSON object body; (body, None) on success, (None, 400) otherwise.
+
+    Pass ``code`` for endpoints whose error contract promises a
+    machine-readable ``code`` on every failure response; the rejection then
+    carries it alongside the human-readable ``error``.
+    """
     try:
         body = await request.json() if request.content_length else {}
     except ValueError:
+        if code:
+            return None, web.json_response(
+                {"error": "invalid JSON body", "code": code}, status=400
+            )
         return None, web.json_response({"error": "invalid JSON body"}, status=400)
     if not isinstance(body, dict):
+        if code:
+            return None, web.json_response(
+                {"error": "body must be an object", "code": code}, status=400
+            )
         return None, web.json_response({"error": "body must be an object"}, status=400)
     return body, None
 
@@ -4689,6 +4717,38 @@ async def api_dev_fleet_pod_token(request: web.Request) -> web.Response:
 @_audited("dev_fleet_pod_provision")
 async def api_dev_fleet_pod_provision(request: web.Request) -> web.Response:
     return await _pod_name_action(request, _pod_provision)
+
+
+@_audited("dev_fleet_pod_provision_dismiss")
+async def api_dev_fleet_pod_provision_dismiss(request: web.Request) -> web.Response:
+    body, err = await _json_body(request, code="invalid_body")
+    if err is not None:
+        return err
+    assert body is not None
+    name = body.get("name")
+    run_id = body.get("run_id")
+    if not isinstance(name, str) or not name:
+        return web.json_response(
+            {"error": "'name' must be a non-empty string", "code": "invalid_name"}, status=400
+        )
+    if not isinstance(run_id, str) or not run_id:
+        return web.json_response(
+            {"error": "'run_id' must be a non-empty string", "code": "invalid_run_id"}, status=400
+        )
+    target, ferr = await _find_worktree(name)
+    if target is None:
+        return web.json_response({"error": ferr, "code": "invalid_worktree"}, status=400)
+    result = await _pod_provision_dismiss(name, run_id)
+    if result.get("ok"):
+        return web.json_response(result, status=200)
+    return web.json_response(
+        {
+            "ok": False,
+            "error": result.get("error", "cannot dismiss provision"),
+            "code": "provision_dismiss_conflict",
+        },
+        status=409,
+    )
 
 
 @_audited("dev_fleet_rebase")
@@ -6101,6 +6161,7 @@ def create_app() -> web.Application:
     app.router.add_post("/api/pod/restart", api_dev_fleet_pod_restart)
     app.router.add_post("/api/pod/token", api_dev_fleet_pod_token)
     app.router.add_post("/api/pod/provision", api_dev_fleet_pod_provision)
+    app.router.add_post("/api/pod/provision/dismiss", api_dev_fleet_pod_provision_dismiss)
     app.router.add_post("/api/rebase", api_dev_fleet_rebase)
     app.router.add_post("/api/restart-gateway", api_dev_fleet_restart_gateway)
     app.router.add_post("/api/make-live", api_dev_fleet_make_live)

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -3179,6 +3179,7 @@ def test_audited_decorator_applied_to_mutations():
         "api_dev_fleet_prune_run", "api_dev_fleet_pod_up",
         "api_dev_fleet_pod_down", "api_dev_fleet_pod_restart",
         "api_dev_fleet_pod_token", "api_dev_fleet_pod_provision",
+        "api_dev_fleet_pod_provision_dismiss",
         "api_dev_fleet_rebase", "api_dev_fleet_restart_gateway",
     ]:
         fn = getattr(mod, name)

--- a/test/test_dev_fleet_server_coverage.py
+++ b/test/test_dev_fleet_server_coverage.py
@@ -822,6 +822,37 @@ async def test_pod_provision_starts_run_and_records_it(monkeypatch):
     assert mod._PROVISION_INFLIGHT["feat"] == "run-9"
 
 
+@pytest.mark.asyncio
+async def test_pod_provision_dismiss_forgets_matching_terminal_run(monkeypatch):
+    monkeypatch.setattr(mod, "_PROVISION_INFLIGHT", {"feat": "run-1"})
+    monkeypatch.setattr(mod, "_RUNS", {"run-1": {"status": "done", "exit_code": 1}})
+
+    assert await mod._pod_provision_dismiss("feat", "run-1") == {
+        "ok": True, "dismissed": True,
+    }
+    assert "feat" not in mod._PROVISION_INFLIGHT
+
+
+@pytest.mark.asyncio
+async def test_pod_provision_dismiss_cannot_clear_replacement_run(monkeypatch):
+    monkeypatch.setattr(mod, "_PROVISION_INFLIGHT", {"feat": "run-new"})
+
+    assert await mod._pod_provision_dismiss("feat", "run-old") == {
+        "ok": True, "dismissed": False,
+    }
+    assert mod._PROVISION_INFLIGHT["feat"] == "run-new"
+
+
+@pytest.mark.asyncio
+async def test_pod_provision_dismiss_refuses_running_run(monkeypatch):
+    monkeypatch.setattr(mod, "_PROVISION_INFLIGHT", {"feat": "run-1"})
+    monkeypatch.setattr(mod, "_RUNS", {"run-1": {"status": "running"}})
+
+    result = await mod._pod_provision_dismiss("feat", "run-1")
+    assert result == {"ok": False, "error": "cannot dismiss a running provision"}
+    assert mod._PROVISION_INFLIGHT["feat"] == "run-1"
+
+
 # --------------------------------------------------------------------------
 # _disk
 # --------------------------------------------------------------------------
@@ -1456,6 +1487,51 @@ async def test_pod_handlers_dispatch_to_their_action(monkeypatch, handler_name, 
     resp = await getattr(mod, handler_name)(_json_request({"name": "feat"}))
     assert json.loads(resp.text) == {"ok": True, "via": action_name}
     action.assert_awaited_once_with("feat")
+
+
+@pytest.mark.asyncio
+async def test_pod_provision_dismiss_handler_validates_and_dispatches(monkeypatch):
+    _sel_capture(monkeypatch)
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=({"path": "/w"}, None)))
+    dismiss = AsyncMock(return_value={"ok": True, "dismissed": True})
+    monkeypatch.setattr(mod, "_pod_provision_dismiss", dismiss)
+
+    resp = await mod.api_dev_fleet_pod_provision_dismiss(
+        _json_request({"name": "feat", "run_id": "run-1"})
+    )
+
+    assert json.loads(resp.text) == {"ok": True, "dismissed": True}
+    dismiss.assert_awaited_once_with("feat", "run-1")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw, json_error",
+    [
+        (b"{oops", ValueError("bad json")),
+        (b"[1, 2]", None),
+    ],
+)
+async def test_pod_provision_dismiss_handler_codes_a_malformed_body(
+    monkeypatch, raw, json_error
+):
+    """Every rejection from this endpoint carries a machine-readable code.
+
+    A malformed or non-object body is rejected by the shared body parser, whose
+    default 400 has no ``code``; the dismiss handler asks for one so a client
+    can branch on the failure instead of matching prose.
+    """
+    _sel_capture(monkeypatch)
+    dismiss = AsyncMock()
+    monkeypatch.setattr(mod, "_pod_provision_dismiss", dismiss)
+
+    resp = await mod.api_dev_fleet_pod_provision_dismiss(
+        _raw_request(raw, json_error=json_error)
+    )
+
+    assert resp.status == 400
+    assert json.loads(resp.text)["code"] == "invalid_body"
+    dismiss.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -581,7 +581,7 @@ interface SyncRun { rid: string; status: 'running' | 'done' | 'error'; lines: st
 // Provision run state: the FULL output is kept (not just the last
 // line) so the expandable log panel can show everything, and a failed run
 // persists (failed=true) until the user dismisses it rather than vanishing.
-interface ProvRun { status: 'starting' | 'running' | 'done' | 'failed'; lines: string[]; startedAt: number; exit?: number | null; failed?: boolean; done?: boolean }
+interface ProvRun { rid?: string; status: 'starting' | 'running' | 'done' | 'failed'; lines: string[]; startedAt: number; exit?: number | null; failed?: boolean; done?: boolean }
 interface RebaseResult { kind: 'ok' | 'conflict' | 'error'; text: string }
 
 /* ─── Detail Panel (expanded row) ─── */
@@ -785,9 +785,28 @@ export default function DevFleetPage() {
     if (rid) cancelledRunsRef.current.add(rid)
     setSyncRun(null); setSyncLogOpen(false)
   }
-  function dismissProv(name: string) {
+  async function dismissProv(name: string) {
+    const rid = prov[name]?.rid
+    if (rid) {
+      try {
+        await api.post('/pod/provision/dismiss', { name, run_id: rid })
+      } catch (e: unknown) {
+        notify((e as Error)?.message || String(e), { type: 'error' })
+        return
+      }
+    }
+    // The POST above is awaited, so a REPLACEMENT provision can fail and
+    // reattach to this worktree while the dismiss is in flight. Clear only the
+    // strip the user actually dismissed: if `rid` moved underneath us a newer
+    // failure is on screen, and deleting it would hide that run (and its log)
+    // until the next reload.
+    let stale = false
+    setProv((p) => {
+      if (p[name]?.rid !== rid) { stale = true; return p }
+      const n = { ...p }; delete n[name]; return n
+    })
+    if (stale) return
     clearTimeout(provDoneTimersRef.current[name])
-    setProv((p) => { const n = { ...p }; delete n[name]; return n })
     setProvLogOpen((o) => { const n = { ...o }; delete n[name]; return n })
     invalidateFleet()
   }
@@ -884,12 +903,12 @@ export default function DevFleetPage() {
           const t0 = run.started ? run.started * 1000 : Date.now()
           const lines = run.output || []
           if (run.status === 'running') {
-            setProv((p) => ({ ...p, [name]: { status: 'running', lines, startedAt: t0 } }))
+            setProv((p) => ({ ...p, [name]: { rid, status: 'running', lines, startedAt: t0 } }))
             void pollProvisionRun(name, rid, t0, lines)
           } else if (run.exit_code !== 0) {
             // Only unsuccessful runs are exposed by the backend, but guard
             // anyway: a successful run has nothing to reattach.
-            setProv((p) => ({ ...p, [name]: { status: 'failed', failed: true, lines, startedAt: t0, exit: run.exit_code ?? null } }))
+            setProv((p) => ({ ...p, [name]: { rid, status: 'failed', failed: true, lines, startedAt: t0, exit: run.exit_code ?? null } }))
             setProvLogOpen((o) => ({ ...o, [name]: true }))
           }
         })
@@ -1096,7 +1115,7 @@ export default function DevFleetPage() {
         if (ok) {
           // Flash a brief green "Provisioned", then clear. The
           // fleet refetch flips the row to its built state in the meantime.
-          setProv((p) => ({ ...p, [name]: { status: 'done', done: true, lines, startedAt, exit: 0 } }))
+          setProv((p) => ({ ...p, [name]: { rid, status: 'done', done: true, lines, startedAt, exit: 0 } }))
           invalidateFleet()
           provDoneTimersRef.current[name] = setTimeout(() => {
             setProv((p) => { const n = { ...p }; delete n[name]; return n })
@@ -1106,7 +1125,7 @@ export default function DevFleetPage() {
           // FAILURE PERSISTENCE: keep the run, auto-expand the log, hold until
           // the user dismisses it — a multi-minute failed provision must not
           // vanish into an empty row.
-          setProv((p) => ({ ...p, [name]: { status: 'failed', failed: true, lines, startedAt, exit: run.exit_code } }))
+          setProv((p) => ({ ...p, [name]: { rid, status: 'failed', failed: true, lines, startedAt, exit: run.exit_code } }))
           setProvLogOpen((o) => ({ ...o, [name]: true }))
           invalidateFleet()
         }
@@ -1114,17 +1133,17 @@ export default function DevFleetPage() {
       }
       if (run.status !== 'running') {
         notify(run.status === 'timeout' ? i18nT('pages.devFleetPage.provision_timed_out') : i18nT('pages.devFleetPage.provision_failed_status', { status: run.status }), { type: 'error' })
-        setProv((p) => ({ ...p, [name]: { status: 'failed', failed: true, lines: lines.length ? lines : ['Provision ' + run.status], startedAt, exit: run.exit_code ?? null } }))
+        setProv((p) => ({ ...p, [name]: { rid, status: 'failed', failed: true, lines: lines.length ? lines : ['Provision ' + run.status], startedAt, exit: run.exit_code ?? null } }))
         setProvLogOpen((o) => ({ ...o, [name]: true }))
         invalidateFleet()
         return
       }
-      setProv((p) => ({ ...p, [name]: { status: 'running', lines, startedAt } }))
+      setProv((p) => ({ ...p, [name]: { rid, status: 'running', lines, startedAt } }))
     }
     // Poll budget exhausted (e.g. run id lost across a gateway restart): keep
     // the failed marker + accumulated log so the user has something to act on.
     notify(i18nT('pages.devFleetPage.provision_polling_timed_out_check_pod_logs'), { type: 'error' })
-    setProv((p) => ({ ...p, [name]: { status: 'failed', failed: true, lines: acc.length ? acc : ['Provision polling timed out \u2014 check pod logs'], startedAt, exit: null } }))
+    setProv((p) => ({ ...p, [name]: { rid, status: 'failed', failed: true, lines: acc.length ? acc : ['Provision polling timed out \u2014 check pod logs'], startedAt, exit: null } }))
     setProvLogOpen((o) => ({ ...o, [name]: true }))
     invalidateFleet()
   }
@@ -1704,7 +1723,7 @@ export default function DevFleetPage() {
           <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--danger)', flexShrink: 0, display: 'inline-flex', alignItems: 'center', gap: 4 }}><X size={12} className="lucide-inline" />{pr.exit != null ? i18nT('pages.devFleetPage.provision_failed_exit_code', { code: pr.exit }) : i18nT('pages.devFleetPage.provision_failed')}</span>
           <span style={{ ...mono, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 } as CSSProperties} title={lastLine(pr.lines)}>{lastLine(pr.lines)}</span>
           {logToggle}
-          <Clickable aria-label={i18nT('pages.devFleetPage.dismiss_provision_status')} onClick={() => dismissProv(w.name)} style={{ background: 'none', border: 'none', color: 'var(--muted)', cursor: 'pointer', fontSize: 14, padding: 2 } as CSSProperties}>{"\u00d7"}</Clickable>
+          <Clickable aria-label={i18nT('pages.devFleetPage.dismiss_provision_status')} onClick={() => { void dismissProv(w.name) }} style={{ background: 'none', border: 'none', color: 'var(--muted)', cursor: 'pointer', fontSize: 14, padding: 2 } as CSSProperties}>{"\u00d7"}</Clickable>
         </div>
       )
     }

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -308,7 +308,8 @@ describe('DevFleetPage', () => {
       worktrees: FLEET.worktrees.map((w) =>
         w.name === 'unprov' ? { ...w, provision_run_id: 'run-prov-dead' } : w),
     }
-    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+    let dismissBody: unknown = null
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url, opts) => {
       const u = typeof url === 'string' ? url : (url as Request).url
       if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_WITH_FAILED), { status: 200 }))
       if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
@@ -316,6 +317,10 @@ describe('DevFleetPage', () => {
         return Promise.resolve(new Response(JSON.stringify({
           status: 'done', exit_code: 1, output: ['npm ERR! build failed'], started: Date.now() / 1000 - 300,
         }), { status: 200 }))
+      }
+      if (u.includes('/pod/provision/dismiss')) {
+        dismissBody = JSON.parse(String(opts?.body))
+        return Promise.resolve(new Response(JSON.stringify({ ok: true, dismissed: true }), { status: 200 }))
       }
       return Promise.resolve(new Response('{}', { status: 200 }))
     })
@@ -325,6 +330,64 @@ describe('DevFleetPage', () => {
     // The last log line renders twice (inline strip + expanded <pre> panel).
     await waitFor(() => expect(screen.getByText('Provision failed (exit 1)')).toBeInTheDocument(), { timeout: 3000 })
     expect(screen.getAllByText('npm ERR! build failed').length).toBeGreaterThanOrEqual(2)
+    fireEvent.click(screen.getByLabelText('Dismiss provision status'))
+    await waitFor(() => expect(dismissBody).toEqual({ name: 'unprov', run_id: 'run-prov-dead' }))
+    await waitFor(() => expect(screen.queryByText('Provision failed (exit 1)')).toBeNull())
+  })
+
+  it('a slow dismiss does not erase a replacement failure that arrived while it was in flight', async () => {
+    // Regression: dismissProv awaits the server round-trip, so a REPLACEMENT
+    // provision can fail and reattach to the same worktree before the response
+    // lands. Deleting the strip unconditionally then hid the NEW failure (and
+    // its log) until the next reload. The clear is now guarded on the run id
+    // the user actually dismissed.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    let rid = 'run-prov-dead'
+    let releaseDismiss: (() => void) | null = null
+    const dismissPending = new Promise<void>((resolve) => { releaseDismiss = resolve })
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          ...FLEET,
+          worktrees: FLEET.worktrees.map((w) => (w.name === 'unprov' ? { ...w, provision_run_id: rid } : w)),
+        }), { status: 200 }))
+      }
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/run?id=run-prov-dead')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          status: 'done', exit_code: 1, output: ['old failure'], started: Date.now() / 1000 - 300,
+        }), { status: 200 }))
+      }
+      if (u.includes('/run?id=run-prov-new')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          status: 'done', exit_code: 2, output: ['new failure'], started: Date.now() / 1000 - 10,
+        }), { status: 200 }))
+      }
+      if (u.includes('/pod/provision/dismiss')) {
+        return dismissPending.then(() => new Response(JSON.stringify({ ok: true, dismissed: true }), { status: 200 }))
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    try {
+      renderPage()
+      await waitFor(() => expect(screen.getByText('Provision failed (exit 1)')).toBeInTheDocument(), { timeout: 3000 })
+
+      // Dismiss the OLD failure; the POST stays in flight.
+      fireEvent.click(screen.getByLabelText('Dismiss provision status'))
+
+      // A replacement provision fails and the next fleet poll reattaches it.
+      rid = 'run-prov-new'
+      await act(async () => { await vi.advanceTimersByTimeAsync(13000) })
+      await waitFor(() => expect(screen.getByText('Provision failed (exit 2)')).toBeInTheDocument(), { timeout: 3000 })
+
+      // The stale dismissal now resolves — it must leave the new strip alone.
+      releaseDismiss!()
+      await act(async () => { await vi.advanceTimersByTimeAsync(50) })
+      expect(screen.getByText('Provision failed (exit 2)')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('reattached polling keeps the fetched log prefix and marks a scrolled gap', async () => {
@@ -1340,6 +1403,7 @@ describe('DevFleetPage', () => {
       const u = typeof url === 'string' ? url : (url as Request).url
       if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET), { status: 200 }))
       if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/pod/provision/dismiss')) return Promise.resolve(new Response(JSON.stringify({ ok: true, dismissed: true }), { status: 200 }))
       if (u.includes('/pod/provision')) return Promise.resolve(new Response(JSON.stringify({ ok: true, run_id: 'run-f' }), { status: 200 }))
       if (u.includes('/run?id=run-f')) return Promise.resolve(new Response(JSON.stringify({ status: 'done', exit_code: 1, output: ['npm ERR! boom', 'FATAL: npm run build failed'] }), { status: 200 }))
       return Promise.resolve(new Response('{}', { status: 200 }))
@@ -1988,6 +2052,9 @@ describe('provision singleflight guard (issue #5294)', () => {
       const u = typeof url === 'string' ? url : (url as Request).url
       if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_UNPROV), { status: 200 }))
       if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/pod/provision/dismiss')) {
+        return Promise.resolve(new Response(JSON.stringify({ ok: true, dismissed: true }), { status: 200 }))
+      }
       if (u.includes('/pod/provision')) {
         posts++
         return Promise.resolve(new Response(JSON.stringify({ ok: true, run_id: 'run-retry-' + posts }), { status: 200 }))


### PR DESCRIPTION
## Problem / Motivation

Dismissing a failed Dev Fleet provision run only clears frontend state. Reloading the page fetches the same failed run from the server, so the dismissed error reappears.

## Why it matters

Operators cannot permanently clear a handled failure. The stale result keeps returning across reloads and can obscure the next provisioning attempt.

## What changed (motivation → approach → change)

The server retained failed provision results because no dismissal mutation existed. This adds an audited dismissal endpoint that accepts the exact run ID, refuses to dismiss an active run, and ignores stale IDs after a replacement run starts. The frontend now carries the run ID and uses that endpoint before clearing local state.

`POST /apps/dev-fleet/api/pod/provision/dismiss` drops the persisted run id only when it still matches the run being dismissed, under `_PROVISION_LOCK`, so a stale dismiss cannot clear a newer provision and an in-flight provision cannot be forgotten. A stale id is an idempotent 200 no-op (`dismissed: false`); a still-running run is a 409. Every new error response carries a machine-readable `code` (`invalid_name`, `invalid_run_id`, `invalid_worktree`, `provision_dismiss_conflict`), so the error-code contract baseline is untouched. The handler is `@_audited` like its sibling mutations, and the worktree name is validated through `_find_worktree` before any state mutation — no id reaches a filesystem path.

Two existing frontend test doubles matched the new route by accident: `/pod/provision/dismiss` is a sibling path under `/pod/provision`, so their `u.includes('/pod/provision')` branch answered the dismiss POST. In the singleflight retry test that inflated the provision-start counter and made `expect(posts).toBe(2)` read 3. Both mocks now match the dismiss route on its own branch first.

## Tests

Re-verified after rebasing onto current `main` (`23d02c227`):

- `pytest test/test_dev_fleet_app.py test/test_dev_fleet_server_coverage.py test/test_error_code_contract.py test/test_config_baseline.py` — 591 passed, 1 skipped
- `npx vitest run src/test/DevFleetPage.test.tsx` — 92 passed (was red pre-rebase: `provision singleflight guard (issue #5294) > guard is released after a failure` asserted 3 vs 2)
- `npx tsc -b` — passed
- `npx eslint src/pages/DevFleetPage.tsx src/test/DevFleetPage.test.tsx` — 0 errors
- `isort --check-only`, `flake8`, `mypy src/kiro_crew` (1153 files), `scripts/check_black_formatting.py` — all passed

New backend coverage locks in the three server outcomes: a matching terminal run is forgotten, a replacement run cannot be cleared by a stale id, and a running run is refused. New frontend coverage asserts the exact request body (`{name, run_id}`) and that the strip clears only after the server accepts.

## Manual verification

N/A — backend and frontend regression tests cover persistence, stale-run protection, and active-run refusal.

<!-- no-visual-delta -->
**Why no screenshot:** the dismiss `×` keeps its position, styling and `aria-label`; only its handler changes (it now awaits the server before clearing, and surfaces a failure through the existing notify toast). No rendered pixel differs on the success path.

## Related Issues

Fixes #3337

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`docs/system-specs/modules/dev-fleet.md` — route table + the dismiss paragraph that previously declared server-side dismissal out of scope)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — exact CLA wording is still pending in the repository template.
