### PR TITLE
fix(fork): inherit project directory from parent session

### DIFF
--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -212,7 +212,10 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
     )
     new_slot.forked_from = effective_session_key(slot)
     new_slot.reasoning_effort = slot.reasoning_effort
-    # Inherit project folder so the fork appears next to its parent in the sidebar.
+    # Inherit the active project directory so the fork starts in the same
+    # working context as its parent (agent resolution, steering, cwd).
+    new_slot.project = slot.project
+    # Inherit the sidebar folder so the fork appears next to its parent.
     new_slot.folder_id = slot.folder_id
     parent_title = slot.title if slot._titled else "Untitled"
     parent_title, _ = redact_exfiltration_urls(parent_title)

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -9920,6 +9920,41 @@ class TestForkSlot:
         assert new_slot.folder_id == ""
 
     @pytest.mark.asyncio
+    async def test_fork_inherits_project(self, tmp_path):
+        """Fork must inherit the parent's active project directory."""
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("src")
+        slot.project = "/home/user/my-project"
+        slot.append("user", "hi", "msg msg-u")
+        slot.drain()
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/chat/slots/src/fork", json={})
+            assert resp.status == 200
+            data = await resp.json()
+
+        new_slot = state._slots.get(data["key"])
+        assert new_slot is not None
+        assert new_slot.project == "/home/user/my-project"
+
+    @pytest.mark.asyncio
+    async def test_fork_inherits_empty_project(self, tmp_path):
+        """Fork of a slot with no project stays projectless."""
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("src")
+        slot.append("user", "hi", "msg msg-u")
+        slot.drain()
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/chat/slots/src/fork", json={})
+            data = await resp.json()
+
+        new_slot = state._slots.get(data["key"])
+        assert new_slot.project == ""
+
+    @pytest.mark.asyncio
     async def test_fork_with_prompt(self, tmp_path):
         state = _make_state(tmp_path)
         slot = state.get_or_create_slot("src")


### PR DESCRIPTION
## Problem / Motivation

When a user forks a session, the new tab loses the parent's active project directory. The forked session starts with no `slot.project`, falling back to the config/workspace default on first message — resetting the working context (agent resolution, steering files, CWD) the user was in.

Additionally, the existing comment on the `folder_id` line (`# Inherit project folder so the fork appears next to its parent in the sidebar`) conflates two unrelated concepts: the sidebar organizational folder (`folder_id`) and the active project directory (`project`). This makes it look like `project` is already handled when it is not.

## What changed

**`src/kiro_crew/dashboard/chat_fork.py`:**
- Added `new_slot.project = slot.project` so the fork inherits the parent's active project directory.
- Split the misleading comment into two: one explaining the project directory copy (working context), one explaining the sidebar folder copy (UI grouping).

**`test/test_dashboard_chat.py`:**
- Added `test_fork_inherits_project` — sets a project on the source slot, forks, asserts the new slot carries it.
- Added `test_fork_inherits_empty_project` — forks a slot with no project, asserts the fork stays projectless (empty string).

## Tests

All 35 `TestForkSlot` tests pass (33 pre-existing + 2 new). The change is additive — existing forks that previously had no project simply receive the parent's value instead of empty string.

Fixes #3298