### PR TITLE
fix(agent): preserve safe managed MCP overrides

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import itertools
 import json
 import logging
+import math
 import os
 import re
 import shutil
@@ -74,6 +75,7 @@ from kiro_crew.env import (
     describe_search_path,
     emit_env,
     mcp_search_path,
+    sanitize_spec_env,
     spec_path_key,
 )
 from kiro_crew.mcp_cleanup import purge_deleted_proxy_from_config
@@ -657,6 +659,10 @@ def _managed_mcp_env() -> dict[str, str]:
 
     Returns ``{}`` on a default install, which keeps the emitted spec
     byte-for-byte what it is today (``_prune_empty`` drops an empty ``env``).
+    That is safe only because a default-install child DERIVES the same home the
+    gateway did, from an inherited ``HOME``. Preserving a user's ``env`` puts
+    that inheritance in reach of a config, so the companion control lives in
+    ``_enforce_managed_mcp_ownership``: see ``_HOME_DERIVING_ENV_KEYS``.
     """
     override = _valid_override_home()
     return {"KIROCREW_HOME": str(override)} if override else {}
@@ -666,6 +672,133 @@ def _managed_mcp_env() -> dict[str, str]:
 # NOT a transport: a `registry` entry is a POINTER into the admin's catalog,
 # carrying only env/headers/timeout overrides, and its command/url are ignored.
 _MCP_REGISTRY_TYPE = "registry"
+
+# Every key a managed MCP server's entry may carry. Derived from kiro-cli's
+# documented local-server schema rather than assembled by hand, so it can be
+# reviewed against an external source instead of against someone's memory:
+# docs/reference/kiro-cli/mcp/configuration.md lists command, args, env,
+# disabled, autoApprove and disabledTools for a local (stdio) server, and
+# url/headers for a REMOTE one. The remote pair is deliberately absent -- these
+# servers are stdio-only, a leftover ``url`` would shadow the command, and older
+# builds left both behind -- so they are dropped by the rule below rather than by
+# name. ``timeout`` is the one addition: not in that table, but emitted by base
+# and one of the customizations #3594 is about, so dropping it would re-introduce
+# the very bug this fixes.
+#
+# ``type`` is here, and only the ``registry`` VALUE is ours. A transport hint the
+# user wrote (``"type": "stdio"``) is theirs and kiro-cli tolerates it, which
+# ``test_refresh_preserves_a_user_transport_hint`` pins deliberately -- so this
+# key is carried and the registry marker is re-derived from the signed-in account
+# below, rather than the whole key being treated as ours.
+#
+# Of the rest, three are OURS and are set on each pass (``command``, ``args``,
+# ``autoApprove``); the other four are the customizations a user may declare and
+# this fix exists to preserve. ``disabledTools`` is a user GUARD, not a
+# preference: dropping it would silently re-expose tools the user turned off,
+# which is why it is carried rather than re-derived (the custom-server PUT
+# endpoint round-trips it for the same reason).
+_MANAGED_MCP_ENTRY_KEYS: frozenset[str] = frozenset(
+    {"command", "args", "type", "autoApprove", "timeout", "env", "disabled", "disabledTools"}
+)
+
+# The type each USER-AUTHORED key must have, from the same schema table as the set
+# above. A right key with a wrong-typed value is rejected by kiro-cli exactly like
+# an unknown field -- and it rejects the whole agent -- so these are checked and
+# dropped in ``_enforce_managed_mcp_ownership`` rather than trusted.
+#
+# ``command`` and ``args`` are absent because both callers set them before the
+# enforcer runs, so their types are ours rather than input. ``env`` is absent
+# because it needs more than a type check: ``sanitize_spec_env`` already validates
+# it per ENTRY, which is the finer-grained version of this same rule.
+_MANAGED_MCP_ENTRY_VALUE_TYPES: dict[str, type | tuple[type, ...]] = {
+    "type": str,
+    "timeout": (int, float),
+    "disabled": bool,
+    "autoApprove": list,
+    "disabledTools": list,
+}
+
+# The ITEM type for each list-valued key above. Both are documented as arrays of
+# tool NAMES, so validating only the container leaves ``disabledTools: [1]``
+# emitting a spec kiro-cli refuses. Kept as its own mapping rather than folded
+# into the one above because the two answer different questions -- is this field
+# the right shape, and are its contents the right shape -- and the second is
+# applied per ITEM so one malformed name cannot discard the ones beside it.
+_MANAGED_MCP_ENTRY_ITEM_TYPES: dict[str, type] = {
+    "autoApprove": str,
+    "disabledTools": str,
+}
+
+# Env keys a managed MCP server's spec must never carry through from
+# agent.json are NOT enumerated here. agent.json is agent-writable (not in
+# _SENSITIVE_HOME_DIRS / _WRITE_PROTECTED_HOME_PATHS) and every managed
+# server's ``env`` is launched verbatim by kiro-cli as the child process's
+# environment, so the filter has to be exactly the one env.sanitize_spec_env
+# already applies for the probe: PREFIX-matched, case-insensitively, over
+# Kiro Crew's whole reserved namespace plus the loader/interpreter channels.
+#
+# Delegating rather than restating is the point. This function exists because
+# two hand-synced copies of the ownership rules drifted (#3594); a local
+# frozenset of reserved NAMES would be a third copy of a rule env.py already
+# owns, and a name list fails open for the next KIROCREW_ variable somebody
+# adds -- the reachable case GPT found on this PR was KIROCREW_CLI, which
+# mcp_cron._caller_is_cli() reads as "skip per-session ownership entirely".
+# env.py states the reviewable property instead: a config cannot author our
+# namespace. KIROCREW_HOME is stripped by that same namespace rule and then
+# re-pinned below to the gateway's actual override, so ours is the only value
+# that can reach the child.
+
+
+# Env keys that decide where ``Path.home()`` points, and therefore where a
+# managed shim resolves its data home when no ``KIROCREW_HOME`` pin is present.
+# Stripped from a MANAGED entry only -- this is not a deny rule for specs in
+# general, and env.sanitize_spec_env deliberately lets ``HOME`` through because a
+# user's own MCP server legitimately needs it.
+#
+# The population is what makes stripping correct here. A managed server is ours:
+# its command and args are ours, and it resolves OUR data home through
+# config_dir() -> Path.home(). On a default install that inheritance is exactly
+# right, which is why _managed_mcp_env() emits nothing there. Letting a
+# config-declared HOME override it would relocate the shim's whole data home:
+# cron_add would report success into a store the gateway never reads and the job
+# would never run -- the same silent split _managed_mcp_env documents, arriving
+# through a door that only opened once user env survived a clean rebuild.
+#
+# Both spellings are listed because Path.home() consults HOME on POSIX and
+# USERPROFILE on Windows, and a spec is portable across both.
+#
+# Held upper-cased and compared against key.upper(), because sanitize_spec_env
+# preserves each key's ORIGINAL case (out[key] = value) -- so a spec declaring
+# "userprofile" arrives with that spelling and an exact-case pop would miss it
+# while Windows, whose env names are case-insensitive, would still honour it.
+# This mirrors the folding sanitize_spec_env already does for its own prefixes;
+# the rest of the tree folds case at every one of these boundaries.
+_HOME_DERIVING_ENV_KEYS: frozenset[str] = frozenset({"HOME", "USERPROFILE"})
+
+# Env names that decide WHAT a managed shim executes, rather than how it behaves
+# once running. Stripped from a MANAGED entry only, for the same reason as the
+# home-deriving pair above and matched the same way (upper-cased, compared against
+# key.upper()): a user's own MCP server may legitimately need any of these, and
+# ``env.sanitize_spec_env`` therefore does not refuse them globally.
+#
+# A managed shim is OURS, and some of them are scripts whose shebang resolves
+# their interpreter by NAME at exec time (``#!/usr/bin/env node`` -- see the note
+# in ``name_grant``). So a config-authored value here does not tune our process,
+# it chooses a different program for us to run:
+#
+# * ``PATH`` picks which ``node``/``python``/binary the shebang resolves to.
+# * ``BASH_ENV`` and ``ENV`` name a file a non-interactive shell SOURCES first.
+# * ``SHELLOPTS``/``BASHOPTS`` inject shell options the launcher never set.
+# * ``NODE_OPTIONS`` carries ``--require``, and ``NODE_PATH`` redirects resolution.
+#
+# Grouped as one class deliberately. The interpreter half of this problem is
+# already stated as a namespace in env.py (``PYTHON`` by prefix) because that
+# population is unbounded; these have no shared prefix to key on, so they are
+# enumerated -- and the enumeration is scoped to the launchers a managed shim
+# actually uses (a shell, and node) rather than trying to cover every runtime.
+_LAUNCHER_EXEC_ENV_KEYS: frozenset[str] = frozenset(
+    {"PATH", "BASH_ENV", "ENV", "SHELLOPTS", "BASHOPTS", "NODE_OPTIONS", "NODE_PATH"}
+)
 
 
 def _mcp_registry_mode() -> bool:
@@ -2119,6 +2252,181 @@ def _apply_user_kiro_hooks(config: dict, mc_cfg: dict) -> None:
         logger.debug("SEL audit for kiro_hooks merge failed", exc_info=True)
 
 
+def _enforce_managed_mcp_ownership(
+    entry: dict,
+    spec: dict,
+    registry_mode: bool,
+    *,
+    auto_approve: str,
+) -> None:
+    """Strip/re-pin the fields Kiro Crew owns on one managed-server entry.
+
+    Applied identically by the fresh-build path (``build_agent_config``) and
+    the existing-config refresh path (``_refresh_dynamic_fields``) so the two
+    can no longer hand-drift: that silent divergence between two copies of
+    this same ownership logic is what let a clean rebuild discard a user's
+    timeout/env in the first place (#3594), and would just as easily reopen a
+    security-relevant strip (e.g. the reserved-env-key scrub below) if only
+    one of the two loops picked it up.
+
+    ``entry["command"]``/``entry["args"]`` are set by the caller beforehand —
+    both loops resolve those slightly differently (build vs. refresh), so
+    ownership of that resolution stays with them.
+
+    ``auto_approve`` names what should happen to ``autoApprove``, as ONE
+    parameter rather than a pair of booleans, so a caller cannot spell a
+    combination that has no meaning. The three values are the three real cases:
+
+    * ``"own"`` (build) -- ``autoApprove`` tracks the spec on every call, like
+      every other field this function owns, so agent- or user-written
+      ``autoApprove`` data never survives a clean build.
+    * ``"seed"`` (refresh, entry absent) -- set it from the spec, because a
+      server the user does not have yet has no preference to respect.
+    * ``"preserve"`` (refresh, entry present) -- leave it alone, so a user who
+      deliberately removed a grant is not silently handed it back on every
+      refresh.
+    """
+    # Entry keys are an ALLOW-LIST, not a list of known-bad names. kiro-cli
+    # rejects a server spec carrying a field it does not know, and it rejects the
+    # WHOLE agent when it does, so a single stray ``cwd`` on a managed entry
+    # takes every Kiro Crew tool down with it. Dropping the key we cannot honour
+    # keeps the agent loadable, which is what the user actually wanted.
+    #
+    # It has to be an allow-list because the deny side is unbounded: ``url`` and
+    # ``headers`` were the two stale fields older builds left behind (these
+    # servers are stdio-only, and a leftover ``url`` would shadow the command and
+    # propagate into the CC config), but naming them one at a time fails open for
+    # the next field anybody hand-writes. Both are absent from the set below, so
+    # they are still dropped -- now as instances of a rule rather than as two
+    # names.
+    #
+    # This became reachable HERE with the fix: the fresh-build path used to
+    # rebuild the entry from scratch and so discarded every unknown key with the
+    # rest, and preserving the user's timeout/env is exactly what put them back
+    # in reach.
+    for stray_key in [k for k in entry if k not in _MANAGED_MCP_ENTRY_KEYS]:
+        entry.pop(stray_key, None)
+        logger.warning(
+            "dropping %r from a managed MCP server's entry: it is not a field a "
+            "managed entry may carry, and kiro-cli rejects the whole agent spec "
+            "over one unknown field",
+            stray_key,
+        )
+    # A right key with a wrong-TYPED value fails exactly the same way: the spec is
+    # schema-checked, so ``"disabled": "false"`` (a string where a boolean belongs)
+    # loses the user every Crew tool just as surely as an unknown field. Dropping
+    # the ill-typed value rather than coercing it is the same call already made one
+    # level down for env ENTRIES in ``sanitize_spec_env``: a value we invent is not
+    # the one the user wrote, and the rest of their entry still survives.
+    #
+    # Only the keys a user may author are checked. ``command``/``args`` are set by
+    # both callers before this runs, so their types are ours, not input. Unlike
+    # the env-NAME case, this list is closed and finite -- exactly the fields
+    # ``_MANAGED_MCP_ENTRY_VALUE_TYPES`` names, with the types the same schema
+    # documents -- so it converges instead of growing a name per round.
+    for typed_key, expected in _MANAGED_MCP_ENTRY_VALUE_TYPES.items():
+        if typed_key not in entry:
+            continue
+        value = entry[typed_key]
+        # ``bool`` is a subclass of ``int``, so a bare isinstance check would let
+        # ``"timeout": true`` through as a number.
+        wrong_type = not isinstance(value, expected) or (
+            expected is not bool and isinstance(value, bool)
+        )
+        # A float can be the right TYPE and still not be representable. Python's
+        # json module accepts bare ``NaN``/``Infinity`` on the way in and writes
+        # them back out verbatim, but neither is JSON, so a strict parser rejects
+        # the file -- and kiro-cli rejects the whole agent with it. isfinite is the
+        # complete test here rather than another name to remember: it covers NaN,
+        # +Infinity and -Infinity, which is every non-finite float there is.
+        if not wrong_type and isinstance(value, float) and not math.isfinite(value):
+            wrong_type = True
+        if wrong_type:
+            entry.pop(typed_key, None)
+            logger.warning(
+                "dropping %r from a managed MCP server's entry: %r is not the "
+                "type kiro-cli's spec schema documents for it, and it would be "
+                "rejected along with the whole agent",
+                typed_key,
+                value,
+            )
+    # A list of the right TYPE can still hold the wrong ITEMS. Both list-valued
+    # keys are documented as arrays of tool NAMES, so ``disabledTools: [1]``
+    # satisfies the check above and still emits a spec kiro-cli refuses -- the
+    # container was validated and its contents were not.
+    #
+    # Filtered per ITEM rather than dropped whole, which is the rule this fix
+    # already applies one level down to env ENTRIES in ``sanitize_spec_env``:
+    # a well-typed sibling survives its neighbour. That matters most for
+    # ``disabledTools``, where discarding the list because one item is malformed
+    # would re-expose every tool the user did name correctly.
+    for list_key in _MANAGED_MCP_ENTRY_ITEM_TYPES:
+        items = entry.get(list_key)
+        if not isinstance(items, list):
+            continue
+        kept = [item for item in items if isinstance(item, str)]
+        for bad_item in [item for item in items if not isinstance(item, str)]:
+            logger.warning(
+                "dropping %r from a managed MCP server's %r: that list carries "
+                "tool names, and a non-string item would be rejected along with "
+                "the whole agent spec",
+                bad_item,
+                list_key,
+            )
+        if len(kept) != len(items):
+            entry[list_key] = kept
+    # Enterprise registry MARKER — the ``registry`` value is ours and tracks the
+    # account the gateway is actually signed in to, so it is set when the
+    # declaration is on and removed (not left stale) when it is off, which stops
+    # a host that leaves an enterprise profile from shipping a marker the inverse
+    # filter would now use to drop these servers. Only that value: a transport
+    # hint the user wrote is theirs and is carried through untouched.
+    if registry_mode:
+        entry["type"] = _MCP_REGISTRY_TYPE
+    elif entry.get("type") == _MCP_REGISTRY_TYPE:
+        entry.pop("type", None)
+    # Env: keep the user's own variables, but only genuine ones. A malformed
+    # (non-dict) override is dropped rather than fed to dict(...), which would
+    # otherwise raise and abort the whole config rebuild over a single bad
+    # agent.json value. sanitize_spec_env then drops Kiro Crew's whole reserved
+    # namespace and the loader/interpreter channels by prefix (see the module
+    # comment above), the home-deriving names are dropped for this population
+    # (see _HOME_DERIVING_ENV_KEYS), and KIROCREW_HOME is re-pinned to the
+    # gateway's actual override afterwards so ours is the value that reaches the
+    # child.
+    existing_env = entry.get("env")
+    env = sanitize_spec_env(existing_env.items()) if isinstance(existing_env, dict) else {}
+    for home_key in [k for k in env if k.upper() in _HOME_DERIVING_ENV_KEYS]:
+        env.pop(home_key, None)
+        logger.warning(
+            "dropping %r from a managed MCP server's env: it would move the "
+            "data home this shim shares with the gateway",
+            home_key,
+        )
+    for exec_key in [k for k in env if k.upper() in _LAUNCHER_EXEC_ENV_KEYS]:
+        env.pop(exec_key, None)
+        logger.warning(
+            "dropping %r from a managed MCP server's env: it would choose what "
+            "this shim executes rather than configure it (see "
+            "_LAUNCHER_EXEC_ENV_KEYS)",
+            exec_key,
+        )
+    env.update(_managed_mcp_env())
+    if env:
+        entry["env"] = env
+    else:
+        entry.pop("env", None)
+    if auto_approve == "own":
+        if "autoApprove" in spec:
+            entry["autoApprove"] = list(spec["autoApprove"])
+        else:
+            # agent.json is agent-writable; it cannot grant auto-approval to a
+            # managed server that does not ship an audited default grant.
+            entry.pop("autoApprove", None)
+    elif auto_approve == "seed" and "autoApprove" in spec:
+        entry["autoApprove"] = list(spec["autoApprove"])
+
+
 def build_agent_config(*, gated_off: "frozenset[str] | None" = None) -> dict:
     """Return the final agent config (shipped defaults + user overrides + dynamic fields).
 
@@ -2192,22 +2500,17 @@ def build_agent_config(*, gated_off: "frozenset[str] | None" = None) -> dict:
         else:
             cmd = spec.get("command") or spec["command_fn"]()
             args = list(spec["args"])
-        entry = {"command": cmd, "args": args}
-        # Enterprise registry mode: without this marker the client drops the
-        # entry before launch (see _mcp_registry_mode). command/args stay so the
-        # spec still describes a runnable server for every other consumer —
-        # doctor's handshake probe, the CC sidecar sync, a later un-governed
-        # refresh — none of which route through the registry.
-        if registry_mode:
-            entry["type"] = _MCP_REGISTRY_TYPE
-        # Pin the data home so the shim cannot read a DIFFERENT one than the
-        # gateway that spawned it (see _managed_mcp_env). Omitted entirely on a
-        # default install, so the emitted spec is unchanged there.
-        env = _managed_mcp_env()
-        if env:
-            entry["env"] = env
-        if "autoApprove" in spec:
-            entry["autoApprove"] = list(spec["autoApprove"])
+        # The deep merge above may have supplied user-owned options such as a
+        # timeout or extra environment variables. Keep those on a clean build,
+        # while replacing the invocation and transport fields that define our
+        # trusted managed server. Ownership of every other field is enforced
+        # by the same helper the refresh path uses (_enforce_managed_mcp_ownership),
+        # so the two loops cannot silently diverge on what counts as "ours".
+        existing = mcp.get(name)
+        entry = dict(existing) if isinstance(existing, dict) else {}
+        entry["command"] = cmd
+        entry["args"] = args
+        _enforce_managed_mcp_ownership(entry, spec, registry_mode, auto_approve="own")
         mcp[name] = entry
 
     # Edition-contributed MCP servers (PlatformContext).  ADD-only: standalone
@@ -2310,42 +2613,13 @@ def _refresh_dynamic_fields(config: dict, *, gated_off: "frozenset[str] | None" 
         else:
             entry["command"] = spec.get("command") or spec["command_fn"]()
             entry["args"] = list(spec["args"])
-        # Strip any stale remote-transport fields from older builds: these
-        # servers are stdio-only, and a leftover ``url`` would otherwise
-        # propagate into the CC config and shadow the command. (Root fix for
-        # the downstream stdio-force in cc_agent / acp.client.)
-        entry.pop("url", None)
-        entry.pop("headers", None)
-        # Enterprise registry marker — refreshed like command/args rather than
-        # preserved like ``autoApprove``, because it tracks the account the
-        # gateway is actually signed in to, not a user preference. Removed (not
-        # left stale) when the declaration is off, so a host that leaves an
-        # enterprise profile stops shipping a marker that would now cause the
-        # inverse filter to drop these servers.
-        if registry_mode:
-            entry["type"] = _MCP_REGISTRY_TYPE
-        elif entry.get("type") == _MCP_REGISTRY_TYPE:
-            entry.pop("type", None)
-        # Data-home pin — refreshed like command/args rather than preserved like
-        # ``autoApprove``, because it is OURS, not a user customization: it must
-        # track the home the gateway is actually running under. A config written
-        # under an override and later refreshed on a default install would
-        # otherwise keep pointing the shims at the stale home. Merged into any
-        # existing ``env`` so a user's own variables survive, and the key is
-        # REMOVED (not left stale) when there is no override.
-        pinned = _managed_mcp_env()
-        env = dict(entry.get("env") or {})
-        env.pop("KIROCREW_HOME", None)
-        env.update(pinned)
-        if env:
-            entry["env"] = env
-        else:
-            entry.pop("env", None)
-        # Seed autoApprove only for genuinely new entries; if the user
-        # deliberately removed autoApprove from an existing entry we
-        # must not re-add it on every refresh.
-        if "autoApprove" in spec and is_new:
-            entry["autoApprove"] = list(spec["autoApprove"])
+        # Strip any stale remote-transport fields from older builds, re-pin the
+        # registry marker and data-home env, and seed autoApprove only for a
+        # genuinely new entry — all via the same helper the fresh-build loop
+        # uses, so the two ownership rules can no longer hand-drift.
+        _enforce_managed_mcp_ownership(
+            entry, spec, registry_mode, auto_approve="seed" if is_new else "preserve"
+        )
 
     # Edition-contributed MCP servers (PlatformContext).  ADD-only: only seed a
     # server the user doesn't already have, so user customizations on a refresh

--- a/src/kiro_crew/env.py
+++ b/src/kiro_crew/env.py
@@ -874,7 +874,7 @@ def mcp_search_path(env_path: str) -> str:
 #
 # * ``LD_*`` / ``DYLD_*`` are dynamic-loader channels honoured by every
 #   ELF/Mach-O binary in the spawn chain, the sandbox wrapper included.
-# * The listed ``PYTHON*`` keys matter because Kiro Crew's Linux sandbox launcher
+# * The ``PYTHON`` namespace matters because Kiro Crew's Linux sandbox launcher
 #   IS a Python process: ``sandbox.namespace_argv`` returns
 #   ``[sys.executable, "-I", "-S", <generated script>, *argv]`` (sandbox.py), and
 #   that interpreter starts with the env we hand ``Popen``. A declared
@@ -884,13 +884,35 @@ def mcp_search_path(env_path: str) -> str:
 #   ``PYTHONUSERBASE`` is too: it relocates user-site, whose ``.pth`` files are
 #   EXECUTED during startup.
 #
-# NOTE this list is a prefix set, not the glob ``PYTHON*`` — do not describe it as
-# such. It does not cover ``HOME``, which also derives the user-site path when
-# ``PYTHONUSERBASE`` is unset, and stripping ``HOME`` from a spec overlay would
-# break servers that legitimately need it. The launcher's ``-I -S`` is what
+# NOTE the ``PYTHON`` entry covers that whole namespace by prefix, but this is
+# still a PREFIX set rather than a general glob: it does not cover ``HOME``,
+# which also derives the user-site path when ``PYTHONUSERBASE`` is unset, and
+# stripping ``HOME`` from a spec overlay would break servers that legitimately
+# need it. The launcher's ``-I -S`` is what
 # actually closes that class (site processing never happens, so no ``.pth`` runs
 # whatever the paths point at); these prefixes are defense in depth for it and the
 # primary control for any future launcher that forgets those flags.
+#
+# ``PYTHON`` is denied as a NAMESPACE, not as a list of the dangerous names in
+# it, for the same reason ``KIROCREW_`` is below: an enumeration cannot cover the
+# variable nobody has added yet. ``python3 --help-env`` documents 29 ``PYTHON*``
+# variables on 3.12 alone, plus platform-only spellings like
+# ``PYTHONEXECUTABLE``, and several are execution channels rather than
+# preferences -- ``PYTHONPATH`` places a ``sitecustomize`` module,
+# ``PYTHONSTARTUP`` names a file, ``PYTHONBREAKPOINT`` takes a dotted callable
+# and imports it, ``PYTHONWARNINGS`` resolves a dotted filter category through
+# ``warnings._getcategory``'s ``__import__``, ``PYTHONHOME`` and
+# ``PYTHONPLATLIBDIR`` move where the standard library is found. Naming them
+# one at a time was tried and did not converge: this set reached six entries by
+# accretion while 23 documented siblings stayed open.
+#
+# The cost is a benign ``PYTHON*`` variable in a spec being refused --
+# ``PYTHONUNBUFFERED=1`` on a user's own Python MCP server is the realistic
+# example. That is a logged refusal rather than a broken server (see the
+# asymmetry note below), and ``denied_spec_env_keys`` names the key so the probe
+# explains itself instead of reading as a bug. Every first-party ``PYTHON*`` use
+# in this tree sets the variable directly on a child process rather than
+# declaring it in a spec ``env``, so none of them route through here.
 #
 # Prefix-matched, case-insensitively (Windows env is case-insensitive).
 #
@@ -906,10 +928,7 @@ def mcp_search_path(env_path: str) -> str:
 _SPEC_ENV_DENIED_PREFIXES: tuple[str, ...] = (
     "LD_",
     "DYLD_",
-    "PYTHONPATH",
-    "PYTHONHOME",
-    "PYTHONSTARTUP",
-    "PYTHONUSERBASE",
+    "PYTHON",
 )
 
 # The env namespace Kiro Crew reserves for ITSELF. A spec-declared ``env`` may
@@ -962,10 +981,24 @@ _SPEC_ENV_RESERVED_PREFIXES: tuple[str, ...] = ("KIROCREW_",)
 def sanitize_spec_env(pairs: Iterable[tuple[str, str]]) -> dict[str, str]:
     """Drop loader-injection and reserved-namespace keys from a spec env.
 
-    For spawn paths that apply a config-declared ``env`` to a child THEY
-    launch (the probe). The declared env is config-file
-    text — the same trust level as the command itself, which those paths
-    already refuse to run unsandboxed — so a key that executes code in the
+    For paths that let a config-declared ``env`` reach a child process. Two
+    shapes qualify and both are covered: a spawn path that launches the child
+    ITSELF (the probe), and a path that EMITS the env into an agent spec for
+    ``kiro-cli`` to launch from (``agent._enforce_managed_mcp_ownership``, for
+    a managed server's entry merged out of the agent-writable
+    ``agent.json``). The launcher's identity does not change the argument --
+    what matters is that config-file text becomes a child's environment.
+
+    That second caller does NOT disturb the ``emit_env`` asymmetry noted above.
+    The asymmetry protects a USER'S OWN Python MCP server, which may
+    legitimately be configured through ``env.PYTHONPATH``; the managed
+    population is ours, its ``command``/``args`` are ours, and it runs as the
+    entry point holding the internal API secret, so no declared loader or
+    namespace variable on it is legitimate in the first place.
+
+    The declared env is config-file
+    text -- the same trust level as the command itself, which those paths
+    already refuse to run unsandboxed -- so a key that executes code in the
     launcher before confinement is established must not pass through.
 
     Two independent classes are dropped, for two different reasons:
@@ -993,9 +1026,33 @@ def sanitize_spec_env(pairs: Iterable[tuple[str, str]]) -> dict[str, str]:
     Dropped keys are logged at WARNING: a spec relying on one is broken by
     policy, not by accident, and silence would read as the credential-drop
     bug this sanitizer's caller exists to fix.
+
+    An entry whose key or value is not a string is dropped for a different
+    reason -- not policy but type. The signature promises ``str -> str`` and
+    every caller builds ``pairs`` from parsed JSON, so without this the
+    ill-typed value reaches an emitted spec whose schema is a string map.
     """
     out: dict[str, str] = {}
     for key, value in pairs:
+        # Honor this function's own str -> str signature. Every caller builds
+        # `pairs` from parsed JSON, where a value may be any JSON type, so an
+        # `env` of {"PORT": 3000} would otherwise be copied through into an
+        # emitted spec whose schema is a string map -- and a spec kiro-cli
+        # rejects costs the user every Crew MCP tool, from one mistyped config
+        # value. Dropped rather than coerced with str(), matching how a
+        # malformed non-dict `env` is dropped by the managed-entry caller: a
+        # value we invent is not the one the user wrote. A non-string KEY is
+        # unreachable from JSON (object keys are always strings) but would
+        # crash `key.upper()` below, so it is guarded in the same place.
+        if not isinstance(key, str) or not isinstance(value, str):
+            logger.warning(
+                "dropping spec env entry %r: keys and values must be strings, got "
+                "key %s and value %s",
+                key,
+                type(key).__name__,
+                type(value).__name__,
+            )
+            continue
         folded = key.upper()
         if any(folded.startswith(p) for p in _SPEC_ENV_DENIED_PREFIXES):
             logger.warning(

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -24,7 +24,18 @@ from windows_sim import replace_sharing_violation
 from conftest import requires_symlinks
 from kiro_crew import agent_state
 from kiro_crew import atomic_write as aw
-from kiro_crew.agent import install_agent, migrate_agent_specs
+from kiro_crew.agent import _MANAGED_MCP_ENTRY_KEYS, install_agent, migrate_agent_specs
+
+
+def _reject_json_constant(name: str):  # pragma: no cover - raises by design
+    """Stand in for a strict JSON reader.
+
+    ``NaN``/``Infinity``/``-Infinity`` are Python extensions, not JSON, so a
+    conforming parser (kiro-cli's) refuses them. Python's own loader accepts them
+    silently, which is exactly why a test that only re-reads with ``json.loads``
+    would pass on a spec kiro-cli cannot read.
+    """
+    raise AssertionError(f"emitted spec carries the non-JSON constant {name!r}")
 
 
 def _run_install(tmp_path: Path, cfg_dir: Path, managed_mcps: dict | None = None, **kwargs) -> Path:  # type: ignore[return]
@@ -75,6 +86,552 @@ class TestInstallAgent:
         config = json.loads(path.read_text(encoding="utf-8"))
         assert config["model"] == "claude-default"
         assert "ReadFile" in config["tools"]
+
+    def test_fresh_install_preserves_safe_managed_server_overrides(self, tmp_path: Path):
+        """A clean rebuild keeps preferences without ceding invocation ownership."""
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir()
+        (user_home / "agent.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "kirocrew-core": {
+                            "command": "/tmp/untrusted",
+                            "args": ["other"],
+                            "url": "https://example.invalid/mcp",
+                            "timeout": 45,
+                            "env": {"MINE": "keep", "KIROCREW_HOME": "/tmp/wrong"},
+                            "autoApprove": ["unreviewed_tool"],
+                        }
+                    }
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-core"]
+
+        assert entry["command"] == "/usr/bin/kirocrew"
+        assert entry["args"] == ["mcp-core"]
+        assert "url" not in entry
+        assert entry["timeout"] == 45
+        assert entry["env"]["MINE"] == "keep"
+        assert entry["env"].get("KIROCREW_HOME") != "/tmp/wrong"
+        assert "autoApprove" not in entry
+
+    def test_fresh_install_drops_unsupported_entry_keys(self, tmp_path: Path):
+        """A managed entry carries only our fields plus the user's own.
+
+        kiro-cli rejects a spec with a field it does not know, and it rejects the
+        WHOLE agent when it does -- so one stray ``cwd`` on a managed server would
+        take every Kiro Crew tool down with it. Preserving the user's
+        timeout/env/disabled is what put unknown keys in reach on this path (the
+        build used to rebuild the entry from scratch), so the allow-list ships
+        with the preservation rather than after it.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir()
+        (user_home / "agent.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "kirocrew-core": {
+                            "cwd": "/tmp/elsewhere",
+                            "initializationOptions": {"x": 1},
+                            "url": "https://example.invalid/mcp",
+                            "headers": {"Authorization": "Bearer x"},
+                            "timeout": 45,
+                            "disabled": False,
+                            "disabledTools": ["delete_file"],
+                            "env": {"MINE": "keep"},
+                        }
+                    }
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-core"]
+
+        # The supported customizations survive -- that is the fix.
+        assert entry["timeout"] == 45
+        assert entry["disabled"] is False
+        assert entry["env"]["MINE"] == "keep"
+        # A user GUARD, not a preference: dropping it would silently re-expose a
+        # tool the user turned off, so it is carried rather than re-derived.
+        assert entry["disabledTools"] == ["delete_file"]
+        # Everything the user cannot declare on a managed server is gone, and
+        # url/headers are dropped as instances of the rule, not as named fields.
+        for unsupported in ("cwd", "initializationOptions", "url", "headers"):
+            assert unsupported not in entry, unsupported
+        # Nothing outside the closed set reaches the spec.
+        assert set(entry) <= _MANAGED_MCP_ENTRY_KEYS
+
+    def test_refresh_drops_unsupported_entry_keys(self, tmp_path: Path):
+        """The refresh path drops the same keys, since one enforcer owns both."""
+        cfg_dir = _bundled_defaults(tmp_path)
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        (kiro_dir / "kirocrew.json").write_text(
+            json.dumps(
+                {
+                    "model": "claude-user-custom",
+                    "tools": [],
+                    "allowedTools": [],
+                    "mcpServers": {
+                        "kirocrew-core": {
+                            "command": "/old/path/kirocrew",
+                            "args": ["mcp-core"],
+                            "cwd": "/tmp/elsewhere",
+                            "timeout": 30,
+                            "disabledTools": ["execute_cmd"],
+                            "env": {"MINE": "keep"},
+                        },
+                    },
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-core"]
+
+        assert entry["timeout"] == 30
+        assert entry["env"]["MINE"] == "keep"
+        # The refresh path is the one that would silently widen the tool surface
+        # by dropping this, since it is the path an existing config takes.
+        assert entry["disabledTools"] == ["execute_cmd"]
+        assert "cwd" not in entry
+        assert set(entry) <= _MANAGED_MCP_ENTRY_KEYS
+
+    def test_fresh_install_strips_launcher_exec_env_from_a_managed_entry(self, tmp_path: Path):
+        """A managed shim's env cannot choose what the shim executes.
+
+        Some managed commands are scripts whose shebang resolves the interpreter by
+        NAME at exec time, so a declared ``PATH`` picks the binary and ``BASH_ENV``
+        names a file a non-interactive shell sources first. Neither configures our
+        process; both replace the program. Case variants are asserted because
+        ``sanitize_spec_env`` keeps each key's original spelling while Windows env
+        names are case-insensitive.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir()
+        (user_home / "agent.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "kirocrew-core": {
+                            "env": {
+                                "PATH": "/tmp/evil/bin",
+                                "BASH_ENV": "/tmp/evil.sh",
+                                "ENV": "/tmp/evil.sh",
+                                "SHELLOPTS": "xtrace",
+                                "BASHOPTS": "expand_aliases",
+                                "NODE_OPTIONS": "--require /tmp/evil.js",
+                                "NODE_PATH": "/tmp/evil/node_modules",
+                                "Path": "/tmp/evil/bin",
+                                "bash_env": "/tmp/evil.sh",
+                                "MINE": "keep",
+                            }
+                        }
+                    }
+                }
+            )
+        )
+
+        # Simulated DEFAULT install, so no data-home pin is emitted and the
+        # assertion below can be an exact equality on the whole env.
+        with patch("kiro_crew.agent._valid_override_home", return_value=None):
+            path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-core"]
+
+        # The user's own variable is still preserved -- that is the fix this PR is.
+        assert entry["env"] == {"MINE": "keep"}
+
+    @pytest.mark.parametrize("literal", ["NaN", "Infinity", "-Infinity"])
+    def test_fresh_install_drops_a_non_finite_timeout(self, tmp_path: Path, literal: str):
+        """A float can be the right type and still not be representable in JSON.
+
+        Python's ``json`` accepts these three literals on the way in and writes them
+        back verbatim, so a type check alone ships a spec no strict parser will
+        read -- and kiro-cli rejects the whole agent with it. All three are
+        parametrized because ``isfinite`` is one test for one class, and a fix that
+        only named ``NaN`` would leave the infinities.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir()
+        (user_home / "agent.json").write_text(
+            '{"mcpServers": {"kirocrew-core": {"timeout": ' + literal + "}}}"
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        raw = path.read_text(encoding="utf-8")
+        entry = json.loads(raw)["mcpServers"]["kirocrew-core"]
+
+        assert "timeout" not in entry
+        # The emitted file is parseable by a STRICT reader, which is the property
+        # that actually matters -- Python's own loader would accept the bad value.
+        assert literal not in raw
+        json.loads(raw, parse_constant=_reject_json_constant)
+
+    def test_refresh_drops_non_string_tool_list_items(self, tmp_path: Path):
+        """A list of the right type can still hold the wrong items.
+
+        Both list-valued keys carry tool NAMES, so ``disabledTools: [1]`` passes a
+        container-only check and still emits a spec kiro-cli refuses. Filtered per
+        ITEM, not dropped whole -- the same rule this fix applies to env entries --
+        because discarding the list would re-expose every tool the user did name
+        correctly, which is the opposite of what a guard is for.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        (kiro_dir / "kirocrew.json").write_text(
+            json.dumps(
+                {
+                    "model": "claude-user-custom",
+                    "tools": [],
+                    "allowedTools": [],
+                    "mcpServers": {
+                        "kirocrew-core": {
+                            "command": "/old/path/kirocrew",
+                            "args": ["mcp-core"],
+                            "disabledTools": ["delete_file", 1, None, {"a": 1}],
+                            "autoApprove": ["read_file", 2],
+                        },
+                    },
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        raw = path.read_text(encoding="utf-8")
+        entry = json.loads(raw)["mcpServers"]["kirocrew-core"]
+
+        # The correctly-named guard survives its malformed neighbours.
+        assert entry["disabledTools"] == ["delete_file"]
+        assert entry["autoApprove"] == ["read_file"]
+        assert all(isinstance(i, str) for i in entry["disabledTools"])
+        assert all(isinstance(i, str) for i in entry["autoApprove"])
+
+    def test_fresh_install_drops_ill_typed_entry_values(self, tmp_path: Path):
+        """A right key with a wrong-typed value is dropped, not shipped.
+
+        The spec is schema-checked, so ``"disabled": "false"`` costs the user every
+        Crew tool exactly like an unknown field would. Dropping beats coercing for
+        the same reason as env entries: a value we invent is not the one they wrote.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir()
+        (user_home / "agent.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "kirocrew-core": {
+                            "disabled": "false",
+                            "timeout": "45",
+                            "disabledTools": "delete_file",
+                            "autoApprove": {"not": "a list"},
+                            "env": {"MINE": "keep"},
+                        }
+                    }
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-core"]
+
+        for ill_typed in ("disabled", "timeout", "disabledTools"):
+            assert ill_typed not in entry, ill_typed
+        # The well-typed sibling in the same entry still survives, so one bad
+        # value does not discard the rest of the user's customization.
+        assert entry["env"]["MINE"] == "keep"
+        assert entry["command"] == "/usr/bin/kirocrew"
+
+    def test_fresh_install_drops_a_boolean_timeout(self, tmp_path: Path):
+        """``bool`` is an ``int`` subclass, so a bare isinstance check leaks here."""
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir()
+        (user_home / "agent.json").write_text(
+            json.dumps({"mcpServers": {"kirocrew-core": {"timeout": True}}})
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-core"]
+
+        assert "timeout" not in entry
+
+    def test_fresh_install_strips_reserved_control_env_keys(self, tmp_path: Path):
+        """agent.json cannot smuggle control-plane env vars into a managed server.
+
+        ``KIROCREW_APPROVAL_MODE`` is read straight out of os.environ by
+        mcp_tools/spawn.py and forwarded as ``approval_mode`` on every
+        ``spawn_run`` subagent launch. If an agent-writable agent.json could
+        seed it onto kirocrew-core's env, a clean rebuild would hand every
+        subagent auto-approval — a full PreToolUse-gate bypass. The other
+        session-identity/secret keys are stripped for the same reason: none
+        of them is something agent.json should ever be able to set.
+
+        The interpreter/loader names are asserted alongside them because they
+        reach the same outcome one layer earlier: a managed server is a Python
+        entry point, so a ``PYTHONPATH`` here lets a ``sitecustomize`` module run
+        during interpreter startup -- inside the process holding the internal API
+        secret, with no tool call for the gate to intercept.
+
+        The strip is ``env.sanitize_spec_env``, so the property under test is
+        the one a name list cannot state: two whole NAMESPACES, ``KIROCREW_``
+        and ``PYTHON``, are refused by PREFIX and case-INSENSITIVELY.
+        ``KIROCREW_CLI`` is asserted because ``mcp_cron._caller_is_cli()`` reads
+        it as "skip per-session ownership entirely";
+        ``PYTHONBREAKPOINT`` because it takes a dotted callable and imports it;
+        ``KIROCREW_NOT_YET_INVENTED`` and ``PYTHONNOTYETINVENTED`` stand for the
+        next variable in each namespace that nobody has added yet, which is the
+        case an enumeration structurally cannot cover. The odd-cased spellings
+        matter on Windows, where environment names are case-insensitive so
+        ``Kirocrew_Approval_Mode`` reaches the consumer exactly like the
+        upper-cased name.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir()
+        (user_home / "agent.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "kirocrew-core": {
+                            "env": {
+                                "MINE": "keep",
+                                "KIROCREW_APPROVAL_MODE": "auto",
+                                "KIROCREW_SESSION_KEY": "forged",
+                                "KIROCREW_INTERNAL_SECRET": "forged",
+                                "KIROCREW_PRINCIPAL": "forged",
+                                "KIROCREW_CLI": "1",
+                                "KIROCREW_NOT_YET_INVENTED": "forged",
+                                "Kirocrew_Approval_Mode": "auto",
+                                "pythonpath": "/x/evil-lowercase",
+                                "PYTHONPATH": "/x/evil",
+                                "PYTHONHOME": "/x/evil",
+                                "PYTHONSTARTUP": "/x/evil.py",
+                                "PYTHONEXECUTABLE": "/x/evil-python",
+                                "PYTHONWARNINGS": "ignore::evil.Boom",
+                                "PYTHONPLATLIBDIR": "evil-lib",
+                                "PYTHONBREAKPOINT": "evil.run",
+                                "PYTHONUSERBASE": "/x/evil-site",
+                                "PYTHONNOTYETINVENTED": "forged",
+                                "LD_PRELOAD": "/x/evil.so",
+                                "LD_LIBRARY_PATH": "/x/evil",
+                                "DYLD_INSERT_LIBRARIES": "/x/evil.dylib",
+                                "DYLD_LIBRARY_PATH": "/x/evil",
+                            },
+                        }
+                    }
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-core"]
+
+        assert entry["env"]["MINE"] == "keep"
+        for reserved in (
+            "KIROCREW_APPROVAL_MODE",
+            "KIROCREW_SESSION_KEY",
+            "KIROCREW_INTERNAL_SECRET",
+            "KIROCREW_PRINCIPAL",
+            "KIROCREW_CLI",
+            "KIROCREW_NOT_YET_INVENTED",
+            "Kirocrew_Approval_Mode",
+            "pythonpath",
+            "PYTHONPATH",
+            "PYTHONHOME",
+            "PYTHONSTARTUP",
+            "PYTHONEXECUTABLE",
+            "PYTHONWARNINGS",
+            "PYTHONPLATLIBDIR",
+            "PYTHONBREAKPOINT",
+            "PYTHONUSERBASE",
+            "PYTHONNOTYETINVENTED",
+            "LD_PRELOAD",
+            "LD_LIBRARY_PATH",
+            "DYLD_INSERT_LIBRARIES",
+            "DYLD_LIBRARY_PATH",
+        ):
+            assert reserved not in entry["env"], reserved
+
+    def test_refresh_strips_reserved_control_env_keys(self, tmp_path: Path):
+        """The refresh path (existing kirocrew.json) scrubs the same reserved keys.
+
+        Asserted on this path too because the shared enforcer is what makes the
+        two agree -- a key stripped on one emit path and preserved on the other
+        is the drift this PR exists to remove.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        existing = {
+            "model": "claude-user-custom",
+            "tools": [],
+            "allowedTools": [],
+            "mcpServers": {
+                "kirocrew-core": {
+                    "command": "/old/path/kirocrew",
+                    "args": ["mcp-core"],
+                    "env": {
+                        "MINE": "keep",
+                        "KIROCREW_APPROVAL_MODE": "auto",
+                        "KIROCREW_CLI": "1",
+                        "KIROCREW_NOT_YET_INVENTED": "forged",
+                        "PYTHONPATH": "/x/evil",
+                        "LD_PRELOAD": "/x/evil.so",
+                    },
+                },
+            },
+        }
+        (kiro_dir / "kirocrew.json").write_text(json.dumps(existing))
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-core"]
+
+        assert entry["env"]["MINE"] == "keep"
+        for reserved in (
+            "KIROCREW_APPROVAL_MODE",
+            "KIROCREW_CLI",
+            "KIROCREW_NOT_YET_INVENTED",
+            "PYTHONPATH",
+            "LD_PRELOAD",
+        ):
+            assert reserved not in entry["env"], reserved
+
+    def test_fresh_install_drops_malformed_non_dict_env(self, tmp_path: Path):
+        """A non-object ``env`` override does not crash the rebuild.
+
+        Pre-fix this fed a non-dict straight to ``dict(...)``, which raises
+        for values like a plain string or a list of non-pair items and would
+        abort the whole config rebuild over a single bad agent.json value.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir()
+        (user_home / "agent.json").write_text(
+            json.dumps({"mcpServers": {"kirocrew-core": {"env": "not-a-dict"}}})
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-core"]
+
+        assert entry["command"] == "/usr/bin/kirocrew"
+        # The malformed string is discarded rather than fed to dict(...); any
+        # remaining ``env`` key is only Kiro Crew's own KIROCREW_HOME pin (the
+        # test harness's tmp_path counts as an override home).
+        assert set(entry.get("env", {})) <= {"KIROCREW_HOME"}
+
+    def test_fresh_install_drops_non_string_env_values(self, tmp_path: Path):
+        """An ill-typed ``env`` value never reaches the emitted spec.
+
+        The container check above guards ``env`` itself; this guards its
+        ENTRIES. JSON permits any type as a value, and the emitted
+        ``mcpServers`` env is a string map, so copying ``{"PORT": 3000}``
+        through would ship a spec kiro-cli rejects -- costing the user every
+        Crew MCP tool because of one mistyped config value. The bad entries are
+        dropped rather than coerced, and a well-typed sibling still survives,
+        so one bad value does not discard the whole block.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir()
+        (user_home / "agent.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "kirocrew-core": {
+                            "env": {
+                                "GOOD": "kept",
+                                "PORT": 3000,
+                                "FLAG": True,
+                                "NOTHING": None,
+                                "LISTY": ["a", "b"],
+                                "NESTED": {"k": "v"},
+                            },
+                        }
+                    }
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-core"]
+
+        assert entry["env"]["GOOD"] == "kept"
+        for bad in ("PORT", "FLAG", "NOTHING", "LISTY", "NESTED"):
+            assert bad not in entry["env"], bad
+        assert all(
+            isinstance(k, str) and isinstance(v, str) for k, v in entry["env"].items()
+        )
+
+    def test_fresh_install_pins_our_data_home_against_a_declared_home(
+        self, tmp_path: Path
+    ):
+        """A declared ``HOME`` cannot relocate a managed shim's data home.
+
+        ``HOME`` is deliberately NOT in ``env.py``'s deny set -- a user's own MCP
+        server legitimately needs it -- so preserving a user's ``env`` means a
+        managed entry can now carry one. That reaches ``Path.home()``, which is
+        how a managed shim resolves OUR data home when no pin is present, so a
+        declared ``HOME`` would relocate the whole store: ``cron_add`` would
+        report success where the gateway never reads and the job would never run.
+
+        Stripped for this population rather than pinned unconditionally. On a
+        default install the child DERIVES the right home by inheriting the
+        gateway's own ``HOME``, and ``TestDataHomePin`` in
+        ``test_computer_use_registration.py`` pins that a default install emits
+        no ``env`` at all, so that an existing user's ``kirocrew.json`` is not
+        churned. Removing the hijack keeps both properties; adding a pin would
+        have broken the second one.
+
+        The case variants are asserted because ``sanitize_spec_env`` preserves
+        each key's ORIGINAL case, so a spec declaring ``userprofile`` arrives
+        with that spelling -- and Windows env names are case-insensitive, so an
+        exact-case strip would miss it while the OS still honoured it.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(exist_ok=True)
+        (user_home / "agent.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "kirocrew-cron": {
+                            "env": {
+                                "HOME": "/x/evil-home",
+                                "USERPROFILE": "C:\\x\\evil-home",
+                                "userprofile": "C:\\x\\evil-lower",
+                                "UserProfile": "C:\\x\\evil-mixed",
+                                "Home": "/x/evil-mixed",
+                                "MINE": "keep",
+                            },
+                        }
+                    }
+                }
+            )
+        )
+
+        # Simulated DEFAULT install: no override home, so nothing pins the child
+        # and the declared HOME would otherwise decide where our data lives.
+        with patch("kiro_crew.agent._valid_override_home", return_value=None):
+            path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["kirocrew-cron"]
+
+        for spelling in ("HOME", "USERPROFILE", "userprofile", "UserProfile", "Home"):
+            assert spelling not in entry["env"], spelling
+        # The user's genuine variable still survives, and no pin was invented --
+        # the default-install spec is not churned.
+        assert entry["env"] == {"MINE": "keep"}
 
     def test_existing_config_preserves_user_model(self, tmp_path: Path):
         """Existing kirocrew.json → user's model choice survives restart."""


