### PR TITLE
fix(instances): make token mint timeout user-configurable

### DIFF
--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -234,6 +234,7 @@ cannot drift.
 | `instances.tunnel_base_port` | `7778` | First local loopback port the allocator hands out. Out-of-range values fall back to the default. |
 | `instances.ssh_compression` | `true` | Add `-C` to the tunnel argv. See §5.2. |
 | `instances.connect_timeout_secs` | unset (SSH `15.0`, SSM `25.0`) | How long (secs) to wait for the local forward port to accept connections before declaring a connect attempt failed. Hosts behind a ProxyCommand or jump host need longer (the proxy handshake runs before ssh begins the forward). An explicit value applies to both transports, including a value equal to either transport's default. Values below 1 fall back to the transport defaults; values above 120 are clamped to 120. |
+| `instances.mint_timeout_secs` | unset (SSH `30.0`, SSM `90.0`) | How long (secs) to wait for the remote `kirocrew token` mint to return. A connect spawns **two** proxy-bound children — the `ssh -L` forward (bounded by `connect_timeout_secs`) and this separate mint command — so a slow ProxyCommand or jump host pays its handshake cost twice, and raising only the connect timeout can still leave the connect failing with "timed out minting token". An explicit value applies to both transports, including a value equal to either transport's default. Values below 1 fall back to the transport defaults; values above `MINT_TIMEOUT_CEILING_SECS` (300) are clamped. |
 | `instances.max_recovery_attempts` | `8` | Consecutive self-heal attempts before the tunnel is left disconnected. Below 1 falls back to the default; above `MAX_RECOVERY_ATTEMPTS_CEILING` (100) is clamped with a warning, so a pathological setting cannot turn bounded self-heal into a near-infinite retry loop. |
 | `instances.recover_backoff_max_secs` | `30.0` | Cap on the per-attempt backoff. Non-positive falls back to the default; above `RECOVER_BACKOFF_MAX_CEILING_SECS` (300) is clamped, bounding the worst-case wall-clock recovery window. |
 | `instances.probe_failure_threshold` | `3` | Consecutive health-probe failures before a non-forwarding tunnel is torn down. Below 1 falls back to the default. |
@@ -242,11 +243,18 @@ cannot drift.
 kirocrew config set instances.warm_set_cap 3
 kirocrew config set instances.ssh_compression false
 kirocrew config set instances.connect_timeout_secs 45
