### PR TITLE
fix(sandbox): reject fractional cgroup limits

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -26,6 +26,7 @@ import errno
 import functools
 import json
 import logging
+import math
 import os
 import re
 import select
@@ -3889,10 +3890,27 @@ def _cgroup_limits_from_config() -> tuple[int, int, int, int]:
         rl = _raw_config().get("resource_limits")
         if isinstance(rl, dict):
             p = rl.get("max_processes")
-            if isinstance(p, (int, float)) and not isinstance(p, bool) and p > 0:
+            # Compare the raw number, not ``int(p)``: config.json (parsed by
+            # Python's permissive json.loads) can carry NaN/Infinity, and
+            # ``int()`` on either raises — inside the try/except below that
+            # would abort parsing of every remaining field (m, w, q), silently
+            # discarding an operator's otherwise-valid stricter limits. A
+            # fraction such as 0.5 still correctly falls through to the
+            # default here, since it truncates to invalid TasksMax=0.
+            if (
+                isinstance(p, (int, float))
+                and not isinstance(p, bool)
+                and math.isfinite(p)
+                and p >= 1
+            ):
                 max_procs = int(p)
             m = rl.get("max_memory_mb")
-            if isinstance(m, (int, float)) and not isinstance(m, bool) and m > 0:
+            if (
+                isinstance(m, (int, float))
+                and not isinstance(m, bool)
+                and math.isfinite(m)
+                and m >= 1
+            ):
                 max_mem_mb = int(m)
             w = rl.get("cpu_weight")
             if isinstance(w, (int, float)) and not isinstance(w, bool) and 1 <= w <= 10000:

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -1331,6 +1331,50 @@ class TestCgroupScopeArgv:
             assert mem == sb._default_max_memory_mb()
             assert weight == sb._CGROUP_DEFAULT_CPU_WEIGHT
             assert quota == 0
+            # Fractions must not truncate into invalid TasksMax=0 /
+            # MemoryMax=0M properties.
+            with patch(
+                "kiro_crew.config.loader._raw_config",
+                return_value={
+                    "resource_limits": {
+                        "max_processes": 0.5,
+                        "max_memory_mb": 0.9,
+                    }
+                },
+            ):
+                procs, mem, _, _ = sb._cgroup_limits_from_config()
+            assert procs == sb._CGROUP_DEFAULT_MAX_PROCESSES
+            assert mem == sb._default_max_memory_mb()
+            # NaN/Infinity (json.loads accepts both) must fall back to
+            # defaults WITHOUT raising: int(nan)/int(inf) raise inside the
+            # surrounding try/except, which would silently discard an
+            # otherwise-valid stricter limit on a later field in the same
+            # block (e.g. a legitimate max_memory_mb after a bogus
+            # max_processes).
+            with patch(
+                "kiro_crew.config.loader._raw_config",
+                return_value={
+                    "resource_limits": {
+                        "max_processes": float("nan"),
+                        "max_memory_mb": 512,
+                    }
+                },
+            ):
+                procs, mem, _, _ = sb._cgroup_limits_from_config()
+            assert procs == sb._CGROUP_DEFAULT_MAX_PROCESSES
+            assert mem == 512  # must not be discarded by the NaN above it
+            with patch(
+                "kiro_crew.config.loader._raw_config",
+                return_value={
+                    "resource_limits": {
+                        "max_processes": 64,
+                        "max_memory_mb": float("inf"),
+                    }
+                },
+            ):
+                procs, mem, _, _ = sb._cgroup_limits_from_config()
+            assert procs == 64  # must not be discarded by the inf below it
+            assert mem == sb._default_max_memory_mb()
         finally:
             self._reset_probe()
 


### PR DESCRIPTION
## Problem / Motivation

A fractional `resource_limits.max_processes` or `max_memory_mb` value below 1 passes the positive-number guard, truncates to zero, and produces an invalid `TasksMax=0` or `MemoryMax=0M` systemd property.

## Why it matters

One hand-edited fractional value can prevent every cgroup-wrapped agent process from starting, while the resulting systemd error does not point back to the configuration field.

## What changed (motivation → approach → change)

The aggregate slice parser already validates the emitted integer after #3344. The per-scope parser now uses the same `int(value) >= 1` rule, so values that would truncate to zero fall back to the safe defaults. A regression test covers both affected settings.

## Tests

- `pytest -q test/test_sandbox_argv.py -k 'config_overrides_cgroup_limits or config_defaults_when_absent_or_zero or config_overrides_slice_limits or config_defaults_when_absent_or_junk'` — 4 passed
- `isort --check-only src/kiro_crew/sandbox.py test/test_sandbox_argv.py` — passed
- `flake8 src/kiro_crew/sandbox.py test/test_sandbox_argv.py` — passed
- `git diff --check` — passed

## Manual verification

N/A — the focused parser tests assert the exact values used to construct systemd properties.

## Related Issues

Addresses the immediate outage path in #3474. The broader schema design remains separate.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — this aligns the existing per-scope rule with the documented/default behavior)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — exact CLA wording is still pending in the repository template.
