### PR TITLE
fix(onboarding): stop the import chapter closing itself after a reopen

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1028,7 +1028,17 @@ export default function App() {
   // can never disagree about what should be on screen.
   useEffect(() => {
     if (!themeBootReady) return
-    setShowAgentImport(!importOnboarded)
+    // OPEN-ONLY for the import chapter. Deriving `false` here is what made the
+    // page close itself: Import is the one chapter with a manual entry point
+    // (the `mc-start-import` event below), and for a user who already finished
+    // it this effect's own answer is `false`. So any later run — theme boot
+    // resolving, or any flag write — drove `initialOpen` true→false, and
+    // AgentImportFlow closes on that edge. Nothing is lost by not closing here:
+    // the real completion paths (`onComplete`, `onSkipAll`) already call
+    // `setShowAgentImport(false)` themselves, so the false branch was redundant
+    // for every case except the one it broke. Same split as the `onboarded`
+    // effect above, which only ever closes the tour.
+    if (!importOnboarded) setShowAgentImport(true)
     setShowPrivacy(importOnboarded && !privacyAcked)
     setShowOnboarding(importOnboarded && privacyAcked && !onboarded)
   }, [importOnboarded, privacyAcked, onboarded, themeBootReady])

--- a/website/src/test/App.importChapterReopen.test.tsx
+++ b/website/src/test/App.importChapterReopen.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Regression: the Import chapter closed itself right after a manual reopen.
+ *
+ * Import is the only first-run chapter with a manual entry point — the
+ * `mc-start-import` event, fired by "import from another agent". The chapter
+ * state was also DERIVED from the completion flags:
+ *
+ *   setShowAgentImport(!importOnboarded)
+ *
+ * For anyone who already finished import, `importOnboarded` is true, so that
+ * line evaluates to `setShowAgentImport(false)`. `AgentImportFlow` syncs on the
+ * `initialOpen` EDGE (true→false closes it), so any later run of the derive
+ * effect — theme boot resolving, or any flag write — closed the page the user
+ * had just opened. The reported symptom is a page that flashes open and
+ * disappears.
+ *
+ * The sequence below is the realistic one: the user clicks while theme boot is
+ * still in flight, and boot resolving is what re-runs the derive.
+ *
+ * The fix makes the derive OPEN-ONLY for this chapter. Nothing is lost: the real
+ * completion paths (`onComplete`, `onSkipAll`) already close it themselves, so
+ * the `false` branch was redundant for every case except the one it broke.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+/** Mutable so a test can flip a flag and re-render, the way boot resolving does. */
+const themeState = {
+  colorTheme: 'kiro',
+  theme: 'dark' as const,
+  mode: 'dark' as const,
+  onboarded: true,
+  importOnboarded: true,
+  privacyAcked: true,
+  themeBootReady: false,
+  themes: [],
+  markOnboarded: vi.fn(),
+  markImportOnboarded: vi.fn(),
+  markPrivacyAcked: vi.fn(),
+  setColorTheme: vi.fn(),
+  setMode: vi.fn(),
+}
+
+vi.mock('../hooks/useTheme', () => ({
+  useTheme: () => themeState,
+  ThemeProvider: ({ children }: { children: ReactNode }) => children,
+}))
+
+vi.mock('../pages/ChatPage', () => ({ default: () => <div data-testid="chat-page">ChatPage</div> }))
+vi.mock('../pages/SystemPage', () => ({ default: () => null }))
+vi.mock('../pages/AgentsPage', () => ({ default: () => null }))
+vi.mock('../pages/ProjectsPage', () => ({ default: () => null }))
+vi.mock('../pages/LogsPage', () => ({ default: () => null }))
+vi.mock('../pages/KiroCrewAgentsPage', () => ({ default: () => null }))
+
+import { renderWithProviders } from './helpers'
+import App from '../App'
+
+/** The Import chapter renders nothing at all while closed. */
+function importChapterOpen(): boolean {
+  return screen.queryByText(/bring your crew with you/i) !== null
+}
+
+beforeEach(() => {
+  themeState.themeBootReady = false
+  themeState.importOnboarded = true
+  themeState.privacyAcked = true
+  themeState.onboarded = true
+})
+
+describe('Import chapter, reopened by hand', () => {
+  it('survives the derive effect re-running after theme boot resolves', async () => {
+    const { rerender } = renderWithProviders(<App />, { route: '/chat' })
+
+    // Precondition: an onboarded user sees no first-run chapter.
+    expect(importChapterOpen()).toBe(false)
+
+    // The manual entry point.
+    act(() => { window.dispatchEvent(new CustomEvent('mc-start-import', { detail: {} })) })
+    await waitFor(() => expect(importChapterOpen()).toBe(true))
+
+    // Theme boot resolves, which re-runs the chapter-deriving effect. Before the
+    // fix this drove initialOpen true→false and closed the page.
+    act(() => { themeState.themeBootReady = true })
+    rerender(<App />)
+
+    await waitFor(() => expect(importChapterOpen()).toBe(true))
+  })
+
+  it('still opens the chapter on its own for a user who has not finished import', async () => {
+    themeState.importOnboarded = false
+    themeState.themeBootReady = true
+    renderWithProviders(<App />, { route: '/chat' })
+    await waitFor(() => expect(importChapterOpen()).toBe(true))
+  })
+})


### PR DESCRIPTION
## Problem

Opening "import from another agent" flashed the page open and then closed it immediately. Reported from a phone, but the cause is not layout — it is a state-machine race, and it reproduces at any width.

## Why it matters

Import is the **only** first-run chapter with a manual entry point (the `mc-start-import` event). Its visibility was also derived from the completion flags:

```js
setShowAgentImport(!importOnboarded)
```

For anyone who already finished import, `importOnboarded` is `true`, so that line evaluates to `setShowAgentImport(false)`. `AgentImportFlow` holds its own `open` state and syncs on the **`initialOpen` edge** — `true→false` closes it. So any later run of the derive effect drove exactly that edge and closed the page the user had just opened.

The effect re-runs on `[importOnboarded, privacyAcked, onboarded, themeBootReady]`, so the trigger is ordinary: theme boot resolving after the click is enough. That is the sequence the test reproduces.

## Fix

The derive is now **open-only** for this chapter:

```js
if (!importOnboarded) setShowAgentImport(true)
```

Nothing is lost by not closing here. The real completion paths — `onComplete` and `onSkipAll` — already call `setShowAgentImport(false)` themselves, so the `false` branch was redundant for every case except the one it broke. It also matches the split `App.tsx` already uses for the tour, where a separate effect only ever *closes* it.

Considered and rejected: an override ref set by the reopen listener. It works, but it introduces state that has to be cleared on every exit path, and the flow can be dismissed internally without notifying `App` — so a stale `true` would then suppress a legitimate auto-open. Removing the redundant close needs no lifecycle at all.

## Scope

Only the import chapter. Privacy and Customize are derived the same way, but neither has a manual entry point, so the same clobber is unreachable for them and widening the change would not be verifiable against a real symptom.

## Tests

2 cases in `App.importChapterReopen.test.tsx`, both falsified:

| Test | Falsified by |
|---|---|
| a hand-reopened chapter survives the derive re-running after theme boot resolves | **restoring the original `setShowAgentImport(!importOnboarded)` — this is the proof the test reproduces the reported bug, not just the fix** |
| the chapter still opens on its own for a user who has not finished import | making the derive never open it |

The first test drives the realistic sequence: onboarded user, theme boot still in flight, dispatch `mc-start-import`, then let boot resolve and re-render.

`npx tsc -b` clean. Full `npx vitest run`: **1252 files, 0 failures** — worth running in full here because the change is in `App.tsx`.

No screenshot: the symptom is a transition, and the assertion is on whether the chapter is mounted at all, which the test states more precisely than a still frame could.
