### PR TITLE
feat: render the app storefront from the published catalog

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -638,3 +638,32 @@ resolution), `dashboard/state.py` (`_send_ws_all`, `_ws_client_allowed`,
 for developer-facing diagnostics, drift-guarded by
 `website/src/test/appSdkEventScope.test.ts`). Runtime-facing summary for app
 authors: [../../../src/kiro_crew/docs/app-platform-trust-model.md](../../../src/kiro_crew/docs/app-platform-trust-model.md).
+
+## 14. The storefront reads the published catalog's display fields
+
+`GET /api/apps/registry` answers from the published catalog when it is reachable:
+`handle_registry` prefers `list_catalog_apps` (`registry.py`), which maps the
+published `official-registry.json` entries through
+`official_catalog.list_catalog_rows` and then applies the same install-status and
+trust stamping as the seed path. The bundled `app-registry.json` seed and the
+per-app `app.json` fetch are the OFFLINE FALLBACK, not the live source: a
+reachable catalog means the store renders the published document's list and
+display copy, and an unreachable one degrades to the seed listing.
+
+The catalog is trusted only as far as TLS, so `list_catalog_rows` emits DISPLAY
+fields only — identity, display name, summary, version, tags, author, and asset
+refs. It never emits clone coordinates (`gitUrl`/`repo`/`branch`) and never emits
+`origin`, so a compromised document cannot point an install at attacker-selected
+code with gateway credentials nor forge a first-party provenance claim. Install
+continues to resolve through the seed and external registries, and `verified`
+stays `false` for a catalog `git` app until the catalog signature is checked:
+wiring signature verification into `official_catalog` is what flips that, not a
+field the catalog can assert about itself.
+
+A name is a filesystem path on install, so `list_catalog_rows` drops any entry
+whose name is not kebab-case (`KEBAB_RE.fullmatch`), and the catalog fetch runs
+off the event loop (`asyncio.to_thread`) so a cache-expired request never blocks
+the gateway loop.
+
+Writers: `apps/official_catalog.py` (`list_catalog_rows`),
+`apps/registry.py` (`list_catalog_apps`), `apps/routes.py` (`handle_registry`).

--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -21,11 +21,14 @@ instead of degrading silently:
   list non-empty is REFUSED outright and the client falls back to the seed. A
   withdrawn app must never be rendered because we skipped the mechanism that
   withdraws it.
