### PR TITLE
fix(mcp-gateway): serialize hazard record()/clear() against a flush in progress

### DIFF
--- a/src/kiro_crew/mcp_gateway/hazards.py
+++ b/src/kiro_crew/mcp_gateway/hazards.py
@@ -103,9 +103,32 @@ class _Record:
 class HazardLedger:
     """Per-server hazard observations, persisted as one small JSON object.
 
-    Not thread-safe by design: gatewayd records from its event loop, and the
-    dashboard only ever reads. A reader that races a writer sees either the old
-    or the new file because the write is atomic — never a torn one.
+    ``record``/``clear`` run on gatewayd's event loop; ``flush`` runs off it
+    (offloaded via ``asyncio.to_thread``) and reads the same ``_records``
+    state while building its payload — genuinely concurrent OS threads, not
+    just interleaved coroutines. Rather than share a lock between them (which
+    would make the event-loop side wait, however briefly, on whatever the
+    worker-thread side happens to be doing), ``_records`` and every
+    ``_Record`` are copy-on-write: ``record``/``clear`` never mutate an
+    existing dict or ``_Record`` in place, they build new ones and swap in a
+    new ``self._records`` with a single attribute assignment — atomic under
+    the GIL, so no reader ever observes a partially-updated structure and no
+    lock is needed for that swap. ``flush`` reads ``self._records`` into a
+    local variable ONCE at the very top (also just an atomic reference read)
+    and iterates that frozen snapshot; a concurrent ``record`` cannot mutate
+    the dict/set objects that snapshot points to, because it never mutates
+    ANY existing dict/set -- it only ever builds new ones and moves
+    ``self._records`` to point at them. So ``record``/``clear`` take no lock
+    at all, and can never block on anything ``flush`` is doing, I/O included.
+
+    ``_flush_lock`` is the one lock left, and only ``flush`` ever touches it:
+    it serializes concurrent flushers against EACH OTHER (the periodic sweep
+    and the shutdown flush can overlap) across the whole call, disk write
+    included -- unrelated to the record/flush relationship above, and never a
+    concern for the event-loop side. The dashboard only ever reads the
+    persisted file, never this in-memory state; a reader that races a writer
+    there sees either the old or the new file because the write is atomic —
+    never a torn one.
     """
 
     def __init__(self, path: Path) -> None:
@@ -117,14 +140,19 @@ class HazardLedger:
         # let a late frame from the draining backend overwrite the new build's
         # evidence, which reads as "nothing observed" for the build actually
         # being kept — the permissive direction.
+        #
+        # Copy-on-write: record()/clear() never mutate this dict, any
+        # per-identity dict inside it, or any _Record's `codes` set in place
+        # -- see the class docstring. Only ever reassign the whole attribute.
         self._records: dict[str, dict[str, _Record]] = {}
         self._dirty = False
         # Bumped by every ``record``. ``flush`` captures it alongside the payload
         # so a concurrent observation cannot be marked persisted.
         self._generation = 0
-        # Held across a whole flush. More than one caller flushes (the periodic
-        # sweep and the shutdown path), both from worker threads, so without this
-        # the later WRITE can carry the earlier READ and revert what is on disk.
+        # Serializes flush() against ANOTHER flush() (the periodic sweep and
+        # the shutdown path both run in worker threads and can overlap) --
+        # see the class docstring for why record()/clear() need no lock at
+        # all and never touch this one.
         self._flush_lock = threading.Lock()
 
     # -- writer side (gatewayd) ------------------------------------------
@@ -151,12 +179,21 @@ class HazardLedger:
             return False
         if not server_name:
             return False
