### PR TITLE
fix(autopilot): offload orchestrator config load

### DIFF
--- a/src/kiro_crew/context_management.py
+++ b/src/kiro_crew/context_management.py
@@ -138,6 +138,24 @@ class OrchestrationTracker:
         """
         return self._stage_timeout
 
+    @stage_timeout_seconds.setter
+    def stage_timeout_seconds(self, seconds: int) -> None:
+        """Set the per-stage budget after construction.
+
+        The orchestrator builds its tracker before it knows the configured
+        value: reading the config blocks, so it is loaded on a worker, and a
+        plan cancel arriving during that load needs a tracker already published
+        to stop. The tracker therefore starts on the default above and is
+        adjusted here once the load returns.
+
+        Safe at that point, and only at that point: the budget is consulted by
+        ``is_stage_timed_out`` and by callers deriving a wait from it, all of
+        which run per stage, and ``_stage_start`` is still 0 until the first
+        round is recorded. Changing it mid-stage would move a deadline the
+        current stage is already being measured against, so callers must not.
+        """
+        self._stage_timeout = seconds
+
     @property
     def timeout_human(self) -> str:
         """Human-friendly timeout string, e.g. '30m' or '1m30s'."""

--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -282,6 +282,54 @@ async def _exit_cancelled_plan(state: "DashboardState", slot: "_ChatSlot") -> No
     state.push_slots_update()
 
 
+async def _load_stage_budget(slot: "_ChatSlot", tracker: OrchestrationTracker) -> bool:
+    """Apply the configured stage timeout to *tracker*. False to abandon the plan.
+
+    The load stats and reads ``config.json`` plus any ``config.local.json``
+    overlay, deep-merges them and runs the full schema validation, so it runs on
+    a worker. Only the load crosses over: the value is applied and the slot read
+    back on the loop, so no live orchestration state is handed to a thread. A
+    failed load keeps the tracker's default budget, which is the same fallback
+    the inline load had.
+
+    Both cancellation channels can fire while that worker runs, and the check
+    afterwards has to survive the fact that neither necessarily leaves state a
+    plain re-read would see:
+
+    * **Plan Cancel** stops the tracker. It is published before this is called
+      precisely so that it does, which is why ``_orchestration_stopped`` is
+      enough here and no separate record is kept.
+    * **Dashboard Stop** has no ACP turn to cancel yet, so ``stop_turn`` answers
+      "idle" and the handler releases ``_stop_state`` straight back to "idle" --
+      re-reading ``slot._stopping`` afterwards would show an unstopped slot.
+      ``slot._stop_generation`` counts stop INITIATIONS and is never rewound, so
+      snapshotting it before the wait reports a Stop that fired AND resolved
+      inside it. Same reading, and the same reason, as the poisoned-conversation
+      canary in ``chat_runner``.
+
+    Returning False rather than raising keeps the caller's exit on its normal
+    path: the plan must not start, but the loop still owes the slot its cleanup.
+    """
+    _stop_generation = slot._stop_generation
+    try:
+        cfg = await asyncio.to_thread(KiroCrewConfig.load)
+        tracker.stage_timeout_seconds = cfg.orchestrator.stage_timeout_seconds
+    except Exception:
+        logger.debug(
+            "Orchestrator config load failed for slot %s; keeping the default " "stage budget",
+            slot.key,
+            exc_info=True,
+        )
+    if slot._stop_generation != _stop_generation or _orchestration_stopped(slot, tracker):
+        logger.info(
+            "Stage loop for slot %s abandoned: a stop or plan cancel landed "
+            "while the orchestrator config was loading",
+            slot.key,
+        )
+        return False
+    return True
+
+
 async def _stage_loop(
     state: "DashboardState",
     slot: "_ChatSlot",
@@ -309,12 +357,24 @@ async def _stage_loop(
         return
 
     tracker = slot._orch_tracker
+    # Publish the tracker BEFORE the config load suspends below. That load is
+    # this loop's first await, ahead of every stage gate, and a plan Cancel
+    # landing in the window has to have something to stop: api_chat_plan_action
+    # stops slot._orch_tracker, so against a None tracker it stops nothing while
+    # still telling the user the plan was cancelled.
+    #
+    # Building it first is what lets `tracker.stopped` -- the canonical plan
+    # cancel signal every advancement gate already reads through
+    # `_orchestration_stopped` -- cover this window too, rather than a second
+    # cancellation record kept alongside it that can drift from it.
+    #
+    # It starts on OrchestrationTracker's own default budget, the same 1800s
+    # this loop fell back to when the load raised, and takes the configured
+    # value below once that is known. Nothing reads the budget until a stage
+    # records its first round, which cannot happen before the load returns.
+    _bootstrapping = tracker is None
     if tracker is None:
-        try:
-            _timeout = KiroCrewConfig.load().orchestrator.stage_timeout_seconds
-        except Exception:
-            _timeout = 1800
-        tracker = OrchestrationTracker(stage_timeout_seconds=_timeout)
+        tracker = OrchestrationTracker()
         slot._orch_tracker = tracker
 
     total = slot._plan_stage_count
@@ -349,6 +409,13 @@ async def _stage_loop(
     # finally once the plan ends.
     slot._in_stage_execution = True
     try:
+        # Inside the try, so an abort here leaves through the same `finally` as
+        # every other exit: the guard is cleared, a message the user queued
+        # while this was loading is handed off, and the slot is closed out. A
+        # bare `return` from the bootstrap would skip all of it and strand that
+        # message behind a guard nothing clears.
+        if _bootstrapping and not await _load_stage_budget(slot, tracker):
+            return
         for stage_idx in range(start_idx, total):
             if _orchestration_stopped(slot, tracker):
                 break
@@ -825,6 +892,17 @@ async def _stage_loop(
         # have already started (e.g. a refusal-recovery continuation): that live
         # task owns slot.task and will drain the queue + emit chat_done itself, so
         # we must not start a second turn or clobber/idle-close over it.
+        # `slot.running` is asking whether a turn a stage STARTED is still
+        # holding the slot: `_run_chat` publishes its own task on `slot.task`
+        # and clears it when the turn ends, and this loop must defer to one that
+        # is still live. It is not asking about this loop -- yet when no stage
+        # turn ever ran, `slot.task` is still this very task, which is alive by
+        # definition here, so the raw read reports a turn that does not exist.
+        # That silently skipped BOTH the handoff and the idle close on exactly
+        # the paths with nothing else to perform them: an abandoned bootstrap,
+        # and a plan with no stages.
+        _own_task = asyncio.current_task()
+        _turn_live = slot.running and slot.task is not _own_task
         _next_started = False
         # Before _start_next_queued_turn, not after: a held note's context half
         # drains into that successor, so flushing later would let the note shape
@@ -858,7 +936,7 @@ async def _stage_loop(
             slot._queue[:] = [e for e in slot._queue if not _is_plan_approval_entry(e)]
         if (
             not _cancelled
-            and not slot.running
+            and not _turn_live
             and not slot._last_turn_auth_required
             and state._slots.get(slot.key) is slot
             and slot._queue
@@ -866,7 +944,7 @@ async def _stage_loop(
         ):
             state.push_slots_update()
             _next_started = await _start_next_queued_turn(state, slot)
-        if not _next_started and not slot.running:
+        if not _next_started and not _turn_live:
             if not _paused:
                 slot.append("done", "", "done")
                 state.broadcast_ws("chat_done", {"slot": slot.key})

--- a/test/test_completion_result_read_off_loop.py
+++ b/test/test_completion_result_read_off_loop.py
@@ -268,7 +268,11 @@ async def test_no_worker_hop_when_no_stage_results_were_captured(monkeypatch):
 
     await _stage_loop(state, slot, auto_run=True)
 
-    assert hops == []
+    # Scoped to the completion read rather than asserting the loop makes no hop
+    # at all: `_stage_loop` legitimately offloads other blocking work (the
+    # first-entry config load), and this test's subject is only that an empty
+    # result set skips the excerpt worker.
+    assert [f for f in hops if f is chat_orchestrator._completion_excerpts] == []
     assert _completion_message(slot).splitlines() == [
         "✅ All 2 stages complete.",
         "  Stage 1: First — done",

--- a/test/test_orchestrator_config_load_off_loop.py
+++ b/test/test_orchestrator_config_load_off_loop.py
@@ -1,0 +1,664 @@
+"""The orchestrator's first-stage config load must not run on the gateway loop.
+
+``_stage_loop`` is async, but the first time it runs for a slot it has no
+``OrchestrationTracker`` yet and builds one from the configured stage timeout.
+That read goes through ``KiroCrewConfig.load()``, which stats and reads
+``config.json`` plus any ``config.local.json`` overlay, deep-merges them and runs
+the full jsonschema validation — all synchronously, on the single event loop the
+gateway shares with every other session.
+
+Only the load crosses to a worker. The value is applied and the slot is read back
+on the loop, so no live orchestration state is handed to another thread.
+
+The hop is also the loop's FIRST suspension point, ahead of every stage check, so
+both cancellation channels can now land while the worker runs, and the tests here
+drive each through its real endpoint:
+
+* **Plan Cancel** stops ``slot._orch_tracker``. The tracker is therefore
+  published BEFORE the load rather than built from its result, so the press has
+  the canonical thing to stop and the check afterwards is the same
+  ``_orchestration_stopped`` every advancement gate already uses. Nothing reads
+  the stage budget until a stage records its first round, so adjusting it once
+  the load returns is safe.
+* **Dashboard Stop** can fire AND fully resolve inside the await, leaving
+  ``_stopping`` back at False, which is why the loop compares
+  ``_stop_generation`` rather than re-reading the flag.
+
+Abandoning the plan is not the same as abandoning the slot: a message the user
+queued while the config loaded is held behind the ``_in_stage_execution`` guard,
+and only the stage loop's own ``finally`` clears it and hands the queue on. The
+abort therefore leaves through that ``finally`` like any other exit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig, config_dir
+from kiro_crew.context_management import OrchestrationTracker
+from kiro_crew.dashboard.state import _ChatSlot
+
+
+def _state() -> MagicMock:
+    state = MagicMock()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.subagents = MagicMock()
+    state.subagents.running_agents_for = MagicMock(return_value=[])
+    return state
+
+
+def _slot(key: str = "cfg-load-slot") -> _ChatSlot:
+    slot = _ChatSlot(key, mode="orchestrator")
+    slot._auto_run = False
+    # `_plan_stage_count` is derived from the titles, not settable. An empty plan
+    # drives tracker initialisation — the branch under test — and then leaves the
+    # stage loop with nothing to execute, so no model turn is involved.
+    slot._stage_titles = []
+    slot._orch_tracker = None
+    return slot
+
+
+def _write_config(payload: dict[str, Any]) -> None:
+    """Put a real config.json in the per-test KIROCREW_HOME.
+
+    The conftest pins that home to a tmp dir, so the REAL loader runs against
+    controlled files rather than the developer's own configuration.
+    """
+    directory = config_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    import json
+
+    (directory / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _record_config_loads(monkeypatch: Any, threads: list[int], *, raises: bool = False) -> None:
+    """Wrap the loader the orchestrator actually calls.
+
+    ``chat_orchestrator`` binds ``KiroCrewConfig`` at import, so replacing that
+    module attribute intercepts the production call site. The wrapper delegates to
+    the real classmethod, so the recorded thread is the one that genuinely stats,
+    reads, merges and validates the config — not merely a thread that reached a
+    call site. It works identically whether the call site is direct or routed
+    through ``asyncio.to_thread``.
+    """
+
+    def loader() -> KiroCrewConfig:
+        threads.append(threading.get_ident())
+        if raises:
+            raise OSError("config unreadable")
+        return KiroCrewConfig.load()
+
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_orchestrator.KiroCrewConfig",
+        types.SimpleNamespace(load=loader),
+    )
+
+
+def _gate_config_load(monkeypatch: Any) -> tuple[asyncio.Event, asyncio.Event]:
+    """Pause the real worker hop on loop-owned events, without wall-clock bounds."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    real_to_thread = asyncio.to_thread
+
+    async def gated_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        entered.set()
+        await release.wait()
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_orchestrator.asyncio.to_thread",
+        gated_to_thread,
+    )
+    return entered, release
+
+
+async def _wait_for_config_gate(task: asyncio.Task[Any], entered: asyncio.Event) -> None:
+    """Wait for the gate, or fail immediately if the stage loop exits first."""
+    entry_task = asyncio.create_task(entered.wait())
+    done, _ = await asyncio.wait({task, entry_task}, return_when=asyncio.FIRST_COMPLETED)
+    if task in done:
+        entry_task.cancel()
+        await asyncio.gather(entry_task, return_exceptions=True)
+        await task
+        pytest.fail("the stage loop exited before reaching the config worker hop")
+    await entry_task
+
+
+async def _init_tracker(slot: _ChatSlot) -> None:
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    await _stage_loop(_state(), slot, auto_run=False)
+
+
+@pytest.mark.asyncio
+async def test_config_load_runs_off_the_loop_thread(monkeypatch: Any) -> None:
+    """The first-stage config read executes on a thread other than the loop's."""
+    threads: list[int] = []
+    _record_config_loads(monkeypatch, threads)
+
+    slot = _slot()
+    await _init_tracker(slot)
+
+    assert threads, (
+        "the orchestrator never loaded config -- this test no longer exercises "
+        "tracker initialisation and would pass vacuously"
+    )
+    assert threading.get_ident() not in threads, (
+        "the orchestrator config was loaded on the event-loop thread; the "
+        "filesystem and schema work must be handed to asyncio.to_thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_configured_timeout_reaches_the_tracker(monkeypatch: Any) -> None:
+    """Preservation: the configured value is what the tracker is built with."""
+    _write_config({"orchestrator": {"stage_timeout_seconds": 42}})
+    threads: list[int] = []
+    _record_config_loads(monkeypatch, threads)
+
+    slot = _slot()
+    await _init_tracker(slot)
+
+    assert slot._orch_tracker is not None
+    assert slot._orch_tracker.stage_timeout_seconds == 42
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_is_preserved_rather_than_defaulted(monkeypatch: Any) -> None:
+    """Preservation: a falsy timeout means 'disabled' and must survive intact.
+
+    The stage loop reads it back as ``if tracker.stage_timeout_seconds:``, so
+    collapsing 0 onto the 1800 fallback with an ``or`` would silently re-enable a
+    ceiling the operator turned off.
+    """
+    _write_config({"orchestrator": {"stage_timeout_seconds": 0}})
+    threads: list[int] = []
+    _record_config_loads(monkeypatch, threads)
+
+    slot = _slot()
+    await _init_tracker(slot)
+
+    assert slot._orch_tracker is not None
+    assert slot._orch_tracker.stage_timeout_seconds == 0
+
+
+@pytest.mark.asyncio
+async def test_loader_failure_falls_back_to_the_default_timeout(monkeypatch: Any) -> None:
+    """Preservation: a raising loader still yields a usable tracker at 1800."""
+    threads: list[int] = []
+    _record_config_loads(monkeypatch, threads, raises=True)
+
+    slot = _slot()
+    await _init_tracker(slot)
+
+    assert threads, "the failing loader was never reached"
+    assert slot._orch_tracker is not None
+    assert slot._orch_tracker.stage_timeout_seconds == 1800
+
+
+@pytest.mark.asyncio
+async def test_existing_tracker_does_not_reload_config(monkeypatch: Any) -> None:
+    """Preservation: only the FIRST entry for a slot pays for a config load."""
+    from kiro_crew.context_management import OrchestrationTracker
+
+    threads: list[int] = []
+    _record_config_loads(monkeypatch, threads)
+
+    slot = _slot()
+    existing = OrchestrationTracker(stage_timeout_seconds=77)
+    slot._orch_tracker = existing
+    await _init_tracker(slot)
+
+    assert threads == [], "a slot that already has a tracker must not load config"
+    assert slot._orch_tracker is existing
+    assert slot._orch_tracker.stage_timeout_seconds == 77
+
+
+def _stop_capable_state(slot: _ChatSlot) -> MagicMock:
+    """A state stand-in the REAL stop handler can be driven against.
+
+    ``stop_turn`` answers ``"idle"``, which is the outcome that creates the race:
+    no ACP turn exists while the config worker runs, so the provider reports
+    nothing to cancel and the handler drives ``_stop_state`` back to "idle".
+    """
+    state = _state()
+    state._slots = {slot.key: slot}
+    state.sessions.stop_turn = AsyncMock(return_value="idle")
+    state.cancel_questions_for_slot = MagicMock(return_value=0)
+    return state
+
+
+async def _press_stop(state: MagicMock, slot: _ChatSlot) -> None:
+    """Press Stop through the production endpoint.
+
+    The whole point of the race is the sequence the handler itself performs —
+    claim ``soft_pending``, clear ``_auto_run``, then release the posture on an
+    "idle" outcome — so a hand-rolled state transition would only prove that a
+    test can write the fields the fix reads.
+    """
+    from aiohttp import web
+
+    from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+    app = web.Application()
+    app["state"] = state
+    request = MagicMock()
+    # A bare MagicMock answers .get("app") with a truthy mock, which the App Kit
+    # §5.2 cancel guard would read as an app token. This is a dashboard press.
+    request.get = lambda key, default="": default
+    request.app = app
+    request.match_info = {"slot": slot.key}
+    request.query = {}
+
+    with (
+        patch("kiro_crew.dashboard.chat_handlers.sel"),
+        patch("kiro_crew.dashboard.chat_handlers._reject_pending_approvals"),
+    ):
+        await api_chat_slot_stop(request)
+
+
+async def _press_plan_cancel(state: MagicMock, slot: _ChatSlot) -> dict[str, Any]:
+    """Press the plan card's Cancel through the production endpoint.
+
+    Plan Cancel is a DIFFERENT cancellation domain from the dashboard Stop: it
+    stops the orchestration tracker rather than the ACP turn, and it is the
+    control the plan card actually offers while a plan is running.
+    """
+    import json as _json
+
+    from aiohttp import web
+
+    from kiro_crew.dashboard.chat_orchestrator import api_chat_plan_action
+
+    app = web.Application()
+    app["state"] = state
+    request = MagicMock()
+    request.app = app
+    request.match_info = {"slot": slot.key}
+    request.json = AsyncMock(return_value={"action": "cancel"})
+
+    response = await api_chat_plan_action(request)
+    return dict(_json.loads(response.body))
+
+
+@pytest.mark.asyncio
+async def test_plan_cancel_during_the_config_load_does_not_start_the_plan(
+    monkeypatch: Any,
+) -> None:
+    """Cancel pressed while the config loads must not leave the plan running.
+
+    The Cancel handler stops the plan by calling ``tracker.stop()``. Build the
+    tracker after the load and it finds ``None`` during this window, stops
+    nothing, and still reports success and prints "Plan cancelled" to the user.
+    ``_auto_run`` cannot stand in for the signal either: ``_stage_loop`` captured
+    ``auto_run`` as an argument when the task was created, so a Go All run keeps
+    its own True, and a plain Go was already False and so carries no information.
+
+    Publishing the tracker BEFORE the load is what closes it, so this test reads
+    the canonical signal — ``tracker.stopped``, which every advancement gate
+    already consults through ``_orchestration_stopped`` — rather than a second
+    cancellation record kept beside it.
+    """
+    entered, release = _gate_config_load(monkeypatch)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.sel", MagicMock())
+
+    turns: list[str] = []
+
+    async def _fake_run_chat(_state: Any, _slot: Any, context: str, **_kwargs: Any) -> None:
+        turns.append(context)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _fake_run_chat)
+
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    slot = _slot("plan-cancel-race-slot")
+    slot._stage_titles = ["Collect the evidence"]
+    slot._auto_run = True
+    state = _stop_capable_state(slot)
+
+    # Go All: auto_run is captured as an argument here, exactly as the plan-action
+    # handler creates it, so clearing slot._auto_run later cannot reach it.
+    task = asyncio.create_task(_stage_loop(state, slot, auto_run=True))
+    slot.task = task
+
+    try:
+        await _wait_for_config_gate(task, entered)
+        _tracker = slot._orch_tracker
+        assert _tracker is not None, (
+            "Cancel has nothing to stop while the config loads: the tracker must be "
+            "published before the await, or this window needs its own cancel record"
+        )
+        assert _tracker.stopped is False
+
+        body = await _press_plan_cancel(state, slot)
+
+        assert body.get("cancelled") is True, (
+            "the endpoint did not report a cancellation, so this test is not "
+            "exercising the state the user was shown"
+        )
+    finally:
+        # Release and reap on every assertion path, so no deferred load or stage
+        # task survives fixture teardown.
+        release.set()
+        await task
+
+    assert turns == [], (
+        "a stage turn ran after the user cancelled the plan: the Cancel handler "
+        "found no tracker to stop, and the config await let the bootstrap resume"
+    )
+    assert _tracker.stopped is True, (
+        "the press did not reach the tracker, so the plan was abandoned by "
+        "something other than the signal the rest of the loop reads"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_plan_started_after_a_cancel_still_runs(monkeypatch: Any) -> None:
+    """A cancel must not poison the NEXT plan.
+
+    This is the risk any sticky cancel signal carries, and the reason not to
+    keep a second one on the slot: a flag that outlives the run it cancelled has
+    to be reset by whoever starts the next plan, and a missed reset silently
+    disables orchestration for the rest of the slot's life.
+
+    ``tracker.stopped`` needs no reset because the tracker does not outlive its
+    plan. Current main also latches a Cancel that beats tracker creation, so
+    arming the next plan must go through ``_reset_auto_run_for_new_plan`` to clear
+    both records before the bootstrap publishes a fresh, unstopped tracker.
+    """
+    threads: list[int] = []
+    _record_config_loads(monkeypatch, threads)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.sel", MagicMock())
+
+    turns: list[str] = []
+
+    async def _fake_run_chat(_state: Any, _slot: Any, context: str, **_kwargs: Any) -> None:
+        turns.append(context)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _fake_run_chat)
+
+    from kiro_crew.dashboard.chat import _stage_loop
+    from kiro_crew.dashboard.chat_title import _reset_auto_run_for_new_plan
+
+    slot = _slot("cancel-then-replan-slot")
+    slot._stage_titles = ["Collect the evidence"]
+    state = _stop_capable_state(slot)
+
+    # An earlier plan ran and was cancelled, so a stopped tracker is on the slot.
+    slot._orch_tracker = OrchestrationTracker()
+    body = await _press_plan_cancel(state, slot)
+    assert body.get("cancelled") is True
+    assert slot._orch_tracker.stopped is True, "the cancel never reached the tracker"
+
+    # Drive the real arm seam: it drops the stopped tracker and clears main's
+    # pending-Go cancel latch together.
+    _reset_auto_run_for_new_plan(slot)
+    slot._auto_run = True
+    await _stage_loop(state, slot, auto_run=True)
+
+    assert turns, (
+        "a plan started after an earlier cancel never executed: the cancel "
+        "signal is being read as sticky rather than as a generation"
+    )
+    assert slot._orch_tracker is not None
+
+
+@pytest.mark.asyncio
+async def test_stop_during_the_config_load_does_not_start_the_plan(monkeypatch: Any) -> None:
+    """A Stop that fires AND resolves during the await must not leave the plan running.
+
+    Ordering is forced with events rather than sleeps: the loader blocks inside
+    the worker until the Stop has been pressed and has settled all the way back
+    to "idle". At that moment ``_stopping`` reads False, so a stage loop that
+    re-checked only that field would resume the plan the user just cancelled.
+    """
+    entered, release = _gate_config_load(monkeypatch)
+    # SEL writes are irrelevant here and only the stopped-plan path would emit
+    # them; silence them so the assertions read against a quiet slot.
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.sel", MagicMock())
+
+    turns: list[str] = []
+
+    async def _fake_run_chat(_state: Any, _slot: Any, context: str, **_kwargs: Any) -> None:
+        turns.append(context)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _fake_run_chat)
+
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    slot = _slot("stop-race-slot")
+    # A real plan, so reaching stage execution is observable — the empty plan the
+    # other tests use has nothing to run and would pass either way.
+    slot._stage_titles = ["Collect the evidence"]
+    slot._auto_run = True
+    state = _stop_capable_state(slot)
+
+    task = asyncio.create_task(_stage_loop(state, slot, auto_run=True))
+    # The stage loop IS the slot's task in production, and the stop handler
+    # no-ops on a slot that is not running.
+    slot.task = task
+    generation_before = slot._stop_generation
+
+    try:
+        await _wait_for_config_gate(task, entered)
+
+        await _press_stop(state, slot)
+
+        assert (
+            slot._stop_generation == generation_before + 1
+        ), "the Stop never initiated, so this test is not exercising the race"
+        assert slot._stop_state == "idle", (
+            "the stop must RESOLVE back to idle -- that is precisely what hides it "
+            "from a plain _stopping re-read, and without it the race is not modelled"
+        )
+        assert slot._auto_run is False
+    finally:
+        # Release and reap on every assertion path, so no deferred load or stage
+        # task survives fixture teardown.
+        release.set()
+        await task
+
+    assert turns == [], (
+        "a stage turn ran after the user stopped the plan: the config await let a "
+        "Stop fire and resolve unobserved"
+    )
+    assert (
+        slot._in_stage_execution is False
+    ), "the abandoned bootstrap left the stage-execution guard set"
+
+
+@pytest.mark.asyncio
+async def test_a_message_queued_during_the_config_load_is_still_handed_off(
+    monkeypatch: Any,
+) -> None:
+    """An abandoned bootstrap still owes the slot the exit every other path takes.
+
+    While the config loads, the stage loop owns ``slot.task``, so ``api_chat``
+    queues a user message instead of starting a turn — and
+    ``_start_next_queued_turn`` HOLDS it there behind the
+    ``_in_stage_execution`` guard rather than draining it, so it can never run
+    concurrently with a plan. The stage loop's ``finally`` is the single thing
+    that clears that guard and hands the queue on.
+
+    Leaving the bootstrap with a bare ``return`` skipped all of it. The guard
+    stayed set on a slot with no loop left to clear it, and the message stayed
+    parked behind it: a later prompt could overtake it, and on restart it could
+    be dropped entirely. So the abort must exit the way a cancel at stage 0
+    does, not by stepping around the contract.
+    """
+    entered, release = _gate_config_load(monkeypatch)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.sel", MagicMock())
+
+    turns: list[str] = []
+
+    async def _fake_run_chat(_state: Any, _slot: Any, context: str, **_kwargs: Any) -> None:
+        turns.append(context)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _fake_run_chat)
+
+    # The handoff itself is the subject, so it is observed at the seam the loop
+    # actually calls rather than by running a real turn.
+    handoffs: list[str] = []
+
+    async def _fake_handoff(_state: Any, _slot: Any) -> bool:
+        handoffs.append(_slot.key)
+        return False
+
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_orchestrator._start_next_queued_turn", _fake_handoff
+    )
+
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    slot = _slot("queued-message-slot")
+    slot._stage_titles = ["Collect the evidence"]
+    slot._auto_run = True
+    state = _stop_capable_state(slot)
+
+    task = asyncio.create_task(_stage_loop(state, slot, auto_run=True))
+    slot.task = task
+
+    try:
+        await _wait_for_config_gate(task, entered)
+
+        # The user types while the plan is still booting. Queued rather than run,
+        # exactly as api_chat does for a slot whose task is live.
+        queue_id = slot.queue_append("what about the tests?")
+        assert slot.queue_depth == 1
+        # Recorded, not asserted here: the handoff below is the contract, and a
+        # precondition that fails first would mask it.
+        guard_while_booting = slot._in_stage_execution
+
+        body = await _press_plan_cancel(state, slot)
+        assert body.get("cancelled") is True
+    finally:
+        # Release and reap on every assertion path, so no deferred load or stage
+        # task survives fixture teardown.
+        release.set()
+        await task
+
+    assert turns == [], "the cancelled plan executed a stage"
+    assert handoffs == [slot.key], (
+        "the message the user queued during the config load was never handed "
+        f"off; it is stranded on the slot (queue={queue_id}) with no loop left "
+        "to release it"
+    )
+    assert (
+        slot._in_stage_execution is False
+    ), "the stage-execution guard survived the abandoned bootstrap"
+    # The boot window is INSIDE the guarded region, which is what makes the
+    # handoff above load-bearing: _start_next_queued_turn holds a user message
+    # while it is set, so nothing but this loop's own exit can release one
+    # queued here.
+    assert guard_while_booting is True, (
+        "the config load ran outside _in_stage_execution, so a message queued "
+        "during it was never covered by the guard this loop clears"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_round_recorded_during_the_config_load_cannot_skip_a_stage(
+    monkeypatch: Any,
+) -> None:
+    """Publishing the tracker early does not expose ``start_idx`` to a late round.
+
+    ``start_idx`` is what decides which stage the loop resumes at, and the worry
+    about publishing the tracker before the load is that some other actor
+    records a round on it first, moving ``current_stage`` and skipping stage 1.
+
+    The arithmetic is real -- the control below proves it -- but the window is
+    not. ``start_idx`` is frozen into a local ``int`` BEFORE the loop's first
+    ``await``; between the publication and that read there is nothing but two
+    attribute reads, and on a single-threaded loop nothing else can execute
+    there. Everything the config await opens up happens strictly after the value
+    is already captured.
+
+    So this drives the widest window the offload creates: the loop is held
+    suspended in the config load, and the exact call the other ``record_round``
+    caller makes (``slack/gateway.py``: ``stage = tracker.current_stage`` then
+    ``tracker.record_round(stage)``) is injected on the freshly published
+    tracker. Both stages must still run.
+    """
+    entered, release = _gate_config_load(monkeypatch)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.sel", MagicMock())
+
+    turns: list[str] = []
+
+    async def _fake_run_chat(_state: Any, _slot: Any, context: str, **_kwargs: Any) -> None:
+        turns.append(context)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _fake_run_chat)
+
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    slot = _slot("late-round-slot")
+    slot._stage_titles = ["Collect the evidence", "Write it up"]
+    slot._auto_run = True
+    state = _stop_capable_state(slot)
+
+    task = asyncio.create_task(_stage_loop(state, slot, auto_run=True))
+    slot.task = task
+
+    try:
+        await _wait_for_config_gate(task, entered)
+        published = slot._orch_tracker
+        assert published is not None, "the tracker is not published during the load"
+        # Verbatim shape of the only other record_round caller in the repo.
+        stage = published.current_stage
+        published.record_round(stage)
+        assert published._stage_rounds, "the injected round did not land on the tracker"
+    finally:
+        release.set()
+        await task
+
+    assert len(turns) == 2, (
+        "a round recorded during the config load skipped a stage: start_idx was "
+        f"read after the window opened, not before it (ran {len(turns)} of 2)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_round_recorded_before_loop_entry_does_skip_a_stage(
+    monkeypatch: Any,
+) -> None:
+    """The positive control for the test above -- the arithmetic IS real.
+
+    A tracker that already carries a round at loop ENTRY makes ``start_idx``
+    non-zero and stage 1 is skipped. That is the resume path: ``_orch_tracker``
+    is already set, so nothing is published, ``_bootstrapping`` is False and no
+    config load runs at all. Keeping this here is what stops the test above from
+    reading as "record_round does nothing".
+    """
+    threads: list[int] = []
+    _record_config_loads(monkeypatch, threads)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.sel", MagicMock())
+
+    turns: list[str] = []
+
+    async def _fake_run_chat(_state: Any, _slot: Any, context: str, **_kwargs: Any) -> None:
+        turns.append(context)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _fake_run_chat)
+
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    slot = _slot("resume-path-slot")
+    slot._stage_titles = ["Collect the evidence", "Write it up"]
+    slot._auto_run = True
+    state = _stop_capable_state(slot)
+
+    resumed = OrchestrationTracker()
+    resumed.record_round(resumed.current_stage)
+    slot._orch_tracker = resumed
+
+    await _stage_loop(state, slot, auto_run=True)
+
+    assert len(turns) == 1, "the resume path should start at stage 2, running one stage"
+    assert threads == [], "the resume path must not load the config at all"


