### PR TITLE
fix: resolve aws binary absolutely for sandboxed deploy verify

### DIFF
--- a/src/kiro_crew/deploy/engine.py
+++ b/src/kiro_crew/deploy/engine.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import secrets
+import shutil
 import time
 from typing import Any, Optional
 
@@ -84,9 +85,59 @@ def random_bucket_name() -> str:
     return f"{BUCKET_PREFIX}{secrets.token_hex(_BUCKET_RAND_BYTES)}"
 
 
+# Well-known AWS CLI install dirs, searched (after the inherited PATH) when
+# resolving the binary absolutely. A Finder/Dock-launched macOS gateway inherits
+# the minimal launchd PATH (``/usr/bin:/bin:/usr/sbin:/sbin``), which contains
+# neither Homebrew nor the official-pkg symlink dir — so a bare ``"aws"`` fails
+# ``execvp`` inside ``sandbox-exec`` with "No such file or directory", which is
+# exactly why the Artifact Deploy "Verify" step failed for Homebrew users until
+# the gateway was relaunched from a shell that carried the full PATH.
+_AWS_BIN_DIRS = (
+    "/opt/homebrew/bin",  # Apple Silicon Homebrew
+    "/usr/local/bin",     # Intel Homebrew + official AWS CLI v2 pkg symlink
+)
+
+
+def _resolve_aws_bin() -> str:
+    """Resolve ``aws`` to an absolute path, falling back to the bare name.
+
+    Searches the inherited ``PATH`` first, then the well-known install dirs in
+    :data:`_AWS_BIN_DIRS`, so the desktop-app gateway resolves the CLI no matter
+    how it was launched (Finder/Dock give a minimal PATH; a terminal launch does
+    not). Falling back to the bare ``"aws"`` preserves the prior behaviour — and
+    its "not found" error — when the CLI genuinely is not installed anywhere.
+
+    A hit found only through the fallback dirs (i.e. NOT reachable via the
+    inherited ``PATH``, which the pre-existing bare-argv behaviour already
+    trusted) is additionally routed through
+    :func:`kiro_crew.github_runner.validate_provider_executable` — the repo's
+    executable-provenance chokepoint — so an agent- or third-party-planted shim
+    in a user-writable install dir is refused rather than executed inside the
+    credential-bearing sandbox. On refusal we fall back to the bare name,
+    preserving the prior not-found/execvp error rather than inventing a new
+    failure mode.
+    """
+    env_path = os.environ.get("PATH", "")
+    found = shutil.which("aws", path=env_path) if env_path else None
+    if found:
+        # Same trust class as the pre-existing behaviour: execvp against the
+        # inherited PATH already executed exactly this binary.
+        return found
+    fallback = os.pathsep.join(p for p in _AWS_BIN_DIRS if p)
+    found = shutil.which("aws", path=fallback) if fallback else None
+    if found:
+        from kiro_crew.github_runner import validate_provider_executable
+
+        try:
+            return validate_provider_executable(found)
+        except ValueError:
+            logger.warning("refusing aws CLI at %s: failed provenance validation", found)
+    return "aws"
+
+
 def _aws(args: list[str], profile: str) -> list[str]:
     """Build an ``aws`` CLI argv with an optional ``--profile`` (never a raw key)."""
-    cmd = ["aws"] + list(args)
+    cmd = [_resolve_aws_bin()] + list(args)
     if profile:
         cmd += ["--profile", profile]
     return cmd

--- a/test/test_deploy_web_engine.py
+++ b/test/test_deploy_web_engine.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 
 import pytest
