### PR TITLE
fix: stop the chat hero eating the first screen on a phone

### DIFF
--- a/website/src/components/WelcomeView.tsx
+++ b/website/src/components/WelcomeView.tsx
@@ -117,8 +117,15 @@ export default function WelcomeView({
       <div className="text-center">
         <div className="flex items-center justify-center gap-4">
           {mode !== 'orchestrator' && brandMark}
-          <h2 className="text-5xl font-light text-text-strong tracking-tight">{mode === 'orchestrator' ? i18nT('components.welcomeView.autopilot') : i18nT('components.welcomeView.what_can_i_do_for_you')}</h2>
-          {mode !== 'orchestrator' && <div className="w-[64px] shrink-0" />}
+          {/* 48px is a desktop size. At 320px the row leaves this heading 189px
+              between the 64px mark and the 64px spacer, which broke "What can I
+              do for you?" over 5 lines in English and 6 in German and French —
+              260-325px of hero before anything else. 30px holds it to 2 lines in
+              every locale measured. */}
+          <h2 className="text-3xl sm:text-5xl font-light text-text-strong tracking-tight">{mode === 'orchestrator' ? i18nT('components.welcomeView.autopilot') : i18nT('components.welcomeView.what_can_i_do_for_you')}</h2>
+          {/* Balances the mark so the heading reads optically centred. Purely
+              decorative, so it does not get to keep 64px of a phone's width. */}
+          {mode !== 'orchestrator' && <div className="hidden sm:block w-[64px] shrink-0" />}
         </div>
         {mode === 'orchestrator' && <p className="text-[13px] text-muted mt-1">{i18nT('components.welcomeView.simple_tasks_run_instantly_complex_ones_get_a_pl')}</p>}
       </div>

--- a/website/src/test/WelcomeViewHeroNarrow.test.ts
+++ b/website/src/test/WelcomeViewHeroNarrow.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The chat hero must not eat the first screen on a phone.
+ *
+ * `text-5xl` (48px) is a desktop size, and the heading sits between a 64px brand
+ * mark and a 64px optical-centering spacer in a `gap-4` row inside `px-8`. At a
+ * 320px viewport that leaves the heading 189px, which measured 5 lines in
+ * English and 6 in German and French — 260-325px of hero. Dropping to 30px and
+ * releasing the decorative spacer below `sm` holds it to 2 lines in every locale
+ * measured (82px).
+ *
+ * happy-dom does no layout, so these pin the declaration: the defect is that the
+ * size and the spacer were unconditional, and that is what a source assertion
+ * can see.
+ */
+import { describe, it, expect } from 'vitest'
+
+async function source(): Promise<string> {
+  return (await import('../components/WelcomeView.tsx?raw')).default as string
+}
+
+describe('WelcomeView hero at narrow widths', () => {
+  it('scales the heading down on base and up from sm', async () => {
+    const src = await source()
+    const h2 = src.match(/<h2 className="[^"]*"/)
+    expect(h2, 'expected an h2 with a className').not.toBeNull()
+    expect(h2![0]).toContain('text-3xl')
+    expect(h2![0]).toContain('sm:text-5xl')
+    // An unqualified text-5xl is the defect: it applies at every width.
+    expect(h2![0]).not.toMatch(/(^|\s)text-5xl/)
+  })
+
+  it('does not spend 64px of a phone on the centering spacer', async () => {
+    const src = await source()
+    const spacer = src.match(/className="[^"]*w-\[64px\][^"]*"/)
+    expect(spacer, 'expected the optical-centering spacer').not.toBeNull()
+    expect(spacer![0]).toContain('hidden')
+    expect(spacer![0]).toContain('sm:block')
+  })
+
+  it('keeps the brand mark, which is content rather than padding', async () => {
+    const src = await source()
+    // The mark carries the product identity; only the blank counterweight is
+    // dropped. Guards against "fix" by deleting both.
+    expect(src).toMatch(/brandMark/)
+    expect(src).toMatch(/size=\{64\}|w-16 h-16/)
+  })
+})


### PR DESCRIPTION
## Problem

The chat welcome heading is `text-5xl` (48px) at **every** width. It sits in a
`gap-4` row between a 64px brand mark and a 64px optical-centering spacer, inside
`px-8` — so at a 320px viewport the heading itself gets **189px**.

Measured standalone with the real padding, gap, mark and font size:

| arm | 320px | 390px |
|---|---|---|
| `text-5xl` + spacer | en **5 lines**, de/fr **6 lines** (325px tall) | en 3 lines, fr **5 lines** |
| `text-3xl`, spacer released | all **2 lines** (82px) | en 1 line, rest 2 lines |

So the hero alone was consuming 260–325px before anything else on the screen.
The tracker's original report ("wraps to 5 lines") matches the English number at
320px exactly; German and French are worse, which is the usual pattern — the
defect is content-dependent and English-only testing understates it.

## Change

Two declarations, both `sm`-gated so desktop is untouched:

- the heading becomes `text-3xl sm:text-5xl`
- the spacer becomes `hidden sm:block`

The spacer is purely decorative — it counterweights the brand mark so the
heading reads optically centred — so it does not get to keep 64px (20% of a
320px viewport). The **brand mark itself stays**: it carries the product
identity, and deleting both would be a different change.

## Verification

Three assertions, each falsified — the suite goes red for all three:

| mutation | caught |
|---|---|
| revert the heading to unconditional `text-5xl` | yes |
| make the heading small at every width (loses desktop) | yes |
| let the spacer keep 64px on a phone | yes |

The third assertion also guards against "fixing" this by deleting the brand mark
along with the spacer.

`npx tsc -b` clean. Full frontend suite: 1256 files, 20216 passed, 0 failures.
