### PR TITLE
fix: persist sync_status column on knowledge source insert (#3701)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **A folder knowledge source added from the dashboard can now be started.**
+  The row's `sync_status` was stored twice — as a table column and inside the
+  properties JSON — and the create path wrote `pending_confirmation` only into
+  the JSON, leaving the column at its `pending` default. The dashboard list
+  reads the column, so a freshly-added `local_folder` / `obsidian_vault` source
+  showed a Pause button instead of the Confirm button that starts the scan and
+  sat at "pending · 0 items · never synced" forever (the workaround was Pause
+  then Resume). Both insert paths (`add_source` and the auto-source path used
+  by drop-folder and project-docs sources) now derive the column from the
+  passed properties, and the store migration repairs already-divergent rows on
+  open, so existing stuck sources become startable without the workaround. (#3701)
+
 - **The Speech-to-Text settings page no longer offers to install Whisper when
   the provider is AWS Transcribe.** With `stt.provider = "transcribe"` the page
   showed an "Install Whisper" button (installing an engine Transcribe never

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -447,6 +447,33 @@ class KnowledgeStore:
         src_cols = {r[1] for r in self.db.execute("PRAGMA table_info(sources)").fetchall()}
         if "sync_status" not in src_cols:
             self.db.execute("ALTER TABLE sources ADD COLUMN sync_status TEXT DEFAULT 'pending'")
+        # Repair rows whose column still holds the un-written 'pending' default
+        # while the properties JSON carries the intended state (rows inserted
+        # before the column was written on INSERT). The dashboard picks the
+        # row's control from the column, so a divergent row renders Pause
+        # instead of Confirm and the source cannot be started. Only 'pending'
+        # rows are candidates: any row a handler transitioned already had its
+        # column written, so a repaired value never overwrites a live state.
+        divergent = self.db.execute(
+            "SELECT id, properties FROM sources WHERE sync_status = 'pending'").fetchall()
+        for row in divergent:
+            try:
+                props = json.loads(row["properties"] or "{}")
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(props, dict):
+                continue
+            json_status = props.get("sync_status")
+            if (isinstance(json_status, str) and json_status != "pending"
+                    and json_status in self._INITIAL_SYNC_STATUSES):
+                # Re-check the column in the UPDATE itself: a concurrent
+                # handler may have transitioned the row between the SELECT
+                # and this write, and its live state must win over the
+                # snapshot taken above.
+                self.db.execute(
+                    "UPDATE sources SET sync_status = ? "
+                    "WHERE id = ? AND sync_status = 'pending'",
+                    (json_status, row["id"]))
         if "summary_topic" not in src_cols:
             self.db.execute("ALTER TABLE sources ADD COLUMN summary_topic TEXT")
         if "summary_themes" not in src_cols:
@@ -989,9 +1016,10 @@ class KnowledgeStore:
             sid = str(uuid4())
             now = datetime.now().isoformat()
             self.db.execute(
-                "INSERT INTO sources (id, name, source_type, uri, properties, "
-                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (sid, name, source_type, uri, json.dumps(properties), now, now),
+                "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (sid, name, source_type, uri, json.dumps(properties),
+                 self._initial_sync_status(properties), now, now),
             )
             self.db.execute("COMMIT")
             return sid, True
@@ -1263,13 +1291,40 @@ class KnowledgeStore:
             (item_id, entity_id, context, now))
         self.db.commit()
 
+    # States a sources row may legitimately START in. Lifecycle states
+    # (syncing/synced/error/paused/missing) are written by handlers as
+    # transitions and are never valid at insert: persisting a caller-supplied
+    # 'syncing' would make the sync endpoint report a conflict forever for a
+    # source whose sync never started.
+    _INITIAL_SYNC_STATUSES = frozenset({"pending", "pending_confirmation", "active"})
+
+    @staticmethod
+    def _initial_sync_status(properties) -> str:
+        """The sync_status column value a new sources row starts with.
+
+        The dashboard reads the sync_status COLUMN (list_sources serves
+        SELECT s.*), while callers express the intended initial state inside
+        the properties JSON. Both insert paths persist the column from the
+        same value so a freshly-added source renders the control matching its
+        state: a column left at its 'pending' default while properties says
+        'pending_confirmation' hides the Confirm button that starts the scan.
+        Values outside the initial-state allowlist fall back to 'pending'.
+        """
+        if isinstance(properties, dict):
+            status = properties.get("sync_status")
+            if isinstance(status, str) and status in KnowledgeStore._INITIAL_SYNC_STATUSES:
+                return status
+        return "pending"
+
     def add_source(self, name, source_type, uri, **kwargs) -> str:
         sid = str(uuid4())
         now = datetime.now().isoformat()
+        properties = kwargs.get("properties", {})
         self.db.execute(
-            "INSERT INTO sources (id, name, source_type, uri, properties, created_at, updated_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (sid, name, source_type, uri, json.dumps(kwargs.get("properties", {})), now, now))
+            "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
+            "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (sid, name, source_type, uri, json.dumps(properties),
+             self._initial_sync_status(properties), now, now))
         self.db.commit()
         return sid
 

