### PR TITLE
fix(apps): key Library card boundary on full data identity (#3719)

### DIFF
--- a/website/src/pages/AppsPage.tsx
+++ b/website/src/pages/AppsPage.tsx
@@ -159,7 +159,7 @@ export function featuredBusyName(actionLoading: string | null, apps: RegistryApp
  * once per distinct row object.
  */
 const cardKeyCache = new WeakMap<object, string>()
-export function cardDataKey(row: object): string {
+function cardDataKey(row: object): string {
   let key = cardKeyCache.get(row)
   if (key === undefined) {
     key = JSON.stringify(row)
@@ -461,8 +461,15 @@ export default function AppsPage() {
     [registry],
   )
   const installedApps = useMemo(
-    () => apps.filter(a => !(a.origin === 'builtin' && !a.enabled)),
-    [apps],
+    () =>
+      apps
+        .filter(a => !(a.origin === 'builtin' && !a.enabled))
+        .map(a => ({
+          ...a,
+          updateAvailable: updateMap.has(a.name),
+          _newVersion: updateMap.get(a.name),
+        })),
+    [apps, updateMap],
   )
   const filteredInstalled = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -1037,7 +1044,11 @@ export default function AppsPage() {
               <div className="space-y-3">
                 {filteredInstalled.map(app => (
                   <ErrorBoundary
-                    key={app.name}
+                    /* Full-data key (cardDataKey): the boundary latches
+                       its error state, so remount when the installed app or its
+                       update availability changes — e.g. when an updated payload
+                       fixes a broken card (#3719). */
+                    key={cardDataKey(app)}
                     scope="apps:installed-card"
                     fallback={
                       <div className="border border-border rounded-lg p-4 flex items-center gap-3">
@@ -1068,7 +1079,7 @@ export default function AppsPage() {
                     }
                   >
                     <InstalledAppCard
-                      app={{ ...app, updateAvailable: updateMap.has(app.name), _newVersion: updateMap.get(app.name) }}
+                      app={app}
                       actionLoading={updatingAll ? `${app.name}:update` : actionLoading}
                       onAction={handleAction}
                       onOpen={() => navigate(app.manifest?.ui?.pages?.[0]?.route || `/apps/${app.name}`)}

--- a/website/src/test/AppsPageCardBoundary.test.tsx
+++ b/website/src/test/AppsPageCardBoundary.test.tsx
@@ -9,7 +9,7 @@
  * deterministic even after the card's own null-guards are fixed.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { i18nT } from '../i18n/t'
@@ -61,8 +61,10 @@ vi.mock('../components/SegmentedControl', () => ({
 // boundary normalized it).
 const cardMock = vi.hoisted(() => ({ apps: [] as { name: string; manifest?: Record<string, unknown> }[] }))
 vi.mock('../components/appstore/InstalledAppCard', () => ({
-  default: ({ app }: { app: { name: string; manifest?: Record<string, unknown> } }) => {
-    if (app.name === 'zzq-broken') throw new Error('zzq-card-render-broke')
+  default: ({ app }: { app: { name: string; manifest?: Record<string, unknown>; _newVersion?: string } }) => {
+    if (app.name === 'zzq-broken' || (app.manifest as { description?: string })?.description === 'zzq-crash') {
+      throw new Error('zzq-card-render-broke')
+    }
     cardMock.apps.push(app)
     return <div data-testid={`zzq-card-${app.name}`} />
   },
@@ -83,10 +85,10 @@ function installed(name: string) {
   }
 }
 
-function renderPage() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+function renderPage(qc?: QueryClient) {
+  const client = qc ?? new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <QueryClientProvider client={qc}>
+    <QueryClientProvider client={client}>
       <MemoryRouter initialEntries={['/apps']}>
         <Routes>
           <Route path="/apps" element={<AppsPage />} />
@@ -131,6 +133,37 @@ describe('AppsPage per-card error boundary (#3689)', () => {
     // fallback must not be a dead end: an enabled app keeps a Disable action.
     const disable = screen.getByRole('button', { name: i18nT('components.appstore.installedAppCard.disable') })
     expect(disable).toBeInTheDocument()
+  })
+
+  it('a corrected payload clears a latched fallback without a route remount (#3719)', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    listApps.mockResolvedValue([
+      installed('zzq-healthy'),
+      {
+        ...installed('zzq-fixable'),
+        manifest: { ...installed('zzq-fixable').manifest, description: 'zzq-crash' },
+      },
+    ])
+
+    renderPage(qc)
+
+    expect(await screen.findByTestId('zzq-card-zzq-healthy')).toBeInTheDocument()
+    expect(screen.getByText('zzq-fixable')).toBeInTheDocument()
+    expect(screen.getByText(i18nT('pages.appsPage.this_app_could_not_be_displayed'))).toBeInTheDocument()
+
+    // Simulate query refetch / data correction for the installed app:
+    await act(async () => {
+      qc.setQueryData(['apps'], [
+        installed('zzq-healthy'),
+        {
+          ...installed('zzq-fixable'),
+          manifest: { ...installed('zzq-fixable').manifest, description: 'corrected' },
+        },
+      ])
+    })
+
+    expect(await screen.findByTestId('zzq-card-zzq-fixable')).toBeInTheDocument()
+    expect(screen.queryByText(i18nT('pages.appsPage.this_app_could_not_be_displayed'))).not.toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Problem / Motivation

In `website/src/pages/AppsPage.tsx`, the Library installed-card `ErrorBoundary` was keyed only by `app.name` (`key={app.name}`). Because `ErrorBoundary` latches its caught error state until its key changes or it unmounts, if an installed app card crashed during render, the boundary remained latched on the degraded fallback placeholder even after the underlying query data was corrected or updated by the server (until the user navigated away from the tab or reloaded the page).

## Why it matters

An installed app card that crashes (e.g. due to temporary manifest drift or rendering errors) leaves the user with a degraded fallback placeholder that only offers Disable/Uninstall actions. When an update or corrected data becomes available, the card remained stuck in its broken state without any discoverable way to recover.

## What changed

- Keyed the Library installed-card `ErrorBoundary` with `cardDataKey(installedApp)` (where `installedApp` includes both app fields and update availability status), matching the pattern established for Browse-tab boundaries in PR #3710.
- When any field of the installed app or its update status changes, `cardDataKey` produces a new key, causing the boundary to automatically remount and attempt rendering with the corrected data.
- Removed the unused `export` on module-local `cardDataKey`.

## Tests

- Added recovery unit test in `website/src/test/AppsPageCardBoundary.test.tsx` verifying that a corrected query payload clears a latched fallback without requiring a route remount.
- Ran the full test suite (`AppsPageCardBoundary.test.tsx` and `AppsPageBrowseCardBoundary.test.tsx`) with all 10 tests passing.

## Manual verification

N/A — covered by automated unit and component boundary tests in Vitest/React Testing Library.

<!-- no-visual-delta -->
**Why no screenshot:** Pure React ErrorBoundary key fix to enable remounting on data update; no changes to the card's visual styling or layout.

## Related Issues

Fixes #3719

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] No secrets, credentials, or internal references in the diff
- [x] Documentation updated (if applicable)
