### PR TITLE
fix(cron): re-arm the timer on job completion instead of waiting out the poll cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **A long-running cron job's next tick is no longer dispatched up to 30s
+  late.** A job is invisible to the scheduler's wake computation while it's
+  executing (`_next_wake_secs` skips anything in `self._executing`), so for
+  a job whose run takes most of its interval, the timer's last wake before
+  completion — capped at the 30s poll interval — is what the next dispatch
+  had to wait for, since finishing a job never re-armed the timer. Measured
+  in the field on a 60s-interval job with a ~57s run: 20% of ticks landed
+  ≥20s late, costing roughly double the job's own `interval - duration`
+  idle-time floor. Job completion now re-arms the timer with its real
+  next-due delay. The naive version of this fix is unsafe: a job's
+  completion runs on its own task, not the timer's, so a blind
+  `_arm_timer()` call racing the timer's own in-flight dispatch sweep
+  (`_on_timer`, yielded at its worker-thread scan) would cancel that sweep
+  mid-flight and drop any due jobs not yet spawned for that tick. A job
+  completing in that narrow window now no-ops instead — `_on_timer`'s own
+  tick already unconditionally re-arms once the sweep finishes, by which
+  point the completed job is no longer `_executing`, so the corrected delay
+  still gets picked up, just moments later rather than being computed
+  twice.
+
 - **Removing a worktree in Dev Fleet no longer strands its pod's isolated
   HOME.** Reclamation was gated on the pod's unit still being ACTIVE, which the
   ordinary path never is: you stop the pod when testing ends and prune days

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -660,6 +660,12 @@ class CronService:
         self._on_job = on_job
         self._jobs: list[CronJob] = []
         self._timer_task: asyncio.Task[None] | None = None
+        # True only for the span of an in-flight _on_timer() dispatch pass
+        # (set/cleared there). _arm_timer() checks this to avoid cancelling
+        # self._timer_task out from under a sweep that hasn't finished
+        # spawning its due jobs yet — see _arm_timer's guard for the failure
+        # mode this prevents.
+        self._on_timer_running = False
         self._running = False
         # The event loop this service is bound to, captured in create()/start()
         # (the gateway's loop). _arm_timer() uses it to re-arm the timer THREAD-
@@ -2361,6 +2367,24 @@ class CronService:
         # create the replacement task below; the finishing tick exits normally.
         # A *different* caller rescheduling while the tick merely waits on
         # shutdown_event still cancels correctly (current is not the timer task).
+        #
+        # A DIFFERENT hazard, same root cause, needs a second guard: a job's
+        # own completion handler calls _arm_timer() (see _run_job_isolated) to
+        # re-arm promptly instead of waiting out the rest of the poll cap, but
+        # that call runs on the JOB's task, not the timer's — so `current is
+        # not self._timer_task` above is true even while _on_timer is still
+        # mid-sweep (yielded at its own to_thread scan). Cancelling here would
+        # abort that sweep exactly as the self-referential case above
+        # describes, just reached from a different caller. Neither cancelling
+        # NOR creating a replacement task is safe in that window (creating one
+        # too would leave two timer tasks alive and double-fire the next
+        # tick), so this arm is dropped entirely: _on_timer's own tick already
+        # unconditionally re-arms in its `finally` once the sweep completes
+        # (by which point the completed job is no longer in self._executing),
+        # so the delay this caller wanted still gets picked up, just a moment
+        # later rather than being computed twice.
+        if self._on_timer_running and current is not self._timer_task:
+            return
         if self._timer_task and not self._timer_task.done() and self._timer_task is not current:
             self._timer_task.cancel()
         if not self._running:
@@ -2426,106 +2450,115 @@ class CronService:
         ``no-blocking-call-on-event-loop`` rule). The mutation-free due-scan —
         which reads loop-owned ``self._executing`` — then runs on the loop
         against the returned snapshot.
