### PR TITLE
fix(kas): base-prompt fallback for prompt-less agents + doctor KAS status

### DIFF
--- a/src/kiro_crew/acp/kas_agents.py
+++ b/src/kiro_crew/acp/kas_agents.py
@@ -68,6 +68,37 @@ class KasAgentTranslationError(ValueError):
     """A spec cannot be projected onto KAS's schema at all."""
 
 
+#: System prompt fed to a prompt-less agent when projecting onto KAS. KAS
+#: requires a non-empty prompt where kiro-cli tolerates an empty one, so any
+#: agent that ships ``"prompt": ""`` (today only Crew's ``kirocrew-lite``, but
+#: the fallback is deliberately not tied to it) would otherwise crash KAS
+#: session creation. Deliberately generic and small: prompt-less agents run
+#: small system-issued text tasks (titles, summaries, tags, rephrases), so the
+#: full orchestration persona in ``prompt.md`` is both wrong and wasteful here.
+#: Only the KAS path uses this — ``resolve_prompt`` is called solely from
+#: ``build_kas_custom_agents`` — so the kiro-cli path keeps its empty-prompt
+#: behaviour (kiro-cli supplies its own default) unchanged.
+_KAS_FALLBACK_PROMPT = """\
+You are a Kiro Crew lightweight background worker. You are dispatched by the
+system — never by a human in a chat — to perform one small, self-contained text
+task per request: naming or summarizing a conversation, classifying or tagging
+content, rephrasing a line, suggesting a short label, and similar. The specific
+task is fully described in each request.
+
+- Do exactly what the request asks, and only that. Treat its stated output
+  format as binding: if it asks for a single line, a length limit, or JSON,
+  return exactly that — no preamble, no explanation, no markdown fences unless
+  the request asks for them.
+- Be concise and deterministic. Prefer the shortest correct answer; add no
+  commentary, caveats, or follow-up questions.
+- You have no tools and touch no external state. Work only from the text in the
+  request. If it is empty or unintelligible, return a minimal safe default (an
+  empty string or a generic label) rather than guessing at length.
+- This is not a conversation: no user to address, no session to remember. Each
+  request stands alone.
+"""
+
+
 def _is_unsafe_prompt_path(path: Path) -> bool:
     """True if *path* must not be read and inlined into a KAS agent prompt.
 
@@ -83,7 +114,12 @@ def _is_unsafe_prompt_path(path: Path) -> bool:
     return any(posix == root or posix.startswith(root + "/") for root in _PSEUDO_FS_ROOTS)
 
 
-def resolve_prompt(spec: dict[str, Any], *, agent_id: str, agents_dir: Path) -> str:
+def resolve_prompt(
+    spec: dict[str, Any],
+    *,
+    agent_id: str,
+    agents_dir: Path,
+) -> str:
     """Return the spec's prompt as literal text, reading a ``file://`` URI.
 
     Separated from :func:`to_client_custom_agent` so the projection itself stays
@@ -95,10 +131,31 @@ def resolve_prompt(spec: dict[str, Any], *, agent_id: str, agents_dir: Path) -> 
       and may not escape it via ``..``.
     * The resolved path must not be a credential/governance location or a
       pseudo-filesystem (see :func:`_is_unsafe_prompt_path`).