### PR DESCRIPTION
## Problem / Motivation

A user customization for a **managed** MCP server (`kirocrew-core`, `kirocrew-cron`, `kirocrew-computer`) declared the supported way -- in `$KIROCREW_HOME/agent.json` -- was silently discarded from the emitted agent spec on every clean rebuild.

`build_agent_config` deep-merged the override file, then the managed-server loop replaced the entry wholesale with `entry = {"command": cmd, "args": args}`. Anything the user declared on that entry -- `timeout`, custom `env`, the `disabled` toggle -- was gone from the spec kiro-cli actually reads, while the override file on disk stayed intact.

## Why it matters

The two emit paths disagreed. `_refresh_dynamic_fields` updated the entry in place and kept user keys, so the SAME declaration worked after a restart and vanished the next time anything triggered a clean rebuild (`--clean`, a corrupt spec falling back to a fresh build, a first install on a new machine that copies the override file over). The failure reads as "my setting stopped working and nothing changed", which is close to undiagnosable from outside: the file still says what the user wrote.

`disabled` makes it concrete beyond preferences -- it is the MCP Management page's own on/off toggle, so dropping it silently re-enabled a server the user had turned off.

## What changed

The symptom was lost user keys; the root cause was that ownership rules lived in two hand-synced copies that could drift.

