### PR TITLE
fix(doctor): stop failing doctor on a dropped API-key report

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -759,24 +759,32 @@ on crash, and starts on boot. Implemented in `src/kiro_crew/service/`.
     world-readable — the unit lives in root-owned `/etc/systemd/system` and the
     override file is installed `0644` — so a model credential placed there
     would be readable by every local user on the host. `service_environment()`
-    therefore carries only `KIROCREW_KIRO_BIN` and `KIROCREW_PORT`, and a test
-    pins the absence so a future "just propagate it" change fails.
+    therefore carries no credential — its only installer-derived values are
+    `PATH`, `KIROCREW_KIRO_BIN` and `KIROCREW_PORT` (it also returns `HOME`,
+    `LANG` and `LC_ALL`) — and a test pins the absence so a future "just
+    propagate it" change fails.
     Consequence: a `KIRO_API_KEY` exported in the installing shell does not
     reach the service, the readiness probe (which forwards that variable from
-    the *gateway's own* environment) sees no credential, and the dashboard
-    reports a signed-out state on a host where `kiro-cli` itself is
-    authenticated. `install_service()` prints a warning naming the variable and
-    the remedy when it detects that case, and `~/.kiro/crew/.env` is the
-    supported home — `load_credentials()` reads every key from that file into
-    the gateway environment at boot and forces `0600` on it first. The warning
-    is diagnostic only: it is non-fatal by construction, since the unit is
-    already written and started by the time it runs. `kirocrew doctor` reports
+    the *gateway's own* environment) sees no credential, and unless a
+    `kiro-cli login` credential store under the baked `HOME` supplies one
+    instead, the dashboard reports a signed-out state on a host where `kiro-cli`
+    itself is authenticated. `install_service()` prints a warning naming the
+    variable and the remedy when it detects that case, and `~/.kiro/crew/.env`
+    is the supported home — `load_credentials()` reads every key from that file
+    into the gateway environment at boot and forces `0600` on it first. The
+    warning is diagnostic only: it is non-fatal by construction, since the unit
+    is already written and started by the time it runs. `kirocrew doctor` reports
     the same condition next to its `kiro login` line — the one output where the
     contradiction is visible, since that line runs `whoami` with the inherited
     environment and reports signed in. Doctor's report is gated on a service
     definition existing (`installed_unit_path()`): without one the gateway runs
     in the foreground and inherits the invoking shell, so the credential does
-    reach it and a warning would be a false positive.
+    reach it and a warning would be a false positive. It is **advisory only** —
+    never appended to doctor's `issues`, which is the exit-code channel — since
+    that gate establishes a definition on disk, not that the serving gateway
+    lacks a credential; a fall-back login store, or a stopped unit beside a
+    foreground `kirocrew gateway`, both leave the host healthy while the check
+    fires.
   - Boot survival via `WantedBy=multi-user.target` (no linger needed —
     that's a user-service concept; this is system-level).
   - Crash-loop safety: `StartLimitBurst=3 StartLimitIntervalSec=300`.

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -912,14 +912,27 @@ def _doctor_headless_auth(issues: list[str]) -> None:
     snapshot, an operator who reaches the docs only after hitting the wall), and
     none of those orderings run ``service install`` again.
 
-    Gated on a service definition existing, which is what makes the claim true
-    rather than merely plausible. Without one the gateway runs in the foreground
-    and inherits this very shell, so the credential DOES reach it and warning
-    here would be a false positive on a working host.
+    Gated on a service definition existing, which is what keeps the report
+    plausible. Without one the gateway runs in the foreground and inherits this
+    very shell, so the credential DOES reach it and warning here would be a
+    false positive on a working host.
+
+    Advisory only (never appended to ``issues``, like the pod-session-bus and
+    memory-pressure probes): ``issues`` is doctor's exit-code channel, so an
+    entry here makes the verdict ❌ and exits non-zero — a claim this shell
+    cannot establish. ``service_environment()`` bakes ``HOME``, so a service on
+    a host that ran ``kiro-cli login`` before the key was exported resolves that
+    credential store and is healthy while the check still fires; and a unit path
+    proves a definition exists on disk, not that the unit is the gateway
+    currently serving, so a stopped unit beside a foreground ``kirocrew gateway``
+    also reads as broken. Reporting the exposure is right; failing doctor on a
+    host where sign-in works is the same contradiction-with-reality this
+    diagnostic exists to surface, one layer up.
 
     Best-effort like the probes around it: a failure to read the environment or
     the unit path must not fail ``doctor``, whose job is to report.
     """
+    del issues  # advisory-only diagnostic; keeps the call-site signature uniform
     try:
         if service_controller.installed_unit_path() is None:
             return
@@ -931,11 +944,6 @@ def _doctor_headless_auth(issues: list[str]) -> None:
     print("  kiro key:    ⚠️  set here, but the installed service cannot see it")
     for line in warning.splitlines():
         print(f"{_INDENT}{line.strip()}" if line.strip() else "")
-    issues.append(
-        "KIRO_API_KEY is set in this shell but absent from the crew .env, so the "
-        "installed service starts without it and the dashboard reports a "
-        "signed-out state"
-    )
 
 
 def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False) -> None:

--- a/src/kiro_crew/service/common.py
+++ b/src/kiro_crew/service/common.py
@@ -185,8 +185,10 @@ def headless_auth_warning(environ: "Mapping[str, str] | None" = None) -> str:
     GATEWAY's own environment. launchd and systemd start the service with a
     minimal, non-login environment, so a key exported in the shell that ran
     ``kirocrew service install`` is not there when the service starts: the probe
-    sees no credential, readiness latches ``authenticated=False``, and the
-    dashboard asks for a sign-in the operator has already done.
+    sees no credential, and unless a ``kiro-cli login`` credential store under
+    the baked ``HOME`` supplies one instead, readiness latches
+    ``authenticated=False`` and the dashboard asks for a sign-in the operator has
+    already done.
 
     The variable is deliberately NOT added to :func:`service_environment`. Both
     baked locations are readable by every local user — the systemd unit lives in
@@ -224,7 +226,8 @@ def headless_auth_warning(environ: "Mapping[str, str] | None" = None) -> str:
     )
     lines = [
         f"Note: {_AUTH_ENV_VAR} is set in this shell but the service will not",
-        "   inherit it, so the dashboard will report a signed-out state. Add it",
+        "   inherit it, so unless kiro-cli has a login credential store to fall",
+        "   back on, the dashboard will report a signed-out state. Add it",
         f"   to {dotenv} (0600) and restart the service:",
         "",
         f"     {remedy}",

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -3521,7 +3521,25 @@ class TestHeadlessApiKeyDoctorReport:
         out = capsys.readouterr().out
         assert "cannot see it" in out
         assert "Note: dropped key" in out
-        assert len(issues) == 1
+        assert issues == [], "the report is advisory; see the exit-code test below"
+
+    def test_the_report_cannot_make_doctor_exit_nonzero(self, monkeypatch, tmp_path):
+        """`issues` is the exit-code channel, and this gate cannot prove failure.
+
+        `_doctor` ends in `if issues: print("❌ Fix these issues: ..."); sys.exit(1)`,
+        so an entry here turns a host where sign-in works into a failed verdict:
+        `service_environment()` bakes `HOME`, so a service that has a
+        `kiro-cli login` credential store is healthy while this fires, and a unit
+        path only proves a definition exists on disk. Both halves are pinned --
+        the append being absent, and the `sys.exit(1)` it would have reached.
+        """
+        from kiro_crew import cli_doctor
+
+        source = inspect.getsource(cli_doctor._doctor_headless_auth)
+        assert "issues.append" not in source
+        assert "del issues" in source
+        assert self._warn(monkeypatch, tmp_path / "kirocrew.service") == []
+        assert "sys.exit(1)" in inspect.getsource(cli_doctor._doctor)
 
     def test_silent_when_no_service_is_installed(self, monkeypatch, capsys):
         """A foreground gateway inherits this shell, so there is nothing wrong."""
@@ -3640,6 +3658,20 @@ class TestHeadlessApiKeyWarning:
         assert self.API_KEY in warning
         assert str(dotenv) in warning, "the warning must name the file to edit"
         assert "kirocrew service restart" in warning
+
+    def test_the_signed_out_claim_is_qualified(self, monkeypatch, tmp_path):
+        """A login credential store under the baked `HOME` can still authenticate.
+
+        `service_environment()` bakes `HOME`, so a service on a host that ran
+        `kiro-cli login` before the key was exported is signed in even though the
+        key is dropped. The note must therefore not state the signed-out outcome
+        as certain: doctor treats this same predicate as advisory rather than a
+        failure precisely because it cannot rule that fall-back out.
+        """
+        self._dotenv(monkeypatch, tmp_path, "")
+        warning = common.headless_auth_warning({self.API_KEY: self.SECRET})
+        assert "signed-out state" in warning
+        assert "unless" in warning, "the outcome is conditional, not certain"
 
     def test_silent_when_dotenv_already_defines_the_key(self, monkeypatch, tmp_path):
         self._dotenv(monkeypatch, tmp_path, f"{self.API_KEY}=already-configured\n")


### PR DESCRIPTION
## Problem

`_doctor_headless_auth` — the dropped-`KIRO_API_KEY` report added in #3285 — ends in `issues.append(...)`, and `_doctor`'s summary is `if issues: print("❌ Fix these issues: …"); sys.exit(1)`. So the report is a **failure verdict**, not a note, on a predicate that cannot establish a failure:

1. **Absence from `.env` does not mean the service has no credential.** `service_environment()` bakes `HOME`, so the service resolves the same user's `kiro-cli login` credential store. A host that ran `kiro-cli login` first and later exported `KIRO_API_KEY` for automation authenticates fine and its dashboard is healthy, while `api_key_will_be_dropped()` (shell + `.env` only) is true. The `kiro login` line above cannot disambiguate — it runs `whoami` with the inherited environment, so it already sees the key.
2. **A unit file existing does not mean that unit is the gateway serving.** `installed_unit_path()` tests `.is_file()`. With a unit installed but stopped or disabled and the operator running `kirocrew gateway` in the foreground, that process inherits the invoking shell, the credential reaches the probe, and `doctor` still exits 1.

The appended text also stated an outcome it never observed: *"the installed service starts without it and the dashboard reports a signed-out state."*

## Why it matters

`doctor` reporting ❌ and exiting non-zero on a host where sign-in works is the same contradiction-with-reality #3285 set out to remove, one layer up — and the exit status is what provisioning scripts and CI gate on. The install-time print uses the same imprecise predicate and that is fine: one advisory line after a successful install, exit code untouched. Promoting it to a verdict is what changes the cost.

The rule was already written in this file. `_doctor_sandbox_apparmor`'s docstring: a probe failure that *says nothing about the service* is reported as "cannot be verified from this shell" and **not counted as an issue**. The new check is in that category but appended anyway.

## Fix

- `cli_doctor.py` — drop the `issues.append` and add `del issues  # advisory-only diagnostic; keeps the call-site signature uniform`, matching `_doctor_pod_session_bus` / `_doctor_memory_pressure` / `_doctor_model_url_reachable`. The printed lines are unchanged: the exposure is still reported where the operator stands. The docstring now carries both false-positive shapes as the reason.
- `service/common.py` — the shared note no longer asserts the outcome as certain: *"unless kiro-cli has a login credential store to fall back on, the dashboard will report a signed-out state."* Same qualifier added to the docstring's diagnosis. This text is shared with the install-time print, where it was equally over-stated.
- `docs/system-specs/modules/cli.md` — records the advisory-only decision and its reason, and fixes an inaccurate sentence from #3285: `service_environment()` "carries only `KIROCREW_KIRO_BIN` and `KIROCREW_PORT`" is not true — it also returns `HOME`, `PATH`, `LANG` and `LC_ALL`, and `PATH` is itself captured from the installer (`service_path()`: "Snapshots the installer's current `$PATH`"). Now stated as *carries no credential*, with the installer-derived values named. That paragraph's job is to be the citable statement of the policy.

Not addressed here: `doctor` resolves `.env` from its own shell rather than the service's home (the third bullet of #3699) — it needs `headless_auth_warning()` to take the service's resolved home, which is a behavior change to the helper rather than a verdict change, and it overlaps #3361.

Closes #3699 for the first two bullets; the third is tracked there.

## Tests

`test/test_service.py`, 266 → 268 in the file (307 with `test_cli_doctor*`):

- `test_the_report_cannot_make_doctor_exit_nonzero` — pins **both** halves of the chain: no `issues.append` in the function, `del issues` present, an installed-unit fixture leaves `issues == []`, and `sys.exit(1)` is still the consequence in `_doctor` that an entry would reach. Falsified by re-adding the append: this test and `test_reports_when_a_service_is_installed` both fail (verified locally), which is the pair that was missing — none of #3285's six doctor tests covered the exit code.
- `test_the_signed_out_claim_is_qualified` — asserts the note keeps `signed-out state` **and** the `unless` qualifier. Falsified by restoring the unconditional sentence.
- `test_reports_when_a_service_is_installed` — assertion flipped from `len(issues) == 1` to `issues == []`; the output assertions are untouched, so it still proves the report is printed.

Gates: `isort` / `flake8` clean on the changed files, `mypy src/kiro_crew/` clean (967 files), `scripts/docs-lint.sh` passes (207 files). Full backend suite 53254 passed; the 15 failures in this environment (`test_terminal_commands`, `test_dashboard_origin`, `test_xdist_auto_cap`, `test_apps_backend_coverage`, `test_app_manager`) reproduce identically on a pristine `origin/main` checkout in the same worktree, file-for-file and count-for-count. No frontend change, so `tsc`/`vitest` were not re-run.