+
+    KAS requires a non-empty prompt where kiro-cli tolerates an empty one, so a
+    spec with no prompt (Crew's own utility agents such as ``kirocrew-lite``
+    ship ``"prompt": ""``) falls back to the small :data:`_KAS_FALLBACK_PROMPT`
+    constant instead of crashing the session. The fallback is an inline literal,
+    not a file read, so it carries none of the ``file://`` path's exfiltration /
+    decode risk. Only KAS reaches this — the kiro-cli path keeps its empty-prompt
+    behaviour untouched.
     """
     raw = spec.get("prompt")
-    if not isinstance(raw, str) or not raw.strip():
-        raise KasAgentTranslationError(f"agent {agent_id!r} has no prompt; KAS requires one")
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        # Missing or blank — an intentionally prompt-less agent. Substitute the
+        # fallback so KAS's non-empty-prompt requirement is met.
+        logger.warning(
+            "agent %r has no prompt; falling back to the lightweight KAS prompt "
+            "(KAS requires a non-empty prompt)",
+            agent_id,
+        )
+        return _KAS_FALLBACK_PROMPT
+    if not isinstance(raw, str):
+        # A non-string prompt is a malformed spec, not a prompt-less one — fail
+        # loud rather than silently running with unrelated fallback text.
+        raise KasAgentTranslationError(
+            f"agent {agent_id!r} prompt must be a string, got {type(raw).__name__}"
+        )
     if not raw.startswith(_PROMPT_FILE_SCHEME):
         return raw
     ref = raw[len(_PROMPT_FILE_SCHEME) :]
@@ -118,7 +175,7 @@ def resolve_prompt(spec: dict[str, Any], *, agent_id: str, agents_dir: Path) -> 
         )
     try:
         text = path.read_text(encoding="utf-8")
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         raise KasAgentTranslationError(
             f"agent {agent_id!r} prompt file {path} is unreadable: {exc}"
         ) from exc
@@ -228,6 +285,10 @@ def build_kas_custom_agents(agents_dir: Path, agent_id: str) -> list[dict[str, A
     the ordinary ``session/set_mode`` activation can select it. Without this the
     session stays on KAS's own default mode and the operator's prompt and tool
     configuration have no effect.
+
+    A prompt-less spec (e.g. ``kirocrew-lite``) is projected with the small
+    :data:`_KAS_FALLBACK_PROMPT` so it satisfies KAS's non-empty-prompt
+    requirement instead of crashing the session (see :func:`resolve_prompt`).
     """
     spec = load_agent_spec(agents_dir, agent_id)
     prompt = resolve_prompt(spec, agent_id=agent_id, agents_dir=agents_dir)

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -18,7 +18,9 @@ from pathlib import Path
 
 from kiro_crew import __version__ as _mc_version
 from kiro_crew import diagnostics, platform_compat, sandbox
+from kiro_crew.acp import kas_assets, kas_auth
 from kiro_crew.acp.client import KIRO_CLI_BIN
+from kiro_crew.acp.types import ACP_BACKEND_KAS
 from kiro_crew.agent import AGENT_FILENAME
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config import KiroCrewConfig
@@ -946,6 +948,70 @@ def _doctor_headless_auth(issues: list[str]) -> None:
         print(f"{_INDENT}{line.strip()}" if line.strip() else "")
 
 
