### PR TITLE
fix(telegram): strip @BotUsername suffix before command matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ All notable changes to KiroCrew are documented in this file.
   everything after it, with only a backend log line. Outbound sends now
   retry once on 429, honoring the Connector API's `Retry-After` header. (#3738)
 
+- **Telegram slash commands (`/new`, `/compact`, `/model`, `/yolo`, `/link`,
+  `/unlink`, `/stop`, `/help`, `/queue`, `/steer`) no longer silently break
+  in a group or forum-topic chat — without executing a command addressed to
+  a different bot in the same group.** Telegram's own clients append
+  `@BotUsername` to a slash command in any chat with more than one
+  participant/bot — standard client behavior triggered by registering a
+  command menu, not something the bot's UI controls — but the command
+  parser matched the raw token verbatim against alias sets defined without
+  that suffix. In the forum-topic supergroups this integration explicitly
+  supports, every command fell through to being sent to the LLM as ordinary
+  chat text with no error. A trailing `@BotUsername` is now stripped before
+  alias matching — but only when it names THIS bot: Telegram fans a command
+  addressed to a different bot in the same group out to every bot present
+  (Bot API convention is to ignore what isn't addressed to you), so
+  stripping any mention unconditionally would let e.g. `/yolo@OtherBot on`
+  match this bot's own alias and enable auto-approval here. The gateway now
+  resolves its own username via `getMe` at startup and only strips a mention
+  that matches it (case-insensitively); any other mention, or none resolved
+  yet, is left attached and falls through as unrecognized. (#3734)
+
 - **A folder knowledge source added from the dashboard can now be started.**
   The row's `sync_status` was stored twice — as a table column and inside the
   properties JSON — and the create path wrote `pending_confirmation` only into

--- a/src/kiro_crew/telegram/commands.py
+++ b/src/kiro_crew/telegram/commands.py
@@ -43,12 +43,59 @@ _STOP_ALIASES = frozenset(("/stop", "/cancel"))
 _MODEL_ALIASES = frozenset(("/model", "/models"))
 _YOLO_ALIASES = frozenset(("/yolo",))
 
+# Telegram bot usernames: 5-32 chars, alphanumeric + underscore, by convention
+# ending in "bot" -- but any alnum/underscore run after @ is accepted here
+# rather than hardcoding that suffix, since the client appends whatever the
+# bot's actual registered username is. Captured (not just matched) so the
+# caller can check it against the bot's OWN username before stripping.
+_BOT_MENTION_RE = re.compile(r"@([A-Za-z0-9_]+)$")
 
-def parse_command(text: str) -> str | None:
-    """Return the command name for *text*, or None when it is not a command."""
+
+def _strip_bot_mention(cmd: str, bot_username: str) -> str:
+    """Strip a trailing ``@BotUsername`` from a command token -- but ONLY when
+    it names *this* bot.
+
+    Telegram's own clients (mobile/desktop) append ``@BotUsername`` to a slash
+    command in any chat with more than one participant/bot -- e.g.
+    ``/new@KiroCrewBot`` instead of bare ``/new``. This is standard,
+    documented Bot API client behavior triggered by registering a command
+    menu (``set_my_commands``, called at gateway startup), not something this
+    codebase's UI controls. Every alias set in this module is defined without
+    the suffix, so without any stripping every command silently fell through
+    to being sent to the LLM as ordinary chat text in exactly the multi-user
+    surface (a Telegram forum-topic supergroup) this integration exists to
+    support.
+
+    Telegram delivers a command addressed to another bot in the same group to
+    every bot present in it (Bot API convention: a bot ignores what is not
+    addressed to it). Stripping any mention unconditionally would let a
+    command meant for a DIFFERENT bot -- e.g. ``/yolo@OtherBot on`` -- match
+    this bot's own alias set and execute here instead of being ignored. The
+    mention is stripped only when it case-insensitively matches
+    *bot_username*; any other mention (or no *bot_username*, e.g. before
+    ``getMe`` has resolved at startup) is left attached, so the token fails
+    every alias match and falls through as an ordinary, unrecognized message
+    rather than being guessed at.
+    """
+    m = _BOT_MENTION_RE.search(cmd)
+    if not m or not bot_username or m.group(1).lower() != bot_username.lower():
+        return cmd
+    return cmd[: m.start()]
+
+
+def parse_command(text: str, bot_username: str = "") -> str | None:
+    """Return the command name for *text*, or None when it is not a command.
+
+    *bot_username* (this bot's own registered username, from ``getMe``) gates
+    ``@BotUsername`` suffix stripping -- see :func:`_strip_bot_mention`.
+    """
     stripped = text.strip()
     # Telegram commands always start with /
-    cmd = stripped.split()[0].lower() if stripped.startswith("/") else ""
+    cmd = (
+        _strip_bot_mention(stripped.split()[0].lower(), bot_username)
+        if stripped.startswith("/")
+        else ""
+    )
     if cmd in _NEW_ALIASES:
         return "new"
     if cmd in _COMPACT_ALIASES:
@@ -78,7 +125,7 @@ _QUEUE_ALIASES = frozenset(("/queue",))
 _STEER_ALIASES = frozenset(("/steer",))
 
 
-def parse_mid_turn_override(text: str) -> tuple[str | None, str]:
+def parse_mid_turn_override(text: str, bot_username: str = "") -> tuple[str | None, str]:
     """Detect a per-message mid-turn override.
 
     ``/queue <msg>`` forces the message to be queued (answered after the current
@@ -87,11 +134,14 @@ def parse_mid_turn_override(text: str) -> tuple[str | None, str]:
     ``(mode, rest)`` with the directive stripped -- ``mode`` is ``"queue"`` or
     ``"steer"`` -- or ``(None, text)`` when there is no directive (or the
     directive carries no message body, e.g. a bare ``/queue``).
+
+    *bot_username* gates ``@BotUsername`` suffix stripping -- see
+    :func:`_strip_bot_mention`.
     """
     parts = text.lstrip().split(None, 1)
     if len(parts) != 2:  # needs a directive AND a message body
         return None, text
-    cmd, rest = parts[0].lower(), parts[1]
+    cmd, rest = _strip_bot_mention(parts[0].lower(), bot_username), parts[1]
     if cmd in _QUEUE_ALIASES:
         return "queue", rest
     if cmd in _STEER_ALIASES:
@@ -99,16 +149,21 @@ def parse_mid_turn_override(text: str) -> tuple[str | None, str]:
     return None, text
 
 
-def is_bare_mid_turn_override(text: str) -> bool:
+def is_bare_mid_turn_override(text: str, bot_username: str = "") -> bool:
     """True for a lone ``/queue`` / ``/steer`` carrying no message body.
 
     Those two are prefixes, not standalone commands, so the bare token matches
     neither :func:`parse_command` nor :func:`parse_mid_turn_override` and would
     otherwise reach the model as ordinary chat text — the user sees an answer to
     the literal string "/queue" instead of being told they left the message off.
+
+    *bot_username* gates ``@BotUsername`` suffix stripping -- see
+    :func:`_strip_bot_mention`.
     """
     parts = text.strip().split()
-    return len(parts) == 1 and parts[0].lower() in (_QUEUE_ALIASES | _STEER_ALIASES)
+    return len(parts) == 1 and _strip_bot_mention(parts[0].lower(), bot_username) in (
+        _QUEUE_ALIASES | _STEER_ALIASES
+    )
 
 
 # ── Command catalogue (help card + Bot API menu) ──

--- a/src/kiro_crew/telegram/gateway.py
+++ b/src/kiro_crew/telegram/gateway.py
@@ -104,8 +104,13 @@ async def maybe_start_telegram(orch: "GatewayOrchestrator") -> "TelegramClient |
         token_ok = False
         startup_error = ""
         try:
-            await client.get_me()
+            me = await client.get_me()
             token_ok = True
+            # Gates @BotUsername suffix stripping in command parsing (see
+            # telegram/commands.py._strip_bot_mention): without this, a
+            # command addressed to a DIFFERENT bot in the same group would be
+            # mistaken for ours.
+            dispatcher.bot_username = me.get("username", "") or ""
         except TelegramAuthError:
             raise
         except Exception as exc:

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -171,7 +171,9 @@ class TelegramDispatcher:
     One instance per gateway lifetime. Holds the per-user conversation state
     (generation counter + soft-threshold flag). ``handle_message`` is wired as
     the transport's dispatch callback; ``on_callback`` is wired as the client's
-    inline-button handler. ``client`` is set by the gateway after construction.
+    inline-button handler. ``client`` and ``bot_username`` are set by the
+    gateway after construction (the latter from ``getMe``, once the token is
+    proven).
     """
 
     def __init__(
@@ -193,6 +195,11 @@ class TelegramDispatcher:
         self.conv_log = conv_log
         self.approval_mode = approval_mode
         self.client: "TelegramClient | None" = None
+        # This bot's own registered username (no leading @), from getMe().
+        # Empty until the gateway's startup call resolves -- see
+        # kiro_crew.telegram.commands._strip_bot_mention for why an unset
+        # value means no @-mention is ever treated as ours.
+        self.bot_username: str = ""
         self._conv = ConversationState(seed_fn=self._seed_gen)
         # The mid-turn queue receipt: one in-place "queued" bubble per session,
         # plus the lock that serializes check-then-send-then-store against the
@@ -273,12 +280,16 @@ class TelegramDispatcher:
         # attachment ingestion, silently discarding the photo the user attached
         # to it. Mirrors discord/transport_dispatch.py's interpret_as_command.
         interpret_as_command = interpret_commands and not msg.attachments
-        if interpret_as_command and parse_command(text) is None:
-            override_mode, text = parse_mid_turn_override(text)
+        if interpret_as_command and parse_command(text, self.bot_username) is None:
+            override_mode, text = parse_mid_turn_override(text, self.bot_username)
 
         # ── Command intercept (no LLM session needed; skipped for override
         # payloads and drained queue content — see above) ──
-        cmd = parse_command(text) if interpret_as_command and override_mode is None else None
+        cmd = (
+            parse_command(text, self.bot_username)
+            if interpret_as_command and override_mode is None
+            else None
+        )
         if cmd == "new":
             self._conv.bump_gen(route)
             await self._reply(chat_id, "✅ New conversation started.", thread=reply_thread)
@@ -312,7 +323,11 @@ class TelegramDispatcher:
         # would answer the literal string and read as a broken feature. Gated on
         # interpret_as_command so a caption on an attachment is never read as a
         # bare directive -- that would answer with usage and drop the file.
-        if interpret_as_command and override_mode is None and is_bare_mid_turn_override(text):
+        if (
+            interpret_as_command
+            and override_mode is None
+            and is_bare_mid_turn_override(text, self.bot_username)
+        ):
             await self._reply(
                 chat_id,
                 "Those take a message: /queue <msg> or /steer <msg>.",

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -520,6 +520,86 @@ class TestParseCommand:
         assert is_bare_mid_turn_override("hello") is False
 
 
+class TestBotMentionSuffix:
+    """Telegram's own clients append @BotUsername to a slash command in any
+    chat with more than one participant/bot -- e.g. /new@KiroCrewBot instead
+    of /new. This is standard Bot API client behavior (triggered by
+    registering a command menu via set_my_commands, done at gateway startup),
+    not something this codebase's UI controls, and it fires in exactly the
+    multi-user surface (a Telegram forum-topic supergroup) this integration
+    is built to support. Every alias is defined without the suffix, so
+    without stripping it every command silently fell through to the LLM as
+    ordinary chat text there.
+
+    The strip is gated on the mention matching THIS bot's own username (from
+    getMe): Telegram delivers a command addressed to a different bot in the
+    same group to every bot present, and stripping any mention unconditionally
+    would let e.g. /yolo@OtherBot execute here instead of being ignored."""
+
+    def test_parse_command_strips_bot_mention(self) -> None:
+        assert parse_command("/new@KiroCrewBot", "KiroCrewBot") == "new"
+        assert parse_command("/compact@KiroCrewBot", "KiroCrewBot") == "compact"
+        assert parse_command("/model@KiroCrewBot", "KiroCrewBot") == "model"
+        assert parse_command("/yolo@KiroCrewBot", "KiroCrewBot") == "yolo"
+        assert parse_command("/link@KiroCrewBot", "KiroCrewBot") == "link"
+        assert parse_command("/unlink@KiroCrewBot", "KiroCrewBot") == "unlink"
+        assert parse_command("/stop@KiroCrewBot", "KiroCrewBot") == "stop"
+        assert parse_command("/help@KiroCrewBot", "KiroCrewBot") == "help"
+
+    def test_parse_command_with_mention_and_trailing_args(self) -> None:
+        assert parse_command("/yolo@KiroCrewBot on", "KiroCrewBot") == "yolo"
+
+    def test_parse_command_mention_is_case_insensitive(self) -> None:
+        assert parse_command("/NEW@KiroCrewBot", "kirocrewbot") == "new"
+        assert parse_command("/NEW@KIROCREWBOT", "KiroCrewBot") == "new"
+
+    def test_unknown_command_with_mention_is_still_unknown(self) -> None:
+        # The mention strip must not accidentally widen matching -- a
+        # nonexistent command stays unrecognised, mention or not.
+        assert parse_command("/frobnicate@KiroCrewBot", "KiroCrewBot") is None
+
+    def test_mid_turn_override_strips_bot_mention(self) -> None:
+        assert parse_mid_turn_override("/steer@KiroCrewBot do this instead", "KiroCrewBot") == (
+            "steer",
+            "do this instead",
+        )
+        assert parse_mid_turn_override("/queue@KiroCrewBot later", "KiroCrewBot") == (
+            "queue",
+            "later",
+        )
+
+    def test_bare_mid_turn_override_strips_bot_mention(self) -> None:
+        assert is_bare_mid_turn_override("/queue@KiroCrewBot", "KiroCrewBot") is True
+        assert is_bare_mid_turn_override("/steer@KiroCrewBot", "KiroCrewBot") is True
+
+    def test_mention_pattern_requires_a_leading_at_sign(self) -> None:
+        # A bare word after the command must not be mistaken for a mention
+        # suffix and stripped -- only a real @-prefixed suffix is a mention.
+        assert parse_command("/newsomething", "KiroCrewBot") is None
+
+    def test_a_command_mentioning_a_different_bot_is_not_executed(self) -> None:
+        """Security regression: Telegram fans a command addressed to another
+        bot in the same group out to every bot present. Stripping the mention
+        regardless of whose it is would let it match our own alias and
+        execute -- e.g. silently turning on YOLO auto-approval because
+        someone else's bot was told to. It must instead stay unrecognised."""
+        assert parse_command("/yolo@OtherBot", "KiroCrewBot") is None
+        assert parse_command("/yolo@OtherBot on", "KiroCrewBot") is None
+        assert parse_command("/stop@OtherBot", "KiroCrewBot") is None
+        assert parse_mid_turn_override("/steer@OtherBot do this", "KiroCrewBot") == (
+            None,
+            "/steer@OtherBot do this",
+        )
+        assert is_bare_mid_turn_override("/queue@OtherBot", "KiroCrewBot") is False
+
+    def test_a_mention_is_never_stripped_before_our_username_is_known(self) -> None:
+        """Before getMe() resolves at startup, bot_username is "" -- the
+        default every caller uses. No mention can be verified as ours yet, so
+        none should be treated as ours (fail closed, not open)."""
+        assert parse_command("/new@KiroCrewBot") is None
+        assert parse_command("/yolo@KiroCrewBot") is None
+
+
 class TestCommandCatalogue:
     """COMMAND_SPEC is the one source behind /help AND the Bot API menu."""
 


### PR DESCRIPTION
## Problem / Motivation

`parse_command`, `parse_mid_turn_override`, and `is_bare_mid_turn_override` in `src/kiro_crew/telegram/commands.py` all match the first whitespace-token of the message verbatim against alias sets like `frozenset(("/new", "/start"))` — none of them strip a trailing `@BotUsername` suffix.

Telegram's own clients (mobile/desktop) append `@BotUsername` to a slash command in any chat with more than one participant/bot — standard, documented Bot API client behavior, triggered by registering a command menu (`client.set_my_commands(bot_command_payload())`, called at gateway startup in `telegram/gateway.py`). It is not something this codebase's UI controls.

## Why it matters

This integration explicitly supports a Telegram forum-topic supergroup (`telegram.allow_forum` / `telegram.allowed_forum_chat_ids`) — exactly the multi-participant chat type this fires in. There, `/new@Bot`, `/compact@Bot`, `/model@Bot`, `/yolo@Bot`, `/link@Bot`, `/unlink@Bot`, `/stop@Bot`, `/queue@Bot <msg>`, and `/steer@Bot <msg>` all fail to match any alias and fall straight through to being sent to the LLM as ordinary chat text — silently, with no error — defeating session reset, compaction, model switching, YOLO mode, and mid-turn steer/queue control in the one multi-user surface this channel supports.

## What changed (motivation → approach → change)

Symptom: every slash command silently breaks in a group/forum chat because clients append `@BotUsername`. Root cause: none of the three command-parsing functions strip that suffix before matching. First approach: added `_strip_bot_mention()`, applied to the first token before alias matching in all three functions, stripping *any* trailing `@`-mention unconditionally.

That first approach had a real gap, caught by review: Telegram delivers a command addressed to a *different* bot in the same group to every bot present (Bot API convention is for each bot to ignore what isn't addressed to it). Stripping any mention unconditionally meant a command meant for another bot — e.g. `/yolo@OtherBot on` — would match this bot's own alias and execute here instead of being ignored, a real cross-bot command-execution path in any group with more than one bot and privacy mode disabled. Final change: the gateway now resolves its own username via `getMe()` at startup (`dispatcher.bot_username`, previously discarded) and `_strip_bot_mention` only strips a mention that case-insensitively matches it. Any other mention, or none resolved yet (fail closed, not open), is left attached, so the token fails every alias match and falls through as an ordinary unrecognized message — same as before this fix existed, not a new failure mode.

## Tests

New `TestBotMentionSuffix` class in `test/test_telegram.py`:
- Every command alias with `@KiroCrewBot` appended, with trailing args, case-insensitivity, an unknown command with a mention (must stay unrecognised), both mid-turn override functions, and a guard that a bare word after a command (no `@`) is NOT mistaken for a mention suffix.
- A mention for a *different* bot (`@OtherBot`) is never treated as ours and never executed — the security-relevant regression test.
- No mention is stripped before `bot_username` is known (fail closed).

Verified the security-regression test fails against the code before that hardening (`TypeError: parse_command() takes 1 positional argument but 2 were given` — the guard didn't exist at all).

`pytest test/test_telegram.py` — 284 passed.

`flake8` / `isort --check-only` / `mypy` on the changed source files — clean (3 pre-existing, unrelated `os.xattr` errors in `hooks.py` reproduce identically on unmodified `main`).

## Manual verification

N/A — unit coverage sufficient. The parsing functions are pure and fully exercised by the automated tests; there's no I/O or UI surface to manually verify beyond what those tests already drive.

## Screenshots / video

N/A — no UI change.

## Related Issues

Fixes #3734

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — CHANGELOG entry added
- [x] No secrets, credentials, or internal references in the diff