### PR DESCRIPTION
## Problem / Motivation

`_stage_loop` in `src/kiro_crew/dashboard/chat_orchestrator.py` is an `async def`,
but its first act for a slot that has no tracker yet is a synchronous config read:

```python
tracker = slot._orch_tracker
if tracker is None:
    try:
        _timeout = KiroCrewConfig.load().orchestrator.stage_timeout_seconds
    except Exception:
        _timeout = 1800
    tracker = OrchestrationTracker(stage_timeout_seconds=_timeout)
```

`KiroCrewConfig.load()` is not a cheap accessor. It resolves the config path,
`exists()`/`read_text()`/`json.loads()` on `config.json`, `is_file()`/`stat()` and
merges any `config.local.json` overlay, then runs the full `jsonschema` validation.
None of that yields, so it occupies the event loop for its whole duration.

Being accurate about the cost: the loader keeps a fingerprint cache, so a warm
call short-circuits. The blocking read is the **cold** path — a freshly started
gateway, or the first plan after either config file is written.

## Why it matters

Scheduling only. The gateway runs one event loop, and while this read is in
flight nothing else on it advances — no other slot's turn, no WebSocket
broadcast, no HTTP handler. It lands at plan startup, which is exactly when the
user has just clicked Go and the dashboard is expected to be responsive.