+def _kas_version_label(script: "Path") -> str:
+    """Derive the extracted-bundle version label from the KAS script path.
+
+    Bundles live at ``{data_dir}/kas/{version}/.../acp-server.js`` (see
+    :mod:`kiro_crew.acp.kas_assets`), so the version is the path component whose
+    parent directory is named ``kas``. Returns ``"unknown"`` for an unexpected
+    layout rather than raising — this is a diagnostic, not a gate.
+    """
+    for parent in script.parents:
+        if parent.parent is not None and parent.parent.name == "kas":
+            return parent.name
+    return "unknown"
+
+
+def _doctor_kas(issues: list[str]) -> None:
+    """Report KAS backend readiness, but only when KAS is the selected backend.
+
+    KAS is opt-in (``agent.acp_backend = "kas"``); when it is not selected this
+    is silent so a kiro-cli / Claude Code install sees no KAS noise. When it IS
+    selected, KAS runs from kiro-cli's extracted bundle and obtains its token
+    from kiro-cli, so this surfaces the two things that make a selected KAS
+    backend fail at session-create time: missing assets and an unobtainable
+    token. The token probe prints only the expiry, never the token bytes.
+    """
+    # Positive backend test (not ``!= ACP_BACKEND_KAS``): an inequality would
+    # silently capture every harness added later — see the harness-parity gate.
+    if KiroCrewConfig.load().agent.acp_backend == ACP_BACKEND_KAS:
+        _report_kas_backend(issues)
+
+
+def _report_kas_backend(issues: list[str]) -> None:
+    """Print the KAS diagnostic block (assets + bundle version + token probe).
+
+    Split from :func:`_doctor_kas` so the backend-selection check there stays a
+    positive ``== ACP_BACKEND_KAS`` rather than an early-return on inequality.
+    """
+    print("\nKAS backend")
+    node = kas_assets.find_kas_node()
+    script = kas_assets.find_kas_server_script()
+    print(f"  node:        {'✅ ' + str(node) if node else '❌ not found'}")
+    if script:
+        print(f"  bundle:      ✅ {_kas_version_label(script)}")
+    else:
+        print("  bundle:      ❌ KAS server script not found")
+    if not (node and script):
+        print("               Fix: install kiro-cli and run it once so it unpacks its")
+        print("               KAS bundle (or set KIROCREW_KAS_NODE / KIROCREW_KAS_SCRIPT).")
+        issues.append("KAS backend selected but assets missing")
+
+    # Token status — a bounded live probe through kiro-cli. Advisory: an
+    # unobtainable token is usually a transient login state, not a broken
+    # install, so it warns rather than failing the doctor run.
+    try:
+        resp = asyncio.run(kas_auth.resolve_kas_access_token(timeout=8.0))
+    except kas_auth.KasAuthCallbackError as exc:
+        print(f"  token:       ⚠️  not obtainable: {exc}")
+        print("               Fix: sign in with `kiro-cli login`.")
+    except Exception as exc:  # noqa: BLE001 - diagnostic must never abort the run
+        print(f"  token:       ⚠️  probe error: {exc}")
+    else:
+        expires = resp.get("expiresAt")
+        print(f"  token:       ✅ obtained via kiro-cli (expires {expires})")
+
+
 def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False) -> None:
     """Verify KiroCrew setup — check dependencies, config, credentials, connectivity.
 
@@ -1184,6 +1250,9 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     # ── Data Home (+ leftover migration archive) ──
     _doctor_data_home()
     _doctor_trust_root()
+
+    # ── KAS backend (only when selected) ──
+    _doctor_kas(issues)
 
     # ── Pods (systemd --user session bus) ──
     _doctor_pod_session_bus(issues)

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -514,3 +514,73 @@ class TestMemoryPressure:
         out = capsys.readouterr().out
         assert "not applicable" in out
         assert issues == []
+
+
+class TestDoctorKas:
+    """`kirocrew doctor` KAS backend section — gated on acp_backend == kas."""
+
+    class _Cfg:
+        def __init__(self, backend: str) -> None:
+            self.agent = type("A", (), {"acp_backend": backend})()
+
+    def _patch_cfg(self, monkeypatch, backend: str) -> None:
+        monkeypatch.setattr(
+            cli_doctor.KiroCrewConfig, "load", classmethod(lambda cls: self._Cfg(backend))
+        )
+
+    def test_version_label_from_bundle_path(self) -> None:
+        script = Path("/home/u/.local/share/kiro-cli/kas/2.18.0-abc123/nm/acp-server.js")
+        assert cli_doctor._kas_version_label(script) == "2.18.0-abc123"
+
+    def test_version_label_unknown_for_unexpected_layout(self) -> None:
+        assert cli_doctor._kas_version_label(Path("/opt/foo/acp-server.js")) == "unknown"
+
+    def test_silent_when_backend_not_kas(self, monkeypatch, capsys) -> None:
+        self._patch_cfg(monkeypatch, "")
+        issues: list[str] = []
+        cli_doctor._doctor_kas(issues)
+        assert "KAS backend" not in capsys.readouterr().out
+        assert issues == []
+
+    def test_selected_but_assets_missing_appends_issue(self, monkeypatch, capsys) -> None:
+        self._patch_cfg(monkeypatch, "kas")
+        from kiro_crew.acp import kas_assets, kas_auth
+
+        monkeypatch.setattr(kas_assets, "find_kas_node", lambda: None)
+        monkeypatch.setattr(kas_assets, "find_kas_server_script", lambda: None)
+
+        async def _raise(*, timeout: float = 8.0):
+            raise kas_auth.KasAuthCallbackError("kiro-cli not found; cannot obtain a KAS token")
+
+        monkeypatch.setattr(kas_auth, "resolve_kas_access_token", _raise)
+        issues: list[str] = []
+        cli_doctor._doctor_kas(issues)
+        out = capsys.readouterr().out
+        assert "KAS backend" in out
+        assert "❌ not found" in out
+        assert "KAS backend selected but assets missing" in issues
+        # Token bytes never printed; only the advisory line.
+        assert "not obtainable" in out
+
+    def test_token_ok_prints_expiry_not_token(self, monkeypatch, capsys) -> None:
+        self._patch_cfg(monkeypatch, "kas")
+        from kiro_crew.acp import kas_assets, kas_auth
+
+        monkeypatch.setattr(kas_assets, "find_kas_node", lambda: Path("/x/node"))
+        monkeypatch.setattr(
+            kas_assets,
+            "find_kas_server_script",
+            lambda: Path("/x/kas/9.9.9-hash/nm/acp-server.js"),
+        )
+
+        async def _ok(*, timeout: float = 8.0):
+            return {"accessToken": "SECRET-DO-NOT-PRINT", "expiresAt": "2099-01-01T00:00:00Z"}
+
+        monkeypatch.setattr(kas_auth, "resolve_kas_access_token", _ok)
+        issues: list[str] = []
+        cli_doctor._doctor_kas(issues)
+        out = capsys.readouterr().out
+        assert "9.9.9-hash" in out
+        assert "2099-01-01T00:00:00Z" in out
+        assert "SECRET-DO-NOT-PRINT" not in out
+        assert issues == []

--- a/test/test_kas_agents.py
+++ b/test/test_kas_agents.py
@@ -15,8 +15,10 @@ import pytest
 
 from kiro_crew import config as kiro_crew_config
 from kiro_crew.acp.kas_agents import (
+    _KAS_FALLBACK_PROMPT,
     KAS_MAX_CUSTOM_AGENTS,
     KasAgentTranslationError,
+    build_kas_custom_agents,
     resolve_prompt,
     to_client_custom_agent,
 )
@@ -204,10 +206,44 @@ class TestPromptResolution:
                 {"prompt": "file://../../etc/passwd"}, agent_id="a", agents_dir=tmp_path
             )
 
-    @pytest.mark.parametrize("bad", [None, "", "   ", 7])
-    def test_absent_prompt_is_refused(self, bad, tmp_path):
-        with pytest.raises(KasAgentTranslationError):
+    @pytest.mark.parametrize("bad", [None, "", "   "])
+    def test_empty_prompt_falls_back_to_the_kas_constant(self, bad, tmp_path, caplog):
+        # KAS requires a non-empty prompt; a missing or blank string is an
+        # intentionally prompt-less agent (e.g. kirocrew-lite ships "prompt": ""),
+        # so the projection substitutes the small inline fallback constant
+        # instead of crashing the session.
+        out = resolve_prompt({"prompt": bad}, agent_id="kirocrew-lite", agents_dir=tmp_path)
+        assert out == _KAS_FALLBACK_PROMPT
+        assert "falling back to the lightweight KAS prompt" in caplog.text
+
+    @pytest.mark.parametrize("bad", [7, 3.14, True, [], {}, ["x"]])
+    def test_non_string_prompt_is_refused_not_defaulted(self, bad, tmp_path):
+        # A non-string prompt is a malformed spec, not a prompt-less one — it
+        # must fail loud rather than silently run with the fallback text.
+        with pytest.raises(KasAgentTranslationError, match="must be a string"):
             resolve_prompt({"prompt": bad}, agent_id="a", agents_dir=tmp_path)
+
+    def test_a_real_prompt_wins_over_the_fallback(self, tmp_path):
+        # The fallback only fires for an empty spec.
+        assert resolve_prompt({"prompt": "own"}, agent_id="a", agents_dir=tmp_path) == "own"
+
+    def test_non_utf8_file_prompt_is_refused_not_crashing(self, tmp_path):
+        # A non-UTF-8 agent-supplied file:// prompt must fail loud as
+        # "unreadable", never raise a raw UnicodeDecodeError out of KAS session
+        # creation.
+        p = tmp_path / "prompt.md"
+        p.write_bytes(b"\xff\xfe not utf-8")
+        with pytest.raises(KasAgentTranslationError, match="unreadable"):
+            resolve_prompt({"prompt": f"file://{p}"}, agent_id="a", agents_dir=tmp_path)
+
+    def test_build_projects_a_prompt_less_spec_with_the_fallback(self, tmp_path):
+        (tmp_path / "kirocrew-lite.json").write_text(
+            json.dumps({"name": "kirocrew-lite", "tools": [], "prompt": ""}), encoding="utf-8"
+        )
+        agents = build_kas_custom_agents(tmp_path, "kirocrew-lite")
+        assert agents[0]["prompt"] == _KAS_FALLBACK_PROMPT
+        # Tool restriction is preserved — the fallback only supplies a prompt.
+        assert agents[0]["tools"] == []
 
 
 def test_the_batch_cap_matches_the_schema():

--- a/test/test_kas_mode_binding.py
+++ b/test/test_kas_mode_binding.py
@@ -18,6 +18,7 @@ import sys
 
 import pytest
 
+from kiro_crew.acp.kas_agents import _KAS_FALLBACK_PROMPT
 from kiro_crew.acp.kas_assets import ENV_KAS_NODE, ENV_KAS_SCRIPT
 from kiro_crew.acp.runtime import AcpRuntime
 from kiro_crew.acp.types import ACP_BACKEND_KAS
@@ -197,14 +198,55 @@ class TestModeBinding:
         assert seen["injected"][0]["prompt"] == "inlined from disk"
 
     @pytest.mark.asyncio
-    async def test_an_unprojectable_agent_fails_loud(self, mode_stub, crew_agent, tmp_path):
-        """Silently continuing would run KAS's default mode instead.
-
-        For a restricted app or subagent agent that means a BROADER agent than
-        the caller asked for, so this must raise rather than degrade.
+    async def test_a_prompt_less_agent_falls_back_to_the_kas_prompt(
+        self, mode_stub, crew_agent, tmp_path
+    ):
+        """KAS requires a non-empty prompt where kiro-cli tolerates an empty
+        one. Crew's own prompt-less utility agents (e.g. ``kirocrew-lite``, which
+        ships ``"prompt": ""``) must fall back to the small inline KAS prompt
+        rather than crash the session. The tool allowlist still comes from the
+        spec, so the fallback never widens the agent's capabilities.
         """
         (crew_agent / "kirocrew.json").write_text(
-            json.dumps({"name": "kirocrew", "tools": ["fs_read"]}), encoding="utf-8"
+            json.dumps({"name": "kirocrew", "tools": ["fs_read"], "prompt": ""}),
+            encoding="utf-8",
+        )
+        runtime = AcpRuntime(
+            work_dir=tmp_path / "ws3",
+            agent="kirocrew",
+            sandbox_mode="off",
+            acp_backend=ACP_BACKEND_KAS,
+        )
+        try:
+            await runtime.spawn()
+            await runtime.create_session(cwd=tmp_path / "ws3", agent="kirocrew")
+        finally:
+            await runtime.kill()
+
+        seen = json.loads(mode_stub.read_text(encoding="utf-8"))
+        assert seen["injected"][0]["prompt"] == _KAS_FALLBACK_PROMPT
+        # Tool restriction is preserved — the fallback only supplies a prompt.
+        assert seen["injected"][0]["tools"] == ["fs_read"]
+
+    @pytest.mark.asyncio
+    async def test_an_unprojectable_agent_fails_loud(self, mode_stub, crew_agent, tmp_path):
+        """A prompt that cannot be resolved AT ALL still fails loud.
+
+        The base-prompt fallback only covers an empty/absent prompt. A
+        ``file://`` prompt pointing at a missing file is a genuine translation
+        failure: silently continuing would run KAS's default mode instead, which
+        for a restricted app or subagent agent means a BROADER agent than the
+        caller asked for, so this must raise rather than degrade.
+        """
+        (crew_agent / "kirocrew.json").write_text(
+            json.dumps(
+                {
+                    "name": "kirocrew",
+                    "tools": ["fs_read"],
+                    "prompt": f"file://{tmp_path / 'does-not-exist.md'}",
+                }
+            ),
+            encoding="utf-8",
         )
         runtime = AcpRuntime(
             work_dir=tmp_path / "ws3",

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -595,6 +595,12 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli_commands.py::_register_app_crons_to_scheduler",
         "cli_doctor.py::_doctor",
         "cli_doctor.py::_doctor_mcp_tools",
+        # NOT a subprocess spawn here: the AST heuristic matches ``asyncio.run``
+        # (attr ``run`` on base ``asyncio``), used only to drive the async KAS
+        # token probe from the synchronous doctor. The actual child process is
+        # spawned inside ``acp/kas_auth.py::resolve_kas_access_token``, which is
+        # allowlisted separately above (kiro-cli reaching its own token store).
+        "cli_doctor.py::_report_kas_backend",
         # ``systemctl is-active <unit>`` probes for the memory-pressure
         # preparedness check: argv is hardcoded (systemd-oomd/earlyoom unit
         # names), no agent influence, 5s-capped, read-only query.


### PR DESCRIPTION
## Problem

Under the KAS ACP backend, **every background session crashed**. Crew's own
utility agent `kirocrew-lite` (auto-titles, summaries, folder suggestions,
optimizer, workflows) ships with `"prompt": ""` and inherits a default — kiro-cli
tolerates that, but KAS requires a non-empty prompt. Projecting `kirocrew-lite`
raised `KasAgentTranslationError: agent 'kirocrew-lite' has no prompt` →
`AcpRuntimeError: cannot project agent 'kirocrew-lite' onto KAS` →
`Failed to create background session`. Main chat (`kirocrew`, which has a real
prompt) worked; all background functions did not.

Separately, when KAS is the selected backend there was **no diagnostic** for the
two things that make it fail at session-create time: missing extracted assets
and an unobtainable token.

## Why it matters

Verified live on real KAS 0.38.7: with `acp_backend=kas`, titles/summaries and
every other background feature fail continuously, with no `doctor` signal
explaining why.

## Fix (symptom → root cause → change)

- **Prompt-less crash** — root cause: `kas_agents.resolve_prompt` had no fallback
  for an empty/absent prompt. Change: an empty spec now falls back to a small
  inline constant, `_KAS_FALLBACK_PROMPT` — a generic, task-agnostic
  lightweight-worker system prompt (~150 tokens), not the full 25 KB
  orchestration persona in `prompt.md`, which is both wrong and wasteful for
  a title/summary agent. Key scoping: `resolve_prompt` is called **only** from
  `build_kas_custom_agents` (the KAS projection), so the fallback fires **only
  on the KAS path**. The kiro-cli path is untouched — `kirocrew-lite.json` still
  ships `"prompt": ""` and kiro-cli keeps supplying its own default. The
  fallback is an inline literal, not a file read, so it carries none of a
  `file://` prompt's path-traversal / symlink / decode risk. Tool restrictions
  still come from the spec, so the fallback only supplies a system prompt and
  never widens an agent's capabilities.
- **Hardening of the `file://` prompt path** (agent-supplied prompts): the read
  now catches `UnicodeDecodeError` alongside `OSError`, so a non-UTF-8 prompt
  file fails loud as "unreadable" instead of raising a raw decode error out of
  session creation.
- **KAS doctor** — `cli_doctor._doctor_kas` reports node path, extracted-bundle
  version, and a bounded (8 s) live token probe via `resolve_kas_access_token`
  (prints only `expiresAt`, never token bytes). It runs **only** when
  `agent.acp_backend == "kas"` (a positive backend test, per the harness-parity
  gate), silent otherwise. Missing assets → a doctor issue; an unobtainable
  token → an advisory warning.

Two related roadmap items needed **no code change** and are noted as resolved:
- **`sessionEviction`** — Crew has zero references to it and never sends it.
- **steering double-inject** — steering injection in `context.py` is gated
  `is_cc` (only `provider_type == "claude_code"`); KAS runs under the `acp`
  provider, so Crew does not inject steering for KAS, and KAS natively loads
  `.kiro/steering` + `AGENTS.md` + the agent's projected `resources`.

## Tests

- `test/test_kas_agents.py` — empty prompt → the fallback constant (with the
  warning logged); a real prompt wins; a non-UTF-8 `file://` prompt is refused
  as "unreadable" (no raw `UnicodeDecodeError`); `build_kas_custom_agents`
  projects a prompt-less spec with the constant and preserves `tools`.
- `test/test_kas_mode_binding.py` — a prompt-less agent projects onto the KAS
  stub with the fallback constant (tools preserved); a `file://`-to-missing-file
  prompt still fails loud with "onto KAS".
- `test/test_cli_doctor.py` — version-label derivation; silent when backend ≠
  kas; selected-but-assets-missing appends an issue; token OK prints the expiry
  and never the token bytes.
- `test/test_spawn_audit.py` — `_report_kas_backend`'s `asyncio.run` is
  allowlisted as the AST false-positive it is (the real subprocess,
  `acp/kas_auth.py::resolve_kas_access_token`, is allowlisted separately).

## Manual verification

The original crash was reproduced live on KAS 0.38.7 (background sessions failing
with the projection error). Unit coverage locks in the fallback + doctor
behaviour; a follow-up live check on KAS confirms background sessions create.

<!-- no-visual-delta -->
**Why no screenshot:** backend + CLI-diagnostic only; no dashboard/browser UI is
changed.
