### PR TITLE
fix: apply the performance rail's fixed width only when there is room

### DIFF
--- a/website/src/pages/system/PerformanceTab.tsx
+++ b/website/src/pages/system/PerformanceTab.tsx
@@ -143,9 +143,22 @@ export default function PerformanceTab({ planeStateRef }: { planeStateRef: Mutab
 
   return (
     <Card>
-      <div style={{ display: 'grid', gridTemplateColumns: '196px minmax(0, 1fr)', gap: '1rem' }}>
+      {/* The rail is a fixed 196px only once there is room for it. As an inline
+          `gridTemplateColumns` it applied at EVERY width and no responsive class
+          could override it — the same defect as the `columns` style below, which
+          is why both are classes now. Measured at 390px it left the right pane
+          147px, which collapsed the storage row's text column to 0px and broke
+          its title over 4 lines; at 320px the row overflowed by 35px.
+          Below `sm` the rail becomes a 2x2 grid rather than a stack: stacking
+          four sparkline tiles is 362px of rail before the graph, where 2x2 is
+          178px and still gives each tile ~175px, enough for the longest
+          localized label. */}
+      <div className="grid gap-4 sm:grid-cols-[196px_minmax(0,1fr)]">
         {/* Left rail — resource selector tiles */}
-        <nav className="flex flex-col gap-1.5" aria-label={i18nT('pages.performanceTab.resource_nav')}>
+        <nav
+          className="grid grid-cols-2 gap-1.5 sm:flex sm:flex-col"
+          aria-label={i18nT('pages.performanceTab.resource_nav')}
+        >
           {resources.map(r => (
             <button
               key={r}

--- a/website/src/test/systemCardColumns.test.ts
+++ b/website/src/test/systemCardColumns.test.ts
@@ -47,7 +47,38 @@ describe('PerformanceTab stats grid', () => {
     expect(el, 'expected the stats grid to start at grid-cols-1').not.toBeNull()
     expect(el![0]).toContain('sm:grid-cols-2')
     expect(el![0]).toContain('lg:grid-cols-3')
-    // An unqualified grid-cols-2 is the defect: it applies at every width.
-    expect(src).not.toMatch(/className="grid grid-cols-2/)
+    // An unqualified two-column stats grid is the defect: it applies at every
+    // width. Matched by the stats grid's own `gap-x-6` rather than by a bare
+    // `grid grid-cols-2`, because the resource rail below is legitimately 2x2
+    // while narrow and would otherwise trip this.
+    expect(src).not.toMatch(/className="grid grid-cols-2 gap-x-6/)
   })
 })
+
+describe('PerformanceTab resource rail', () => {
+  it('applies the fixed 196px rail only from sm up, as a class', async () => {
+    const src = await read('../pages/system/PerformanceTab.tsx?raw')
+    const el = src.match(/className="grid gap-4 sm:grid-cols-\[196px_minmax\(0,1fr\)\]"/)
+    expect(el, 'expected the pane to be one column until sm').not.toBeNull()
+  })
+
+  it('does not set the pane columns inline, which would apply at every width', async () => {
+    const src = await read('../pages/system/PerformanceTab.tsx?raw')
+    // Same false-positive guard as above: the comment quotes what it forbids.
+    const code = src.replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+    expect(code).not.toMatch(/gridTemplateColumns/)
+    // The 196px literal must not reappear as an unconditional inline value.
+    expect(code).not.toMatch(/style=\{\{[^}]*196px/)
+  })
+
+  it('lays the four tiles out 2x2 while narrow instead of stacking them', async () => {
+    const src = await read('../pages/system/PerformanceTab.tsx?raw')
+    const nav = src.match(/className="grid grid-cols-2 gap-1\.5 sm:flex sm:flex-col"/)
+    expect(nav, 'expected the rail to be 2x2 below sm and a column above').not.toBeNull()
+    // Stacking all four sparkline tiles costs 362px of rail before the graph;
+    // 2x2 is 178px. An unconditional flex-col is that regression.
+    expect(src).not.toMatch(/className="flex flex-col gap-1\.5"/)
+  })
+})
+
+


### PR DESCRIPTION
## Problem

`PerformanceTab`'s two-pane layout set its columns in an **inline style**:

```jsx
<div style={{ display: 'grid', gridTemplateColumns: '196px minmax(0, 1fr)', gap: '1rem' }}>
```

An inline style outranks any stylesheet rule, so the 196px rail applied at
every width and no responsive class could have overridden it. This is the same
defect #3778 fixed for `style={{ columns: 3 }}` **in this same file** — I found
this second instance only after that PR merged, because I had been looking at
the `columns` property rather than `gridTemplateColumns`.

Measured with both container shapes mounted standalone at the real Card padding:

| viewport | right pane | storage-row text column | title | row overflow |
|---|---|---|---|---|
| 320px | **77px** | **0px** | 4 lines | 35px |
| 390px | 147px | 23px | 4 lines | 0px |
| 768px | 525px | 401px | 1 line | 0px |

At 320px the text column is collapsed to nothing and the row overflows its card.

## Change

The rail becomes a class that only applies from `sm` up, so the pane is one
column on a phone. Below `sm` the four resource tiles lay out 2x2 rather than
stacking, which was chosen on measurement rather than taste:

| variant at 390px | rail height | right pane | graph starts at |
|---|---|---|---|
| before (196px rail) | 362px | **147px** | 17px |
| stack, tiles unchanged | 362px | 356px | **392px** |
| **2x2 (this PR)** | **178px** | 356px | 208px |
| stack, drop sparkline | 234px | 356px | 264px |

Stacking would have traded a squeezed pane for 362px of rail above the graph —
pushing the content off the first screen, which is the defect class it was
supposed to avoid. 2x2 halves that and still leaves each tile ~175px, wide
enough for the longest localized label ("Processeur" ≈ 70px) plus its headline
figure. Desktop geometry is unchanged at 768px and above.

## Verification

Three new assertions, each falsified — the suite goes red for all three:

| mutation | caught |
|---|---|
| revert the pane to the inline `gridTemplateColumns` | yes |
| keep 196px at every width (as a class) | yes |
| stack the rail instead of 2x2 | yes |

The existing stats-grid assertion had to be tightened: it forbade a bare
`className="grid grid-cols-2`, which the new 2x2 rail legitimately matches, so
it now keys on the stats grid's own `gap-x-6`.

`npx tsc -b` clean. Full frontend suite: 1254 files, 20213 passed, 0 failures.