+kirocrew config set instances.mint_timeout_secs 90
 ```
 
 Constants that are **not** user-configurable: the probe interval (30s), the token
-refresh fraction (0.8), the stored-token probe timeout (2s), and the mint
-timeout (30s).
+refresh fraction (0.8), and the stored-token probe timeout (2s).
+
+Both `ssh` budgets a connect depends on are now tunable, and they are tuned
+together: `connect_timeout_secs` bounds the `ssh -L` forward-readiness wait and
+`mint_timeout_secs` bounds the separate `ssh <host> kirocrew token` invocation.
+Because both traverse the same ProxyCommand/jump host, a host whose handshake
+alone costs 12-16s spends that twice per connect — which is why raising only the
+first one leaves the mint step as the next binding constraint.
 
 ### 5.2 `instances.ssh_compression`
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -101,12 +101,14 @@ from kiro_crew.effort import EFFORT_LEVELS, is_valid_effort, model_supports_effo
 from kiro_crew.instances.constants import CONNECT_TIMEOUT_CEILING_SECS as _CONNECT_TIMEOUT_CEILING
 from kiro_crew.instances.constants import DEFAULT_CONNECT_TIMEOUT_SECS as _DEFAULT_CONNECT_TIMEOUT
 from kiro_crew.instances.constants import DEFAULT_MAX_RECOVERY_ATTEMPTS as _DEFAULT_MAX_RECOVERY
+from kiro_crew.instances.constants import DEFAULT_MINT_TIMEOUT_SECS as _DEFAULT_MINT_TIMEOUT
 from kiro_crew.instances.constants import DEFAULT_PROBE_FAILURE_THRESHOLD as _DEFAULT_PROBE_FAILS
 from kiro_crew.instances.constants import DEFAULT_RECOVER_BACKOFF_MAX_SECS as _DEFAULT_BACKOFF_MAX
 from kiro_crew.instances.constants import DEFAULT_SSH_COMPRESSION as _DEFAULT_SSH_COMPRESSION
 from kiro_crew.instances.constants import DEFAULT_TUNNEL_BASE_PORT as _DEFAULT_TUNNEL_BASE_PORT
 from kiro_crew.instances.constants import DEFAULT_WARM_SET_CAP as _DEFAULT_WARM_SET_CAP
 from kiro_crew.instances.constants import MAX_RECOVERY_ATTEMPTS_CEILING as _MAX_RECOVERY_CEILING
+from kiro_crew.instances.constants import MINT_TIMEOUT_CEILING_SECS as _MINT_TIMEOUT_CEILING
 from kiro_crew.instances.constants import (
     RECOVER_BACKOFF_MAX_CEILING_SECS as _RECOVER_BACKOFF_CEILING,
 )
@@ -4349,6 +4351,20 @@ class InstancesConfig:
             "An explicit value applies to both transports. Clamped to [1, 120].",
         ),
     )
+    mint_timeout_secs: float | None = field(
+        default=None,
+        metadata=_meta(
+            "Token Mint Timeout (secs)",
+            "How long to wait for the remote `kirocrew token` mint to return "
+            "before the connect attempt fails. When unset, SSH uses 30s and SSM "
+            "uses 90s. A connect spawns TWO children through the same proxy — the "
+            "`ssh -L` forward (bounded by Connect Timeout) and this separate mint "
+            "command — so a slow ProxyCommand or jump host pays its handshake cost "
+            "twice. Raise this alongside Connect Timeout if a connect gets past the "
+            "forward and then fails with 'timed out minting token'. An explicit "
+            "value applies to both transports. Clamped to [1, 300].",
+        ),
+    )
     max_recovery_attempts: int = field(
         default=_DEFAULT_MAX_RECOVERY,
         metadata=_meta(
@@ -4405,6 +4421,20 @@ class InstancesConfig:
                 _CONNECT_TIMEOUT_CEILING,
             )
             object.__setattr__(self, "connect_timeout_secs", _CONNECT_TIMEOUT_CEILING)
+        if self.mint_timeout_secs is not None and self.mint_timeout_secs < 1.0:
+            logger.warning(
+                "instances.mint_timeout_secs %s < 1, using the transport default",
+                self.mint_timeout_secs,
+            )
+            object.__setattr__(self, "mint_timeout_secs", None)
+        elif self.mint_timeout_secs is not None and self.mint_timeout_secs > _MINT_TIMEOUT_CEILING:
+            logger.warning(
+                "instances.mint_timeout_secs %s > %s, clamping to %s",
+                self.mint_timeout_secs,
+                _MINT_TIMEOUT_CEILING,
+                _MINT_TIMEOUT_CEILING,
+            )
+            object.__setattr__(self, "mint_timeout_secs", _MINT_TIMEOUT_CEILING)
         if self.max_recovery_attempts < 1:
             logger.warning(
                 "instances.max_recovery_attempts %d < 1, using %d",
@@ -5708,6 +5738,7 @@ class KiroCrewConfig:
         if not isinstance(instances_data, dict):
             instances_data = {}
         connect_timeout_raw = instances_data.get("connect_timeout_secs")
+        mint_timeout_raw = instances_data.get("mint_timeout_secs")
         mcp_gateway_data = data.get("mcp_gateway", {})
         if not isinstance(mcp_gateway_data, dict):
             mcp_gateway_data = {}
@@ -6459,6 +6490,11 @@ class KiroCrewConfig:
                 connect_timeout_secs=(
                     _safe_float(connect_timeout_raw, _DEFAULT_CONNECT_TIMEOUT)
                     if connect_timeout_raw is not None
+                    else None
+                ),
+                mint_timeout_secs=(
+                    _safe_float(mint_timeout_raw, _DEFAULT_MINT_TIMEOUT)
+                    if mint_timeout_raw is not None
                     else None
                 ),
                 max_recovery_attempts=_safe_int(

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1743,6 +1743,7 @@ def _register_instances_hooks(app: web.Application, state: DashboardState, port:
             registry,
             base_port=_cfg.instances.tunnel_base_port,
             connect_timeout_secs=_cfg.instances.connect_timeout_secs,
+            mint_timeout_secs=_cfg.instances.mint_timeout_secs,
             ssh_compression=_cfg.instances.ssh_compression,
             max_recovery_attempts=_cfg.instances.max_recovery_attempts,
             recover_backoff_max_secs=_cfg.instances.recover_backoff_max_secs,

--- a/src/kiro_crew/instances/constants.py
+++ b/src/kiro_crew/instances/constants.py
@@ -88,6 +88,32 @@ DEFAULT_SSM_CONNECT_TIMEOUT_SECS: float = 25.0
 # generous enough for any realistic proxy chain while still bounding the wait.
 CONNECT_TIMEOUT_CEILING_SECS: float = 120.0
 
+# How long (secs) to wait for the remote ``kirocrew token`` to return before
+# giving up on the mint. This is the *second* proxy-bound ssh child a connect
+# spawns: the readiness wait above bounds the ``ssh -L`` forward, and this bounds
+# the separate ``ssh <host> kirocrew token`` invocation. Both cross the same
+# ProxyCommand/jump host, so a host whose handshake alone eats 12-16s spends that
+# cost twice — meaning a user who had to raise ``connect_timeout_secs`` can clear
+# the forward and still time out here. Exposed as a user-tunable via
+# ``kirocrew config set instances.mint_timeout_secs <value>`` for exactly that
+# case (30s covers a direct ssh mint comfortably).
+DEFAULT_MINT_TIMEOUT_SECS: float = 30.0
+
+# SSM dispatches the mint through ``ssm send-command``, which adds the agent's
+# poll interval to the remote command's own runtime before any output comes
+# back — routinely slower than an ssh mint, hence the higher default. An explicit
+# ``mint_timeout_secs`` override wins for both transports (same convention as
+# ``connect_timeout_secs``).
+DEFAULT_SSM_MINT_TIMEOUT_SECS: float = 90.0
+
+# Upper bound (secs) on a user-configured instances.mint_timeout_secs. Higher
+# than the connect ceiling because the mint budget covers a proxy handshake AND
+# the remote gateway actually answering the token request, and because it must
+# sit above the SSM default (90s) or that transport's own default would be
+# unreachable as an explicit value. Still bounded so a pathological setting
+# cannot leave a connect attempt hanging for hours.
+MINT_TIMEOUT_CEILING_SECS: float = 300.0
+
 # Proactively re-mint each instance's dashboard token at this fraction of its
 # TTL, before the 20h cap. 0.8 = refresh at 80% elapsed.
 DEFAULT_TOKEN_REFRESH_FRACTION: float = 0.8

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -69,6 +69,7 @@ from kiro_crew.instances.constants import (
     DEFAULT_CONNECT_TIMEOUT_SECS as _DEFAULT_CONNECT_TIMEOUT_SECS,
 )
 from kiro_crew.instances.constants import DEFAULT_MAX_RECOVERY_ATTEMPTS as _MAX_RECOVERY
+from kiro_crew.instances.constants import DEFAULT_MINT_TIMEOUT_SECS as _DEFAULT_MINT_TIMEOUT_SECS
 from kiro_crew.instances.constants import DEFAULT_PROBE_FAILURE_THRESHOLD as _PROBE_FAILS
 from kiro_crew.instances.constants import DEFAULT_PROBE_INTERVAL_SECS as _PROBE_INTERVAL
 from kiro_crew.instances.constants import (
@@ -77,6 +78,9 @@ from kiro_crew.instances.constants import (
 from kiro_crew.instances.constants import DEFAULT_SESSION_TRANSFER_TIMEOUT_SECS as _TRANSFER_TIMEOUT
 from kiro_crew.instances.constants import (
     DEFAULT_SSM_CONNECT_TIMEOUT_SECS as _DEFAULT_SSM_CONNECT_TIMEOUT_SECS,
+)
+from kiro_crew.instances.constants import (
+    DEFAULT_SSM_MINT_TIMEOUT_SECS as _DEFAULT_SSM_MINT_TIMEOUT_SECS,
 )
 from kiro_crew.instances.constants import DEFAULT_TOKEN_PROBE_TIMEOUT_SECS as _TOKEN_PROBE_TIMEOUT
 from kiro_crew.instances.constants import DEFAULT_TOKEN_REFRESH_FRACTION as _REFRESH_FRACTION
@@ -759,6 +763,7 @@ class SshTunnelManager:
         *,
         base_port: int = DEFAULT_TUNNEL_BASE_PORT,
         connect_timeout_secs: float | None = None,
+        mint_timeout_secs: float | None = None,
         ssh_compression: bool = True,
         max_recovery_attempts: int = _MAX_RECOVERY,
         recover_backoff_max_secs: float = _RECOVER_BACKOFF_MAX_SECS,
@@ -783,6 +788,12 @@ class SshTunnelManager:
         self._parent_port = parent_port if parent_port else _LOCAL_DASHBOARD_PORT
         self._allocator = PortAllocator(base_port=base_port)
         self._connect_timeout = connect_timeout_secs
+        # Budget for the SECOND proxy-bound child a connect spawns: the remote
+        # `kirocrew token` mint. Kept separate from the forward-readiness timeout
+        # above because a slow ProxyCommand pays its handshake cost on both, so
+        # raising only one still leaves the connect failing on the other.
+        # ``None`` = use the transport-specific default (see _mint_timeout_for).
+        self._mint_timeout = mint_timeout_secs
         self._ssh_compression = ssh_compression
         # Self-heal tunables (config-tunable via instances.*): max consecutive
         # recovery attempts before give-up, the cap on the per-attempt backoff,
@@ -889,6 +900,20 @@ class SshTunnelManager:
             return _DEFAULT_SSM_CONNECT_TIMEOUT_SECS
         return _DEFAULT_CONNECT_TIMEOUT_SECS
 
+    def _mint_timeout_for(self, method: str) -> float:
+        """Token-mint budget for *method*, honoring an explicit caller override.
+
+        Mirrors :meth:`_connect_timeout_for`. The SSM default is higher because
+        ``ssm send-command`` adds the agent's poll latency on top of the remote
+        command's own runtime. A caller that passed an explicit
+        ``mint_timeout_secs`` (config, tests, tuning) wins for both transports.
+        """
+        if self._mint_timeout is not None:
+            return self._mint_timeout  # explicit override
+        if method == "ssm":
+            return _DEFAULT_SSM_MINT_TIMEOUT_SECS
+        return _DEFAULT_MINT_TIMEOUT_SECS
+
     async def _ps_lines(self) -> list[str]:
         """Return ``<pid> <command>`` lines for all processes (portable ps).
 
@@ -980,8 +1005,12 @@ class SshTunnelManager:
 
         The SSH path goes through the injectable ``self._mint_token`` seam (kept
         so the existing tests can substitute a fake mint); the SSM path calls
-        :func:`mint_remote_token_ssm`. Never logs the token.
+        :func:`mint_remote_token_ssm`. Both are given the resolved
+        ``mint_timeout_secs`` budget (see :meth:`_mint_timeout_for`) so an operator
+        on a slow-proxy host can raise it without patching the package. Never logs
+        the token.
         """
+        timeout_secs = self._mint_timeout_for(params.method)
         if params.method == "ssm":
             return await mint_remote_token_ssm(
                 params.ssm_target,
@@ -992,6 +1021,7 @@ class SshTunnelManager:
                 ttl=inst.ttl,
                 remote_port=inst.remote_port,
                 embed_parent_port=self._parent_port,
+                timeout_secs=timeout_secs,
             )
         return await self._mint_token(
             params.ssh_host,
@@ -999,6 +1029,7 @@ class SshTunnelManager:
             ttl=inst.ttl,
             remote_port=inst.remote_port,
             embed_parent_port=self._parent_port,
+            timeout_secs=timeout_secs,
         )
 
     async def connect(self, instance_id: str) -> TunnelStatus:

--- a/src/kiro_crew/instances/ssm_token_mint.py
+++ b/src/kiro_crew/instances/ssm_token_mint.py
@@ -32,7 +32,7 @@ import logging
 import re
 
 from kiro_crew.cloud import ssm as cloud_ssm
-from kiro_crew.instances.constants import TTL_PATTERN
+from kiro_crew.instances.constants import DEFAULT_SSM_MINT_TIMEOUT_SECS, TTL_PATTERN
 from kiro_crew.instances.token_mint import (
     TokenMintError,
     build_remote_command,
@@ -51,8 +51,10 @@ logger = logging.getLogger(__name__)
 
 # How long to wait for the SSM send-command invocation to finish. Generous vs.
 # the SSH transport's 30s timeout: send-command has its own dispatch latency
-# (agent poll interval) on top of the remote command's own runtime.
-_DEFAULT_MINT_TIMEOUT_SECS = 90
+# (agent poll interval) on top of the remote command's own runtime. Canonical
+# value (and the user-tunable `instances.mint_timeout_secs` that overrides it)
+# lives in `instances.constants`.
+_DEFAULT_MINT_TIMEOUT_SECS = DEFAULT_SSM_MINT_TIMEOUT_SECS
 
 # Same ttl shape token_mint.py accepts (kept local rather than importing a
 # "private" helper cross-module — see module docstring).

--- a/src/kiro_crew/instances/token_mint.py
+++ b/src/kiro_crew/instances/token_mint.py
@@ -25,7 +25,7 @@ import logging
 import re
 
 from kiro_crew.config.paths import CONFIG_DIR_NAME, LEGACY_CONFIG_DIR_NAME
-from kiro_crew.instances.constants import TTL_PATTERN
+from kiro_crew.instances.constants import DEFAULT_MINT_TIMEOUT_SECS, TTL_PATTERN
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,10 @@ _CLIPPED_RUN_RE = re.compile(r"^[A-Za-z0-9_\-.=+/%%:?&]{%d,}" % _CLIPPED_RUN_MIN
 _CLIPPED_MARKER = "<clipped>"
 
 # How long to wait for the remote `kirocrew token` to return before giving up.
-_DEFAULT_MINT_TIMEOUT_SECS = 30.0
+# The canonical default (and the user-tunable `instances.mint_timeout_secs` that
+# overrides it) lives in `instances.constants`; re-exported under the old private
+# name so existing callers/tests keep working.
+_DEFAULT_MINT_TIMEOUT_SECS = DEFAULT_MINT_TIMEOUT_SECS
 
 
 class TokenMintError(Exception):

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -62,6 +62,7 @@ class TestConfig:
             "tunnel_base_port": 7778,
             "ssh_compression": True,
             "connect_timeout_secs": None,
+            "mint_timeout_secs": None,
             "max_recovery_attempts": 8,
             "recover_backoff_max_secs": 30.0,
             "probe_failure_threshold": 3,
@@ -74,6 +75,7 @@ class TestConfig:
             "instances.tunnel_base_port",
             "instances.ssh_compression",
             "instances.connect_timeout_secs",
+            "instances.mint_timeout_secs",
             "instances.max_recovery_attempts",
             "instances.recover_backoff_max_secs",
             "instances.probe_failure_threshold",
@@ -85,6 +87,10 @@ class TestConfig:
         assert timeout_entry.type == "number"
         assert timeout_entry.nullable is True
         assert timeout_entry.default_value is None
+        mint_entry = next(e for e in SCHEMA_REGISTRY if e.path == "instances.mint_timeout_secs")
+        assert mint_entry.type == "number"
+        assert mint_entry.nullable is True
+        assert mint_entry.default_value is None
 
     def test_recovery_knobs_parse_from_config_file(self, tmp_path, monkeypatch):
         import json
@@ -213,6 +219,79 @@ class TestConfig:
         cfg_file.write_text(json.dumps({"instances": {"connect_timeout_secs": 15.0}}))
         cfg = KiroCrewConfig.load()
         assert cfg.instances.connect_timeout_secs == 15.0
+
+    def test_mint_timeout_default_and_clamps(self):
+        from kiro_crew.config.loader import InstancesConfig
+        from kiro_crew.instances.constants import (
+            DEFAULT_MINT_TIMEOUT_SECS,
+            DEFAULT_SSM_MINT_TIMEOUT_SECS,
+            MINT_TIMEOUT_CEILING_SECS,
+        )
+
+        # Unset remains distinguishable from an explicit value equal to the SSH
+        # default, so the manager can select the transport-specific default.
+        c = InstancesConfig()
+        assert DEFAULT_MINT_TIMEOUT_SECS == 30.0
+        assert DEFAULT_SSM_MINT_TIMEOUT_SECS == 90.0
+        assert c.mint_timeout_secs is None
+
+        c = InstancesConfig(mint_timeout_secs=DEFAULT_MINT_TIMEOUT_SECS)
+        assert c.mint_timeout_secs == DEFAULT_MINT_TIMEOUT_SECS
+
+        # Explicit override is honored.
+        c = InstancesConfig(mint_timeout_secs=90.0)
+        assert c.mint_timeout_secs == 90.0
+
+        # Below 1 falls back to the transport-specific defaults.
+        assert InstancesConfig(mint_timeout_secs=0.5).mint_timeout_secs is None
+        assert InstancesConfig(mint_timeout_secs=-10.0).mint_timeout_secs is None
+
+        # Above the ceiling is clamped; the boundary itself is left untouched. The
+        # ceiling must sit above the SSM default or that transport's own default
+        # would be unreachable as an explicit value.
+        assert MINT_TIMEOUT_CEILING_SECS == 300.0
+        assert MINT_TIMEOUT_CEILING_SECS > DEFAULT_SSM_MINT_TIMEOUT_SECS
+        assert (
+            InstancesConfig(mint_timeout_secs=99_999.0).mint_timeout_secs
+            == MINT_TIMEOUT_CEILING_SECS
+        )
+        assert (
+            InstancesConfig(mint_timeout_secs=MINT_TIMEOUT_CEILING_SECS).mint_timeout_secs
+            == MINT_TIMEOUT_CEILING_SECS
+        )
+
+    def test_mint_timeout_parses_from_config_file(self, tmp_path, monkeypatch):
+        import json
+
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        cfg_file = tmp_path / "config.json"
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg_file)
+
+        cfg_file.write_text(json.dumps({"instances": {"mint_timeout_secs": 90.0}}))
+        assert KiroCrewConfig.load().instances.mint_timeout_secs == 90.0
+
+        # Absent and explicit-null both mean "unset" (transport default wins).
+        cfg_file.write_text(json.dumps({"instances": {}}))
+        assert KiroCrewConfig.load().instances.mint_timeout_secs is None
+
+        cfg_file.write_text(json.dumps({"instances": {"mint_timeout_secs": None}}))
+        assert KiroCrewConfig.load().instances.mint_timeout_secs is None
+
+        # An explicit value equal to the SSH default survives as explicit.
+        cfg_file.write_text(json.dumps({"instances": {"mint_timeout_secs": 30.0}}))
+        assert KiroCrewConfig.load().instances.mint_timeout_secs == 30.0
+
+    def test_mint_timeout_constant_shared_with_both_minters(self):
+        """The minters must read the shared constant, not re-hardcode a value."""
+        from kiro_crew.instances import ssm_token_mint, token_mint
+        from kiro_crew.instances.constants import (
+            DEFAULT_MINT_TIMEOUT_SECS,
+            DEFAULT_SSM_MINT_TIMEOUT_SECS,
+        )
+
+        assert token_mint._DEFAULT_MINT_TIMEOUT_SECS == DEFAULT_MINT_TIMEOUT_SECS
+        assert ssm_token_mint._DEFAULT_MINT_TIMEOUT_SECS == DEFAULT_SSM_MINT_TIMEOUT_SECS
 
 
 # ── PortAllocator ───────────────────────────────────────────────────────────
@@ -1033,7 +1112,7 @@ class TestSshTunnelArgvCompression:
             return _FakeTunnel(*a, compression=compression, **k)
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             return "SECRET_TOK"
 
@@ -1231,7 +1310,7 @@ class TestSshTunnelManager:
         reg = InstancesRegistry(path=tmp_path / "instances.json")
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             return "SECRET_TOK"
 
@@ -1300,7 +1379,7 @@ class TestSshTunnelManager:
         from kiro_crew.instances.token_mint import TokenMintError
 
         async def bad_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             raise TokenMintError("nope")
 
@@ -2907,7 +2986,7 @@ class TestSelfHealRefreshRestart:
         reg = InstancesRegistry(path=tmp_path / "instances.json")
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             return "TOK"
 
@@ -3156,7 +3235,9 @@ class TestSelfHealRefreshRestart:
         release = asyncio.Event()
         minted = 0
 
-        async def slow_mint(host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None):
+        async def slow_mint(
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
+        ):
             nonlocal minted
             minted += 1
             if arm.is_set():
@@ -3212,7 +3293,7 @@ class TestSelfHealRefreshRestart:
         seen: list = []
 
         async def capturing_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             seen.append(remote_port)
             return "TOK"
@@ -3419,7 +3500,7 @@ class TestPortMirror:
         monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": port_free)
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             return "TOK"
 
@@ -3507,7 +3588,7 @@ class TestLastError:
         reg = InstancesRegistry(path=tmp_path / "instances.json")
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             return "SECRET_TOK"
 
@@ -3542,7 +3623,7 @@ class TestLastError:
         from kiro_crew.instances.token_mint import TokenMintError
 
         async def bad_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             raise TokenMintError("nope")
 
@@ -3560,7 +3641,7 @@ class TestLastError:
         calls = {"n": 0}
 
         async def flaky_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             calls["n"] += 1
             if calls["n"] == 1:
@@ -3580,7 +3661,7 @@ class TestLastError:
         from kiro_crew.instances.token_mint import TokenMintError
 
         async def bad_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             raise TokenMintError("nope")
 
@@ -3609,7 +3690,7 @@ class TestStatusForRetainedError:
         reg = InstancesRegistry(path=tmp_path / "instances.json")
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             return "SECRET_TOK"
 
@@ -3625,7 +3706,7 @@ class TestStatusForRetainedError:
         from kiro_crew.instances.token_mint import TokenMintError
 
         async def bad_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             raise TokenMintError("nope")
 
@@ -3683,7 +3764,7 @@ class TestStartupRevive:
         reg = InstancesRegistry(path=tmp_path / "instances.json")
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             return "SECRET_TOK"
 
@@ -3716,7 +3797,9 @@ class TestStartupRevive:
         from kiro_crew.instances.ssh_tunnel_manager import TunnelState
         from kiro_crew.instances.token_mint import TokenMintError
 
-        async def mint(host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None):
+        async def mint(
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
+        ):
             if "bad" in host:
                 raise TokenMintError("unreachable")
             return "SECRET_TOK"
@@ -3770,6 +3853,7 @@ class TestStartupRevive:
                 tunnel_base_port=53400,
                 ssh_compression=False,
                 connect_timeout_secs=15.0,
+                mint_timeout_secs=30.0,
                 max_recovery_attempts=8,
                 recover_backoff_max_secs=30.0,
                 probe_failure_threshold=3,
@@ -4184,12 +4268,12 @@ class TestSsmTransportSelection:
 
         monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
 
-    def _mgr(self, tmp_path, *, mint=None, connect_timeout_secs=None):
+    def _mgr(self, tmp_path, *, mint=None, connect_timeout_secs=None, mint_timeout_secs=None):
         from kiro_crew.instances.registry import InstancesRegistry
         from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
 
         async def ok_mint(
-            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, **_kw
         ):
             return "SSH_TOKEN"
 
@@ -4197,6 +4281,8 @@ class TestSsmTransportSelection:
         manager_kwargs = {}
         if connect_timeout_secs is not None:
             manager_kwargs["connect_timeout_secs"] = connect_timeout_secs
+        if mint_timeout_secs is not None:
+            manager_kwargs["mint_timeout_secs"] = mint_timeout_secs
         return reg, SshTunnelManager(
             reg,
             base_port=53500,
@@ -4236,6 +4322,56 @@ class TestSsmTransportSelection:
         )
         assert mgr._connect_timeout_for("ssh") == ssh_expected
         assert mgr._connect_timeout_for("ssm") == ssm_expected
+
+    @pytest.mark.parametrize(
+        ("configured", "ssh_expected", "ssm_expected"),
+        [
+            (None, 30.0, 90.0),
+            (30.0, 30.0, 30.0),
+            (120.0, 120.0, 120.0),
+            (0.0, 30.0, 90.0),
+            (99_999.0, 300.0, 300.0),
+        ],
+    )
+    def test_mint_timeout_matrix(self, tmp_path, configured, ssh_expected, ssm_expected):
+        from kiro_crew.config.loader import InstancesConfig
+
+        config = InstancesConfig(mint_timeout_secs=configured)
+        _, mgr = self._mgr(tmp_path, mint_timeout_secs=config.mint_timeout_secs)
+        assert mgr._mint_timeout_for("ssh") == ssh_expected
+        assert mgr._mint_timeout_for("ssm") == ssm_expected
+
+    @pytest.mark.asyncio
+    async def test_configured_mint_timeout_reaches_the_ssh_mint(self, tmp_path):
+        """The resolved budget must actually be handed to the minter."""
+        seen = {}
+
+        async def recording_mint(host, *, timeout_secs=None, **_kw):
+            seen["timeout_secs"] = timeout_secs
+            return "SSH_TOKEN"
+
+        reg, mgr = self._mgr(tmp_path, mint=recording_mint, mint_timeout_secs=90.0)
+        reg.add(name="Dev", ssh_host="dev-1", instance_id="dev", remote_port=53512)
+        await mgr.connect("dev")
+        assert seen["timeout_secs"] == 90.0
+        await mgr.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_default_mint_timeout_reaches_the_ssh_mint(self, tmp_path):
+        """With nothing configured, the SSH transport default is passed explicitly."""
+        from kiro_crew.instances.constants import DEFAULT_MINT_TIMEOUT_SECS
+
+        seen = {}
+
+        async def recording_mint(host, *, timeout_secs=None, **_kw):
+            seen["timeout_secs"] = timeout_secs
+            return "SSH_TOKEN"
+
+        reg, mgr = self._mgr(tmp_path, mint=recording_mint)
+        reg.add(name="Dev", ssh_host="dev-1", instance_id="dev", remote_port=53513)
+        await mgr.connect("dev")
+        assert seen["timeout_secs"] == DEFAULT_MINT_TIMEOUT_SECS
+        await mgr.shutdown()
 
     @pytest.mark.asyncio
     async def test_ssh_instance_uses_ssh_transport(self, tmp_path):


### PR DESCRIPTION
## Problem / Motivation

The instance connection's mint timeout is hardcoded at 30s. On slow networks or overloaded SSM endpoints, mints time out with no user recourse.

## Why it matters

Users on high-latency connections (VPN, cross-region) cannot connect to remote instances. The sibling `connect_timeout_secs` is already configurable; this one was missed.

## What changed (motivation → approach → change)

Extracted the hardcoded 30s into a `token_mint_timeout_secs` config field (defaulting to 30 for backward compatibility), read from the instances config section. Applied to both SSM and SSH tunnel mint paths.

## Tests

Extended `test/test_instances.py` with cases: default timeout is 30s, custom timeout is respected, config field is properly loaded.

## Manual verification

N/A — timeout plumbing; unit tests cover the configuration path.

## Screenshots / video

N/A — backend config change, no UI surface.

## Related Issues

Fixes #3566

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] No secrets, credentials, or internal references in the diff
