### PR TITLE
docs(secrets): document env-variable routes and warn on ignored .env keys

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,6 +13,7 @@ system is built, see [../architecture/](../architecture/README.md).
 | [remote-crew-on-ec2.md](remote-crew-on-ec2.md) | Reaching a Remote Crew gateway on EC2 over SSH or AWS SSM, plus the common EC2 setup gotchas (sandbox backend, linger, port/tunnel matching). |
 | [slack-setup.md](slack-setup.md) | Creating and configuring the Slack app. |
 | [enterprise-mcp-governance.md](enterprise-mcp-governance.md) | Running Kiro Crew on an enterprise Kiro account (IAM Identity Center / API key) whose administrator allow-lists MCP servers through a registry: why features go silently missing, and the two-sided fix. |
+| [secrets-env.md](secrets-env.md) | Passing secrets (API keys, tokens) to MCP servers via systemd environment directives or a shell wrapper — interim workarounds pending the encrypted vault. |
 | — | Other chat channels (Discord, Telegram, Teams, Webex, WeCom, WeChat) are documented in [../../src/kiro_crew/docs/](../../src/kiro_crew/docs/README.md); the channel-neutral transport contract is [messaging.md](../system-specs/modules/messaging.md). |
 
 `assets/` holds the copy-pasteable service unit, launchd plist, and setup script

