### PR TITLE
fix(prompt): use markdown link syntax for PR URLs to prevent CJK autolink greediness

### DIFF
--- a/src/kiro_crew/config/prompt-orchestrator.md
+++ b/src/kiro_crew/config/prompt-orchestrator.md
@@ -12,7 +12,7 @@ After ANY file change (create, edit, append, delete), you MUST show a ```diff co
 +Body line
 ```
 
-Whenever you mention a pull request or merge request you opened, updated, or are working on, write the **full URL** at least once in that message (`https://github.com/<owner>/<repo>/pull/843`, `https://gitlab.com/<group>/<project>/-/merge_requests/12`). The dashboard builds its Changes panel — PR state, checks, review threads — by finding full PR/MR links in your messages, so a bare `PR #843` gives the user nothing to open and no panel. Tool output does not count: only the text of your own message is scanned, so paste the URL yourself instead of relying on `gh pr create` having printed it.
+Whenever you mention a pull request or merge request you opened, updated, or are working on, write the **full URL** at least once in that message using explicit markdown link syntax: `[PR #843](https://github.com/<owner>/<repo>/pull/843)` or `[MR !12](https://gitlab.com/<group>/<project>/-/merge_requests/12)`. Never paste a bare URL — bare URLs cause rendering bugs when adjacent to CJK text or full-width punctuation. The dashboard builds its Changes panel — PR state, checks, review threads — by extracting links from both markdown link syntax and bare URLs, so a `[text](url)` link works. A bare `PR #843` without the URL gives the user nothing to open and no panel. Tool output does not count: only the text of your own message is scanned, so write the link yourself instead of relying on `gh pr create` having printed it.
 
 ## KiroCrew Capabilities
 

--- a/src/kiro_crew/config/prompt.md
+++ b/src/kiro_crew/config/prompt.md
@@ -14,7 +14,7 @@ After ANY file change (create, edit, append, delete), you MUST show a ```diff co
 
 To show the user an image, use `![description](/absolute/path/to/image.png)` — the dashboard renders a clickable thumbnail (PNG, JPEG, GIF, WebP, BMP, SVG).
 
-Whenever you mention a pull request or merge request you opened, updated, or are working on, write the **full URL** at least once in that message (`https://github.com/<owner>/<repo>/pull/843`, `https://gitlab.com/<group>/<project>/-/merge_requests/12`). The dashboard builds its Changes panel — PR state, checks, review threads — by finding full PR/MR links in your messages, so a bare `PR #843` gives the user nothing to open and no panel. Tool output does not count: only the text of your own message is scanned, so paste the URL yourself instead of relying on `gh pr create` having printed it.
+Whenever you mention a pull request or merge request you opened, updated, or are working on, write the **full URL** at least once in that message using explicit markdown link syntax: `[PR #843](https://github.com/<owner>/<repo>/pull/843)` or `[MR !12](https://gitlab.com/<group>/<project>/-/merge_requests/12)`. Never paste a bare URL — bare URLs cause rendering bugs when adjacent to CJK text or full-width punctuation. The dashboard builds its Changes panel — PR state, checks, review threads — by extracting links from both markdown link syntax and bare URLs, so a `[text](url)` link works. A bare `PR #843` without the URL gives the user nothing to open and no panel. Tool output does not count: only the text of your own message is scanned, so write the link yourself instead of relying on `gh pr create` having printed it.
 
 ## KiroCrew Capabilities
 

--- a/website/src/test/cjkAutolinkBoundaries.test.tsx
+++ b/website/src/test/cjkAutolinkBoundaries.test.tsx
@@ -651,4 +651,30 @@ describe('fixCjkAutolinkBoundaries — rendered output', () => {
     expect(container.textContent).not.toContain('_')
     expect(container.textContent).toContain('（revision 1，还没 publish）。')
   })
