### PR TITLE
fix(apps): surface errors on Notes GitHub PAT save/clear

### DIFF
--- a/website/src/apps/md-notebook/SettingsPage.tsx
+++ b/website/src/apps/md-notebook/SettingsPage.tsx
@@ -95,7 +95,7 @@ export function SettingsPage({
   const [busy, setBusy] = useState(false)
   // Messages are scoped to the control that produced them, so feedback appears
   // where the click happened rather than at the foot of the page.
-  const [patNote, setPatNote] = useState<string | null>(null)
+  const [patNote, setPatNote] = useState<{ text: string; error?: boolean } | null>(null)
   const [knowledgeMsg, setKnowledgeMsg] = useState<
     Record<string, { text: string; error?: boolean } | null>
   >({})
@@ -174,6 +174,32 @@ export function SettingsPage({
       }
     },
     [onSetKnowledge],
+  )
+
+  // Both token buttons go through here, because the failure handling is the
+  // whole point: `onSetPat` rejects when the host rejects the write, and an
+  // unguarded `await` left `busy` latched true — disabling BOTH buttons for the
+  // rest of the page's life — while reporting nothing at all. `finally` releases
+  // the buttons on every path, and the reason is shown where the click happened.
+  //
+  // The field is deliberately NOT cleared on failure: the token the user pasted
+  // is the only copy they have in hand, and retrying should not mean pasting it
+  // again.
+  const writePat = useCallback(
+    async (next: string, okText: string) => {
+      setBusy(true)
+      setPatNote(null)
+      try {
+        await onSetPat(next)
+        if (next) setPat('')
+        setPatNote({ text: okText })
+      } catch (e) {
+        setPatNote({ text: e instanceof Error ? e.message : String(e), error: true })
+      } finally {
+        setBusy(false)
+      }
+    },
+    [onSetPat],
   )
 
   // Escape leaves the page. No outside-click dismissal — this is a page, so a
@@ -544,8 +570,13 @@ export function SettingsPage({
                       const id = confirmForget
                       setConfirmForget(null)
                       setBusy(true)
-                      await onForget(id)
-                      setBusy(false)
+                      try {
+                        await onForget(id)
+                      } finally {
+                        // `busy` also gates the token buttons below, so leaking it
+                        // here would disable Save/Clear as collateral damage.
+                        setBusy(false)
+                      }
                     }}
                     style={{
                       ...pill(false),
@@ -596,13 +627,9 @@ export function SettingsPage({
               <button
                 type="button"
                 disabled={busy || !pat}
-                onClick={async () => {
-                  setBusy(true)
-                  await onSetPat(pat)
-                  setPat('')
-                  setPatNote(i18nT('apps.mdNotebook.settings.tokenSaved'))
-                  setBusy(false)
-                }}
+                onClick={() =>
+                  void writePat(pat, i18nT('apps.mdNotebook.settings.tokenSaved'))
+                }
                 style={pill(true)}
               >
                 {i18nT('apps.mdNotebook.settings.save')}
@@ -611,25 +638,29 @@ export function SettingsPage({
                 <button
                   type="button"
                   disabled={busy}
-                  onClick={async () => {
-                    setBusy(true)
-                    await onSetPat('')
-                    setPatNote(i18nT('apps.mdNotebook.settings.tokenCleared'))
-                    setBusy(false)
-                  }}
+                  onClick={() =>
+                    void writePat('', i18nT('apps.mdNotebook.settings.tokenCleared'))
+                  }
                   style={pill(false)}
                 >
                   {i18nT('apps.mdNotebook.settings.clear')}
                 </button>
               )}
             </div>
-            {/* Result under the token controls, not at the foot of the page. */}
+            {/* Result under the token controls, not at the foot of the page. A
+                failure is an alert, not a status, so a screen reader announces it
+                without the user having to go looking for it. */}
             {patNote && (
               <div
-                role="status"
-                style={{ fontSize: '11px', color: ACCENT, marginTop: '6px' }}
+                role={patNote.error ? 'alert' : 'status'}
+                style={{
+                  fontSize: '11px',
+                  lineHeight: 1.45,
+                  color: patNote.error ? 'var(--danger)' : ACCENT,
+                  marginTop: '6px',
+                }}
               >
-                {patNote}
+                {patNote.text}
               </div>
             )}
           </div>

--- a/website/src/test/mdNotebookSettingsPat.test.tsx
+++ b/website/src/test/mdNotebookSettingsPat.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * A failed GitHub PAT write must SAY it failed.
+ *
+ * `onSetPat` rejects when the host rejects the write (`notesApi.setPat` throws on
+ * any non-OK response, and `savePat` does not catch). Both token buttons used to
+ * `await` it unguarded, which cost two things at once: the rejection escaped
+ * before `setBusy(false)`, latching `busy` true so BOTH Save and Clear stayed
+ * disabled for the rest of the page's life, and nothing was ever rendered — the
+ * user saw a dead button and no reason. Worse, the success notice is written on
+ * the line after the `await`, so a failure was indistinguishable from a click
+ * that never registered.
+ *
+ * These tests pin the three things that make the failure legible: the reason is
+ * shown, it is shown as an alert rather than a status, and the buttons come back.
+ * The pasted token surviving a failure is part of the contract too — it is the
+ * only copy the user has in hand.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+import { SettingsPage } from '../apps/md-notebook/SettingsPage'
+import type { SettingsPageProps } from '../apps/md-notebook/SettingsPage'
+import { DEFAULT_SYNC_SHORTCUT } from '../apps/md-notebook/constants'
+
+function renderSettings(overrides: Partial<SettingsPageProps> = {}) {
+  const props: SettingsPageProps = {
+    vaults: [],
+    activeVaultId: null,
+    hasPat: false,
+    hasGhAuth: false,
+    autoSync: false,
+    autoSyncMins: 15,
+    autoCommit: false,
+    shortcut: DEFAULT_SYNC_SHORTCUT,
+    onClose: () => {},
+    onSwitchVault: () => {},
+    onConnect: () => {},
+    onForget: async () => {},
+    onSetPat: async () => {},
+    onSetKnowledge: async () => {},
+    onAutoSync: () => {},
+    onAutoSyncMins: () => {},
+    onAutoCommit: () => {},
+    onSetShortcut: () => {},
+    onRecordingChange: () => {},
+    ...overrides,
+  }
+  return render(<SettingsPage {...props} />)
+}
+
+const tokenField = () => screen.getByLabelText(/access token/i) as HTMLInputElement
+const saveButton = () => screen.getByRole('button', { name: /^save$/i }) as HTMLButtonElement
+const clearButton = () => screen.getByRole('button', { name: /^clear$/i }) as HTMLButtonElement
+
+describe('md-notebook Settings — GitHub PAT save', () => {
+  it('reports the reason, re-enables Save and keeps the pasted token', async () => {
+    const onSetPat = vi.fn().mockRejectedValue(new Error('keychain is locked'))
+    renderSettings({ onSetPat })
+
+    fireEvent.change(tokenField(), { target: { value: 'github_pat_abc' } })
+    fireEvent.click(saveButton())
+
+    // The reason reaches the user, as an alert — a silent failure is the bug.
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('keychain is locked')
+
+    // `busy` was released, so the user can actually retry.
+    await waitFor(() => expect(saveButton().disabled).toBe(false))
+
+    // Retrying must not mean pasting the token again.
+    expect(tokenField().value).toBe('github_pat_abc')
+    expect(onSetPat).toHaveBeenCalledWith('github_pat_abc')
+  })
+
+  it('reports a non-Error rejection rather than rendering nothing', async () => {
+    const onSetPat = vi.fn().mockRejectedValue('403')
+    renderSettings({ onSetPat })
+
+    fireEvent.change(tokenField(), { target: { value: 'github_pat_abc' } })
+    fireEvent.click(saveButton())
+
+    expect((await screen.findByRole('alert')).textContent).toContain('403')
+  })
+
+  it('still confirms success as a status, and clears the field', async () => {
+    const onSetPat = vi.fn().mockResolvedValue(undefined)
+    renderSettings({ onSetPat })
+
+    fireEvent.change(tokenField(), { target: { value: 'github_pat_abc' } })
+    fireEvent.click(saveButton())
+
+    expect((await screen.findByRole('status')).textContent).toContain('Token saved')
+    expect(screen.queryByRole('alert')).toBeNull()
+    await waitFor(() => expect(tokenField().value).toBe(''))
+  })
+})
+
+describe('md-notebook Settings — GitHub PAT clear', () => {
+  it('reports the reason and re-enables Clear', async () => {
+    const onSetPat = vi.fn().mockRejectedValue(new Error('host unreachable'))
+    renderSettings({ hasPat: true, onSetPat })
+
+    fireEvent.click(clearButton())
+
+    expect((await screen.findByRole('alert')).textContent).toContain('host unreachable')
+    await waitFor(() => expect(clearButton().disabled).toBe(false))
+    expect(onSetPat).toHaveBeenCalledWith('')
+  })
+
+  it('confirms success as a status', async () => {
+    renderSettings({ hasPat: true, onSetPat: vi.fn().mockResolvedValue(undefined) })
+
+    fireEvent.click(clearButton())
+
+    expect((await screen.findByRole('status')).textContent).toContain('Token cleared')
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Saving or clearing a GitHub PAT in the Notes app's Settings panel has no error handling. If the request fails, the button stays disabled forever and no feedback reaches the user.

## Why it matters

A network hiccup or 401 leaves the user stuck with a disabled Save/Clear button, no error message, and no recovery path short of reloading the page.

## What changed (motivation → approach → change)

Wrapped `onSetPat`/`onClearPat` in try/catch. On failure: show an inline error notice, re-enable the button, and preserve the input value so the user can retry without retyping.

## Tests

Component test added verifying the error notice renders and the button re-enables on rejection.

## Manual verification

Simulated a 500 response — error notice appears, button returns to enabled state.

## Screenshots / video

N/A — the error notice is a text-only inline element identical in style to existing notices in the panel.

## Related Issues

Fixes #3743

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] No secrets, credentials, or internal references in the diff
