### PR TITLE
fix(knowledge): make export_item's bundle importable, and 400 on malformed imports

### DIFF
--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -15,6 +15,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from aiohttp import web
 
+from kiro_crew._sqlite_compat import sqlite3
 from kiro_crew.artifacts import get_default_store
 from kiro_crew.config.loader import KiroCrewConfig, config_dir, data_home
 from kiro_crew.dashboard.handlers.files import (
@@ -71,6 +72,77 @@ def _sel_log(tool: str, **kwargs: object) -> None:
         tool_name=f"knowledge.{tool}", outcome=str(kwargs.pop("outcome", "completed")),
         resources=str(kwargs) if kwargs else "",
     )
+
+
+_BUNDLE_LIST_FIELDS = ("items", "entities", "relations", "sources", "source_locations", "mentions")
+# The fields import_bundle's redaction loops pass to _redact(); each has to be
+# a string or null before it reaches _redact() -> redact_exfiltration_urls(),
+# whose regex .finditer() raises an unhandled TypeError on anything else.
+_BUNDLE_REDACTED_FIELDS = {
+    "items": ("title", "summary", "content"),
+    "entities": ("name", "description"),
+    "relations": ("relation_type", "description"),
+}
+
+
+def _validate_knowledge_bundle(body: object) -> str | None:
+    """Return an error string if body isn't an importable bundle shape, else None.
+
+    Runs before the redaction loops and the store call so a malformed bundle
+    fails with a clean 400 instead of an unhandled AttributeError/TypeError
+    (non-dict body or entries) or a silently-committed corrupt row (non-JSON
+    sources.properties / entities.aliases, which every reader parses with
+    json.loads()).
+    """
+    if not isinstance(body, dict):
+        return "bundle must be a JSON object"
+    for field in _BUNDLE_LIST_FIELDS:
+        value = body.get(field, [])
+        if not isinstance(value, list):
+            return f"'{field}' must be a list"
+        for entry in value:
+            if not isinstance(entry, dict):
+                return f"'{field}' entries must be objects"
+    for field, keys in _BUNDLE_REDACTED_FIELDS.items():
+        for entry in body.get(field, []):
+            for key in keys:
+                value = entry.get(key)
+                if value is not None and not isinstance(value, str):
+                    return f"'{field}.{key}' must be a string or null"
+    # store.import_bundle() writes these two columns through unparsed (with
+    # '{}'/'[]' defaults when ABSENT), so anything present must already be the
+    # JSON text every reader json.loads() back: readers such as the source
+    # detail handlers parse the raw column with no empty-string guard, and
+    # find_entity() calls .lower() on each parsed alias.  Only absent/null
+    # falls through to the store defaults; a present non-string (1 -> TEXT
+    # "1"), an empty string, or the wrong parsed shape would commit a row
+    # that crashes a later, unrelated read.  json.loads raises RecursionError
+    # (not ValueError) on deeply-nested input, so catch it here too.
+    for src in body.get("sources", []):
+        props = src.get("properties")
+        if props is None:
+            continue
+        if not isinstance(props, str):
+            return "'sources.properties' must be a JSON object string or null"
+        try:
+            parsed = json.loads(props)
+        except (ValueError, RecursionError):
+            return "'sources.properties' must be valid JSON"
+        if not isinstance(parsed, dict):
+            return "'sources.properties' must be a JSON object"
+    for ent in body.get("entities", []):
+        aliases = ent.get("aliases")
+        if aliases is None:
+            continue
+        if not isinstance(aliases, str):
+            return "'entities.aliases' must be a JSON array string or null"
+        try:
+            parsed = json.loads(aliases)
+        except (ValueError, RecursionError):
+            return "'entities.aliases' must be valid JSON"
+        if not isinstance(parsed, list) or not all(isinstance(a, str) for a in parsed):
+            return "'entities.aliases' must be a JSON array of strings"
+    return None
 
 
 def _store(request: web.Request):