`_enforce_managed_mcp_ownership` is now the single writer for what Kiro Crew owns on a managed entry, and both loops call it. Every difference between them is a parameter, so the two spellings sit side by side and cannot silently diverge again. The fresh path keeps what the merge produced and re-establishes only our fields. The refresh path still preserves a user's own `timeout`/`env`/`disabled`, with one deliberate tightening: it now scrubs the reserved and interpreter namespaces from a pre-existing entry, where base emitted them verbatim and popped only `KIROCREW_HOME`. That closes a pre-existing hole on the very path this PR starts preserving env for, so it belongs here rather than in a follow-up -- but it does change what an existing `agent.json` carrying `KIROCREW_CLI`, `PYTHONPATH` or `LD_PRELOAD` emits on its next refresh.

Preserving a user's `env` means the emitted entry now carries `agent.json` text into the child `kiro-cli` launches, which the old wholesale replacement discarded. That filter is **not** restated here. `env.sanitize_spec_env` already owns it for the probe and cron paths, and it is the version that holds up: it matches by PREFIX and case-insensitively over Kiro Crew's whole reserved namespace plus the loader/interpreter channels. A list of reserved NAMES fails open twice over, and both holes are reachable:

- It misses `KIROCREW_CLI`, which `mcp_cron._caller_is_cli()` reads as "skip per-session ownership entirely" -- forged, it turns `cron_remove_all` into "delete every session's jobs".
- On Windows it misses `Kirocrew_Approval_Mode`, because environment names are case-insensitive there while a Python dict lookup is not. `mcp_tools/spawn.py` forwards `KIROCREW_APPROVAL_MODE` as `approval_mode` to every `spawn_run` launch, so that spelling hands every subagent auto-approval.

