### PR TITLE
fix(wecom): recognize commands after group mentions

### DIFF
--- a/src/kiro_crew/docs/wecom-integration.md
+++ b/src/kiro_crew/docs/wecom-integration.md
@@ -76,6 +76,10 @@ own, and it has no buttons (so `OPTIONS` arrive as plain text).
 - `/new` (or `新对话`, `清空`) — start a fresh conversation
 - `/compact` — free up room when the context fills
 
+In a group chat, where addressing the bot is required, send the command on its
+own after the mention — `@Kiro /new`. Anything else after the mention is treated
+as an ordinary message.
+
 ## Settings & reference
 
 Everything lives in the `wecom` section of `config.json`:

--- a/src/kiro_crew/wecom/commands.py
+++ b/src/kiro_crew/wecom/commands.py
@@ -21,11 +21,10 @@ _LINK_ALIASES = frozenset(("/link",))
 _UNLINK_ALIASES = frozenset(("/unlink",))
 
 
-def parse_command(text: str) -> str | None:
-    """Return 'new', 'compact', 'link', 'unlink', or None."""
-    stripped = text.strip()
-    lower = stripped.lower()
-    if lower in _NEW_ALIASES or stripped in _NEW_ALIASES:
+def _match_alias(text: str) -> str | None:
+    """Exact-match one command alias."""
+    lower = text.lower()
+    if lower in _NEW_ALIASES or text in _NEW_ALIASES:
         return "new"
     if lower in _COMPACT_ALIASES:
         return "compact"
@@ -34,3 +33,38 @@ def parse_command(text: str) -> str | None:
     if lower in _UNLINK_ALIASES:
         return "unlink"
     return None
+
+
+def _after_leading_mention(text: str) -> str | None:
+    """Return the text following ONE leading ``@name`` token, else ``None``.
+
+    Addressing the bot is mandatory in a WeCom group, so the platform delivers
+    the command as ``@Kiro /new``. Unlike Slack's ``<@BOTID>``, the mention
+    arrives as plain text with no delimiter and no ``is_mention`` flag, and the
+    bot's display name never reaches this module — so it is recognized purely
+    structurally: a leading ``@`` run of non-whitespace, then whitespace, then
+    the remainder. Exactly one token is consumed and the remainder is not
+    otherwise touched, which keeps ``@a @b /new`` and ``@Kiro please /new`` out.
+    """
+    if not text.startswith("@"):
+        return None
+    parts = text.split(None, 1)
+    if len(parts) != 2:
+        return None
+    return parts[1].strip()
+
+
+def parse_command(text: str) -> str | None:
+    """Return 'new', 'compact', 'link', 'unlink', or None."""
+    stripped = text.strip()
+    cmd = _match_alias(stripped)
+    if cmd is not None:
+        return cmd
+    # Retry once past a group mention. Only the command CANDIDATE is normalized:
+    # the message itself is never rewritten, so mentioned prose still reaches the
+    # model verbatim, and the alias match stays exact so only a bare command
+    # behind the mention is intercepted.
+    candidate = _after_leading_mention(stripped)
+    if candidate is None:
+        return None
+    return _match_alias(candidate)

--- a/test/test_wecom_dispatch.py
+++ b/test/test_wecom_dispatch.py
@@ -374,6 +374,91 @@ class TestCommands:
         assert parse_command("/unlink") == "unlink"
         assert parse_command("hello") is None
 
