### PR TITLE
fix(agents): unlink queued image temp files on every whole-session teardown

### DIFF
--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -840,6 +840,24 @@ def unlink_queued_temp_paths(kwargs: dict) -> None:
             pass
 
 
+def _unlink_session_queue(session: "_Session") -> None:
+    """Unlink temp files for every entry still queued on a popped session.
+
+    Every teardown path that pops a whole ``_Session`` out of ``_sessions``
+    (stale-provider eviction, ``reset``, RSS recycle, ``remove``,
+    ``remove_if_unclaimed``, ``destroy``, ``discard_conversation``,
+    ``drain_all_providers``) discards ``session.queue`` along with it.
+    Anything still sitting there never reaches ``_dispatch_queued``'s own
+    cleanup — that only runs for an entry that actually gets dispatched —
+    so this is the one place responsible for unlinking the images behind a
+    whole-session teardown, the same way ``cancel_queued``/``clear_queue``/
+    ``dequeue``'s cancelled-skip already do for a live session's own
+    piecemeal discards.
+    """
+    for _, _, kwargs in session.queue:
+        unlink_queued_temp_paths(kwargs)
+
+
 class SessionManager:
     """Thread-keyed LLM provider pool with warm session pre-spawning."""
 
@@ -1578,6 +1596,7 @@ class SessionManager:
                 del self._sessions[key]
                 dead = sess.provider
         if dead is not None:
+            await asyncio.to_thread(_unlink_session_queue, sess)
             try:
                 await dead.shutdown()
             except Exception:
@@ -2559,6 +2578,7 @@ class SessionManager:
         # cold-starts a context-free duplicate (thread split).
         key = self._fold_key(key)
         stale_provider = None
+        stale_session: "_Session | None" = None
         _claimed: "_Session | None" = None
         try:
             async with self._lock:
@@ -2614,6 +2634,7 @@ class SessionManager:
                                 "Session %s has dead provider — removing stale entry", key
                             )
                             stale_provider = sess.provider
+                            stale_session = sess
                             del self._sessions[key]
                             # Preserve session_map entry: the kiro-cli session
                             # files survive on disk, enabling lossless resume
@@ -2661,6 +2682,8 @@ class SessionManager:
             # Kill orphaned child processes (MCP servers, kiro-cli-chat)
             # outside the lock — shutdown() may involve signals/waitpid.
             if stale_provider is not None:
+                if stale_session is not None:
+                    await asyncio.to_thread(_unlink_session_queue, stale_session)
                 try:
                     await stale_provider.shutdown()
                 except Exception:
@@ -3245,6 +3268,7 @@ class SessionManager:
             # Same tick as the pop — see the docstring.
             self._session_map.clear_sid(key)
         if session:
+            await asyncio.to_thread(_unlink_session_queue, session)
             # Capture PID and child tree before shutdown clears them
             client = getattr(session.provider, "_client", None)
             raw_pid = getattr(client, "_pid", None) if client else None
@@ -3705,6 +3729,9 @@ class SessionManager:
                 popped = None
                 if self._sessions.get(key) is session:
                     popped = self._sessions.pop(key, None)
+            # popped is session by identity when non-None (see pop-by-identity
+            # above), but session's queue is abandoned in either branch below.
+            await asyncio.to_thread(_unlink_session_queue, session)
             if popped is None:
                 # A racing cold-start already replaced the entry — the map
                 # now points at a fresh, healthy session. Reap OUR old
@@ -4057,6 +4084,7 @@ class SessionManager:
             self._compact_pending_verdict.pop(key, None)
             self._origin_links.pop(key, None)
         if session:
+            await asyncio.to_thread(_unlink_session_queue, session)
             await session.provider.shutdown()
             # Reap any companion subagent runtime keyed by this parent (the
             # get_subagent_runtime fallback path). shutdown() covers the common
@@ -4374,6 +4402,7 @@ class SessionManager:
             self._compact_cooldown_until.pop(key, None)
             self._compact_pending_verdict.pop(key, None)
             self._origin_links.pop(key, None)
+        await asyncio.to_thread(_unlink_session_queue, session)
         await session.provider.shutdown()
         await self.release_subagent_runtime(key)
         logger.info("Removed unclaimed speculative session (map preserved): %s", key)
@@ -4392,6 +4421,7 @@ class SessionManager:
             self._compact_pending_verdict.pop(key, None)
         try:
             if session:
+                await asyncio.to_thread(_unlink_session_queue, session)
                 await session.provider.shutdown()
             # Reap any companion subagent runtime keyed by this parent (see remove()).
             await self.release_subagent_runtime(key)
@@ -4420,6 +4450,7 @@ class SessionManager:
             self._compact_pending_verdict.pop(key, None)
         try:
             if session:
+                await asyncio.to_thread(_unlink_session_queue, session)
                 await session.provider.shutdown()
             # Reap any companion subagent runtime keyed by this parent (see remove()).
             await self.release_subagent_runtime(key)
@@ -5465,12 +5496,19 @@ class SessionManager:
     async def drain_all_providers(self) -> list:
         """Pop all sessions and return their providers. Thread-safe."""
         providers = []
+        popped: list["_Session"] = []
         async with self._lock:
             keys = list(self._sessions.keys())
             for key in keys:
                 sess = self._sessions.pop(key, None)
                 if sess:
                     providers.append(sess.provider)
+                    popped.append(sess)
+        # Unlink off the lock: a bulk drain (every gateway shutdown/restart)
+        # can pop many sessions at once, and os.unlink is blocking I/O that
+        # would otherwise stall every other coroutine waiting on self._lock.
+        for sess in popped:
+            await asyncio.to_thread(_unlink_session_queue, sess)
         return providers
 
     async def drain_warm_pool(self) -> list:

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -201,6 +201,21 @@ class TestSessionManager:
         await mgr.close_all()
 
     @pytest.mark.asyncio
+    async def test_recycle_held_unlinks_temp_files_from_the_session_queue(self, cfg, tmp_path):
+        img = tmp_path / "img.png"
+        img.write_bytes(b"fake")
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("thread1")
+        key = mgr._fold_key("thread1")
+        session = mgr._sessions[key]
+        mgr.enqueue(key, "ts2", "second", force=True, image_temp_paths=[str(img)])
+
+        await mgr._recycle_held(key, session, 95.0)
+
+        assert not img.exists()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
     async def test_creates_session(self, cfg):
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
         provider, is_new, _resumed = await mgr.get_or_create("thread1")
@@ -969,6 +984,30 @@ class TestDeadProviderCleanup:
         await mgr.close_all()
 
     @pytest.mark.asyncio
+    async def test_dead_provider_removal_unlinks_temp_files_from_its_queue(self, cfg, tmp_path):
+        img = tmp_path / "img.png"
+        img.write_bytes(b"fake")
+        dead_provider = self._make_provider(alive=True)
+        call_count = 0
+
+        def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return dead_provider if call_count == 1 else self._make_provider()
+
+        mgr = SessionManager(cfg, provider_factory=factory)
+        await mgr.get_or_create("sess1")
+        mgr.enqueue("sess1", "ts1", "queued", force=True, image_temp_paths=[str(img)])
+        mgr.release("sess1")
+
+        dead_provider.is_alive.return_value = False
+        dead_provider.is_process_alive.return_value = False
+        await mgr.get_or_create("sess1")
+
+        assert not img.exists()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
     async def test_dead_provider_shutdown_exception_does_not_propagate(self, cfg):
         """If shutdown() raises on a dead provider, get_or_create still succeeds."""
         dead_provider = self._make_provider(alive=True)
@@ -1693,6 +1732,25 @@ class TestDrainProviders:
         assert providers == []
 
     @pytest.mark.asyncio
+    async def test_drain_all_providers_unlinks_temp_files_from_every_queue(
+        self, cfg, tmp_path
+    ):
+        img1 = tmp_path / "img1.png"
+        img2 = tmp_path / "img2.png"
+        img1.write_bytes(b"fake")
+        img2.write_bytes(b"fake")
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True, image_temp_paths=[str(img1)])
+        await mgr.get_or_create("k2")
+        mgr.enqueue("k2", "ts3", "third", force=True, image_temp_paths=[str(img2)])
+
+        await mgr.drain_all_providers()
+
+        assert not img1.exists()
+        assert not img2.exists()
+
+    @pytest.mark.asyncio
     async def test_drain_warm_pool(self, cfg):
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
         # Manually put items in the warm pool
@@ -1796,6 +1854,18 @@ class TestResetWithPid:
         await mgr.reset("k1")
         provider.shutdown.assert_awaited_once()
         assert not mgr.has_session("k1")