@@ -1524,6 +1596,13 @@ async def import_bundle(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
+    shape_error = _validate_knowledge_bundle(body)
+    if shape_error is not None:
+        _sel_log("import", outcome="rejected", reason=shape_error)
+        return web.json_response(
+            {"error": f"malformed bundle: {shape_error}", "code": "malformed_knowledge_bundle"},
+            status=400,
+        )
     # Redact imported text fields (may contain LLM-derived content from another instance)
     for item in body.get("items", []):
         redacted_title = _redact(item.get("title"))
@@ -1539,7 +1618,18 @@ async def import_bundle(request: web.Request) -> web.Response:
         redacted_type = _redact(rel.get("relation_type"))
         rel["relation_type"] = redacted_type if redacted_type is not None else ""
         rel["description"] = _redact(rel.get("description"))
-    result = _store(request).import_bundle(body)
+    try:
+        result = _store(request).import_bundle(body)
+    except (KeyError, sqlite3.Error, OverflowError) as exc:
+        # OverflowError: a bundle integer field (e.g. chunk_index) too large
+        # for SQLite's 64-bit INTEGER, raised at bind time inside the store
+        # call -- neither a KeyError nor a sqlite3.Error, so it needs its own
+        # arm or it leaks through as an unhandled 500.
+        _sel_log("import", outcome="rejected", reason=str(exc))
+        return web.json_response(
+            {"error": f"malformed bundle: {exc}", "code": "malformed_knowledge_bundle"},
+            status=400,
+        )
     _sel_log("import", **result)
     return web.json_response(result)
 

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -1420,6 +1420,7 @@ class KnowledgeStore:
             return {}
         mentions = self.db.execute("SELECT entity_id FROM mentions WHERE item_id = ?", (item_id,)).fetchall()
         entity_ids = [m["entity_id"] for m in mentions]
+        entity_id_set = set(entity_ids)
         entities = []
         for eid in entity_ids:
             row = self.db.execute("SELECT * FROM entities WHERE id = ?", (eid,)).fetchone()
@@ -1431,12 +1432,38 @@ class KnowledgeStore:
             for row in self.db.execute(
                     "SELECT * FROM entity_relations WHERE source_id = ? OR target_id = ?", (eid, eid)):
                 r = dict(row)
-                if r["id"] not in seen_ids:
-                    seen_ids.add(r["id"])
-                    relations.append(r)
+                if r["id"] in seen_ids:
+                    continue
+                # A relation whose OTHER endpoint isn't among this item's
+                # mentioned entities, or that was recorded under a different
+                # item's observation (source_item_id), would re-import
+                # referencing an entity/item this single-item bundle never
+                # carries -- an FK violation on the receiving end. Only keep
+                # relations fully contained in what this bundle exports.
+                if r["source_id"] not in entity_id_set or r["target_id"] not in entity_id_set:
+                    continue
+                if r["source_item_id"] not in (None, item_id):
+                    continue
+                seen_ids.add(r["id"])
+                relations.append(r)
         locations = [dict(r) for r in self.db.execute(
             "SELECT * FROM source_locations WHERE item_id = ?", (item_id,))]
-        return {"item": item, "entities": entities, "relations": relations, "source_locations": locations}
+        mentions = [dict(r) for r in self.db.execute(
+            "SELECT * FROM mentions WHERE item_id = ?", (item_id,))]
+        source_ids = {sid for sid in (item.get("source_id"), *(loc["source_id"] for loc in locations)) if sid}
+        sources = []
+        for sid in source_ids:
+            row = self.db.execute("SELECT * FROM sources WHERE id = ?", (sid,)).fetchone()
+            if row:
+                sources.append(dict(row))
+        return {
+            "items": [item],
+            "sources": sources,
+            "entities": entities,
+            "relations": relations,
+            "source_locations": locations,
+            "mentions": mentions,
+        }
 
     def export_all(self, namespace: str | None = None) -> dict:
         if namespace:

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -911,13 +911,87 @@ class TestKnowledgeStoreExtended:
         store.add_entity_relation(e1, e2, "uses", source_item_id=item_id)
         store.add_source_location(item_id, sid, section_title="Main")
         bundle = store.export_item(item_id)
-        assert bundle["item"]["id"] == item_id
+        assert bundle["items"][0]["id"] == item_id
         assert len(bundle["entities"]) == 2
         assert len(bundle["relations"]) == 1
         assert len(bundle["source_locations"]) == 1
+        assert len(bundle["mentions"]) == 2
+        assert bundle["sources"][0]["id"] == sid
 
     def test_export_item_missing(self, store):
         assert store.export_item("nope") == {}
+
+    def test_export_item_without_source(self, store):
+        item_id = store.add_item("Doc", "content", "doc")
+        bundle = store.export_item(item_id)
+        assert bundle["items"][0]["id"] == item_id
+        assert bundle["sources"] == []
+
+    def test_export_item_roundtrips_into_a_fresh_instance(self, store_factory):
+        s1 = store_factory("export_item_src.db")
+        sid = s1.add_source("f", "local_file", "/tmp/exp2.md")
+        item_id = s1.add_item("Doc", "content", "doc", source_id=sid)
+        eid = s1.add_entity("Svc", "service")
+        s1.add_mention(item_id, eid)
+        s1.add_source_location(item_id, sid, section_title="Main")
+        bundle = s1.export_item(item_id)
+
+        s2 = store_factory("export_item_dst.db")
+        result = s2.import_bundle(bundle)
+        assert result["items_imported"] == 1
+        assert s2.get_item(item_id)["title"] == "Doc"
+        mentions = s2.db.execute(
+            "SELECT * FROM mentions WHERE item_id = ?", (item_id,)
+        ).fetchall()
+        assert len(mentions) == 1
+        assert mentions[0]["entity_id"] == eid
+
+    def test_export_item_excludes_relations_whose_other_endpoint_is_not_exported(self, store):
+        """A relation touching an entity outside this item's mentions must not
+        ride along -- the receiving store never gets that entity's row, so
+        re-importing the relation would violate entity_relations' FK on
+        source_id/target_id."""
+        item_id = store.add_item("Doc", "content", "doc")
+        mentioned = store.add_entity("Svc", "service")
+        outside = store.add_entity("Unrelated", "service")
+        store.add_mention(item_id, mentioned)
+        store.add_entity_relation(mentioned, outside, "calls")
+        bundle = store.export_item(item_id)
+        assert bundle["relations"] == []
+        assert {e["id"] for e in bundle["entities"]} == {mentioned}
+
+    def test_export_item_excludes_relations_owned_by_a_different_item(self, store):
+        """A relation recorded under another item's observation (source_item_id
+        set to that other item) must not ride along either -- re-importing it
+        here references an item that was never exported alongside it."""
+        item_id = store.add_item("Doc", "content", "doc")
+        other_item_id = store.add_item("Other", "content", "doc")
+        e1 = store.add_entity("A", "service")
+        e2 = store.add_entity("B", "service")
+        store.add_mention(item_id, e1)
+        store.add_mention(item_id, e2)
+        store.add_entity_relation(e1, e2, "calls", source_item_id=other_item_id)
+        bundle = store.export_item(item_id)
+        assert bundle["relations"] == []
+
+    def test_export_item_with_a_cross_referencing_relation_roundtrips_cleanly(self, store_factory):
+        """End-to-end reproduction of the FK bug: exporting an item whose
+        mentioned entity has a relation to an unexported entity must still
+        re-import cleanly (the offending relation is simply dropped, not
+        carried along to break the import)."""
+        s1 = store_factory("cross_ref_src.db")
+        item_id = s1.add_item("Doc", "content", "doc")
+        mentioned = s1.add_entity("Svc", "service")
+        outside = s1.add_entity("Unrelated", "service")
+        s1.add_mention(item_id, mentioned)
+        s1.add_entity_relation(mentioned, outside, "calls")
+        bundle = s1.export_item(item_id)
+
+        s2 = store_factory("cross_ref_dst.db")
+        result = s2.import_bundle(bundle)
+        assert result["items_imported"] == 1
+        assert result["relations_rebuilt"] == 0
+        assert s2.get_item(item_id) is not None
 
     def test_delete_item_cleans_mentions(self, store):
         item_id = store.add_item("Doc", "content", "doc")

--- a/test/test_knowledge_handlers_coverage.py
+++ b/test/test_knowledge_handlers_coverage.py
@@ -596,7 +596,7 @@ class TestExport:
             resp = await client.get(f"/api/knowledge/items/{item_id}/export")
             assert resp.status == 200
             assert "item.knowledge" in resp.headers["Content-Disposition"]
-            assert (await resp.json())["item"]["id"] == item_id
+            assert (await resp.json())["items"][0]["id"] == item_id
 
     @pytest.mark.asyncio
     async def test_export_all_default_filename(self, store):
@@ -669,6 +669,247 @@ class TestImportBundle:
             assert (await client.post("/api/knowledge/import", json=bundle)).status == 200
         content = store.db.execute("SELECT content FROM items").fetchone()["content"]
         assert secret not in content
+
+    @pytest.mark.asyncio
+    async def test_export_item_bundle_reimports_into_a_fresh_instance(self, store, tmp_path):
+        source_store = KnowledgeStore(str(tmp_path / "source.db"))
+        try:
+            sid = source_store.add_source("f", "local_file", "/tmp/exp.md")
+            item_id = source_store.add_item("a", "body", "note", source_id=sid)
+            eid = source_store.add_entity("Svc", "service")
+            source_store.add_mention(item_id, eid)
+            source_store.add_source_location(item_id, sid, section_title="Main")
+            async with _client(_make_app(source_store)) as export_client:
+                bundle = await (
+                    await export_client.get(f"/api/knowledge/items/{item_id}/export")
+                ).json()
+        finally:
+            source_store.close()
+
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 200
+            result = await resp.json()
+        assert result["items_imported"] == 1
+        assert store.get_item(item_id) is not None
+
+    @pytest.mark.asyncio
+    async def test_bundle_violating_foreign_keys_is_400_not_500(self, store):
+        bundle = {"source_locations": [
+            {"id": "sl1", "item_id": "missing-item", "source_id": "missing-source"}]}
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        # A machine-readable code, not just prose -- the dashboard renders
+        # `error` verbatim into a localized UI (test_error_code_contract.py).
+        assert body["code"] == "malformed_knowledge_bundle"
+        assert store.db.execute("SELECT COUNT(*) c FROM source_locations").fetchone()["c"] == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [[1, 2, 3], "just a string", 42])
+    async def test_non_object_json_is_400_not_500(self, store, payload):
+        # request.json() happily parses a bare array/string/number/null; the
+        # handler's own redaction loop then calls body.get(...) on it, an
+        # AttributeError past every try/except in the function.
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=payload)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bundle", [
+        {"items": [1]},
+        {"items": "not-a-list"},
+        {"entities": [None]},
+        {"relations": [["nested"]]},
+    ])
+    async def test_non_object_collection_items_is_400_not_500(self, store, bundle):
+        # A well-formed top-level dict whose collection isn't a list-of-objects
+        # still reaches the redaction loop's item.get(...) on a non-dict entry.
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bundle", [
+        {"sources": [1]},
+        {"source_locations": ["x"]},
+        {"mentions": [42]},
+    ])
+    async def test_non_object_source_collections_is_400_not_500(self, store, bundle):
+        # sources/source_locations/mentions are never touched by the handler's
+        # redaction loops (only items/entities/relations are), so a non-dict
+        # entry there reaches store.import_bundle() directly -- e.g. src["id"]
+        # on an int raises TypeError, which is neither a KeyError nor a
+        # sqlite3.Error.
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bundle", [
+        {"items": [{"id": "i1", "item_type": "note", "title": [1, 2]}]},
+        {"items": [{"id": "i1", "item_type": "note", "content": {"a": 1}}]},
+        {"entities": [{"id": "e1", "entity_type": "person", "name": 5}]},
+        {"relations": [{"id": "r1", "source_id": "e1", "target_id": "e1",
+                        "relation_type": ["x"]}]},
+    ])
+    async def test_non_string_redacted_field_is_400_not_500(self, store, bundle):
+        # Every field the redaction loops pass to _redact() has to be a
+        # string or null -- _redact() forwards non-empty values straight into
+        # a regex .finditer() call, which raises TypeError on anything else.
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+
+    @pytest.mark.asyncio
+    async def test_oversized_integer_field_is_400_not_500(self, store):
+        # Python ints have no size ceiling; SQLite's INTEGER column is 64-bit.
+        # Binding an oversized value raises OverflowError at bind time inside
+        # store.import_bundle(), which is neither a KeyError nor sqlite3.Error.
+        bundle = {"items": [{"id": "i1", "title": "t", "content": "c",
+                             "item_type": "note", "chunk_index": 10**101}]}
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+        assert store.db.execute("SELECT COUNT(*) c FROM items").fetchone()["c"] == 0
+
+    @pytest.mark.asyncio
+    async def test_source_with_non_json_properties_is_400_not_500(self, store):
+        # sources.properties is a TEXT column store.import_bundle() writes
+        # through unparsed, but every consumer reads it back with
+        # json.loads() -- a non-JSON string commits cleanly (200) and only
+        # breaks a later, unrelated request (e.g. Sync).
+        bundle = {"sources": [{"id": "s1", "name": "n", "source_type": "local_file",
+                               "uri": "/tmp/x", "properties": "not-json"}]}
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+        assert store.db.execute("SELECT COUNT(*) c FROM sources").fetchone()["c"] == 0
+
+    @pytest.mark.asyncio
+    async def test_entity_with_non_json_aliases_is_400_not_500(self, store):
+        # entities.aliases has the same shape of bug, with a worse blast
+        # radius: find_entity() parses every entity's aliases on every
+        # lookup, so one malformed row poisons every subsequent call.
+        bundle = {"entities": [{"id": "e1", "name": "n", "entity_type": "person",
+                                "aliases": "not-json"}]}
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+        assert store.db.execute("SELECT COUNT(*) c FROM entities").fetchone()["c"] == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("props", [
+        pytest.param(1, id="int"),          # SQLite TEXT-coerces to "1"; readers json.loads -> not a dict
+        pytest.param([], id="list"),        # wrong container entirely
+        pytest.param({}, id="dict"),        # right shape but store expects the JSON *string*
+        pytest.param("", id="empty"),       # detail readers json.loads("") -> ValueError
+        pytest.param("[]", id="json-array"),  # valid JSON, wrong parsed shape (array, not object)
+        # Depth > the 3.10/3.11 recursion limit (1000) -> RecursionError there;
+        # platforms whose C-scanner limit is higher parse to end-of-input and
+        # raise ValueError instead -- either way the contract is a clean 400.
+        # Kept moderate: a huge depth (100k) actually stack-overflowed the
+        # Windows CI worker inside the C json scanner before the recursion
+        # guard could fire (2MB stack vs Linux's 8MB) -- the guard is what
+        # makes deep input raise instead of crash, and it isn't reachable
+        # arbitrarily far down the stack.
+        pytest.param("[" * 1500, id="deeply-nested"),
+    ])
+    async def test_source_with_non_object_properties_is_400_not_500(self, store, props):
+        # The old guard (`isinstance(props, str) and props`) SKIPPED validation
+        # for every non-string and for "", committing a row that only crashes a
+        # later read (source detail handlers json.loads the raw column with no
+        # empty guard).  Anything present must be a JSON *object string*.
+        bundle = {"sources": [{"id": "s1", "name": "n", "source_type": "local_file",
+                               "uri": "/tmp/x", "properties": props}]}
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+        assert store.db.execute("SELECT COUNT(*) c FROM sources").fetchone()["c"] == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("aliases", [
+        pytest.param(5, id="int"),          # non-string: TEXT-coerces to "5"; find_entity json.loads -> not a list
+        pytest.param("[1]", id="non-string-elems"),  # find_entity calls a.lower() on each element -> crash
+        pytest.param("", id="empty"),       # empty string is not valid JSON
+        pytest.param("{}", id="json-object"),  # valid JSON, wrong parsed shape (object, not array)
+        pytest.param("[" * 1500, id="deeply-nested"),  # see properties note above
+    ])
+    async def test_entity_with_non_string_array_aliases_is_400_not_500(self, store, aliases):
+        # Same class as properties above; aliases must additionally be an
+        # array OF STRINGS because find_entity() lower()s each element.
+        bundle = {"entities": [{"id": "e1", "name": "n", "entity_type": "person",
+                                "aliases": aliases}]}
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+        assert store.db.execute("SELECT COUNT(*) c FROM entities").fetchone()["c"] == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field_bundle", [
+        pytest.param({"sources": [{"id": "s1", "name": "n", "source_type": "local_file",
+                                   "uri": "/tmp/x", "properties": "@@boom@@"}]},
+                     id="properties"),
+        pytest.param({"entities": [{"id": "e1", "name": "n", "entity_type": "person",
+                                    "aliases": "@@boom@@"}]},
+                     id="aliases"),
+    ])
+    async def test_recursion_error_during_validation_is_400_not_500(
+            self, store, monkeypatch, field_bundle):
+        # Deterministic RecursionError discriminator: the depth at which the
+        # platform's json C-scanner raises (vs parses) varies, so force the
+        # error instead of gambling on real nesting.  The old guard caught only
+        # ValueError, leaking RecursionError as an unhandled 500.
+        from kiro_crew.dashboard.handlers import knowledge as knowledge_mod
+        real_loads = knowledge_mod.json.loads
+
+        def exploding_loads(s, *args, **kwargs):
+            if s == "@@boom@@":
+                raise RecursionError("maximum recursion depth exceeded")
+            return real_loads(s, *args, **kwargs)
+
+        monkeypatch.setattr(knowledge_mod.json, "loads", exploding_loads)
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=field_bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+        assert store.db.execute("SELECT COUNT(*) c FROM sources").fetchone()["c"] == 0
+        assert store.db.execute("SELECT COUNT(*) c FROM entities").fetchone()["c"] == 0
+
+    @pytest.mark.asyncio
+    async def test_null_properties_and_aliases_still_import(self, store):
+        # Absent/null falls through to the store's '{}'/'[]' defaults -- the
+        # tightened validator must not reject the shapes export never writes
+        # but hand-built bundles legitimately omit.
+        bundle = {"sources": [{"id": "s1", "name": "n", "source_type": "local_file",
+                               "uri": "/tmp/x", "properties": None}],
+                  "entities": [{"id": "e1", "name": "n", "entity_type": "person",
+                                "aliases": None}]}
+        async with _client(_make_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 200
+        assert store.db.execute("SELECT COUNT(*) c FROM sources").fetchone()["c"] == 1
+        assert store.db.execute("SELECT COUNT(*) c FROM entities").fetchone()["c"] == 1
 
 
 # ----------------------------------------------------------------- embeddings


### PR DESCRIPTION
## Problem / Motivation

`export_item()` (backing `GET /api/knowledge/items/{id}/export`, the item detail view's Export button) and `import_bundle()` (backing `POST /api/knowledge/import`) disagreed on bundle shape, so exporting a single item and re-importing it never worked:

- `export_item` wrote the item under a singular `"item"` key. `import_bundle` only ever reads plural `"items"`, so it always saw zero items.
- An item with `source_locations` rows (i.e. almost anything ingested from a real source) still had those rows inserted from their own matching bundle key, but with no `items` row to satisfy `source_locations.item_id REFERENCES items(id)` — raising an uncaught `sqlite3.IntegrityError` that the handler had no try/except around, propagating as an unhandled 500.
- An item with no `source_locations` silently reported `items_imported: 0` with a 200 instead of any error.
- Even with the key fixed, `export_item` never included the item's owning `sources` row or its `mentions` rows, so importing into a fresh instance would still hit an FK failure via `items.source_id REFERENCES sources(id)`, and any entity links would be silently dropped.

## Why it matters

The single-item export/import path is a normal, user-visible flow (the item detail view's Export button, and the import screen). It silently fails to import anything for the common case, or 500s outright for anything ingested from a real source — with no indication to the user why the round trip didn't work.

## What changed (motivation → approach → change)

Symptom: exporting one Knowledge item and re-importing it does nothing (or 500s). Root cause: `export_item` and `import_bundle` were written against two different bundle shapes — singular `"item"` vs. the plural `"items"`/`"sources"` the full-library `export_all`/`import_bundle` path already agrees on. Fix: `export_item` now returns `{"items": [item], "sources": [...], "entities": [...], "relations": [...], "source_locations": [...], "mentions": [...]}`, matching what `import_bundle` reads — `sources` covers the item's own `source_id` plus any source ids referenced by its `source_locations` rows, and `mentions` (previously omitted entirely) preserves entity links. `import_bundle`'s handler now wraps the store call in `try/except (KeyError, sqlite3.Error)` and returns a clean 400 with a machine-readable `code` instead of leaking a 500 for a malformed or FK-violating bundle.

A second issue surfaced by CI after this: on Linux x86_64, `KnowledgeStore` resolves `sqlite3` via `import pysqlite3 as sqlite3` (this repo installs `pysqlite3-binary` there for FTS5), but the handler plain-imported stdlib `sqlite3` — a *different* exception hierarchy, so `except sqlite3.Error` never matched the real `pysqlite3.dbapi2.IntegrityError` the store actually raised, and the 500 leaked through anyway in that environment (never reproduced locally on macOS, where no `pysqlite3` wheel exists and both names resolve to the same stdlib fallback). Fixed by importing `sqlite3` via the shared `kiro_crew._sqlite_compat` shim that mirrors `store.py`'s own resolution, so both names are guaranteed to be the identical module object on any platform.

**Two more gaps caught by GPT 5.6 Review, verified and fixed in the same commit:**
- `export_item`'s relations query pulled *any* relation touching a mentioned entity, including one whose OTHER endpoint (`source_id`/`target_id`) was never mentioned by this item and so never made it into the exported `entities` list — exporting that relation alone and re-importing it hit `entity_relations.source_id`/`target_id REFERENCES entities(id)` with no matching row. Same for a relation recorded under a *different* item's observation (`source_item_id` set to that other item): re-importing it here references an item that was never exported alongside it. Both are now excluded — only relations whose both endpoints are in the exported entity set, and whose `source_item_id` is null or this item, are kept.
- `request.json()` happily parses a bare JSON array/string/number, and the handler's redaction loop called `body.get("items", [])` on it before any type check — an `AttributeError` past every `try`/`except` in the function, propagating as an unhandled 500. Now validated with `isinstance(body, dict)` immediately after parsing, returning a clean 400.

**A third gap, `[BLOCK-MERGE]`, caught by a later GPT 5.6 Review pass on the pushed fix above:** the top-level `isinstance(body, dict)` check doesn't go deep enough — `{"items": [1]}` is a well-formed dict at the top level, passes that check, and then the redaction loop's `item.get("title")` on the int `1` raises the exact same unhandled `AttributeError` → 500 the top-level check exists to prevent, just one level deeper. Verified directly: reproduced the real `AttributeError: 'int' object has no attribute 'get'` against pre-fix code. Fixed by validating `items`/`entities`/`relations` are each a list of objects (not just present) immediately after the top-level dict check, before the redaction loops touch any of their contents — same 400 + `malformed_knowledge_bundle` code as the other malformed-bundle cases.

**A fourth gap, again `[BLOCK-MERGE]`, on the very next review pass:** the third fix was still one level too narrow, in two distinct ways I verified by reading `store.import_bundle()` and `_redact()` directly:
1. `sources`/`source_locations`/`mentions` are never touched by the handler's redaction loops (only `items`/`entities`/`relations` are), so those three collections were never validated at all. `{"sources": [1]}` sails past every check in the handler and reaches `src["id"]` in `store.import_bundle()`, raising an unhandled `TypeError` — not a `KeyError` or `sqlite3.Error`, so the existing `except` clause doesn't catch it either. Reproduced directly (`src["id"]` on an int → `TypeError: 'int' object is not subscriptable`).
2. Even within the three already-validated collections, a field that reaches `_redact()` (`title`/`summary`/`content`/`name`/`description`/`relation_type`) has to actually be a string or null — `_redact()`'s docstring type is `str | None`, but nothing enforced it. `{"items": [{"title": [1, 2]}]}` passes the "is a list of dicts" check, then `_redact([1, 2])` calls `redact_exfiltration_urls([1, 2])`, whose regex `.finditer([1, 2])` raises an unhandled `TypeError: expected string or bytes-like object, got 'list'`. Reproduced this directly too, isolated to `_redact()` alone before touching the handler.

Fixed both: all six collections (`items`/`entities`/`relations`/`sources`/`source_locations`/`mentions`) are now validated as lists of objects, and each field the redaction loops touch is validated as a string or null immediately before the redaction loops run.

**A fifth gap, `[BLOCK-MERGE]`, on the push after that:** a Python `int` has no size ceiling, but SQLite's `INTEGER` column is a 64-bit type — a bundle with an oversized value for an integer field (the review's example: `chunk_index`) raises `OverflowError` at SQLite bind time inside `store.import_bundle()`, and `OverflowError` is neither a `KeyError` nor a `sqlite3.Error`, so the handler's `except` clause lets it through as an unhandled 500. Verified directly (`sqlite3` binding `10**101` into an `INTEGER` column raises exactly this). Also checked whether the other malformed-type case — a list/dict where a scalar is expected — needed the same treatment: it doesn't, `sqlite3.ProgrammingError` ("type 'list' is not supported") is already a subclass of `sqlite3.Error` and was already caught. Fixed by adding `OverflowError` to the handled exception tuple.

**A sixth gap, `[BLOCK-MERGE]`, of a genuinely different shape than the first five:** every prior gap was import_bundle() *crashing* on bad input. This one is import_bundle() *succeeding* (200) while quietly committing a corrupted row. `sources.properties` is a `TEXT` column `store.import_bundle()` writes through completely unparsed (`src.get("properties", "{}")` straight into the `INSERT`), but every consumer reads it back with `json.loads()` — `sync_source()` (the `POST /api/knowledge/sources/{id}/sync` handler), the dashboard's source list, folder/file watchers. A bundle supplying `{"sources": [{..., "properties": "not-json"}]}` passes every existing check (it's a list of dicts, per gap #3's fix) and commits cleanly; the crash only happens later, on an unrelated request (clicking Sync), with no way for whoever hits it to connect it back to the import that planted it. Verified end to end: posting that bundle against pre-fix code returns 200 and leaves the malformed string in the `sources` row.

While fixing this I checked for the same shape elsewhere rather than wait for a seventh round: `entities.aliases` is written through identically unparsed (`ent.get("aliases", "[]")`) and read back with `json.loads()` in `find_entity()` — with a *worse* blast radius, since `find_entity()` walks and parses every entity's `aliases` on every lookup (called from ingestion's entity-extraction and from retrieval's search), so one malformed row poisons every subsequent entity lookup store-wide, not just that one entity. Verified the same way: pre-fix, a bundle with a malformed `aliases` string returns 200 and commits.

Fixed both with the same validation: when present as a string, `sources[].properties` must parse to a JSON object and `entities[].aliases` must parse to a JSON array, checked before import.

## Tests

- `test/test_knowledge.py::TestKnowledgeStoreExtended`: updated `test_export_item_with_entities` for the new shape, plus new `test_export_item_without_source` and `test_export_item_roundtrips_into_a_fresh_instance` (exports from one store, imports into a second, asserts the item and its mention survive); new `test_export_item_excludes_relations_whose_other_endpoint_is_not_exported`, `test_export_item_excludes_relations_owned_by_a_different_item`, and `test_export_item_with_a_cross_referencing_relation_roundtrips_cleanly` (end-to-end reproduction of the review-caught FK bug).
- `test/test_knowledge_handlers_coverage.py::TestExport`/`TestImportBundle`: updated `test_export_item_attaches_download_header` for the new key, plus new `test_export_item_bundle_reimports_into_a_fresh_instance` (full HTTP round trip through both endpoints), `test_bundle_violating_foreign_keys_is_400_not_500` (asserts 400 not 500, the `code` field, and that the failed import left no partial rows), and `test_non_object_json_is_400_not_500` (array/string/number top-level JSON).

New `test_non_object_collection_items_is_400_not_500` (`{"items": [1]}`, `{"items": "not-a-list"}`, `{"entities": [None]}`, `{"relations": [["nested"]]}`) covers the third gap; verified failing against pre-fix code with the real `AttributeError: 'int' object has no attribute 'get'`.

New `test_non_object_source_collections_is_400_not_500` (`{"sources": [1]}`, `{"source_locations": ["x"]}`, `{"mentions": [42]}`) and `test_non_string_redacted_field_is_400_not_500` (non-string `title`/`content`/`name`/`relation_type`) cover the fourth gap; both verified failing against the third fix (the version already pushed at that point, via `git stash` on just the handler) with real unhandled 500s — `src["id"]` → `TypeError: 'int' object is not subscriptable`, and `_URL_RE.finditer([1, 2])` → `TypeError: expected string or bytes-like object, got 'list'`.

New `test_oversized_integer_field_is_400_not_500` (`chunk_index: 10**101`) covers the fifth gap; verified failing against the fourth fix with `assert 500 == 400`.

New `test_source_with_non_json_properties_is_400_not_500` and `test_entity_with_non_json_aliases_is_400_not_500` cover the sixth gap; both verified failing against pre-fix code with `assert 200 == 400` (the bad import silently succeeded) and asserting zero rows were committed.

Verified all new/changed assertions fail against pre-fix code (`git stash`) with the exact reported symptoms: `KeyError: 'items'`, `sqlite3.IntegrityError: FOREIGN KEY constraint failed`, `assert 500 == 400`/`assert 500 == 200`, and real `AttributeError`/`TypeError` for the four malformed-shape cases above.

`test/test_knowledge.py` + `test/test_knowledge_handlers_coverage.py`: 250 passed.

`flake8` / `isort` / `mypy` clean on all touched files (mypy's 3 pre-existing `hooks.py` Linux-xattr errors are unrelated and present on unmodified `main`).

## Manual verification

N/A — unit coverage sufficient. The HTTP-level tests drive the real handler + real SQLite store end to end (export from one store instance, import into a fresh one), which is the actual round trip a user's Export/Import click performs.

## Screenshots / video

N/A — no UI change (the Export button and import screen are pre-existing; only their backend behavior changed).

## Related Issues

Fixes #3747

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — CHANGELOG entry added
- [x] No secrets, credentials, or internal references in the diff





