### PR TITLE
fix(ci): guard vulnerability exception maintenance

### DIFF
--- a/scripts/check_npm_audit.py
+++ b/scripts/check_npm_audit.py
@@ -16,6 +16,10 @@ from typing import Any, Callable, Mapping, Sequence
 NPM_VERSION = "10.8.2"
 AUDIT_TIMEOUT_SECONDS = 120
 MAX_EXCEPTION_DAYS = 30
+# Lead time on the expiry warning. An exception stays valid through its expiry
+# date and the gate fails closed the day after, so this is the window in which
+# the owner can still renew or remove it before a build breaks.
+EXPIRY_WARNING_DAYS = 7
 EXCEPTIONS_FILENAME = ".vulnerability-exceptions.json"
 AUDITED_LOCKFILES = (
     "website/package-lock.json",
@@ -167,6 +171,49 @@ def load_exception_rules(path: Path, *, today: date | None = None) -> list[Excep
     except json.JSONDecodeError as exc:
         raise GateError(f"exception file {path} is not valid JSON: {exc}") from exc
     return validate_exception_document(document, today=today)
+
+
+def expiring_exception_rules(
+    rules: Sequence[ExceptionRule],
+    *,
+    today: date,
+    within_days: int = EXPIRY_WARNING_DAYS,
+) -> list[tuple[ExceptionRule, int]]:
+    """Return (rule, days remaining) for exceptions inside the warning window.
+
+    An already-expired rule is never returned: ``validate_exception_document``
+    rejects it outright, so by the time a rule reaches here it is still valid and
+    the count is zero or positive. Zero means the expiry date itself, which is
+    the last day the rule holds.
+    """
+    upcoming: list[tuple[ExceptionRule, int]] = []
+    for rule in rules:
+        remaining = (rule.expires - today).days
+        if 0 <= remaining <= within_days:
+            upcoming.append((rule, remaining))
+    # Soonest first, then by scope, so repeated runs emit an identical ordering.
+    upcoming.sort(key=lambda item: (item[0].expires, item[0].package, item[0].advisory))
+    return upcoming
+
+
+def expiry_warning_lines(
+    rules: Sequence[ExceptionRule],
+    *,
+    today: date,
+    within_days: int = EXPIRY_WARNING_DAYS,
+) -> list[str]:
+    """Render one actionable GitHub warning annotation per expiring exception."""
+    lines: list[str] = []
+    for rule, remaining in expiring_exception_rules(rules, today=today, within_days=within_days):
+        when = "today" if remaining == 0 else f"in {remaining} day(s)"
+        fails_on = rule.expires + timedelta(days=1)
+        lines.append(
+            f"::warning::vulnerability exception for {rule.package} {rule.advisory} "
+            f"(owner {rule.owner}) expires {when} on {rule.expires.isoformat()}; "
+            f"this audit fails closed from {fails_on.isoformat()} until the exception is "
+            f"renewed or removed in {EXCEPTIONS_FILENAME}"
+        )
+    return lines
 
 
 def locate_npx(which: Callable[[str], str | None] = shutil.which) -> str:
@@ -408,7 +455,16 @@ def unexcepted_findings(
 
 def main() -> int:
     try:
-        rules = load_exception_rules(_REPO_ROOT / EXCEPTIONS_FILENAME)
+        # One `today` for both the validation and the warning, so a run spanning
+        # UTC midnight cannot judge the same rule against two different dates.
+        today = _utc_today()
+        rules = load_exception_rules(_REPO_ROOT / EXCEPTIONS_FILENAME, today=today)
+        # Emitted BEFORE the audit: the audit reaches the network and can fail
+        # for reasons of its own, and the owner still needs the expiry notice
+        # when it does. This runs on every nightly, which is what makes the
+        # warning time-based rather than dependent on someone opening a PR.
+        for line in expiry_warning_lines(rules, today=today):
+            print(line)
         npx = locate_npx()
         findings: list[Finding] = []
         for lockfile in AUDITED_LOCKFILES:

--- a/test/fixtures/npm-audit/10.8.2/clean.json
+++ b/test/fixtures/npm-audit/10.8.2/clean.json
@@ -1,0 +1,22 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {},
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    },
+    "dependencies": {
+      "prod": 412,
+      "dev": 0,
+      "optional": 7,
+      "peer": 0,
+      "peerOptional": 0,
+      "total": 418
+    }
+  }
+}