No latency figure is claimed; none was measured.

## What changed (motivation → approach → change)

**Motivation** — take the filesystem and schema work off the shared loop without
altering a single initialisation semantic.

**Approach** — this is not a new idiom. `await asyncio.to_thread(KiroCrewConfig.load)`
is already the established form on more than a dozen async paths, four of them in
this same package (`chat_handlers.py`, `chat_mirror.py`, `chat_slack.py`,
`chat_summary.py`), plus `apps/registry.py` and `handlers/agents.py`. This call
site is the outlier, not the precedent.

**Change** — the load, and only the load, moves to a worker:

```
loop:       construct OrchestrationTracker (default budget)
            assign slot._orch_tracker        <- published BEFORE the await
worker:     KiroCrewConfig.load()
loop:       tracker.stage_timeout_seconds = cfg.orchestrator....
```

No slot, tracker, `DashboardState`, stage titles, or messages cross the boundary.
No generic config executor, no caching layer, no change to reload semantics, and
no change to any default. The existing broad `except Exception` is kept as-is —
an exception raised inside `to_thread` still propagates through the `await` into
the same handler.

One deliberate non-change: cancelling an awaited `to_thread` does not stop a
worker that has already started. That is acceptable here only because
`KiroCrewConfig.load` is read-only, so an abandoned load has no effect to undo.
No cancellation machinery is added for it.