`env.py`'s own comment already states the property a list only approximates: a config cannot author our namespace. Writing a fourth copy of that rule in `agent.py` would have reproduced, one level up, the very duplication this PR exists to remove.

`_SPEC_ENV_DENIED_PREFIXES` now denies the **`PYTHON` namespace by prefix** instead of naming members of it. `python3 --help-env` documents 29 `PYTHON*` variables on 3.12 alone, and several are execution channels rather than preferences: `PYTHONPATH` places a `sitecustomize` module, `PYTHONSTARTUP` names a file, `PYTHONBREAKPOINT` takes a dotted callable and imports it, `PYTHONWARNINGS` resolves a dotted filter category through `warnings._getcategory`'s `__import__`, and `PYTHONHOME` / `PYTHONPLATLIBDIR` move where the standard library is found.

Naming them individually was tried across review rounds and did not converge -- the set reached six entries by accretion while 23 documented siblings stayed open. That is the same fail-open shape as the reserved-key list this PR already deleted, and the same rule `env.py` states for `KIROCREW_`: a config cannot author our namespace, which a prefix states and a list only approximates.

The cost is a benign `PYTHON*` variable in a spec being refused -- `PYTHONUNBUFFERED=1` on a user's own Python MCP server is the realistic example. That is a logged refusal rather than a broken server: the documented `emit_env` asymmetry means a kiro-cli session still receives the declared value, and `denied_spec_env_keys` names the key so the probe explains itself instead of reading as a bug. Every first-party `PYTHON*` use in this tree sets the variable directly on a child process rather than declaring it in a spec `env`, so none of them route through this sanitizer.