-- **No new inventory.** Every entry annotates a row that already exists (a
-  built-in discovered from disk, or a seed-index row). A published ``git`` source
-  is pinned to a COMMIT, and the install path clones with ``--branch``, which a
-  commit id is not -- so adding installable entries needs that path changed
-  first. An entry matching nothing is ignored.
+- **Display-only inventory.** ``list_catalog_rows`` maps the published list's
+  DISPLAY fields (identity, name, summary, version, tags, author, asset refs)
+  into storefront rows. It emits no clone coordinates and no ``origin``, because
+  the catalog is trusted only as far as TLS: install coordinates stay with the
+  seed and external registries, and a non-builtin row never mints the verified
+  badge. ``list_catalog_apps`` intersects the rendered set with the seed's
+  installable entries, so a catalog-only ``git`` name renders nothing until it is
+  installable.
 """
 
 from __future__ import annotations
@@ -41,6 +44,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from kiro_crew.apps.manifest import KEBAB_RE
 from kiro_crew.config.loader import config_dir
 
 logger = logging.getLogger(__name__)
@@ -387,3 +391,56 @@ def annotate(rows: list[dict[str, Any]], entries: list[dict[str, Any]]) -> None:
             row["iconUrlDark"] = dark
         if hero := _resolve_ref(entry.get("heroRef")):
             row["heroImage"] = hero
+
+
+def list_catalog_rows() -> list[dict[str, Any]]:
+    """Build display rows straight from the published catalog's entries.
+
+    This is the JSON-only storefront path: the published document IS the list,
+    so its curated display fields ARE the copy the store renders, and there is
+    no per-app ``app.json`` to prefer over them. Rows carry identity and display
+    fields ONLY — no clone coordinates and no ``origin`` — because the catalog
+    is trusted only as far as TLS, so it must not supply install coordinates or
+    a first-party provenance claim. Install status and trust are stamped later by
+    ``registry.py`` from the installed app, never from this document.
+
+    Returns ``[]`` when the catalog is unavailable, which is the caller's signal
+    to fall back to the seed listing offline. Every field is type-guarded on the
+    way in for the same reason as ``annotate``: the document arrived over the
+    network, so its types are as untrusted as its content. A name that is not
+    kebab-case is dropped, because a name becomes a filesystem path on install.
+    """
+    rows: list[dict[str, Any]] = []
+    for entry in load_official_catalog():
+        name = entry.get("name")
+        if not isinstance(name, str) or not KEBAB_RE.fullmatch(name):
+            continue
+        row: dict[str, Any] = {"name": name}
+        if display := _curated_str(entry.get("displayName")):
+            row["displayName"] = display
+        if summary := _curated_str(entry.get("summary")):
+            row["description"] = summary
+        if version := _curated_str(entry.get("version")):
+            row["version"] = version
+        if tags := _curated_tags(entry.get("tags")):
+            row["tags"] = tags
+        author = entry.get("author")
+        if isinstance(author, dict) and (author_name := _curated_str(author.get("name"))):
+            row["author"] = author_name
+        if icon := _resolve_ref(entry.get("iconRef")):
+            row["iconUrl"] = icon
+        if dark := _resolve_ref(entry.get("iconRefDark")):
+            row["iconUrlDark"] = dark
+        if hero := _resolve_ref(entry.get("heroRef")):
+            row["heroImage"] = hero
+        source = entry.get("source")
+        if isinstance(source, dict):
+            # The source TYPE is a display marker (builtin vs git), not install
+            # coordinates: url/ref stay out, so the catalog cannot name a clone
+            # target. ``registry.list_catalog_apps`` uses it to intersect git rows
+            # with the seed's installable set.
+            stype = _curated_str(source.get("type"))
+            if stype in ("builtin", "git"):
+                row["source"] = {"type": stype}
+        rows.append(row)
+    return rows

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -748,17 +748,6 @@ async def _fetch_app_manifest(
     tmp_root: str | None = None
     try:
         tmp_root = await asyncio.to_thread(tempfile.mkdtemp, prefix="kirocrew-manifest-")
-        clone_cmd = [
-            "git",
-            "clone",
-            "--depth",
-            "1",
-            "--branch",
-            branch,
-            "--single-branch",
-            git_url,
-            tmp_root,
-        ]
         # Credential posture for the manifest clone. Default: anonymous+strict
         # (confused-deputy defense — see anonymous_git_env). Same-repo
         # carve-out: when owner_designated is True the clone URL is the
@@ -771,6 +760,17 @@ async def _fetch_app_manifest(
         else:
             clone_env = anonymous_git_env()
             sandbox_mode = "strict"
+        clone_cmd = [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            branch,
+            "--single-branch",
+            git_url,
+            tmp_root,
+        ]
         sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode=sandbox_mode)
         sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
         proc = await create_subprocess_limited(
@@ -1798,6 +1798,38 @@ async def list_registry() -> list[dict[str, Any]]:
     return _apply_trust_fields(
         _enrich_with_install_status(entries, installed_map, detected)
     )
+
+
+async def list_catalog_apps() -> list[dict[str, Any]]:
+    """Store rows built from the published catalog, enriched and trust-stamped.
+
+    The JSON-only storefront path: when the published catalog is available its
+    rows REPLACE the seed + per-app manifest fetch, so the store renders the
+    published document's list and display copy. An empty result means the catalog
+    was unavailable, and the caller falls back to ``list_registry`` offline.
+
+    Install coordinates stay with the seed: the catalog is trusted only as far as
+    TLS, so a ``git`` row is kept only when the seed or an external registry also
+    names it, and it carries no clone URL of its own — install resolves the seed
+    entry by name. A catalog-only ``git`` name renders nothing until it is
+    installable. ``verified`` stays ``False`` for non-builtin rows until the
+    catalog signature is checked, so this path never mints the first-party badge
+    from a document trusted only as far as TLS.
+    """
+    # Off the event loop: the first call after a cache expiry does network I/O.
+    rows = await asyncio.to_thread(official_catalog.list_catalog_rows)
+    if not rows:
+        return []
+    installable = await asyncio.to_thread(_load_registry_file)
+    installable_names = {e.get("name") for e in installable if isinstance(e, dict)}
+    rows = [
+        row
+        for row in rows
+        if row.get("source", {}).get("type") != "git" or row.get("name") in installable_names
+    ]
+    installed = await asyncio.to_thread(list_installed_apps)
+    installed_map = {a["name"]: a for a in installed}
+    return _apply_trust_fields(_enrich_with_install_status(rows, installed_map))
 
 
 def get_server_platform() -> dict[str, str]:

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -80,6 +80,7 @@ from kiro_crew.apps.registry import (
     install_from_registry,
     is_registry_source,
     known_registry_repos,
+    list_catalog_apps,
     list_registry,
     registry_name_from_source,
 )
@@ -1512,7 +1513,12 @@ async def handle_open_app(request: web.Request) -> web.Response:
 
 async def handle_registry(request: web.Request) -> web.Response:
     """GET /api/apps/registry — list all apps available for installation."""
-    apps = await list_registry()
+    # The published catalog is the storefront's source of truth when it is
+    # reachable: its rows replace the seed + per-app manifest fetch. Offline the
+    # catalog is empty and the seed listing answers instead.
+    apps = await list_catalog_apps()
+    if not apps:
+        apps = await list_registry()
     # Published rail order and layout ride along on the response the store already
     # makes, rather than endpoints the page would have to wait on separately. Off
     # the event loop: the first call after a cache expiry does network I/O. Both

--- a/test/test_official_catalog.py
+++ b/test/test_official_catalog.py
@@ -610,3 +610,49 @@ class TestRedirectsAreRefused:
     def test_the_handler_is_installed_on_the_opener(self):
         opener = urllib.request.build_opener(oc._NoRedirects)
         assert any(isinstance(h, oc._NoRedirects) for h in opener.handlers)
+
+
+class TestListCatalogRows:
+    def _git(self):
+        return {
+            "name": "git-app",
+            "source": {"type": "git", "url": "https://example.com/r.git", "ref": "a" * 40},
+            "displayName": "Git App",
+            "summary": "One line.",
+            "version": "1.0.0",
+            "tags": ["dev"],
+            "author": {"name": "Alice"},
+            "iconRef": "assets/icon.png",
+        }
+
+    def test_maps_display_fields_only(self, monkeypatch):
+        monkeypatch.setattr(oc, "load_official_catalog", lambda: [self._git()])
+        [row] = oc.list_catalog_rows()
+        assert row["name"] == "git-app"
+        assert row["displayName"] == "Git App"
+        assert row["description"] == "One line."
+        assert row["version"] == "1.0.0"
+        assert row["author"] == "Alice"
+
+    def test_a_row_carries_no_install_coordinates_or_trust(self, monkeypatch):
+        """The catalog is TLS-trusted only, so a row must not hand the install
+        path a clone URL or the trust stamp a provenance claim."""
+        monkeypatch.setattr(oc, "load_official_catalog", lambda: [self._git()])
+        [row] = oc.list_catalog_rows()
+        assert "gitUrl" not in row and "repo" not in row and "branch" not in row
+        assert "origin" not in row
+
+    def test_unavailable_catalog_yields_no_rows(self, monkeypatch):
+        monkeypatch.setattr(oc, "load_official_catalog", lambda: [])
+        assert oc.list_catalog_rows() == []
+
+    def test_a_non_kebab_name_is_dropped(self, monkeypatch):
+        """A catalog name becomes a filesystem path on install, so anything that
+        is not kebab-case must never reach list_catalog_rows."""
+        monkeypatch.setattr(oc, "load_official_catalog", lambda: [
+            {
+                "name": "/tmp/victim",
+                "source": {"type": "git", "url": "https://e.com/r", "ref": "c" * 40},
+            }
+        ])
+        assert oc.list_catalog_rows() == []

--- a/test/test_registry_endpoint_category_order.py
+++ b/test/test_registry_endpoint_category_order.py
@@ -27,12 +27,21 @@ async def _call() -> tuple[int, dict[str, Any]]:
 
 @pytest.fixture(autouse=True)
 def _quiet_registry(monkeypatch):
-    """Keep the test about the editorial half: the app list is stubbed."""
+    """Keep the test about the editorial half: the app list is stubbed.
+
+    ``handle_registry`` prefers the published catalog and falls back to the seed,
+    so BOTH sources are stubbed: an empty catalog lets the seed stub answer with
+    the single demo row the assertions expect.
+    """
 
     async def _apps():
         return [{"name": "demo", "tags": ["git"]}]
 
+    async def _no_catalog():
+        return []
+
     monkeypatch.setattr(routes, "list_registry", _apps)
+    monkeypatch.setattr(routes, "list_catalog_apps", _no_catalog)
     monkeypatch.setattr(routes, "get_server_platform", lambda: {"os": "linux", "arch": "x86_64"})
 
 


### PR DESCRIPTION
## Summary

The App Store (Discover) now renders from the published `official-registry.json` instead of the bundled seed + per-app manifest fetch.

## Scope (display-only)

The catalog is TLS-trusted but not yet signature-verified, so it supplies **display fields only** — name, displayName, summary, version, tags, author, icon/hero. It does **not** supply install coordinates (`gitUrl`/`repo`/`branch`) or an `origin`/provenance claim: install still resolves through the seed, and `verified` stays false for non-builtin rows. Catalog-backed install and the verified badge are deferred until signature verification lands.

## Changes

- `apps/official_catalog.py`: `list_catalog_rows()` maps published entries to display rows; drops non-kebab-case names (a name becomes a filesystem path on install).
- `apps/registry.py`: `list_catalog_apps()` maps the rows and applies the existing install-status + trust stamping; the catalog fetch runs off the event loop.
- `apps/routes.py`: `handle_registry` prefers `list_catalog_apps()` and falls back to the seed offline.
- `docs/system-specs/modules/app-kit-platform.md`: section 14.
- Tests for `list_catalog_rows` and the endpoint fallback.

## Behavior

- Reachable catalog → storefront lists the published entries' display copy; offline → seed.
- Non-builtin rows never mint the verified badge; install resolves through the seed/external registries.
