### PR TITLE
fix(md-notebook): fix spurious blank line on append to a note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **Notes: appending text to a note whose file ends with a trailing newline
+  no longer inserts a spurious blank line — and clicking to append no longer
+  flashes an editor shut before you can type into it.** `String.split('\n')`
+  produces a trailing empty element whenever the body ends with `\n` — not a
+  real line of content — and the click-below-to-append insertion point
+  counted it as one, landing new text one slot past where the actual splice
+  happens. Any note whose file ends in `\n` (the common case for anything
+  checked out of a git-backed vault) silently gained an extra blank line on
+  every append; a brand-new empty note gained a leading one instead.
+  Realigning the insertion index with that phantom line's own position
+  (rather than one slot past it) introduced a second issue: `Preview` also
+  renders that phantom line as its own clickable block, so once the
+  insertion index landed on the same index, a click on either the append
+  region or that phantom line itself double-mounted a block editor there —
+  the second one's autofocus stole focus from the first, whose blur-commit
+  reset the edit state and unmounted both before a keystroke could land.
+  Both consumers of the shared index now require its distinct signature
+  (an insertion, not a same-line edit) before opening an editor. (#3741)
+
 - **A folder knowledge source added from the dashboard can now be started.**
   The row's `sync_status` was stored twice — as a table column and inside the
   properties JSON — and the create path wrote `pending_confirmation` only into

--- a/website/src/apps/md-notebook/Preview.tsx
+++ b/website/src/apps/md-notebook/Preview.tsx
@@ -211,7 +211,17 @@ export function Preview({
     textStyle?: CSSProperties,
     opts?: { split?: boolean },
   ): ReactNode => {
-    if (editRange && start === editRange.start) {
+    // `editRange.end < start` is the trailing append slot's insertion
+    // signature (see its own `onStartEdit(appendStart, appendStart - 1)`
+    // below), never a real per-line edit -- every other caller of
+    // `onStartEdit` in this file passes `end >= start`. Without this guard,
+    // a note whose `appendStart` lands on the phantom trailing line this
+    // loop ALSO renders as its own block (any trailing-newline-terminated
+    // note, i.e. the common case) double-mounts a BlockEditor here AND in
+    // the append slot for the same click; the second one's autofocus blurs
+    // the first, whose blur-commit resets `editRange` to null and unmounts
+    // both before the user can type.
+    if (editRange && start === editRange.start && editRange.end >= editRange.start) {
       return (
         <BlockEditor
           key={`edit-${start}`}
@@ -488,9 +498,29 @@ export function Preview({
 
   // Trailing click-to-append region: clicking the empty space below the note
   // starts a new block at the end (an insertion — editRange with end < start).
-  const appendStart = lines.length
+  //
+  // `lines.length` alone over-counts by one whenever `body` ends with `\n`
+  // (or is empty): String.split produces a trailing empty element for the
+  // text AFTER the final newline, which is not a real line of content. Using
+  // it as the insertion index landed new text one slot past where
+  // `commitBlockEdit`/`splitBlockEdit` (MdNotebookPage.tsx) splice against
+  // their OWN `contentRef.current.split('\n')` — inserting AFTER that
+  // phantom empty element instead of at it, so every append to a
+  // trailing-newline-terminated note (the common case for anything that's
+  // been through git) silently wrote an extra blank line before the new
+  // text. Subtracting the phantom element here keeps this index aligned
+  // with the "number of real lines" both sides actually agree on.
+  const appendStart = body === '' ? 0 : lines.length - (body.endsWith('\n') ? 1 : 0)
+  // `editRange.start === appendStart` alone is not enough to identify a
+  // click on THIS slot: whenever `appendStart` lands on the phantom trailing
+  // line's own index (any trailing-newline-terminated note), a genuine
+  // same-line edit of that line ALSO carries `start === appendStart` (with
+  // `end === start`, not an insertion). Requiring the insertion signature
+  // here keeps that click confined to `blk()`'s own editor above instead of
+  // double-mounting this one too.
+  const isAppendInsertion = !!editRange && editRange.start === appendStart && editRange.end < appendStart
   out.push(
-    editRange && editRange.start === appendStart ? (
+    isAppendInsertion ? (
       <BlockEditor
         key="edit-append"
         initial=""

--- a/website/src/test/Preview.appendStart.test.tsx
+++ b/website/src/test/Preview.appendStart.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Regression guard for the Notes app's "click below the note to append"
+ * insertion point.
+ *
+ * Background
+ * ----------
+ * `body.split('\n')` produces a trailing EMPTY element whenever `body` ends
+ * with `\n` (String.split behavior: N newlines -> N+1 elements) -- that
+ * element is not a real line of content. `appendStart` used to be plain
+ * `lines.length`, over-counting by one in exactly that case. Clicking the
+ * append region then opened an insertion at one slot PAST where
+ * `commitBlockEdit`/`splitBlockEdit` (MdNotebookPage.tsx) splice against
+ * their OWN `contentRef.current.split('\n')`, landing the new text AFTER the
+ * phantom empty element instead of at it -- so appending to any note whose
+ * file ends with a trailing newline (the common case for anything that's
+ * been through git) silently wrote an extra blank line before the new text.
+ *
+ * `Preview` alone doesn't own the splice (that's the parent component), so
+ * these tests pin the CONTRACT `Preview` must uphold: `onStartEdit` is
+ * called with the append-region's `(start, end)` pointing at the number of
+ * REAL lines in the body, not the raw split-array length.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { Preview } from '../apps/md-notebook/Preview'
+
+function renderAndClickAppend(content: string) {
+  const onStartEdit = vi.fn()
+  render(
+    <Preview
+      content={content}
+      onToggleCheckbox={vi.fn()}
+      editRange={null}
+      onStartEdit={onStartEdit}
+      onCommitEdit={vi.fn()}
+      onCancelEdit={vi.fn()}
+      onSplitEdit={vi.fn()}
+    />,
+  )
+  // The append region is always the LAST rendered block (every content block
+  // above it also carries role="button" for click-to-edit).
+  const buttons = screen.getAllByRole('button')
+  fireEvent.click(buttons[buttons.length - 1])
+  return onStartEdit
+}
+
+/**
+ * Drives the real click -> setEditBlock -> re-render sequence `MdNotebookPage`
+ * performs, instead of asserting `onStartEdit`'s arguments in isolation: a
+ * `Preview` that only agrees with its OWN emitted range on `(start, end)`
+ * would still pass the tests above while double-mounting a `BlockEditor`
+ * once that range is actually fed back in as `editRange` (see the two
+ * `mounts exactly one editor` tests below).
+ */
+function renderClickAndFollowUp(content: string) {
+  const onStartEdit = vi.fn()
+  const view = render(
+    <Preview
+      content={content}
+      onToggleCheckbox={vi.fn()}
+      editRange={null}
+      onStartEdit={onStartEdit}
+      onCommitEdit={vi.fn()}
+      onCancelEdit={vi.fn()}
+      onSplitEdit={vi.fn()}
+    />,
+  )
+  const buttons = screen.getAllByRole('button')
+  fireEvent.click(buttons[buttons.length - 1])
+  const [start, end] = onStartEdit.mock.calls[0] as [number, number]
+  view.rerender(
+    <Preview
+      content={content}
+      onToggleCheckbox={vi.fn()}
+      editRange={{ start, end }}
+      onStartEdit={onStartEdit}
+      onCommitEdit={vi.fn()}
+      onCancelEdit={vi.fn()}
+      onSplitEdit={vi.fn()}
+    />,
+  )
+  return view
+}
+
+describe('Preview append-region insertion point', () => {
+  it('a single line with a trailing newline appends at index 1, not 2', () => {
+    // "Hello\n".split('\n') === ["Hello", ""] -- the trailing "" is the
+    // phantom, not a second real line.
+    const onStartEdit = renderAndClickAppend('Hello\n')
+    expect(onStartEdit).toHaveBeenCalledWith(1, 0)
+  })
+
+  it('a single line with NO trailing newline also appends at index 1', () => {
+    // Must agree with the trailing-newline case above: the file has exactly
+    // one real line either way.
+    const onStartEdit = renderAndClickAppend('Hello')
+    expect(onStartEdit).toHaveBeenCalledWith(1, 0)
+  })
+
+  it('a brand-new empty note appends at index 0', () => {
+    const onStartEdit = renderAndClickAppend('')
+    expect(onStartEdit).toHaveBeenCalledWith(0, -1)
+  })
+
+  it('a real trailing blank line is still counted, only the phantom is not', () => {
+    // "Hello\n\n".split('\n') === ["Hello", "", ""] -- two real lines
+    // (Hello, then a blank line), plus the phantom from the final \n.
+    const onStartEdit = renderAndClickAppend('Hello\n\n')
+    expect(onStartEdit).toHaveBeenCalledWith(2, 1)
+  })
+
+  it('multiple lines with a trailing newline append after the last real line', () => {
+    const onStartEdit = renderAndClickAppend('one\ntwo\nthree\n')
+    expect(onStartEdit).toHaveBeenCalledWith(3, 2)
+  })
+})
+
+describe('Preview append-region editor mounting', () => {
+  /**
+   * `appendStart` lands on the SAME index as the phantom trailing line's own
+   * rendered block for every trailing-newline-terminated note (the common
+   * case) and for a brand-new empty note. Both `blk()` and the append slot
+   * used to key off `editRange.start` alone, so the click that opens the
+   * append editor also matched the phantom line's own block and mounted a
+   * SECOND `BlockEditor` there; its autofocus stole focus from the first,
+   * whose blur-commit reset `editRange` to null and unmounted both before a
+   * keystroke landed -- append going from "adds a spurious blank line" to
+   * "does nothing".
+   */
+  it('clicking the append region mounts exactly one editor, and it stays mounted', () => {
+    const view = renderClickAndFollowUp('Hello\n')
+    expect(screen.getAllByRole('textbox')).toHaveLength(1)
+    // React ran every mounted editor's autofocus effect by now; if a second
+    // one had mounted and stolen focus, the blur-commit path would already
+    // have reset editRange to null and unmounted this one too.
+    expect(view.container.querySelector('textarea')).not.toBeNull()
+  })
+
+  it('clicking the append region on a brand-new empty note also mounts exactly one editor', () => {
+    renderClickAndFollowUp('')
+    expect(screen.getAllByRole('textbox')).toHaveLength(1)
+  })
+
+  it('clicking the phantom trailing line itself (not the append region) also mounts exactly one editor', () => {
+    // Distinct trigger, same collision: onStartEdit(1, 1) is a genuine
+    // same-line edit (end === start, not an insertion), but its `start` is
+    // still equal to `appendStart` -- the append slot's own condition must
+    // not fire for this shape either.
+    const onStartEdit = vi.fn()
+    const view = render(
+      <Preview
+        content={'Hello\n'}
+        onToggleCheckbox={vi.fn()}
+        editRange={{ start: 1, end: 1 }}
+        onStartEdit={onStartEdit}
+        onCommitEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSplitEdit={vi.fn()}
+      />,
+    )
+    expect(screen.getAllByRole('textbox')).toHaveLength(1)
+    expect(view.container.querySelector('textarea')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #3741. `Preview.tsx`'s click-below-to-append region computed its insertion index as `appendStart = lines.length` where `lines = body.split('\n')`. `String.split('\n')` produces a trailing **empty** element whenever the string ends with `\n` (N newlines → N+1 elements) — that element is not a real line of content:

```js
"Hello\n".split('\n')  // ["Hello", ""] -- length 2, but only 1 real line
```

`commitBlockEdit`/`splitBlockEdit` in `MdNotebookPage.tsx` independently split `contentRef.current` the same way and splice against that same phantom-containing array. Since `appendStart` pointed one slot **past** the phantom element instead of **at** it, the new text landed after the phantom — inserting a spurious blank line:

- Content `"Hello\n"`, append `"World"` → `"Hello\n\nWorld"` (traced through the actual splice/join logic) instead of `"Hello\nWorld"`.
- A brand-new empty note, append `"Hello"` → `"\nHello"` (leading blank line) instead of `"Hello"`.

This is the app's primary "add content" affordance, and any note whose file ends in `\n` — the common case for anything checked out of a git-backed vault — silently gained an extra blank line on every append.

## Fix

Subtract the phantom trailing element when `body.endsWith('\n')`, and treat a genuinely empty body as 0 real lines, so `appendStart` agrees with what the splice sites in `MdNotebookPage.tsx` actually operate on. No change needed on the splice side — once `appendStart` points at the phantom element instead of past it, the existing splice logic there already does the right thing.

## Test plan

- [x] Verified the fix directly with a standalone JS simulation of the exact splice/join logic across 4 shapes (trailing-newline single line, empty note, no-trailing-newline single line, a real trailing blank line) before writing any test — all four now correct
- [x] New `Preview.appendStart.test.tsx`: renders `Preview` directly and asserts the `onStartEdit(start, end)` args for each of those shapes, plus a multi-line case
- [x] **Verified 4 of 5 new tests fail against the pre-fix code** (`git stash` the fix, re-run — 4/5 fail; the 5th documents already-correct behavior — a body with no trailing newline — that must stay unbroken, and correctly passes on both sides; restored after)
- [x] `vitest run` across `Preview.appendStart.test.tsx` plus 8 other Notes-app suites (headings, tables, note row, page coverage x2, notebook, frontend coverage, API coverage) — 9 files, 253 passed
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — clean, no errors or warnings

## Update: fixed a regression the initial fix introduced

Both **Design Review** and **UX Review** (fork AI pipeline) independently caught a real double-mount bug the fix above introduced, with matching line-level traces. Verified by reading the actual render/commit paths and reproducing it with a real click → re-render → editor-count test (see below) — confirmed real, not a false positive.

**Root cause:** realigning `appendStart` with the phantom trailing line's own index (rather than one slot past it) means that for every trailing-newline-terminated note, `appendStart` now equals the SAME index `Preview`'s own per-line loop ALSO renders as its own clickable block (the phantom line is rendered like any other blank line, not specially skipped). `blk()`'s editor swap-in checked only `start === editRange.start`, and the append slot's own check was only `editRange.start === appendStart` — neither disambiguated an *insertion* (the append click's `editRange = {start: appendStart, end: appendStart - 1}`) from a genuine same-line edit at that same index. So a click on either the append region or the phantom line's own block matched BOTH conditions and mounted two `BlockEditor`s simultaneously; the second one's autofocus effect stole focus from the first, whose blur triggered `onCommit('')` → `commitBlockEdit` reset `editRange` to `null`, unmounting both before a keystroke could land. Append went from "adds a spurious blank line" to "flashes and does nothing" for the exact notes this PR targets.

**Fix:** `blk()` now also requires `editRange.end >= editRange.start` (true for every real per-line edit, false only for the append slot's insertion signature) before treating a block as the active edit target. The append slot now also requires `editRange.end < appendStart` (the insertion signature) rather than matching any `editRange` whose `start` happens to coincide with `appendStart`.

**New tests** drive the real click → `setEditBlock` → re-render sequence `MdNotebookPage` performs (the prior tests only asserted `onStartEdit`'s arguments in isolation, which is exactly why this shipped green — both reviews flagged this gap) and assert exactly one editor mounts, for: the append region on a trailing-newline note, the append region on a brand-new empty note, and a direct click on the phantom line itself. Verified all three fail against the pre-fix code with 2 mounted textareas each.

<!-- no-visual-delta -->
**Why no screenshot:** this update fixes which of two internal states double-mounts an editor on click; it does not add, remove, or restyle any visual element — the same `BlockEditor` component renders in the same place with the same styling either way. The regression itself was a functional/interaction defect (an editor closing before a keystroke could land), not a visual layout difference a screenshot could meaningfully show.