`sanitize_spec_env`'s docstring gains the second shape it now serves: a spec **emitted** for `kiro-cli` to launch from, not only a child the caller spawns itself. It also records why that does not disturb the `emit_env` asymmetry documented above it -- that asymmetry protects a *user's own* Python MCP server, which may legitimately be configured through `env.PYTHONPATH`, whereas the managed population is ours, its `command`/`args` are ours, and it runs as the entry point holding the internal API secret. `KIROCREW_HOME` is stripped by that same namespace rule and then re-pinned to the gateway's actual override, so ours is the only value that can reach the child, and a user's own variables survive alongside it.

`autoApprove` handling becomes one `auto_approve` mode (`"own"` / `"seed"` / `"preserve"`) instead of two booleans that could spell a combination with no meaning -- the build path used to pass `is_new` alongside a flag that never read it.

The **home-deriving env names are stripped from a managed entry**, and this is the sharpest consequence of preserving a user's `env`. A managed entry can now carry `HOME`, which `env.py` deliberately does not deny because a user's own MCP server legitimately needs it. But a managed shim resolves *our* data home through `config_dir()` -> `Path.home()`, so a declared `HOME` relocated the entire store: `cron_add` reported success into a store the gateway never reads, and the job never ran. `USERPROFILE` is stripped alongside it because `Path.home()` consults that spelling on Windows and a spec is portable across both. The comparison folds case (`key.upper()`), because `sanitize_spec_env` preserves each key's **original** case -- so a spec declaring `userprofile` arrives with that spelling, and an exact-case removal would miss it while Windows, whose env names are case-insensitive, would still honour it.

