### PR TITLE
fix(autopilot): offload stage-result writes

### DIFF
--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import os
+import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -126,13 +129,69 @@ async def _previous_result_paths(
     return await asyncio.to_thread(_read_previous_results, recorded)
 
 
-def _capture_stage_result(
+def _write_stage_result(
+    slot_key: str,
+    stage_num: int,
+    result_text: str,
+    abandoned: threading.Event,
+) -> str | None:
+    """Write *result_text* and publish it, entirely on the worker thread.
+
+    Returns the published path, or ``None`` when the capture was abandoned
+    before publication. Takes only immutable values plus *abandoned* — never
+    the slot — so nothing the loop owns is reachable from the worker.
+
+    EVERY filesystem call lives here, ``os.replace`` included. The session
+    directory can be network-backed, where a rename is a round trip and not the
+    "metadata-only, therefore free" syscall it looks like locally; running it on
+    the loop stalls chat streaming, WebSocket frames and cron dispatch for that
+    duration, which is what ``no-blocking-call-on-event-loop`` forbids.
+
+    Publication stays SAFE without being on the loop. The payload still goes to
+    a ``uuid``-named sibling that no other writer knows, and the canonical path
+    is touched only after re-reading *abandoned* — which the caller sets when
+    its await is cancelled (stop button, slot close, slot-key reuse). So a
+    worker abandoned during the write — the long half, and the whole of the
+    window on a slow filesystem — unlinks its temp file and publishes nothing.
+
+    What this does NOT claim: the check and the rename are two operations, so a
+    cancellation landing between them still publishes. That window is one
+    already-resolved rename rather than the entire payload write, and it cannot
+    be closed from the loop side at all while the rename runs on the loop —
+    there the loop is not even free to observe the cancellation.
+    """
+    session_dir = config_dir() / "sessions" / slot_key
+    session_dir.mkdir(parents=True, exist_ok=True)
+    final = session_dir / f"stage_{stage_num}_result.md"
+    tmp = session_dir / f".stage_{stage_num}_result.{uuid.uuid4().hex}.tmp"
+    tmp.write_text(result_text, encoding="utf-8")
+    if abandoned.is_set():
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        return None
+    try:
+        os.replace(str(tmp), str(final))
+    except OSError:
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        raise
+    return str(final)
+
+
+async def _capture_stage_result(
     slot: "_ChatSlot",
     stage_num: int,
 ) -> str:
     """Extract assistant messages since stage start and write to disk.
 
     Returns the path to the result file.
+
+    The extraction stays on the event-loop thread because ``slot.messages`` is
+    live mutable state the loop owns; only the finished text crosses into the
+    worker, so a concurrent append cannot be read from another thread. The
+    filesystem half runs off-loop: ``_stage_loop`` is async and this runs at every
+    stage boundary, so a slow ``mkdir``/``write_text`` would stall chat streaming,
+    WebSocket frames and cron dispatch for its duration.
     """
     # Collect assistant text from the most recent messages (since last stage separator)
     result_parts: list[str] = []
@@ -154,11 +213,33 @@ def _capture_stage_result(
     result_parts.reverse()
     result_text = "\n\n".join(result_parts)
 
-    session_dir = config_dir() / "sessions" / slot.key
-    session_dir.mkdir(parents=True, exist_ok=True)
-    path = session_dir / f"stage_{stage_num}_result.md"
-    path.write_text(result_text, encoding="utf-8")
-    return str(path)
+    # The worker owns the whole filesystem half: payload write AND publication.
+    # Nothing here touches the disk, because the session directory can be
+    # network-backed and a rename there is a round trip, not a free
+    # metadata-only syscall.
+    #
+    # ``asyncio.to_thread`` cannot interrupt a running worker, so the orphan
+    # writer is held off with a flag instead of with placement: the worker
+    # re-reads ``abandoned`` immediately before it publishes, and this handler
+    # sets it the moment the await is cancelled. A capture abandoned during the
+    # payload write — the long half, and effectively all of the window on the
+    # slow filesystem this offload exists for — therefore unlinks its temp file
+    # and leaves ``stage_N_result.md`` alone.
+    abandoned = threading.Event()
+    try:
+        published = await asyncio.to_thread(
+            _write_stage_result, slot.key, stage_num, result_text, abandoned
+        )
+    except asyncio.CancelledError:
+        abandoned.set()
+        raise
+    if published is None:
+        # Only reachable when the worker saw ``abandoned``, which is set solely
+        # in the handler above -- so the await raised and this line did not run.
+        # Kept so the signature stays honest rather than asserting the
+        # invariant with a cast.
+        raise asyncio.CancelledError()
+    return published
 
 
 def _completion_excerpts(result_paths: tuple[tuple[int, str], ...]) -> dict[int, str]:
@@ -560,10 +641,18 @@ async def _stage_loop(
 
             # Capture result to disk
             try:
-                result_path = _capture_stage_result(slot, stage_num)
+                result_path = await _capture_stage_result(slot, stage_num)
                 tracker.record_stage_result(stage_num, result_path)
             except OSError:
                 logger.warning("Failed to capture stage %d result to disk", stage_num, exc_info=True)
+
+            # The offloaded write above is a suspension point between the
+            # loop's last stop check and the next stage. A stop that lands
+            # while the worker is writing (user cancel sets tracker.stopped
+            # and slot._auto_run, but `auto_run` below is a call-time
+            # snapshot) must not let the run advance to another stage.
+            if slot._stopping or tracker.stopped:
+                break
 
             # Gate: if not auto_run, wait for user approval
             if not auto_run:

--- a/test/test_completion_result_read_off_loop.py
+++ b/test/test_completion_result_read_off_loop.py
@@ -213,8 +213,8 @@ async def test_completion_summary_survives_a_deleted_result_file(monkeypatch, tm
 
     real_capture = None
 
-    def _capture_then_delete_stage_1(s, stage_num):
-        path = real_capture(s, stage_num)
+    async def _capture_then_delete_stage_1(s, stage_num):
+        path = await real_capture(s, stage_num)
         if stage_num == 1:
             (tmp_path / "sessions" / s.key / "stage_1_result.md").unlink()
         return path

--- a/test/test_display_time_redaction.py
+++ b/test/test_display_time_redaction.py
@@ -162,11 +162,16 @@ def test_side_chat_parent_snapshot_keeps_user_text() -> None:
     assert "my own question" in _format_parent_snapshot(slot)
 
 
-def test_stage_result_capture_redacts_before_writing_to_disk(tmp_path, monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_stage_result_capture_redacts_before_writing_to_disk(tmp_path, monkeypatch) -> None:
     """_capture_stage_result writes assistant text to a NEW file on disk.
 
     A gateway restart mid-orchestration leaves restored (now unredacted) turns in
     the window, so without redaction here those bytes would be written out.
+
+    Redaction runs on the event-loop thread and only the finished text is handed
+    to the worker that writes it, so the credential cannot reach disk even though
+    the write itself is off-loop.
     """
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
@@ -176,7 +181,7 @@ def test_stage_result_capture_redacts_before_writing_to_disk(tmp_path, monkeypat
     slot = _ChatSlot("chat-1-stage")
     slot.append("assistant", f"result with {SECRET}", "msg msg-a", broadcast=False)
 
-    path = _capture_stage_result(slot, 1)
+    path = await _capture_stage_result(slot, 1)
     written = pathlib.Path(path).read_text()
     assert SECRET not in written, "stage result persisted an unredacted credential"
 

--- a/test/test_stage_result_off_loop.py
+++ b/test/test_stage_result_off_loop.py
@@ -1,0 +1,375 @@
+"""The autopilot stage-result write must not run on the gateway event loop.
+
+``_stage_loop`` is async and drives the whole autopilot run, but it persists each
+stage's result with a synchronous ``mkdir`` + ``write_text``. Every other task on
+the loop — chat streaming, WebSocket frames, cron dispatch — is stalled for the
+duration of that filesystem work, once per stage boundary.
+
+Only the filesystem mutation belongs off-loop. Reading ``slot.messages`` and
+redacting stays on the loop thread: it is live mutable slot state, and handing it
+to a worker would buy nothing while widening the change into cross-thread access.
+These tests pin both halves of that boundary.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import pathlib
+import threading
+
+import pytest
+
+
+async def _capture(slot, stage_num):
+    """Drive the real production capture, sync or async.
+
+    Deliberately tolerant of both shapes so the thread assertions below are what
+    fails on an unfixed tree. A bare ``await`` would raise "can't be used in
+    'await' expression" against the synchronous version, which proves only that
+    the symbol changed — not that the write was ever on the wrong thread.
+    """
+    from kiro_crew.dashboard.chat_orchestrator import _capture_stage_result
+
+    result = _capture_stage_result(slot, stage_num)
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
+def _slot_with(*assistant_texts: str):
+    from kiro_crew.dashboard.state import _ChatSlot
+
+    slot = _ChatSlot("chat-1-stage")
+    for i, text in enumerate(assistant_texts):
+        slot.append("assistant", text, f"msg msg-a{i}", broadcast=False)
+    return slot
+
+
+@pytest.mark.asyncio
+async def test_stage_result_write_runs_off_the_loop_thread(tmp_path, monkeypatch):
+    """The bytes reach disk on some thread other than the loop's."""
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+    slot = _slot_with("stage one output")
+
+    seen_threads: list[int] = []
+    real_write = pathlib.Path.write_text
+    target_dir = tmp_path / "sessions" / "chat-1-stage"
+
+    def recording_write(self, *args, **kwargs):
+        # Scoped to the stage-result payload write (canonical or temp name,
+        # so the assertion tracks the write wherever the implementation puts
+        # the bytes) -- unrelated writes cannot decide this.
+        if self.parent == target_dir and "stage_1_result" in self.name:
+            seen_threads.append(threading.get_ident())
+        return real_write(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "write_text", recording_write)
+
+    await _capture(slot, 1)
+
+    assert seen_threads, (
+        "the stage result file was never written -- this test no longer "
+        "exercises the write and would pass vacuously"
+    )
+    assert threading.get_ident() not in seen_threads, (
+        "the stage result was written on the event-loop thread; the filesystem "
+        "work must be handed to asyncio.to_thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stage_result_mkdir_runs_off_the_loop_thread(tmp_path, monkeypatch):
+    """``mkdir`` is the other blocking syscall, and it is first.
+
+    Offloading only the write would leave a directory creation — which on a cold
+    or networked session directory is the slower of the two — still on the loop.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+    slot = _slot_with("stage one output")
+
+    seen_threads: list[int] = []
+    real_mkdir = pathlib.Path.mkdir
+    target = tmp_path / "sessions" / "chat-1-stage"
+
+    def recording_mkdir(self, *args, **kwargs):
+        # Scoped to the stage-result directory: unrelated mkdir traffic from
+        # fixtures or lazily-created config dirs runs on the loop legitimately
+        # and would make a global assertion fail for the wrong reason.
+        if self == target:
+            seen_threads.append(threading.get_ident())
+        return real_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "mkdir", recording_mkdir)
+
+    await _capture(slot, 1)
+
+    assert seen_threads, (
+        "the session directory was never created -- this test no longer "
+        "exercises the stage-result mkdir and would pass vacuously"
+    )
+    assert threading.get_ident() not in seen_threads, (
+        "the session directory was created on the event-loop thread; it must be "
+        "handed to asyncio.to_thread with the write"
+    )
+
+
+@pytest.mark.asyncio
+async def test_slot_messages_are_read_on_the_loop_thread(tmp_path, monkeypatch):
+    """The offload stops at the filesystem — live slot state is not shared.
+
+    ``slot.messages`` is mutable and owned by the loop. Moving the traversal into
+    a worker would make an unrelated append during the capture a cross-thread
+    read, so the boundary is asserted from the safe side too, not just the fast
+    one.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+    slot = _slot_with("stage one output")
+
+    seen_threads: list[int] = []
+
+    class RecordingList(list):
+        def __reversed__(self):
+            seen_threads.append(threading.get_ident())
+            return super().__reversed__()
+
+    slot.messages = RecordingList(slot.messages)
+
+    await _capture(slot, 1)
+
+    assert seen_threads, (
+        "slot.messages was never traversed -- this test no longer exercises the "
+        "extraction and would pass vacuously"
+    )
+    assert seen_threads == [threading.get_ident()] * len(seen_threads), (
+        "slot.messages was traversed off the event-loop thread; only the "
+        "filesystem write may cross into a worker"
+    )
+
+
+@pytest.mark.asyncio
+async def test_capture_preserves_path_ordering_and_redaction(tmp_path, monkeypatch):
+    """The offload changes scheduling only — every output contract holds."""
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    slot = _slot_with("first part", f"second part with {secret}")
+
+    path = await _capture(slot, 3)
+
+    assert path == str(tmp_path / "sessions" / "chat-1-stage" / "stage_3_result.md")
+    written = pathlib.Path(path).read_text(encoding="utf-8")
+    # Oldest first: the extraction walks backwards then reverses.
+    assert written.index("first part") < written.index("second part")
+    assert secret not in written, "stage result persisted an unredacted credential"
+
+
+@pytest.mark.asyncio
+async def test_stop_landing_during_the_offloaded_write_does_not_advance(tmp_path, monkeypatch):
+    """A stop that lands while the worker is writing must halt the run.
+
+    The offloaded write is a suspension point between the loop's last stop
+    check and the next stage. The user cancel path sets ``tracker.stopped``
+    (and ``slot._auto_run``), not ``slot._stopping`` -- and ``auto_run`` is a
+    call-time snapshot -- so without a re-check after the await the loop
+    resumes and executes the next stage against a revoked approval.
+    """
+    from unittest.mock import MagicMock
+
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+    from kiro_crew.dashboard.chat_orchestrator import _stage_loop
+    from kiro_crew.dashboard.state import _ChatSlot
+
+    state = MagicMock()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.subagents = MagicMock()
+    state.subagents.running_agents_for = MagicMock(return_value=[])
+
+    slot = _ChatSlot("stop-mid-write", mode="orchestrator")
+    slot._stage_titles = ["A", "B"]
+    slot._orch_tracker = None
+
+    executed: list[int] = []
+
+    async def _turn(s, sl, msg, **kw):
+        executed.append(len(executed) + 1)
+        sl.append("assistant", f"stage {len(executed)} output", "msg msg-a", broadcast=False)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _turn)
+
+    # The cancel lands while the stage-1 result is being written: the worker
+    # is mid-write when the user's stop is processed on the loop thread.
+    real_write = pathlib.Path.write_text
+
+    def stopping_write(self, *args, **kwargs):
+        if "stage_1_result" in self.name:
+            slot._orch_tracker.stop()
+            slot._auto_run = False
+        return real_write(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "write_text", stopping_write)
+
+    await _stage_loop(state, slot, auto_run=True)
+
+    assert executed == [1], (
+        "stage 2 executed after the user's stop landed during the stage-1 "
+        "result write -- the loop must re-check the stop flags after the "
+        "offloaded write instead of advancing on a stale snapshot"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_capture_never_publishes_the_stage_file(tmp_path, monkeypatch):
+    """A cancelled capture must leave the canonical stage file untouched.
+
+    ``asyncio.to_thread`` cannot interrupt a worker mid-syscall, so a
+    cancelled await abandons a still-running writer. If that writer owned
+    the canonical ``stage_N_result.md``, its bytes could land AFTER a
+    resumed plan (or a new slot reusing the key) wrote its own result —
+    silent corruption. The structural guarantee pinned here: the worker
+    only ever writes a uniquely-named temp file, and publication to the
+    canonical path happens on the loop thread strictly after an uncancelled
+    return. An abandoned worker's entire blast radius is an orphan temp
+    file.
+    """
+    import asyncio
+    import threading
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+    slot = _slot_with("slow stage output")
+
+    session_dir = tmp_path / "sessions" / slot.key
+    final = session_dir / "stage_1_result.md"
+
+    started = threading.Event()
+    release = threading.Event()
+    real_write = pathlib.Path.write_text
+
+    def slow_write(self, *args, **kwargs):
+        if self.parent == session_dir:
+            started.set()
+            release.wait(timeout=10)
+        return real_write(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "write_text", slow_write)
+
+    task = asyncio.ensure_future(_capture(slot, 1))
+    for _ in range(500):
+        if started.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert started.is_set(), "the worker never reached the write -- test scaffold broke"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The new plan's result lands on the canonical path...
+    session_dir.mkdir(parents=True, exist_ok=True)
+    real_write(final, "NEW PLAN RESULT", encoding="utf-8")
+
+    # ...then the abandoned worker finishes. It must not clobber the file.
+    release.set()
+    for _ in range(500):
+        await asyncio.sleep(0.01)
+        if threading.active_count() == 1:
+            break
+    await asyncio.sleep(0.05)
+
+    assert final.read_text(encoding="utf-8") == "NEW PLAN RESULT", (
+        "an abandoned stage-result writer overwrote the canonical stage file "
+        "written by a resumed plan -- the worker must only ever write a "
+        "uniquely-named temp file, with publication happening on the loop "
+        "thread after an uncancelled return"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stage_result_publication_runs_off_the_loop_thread(tmp_path, monkeypatch):
+    """The rename that PUBLISHES the result must not run on the loop either.
+
+    ``os.replace`` reads as a free metadata-only syscall, which is why it is easy
+    to leave behind on the loop after the payload write has been offloaded. On a
+    network-backed session directory it is a round trip like any other, so it
+    stalls chat streaming, WebSocket frames and cron dispatch exactly as the
+    write did — the same ``no-blocking-call-on-event-loop`` anchor covers both.
+
+    Pinned separately from the write because the two moved at different times:
+    an implementation can satisfy the write assertion above while still
+    publishing on the loop, which is precisely the state this test was added for.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+    slot = _slot_with("stage one output")
+
+    seen_threads: list[int] = []
+    real_replace = os.replace
+    target_dir = tmp_path / "sessions" / "chat-1-stage"
+
+    def recording_replace(src, dst, *args, **kwargs):
+        dst_path = pathlib.Path(dst)
+        if dst_path.parent == target_dir and "stage_1_result" in dst_path.name:
+            seen_threads.append(threading.get_ident())
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", recording_replace)
+
+    final = await _capture(slot, 1)
+
+    assert seen_threads, (
+        "the stage result was never published through os.replace -- this test no "
+        "longer exercises publication and would pass vacuously"
+    )
+    assert threading.get_ident() not in seen_threads, (
+        "the stage result was published on the event-loop thread; the rename is "
+        "filesystem I/O and belongs in the same worker as the payload write"
+    )
+    assert (
+        pathlib.Path(final).read_text(encoding="utf-8") == "stage one output"
+    ), "publication moved off the loop but stopped producing the canonical file"
+
+
+@pytest.mark.asyncio
+async def test_no_filesystem_call_reaches_the_loop_thread(tmp_path, monkeypatch):
+    """Whole-boundary check: mkdir, write and replace are all off the loop.
+
+    The per-call tests above each pin one syscall, so a future fourth one could
+    be added on the loop without failing any of them. This asserts the boundary
+    itself rather than its current members.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+    slot = _slot_with("stage one output")
+
+    loop_thread = threading.get_ident()
+    offenders: list[str] = []
+
+    real_mkdir = pathlib.Path.mkdir
+    real_write = pathlib.Path.write_text
+    real_replace = os.replace
+    target_dir = tmp_path / "sessions" / "chat-1-stage"
+
+    def recording_mkdir(self, *args, **kwargs):
+        if threading.get_ident() == loop_thread and self == target_dir:
+            offenders.append("mkdir")
+        return real_mkdir(self, *args, **kwargs)
+
+    def recording_write(self, *args, **kwargs):
+        if threading.get_ident() == loop_thread and self.parent == target_dir:
+            offenders.append("write_text")
+        return real_write(self, *args, **kwargs)
+
+    def recording_replace(src, dst, *args, **kwargs):
+        if threading.get_ident() == loop_thread and pathlib.Path(dst).parent == target_dir:
+            offenders.append("os.replace")
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "mkdir", recording_mkdir)
+    monkeypatch.setattr(pathlib.Path, "write_text", recording_write)
+    monkeypatch.setattr(os, "replace", recording_replace)
+
+    await _capture(slot, 1)
+
+    assert offenders == [], (
+        "stage-result capture performed filesystem work on the event-loop "
+        "thread: %s" % ", ".join(offenders)
+    )


### PR DESCRIPTION
## Problem / Motivation

`_stage_loop` is async and drives the whole autopilot run, but stage-result persistence is synchronous. At every stage boundary `_capture_stage_result` calls `session_dir.mkdir(parents=True, exist_ok=True)` and `path.write_text(...)` directly on the gateway event loop.

## Why it matters

The gateway runs a single asyncio loop, so those syscalls block every other task on it for as long as they take — chat streaming, WebSocket frames, cron dispatch. It happens once per stage, so a run with several stages pays it repeatedly, and `mkdir` on a cold or networked session directory is the slower of the two.

Scope note, stated deliberately: this is a scheduling defect. I have not measured the stall duration, so the claim here is only that unrelated loop work is blocked for the duration of the write, not that the duration is large.

## What changed (motivation → approach → change)

**Motivation** — no part of stage-result persistence belongs on the loop.

**Approach** — draw the boundary at the filesystem, not at "the slow-looking calls". Everything that touches disk goes to one worker; everything that touches live slot state stays on the loop.

**Change** — the filesystem half moves into `_write_stage_result`, handed to `asyncio.to_thread`:

- **stays on the loop thread** — walking `slot.messages` back to the stage separator, collecting assistant content, `redact_exfiltration_urls` + `redact_credentials`, building `result_text`
- **crosses into the worker** — `slot.key`, `stage_num`, the finished immutable `result_text`, and an `abandoned` event; nothing else
- **runs in the worker** — `mkdir`, `write_text`, **and the publishing `os.replace`**

`slot.messages` is live mutable state; passing the slot itself would have turned a concurrent append into a cross-thread read for no benefit, so the worker never receives it.

Unchanged: the `sessions/<slot_key>/stage_<n>_result.md` path format, message ordering, redaction (still before any byte reaches disk), and failure semantics — `to_thread` re-raises, so the caller's `except OSError` still logs and continues. No retries, no dedicated executor, no filesystem abstraction.

### The publication moved too, and why the earlier reasoning did not hold

An earlier revision of this PR kept `os.replace` on the loop **on purpose**, arguing that (a) a rename is metadata-only and therefore cheap, and (b) publishing strictly after an uncancelled await made the orphan-writer class *structurally* unreachable.

(a) is false in the case this offload exists for. The session directory can be network-backed, and there a rename is a server round trip like any other call — the same stall the rest of the change removes, and the same `no-blocking-call-on-event-loop` anchor covers it. Keeping it was importing the defect back at a smaller size.

(b) is real and is preserved — by a flag instead of by placement. `asyncio.to_thread` cannot interrupt a running worker, so the worker re-reads `abandoned` immediately before it publishes, and the caller sets that event the moment its await is cancelled (stop button, slot close, slot-key reuse). A capture abandoned during the payload write unlinks its temp file and leaves `stage_N_result.md` untouched. That is the whole of the window on the slow filesystem this change targets, and it is what `test_cancelled_capture_never_publishes_the_stage_file` pins — that test is unchanged and still passes.

**What this does not claim:** the check and the rename are two operations, so a cancellation landing between them still publishes. That residual window is one already-resolved rename rather than the entire payload write. It is stated rather than claimed away, and it cannot be closed by moving the rename back to the loop — while a loop-thread rename runs, the loop is not free to observe the cancellation either.

Two production functions, one test file.

## Tests

`test/test_stage_result_off_loop.py`, eight tests:

| Test | Pins |
|---|---|
| `..._write_runs_off_the_loop_thread` | the payload write lands on a non-loop thread |
| `..._mkdir_runs_off_the_loop_thread` | so does the directory creation |
| `test_stage_result_publication_runs_off_the_loop_thread` | **new** — so does `os.replace`, pinned separately because an implementation can satisfy the write assertion while still publishing on the loop, which is exactly the state this was added for |
| `test_no_filesystem_call_reaches_the_loop_thread` | **new** — the boundary itself rather than its current members: no `mkdir`, `write_text` or `os.replace` for this stage runs on the loop thread, so a future fourth syscall cannot be added on the loop without failing something |
| `test_slot_messages_are_read_on_the_loop_thread` | the offload *stops* at the filesystem — extraction stays on the loop |
| `test_capture_preserves_path_ordering_and_redaction` | path, oldest-first ordering, credential redaction |
| `test_stop_landing_during_the_offloaded_write_does_not_advance` | a stop landing during the offloaded write halts the run before the next stage |
| `test_cancelled_capture_never_publishes_the_stage_file` | a cancelled capture leaves the canonical stage file untouched — **unchanged by this revision**, and the reason the flag exists |

Thread assertions are scoped to this stage's own directory and file, so unrelated filesystem traffic from fixtures cannot decide them, and each carries a non-empty guard so it cannot pass vacuously.

Fail-before / pass-after for the two new tests, with `chat_orchestrator.py` reverted to the previous head `16e9d15a6` and the tests left in place:

```
FAILED test_stage_result_publication_runs_off_the_loop_thread
  - AssertionError: the stage result was published on the event-loop thread; the
    rename is filesystem I/O and belongs in the same worker as the payload write
FAILED test_no_filesystem_call_reaches_the_loop_thread
  - AssertionError: stage-result capture performed filesystem work on the
    event-loop thread: os.replace

2 failed, 6 passed
```

The other six pass on **both** trees by design — including the cancellation test, which is the point: the orphan-writer guarantee is not weakened to buy the off-loop rename.

```
pytest test/test_stage_result_off_loop.py -q                                   8 passed
pytest test/test_stage_result_off_loop.py \
       test/test_completion_result_read_off_loop.py \
       test/test_display_time_redaction.py -q                                 42 passed
```

Gates: `flake8` · `isort --check-only` clean on both changed files. `test_stage_result_off_loop.py` is **not** in `.github/black-baseline.txt`, so it is held to `black` and is formatted; `chat_orchestrator.py` **is** baselined and `black --diff` reports no hunk overlapping any changed region, so it is left unformatted rather than graduated off the baseline.

## Manual verification

N/A — unit coverage sufficient: every claim here is a thread-identity or file-content property, and both are asserted directly against the real `_capture_stage_result` at the syscall boundary. Reproducing the stall by hand means running autopilot against a network-mounted session directory, which is the condition the tests encode rather than observe.

## Related Issues

Refs #1783 — only the P2 bullet "`_capture_stage_result` does blocking disk I/O on the event loop". #1783 is an umbrella tracker whose body states each remaining finding is independently shippable; every other bullet is untouched and it stays open.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — internal scheduling change, no user-facing behaviour documented
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
