### PR TITLE
perf(security): gate the self-floor descent behind an O(n) necessary condition (#3603)

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -3543,6 +3543,88 @@ def _python_reads_stdin(later_tokens: list[str]) -> bool:
     return True  # nothing but flags → bare interpreter reads stdin
 
 
+# ── Self-protection floor short-circuit (perf, issue #3603) ──
+# The floor predicates below re-tokenize the command and descend every nested
+# shell payload (`_self_token_frames`), which is where the cost of the deny
+# scan concentrates: it scales with NESTING COMPLEXITY, and each `is_denied`
+# call runs the descent three times (mint once, kill twice). The common tool
+# call — a tool name plus a path — can never fire either predicate, so the
+# descent is pure waste there.
+#
+# The gate is a NECESSARY condition, deliberately wider than the issue's
+# proposal of a raw `_SELF_NAME_RE` search. That proposal is UNSOUND: the
+# predicates fire on inputs whose raw text never matches `kiro[-.]?crew` —
+# `python -m kiro_crew token` (the underscored import spelling), `[k]irocrew
+# token` (one-char bracket class), `kiro$()crew` (empty substitution),
+# `kiro${x:-crew}` (parameter default), `bash -c "\x6birocrew token"` (printf
+# escapes), `kiro?rew` (glob the shell expands before exec), and a `-c`
+# payload reaching the CLI through `exec`/`b64decode` with no name at all.
+# Every one of those was verified to be denied by the floor today, so a gate
+# that skipped them would be a real bypass, not an optimization.
+#
+# Sound formulation: the floor can only fire if, after the normalizations the
+# predicates themselves apply (shlex quote-stripping, `_debracket`,
+# `_resolve_param_defaults`, `_EMPTY_SUBST_RE`, `_decode_printf_escapes`,
+# `_glob_could_expand_to`), the text yields a self name/module — or an inline
+# dynamic-exec primitive stands in for it. Each normalization needs specific
+# MACHINERY characters present in the raw text, so the union below is a
+# superset of every firing path:
+#   * the literal name in any spelling (`kiro[-._]?crew` — underscore included
+#     for the module/import form, which `_SELF_NAME_RE` deliberately omits);
+#   * any machinery character that lets a normalization synthesize the name or
+#     a program spelling: glob/brace chars (`? * [ ] { }` — `_glob_could_expand_to`
+#     admits e.g. `k*w` for the program AND `*kill` for the kill verbs),
+#     `$` (substitutions, parameter defaults, ANSI-C quoting), backticks, and
+#     `~` (tilde expansion — the kill predicates expanduser their targets, so
+#     `pkill -f ~` IS a self-kill whenever $HOME lies under the product tree,
+#     with no name and no other machinery in the raw text);
+#   * printf numeric escapes (`\xHH`, `\NNN`) that can spell arbitrary
+#     characters once `_decode_printf_escapes` runs on a nested payload;
+#   * the dynamic-exec markers `_inline_payload_reaches_cli` accepts in place
+#     of a literal import — checked on the raw text AND on the quote-stripped
+#     text, because empty-quote glue hides the verb exactly as it hides the
+#     name (`python -c "ex""ec(...)"` carries no name and no other machinery,
+#     yet the floor denies it: pre-merge review finding);
+#   * the literal name after stripping quotes/backslashes (`k""iro""crew`,
+#     `ki\rocrew` — shlex removes those before the predicates compare).
+# When none of these is present, no predicate can return True, so the descent
+# is skipped. False positives (e.g. any `$VAR` in a command) merely fall back
+# to the full scan — the safe direction.
+#
+# Matched WITHOUT re.IGNORECASE on purpose: the floor's own contract is that
+# callers pass already-lowercased text (`is_denied` lowercases once), and the
+# predicates' regexes are lowercase-only too.
+_SELF_FLOOR_NAME_HINT_RE = re.compile(r"kiro[-._]?crew")
+_SELF_FLOOR_MACHINERY_RE = re.compile(r"[?*\[\]{}$`~]|\\x[0-9a-f]|\\0?[0-7]{1,3}")
+_SELF_FLOOR_QUOTE_JUNK_RE = re.compile(r"[\"'\\\\]")
+
+
+def _self_floor_can_fire(text_lower: str) -> bool:
+    """Cheap O(n) necessary condition for the self-protection floor predicates.
+
+    Returns False only when ``_is_credential_mint`` and ``_is_self_kill`` are
+    PROVABLY unable to fire on *text_lower*, so both can skip the recursive
+    payload descent. Any "maybe" answers True and runs the full scan — the
+    gate can over-trigger but never under-trigger (see the block comment above
+    for the case analysis).
+    """
+    if _SELF_FLOOR_NAME_HINT_RE.search(text_lower):
+        return True
+    if _SELF_FLOOR_MACHINERY_RE.search(text_lower):
+        return True
+    if _INLINE_DYNAMIC_EXEC_RE.search(text_lower):
+        return True
+    # Quote/backslash glue is removable by the tokenizer, so the name AND the
+    # dynamic-exec verb may only materialize once those come off:
+    # `k""iro""crew token`, `"kirocrew" token`, `python -c "ex""ec(...)"`.
+    # Both must be re-checked here -- testing only the name would let a glued
+    # `exec(` payload skip the descent while the floor still denies it.
+    stripped = _SELF_FLOOR_QUOTE_JUNK_RE.sub("", text_lower)
+    if _SELF_FLOOR_NAME_HINT_RE.search(stripped):
+        return True
+    return bool(_INLINE_DYNAMIC_EXEC_RE.search(stripped))
+
+
 def _is_credential_mint(text_lower: str) -> bool:
     """True if *text_lower* invokes the ``kirocrew token`` credential mint.
 
@@ -3559,6 +3641,11 @@ def _is_credential_mint(text_lower: str) -> bool:
     argv whose PROGRAM is the CLI, and ``kirocrew doctor | grep token`` puts the
     word in ``grep``'s argv, not the CLI's.
     """
+    # Perf short-circuit (#3603): the tokenize-and-descend below is the deny
+    # scan's dominant cost, and it cannot produce a hit when the gate says the
+    # input carries neither a self name nor the machinery to synthesize one.
+    if not _self_floor_can_fire(text_lower):
+        return False
     for tokens in _self_token_frames(text_lower):
         programs = _argv_programs(tokens)
         for i, token in enumerate(tokens):
@@ -3667,6 +3754,11 @@ def _is_self_kill(text_lower: str) -> bool:
       product path is NOT a self-kill -- that is the false positive this
       replaced.
     """
+    # Perf short-circuit (#3603): both loops below re-run the payload descent.
+    # A kill can only target the product if the gate's necessary condition
+    # holds, so a miss skips both descents.
+    if not _self_floor_can_fire(text_lower):
+        return False
     for tokens in _self_token_frames(text_lower):
         programs = _argv_programs(tokens)
         for i, token in enumerate(tokens):

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -2922,3 +2922,149 @@ class TestCredentialMintSegmentScoping:
         mentioned_after = f"grep {_TOK}_auth.py  # in a {_NAME} worktree"
         assert _denied_by(under_path) is None
         assert _denied_by(mentioned_after) is None
+
+
+class TestSelfFloorShortCircuit:
+    """Perf gate for the self-protection floor (issue #3603).
+
+    The floor predicates tokenize the command and descend every nested shell
+    payload, which dominates deny-scan cost on complex bash. The gate
+    ``_self_floor_can_fire`` skips that descent when firing is provably
+    impossible. Ratcheted on STRUCTURE, never timing: (a) a benign command
+    performs ZERO descents; (b) every obfuscated spelling the floor denies
+    today still passes the gate, so no bypass window opens.
+    """
+
+    def _descent_calls(self, monkeypatch, text: str) -> int:
+        from kiro_crew import security
+
+        calls = {"n": 0}
+        real = security._self_token_frames
+
+        def spy(t: str):
+            calls["n"] += 1
+            return real(t)
+
+        monkeypatch.setattr(security, "_self_token_frames", spy)
+        security._is_credential_mint(text)
+        security._is_self_kill(text)
+        return calls["n"]
+
+    def test_benign_command_skips_the_descent_entirely(self, monkeypatch):
+        # The 95%+ common case: a tool name plus a path. No self name, no
+        # shell machinery — the recursive tokenize-and-descend must not run.
+        for benign in (
+            "fs_read /workplace/user/project/src/main.py",
+            "ls -la /tmp/foo",
+            "git status",
+            "cat notes.txt",
+            "npm run build",
+        ):
+            assert self._descent_calls(monkeypatch, benign) == 0, (
+                f"descent ran for benign input: {benign!r}"
+            )
+
+    def test_name_carrying_command_still_descends(self, monkeypatch):
+        # A real candidate must reach the full structural scan.
+        assert self._descent_calls(monkeypatch, "kirocrew token") >= 1
+        assert self._descent_calls(monkeypatch, "pkill -f kirocrew") >= 1
+
+    def test_gate_is_a_necessary_condition_not_a_name_grep(self):
+        """Every obfuscated spelling the floor denies must pass the gate.
+
+        The issue proposed gating on a raw ``_SELF_NAME_RE`` search; that is
+        UNSOUND — each input below fires a predicate today while its raw text
+        never matches ``kiro[-.]?crew``. The gate must answer True for all of
+        them (over-matching is safe; under-matching is a bypass).
+        """
+        from kiro_crew import security
+
+        for evasive in (
+            "python -m kiro_crew token",  # underscored module spelling
+            "[k]irocrew token",  # one-char bracket class
+            "kiro$()crew token",  # empty command substitution
+            "kiro${x:-crew} token",  # parameter default
+            'bash -c "\\x6birocrew token"',  # printf hex escape
+            'k""iro""crew token',  # empty-string concatenation
+            "kiro?rew token",  # glob the shell expands before exec
+            "kill $(pgrep -f kirocrew)",  # bare kill via substitution
+            'python -c "exec(__import__(\'base64\').b64decode(\'x\'))" token',
+        ):
+            assert security._self_floor_can_fire(evasive), (
+                f"gate would bypass the floor for {evasive!r}"
+            )
+
+    def test_gated_predicates_still_deny_the_obfuscation_corpus(self):
+        """End-to-end: the predicates (with the gate in front) keep firing."""
+        from kiro_crew import security
+
+        for mint in (
+            "[k]irocrew token",
+            "kiro$()crew token",
+            "kiro${x:-crew} token",
+            'bash -c "\\x6birocrew token"',
+            'k""iro""crew token',
+            "kiro?rew token",
+        ):
+            assert security._is_credential_mint(mint), f"mint not caught: {mint!r}"
+        assert security._is_self_kill("kill $(pgrep -f kirocrew)")
+        assert security._is_self_kill("pkill -f kirocrew")
+
+    def test_gate_declines_plain_text_without_machinery(self):
+        from kiro_crew import security
+
+        for plain in (
+            "ls -la /tmp/foo",
+            "git status",
+            "grep token app.log",
+            "cat /workplace/user/notes.txt",
+        ):
+            assert not security._self_floor_can_fire(plain), (
+                f"gate over-triggered on {plain!r}"
+            )
+
+    def test_tilde_expansion_still_reaches_the_floor(self, monkeypatch):
+        """``pkill -f ~`` IS a self-kill whenever $HOME lies under the product
+        tree: the kill predicates expanduser their targets, so the raw text
+        carries neither the self name nor any other machinery character.
+        ``~`` must therefore be in the machinery class, or the gate opens a
+        real bypass (pre-push review finding).
+        """
+        from kiro_crew import security
+
+        # expanduser reads HOME on POSIX but USERPROFILE on Windows — set
+        # both so the tilde target resolves under the product tree everywhere.
+        monkeypatch.setenv("HOME", "/opt/kiro-crew")
+        monkeypatch.setenv("USERPROFILE", "/opt/kiro-crew")
+        for kill in ("pkill -f ~", "killall ~", "pkill -f ~/"):
+            assert security._self_floor_can_fire(kill), (
+                f"gate would bypass the floor for {kill!r}"
+            )
+        # End-to-end: the gated predicate still denies it.
+        assert security._is_self_kill("pkill -f ~")
+
+    def test_quote_glued_dynamic_exec_still_reaches_the_floor(self):
+        """Empty-quote glue hides the dynamic-exec verb exactly as it hides the
+        name.  ``python -c "ex""ec(...)"`` carries no product name, no machinery
+        character, and no *raw* ``exec(`` — yet the floor denies it as a
+        credential mint, because the tokenizer removes the quotes before
+        ``_inline_payload_reaches_cli`` looks.  The gate must therefore search
+        the dynamic-exec marker on the quote-stripped text too, not only on the
+        raw text (pre-merge review finding, confirmed by two reviewers).
+        """
+        from kiro_crew import security
+
+        glued = "ex" + '""' + "ec"
+        cmd = f'python -c "{glued}(open(chr(47)).read())"'
+
+        # Precondition: none of the other branches can catch this input, so the
+        # test genuinely exercises the stripped dynamic-exec branch.
+        assert not security._SELF_FLOOR_NAME_HINT_RE.search(cmd)
+        assert not security._SELF_FLOOR_MACHINERY_RE.search(cmd)
+        assert not security._INLINE_DYNAMIC_EXEC_RE.search(cmd)
+
+        assert security._self_floor_can_fire(cmd), (
+            "gate would bypass the floor for quote-glued dynamic exec"
+        )
+        # And the floor's verdict survives the gate: still denied end-to-end.
+        assert security._is_credential_mint(cmd)


### PR DESCRIPTION
## What is the problem?

Credential redaction and the deny-command scan run synchronously on the event loop for every tool call. The reported 2.1s median stall turned out to be a worst case that scales with a shell command's NESTING COMPLEXITY: the self-protection floor predicates (`_is_credential_mint`, `_is_self_kill`) re-tokenize the command and recursively descend every nested `bash -c` payload, and each `is_denied` call runs that descent three times. The common tool call — a tool name plus a path — can never fire either predicate, so the descent is pure waste on the 95%+ fast path.

## Why this issue matters to the user

Every tool call in every session pays this scan on the event loop before the call is allowed to run. On complex bash the stall is user-visible (seconds of dead air before a command starts), and because it runs on the loop it also delays every other concurrent session on the gateway.

## How our fix solves it

Chain from symptom to root cause: stall → the deny scan's recursive payload descent → the descent runs even when firing is provably impossible → add the missing O(n) necessary-condition gate in front of both predicates (`_self_floor_can_fire`), so a miss skips the whole descent.

The issue proposed gating on a raw `_SELF_NAME_RE` search. That is UNSOUND: the predicates fire on inputs whose raw text never matches `kiro[-.]?crew` — `python -m kiro_crew token` (underscored module spelling), `[k]irocrew token` (bracket class), `kiro$()crew` (empty substitution), `kiro${x:-crew}` (parameter default), `\x6birocrew` (printf escapes), `kiro?rew` (glob), quote-glued spellings, dynamic-exec payloads carrying no name at all, and `pkill -f ~` when $HOME lies under the product tree (the predicates expanduser their targets). The shipped gate is a NECESSARY condition covering every normalization the predicates themselves apply: name hint in any spelling, shell machinery characters (glob/brace/`$`/backtick/`~`), printf numeric escapes, dynamic-exec markers, and the name after quote/backslash stripping. Over-matching merely falls back to the full scan — the safe direction; under-matching would be a security bypass, which is why every listed spelling is locked in by tests.

Steps 2 and 3 from the issue (path-cache, thread offload) were deliberately NOT taken: step 1 removes the dominant cost outright, the remaining fast path is already sub-millisecond, and the thread offload was rejected in the issue itself for moving cost instead of removing it.

## What tests we did

- New `TestSelfFloorShortCircuit` ratchet (structure, never timing): a benign command performs ZERO descents (spy on `_self_token_frames`); every obfuscated spelling the floor denies today still passes the gate; the gated predicates still deny the full obfuscation corpus; plain text without machinery declines the gate; tilde expansion (`pkill -f ~`, `killall ~`) still reaches the floor under a product-tree $HOME.
- Full `test_denied_commands_security.py`: 494 passed.
- Mutation checks: gate hard-wired to `False` → 4 failures; hard-wired to `True` → ratchet failure; `~` removed from the machinery class → tilde test failure. All mutants killed, real implementation restored and re-verified.
- 120k-input structured fuzz over name fragments, kill verbs, and machinery characters: 0 gate bypasses (every input a predicate fires on passes the gate).
- isort/flake8 clean; mypy delta clean (the 2 pre-existing `transcribe.py` errors reproduce on clean main).
- Pre-push model-pinned review: Opus (claude-opus-5) found 1 BLOCKING — the tilde-expansion bypass — which was verified against the real predicates, fixed, and mutation-locked. The GPT (gpt-5.6-sol) run completed but its report was lost to a /tmp sweep before it could be read; the server-side GPT review bot on this PR is the authoritative re-check.

## Any other suggestions on the work

`is_sensitive_path` caching (issue step 2) remains available as a follow-up if profiling ever shows the single `os.path.realpath` on the fast path mattering; it was not needed to resolve the reported stall.

Closes #3603
