### PR TITLE
refactor(acp): convert harness-identity negatives to positive form (KAS Group C)

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -46,6 +46,7 @@ from kiro_crew.acp.liveness import VERDICT_UNKNOWN, VERDICT_WORKING, LivenessOra
 from kiro_crew.acp.prompt_blocks import build_prompt_blocks
 from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_KIRO,
     ACP_BACKENDS_INTERNAL_SANDBOX,
     ACP_BACKENDS_STEER,
     ACP_CLIENT_CAPABILITIES,
@@ -2097,6 +2098,17 @@ class AcpClient:
     def _is_claude(self) -> bool:
         return self.backend == ACP_BACKEND_CLAUDE
 
+    @property
+    def _is_kiro(self) -> bool:
+        """True when this client drives kiro-cli (the AcpClient default).
+
+        AcpClient serves exactly two backends — kiro-cli and the dormant claude
+        seam — so this is the positive spelling of the sites that used to read
+        ``not self._is_claude`` (harness-parity H5). KAS runs on AcpRuntime, not
+        AcpClient, so it never reaches this property.
+        """
+        return self.backend == ACP_BACKEND_KIRO
+
     def _pooled_mcp_servers(self) -> list[dict[str, Any]]:
         """Broker-stub ``mcpServers`` entries for this session's ``session/new``.
 
@@ -2211,7 +2223,7 @@ class AcpClient:
         # instead of calling into here — otherwise the same stale setting that is
         # quietly withheld on a cold start would raise and kill a warm claim,
         # making the outcome depend on whether a pooled process happened to exist.
-        if not self._is_claude and self._model_is_unusable(model_id):
+        if self._is_kiro and self._model_is_unusable(model_id):
             _rejected_log, _ = redact_exfiltration_urls(str(model_id))
             _rejected_log, _ = redact_credentials(_rejected_log)
             raise AcpModelUnavailable(_rejected_log, self._advertised_model_ids())
@@ -2326,7 +2338,7 @@ class AcpClient:
         if not self._model or self._model == DEFAULT_MODEL:
             logger.info("ACP model: %s (from agent config)", self._model or "auto")
             return
-        if not self._is_claude and self._model_is_unusable(self._model):
+        if self._is_kiro and self._model_is_unusable(self._model):
             _withheld_log, _ = redact_exfiltration_urls(str(self._model))
             _withheld_log, _ = redact_credentials(_withheld_log)
             logger.warning(
@@ -2627,7 +2639,7 @@ class AcpClient:
         # ONE thread hop. Guarded: the sandbox temp file is live, so a
         # cancellation here must not orphan it.
         env = await self._to_thread_guarding_sandbox(
-            functools.partial(_resolve_spawn_env, kiro_api_key=not self._is_claude), env
+            functools.partial(_resolve_spawn_env, kiro_api_key=self._is_kiro), env
         )
         # Positive-identity marker for the orphan sweep: kiro-cli and every MCP
         # server it spawns inherit this, so escaped launcher trees (``npx
@@ -3192,7 +3204,7 @@ class AcpClient:
 
         # Seek to end of JSONL so we only read new tool results.
         # claude-agent-acp stores sessions via its own SDK, not ~/.kiro/ — skip.
-        if self._session_id and not self._is_claude:
+        if self._session_id and self._is_kiro:
             _jpath = kiro_sessions_dir() / f"{self._session_id}.jsonl"
             try:
                 self._jsonl_pos = _jpath.stat().st_size if _jpath.exists() else 0
@@ -3208,7 +3220,7 @@ class AcpClient:
         #    default (broader) mode, which for a restricted agent is a privilege
         #    escalation. Self-heal (B, in _spawn) regenerates the managed default
         #    so the common case never reaches this branch.
-        if not self._is_claude:
+        if self._is_kiro:
             if not self._modes_advertised or self._agent in self._available_mode_ids:
                 await self._send_request(
                     METHOD_SET_MODE,

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -882,7 +882,7 @@ class AcpRuntime:
                 strip_kiro_cli_api_key,
             )
 
-            if self._acp_backend != ACP_BACKEND_KAS:
+            if self._acp_backend == ACP_BACKEND_KIRO:
                 inject_kiro_cli_api_key(env)
             else:
                 strip_kiro_cli_api_key(env)

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -165,6 +165,20 @@ ACP_BACKENDS_STEER = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
 # qualifies; a Node or Python harness does not, however it is spawned.
 ACP_BACKENDS_INTERNAL_SANDBOX = frozenset({ACP_BACKEND_KIRO})
 
+# Backends served by AcpRuntime + AcpSessionHandle — the kiro-agent family
+# (kiro-cli and KAS) whose single process hosts N sessions via demux. The
+# dormant claude-agent-acp seam runs one AcpClient per session and is NOT a
+# member. Membership drives the shared runtime start path and the kiro-family
+# spawn conventions: members read the cli.json effort/tool-search overlay and
+# receive effort at spawn, whereas claude applies it via a live push after the
+# session is ready. Stated as opt-in membership (harness-parity H5/H6) so the
+# four sites that mean "kiro or kas" say so positively rather than as
+# ``not is_claude_backend`` — an inference that silently captures every harness
+# added later. This is a SUPERSET of ACP_BACKENDS_SESSION_SHARING: running on
+# AcpRuntime is necessary for session sharing but not sufficient (KAS runs here
+# yet is excluded from sharing until keep-aware teardown lands).
+ACP_BACKENDS_ACP_RUNTIME = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
+
 # ── Provider labels ──
 # The backend identity key persisted in the session map. It indexes three
 # things, so every producer must agree on it: resume compatibility

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -26,6 +26,7 @@ from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
     ACP_BACKEND_KAS,
     ACP_BACKEND_KIRO,
+    ACP_BACKENDS_ACP_RUNTIME,
     ACP_BACKENDS_KNOWN,
     ACP_BACKENDS_SESSION_SHARING,
     EVENT_COMPACTION_STATUS,
@@ -357,7 +358,7 @@ class AcpProvider(LLMProvider):
             if tool_search_min_tokens is None
             else tool_search_min_tokens
         )
-        if not self.is_claude_backend:
+        if self.is_acp_runtime_backend:
             # Recover overlay-persisted levels (server-restart resilience) and
             # write the overlay BEFORE the first spawn so kiro-cli reads it on
             # session/new. Caller-provided overrides win — only fill gaps.
@@ -431,6 +432,19 @@ class AcpProvider(LLMProvider):
         captures every future backend.
         """
         return self._client.backend == ACP_BACKEND_KIRO