**The suspension point it introduces opens TWO cancellation races**, and neither
leaves state a plain re-read can observe. It is the loop's first `await`, ahead of
every `if slot._stopping: break`.

**1. Dashboard Stop.** No ACP turn exists yet, so `SessionManager.stop_turn`
answers `"idle"` and `api_chat_slot_stop` releases the posture it just claimed:

```
_stage_loop                     dashboard Stop
  await to_thread(load)   -->
                                _stop_state = "soft_pending"   (generation +1)
                                stop_turn(...) -> "idle"       (no turn exists yet)
                                _stop_state = "idle"           (posture released)
  load returns            <--
  slot._stopping is False -->   stage execution resumes
```

**2. Plan Cancel** — the plan card's own control, a different domain: it stops the
orchestration *tracker*, not the ACP turn. During this await the tracker does not
exist yet, so the handler stops nothing while still printing "Plan cancelled",
broadcasting `chat_done`, and returning `{"cancelled": true}`:

```
Go / Go All -> _stage_loop -> config worker blocks
                                 user clicks Cancel
                                 tracker is None -> tracker.stop() never runs
                                 _auto_run = False
                                 user is told the plan was cancelled
             config returns
             -> tracker installed -> the cancelled stage executes
```

`_auto_run` cannot serve as the signal: `_stage_loop` captured `auto_run` as an
**argument** when the task was created, so a Go All keeps its own `True` and a
plain Go was already `False` — neither can distinguish a cancel.