Stripped for this population rather than pinned unconditionally, which is the narrower of the two fixes and the one that keeps an existing contract intact. On a default install the child already **derives** the right home by inheriting the gateway's own `HOME` -- that is why `_managed_mcp_env()` emits nothing there, and why `TestDataHomePin` in `test_computer_use_registration.py` pins that a default install emits no `env` at all, so an existing user's `kirocrew.json` is not churned. Removing the hijack keeps both properties. Pinning `KIROCREW_HOME` unconditionally would have fixed the bug too, but it broke that contract and its six tests, so the defect is better read as "a config can override an inheritance that was already correct" than as "we fail to state our home".

The same population also has the **names that decide what a managed shim executes** stripped from it (`_LAUNCHER_EXEC_ENV_KEYS`). Some managed commands are scripts whose shebang resolves the interpreter by NAME at exec time (`#!/usr/bin/env node`), so a declared `PATH` chooses which binary runs; `BASH_ENV` and `ENV` name a file a non-interactive shell sources first; `SHELLOPTS`/`BASHOPTS` inject options the launcher never set; `NODE_OPTIONS` carries `--require` and `NODE_PATH` redirects resolution. None of these configure our process -- they replace the program, which is code execution outside the tool gates. Managed entries only, and for the same reason as `HOME`: `env.py` must not refuse them globally because a user's own server may legitimately set any of them. Same case folding, same Windows reason.

