### PR TITLE
feat(discord): start allowed channel messages in threads

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -508,9 +508,12 @@ DM denials and authorization failures in configured threads are SEL-audited.
 Because Discord's global guild/message-content intents deliver every visible
 channel message, unrelated guild chatter is discarded silently; an approved
 user attempting an unapproved thread remains audit-worthy. Guild turns require
-both an approved sender and an exact `discord.allowed_thread_ids` match, then a
-REST channel lookup must confirm Discord type 10/11/12 before dispatch. Normal
-guild channels are always rejected. An approved thread is a shared disclosure
+an approved sender and either an exact `discord.allowed_thread_ids` match or an
+exact `discord.allowed_channel_ids` match. An allowed channel message is never
+handled in the shared channel itself: with `discord.auto_thread` enabled, the
+transport creates a public thread from that message and dispatches the turn
+there. Existing thread IDs still require a REST channel lookup confirming
+Discord type 10/11/12. An approved thread is a shared disclosure
 boundary: every member who can view it can read agent/tool output. Enabling any
 thread also means Discord delivers message content from every server channel
 the bot can see, although Kiro Crew immediately discards traffic outside
@@ -558,8 +561,9 @@ An inbound resume binding lives on the bound session's `session_map.json` row. A
   and are verified against Discord `GET /users/@me` before storage; rejection
   returns 400 and writes nothing, network failure saves with
   `verify_warning`. `bot_token_clear` must be a strict boolean.
-  `allowed_user_ids` and `allowed_thread_ids` accept numeric snowflake strings
-  only. Secrets land in `config_dir/.env` (atomic 0600) with `os.environ`
+  `allowed_user_ids`, `allowed_thread_ids`, and `allowed_channel_ids` accept
+  numeric snowflake strings only; `auto_thread` is a strict boolean. Secrets
+  land in `config_dir/.env` (atomic 0600) with `os.environ`
   synced; non-secrets go to
   `config.json` under `discord`. All fields are boot-read, so
   `restart_required` is true on any actual change.

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -5345,6 +5345,22 @@ class DiscordConfig:
             tags=["discord"],
         ),
     )
