### PR TITLE
feat(events): structured lifecycle event schema + production validator

### DIFF
--- a/src/kiro_crew/events/__init__.py
+++ b/src/kiro_crew/events/__init__.py
@@ -1,0 +1,39 @@
+"""Structured lifecycle event schema (parallel, additive track).
+
+Public surface:
+
+- :mod:`kiro_crew.events.base` — envelope, typed registry, serialize/parse
+- :mod:`kiro_crew.events.kinds` — the registered event types
+- :mod:`kiro_crew.events.backfill` — read-only validator over existing stores
+
+This package is the SCHEMA and its production-data proof, nothing more. The
+on-disk store (writer, watermark reader, retention) lands with the first emit
+site that produces events and the first consumer that folds them; the envelope's
+additive-only rule makes adding those later free. Nothing here modifies an
+existing store; see base.py's module docstring for the schema contract.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.events import kinds as kinds  # noqa: F401  (registers event types)
+from kiro_crew.events.base import (
+    REGISTRY,
+    Event,
+    Parsed,
+    RawEvent,
+    kind_of,
+    parse,
+    register,
+    serialize,
+)
+
+__all__ = [
+    "REGISTRY",
+    "Event",
+    "Parsed",
+    "RawEvent",
+    "kind_of",
+    "parse",
+    "register",
+    "serialize",
+]

--- a/src/kiro_crew/events/backfill.py
+++ b/src/kiro_crew/events/backfill.py
@@ -1,0 +1,607 @@
+"""Read-only backfill validator: prove the event schema fits real stores.
+
+Derives typed events from the EXISTING stores — transcripts, subagent run
+dirs, the cron and autonudge snapshots, and usage shards — without modifying
+any of them, then reports what fit and what did not. This is the progressive
+validation step for the parallel event-log track: schema problems surface
+here, against production-shaped data, before any live emit site exists.
+
+This validator is read-only: it reports, and writes nothing. The report IS the
+deliverable, and a write path would serve no reader while the log has none — it
+lands with the first consumer that folds the log.
+
+LIFECYCLE — this module is DISPOSABLE. It hand-reads five store formats (nested
+cron ``schedule``, the three-way paused split, tombstone ``cause`` semantics)
+rather than routing through each store's owning reader, deliberately: the
+parallel track must not import the internals of the stores it validates, and a
+one-shot schema probe is not worth coupling them. The cost is real — these
+parsers can drift from the stores silently, because the fixtures pin today's
+formats, not tomorrow's. So this module is NOT a historical-migration path and
+must not become one: it is deleted when the live emit sites land, and anything
+that needs to read a store in earnest goes through that store's own reader.
+
+Usage::
+
+    python -m kiro_crew.events.backfill            # report
+    python -m kiro_crew.events.backfill --limit 200 --home /path/to/home
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import math
+import os
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+from kiro_crew.config.paths import data_home
+from kiro_crew.events.base import Event, kind_of, serialize
+from kiro_crew.events.kinds import (
+    AutonudgeArmed,
+    CronRegistered,
+    SessionMessage,
+    SubagentCompleted,
+    SubagentFailed,
+    SubagentSpawned,
+    TurnUsage,
+)
+from kiro_crew.history import transcript_stems
+from kiro_crew.platform_compat import is_link_or_junction
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+
+def _to_ms(value: object) -> int | None:
+    """Best-effort epoch-milliseconds from ISO strings or numeric epochs.
+
+    Store data is untrusted here by definition (that is what the validator is
+    for), so the whole conversion is exception-bounded: non-finite floats,
+    arbitrarily large integers (``math.isfinite`` itself overflows on them),
+    bools, and unparseable strings all return ``None`` rather than aborting
+    the run. A corrupt timestamp degrades one field, never the validation.
+    """
+    try:
+        if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+            return None
+        if isinstance(value, str):
+            if not value:
+                return None
+            return int(datetime.fromisoformat(value).timestamp() * 1000)
+        as_float = float(value)
+        if not math.isfinite(as_float) or as_float <= 0:
+            return None
+        # Heuristic: values below ~2001-09 in ms are second-resolution epochs.
+        return int(as_float * 1000) if as_float < 1_000_000_000_000 else int(as_float)
+    except (ValueError, OverflowError, OSError):
+        return None
+
+
+def _to_float(value: object) -> float | None:
+    """Exception-bounded float conversion for untrusted numeric fields."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        as_float = float(value)
+    except (ValueError, OverflowError):
+        return None
+    return as_float if math.isfinite(as_float) else None
+
+
+def _mtime_ms(path: Path) -> int:
+    try:
+        return int(path.stat().st_mtime * 1000)
+    except OSError:
+        return 0
+
+
+class SourceReport:
+    """Per-source tally: derived events, parse failures, samples."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.events: list[Event] = []
+        self.failures = 0
+        #: Events whose ``ts_ms`` came from the FILE mtime because the store
+        #: row carried no usable timestamp of its own.
+        self.ts_fallbacks = 0
+
+    def add(self, event: Event) -> None:
+        self.events.append(event)
+
+    def fail(self) -> None:
+        self.failures += 1
+
+    def ts_or_mtime(self, value: object, path: Path) -> int:
+        """The row's own timestamp, or *path*'s mtime when it has none.
+
+        The fallback is COUNTED. A report claiming "zero failures" while most
+        timestamps were invented from file mtimes is measuring the schema's
+        tolerance, not how well the store actually fits it -- so the count is
+        reported alongside the totals and the caller cannot silently rely on
+        the fallback.
+        """
+        ms = _to_ms(value)
+        if ms:
+            return ms
+        self.ts_fallbacks += 1
+        return _mtime_ms(path)
+
+
+# ── sources (each strictly read-only) ─────────────────────────────────────
+
+
+def _as_int(value: object) -> int | None:
+    """*value* as an int, or ``None``. Rejects bool: a JSON ``true`` in a
+    numeric field would serialize as a typed event the reader then refuses
+    (its field validation excludes bool from int), so the writer must too.
+    """
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _open_no_follow(path: Path) -> "io.TextIOWrapper":
+    """Open *path* for text reading, refusing symlinks.
+
+    Every store file this validator reads is attacker-influenceable in
+    principle (``--home`` may point anywhere), and parsed field values
+    surface in the report's samples — so a symlink planted where a store
+    file belongs could exfiltrate content from a protected path. O_NOFOLLOW
+    makes the OPEN itself refuse the link (raising ``OSError``), which the
+    callers' existing per-file error handling already counts as a source
+    failure. On platforms without O_NOFOLLOW the flag is 0 and the lstat
+    guard below still refuses the link (TOCTOU-tolerant: worst case reads a
+    file swapped in at the same path, never a followed link on POSIX).
+    """
+    if is_link_or_junction(path):
+        raise OSError(f"refusing symlinked store file: {path}")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags)
+    return io.TextIOWrapper(io.FileIO(fd, "r"), encoding="utf-8", errors="replace")
+
+
+def _read_json_no_follow(path: Path) -> object:
+    """``json.loads`` of *path* through the no-follow open."""
+    with _open_no_follow(path) as fh:
+        return json.loads(fh.read())
+
+
+def _stem_to_key_index(home: Path) -> dict[str, str]:
+    """Map transcript filename stems back to canonical session keys.
+
+    ``session_map.json`` holds the raw session keys; ``transcript_stem`` is the
+    exported sanitizer those keys pass through on their way to filenames (its
+    docstring designates it for exactly this pairing, so the rule is never
+    re-derived here). Stems with no session-map entry fall back to heuristics
+    at the call site.
+    """
+    index: dict[str, str] = {}
+    map_path = home / "session_map.json"
+    if not map_path.exists():
+        return index
+    try:
+        raw = _read_json_no_follow(map_path)
+    except (OSError, ValueError, RecursionError):
+        return index
+    if not isinstance(raw, dict):
+        return index
+    for key in raw:
+        if isinstance(key, str) and key:
+            try:
+                # transcript_stems returns EVERY stem a key's files may occupy
+                # (canonical first, plus e.g. the bare thread_ts a legacy
+                # Slack transcript still lives under) — its docstring
+                # designates it over the singular form for exactly this
+                # file-pairing decision.
+                for stem in transcript_stems(key):
+                    index.setdefault(stem, key)
+            except Exception:  # noqa: BLE001 - one bad key must not kill the index
+                continue
+    return index
+
+
+def _resolve_session_key(stem: str, index: dict[str, str]) -> str:
+    """Canonical session key for a transcript filename stem.
+
+    Dashboard keys are emitted WITHOUT the ``dashboard:`` prefix: the
+    unmapped fallback below can only produce the bare form (stem strip),
+    and usage rows carry bare slots, so the prefixed spelling would split
+    one session's events across two correlation keys depending on whether
+    its map entry survived.
+    """
+    if stem in index:
+        key = index[stem]
+        if key.startswith("dashboard:"):
+            return key[len("dashboard:") :]
+        return key
+    if stem.startswith("dashboard_"):
+        return stem[len("dashboard_") :]
+    return stem
+
+
+#: Transcript ``role`` values that represent an actual conversational turn.
+#: Everything else a transcript persists (``tool`` records, injected ``nudge`` /
+#: ``inject`` turns, ``error`` / ``notice`` / ``file`` / ``subagent`` rows) is a
+#: different lifecycle fact and needs its own kind before it can be emitted.
+_MESSAGE_ROLES = frozenset({"user", "assistant"})
+
+
+def backfill_transcripts(home: Path, limit: int | None = None) -> SourceReport:
+    """``sessions/*.jsonl`` conversational rows -> ``session/message`` events.
+
+    Includes rotated history: ``sessions/archive/<stem>__<segment>.jsonl``
+    segments fold under the same session key as their live transcript.
+    """
+    rep = SourceReport("transcripts")
+    sessions = home / "sessions"
+    if not sessions.exists():
+        return rep
+    index = _stem_to_key_index(home)
+    paths: list[tuple[Path, str]] = []
+    for path in sorted(sessions.glob("*.jsonl")):
+        paths.append((path, path.stem))
+    archive = sessions / "archive"
+    if archive.exists():
+        for path in sorted(archive.glob("*.jsonl")):
+            # The segment suffix is appended at rotation time, so it is the
+            # LAST __-delimited token; a session key may itself contain __.
+            stem = path.stem.rsplit("__", 1)[0]
+            paths.append((path, stem))
+    for path, stem in paths:
+        key = _resolve_session_key(stem, index)
+        try:
+            with _open_no_follow(path) as fh:
+                for line in fh:
+                    if limit is not None and len(rep.events) >= limit:
+                        return rep
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except (ValueError, RecursionError):
+                        rep.fail()
+                        continue
+                    if not isinstance(row, dict):
+                        continue
+                    # Transcripts interleave conversation turns with tool
+                    # records, injected nudges, and error/notice rows, and a
+                    # `tool` row outnumbers real messages several to one. Only
+                    # an actual conversational turn is a session/message; the
+                    # rest are other lifecycle facts that need their own kinds,
+                    # and counting them here would inflate the validator's
+                    # totals with events whose payload contract does not hold.
+                    if row.get("role") not in _MESSAGE_ROLES:
+                        continue
+                    ts = rep.ts_or_mtime(row.get("ts"), path)
+                    content = row.get("content")
+                    rep.add(
+                        SessionMessage(
+                            key=key,
+                            ts_ms=ts,
+                            role=str(row.get("role") or ""),
+                            content_chars=len(content) if isinstance(content, str) else 0,
+                        )
+                    )
+        except OSError:
+            rep.fail()
+            continue
+    return rep
+
+
+def backfill_subagents(home: Path, limit: int | None = None) -> SourceReport:
+    """``subagents/<id>/`` run dirs -> spawned / completed / failed events."""
+    rep = SourceReport("subagents")
+    root = home / "subagents"
+    if not root.exists():
+        return rep
+    try:
+        run_dirs = sorted(p for p in root.iterdir() if p.is_dir())
+    except OSError:
+        rep.fail()
+        return rep
+    for d in run_dirs:
+        if limit is not None and len(rep.events) >= limit:
+            return rep
+        key = f"subagent:{d.name}"
+        state_path = d / "state.json"
+        state: dict = {}
+        if state_path.exists():
+            try:
+                loaded = _read_json_no_follow(state_path)
+                state = loaded if isinstance(loaded, dict) else {}
+            except (OSError, ValueError, RecursionError):
+                rep.fail()
+        task = state.get("task")
+        pid = _as_int(state.get("pid"))
+        parent = state.get("parent_session")
+        # Parent keys must join session/message events, which emit the BARE
+        # dashboard spelling; keep both sides on the same form.
+        parent_key = str(parent) if parent else None
+        if parent_key and parent_key.startswith("dashboard:"):
+            parent_key = parent_key[len("dashboard:") :]
+        tombstone = d / "tombstone.json"
+        result = d / "result.txt"
+        # Read the tombstone BEFORE emitting spawned: M0's vocabulary has no
+        # neutral "stopped" terminal kind, so a user-stopped run is skipped
+        # whole — a spawned event with no terminal would replay forever as
+        # an active run.
+        cause: str | None = None
+        outcome: str | None = None
+        died_ms: int | None = None
+        readable = False
+        if tombstone.exists():
+            try:
+                t = _read_json_no_follow(tombstone)
+                if isinstance(t, dict):
+                    readable = True
+                    cause = str(t.get("cause") or "") or None
+                    outcome = str(t.get("outcome") or "") or None
+                    died_ms = _to_ms(t.get("died"))
+            except (OSError, ValueError, RecursionError):
+                pass
+            if readable and outcome == "stopped":
+                continue
+            # Restart reconciliation writes cause="gateway_restart" (legacy
+            # paths "interrupted") for runs the gateway itself orphaned; the
+            # run may well have delivered (recovery_action records that). M0
+            # has no interrupted terminal kind, so these are skipped whole
+            # like stopped runs — recording them as subagent/failed
+            # fabricates errors for possibly-successful work.
+            if readable and cause in ("gateway_restart", "interrupted"):
+                continue
+        rep.add(
+            SubagentSpawned(
+                key=key,
+                ts_ms=rep.ts_or_mtime(state.get("started"), d),
+                task_preview=(str(task)[:120] if isinstance(task, str) else None),
+                pid=pid,
+                parent_key=parent_key,
+            )
+        )
+        # Only a tombstone is terminal evidence. ``result.txt`` exists while a
+        # subagent is still STREAMING its answer, so its presence alone proves
+        # nothing — a run dir with state but no tombstone is in-flight (or was
+        # orphaned) and gets only the spawned event.
+        if tombstone.exists():
+            # A tombstone does NOT mean failure: successful delivery writes a
+            # ``cause="delivered"`` tombstone instead of deleting the folder
+            # (deferred-TTL cleanup). Only a non-delivered cause is abnormal —
+            # and an UNREADABLE tombstone proves nothing either way, so it is
+            # recorded as a source failure with NO terminal event rather than
+            # fabricating a failure for a possibly-successful run.
+            if not readable:
+                rep.fail()
+                continue
+            ts = died_ms if died_ms else rep.ts_or_mtime(None, tombstone)
+            if cause == "delivered":
+                turns = _as_int(state.get("turns"))
+                size: int | None = None
+                if result.exists():
+                    try:
+                        size = result.stat().st_size
+                    except OSError:
+                        size = None
+                rep.add(SubagentCompleted(key=key, ts_ms=ts, turns=turns, result_bytes=size))
+            else:
+                rep.add(SubagentFailed(key=key, ts_ms=ts, reason=cause))
+    return rep
+
+
+def backfill_crons(home: Path, limit: int | None = None) -> SourceReport:
+    """``crons.json`` snapshot -> ``cron/registered`` events."""
+    rep = SourceReport("crons")
+    path = home / "crons.json"
+    if not path.exists():
+        return rep
+    try:
+        store = _read_json_no_follow(path)
+    except (OSError, ValueError, RecursionError):
+        rep.fail()
+        return rep
+    jobs = store.get("jobs") if isinstance(store, dict) else None
+    if not isinstance(jobs, list):
+        rep.fail()
+        return rep
+    for job in jobs:
+        if limit is not None and len(rep.events) >= limit:
+            return rep
+        if not isinstance(job, dict):
+            rep.fail()
+            continue
+        job_id = str(job.get("id") or job.get("name") or "unknown")
+        # Schedule is a NESTED object: {"kind": "every"|"at"|"cron",
+        # "every_secs": ..., "at_ts": ..., "cron_expr": ...}.
+        sched_val = job.get("schedule")
+        sched: dict = sched_val if isinstance(sched_val, dict) else {}
+        kind = str(sched.get("kind") or "")
+        schedule = next(
+            (
+                f"{kind}:{sched[f]}"
+                for f in ("cron_expr", "every_secs", "at_ts")
+                if sched.get(f) is not None
+            ),
+            kind or None,
+        )
+        # Paused state is split across three fields by the store writer:
+        # disabled entirely, paused by the user, or auto-paused on failures.
+        paused: bool | None = None
+        if any(f in job for f in ("enabled", "user_paused", "auto_paused")):
+            paused = (
+                not job.get("enabled", True)
+                or bool(job.get("user_paused"))
+                or bool(job.get("auto_paused"))
+            )
+        kind_label = "script" if job.get("script") else "command" if job.get("command") else "llm"
+        rep.add(
+            CronRegistered(
+                key=f"cron:{job_id}",
+                ts_ms=rep.ts_or_mtime(job.get("created_ts"), path),
+                name=(str(job["name"]) if job.get("name") else None),
+                schedule=schedule,
+                paused=paused,
+                kind_label=kind_label,
+            )
+        )
+    return rep
+
+
+def backfill_autonudge(home: Path, limit: int | None = None) -> SourceReport:
+    """``autonudge.json`` snapshot -> ``autonudge/armed`` events."""
+    rep = SourceReport("autonudge")
+    path = home / "autonudge.json"
+    if not path.exists():
+        return rep
+    try:
+        store = _read_json_no_follow(path)
+    except (OSError, ValueError, RecursionError):
+        rep.fail()
+        return rep
+    loops = store.get("loops") if isinstance(store, dict) else None
+    if not isinstance(loops, list):
+        rep.fail()
+        return rep
+    for loop in loops:
+        if limit is not None and len(rep.events) >= limit:
+            return rep
+        if not isinstance(loop, dict):
+            rep.fail()
+            continue
+        # ``active: false`` marks a stopped loop in the store; the writer's
+        # default is live, so only an explicit False is skipped.
+        if loop.get("active") is False:
+            continue
+        loop_id = str(loop.get("id") or "unknown")
+        # The store writer's field is ``idle_secs`` (NudgeLoop); it is the
+        # loop's re-injection interval.
+        rep.add(
+            AutonudgeArmed(
+                key=f"nudge:{loop_id}",
+                ts_ms=rep.ts_or_mtime(loop.get("created_ts"), path),
+                interval_secs=_as_int(loop.get("idle_secs")),
+                max_cycles=_as_int(loop.get("max_cycles")),
+            )
+        )
+    return rep
+
+
+def backfill_usage(home: Path, limit: int | None = None) -> SourceReport:
+    """Usage shards -> ``turn/usage`` events (one per shard row)."""
+    rep = SourceReport("usage")
+    shard_dir = home / "usage" / "tokens"
+    if not shard_dir.exists():
+        return rep
+    for path in sorted(shard_dir.glob("*.jsonl")):
+        try:
+            with _open_no_follow(path) as fh:
+                for line in fh:
+                    if limit is not None and len(rep.events) >= limit:
+                        return rep
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except (ValueError, RecursionError):
+                        rep.fail()
+                        continue
+                    if not isinstance(row, dict):
+                        rep.fail()
+                        continue
+                    ts = rep.ts_or_mtime(row.get("ts"), path)
+                    rep.add(
+                        TurnUsage(
+                            key=str(row.get("slot") or "unknown"),
+                            ts_ms=ts,
+                            model=(str(row["model"]) if row.get("model") else None),
+                            provider=(str(row["provider"]) if row.get("provider") else None),
+                            credits=_to_float(row.get("credits")),
+                            cost=_to_float(row.get("cost")),
+                            turns=(_as_int(row.get("turns"))),
+                            duration_ms=_as_int(row.get("duration_ms")),
+                        )
+                    )
+        except OSError:
+            rep.fail()
+            continue
+    return rep
+
+
+ALL_SOURCES = (
+    backfill_transcripts,
+    backfill_subagents,
+    backfill_crons,
+    backfill_autonudge,
+    backfill_usage,
+)
+
+
+def run_backfill(
+    home: Path | None = None,
+    *,
+    limit: int | None = None,
+) -> dict:
+    """Run every source read-only; return the report dict.
+
+    Nothing is written. The validator's job is to prove the v1 schema fits
+    production-shaped data, and the report is that proof — a write path would
+    have no reader while the log has none, so it lands with the first consumer
+    that folds the log.
+
+    The report deliberately carries more than a failure count. Every payload
+    field is optional and degrades to ``None``, so "zero parse failures" is
+    close to structurally guaranteed and on its own measures the schema's
+    TOLERANCE rather than how well a store fits it. ``fill`` therefore reports,
+    per kind, how many events actually populated each field, and
+    ``ts_fallbacks`` how many timestamps had to be taken from a file mtime. A
+    field that is always empty is a field this schema has not earned.
+    """
+    root = home if home is not None else data_home()
+    reports = [source(root, limit) for source in ALL_SOURCES]
+    kind_counts: Counter[str] = Counter()
+    samples: dict[str, str] = {}
+    fill: dict[str, dict[str, int]] = {}
+    for rep in reports:
+        for ev in rep.events:
+            kind = kind_of(ev)
+            kind_counts[kind] += 1
+            slot = fill.setdefault(kind, {})
+            for name, value in ev.data().items():
+                # setdefault FIRST: a field that is never populated must still
+                # appear, at 0, or the gap it represents stays invisible.
+                slot.setdefault(name, 0)
+                if value is not None:
+                    slot[name] += 1
+            if kind not in samples:
+                # Samples reach CLI stdout; store fields (task previews,
+                # cron names) can carry secrets, so redact like any
+                # other agent-visible output.
+                line = serialize(ev, src="backfill")
+                line, _ = redact_credentials(line)
+                line, _ = redact_exfiltration_urls(line)
+                samples[kind] = line
+    return {
+        "home": str(root),
+        "kinds": dict(sorted(kind_counts.items())),
+        "failures": {rep.name: rep.failures for rep in reports},
+        "ts_fallbacks": {rep.name: rep.ts_fallbacks for rep in reports},
+        "totals": {rep.name: len(rep.events) for rep in reports},
+        "fill": {
+            kind: {name: fill[kind][name] for name in sorted(fill[kind])} for kind in sorted(fill)
+        },
+        "samples": samples,
+    }
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=None, help="max events per source")
+    parser.add_argument("--home", type=Path, default=None, help="data home override")
+    args = parser.parse_args()
+    report = run_backfill(args.home, limit=args.limit)
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI shim
+    raise SystemExit(_main())