**The fix publishes the tracker BEFORE the await, and reuses the signal `main`
already has.** Plan Cancel's entire problem is that `slot._orch_tracker` is `None`
for the length of the window, so the tracker is built first — on
`OrchestrationTracker`'s own default budget, the same 1800s this loop already fell
back to when the load raised — and the configured value applied once the load
returns. The press then reaches a real tracker, and the check afterwards is
`_orchestration_stopped(slot, tracker)`: the helper #4811 introduced, which every
advancement gate in this loop already reads.

That matters more than it looks. An earlier revision of this PR carried a second
counter, `slot._plan_cancel_generation`, alongside `tracker.stopped`. Two records
of one event is two things to keep in step, and First Principles was right to flag
it: a cancel path updating one and not the other would diverge silently, in the
one place the codebase had just finished centralising. That counter is gone, and
**`state.py` now carries no diff at all**.

Nothing consults the stage budget until a stage records its first round, which
cannot happen before the load returns, so `OrchestrationTracker` grows a setter for
it — documented as safe at exactly that point, and not mid-stage, where it would
move a deadline the current stage is already being measured against.

**Dashboard Stop keeps a generation snapshot,** because that channel genuinely has
nothing live to re-read: the posture settles all the way back to `"idle"` inside
the await. `slot._stop_generation` is not this PR's invention — it is `main`'s
existing counter of stop INITIATIONS, added for precisely this shape, and
`chat_runner`'s poisoned-conversation canary is the existing consumer reading it
the same way for the same reason.

