### PR TITLE
fix(session): rescue queued follow-ups from a mid-turn reset

### DIFF
--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -876,6 +876,10 @@ class _Session:
     agent: str = ""  # kiro agent name used for this session
     # Slack message queue: FIFO of (msg_ts, text, kwargs) waiting for the semaphore
     queue: deque[tuple[str, str, dict]] = field(default_factory=deque)
+    # True only when this session adopted a queue rescued by reset(). An
+    # unclaimed speculative session re-rescues that queue; an ordinary queue
+    # is cleaned up with the session as before.
+    rescued_queue_adopted: bool = False
     # Set when this session's last turn was cancelled via soft-stop.
     # kiro-cli discards cancelled turns from its conversation log, so callers
     # must re-inject the cancelled turn (user prompt + partial assistant) as a
@@ -1270,6 +1274,14 @@ class SessionManager:
     @_on_recycled.setter
     def _on_recycled(self, value: _RecycleCallback | None) -> None:
         self._lifecycle_state_boundary().on_recycled = value
+
+    @property
+    def _orphaned_queues(self) -> dict[str, "deque[tuple[str, str, dict]]"]:
+        return self._lifecycle_state_boundary().orphaned_queues
+
+    @_orphaned_queues.setter
+    def _orphaned_queues(self, value: dict[str, "deque[tuple[str, str, dict]]"]) -> None:
+        self._lifecycle_state_boundary().orphaned_queues = value
 
     @property
     def _sessions(self) -> dict[str, "_Session"]:
@@ -2250,6 +2262,10 @@ class SessionManager:
     def clear_queue(self, key: str) -> None:
         """Clear queued messages and their temporary paths."""
         self._allocation_boundary().clear_queue(key)
+
+    def _drop_orphaned_queue(self, key: str) -> None:
+        """Discard a queue reset() rescued for a folded key, unlinking temp files."""
+        self._allocation_boundary()._drop_orphaned_queue(key)
 
     async def is_provider_alive(self, key: str) -> bool | None:
         """Probe a folded session provider outside the registry lock."""

--- a/src/kiro_crew/session_allocation.py
+++ b/src/kiro_crew/session_allocation.py
@@ -130,6 +130,10 @@ class _AllocationOwner(Protocol):
     _provider_factory: ProviderFactory | None
     _session_map: Any
     _recycling: dict[str, Any]
+    # Owned by the lifecycle boundary (see session_lifecycle.SessionLifecycleState);
+    # exposed here so a cold start can adopt a queue reset() rescued for this
+    # key and so clear_queue()/cancel_queued() can reach it too.
+    _orphaned_queues: dict[str, Any]
     _pool_size: int
     _pool_agent: str
     _pool_cwd: str
@@ -916,6 +920,20 @@ class SessionAllocationService:
         key = self._owner._fold_key(key)
         session = self._sessions.get(key)
         if not session:
+            # No live session for this key doesn't mean nothing is queued: a
+            # reset() may have rescued a queue into _orphaned_queues that
+            # hasn't been adopted by a new session yet (see
+            # SessionLifecycleState.orphaned_queues). A deletion landing in
+            # that window must still be able to cancel the entry it names --
+            # otherwise the next cold start adopts and dispatches a message
+            # the user already deleted.
+            orphaned = self._owner._orphaned_queues.get(key)
+            if orphaned:
+                for index, (queued_ts, _, kwargs) in enumerate(orphaned):
+                    if queued_ts == msg_ts:
+                        self._deps.unlink_queued_temp_paths(kwargs)
+                        del orphaned[index]
+                        return True
             return False
         for index, (queued_ts, _, kwargs) in enumerate(session.queue):
             if queued_ts == msg_ts:
@@ -937,6 +955,17 @@ class SessionAllocationService:
         return False
 
     def clear_queue(self, key: str) -> None:
+        """Clear queued messages and cancelled markers, unlinking temp files.
+
+        Also drops any queue reset() rescued into ``_orphaned_queues`` for
+        this key (see ``SessionLifecycleState.orphaned_queues``) -- without
+        this, a stop/clear issued after a reset already rescued a queue but
+        before the next session opens for the key would leave that rescued
+        queue untouched (no live session exists yet to route through), and
+        the messages the caller just asked to clear would resurface once a
+        session next opens for this key. A rescued entry is just as far from
+        dequeue()'s cleanup as a live one, so it needs the same unlink pass.
+        """
         key = self._owner._fold_key(key)
         session = self._sessions.get(key)
         if session:
@@ -944,6 +973,18 @@ class SessionAllocationService:
                 self._deps.unlink_queued_temp_paths(kwargs)
             session.queue.clear()
             session.cancelled.clear()
+        self._drop_orphaned_queue(key)
+
+    def _drop_orphaned_queue(self, key: str) -> None:
+        """Discard a rescued queue for ``key``, unlinking its temp files.
+
+        Every path that discards a queue entry must unlink (see
+        ``unlink_queued_temp_paths``), and a rescued entry is exactly as far
+        from ``dequeue()``'s cleanup as a live one -- it has no session left
+        to consume it. Callers already hold ``key`` folded.
+        """
+        for _, _, kwargs in self._owner._orphaned_queues.pop(key, ()):
+            self._deps.unlink_queued_temp_paths(kwargs)
 
     async def is_provider_alive(self, key: str) -> bool | None:
         key = self._owner._fold_key(key)
@@ -1401,6 +1442,14 @@ class SessionAllocationService:
                         approval_policy=approval_policy,
                         agent=agent or "",
                     )
+                    # Adopt any queue a reset() rescued for this key (see
+                    # SessionLifecycleState.orphaned_queues) so a mid-turn
+                    # teardown's queued follow-ups resume on this cold start
+                    # instead of being lost with the killed session.
+                    rescued_queue = owner._orphaned_queues.pop(key, None)
+                    if rescued_queue:
+                        session.queue = rescued_queue
+                        session.rescued_queue_adopted = True
                     replay_needed = getattr(provider, "_history_replay_needed", False) is True
                     if provider_switched or replay_needed:
                         session.provider_switch_replay = True

--- a/src/kiro_crew/session_lifecycle.py
+++ b/src/kiro_crew/session_lifecycle.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import deque
 from collections.abc import Awaitable, Callable, MutableMapping
 from concurrent.futures import Executor
 from dataclasses import dataclass, field
@@ -47,6 +48,8 @@ class _SessionEntry(Protocol):
     first_turn: object
     retire_on_identity_change: bool
     prev_turn_cancelled: bool
+    queue: deque[tuple[str, str, dict[str, Any]]]
+    rescued_queue_adopted: bool
 
 
 class _SessionMapPort(Protocol):
@@ -111,6 +114,8 @@ class SessionLifecycleOwner(Protocol):
     def _is_continuable_key(self, key: str) -> bool: ...
 
     def clear_queue(self, key: str) -> None: ...
+
+    def _drop_orphaned_queue(self, key: str) -> None: ...
 
     def release(self, key: str) -> None: ...
 
@@ -204,6 +209,19 @@ class SessionLifecycleState:
     suppress_replay: set[str] = field(default_factory=set)
     origin_links: dict[str, Any] = field(default_factory=dict)
     on_recycled: _RecycleCallback | None = None
+    # Queued follow-up messages (enqueue()/dequeue()) rescued from a session
+    # torn down mid-turn by reset() -- e.g. record_failure's circuit breaker,
+    # or AcpPromptBusy recovery -- so the next cold start for the same key
+    # resumes them instead of the caller they were queued behind silently
+    # discarding them along with the killed session. Only reset() (and
+    # remove_if_unclaimed()'s re-rescue) populate this; destroy(),
+    # discard_conversation() and clear_queue() drop it (those are
+    # intentional, user-visible wipes where pending follow-ups are expected
+    # to go too — mirrors stop_turn's explicit clear_queue() before a
+    # user-initiated hard kill).
+    orphaned_queues: dict[str, "deque[tuple[str, str, dict[str, Any]]]"] = field(
+        default_factory=dict
+    )
 
 
 class SessionLifecycleService:
@@ -258,6 +276,16 @@ class SessionLifecycleService:
     @_on_recycled.setter
     def _on_recycled(self, callback: _RecycleCallback | None) -> None:
         self.state.on_recycled = callback
+
+    @property
+    def _orphaned_queues(self) -> dict[str, "deque[tuple[str, str, dict[str, Any]]]"]:
+        return self.state.orphaned_queues
+
+    @_orphaned_queues.setter
+    def _orphaned_queues(
+        self, orphaned_queues: dict[str, "deque[tuple[str, str, dict[str, Any]]]"]
+    ) -> None:
+        self.state.orphaned_queues = orphaned_queues
 
     async def refresh_defaults(self) -> None:
         """Adopt config changes that only affect new sessions."""
@@ -398,6 +426,14 @@ class SessionLifecycleService:
                 # own suspension point, so that ordering still holds; only the
                 # crumb unlink is deferred to a worker.
                 await record_session_ended(key, end_reason=END_REASON_RESET)
+            # Rescue any messages queued behind the turn that triggered this
+            # reset (e.g. via AcpPromptBusy recovery) so the next cold start
+            # for this key picks them up instead of losing them with the
+            # session object. Reuses the deque directly -- the session being
+            # discarded has no other use for it.
+            rescued_queue = session is not None and bool(session.queue)
+            if session is not None and session.queue:
+                self._orphaned_queues[key] = session.queue
         if clear_conversation and session is not None:
             # The registry lock, not an absence of suspension points, is what makes
             # this safe: the end record above awaits, but it awaits while this
@@ -408,7 +444,14 @@ class SessionLifecycleService:
             # any of them runs, and this clear cannot erase a successor's pointer.
             owner._session_map.clear_sid(key)
         if session:
-            await asyncio.to_thread(self._deps.get_unlink_session_queue(), session)
+            if not rescued_queue:
+                # A rescued queue is aliased into _orphaned_queues above, not
+                # discarded -- unlinking here would delete the temp images
+                # behind messages that are still alive and waiting for the
+                # next cold start. Its eventual unlink is owed by whichever
+                # path actually drops it later (_drop_orphaned_queue, or the
+                # unclaimed-session TTL backstop's own rescue-then-unlink).
+                await asyncio.to_thread(self._deps.get_unlink_session_queue(), session)
             # Capture PID and child tree before shutdown clears them.
             client = getattr(session.provider, "_client", None)
             raw_pid = getattr(client, "_pid", None) if client else None
@@ -686,7 +729,23 @@ class SessionLifecycleService:
             self._origin_links.pop(key, None)
             # Same tick as the removal: see reset.
             await record_session_ended(key, end_reason=END_REASON_UNCLAIMED)