+    allowed_channel_ids: list[str] = field(
+        default_factory=list,
+        metadata=_meta(
+            "Allowed Channel IDs",
+            "Discord server channels where approved users may start a new agent thread.",
+            tags=["discord"],
+        ),
+    )
+    auto_thread: bool = field(
+        default=True,
+        metadata=_meta(
+            "Auto-create Threads",
+            "Create one Discord thread per approved message in an allowed channel.",
+            tags=["discord"],
+        ),
+    )
     soft_threshold_pct: int = field(
         default=80,
         metadata=_meta(
@@ -6323,6 +6339,8 @@ class KiroCrewConfig:
                 # transport's string comparison).
                 allowed_user_ids=_coerce_str_ids(discord_data.get("allowed_user_ids")),
                 allowed_thread_ids=_coerce_str_ids(discord_data.get("allowed_thread_ids")),
+                allowed_channel_ids=_coerce_str_ids(discord_data.get("allowed_channel_ids")),
+                auto_thread=bool(discord_data.get("auto_thread", True)),
                 soft_threshold_pct=max(
                     1, min(100, _coerce_int(discord_data.get("soft_threshold_pct"), 80))
                 ),

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -2762,6 +2762,8 @@ async def api_discord_config_get(request: web.Request) -> web.Response:
             "enabled": bool(dc.enabled),
             "allowed_user_ids": [str(u) for u in dc.allowed_user_ids],
             "allowed_thread_ids": [str(t) for t in dc.allowed_thread_ids],
+            "allowed_channel_ids": [str(c) for c in dc.allowed_channel_ids],
+            "auto_thread": bool(dc.auto_thread),
             "soft_threshold_pct": int(dc.soft_threshold_pct),
             "session_folder": dc.session_folder,
         }
@@ -2903,6 +2905,31 @@ async def _discord_config_save_locked(request: web.Request) -> web.Response:
         if new_ids != [str(t) for t in dc_cfg.get("allowed_thread_ids", [])]:
             staged["allowed_thread_ids"] = new_ids
             applied.append("allowed_thread_ids")
+
+    if "allowed_channel_ids" in body:
+        raw_ids = body.get("allowed_channel_ids")
+        if not isinstance(raw_ids, list):
+            return _deny("allowed_channel_ids must be a list")
+        new_ids = []
+        for item in raw_ids:
+            s = str(item).strip()
+            if not s:
+                continue
+            if not s.isdigit():
+                return _deny(f"invalid Discord channel ID: {s} (numeric IDs only)")
+            if s not in new_ids:
+                new_ids.append(s)
+        if new_ids != [str(c) for c in dc_cfg.get("allowed_channel_ids", [])]:
+            staged["allowed_channel_ids"] = new_ids
+            applied.append("allowed_channel_ids")
+
+    if "auto_thread" in body:
+        val = body.get("auto_thread")
+        if not isinstance(val, bool):
+            return _deny("auto_thread must be a boolean")
+        if val != bool(dc_cfg.get("auto_thread", True)):
+            staged["auto_thread"] = val
+            applied.append("auto_thread")
 
     if "soft_threshold_pct" in body:
         pct = body.get("soft_threshold_pct")

--- a/src/kiro_crew/discord/client.py
+++ b/src/kiro_crew/discord/client.py
@@ -241,6 +241,22 @@ class DiscordClient:
         result = await self._api("POST", f"/channels/{channel_id}/messages", payload)
         return str(result.get("id")) if result else None
 
+    async def create_thread_from_message(
+        self, channel_id: str, message_id: str, name: str
+    ) -> str | None:
+        """Create a public thread rooted at an existing channel message."""
+        result = await self._api(
+            "POST",
+            f"/channels/{channel_id}/messages/{message_id}/threads",
+            {"name": name[:100], "auto_archive_duration": 1440},
+        )
+        if not result:
+            return None
+        thread_id = str(result.get("id") or "")
+        if thread_id:
+            self._channel_types[thread_id] = 11
+        return thread_id or None
+
     async def edit_message(
         self,
         channel_id: str,

--- a/src/kiro_crew/discord/gateway.py
+++ b/src/kiro_crew/discord/gateway.py
@@ -62,6 +62,10 @@ async def maybe_start_discord(orch: "GatewayOrchestrator") -> "DiscordClient | N
         allowed_threads: set[str] = set(
             getattr(orch, "_discord_allowed_thread_ids", []) or []
         )
+        allowed_channels: set[str] = set(
+            getattr(orch, "_discord_allowed_channel_ids", []) or []
+        )
+        auto_thread = bool(getattr(orch, "_discord_auto_thread", True))
         if not allowed_ids:
             logger.warning(
                 "Discord: allowed_user_ids is empty — the bot is reachable by "
@@ -83,12 +87,15 @@ async def maybe_start_discord(orch: "GatewayOrchestrator") -> "DiscordClient | N
         client = DiscordClient(
             token=bot_token,
             on_interaction=dispatcher.on_interaction,
-            enable_guild_threads=bool(allowed_threads),
+            enable_guild_threads=bool(allowed_threads or allowed_channels),
         )
         transport = DiscordTransport(
             client,
             allowed_user_ids=allowed_ids,
             allowed_thread_ids=allowed_threads,
+            allowed_channel_ids=allowed_channels,
+            auto_thread=auto_thread,
+            on_thread_created=dispatcher.register_allowed_thread,
             dispatch=dispatcher.handle_message,
         )
         # Inbound: Gateway WS -> transport.receive (authorize + normalize)

--- a/src/kiro_crew/discord/transport.py
+++ b/src/kiro_crew/discord/transport.py
@@ -10,9 +10,9 @@ Dependency direction is ``discord -> messaging`` (allowed); the neutral
 
 Security: :meth:`authorize` is **deny-by-default**. A Discord bot can be DM'd
 by anyone who shares a server with it, so an empty ``allowed_user_ids`` MUST
-authorize nobody. Guild traffic additionally requires an exact thread-ID
-allow-list match and a Discord-confirmed thread channel type; normal guild
-channels are always denied.
+authorize nobody. Guild traffic additionally requires either an exact thread-ID
+allow-list match or an approved channel whose message can be promoted into a
+new thread; turns never run directly in a normal guild channel.
 """
 
 from __future__ import annotations
@@ -26,6 +26,7 @@ from kiro_crew.discord.client import (
     DiscordClient,
     DiscordInbound,
 )
+from kiro_crew.messaging.identity import channel_inbound_permitted
 from kiro_crew.messaging.transport import (
     ConfiguredChannelTarget,
     InboundMessage,
@@ -93,13 +94,25 @@ class DiscordTransport(MessagingTransport):
         *,
         allowed_user_ids: Iterable[str] = (),
         allowed_thread_ids: Iterable[str] = (),
+        allowed_channel_ids: Iterable[str] = (),
+        auto_thread: bool = True,
+        on_thread_created: Callable[[str], None] | None = None,
         dispatch: DispatchFn | None = None,
     ) -> None:
         self._client = client
         # Deny-by-default: freeze both allow-lists as snowflake strings so they
         # cannot mutate under an in-flight authorization decision.
         self._allowed: frozenset[str] = frozenset(str(u) for u in allowed_user_ids)
-        self._allowed_threads: frozenset[str] = frozenset(str(t) for t in allowed_thread_ids)
+        # Mutable: an approved user's message in an allowed channel can promote
+        # itself into a brand-new thread at runtime (see ``receive`` below), and
+        # that thread must immediately become valid for the user's own follow-up
+        # replies -- not just for button interactions (tracked separately on the
+        # dispatcher's own allow-set). A frozenset here would silently strand
+        # every reply the user sends into the thread the bot just created.
+        self._allowed_threads: set[str] = {str(t) for t in allowed_thread_ids}
+        self._allowed_channels: frozenset[str] = frozenset(str(c) for c in allowed_channel_ids)
+        self._auto_thread = auto_thread
+        self._on_thread_created = on_thread_created
         self._dispatch = dispatch
         self.capabilities = DISCORD_CAPABILITIES
 
@@ -203,13 +216,66 @@ class DiscordTransport(MessagingTransport):
         if not inbound.text and not inbound.attachments:
             return
         thread_id: str | None = None
+        conversation_id = inbound.channel_id
         if inbound.guild_id:
             # Discord's guild intents deliver every visible channel message.
             # Unrelated chatter is expected background traffic, not a security
             # event: discard it silently unless an approved user tried to use
             # an unapproved thread. Messages in configured threads still pass
             # through the normal user authorization audit below.
-            if inbound.channel_id not in self._allowed_threads:
+            if inbound.channel_id in self._allowed_channels:
+                if inbound.user_id not in self._allowed:
+                    # Reuse the normal denial audit without creating a shared
+                    # channel thread for an unauthorized sender.
+                    self.authorize(
+                        DiscordInboundMessage(
+                            channel_type="discord",
+                            user_id=inbound.user_id,
+                            conversation_id=inbound.channel_id,
+                            text=inbound.text,
+                        )
+                    )
+                    return
+                if not self._auto_thread or not inbound.message_id:
+                    return
+                # Re-check the same runtime channels-governance gate that
+                # ``DiscordDispatcher.handle_message`` enforces, but *before* the
+                # REST call below: creating the thread is itself a visible,
+                # irreversible side effect (a real public thread appears in the
+                # server), so a policy that denies Discord inbound after connect
+                # must stop it from happening at all -- not just stop the turn
+                # that would have followed it.
+                if not await channel_inbound_permitted("discord"):
+                    sel().log_api_access(
+                        caller=inbound.user_id,
+                        operation="discord_transport.receive",
+                        outcome="denied_by_channels_governance",
+                        source="discord",
+                    )
+                    return
+                title = " ".join(inbound.text.split())[:90] or "Kiro Crew"
+                created = await self._client.create_thread_from_message(
+                    inbound.channel_id, inbound.message_id, title
+                )
+                if not created:
+                    sel().log_api_access(
+                        caller=inbound.user_id,
+                        operation="discord_transport.receive",
+                        outcome="thread_create_failed",
+                        source="discord",
+                    )
+                    return
+                thread_id = created
+                conversation_id = created
+                # Authorize the thread transport-side FIRST: this is the set
+                # ``receive`` itself checks for every subsequent message
+                # (`elif inbound.channel_id not in self._allowed_threads` below).
+                # The dispatcher's own copy (button interactions) is updated via
+                # the callback right after.
+                self._allowed_threads.add(created)
+                if self._on_thread_created is not None:
+                    self._on_thread_created(created)
+            elif inbound.channel_id not in self._allowed_threads:
                 if inbound.user_id in self._allowed:
                     sel().log_api_access(
                         caller=inbound.user_id,
@@ -218,11 +284,12 @@ class DiscordTransport(MessagingTransport):
                         source="discord",
                     )
                 return
-            thread_id = inbound.channel_id
+            else:
+                thread_id = inbound.channel_id
         msg = DiscordInboundMessage(
             channel_type="discord",
             user_id=inbound.user_id,
-            conversation_id=inbound.channel_id,
+            conversation_id=conversation_id,
             text=inbound.text,
             thread_id=thread_id,
             message_id=inbound.message_id,

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -176,6 +176,10 @@ class DiscordDispatcher:
         # Kept as a direct alias for diagnostics/tests; the controller owns it.
         self._session_pickers = self._session_resume.pickers
 
+    def register_allowed_thread(self, thread_id: str) -> None:
+        """Authorize interactions in a thread created by the inbound transport."""
+        self._allowed_threads.add(thread_id)
+
     # ── Turn dispatch (transport's dispatch callback) ──────────────────────
 
     async def handle_message(

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -1050,6 +1050,10 @@ class GatewayOrchestrator:
         self._discord_allowed_thread_ids: list[str] = [
             str(t) for t in cfg.discord.allowed_thread_ids
         ]
+        self._discord_allowed_channel_ids: list[str] = [
+            str(c) for c in cfg.discord.allowed_channel_ids
+        ]
+        self._discord_auto_thread = bool(cfg.discord.auto_thread)
         self._discord_client: "DiscordClient | None" = None
         # Webex — the WEBEX_BOT_TOKEN credential (env/.env) overrides
         # cfg.webex.bot_token; all other settings come from the typed

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -83,6 +83,7 @@ class FakeClient:
         self.acked: list[str] = []
         self.reactions: list[tuple[str, str]] = []
         self.thread_channels: set[str] = set()
+        self.created_threads: list[tuple[str, str, str]] = []
         self.attachment_bodies: dict[str, bytes] = {}
         self.attachment_downloads: list[str] = []
         self._mid = 100
@@ -131,6 +132,14 @@ class FakeClient:
 
     async def create_dm_channel(self, user_id: str) -> str:
         return f"dm-{user_id}"
+
+    async def create_thread_from_message(
+        self, channel_id: str, message_id: str, name: str
+    ) -> str:
+        thread_id = f"thread-{message_id}"
+        self.created_threads.append((channel_id, message_id, name))
+        self.thread_channels.add(thread_id)
+        return thread_id
 
     async def download_attachment(self, url: str, dest: str) -> None:
         self.attachment_downloads.append(url)
@@ -1092,7 +1101,10 @@ class TestConfiguredTargets:
 
 class TestTransportReceive:
     def _transport(
-        self, allowed: list[str], allowed_threads: list[str] | None = None
+        self,
+        allowed: list[str],
+        allowed_threads: list[str] | None = None,
+        allowed_channels: list[str] | None = None,
     ) -> tuple[DiscordTransport, list[InboundMessage], FakeClient]:
         dispatched: list[InboundMessage] = []
 
@@ -1105,6 +1117,7 @@ class TestTransportReceive:
             client,  # type: ignore[arg-type]
             allowed_user_ids=allowed,
             allowed_thread_ids=allowed_threads or [],
+            allowed_channel_ids=allowed_channels or [],
             dispatch=_dispatch,
         )
         return t, dispatched, client
@@ -1155,6 +1168,99 @@ class TestTransportReceive:
         await t.receive(DiscordInbound(channel_id="t1", user_id="u1", text="hello", guild_id="g1"))
         assert len(dispatched) == 1
         assert dispatched[0].thread_id == "t1"
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_channel_creates_thread_before_dispatch(self) -> None:
+        t, dispatched, client = self._transport(["u1"], allowed_channels=["c1"])
+        await t.receive(
+            DiscordInbound(
+                channel_id="c1",
+                user_id="u1",
+                text="Plan the release",
+                message_id="m1",
+                guild_id="g1",
+            )
+        )
+
+        assert client.created_threads == [("c1", "m1", "Plan the release")]
+        assert len(dispatched) == 1
+        assert dispatched[0].conversation_id == "thread-m1"
+        assert dispatched[0].thread_id == "thread-m1"
+
+    @pytest.mark.asyncio
+    async def test_followup_message_in_auto_created_thread_dispatches(self) -> None:
+        """The thread the transport just created must be immediately valid for
+        the same user's next message, not just for button interactions -- a
+        frozen ``_allowed_threads`` would silently strand every reply."""
+        t, dispatched, _ = self._transport(["u1"], allowed_channels=["c1"])
+        await t.receive(
+            DiscordInbound(
+                channel_id="c1",
+                user_id="u1",
+                text="Plan the release",
+                message_id="m1",
+                guild_id="g1",
+            )
+        )
+        assert len(dispatched) == 1
+        created_thread_id = dispatched[0].conversation_id
+
+        await t.receive(
+            DiscordInbound(
+                channel_id=created_thread_id,
+                user_id="u1",
+                text="Here's a follow-up",
+                message_id="m2",
+                guild_id="g1",
+            )
+        )
+
+        assert len(dispatched) == 2
+        assert dispatched[1].conversation_id == created_thread_id
+        assert dispatched[1].thread_id == created_thread_id
+        assert dispatched[1].text == "Here's a follow-up"
+
+    @pytest.mark.asyncio
+    async def test_channels_governance_denial_blocks_thread_creation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A runtime channels-governance deny must stop the REST thread-create
+        call itself -- not just the turn that would have followed it -- since
+        creating the thread is a visible, irreversible side effect."""
+
+        async def _denied(_channel_type: str) -> bool:
+            return False
+
+        monkeypatch.setattr("kiro_crew.discord.transport.channel_inbound_permitted", _denied)
+        t, dispatched, client = self._transport(["u1"], allowed_channels=["c1"])
+        await t.receive(
+            DiscordInbound(
+                channel_id="c1",
+                user_id="u1",
+                text="Plan the release",
+                message_id="m1",
+                guild_id="g1",
+            )
+        )
+
+        assert client.created_threads == []
+        assert dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_channel_rejects_unapproved_user_without_thread(self) -> None:
+        t, dispatched, client = self._transport(["u1"], allowed_channels=["c1"])
+        await t.receive(
+            DiscordInbound(
+                channel_id="c1",
+                user_id="u2",
+                text="hello",
+                message_id="m1",
+                guild_id="g1",
+            )
+        )
+
+        assert client.created_threads == []
+        assert dispatched == []
 
     @pytest.mark.asyncio
     async def test_normal_channel_denied_even_if_id_is_allowlisted(self) -> None:

--- a/test/test_discord_client_coverage.py
+++ b/test/test_discord_client_coverage.py
@@ -382,6 +382,30 @@ class TestOutboundRest:
         assert await client.send_message("c1", "hi") is None
 
     @pytest.mark.asyncio
+    async def test_create_thread_from_message_uses_root_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = _make_client()
+        calls: list[tuple[str, str, Any]] = []
+
+        async def _api(method: str, path: str, payload: Any, timeout: int = 30) -> Any:
+            calls.append((method, path, payload))
+            return {"id": "t9"}
+
+        monkeypatch.setattr(client, "_api", _api)
+        result = await client.create_thread_from_message("c1", "m2", "Topic")
+
+        assert result == "t9"
+        assert calls == [
+            (
+                "POST",
+                "/channels/c1/messages/m2/threads",
+                {"name": "Topic", "auto_archive_duration": 1440},
+            )
+        ]
+        assert await client.is_thread_channel("t9") is True
+
+    @pytest.mark.asyncio
     async def test_edit_message_omits_components_when_not_supplied(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/test/test_discord_config_handlers.py
+++ b/test/test_discord_config_handlers.py
@@ -101,6 +101,8 @@ def test_save_persists_token_and_config(tmp_path: Path, monkeypatch) -> None:
             "enabled": True,
             "allowed_user_ids": ["123456789012345678", "987654321098765432"],
             "allowed_thread_ids": ["234567890123456789"],
+            "allowed_channel_ids": ["345678901234567890"],
+            "auto_thread": False,
             "soft_threshold_pct": 75,
         },
     )
@@ -117,9 +119,11 @@ def test_save_persists_token_and_config(tmp_path: Path, monkeypatch) -> None:
         "987654321098765432",
     ]
     assert cfg["discord"]["allowed_thread_ids"] == ["234567890123456789"]
-    assert loader.KiroCrewConfig.load().discord.allowed_thread_ids == [
-        "234567890123456789"
-    ]
+    assert cfg["discord"]["allowed_channel_ids"] == ["345678901234567890"]
+    loaded = loader.KiroCrewConfig.load().discord
+    assert loaded.allowed_thread_ids == ["234567890123456789"]
+    assert loaded.allowed_channel_ids == ["345678901234567890"]
+    assert loaded.auto_thread is False
     assert cfg["discord"]["soft_threshold_pct"] == 75
 
 
@@ -199,6 +203,26 @@ def test_save_rejects_non_numeric_thread_ids(tmp_path: Path, monkeypatch) -> Non
     assert status == 400
     assert "thread ID" in body["error"]
     assert "numeric" in body["error"]
+
+
+def test_save_rejects_non_numeric_channel_ids(tmp_path: Path, monkeypatch) -> None:
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    _accept_token(monkeypatch, mod)
+    (status_body, _) = _client_put(
+        mod, monkeypatch, tmp_path, {"allowed_channel_ids": ["general"]}
+    )
+    status, body = status_body
+    assert status == 400
+    assert "channel ID" in body["error"]
+
+
+def test_save_requires_boolean_auto_thread(tmp_path: Path, monkeypatch) -> None:
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    _accept_token(monkeypatch, mod)
+    (status_body, _) = _client_put(mod, monkeypatch, tmp_path, {"auto_thread": "true"})
+    assert status_body[0] == 400
 
 
 def test_clear_flag_must_be_strict_boolean(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Problem / Motivation

Discord guild traffic currently works only in pre-registered threads. Even an approved user cannot start a conversation from a normal server channel.

## Why it matters

Users must either mix every topic in one DM or manually copy thread IDs into configuration and restart before each new conversation.

## What changed (motivation → approach → change)

Discord configuration now supports `allowed_channel_ids` and `auto_thread`. A message from an approved user in an allowed channel creates a public thread rooted at that message, registers the new thread for subsequent interactions, and dispatches the turn there. Unknown users cannot create threads, existing `allowed_thread_ids` behavior remains intact, and turns never execute directly in a shared root channel. The settings API validates and persists the new fields, and the messaging specification documents the disclosure boundary.

## Tests

- `pytest -q test/test_discord_config_handlers.py` — 24 passed
- `pytest -q test/test_discord.py -k TransportReceive` — 13 passed
- `pytest -q test/test_discord_client_coverage.py -k create_thread_from_message` — passed
- `./scripts/docs-lint.sh` — passed
- `isort --check-only` on changed Python files — passed
- `flake8` on changed Python files — passed
- `git diff --check` — passed

## Manual verification

N/A — a live Discord bot credential and guild are not available locally; REST construction, authorization, thread registration, dispatch routing, configuration persistence, and validation are covered by focused tests.

## Related Issues

Fixes #3680

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — exact CLA wording is still pending in the repository template.