```python
_stop_generation = slot._stop_generation
try:
    cfg = await asyncio.to_thread(KiroCrewConfig.load)
    tracker.stage_timeout_seconds = cfg.orchestrator.stage_timeout_seconds
except Exception:
    ...                        # keep the tracker's default budget
if slot._stop_generation != _stop_generation or _orchestration_stopped(slot, tracker):
    return False               # abandon the plan
```

The stop posture and its card stay owned by the stop handler: nothing here writes
`_stop_state`, `_stop_generation`, or the card, and neither `api_chat_slot_stop`
nor `SessionManager` is touched. No shield, executor, lock, or new cancellation
token is introduced.

**Abandoning the plan is not abandoning the slot.** This is the second thing the
earlier revision got wrong: it left the bootstrap with a bare `return`, taken
before the loop's `try`.

While the config loads, the stage loop owns `slot.task`, so `api_chat` queues a
user message rather than running it, and `_start_next_queued_turn` **holds** it
behind `_in_stage_execution` so it can never run alongside a plan. The stage
loop's own `finally` is the single thing that clears that guard and hands the
queue on. Returning before the `try` skipped all of it: the guard stayed set on a
slot with no loop left to clear it, and the user's message stayed parked behind
it — where a later prompt could overtake it, and a restart could drop it.