--- a/test/fixtures/npm-audit/10.8.2/direct-high.json
+++ b/test/fixtures/npm-audit/10.8.2/direct-high.json
@@ -1,0 +1,45 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {
+    "example-package": {
+      "name": "example-package",
+      "severity": "high",
+      "isDirect": true,
+      "via": [
+        {
+          "source": 1234567,
+          "name": "example-package",
+          "dependency": "example-package",
+          "title": "Example direct production vulnerability",
+          "url": "https://github.com/advisories/GHSA-2345-6789-cfgh",
+          "severity": "high",
+          "cwe": ["CWE-79"],
+          "cvss": { "score": 7.5, "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N" },
+          "range": "<2.0.0"
+        }
+      ],
+      "effects": [],
+      "range": "<2.0.0",
+      "nodes": ["node_modules/example-package"],
+      "fixAvailable": true
+    }
+  },
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 1,
+      "critical": 0,
+      "total": 1
+    },
+    "dependencies": {
+      "prod": 412,
+      "dev": 0,
+      "optional": 7,
+      "peer": 0,
+      "peerOptional": 0,
+      "total": 418
+    }
+  }
+}

--- a/test/fixtures/npm-audit/10.8.2/indirect-high.json
+++ b/test/fixtures/npm-audit/10.8.2/indirect-high.json
@@ -1,0 +1,55 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {
+    "example-package": {
+      "name": "example-package",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1234567,
+          "name": "example-package",
+          "dependency": "example-package",
+          "title": "Example transitive production vulnerability",
+          "url": "https://github.com/advisories/GHSA-2345-6789-cfgh",
+          "severity": "high",
+          "cwe": ["CWE-1333"],
+          "cvss": { "score": 7.5, "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H" },
+          "range": "<2.0.0"
+        }
+      ],
+      "effects": ["example-wrapper"],
+      "range": "<2.0.0",
+      "nodes": ["node_modules/example-package"],
+      "fixAvailable": true
+    },
+    "example-wrapper": {
+      "name": "example-wrapper",
+      "severity": "high",
+      "isDirect": true,
+      "via": ["example-package"],
+      "effects": [],
+      "range": "<=3.1.4",
+      "nodes": ["node_modules/example-wrapper"],
+      "fixAvailable": true
+    }
+  },
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 2,
+      "critical": 0,
+      "total": 2
+    },
+    "dependencies": {
+      "prod": 412,
+      "dev": 0,
+      "optional": 7,
+      "peer": 0,
+      "peerOptional": 0,
+      "total": 418
+    }
+  }
+}

--- a/test/test_dependency_vulnerability_gate.py
+++ b/test/test_dependency_vulnerability_gate.py
@@ -153,6 +153,25 @@ class TestWorkflowContract:
             assert jobs["build-wheel"]["needs"] == expected_needs
             assert jobs["build-desktop"]["needs"] == expected_needs
 
