### PR TITLE
fix(doctor): make the headless API-key check advisory so doctor exits 0 on healthy hosts (#3699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **`kirocrew doctor` no longer exits 1 on healthy hosts where an exported
+  `KIRO_API_KEY` is absent from the crew `.env`.** The headless API-key check
+  counted the dropped variable as a failure, but the shell running doctor
+  cannot establish the failure it asserted: the installed service bakes `HOME`,
+  so the gateway resolves the user's `kiro-cli` login credential store anyway,
+  and an installed unit file does not prove that unit is the gateway serving.
+  The check now prints the same advisory warning without failing doctor —
+  matching the pod session-bus and embedding-model URL probes — and a
+  regression test pins the exit-code consequence. Tradeoff, shared with every
+  sibling advisory probe: a host authenticating solely via the exported
+  variable (no login store) now passes doctor with only the printed warning.
+  The module spec's
+  `service_environment()` description now lists everything the baked
+  environment carries (`HOME`, `PATH`, `LANG`/`LC_ALL`, `KIROCREW_KIRO_BIN`,
+  `KIROCREW_PORT`) instead of just two keys.
+
 - **`kirocrew` commands start up to ~0.8 s faster, and each MCP stdio server
   drops ~58 MB of resident memory.** `cli.py` imported its full 132-subcommand
   dispatch table at module scope — including the Slack gateway, the dashboard

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -759,21 +759,25 @@ on crash, and starts on boot. Implemented in `src/kiro_crew/service/`.
     world-readable — the unit lives in root-owned `/etc/systemd/system` and the
     override file is installed `0644` — so a model credential placed there
     would be readable by every local user on the host. `service_environment()`
-    therefore carries only `KIROCREW_KIRO_BIN` and `KIROCREW_PORT`, and a test
-    pins the absence so a future "just propagate it" change fails.
+    therefore carries no credential — its installer-derived values are `PATH`
+    (snapshotted from the installer's shell), `KIROCREW_KIRO_BIN`, and
+    `KIROCREW_PORT`, alongside `HOME` and a fixed UTF-8 `LANG`/`LC_ALL` — and a
+    test pins the credential's absence so a future "just propagate it" change
+    fails.
     Consequence: a `KIRO_API_KEY` exported in the installing shell does not
-    reach the service, the readiness probe (which forwards that variable from
-    the *gateway's own* environment) sees no credential, and the dashboard
-    reports a signed-out state on a host where `kiro-cli` itself is
-    authenticated. `install_service()` prints a warning naming the variable and
+    reach the service. The gateway may still be signed in — the baked `HOME`
+    resolves the user's `kiro-cli` login credential store — but the exported
+    variable itself is dropped. `install_service()` prints a warning naming the
+    variable and
     the remedy when it detects that case, and `~/.kiro/crew/.env` is the
     supported home — `load_credentials()` reads every key from that file into
     the gateway environment at boot and forces `0600` on it first. The warning
     is diagnostic only: it is non-fatal by construction, since the unit is
-    already written and started by the time it runs. `kirocrew doctor` reports
-    the same condition next to its `kiro login` line — the one output where the
-    contradiction is visible, since that line runs `whoami` with the inherited
-    environment and reports signed in. Doctor's report is gated on a service
+    already written and started by the time it runs. `kirocrew doctor` repeats
+    the same warning next to its `kiro login` line, and it is advisory there
+    too — never counted as a failure — because the shell running doctor cannot
+    establish that the installed service is the gateway serving, nor that the
+    dropped variable left it signed out. Doctor's report is gated on a service
     definition existing (`installed_unit_path()`): without one the gateway runs
     in the foreground and inherits the invoking shell, so the credential does
     reach it and a warning would be a false positive.

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -903,23 +903,31 @@ def _doctor_model_url_reachable(issues: list[str]) -> None:
 def _doctor_headless_auth(issues: list[str]) -> None:
     """Report an API-key credential the INSTALLED service cannot see.
 
-    This is the one place the contradiction is visible in a single output: the
-    ``kiro login`` line above runs ``whoami`` with the inherited environment and
-    reports signed in, while the dashboard's readiness gate reads the gateway's
-    own environment and reports signed out. Install-time is too early to be the
-    only report — the symptom surfaces when the service is ALREADY installed (a
-    key added to a shell profile afterwards, a host re-provisioned from a
-    snapshot, an operator who reaches the docs only after hitting the wall), and
-    none of those orderings run ``service install`` again.
+    Install-time is too early to be the only report — the symptom surfaces when
+    the service is ALREADY installed (a key added to a shell profile afterwards,
+    a host re-provisioned from a snapshot, an operator who reaches the docs only
+    after hitting the wall), and none of those orderings run ``service install``
+    again — so doctor repeats the warning next to its ``kiro login`` line.
 
-    Gated on a service definition existing, which is what makes the claim true
-    rather than merely plausible. Without one the gateway runs in the foreground
-    and inherits this very shell, so the credential DOES reach it and warning
-    here would be a false positive on a working host.
+    Gated on a service definition existing. Without one the gateway runs in the
+    foreground and inherits this very shell, so the credential DOES reach it and
+    warning here would be a false positive on a working host.
+
+    Advisory only (never appended to ``issues``, like the pod session-bus and
+    embedding-model URL probes): this shell cannot establish the failure it
+    would assert. The service bakes ``HOME`` via ``service_environment()``, so
+    the gateway resolves the user's ``kiro-cli`` login credential store even
+    when the API key is absent from the crew ``.env``; and a unit file existing
+    does not mean that unit is the gateway currently serving — an operator
+    running the gateway in the foreground inherits this shell's credential
+    despite the installed definition. Counting an unverified condition as a
+    failure would make ``doctor`` exit 1 on healthy hosts — the same
+    contradiction-with-reality the sign-in check itself was cured of.
 
     Best-effort like the probes around it: a failure to read the environment or
     the unit path must not fail ``doctor``, whose job is to report.
     """
+    del issues  # advisory-only diagnostic; keeps the call-site signature uniform
     try:
         if service_controller.installed_unit_path() is None:
             return
@@ -931,11 +939,6 @@ def _doctor_headless_auth(issues: list[str]) -> None:
     print("  kiro key:    ⚠️  set here, but the installed service cannot see it")
     for line in warning.splitlines():
         print(f"{_INDENT}{line.strip()}" if line.strip() else "")
-    issues.append(
-        "KIRO_API_KEY is set in this shell but absent from the crew .env, so the "
-        "installed service starts without it and the dashboard reports a "
-        "signed-out state"
-    )
 
 
 def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False) -> None:

--- a/src/kiro_crew/service/common.py
+++ b/src/kiro_crew/service/common.py
@@ -185,8 +185,11 @@ def headless_auth_warning(environ: "Mapping[str, str] | None" = None) -> str:
     GATEWAY's own environment. launchd and systemd start the service with a
     minimal, non-login environment, so a key exported in the shell that ran
     ``kirocrew service install`` is not there when the service starts: the probe
-    sees no credential, readiness latches ``authenticated=False``, and the
-    dashboard asks for a sign-in the operator has already done.
+    sees no credential unless a ``kiro-cli`` login credential store resolves
+    under the baked ``HOME``, in which case the gateway is signed in anyway. On
+    a host relying solely on the variable, readiness latches
+    ``authenticated=False`` and the dashboard asks for a sign-in the operator
+    has already done.
 
     The variable is deliberately NOT added to :func:`service_environment`. Both
     baked locations are readable by every local user — the systemd unit lives in
@@ -224,7 +227,7 @@ def headless_auth_warning(environ: "Mapping[str, str] | None" = None) -> str:
     )
     lines = [
         f"Note: {_AUTH_ENV_VAR} is set in this shell but the service will not",
-        "   inherit it, so the dashboard will report a signed-out state. Add it",
+        "   inherit it, so the dashboard may report a signed-out state. Add it",
         f"   to {dotenv} (0600) and restart the service:",
         "",
         f"     {remedy}",

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -3491,13 +3491,14 @@ class TestSandboxProfileControllerDispatch:
 
 
 class TestHeadlessApiKeyDoctorReport:
-    """`doctor` must report the same dropped credential, and only when it is real.
+    """`doctor` must repeat the dropped-credential warning, advisory-only.
 
     Install-time alone misses every ordering where the service is already
-    installed. Doctor is where the operator stands and where the contradiction is
-    visible in one output, so the same helper is called there -- but only when a
+    installed, so the same helper is called from doctor -- but only when a
     service definition exists, because a foreground gateway inherits the shell
-    that runs doctor and the credential does reach it.
+    that runs doctor and the credential does reach it. The report never counts
+    as a failure: this shell cannot establish that the installed unit is the
+    gateway serving, or that the dropped variable left it signed out (#3699).
     """
 
     API_KEY = "KIRO_API_KEY"
@@ -3521,7 +3522,45 @@ class TestHeadlessApiKeyDoctorReport:
         out = capsys.readouterr().out
         assert "cannot see it" in out
         assert "Note: dropped key" in out
-        assert len(issues) == 1
+        assert issues == []
+
+    def test_healthy_host_keeps_doctor_exit_zero(self, monkeypatch, tmp_path):
+        """The warning firing must not flip `doctor`'s exit code to 1.
+
+        `_doctor` exits 1 iff `issues` is non-empty, so `issues` staying empty
+        IS the exit-code consequence — pinned here because this shell cannot
+        establish the failure the old append asserted: the service bakes HOME
+        (`service_environment()`), so the gateway resolves the `kiro-cli` login
+        credential store even without the exported key, and an installed unit
+        file does not prove that unit is the gateway serving. Regression for
+        the healthy-host case where doctor reported failure on a working
+        install (#3699).
+        """
+        from kiro_crew import cli_doctor
+
+        # Behavioural ratchet: any future append fails regardless of spelling.
+        # (`_doctor` runs dozens of live host probes, so the property is pinned
+        # at the unit level rather than end-to-end.)
+        class _NoAppend(list):
+            def append(self, item):  # pragma: no cover - failure path only
+                raise AssertionError(
+                    "_doctor_headless_auth must stay advisory-only: appending "
+                    "to `issues` makes doctor exit 1 on healthy hosts (#3699)"
+                )
+
+        monkeypatch.setattr(
+            cli_doctor.service_controller,
+            "installed_unit_path",
+            lambda: tmp_path / "kirocrew.service",
+        )
+        monkeypatch.setattr(
+            cli_doctor.common_service,
+            "headless_auth_warning",
+            lambda: "Note: dropped key",
+        )
+        issues: list = _NoAppend()
+        cli_doctor._doctor_headless_auth(issues)
+        assert list(issues) == []
 
     def test_silent_when_no_service_is_installed(self, monkeypatch, capsys):
         """A foreground gateway inherits this shell, so there is nothing wrong."""


### PR DESCRIPTION
# What is the problem?

`kirocrew doctor` exits 1 on healthy hosts. `_doctor_headless_auth` (`src/kiro_crew/cli_doctor.py`) ends in `issues.append(...)`, and `_doctor` exits 1 whenever `issues` is non-empty — so a host where sign-in actually works reports `❌ Fix these issues: KIRO_API_KEY is set in this shell but absent from the crew .env...` and fails.

# Why this issue matters to the user

Operators script `kirocrew doctor` as a health gate (`doctor && gateway`, CI provisioning checks). A false failure breaks those scripts and sends the operator chasing a remedy for a problem they do not have. It is the same contradiction-with-reality #3285 removed, one layer up: doctor asserting a broken state the host disproves.

# How our fix solves it

Symptom → root cause: the check cannot establish the failure it asserts. (1) The installed service bakes `HOME` via `service_environment()`, so the gateway resolves the user's `kiro-cli` login credential store even when the API key is absent from the crew `.env` — the gateway can be signed in regardless. (2) `installed_unit_path().is_file()` proves a unit definition exists, not that that unit is the gateway serving — a foreground gateway inherits this very shell's credential.

Change: `_doctor_headless_auth` stops appending to `issues` and keeps the printed advisory lines, exactly matching the established unverifiable-branch pattern in the same file (`_doctor_pod_session_bus`, `_doctor_model_url_reachable`, `_doctor_memory_pressure` — `del issues` for call-site uniformity). The operator-facing warning text softens `will report a signed-out state` → `may report`, since the outcome depends on whether a login store resolves; two docstrings stating the retracted chain as fact (`headless_auth_warning`, the doctor test class) are hedged in the same commit so a future maintainer does not re-derive the append.

Doc accuracy fix from the same review: `docs/system-specs/modules/cli.md` claimed `service_environment()` "carries only `KIROCREW_KIRO_BIN` and `KIROCREW_PORT`"; it also returns `HOME`, `PATH` (snapshotted from the installer), and a fixed UTF-8 `LANG`/`LC_ALL`. Reworded to state it carries no credential and to list the installer-derived values.

Acknowledged tradeoff (stated in CHANGELOG too): a host authenticating solely via the exported variable with no login store now passes doctor with only the printed warning — shared behavior with every sibling advisory probe, and what #3699 asked for. Narrowing the check to that sub-case would require a second `whoami` with the variable stripped from the child env; out of scope here.

The minor `.env`-resolution-home item (#3361-related) is not addressed — it is not trivial to verify from this change's surface and expanding scope was explicitly ruled out.

# What tests we did

- Updated `TestHeadlessApiKeyDoctorReport::test_reports_when_a_service_is_installed`: warning prints still asserted, `issues == []` now pinned.
- New `test_healthy_host_keeps_doctor_exit_zero`: regression for the exit-code consequence — `_doctor` exits 1 iff `issues` is non-empty, so the test passes a `list` subclass whose `append` raises, making any future re-append fail behaviorally regardless of spelling (per local Opus review advisory).
- All 24 headless-auth/doctor-report tests green; `test/test_service.py` + `test/test_cli_doctor.py` targeted run green (3 pre-existing host-specific failures unrelated to this diff, identical on pristine main: uid-65534 /tmp ownership quirk).
- Gates: `isort --check-only`, `flake8`, `mypy` clean on changed files.
- Local model-pinned reviews: GPT mirror (gpt-5.6-sol) — NO FINDINGS; Opus mirror — no blocking, 4 advisories, all 4 adopted in this commit.

# Manual verification

N/A — unit coverage sufficient: the change removes one append and rewords prose; the exit-code path is pinned by the new test.

<!-- no-visual-delta -->
**Why no screenshot:** CLI-only change (doctor terminal output + docs); no frontend paths touched.

Closes #3699