--- a/docs/guides/secrets-env.md
+++ b/docs/guides/secrets-env.md
@@ -1,0 +1,127 @@
+# Passing secrets to MCP servers
+
+MCP servers often need API keys, database passwords, or other secrets at
+runtime.  Kiro Crew deliberately keeps secrets **out** of
+`~/.kiro/mcp.json` (which is versioned and may be shared across machines).
+
+> **Security note:** Both routes below are **interim workarounds** pending
+> the encrypted vault (planned — see
+> [issue tracker](https://github.com/kirodotdev/KiroCrew/issues/2351)).
+> They deliver the secret to the MCP server subprocess, but a
+> prompt-injected agent running in the same process tree can observe
+> environment variables that the sandbox does not explicitly scrub.  Use
+> these only when you accept that risk; the vault will close this gap by
+> resolving secrets at spawn time without exposing them to the agent.
+
+---
+
+## Route 1: systemd service unit `EnvironmentFile=`
+
+If you run Kiro Crew as a systemd service (see
+[remote-and-mobile.md](remote-and-mobile.md)), point the unit at a
+protected secrets file:
+
+```ini
+# /etc/systemd/system/kirocrew.service.d/secrets.conf
+[Service]
+EnvironmentFile=/etc/kirocrew/secrets.env
+```
+
+Create the secrets file with owner-only access:
+
+```bash
+sudo install -m 600 /dev/null /etc/kirocrew/secrets.env
+# Use an editor or redirect from a non-history source to avoid
+# leaving the token in shell history:
+sudo sh -c 'read -rp "Secret: " val && printf "MY_MCP_SECRET=%s\n" "$val" >> /etc/kirocrew/secrets.env'
+```
+
+Then reload and restart:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart kirocrew
+```
+
+The variables are visible to the gateway process and its MCP server
+children.  The file itself (`/etc/kirocrew/secrets.env`) is owned by root
+with mode `0600`, so the agent cannot read it via filesystem access.
+
+**Required:** after adding a secret, you **must** also add its key name to
+`_AGENT_DENIED_ENV_KEYS` in `src/kiro_crew/sandbox.py` to prevent the
+agent subprocess from inheriting it.  Without this step, the variable
+propagates through `AcpClient._spawn()` and a prompt-injected agent can
+read it from its own environment.
+
+> The encrypted vault (PR 1+) will eliminate this manual step — secrets
+> resolved via `secret://` are injected only into the bound MCP server's
+> env, never the agent's.
+
+---
+
+## Route 2: per-server shell wrapper with a root-owned secrets file
+
+Source a dedicated secrets file in the server's `command` array using a
+shell wrapper.  The file **must** be owned by root with mode `0600` so
+the agent (running as your user) cannot read it:
+
+```jsonc
+// ~/.kiro/mcp.json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "set -a; . /etc/kirocrew/mcp-secrets.env; set +a; exec my-mcp-server --stdio"
+      ]
+    }
+  }
+}
+```
+
+**How it works:**
+
+| Fragment | Purpose |
+|---|---|
+| `set -a` | Auto-export every variable assigned after this point. |
+| `. /etc/kirocrew/mcp-secrets.env` | Source secrets from a root-owned file. |
+| `set +a` | Stop auto-exporting (keeps the child env minimal). |
+| `exec …` | Replace the shell with the actual server process. |
+
+Create the secrets file with root ownership:
+
+```bash
+sudo install -m 600 /dev/null /etc/kirocrew/mcp-secrets.env
+sudo sh -c 'read -rp "Secret: " val && printf "MY_MCP_SECRET=%s\n" "$val" >> /etc/kirocrew/mcp-secrets.env'
+```
+
+The gateway process (running as root under systemd) can read the file.
+Agent subprocesses are spawned as a non-root user (`User=` in the service
+unit), so they cannot read the root-owned file.
+
+> **Important:** the systemd unit **must** set `User=<your-user>` for the
+> agent subprocess isolation to hold.  Running the entire gateway as root
+> without dropping privileges would give the agent root access too.
+
+> **Agent exposure caveat:** the MCP server receives the variable via its
+> process environment; the agent shares that process tree and can observe
+> the variable unless it is scrubbed by the sandbox.  This route protects
+> the **file** from agent reads but not the **runtime value** from agent
+> environment inspection.
+
+---
+
+## What NOT to do
+
+- **Do not** put secrets as plain string values inside `mcp.json` — the
+  file has no access controls beyond POSIX permissions and is easy to
+  accidentally commit or share.
+- **Do not** add custom keys to `~/.kiro/crew/.env` expecting them to be
+  agent-isolated — the gateway loads them and propagates them to all child
+  processes including the agent.  A warning is logged, but the key still
+  reaches the process tree.  Use the vault once available.
+- **Do not** store MCP secrets in user-readable paths — a file at
+  `~/.kiro/crew/mcp-secrets.env` or `~/.kiro/.env` is accessible to the
+  agent via filesystem reads.  Use root-owned paths (`/etc/kirocrew/`)
+  or wait for the encrypted vault.

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -210,6 +210,9 @@ _CREDENTIAL_KEYS = (
     CRED_KIRO_API_KEY,
 )
 
+# Keys from .env that were already warned about (fire once per gateway boot).
+_warned_env_keys: set[str] = set()
+
 DEFAULT_MODEL = "auto"
 DEFAULT_SESSION_TIMEOUT = 3600  # 60 min
 DEFAULT_MAX_PARALLEL_STEPS = (
@@ -6746,6 +6749,23 @@ class KiroCrewConfig:
                 if "=" in line:
                     k, v = line.split("=", 1)
                     creds[k.strip()] = v.strip()
+
+            # Warn once per boot about keys not in the recognised allowlist.
+            # These keys still propagate (operators use them for proxy/feature
+            # settings), but the warning makes the behavior visible rather than
+            # silently surprising.  The encrypted vault (PR 1+) will provide a
+            # proper agent-isolated path for secrets.
+            unknown = set(creds) - set(_CREDENTIAL_KEYS) - _warned_env_keys
+            if unknown:
+                _warned_env_keys.update(unknown)
+                for uk in sorted(unknown):
+                    logger.warning(
+                        "Unknown key %s in .env is not a recognised credential"
+                        " -- it will propagate to child processes but is NOT"
+                        " agent-isolated. Recognised keys: %s",
+                        uk,
+                        ", ".join(sorted(_CREDENTIAL_KEYS)),
+                    )
 
         for key in _CREDENTIAL_KEYS:
             val = os.environ.get(key)


### PR DESCRIPTION
## Problem / Motivation

Managing API tokens and service keys for MCP servers is currently fragile: `~/.kiro/crew/.env` silently ignores unknown keys, and there is no documented route for operators to pass secrets to spawned MCP server processes.

## Why it matters

Operators add a key to `.env`, the gateway boots without error, but the MCP server never receives it — leading to hours of debugging what reads as "broken" rather than "unsupported". Two pre-vault mitigations (docs + a warning) convert this silent failure into an actionable signal.

## What changed (motivation → approach → change)

1. **New guide** (`docs/guides/secrets-env.md`): documents the two supported routes — systemd `Environment=` directive, and a shell wrapper in `mcpServers` entries.
2. **Loader warning**: when `load_credentials()` reads `.env` and finds keys not in the 13-key `_CREDENTIAL_KEYS` whitelist, it now logs a one-per-boot `logger.warning` naming the ignored key and listing the valid set.

## Tests

N/A — the loader warning fires through the existing `load_credentials()` code path. No new error responses or API surface added.

## Manual verification

1. Add `YOUTRACK_TOKEN=test` to `~/.kiro/crew/.env`
2. Start the gateway
3. Observe: `WARNING ... Ignoring unknown key YOUTRACK_TOKEN in .env`
4. Confirm the warning fires only once per boot (restart → one more warning, no repeats during runtime)

---

Part of #2351 (PR 0 of 7: quick wins). These are the two cheap mitigations Kyle identified in his review comment.