+    def test_nightly_schedule_runs_the_gate_unconditionally(self) -> None:
+        # The expiry warning is emitted by the gate script itself, so its
+        # time-based delivery rests entirely on this schedule invoking the gate
+        # every day. Gating the job behind an `if:` would silently downgrade the
+        # reminder to "whenever someone opens a PR".
+        #
+        # The cron is pinned by exact value rather than merely asserted to exist,
+        # because the CADENCE is what the EXPIRY_WARNING_DAYS window depends on:
+        # a change to, say, a monthly schedule leaves a "a cron is present" check
+        # green while letting an exception jump from outside the window straight
+        # to expired. Pinning the literal also catches a harmless time-of-day
+        # move, which is the intended cost — retuning the nightly schedule should
+        # make someone re-confirm the reminder still has enough lead time.
+        nightly = yaml.safe_load((WORKFLOWS / "nightly.yml").read_text(encoding="utf-8"))
+        # PyYAML resolves an unquoted `on:` key to the boolean True.
+        triggers = nightly.get("on", nightly.get(True))
+        assert triggers["schedule"] == [{"cron": "0 6 * * *"}]
+        assert "if" not in nightly["jobs"]["dependency-vulnerability-gate"]
+
 
 class TestExceptionContract:
     def test_schema_and_committed_registry_are_valid(self) -> None:
@@ -384,3 +403,179 @@ class TestFailClosedAudit:
         assert "--ignore-scripts" in command
         assert "--audit-level=high" in command
         assert command[-1] == "--json"
