### PR TITLE
fix: name and focus the read-only provider-hooks scrollport

### DIFF
--- a/website/src/pages/HooksPage.tsx
+++ b/website/src/pages/HooksPage.tsx
@@ -268,7 +268,29 @@ export default function HooksPage({ embedded }: { embedded?: boolean } = {}) {
           {providerHookError ? (
             <EmptyState icon={<AlertTriangle className="lucide-inline text-warning" />} title={i18nT('pages.hooksPage.failed_to_load', { section: provider.labels.hooksSection.toLowerCase() })} subtitle={i18nT('pages.hooksPage.check_your_connection_or_configuration_and_try_a')} />
           ) : Object.values(providerHooks).some(entries => entries.length > 0) ? (
-            <div className="overflow-x-auto">
+            // Focusable, named scrollport. This table is read-only — every cell
+            // is plain text — and its columns reserve 700px, so at phone width
+            // ~412px of the Command column is clipped and can only be reached by
+            // scrolling. Two separate problems, and the tabIndex is not the whole
+            // fix for either:
+            //   Reach. Chromium >=130 already focuses a scroller that has no
+            //   focusable children, so Chrome alone is fine. That behaviour came
+            //   through blink-dev and no other engine has shipped it, and the
+            //   accessibility rule engines (axe scrollable-region-focusable, IBM,
+            //   BrowserStack) still require the explicit stop, so we keep it.
+            //   Name. Even where the scroller IS auto-focused, it lands focus on
+            //   an anonymous <div>. role + aria-label are what stop it announcing
+            //   as nothing in particular, in every engine including Chrome.
+            // Do NOT copy this onto the hooks table above. Its rows hold tabbable
+            // controls, which is exactly the case Chromium excludes and where
+            // focus already arrives via the control; a stop there would insert a
+            // redundant Tab press between every row.
+            <div
+              className="overflow-x-auto"
+              tabIndex={0}
+              role="region"
+              aria-label={provider.labels.hooksSection}
+            >
               <table className="w-full border-collapse table-striped">
                 <thead>
                   <tr>

--- a/website/src/test/HooksPage.scrollKeyboard.test.tsx
+++ b/website/src/test/HooksPage.scrollKeyboard.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * The two horizontally-scrolling tables on the Hooks page get deliberately
+ * different keyboard treatment, and this pins both halves.
+ *
+ * The provider-hooks table is READ-ONLY: every cell is plain text, and its
+ * columns reserve 700px, so at phone width ~412px of the Command column is
+ * only reachable by scrolling. Measured in Chromium 145: a scroller with no
+ * focusable children is ALREADY the first tab stop without any tabindex
+ * (keyboard-focusable scrollers, Chromium >=130), so the explicit stop is
+ * belt-and-braces for engines that have not shipped that — while role and
+ * aria-label are load-bearing everywhere, since the auto-focused scroller would
+ * otherwise land focus on an anonymous <div>.
+ *
+ * The editable hooks table above it is the case Chromium excludes: its rows hold
+ * tabbable controls, so focus arrives via the control and the scroller is
+ * skipped (also measured). A stop there would only insert an extra Tab press
+ * between every row, so it is asserted to stay absent — the tempting
+ * "make them consistent" change is a regression on that table.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+
+let hooksPayload: { hooks: unknown[] } = { hooks: [] }
+
+vi.mock('../api/client', () => ({
+  api: new Proxy({} as Record<string, unknown>, {
+    get: (_t, prop: string) => {
+      if (prop === 'hooks') return vi.fn(async () => hooksPayload)
+      return vi.fn().mockResolvedValue({})
+    },
+  }),
+}))
+
+vi.mock('../providers', () => ({
+  useProvider: () => ({
+    id: 'acp',
+    capabilities: { hooks: true },
+    labels: { hooksSection: 'Provider hooks', configFile: '~/.kiro/config.json' },
+    fetchProviderHooks: () =>
+      Promise.resolve({
+        PreToolUse: [
+          { source: 'config', matcher: 'Bash', command: 'echo before-tool-use' },
+        ],
+      }),
+  }),
+}))
+
+import HooksPage from '../pages/HooksPage'
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <HooksPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  hooksPayload = {
+    hooks: [
+      {
+        id: 'h1',
+        name: 'fmt',
+        event: 'PreToolUse',
+        command: 'black .',
+        matcher: 'Bash',
+        enabled: true,
+        run_count: 2,
+        last_status: 'ok',
+      },
+    ],
+  }
+})
+
+describe('Hooks page scroll containers — keyboard reach', () => {
+  it('makes the read-only provider-hooks scrollport a named, focusable region', async () => {
+    renderPage()
+    const region = await screen.findByRole('region', { name: 'Provider hooks' })
+    // An explicit tab stop, for the engines that do not focus a childless
+    // scroller on their own. Chromium already would; nothing else is known to.
+    expect(region.tabIndex).toBe(0)
+    // The stop has to be ON the element that actually scrolls, not a wrapper.
+    expect(region.className).toContain('overflow-x-auto')
+    // And it really is the provider table's container.
+    expect(region.querySelector('table')).not.toBeNull()
+  })
+
+  it('contains nothing else focusable, which is why the container needs the stop', async () => {
+    renderPage()
+    const region = await screen.findByRole('region', { name: 'Provider hooks' })
+    const focusable = region.querySelectorAll(
+      'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    )
+    // Only the container itself carries a tabindex; nothing within it does.
+    expect([...focusable].filter(el => el !== region)).toHaveLength(0)
+  })
+
+  it('leaves the editable hooks table container without a redundant tab stop', async () => {
+    renderPage()
+    // The editable table is the one with a sortable "Name" column; the
+    // provider table has no Name header.
+    await waitFor(() => expect(screen.getByText('Name')).toBeInTheDocument())
+    const editable = [...document.querySelectorAll('table')].find(t =>
+      [...t.querySelectorAll('th')].some(th => th.textContent?.trim() === 'Name'),
+    )
+    expect(editable).toBeDefined()
+    const scroller = editable!.parentElement!
+    expect(scroller.className).toContain('overflow-x-auto')
+    // Its rows are already tabbable, so the container must NOT be a tab stop.
+    expect(scroller.getAttribute('tabindex')).toBeNull()
+    expect(scroller.getAttribute('role')).toBeNull()
+    expect(
+      scroller.querySelectorAll('button, input, [role="switch"]').length,
+    ).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Problem

The **provider hooks** table on the Hooks page is read-only, and its five
columns reserve 700px. Measured at a 390px viewport: `scrollWidth 800` vs
`clientWidth 388`, so **412px of the Command column can only be reached by
scrolling the container**.

I set out to fix this as a WCAG 2.1.1 keyboard-reach failure. Measuring it
showed that framing is wrong in Chrome, so the change is narrower than planned.

## What the measurement showed

Real browser, Chromium 145, both container shapes mounted standalone with the
page's real column widths:

| arm | tab order from the button above |
|---|---|
| read-only, bare scrollport | `div` → `button#after` |
| read-only, with `tabindex`+`role`+name | `div role=region name="Provider hooks"` → `button#after` |
| editable table (bare, but a tabbable cell) | `button#rowbtn` → `button#after` |

The bare scroller is **already** the first tab stop with no `tabindex`: Chromium
≥130 focuses a scroller that has no keyboard-focusable children
([keyboard-focusable scrollers](https://developer.chrome.com/blog/keyboard-focusable-scrollers),
shipped in 127). So reach is not broken in Chrome.

Two things still are:

1. **Other engines.** That behaviour arrived through blink-dev and no other
   engine has shipped it. The accessibility rule engines still require the
   explicit stop — axe `scrollable-region-focusable`, IBM
   `element_scrollable_tabbable`, BrowserStack. I could not run Firefox/WebKit
   here (not installed), so this rests on the feature's provenance and those
   rules, not on my own cross-engine measurement.
2. **The name.** Even where the scroller *is* auto-focused, focus lands on an
   anonymous `<div>`. `role="region"` + `aria-label` are load-bearing in every
   engine including Chrome.

## Change

One container. `tabIndex={0}`, `role="region"`, and `aria-label` reusing the
section's existing dynamic title (no new string, no i18n key). Follows the house
precedent in `CodeBlock.tsx`, which already does exactly this on its
`overflow-x-auto` `<pre>`.

## Deliberately NOT applied to the editable hooks table

Its rows hold tabbable controls — precisely the case Chromium excludes, and the
third arm above confirms focus arrives via the control while the scroller is
skipped. A stop there would insert a redundant Tab press between every row.

Both halves are pinned by the new test, because the tempting "make them
consistent" change is a regression on the editable table.

## Verification

Three tests, each falsified — the suite goes red for all four mutations:

| mutation | caught |
|---|---|
| revert the fix entirely | yes |
| drop `role`+name, keep `tabIndex` | yes |
| drop `tabIndex`, keep `role`+name | yes |
| give the editable table the same treatment | yes |

`npx tsc -b` clean. Full frontend suite: 1254 files, 20211 passed, 0 failures.