+    def test_parse_command_after_a_group_mention(self) -> None:
+        """A group chat requires @-mentioning the bot, so the command arrives prefixed."""
+        assert parse_command("@Kiro /new") == "new"
+        assert parse_command("@Kiro /compact") == "compact"
+        assert parse_command("@Kiro 新对话") == "new"
+        assert parse_command("@Kiro 清空") == "new"
+        assert parse_command("@Kiro /link") == "link"
+        assert parse_command("@Kiro /unlink") == "unlink"
+
+    def test_mention_does_not_loosen_command_matching(self) -> None:
+        """Only ONE leading mention token in front of an EXACT command counts.
+
+        Everything here must keep reaching the model as ordinary text. The bot's
+        display name is not known to the parser, so the mention is recognized
+        structurally -- which is exactly why the rest of the match has to stay
+        exact rather than becoming a prefix or substring test.
+        """
+        for text in (
+            "@Kiro hello",  # mentioned prose
+            "@Kiro",  # bare mention, no remainder
+            "@Kiro please /new",  # command embedded in prose
+            "@Kiro /new extra",  # trailing argument
+            "@someone ordinary text",  # a mention of somebody else
+            "@a @b /new",  # only one mention token is consumed
+            "hello /new",  # command not at the start
+            "/new @Kiro",  # trailing mention
+            "/new@Kiro",  # Telegram's suffix syntax, not WeCom's
+            "@Kiro /bogus",  # unknown command stays unknown
+            "@Kiro/new",  # no separator -- not a mention token
+        ):
+            assert parse_command(text) is None, text
+
+    @pytest.mark.asyncio
+    async def test_group_mention_new_bumps_gen_and_acks(self) -> None:
+        """The reported shape: '@Kiro /new' must reset, not steer into the turn."""
+        sessions = FakeSessions(FakeProvider([]))
+        client = FakeClient()
+        d = _dispatcher(sessions, FakeCtx(), client)
+
+        await d.handle_message(_inbound("@Kiro /new"))
+
+        assert client.replies == [("https://r", "✅ 已开始新对话")]
+        assert d._conv.current_gen("Wei") == 1
+        assert sessions.successes == []  # no LLM turn
+
+    @pytest.mark.asyncio
+    async def test_group_mention_compact_reaches_compaction(self) -> None:
+        provider = FakeProvider([])
+        sessions = FakeSessions(provider)
+        client = FakeClient()
+        d = _dispatcher(sessions, FakeCtx(), client)
+
+        await d.handle_message(_inbound("@Kiro /compact"))
+
+        assert provider.compacted is True
+        assert client.replies == [("https://r", "🗜️ 已压缩上下文。")]
+
+    @pytest.mark.asyncio
+    async def test_mentioned_prose_still_runs_a_turn_with_text_intact(self) -> None:
+        """Ordinary inbound text is never rewritten -- the model sees the mention."""
+        provider = FakeProvider(
+            [AcpEvent(kind=EVENT_TEXT_CHUNK, text="sure"), AcpEvent(kind=EVENT_COMPLETE)]
+        )
+        sessions = FakeSessions(provider)
+        conv = FakeConvLog()
+        d = _dispatcher(sessions, FakeCtx(), FakeClient(), conv_log=conv)
+
+        await d.handle_message(_inbound("@Kiro explain this stack trace"))
+
+        key = d._session_key("Wei")
+        assert sessions.successes == [key]
+        assert (key, "user", "@Kiro explain this stack trace") in conv.appended
+        assert d._conv.current_gen("Wei") == 0  # not treated as /new
+
+    @pytest.mark.asyncio
+    async def test_mentioned_unknown_command_still_runs_a_turn(self) -> None:
+        provider = FakeProvider([AcpEvent(kind=EVENT_COMPLETE)])
+        sessions = FakeSessions(provider)
+        d = _dispatcher(sessions, FakeCtx(), FakeClient())
+
+        await d.handle_message(_inbound("@Kiro /bogus"))
+
+        assert sessions.successes == [d._session_key("Wei")]
+        assert d._conv.current_gen("Wei") == 0
+
     def test_conversation_state(self) -> None:
         s = ConversationState()
         assert s.current_gen("u") == 0


### PR DESCRIPTION
## Problem / Motivation

Addressing the bot is mandatory in a WeCom group chat, so the text the platform
delivers is `@Kiro /new`, not `/new`. Nothing on the path normalizes that:

- `WeComClient._dispatch_callback` (`wecom/client.py`) assigns
  `text=text_obj.get("content", "")` straight onto `WeComInbound` — the wire
  content is stored verbatim, which is correct for a transport parser.
- `WeComDispatcher.handle_message` (`wecom/transport_dispatch.py`) then does
  `text = inbound.text` and `cmd = parse_command(text)` with no normalization in
  between.
- `parse_command` (`wecom/commands.py`) matches by exact set membership
  (`lower in _NEW_ALIASES`), so `"@kiro /new" != "/new"` and it returns `None`.

The message therefore falls through to the ordinary turn path. Because a turn is
usually already in flight, `_handle_busy` folds it into that turn via steer
(`已合并到当前回复`) instead of resetting the conversation.

