### PR TITLE
fix(autopilot): offload previous-result reads

### DIFF
--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -22,14 +22,15 @@ from kiro_crew.sel import SecurityEvent, sel
 logger = logging.getLogger(__name__)
 
 
-def _build_stage_context(
+async def _build_stage_context(
     slot: "_ChatSlot",
     tracker: "OrchestrationTracker",
     stage_idx: int,
 ) -> str:
     """Build a focused context message for a single stage.
 
-    *stage_idx* is 0-based.
+    *stage_idx* is 0-based. Async because inlining the previous stages' results
+    reads them off disk, which must not block the event loop the stage runs on.
     """
     titles = getattr(slot, "_stage_titles", [])
     goal = getattr(slot, "_plan_goal", "")
@@ -42,7 +43,7 @@ def _build_stage_context(
     parts.append(tracker.status_summary(stage_idx, total, titles))
 
     # Previous stage result paths (LLM can read details via file tools)
-    prev_paths = _previous_result_paths(tracker, stage_idx)
+    prev_paths = await _previous_result_paths(tracker, stage_idx)
     if prev_paths:
         parts.append(f"## Previous Stage Results\n{prev_paths}")
 
@@ -62,17 +63,16 @@ def _build_stage_context(
     return "\n\n".join(parts)
 
 
-def _previous_result_paths(
-    tracker: "OrchestrationTracker",
-    current_idx: int,
-) -> str:
-    """Return compacted previous stage results with paths for full details."""
+def _read_previous_results(recorded: list[tuple[int, str]]) -> str:
+    """Read each recorded stage result and compact it. Blocking.
+
+    Split out so the reads can be handed to a worker thread as a unit. It takes
+    an already-materialised ``(stage_num, path)`` list rather than the tracker,
+    so nothing the event loop mutates is reachable from the worker.
+    """
     _max_per_stage = 2000
     parts: list[str] = []
-    for stage_num in range(1, current_idx + 1):
-        path_str = tracker._stage_results.get(stage_num)
-        if not path_str:
-            continue
+    for stage_num, path_str in recorded:
         p = Path(path_str)
         content = ""
         if p.exists() and not is_sensitive_path(str(p)):
@@ -101,6 +101,29 @@ def _previous_result_paths(
         else:
             parts.append(f"{header}\nFull result: `{path_str}`")
     return "\n\n".join(parts)
+
+
+async def _previous_result_paths(
+    tracker: "OrchestrationTracker",
+    current_idx: int,
+) -> str:
+    """Return compacted previous stage results with paths for full details.
+
+    Stage N inlines every earlier stage's result, so the read count grows with
+    the plan and lands at each stage boundary. ``_stage_loop`` is async, so those
+    reads are offloaded; the path list is snapshotted here first because
+    ``tracker._stage_results`` is mutated on the loop by ``record_stage_result``
+    as stages finish.
+    """
+    recorded: list[tuple[int, str]] = []
+    for stage_num in range(1, current_idx + 1):
+        path_str = tracker._stage_results.get(stage_num)
+        if path_str:
+            recorded.append((stage_num, path_str))
+    if not recorded:
+        # The first stage has nothing to inline; skip the worker hop entirely.
+        return ""
+    return await asyncio.to_thread(_read_previous_results, recorded)
 
 
 def _capture_stage_result(
@@ -243,7 +266,7 @@ async def _stage_loop(
             )
 
             # Build focused context and execute
-            context = _build_stage_context(slot, tracker, stage_idx)
+            context = await _build_stage_context(slot, tracker, stage_idx)
             context, _ = redact_exfiltration_urls(context)
             context, _ = redact_credentials(context)
             sel().log(

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -7406,7 +7406,8 @@ class TestPythonStageLoop:
             content = path.read_text(encoding="utf-8")
             assert "Result for stage" in content
 
-    def test_build_stage_context_includes_goal_and_status(self):
+    @pytest.mark.asyncio
+    async def test_build_stage_context_includes_goal_and_status(self):
         """_build_stage_context includes goal, status summary, and stage instruction."""
         from kiro_crew.context_management import OrchestrationTracker
         from kiro_crew.dashboard.chat import _build_stage_context
@@ -7417,13 +7418,14 @@ class TestPythonStageLoop:
         tracker = OrchestrationTracker()
         slot._orch_tracker = tracker
 
-        ctx = _build_stage_context(slot, tracker, stage_idx=0)
+        ctx = await _build_stage_context(slot, tracker, stage_idx=0)
         assert "Build feature X" in ctx
         assert "▶️ Stage 1: Research — execute now" in ctx
         assert "⬜ Stage 2: Implement — pending" in ctx
         assert "Stage 1 of 3" in ctx
 
-    def test_build_stage_context_includes_previous_results(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_build_stage_context_includes_previous_results(self, tmp_path, monkeypatch):
         """_build_stage_context includes paths to previous stage results."""
         monkeypatch.setattr("kiro_crew.dashboard.chat.config_dir", lambda: tmp_path)
         from kiro_crew.context_management import OrchestrationTracker
@@ -7440,7 +7442,7 @@ class TestPythonStageLoop:
         result_file.write_text("Stage 1 completed successfully")
         tracker.record_stage_result(1, str(result_file))
 
-        ctx = _build_stage_context(slot, tracker, stage_idx=1)
+        ctx = await _build_stage_context(slot, tracker, stage_idx=1)
         assert "Stage 1 completed successfully" in ctx
         assert str(result_file) in ctx
         assert "✅ Stage 1: A — completed" in ctx
@@ -7595,7 +7597,8 @@ class TestPythonStageLoop:
         ctx = run_chat_mock.call_args[0][2]
         assert "▶️ Stage 2" in ctx
 
-    def test_previous_result_paths_compaction(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_previous_result_paths_compaction(self, tmp_path, monkeypatch):
         """Long stage results are truncated with tail bias (30% head, 70% tail)."""
         monkeypatch.setattr("kiro_crew.dashboard.chat.is_sensitive_path", lambda p: False)
         from kiro_crew.context_management import OrchestrationTracker
@@ -7618,7 +7621,7 @@ class TestPythonStageLoop:
         result_file.write_text(large_content)
         tracker.record_stage_result(1, str(result_file))
 
-        loaded = _previous_result_paths(tracker, 1)
+        loaded = await _previous_result_paths(tracker, 1)
         # Should be truncated (2000 chars max per stage + header + path)
         assert len(loaded) < 3000
         assert "...[truncated]..." in loaded

--- a/test/test_previous_result_read_off_loop.py
+++ b/test/test_previous_result_read_off_loop.py
@@ -1,0 +1,213 @@
+"""Previous-stage-result reads must not run on the gateway event loop.
+
+``_stage_loop`` builds a fresh context message before every stage, and
+``_build_stage_context`` inlines the previous stages' results by reading each one
+off disk. Those reads are synchronous, and the count grows with the plan: stage N
+re-reads all N-1 earlier result files, so a long plan pays more at each boundary,
+not less.
+
+Only the filesystem work belongs off-loop. The path list comes from
+``tracker._stage_results``, which the loop mutates via ``record_stage_result``,
+so the paths are snapshotted on the loop thread and only immutable data crosses
+into the worker.
+"""
+
+from __future__ import annotations
+
+import builtins
+import inspect
+import pathlib
+import threading
+
+import pytest
+
+
+async def _context(slot, tracker, stage_idx):
+    """Drive the real production context builder, sync or async.
+
+    Tolerant of both shapes so the thread assertion is what fails on an unfixed
+    tree; a bare ``await`` against the synchronous version would raise "can't be
+    used in 'await' expression", which proves only that the symbol changed.
+    """
+    from kiro_crew.dashboard.chat_orchestrator import _build_stage_context
+
+    result = _build_stage_context(slot, tracker, stage_idx)
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
+def _fixture(tmp_path, monkeypatch, *, content="stage one output"):
+    """A slot + tracker where stage 1 has a result file on disk."""
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_orchestrator.is_sensitive_path", lambda p: False
+    )
+    from kiro_crew.context_management import OrchestrationTracker
+    from kiro_crew.dashboard.state import _ChatSlot
+
+    slot = _ChatSlot("prev-result-slot", mode="orchestrator")
+    # `_plan_stage_count` is derived from the titles, not settable.
+    slot._stage_titles = ["First", "Second"]
+
+    result_dir = tmp_path / "sessions" / "prev-result-slot"
+    result_dir.mkdir(parents=True)
+    result_file = result_dir / "stage_1_result.md"
+    result_file.write_text(content, encoding="utf-8")
+
+    tracker = OrchestrationTracker()
+    tracker.record_stage_result(1, str(result_file))
+    return slot, tracker, result_file
+
+
+@pytest.mark.asyncio
+async def test_previous_result_read_runs_off_the_loop_thread(tmp_path, monkeypatch):
+    """The small-file read path executes on some thread other than the loop's."""
+    slot, tracker, result_file = _fixture(tmp_path, monkeypatch)
+
+    seen_threads: list[int] = []
+    real_read = pathlib.Path.read_bytes
+
+    def recording_read(self, *args, **kwargs):
+        # Scoped to this stage's result file: unrelated reads run on the loop
+        # legitimately and must not decide this assertion.
+        if self == result_file:
+            seen_threads.append(threading.get_ident())
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "read_bytes", recording_read)
+
+    await _context(slot, tracker, 1)
+
+    assert seen_threads, (
+        "the stage 1 result was never read -- this test no longer exercises the "
+        "previous-result read and would pass vacuously")
+    assert threading.get_ident() not in seen_threads, (
+        "the previous stage result was read on the event-loop thread; the "
+        "filesystem work must be handed to asyncio.to_thread")
+
+
+@pytest.mark.asyncio
+async def test_previous_result_stat_runs_off_the_loop_thread(tmp_path, monkeypatch):
+    """``stat`` decides the truncation branch and is a syscall of its own."""
+    slot, tracker, result_file = _fixture(tmp_path, monkeypatch)
+
+    seen_threads: list[int] = []
+    real_stat = pathlib.Path.stat
+
+    def recording_stat(self, *args, **kwargs):
+        if self == result_file:
+            seen_threads.append(threading.get_ident())
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "stat", recording_stat)
+
+    await _context(slot, tracker, 1)
+
+    assert seen_threads, (
+        "the stage 1 result was never stat'd -- this test no longer exercises "
+        "the size probe and would pass vacuously")
+    assert threading.get_ident() not in seen_threads, (
+        "the previous stage result was stat'd on the event-loop thread; it must "
+        "be handed to asyncio.to_thread with the read")
+
+
+@pytest.mark.asyncio
+async def test_truncated_read_runs_off_the_loop_thread(tmp_path, monkeypatch):
+    """The large-file branch uses open/read/seek/read — also off-loop."""
+    slot, tracker, result_file = _fixture(tmp_path, monkeypatch, content="z" * 5000)
+
+    seen_threads: list[int] = []
+    # The truncation branch uses the BUILTIN open, not Path.open, so that is what
+    # has to be instrumented — patching Path.open records nothing and the test
+    # would report "never opened" instead of the thread it ran on.
+    real_open = builtins.open
+
+    def recording_open(file, *args, **kwargs):
+        if str(file) == str(result_file):
+            seen_threads.append(threading.get_ident())
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", recording_open)
+
+    ctx = await _context(slot, tracker, 1)
+
+    assert seen_threads, (
+        "the truncation branch never opened the file -- this test no longer "
+        "exercises the large-result path and would pass vacuously")
+    assert threading.get_ident() not in seen_threads, (
+        "the truncated read ran on the event-loop thread")
+    assert "...[truncated]..." in ctx
+
+
+@pytest.mark.asyncio
+async def test_tracker_state_is_read_on_the_loop_thread(tmp_path, monkeypatch):
+    """The offload stops at the filesystem — live tracker state is not shared.
+
+    ``tracker._stage_results`` is mutated on the loop by ``record_stage_result``
+    as each stage finishes, so the path list is snapshotted before the hop and
+    the worker never reaches the tracker.
+    """
+    slot, tracker, _ = _fixture(tmp_path, monkeypatch)
+
+    seen_threads: list[int] = []
+    real_results = tracker._stage_results
+
+    class RecordingDict(dict):
+        def get(self, *args, **kwargs):
+            seen_threads.append(threading.get_ident())
+            return super().get(*args, **kwargs)
+
+        def items(self):
+            seen_threads.append(threading.get_ident())
+            return super().items()
+
+    tracker._stage_results = RecordingDict(real_results)
+
+    await _context(slot, tracker, 1)
+
+    assert seen_threads, (
+        "tracker._stage_results was never consulted -- this test no longer "
+        "exercises the path selection and would pass vacuously")
+    assert seen_threads == [threading.get_ident()] * len(seen_threads), (
+        "tracker state was read off the event-loop thread; only the filesystem "
+        "read may cross into a worker")
+
+
+@pytest.mark.asyncio
+async def test_context_preserves_content_and_missing_file_semantics(tmp_path, monkeypatch):
+    """The offload changes scheduling only — every output contract holds."""
+    slot, tracker, result_file = _fixture(tmp_path, monkeypatch, content="stage one body")
+
+    ctx = await _context(slot, tracker, 1)
+    assert "stage one body" in ctx
+    assert f"Full result: `{result_file}`" in ctx
+
+    # A recorded path that no longer exists degrades to the path-only form.
+    tracker.record_stage_result(1, str(tmp_path / "sessions" / "gone" / "stage_1_result.md"))
+    ctx_missing = await _context(slot, tracker, 1)
+    assert "Full result:" in ctx_missing
+    assert "stage one body" not in ctx_missing
+
+
+@pytest.mark.asyncio
+async def test_sensitive_path_is_not_read(tmp_path, monkeypatch):
+    """The sensitive-path refusal still short-circuits before any read."""
+    slot, tracker, result_file = _fixture(tmp_path, monkeypatch, content="secret body")
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_orchestrator.is_sensitive_path", lambda p: True
+    )
+
+    reads: list[str] = []
+    real_read = pathlib.Path.read_bytes
+
+    def recording_read(self, *args, **kwargs):
+        reads.append(str(self))
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "read_bytes", recording_read)
+
+    ctx = await _context(slot, tracker, 1)
+
+    assert str(result_file) not in reads, "a sensitive path was read"
+    assert "secret body" not in ctx
+    assert "Full result:" in ctx


### PR DESCRIPTION
## Problem / Motivation

`_stage_loop` builds a fresh context message before every autopilot stage, and `_build_stage_context` inlines each earlier stage's result by reading it off disk — synchronously, on the gateway event loop:

```
async def _stage_loop(...)                     # chat_orchestrator.py:141
    context = _build_stage_context(...)        # :246  — sole production caller
        prev_paths = _previous_result_paths()  # :45
            p.exists() / p.stat()
            p.read_bytes()                     # small results
            open(p,"rb") / read / seek / read  # truncated results
```

`_build_stage_context` has exactly one production caller and it is inside the async loop, so every one of those syscalls lands on it.

## Why it matters

The read count grows with the plan rather than staying flat: stage N re-reads all N-1 earlier result files, so a five-stage run performs ten file reads spread across its boundaries, each up to four syscalls. Every one of them blocks the single gateway loop — chat streaming, WebSocket frames, cron dispatch — for its duration.

Stated precisely: this is a scheduling defect. I have not measured the stall, so the claim is that unrelated loop work is blocked for the duration of the reads, not that the duration is large.

## What changed

The reads move into `_read_previous_results`, handed to `asyncio.to_thread`. The boundary keeps live state on the loop:

- **loop thread** — walk `range(1, current_idx + 1)`, pull each recorded path out of `tracker._stage_results`, build an immutable `(stage_num, path)` list
- **crosses into the worker** — that list, nothing else
- **worker** — `exists`, `stat`, `read_bytes` / `open`+`seek`+`read`, and the compaction

`tracker._stage_results` is mutated on the loop by `record_stage_result` as each stage finishes, so passing the tracker into a worker would have made a concurrent record a cross-thread read for no benefit. A first stage has nothing recorded and returns early without a worker hop at all.

`_build_stage_context` becomes `async` and its single caller awaits it. `chat.py` re-exports both symbols under `noqa: F401` and calls neither, so no other production code is affected.

Unchanged: the 2000-byte budget and its 30/70 head/tail split, the sensitive-path refusal, `except (OSError, ValueError)`, which stages are injected, and the emitted text.

## Tests

New `test/test_previous_result_read_off_loop.py`, six tests:

| Test | Pins |
|---|---|
| `..._read_runs_off_the_loop_thread` | the small-file `read_bytes` lands off-loop |
| `..._stat_runs_off_the_loop_thread` | so does the size probe that picks the branch |
| `test_truncated_read_runs_off_the_loop_thread` | so does the large-file `open`/`seek`/`read` |
| `test_tracker_state_is_read_on_the_loop_thread` | the offload *stops* at the filesystem |
| `test_context_preserves_content_and_missing_file_semantics` | inlined content, and a missing path degrading to path-only |
| `test_sensitive_path_is_not_read` | the refusal still short-circuits before any read |

Thread assertions are scoped to this stage's own result file so unrelated filesystem traffic cannot decide them, and each carries a non-empty guard against a vacuous pass. The driver tolerates a sync or async `_build_stage_context` deliberately: a bare `await` against the old signature would raise "can't be used in 'await' expression", which proves the symbol changed rather than that a read was mis-scheduled.

The truncation test instruments the **builtin** `open`, not `Path.open`, because that is what the production branch calls — patching `Path.open` records nothing and reports "never opened" instead of the thread.

- **Fail-before on `85cf65b22`: 3 failed, 3 passed.** All three failures are the real thread assertions; the three preservation tests pass on both sides.
- **Pass-after: 6 passed.**
- Three existing direct callers in `test_dashboard_chat.py` updated to `await` the real functions; no assertion weakened.
- Adjacent `test_dashboard_chat.py`, which drives `_stage_loop` end to end: **563 passed, 1 skipped**.
- flake8, isort, mypy (`chat_orchestrator.py`, no issues), docs lint (207 files), brand gate, harness-parity gate, `git diff --check`: all clean.

## Screenshots / video

<!-- no-visual-delta -->

Backend scheduling only. No component, markup, copy, style or catalog string changed.

## Related Issues

None. Self-discovered while scoping #3771 (the sibling stage-result *write*), and deliberately not filed against #1783 — that umbrella tracker does not list previous-result reads as one of its bullets, so claiming it would misattribute the finding. The reproduction above stands on its own.
