### PR TITLE
fix(code-review-sage): collapse the rail to a strip on a phone

### DIFF
--- a/website/src/apps/code-review-sage/Workspace.tsx
+++ b/website/src/apps/code-review-sage/Workspace.tsx
@@ -9,15 +9,19 @@
 // Reports are the widest content in the app (finding bodies, diffs, check
 // tables), so the space belongs to them.
 import { ScanSearch } from 'lucide-react'
+import { useEffect } from 'react'
 
-import { useColumnResize } from '../../hooks/useColumnResize'
+import { IconButton } from '../../components/ui'
+import { type CollapseConfig, useColumnResize } from '../../hooks/useColumnResize'
+import { useIsMobile } from '../../hooks/useIsMobile'
 import EmptyState from './components/EmptyState'
 import LeftRail from './components/LeftRail'
 import PrReviewDetail from './components/PrReviewDetail'
 import RunDetail from './components/RunDetail'
 import { useSage } from './context'
 import {
-  MAX_RAIL_WIDTH, MIN_RAIL_WIDTH, RAIL_WIDTH_KEY, loadRailWidth,
+  COLLAPSED_RAIL_WIDTH, MAX_RAIL_WIDTH, MIN_RAIL_WIDTH, RAIL_COLLAPSED_KEY, RAIL_WIDTH_KEY,
+  loadRailCollapsed, loadRailWidth,
 } from './lib/layout'
 import LearningView from './views/LearningView'
 import SettingsView from './views/SettingsView'
@@ -41,20 +45,66 @@ function Splitter({ handleProps, label }: {
   )
 }
 