+
+    @pytest.mark.asyncio
+    async def test_reset_unlinks_temp_files_from_the_dropped_queue(self, cfg, tmp_path):
+        img = tmp_path / "img.png"
+        img.write_bytes(b"fake")
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True, image_temp_paths=[str(img)])
+
+        await mgr.reset("k1")
+
+        assert not img.exists()
 
     @pytest.mark.asyncio
     async def test_reset_with_acp_pid_dead_after_shutdown(self, cfg):
@@ -2071,6 +2141,18 @@ class TestDestroy:
         assert not mgr.has_session("k1")
 
     @pytest.mark.asyncio
+    async def test_destroy_unlinks_temp_files_from_the_session_queue(self, cfg, tmp_path):
+        img = tmp_path / "img.png"
+        img.write_bytes(b"fake")
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True, image_temp_paths=[str(img)])
+
+        await mgr.destroy("k1")
+
+        assert not img.exists()
+
+    @pytest.mark.asyncio
     async def test_destroy_nonexistent_still_deletes_map(self, cfg):
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
         with patch.object(mgr._session_map, "delete") as mock_delete:
@@ -2113,6 +2195,20 @@ class TestDiscardConversation:
         mock_clear.assert_called_once_with("k1")
         mock_delete.assert_not_called()
         assert not mgr.has_session("k1")
+
+    @pytest.mark.asyncio
+    async def test_discard_conversation_unlinks_temp_files_from_the_session_queue(
+        self, cfg, tmp_path
+    ):
+        img = tmp_path / "img.png"
+        img.write_bytes(b"fake")
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True, image_temp_paths=[str(img)])
+
+        await mgr.discard_conversation("k1")
+
+        assert not img.exists()
 
     @pytest.mark.asyncio
     async def test_discard_preserves_slack_linkage(self, cfg):
@@ -3610,6 +3706,18 @@ class TestRemove:
         provider.shutdown.assert_awaited_once()
         mock_delete.assert_not_called()  # remove preserves map
         assert not mgr.has_session("k1")
+
+    @pytest.mark.asyncio
+    async def test_remove_unlinks_temp_files_from_the_session_queue(self, cfg, tmp_path):
+        img = tmp_path / "img.png"
+        img.write_bytes(b"fake")
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.enqueue("k1", "ts2", "second", force=True, image_temp_paths=[str(img)])
+
+        await mgr.remove("k1")
+
+        assert not img.exists()
 
     @pytest.mark.asyncio
     async def test_remove_missing_key_is_noop(self, cfg):

--- a/test/test_session_coverage.py
+++ b/test/test_session_coverage.py
@@ -575,6 +575,19 @@ class TestRemoveIfUnclaimed:
         assert mgr.get_origin_link("dashboard:1") is None
         sess.provider.shutdown.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_an_unclaimed_session_unlinks_its_queued_temp_files(
+        self, mgr, tmp_path
+    ) -> None:
+        img = tmp_path / "img.png"
+        img.write_bytes(b"fake")
+        sess = _register(mgr, "dashboard:1", is_new=True)
+        sess.queue.append(("ts1", "queued", {"image_temp_paths": [str(img)]}))
+
+        assert await mgr.remove_if_unclaimed("dashboard:1") is True
+
+        assert not img.exists()
+
 
 class TestRecycleHeartbeat:
     @pytest.mark.asyncio

--- a/test/test_session_more_coverage.py
+++ b/test/test_session_more_coverage.py
@@ -513,6 +513,15 @@ class TestEvictStaleSession:
         assert mgr._sessions["task:step1"] is theirs
         ours.provider.shutdown.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_eviction_unlinks_temp_files_from_the_session_queue(self, mgr, tmp_path) -> None:
+        img = tmp_path / "img.png"
+        img.write_bytes(b"fake")
+        sess = _register(mgr, "task:step1")
+        sess.queue.append(("ts1", "queued", {"image_temp_paths": [str(img)]}))
+        await mgr._evict_stale_session("task:step1", sess)
+        assert not img.exists()
+
 
 # ── Background provider dispatch ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem / Motivation