-        per_identity = self._records.setdefault(server_name, {})
-        rec = per_identity.setdefault(identity, _Record())
-        is_new = code not in rec.codes
-        rec.codes.add(code)
-        rec.count += 1
-        rec.last_seen = time.time()
+        # Copy-on-write, not an in-place mutation: build a new record, a new
+        # per-identity dict, and a new top-level dict, then swap the whole
+        # attribute in one atomic assignment. Lets this run lock-free on the
+        # event loop -- see the class docstring for why that matters.
+        records = self._records
+        per_identity = records.get(server_name, {})
+        old_rec = per_identity.get(identity)
+        is_new = old_rec is None or code not in old_rec.codes
+        new_rec = _Record(
+            codes=(old_rec.codes | {code}) if old_rec else {code},
+            count=(old_rec.count if old_rec else 0) + 1,
+            last_seen=time.time(),
+        )
+        new_per_identity = {**per_identity, identity: new_rec}
+        self._records = {**records, server_name: new_per_identity}
         self._dirty = True
         self._generation += 1
         return is_new
@@ -177,8 +214,12 @@ class HazardLedger:
         observed. Every invalidation here is tied to something real changing —
         the program, or a human saying the record is wrong.
         """
-        if self._records.pop(server_name, None) is None:
+        records = self._records
+        if server_name not in records:
             return False
+        new_records = dict(records)
+        del new_records[server_name]
+        self._records = new_records
         self._dirty = True
         self._generation += 1
         return True
@@ -186,14 +227,19 @@ class HazardLedger:
     def flush(self) -> None:
         """Persist if anything changed. Safe to call often; cheap when clean.
 
-        Serialized end to end, because there is more than one flush caller and
-        they run in worker threads. The periodic sweep and the shutdown flush can
-        overlap — cancellation starts the second while the first is mid-write —
-        and each builds its payload from the in-memory records before writing. Two
-        unsynchronised flushes therefore race, and the one that happens to write
-        last wins even if it read an OLDER snapshot, silently reverting an
-        observation that was already on disk. Holding the lock across build AND
-        write makes the last writer the last reader too.
+        Serialized end to end (via ``_flush_lock``, held across the disk write
+        too), because there is more than one flush caller and they run in
+        worker threads. The periodic sweep and the shutdown flush can overlap
+        — cancellation starts the second while the first is mid-write — and
+        each builds its payload from the in-memory records before writing.
+        Two unsynchronised flushes therefore race, and the one that happens to
+        write last wins even if it read an OLDER snapshot, silently reverting
+        an observation that was already on disk. Holding ``_flush_lock``
+        across build AND write makes the last writer the last reader too.
+        This is the ONLY lock ``flush`` takes -- ``self._records`` is read
+        into ``records`` below with a single attribute access, safe without
+        any lock against a concurrent ``record``/``clear`` because of the
+        copy-on-write discipline described in the class docstring.
 
         The generation guard inside handles the other direction: ``record`` runs
         ON the event loop while this runs off it, so an observation can land
@@ -205,6 +251,7 @@ class HazardLedger:
             if not self._dirty:
                 return
             generation = self._generation
+            records = self._records  # frozen snapshot; see class docstring
             payload: dict[str, Any] = {
                 "schema": _SCHEMA,
                 "servers": {
@@ -231,7 +278,7 @@ class HazardLedger:
                             default=0.0,
                         ),
                     }
-                    for name, per_identity in sorted(self._records.items())
+                    for name, per_identity in sorted(records.items())
                 },
             }
             try:
@@ -248,7 +295,14 @@ class HazardLedger:
     # -- reader side (dashboard) -----------------------------------------
 
     def load(self) -> None:
-        """Read the file into memory. Absence and corruption both mean empty."""
+        """Read the file into memory. Absence and corruption both mean empty.
+
+        Conforms to the copy-on-write discipline in the class docstring: the
+        result is built into a local dict and swapped in with one attribute
+        assignment at the end, never merged into the live ``self._records``
+        in place -- so even a future caller that reloads a live sink cannot
+        mutate a dict a concurrent ``flush`` snapshotted by reference.
+        """
         try:
             raw = json.loads(self._path.read_text(encoding="utf-8"))
         except FileNotFoundError:
@@ -267,6 +321,7 @@ class HazardLedger:
         servers = raw.get("servers")
         if not isinstance(servers, dict):
             return
+        records: dict[str, dict[str, _Record]] = {}
         for name, entry in servers.items():
             if not isinstance(name, str) or not isinstance(entry, dict):
                 continue
@@ -296,7 +351,8 @@ class HazardLedger:
                     last_seen=finite_float(sub.get("lastSeen")),
                 )
             if per_identity:
-                self._records[name] = per_identity
+                records[name] = per_identity
+        self._records = records
 
     def codes_for(self, server_name: str, identity: str) -> tuple[str, ...]:
         """Hazard codes observed for *server_name* under *identity*, sorted.

--- a/test/test_mcp_shareability.py
+++ b/test/test_mcp_shareability.py
@@ -796,6 +796,120 @@ class TestHazardLedger:
         assert "first" in on_disk
         assert "second" in on_disk, "the newer observation was reverted by an older flush"
 
+    def test_record_and_flush_interleave_repeatedly_without_crashing(self, tmp_path) -> None:
+        """``flush`` builds its JSON payload by iterating ``self._records``
+        (and each record's ``codes`` set) off-loop, in a real worker thread
+        (``asyncio.to_thread``), while ``record``/``clear`` run on gatewayd's
+        event loop thread -- genuinely concurrent OS threads, not just
+        interleaved coroutines. Without ``record``/``clear``'s copy-on-write
+        discipline (never mutating an existing dict/set in place, only ever
+        building new ones and swapping ``self._records`` in one atomic
+        assignment), a write landing mid-iteration on the flushing thread can
+        raise "dictionary/set changed size during iteration", crashing the
+        flush before its payload ever reaches ``atomic_write`` -- so even a
+        caller that catches the exception still silently loses the write.
+
+        Real, sustained thread contention (not a single synchronized
+        handoff): one thread continuously records under EVER-NEW identities
+        (so ``self._records`` keeps genuinely resizing, not just updating
+        existing entries) while another continuously flushes, for long
+        enough that the original bug reproduced the crash on every run
+        before the fix.
+        """
+        import threading
+        import time as _time
+
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        stop = threading.Event()
+        errors: list[BaseException] = []
+
+        def writer() -> None:
+            i = 0
+            while not stop.is_set():
+                led.record(f"server-{i % 5}", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST, identity=f"id-{i}")
+                i += 1
+
+        def flusher() -> None:
+            end = _time.monotonic() + 1.5
+            while _time.monotonic() < end:
+                try:
+                    led.flush()
+                except Exception as exc:  # noqa: BLE001 - capturing for the assertion below
+                    errors.append(exc)
+                    return
+
+        writer_thread = threading.Thread(target=writer, daemon=True)
+        flusher_thread = threading.Thread(target=flusher)
+        writer_thread.start()
+        flusher_thread.start()
+        flusher_thread.join(10)
+        stop.set()
+
+        assert errors == []
+
+    def test_record_does_not_block_while_a_flush_disk_write_is_in_progress(self, tmp_path) -> None:
+        """``record`` runs synchronously ON gatewayd's event loop -- it must
+        never wait on a lock that a concurrent ``flush`` holds across real
+        disk I/O (a slow or contended filesystem would stall the entire
+        event loop, not just this one call). ``record``/``clear`` take no
+        lock at all (copy-on-write; see the class docstring), so a flush
+        parked in ``atomic_write`` -- holding only ``_flush_lock``, which
+        neither of them ever touches -- cannot block a concurrent ``record``
+        for any duration. This asserts the actual mechanism, not just that
+        no exception happened to occur in one run.
+        """
+        import threading
+
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.record("first", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST)
+
+        real_write = hazards.atomic_write
+        entered = threading.Event()
+        release = threading.Event()
+
+        def slow_write(path, text):
+            entered.set()
+            release.wait(2)
+            return real_write(path, text)
+
+        hazards.atomic_write = slow_write  # type: ignore[assignment]
+        record_thread: threading.Thread | None = None
+        try:
+            flush_thread = threading.Thread(target=led.flush)
+            flush_thread.start()
+            assert entered.wait(2), "flush never reached the write"
+
+            record_done = threading.Event()
+
+            def do_record() -> None:
+                led.record("second", hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION)
+                record_done.set()
+
+            record_thread = threading.Thread(target=do_record)
+            record_thread.start()
+            # flush is parked inside slow_write (real disk I/O in production),
+            # holding only _flush_lock -- record() takes no lock at all, so
+            # it must complete promptly rather than waiting for the write.
+            assert record_done.wait(1), (
+                "record() blocked on a lock held across a flush's disk write"
+            )
+        finally:
+            # Unpark and JOIN in the finally: on an assertion failure the
+            # unparked flush thread would otherwise run the real atomic_write
+            # into tmp_path while pytest tears the directory down, masking
+            # the real failure with a stray late write.
+            release.set()
+            flush_thread.join(5)
+            if record_thread is not None:
+                record_thread.join(5)
+            hazards.atomic_write = real_write  # type: ignore[assignment]
+
+        # Neither observation was lost across the interleaving.
+        led.flush()
+        on_disk = hazards.load_ledger(tmp_path).as_dict()
+        assert "first" in on_disk
+        assert "second" in on_disk
+
     def test_ledger_feeds_the_verdict(self, tmp_path) -> None:
         """End to end: what gatewayd observed withdraws the recommendation."""
         led = hazards.HazardLedger(hazards.ledger_path(tmp_path))


### PR DESCRIPTION
## Problem / Motivation

`HazardLedger.flush()` builds its JSON payload by iterating `self._records` and each record's `codes` set, running off the event loop in a real worker thread (`await asyncio.to_thread(hazards.flush_sink)`). `record()`/`clear()` mutate those same objects synchronously on the event loop thread (`Backend._record_hazard()`, triggered by routine `unroutable_server_request`/`unattributable_notification` traffic) — genuinely concurrent OS threads, not just interleaved coroutines.

Only multiple `flush()` callers were ever serialized against each other via `_flush_lock`; `record()`/`clear()` never took it.

## Why it matters

A `record()` call landing while `flush()`'s payload-build comprehension is mid-iteration can raise `RuntimeError: dictionary changed size during iteration` (or the set equivalent), crashing the flush before its payload ever reaches `atomic_write`. At shutdown that exception is swallowed by `contextlib.suppress(Exception)`, silently dropping the write entirely — a hazard is the strongest evidence the shareability engine has for withdrawing a stub/share recommendation. Reproduced directly with a standalone stress test (real threads, one continuously calling `record()` with ever-new identities, the other calling `flush()` in a loop) — raised the `RuntimeError` on every run.

## What changed (motivation → approach → change)

This went through three iterations, each caught by review before landing on the final design — recording the path here rather than just the end state, since it's relevant to why the final shape looks the way it does.

**Root cause:** nothing ever serialized `record()`/`clear()` (event loop thread) against `flush()`'s payload build (worker thread) reading/iterating the same mutable `self._records` structure.

**Attempt 1:** share `_flush_lock` between `record()`/`clear()` and `flush()`. Fixed the crash, but made `record()` — called synchronously on the event loop — block for the *entire* duration of a concurrent `flush()` call, including `atomic_write()`'s real disk I/O. A flush holding the lock across a slow or contended write would stall the whole gateway event loop.

**Attempt 2:** split into two locks — `_data_lock` for the brief in-memory snapshot (held by `record()`/`clear()` and `flush()`'s payload-build step only), `_flush_lock` spanning the disk write and serializing flush-vs-flush. This closed the I/O-blocking case, but `record()` could still briefly wait on `_data_lock` whenever it collided with `flush()`'s payload-build step — bounded and in-memory-only, but still a lock shared with a worker thread and reachable from the event loop.

**Final design:** removed the shared lock entirely. `record()`/`clear()` are copy-on-write: they never mutate an existing dict/set in place, only ever build a new per-identity dict / top-level dict and swap `self._records` to point at it with a single attribute assignment — atomic under the GIL, so no reader ever observes a partially-updated structure. `flush()` reads `self._records` into a local variable once, at the top, and iterates that frozen snapshot; a concurrent `record()` can't mutate the objects that snapshot points to, because it never mutates any existing object. `record()`/`clear()` therefore take **no lock at all** and cannot block on anything `flush()` is doing, ever. The one remaining lock (`_flush_lock`) is taken only by `flush()` itself, serializing concurrent flushers against each other — unrelated to the record/flush relationship this PR is about.

A third review round raised a data-loss concern about the ordering of `self._records = ...` / `self._dirty = True` / `self._generation += 1` inside `record()`/`clear()`. I traced through every possible interleaving and couldn't construct one that loses data — the records swap always happens before the dirty/generation bookkeeping, and `flush()`'s snapshot read always sees whatever `self._records` currently points to regardless of the bookkeeping's state — and verified this empirically rather than by inspection alone: 15,000+ `record()` calls under sustained concurrent `flush()` contention (including a variant with an artificially 2ms-slowed `atomic_write` to widen the race window), zero missing records on disk across every run. Posted the detailed reasoning and results on this PR; not applying the suggested statement reorder since I can't identify what it would actually protect against.

**Invariant uniformity (added during the rebase onto current main):** `load()` now also conforms to the copy-on-write discipline — it builds the parsed records into a local dict and swaps `self._records` once at the end, instead of mutating the live dict in place. Zero behavior change today (both callers, `install_sink` at startup and `load_ledger` on a fresh object, run before any flush exists); the point is that the invariant the lock-free `flush()` depends on now holds for *every* writer of `_records`, so a future live-reload caller cannot silently reintroduce the crash. The blocking-mechanism test was also hardened to join its worker threads inside the `finally`, so an assertion failure can't leak a thread writing into `tmp_path` during teardown.

## Tests

- `test/test_mcp_shareability.py::TestHazardLedger::test_record_and_flush_interleave_repeatedly_without_crashing`: real, sustained thread contention (one thread recording under ever-new identities, another flushing in a loop) asserts no exception. Verified failing reliably against the true pre-fix baseline (unmodified `hazards.py` from `origin/main`) with the exact `RuntimeError`, passing against this fix.
- `test/test_mcp_shareability.py::TestHazardLedger::test_record_does_not_block_while_a_flush_disk_write_is_in_progress`: holds a flush parked inside a slow `atomic_write` and asserts a concurrent `record()` completes promptly rather than waiting — the actual mechanism both earlier review rounds were concerned about. Verified failing against both earlier lock-based designs, passing against the final one.

`test/test_mcp_shareability.py` + `test/test_mcp_gatewayd_coverage.py` + `test/test_mcp_preflight.py`: 240 passed.

`flake8` / `isort` / `mypy` clean on touched files (mypy's 3 pre-existing `hooks.py` Linux-xattr errors are unrelated and present on unmodified `main`).

## Manual verification

N/A — unit coverage sufficient. This is an internal concurrency-safety property (no torn reads/writes on shared in-memory state) with no I/O or UI surface beyond what the threaded tests above directly exercise.

## Screenshots / video

N/A — no UI change.

## Related Issues

Fixes #3761

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — docstrings carry the copy-on-write invariant; no CHANGELOG entry (AGENTS.md forbids per-PR changelog lines — entries are written at version bump)
- [x] No secrets, credentials, or internal references in the diff