--- a/src/kiro_crew/events/base.py
+++ b/src/kiro_crew/events/base.py
@@ -1,0 +1,255 @@
+"""Typed envelope and registry for the structured lifecycle event log.
+
+This package is a **parallel, additive** track: it does not read from, write
+to, or import any existing store (transcripts, usage shards, SEL, cron or
+autonudge snapshots). Those stores stay authoritative; this log records
+lifecycle *facts* — small, structured, append-only — so later consumers
+(projections such as a task manager or the context-breakdown panel) can fold
+them into state without bespoke store-to-panel pipelines.
+
+Schema contract (v1):
+
+- Every line is one JSON object: ``{"v": 1, "kind": "<domain>/<action>",
+  "src": "<emitting subsystem>", "key": "<correlation key>",
+  "ts_ms": <int>, "data": {...}}``.
+- ``kind`` is namespaced ``domain/action`` and owned by exactly one registered
+  :class:`Event` subclass.
+- ``key`` is the cross-domain join axis. It is an OPAQUE correlation string,
+  unique within its kind's domain, and its shape is NOT load-bearing: what an
+  event is about is read from ``kind``, which every event already carries.
+  By convention a non-session entity is written ``<domain>:<id>``
+  (``cron:daily-report``, ``subagent:ab12``, ``nudge:chat-3``) and a session is
+  written with the identifier the rest of the codebase already uses for it
+  (``chat-31``, and ``slack:1712793600.123`` for a Slack thread). That last one
+  is why shape cannot classify: a session key may itself contain a colon, so
+  "has a prefix" does not mean "is not a session". Deliberately there is NO
+  registry of entity domains, because defining "session" as the complement of an
+  open prefix list would let a future domain silently reclassify existing keys --
+  the ``kind`` field already answers the question without that hazard.
+- There is deliberately NO sequence/ordering field yet. Ordering is the axis
+  consumers will fold on, so it needs a defined scope (per writer? per key?
+  global?) and a writer that assigns it -- neither of which exists while
+  nothing emits. It arrives, specified and exercised, with the first emitter;
+  ``ts_ms`` carries the event's own time meanwhile.
+- Evolution is **additive only**: new kinds, new optional ``data`` fields, and
+  new optional ENVELOPE keys may be added; existing fields are never renamed or
+  repurposed. ``v`` exists as the escape hatch for a future incompatible break,
+  not as a versioning workflow.
+- Parsing is tolerant by construction: an unknown ``kind`` (or a known kind
+  whose required fields cannot be satisfied) parses as :class:`RawEvent`
+  instead of raising, and an unrecognised envelope key is ignored rather than
+  rejected -- so an old reader never chokes on a newer writer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import types
+from dataclasses import dataclass, field
+from dataclasses import fields as dc_fields
+from typing import Any, ClassVar, Union, get_args, get_origin, get_type_hints
+
+logger = logging.getLogger(__name__)
+
+#: Envelope schema version. Bumped only for an incompatible break (see module
+#: docstring); additive changes never bump it.
+SCHEMA_VERSION = 1
+
+#: Base-envelope attribute names — everything else on a subclass is ``data``.
+_BASE_FIELDS = frozenset({"key", "ts_ms"})
+
+_HINTS_CACHE: dict[type, dict[str, Any]] = {}
+
+
+def _field_ok(value: Any, tp: Any) -> bool:
+    """True when *value* satisfies annotation *tp* (scalars and unions).
+
+    ``bool`` is rejected for int/float fields even though it subclasses
+    ``int`` — a JSON ``true`` in a numeric field is corruption, not a count.
+    Unrecognized annotation shapes pass rather than block.
+    """
+    origin = get_origin(tp)
+    if origin is Union or isinstance(tp, types.UnionType):
+        return any(_field_ok(value, a) for a in get_args(tp))
+    if tp is type(None):
+        return value is None
+    if tp is Any:
+        return True
+    if isinstance(tp, type):
+        if tp is int:
+            return isinstance(value, int) and not isinstance(value, bool)
+        if tp is float:
+            return isinstance(value, (int, float)) and not isinstance(value, bool)
+        return isinstance(value, tp)
+    return True
+
+
+def _payload_matches(cls: type, kwargs: dict[str, Any]) -> bool:
+    hints = _HINTS_CACHE.get(cls)
+    if hints is None:
+        try:
+            hints = get_type_hints(cls)
+        except Exception:
+            hints = {}
+        _HINTS_CACHE[cls] = hints
+    return all(_field_ok(val, hints.get(name, Any)) for name, val in kwargs.items())
+
+
+@dataclass(frozen=True)
+class Event:
+    """Base event: correlation key + timestamp.
+
+    Subclasses declare ``KIND`` (``domain/action``) and typed fields; those
+    extra fields serialize under the envelope's ``data`` object.
+    """
+
+    KIND: ClassVar[str] = ""
+
+    #: Correlation key, e.g. ``chat-31``, ``cron:daily-report``, ``subagent:ab12``.
+    key: str
+    #: Event time, epoch milliseconds (UTC).
+    ts_ms: int
+
+    def data(self) -> dict[str, Any]:
+        """Typed fields beyond the base envelope, for serialization."""
+        return {
+            f.name: getattr(self, f.name) for f in dc_fields(self) if f.name not in _BASE_FIELDS
+        }
+
+
+@dataclass(frozen=True)
+class RawEvent(Event):
+    """Forward-compatibility fallback: an event this build cannot type.
+
+    Produced by :func:`parse` for an unknown ``kind`` or a known kind whose
+    payload does not satisfy the typed constructor. Carries the wire ``kind``
+    and the raw ``data`` payload untouched so nothing is lost round-tripping.
+    """
+
+    KIND: ClassVar[str] = ""
+
+    kind: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def data(self) -> dict[str, Any]:
+        return dict(self.payload)
+
+
+#: kind -> registered Event subclass. Populated by :func:`register`.
+REGISTRY: dict[str, type[Event]] = {}
+
+
+def register(cls: type[Event]) -> type[Event]:
+    """Class decorator: validate ``KIND`` and add the class to the registry.
+
+    ``KIND`` must be lowercase ``domain/action`` (exactly one slash) and unique
+    across the process. Violations raise at import time — a malformed kind is
+    a programming error, not a runtime condition.
+    """
+    kind = cls.KIND
+    domain, sep, action = kind.partition("/")
+    valid = (
+        bool(sep) and bool(domain) and bool(action) and "/" not in action and kind == kind.lower()
+    )
+    if not valid:
+        raise ValueError(f"event KIND must be lowercase 'domain/action', got {kind!r}")
+    existing = REGISTRY.get(kind)
+    if existing is not None and existing is not cls:
+        raise ValueError(f"event KIND {kind!r} already registered by {existing.__name__}")
+    REGISTRY[kind] = cls
+    return cls
+
+
+def kind_of(event: Event) -> str:
+    """The wire ``kind`` for *event* (RawEvent carries it per-instance)."""
+    if isinstance(event, RawEvent):
+        return event.kind
+    return type(event).KIND
+
+
+def serialize(event: Event, *, src: str) -> str:
+    """One compact JSON line for *event* under the v1 envelope."""
+    rec: dict[str, Any] = {
+        "v": SCHEMA_VERSION,
+        "kind": kind_of(event),
+        "src": src,
+        "key": event.key,
+        "ts_ms": event.ts_ms,
+    }
+    rec["data"] = event.data()
+    return json.dumps(rec, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+@dataclass(frozen=True)
+class Parsed:
+    """A parsed line: the (typed or raw) event plus envelope metadata."""
+
+    event: Event
+    kind: str
+    src: str
+    v: int
+
+
+def parse(line: str) -> Parsed | None:
+    """Parse one log line. Returns ``None`` only for non-JSON / non-object input.
+
+    Guarantees for well-formed envelopes: never raises. A ``kind`` this build
+    does not know — or a known kind whose required fields are absent — yields
+    a :class:`RawEvent` carrying the payload verbatim. Unknown fields inside
+    ``data`` for a known kind are ignored (additive evolution).
+    """
+    try:
+        rec = json.loads(line)
+    except (ValueError, RecursionError):
+        return None
+    if not isinstance(rec, dict):
+        return None
+    kind = rec.get("kind")
+    key = rec.get("key")
+    ts_ms = rec.get("ts_ms")
+    # bool subclasses int, so isinstance alone would accept "ts_ms": true
+    # and timestamp the event at epoch millisecond 1.
+    if (
+        not isinstance(kind, str)
+        or not isinstance(key, str)
+        or not isinstance(ts_ms, int)
+        or isinstance(ts_ms, bool)
+    ):
+        return None
+    src_val = rec.get("src")
+    src = src_val if isinstance(src_val, str) else ""
+    v_val = rec.get("v")
+    v = v_val if isinstance(v_val, int) and not isinstance(v_val, bool) else 0
+    # An ABSENT data key is a legitimately empty payload; a PRESENT non-dict
+    # value — explicit null included, which rec.get() cannot distinguish
+    # from absence — violates the envelope contract (the serializer always
+    # writes a dict), and substituting {} would hand consumers a typed
+    # event with invented defaults. Corrupt like a bad ts_ms.
+    if "data" not in rec:
+        data: dict[str, Any] = {}
+    else:
+        data_val = rec.get("data")
+        if isinstance(data_val, dict):
+            data = data_val
+        else:
+            return None
+    cls = REGISTRY.get(kind)
+    event: Event
+    if cls is not None:
+        allowed = {f.name for f in dc_fields(cls)} - _BASE_FIELDS
+        kwargs = {k: val for k, val in data.items() if k in allowed}
+        # A retained value that violates the field's declared type must not
+        # reach consumers as a typed event — that would make the dataclass
+        # schema a lie. Such lines degrade to RawEvent like unknown kinds.
+        if not _payload_matches(cls, kwargs):
+            event = RawEvent(key=key, ts_ms=ts_ms, kind=kind, payload=data)
+        else:
+            try:
+                event = cls(key=key, ts_ms=ts_ms, **kwargs)
+            except TypeError:
+                # Required typed field missing — fall back rather than fail.
+                event = RawEvent(key=key, ts_ms=ts_ms, kind=kind, payload=data)
+    else:
+        event = RawEvent(key=key, ts_ms=ts_ms, kind=kind, payload=data)
+    return Parsed(event=event, kind=kind, src=src, v=v)

--- a/src/kiro_crew/events/kinds.py
+++ b/src/kiro_crew/events/kinds.py
@@ -1,0 +1,130 @@
+"""Typed event set for the structured lifecycle log.
+
+Deliberately minimal and consumer-driven: every kind here is CONSTRUCTED by a
+shipped caller -- today the backfill validator, proving schema fit against the
+real stores. That rule holds only while the validator exists: it is disposable
+by contract, so when the first emit sites land and it is deleted, the SAME rule
+requires those emitters to be the constructors. A kind that arrives at that
+point with no emitter constructing it does not belong here. Kinds for facts no
+one writes yet (turn boundaries, cron fires, nudge cycles, workflow phases)
+therefore land WITH their emitters -- additive-only evolution makes that free,
+and shipping the names early would publish a vocabulary nothing writes.
+
+All fields beyond the base envelope are optional wherever the historical stores
+cannot guarantee them. The validator's job is to measure how much of the real
+data actually fits, which is why its report carries per-field fill counts: a
+field no store ever populates is a field this schema has not earned.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from kiro_crew.events.base import Event, register
+
+# ── session domain ────────────────────────────────────────────────────────
+
+
+@register
+@dataclass(frozen=True)
+class SessionMessage(Event):
+    """One conversation row (user or assistant) appended to a session.
+
+    No ``agent`` field: the transcript store does not record one. Validating
+    against a live data home found it populated on 0 of 56,384 real rows, so it
+    would be a field the schema had not earned. The store DOES carry
+    ``source_thread`` / ``source_user`` / ``meta``, which a later revision can
+    add additively once something consumes them.
+    """
+
+    KIND = "session/message"
+
+    role: str = ""
+    content_chars: int = 0
+
+
+# ── turn domain ───────────────────────────────────────────────────────────
+
+
+@register
+@dataclass(frozen=True)
+class TurnUsage(Event):
+    """Per-turn usage snapshot (mirrors one usage-shard row, by reference)."""
+
+    KIND = "turn/usage"
+
+    model: str | None = None
+    provider: str | None = None
+    credits: float | None = None
+    cost: float | None = None
+    turns: int | None = None
+    duration_ms: int | None = None
+
+
+# ── subagent domain ───────────────────────────────────────────────────────
+
+
+@register
+@dataclass(frozen=True)
+class SubagentSpawned(Event):
+    KIND = "subagent/spawned"
+
+    task_preview: str | None = None
+    pid: int | None = None
+    parent_key: str | None = None
+
+
+@register
+@dataclass(frozen=True)
+class SubagentCompleted(Event):
+    KIND = "subagent/completed"
+
+    turns: int | None = None
+    result_bytes: int | None = None
+
+
+@register
+@dataclass(frozen=True)
+class SubagentFailed(Event):
+    KIND = "subagent/failed"
+
+    reason: str | None = None
+
+
+# ── cron domain ───────────────────────────────────────────────────────────
+
+
+@register
+@dataclass(frozen=True)
+class CronRegistered(Event):
+    """A job present in the cron store (registration/backfill snapshot)."""
+
+    KIND = "cron/registered"
+
+    name: str | None = None
+    schedule: str | None = None
+    paused: bool | None = None
+    kind_label: str | None = None
+
+
+# ── autonudge domain ──────────────────────────────────────────────────────
+
+
+@register
+@dataclass(frozen=True)
+class AutonudgeArmed(Event):
+    KIND = "autonudge/armed"
+
+    interval_secs: int | None = None
+    max_cycles: int | None = None
+
+
+__all__ = [
+    "SessionMessage",
+    "TurnUsage",
+    "SubagentSpawned",
+    "SubagentCompleted",
+    "SubagentFailed",
+    "CronRegistered",
+    "AutonudgeArmed",
+]

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -118,6 +118,15 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "exfiltration-URL chain at the source, before it is put on an `Identity`.",
     ),
     (
+        "Event backfill report samples",
+        "events/backfill.py",
+        "One serialized sample event per kind in the backfill validator's "
+        "report, printed to CLI stdout. Store fields folded into samples "
+        "(subagent task previews, cron names) can carry tokens the operator "
+        "pasted into a task, so each sample passes the shared two-pass "
+        "redaction before leaving the process.",
+    ),
+    (
         "Browser CLI install failures",
         "browser_cli/install.py",
         "The stderr of a failed `npm install -g @playwright/cli` / browser download, "

--- a/test/test_events_backfill.py
+++ b/test/test_events_backfill.py
@@ -1,0 +1,668 @@
+"""Backfill validator tests against fixtures replicating each real store shape."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conftest import make_dir_link
+from kiro_crew.events.backfill import ALL_SOURCES, run_backfill
+from kiro_crew.events.kinds import (
+    AutonudgeArmed,
+    CronRegistered,
+    SessionMessage,
+    SubagentCompleted,
+    SubagentFailed,
+    SubagentSpawned,
+    TurnUsage,
+)
+
+
+def _fixture_home(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    # Transcript: two message rows, one metadata row, one corrupt line.
+    sessions = home / "sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "dashboard_chat-1.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "role": "user",
+                        "content": "hello",
+                        "ts": "2026-08-01T10:00:00+00:00",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": "hi there",
+                        "ts": "2026-08-01T10:00:05+00:00",
+                    }
+                ),
+                json.dumps({"sig": "abc", "summary": "meta row without role"}),
+                "{not json",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    # Subagent runs: one delivered (tombstone cause="delivered" = SUCCESS),
+    # one abnormal (cause="timeout"), one still running (no tombstone, result
+    # streaming).
+    ok_run = home / "subagents" / "aa11"
+    ok_run.mkdir(parents=True)
+    (ok_run / "state.json").write_text(
+        json.dumps({"task": "survey the repo", "pid": 4242, "turns": 9, "started": 1754000100.0}),
+        encoding="utf-8",
+    )
+    (ok_run / "result.txt").write_text("findings " * 10, encoding="utf-8")
+    (ok_run / "tombstone.json").write_text(
+        json.dumps({"cause": "delivered", "recovery_action": "delivered", "died": 1754000200.0}),
+        encoding="utf-8",
+    )
+    bad_run = home / "subagents" / "bb22"
+    bad_run.mkdir(parents=True)
+    (bad_run / "state.json").write_text(
+        json.dumps({"task": "doomed", "started": 1754000300.0}), encoding="utf-8"
+    )
+    (bad_run / "tombstone.json").write_text(
+        json.dumps({"cause": "timeout", "recovery_action": "reap", "died": 1754000400.0}),
+        encoding="utf-8",
+    )
+    # An in-flight run: state + streaming result.txt but NO tombstone yet —
+    # must produce only spawned, never completed.
+    live_run = home / "subagents" / "cc33"
+    live_run.mkdir(parents=True)
+    (live_run / "state.json").write_text(
+        json.dumps({"task": "still running", "started": 1754000500.0}), encoding="utf-8"
+    )
+    (live_run / "result.txt").write_text("partial stream...", encoding="utf-8")
+    # Cron snapshot in the REAL store shape: nested schedule object plus the
+    # three-way paused split (enabled / user_paused / auto_paused).
+    (home / "crons.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "jobs": [
+                    {
+                        "id": "j1",
+                        "name": "daily-report",
+                        "schedule": {"kind": "cron", "cron_expr": "0 9 * * *"},
+                        "enabled": True,
+                        "user_paused": False,
+                        "auto_paused": False,
+                        "created_ts": 1754000000.0,
+                    },
+                    {
+                        "id": "j2",
+                        "name": "poller",
+                        "schedule": {"kind": "every", "every_secs": 300},
+                        "enabled": True,
+                        "user_paused": True,
+                        "auto_paused": False,
+                        "script": "x.py:run",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    # AutoNudge snapshot: the store writer's interval field is idle_secs.
+    (home / "autonudge.json").write_text(
+        json.dumps({"loops": [{"id": "n1", "idle_secs": 300, "max_cycles": 24}]}),
+        encoding="utf-8",
+    )
+    # Usage shard row exactly as production writes it.
+    usage = home / "usage" / "tokens"
+    usage.mkdir(parents=True)
+    (usage / "2026-08-01.jsonl").write_text(
+        json.dumps(
+            {
+                "_type": "tokens",
+                "ts": "2026-08-01T10:00:06+00:00",
+                "slot": "chat-1-1784000000",
+                "provider": "acp",
+                "model": "claude-opus-4.8",
+                "input": 0,
+                "output": 0,
+                "cache_create": 0,
+                "cache_read": 0,
+                "cost": 0.0,
+                "credits": 12.5,
+                "turns": 3,
+                "duration_ms": 4200,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return home
+
+
+def _derived(home: Path) -> list:
+    """Every event the sources derive, in source order — the validator's subject."""
+    events: list = []
+    for source in ALL_SOURCES:
+        events.extend(source(home).events)
+    return events
+
+
+def test_report_counts_every_derived_kind_and_writes_nothing(tmp_path: Path) -> None:
+    home = _fixture_home(tmp_path)
+    report = run_backfill(home)
+    assert report["kinds"] == {
+        "autonudge/armed": 1,
+        "cron/registered": 2,
+        "session/message": 2,
+        "subagent/completed": 1,
+        "subagent/failed": 1,
+        "subagent/spawned": 3,
+        "turn/usage": 1,
+    }
+    assert report["failures"]["transcripts"] == 1  # the corrupt line
+    assert set(report["samples"]) == set(report["kinds"])
+    # The validator is read-only: reporting must leave no store behind.
+    assert not (home / "events").exists()
+
+
+def test_derived_events_carry_typed_payloads(tmp_path: Path) -> None:
+    home = _fixture_home(tmp_path)
+    events = _derived(home)
+    assert len(events) == 11
+    assert {type(e) for e in events} == {
+        SessionMessage,
+        SubagentSpawned,
+        SubagentCompleted,
+        SubagentFailed,
+        CronRegistered,
+        AutonudgeArmed,
+        TurnUsage,
+    }
+
+    usage = [e for e in events if isinstance(e, TurnUsage)]
+    assert usage[0].credits == 12.5 and usage[0].key == "chat-1-1784000000"
+    # cause="delivered" tombstone is SUCCESS, not failure; ts from `died`.
+    completed = [e for e in events if isinstance(e, SubagentCompleted)]
+    assert completed[0].key == "subagent:aa11" and completed[0].turns == 9
+    assert completed[0].ts_ms == 1754000200000
+    # An in-flight run (result.txt streaming, no tombstone) is NEVER completed.
+    assert not any(e.key == "subagent:cc33" for e in completed)
+    failed = [e for e in events if isinstance(e, SubagentFailed)]
+    assert failed[0].key == "subagent:bb22" and failed[0].reason == "timeout"
+    assert failed[0].ts_ms == 1754000400000
+    spawned = sorted((e for e in events if isinstance(e, SubagentSpawned)), key=lambda e: e.key)
+    assert spawned[0].ts_ms == 1754000100000  # from state.json `started`
+    # Nudge interval comes from the store's idle_secs field.
+    nudges = [e for e in events if isinstance(e, AutonudgeArmed)]
+    assert nudges[0].interval_secs == 300 and nudges[0].max_cycles == 24
+    crons = sorted((e for e in events if isinstance(e, CronRegistered)), key=lambda e: e.key)
+    assert crons[0].kind_label == "llm" and crons[0].schedule == "cron:0 9 * * *"
+    assert crons[0].paused is False and crons[0].ts_ms == 1754000000000
+    assert crons[1].kind_label == "script" and crons[1].schedule == "every:300"
+    assert crons[1].paused is True  # user_paused folds into paused
+
+
+def test_limit_caps_each_source(tmp_path: Path) -> None:
+    home = _fixture_home(tmp_path)
+    report = run_backfill(home, limit=1)
+    assert report["totals"]["transcripts"] == 1
+    assert report["totals"]["usage"] == 1
+    # Subagent runs emit up to two events per dir; the cap is per source.
+    assert report["totals"]["subagents"] <= 2
+
+
+def test_missing_stores_are_not_failures(tmp_path: Path) -> None:
+    home = tmp_path / "empty-home"
+    home.mkdir()
+    report = run_backfill(home)
+    assert report["kinds"] == {}
+    assert all(count == 0 for count in report["failures"].values())
+
+
+def test_non_finite_timestamps_do_not_abort(tmp_path: Path) -> None:
+    # json.loads accepts Infinity/NaN; a corrupt ts must degrade, not raise.
+    from kiro_crew.events.backfill import _to_ms
+
+    assert _to_ms(float("inf")) is None
+    assert _to_ms(float("nan")) is None
+    assert _to_ms(True) is None
+    assert _to_ms(10**400) is None  # float() overflow is caught, not raised
+    assert _to_ms("not a date") is None
+    assert _to_ms(1754000000.0) == 1754000000000
+
+    home = tmp_path / "home"
+    (home / "subagents" / "zz99").mkdir(parents=True)
+    (home / "subagents" / "zz99" / "state.json").write_text(
+        json.dumps({"task": "corrupt", "started": float("inf")}), encoding="utf-8"
+    )
+    report = run_backfill(home)
+    assert report["kinds"].get("subagent/spawned") == 1  # fell back to mtime
+
+
+def test_dashboard_transcript_key_is_normalized(tmp_path: Path) -> None:
+    home = _fixture_home(tmp_path)
+    report = run_backfill(home)
+    import json as _json
+
+    sample = _json.loads(report["samples"]["session/message"])
+    # dashboard_chat-1.jsonl folds under the bare slot key, matching usage.
+    assert sample["key"] == "chat-1"
+
+
+def test_stopped_subagent_emits_no_events_at_all(tmp_path: Path) -> None:
+    # M0 has no neutral "stopped" terminal kind, so a stopped run is skipped
+    # whole: a spawned with no terminal would replay forever as active.
+    home = tmp_path / "home"
+    d = home / "subagents" / "sa-stop"
+    d.mkdir(parents=True)
+    (d / "state.json").write_text(json.dumps({"id": "sa-stop", "task": "t"}), encoding="utf-8")
+    (d / "tombstone.json").write_text(
+        json.dumps({"cause": "user_stop", "outcome": "stopped", "died": 1754906400}),
+        encoding="utf-8",
+    )
+    # A stopped run whose partial result was still DELIVERED must not be
+    # rewritten as a completion: outcome wins over cause.
+    d2 = home / "subagents" / "sa-stop-delivered"
+    d2.mkdir(parents=True)
+    (d2 / "state.json").write_text(json.dumps({"id": "sa-stop-delivered"}), encoding="utf-8")
+    (d2 / "tombstone.json").write_text(
+        json.dumps({"cause": "delivered", "outcome": "stopped", "died": 1754906500}),
+        encoding="utf-8",
+    )
+    report = run_backfill(home)
+    assert report["kinds"].get("subagent/failed") is None
+    assert report["kinds"].get("subagent/completed") is None
+    assert report["kinds"].get("subagent/spawned") is None
+
+
+def test_restart_orphan_emits_no_events(tmp_path: Path) -> None:
+    # gateway_restart tombstones mark runs the gateway itself orphaned --
+    # possibly delivered. No interrupted kind exists, so skip whole.
+    home = tmp_path / "home"
+    d = home / "subagents" / "sa-orphan"
+    d.mkdir(parents=True)
+    (d / "state.json").write_text(json.dumps({"id": "sa-orphan"}), encoding="utf-8")
+    (d / "tombstone.json").write_text(
+        json.dumps(
+            {
+                "cause": "gateway_restart",
+                "recovery_action": "result_available",
+                "died": 1754906400,
+            }
+        ),
+        encoding="utf-8",
+    )
+    report = run_backfill(home)
+    assert report["kinds"].get("subagent/failed") is None
+    assert report["kinds"].get("subagent/spawned") is None
+
+
+def test_samples_redact_credentials(tmp_path: Path) -> None:
+    # Samples reach CLI stdout; a credential in a task preview must not
+    # survive into the report verbatim.
+    home = tmp_path / "home"
+    d = home / "subagents" / "sa-cred"
+    d.mkdir(parents=True)
+    token = "ghp_" + "a1B2c3D4e5F6g7H8i9J0" * 2
+    (d / "state.json").write_text(
+        json.dumps({"id": "sa-cred", "task": f"use {token} to push"}), encoding="utf-8"
+    )
+    report = run_backfill(home)
+    sample = report["samples"]["subagent/spawned"]
+    assert token not in sample
+
+
+def test_symlinked_store_files_are_refused(tmp_path: Path) -> None:
+    # A symlink planted where a store file belongs must be refused at open
+    # (counted as a source failure), never followed -- parsed values surface
+    # in report samples, so a followed link could exfiltrate content from a
+    # protected path.
+    home = tmp_path / "home"
+    sessions = home / "sessions"
+    sessions.mkdir(parents=True)
+    secret_dir = tmp_path / "secret-dir"
+    secret_dir.mkdir()
+    secret = secret_dir / "secret.jsonl"
+    secret.write_text(
+        json.dumps({"role": "user", "content": "hunter2", "ts": "2026-08-01T10:00:00+00:00"})
+        + "\n",
+        encoding="utf-8",
+    )
+    make_dir_link(sessions / "dashboard_chat-1.jsonl", secret_dir)
+    report = run_backfill(home)
+    assert report["kinds"].get("session/message") is None
+    assert report["failures"].get("transcripts", 0) >= 1
+
+
+def test_mapped_dashboard_key_emits_bare_slot(tmp_path: Path) -> None:
+    # A dashboard session WITH a session_map entry must emit the same bare
+    # key as the unmapped stem-strip fallback and as usage slots, or one
+    # session's events split across two correlation keys.
+    home = tmp_path / "home"
+    sessions = home / "sessions"
+    sessions.mkdir(parents=True)
+    (home / "session_map.json").write_text(
+        json.dumps({"dashboard:chat-9-123": {"sid": "s-1"}}), encoding="utf-8"
+    )
+    (sessions / "dashboard_chat-9-123.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "message",
+                "role": "user",
+                "ts": "2026-08-01T10:00:00+00:00",
+                "content": "hi",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report = run_backfill(home)
+    sample = json.loads(report["samples"]["session/message"])
+    assert sample["key"] == "chat-9-123"
+
+
+def test_pathological_json_counts_as_parse_failure(tmp_path: Path) -> None:
+    # A huge integer literal is VALID JSON grammar but json.loads raises a
+    # bare ValueError (int_max_str_digits), not JSONDecodeError; it must be
+    # a counted failure, not a crash.
+    home = tmp_path / "home"
+    usage = home / "usage" / "tokens"
+    usage.mkdir(parents=True)
+    (usage / "2026-08-01.jsonl").write_text('{"n": ' + "9" * 5000 + "}\n", encoding="utf-8")
+    report = run_backfill(home)
+    assert report["failures"].get("usage", 0) >= 1
+
+
+def test_boolean_numeric_fields_degrade_to_none_and_stay_typed(tmp_path: Path) -> None:
+    # bool subclasses int: idle_secs true must not serialize into a typed
+    # event the reader's field validation would then degrade to RawEvent.
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "autonudge.json").write_text(
+        json.dumps({"loops": [{"id": "b1", "active": True, "idle_secs": True}]}),
+        encoding="utf-8",
+    )
+    report = run_backfill(home)
+    sample = json.loads(report["samples"]["autonudge/armed"])
+    assert sample["data"]["interval_secs"] is None
+    # Round-trip: the serialized sample parses back as the TYPED kind.
+    from kiro_crew.events.base import RawEvent, parse
+
+    parsed = parse(report["samples"]["autonudge/armed"])
+    assert parsed is not None
+    assert not isinstance(parsed.event, RawEvent)
+
+
+def test_inactive_autonudge_loop_is_not_armed(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "autonudge.json").write_text(
+        json.dumps(
+            {
+                "loops": [
+                    {"id": "live", "active": True, "idle_secs": 300},
+                    {"id": "legacy"},  # no flag: writer default is live
+                    {"id": "stopped", "active": False, "idle_secs": 300},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    report = run_backfill(home)
+    assert report["kinds"].get("autonudge/armed") == 2
+
+
+def test_corrupt_usage_numerics_degrade_to_none(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    usage = home / "usage" / "tokens"
+    usage.mkdir(parents=True)
+    (usage / "2026-08-01.jsonl").write_text(
+        json.dumps(
+            {
+                "_type": "tokens",
+                "ts": "2026-08-01T10:00:06+00:00",
+                "slot": "chat-2",
+                "credits": int("9" * 400),  # float() overflows
+                "cost": True,  # bool is not a number here
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report = run_backfill(home)
+    assert report["kinds"].get("turn/usage") == 1
+    import json as _json
+
+    sample = _json.loads(report["samples"]["turn/usage"])
+    assert sample["data"]["credits"] is None
+    assert sample["data"]["cost"] is None
+
+
+def test_transcript_keys_resolve_via_session_map_and_archive_folds(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    sessions = home / "sessions"
+    sessions.mkdir(parents=True)
+    # A channel session whose sanitized stem differs from its raw key.
+    from kiro_crew.history import transcript_stem
+
+    raw_key = "slack:1723456789.123456"
+    stem = transcript_stem(raw_key)
+    assert stem != raw_key  # sanitization actually changes it
+    (home / "session_map.json").write_text(
+        json.dumps({raw_key: "some-cli-session-id"}), encoding="utf-8"
+    )
+    row = json.dumps({"role": "user", "content": "hi", "ts": "2026-08-01T10:00:00+00:00"})
+    (sessions / f"{stem}.jsonl").write_text(row + "\n", encoding="utf-8")
+    # A rotated archive segment for the same session.
+    archive = sessions / "archive"
+    archive.mkdir()
+    (archive / f"{stem}__20260801-090000.jsonl").write_text(row + "\n", encoding="utf-8")
+
+    report = run_backfill(home)
+    assert report["kinds"]["session/message"] == 2  # live + archived
+    import json as _json
+
+    sample = _json.loads(report["samples"]["session/message"])
+    assert sample["key"] == raw_key  # canonical key, not the sanitized stem
+
+
+def test_legacy_slack_stem_resolves_to_canonical_key(tmp_path: Path) -> None:
+    # A Slack thread predating the canonical slack:<ts> key logs under its
+    # bare thread_ts stem; transcript_stems covers that alias, so backfill
+    # must fold it under the canonical key too.
+    from kiro_crew.history import transcript_stems
+
+    home = tmp_path / "home"
+    sessions = home / "sessions"
+    sessions.mkdir(parents=True)
+    raw_key = "slack:1723456789.123456"
+    stems = transcript_stems(raw_key)
+    assert len(stems) > 1  # canonical + legacy alias
+    legacy_stem = stems[-1]
+    (home / "session_map.json").write_text(
+        json.dumps({raw_key: "cli-session-id"}), encoding="utf-8"
+    )
+    row = json.dumps({"role": "user", "content": "hi", "ts": "2026-08-01T10:00:00+00:00"})
+    (sessions / f"{legacy_stem}.jsonl").write_text(row + "\n", encoding="utf-8")
+    report = run_backfill(home)
+    import json as _json
+
+    sample = _json.loads(report["samples"]["session/message"])
+    assert sample["key"] == raw_key
+
+
+def test_corrupt_tombstone_yields_no_terminal_event(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    run = home / "subagents" / "tt55"
+    run.mkdir(parents=True)
+    (run / "state.json").write_text(json.dumps({"task": "unknown fate"}), encoding="utf-8")
+    (run / "tombstone.json").write_text("{corrupt json", encoding="utf-8")
+    report = run_backfill(home)
+    # An unreadable tombstone proves neither success nor failure: spawned only.
+    assert report["kinds"].get("subagent/spawned") == 1
+    assert "subagent/failed" not in report["kinds"]
+    assert "subagent/completed" not in report["kinds"]
+    assert report["failures"]["subagents"] == 1
+
+
+def test_archive_stem_with_dunder_in_key_resolves_right(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    sessions = home / "sessions"
+    archive = sessions / "archive"
+    archive.mkdir(parents=True)
+    row = json.dumps({"role": "user", "content": "x", "ts": "2026-08-01T10:00:00+00:00"})
+    # A stem that itself contains __ : only the LAST segment is the rotation
+    # suffix.
+    (archive / "app__task__20260801-090000.jsonl").write_text(row + "\n", encoding="utf-8")
+    report = run_backfill(home)
+    import json as _json
+
+    sample = _json.loads(report["samples"]["session/message"])
+    assert sample["key"] == "app__task"
+
+
+def test_spawned_carries_parent_correlation(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    run = home / "subagents" / "pp77"
+    run.mkdir(parents=True)
+    (run / "state.json").write_text(
+        json.dumps({"task": "child", "parent_session": "dashboard:chat-9"}),
+        encoding="utf-8",
+    )
+    report = run_backfill(home)
+    import json as _json
+
+    sample = _json.loads(report["samples"]["subagent/spawned"])
+    assert sample["data"]["parent_key"] == "chat-9"
+
+
+def test_only_conversational_roles_become_session_messages(tmp_path: Path) -> None:
+    # A transcript interleaves conversation turns with tool records, injected
+    # nudges, and error/notice rows -- and in real transcripts `tool` rows
+    # OUTNUMBER real messages several to one. Counting them as session/message
+    # would inflate the validator's totals with events whose payload contract
+    # does not hold, so only an actual conversational turn may be emitted.
+    home = tmp_path / "home"
+    sessions = home / "sessions"
+    sessions.mkdir(parents=True)
+    rows = [
+        {"role": "user", "content": "hi", "ts": "2026-08-01T10:00:00+00:00"},
+        {"role": "assistant", "content": "hello", "ts": "2026-08-01T10:00:01+00:00"},
+        # Every one of these is a real shape observed in live transcripts.
+        {"role": "tool", "content": "tool output", "ts": "2026-08-01T10:00:02+00:00"},
+        {"role": "nudge", "content": "auto-nudge", "ts": "2026-08-01T10:00:03+00:00"},
+        {"role": "inject", "content": "injected", "ts": "2026-08-01T10:00:04+00:00"},
+        {"role": "error", "content": "boom", "ts": "2026-08-01T10:00:05+00:00"},
+        {"role": "system", "content": "sys", "ts": "2026-08-01T10:00:06+00:00"},
+        {"role": "subagent", "content": "sa", "ts": "2026-08-01T10:00:07+00:00"},
+        {"role": "file", "content": "f", "ts": "2026-08-01T10:00:08+00:00"},
+        {"role": "notice", "content": "n", "ts": "2026-08-01T10:00:09+00:00"},
+        {"role": "mcp_oauth", "content": "o", "ts": "2026-08-01T10:00:10+00:00"},
+        {"sig": "abc", "summary": "metadata row with no role at all"},
+    ]
+    (sessions / "dashboard_chat-1.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in rows), encoding="utf-8"
+    )
+    report = run_backfill(home)
+    # Only the user + assistant turns, and no parse failures: a non-message
+    # row is a deliberate skip, not corrupt input.
+    assert report["kinds"] == {"session/message": 2}
+    assert report["failures"]["transcripts"] == 0
+    roles = sorted(
+        e.role for e in _derived(home) if isinstance(e, SessionMessage)  # type: ignore[attr-defined]
+    )
+    assert roles == ["assistant", "user"]
+
+
+def test_report_measures_field_fill_not_just_failures(tmp_path: Path) -> None:
+    # "Zero parse failures" is close to structurally guaranteed: every payload
+    # field is optional and degrades to None. So the report must also say how
+    # much of each kind was actually POPULATED, or it measures the schema's
+    # tolerance rather than the store's fit.
+    home = _fixture_home(tmp_path)
+    report = run_backfill(home)
+    fill = report["fill"]
+    assert fill["session/message"]["role"] == 2
+    assert fill["session/message"]["content_chars"] == 2
+    assert fill["cron/registered"]["name"] == 2
+    # `pid` is present on the kind but absent from one of the fixture's runs,
+    # so a partially-filled field must report its real count, not 100%.
+    assert fill["subagent/spawned"]["pid"] < report["kinds"]["subagent/spawned"]
+    for kind, fields in fill.items():
+        assert fields, f"{kind} reported no field fill at all"
+        for name, count in fields.items():
+            assert 0 <= count <= report["kinds"][kind], f"{kind}.{name} out of range"
+
+
+def test_report_counts_mtime_timestamp_fallbacks(tmp_path: Path) -> None:
+    # A timestamp invented from a file mtime is not evidence the store carries
+    # one, so the fallback is counted rather than silently absorbed.
+    home = tmp_path / "home"
+    sessions = home / "sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "dashboard_chat-1.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {"role": "user", "content": "has ts", "ts": "2026-08-01T10:00:00+00:00"}
+                ),
+                json.dumps({"role": "assistant", "content": "no ts at all"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    report = run_backfill(home)
+    assert report["totals"]["transcripts"] == 2
+    assert report["failures"]["transcripts"] == 0
+    # Exactly the one row lacking a usable ts fell back to the file mtime.
+    assert report["ts_fallbacks"]["transcripts"] == 1
+
+
+def test_backfill_must_be_deleted_once_a_real_consumer_lands() -> None:
+    """A tripwire, not a style check.
+
+    ``backfill.py`` declares itself disposable: it hand-reads five store
+    formats instead of using their owning readers, so its parsers can drift
+    from the stores silently. "Delete it later" is worth nothing if nothing
+    enforces it, and the failure mode is specific -- if the emit-site PR slips,
+    this module quietly becomes the historical-migration path its own docstring
+    forbids.
+
+    So this test fails the moment ``kiro_crew.events`` gains a real (non-test,
+    outside-the-package) importer while the validator is still present. At that
+    point the schema HAS a consumer, the validator has done its job, and
+    whoever landed the emit site must delete it and this test together.
+    """
+    root = Path(__file__).resolve().parent.parent
+    src = root / "src"
+    pkg = src / "kiro_crew" / "events"
+    backfill = pkg / "backfill.py"
+    if not backfill.exists():
+        return  # already deleted -- the contract was honoured
+    importers: list[str] = []
+    kiro_root = src / "kiro_crew"
+    for path in src.rglob("*.py"):
+        if pkg in path.parents or path.parent == pkg:
+            continue
+        if "test" in path.name:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        # Absolute imports are unambiguous. A RELATIVE `from .events import`
+        # only refers to this package when the importer sits directly in
+        # kiro_crew/ -- `kiro_crew/workflows/events.py` is a different module
+        # with the same leaf name, and matching it would make this tripwire cry
+        # wolf forever.
+        hit = "kiro_crew.events" in text or (
+            path.parent == kiro_root and "from .events import" in text
+        )
+        if hit:
+            importers.append(str(path.relative_to(src)))
+    assert not importers, (
+        "kiro_crew.events now has real consumers "
+        f"({', '.join(sorted(importers))}), so the disposable validator has "
+        "served its purpose: delete src/kiro_crew/events/backfill.py, its "
+        "tests, and this tripwire in the same change."
+    )

--- a/test/test_events_base.py
+++ b/test/test_events_base.py
@@ -1,0 +1,259 @@
+"""Envelope + registry contract tests for the structured event log."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from kiro_crew.events.base import (
+    REGISTRY,
+    Event,
+    RawEvent,
+    kind_of,
+    parse,
+    register,
+    serialize,
+)
+
+
+def _dummy_value(annotation: str):
+    """A representative value for a kinds.py field annotation."""
+    if "int" in annotation:
+        return 7
+    if "float" in annotation:
+        return 1.5
+    if "bool" in annotation:
+        return True
+    return "x"
+
+
+def _instance_of(cls: type[Event]) -> Event:
+    kwargs = {}
+    for f in dataclasses.fields(cls):
+        if f.name in ("key", "ts_ms"):
+            continue
+        kwargs[f.name] = _dummy_value(str(f.type))
+    return cls(key="k-1", ts_ms=1_755_000_000_000, **kwargs)
+
+
+def test_every_registered_kind_roundtrips() -> None:
+    assert REGISTRY, "kinds.py must register at least one event type"
+    for kind, cls in sorted(REGISTRY.items()):
+        event = _instance_of(cls)
+        line = serialize(event, src="test")
+        parsed = parse(line)
+        assert parsed is not None, kind
+        assert parsed.kind == kind
+        assert parsed.src == "test"
+        assert parsed.event == event, f"{kind} did not roundtrip"
+
+
+def test_envelope_shape_is_stable() -> None:
+    cls = next(iter(REGISTRY.values()))
+    rec = json.loads(serialize(_instance_of(cls), src="s"))
+    assert rec["v"] == 1
+    assert set(rec) <= {"v", "kind", "src", "key", "ts_ms", "data"}
+    assert isinstance(rec["data"], dict)
+
+
+def test_type_violating_payload_degrades_to_raw_event() -> None:
+    # A known kind whose retained field violates the declared type must not
+    # construct a typed event — the schema would be a lie. bool-in-int is
+    # the sneaky case (bool subclasses int).
+    for bad_data in ({"turns": "seven"}, {"turns": True}, {"result_bytes": 3.5}):
+        line = json.dumps(
+            {
+                "v": 1,
+                "kind": "subagent/completed",
+                "src": "t",
+                "seq": 1,
+                "key": "subagent:x",
+                "ts_ms": 5,
+                "data": bad_data,
+            }
+        )
+        parsed = parse(line)
+        assert parsed is not None
+        assert isinstance(parsed.event, RawEvent), bad_data
+        assert parsed.event.payload == bad_data
+    # A well-typed payload still constructs the typed event.
+    ok = json.dumps(
+        {
+            "v": 1,
+            "kind": "subagent/completed",
+            "src": "t",
+            "seq": 2,
+            "key": "subagent:x",
+            "ts_ms": 6,
+            "data": {"turns": 7},
+        }
+    )
+    parsed_ok = parse(ok)
+    assert parsed_ok is not None
+    assert not isinstance(parsed_ok.event, RawEvent)
+
+
+def test_non_dict_data_is_rejected_as_corrupt() -> None:
+    # A PRESENT non-dict data violates the envelope; substituting {} would
+    # fabricate a typed event with invented defaults. Absent data stays a
+    # legitimately empty payload.
+    bad = json.dumps(
+        {
+            "v": 1,
+            "kind": "cron/registered",
+            "src": "s",
+            "seq": 1,
+            "key": "cron:x",
+            "ts_ms": 5,
+            "data": [1, 2],
+        }
+    )
+    assert parse(bad) is None
+    explicit_null = json.dumps(
+        {
+            "v": 1,
+            "kind": "cron/registered",
+            "src": "s",
+            "seq": 3,
+            "key": "cron:x",
+            "ts_ms": 7,
+            "data": None,
+        }
+    )
+    assert parse(explicit_null) is None
+    absent = json.dumps(
+        {"v": 1, "kind": "cron/registered", "src": "s", "seq": 2, "key": "cron:x", "ts_ms": 6}
+    )
+    assert parse(absent) is not None
+
+
+def test_boolean_envelope_numerics_are_rejected() -> None:
+    # bool subclasses int: ts_ms true must not become epoch millisecond 1,
+    # and a bool `v` must fall back to its default rather than reading as 1.
+    bad_ts = json.dumps({"v": 1, "kind": "k", "src": "s", "key": "x", "ts_ms": True})
+    assert parse(bad_ts) is None
+    bool_v = json.dumps({"v": True, "kind": "future/k", "src": "s", "key": "x", "ts_ms": 5})
+    parsed = parse(bool_v)
+    assert parsed is not None
+    assert parsed.v == 0
+
+
+def test_unknown_kind_parses_as_raw_event() -> None:
+    line = json.dumps(
+        {
+            "v": 1,
+            "kind": "future/thing",
+            "src": "newer-build",
+            "seq": 9,
+            "key": "k",
+            "ts_ms": 5,
+            "data": {"payload_field": [1, 2, 3]},
+        }
+    )
+    parsed = parse(line)
+    assert parsed is not None
+    assert isinstance(parsed.event, RawEvent)
+    assert parsed.event.kind == "future/thing"
+    assert parsed.event.payload == {"payload_field": [1, 2, 3]}
+    assert kind_of(parsed.event) == "future/thing"
+    # Round-trip preserves the payload verbatim.
+    rec = json.loads(serialize(parsed.event, src="relay"))
+    assert rec["kind"] == "future/thing"
+    assert rec["data"] == {"payload_field": [1, 2, 3]}
+
+
+def test_unknown_field_on_known_kind_is_tolerated() -> None:
+    kind, cls = sorted(REGISTRY.items())[0]
+    line = json.dumps(
+        {
+            "v": 1,
+            "kind": kind,
+            "src": "newer-build",
+            "seq": 0,
+            "key": "k",
+            "ts_ms": 5,
+            "data": {"field_added_in_v99": "surprise"},
+        }
+    )
+    parsed = parse(line)
+    assert parsed is not None
+    assert isinstance(parsed.event, cls)
+
+
+def test_missing_required_field_falls_back_to_raw() -> None:
+    # A required field is only expressible with kw_only=True (the base class
+    # carries defaults); parse() must degrade to RawEvent when it is absent.
+    @register
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class _Strict(Event):
+        KIND = "testonly/strict"
+        mandatory: str
+
+    line = json.dumps(
+        {
+            "v": 1,
+            "kind": "testonly/strict",
+            "src": "s",
+            "seq": 0,
+            "key": "k",
+            "ts_ms": 1,
+            "data": {},
+        }
+    )
+    parsed = parse(line)
+    assert parsed is not None
+    assert isinstance(parsed.event, RawEvent)
+    assert parsed.event.kind == "testonly/strict"
+
+
+def test_unknown_envelope_key_is_tolerated() -> None:
+    # The additive-only rule promises a LATER writer may add an envelope key
+    # (a distributed-trace slot is the concrete planned case) without breaking
+    # a reader shipped today. That promise is what makes deferring such a slot
+    # free, so pin it: an unrecognised top-level key is ignored, not rejected,
+    # and the typed event still parses.
+    cls = next(iter(REGISTRY.values()))
+    rec = json.loads(serialize(_instance_of(cls), src="test"))
+    rec["trace"] = {"trace_id": "t" * 32, "span_id": "s" * 16}
+    rec["some_future_key"] = 42
+    parsed = parse(json.dumps(rec))
+    assert parsed is not None
+    assert not isinstance(parsed.event, RawEvent)
+    assert parsed.kind == kind_of(_instance_of(cls))
+
+
+@pytest.mark.parametrize("bad", ["not json", "[]", '"str"', json.dumps({"kind": 5})])
+def test_garbage_lines_return_none(bad: str) -> None:
+    assert parse(bad) is None
+
+
+def test_register_rejects_malformed_kind() -> None:
+    with pytest.raises(ValueError):
+
+        @register
+        @dataclasses.dataclass(frozen=True)
+        class _NoSlash(Event):
+            KIND = "noslash"
+
+    with pytest.raises(ValueError):
+
+        @register
+        @dataclasses.dataclass(frozen=True)
+        class _Upper(Event):
+            KIND = "Domain/Action"
+
+
+def test_register_rejects_duplicate_kind() -> None:
+    @register
+    @dataclasses.dataclass(frozen=True)
+    class _First(Event):
+        KIND = "testonly/dup"
+
+    with pytest.raises(ValueError):
+
+        @register
+        @dataclasses.dataclass(frozen=True)
+        class _Second(Event):
+            KIND = "testonly/dup"


### PR DESCRIPTION
## What is the problem?

KiroCrew's work-in-flight state lives in heterogeneous stores with no uniform,
indexable record of lifecycle facts. Cron and autonudge REGISTRATION state are
rewrite-in-place snapshots (`crons.json`, `autonudge.json`); cron FIRE history
does exist (`cron_history.py`, per-job JSONL), but it is a cron-only store with
its own schema and readers -- one more bespoke store-to-panel pipeline, which is
the pattern this work exists to converge. Autonudge cycles have no history at
all; subagent liveness is derived by scanning `/proc/<pid>/status` at read time;
transcripts are per-session and omit lifecycle boundaries. No single ordered
record can answer "what happened, across everything, in order" after a restart.

Before committing to such a record, one thing has to be settled: **is a single
envelope shape actually able to carry the facts these five stores already hold?**
That question is answerable now, and answering it wrong is expensive later.

## Why this issue matters to the user

Planned surfaces -- a task manager showing everything in flight, and richer
per-turn context views -- need one ordered, replayable record to fold state from.
Without it each new surface re-invents polling, correlation, and freshness logic
against a different bespoke store, and stale rows (e.g. a dead subagent still
shown as running) cannot be detected uniformly. If the envelope those surfaces
are built on turns out to be wrong, every consumer pays for the correction, so
the schema is worth proving against real data before anything depends on it.

## How our fix solves it

Adds a **fully parallel** package, `kiro_crew.events`, containing the v1 schema
and the evidence that it fits. No existing store or code path changes behaviour.

- `base.py` -- versioned envelope (`v`, `kind`, `src`, `key`, `ts_ms`, `data`)
  with a typed registry. Kinds are namespaced `domain/action`; evolution
  is additive-only; parsing is tolerant by construction: an unknown kind, a
  payload that violates a declared field type, and an unrecognised ENVELOPE key
  all degrade instead of raising, so a reader shipped today survives a newer
  writer.
- `kinds.py` -- the 7 kinds the validator constructs, across
  session/subagent/cron/autonudge/turn domains.
- `backfill.py` -- a **read-only** validator that derives events from the
  existing stores (transcripts, subagent run dirs, cron/autonudge snapshots,
  usage shards) and reports how well the schema fits. It reports and writes
  nothing; the report is the deliverable. Declared **disposable** in its own
  module docstring: it hand-reads five store formats rather than importing their
  owning readers (the parallel track must not couple to the stores it
  validates), so it is deleted when the emit sites land and must not become a
  historical-migration path. That is **enforced, not just asserted**:
  `test_backfill_must_be_deleted_once_a_real_consumer_lands` fails the moment
  `kiro_crew.events` gains a real non-test importer while the validator still
  exists, so whoever lands the first emit site is forced to delete it.
- `security_posture.py` -- **an edit, not an addition** (the only one in this
  diff): registers the validator's report samples in `_REDACTION_SINKS`. Store
  fields folded into samples (subagent task previews, cron names) can carry
  operator-pasted tokens, and the samples reach CLI stdout, so the sink must be
  declared for the drift guard that checks every redactor call site.

### The report measures fit, not just tolerance

Every payload field is optional and degrades to `None`, so a bare "zero parse
failures" is close to structurally guaranteed -- a store filling 10% of a kind's
fields would still report clean. The report therefore also carries:

- **`fill`** -- per kind, how many events actually populated each field. A field
  that is never populated is reported AT ZERO rather than omitted, because that
  gap is the finding.
- **`ts_fallbacks`** -- per source, how many events had a timestamp invented from
  the file mtime because the store row carried none.

This immediately paid for itself: it showed `session/message.agent` populated on
**0 of 56,384** real rows. Checking the store confirmed conversational rows carry
only `role`, `content`, `ts`, `source_thread`, `source_user`, `meta` -- there is
no agent field under any spelling, and the test fixture had been modelling a
shape that does not exist. The field is removed; the fixture is corrected.

### What is deliberately NOT here

The on-disk store -- daily-shard writer, watermark reader, retention pruning, and
a distributed-trace envelope slot -- is not in this PR. Earlier revisions shipped
all of it. It was removed because nothing emits yet, so the writer would have no
writer and the reader no consumer, and a store nobody writes or reads cannot be
validated by anything except its own unit tests. The same standard removed a
`--apply` write mode from the validator and a retention CLI shim.

**There is also no `seq`/ordering field, and that is the most consequential
omission.** An earlier revision carried one. It was removed because ordering is
precisely the axis consumers will fold on, and the field had no defined scope --
per writer? per key? global? -- no writer to assign it (the only caller passed a
constant `0`), and no order-checking in the validator. Its one written definition
("monotonic per shard per writer process") described the shards that were
themselves deferred, so it survived as an envelope key with no meaning at all.
Shipping the ordering axis unspecified is worse than omitting it: it is exactly
the wrong-envelope correction this PR exists to preempt, frozen under an
additive-only contract. It lands specified and exercised with the first emitter;
`ts_ms` carries the event's own time meanwhile.

`key`, the other axis consumers join on, is specified instead of left implicit --
and specified so that its SHAPE is not load-bearing. What an event is about is
read from `kind`, which every event already carries. By convention a non-session
entity is written `<domain>:<id>` (`cron:daily-report`, `subagent:ab12`) and a
session uses the identifier the rest of the codebase already uses for it
(`chat-31`, or `slack:1712793600.123` for a Slack thread). That last case is why
shape cannot classify: a session key may itself contain a colon. There is
deliberately no registry of entity domains, because defining "session" as the
complement of an open prefix list would let a future domain silently reclassify
existing keys -- the same wrong-envelope hazard, on the axis this PR chose to
specify rather than defer.

That deferral is cheap by the schema's own contract: the additive-only rule
admits new kinds, new `data` fields, AND new envelope keys, and there is now a
test pinning that an unrecognised envelope key is ignored rather than rejected.
So the store and the trace slot land with the first emit site, additively.

What remains is a complete, self-contained claim: **here is the envelope, and
here is measured evidence that it carries what KiroCrew's existing stores hold.**

### Why not reuse an existing envelope

The repo has two other event shapes, and neither fits this job. `sel.py` is a
tamper-evident security audit log: its value is an HMAC chain over an
append-only file, which constrains its schema and makes it the wrong place for
routine lifecycle facts. `workflows/events.py` carries `WorkflowEvent(run_id,
seq, ts, type, data)` and is scoped to a single workflow run -- its correlation
key IS a run id, where this record needs one key space spanning sessions, crons,
nudges and subagents. Converging those two is a fair later question; doing it in
the same change that first proves the envelope would couple an unvalidated
schema to a working audit log.

## What tests we did

- **39 tests across two files**: registry roundtrip for every registered kind;
  forward-compatibility guarantees (unknown kind -> `RawEvent`, unknown `data`
  field tolerated, unknown ENVELOPE key tolerated, missing required field
  degrades, type-violating payload degrades rather than constructing a lying
  typed event, boolean-vs-numeric envelope values rejected); kind registration
  rules; per-field fill accounting and mtime-fallback counting; and backfill
  fixtures replicating each real store format including a corrupt-line case and
  a symlinked store file refused at open.
- Only conversational rows become `session/message`: a regression test covers
  every role shape observed live (`tool`, `nudge`, `inject`, `error`, `system`,
  `subagent`, `file`, `notice`, `mcp_oauth`) and asserts a skipped row is a
  deliberate skip, not a parse failure. Mutation-verified.
- Derived-payload semantics are asserted against the source functions
  (`ALL_SOURCES`) directly: a `delivered` tombstone is SUCCESS not failure, an
  in-flight run with no tombstone is never `completed`, timestamps come from the
  store's own fields, `user_paused` folds into `paused`.
- Local gates green: `black --target-version py310` (repo pin 26.3.1),
  `isort --check-only`, `flake8`, `mypy` (0 errors in the package), pytest 38/38
  plus 42/42 for `test_security_posture.py`.
- **Validation against real production data** (read-only, live data home):
  **71,808 events derived, 0 parse failures, 0 invented timestamps** --

  | source | events | failures | mtime fallbacks |
  |---|---|---|---|
  | transcripts (`session/message`) | 56,392 | 0 | 0 |
  | usage shards (`turn/usage`) | 15,352 | 0 | 0 |
  | subagent dirs (`subagent/*`) | 43 | 0 | 0 |
  | cron snapshot (`cron/registered`) | 15 | 0 | 0 |
  | autonudge snapshot (`autonudge/armed`) | 6 | 0 | 0 |

  And on fit rather than tolerance: **no field is ever unpopulated**, and the
  two lowest-filled fields are legitimately optional -- `subagent/spawned.pid`
  at 18/22 (a finished run has no live pid) and `turn/usage.model` at
  13,063/15,352 (older usage shards predate the field). Every other field is at
  100%.

  This total is deliberately **lower** than an earlier revision's figure. That
  revision counted every transcript row carrying a `role` key as a
  `session/message`, and `tool` rows outnumber genuine messages roughly three to
  one, so the old number was inflated by roughly 142,000 non-message rows.

## Any other suggestions on the work

- Next steps (separate PRs, in order): the on-disk store (writer + watermark
  reader + retention) landing together with the first live emit sites behind an
  opt-in config flag; the projection layer with the task manager as first
  consumer; kinds for the transcript row types this validator skips (`tool`,
  `nudge`, `inject`, `error`); an OTEL span exporter, which is where the
  deferred trace envelope key earns its place.
- The transcript store also carries `source_thread`, `source_user` and `meta` on
  conversational rows, which this schema does not capture. Worth adding when
  something consumes them -- additively, and with fill measured the same way.
- `cron_history.py` is deliberately not a backfill source here: cron FIRE events
  need a kind that does not exist yet, and the kind set is exactly what the five
  sources construct. Fire-history emit sites and their kind are follow-up work.