+
+        Brackets the whole body with ``self._on_timer_running`` so a job
+        completing during either ``to_thread`` await below (the scan, and the
+        admission check) cannot have its ``_arm_timer()`` call cancel
+        ``self._timer_task`` out from under this sweep — see ``_arm_timer``.
         """
-        snapshot = await asyncio.to_thread(self._tick_scan_locked)
-        now = time.time()
-        due = [
-            j
-            for j in snapshot
-            if j.enabled and j.id not in self._executing and self._is_due(j, now)
-        ]
+        self._on_timer_running = True
+        try:
+            snapshot = await asyncio.to_thread(self._tick_scan_locked)
+            now = time.time()
+            due = [
+                j
+                for j in snapshot
+                if j.enabled and j.id not in self._executing and self._is_due(j, now)
+            ]
 
-        # An empty due-scan can only end the tick when no deferral episode is
-        # in progress: the recovery log (below) must still fire on a quiet
-        # tick, otherwise an episode that ends during a lull is never closed.
-        if not due and not self._admission_deferring:
-            return
+            # An empty due-scan can only end the tick when no deferral episode is
+            # in progress: the recovery log (below) must still fire on a quiet
+            # tick, otherwise an episode that ends during a lull is never closed.
+            if not due and not self._admission_deferring:
+                return
 
-        # Posture-gated admission: while host memory is CRITICAL, defer this
-        # tick's ``every``/``at`` firings instead of admitting more work onto
-        # a host that cannot absorb it. The verdict is computed off-loop
-        # (config + procfs reads must not stall the event loop). Deferral is
-        # deliberately STATELESS and only applies to schedule kinds that stay
-        # due on their own (``last_run_ts`` untouched, so a deferred job fires
-        # on the first admitted tick). A cron-expression job is only due while
-        # its expression matches the current minute, so it cannot be deferred
-        # statelessly: an in-memory catch-up marker loses the occurrence on
-        # gateway restart, and dropping it silently loses the occurrence
-        # outright — so cron-expression jobs run normally even under critical
-        # posture (persisted deferral markers are a possible follow-up).
-        # Manual runs (run_job / cron_trigger) never pass through this scan
-        # and are not deferred. Fails open on unknown posture. The INFO log
-        # fires once per deferral episode and re-fires every 15 minutes so a
-        # long suspension stays diagnosable.
-        decision = await asyncio.to_thread(admission_check)
+            # Posture-gated admission: while host memory is CRITICAL, defer this
+            # tick's ``every``/``at`` firings instead of admitting more work onto
+            # a host that cannot absorb it. The verdict is computed off-loop
+            # (config + procfs reads must not stall the event loop). Deferral is
+            # deliberately STATELESS and only applies to schedule kinds that stay
+            # due on their own (``last_run_ts`` untouched, so a deferred job fires
+            # on the first admitted tick). A cron-expression job is only due while
+            # its expression matches the current minute, so it cannot be deferred
+            # statelessly: an in-memory catch-up marker loses the occurrence on
+            # gateway restart, and dropping it silently loses the occurrence
+            # outright — so cron-expression jobs run normally even under critical
+            # posture (persisted deferral markers are a possible follow-up).
+            # Manual runs (run_job / cron_trigger) never pass through this scan
+            # and are not deferred. Fails open on unknown posture. The INFO log
+            # fires once per deferral episode and re-fires every 15 minutes so a
+            # long suspension stays diagnosable.
+            decision = await asyncio.to_thread(admission_check)
 
-        # The admission await yielded the loop, so the due snapshot may be
-        # stale: a manual run (run_job / cron_trigger) can have claimed — or
-        # even completed — a job meanwhile, and a job can have been edited,
-        # disabled, or queued for removal. Rebuild the due list from the LIVE
-        # job objects and re-run the due check BEFORE the deferral partition
-        # below: classifying by the stale snapshot's schedule kind would let
-        # an interval job edited into a matching cron expression during the
-        # await be deferred-and-dropped (its occurrence lost), and dispatching
-        # the snapshot object would execute a stale definition. An id-only
-        # check would double-fire a job whose manual run already finished.
-        # The re-check deliberately reuses the scan-time ``now``: a live
-        # ``last_run_ts`` advanced by a finished manual run still fails it
-        # (interval math for ``every``/``at``, the same-minute guard for cron
-        # expressions), while a minute boundary crossed during the await
-        # cannot drop a cron-expression occurrence that was genuinely due at
-        # scan time.
-        live_by_id = {j.id: j for j in self._jobs if j.enabled}
-        due = [
-            live_by_id[j.id]
-            for j in due
-            if j.id in live_by_id
-            and j.id not in self._executing
-            and j.id not in self._pending_removals
-            and self._is_due(live_by_id[j.id], now)
-        ]
+            # The admission await yielded the loop, so the due snapshot may be
+            # stale: a manual run (run_job / cron_trigger) can have claimed — or
+            # even completed — a job meanwhile, and a job can have been edited,
+            # disabled, or queued for removal. Rebuild the due list from the LIVE
+            # job objects and re-run the due check BEFORE the deferral partition
+            # below: classifying by the stale snapshot's schedule kind would let
+            # an interval job edited into a matching cron expression during the
+            # await be deferred-and-dropped (its occurrence lost), and dispatching
+            # the snapshot object would execute a stale definition. An id-only
+            # check would double-fire a job whose manual run already finished.
+            # The re-check deliberately reuses the scan-time ``now``: a live
+            # ``last_run_ts`` advanced by a finished manual run still fails it
+            # (interval math for ``every``/``at``, the same-minute guard for cron
+            # expressions), while a minute boundary crossed during the await
+            # cannot drop a cron-expression occurrence that was genuinely due at
+            # scan time.
+            live_by_id = {j.id: j for j in self._jobs if j.enabled}
+            due = [
+                live_by_id[j.id]
+                for j in due
+                if j.id in live_by_id
+                and j.id not in self._executing
+                and j.id not in self._pending_removals
+                and self._is_due(live_by_id[j.id], now)
+            ]
 
-        if not decision.admitted:
-            deferred = [j for j in due if j.schedule.kind != "cron"]
-            due = [j for j in due if j.schedule.kind == "cron"]
-            now_mono = time.monotonic()
-            if not self._admission_deferring:
-                self._admission_deferring = True
-                self._admission_last_log = now_mono
+            if not decision.admitted:
+                deferred = [j for j in due if j.schedule.kind != "cron"]
+                due = [j for j in due if j.schedule.kind == "cron"]
+                now_mono = time.monotonic()
+                if not self._admission_deferring:
+                    self._admission_deferring = True
+                    self._admission_last_log = now_mono
+                    logger.info(
+                        "Cron: deferring interval/one-shot firings (%d deferred "
+                        "this tick; cron-expression jobs run normally) — %s "
+                        "(re-logged every 15 min while the episode lasts)",
+                        len(deferred),
+                        decision.reason,
+                    )
+                elif now_mono - self._admission_last_log >= 900.0:
+                    self._admission_last_log = now_mono
+                    logger.info(
+                        "Cron: STILL deferring interval/one-shot firings (%d "
+                        "deferred this tick) — %s",
+                        len(deferred),
+                        decision.reason,
+                    )
+                else:
+                    logger.debug(
+                        "Cron: still deferring %d scheduled job(s)", len(deferred)
+                    )
+            elif self._admission_deferring:
+                self._admission_deferring = False
                 logger.info(
-                    "Cron: deferring interval/one-shot firings (%d deferred "
-                    "this tick; cron-expression jobs run normally) — %s "
-                    "(re-logged every 15 min while the episode lasts)",
-                    len(deferred),
-                    decision.reason,
+                    "Cron: memory posture recovered — resuming scheduled firings"
                 )
-            elif now_mono - self._admission_last_log >= 900.0:
-                self._admission_last_log = now_mono
-                logger.info(
-                    "Cron: STILL deferring interval/one-shot firings (%d "
-                    "deferred this tick) — %s",
-                    len(deferred),
-                    decision.reason,
-                )
-            else:
-                logger.debug(
-                    "Cron: still deferring %d scheduled job(s)", len(deferred)
-                )
-        elif self._admission_deferring:
-            self._admission_deferring = False
-            logger.info(
-                "Cron: memory posture recovered — resuming scheduled firings"
-            )
 
-        if not due:
-            return
+            if not due:
+                return
 
-        # Fire each job independently — one hung job never blocks others.
-        for j in due:
-            self._executing.add(j.id)
-            self._job_run_meta.setdefault(j.id, (time.time(), "scheduled"))
-            task = asyncio.create_task(self._run_job_isolated(j))
-            self._running_tasks[j.id] = task
+            # Fire each job independently — one hung job never blocks others.
+            for j in due:
+                self._executing.add(j.id)
+                self._job_run_meta.setdefault(j.id, (time.time(), "scheduled"))
+                task = asyncio.create_task(self._run_job_isolated(j))
+                self._running_tasks[j.id] = task
+        finally:
+            self._on_timer_running = False
 
     async def _run_job_isolated(self, job: CronJob) -> None:
         """Execute a single job and merge results back to disk."""
@@ -2648,6 +2681,20 @@ class CronService:
                         self._push_refresh("cron_history")
                 except Exception:
                     logger.exception("Failed to record history for job '%s'", job.name)
+            # Re-arm now rather than waiting for whatever wake was already
+            # armed: a job that ran for most of its interval was invisible to
+            # every _next_wake_secs() computed while self._executing held it
+            # (see _next_wake_secs), so the armed delay can be stale by up to
+            # _TIMER_POLL_SECS by the time this job becomes due again. Placed
+            # at the very end, after last_run_ts/history are settled, so the
+            # delay this computes reflects this run's actual outcome. Safe to
+            # call unconditionally (also when reaped/cancelled, or when
+            # nothing changed): _arm_timer() itself no-ops when the service
+            # isn't running, and the self._on_timer_running guard there
+            # covers the one case where this job's own completion happens to
+            # race an in-flight dispatch sweep.
+            if self._running:
+                self._arm_timer()
 
     @staticmethod
     def _compute_jitter(job: CronJob) -> float:

--- a/test/test_cron.py
+++ b/test/test_cron.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -484,6 +486,158 @@ class TestEffectiveDelay:
         job.enabled = False
 
         assert svc._effective_delay() == _TIMER_POLL_SECS
+
+
+class TestJobCompletionRearmsTimer:
+    """A job that ran for most of its interval must not have to wait out a
+    stale wake (up to _TIMER_POLL_SECS) before its next tick is dispatched:
+    completion re-arms the timer with the job's real next-due delay."""
+
+    @pytest.mark.asyncio
+    async def test_run_job_isolated_rearms_the_timer(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        job = CronJob(
+            id="j1", name="watch", message="go",
+            schedule=CronSchedule(kind="every", every_secs=60),
+        )
+        svc._jobs = [job]
+        svc._save()
+        svc._running = True
+
+        with (
+            patch.object(svc, "_execute_with_timeout", return_value=None),
+            patch.object(svc, "_arm_timer") as mock_arm,
+        ):
+            await svc._run_job_isolated(job)
+
+        mock_arm.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_job_isolated_does_not_rearm_a_stopped_service(
+        self, tmp_path: Path
+    ) -> None:
+        """A job finishing during/after shutdown must not spin up a fresh
+        timer task behind close_all()'s back."""
+        svc = CronService(base_dir=tmp_path)
+        job = CronJob(
+            id="j1", name="watch", message="go",
+            schedule=CronSchedule(kind="every", every_secs=60),
+        )
+        svc._jobs = [job]
+        svc._save()
+        svc._running = False
+
+        with (
+            patch.object(svc, "_execute_with_timeout", return_value=None),
+            patch.object(svc, "_arm_timer") as mock_arm,
+        ):
+            await svc._run_job_isolated(job)
+
+        mock_arm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_completed_job_replaces_a_longer_sleeping_timer_task(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression for the reported bug: before this fix, nothing called
+        _arm_timer() on job completion, so a job that became due again
+        sooner than the CURRENTLY armed (long) sleep had to wait out that
+        stale wake -- up to _TIMER_POLL_SECS late. Simulates that exact
+        situation: a timer task already sleeping for a long time is armed
+        when the job finishes; completion must cancel it and arm a fresh,
+        shorter one instead of leaving the stale one in place."""
+        svc = CronService(base_dir=tmp_path)
+        job = CronJob(
+            id="j1", name="watch", message="go",
+            schedule=CronSchedule(kind="every", every_secs=60),
+        )
+        svc._jobs = [job]
+        svc._save()
+        svc._running = True
+        svc._loop = asyncio.get_running_loop()
+
+        async def _sleep_forever() -> None:
+            await asyncio.sleep(9999)
+
+        stale_timer_task = asyncio.create_task(_sleep_forever())
+        svc._timer_task = stale_timer_task
+        await asyncio.sleep(0)  # let it actually start sleeping
+
+        with patch.object(svc, "_execute_with_timeout", return_value=None):
+            await svc._run_job_isolated(job)
+        await asyncio.sleep(0)  # let the cancellation propagate
+
+        assert stale_timer_task.cancelled()
+        assert svc._timer_task is not None
+        assert svc._timer_task is not stale_timer_task
+
+        svc._timer_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await svc._timer_task
+
+
+class TestArmTimerDuringOnTimer:
+    """_arm_timer(), called from a job's own completion handler, must not
+    cancel self._timer_task while _on_timer is still mid-sweep on it (the
+    yield at its own to_thread scan) -- that's a DIFFERENT task calling in
+    than the timer's own, so the pre-existing self-referential guard alone
+    doesn't cover it. See _arm_timer's second guard clause."""
+
+    @pytest.mark.asyncio
+    async def test_arm_timer_does_not_cancel_the_timer_task_mid_sweep(
+        self, tmp_path: Path
+    ) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._running = True
+        svc._loop = asyncio.get_running_loop()
+
+        async def _sleep_forever() -> None:
+            await asyncio.sleep(9999)
+
+        fake_timer_task = asyncio.create_task(_sleep_forever())
+        svc._timer_task = fake_timer_task
+        svc._on_timer_running = True
+        try:
+            svc._arm_timer()  # called from THIS task, not svc._timer_task
+            await asyncio.sleep(0)
+            assert not fake_timer_task.cancelled()
+            assert not fake_timer_task.done()
+            assert svc._timer_task is fake_timer_task
+        finally:
+            svc._on_timer_running = False
+            fake_timer_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await fake_timer_task
+
+    @pytest.mark.asyncio
+    async def test_arm_timer_still_replaces_the_task_once_the_sweep_is_done(
+        self, tmp_path: Path
+    ) -> None:
+        """The guard is scoped to the sweep window only -- once _on_timer
+        has returned (the common case: the timer task is just sleeping,
+        not mid-dispatch), a completion-triggered re-arm still cancels and
+        replaces it immediately, which is the actual fix for the reported
+        lateness."""
+        svc = CronService(base_dir=tmp_path)
+        svc._running = True
+        svc._loop = asyncio.get_running_loop()
+
+        async def _sleep_forever() -> None:
+            await asyncio.sleep(9999)
+
+        fake_timer_task = asyncio.create_task(_sleep_forever())
+        svc._timer_task = fake_timer_task
+        svc._on_timer_running = False
+        try:
+            svc._arm_timer()
+            await asyncio.sleep(0)
+            assert fake_timer_task.cancelled()
+            assert svc._timer_task is not fake_timer_task
+        finally:
+            if svc._timer_task and not svc._timer_task.done():
+                svc._timer_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await svc._timer_task
 
 
 class TestFormatSchedule:


### PR DESCRIPTION
## Problem / Motivation

A cron job whose run takes up most of its interval can have its next tick dispatched up to 30 seconds late. `_next_wake_secs()` skips any job currently in `self._executing`, so a running job is invisible to every wake computed while it's executing. Finishing a job never re-arms the timer, so the next dispatch has to wait for whatever wake was already armed — which the 30s poll cap (`_TIMER_POLL_SECS`) bounds at up to 30s stale.

## Why it matters

Measured in the field on a real job (60s interval, ~57s median run — a file-watch loop): over a 2.3h window, 22 of 109 gaps between consecutive runs (20%) were ≥20s, against a structural floor of ~3s (`interval - duration`). That job spent 11.3% of its wall clock not watching, where the floor implied ~5.2% — roughly half its idle time was this defect, not the job's own duration. Any job whose duration approaches its interval degrades the same way; short jobs relative to their interval never notice, which is why this went unreported for a while.

## What changed (motivation → approach → change)

Symptom: a job that ran for most of its interval waits out a stale, already-armed wake before its next tick dispatches. Root cause: nothing in `_run_job_isolated`'s completion path calls `_arm_timer()` — every other `_arm_timer()` call site is either a job-set mutation (add/update/remove/pause/resume/store reload) or the timer's own re-arm after `_on_timer`; "a job finished" was never one of them, even though it changes a job's due-ness exactly the way a mutation changes the set.

The obvious fix — call `_arm_timer()` from the completion path — is not safe as-is. `_arm_timer()` cancels `self._timer_task` to replace it with one carrying the fresh delay, guarded against a narrow self-referential case (the timer's own tick re-arming itself in its `finally`, which must not cancel the task it's running as). A job's completion runs on the *job's own task*, not the timer's, so that existing guard doesn't cover it: if the completion lands while `_on_timer` is mid-sweep (yielded at its own `asyncio.to_thread` scan), a naive `_arm_timer()` call would still cancel `self._timer_task` out from under that sweep, aborting it and dropping any due jobs the sweep hadn't spawned yet for that tick — a real, if narrow, regression the naive version of this fix would introduce.

Fix: added `self._on_timer_running`, a flag set only for the span of an in-flight `_on_timer()` sweep. `_arm_timer()`'s guard now also no-ops (skips both the cancel and the replacement) when called from a *different* task while that flag is set, rather than cancelling. This is safe without a deferred/pending-rearm mechanism: `_on_timer`'s own tick already unconditionally re-arms in its `finally` once the sweep completes (`if self._running: self._arm_timer()`), and by that point the completed job is no longer in `self._executing` — so the corrected delay still gets computed and armed, just a few moments later rather than by racing the in-flight sweep, and without a second timer task ever existing concurrently. `_run_job_isolated`'s completion `finally` now calls `_arm_timer()` unconditionally (also for reaped/cancelled runs — the job still leaves `self._executing` either way, becoming visible again), placed at the very end of the block, after `last_run_ts` and history are settled, so the delay it computes reflects the run's actual outcome rather than stale state.

## Tests

New in `test/test_cron.py`:
- `TestJobCompletionRearmsTimer::test_run_job_isolated_rearms_the_timer` — a job completing with the service running calls `_arm_timer()`.
- `TestJobCompletionRearmsTimer::test_run_job_isolated_does_not_rearm_a_stopped_service` — a job finishing during/after shutdown must not spin up a fresh timer task behind `close_all()`'s back.
- `TestJobCompletionRearmsTimer::test_completed_job_replaces_a_longer_sleeping_timer_task` — the actual regression, reproduced directly: arms a long-sleeping fake timer task, completes a job, and asserts the stale task is cancelled and replaced rather than left in place.
- `TestArmTimerDuringOnTimer::test_arm_timer_does_not_cancel_the_timer_task_mid_sweep` — the safety property this PR is really about: with `_on_timer_running=True`, a completion-triggered `_arm_timer()` call from a different task must leave `self._timer_task` untouched.
- `TestArmTimerDuringOnTimer::test_arm_timer_still_replaces_the_task_once_the_sweep_is_done` — confirms the guard is scoped to the sweep window only; once `_on_timer` has returned, a completion-triggered re-arm still cancels and replaces immediately (the actual fix for the reported lateness).

Verified all 5 against pre-fix code (`git stash` on just `src/kiro_crew/cron.py`): the 3 regression-proving tests fail exactly as expected (`_arm_timer` never called; stale task never replaced; the mid-sweep cancellation actually happens), and the 2 negative/safety tests correctly pass in both states (confirming they're not accidentally vacuous — the stopped-service guard and the existing self-referential-safe case were never broken). Restored after.

Stress-tested the 5 new tests for flakiness given the `asyncio.sleep(0)`-based interleave assertions: 15 consecutive clean runs.

`test/test_cron.py`: 88 passed. Full cron suite (`test_cron*.py` + `test_mcp_cron*.py` + `test_dashboard_cron*.py` + `test_handler_cron_list.py`): 1112 passed, 1 skipped. `flake8` / `isort` clean on touched files. `mypy` clean except the 3 pre-existing, unrelated `hooks.py` Linux-xattr errors present on unmodified `main`.

## Manual verification

N/A — unit coverage sufficient. The regression tests drive the real `_run_job_isolated`/`_arm_timer`/`_on_timer_running` interaction directly with real `asyncio.Task` objects (not mocks of the timer mechanism itself), which is the actual property in question; reproducing the field timing behavior end-to-end would need a multi-minute real-clock run to observe a >20s gap.

## Related Issues

Fixes #3651

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — CHANGELOG entry added
- [x] No secrets, credentials, or internal references in the diff
