### PR TITLE
fix(ci): provide complete screenshot config fixtures

### DIFF
--- a/website/src/test/stubDashboardApi.test.ts
+++ b/website/src/test/stubDashboardApi.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Page, Route } from 'playwright'
+import {
+  AGENT_CONFIG_FIXTURE,
+  KIROCREW_CONFIG_FIXTURE,
+  stubDashboardApi,
+} from '../../scripts/lib/stub-dashboard-api.mjs'
+
+async function responseFor(path: string) {
+  let handler: ((route: Route) => unknown) | undefined
+  const page = {
+    routeWebSocket: vi.fn(),
+    route: vi.fn((_pattern: string, next: (route: Route) => unknown) => { handler = next }),
+    addInitScript: vi.fn(),
+  }
+  await stubDashboardApi(page as unknown as Page)
+  const fulfill = vi.fn()
+  await handler?.({
+    request: () => ({ url: () => `http://localhost${path}` }),
+    fulfill,
+  } as unknown as Route)
+  return JSON.parse(fulfill.mock.calls[0][0].body)
+}
+
+describe('shared dashboard screenshot config fixtures', () => {
+  it('serves the complete Kiro Crew config shape before the catch-all', async () => {
+    const body = await responseFor('/api/config/kirocrew')
+    expect(body).toEqual(KIROCREW_CONFIG_FIXTURE)
+    expect(Object.keys(body.agents)).toContain('kirocrew')
+    expect(Object.keys(body.workspaces)).toContain('default')
+    expect(Object.keys(body.memory_stores)).toContain('default')
+  })
+
+  it('serves an agent config object before the catch-all', async () => {
+    await expect(responseFor('/api/agent/config')).resolves.toEqual(AGENT_CONFIG_FIXTURE)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The shared screenshot API stub answers `/api/config/kirocrew` and `/api/agent/config` through its generic config catch-all, returning `{}`.

## Why it matters

The Config tab enumerates required maps and throws on the empty response. A screenshot harness can therefore write a blank image and still exit successfully, while individual harnesses duplicate local fixtures to avoid the trap.

## What changed (motivation → approach → change)

The shared stub now defines named, complete fixtures for both config endpoints and routes them before the catch-all. A focused test drives the actual route handler and locks the enumerable maps and agent shape.

## Tests

- Added `stubDashboardApi.test.ts` with two shared-route regressions.
- `npx vitest run src/test/stubDashboardApi.test.ts` — 2 passed.
- Frontend typecheck and ESLint passed.

## Manual verification

N/A — the regression test invokes the shared route handler directly and verifies the exact JSON shapes consumed by screenshot harnesses.

## Related Issues

Addresses #3696. This focused PR fixes the blank-config response; broad deduplication of local harness fixtures and catch-all diagnostics remain separate follow-ups.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — fixture behavior is covered inline and by tests)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Repository template currently contains a placeholder; no contributor action is available yet.
