### PR TITLE
chore: restrain interruption cards to default-to-silence

### DIFF
--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -2638,20 +2638,25 @@ class ContextBuilder:
                 parts.append(
                     "\n\n(If you need the user's answer to a blocking question BEFORE "
                     "you can continue the current turn, use the ask_question tool — it "
-                    "pauses and returns the answer as the tool result. This is situational, "
-                    "not per-turn: when you are ENDING your turn, use the final [OPTIONS:] "
-                    "line instead, and do not interrupt the user for a non-blocking choice.)"
+                    "pauses and returns the answer as the tool result. Use it SPARINGLY: "
+                    "only when you genuinely cannot proceed without the answer. When you "
+                    "are ENDING your turn, use the final [OPTIONS:] line instead. Never "
+                    "interrupt the user for a non-blocking choice, and never ask what you "
+                    "can reasonably decide or discover yourself.)"
                 )
                 # A follow-up card is distinct from both: it offers concrete NEXT
                 # tasks after work is done, optionally handing one to a worktree.
                 parts.append(
-                    "\n\n(When you have FINISHED a substantive piece of work and see "
-                    "concrete, worth-doing next steps, you MAY offer them with the "
-                    "suggest_followup tool — up to 3 items, each carrying a complete, "
-                    "standalone handoff prompt. This is situational, NOT per-turn: prefer "
-                    "silence when there is no real next step, do not repeat a card the user "
-                    "already acted on, and never use it to ask a clarifying question you "
-                    "need answered to continue — just ask that inline.)"
+                    "\n\n(The suggest_followup tool renders a card below the composer "
+                    "offering concrete NEXT tasks. DEFAULT TO SILENCE: only raise it when "
+                    "a follow-up is genuinely valuable to the user AND you have just "
+                    "finished a genuinely large task (multi-file changes, a full PR cycle, "
+                    "a major investigation). A card is an interruption — it must earn its "
+                    "place. NEVER raise it after small tasks (answering a question, a "
+                    "single-file edit, a quick lookup, a simple fix), never per-turn, never "
+                    "to repeat a card the user already acted on, and never to ask a "
+                    "clarifying question — just ask that inline. When in doubt, stay silent. "
+                    "Each item carries a complete, standalone handoff prompt; up to 3.)"
                 )
 
         # Widget instructions live in the bundled `widgets` skill.


### PR DESCRIPTION
## Problem
The `suggest_followup` and `ask_question` cards were appearing far too often — including after small tasks like answering a question or a single-line edit. The user reported them as actively disruptive.
## Why it matters
These cards render below the composer and interrupt the user mid-flow. When they fire routinely rather than only when useful, they train the user to ignore them — which defeats the point of both tools and adds friction to every turn. An interruption surface only works if it is rare and high-value.

## Fix (symptom → root cause → change)
- **Symptom:** cards fire after almost every turn, regardless of task size.
- **Root cause:** the prompt guidance in `context.py` used permissive framing — `you MAY offer them` for `suggest_followup` and merely "situational" for `ask_question`. "MAY" reads as standing permission, so the agent raised a card whenever it *could*, not only when it *should*. The limiting condition ("substantive piece of work") was too vague and got read to include small tasks.
- **Change:** reframe both to **default-to-silence**, making the restraint the primary instruction rather than a caveat:
  - `suggest_followup`: replace `you MAY offer them` with `DEFAULT TO SILENCE` — only raise it after a genuinely large task (multi-file change, full PR cycle, major investigation) *and* when the follow-up is genuinely valuable. Explicitly never after small tasks, never per-turn, never to repeat a card the user already acted on.
  - `ask_question`: use `SPARINGLY`, only when genuinely blocked; never ask what the agent can decide or discover itself.

The underlying principle: an interruption card must *earn* its place; when in doubt, stay silent.

## Tests
N/A — this is a prompt-string-only change with no logic path. No behavioral code changed, so no unit test locks in prose wording. Backend static gates (py_compile / isort / flake8) pass on the changed file.

## Manual verification
N/A — unit coverage sufficient. The change is confined to string literals inside the prompt-assembly `parts.append(...)` calls; verified by inspection that no control flow, type, or import was altered.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only prompt string edit in `src/kiro_crew/context.py`; no frontend path touched, no rendered UI delta.

no linked issue: driven by direct user feedback, no tracked issue filed.
