### PR TITLE
fix(updates): correct wheel install guidance

### DIFF
--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -1506,7 +1506,7 @@ async def api_update_apply(request: web.Request) -> web.Response:
     )
     if capability.managed_by != MANAGED_BY_GIT:
         return web.json_response(
-            {"error": "Not a git checkout — update by redeploying (e.g. `kirocrew cloud launch`)"},
+            {"error": "Not a git checkout — update this install with `kirocrew update`, then restart the gateway"},
             status=409,
         )
 

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -1506,7 +1506,9 @@ async def api_update_apply(request: web.Request) -> web.Response:
     )
     if capability.managed_by != MANAGED_BY_GIT:
         return web.json_response(
-            {"error": "Not a git checkout — update this install with `kirocrew update`, then restart the gateway"},
+            {
+                "error": "Not a git checkout — update this install with `kirocrew update`, then restart the gateway"
+            },
             status=409,
         )
 

--- a/test/test_dashboard_updates_coverage.py
+++ b/test/test_dashboard_updates_coverage.py
@@ -583,7 +583,10 @@ class TestApplyRefusals:
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(plain))
         resp = await updates.api_update_apply(_request({}))
         assert resp.status == 409
-        assert "Not a git checkout" in json.loads(resp.body.decode())["error"]
+        error = json.loads(resp.body.decode())["error"]
+        assert "Not a git checkout" in error
+        assert "kirocrew update" in error
+        assert "cloud launch" not in error
 
     @pytest.mark.asyncio
     async def test_a_pinned_remote_is_refused_before_any_spinner_is_shown(

--- a/test/test_update_git_guard.py
+++ b/test/test_update_git_guard.py
@@ -72,7 +72,10 @@ class TestUpdateCheckGitGuard:
 
     def test_apply_rejects_non_git_checkout(self, monkeypatch, tmp_path):
         # POST /api/update on a tarball install must 409 with a clear
-        # "redeploy" message instead of running git status/pull and failing.
+        # "run `kirocrew update`" message instead of running git status/pull
+        # and failing. `kirocrew update` (unlike this endpoint) dispatches on
+        # install layout and handles wheel/cli.sh installs correctly, so it is
+        # the right redirect — see cli_server.py::_update().
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
 
         def _boom(*a, **k):  # pragma: no cover - must not be called
@@ -85,7 +88,7 @@ class TestUpdateCheckGitGuard:
 
         resp = asyncio.run(updates.api_update_apply(_Req()))
         assert resp.status == 409
-        assert b"redeploy" in resp.body
+        assert b"kirocrew update" in resp.body
 
     def test_apply_refuses_a_diverged_checkout_before_pulling(self, monkeypatch, tmp_path):
         # The render-site guards only cover clients that ran a fresh check; a


### PR DESCRIPTION
## Problem / Motivation

When `POST /api/update` rejects a non-git install, its HTTP 409 tells every user to redeploy with `kirocrew cloud launch`.

## Why it matters

That command is unrelated to normal cli.sh wheel installs and can send users toward provisioning a new cloud instance instead of updating the installation they already have.

## What changed (motivation → approach → change)

The rejection now points non-git users to the supported `kirocrew update` path and tells them to restart the gateway afterward. Update mechanics are intentionally unchanged.

## Tests

- Strengthened the existing tarball/non-git refusal test to require `kirocrew update` and reject the old `cloud launch` guidance.
- Focused pytest result: 1 passed.

## Manual verification

N/A — this is a response-copy correction fully exercised through the handler test.

## Related Issues

Addresses #2541. This is the separately identified guidance correction only; it does not implement or close the broader one-click update request.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no documentation surface changed)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Repository template currently contains a placeholder; no contributor action is available yet.


## Pattern harvest

Not generalizable: a single stale recovery-guidance string — the 409 body predated the CLI update verb gaining install-layout dispatch and was never updated to point at it. A repo-wide search found no other user-facing string steering non-git installs to `cloud launch`.