+// Module-level so the resize hook's memoised resolver isn't invalidated every
+// render. `whenNarrow` collapses the rail to its strip on a phone, where a 280px
+// minimum would otherwise leave the report pane ~100px of a 390px viewport. The
+// opened state below is FULL WIDTH, not `rail.width`: a strip whose expand button
+// only restored 280px would hand the user straight back into the squeeze.
+const RAIL_COLLAPSE: CollapseConfig = {
+  width: COLLAPSED_RAIL_WIDTH, storageKey: RAIL_COLLAPSED_KEY, whenNarrow: true,
+}
+
 export default function Workspace() {
   const { mainView, activeRun, selectedPr } = useSage()
 
-  const rail = useColumnResize(RAIL_WIDTH_KEY, loadRailWidth, MIN_RAIL_WIDTH, MAX_RAIL_WIDTH)
+  const rail = useColumnResize(
+    RAIL_WIDTH_KEY, loadRailWidth, MIN_RAIL_WIDTH, MAX_RAIL_WIDTH, RAIL_COLLAPSE, loadRailCollapsed,
+  )
+  const isMobile = useIsMobile()
+  // Narrow AND expanded: the rail IS the page, so the report steps aside below.
+  const mobileRailOpen = isMobile && !rail.collapsed
+  // Collapse on select — the third leg of this pattern, and the one that makes
+  // the expanded rail a drill-down instead of a one-way door. Without it, picking
+  // a review from the full-width rail changes nothing visible: the rail keeps the
+  // viewport, the report stays hidden, and the drag handle that would otherwise
+  // collapse it is gone on touch. `whenNarrow`'s own contract requires it.
+  //
+  // Keyed on the selection rather than run imperatively from the row handler,
+  // because selection lives in the Sage context, which cannot reach this hook.
+  // Keying on identity is what keeps it from fighting the user's own expand: it
+  // fires when the selection actually changes, not on every mobile render.
+  useEffect(() => {
+    if (isMobile) rail.collapse()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPr, activeRun, mainView, isMobile])
+  // Every main pane shares this: hidden while the rail owns the viewport, so a
+  // 100%-wide rail cannot push the report off-screen instead of replacing it.
+  const mainClass = `flex-1 min-w-0 min-h-0 flex-col ${mobileRailOpen ? 'hidden' : 'flex'}`
 
   return (
     // overflow-hidden so a mis-sized child can never grow the shell past the
     // viewport and push the rail's identity footer below the fold — each column
     // owns its own scrolling.
     <div className="flex h-full overflow-hidden bg-bg text-text">
-      <div style={{ width: rail.width }} className="flex-shrink-0 min-h-0 flex">
-        <LeftRail />
+      <div
+        style={{ width: mobileRailOpen ? '100%' : rail.width }}
+        className="flex-shrink-0 min-h-0 flex"
+      >
+        {rail.collapsed ? (
+          <div className="w-full flex flex-col items-center border-r border-border bg-bg-accent pt-2">
+            <IconButton aria-label={i18nT('app.expand_sidebar')} onClick={rail.expand}>
+              <ScanSearch size={16} className="text-accent" />
+            </IconButton>
+          </div>
+        ) : (
+          <LeftRail />
+        )}
       </div>
-      <Splitter handleProps={rail.handleProps} label={i18nT('apps.codeReviewSage.workspace.resize_sidebar')} />
+      {/* The drag handle is a pointer affordance and costs width a phone does
+          not have; the strip's expand button is the narrow-width control. */}
+      {!isMobile && (
+        <Splitter handleProps={rail.handleProps} label={i18nT('apps.codeReviewSage.workspace.resize_sidebar')} />
+      )}
 
       {mainView === 'reviews' ? (
         <>
@@ -63,7 +113,7 @@ export default function Workspace() {
               child) sizes itself with flex-1, which is inert unless this element
               is itself a flex container — that bug left the empty state
               collapsed to content height and pinned to the top of the pane. */}
-          <main className="flex-1 min-w-0 min-h-0 flex flex-col">
+          <main className={mainClass}>
             {selectedPr ? (
               <PrReviewDetail pr={selectedPr} />
             ) : activeRun ? (
@@ -78,9 +128,9 @@ export default function Workspace() {
           </main>
         </>
       ) : mainView === 'learning' ? (
-        <main className="flex-1 min-w-0 min-h-0 flex flex-col"><LearningView /></main>
+        <main className={mainClass}><LearningView /></main>
       ) : (
-        <main className="flex-1 min-w-0 min-h-0 flex flex-col"><SettingsView /></main>
+        <main className={mainClass}><SettingsView /></main>
       )}
     </div>
   )

--- a/website/src/apps/code-review-sage/lib/layout.ts
+++ b/website/src/apps/code-review-sage/lib/layout.ts
@@ -14,6 +14,13 @@ export const DEFAULT_RAIL_WIDTH = 360
 export const MIN_RAIL_WIDTH = 280
 export const MAX_RAIL_WIDTH = 560
 
+/** Width of the collapsed rail strip — icon-only, so it never competes with the
+ * detail pane for a phone's width. `MIN_RAIL_WIDTH` is 280px, which on a 390px
+ * viewport leaves the review pane ~100px; the strip is the narrow-width state
+ * the resize hook falls back to. */
+export const COLLAPSED_RAIL_WIDTH = 44
+export const RAIL_COLLAPSED_KEY = 'kc:code-review-sage:rail-collapsed'
+
 export const DEFAULT_LIST_WIDTH = 330
 export const MIN_LIST_WIDTH = 260
 export const MAX_LIST_WIDTH = 620
@@ -37,6 +44,18 @@ export function loadRailWidth(): number {
 
 export function loadListWidth(): number {
   return loadWidth(LIST_WIDTH_KEY, MIN_LIST_WIDTH, MAX_LIST_WIDTH, DEFAULT_LIST_WIDTH)
+}
+
+/** The DESKTOP collapsed preference. The narrow-viewport strip is a session-only
+ * override inside the resize hook and deliberately never reaches storage, so one
+ * phone visit cannot leave the desktop rail collapsed. */
+export function loadRailCollapsed(): boolean {
+  try {
+    return localStorage.getItem(RAIL_COLLAPSED_KEY) === '1'
+  } catch {
+    // Storage blocked (private mode, quota) — start expanded.
+    return false
+  }
 }
 
 /** Poll cadence while at least one run is live. Reviews advance on the order of

--- a/website/src/test/codeReviewSageRailNarrow.test.ts
+++ b/website/src/test/codeReviewSageRailNarrow.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Code Review Sage's rail must stop competing with the report on a phone.
+ *
+ * The rail is a resizable column with `MIN_RAIL_WIDTH = 280`, set through an
+ * inline `style={{ width }}` on a `flex-shrink-0` box — so at a 390px viewport it
+ * held 280-360px and left the report pane roughly 100px. `useColumnResize`
+ * already supports a narrow-viewport strip, but it is OPT-IN via the collapse
+ * config's `whenNarrow`, and this shell never passed one.
+ *
+ * Two halves, and the second is the load-bearing one. `ProjectsPage` states the
+ * trap directly: "A page that only got the strip would hand the user an expand
+ * button that leads straight back into the squeeze." So the strip alone is not
+ * the fix — the EXPANDED state has to take the whole viewport, with the report
+ * stepping aside, which is what `WebhooksPage` and `ProjectsPage` both do.
+ *
+ * Asserted over the source: the defect is which declaration each element carries
+ * (an inline px width vs `100%`, `flex` vs `hidden`), and jsdom does no layout,
+ * so a render could not measure the difference anyway.
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  COLLAPSED_RAIL_WIDTH, MIN_RAIL_WIDTH, RAIL_COLLAPSED_KEY,
+} from '../apps/code-review-sage/lib/layout'
+
+async function shell(): Promise<string> {
+  return (await import('../apps/code-review-sage/Workspace.tsx?raw')).default as string
+}
+
+describe('Code Review Sage rail at narrow widths', () => {
+  it('opts into the narrow-viewport strip', async () => {
+    const src = await shell()
+    const cfg = src.match(/const RAIL_COLLAPSE: CollapseConfig = \{[\s\S]*?\}/)
+    expect(cfg, 'expected a module-level RAIL_COLLAPSE config').not.toBeNull()
+    // Without `whenNarrow` the hook's narrowMode stays false and the rail keeps
+    // its px width on a phone — the config alone is not enough.
+    expect(cfg![0]).toContain('whenNarrow: true')
+    expect(cfg![0]).toContain('COLLAPSED_RAIL_WIDTH')
+  })
+
+  it('gives the whole viewport to the rail once expanded while narrow', async () => {
+    const src = await shell()
+    expect(src).toMatch(/mobileRailOpen = isMobile && !rail\.collapsed/)
+    // The anti-squeeze invariant: expanded-while-narrow is 100%, never rail.width.
+    expect(src).toMatch(/width: mobileRailOpen \? '100%' : rail\.width/)
+  })
+
+  it('steps the report aside instead of pushing it off-screen', async () => {
+    const src = await shell()
+    // A 100%-wide rail beside a flex-1 main would push the report out of view
+    // rather than replace it, leaving nothing reachable by scrolling.
+    expect(src).toMatch(/mobileRailOpen \? 'hidden' : 'flex'/)
+    // And no main pane may keep an unconditional `flex` class.
+    expect(src).not.toMatch(/className="flex-1 min-w-0 min-h-0 flex flex-col"/)
+  })
+
+  it('leaves the collapsed strip an expand control with an accessible name', async () => {
+    const src = await shell()
+    expect(src).toMatch(/rail\.collapsed \?/)
+    expect(src).toMatch(/onClick=\{rail\.expand\}/)
+    // Reuses the app-agnostic catalog key, so this adds no untranslated string.
+    expect(src).toContain("i18nT('app.expand_sidebar')")
+  })
+
+  it('collapses the rail on select, so the expanded rail is not a one-way door', async () => {
+    const src = await shell()
+    // The third leg of the pattern. Without it, picking a review from the
+    // full-width rail changes nothing visible: the rail keeps the viewport, the
+    // report stays hidden, and the drag handle that would collapse it is gone on
+    // touch — leaving a reload as the only escape. `whenNarrow` requires it, and
+    // both cited shells (ProjectsPage, WebhooksPage) call rail.collapse().
+    expect(src).toMatch(/if \(isMobile\) rail\.collapse\(\)/)
+    // Keyed on the selection, not on every mobile render, or it would fight the
+    // user's own expand and the strip could never be opened at all.
+    expect(src).toMatch(/\}, \[selectedPr, activeRun, mainView, isMobile\]\)/)
+  })
+
+  it('keeps the drag handle off touch, where it costs width and does nothing', async () => {
+    const src = await shell()
+    expect(src).toMatch(/\{!isMobile && \(\s*<Splitter/)
+  })
+
+  it('has a strip narrower than the column minimum it replaces', async () => {
+    // A "collapsed" width at or above the minimum would not free any room.
+    expect(COLLAPSED_RAIL_WIDTH).toBeLessThan(MIN_RAIL_WIDTH)
+    expect(RAIL_COLLAPSED_KEY).toMatch(/^kc:code-review-sage:/)
+  })
+})


### PR DESCRIPTION
## Problem

Code Review Sage's left rail is a resizable column with `MIN_RAIL_WIDTH = 280`, applied through an inline `style={{ width }}` on a `flex-shrink-0` box. Nothing in that shell consulted the viewport, so on a 390px phone the rail held 280-360px and left the review report roughly 100px — and the report is the widest content in the app (finding bodies, diffs, check tables).

`useColumnResize` has supported a narrow-viewport strip since #3703, but it is **opt-in** through the collapse config's `whenNarrow`, and this shell passed no collapse config at all.

## Why the strip alone is not the fix

`ProjectsPage` states the trap in a comment, and it is the load-bearing constraint here:

> A page that only got the strip would hand the user an expand button that leads straight back into the squeeze.

So this change does both halves, matching the two shells that already do it (`ProjectsPage`, `WebhooksPage`):

- **collapsed** → a 44px icon-only strip carrying the expand control;
- **expanded while narrow** → `width: '100%'`, with every main pane `hidden`, so the rail replaces the report instead of pushing it off-screen.

The collapsed state stays a session-only override inside the hook and never reaches `localStorage`, so one phone visit cannot leave the desktop rail collapsed.

## Notes

- The expand control reuses the existing app-agnostic `app.expand_sidebar` key, already translated in all 12 locales, so **no new locale strings**.
- The drag handle is dropped on touch, where it is inert and costs width the viewport does not have.

## Verification

- `codeReviewSageRailNarrow.test.ts` — 6 assertions, each falsified: dropping `whenNarrow`, keeping `rail.width` instead of `100%` when expanded (the "back into the squeeze" shape), leaving a main pane unconditionally `flex`, removing the expand handler, and keeping the drag handle on touch are all caught.
- `tsc -b` clean; full frontend suite 1260 files / 20251 tests passing.

Tracker item M26. Issue Radar's rail plus its two list columns are the same class but a three-column shell, and need the list to drill down rather than collapse — that is a separate PR.