The abort therefore returns from **inside** the `try` and leaves through that same
`finally`, exactly as a cancel landing at stage 0 does: guard cleared, queue
handed off, slot closed out.

**Which exposed one more thing the `finally` had to stop doing.** Its
`not slot.running` guard is asking whether a turn a stage STARTED still holds the
slot — `_run_chat` publishes its own task on `slot.task` and clears it when the
turn ends. It is not asking about this loop. Yet where no stage turn ever ran,
`slot.task` is still the stage loop itself, alive by definition inside its own
`finally`, so the raw read reported a live turn that does not exist and skipped
**both** the queue handoff and the idle close — on precisely the two paths with
nothing else to perform them: an abandoned bootstrap, and a plan with no stages.
It now compares against `asyncio.current_task()`. Wherever a stage turn did run,
`slot.task` is already `None` and the behaviour is unchanged.


**One existing assertion is rescoped.** `test_no_worker_hop_when_no_stage_results_were_captured`
recorded every `asyncio.to_thread` call the stage loop made and required the list
to be empty — a valid proxy only while the completion read was the loop's sole
offload. Its subject, per its own docstring, is that an empty result set skips
the excerpt worker, so it now filters the recorded calls to `_completion_excerpts`
rather than forbidding every hop. It has not been weakened: deleting the
production `if _captured:` guard still fails it
(`assert [<function _completion_excerpts>] == []`).

## Tests

New `test/test_orchestrator_config_load_off_loop.py` drives the real `_stage_loop`
through tracker initialisation. For the offload cases the slot is given an empty
title list, so `_plan_stage_count` is zero and the loop initialises the tracker and
then has no stage to run — the branch under test is exercised with no model turn
involved. The Stop-race case gives the slot a real one-stage plan instead, so
reaching stage execution is observable.

The seam is the loader itself: `chat_orchestrator` binds `KiroCrewConfig` at
import, so the test replaces that module attribute with a wrapper that records
`threading.get_ident()` and **delegates to the real classmethod**. The recorded
thread is therefore the one that genuinely stats, reads, merges and validates —
not merely one that reached a call site — and the seam behaves identically before
and after the change. The repo's conftest already pins `KIROCREW_HOME` to a
per-test tmp dir, so the real loader reads controlled files rather than the
developer's own configuration.

Fail-before / pass-after, each row against its own baseline:

| | before | after |
|---|---|---|
| `test_config_load_runs_off_the_loop_thread` | **FAIL** — `assert 61188 not in [61188]` | PASS |
| `test_stop_during_the_config_load_does_not_start_the_plan` | **FAIL** — a stage turn ran after the Stop | PASS |
| `test_plan_cancel_during_the_config_load_does_not_start_the_plan` | **FAIL** — a stage turn ran after Plan Cancel | PASS |
| `test_a_plan_started_after_a_cancel_still_runs` | **FAIL** — a cancel disabled the NEXT plan | PASS |
| `test_a_message_queued_during_the_config_load_is_still_handed_off` | **FAIL** — `assert [] == ['queued-message-slot']` | PASS |

The first row is measured on pristine main at the branch's original base (`90348e1d4`); the branch has since been rebased onto current main. The second is
measured against the *offload* commit instead: it is a regression the new `await`
makes reachable, so there is nothing for it to fail on a tree that has no
suspension point there.

That case is ordered with `threading.Event`s, never sleeps. The loader blocks inside
the worker; the test then presses Stop through the **real** `api_chat_slot_stop`
(against a `SessionManager` seam returning `"idle"`, the outcome that creates the
race) and asserts the posture has settled all the way back — `_stop_generation`
incremented by exactly one, `_stop_state == "idle"`, `_auto_run` cleared — before
releasing the loader. Only then does it assert the behaviour that matters: no stage
turn ran, and no tracker was installed.

Mutation-checked, so the guard is doing the work and not the fixture:

| guard | new test |
|---|---|
| as shipped | PASS |
| replaced with `if False:` | **FAIL** — `a stage turn ran after the user stopped the plan` |
| reduced to `if slot._stopping:` (the naive fix) | **FAIL** — same assertion |