+
+    @property
+    def is_acp_runtime_backend(self) -> bool:
+        """True when this provider is served by AcpRuntime (kiro-cli or KAS).
+
+        Membership in ``ACP_BACKENDS_ACP_RUNTIME`` (harness-parity H5). Names
+        the "kiro or kas" set positively so the shared-runtime start path, the
+        cli.json overlay recovery, and the skip-live-effort branch stop being
+        spelled ``not is_claude_backend`` — which would hand the kiro-family
+        path to every harness added later. The dormant claude AcpClient seam is
+        not a member.
+        """
+        return self._client.backend in ACP_BACKENDS_ACP_RUNTIME
 
     @property
     def is_session_sharing_eligible(self) -> bool:
@@ -1035,7 +1049,7 @@ class AcpProvider(LLMProvider):
             # Roll back to the prior state before propagating to the caller.
             if _prev is None:
                 self._effort_per_model.pop(model, None)
-                if not self.is_claude_backend:
+                if self.is_acp_runtime_backend:
                     _clear_cli_overlay_effort(self._client._work_dir, model)
             else:
                 self._effort_per_model[model] = _prev
@@ -1096,7 +1110,7 @@ class AcpProvider(LLMProvider):
         self._apply_effort_overlay()
         self._apply_tool_search_overlay()
 
-        if not self.is_claude_backend:
+        if self.is_acp_runtime_backend:
             # ── Kiro unified path: AcpRuntime + AcpSessionHandle ──
             # Spawn a runtime, create/resume a session, wrap in
             # AcpSessionProvider. One process hosts parent + all subagent