+
+  it('markdown link syntax avoids autolink greediness entirely', () => {
+    // When the agent uses [text](url) syntax instead of bare URLs, GFM autolink
+    // is never triggered — the URL lives inside the parentheses of a proper link
+    // node, so CJK punctuation around it cannot be swallowed.
+    const src = 'PR：[PR #3739](https://github.com/kirodotdev/KiroCrew/pull/3739)（commit `e6b4bf448`）'
+    const { container } = renderMd(src)
+    const a = container.querySelector('a')
+    expect(a?.getAttribute('href')).toBe('https://github.com/kirodotdev/KiroCrew/pull/3739')
+    expect(a?.textContent).toBe('PR #3739')
+    // The surrounding text must NOT be swallowed into the link.
+    expect(container.textContent).toContain('（commit')
+    expect(container.textContent).toContain('e6b4bf448')
+  })
+
+  it('documents the known limitation: bare URL + （ without opener cannot be fixed', () => {
+    // This is the edge case from the bug report: bare URL immediately followed
+    // by （ with no matching opener earlier on the line. fixCjkAutolinkBoundaries
+    // cannot prove （ does not belong to the URL (it could be a path component),
+    // so it leaves it alone — GFM then swallows everything up to the next space.
+    // The fix is to use markdown link syntax (tested above), not to make this
+    // function more aggressive (which would break legitimate CJK-titled URLs).
+    const src = 'PR：https://github.com/o/r/pull/3739（commit `e6b4bf448`）'
+    // Without a matching opener, the function correctly leaves it untouched.
+    expect(fixCjkAutolinkBoundaries(src)).toBe(src)
+  })
 })

--- a/website/src/test/pullRequestLinks.test.ts
+++ b/website/src/test/pullRequestLinks.test.ts
@@ -44,6 +44,30 @@ describe('extractPullRequestLinks', () => {
     ])
   })
 
+  it('extracts from markdown link syntax embedded in CJK prose', () => {
+    // The prompt now instructs the agent to use [text](url) syntax to avoid the
+    // CJK autolink-greediness rendering bug. This asserts the Changes panel still
+    // surfaces the PR when the URL is wrapped in a markdown link next to
+    // full-width punctuation — the extractor must not depend on a bare URL.
+    expect(extractPullRequestLinks(messages(
+      'PR：[PR #3739](https://github.com/acme/widgets/pull/3739)（commit `e6b4bf448`）',
+    ))).toEqual([
+      { url: 'https://github.com/acme/widgets/pull/3739', provider: 'github', number: 3739, repo: 'widgets', kind: 'change' },
+    ])
+  })
+
+  it('extracts a bare URL abutted by full-width punctuation', () => {
+    // The URL candidate regex is ASCII-only, so a trailing full-width paren is a
+    // natural boundary for extraction (the rendering-side greediness is a
+    // separate GFM concern handled by fixCjkAutolinkBoundaries). This locks in
+    // that the Changes panel still works even if the agent regresses to a bare URL.
+    expect(extractPullRequestLinks(messages(
+      'PR：https://github.com/acme/widgets/pull/3739（commit e6b4bf448）',
+    ))).toEqual([
+      { url: 'https://github.com/acme/widgets/pull/3739', provider: 'github', number: 3739, repo: 'widgets', kind: 'change' },
+    ])
+  })
+
   it('does not treat lookalike hosts as providers', () => {
     expect(extractPullRequestLinks(messages(
       'https://github.com.evil.example/acme/widgets/pull/12 and https://example.com/github.com/acme/widgets/pull/13',


### PR DESCRIPTION
## Problem

PR #847 added a prompt instruction requiring the full PR URL so the Changes panel can surface it. The instruction gave bare-URL examples (`https://github.com/.../pull/843`), causing models to output bare URLs.

When a bare URL is placed adjacent to CJK text or full-width punctuation **without a matching opener bracket earlier on the line**, GFM's autolink literal extension greedily swallows the punctuation into the href. `fixCjkAutolinkBoundaries` correctly refuses to cut in this case — it cannot prove the bracket isn't part of the URL path (e.g. a Wikipedia article title).

**Reported case:**
```
PR：https://github.com/kirodotdev/KiroCrew/pull/3739（commit `e6b4bf448`）
```
The `（commit...` gets linked as part of the URL.

## Fix

Change the prompt instruction to require **explicit markdown link syntax** `[PR #N](url)` instead of bare URLs. GFM never triggers autolink parsing inside a proper link node, so the surrounding CJK punctuation stays clean.

The PR link extractor (Changes panel) already supports extracting from markdown links — verified by existing test (line 31 of pullRequestLinks.test.ts).

## Tests added

- `pullRequestLinks.test.ts`: extraction from markdown link in CJK prose
- `pullRequestLinks.test.ts`: extraction from bare URL abutted by full-width paren (locks in existing correct behavior)
- `cjkAutolinkBoundaries.test.tsx`: markdown link avoids the greediness entirely
- `cjkAutolinkBoundaries.test.tsx`: documents the known limitation (bare URL + `（` without opener)