-        await asyncio.to_thread(self._deps.get_unlink_session_queue(), session)
+            # This session can carry a queue reset() rescued from a PRIOR
+            # reset() (see its docstring): a resume prefetch racing ahead of
+            # the real turn adopts that rescue speculatively, and if nothing
+            # claims it before this TTL backstop fires, discarding it here
+            # with no re-rescue would silently finish the data loss reset()
+            # tried to prevent in the first place -- the messages would never
+            # reach any live session. Put it back exactly as reset() does, so
+            # the next real cold start for this key adopts it same as if this
+            # speculative detour never happened.
+            rescued_queue = session.rescued_queue_adopted and bool(session.queue)
+            if rescued_queue:
+                self._orphaned_queues[key] = session.queue
+        if not rescued_queue:
+            # See reset()'s matching guard: a rescued queue is aliased into
+            # _orphaned_queues above, not discarded, so unlinking here would
+            # delete temp images still owed to a next cold start.
+            await asyncio.to_thread(self._deps.get_unlink_session_queue(), session)
         await session.provider.shutdown()
         await owner.release_subagent_runtime(key)
         self._deps.logger.info(
@@ -716,6 +775,12 @@ class SessionLifecycleService:
             if session is not None:
                 # Same tick as the pop: see reset.
                 await record_session_ended(key, end_reason=END_REASON_DESTROYED)
+            # A destroy promises no resume, so a queue a PRIOR reset()
+            # rescued for this key must not survive to be replayed into the
+            # next cold start (reset() itself deliberately leaves live queues
+            # alone -- see its docstring -- but its leftovers are this
+            # method's to drop).
+            owner._drop_orphaned_queue(key)
         try:
             if session:
                 await asyncio.to_thread(self._deps.get_unlink_session_queue(), session)
@@ -774,6 +839,11 @@ class SessionLifecycleService:
             if session is not None:
                 # Same lock hold as the pop, exactly like the clear_sid below.
                 await record_session_ended(key, end_reason=END_REASON_DISCARDED)
+            # Same reasoning as destroy(): the conversation this key's
+            # rescued queue was addressed to is gone, so replaying it into
+            # the fresh one would land follow-ups with no context to follow
+            # up on.
+            owner._drop_orphaned_queue(key)
         # The registry lock, not an absence of suspension points, is what keeps a
         # cold start racing this teardown from registering a replacement sid for the
         # key in between, so this clear cannot erase a SUCCESSOR's pointer. The end
@@ -1060,11 +1130,21 @@ class SessionLifecycleService:
         logger = self._deps.logger
         key = owner._fold_key(key)
         session = owner._sessions.get(key)
+
+        if not preserve_queue:
+            # Ahead of the no-session early-return below on purpose: a
+            # reset() can rescue a queue into _orphaned_queues (see its
+            # docstring) before the next session reopens this key, and
+            # clear_queue() drops that rescue too. Skipping this call
+            # whenever session is None would leave a stop issued during that
+            # orphan window unable to clear it, and the messages it just
+            # asked to drop would resurface once a session next opens for
+            # this key.
+            owner.clear_queue(key)
+
         if not session:
             return "idle"
 
-        if not preserve_queue:
-            owner.clear_queue(key)
         budget: float = owner._cfg.agent.soft_stop_budget_secs
         t0 = self._deps.monotonic()
 

--- a/test/test_eager_spawn.py
+++ b/test/test_eager_spawn.py
@@ -793,6 +793,39 @@ class TestRemoveIfUnclaimed:
         mgr = SessionManager(cfg, provider_factory=_stub_factory())
         assert await mgr.remove_if_unclaimed("dashboard:absent") is False
 
+    @pytest.mark.asyncio
+    async def test_unclaimed_removal_re_rescues_a_previously_rescued_queue(self, cfg):
+        """A resume prefetch can race ahead of the real follow-up and adopt a
+        queue reset() rescued into _orphaned_queues (see get_or_create's
+        cold-start seeding and reset()'s own docstring). If nothing claims
+        the speculative session before this TTL backstop reaps it, the queue
+        must go back into _orphaned_queues instead of vanishing with the
+        discarded session -- otherwise an unclaimed prefetch silently
+        finishes the exact data loss reset() exists to prevent."""
+        from kiro_crew.session import SessionManager
+
+        mgr = SessionManager(cfg, provider_factory=_stub_factory())
+        key = "dashboard:ttl-rescue"
+        await mgr.get_or_create(key)  # turn 1 in flight
+        mgr.enqueue(key, "ts2", "second", force=True)
+        await mgr.reset(key)  # rescues the queue into _orphaned_queues
+        assert mgr._orphaned_queues.get(key)
+
+        # A resume prefetch races ahead of the real follow-up and adopts the
+        # rescued queue as part of its speculative cold start.
+        await mgr.get_or_create(key, speculative=True)
+        assert key not in mgr._orphaned_queues  # adopted onto the speculative session
+        mgr.release(key)
+
+        assert await mgr.remove_if_unclaimed(key) is True
+        assert key not in mgr._sessions
+        assert mgr._orphaned_queues.get(key)  # re-rescued, not lost
+
+        await mgr.get_or_create(key)  # the next real cold start for this key
+        assert mgr.dequeue(key) == ("ts2", "second", {})
+        mgr.release(key)
+        await mgr.close_all()
+
 
 class TestResumePrefetchWiring:
     """chat_runner's allow_resume path: flag pass-through and the TTL arm."""

--- a/test/test_message_queue.py
+++ b/test/test_message_queue.py
@@ -40,6 +40,7 @@ class TestSessionManagerQueue:
         mgr = SessionManager.__new__(SessionManager)
         mgr._sessions = {}
         mgr._lock = asyncio.Lock()
+        mgr._orphaned_queues = {}
         provider = MagicMock()
         provider.is_alive.return_value = True
         sess = _Session(provider=provider)
@@ -549,6 +550,7 @@ class TestStopTurnPreserveQueue:
         mgr._sessions = {}
         mgr._lock = asyncio.Lock()
         mgr._background_tasks = set()
+        mgr._orphaned_queues = {}
         cfg = MagicMock()
         cfg.agent.soft_stop_budget_secs = 5.0
         mgr._cfg = cfg

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -1743,6 +1743,229 @@ class TestMessageQueue:
         assert mgr.is_cancelled("nope", "ts1") is False
 
 
+class TestResetPreservesQueuedMessages:
+    """reset() (e.g. record_failure's circuit breaker, or AcpPromptBusy
+    recovery) tears down a session mid-turn. Any follow-up messages a caller
+    had queued behind that turn must survive the teardown and reach the next
+    session opened for the same key, instead of being silently discarded
+    along with the killed session object."""
+
+    @pytest.mark.asyncio
+    async def test_queued_messages_survive_a_reset_and_reach_the_next_session(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")  # turn 1 in flight
+        mgr.enqueue("k1", "ts2", "second", force=True)
+        mgr.enqueue("k1", "ts3", "third", force=True)
+
+        await mgr.reset("k1")  # e.g. AcpPromptBusy recovery, still "holding" the old semaphore
+        assert "k1" not in mgr._sessions
+
+        await mgr.get_or_create("k1")  # the next cold start for this key
+        assert mgr.dequeue("k1") == ("ts2", "second", {})
+        assert mgr.dequeue("k1") == ("ts3", "third", {})
+        assert mgr.dequeue("k1") is None
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_reset_with_no_queued_messages_leaves_the_next_session_empty(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        await mgr.reset("k1")
+        await mgr.get_or_create("k1")
+        assert mgr.dequeue("k1") is None
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_destroy_does_not_rescue_the_queue(self, cfg):
+        """destroy() is an intentional, user-visible wipe (permanent history
+        deletion, bulk clear) -- unlike reset()'s transparent failure
+        recovery, dropping anything queued behind it is the expected
+        behavior, mirroring stop_turn's explicit clear_queue() before a
+        user-initiated hard kill."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True)
+        await mgr.destroy("k1")
+        await mgr.get_or_create("k1")
+        assert mgr.dequeue("k1") is None
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_discard_conversation_does_not_rescue_the_queue(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True)
+        await mgr.discard_conversation("k1")
+        await mgr.get_or_create("k1")
+        assert mgr.dequeue("k1") is None
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_clear_queue_also_drops_an_already_rescued_queue(self, cfg):
+        """A stop/clear issued after reset() already rescued a queue, but
+        before any new session reopens the key, must not leave that rescued
+        queue reachable -- otherwise messages the caller explicitly asked to
+        clear resurface once a session next opens for the key. There is no
+        live session at this point (stop_turn's own early-return on a
+        missing session is exactly why clear_queue must not depend on one
+        existing), so clear_queue is called directly, as stop_turn's
+        preserve_queue=False path would.
+        """
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True)
+        await mgr.reset("k1")  # rescues the queue into _orphaned_queues
+        assert "k1" not in mgr._sessions
+
+        mgr.clear_queue("k1")  # e.g. a /stop issued before the next message arrives
+
+        await mgr.get_or_create("k1")  # the next cold start for this key
+        assert mgr.dequeue("k1") is None
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.parametrize("wipe", ["destroy", "discard_conversation"])
+    @pytest.mark.asyncio
+    async def test_a_wipe_after_a_reset_drops_the_rescued_queue(self, cfg, wipe):
+        """Same gap clear_queue had, reached through the other two wipes: the
+        queue is already rescued (reset ran) and no session holds the key yet,
+        so the wipe's own ``self._sessions.pop`` has nothing to drop. A
+        destroy promises no resume, and discard_conversation throws away the
+        conversation the follow-ups were addressed to, so neither may leave
+        the rescued queue behind for the next cold start to replay."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True)
+        await mgr.reset("k1")  # rescues the queue into _orphaned_queues
+        assert mgr._orphaned_queues.get("k1")
+
+        await getattr(mgr, wipe)("k1")
+        assert "k1" not in mgr._orphaned_queues
+
+        await mgr.get_or_create("k1")  # the next cold start for this key
+        assert mgr.dequeue("k1") is None
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.parametrize("drop", ["clear_queue", "destroy", "discard_conversation"])
+    @pytest.mark.asyncio
+    async def test_dropping_a_rescued_queue_unlinks_its_temp_images(self, cfg, tmp_path, drop):
+        """A rescued entry is as far from _dispatch_queued's cleanup as a live
+        one -- it has no session left to consume it -- so every path that
+        discards one owes it the same unlink pass live entries get."""
+        temp = tmp_path / "queued-image.png"
+        temp.write_bytes(b"x")
+
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True, image_temp_paths=[str(temp)])
+        await mgr.reset("k1")
+        assert temp.exists()  # the rescue must NOT unlink -- the entry still lives
+
+        result = getattr(mgr, drop)("k1")
+        if result is not None:
+            await result
+        assert not temp.exists()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_cancel_queued_cancels_an_already_rescued_message(self, cfg):
+        """A Slack ``message_deleted`` landing in the orphan window -- after
+        reset() rescued the queue but before the next session reopens the
+        key -- must still be able to cancel the entry it names. Without
+        this, the next cold start adopts and dispatches a message the user
+        already deleted."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True)
+        await mgr.reset("k1")  # rescues the queue into _orphaned_queues
+        assert "k1" not in mgr._sessions
+
+        assert mgr.cancel_queued("k1", "ts2") is True
+
+        await mgr.get_or_create("k1")  # the next cold start for this key
+        assert mgr.dequeue("k1") is None
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_cancel_queued_unlinks_temp_images_for_a_rescued_message(self, cfg, tmp_path):
+        temp = tmp_path / "queued-image.png"
+        temp.write_bytes(b"x")
+
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True, image_temp_paths=[str(temp)])
+        await mgr.reset("k1")
+        assert temp.exists()
+
+        assert mgr.cancel_queued("k1", "ts2") is True
+        assert not temp.exists()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_cancel_queued_misses_land_safely_during_the_orphan_window(self, cfg):
+        """A cancel for an unrelated msg_ts while a rescued queue sits in
+        _orphaned_queues (no live session) must miss cleanly -- not raise,
+        and not touch the rescued entries it doesn't name."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True)
+        await mgr.reset("k1")
+
+        assert mgr.cancel_queued("k1", "no-such-ts") is False
+
+        await mgr.get_or_create("k1")
+        assert mgr.dequeue("k1") == ("ts2", "second", {})
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_stop_turn_clears_an_already_rescued_queue(self, cfg):
+        """A ``/stop`` issued in the orphan window -- no live session yet,
+        but a queue reset() rescued is sitting in _orphaned_queues -- must
+        still clear it, matching clear_queue's own no-live-session handling.
+        Before the fix, stop_turn's early return on a missing session
+        skipped clear_queue entirely, leaving the rescued queue to resurface
+        on the next cold start despite the explicit stop."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True)
+        await mgr.reset("k1")  # rescues the queue into _orphaned_queues
+        assert "k1" not in mgr._sessions
+
+        outcome = await mgr.stop_turn("k1")
+        assert outcome == "idle"
+        assert "k1" not in mgr._orphaned_queues
+
+        await mgr.get_or_create("k1")  # the next cold start for this key
+        assert mgr.dequeue("k1") is None
+        mgr.release("k1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_stop_turn_preserve_queue_leaves_a_rescued_queue_alone(self, cfg):
+        """preserve_queue=True must skip the rescued-queue drop too, same as
+        it already skips the live-queue drop."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True)
+        await mgr.reset("k1")
+
+        outcome = await mgr.stop_turn("k1", preserve_queue=True)
+        assert outcome == "idle"
+        assert mgr._orphaned_queues.get("k1")
+
+        await mgr.get_or_create("k1")
+        assert mgr.dequeue("k1") == ("ts2", "second", {})
+        mgr.release("k1")
+        await mgr.close_all()
+
+
 class TestDrainProviders:
     """Tests for drain_all_providers and drain_warm_pool."""
 
@@ -1891,7 +2114,11 @@ class TestResetWithPid:
         assert not mgr.has_session("k1")
 
     @pytest.mark.asyncio
-    async def test_reset_unlinks_temp_files_from_the_dropped_queue(self, cfg, tmp_path):
+    async def test_reset_rescues_the_queue_instead_of_unlinking_its_temp_files(self, cfg, tmp_path):
+        """reset() no longer drops the queue outright -- it rescues it into
+        ``_orphaned_queues`` (see TestResetPreservesQueuedMessages), so the
+        temp file behind a queued image must survive the reset and is only
+        unlinked once something actually drops that rescue."""
         img = tmp_path / "img.png"
         img.write_bytes(b"fake")
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
@@ -1900,6 +2127,10 @@ class TestResetWithPid:
 
         await mgr.reset("k1")
 
+        assert img.exists()
+        assert mgr._orphaned_queues.get("k1")
+
+        await mgr.destroy("k1")  # drops the rescue -- now it unlinks
         assert not img.exists()
 
     @pytest.mark.asyncio

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -2115,7 +2115,7 @@ class TestResetWithPid:
 
     @pytest.mark.asyncio
     async def test_reset_rescues_the_queue_instead_of_unlinking_its_temp_files(self, cfg, tmp_path):
-        """reset() no longer drops the queue outright -- it rescues it into
+        """reset() preserves the queue by rescuing it into
         ``_orphaned_queues`` (see TestResetPreservesQueuedMessages), so the
         temp file behind a queued image must survive the reset and is only
         unlinked once something actually drops that rescue."""


### PR DESCRIPTION
Fixes #3752

## Problem / Motivation

When `reset()` tears down a session during an active turn, queued follow-up messages live on the removed session object. The reset path then unlinks their temporary files and discards the queue, so messages accepted moments earlier can disappear without delivery.

## Why it matters

The queue acknowledges user input before reset runs. Silently dropping that acknowledged work breaks the messaging contract and can also make channel receipts disagree with what the agent eventually processes.

## What changed

- Rebased and manually ported the implementation onto the current split session architecture.
- Rescue a removed session's queue into manager-owned orphan storage during reset.
- Canonicalize orphan keys so historical Slack key forms address the same rescued queue.
- Let the normal dequeue path drain an orphan immediately after the interrupted turn completes.
- Adopt any remaining orphan during a later cold start.
- Make enqueue, cancel, clear, stop, destroy, and discard paths account for rescued entries and unlink temporary image files when an entry is truly dropped.
- Keep the orphan store visible through the current lifecycle/allocation boundaries and protocols.

## Tests

- `test/test_session.py`, `test/test_message_queue.py`, and `test/test_eager_spawn.py`: 484 passed.
- `mypy` clean on all three changed source files.
- `isort --check-only` and `flake8` clean on all changed Python files.
- `git diff --check`.

## Screenshots

N/A — session queue lifecycle correction with no visual UI change.