@@ -1119,7 +1133,7 @@ class AcpProvider(LLMProvider):
         must not break session start. The kiro backend already gets effort
         from the cli.json overlay at spawn, so this is a no-op there.
         """
-        if not self.is_claude_backend:
+        if self.is_acp_runtime_backend:
             return
         level = self._resolve_effort()
         if not level:

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -96,7 +96,11 @@ if TYPE_CHECKING:
 
 from kiro_crew import model_registry, platform_compat, shutdown_event
 from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
-from kiro_crew.acp.types import PROVIDER_LABEL_CLAUDE, PROVIDER_LABEL_DEFAULT
+from kiro_crew.acp.types import (
+    ACP_BACKEND_CLAUDE,
+    PROVIDER_LABEL_CLAUDE,
+    PROVIDER_LABEL_DEFAULT,
+)
 from kiro_crew.agent import kiro_agents_dir_path
 from kiro_crew.agent_discovery import spec_model
 from kiro_crew.config import KiroCrewConfig
@@ -176,7 +180,7 @@ def _is_claude_backend(provider: Any) -> bool:
     if not isinstance(provider, AcpProvider):
         return False
     backend = getattr(provider.client, "backend", "")
-    return backend == "claude"
+    return backend == ACP_BACKEND_CLAUDE
 
 
 def _provider_label(provider: Any) -> str:

--- a/test/test_acp_backend_kas.py
+++ b/test/test_acp_backend_kas.py
@@ -55,18 +55,21 @@ class TestBackendPredicates:
         assert provider.is_kiro_backend is True
         assert provider.is_kas_backend is False
         assert provider.is_claude_backend is False
+        assert provider.is_acp_runtime_backend is True
 
     def test_kas_backend(self):
         provider = _build_provider(ACP_BACKEND_KAS)
         assert provider.is_kas_backend is True
         assert provider.is_kiro_backend is False
         assert provider.is_claude_backend is False
+        assert provider.is_acp_runtime_backend is True
 
     def test_claude_backend_unchanged(self):
         provider = _build_provider(ACP_BACKEND_CLAUDE)
         assert provider.is_claude_backend is True
         assert provider.is_kiro_backend is False
         assert provider.is_kas_backend is False
+        assert provider.is_acp_runtime_backend is False
 
     @pytest.mark.parametrize("backend", sorted(ACP_BACKENDS_KNOWN))
     def test_exactly_one_predicate_holds_for_every_known_backend(self, backend):
@@ -77,6 +80,14 @@ class TestBackendPredicates:
             provider.is_kas_backend,
         ]
         assert sum(held) == 1
+
+    @pytest.mark.parametrize("backend", sorted(ACP_BACKENDS_KNOWN))
+    def test_acp_runtime_backend_is_the_positive_form_of_not_claude(self, backend):
+        # The four provider sites that used to read ``not is_claude_backend``
+        # now read ``is_acp_runtime_backend``; the two must stay equivalent for
+        # every known backend so the conversion is behavior-preserving.
+        provider = _build_provider(backend)
+        assert provider.is_acp_runtime_backend is (not provider.is_claude_backend)
 
 
 class TestUnknownBackendRejected:

--- a/test/test_harness_parity.py
+++ b/test/test_harness_parity.py
@@ -29,6 +29,7 @@ from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
     ACP_BACKEND_KAS,
     ACP_BACKEND_KIRO,
+    ACP_BACKENDS_ACP_RUNTIME,
     ACP_BACKENDS_INTERNAL_SANDBOX,
     ACP_BACKENDS_KNOWN,
     ACP_BACKENDS_SELECTABLE,
@@ -185,6 +186,7 @@ def test_capability_sets_are_subsets_of_known_backends() -> None:
         ("ACP_BACKENDS_SESSION_SHARING", ACP_BACKENDS_SESSION_SHARING),
         ("ACP_BACKENDS_STEER", ACP_BACKENDS_STEER),
         ("ACP_BACKENDS_INTERNAL_SANDBOX", ACP_BACKENDS_INTERNAL_SANDBOX),
+        ("ACP_BACKENDS_ACP_RUNTIME", ACP_BACKENDS_ACP_RUNTIME),
     ):
         assert members <= ACP_BACKENDS_KNOWN, f"{name} names an unknown backend"
 


### PR DESCRIPTION
## What

KAS **Group C** — close the pre-existing harness-parity **negative-identity backlog**. Eleven production sites expressed "the Kiro harness" as the *absence* of another harness (`not self._is_claude`, `!= ACP_BACKEND_KAS`, `== "claude"`). Each now tests identity **positively**, so a harness added later cannot silently inherit a branch by default (harness-parity **H5 / H8**).

This is exactly the "separate conversion change" that `docs/ci/harness-parity-gate.md` references as the reason the added-line gate is diff-scoped. Before: `check_harness_parity.py` reported 11 whole-tree negatives. After: **"Kiro identity tested positively in the whole tree ✓"**.

## Changes

| File | Sites | Conversion |
|---|---|---|
| `acp/client.py` | 5 | AcpClient serves `{kiro, claude}`; add positive `_is_kiro`; `not self._is_claude` → `self._is_kiro` (model preflight ×2, `set_mode` activation, jsonl seek, spawn-env kiro api-key) |
| `providers/acp.py` | 4 | AcpProvider serves `{kiro, kas, claude}`; `not self.is_claude_backend` gated "served by AcpRuntime" = `{kiro, kas}` → new named set **`ACP_BACKENDS_ACP_RUNTIME`** via `is_acp_runtime_backend` (overlay recovery, effort rollback, runtime start path, initial-effort skip) |
| `acp/runtime.py` | 1 | kiro-cli api-key inject/strip: `!= ACP_BACKEND_KAS` → `== ACP_BACKEND_KIRO` (identical over `{kiro, kas}`; fails **safe** to strip for any future backend) |
| `session.py` | 1 | bare literal `backend == "claude"` → `== ACP_BACKEND_CLAUDE` |
| `acp/types.py` | — | define `ACP_BACKENDS_ACP_RUNTIME = {KIRO, KAS}` (superset of `ACP_BACKENDS_SESSION_SHARING`) |

**Behavior-preserving.** No symbol is renamed or removed — `_is_claude`, `is_claude_backend`, and `session._is_claude_backend` all stay, so no monkeypatch/mock target moves. The `client.py` sites are the AcpClient `{kiro, claude}` path (KAS runs on AcpRuntime, never reaches them), so those are pure legibility with zero KAS impact.

## Tests

- `test_harness_parity.py`: `ACP_BACKENDS_ACP_RUNTIME` registered in the subset-of-known pin. H5/H6/H7 validators pass (they assert the absence of the negatives this PR removes).
- `test_acp_backend_kas.py`: `is_acp_runtime_backend` pinned across the predicate tests, plus a parametrized invariant that `is_acp_runtime_backend == (not is_claude_backend)` for **every** known backend — proving the conversion is equivalent.

## Verification (local, CI-parity venv, no faiss)

- harness-parity scanner: whole-tree ✓
- `isort` ✓ · `flake8` ✓ · `mypy` ✓ (970 files)
- targeted suite (harness_parity, acp_backend_kas, acp_provider, acp_provider_cov80, acp_client, acp_client_more_coverage, provider_dispatch, session, session_coverage, credential_scrub_sync): **1107 passed**
- full backend suite: the only failures are host-environment (`unshare(CLONE_NEWUSER) EPERM`, missing `gh` CLI, git remotes) in apps/infra tests — none in acp/session/providers, and they pass on CI runners.

## Deferred (follow-up, not this PR)

The H14 getattr/hasattr probe bucket. Investigation found those sites are mostly **defensive double-guards** (`session.py` deliberately guards `AsyncMock`/stub doubles — must not be removed) or **already safe** (the ABC already declares `served_model`, `context_*`, `exit_code`, `session_id`, etc.). Declaring the remaining capabilities on the `LLMProvider` ABC has a `MagicMock(spec=)` footgun and is a review-only invariant — it deserves its own focused PR.

Part of the KAS ACP backend roadmap (Group A #3621, Group B #3666 merged; Group D in a parallel branch).
