### PR TITLE
fix: unlink temp files when queued entries are discarded (#3768)

### DIFF
--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -250,7 +250,7 @@ Slack `file_share` messages are processed in `_route_message()` after dedup + au
 - **Mimetypes**: `image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/bmp` (aligned with `AcpClient._send_prompt()` regex)
 - **Size limit**: 10 MB (checked from Slack metadata before download)
 - **Flow**: Download to temp file → inject local path into message text → `_send_prompt()` detects path, base64-encodes, sends as `{"type": "image"}` content block to kiro-cli
-- **Temp lifecycle**: Caller (`_route_message`) owns cleanup. Done callback on `handle_message` task cleans up after `_send_prompt()` reads the file. Early-return paths and `create_task` failures also clean up.
+- **Temp lifecycle**: Caller (`_route_message`) owns cleanup. Done callback on `handle_message` task cleans up after `_send_prompt()` reads the file. Early-return paths and `create_task` failures also clean up. Queued messages carry their paths in the entry's `image_temp_paths` kwargs; `_dispatch_queued` unlinks after the turn consumes them, and the queue-discard paths — `cancel_queued`, `clear_queue`, `dequeue`'s cancelled-skip, and the `_pending_queue` drops in `_handle_message_deleted` and the `!stop` handler — unlink via `session.unlink_queued_temp_paths()` so entries that never dispatch don't leak files. Known gap: session-teardown paths (restart/remove/destroy/idle sweep) drop `session.queue` without unlinking.
 - **Unsupported image types** (`image/svg+xml`, `image/tiff`, etc.) fall through to unsupported handler — metadata note only, no download
 
 ### Text / Code Files (`files.py`)

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -748,6 +748,24 @@ class _ProviderBgSession:
         self._release()
 
 
+def unlink_queued_temp_paths(kwargs: dict) -> None:
+    """Unlink the temp files a queue entry tracks in ``image_temp_paths``.
+
+    Queued Slack messages defer temp-image cleanup to whichever code path
+    consumes the entry, so the queued turn's text can still resolve its image
+    paths at dispatch time. Every path that consumes an entry — dispatch, or
+    any discard (cancel, queue clear, cancelled-skip on dequeue) — must unlink
+    here, or the files sit on disk until external cleanup. Already-missing
+    files are ignored: a discard can benignly follow a dispatch that already
+    cleaned up.
+    """
+    for p in kwargs.get("image_temp_paths") or []:
+        try:
+            os.unlink(p)
+        except OSError:
+            pass
+
+
 class SessionManager:
     """Thread-keyed LLM provider pool with warm session pre-spawning."""
 
@@ -4172,6 +4190,9 @@ class SessionManager:
             if msg_ts not in session.cancelled:
                 return msg_ts, text, kwargs
             session.cancelled.discard(msg_ts)
+            # A skipped entry never reaches _dispatch_queued's cleanup, so its
+            # temp files must be unlinked here or they leak.
+            unlink_queued_temp_paths(kwargs)
         return None
 
     def cancel_queued(self, key: str, msg_ts: str) -> bool:
@@ -4184,8 +4205,11 @@ class SessionManager:
         session = self._sessions.get(key)
         if not session:
             return False
-        for i, (ts, _, _) in enumerate(session.queue):
+        for i, (ts, _, kwargs) in enumerate(session.queue):
             if ts == msg_ts:
+                # The entry will never reach _dispatch_queued's cleanup, so its
+                # temp files must be unlinked here or they leak.
+                unlink_queued_temp_paths(kwargs)
                 del session.queue[i]
                 return True
         # Not in queue — only mark cancelled if something is actually in-flight
@@ -4205,10 +4229,16 @@ class SessionManager:
         return False
 
     def clear_queue(self, key: str) -> None:
-        """Clear all queued messages and cancelled set for a session."""
+        """Clear all queued messages and cancelled set for a session.
+
+        Unlinks each discarded entry's temp files: cleared entries never reach
+        ``_dispatch_queued``'s cleanup, so skipping this leaks them on disk.
+        """
         key = self._fold_key(key)
         session = self._sessions.get(key)
         if session:
+            for _, _, kwargs in session.queue:
+                unlink_queued_temp_paths(kwargs)
             session.queue.clear()
             session.cancelled.clear()
 

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -56,6 +56,7 @@ from kiro_crew.security import (
     should_record_observe_history,
 )
 from kiro_crew.sel import sel
+from kiro_crew.session import unlink_queued_temp_paths
 from kiro_crew.skills import SkillsLoader
 from kiro_crew.slack.allowlist import prompt_track_channel, send_dashboard_link
 from kiro_crew.slack.blocks import (
@@ -1543,6 +1544,11 @@ async def _handle_message_deleted(orch: GatewayOrchestrator, event: dict) -> Non
             _filtered = [item for item in _pq if item[0] != deleted_ts]
             if len(_filtered) < len(_pq):
                 was_queued = True
+                # Dropped entries never reach _dispatch_queued's cleanup, so
+                # their temp files must be unlinked here or they leak.
+                for item in _pq:
+                    if item[0] == deleted_ts:
+                        unlink_queued_temp_paths(item[2])
                 if _filtered:
                     orch._pending_queue[_del_session_key] = _filtered
                 else:
@@ -1656,11 +1662,7 @@ async def _dispatch_queued(
         # turn's text could still resolve its image paths (see _route_message).
         # Unlink them now that the turn has consumed them — in finally so a
         # raising turn can't leak the temp files.
-        for _p in kwargs.get("image_temp_paths") or []:
-            try:
-                os.unlink(_p)
-            except OSError:
-                pass
+        unlink_queued_temp_paths(kwargs)
 
 
 # Maximum characters to recover from block extraction (DoS guard).
@@ -2309,7 +2311,10 @@ async def _route_message(
         active_task = orch._session_tasks.pop(session_key, None)
         if has_session or active_task:
             orch.sessions.clear_queue(session_key)
-            orch._pending_queue.pop(session_key, None)
+            # Dropped pending (pre-session) entries never reach
+            # _dispatch_queued's cleanup, so unlink their temp files here.
+            for _item in orch._pending_queue.pop(session_key, None) or []:
+                unlink_queued_temp_paths(_item[2])
 
             # Post ephemeral "Stopping…" block with Kill Now button
             if orch.slack:

--- a/test/test_message_queue.py
+++ b/test/test_message_queue.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kiro_crew.session import SessionManager, _Session
+from kiro_crew.session import SessionManager, _Session, unlink_queued_temp_paths
 
 # ── Unit tests for _Session queue fields ──
 
@@ -220,6 +221,30 @@ class TestHandleMessageDeleted:
              patch("kiro_crew.slack.events.sel"):
             await _handle_message_deleted(orch, event)
         assert orch._pending_queue == {"thread1": [("ts_other", "keep", {})]}
+
+    @pytest.mark.asyncio
+    async def test_pending_queue_drop_unlinks_temp_files(self, tmp_path):
+        """A pre-session entry dropped by message_deleted must unlink its temps."""
+        from kiro_crew.slack.events import _handle_message_deleted
+
+        dropped = tmp_path / "dropped.png"
+        dropped.write_bytes(b"fake")
+        kept = tmp_path / "kept.png"
+        kept.write_bytes(b"fake")
+        orch = self._make_orch()
+        orch._pending_queue = {
+            "thread1": [
+                ("ts_del", "hello", {"image_temp_paths": [str(dropped)]}),
+                ("ts_other", "keep", {"image_temp_paths": [str(kept)]}),
+            ]
+        }
+        event = self._make_event()
+        with patch("kiro_crew.slack.events.is_allowed_user", return_value=True), \
+             patch("kiro_crew.slack.events.sel"):
+            await _handle_message_deleted(orch, event)
+        assert not dropped.exists()
+        assert kept.exists()
+        assert len(orch._pending_queue["thread1"]) == 1
 
     @pytest.mark.asyncio
     async def test_pending_queue_cleaned_when_empty(self):
@@ -620,3 +645,100 @@ class TestQueuedMessageImagePaths:
 
         assert seen_paths["existed_at_dispatch"] is True  # survived until the turn
         assert not img.is_file()  # cleaned up afterwards (no leak)
+
+
+# ── Regression tests: discarded queue entries unlink their temp files ──
+
+
+class TestQueueTempFileCleanup:
+    """Discard paths must unlink image_temp_paths; the dispatch path must not."""
+
+    @staticmethod
+    def _temp_files(tmp_path, n: int = 2) -> list[str]:
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        paths = []
+        for i in range(n):
+            p = tmp_path / f"img{i}.png"
+            p.write_bytes(b"fake")
+            paths.append(str(p))
+        return paths
+
+    def test_cancel_queued_unlinks_temp_files(self, tmp_path):
+        mgr, sess = TestSessionManagerQueue._make_mgr()
+        paths = self._temp_files(tmp_path)
+        sess.queue.append(("ts1", "hello", {"image_temp_paths": paths}))
+        assert mgr.cancel_queued("thread1", "ts1") is True
+        assert len(sess.queue) == 0
+        for p in paths:
+            assert not os.path.exists(p)
+
+    def test_cancel_queued_leaves_other_entries_files(self, tmp_path):
+        mgr, sess = TestSessionManagerQueue._make_mgr()
+        cancelled_paths = self._temp_files(tmp_path / "a")
+        kept_paths = self._temp_files(tmp_path / "b")
+        sess.queue.append(("ts1", "cancel me", {"image_temp_paths": cancelled_paths}))
+        sess.queue.append(("ts2", "keep me", {"image_temp_paths": kept_paths}))
+        assert mgr.cancel_queued("thread1", "ts1") is True
+        for p in cancelled_paths:
+            assert not os.path.exists(p)
+        for p in kept_paths:
+            assert os.path.exists(p)
+
+    def test_clear_queue_unlinks_all_entries_temp_files(self, tmp_path):
+        mgr, sess = TestSessionManagerQueue._make_mgr()
+        paths1 = self._temp_files(tmp_path / "e1")
+        paths2 = self._temp_files(tmp_path / "e2")
+        sess.queue.append(("ts1", "one", {"image_temp_paths": paths1}))
+        sess.queue.append(("ts2", "two", {"image_temp_paths": paths2}))
+        mgr.clear_queue("thread1")
+        assert len(sess.queue) == 0
+        for p in paths1 + paths2:
+            assert not os.path.exists(p)
+
+    def test_dequeue_cancelled_skip_unlinks_temp_files(self, tmp_path):
+        mgr, sess = TestSessionManagerQueue._make_mgr()
+        paths = self._temp_files(tmp_path)
+        sess.queue.append(("ts1", "cancelled", {"image_temp_paths": paths}))
+        sess.queue.append(("ts2", "live", {}))
+        sess.cancelled.add("ts1")
+        result = mgr.dequeue("thread1")
+        assert result is not None
+        assert result[0] == "ts2"
+        for p in paths:
+            assert not os.path.exists(p)
+
+    def test_dequeue_returned_entry_keeps_temp_files(self, tmp_path):
+        """The dispatch path owns cleanup; dequeue must NOT unlink what it returns."""
+        mgr, sess = TestSessionManagerQueue._make_mgr()
+        paths = self._temp_files(tmp_path)
+        sess.queue.append(("ts1", "live", {"image_temp_paths": paths}))
+        result = mgr.dequeue("thread1")
+        assert result is not None
+        assert result[0] == "ts1"
+        for p in paths:
+            assert os.path.exists(p)
+
+    def test_already_missing_files_do_not_raise(self, tmp_path):
+        mgr, sess = TestSessionManagerQueue._make_mgr()
+        missing = [str(tmp_path / "gone1.png"), str(tmp_path / "gone2.png")]
+        sess.queue.append(("ts1", "hello", {"image_temp_paths": missing}))
+        assert mgr.cancel_queued("thread1", "ts1") is True
+        sess.queue.append(("ts2", "world", {"image_temp_paths": missing}))
+        mgr.clear_queue("thread1")  # must not raise either
+        assert len(sess.queue) == 0
+
+    def test_entries_without_temp_paths_are_fine(self):
+        mgr, sess = TestSessionManagerQueue._make_mgr()
+        sess.queue.append(("ts1", "no kwargs key", {}))
+        sess.queue.append(("ts2", "none value", {"image_temp_paths": None}))
+        assert mgr.cancel_queued("thread1", "ts1") is True
+        mgr.clear_queue("thread1")
+        assert len(sess.queue) == 0
+
+    def test_unlink_helper_directly(self, tmp_path):
+        p = tmp_path / "img.png"
+        p.write_bytes(b"fake")
+        unlink_queued_temp_paths({"image_temp_paths": [str(p)]})
+        assert not p.exists()
+        unlink_queued_temp_paths({"image_temp_paths": [str(p)]})  # idempotent
+        unlink_queued_temp_paths({})  # no key


### PR DESCRIPTION
## Summary

`SessionManager.cancel_queued` and `clear_queue` discarded queued Slack message entries without unlinking the temp files tracked in each entry's `image_temp_paths` kwargs. Only `_dispatch_queued`'s `finally` block performed cleanup, so entries that never reached dispatch leaked their temp files (up to 10 MB each) until external cleanup. Auditing the whole defect class surfaced two more discard sites: `dequeue`'s cancelled-skip path, and both drops of the pre-session `orch._pending_queue` (the `message_deleted` fallback and the `!stop` handler).

Closes #3768

## Changes

- **`src/kiro_crew/session.py`**: new module-level `unlink_queued_temp_paths()` helper (mirrors the pre-existing `_dispatch_queued` pattern: `os.unlink` with `OSError` swallowed, so already-missing files stay benign). Called on all three `SessionManager` discard paths: `cancel_queued`, `clear_queue`, and `dequeue`'s cancelled-skip.
- **`src/kiro_crew/slack/events.py`**: `_dispatch_queued`'s consume-path cleanup now reuses the helper; both `_pending_queue` discard sites (`_handle_message_deleted` fallback, `!stop` handler) unlink before dropping entries.
- **`docs/system-specs/modules/slack-gateway.md`**: temp-lifecycle section documents the discard-path cleanup and names the one known remaining gap (session-teardown queue drops), deferred to a follow-up issue.
- **`test/test_message_queue.py`**: 9 regression tests — cancel unlinks, clear unlinks all, cancelled-skip unlinks, dispatch-bound entries keep their files, already-missing files don't raise, entries without paths are fine, helper idempotence, and the pending-queue drop path.

## Testing

- `python -m pytest` full suite: 53805 passed; 92 failures verified pre-existing/environmental (reproduce at pristine main: sandbox-unavailable, uid-65534, occupied port 7778)
- `isort` / `flake8` / `mypy`: clean
- Pre-push reviews: GPT (gpt-5.6-sol) 1 Medium and Opus (claude-opus-5) 1 BLOCKING — both independently flagged the `_pending_queue` residual, fixed here. Opus Low (session-teardown queue drops) accepted and deferred with doc disclosure.

## Out of scope

Session-teardown paths (restart / remove / destroy / idle sweep) drop `session.queue` without unlinking. Deferred to a follow-up issue: those sites need a shared teardown helper and interact with in-flight-turn ownership, so they warrant their own review.
