### PR TITLE
ci(release): enable namespace sandbox in release test job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,15 +110,33 @@ jobs:
       - name: Install pinned test dependencies
         run: uv pip install --system -e ".[voice,desktop]" --group dev
 
+      - name: Enable unprivileged user namespaces
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Verify namespace sandbox is available
+        run: unshare --mount --map-root-user true
+
       - name: Run release candidate tests
         run: |
-          # KNOWN BLIND SPOT: the two deselected suites do not run at
-          # release time; merge-time ci.yml already ran them on this same
-          # commit, so the exposure is limited to a tag placed on a commit
-          # that bypassed PR CI.
-          pytest -q -n auto --timeout=120 --no-cov \
-            --deselect=test/test_script_hooks.py \
-            --deselect=test/test_cron_script.py
+          # The sysctl above enables the namespace sandbox on this runner,
+          # so all sandbox-dependent tests can run here.  If for any reason
+          # the sysctl is reverted, uncomment the deselects below to match
+          # ci.yml's sharded matrix (which cannot sysctl and deselects them
+          # into a dedicated namespace-sandbox job instead).
+          #
+          # Fallback deselects (mirror of ci.yml BACKEND_DESELECTS):
+          #   --deselect=test/test_script_hooks.py
+          #   --deselect=test/test_cron_script.py
+          #   --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py
+          #   --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py
+          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
+          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py
+          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_lint_findings.py
+          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py
+          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_profile_capture.py
+          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py
+          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_perf_track_propose.py
+          pytest -q -n auto --timeout=120 --no-cov
 
   resolve-promotion:
     name: Resolve Tested Candidate


### PR DESCRIPTION
## Problem

The release workflow's `Test Release Candidate SHA` job ran pytest without enabling unprivileged user namespaces (`unshare CLONE_NEWNS`), causing 68 test failures from sandbox-dependent suites. These suites are routed to a dedicated `Backend Tests (namespace sandbox)` job in ci.yml which runs `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`, but release.yml had no equivalent.

## Fix

- Add `sudo sysctl` + `unshare --mount` verification step before pytest
- Remove the old partial deselect (only 2 files) that left 9 sandbox suites unguarded
- Document the full ci.yml BACKEND_DESELECTS list as a commented fallback

## Verification

Cherry-picked from `release/0.3.0` (1ff02ca12) where it is already live as `v0.3.0-insider.3`. Release CI running now will confirm the fix.