This set is enumerated rather than expressed as a prefix, which is worth flagging because the rest of this PR argues the other way. The interpreter family already IS a namespace (`PYTHON`, denied by prefix) precisely because that population is unbounded; these names share no prefix to key on, so the set is scoped to the launchers a managed shim actually uses -- a shell, and node -- rather than pretending to cover every runtime. That is a real asymmetry rather than a tidy rule, and it is the open question left at the end of this description.

A malformed non-dict `env` is dropped rather than fed to `dict(...)`, which used to raise and abort the whole rebuild over one bad value. Its **entries** are guarded too, in `sanitize_spec_env`, which already promised `str -> str` in its signature while copying any JSON value through: an `env` of `{"PORT": 3000}` would have shipped a spec whose schema is a string map, costing the user every Crew MCP tool over one mistyped value. Ill-typed entries are dropped with a warning rather than coerced -- a value we invent is not the one the user wrote -- and a well-typed sibling in the same block still survives, so one bad value does not discard the rest.

One level up from `env`, the **entry's own keys are an allow-list** (`_MANAGED_MCP_ENTRY_KEYS`), derived from kiro-cli's documented local-server schema rather than assembled by hand so it can be reviewed against an external source: `command`, `args`, `env`, `disabled`, `autoApprove` and `disabledTools` (`docs/reference/kiro-cli/mcp/configuration.md`), plus `type` for the registry marker and `timeout`, which base already emitted and #3594 is partly about. `url` and `headers` are the REMOTE-server pair and are deliberately absent, so they are still dropped -- now as instances of the rule rather than as two named fields. Anything else is dropped with a warning. kiro-cli rejects a spec carrying a field it does not know and it rejects the WHOLE agent when it does, so a single stray `cwd` on a managed entry would cost the user every Kiro Crew tool. This became reachable *here* with the fix: the fresh-build path used to rebuild the entry from scratch and discarded every unknown key along with the user's customizations, so preserving `timeout`/`env`/`disabled` is exactly what put unknown keys back in reach.

Two of those keys are carried rather than re-derived for reasons worth naming. `disabledTools` is a user **guard**, not a preference -- dropping it would silently re-expose tools the user turned off, which is the same reasoning the custom-server `PUT` endpoint already applies when it round-trips that key. And only the `registry` **value** of `type` is ours: a transport hint the user wrote is theirs and kiro-cli tolerates it, which `test_refresh_preserves_a_user_transport_hint` pins deliberately, so the key is carried while the marker is re-derived from the signed-in account.

The right key with a wrong-**typed** value fails identically, because the spec is schema-checked: `"disabled": "false"` costs the user every Crew tool just as an unknown field does. So each user-authored key is checked against the type that same schema documents (`_MANAGED_MCP_ENTRY_VALUE_TYPES`) and dropped when it does not match -- dropped rather than coerced, the same call already made one level down for env entries, since a value we invent is not the one the user wrote and their well-typed siblings still survive. `command`/`args` are excluded because both callers set them before the enforcer runs, so their types are ours rather than input, and `env` is excluded because `sanitize_spec_env` already validates it per entry. One subtlety is pinned by its own test: `bool` is a subclass of `int` in Python, so a bare `isinstance` check would ship `"timeout": true` as a number.

Unlike the env-NAME case, this list is closed and finite -- the seven keys above with their documented types -- so it converges rather than growing a name per round.

A number can also be the right **type** and still not be representable. Python's `json` accepts bare `NaN`, `Infinity` and `-Infinity` on the way in, `isinstance` calls them floats, and `json.dumps` writes them straight back out -- but none of the three is JSON, so a conforming parser refuses the file and kiro-cli refuses the agent with it. The numeric check therefore also requires `math.isfinite`, which is one test for the whole class rather than another literal to remember: it covers all three at once.

And a list of the right type can hold the wrong **items**: both list-valued keys carry tool NAMES, so `disabledTools: [1]` satisfies a container-only check and still emits a spec kiro-cli refuses. `_MANAGED_MCP_ENTRY_ITEM_TYPES` validates the contents, filtered per ITEM rather than dropping the list -- the same rule already applied one level down to env entries. That distinction matters most for `disabledTools`: discarding the whole list because one item is malformed would re-expose every tool the user *did* name correctly, which is the opposite of what a guard is for.

## Tests

