### PR TITLE
docs(mcp): distinguish connection from tool exposure

### DIFF
--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -353,6 +353,12 @@ request, so one dead entry surfaces as a transient 5xx and then a hard error for
 **all** requests, not just that app's. The enable path re-registers with the
 real port once the backend is up.
 
+Connection and tool exposure are separate. An entry in `mcpServers` is still
+connected even when it has no matching `@server` reference in `tools`; omitting
+the reference hides that server's tools from the agent but does not avoid the
+process or connection cost. Isolation and feature gates that must avoid that
+cost therefore remove the server entry itself as well as its tool reference.
+
 An app agent that references a host-managed server (`@kirocrew-core`,
 `@kirocrew-cron`) in its `tools` gets the launch spec copied in by
 `_materialize_managed_refs()`. kiro-cli resolves a `@server` ref against the

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2379,9 +2379,9 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     for _app_srv, _app_spec in _collect_app_mcp_servers().items():
         if _app_srv not in managed_names:
             config.setdefault("mcpServers", {})[_app_srv] = _app_spec
-            # MOUNT it: a server present only in `mcpServers` is defined but never
-            # referenced, so kiro-cli never loads it and the app's tools are
-            # silently unavailable. `tools` is the unconditional mount (the final
+            # EXPOSE it: kiro-cli connects entries declared in `mcpServers`, but
+            # an unreferenced server contributes no tools to the agent. `tools`
+            # is the unconditional exposure list (the final
             # dedup below removes any duplicate); auto-approve stays governed —
             # the spec's `autoApprove` was already ceiling-filtered in
             # _collect_app_mcp_servers, and the final allowedTools pass covers the


### PR DESCRIPTION
## Problem / Motivation

The app-agent writer says an unreferenced `mcpServers` entry is never loaded, while the MCP architecture says every declared entry is connected. Those statements make opposite recommendations for zero-cost feature gates.

## Why it matters

A contributor can remove only an `@server` tool reference, believe the backend will not start, and leave the process or connection cost in place.

## What changed (motivation → approach → change)

The two behaviors apply to separate layers: declaration controls connection, while the `tools` reference controls exposure to the agent. The code comment now uses “expose” instead of “mount/load,” and the architecture guide explicitly states that hiding a tool reference does not avoid connection cost. Gates that require zero cost must remove both the declaration and the reference.

## Tests

- `pytest -q test/test_agent.py -k dashboard_added_remote_server_reaches_the_tools_allowlist` — passed
- `./scripts/docs-lint.sh` — passed
- `isort --check-only src/kiro_crew/agent.py` — passed
- `flake8 src/kiro_crew/agent.py` — passed
- `git diff --check` — passed

## Manual verification

N/A — this reconciles documentation around an existing contract; the focused agent-config test verifies that a declared dashboard server receives its exposure reference.

## Related Issues

Fixes #3509

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — exact CLA wording is still pending in the repository template.
