### PR TITLE
refactor(apps): normalize InstalledApp manifests at the query boundary (#3706)

### DIFF
--- a/website/src/appNav.ts
+++ b/website/src/appNav.ts
@@ -87,8 +87,10 @@ export function isAppNavigable(app: AppNavRecord): boolean {
  *     registered at the page's own route.
  */
 export function appNavTarget(app: AppNavRecord): AppNavTarget | null {
-  if (!isAppNavigable(app)) return null
-  const page = app.manifest!.ui!.pages![0]
+  // `!page` re-narrows what `isAppNavigable` already guarantees, so the
+  // destination read can never drift from the eligibility check.
+  const page = app.manifest?.ui?.pages?.[0]
+  if (!isAppNavigable(app) || !page) return null
   const isBuiltin = app.origin === 'builtin'
   const orphaned = !!app.orphaned
   const appHostRouted = !isBuiltin || !!app.manifest?.ui?.entry

--- a/website/src/components/appstore/InstalledAppCard.tsx
+++ b/website/src/components/appstore/InstalledAppCard.tsx
@@ -39,7 +39,8 @@ export default function InstalledAppCard({
   const skillCount = m?.skills?.length || 0
   const cronCount = m?.crons?.length || 0
   const sopCount = m?.sops?.length || 0
-  const pageCount = m?.ui?.pages?.length || 0
+  const uiPages = m?.ui?.pages || []
+  const pageCount = uiPages.length
   const tags = m?.tags || []
   const mcpTools = m?.permissions?.mcpTools || []
   const hasUI = !!(m?.ui?.entry) || pageCount > 0
@@ -218,10 +219,10 @@ export default function InstalledAppCard({
               <span className="text-text">{mcpTools.join(', ')}</span>
             </div>
           )}
-          {hasUI && m?.ui?.pages && (
+          {hasUI && pageCount > 0 && (
             <div>
               <span className="text-muted">{i18nT('components.appstore.installedAppCard.ui_pages')} </span>
-              {m.ui.pages.map(p => (
+              {uiPages.map(p => (
                 <span key={p.route} className="text-text mr-3">{p.label} ({p.route})</span>
               ))}
             </div>

--- a/website/src/components/appstore/types.ts
+++ b/website/src/components/appstore/types.ts
@@ -183,3 +183,70 @@ export function normalizeRegistryApp(raw: RegistryApp): RegistryApp {
     tags: Array.isArray(raw?.tags) ? raw.tags.filter((t): t is string => typeof t === 'string') : [],
   }
 }
+
+/**
+ * Coerce an untrusted value to a list of strings: non-arrays collapse to
+ * ``[]`` and non-string members are dropped. Shared by the query-boundary
+ * normalizers and by render sites on fetch paths that have no normalizer
+ * (e.g. the app detail page's ``/api/apps/{name}`` payload), so a truthy
+ * non-array can never reach ``.map``.
+ */
+export function stringList(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((t): t is string => typeof t === 'string') : []
+}
+
+/**
+ * Normalize an installed-app record for rendering.
+ *
+ * ``GET /api/apps`` mirrors app-manager records whose manifests come from
+ * user-authored ``app.json`` files, so the optional manifest collections
+ * (``agents``, ``skills``, ``crons``, ``ui.pages``, …) can be missing or the
+ * wrong type — an entry-only UI has no ``pages`` array at all. Render sites
+ * that defend per call site with non-null assertions drift from their guards
+ * and crash the whole route, so coerce once at the query boundary instead:
+ * after this pass every enumerated collection is a well-typed array and the
+ * display strings are strings, and downstream code needs no ``!`` escapes.
+ */
+export function normalizeInstalledApp(raw: InstalledApp): InstalledApp {
+  const str = (v: unknown, fallback = '') => (typeof v === 'string' ? v : fallback)
+  // A drifted record can lack the manifest entirely even though the type
+  // declares it required; rebuild it rather than dereference it.
+  const manifest = (raw?.manifest ?? {}) as InstalledApp['manifest']
+  const ui = (manifest.ui && typeof manifest.ui === 'object' ? manifest.ui : {}) as
+    NonNullable<InstalledApp['manifest']['ui']>
+  const name = str(raw?.name)
+  const version = str(raw?.version, '0.0.0')
+  const displayName = str(raw?.displayName, name)
+  return {
+    ...raw,
+    name,
+    version,
+    displayName,
+    manifest: {
+      ...manifest,
+      name: str(manifest.name, name),
+      version: str(manifest.version, version),
+      displayName: str(manifest.displayName, displayName),
+      description: str(manifest.description),
+      author: str(manifest.author),
+      agents: stringList(manifest.agents),
+      skills: stringList(manifest.skills),
+      sops: stringList(manifest.sops),
+      tags: stringList(manifest.tags),
+      jobFamilies: stringList(manifest.jobFamilies),
+      crons: Array.isArray(manifest.crons)
+        ? manifest.crons.filter(c => !!c && typeof c.name === 'string')
+        : [],
+      // Preserve ``ui.entry`` (and any extra keys) untouched: ``hasUI`` and
+      // AppHost routing read entry truthiness, so injecting one would change
+      // eligibility. Only ``pages`` is coerced; rows without a string route
+      // are dropped because every consumer routes through ``pages[0].route``.
+      ui: {
+        ...ui,
+        pages: Array.isArray(ui.pages)
+          ? ui.pages.filter(p => !!p && typeof p.route === 'string')
+          : [],
+      },
+    },
+  }
+}

--- a/website/src/pages/AppDetailPage.tsx
+++ b/website/src/pages/AppDetailPage.tsx
@@ -24,6 +24,7 @@ import AskAgentButton from '../components/AskAgentButton'
 
 import { i18nT } from '../i18n/t'
 import { appDisplayName, appDescription, appHighlights } from '../components/appstore/appManifest'
+import { stringList } from '../components/appstore/types'
 import { fmtDateNumeric } from '../i18n/format'
 type AppInfo = {
   name: string
@@ -545,9 +546,16 @@ export default function AppDetailPage() {
   const desktopOnly = needsDesktopApp(app)
   const canUpdate = app.lifecycle === 'gateway'
   const canUninstall = app.lifecycle !== 'locked'
-  const agentCount = app.manifest?.agents?.length || 0
-  const skillCount = app.manifest?.skills?.length || 0
-  const cronCount = app.manifest?.crons?.length || 0
+  // stringList (not `|| []`): a mistyped truthy non-array from a user-authored
+  // manifest would pass `||` and then throw on `.map`. This fetch path
+  // (/api/apps/{name}) has no query-boundary normalizer, so coerce here.
+  const manifestAgents = stringList(app.manifest?.agents)
+  const manifestSkills = stringList(app.manifest?.skills)
+  const rawCrons = app.manifest?.crons
+  const manifestCrons = Array.isArray(rawCrons) ? rawCrons.filter(c => !!c && typeof c.name === 'string') : []
+  const agentCount = manifestAgents.length
+  const skillCount = manifestSkills.length
+  const cronCount = manifestCrons.length
   // Theme-aware hero banner source (mirrors the Browse card resolution).
   // Prefer the wide detail-ratio banner (heroImageDetail*); fall back to the
   // Browse hero, then the opposite theme.
@@ -964,22 +972,22 @@ export default function AppDetailPage() {
             <Card>
               <CardTitle>{i18nT('pages.appDetailPage.resources')}</CardTitle>
               <div className="grid gap-1.5 mt-2 text-[13px]">
-                {(app.manifest?.agents || []).length > 0 && (
+                {agentCount > 0 && (
                   <div className="flex items-start gap-2 text-muted">
                     <Bot size={13} className="mt-0.5 shrink-0" />
-                    <div>{app.manifest!.agents!.map((a: string) => a.split('/').pop()?.replace('.json', '')).join(', ')}</div>
+                    <div>{manifestAgents.map((a: string) => a.split('/').pop()?.replace('.json', '')).join(', ')}</div>
                   </div>
                 )}
-                {(app.manifest?.skills || []).length > 0 && (
+                {skillCount > 0 && (
                   <div className="flex items-start gap-2 text-muted">
                     <Zap size={13} className="mt-0.5 shrink-0" />
-                    <div>{app.manifest!.skills!.map((s: string) => s.split('/').pop()).join(', ')}</div>
+                    <div>{manifestSkills.map((s: string) => s.split('/').pop()).join(', ')}</div>
                   </div>
                 )}
-                {(app.manifest?.crons || []).length > 0 && (
+                {cronCount > 0 && (
                   <div className="flex items-start gap-2 text-muted">
                     <Clock size={13} className="mt-0.5 shrink-0" />
-                    <div>{app.manifest!.crons!.map((c) => c.name).join(', ')}</div>
+                    <div>{manifestCrons.map((c) => c.name).join(', ')}</div>
                   </div>
                 )}
               </div>

--- a/website/src/pages/AppsPage.tsx
+++ b/website/src/pages/AppsPage.tsx
@@ -36,7 +36,7 @@ import TrustAppModal, { isTrustDeniedError, useTrustGate, type TrustAppTarget } 
 import SourcesPopover from '../components/appstore/SourcesPopover'
 import { categoryFor, categoryCounts, mergeCategoryOrder, type Category } from '../components/appstore/categories'
 import { hasHeroArt } from '../components/appstore/useHeroArt'
-import { isVerified, normalizeRegistryApp, type InstalledApp, type RegistryApp } from '../components/appstore/types'
+import { isVerified, normalizeInstalledApp, normalizeRegistryApp, type InstalledApp, type RegistryApp } from '../components/appstore/types'
 
 import { i18nT } from '../i18n/t'
 import ErrorNotice from '../components/ErrorNotice'
@@ -231,6 +231,14 @@ export default function AppsPage() {
   const { data: apps = [], isLoading: appsLoading, error: appsError } = useQuery<InstalledApp[]>({
     queryKey: ['apps'],
     queryFn: () => api.listApps(),
+    // The ['apps'] cache is shared with observers that fetch it raw
+    // (MigrationCheck, the command palette's apps provider), and React Query
+    // keeps one queryFn per key — whichever observer registered last fetches.
+    // Normalization therefore lives in `select`, which runs on every read of
+    // THIS observer no matter which caller populated the cache. Manifests
+    // come from user-authored app.json files, so optional collections may be
+    // missing or mistyped (mirrors the registry normalization below).
+    select: rows => rows.map(normalizeInstalledApp),
   })
 
   const { data: registryData, isLoading: registryLoading, error: registryError } = useQuery<{
@@ -735,13 +743,13 @@ export default function AppsPage() {
                   </div>
                 )}
                 {(uninstallTarget.manifest?.agents?.length || 0) > 0 && (
-                  <div className="flex items-center gap-2"><Bot size={12} className="text-muted" /> {i18nT('pages.appsPage.agent', { count: uninstallTarget.manifest.agents!.length })}</div>
+                  <div className="flex items-center gap-2"><Bot size={12} className="text-muted" /> {i18nT('pages.appsPage.agent', { count: uninstallTarget.manifest?.agents?.length || 0 })}</div>
                 )}
                 {(uninstallTarget.manifest?.skills?.length || 0) > 0 && (
-                  <div className="flex items-center gap-2"><Zap size={12} className="text-muted" /> {i18nT('pages.appsPage.skill', { count: uninstallTarget.manifest.skills!.length })}</div>
+                  <div className="flex items-center gap-2"><Zap size={12} className="text-muted" /> {i18nT('pages.appsPage.skill', { count: uninstallTarget.manifest?.skills?.length || 0 })}</div>
                 )}
                 {(uninstallTarget.manifest?.crons?.length || 0) > 0 && (
-                  <div className="flex items-center gap-2"><Clock size={12} className="text-muted" /> {i18nT('pages.appsPage.cron_job', { count: uninstallTarget.manifest.crons!.length })}</div>
+                  <div className="flex items-center gap-2"><Clock size={12} className="text-muted" /> {i18nT('pages.appsPage.cron_job', { count: uninstallTarget.manifest?.crons?.length || 0 })}</div>
                 )}
               </div>
 

--- a/website/src/test/AppsPageCardBoundary.test.tsx
+++ b/website/src/test/AppsPageCardBoundary.test.tsx
@@ -56,9 +56,14 @@ vi.mock('../components/SegmentedControl', () => ({
 // Throw from ONE card's render. Driven by app identity (not a mutable
 // counter): React re-invokes a throwing render to rebuild the component
 // stack, so a "throw once" mock would silently pass on the retry.
+// Every other card records the `app` prop it received, so tests can assert
+// on the record AppsPage actually hands the card (e.g. that the query
+// boundary normalized it).
+const cardMock = vi.hoisted(() => ({ apps: [] as { name: string; manifest?: Record<string, unknown> }[] }))
 vi.mock('../components/appstore/InstalledAppCard', () => ({
-  default: ({ app }: { app: { name: string } }) => {
+  default: ({ app }: { app: { name: string; manifest?: Record<string, unknown> } }) => {
     if (app.name === 'zzq-broken') throw new Error('zzq-card-render-broke')
+    cardMock.apps.push(app)
     return <div data-testid={`zzq-card-${app.name}`} />
   },
 }))
@@ -126,5 +131,39 @@ describe('AppsPage per-card error boundary (#3689)', () => {
     // fallback must not be a dead end: an enabled app keeps a Disable action.
     const disable = screen.getByRole('button', { name: i18nT('components.appstore.installedAppCard.disable') })
     expect(disable).toBeInTheDocument()
+  })
+})
+
+describe('AppsPage normalizes installed apps at the query boundary (#3706)', () => {
+  beforeEach(() => {
+    sessionStorage.setItem('appstore-tab', 'library')
+    listRegistry.mockResolvedValue({ apps: [], categoryOrder: [], editorialSections: [] })
+    listRegistries.mockResolvedValue([])
+    cardMock.apps.length = 0
+  })
+  afterEach(() => {
+    sessionStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('hands the card a normalized record even for a manifest-less API row', async () => {
+    // A drifted record can lack the manifest entirely; the query boundary
+    // must rebuild it so no render site needs per-site null defenses.
+    listApps.mockResolvedValue([
+      { name: 'zzq-bare', enabled: true },
+      { name: 'zzq-mistyped', enabled: true, manifest: { name: 'zzq-mistyped', tags: 'not-an-array', skills: ['ok', 7] } },
+    ])
+    renderPage()
+    expect(await screen.findByTestId('zzq-card-zzq-bare')).toBeInTheDocument()
+    expect(screen.getByTestId('zzq-card-zzq-mistyped')).toBeInTheDocument()
+
+    const bare = cardMock.apps.find(a => a.name === 'zzq-bare')
+    expect(bare?.manifest).toBeTruthy()
+    expect(bare?.manifest?.agents).toEqual([])
+    expect((bare?.manifest?.ui as { pages?: unknown[] })?.pages).toEqual([])
+
+    const mistyped = cardMock.apps.find(a => a.name === 'zzq-mistyped')
+    expect(mistyped?.manifest?.tags).toEqual([])
+    expect(mistyped?.manifest?.skills).toEqual(['ok'])
   })
 })

--- a/website/src/test/appstoreCategories.test.ts
+++ b/website/src/test/appstoreCategories.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { categoryFor, categoryCounts } from '../components/appstore/categories'
 import { gradientFor } from '../components/appstore/gradient'
-import { sourceLabel, isVerified, normalizeRegistryApp, type RegistryApp } from '../components/appstore/types'
+import { sourceLabel, isVerified, normalizeInstalledApp, normalizeRegistryApp, stringList, type InstalledApp, type RegistryApp } from '../components/appstore/types'
 import { pickFeatured } from '../pages/AppsPage'
 
 const app = (over: Partial<RegistryApp>): RegistryApp => ({
@@ -244,5 +244,102 @@ describe('categoryFor — malformed tags cannot crash the storefront', () => {
     expect(categoryFor([7, null, undefined] as unknown)).toBe('Other')
     expect(categoryFor([null, 'github'] as unknown)).toBe('Developer Tools')
     expect(() => categoryCounts([{ tags: 'nope' }, { tags: [1, 2] }])).not.toThrow()
+  })
+})
+
+describe('stringList', () => {
+  it('collapses truthy non-arrays to [] and drops non-string members', () => {
+    // A mistyped truthy value ('abc' || [] yields 'abc') must never reach
+    // .map at a render site; stringList is the shared coercion for that.
+    expect(stringList('abc')).toEqual([])
+    expect(stringList({ 0: 'x' })).toEqual([])
+    expect(stringList(undefined)).toEqual([])
+    expect(stringList(['a', 7, null, 'b'])).toEqual(['a', 'b'])
+  })
+})
+
+describe('normalizeInstalledApp', () => {
+  const installed = (over: Record<string, unknown> = {}, manifest: Record<string, unknown> = {}): InstalledApp =>
+    ({
+      name: 'zzq-app', version: '1.0.0', displayName: 'Zzq App', enabled: true,
+      installedAt: '2026-08-01T00:00:00Z',
+      manifest: {
+        name: 'zzq-app', version: '1.0.0', displayName: 'Zzq App',
+        description: 'd', author: 'a', ...manifest,
+      },
+      ...over,
+    } as unknown as InstalledApp)
+
+  it('defaults every optional manifest collection to an array', () => {
+    const out = normalizeInstalledApp(installed())
+    expect(out.manifest.agents).toEqual([])
+    expect(out.manifest.skills).toEqual([])
+    expect(out.manifest.sops).toEqual([])
+    expect(out.manifest.crons).toEqual([])
+    expect(out.manifest.tags).toEqual([])
+    expect(out.manifest.jobFamilies).toEqual([])
+    expect(out.manifest.ui?.pages).toEqual([])
+  })
+
+  it('survives a record with no manifest at all (the drifted-assertion crash class)', () => {
+    const out = normalizeInstalledApp({ name: 'bare' } as unknown as InstalledApp)
+    expect(out.manifest.name).toBe('bare')
+    expect(out.manifest.displayName).toBe('bare')
+    expect(out.manifest.description).toBe('')
+    expect(out.manifest.author).toBe('')
+    expect(out.manifest.agents).toEqual([])
+    expect(out.manifest.ui?.pages).toEqual([])
+    // Enumerating a normalized manifest collection cannot throw.
+    expect(() => (out.manifest.agents ?? []).map(a => a.toLowerCase())).not.toThrow()
+  })
+
+  it('coerces mistyped collections and drops malformed members', () => {
+    const out = normalizeInstalledApp(installed({}, {
+      agents: 'not-an-array',
+      skills: ['ok', 7, null],
+      crons: [{ name: 'tick' }, { nope: true }, null, 'raw'],
+      tags: { 0: 'x' },
+    }))
+    expect(out.manifest.agents).toEqual([])
+    expect(out.manifest.skills).toEqual(['ok'])
+    expect(out.manifest.crons).toEqual([{ name: 'tick' }])
+    expect(out.manifest.tags).toEqual([])
+  })
+
+  it('keeps ui.entry and extra page keys while coercing pages', () => {
+    const out = normalizeInstalledApp(installed({}, {
+      ui: {
+        entry: 'main.js',
+        pages: [
+          { route: '/apps/zzq', label: 'Zzq', icon: 'bot', iconUrl: 'icon.svg' },
+          { label: 'no-route' },
+          null,
+        ],
+      },
+    }))
+    expect(out.manifest.ui?.entry).toBe('main.js')
+    expect(out.manifest.ui?.pages).toEqual([
+      { route: '/apps/zzq', label: 'Zzq', icon: 'bot', iconUrl: 'icon.svg' },
+    ])
+  })
+
+  it('does not invent a ui entry for an app without one', () => {
+    const out = normalizeInstalledApp(installed())
+    // hasUI/AppHost routing read entry truthiness; normalization must not
+    // change navigation eligibility, only make the pages read safe.
+    expect(out.manifest.ui?.entry).toBeUndefined()
+  })
+
+  it('fills required display strings from mistyped values', () => {
+    const out = normalizeInstalledApp(installed(
+      { displayName: 42, version: null },
+      { displayName: undefined, version: undefined, description: null, author: 9 },
+    ))
+    expect(out.displayName).toBe('zzq-app')
+    expect(out.version).toBe('0.0.0')
+    expect(out.manifest.displayName).toBe('zzq-app')
+    expect(out.manifest.version).toBe('0.0.0')
+    expect(out.manifest.description).toBe('')
+    expect(out.manifest.author).toBe('')
   })
 })


### PR DESCRIPTION
Closes #3706

## Problem
Installed-app manifests were defended per render site with non-null assertions (`!`) that drift from their guards. #3689 was a crash from exactly that drift (`m.ui!.pages!.length` on an entry-only manifest unmounted the whole /apps route). After #3698's spot fix, 7 `!`-asserted manifest reads survived behind manual guards: 3 in `AppDetailPage.tsx`, 1 in `appNav.ts` (`app.manifest!.ui!.pages![0]`), and 3 in `AppsPage.tsx`'s uninstall dialog.

## Why it matters
Each surviving assertion is a latent route-crash: manifests come from user-authored `app.json` files, so optional collections can be missing or mistyped, and the next guard/assertion drift ships another #3689.

## Fix (symptom → root cause → change)
Root cause is defending everywhere instead of coercing once, so this follows the existing `normalizeRegistryApp` pattern:
- **`types.ts`**: new `normalizeInstalledApp(raw: InstalledApp): InstalledApp` adjacent to `normalizeRegistryApp` — rebuilds a missing manifest, coerces display strings, defaults `agents`/`skills`/`sops`/`crons`/`tags`/`jobFamilies`/`ui.pages` to well-typed arrays. `ui.entry` is deliberately preserved untouched (hasUI/AppHost routing read entry truthiness, so injecting one would change navigation eligibility).
- **`AppsPage.tsx`**: normalization applied via `select` (not `queryFn`): the `['apps']` cache is shared with observers that fetch it raw (`MigrationCheck`, the command palette's apps provider) and React Query keeps one queryFn per key, so `select` is the only placement that guarantees this observer always reads normalized rows regardless of which caller populated the cache. The 3 uninstall-dialog `!` reads become `?.`-safe counts.
- **`AppDetailPage.tsx`**: its data comes from a different fetch (`/api/apps/{name}`), so it gets a guard-restructure instead: hoisted `manifestAgents`/`manifestSkills`/`manifestCrons` bindings shared by guard and render, deleting all 3 `!` pairs.
- **`appNav.ts`**: `const page = app.manifest?.ui?.pages?.[0]; if (!isAppNavigable(app) || !page) return null` — the destination read can no longer drift from the eligibility check. Strictly safer: a `pages: [null]` row previously passed `isAppNavigable` and threw; it now returns null.
- **`InstalledAppCard.tsx`**: the UI-pages section guard moves from array existence to `pageCount > 0`, because normalization makes `pages` always an array and `[]` is truthy — without this, an entry-only app would render a dangling "UI pages:" label.
- **Deliberately not normalized**: `App.tsx`'s nav builder and the command palette use their own pinned optional types plus the now-safe `appNavTarget`; casting their raw payloads to `InstalledApp` would defeat the pinned-type design documented in `appNav.ts`.

Zero non-test `manifest…!` assertion sites remain in the frontend.

## Tests
- `appstoreCategories.test.ts`: 6-test `normalizeInstalledApp` suite — collection defaults, manifest-less record survival (the drifted-assertion crash class), mistyped-collection coercion, `ui.entry` preservation + page-row filtering, no invented `ui.entry`, display-string coercion.
- `AppsPageCardBoundary.test.tsx`: new boundary test feeding a manifest-less and a mistyped record through the real AppsPage query, asserting the card receives normalized manifests — fails if the `select` line is reverted.

## Manual verification
N/A — unit coverage sufficient: the change is behavior-preserving for all well-formed manifests (verified by the untouched 20 000+ frontend tests), and the malformed-manifest paths are locked by the new unit/boundary tests.

## Screenshots
N/A — no visible UI change for any in-tree app: pure refactor of null-defense placement. The only render delta is suppressing a dangling "UI pages:" label for third-party entry-only manifests, a state no in-tree app exercises.

## Gates
`npx tsc -b` clean · vitest 20137 passed / 1244 files · isort/flake8/mypy clean · backend pytest zero-delta (no Python files changed; failures match the host's pre-existing baseline)