`unlink_queued_temp_paths` (added by #3768/#3776) unlinks a queue entry's `image_temp_paths` on every path that discards it piecemeal — `cancel_queued`, `clear_queue`, and `dequeue`'s cancelled-skip. But nine other places in `SessionManager` pop an entire `_Session` object out of `_sessions` — discarding its `.queue` along with it — and never call it: stale-provider eviction on `get_or_create`'s fast path, `reset()`, the RSS-recycle watchdog (`_recycle_held`), `remove()`, `remove_if_unclaimed()` (the resume-prefetch TTL backstop), `destroy()`, `discard_conversation()`, and the bulk `drain_all_providers()` that every gateway shutdown/restart runs through.

## Why it matters

Any of these nine paths reachable while a busy session held queued image-bearing messages — a history delete, error recovery, an idle sweep, a gateway restart — silently leaks the queued messages' temp image files on disk permanently, with no cleanup path ever running for them.

## What changed (motivation → approach → change)

Symptom: temp files behind a queued message accumulate on disk whenever the session holding them is torn down as a whole, rather than dispatched or individually cancelled. Root cause: `unlink_queued_temp_paths` was wired into the three piecemeal-discard paths when it was added, but nothing audited the other whole-session teardown paths for the same gap.

Fix, per this issue's own suggested direction (a shared helper rather than scattering more call sites): added `_unlink_session_queue(session)`, a small module-level helper that iterates `session.queue` and unlinks every entry's temp files. Routed all nine identified pop sites through it:

- `_evict_stale_session` and the dead-provider-removal branch inside `get_or_create`'s fast path — both eviction paths for a session whose provider process died.
- `reset()` — context-overflow / `AcpPromptBusy` recovery.
- `_recycle_held` — the RSS-recycle watchdog's context-overflow recycle.
- `remove()` / `remove_if_unclaimed()` — session-map-preserving teardown, and the resume-prefetch TTL backstop.
- `destroy()` / `discard_conversation()` — the two deliberate, user-visible wipes.
- `drain_all_providers()` — the bulk pop every `close_all()` (gateway restart, Dev-Fleet cutover) runs through.

In every case the unlink call runs after the session leaves `self._lock` (matching how `provider.shutdown()` is already deliberately kept off-lock at each of these sites) — `os.unlink` is blocking I/O, and `drain_all_providers()` in particular can pop many sessions in a single shutdown, which would otherwise stall every other coroutine waiting on the manager lock.

Not touched: the persistent `HEARTBEAT_KEY` background session and `recycle_background()`'s `BACKGROUND_KEY` session — both are documented as stateless internal sessions (cron, heartbeat, lessons) that never receive Slack image-bearing user messages, so they cannot hold anything `_unlink_session_queue` would need to touch.

## Tests

One test per identified pop site, each enqueuing a message with `image_temp_paths` onto a real temp file before triggering the teardown path, then asserting the file no longer exists:

- `test/test_session.py`: `TestDestroy::test_destroy_unlinks_temp_files_from_the_session_queue`, `TestDiscardConversation::test_discard_conversation_unlinks_temp_files_from_the_session_queue`, `TestRemove::test_remove_unlinks_temp_files_from_the_session_queue`, `TestSessionManager::test_recycle_held_unlinks_temp_files_from_the_session_queue`, `TestResetWithPid::test_reset_unlinks_temp_files_from_the_dropped_queue`, `TestDrainProviders::test_drain_all_providers_unlinks_temp_files_from_every_queue` (two sessions, two files, both must go), `TestDeadProviderCleanup::test_dead_provider_removal_unlinks_temp_files_from_its_queue`.
- `test/test_session_more_coverage.py`: `TestEvictStaleSession::test_eviction_unlinks_temp_files_from_the_session_queue`.
- `test/test_session_coverage.py`: `TestRemoveIfUnclaimed::test_an_unclaimed_session_unlinks_its_queued_temp_files`.

All 9 verified failing against pre-fix code in one pass (`git stash` on just `src/kiro_crew/session.py`, re-run, all 9 fail with `assert not True` — the temp file still existed — restored after).

`test/test_session.py` + `test/test_session_more_coverage.py` + `test/test_session_coverage.py` + `test/test_message_queue.py`: 474 passed. Broader sweep — every `test_session*.py` file + `test_eager_spawn.py` + `test_slack_events_coverage.py` + `test_slack_gateway.py` + `test_message_queue.py` (this touches 9 distinct methods across the file, so I wanted the wider net): 2115 passed.

`flake8` / `isort` clean on touched files. `mypy` clean except the 3 pre-existing, unrelated `hooks.py` Linux-xattr errors present on unmodified `main`.

## Manual verification

N/A — unit coverage sufficient. Each test drives the real `SessionManager` method exactly as its production caller does, with a real temp file on disk and a real `os.path.exists()` assertion — there's no UI or external-service surface here.

## Related Issues

Fixes #3777

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — CHANGELOG entry added
- [x] No secrets, credentials, or internal references in the diff
