### PR TITLE
fix(teams): retry outbound sends once on 429, honoring Retry-After

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **A Teams answer no longer gets silently truncated by a rate-limited
+  chunk.** The Bot Framework Connector API enforces per-bot rate limits and
+  can return HTTP 429, but the Teams outbound send raised immediately with
+  no retry, unlike the Discord/Telegram/Webex clients (which all absorb a
+  single 429 honoring the server's back-off hint). A multi-chunk answer
+  stops at its first failed chunk, so a throttled chunk dropped it and
+  everything after it, with only a backend log line. Outbound sends now
+  retry once on 429, honoring the Connector API's `Retry-After` header. (#3738)
+
 - **A folder knowledge source added from the dashboard can now be started.**
   The row's `sync_status` was stored twice — as a table column and inside the
   properties JSON — and the create path wrote `pending_confirmation` only into

--- a/src/kiro_crew/teams/client.py
+++ b/src/kiro_crew/teams/client.py
@@ -443,19 +443,36 @@ class TeamsClient:
         try:
             token = await self._get_app_token()
             session = await self._ensure_session()
-            async with session.post(
-                url,
-                json=activity,
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=aiohttp.ClientTimeout(total=_CONNECTOR_API_TIMEOUT),
-            ) as resp:
-                if resp.status >= 400:
-                    text = await resp.text()
-                    raise RuntimeError(f"HTTP {resp.status}: {text[:200]}")
-                try:
-                    return await resp.json()
-                except Exception:
-                    return {}
+            # Honors a single 429 Retry-After back-off, mirroring the
+            # Discord/Telegram/Webex clients' _api(): the Bot Framework
+            # Connector API enforces per-bot rate limits and returns 429 on
+            # excess traffic, and TeamsRenderer.on_done stops at the first
+            # failed chunk of a multi-chunk answer (so it doesn't deliver an
+            # incoherent gap) -- an un-retried 429 here silently truncates
+            # the user's answer instead of a single short wait.
+            for attempt in range(2):
+                async with session.post(
+                    url,
+                    json=activity,
+                    headers={"Authorization": f"Bearer {token}"},
+                    timeout=aiohttp.ClientTimeout(total=_CONNECTOR_API_TIMEOUT),
+                ) as resp:
+                    if resp.status == 429 and attempt == 0:
+                        retry_after = 1.0
+                        try:
+                            retry_after = float(resp.headers.get("Retry-After", "1"))
+                        except (TypeError, ValueError):
+                            pass
+                        await asyncio.sleep(min(max(retry_after, 0.5), 10.0))
+                        continue
+                    if resp.status >= 400:
+                        text = await resp.text()
+                        raise RuntimeError(f"HTTP {resp.status}: {text[:200]}")
+                    try:
+                        return await resp.json()
+                    except Exception:
+                        return {}
+            return None
         except Exception as exc:
             self.last_error = f"send failed: {type(exc).__name__}"
             logger.warning("Teams: outbound send failed: %s", type(exc).__name__)

--- a/test/test_teams_client.py
+++ b/test/test_teams_client.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import pytest
 
+import kiro_crew.teams.client as teams_client_mod
 from kiro_crew.teams.client import (
     JwtValidator,
     TeamsAuthError,
@@ -277,10 +278,17 @@ class TestInboundWebhook:
 
 
 class _FakeResp:
-    def __init__(self, status: int = 200, json_data: Any = None, text_data: str = "") -> None:
+    def __init__(
+        self,
+        status: int = 200,
+        json_data: Any = None,
+        text_data: str = "",
+        headers: dict | None = None,
+    ) -> None:
         self.status = status
         self._json = json_data if json_data is not None else {}
         self._text = text_data
+        self.headers = headers or {}
 
     async def __aenter__(self) -> "_FakeResp":
         return self
@@ -370,3 +378,89 @@ class TestOutbound:
         c = TeamsClient(app_id=_APP_ID, app_password="pw")
         mid = await c.send_message("conv-1", "hi", "")
         assert mid is None
+
+    @pytest.mark.asyncio
+    async def test_429_is_retried_once_honoring_retry_after(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mirrors the Discord/Telegram/Webex clients' _api(): a rate-limited
+        outbound send must not be dropped on the first 429 -- the Bot
+        Framework Connector API enforces per-bot rate limits and returns 429
+        on excess traffic, and TeamsRenderer.on_done stops at the first
+        failed chunk of a multi-chunk answer, so an un-retried 429 here used
+        to silently truncate the user's answer."""
+        slept: list[float] = []
+
+        async def _fake_sleep(delay: float, *a: Any, **k: Any) -> None:
+            slept.append(delay)
+
+        monkeypatch.setattr(teams_client_mod.asyncio, "sleep", _fake_sleep)
+
+        c = TeamsClient(app_id=_APP_ID, app_password="pw")
+        c._token = "tok"
+        c._token_expiry = time.monotonic() + 999
+        c._session = _FakeSession(
+            [
+                _FakeResp(status=429, headers={"Retry-After": "2.5"}),
+                _FakeResp(json_data={"id": "activity-retried"}),
+            ]
+        )
+        mid = await c.send_message("conv-1", "hi", "https://smba.example.com/")
+        assert mid == "activity-retried"
+        assert slept == [2.5]
+        assert len(c._session.calls) == 2  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_persistent_429_still_fails_after_one_retry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A genuine outage/persistent throttle must still surface as a
+        failure once the single-retry budget is exhausted -- this is a
+        bounded retry, not a mask."""
+
+        async def _fake_sleep(delay: float, *a: Any, **k: Any) -> None:
+            pass
+
+        monkeypatch.setattr(teams_client_mod.asyncio, "sleep", _fake_sleep)
+        c = TeamsClient(app_id=_APP_ID, app_password="pw")
+        c._token = "tok"
+        c._token_expiry = time.monotonic() + 999
+        states: list[tuple[bool, str]] = []
+        c.on_state_change = lambda ok, err: states.append((ok, err))
+        c._session = _FakeSession(
+            [
+                _FakeResp(status=429, headers={"Retry-After": "1"}),
+                _FakeResp(status=429, headers={"Retry-After": "1"}),
+            ]
+        )
+        mid = await c.send_message("conv-1", "hi", "https://smba.example.com/")
+        assert mid is None
+        assert states and states[-1][0] is False
+        assert len(c._session.calls) == 2  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_retry_after_is_clamped_and_defaulted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        slept: list[float] = []
+
+        async def _fake_sleep(delay: float, *a: Any, **k: Any) -> None:
+            slept.append(delay)
+
+        monkeypatch.setattr(teams_client_mod.asyncio, "sleep", _fake_sleep)
+
+        cases = [
+            ({}, 1.0),  # header absent -> the "1" string default
+            ({"Retry-After": "not-a-number"}, 1.0),  # unparsable -> default
+            ({"Retry-After": "0.01"}, 0.5),  # below floor -> clamped up
+            ({"Retry-After": "900"}, 10.0),  # above ceiling -> clamped down
+        ]
+        for headers, expected in cases:
+            c = TeamsClient(app_id=_APP_ID, app_password="pw")
+            c._token = "tok"
+            c._token_expiry = time.monotonic() + 999
+            c._session = _FakeSession(
+                [_FakeResp(status=429, headers=headers), _FakeResp(json_data={"id": "x"})]
+            )
+            await c.send_message("conv-1", "hi", "https://smba.example.com/")
+            assert slept[-1] == expected, f"{headers} -> expected {expected}, got {slept[-1]}"


### PR DESCRIPTION
## Summary

Fixes #3738. `_post_activity` in `src/kiro_crew/teams/client.py` — the single outbound path for both `send_message` and `send_typing` — raised on any HTTP 429 immediately, with no retry and no `Retry-After` handling. The Bot Framework Connector API enforces per-bot rate limits and does return 429 on excess traffic, and every other channel client in this codebase (Discord, Telegram, Webex) already absorbs a single 429 with a bounded retry honoring the server's back-off hint — Teams was the one outlier.

`TeamsRenderer.on_done` sends a multi-chunk answer in a loop and explicitly stops at the first failed chunk (so the delivered prefix stays coherent). A throttled chunk that every sibling channel would absorb via one retry instead silently dropped it and every chunk after it — the user got a truncated answer with only a backend `logger.warning`.

## Fix

Mirror the Discord/Telegram/Webex `_api()` pattern in `_post_activity`: retry once on 429, honoring the Connector API's `Retry-After` header (same header shape Webex uses), clamped to `[0.5, 10]` seconds. A persistent throttle (429 again on the retry) still fails — this is a bounded single retry, not a mask.

## Test plan

- [x] New tests in `TestOutbound` (`test/test_teams_client.py`): a 429 followed by a 200 succeeds and sleeps for the header's value once; a persistent 429 (both attempts) still fails and flips connection state, with exactly 2 calls made; `Retry-After` clamping/defaulting across absent/unparsable/below-floor/above-ceiling header values, mirroring the existing Discord clamp-test shape (`test_retry_after_is_clamped_and_defaulted`)
- [x] `asyncio.sleep` is monkeypatched to a fast no-op recorder for all new tests (mirrors the established pattern in `test_discord_client_coverage.py`'s `_patch_sleep`), so no test incurs a real delay
- [x] **Verified all 3 new tests fail against the pre-fix code** (`git stash` the fix, re-run — 3/3 fail, including the exact call-count assertion; restored after)
- [x] `pytest test/test_teams_client.py test/test_teams_*.py` — 94 passed
- [x] `flake8` / `isort --check-only` / `mypy` on the changed source file — clean (3 pre-existing, unrelated `os.xattr` errors in `hooks.py` reproduce identically on unmodified `main`)