### PR TITLE
fix(autopilot): offload completion result reads

### DIFF
--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -138,6 +138,29 @@ def _capture_stage_result(
     return str(path)
 
 
+def _completion_excerpts(result_paths: tuple[tuple[int, str], ...]) -> dict[int, str]:
+    """Read captured stage results and return one summary excerpt per stage.
+
+    Runs on a worker thread, so it takes an already-snapshotted sequence of
+    ``(stage number, path)`` pairs rather than the live tracker: nothing mutable
+    crosses the boundary in either direction. A stage whose result cannot be read
+    is simply absent from the mapping, which is what makes the caller fall back
+    to a plain "done" line for it.
+    """
+    excerpts: dict[int, str] = {}
+    for stage_num, path_str in result_paths:
+        try:
+            text = safe_read_file(path_str).strip()
+        except (OSError, PermissionError):
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if line and not line.startswith("───"):
+                excerpts[stage_num] = line[:120]
+                break
+    return excerpts
+
+
 async def _stage_loop(
     state: "DashboardState",
     slot: "_ChatSlot",
@@ -542,23 +565,25 @@ async def _stage_loop(
             # for loop completed without break — all stages done
             if not slot._stopping and start_idx < total:
                 slot._auto_run = False
+                # Snapshot the result paths on the loop thread — `_stage_results`
+                # is live orchestration state the loop mutates — then read the
+                # files on a worker: one read per completed stage, all of them
+                # landing at once on the gateway's single event loop.
+                _captured: list[tuple[int, str]] = []
+                for s_idx in range(total):
+                    _path = tracker._stage_results.get(s_idx + 1)
+                    if _path:
+                        _captured.append((s_idx + 1, _path))
+                # Nothing captured means nothing to read: skip the worker hop.
+                excerpts: dict[int, str] = {}
+                if _captured:
+                    excerpts = await asyncio.to_thread(_completion_excerpts, tuple(_captured))
                 # Build execution summary from captured stage results
                 summary_lines = [f"✅ All {total} stages complete."]
                 for s_idx in range(total):
                     s_num = s_idx + 1
                     s_title = titles[s_idx] if s_idx < len(titles) else ""
-                    result_path = tracker._stage_results.get(s_num)
-                    excerpt = ""
-                    if result_path:
-                        try:
-                            text = safe_read_file(result_path).strip()
-                            for line in text.splitlines():
-                                line = line.strip()
-                                if line and not line.startswith("───"):
-                                    excerpt = line[:120]
-                                    break
-                        except (OSError, PermissionError):
-                            pass
+                    excerpt = excerpts.get(s_num, "")
                     label = f"Stage {s_num}: {s_title}" if s_title else f"Stage {s_num}"
                     if excerpt:
                         summary_lines.append(f"  {label} — {excerpt}")

--- a/test/test_completion_result_read_off_loop.py
+++ b/test/test_completion_result_read_off_loop.py
@@ -1,0 +1,285 @@
+"""Plan-completion stage-result reads must not run on the gateway event loop.
+
+When ``_stage_loop`` finishes every stage it builds one final summary message,
+and it does that by re-reading each captured stage-result file off disk. That is
+a separate lifecycle boundary from the per-stage context build: it happens once,
+after the loop, and the number of files it reads is the whole plan's stage count.
+
+Only the filesystem work belongs off-loop. The paths come from
+``tracker._stage_results``, which the loop mutates via ``record_stage_result``,
+so they are snapshotted on the loop thread and only immutable data crosses into
+the worker; the summary text, the slot append, and the broadcast stay on the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.dashboard.state import _ChatSlot
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config_dir(tmp_path, monkeypatch):
+    """Stage results are written under ``config_dir()`` — keep them per-test.
+
+    ``chat_orchestrator`` imports ``config_dir`` into its own namespace, so
+    patching only ``state`` would leave results writing to the live data home
+    and let parallel workers race on the shared slot key.
+    """
+    for module in ("state", "chat", "chat_orchestrator"):
+        monkeypatch.setattr(f"kiro_crew.dashboard.{module}.config_dir", lambda: tmp_path)
+
+
+def _make_state():
+    state = MagicMock()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.subagents = MagicMock()
+    state.subagents.running_agents_for = MagicMock(return_value=[])
+    return state
+
+
+def _make_slot(titles):
+    slot = _ChatSlot("completion-read-slot", mode="orchestrator")
+    slot._auto_run = False
+    # `_plan_stage_count` is derived from the titles, not settable.
+    slot._stage_titles = list(titles)
+    slot._plan_goal = "Test goal"
+    slot._orch_tracker = None
+    return slot
+
+
+def _stage_texts(monkeypatch, texts):
+    """Make each stage's captured result file hold ``texts[stage_num - 1]``.
+
+    The real ``_capture_stage_result`` harvests assistant messages appended by
+    ``_run_chat``, which is mocked here; giving the mock a per-stage body is what
+    puts distinguishable content on disk for the completion read to find.
+    """
+    stage_box = {"n": 0}
+
+    async def _mock_run_chat(state, slot, message, **kwargs):
+        idx = stage_box["n"]
+        stage_box["n"] += 1
+        if idx < len(texts):
+            slot.append("assistant", texts[idx], "msg msg-a")
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+
+
+def _completion_message(slot):
+    """The single '✅ All N stages complete.' summary the loop emits."""
+    matches = [
+        m.get("content", "")
+        for m in slot.messages
+        if m.get("content", "").startswith("✅ All ")
+    ]
+    assert len(matches) == 1, f"expected exactly one completion summary, got {len(matches)}"
+    return matches[0]
+
+
+async def _run_plan(monkeypatch, titles, texts):
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    state = _make_state()
+    slot = _make_slot(titles)
+    _stage_texts(monkeypatch, texts)
+    await _stage_loop(state, slot, auto_run=True)
+    return slot
+
+
+def _record_reads(monkeypatch, seen_threads, paths_read):
+    """Wrap the read the completion branch actually performs.
+
+    ``chat_orchestrator`` binds ``safe_read_file`` at import, so replacing that
+    module attribute intercepts the production call site itself. The wrapper
+    delegates to the real implementation, so the recorded thread is the thread
+    that genuinely opened and read the file — not merely the thread that reached
+    a call site.
+    """
+    from kiro_crew import hooks
+
+    def recording(path):
+        seen_threads.append(threading.get_ident())
+        paths_read.append(path)
+        return hooks.safe_read_file(path)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.safe_read_file", recording)
+
+
+@pytest.mark.asyncio
+async def test_completion_result_read_runs_off_the_loop_thread(monkeypatch):
+    """The plan-completion result reads execute on some thread other than the loop's."""
+    seen_threads: list[int] = []
+    paths_read: list[str] = []
+    _record_reads(monkeypatch, seen_threads, paths_read)
+
+    slot = await _run_plan(
+        monkeypatch,
+        ["First", "Second", "Third"],
+        ["alpha done", "beta done", "gamma done"],
+    )
+
+    assert paths_read, (
+        "no stage result was read at plan completion -- this test no longer "
+        "exercises the completion read and would pass vacuously")
+    assert threading.get_ident() not in seen_threads, (
+        "a completed stage result was read on the event-loop thread; the "
+        "filesystem work must be handed to asyncio.to_thread")
+    # The summary really is built from what was read off disk, so the assertion
+    # above covers the read that produces the user-visible text.
+    assert "alpha done" in _completion_message(slot)
+
+
+@pytest.mark.asyncio
+async def test_completion_reads_every_captured_stage_result(monkeypatch):
+    """One read per captured stage — the cost the offload is there to move."""
+    seen_threads: list[int] = []
+    paths_read: list[str] = []
+    _record_reads(monkeypatch, seen_threads, paths_read)
+
+    await _run_plan(
+        monkeypatch,
+        ["First", "Second", "Third"],
+        ["alpha done", "beta done", "gamma done"],
+    )
+
+    assert len(paths_read) == 3
+    assert all("stage_" in p for p in paths_read)
+    assert threading.get_ident() not in seen_threads
+
+
+@pytest.mark.asyncio
+async def test_completion_summary_lists_every_stage_in_order(monkeypatch):
+    """Preservation: ordering, titles, and one line per stage are unchanged."""
+    slot = await _run_plan(
+        monkeypatch,
+        ["First", "Second", "Third"],
+        ["alpha done", "beta done", "gamma done"],
+    )
+
+    lines = _completion_message(slot).splitlines()
+    assert lines[0] == "✅ All 3 stages complete."
+    assert lines[1:] == [
+        "  Stage 1: First — alpha done",
+        "  Stage 2: Second — beta done",
+        "  Stage 3: Third — gamma done",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_completion_summary_skips_stage_separator_lines(monkeypatch):
+    """Preservation: the excerpt is the first non-empty, non-separator line."""
+    slot = await _run_plan(
+        monkeypatch,
+        ["First"],
+        ["\n\n───── Stage 1: First ─────\n\nreal first line\nsecond line"],
+    )
+
+    assert _completion_message(slot).splitlines()[1] == "  Stage 1: First — real first line"
+
+
+@pytest.mark.asyncio
+async def test_completion_summary_truncates_the_excerpt_at_120_chars(monkeypatch):
+    """Preservation: the 120-char excerpt cap is unchanged."""
+    slot = await _run_plan(monkeypatch, ["First"], ["x" * 300])
+
+    assert _completion_message(slot).splitlines()[1] == "  Stage 1: First — " + "x" * 120
+
+
+@pytest.mark.asyncio
+async def test_completion_summary_falls_back_to_done_for_blank_result(monkeypatch):
+    """Preservation: an empty result file yields '— done', not a crash."""
+    slot = await _run_plan(monkeypatch, ["First"], [""])
+
+    assert _completion_message(slot).splitlines()[1] == "  Stage 1: First — done"
+
+
+@pytest.mark.asyncio
+async def test_completion_summary_survives_a_deleted_result_file(monkeypatch, tmp_path):
+    """Preservation: an unreadable path degrades to '— done' and does not raise.
+
+    The read error must stay contained per stage: stage 2 still gets its excerpt.
+    """
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    state = _make_state()
+    slot = _make_slot(["First", "Second"])
+    _stage_texts(monkeypatch, ["alpha done", "beta done"])
+
+    real_capture = None
+
+    def _capture_then_delete_stage_1(s, stage_num):
+        path = real_capture(s, stage_num)
+        if stage_num == 1:
+            (tmp_path / "sessions" / s.key / "stage_1_result.md").unlink()
+        return path
+
+    from kiro_crew.dashboard import chat_orchestrator
+
+    real_capture = chat_orchestrator._capture_stage_result
+    monkeypatch.setattr(chat_orchestrator, "_capture_stage_result", _capture_then_delete_stage_1)
+
+    await _stage_loop(state, slot, auto_run=True)
+
+    assert _completion_message(slot).splitlines()[1:] == [
+        "  Stage 1: First — done",
+        "  Stage 2: Second — beta done",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_completion_summary_redacts_credentials_from_the_excerpt(monkeypatch):
+    """Preservation: redaction still runs on the loop, after the reads return."""
+    slot = await _run_plan(monkeypatch, ["First"], ["key AKIAIOSFODNN7EXAMPLE here"])
+
+    summary = _completion_message(slot)
+    assert "AKIAIOSFODNN7EXAMPLE" not in summary
+    assert "Stage 1: First" in summary
+
+
+@pytest.mark.asyncio
+async def test_no_worker_hop_when_no_stage_results_were_captured(monkeypatch):
+    """A plan with nothing on disk must not pay for an empty thread round-trip."""
+    from kiro_crew.dashboard import chat_orchestrator
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    def _capture_fails(s, stage_num):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(chat_orchestrator, "_capture_stage_result", _capture_fails)
+
+    hops: list[object] = []
+    real_to_thread = asyncio.to_thread
+
+    async def counting_to_thread(func, /, *args, **kwargs):
+        hops.append(func)
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", counting_to_thread)
+
+    state = _make_state()
+    slot = _make_slot(["First", "Second"])
+    _stage_texts(monkeypatch, ["alpha done", "beta done"])
+
+    await _stage_loop(state, slot, auto_run=True)
+
+    assert hops == []
+    assert _completion_message(slot).splitlines() == [
+        "✅ All 2 stages complete.",
+        "  Stage 1: First — done",
+        "  Stage 2: Second — done",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_completion_summary_is_emitted_once_with_auto_run_cleared(monkeypatch):
+    """Preservation: terminal state around the reads is unchanged."""
+    slot = await _run_plan(monkeypatch, ["First", "Second"], ["alpha done", "beta done"])
+
+    assert slot._auto_run is False
+    assert _completion_message(slot).startswith("✅ All 2 stages complete.")


### PR DESCRIPTION
## Problem / Motivation

`_stage_loop` in `src/kiro_crew/dashboard/chat_orchestrator.py` is an `async def`
that drives a plan stage by stage. When the `for` loop completes without a break
— every stage ran — it falls into the `else` branch and builds the terminal
"✅ All N stages complete." summary.

That summary is assembled by re-reading the captured stage results off disk:

```python
for s_idx in range(total):
    result_path = tracker._stage_results.get(s_num)
    if result_path:
        try:
            text = safe_read_file(result_path).strip()
```

`safe_read_file` is synchronous. It calls `os.path.realpath`, checks
`is_sensitive_path`, then `os.open(..., O_NOFOLLOW)` and reads the file to
completion. Nothing about that call yields to the event loop, and the branch runs
one such call per completed stage — so a plan's entire final read set is issued
back to back, on the loop, at the moment the plan ends.

This is a different lifecycle boundary from the per-stage previous-result reads
in #3772. Those happen *before each next stage* and feed that stage's prompt;
these happen *after the whole loop* and feed the final user-visible message. The
caller branch, the timing, the consumer, and the failure semantics are all
separate, so this is verified on its own.

## Why it matters

Scheduling only. The gateway runs a single asyncio event loop, and for the
duration of these filesystem operations that loop cannot advance anything else —
no WebSocket broadcast, no other slot's turn, no HTTP handler. The number of
reads scales with the plan's stage count, and they all land in the same
uninterrupted window.

No latency figure is claimed here; none was measured.

## What changed

The read set is moved off the loop without moving any state with it.

- **Loop:** snapshot `(stage number, path)` pairs out of
  `tracker._stage_results` into an immutable tuple. The tracker's result map is
  live orchestration state the loop mutates via `record_stage_result`, so it is
  read on the loop thread only.
- **Worker:** a new module-level `_completion_excerpts(...)` takes that tuple,
  performs the `safe_read_file` calls, derives each stage's excerpt, and returns
  a plain `dict[int, str]`. It touches no slot, no tracker, and no live flag.
- **Loop:** consumes the returned mapping to build `summary_lines`, then runs
  redaction, `slot.append`, `broadcast_ws`, and the SEL `auto_run_completed`
  record exactly as before.

A plan that captured no result paths skips the `asyncio.to_thread` hop entirely
rather than paying for an empty round trip.

Semantics are preserved deliberately: excerpt selection (first non-empty line
that does not start with `───`), the 120-character cap, stage ordering, the
per-stage containment of a read error, and the `— done` fallback for a missing or
unreadable result are all unchanged. A stage whose read fails is simply absent
from the returned mapping, which reproduces the old `excerpt = ""` fallback.

No new executor, abstraction, caching, retry, or error-handling policy is
introduced, and no truncation limit or result content changes.

## Testing

New `test/test_completion_result_read_off_loop.py` drives the real `_stage_loop`
to plan completion and wraps the production `safe_read_file` binding in
`chat_orchestrator` with a recorder that delegates to the real implementation —
so the recorded thread is the thread that genuinely opened and read the file, not
merely one that reached a call site. The observation is scoped to the stage-result
paths, and a non-empty guard makes a vacuous pass impossible.

Deterministic fail-before / pass-after on this branch:

| | before | after |
|---|---|---|
| `test_completion_result_read_runs_off_the_loop_thread` | FAIL — `assert 62540 not in [62540, 62540, 62540]` | PASS |
| `test_completion_reads_every_captured_stage_result` | FAIL — same loop-thread id, 3 reads | PASS |

The remaining eight cases are preservation coverage and pass on both trees, which
is what pins the behaviour this change must not alter: ordering and titles,
separator-line skipping, the 120-char cap, blank-result fallback, a deleted
result file degrading to `— done` while its sibling still resolves, credential
redaction of the excerpt, the no-worker-hop path when nothing was captured, and
terminal `_auto_run` state.

```
pytest test/test_completion_result_read_off_loop.py     10 passed
pytest test/test_dashboard_chat.py \
       test/test_display_time_redaction.py             587 passed, 1 skipped
```

Also green: `flake8`, `isort --check-only`, `mypy --platform linux` on the
changed module ("Success: no issues found"), `scripts/docs_lint.py`,
`BRAND_BASE_REF=origin/main scripts/check_brand_name.py`, `git diff --check`.

## Screenshots / video

<!-- no-visual-delta -->

Backend scheduling only — the completion message's text is byte-identical.

## Related Issues

None. Self-discovered while validating the sibling event-loop I/O findings in
#3772.
