### PR TITLE
fix(security): require a real bool for dangerously_skip_permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ All notable changes to KiroCrew are documented in this file.
   that matches it (case-insensitively); any other mention, or none resolved
   yet, is left attached and falls through as unrecognized. (#3734)
 
+- **`agent.dangerously_skip_permissions` no longer treats a string value as an
+  affirmative grant.** The config loader coerced this field with a bare
+  `bool(...)`, so a plausible config shape like `"dangerously_skip_permissions":
+  "false"` (any non-empty string is truthy in Python) silently activated the
+  standing, unattended tool-auto-approve grant this key controls — every tool
+  call gets auto-approved with no confirmation prompt — instead of the
+  explicit disable the value said. Now requires a real boolean, matching
+  every other boolean field in the loader; a non-bool value falls through to
+  the next accepted spelling instead of being read as a grant. (#3730)
+
 - **A folder knowledge source added from the dashboard can now be started.**
   The row's `sync_status` was stored twice — as a table column and inside the
   properties JSON — and the create path wrote `pending_confirmation` only into

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3804,10 +3804,26 @@ def _read_skip_permissions(agent_data: dict) -> bool:
     ``dangerouslySkipPermissions`` (the camelCase form used by other agent tools,
     so a config copied from one still works) and the legacy ``yolo`` (so no
     existing config silently loses auto-approve on upgrade).
+
+    Requires a REAL ``bool``, not Python truthiness: a stringly-typed value
+    from a templated/generated config — ``"false"``, ``"0"``, ``"no"``, or any
+    other non-empty string a hand-edit or a config generator might write — is
+    truthy in Python, so a bare ``bool(...)`` here would silently turn
+    "explicitly disabled" into the standing, unattended tool-auto-approve
+    grant this key controls. A non-bool value is never treated as an
+    affirmative grant; it falls through to check the next spelling, then to
+    the ``False`` default.
     """
     for key in ("dangerously_skip_permissions", "dangerouslySkipPermissions", "yolo"):
         if key in agent_data:
-            return bool(agent_data.get(key))
+            value = agent_data[key]
+            if isinstance(value, bool):
+                return value
+            logger.warning(
+                "agent.%s must be a real boolean, got %r — treating as unset",
+                key,
+                value,
+            )
     return False
 
 

--- a/test/test_safety_override.py
+++ b/test/test_safety_override.py
@@ -1159,6 +1159,35 @@ class TestRenamedConfigKey:
     def test_absent_defaults_to_off(self) -> None:
         assert self._load({}) is False
 
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off", "disabled", ""])
+    def test_falsy_looking_string_is_never_an_affirmative_grant(self, value: str) -> None:
+        """A bare ``bool(...)`` treats any non-empty string as True, so a
+        stringly-typed value from a templated/generated config -- someone's
+        hand-edit, a Docker-style generator that quotes every value -- used to
+        silently turn "explicitly disabled" into the standing, unattended
+        tool-auto-approve grant this key controls. A non-bool value must never
+        be read as an affirmative grant, regardless of what it looks like."""
+        assert self._load({"dangerously_skip_permissions": value}) is False
+
+    @pytest.mark.parametrize("value", ["true", "1", 1, 1.0, None, [], {}])
+    def test_non_bool_value_of_any_shape_falls_through(self, value: object) -> None:
+        """Not just falsy-looking strings -- ANY non-bool value (including one
+        that looks like an affirmative grant, e.g. "true"/1) must be rejected,
+        not coerced. Falls through to check the next spelling."""
+        assert self._load({"dangerously_skip_permissions": value}) is False
+        assert self._load({"dangerously_skip_permissions": value, "yolo": True}) is True
+
+    def test_bad_primary_key_does_not_shadow_a_valid_legacy_spelling(self) -> None:
+        """A malformed dangerously_skip_permissions must not block a
+        well-formed yolo/dangerouslySkipPermissions from being honoured --
+        the original bug's fallback path (renamed key) must still work even
+        when the new key is present but garbage."""
+        assert self._load({"dangerously_skip_permissions": "true", "yolo": True}) is True
+        assert (
+            self._load({"dangerously_skip_permissions": "1", "dangerouslySkipPermissions": True})
+            is True
+        )
+
 
 # ─── Never-expiring grants must not be described as expiring ─────────────────
 


### PR DESCRIPTION
## Problem / Motivation

`_read_skip_permissions` (`src/kiro_crew/config/loader.py`) coerced `agent.dangerously_skip_permissions` (and its `dangerouslySkipPermissions`/`yolo` spellings) with a bare `bool(...)`. Any non-empty string is truthy in Python, so a plausible config shape like `{"dangerously_skip_permissions": "false"}` — quoting every value is a common templating/generator convention — silently activated the standing, unattended tool-auto-approve grant this key controls, instead of the explicit disable the value said.

## Why it matters

The grant this key controls auto-approves every tool call with no confirmation prompt (`dashboard/server.py:1475`'s startup `grant_declared_yolo()` call, and Slack's yolo mode at `slack/events.py:807`). A user who writes `"dangerously_skip_permissions": "false"` — a completely reasonable-looking config, especially from a generator/templating tool that quotes every value — believes they've left auto-approve off, but the process actually starts with it silently on. Every other boolean field in this same loader already goes through `_safe_bool()` (`isinstance(value, bool)`), which correctly rejects a non-bool — this was the one call site that bypassed it.

## What changed (motivation → approach → change)

Symptom: a string value for `dangerously_skip_permissions` is read as an affirmative grant regardless of its content. Root cause: `bool(...)` on a string is true for any non-empty string, including `"false"`. Fix: `_read_skip_permissions` now requires `isinstance(value, bool)`, matching the `_safe_bool()` pattern every other boolean field in the loader already uses. A non-bool value is never read as an affirmative grant — it falls through to check the next accepted spelling, then defaults to `False`, rather than silently disabling or enabling based on a malformed value's coincidental truthiness.

## Tests

Added to `TestRenamedConfigKey` in `test/test_safety_override.py` (which already covers this function):
- A parametrized test that no falsy-looking string (`"false"`, `"0"`, `"no"`, `"off"`, `"disabled"`, `""`) is ever read as a grant.
- A parametrized test that no non-bool value of any shape (`"true"`, `"1"`, `1`, `1.0`, `None`, `[]`, `{}`) is coerced, and that it correctly falls through to the next spelling.
- A test that a malformed primary key doesn't shadow a well-formed legacy spelling.

Verified all new failure-mode assertions fail against the pre-fix code (`git stash` the fix, re-run — 12 of 20 new/updated test cases fail as expected, including every genuinely-truthy string; restored after).

`pytest test/test_safety_override.py test/test_config_loader.py test/test_config_overlay.py test/test_dashboard_yolo_startup.py` — 443 passed, 6 skipped (pre-existing skips).

`flake8` / `isort --check-only` / `mypy` on the changed source file — clean (3 pre-existing, unrelated `os.xattr` errors in `hooks.py` reproduce identically on unmodified `main`).

## Manual verification

N/A — unit coverage sufficient. This is a pure config-coercion function with no I/O or UI surface; the parametrized tests exercise every value shape the real config loader could hand it.

## Screenshots / video

N/A — no UI change.

## Related Issues

Fixes #3730

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — CHANGELOG entry added
- [x] No secrets, credentials, or internal references in the diff