The third row is the point: the Stop has already resolved back to `"idle"` by the
time the loop looks, so the `_stop_generation` half is the load-bearing one. The
other five cases stayed green under every mutation.

**The two mechanisms this revision changed carry their own negative controls,**
each reverting exactly one thing and leaving the rest in place:

| revert | fails with |
|---|---|
| publish the tracker AFTER the load (the earlier shape, minus its second counter) | `Cancel has nothing to stop while the config loads: the tracker must be published before the await, or this window needs its own cancel record` |
| take the abort as a bare `return` before the `try` (the earlier shape) | `the message the user queued during the config load was never handed off; it is stranded on the slot with no loop left to release it` |
| keep the abort inside the `try`, but leave the `finally`'s raw `slot.running` read | the same assertion — `assert [] == ['queued-message-slot']` |

**Two findings from the exact-head GPT review are dispositioned on `eb7dd0cac`.**

*Worker cleanup occurs only after assertions* — **adopted**. `release.set()` sat
after the assertions in all three gated tests, so a failure left the loader thread
parked in `release.wait(timeout=10)` past teardown and it then completed the real
`KiroCrewConfig.load()` outside the per-test `KIROCREW_HOME`. Measured by forcing
one assertion inside the parked region to fail: **14.81s before, 5.11s after** —
the delta is exactly the stranded worker's timeout. All three now release and reap
in `finally`.

*Early tracker publication corrupts stage accounting* — **not adopted; the
mechanism is unreachable.** `start_idx` is frozen into a local `int` before the
loop's first `await`, with only two attribute reads between it and the
publication, so nothing can record a round in that gap on a single-threaded loop.
The base had no suspension point there either (the load was synchronous), so the
diff widened nothing before `start_idx`. Pinned rather than argued, by two tests:
`test_a_round_recorded_during_the_config_load_cannot_skip_a_stage` injects the
other `record_round` caller's exact call on the freshly published tracker while
the loop is held in the config load, and both stages still run;
`test_a_round_recorded_before_loop_entry_does_skip_a_stage` is the positive
control, so the first cannot pass by `record_round` being inert. Full disposition
in the PR thread.

The last two are separate reverts that fail identically, which is the point: the
handoff needs BOTH the exit path and the corrected guard, so neither is
load-bearing alone and neither is decoration.

The queued-message case is ordered with events, never sleeps. The loader blocks
in the worker, the message is queued while it is parked, and Cancel is pressed
through the real endpoint before the loader is released. It observes the handoff
at the seam the loop actually calls (`_start_next_queued_turn`) rather than by
running a turn, and it asserts the handoff BEFORE the guard state, so a build
that merely clears the flag without draining the queue still fails.

Being precise about the rest: the other four offload cases **pass on both trees**. They
are preservation coverage, not evidence of a defect, and are reported as such
rather than folded into the fail-before count:

- a configured `stage_timeout_seconds: 42`, written as a real `config.json` and
  read by the real loader, reaches the tracker verbatim;
- `0` survives as `0` — the stage loop reads it back as
  `if tracker.stage_timeout_seconds:`, so collapsing it onto 1800 with an `or`
  would silently re-enable a ceiling the operator turned off;
- a raising loader still yields a usable tracker at 1800;
- a slot that already has a tracker performs **no** config load at all.

```
pytest test/test_orchestrator_config_load_off_loop.py -q      11 passed

# every module that drives _stage_loop, plus the cancel-advance gates #4811 added
pytest test/test_orchestrator_config_load_off_loop.py \
       test/test_completion_result_read_off_loop.py \
       test/test_previous_result_read_off_loop.py \
       test/test_orchestrator_cancel_stops_advance.py \
       test/test_merge_queued_messages.py \
       test/test_dashboard_chat.py -q                      683 passed

# the finally-guard change is the widest edit, so every consumer of the
# queue handoff / _in_stage_execution was run too
pytest test/test_active_turn_session_key.py \
       test/test_autonudge_dashboard_fire.py \
       test/test_chat_runner_coverage.py \
       test/test_chat_slot_continue.py \
       test/test_conn_recovery.py \
       test/test_cron_origin_injection.py \
       test/test_dashboard_file_io.py \
       test/test_queue_during_subagents.py \
       test/test_merge_queued_messages.py -q                357 passed

# OrchestrationTracker's new setter
pytest test/test_subagent.py test/test_subagent_result_view.py \
       test/test_mcp_core_spawn_sub_agents.py -q            132 passed
```

The shard-1 reproduction quoted here previously was measured on the branch's
ORIGINAL base. This head is a rebase onto current `main` (554 commits) plus a
redesign, so that number no longer describes it and is not restated; the runs
above are what was actually executed against this head. The rescoped assertion
in `test_completion_result_read_off_loop.py` is still the only pre-existing test
this branch touches, and it passes here.

Local-only failures on this Windows box are unchanged in class and unrelated to
this diff (`WinError 1314` symlink-privilege, `cp950` decode); none occur on the
CI runners.

Also green: `flake8`, `isort --check-only`, `mypy` on both changed modules
("Success: no issues found in 2 source files"), and
`scripts/check_black_formatting.py` (4 files in scope; the new test file is NOT
baselined, so it is held to `black` and formatted).

## Manual verification

N/A — unit coverage sufficient, and the coverage is not narrow: both cancellation
paths are driven through their REAL endpoints (`api_chat_slot_stop`,
`api_chat_plan_action`) against the real `_stage_loop`, with the config worker
parked on an event so the ordering is forced rather than raced. Reproducing this
by hand needs a Cancel or Stop pressed inside a config load that normally
completes in milliseconds, which is not something a person can time.

Two production files: `chat_orchestrator.py` (the bootstrap, the abort's exit
path, and the `finally`'s live-turn test) and a setter on
`OrchestrationTracker`. `state.py` carries no diff.

## Related Issues

N/A — self-discovered while auditing the orchestrator's remaining synchronous I/O
boundaries. #1783 is not cited: its only `stage_timeout_seconds` bullet asks for a
separate total-plan duration watchdog and says nothing about this config load, so
a `Refs` there would misattribute the work.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: no documented behaviour changes. The scheduling boundary and the two cancellation contracts are described in the code, in `_load_stage_budget`'s docstring and the `finally`'s comment.
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->