+
+
+def _rules_expiring_in(days: int) -> list[Any]:
+    entry = _exception(expires=(TODAY + timedelta(days=days)).isoformat())
+    return gate.validate_exception_document(_document(entry), today=TODAY)
+
+
+# Spelled as a literal so this module still COLLECTS against a tree without the
+# warning feature — a parametrize decorator reading gate.EXPIRY_WARNING_DAYS is
+# evaluated at import and would turn a fail-before run into a collection error,
+# which proves only that the symbol is new. The literal is pinned to the constant
+# by test_warning_window_matches_the_declared_lead_time below.
+WARNING_DAYS = 7
+
+
+class TestExpiryWarning:
+    """An exception is valid THROUGH its expiry date and fails closed the next
+    day. These pin both halves of that boundary and the lead time around it."""
+
+    def test_warning_window_matches_the_declared_lead_time(self) -> None:
+        assert gate.EXPIRY_WARNING_DAYS == WARNING_DAYS
+
+    @pytest.mark.parametrize(
+        ("days", "expected"),
+        [
+            (WARNING_DAYS + 1, 0),  # outside the window: silent
+            (WARNING_DAYS, 1),  # the threshold itself warns
+            (1, 1),
+            (0, 1),  # the expiry date: last valid day, still warns
+        ],
+    )
+    def test_warning_window_boundaries(self, days: int, expected: int) -> None:
+        rules = _rules_expiring_in(days)
+        assert len(gate.expiring_exception_rules(rules, today=TODAY)) == expected
+        assert len(gate.expiry_warning_lines(rules, today=TODAY)) == expected
+
+    def test_expiry_date_is_still_valid_and_the_next_day_is_not(self) -> None:
+        expires = TODAY + timedelta(days=3)
+        document = _document(_exception(expires=expires.isoformat()))
+
+        # Valid through the expiry date, and warned about on it.
+        rules = gate.validate_exception_document(document, today=expires)
+        assert [remaining for _rule, remaining in gate.expiring_exception_rules(rules, today=expires)] == [0]
+
+        # The day after, validation itself refuses — the warning never softens this.
+        with pytest.raises(gate.GateError, match="expired"):
+            gate.validate_exception_document(document, today=expires + timedelta(days=1))
+
+    def test_warning_is_actionable(self) -> None:
+        (line,) = gate.expiry_warning_lines(_rules_expiring_in(3), today=TODAY)
+        expires = (TODAY + timedelta(days=3)).isoformat()
+        fails_on = (TODAY + timedelta(days=4)).isoformat()
+
+        assert line.startswith("::warning::")
+        for token in (
+            "example-package",  # package
+            "GHSA-2345-6789-cfgh",  # advisory
+            "@security-team",  # owner
+            expires,  # expiry date
+            "in 3 day(s)",  # days remaining
+            fails_on,  # when the gate starts failing
+            gate.EXCEPTIONS_FILENAME,  # where to act
+        ):
+            assert token in line, token
+
+    def test_expiry_day_warning_reads_as_today(self) -> None:
+        (line,) = gate.expiry_warning_lines(_rules_expiring_in(0), today=TODAY)
+        assert "expires today on" in line
+
+    def test_multiple_exceptions_are_reported_soonest_first(self) -> None:
+        rules = gate.validate_exception_document(
+            _document(
+                _exception(package="later-package", expires=(TODAY + timedelta(days=5)).isoformat()),
+                _exception(package="sooner-package", expires=(TODAY + timedelta(days=2)).isoformat()),
+                _exception(package="distant-package", expires=(TODAY + timedelta(days=20)).isoformat()),
+            ),
+            today=TODAY,
+        )
+        assert [rule.package for rule, _ in gate.expiring_exception_rules(rules, today=TODAY)] == [
+            "sooner-package",
+            "later-package",
+        ]
+
+    def _run_main(self, monkeypatch: Any, tmp_path: Path, *, days: int) -> str:
+        """Drive the real main() with a near-expiry registry and no network."""
+        (tmp_path / gate.EXCEPTIONS_FILENAME).write_text(
+            json.dumps(_document(_exception(expires=(TODAY + timedelta(days=days)).isoformat()))),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gate, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(gate, "_utc_today", lambda: TODAY)
+        monkeypatch.setattr(gate, "locate_npx", lambda *_a, **_k: "/usr/bin/npx")
+        monkeypatch.setattr(gate, "run_audit", lambda *_a, **_k: [])
+        assert gate.main() == 0
+        return sys.stdout.getvalue() if hasattr(sys.stdout, "getvalue") else ""
+
+    def test_main_warns_on_the_nightly_run(
+        self, monkeypatch: Any, tmp_path: Path, capsys: Any
+    ) -> None:
+        # The gate already runs daily (nightly.yml calls the reusable workflow
+        # unconditionally), so emitting from main() is what gives the reminder a
+        # time-based path rather than one that waits for somebody to open a PR.
+        self._run_main(monkeypatch, tmp_path, days=3)
+        out = capsys.readouterr().out
+        assert "::warning::" in out
+        assert "example-package" in out
+        assert "@security-team" in out
+
+    def test_main_is_silent_outside_the_window(
+        self, monkeypatch: Any, tmp_path: Path, capsys: Any
+    ) -> None:
+        self._run_main(monkeypatch, tmp_path, days=WARNING_DAYS + 1)
+        assert "::warning::" not in capsys.readouterr().out
+
+
+NPM_FIXTURES = ROOT / "test" / "fixtures" / "npm-audit"
+
+
+def _fixture(name: str) -> str:
+    return (NPM_FIXTURES / gate.NPM_VERSION / name).read_text(encoding="utf-8")
+
+
+class TestPinnedNpmOutputFixtures:
+    """`parse_audit_report` is deliberately strict about npm's output shape, so a
+    change to the pinned npm version can brick the gate. These feed representative
+    captured output for the CURRENTLY pinned version through the real parser."""
+
+    def test_pinned_version_has_compatibility_fixtures(self) -> None:
+        directory = NPM_FIXTURES / gate.NPM_VERSION
+        missing = [
+            name
+            for name in ("clean.json", "direct-high.json", "indirect-high.json")
+            if not (directory / name).is_file()
+        ]
+        assert not missing, (
+            f"npm is pinned to {gate.NPM_VERSION} but {directory} is missing {missing}. "
+            "Capture `npm audit --omit=dev --package-lock-only --json` output from that "
+            "version and add it, so parse_audit_report is proven against the shape the "
+            "gate actually runs."
+        )
+
+    def test_clean_report_parses_to_no_findings(self) -> None:
+        assert gate.parse_audit_report(_fixture("clean.json"), returncode=0, lockfile=LOCKFILE) == []
+
+    def test_direct_high_advisory_parses(self) -> None:
+        findings = gate.parse_audit_report(
+            _fixture("direct-high.json"), returncode=1, lockfile=LOCKFILE
+        )
+        assert findings == [
+            gate.Finding(
+                lockfile=LOCKFILE,
+                package="example-package",
+                advisory="GHSA-2345-6789-cfgh",
+                severity="high",
+                title="Example direct production vulnerability",
+            )
+        ]
+
+    def test_indirect_advisory_resolves_through_the_via_reference(self) -> None:
+        findings = gate.parse_audit_report(
+            _fixture("indirect-high.json"), returncode=1, lockfile=LOCKFILE
+        )
+        # The wrapper's `via` is a STRING reference; the parser must follow it to
+        # the referenced package's advisory rather than dropping the finding.
+        assert {(finding.package, finding.advisory) for finding in findings} == {
+            ("example-package", "GHSA-2345-6789-cfgh"),
+            ("example-wrapper", "GHSA-2345-6789-cfgh"),
+        }
+
+    def test_fixture_still_fails_closed_when_its_counts_are_contradicted(self) -> None:
+        # The fixtures are only trustworthy if they are being genuinely parsed:
+        # feeding a blocking report as if npm had exited 0 must still be refused.
+        with pytest.raises(gate.GateError, match="contradicts"):
+            gate.parse_audit_report(
+                _fixture("direct-high.json"), returncode=0, lockfile=LOCKFILE
+            )


### PR DESCRIPTION
## Problem / Motivation

The production dependency gate fails closed the day after a vulnerability
exception expires — `validate_exception_document` raises `expired on <date>`
once `expires < today`. That refusal is correct and this PR does not touch it.

What is missing is any warning before it. The gate prints the same lines on the
run before the cliff as on a run a year earlier, so the first signal an owner
gets is a red build on an unrelated change. The two committed exceptions
(`react-router` / `react-router-dom`, `GHSA-qwww-vcr4-c8h2`, owner `@pepmach`)
both expire on **2026-08-31**, and the gate blocks the nightly build, the release
build, and PR code review.

Separately, `parse_audit_report` is deliberately strict about npm's output shape
— it requires `auditReportVersion == 2`, cross-checks metadata counts against
resolved advisories, and fails closed on anything it does not recognise. npm is
pinned at `NPM_VERSION = "10.8.2"`, but no fixture records what that version
actually emits. A bump to the pin can therefore brick the security gate, and
nothing local would catch it.

## Why it matters

Both are maintenance cliffs on a **fail-closed security control**, which is the
worst place to have one: the failure mode is a blocked release, and the person
who hits it is whoever happens to push that day rather than the exception's owner.

The npm one is worse in kind — the parser only breaks *after* someone changes the
pin, so the gate looks healthy right up until the version bump lands.

## What changed (motivation → approach → change)

**Motivation** — give the owner lead time, and pin the parser's accepted input
shape to the version actually being run.

**Approach** — the reminder needs a reliable *time-based* path, not one that
waits for somebody to open a PR. It already has one: `nightly.yml` runs on
`cron: "0 6 * * *"` and calls the reusable gate workflow with **no `if:`
condition**, so `check_npm_audit.py` executes daily. Emitting from the script
itself therefore needs no new workflow and no extra networked `npm audit` — it
rides a run that already happens. A dedicated scheduled workflow was considered
and rejected as redundant.

**Change**

- `EXPIRY_WARNING_DAYS = 7`, plus two small pure helpers:
  `expiring_exception_rules()` returns `(rule, days_remaining)` for rules inside
  the window, soonest first for deterministic output; `expiry_warning_lines()`
  renders one `::warning::` annotation each — the repo's existing convention in
  `check_brand_name.py` / `check_harness_parity.py`.
- `main()` emits them **before** the audit, so a network or tooling failure
  cannot swallow the notice, and derives one `today` for both validation and the
  warning so a run spanning UTC midnight cannot judge one rule against two dates.
- Each annotation carries package, advisory, owner, expiry date, days remaining,
  the date the audit starts failing, and the file to edit.
- `test/fixtures/npm-audit/10.8.2/{clean,direct-high,indirect-high}.json` —
  representative captured output for the pinned version, fed through the **real**
  `parse_audit_report`. The indirect fixture exercises the `via` *string*
  reference path, which is the recursion most likely to break on an output-shape
  change.
- A ratchet derives the expected fixture directory from `NPM_VERSION`, so moving
  the pin without adding fixtures fails with an actionable message naming the
  command to capture.

**Expiry semantics are unchanged.** An exception is valid **through** its expiry
date and rejected the day after. The warning is pre-expiry guidance only: it
never renews, never mutates `.vulnerability-exceptions.json`, and never downgrades
an expired exception. No security policy moved — blocked severities,
`MAX_EXCEPTION_DAYS`, matching semantics, audited lockfiles, audit flags, the npm
pin, and the committed exceptions are all as they were.

## Tests

`test/test_dependency_vulnerability_gate.py`, 30 → **42 passing**.

Fail-before measured by checking out `origin/main`'s `scripts/check_npm_audit.py`
under the new tests — **10 failed, 31 passed**. Being precise about what that
number is worth:

- **One is behavioural**, and it is the load-bearing one.
  `test_main_warns_on_the_nightly_run` drives the real `main()` with a registry
  three days from expiry and no network, and on `main` it fails on output, not on
  a missing symbol:
  ```
  AssertionError: assert '::warning::' in 'Auditing production dependencies in
  website/package-lock.json with npm@10.8.2 ...\n...\nProduction dependency audit
  passed: 3 lockfiles, 0 governed exception(s).\n'
  ```
- **Nine are `AttributeError`** on the new helpers. They are new-contract tests,
  not regressions, and are reported as such rather than dressed up as a defect.
- **The fixture tests pass on `main` too** — `parse_audit_report` is unchanged, so
  they are preservation and ratchet infrastructure, not evidence of a fix. Stating
  that plainly rather than folding them into the fail-before count.

The test module is written to **collect** against a tree without the feature: the
warning window is a module-level literal pinned to `gate.EXPIRY_WARNING_DAYS` by
its own test, because reading the constant inside a `parametrize` decorator is
evaluated at import and turns the whole fail-before run into a collection error —
which would have proved only that the symbol is new.

Boundary coverage: 8 days → silent; 7 days → warns; 1 day → warns; expiry date →
warns and **still valid**; the day after → `GateError: expired` as before.
Also covered: the annotation carries every actionable field, multiple exceptions
report soonest-first, the clean/direct/indirect fixtures parse to the expected
`Finding`s, and a blocking fixture presented with `returncode=0` still fails
closed — so the fixtures cannot silently stop being parsed.

```
pytest test/test_dependency_vulnerability_gate.py -q     42 passed
```

`flake8`, `isort --check-only`, `git diff --check` clean on both changed Python
files; `scripts/docs_lint.py` and `BRAND_BASE_REF=origin/main
scripts/check_brand_name.py` pass. `mypy` reports no issues on the script,
though CI's typed gate is `src/kiro_crew/` and does not cover `scripts/`.

## Manual verification

Ran the gate's real `main()` against a temporary registry with `run_audit` stubbed
and `_utc_today` frozen, confirming the annotation text end to end:

```
::warning::vulnerability exception for example-package GHSA-2345-6789-cfgh
(owner @security-team) expires in 3 day(s) on 2026-08-04; this audit fails closed
from 2026-08-05 until the exception is renewed or removed in
.vulnerability-exceptions.json
```

Confirmed against current `main` that `nightly.yml` schedules `cron: "0 6 * * *"`
and its `dependency-vulnerability-gate` job carries no `if:`, which is what makes
the reminder time-based; a test now pins both so that path cannot be removed
silently. No UI surface is involved.

## Screenshots / video

<!-- no-visual-delta -->

CI tooling only — no user-visible surface.

## Related Issues

Closes #1035 — both requested safeguards land here: the pre-expiry reminder and
the versioned npm-audit parser fixtures with a pinned-version ratchet.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — no documented behaviour changed; the exception contract and its schema are untouched
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