--- a/test/test_folder_watch_handlers.py
+++ b/test/test_folder_watch_handlers.py
@@ -75,6 +75,13 @@ class TestAddSourceFolder:
             data = await resp.json()
             assert data["status"] == "pending_confirmation"
             assert data["file_count"] == 1
+            # The dashboard picks the row's control from the sync_status COLUMN,
+            # not the properties JSON: only 'pending_confirmation' there renders
+            # the Confirm button that starts the scan. A column left at its
+            # 'pending' default makes the source unstartable.
+            row = store.db.execute(
+                "SELECT sync_status FROM sources WHERE id = ?", (data["id"],)).fetchone()
+            assert row["sync_status"] == "pending_confirmation"
 
     @pytest.mark.asyncio
     async def test_folder_sensitive_path_rejected(self, store, tmp_path):

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -9,6 +9,7 @@ import logging
 import sys
 from datetime import datetime, timedelta
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 
@@ -563,6 +564,106 @@ class TestKnowledgeStoreExtended:
         assert found is not None
         assert found["id"] == sid
         assert store.get_source_by_uri("/tmp/nope") is None
+
+    def test_add_source_persists_sync_status_column(self, store):
+        """The sync_status column and the properties JSON must agree on insert.
+
+        The dashboard reads the COLUMN to pick the row's control (the Confirm
+        button renders only for 'pending_confirmation'), so a column stuck at
+        the 'pending' default while properties carries 'pending_confirmation'
+        makes a folder source unstartable.
+        """
+        sid = store.add_source(
+            "vault", "local_folder", "/tmp/vault",
+            properties={"sync_status": "pending_confirmation"})
+        row = store.db.execute(
+            "SELECT sync_status, properties FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["sync_status"] == "pending_confirmation"
+        assert json.loads(row["properties"])["sync_status"] == "pending_confirmation"
+
+    def test_add_source_sync_status_defaults_to_pending(self, store):
+        """A caller that states no sync_status keeps the column's default."""
+        sid = store.add_source("f", "local_file", "/tmp/nostatus.md", properties={})
+        row = store.db.execute(
+            "SELECT sync_status FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["sync_status"] == "pending"
+
+    def test_add_source_rejects_non_initial_sync_status(self, store):
+        """A lifecycle state in properties never seeds the column.
+
+        The create endpoint passes request-body properties through, so a
+        caller-supplied 'syncing' would otherwise persist and make the sync
+        endpoint report a conflict forever for a source whose sync never
+        started. Only genuine initial states pass; the rest fall back to
+        'pending'.
+        """
+        for forged in ("syncing", "synced", "error", "paused", "missing", "garbage"):
+            sid = store.add_source(
+                "f", "local_file", f"/tmp/forged-{forged}.md",
+                properties={"sync_status": forged})
+            row = store.db.execute(
+                "SELECT sync_status FROM sources WHERE id = ?", (sid,)).fetchone()
+            assert row["sync_status"] == "pending", forged
+
+    def test_auto_source_persists_sync_status_column(self, store):
+        """The auto-source insert path keeps the same column/JSON invariant.
+
+        Drop-folder and project-docs auto sources seed sync_status='active' in
+        properties; the column must match or the dashboard renders the stale
+        'pending' control for a source the watcher is actively scanning.
+        """
+        sid, created = store.create_auto_source_unless_dismissed(
+            "drop", "local_folder", "/tmp/auto-drop",
+            {"sync_status": "active", "auto_added": True})
+        assert created and sid is not None
+        row = store.db.execute(
+            "SELECT sync_status FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["sync_status"] == "active"
+
+    def test_migration_repairs_divergent_sync_status_rows(self, store, tmp_path):
+        """Reopening a store repairs rows whose column diverged from the JSON.
+
+        Rows inserted while the INSERT paths wrote only the properties JSON
+        have a column stuck at 'pending'; the migration copies the JSON state
+        over so those sources become startable. Rows a handler already
+        transitioned (non-'pending' column) are never touched.
+        """
+        divergent = str(uuid4())
+        live = str(uuid4())
+        agree = str(uuid4())
+        listprops = str(uuid4())
+        forged = str(uuid4())
+        now = datetime.now().isoformat()
+        for sid, column, props_json, uri in (
+            (divergent, "pending", json.dumps({"sync_status": "pending_confirmation"}), "/tmp/div"),
+            (live, "paused", json.dumps({"sync_status": "active"}), "/tmp/live"),
+            (agree, "pending", json.dumps({}), "/tmp/agree"),
+            # Imported/legacy rows can hold non-object JSON; the repair must
+            # skip them instead of crashing store initialization.
+            (listprops, "pending", "[]", "/tmp/listprops"),
+            # A lifecycle state in the JSON is never a valid initial state and
+            # must not be copied over (a forged 'syncing' would lock the sync
+            # endpoint into reporting a conflict).
+            (forged, "pending", json.dumps({"sync_status": "syncing"}), "/tmp/forged"),
+        ):
+            store.db.execute(
+                "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (sid, "s", "local_folder", uri, props_json, column, now, now))
+        store.db.commit()
+        store.close()
+
+        reopened = KnowledgeStore(str(tmp_path / "test.db"))
+        try:
+            rows = {r["id"]: r["sync_status"] for r in reopened.db.execute(
+                "SELECT id, sync_status FROM sources").fetchall()}
+            assert rows[divergent] == "pending_confirmation"
+            assert rows[live] == "paused"
+            assert rows[agree] == "pending"
+            assert rows[listprops] == "pending"
+            assert rows[forged] == "pending"
+        finally:
+            reopened.close()
 
     def test_update_source(self, store):
         sid = store.add_source("f", "local_file", "/tmp/f.md")

--- a/test/test_knowledge_budget.py
+++ b/test/test_knowledge_budget.py
@@ -114,6 +114,7 @@ class TestMaxSourcesCap:
                 source_type TEXT,
                 uri TEXT UNIQUE,
                 properties TEXT,
+                sync_status TEXT DEFAULT 'pending',
                 created_at TEXT,
                 updated_at TEXT
             )
@@ -136,6 +137,7 @@ class TestMaxSourcesCap:
         store.create_auto_source_unless_dismissed = (
             lambda *a, **kw: RealStore.create_auto_source_unless_dismissed(store, *a, **kw)
         )
+        store._initial_sync_status = RealStore._initial_sync_status
         return store
 
     def test_under_cap_allows_creation(self, tmp_path):


### PR DESCRIPTION
# fix: persist sync_status column on knowledge source insert

## Problem

A folder knowledge source (`local_folder` / `obsidian_vault`) added through the dashboard can never start scanning: the row sits at `pending · 0 items · never synced` and shows a **Pause** button instead of the **Confirm** button that would start the scan. The only workaround is Pause then Resume.

## Why it matters

The manual folder-add flow — the primary way users bring a directory into their knowledge base — is dead on arrival: every freshly-added folder source is unstartable until the user discovers the unintuitive Pause/Resume workaround. Drop-folder and project-docs auto sources show the same stale `pending` control even while the watcher is actively scanning them.

## Fix (symptoms -> root cause -> change)

- **Symptom:** the frontend (`website/src/pages/knowledge/SourcesList.tsx:512`) shows Confirm only when `s.sync_status === 'pending_confirmation'`, and it reads the **table column** (the list endpoint serves `SELECT s.*`).
- **Root cause:** `sync_status` is stored twice on a `sources` row — as a table column (default `'pending'`, added by migration at `store.py:449`) and inside the properties JSON. Both insert paths (`store.add_source` and `store.create_auto_source_unless_dismissed`) INSERTed without the `sync_status` column, so it kept its `'pending'` default while the create handler put `pending_confirmation` only into the JSON. Column ≠ JSON → wrong control.
- **Change:** both inserts now derive the column from the passed properties via a shared helper (`KnowledgeStore._initial_sync_status`, defaulting to `'pending'`), so the column and JSON agree from the moment the row exists. The store migration additionally repairs already-divergent rows — column still at the un-written `'pending'` default while the JSON carries the intended state — so existing installs' stuck sources become startable, not just newly-added ones (a handler-transitioned row has a non-`'pending'` column and is never touched). Backend-local; the frontend read path is untouched. `resume_source` / `pause_source` / `confirm_source` are unchanged (they already write both stores).

All other `add_source` callers are behavior-neutral: they pass no `sync_status` (column stays `'pending'`, same as before) or immediately UPDATE to `'syncing'`. The one intentional side correction: the always-on agent-source aggregate row's column now reads `'active'` (matching its properties JSON and its `project_docs` sibling) instead of a stale `'pending'`.

## Tests

- `test_knowledge.py::test_add_source_persists_sync_status_column` — locks column/JSON agreement on `add_source` with `pending_confirmation`.
- `test_knowledge.py::test_add_source_sync_status_defaults_to_pending` — locks the default for callers that state no status.
- `test_knowledge.py::test_auto_source_persists_sync_status_column` — locks the same invariant on the auto-source insert path (`active`).
- `test_knowledge.py::test_migration_repairs_divergent_sync_status_rows` — locks the migration backfill: a divergent pre-fix row is repaired on store open; a handler-transitioned row and an agreeing default row are untouched.
- `test_folder_watch_handlers.py::test_folder_returns_pending_confirmation` — extended to assert the **column** (the value the dashboard control is picked from) reads `pending_confirmation` after the real folder-add endpoint runs.
- `test_knowledge_budget.py` fixture updated: its hand-rolled minimal `sources` table now mirrors the real schema's `sync_status` column.

## Manual verification

N/A — unit coverage sufficient: the handler-level test drives the real `POST /api/knowledge/sources` endpoint and asserts the exact column the frontend control is derived from.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no frontend file touched (the frontend now receives the column value it was already coded to expect).

Closes #3701