- `test_fresh_install_preserves_safe_managed_server_overrides` -- a clean rebuild keeps `timeout` / `disabled` / a user env key while `command`/`args` are restored and `url` is stripped.
- `test_fresh_install_strips_reserved_control_env_keys` -- pins the property a name list cannot state: two whole namespaces, `KIROCREW_` and `PYTHON`, refused by prefix and case-insensitively. It asserts `KIROCREW_CLI`, `PYTHONBREAKPOINT` and `PYTHONPLATLIBDIR`, plus `KIROCREW_NOT_YET_INVENTED` and `PYTHONNOTYETINVENTED` standing for the next variable in each namespace nobody has added yet, and the odd-cased `Kirocrew_Approval_Mode` / `pythonpath`. The user's own key still survives.
- `test_refresh_strips_reserved_control_env_keys` -- the refresh path scrubs the same set, since the shared enforcer is what makes the two paths agree.
- `test_fresh_install_drops_malformed_non_dict_env` -- a non-object `env` no longer aborts the rebuild.
- `test_fresh_install_drops_non_string_env_values` -- an `env` mixing an int, a bool, `null`, a list and a nested object keeps only the well-typed sibling, and every surviving pair is `str`/`str`.
- `test_fresh_install_pins_our_data_home_against_a_declared_home` -- `HOME`, `USERPROFILE` and the case variants `userprofile` / `UserProfile` / `Home` are all dropped from a managed entry while the user's genuine variable survives, asserted on a **simulated default install** because that is the configuration where the hijack was reachable. The assertion is `env == {"MINE": "keep"}`, so it also pins that no `env` churn was invented.
- `test_fresh_install_drops_unsupported_entry_keys` -- an entry declaring `cwd`, `initializationOptions`, `url` and `headers` keeps only `timeout` / `disabled` / `env` / `disabledTools`, and `set(entry) <= _MANAGED_MCP_ENTRY_KEYS` pins the closed set rather than the individual names, so the next unsupported field is caught without a new test.
- `test_refresh_drops_unsupported_entry_keys` -- the refresh path drops the same `cwd` and keeps the same `disabledTools`, since one enforcer owns both paths. Asserted on this path specifically because it is the one an existing config takes, so it is where dropping a guard would actually widen a live tool surface.
- `test/test_agent.py` 225 passed. Because this touched shared helpers, the suites that exercise them were run rather than just the obvious one: `test_computer_use_registration.py`, `test_computer_use_api.py`, `test_agent_config_merge_on_write.py`, `test_agent_home_isolation.py`, `test_agent_spec_preflight.py`, `test_mcp_rebuild_reconsumption.py`, `test_env.py`, `test_cron_script.py`, `test_runtime_home_write_paths.py`, `test_mcp_sync_agent.py`, `test_mcp_apply.py`, `test_connections_kiro_spec_fields.py` -- 921 passed / 3 skipped together -- plus a second batch over `test_cli.py`, `test_mcp_custom_api.py`, `test_mcp_dashboard_registration.py`, `test_mcp_registry_governance.py`, `test_app_mcp_scoping.py`, `test_config_patch.py`, `test_doctor_deadpath.py`, `test_installer_shim_and_cleanup.py`, `test_capability_agents_plugins.py`, `test_governance_distribution.py`, `test_spawn_audit.py`, `test_kiro_prerequisite.py` -- 1401 passed. isort, flake8, the black baseline gate and the brand-name gate all clean; mypy clean on both changed sources.
- `test_fresh_install_strips_launcher_exec_env_from_a_managed_entry` -- a managed entry declaring `PATH`, `BASH_ENV`, `ENV`, `SHELLOPTS`, `BASHOPTS`, `NODE_OPTIONS`, `NODE_PATH` and the case variants `Path` / `bash_env` emits `env == {"MINE": "keep"}`: every execution channel gone, the user's own variable intact, and no pin invented on a default install.
- `test_fresh_install_drops_a_non_finite_timeout` -- parametrized over `NaN`, `Infinity` and `-Infinity`, because `isfinite` is one test for one class and a fix naming only `NaN` would leave the infinities. It asserts the key is gone AND re-reads the emitted file with `parse_constant` wired to raise, since Python's own loader would happily accept the value that kiro-cli rejects.
- `test_refresh_drops_non_string_tool_list_items` -- a `disabledTools` of `["delete_file", 1, None, {"a": 1}]` and an `autoApprove` of `["read_file", 2]` emit exactly `["delete_file"]` and `["read_file"]`, so the correctly-named guard survives its malformed neighbours instead of being discarded with them.
- `test_fresh_install_drops_ill_typed_entry_values` -- an entry whose `disabled` is the string `"false"`, `timeout` the string `"45"` and `disabledTools` a bare string loses all three while the well-typed `env` sibling and our `command` survive.
- `test_fresh_install_drops_a_boolean_timeout` -- its own test because `bool` subclasses `int`, so a bare isinstance check leaks exactly here.
- Mutation-verified, fourteen ways: pointing `_SPEC_ENV_RESERVED_PREFIXES` at a name nothing matches turns both reserved-key tests red; narrowing the `PYTHON` prefix back to a single `PYTHONPATH` entry turns the fresh-path test red (naming `PYTHONHOME`, `PYTHONBREAKPOINT`, `PYTHONEXECUTABLE` as survivors); disabling the env type guard turns the typing test red, with the failure printing `PORT: 3000`, `FLAG: True` and `LISTY: ['a', 'b']` sitting in the emitted spec; emptying `_HOME_DERIVING_ENV_KEYS` turns the data-home test red with the declared `HOME` and `USERPROFILE` both surviving, while narrowing that strip back to an exact-case comparison turns it red on `userprofile` specifically; reverting the entry-key allow-list to the old two-name deny (`url`, `headers`) turns both entry-key tests red, while dropping `disabledTools` from the set alone turns both red on the guard specifically; and disabling the entry VALUE check turns both typing tests red, while keeping it but removing only the `bool`-is-an-`int` guard turns exactly the boolean-timeout test red; and pointing `_LAUNCHER_EXEC_ENV_KEYS` at a name nothing matches turns the launcher-exec test red, while reverting its comparison to exact case turns it red on the `Path` / `bash_env` spellings specifically; and removing the isfinite guard turns all three non-finite cases red, each failing on the strict re-read rather than on the missing key; and neutering the list-ITEM filter turns the tool-list test red, while switching it from per-item filtering to dropping the whole list turns it red on the surviving name specifically, so the per-item semantics are pinned and not just the filtering. The assertions are load-bearing rather than vacuous.
- One regression was caught by running the wider batch rather than the obvious file, and is worth recording because the reviewer's narrower fix turned out to be the right one. Treating the whole `type` key as ours -- dropping it and re-deriving it -- broke `test_mcp_registry_governance.py::TestRefreshMarker::test_refresh_preserves_a_user_transport_hint`, whose docstring already settles the question: "Only the registry marker is ours. A transport hint the user wrote is theirs, and kiro-cli tolerates it." The shipped version carries the key and re-derives only the `registry` value.
- Three failures on this workstation are base-owned and reproduce with this diff stashed, so they are not regressions: `test_mcp_discovery.py::TestProbeRemote::test_importing_this_module_does_not_pull_in_the_mint_engine` (`ModuleNotFoundError: No module named 'kiro_crew'` from a bare `python3 -c` subprocess), and two `test_cli.py` cases that depend on a bundled desktop ffmpeg and on the `cp950` codec being available.
- One local-only failure worth naming so it is not mistaken for a regression: `test_mcp_discovery.py::TestProbeRemote::test_importing_this_module_does_not_pull_in_the_mint_engine` fails on this workstation with `ModuleNotFoundError: No module named 'kiro_crew'`, because it spawns a bare `python3 -c` and the package is not installed in that interpreter. It fails identically with this diff stashed, and CI's backend shards pass it.
- `mypy` is clean on both changed source files; the 2 errors it reports in `src/kiro_crew/transcribe.py` are untouched by this diff and reproduce with these changes stashed.

## Pattern harvest

Rule candidate: semgrep
Pattern: an env map assembled from a user- or agent-writable source and handed to a trusted child process without routing through `env.sanitize_spec_env`

This is the second instance of that class in the repo -- `slack/gateway._cron_extra_env` strips `KIROCREW_APPROVAL_MODE` from `job.env` for exactly the same reason, and a managed `mcpServers` entry is the same shape reached through a different file.

The sharper harvest is that this PR's own first revision committed the defect it was written to fix. The reported bug was two hand-synced copies of an ownership rule drifting; the fix then hand-copied a reserved-key filter that `env.py` already owned, making a fourth spelling of the loader half and a second of the namespace half. Both reachable holes the reviewers found -- a missing `KIROCREW_CLI`, a case-sensitive compare -- are just the shared version's existing properties absent from the copy. Generalizable rule: a security filter expressed as a literal collection of names, in a file that is not the one owning that filter, is the smell; grep for a sibling deny-list before writing one, and prefer a prefix or namespace predicate over an enumeration, because an enumeration cannot cover the name nobody has added yet.

## Any other suggestions on the work

One improvement was deliberately left out to keep this fix's scope honest, and is better as a follow-up:

1. **Write-protect the override file itself.** `agent.json` is merged into a spec whose own directory (`.kiro/agents`) is already write-protected, so leaving the input writable makes it a side door into a protected output. Kiro Crew has one reader and zero writers for that file, so protecting it costs no feature. Note it would be an anchored entry, not a bare-token one -- `agent.json` is a generic filename, which is the case the scope note on `_BARE_TOKEN_PROTECTED_LEAVES` forbids.

The entry-key allow-list was originally listed here as a follow-up. GPT 5.6 was right that it could not wait: preserving a user's entry is what puts an unsupported key in reach, so the fail-open surface is one this PR opens rather than one it inherits. It is implemented above.

Closes #3594