```
parse_command("/new")       -> "new"
parse_command("@Kiro /new") -> None
```

## Why it matters

`/new` and `/compact` are unreachable in group chats — the setting where the
WeCom AI bot is normally used. They work only in a 1:1 DM, where no mention is
required. The failure is silent: the user sees their command answered as a chat
message, with no indication the command was not recognized.

This is scoped to command recognition. No claim is made about any other WeCom
group behaviour.

## What changed

`parse_command` retries the alias match once against the text following a single
leading mention token:

```
exact alias            -> command          (unchanged)
"@name " + exact alias -> command          (new)
anything else          -> None             (unchanged)
```

**Ordinary inbound text is not rewritten.** `WeComInbound.text` is untouched and
`drive_turn` still receives the raw message, so `@Kiro explain this stack trace`
reaches the model with the mention intact, exactly as today. Only the *command
candidate* is normalized, and the alias match on it stays exact.

Two deliberate restrictions, both pinned by tests:

- **The mention is recognized structurally**, as a leading `@` run of
  non-whitespace followed by whitespace. Slack can afford to strip mentions
  globally (`slack/events.py`) because its mention is a delimited `<@BOTID>`
  token and the platform sets `is_mention`; WeCom gives neither, and the bot's
  display name never reaches this module. So the grammar consumes exactly one
  token and requires an exact command after it.
- **Nothing gates on `chatid`.** The gateway carries it on `WeComInbound`, but no
  production code reads it and its only test calls it a missing optional field —
  the repository does not establish it as a group-vs-DM discriminator, so gating
  on it would invent a wire contract. The narrow grammar is what makes the change
  safe instead, and DM behaviour is unchanged because a DM carries no mention.

These stay ordinary text: `@Kiro hello`, `@Kiro`, `@Kiro please /new`,
`@Kiro /new extra`, `@someone ordinary text`, `@a @b /new`, `hello /new`,
`/new @Kiro`, `@Kiro/new`, `@Kiro /bogus`, and Telegram's `/new@Kiro` suffix
form (a different syntax on a different transport — see #3736).

Every existing alias keeps its current behaviour, including case handling; no
alias, command, or ack copy is added or changed, and generation/session semantics
are untouched. `wecom.commands.parse_command` has exactly one caller, WeCom's own
dispatcher, so no other channel is affected.

The user-facing command list in `docs/wecom-integration.md` gains the group form,
per the repo rule that documented behaviour is updated in the same commit.

## Tests

Extended the existing `TestCommands` in `test/test_wecom_dispatch.py` — no new
harness. Fail-before was captured on pristine `origin/main` (`88785e56e`):

| | before | after |
|---|---|---|
| `test_parse_command_after_a_group_mention` | FAIL — `assert None == 'new'` | PASS |
| `test_group_mention_new_bumps_gen_and_acks` | FAIL — `assert [] == [('https://r', '✅ 已开始新对话')]` | PASS |
| `test_group_mention_compact_reaches_compaction` | FAIL — `assert False is True` | PASS |

The dispatcher-level cases are the load-bearing ones: they drive the real
`handle_message` and assert the generation bump, the existing ack, and that no
LLM turn is acquired.

The remaining new cases pass on **both** trees, which is what pins the behaviour
this must not change: the negative-grammar table above, mentioned prose still
running a turn with `(key, "user", "@Kiro explain this stack trace")` reaching the
conversation log unmodified, and a mentioned unknown command still running a turn.

```
pytest test/test_wecom_dispatch.py                       22 passed  (was 3F/19P)
pytest test/test_wecom_{dispatch,client,transport,wire,client_cov80}.py
                                                        108 passed
```

Also green: `flake8`, `isort --check-only`, `mypy --platform linux` on the changed
module ("Success: no issues found"), `scripts/docs_lint.py`,
`BRAND_BASE_REF=origin/main scripts/check_brand_name.py`, `git diff --check`.

## Screenshots / video

<!-- no-visual-delta -->

Backend channel command parsing only.

## Related Issues

Refs #304 — only the group-command mention defect (problem 4). The credential
fallback, the `.env`/guard contradiction, and the silent startup failure remain
out of scope and the issue stays open for them.