@@ -56,6 +57,99 @@ def fake(monkeypatch):
     f = FakeAWS()
     monkeypatch.setattr(engine, "run_aws", f)
     return f
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="the fallback install dirs are macOS path literals and provenance "
+    "validation needs POSIX uid semantics; the fallback branch is dead on "
+    "Windows by design (PATH-hit and bare-name behaviour are covered below)",
+)
+def test_aws_bin_resolved_absolutely_from_extra_dirs(monkeypatch, tmp_path):
+    """A Finder-launched gateway has a minimal PATH; _aws must still resolve the
+    CLI absolutely from a well-known install dir instead of emitting a bare
+    'aws' that fails execvp inside the sandbox."""
+    fake_aws = tmp_path / "aws"
+    fake_aws.write_text("#!/bin/sh\n")
+    fake_aws.chmod(0o755)
+    # Simulate the minimal launchd-style PATH *hermetically*: a PATH that does
+    # not contain aws (a literal /usr/bin would flake on hosts where the real
+    # CLI is installed there), and point the well-known dirs at our temp bin so
+    # the resolver can only find it through the fallback search.
+    empty_bin = tmp_path / "emptybin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(tmp_path),))
+
+    # Isolate the provenance chokepoint (it has its own dedicated tests and its
+    # verdict depends on host /tmp ownership): assert the resolver routes the
+    # fallback hit through it and returns its canonical result.
+    from kiro_crew import github_runner
+
+    validated = []
+
+    def _passthrough(candidate):
+        validated.append(candidate)
+        return candidate
+
+    monkeypatch.setattr(github_runner, "validate_provider_executable", _passthrough)
+
+    argv = engine._aws(["sts", "get-caller-identity"], "kauai")
+
+    assert argv[0] == str(fake_aws)  # absolute, not a bare "aws"
+    assert argv[1:] == ["sts", "get-caller-identity", "--profile", "kauai"]
+    assert validated == [str(fake_aws)]  # fallback hit went through provenance
+
+
+def test_aws_bin_path_hit_wins_without_fallback(monkeypatch, tmp_path):
+    """A PATH hit is the pre-existing trust class (execvp already ran exactly
+    this binary) and resolves absolutely with no fallback-dir involvement."""
+    if os.name == "nt":
+        # Windows resolves executables by PATHEXT extension, not the exec bit.
+        fake_aws = tmp_path / "aws.cmd"
+        fake_aws.write_text("@echo off\n")
+        monkeypatch.setenv("PATHEXT", ".cmd")
+    else:
+        fake_aws = tmp_path / "aws"
+        fake_aws.write_text("#!/bin/sh\n")
+        fake_aws.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", ())
+
+    assert engine._resolve_aws_bin() == str(fake_aws)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="fallback branch is dead on Windows")
+def test_aws_bin_fallback_hit_failing_provenance_returns_bare_name(monkeypatch, tmp_path):
+    """A fallback-dir hit that fails the repo's executable-provenance check is
+    refused: fall back to the bare name (the prior not-found behaviour) instead
+    of executing a possibly planted shim inside the credential sandbox."""
+    fake_aws = tmp_path / "aws"
+    fake_aws.write_text("#!/bin/sh\n")
+    fake_aws.chmod(0o755)
+    empty_bin = tmp_path / "emptybin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(tmp_path),))
+
+    from kiro_crew import github_runner
+
+    def _refuse(candidate):
+        raise ValueError("planted shim")
+
+    monkeypatch.setattr(github_runner, "validate_provider_executable", _refuse)
+
+    assert engine._resolve_aws_bin() == "aws"
+
+
+def test_aws_bin_prefers_path_then_falls_back_to_bare_name(monkeypatch):
+    """When the CLI is nowhere on PATH or the extra dirs, fall back to the bare
+    'aws' so the prior 'not found' behaviour/error is preserved."""
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", ())
+
+    assert engine._resolve_aws_bin() == "aws"
+    assert engine._aws(["s3", "ls"], "")[0] == "aws"
 
 
 def test_random_bucket_name_format():


### PR DESCRIPTION
## Problem / Motivation

On macOS, the Artifact Deploy **Verify** step fails with:

```
sandbox-exec: execvp() of 'aws' failed: No such file or directory
Profile did not resolve — run `aws sso login --profile <name>` and retry.
```

even when the AWS CLI is installed and a `get-caller-identity` succeeds in the
user's terminal. The misleading "run `aws sso login`" hint sends users down an
auth rabbit hole when the real issue is that the `aws` binary is never found.

## Why it matters

This hits **any macOS contributor who installed the AWS CLI via Homebrew** (the
common case) and launches the app normally (Finder/Dock). Deploy Verify is the
gate before every publish, so the feature is effectively unusable until the user
stumbles onto the non-obvious workaround (relaunch the whole app from a terminal
so the gateway inherits a full PATH).

## What changed (motivation → approach → change)

- **Symptom:** `execvp() of 'aws' failed: No such file or directory` on Verify.
- **Root cause:** `deploy/engine.py::_aws` — the single `aws` argv chokepoint —
  emitted a bare `"aws"`. That argv is handed to `sandbox-exec`, which resolves
  it with `execvp` against the **gateway process's PATH**, with no shell. A
  Finder/Dock-launched macOS app inherits the minimal launchd PATH
  (`/usr/bin:/bin:/usr/sbin:/sbin`), which contains neither `/opt/homebrew/bin`
  (Apple Silicon Homebrew) nor `/usr/local/bin` (Intel Homebrew + the official
  AWS CLI v2 pkg symlink) — so the bare name never resolves.
- **Fix:** resolve `aws` to an absolute path via `shutil.which`, searching the
  inherited `PATH` first and then the well-known install dirs, before building
  the argv. Falls back to the bare `"aws"` when the CLI is genuinely absent, so
  the prior not-found behaviour/error is preserved. This mirrors the existing
  absolute-resolution pattern already used elsewhere in the codebase for
  GUI-launched-PATH cases (e.g. `transcribe.py`, `env.find_node_tool`).

Because `run_aws` is the documented single subprocess chokepoint, this one fix
covers verify, deploy, and destroy.

## Tests

Added to `test/test_deploy_web_engine.py`:
- `test_aws_bin_resolved_absolutely_from_extra_dirs` — with a minimal launchd
  PATH, `_aws` resolves the CLI absolutely from a well-known install dir instead
  of emitting a bare `"aws"`, and still appends `--profile`.
- `test_aws_bin_prefers_path_then_falls_back_to_bare_name` — when the CLI is
  nowhere, it falls back to the bare `"aws"` (prior behaviour preserved).

All 116 tests in the deploy-web engine/iam/handlers/profiles suites pass locally.

## Manual verification

N/A — the failure and fix are in argv construction (`_aws`), fully covered by the
unit tests above. The original bug was reproduced/diagnosed from the live
`sandbox-exec execvp` error on a Homebrew macOS install.

## Related Issues

N/A — no existing issue; happy to open one if maintainers prefer a tracking issue.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff