### PR TITLE
fix(instances): thread the configured connect timeout into restart and diagnostics ssh calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ All notable changes to KiroCrew are documented in this file.
   SSM mint paths; an explicit value applies to both transports, including a
   value equal to either transport's default. (#3566)
 
+- **Restarting a remote instance and diagnosing a connection failure now
+  honor the same connect budget the token mint already does, instead of a
+  hardcoded ~10s `ConnectTimeout`.** A user behind a slow ProxyCommand/jump
+  host who raised `instances.connect_timeout_secs` (or
+  `instances.mint_timeout_secs`) so the tunnel and mint would work still had
+  three sibling ssh call sites stuck at the old fail-fast default: the
+  dashboard's "restart remote" action (which pays the same proxy handshake
+  cost as the mint — it's the same one-shot ssh-exec shape), and the two
+  diagnostics probes (`ssh <host> true`, and the remote-dashboard `curl`
+  check), which would misreport a reachable-but-slow host as unreachable.
+  Restart now reuses the configured mint budget. Diagnostics reuse the
+  configured connect budget too, but capped at a new
+  `DIAGNOSTICS_CONNECT_TIMEOUT_CAP_SECS` (15s): a diagnosis has its own UX
+  budget independent of how long a real connect is allowed to take, so a
+  user who tuned `connect_timeout_secs` up to, say, 90s for a genuinely slow
+  proxy still gets a diagnosis back in well under a minute rather than
+  silently inheriting the full tunable. (#3579)
+
 - **A Teams answer no longer gets silently truncated by a rate-limited
   chunk.** The Bot Framework Connector API enforces per-bot rate limits and
   can return HTTP 429, but the Teams outbound send raised immediately with

--- a/src/kiro_crew/instances/constants.py
+++ b/src/kiro_crew/instances/constants.py
@@ -88,6 +88,15 @@ DEFAULT_SSM_CONNECT_TIMEOUT_SECS: float = 25.0
 # generous enough for any realistic proxy chain while still bounding the wait.
 CONNECT_TIMEOUT_CEILING_SECS: float = 120.0
 
+# Cap on the ssh ConnectTimeout the diagnostics probes (_probe_ssh,
+# _probe_remote_dashboard) borrow from instances.connect_timeout_secs. The
+# tunable above is sized for how long a slow-proxy CONNECT should be allowed
+# to take — a diagnosis is a different use case with its own UX budget: a user
+# who tuned connect_timeout_secs up to, say, 90s for a genuinely slow proxy
+# still wants a diagnosis to resolve in well under a minute, not silently
+# inherit the full tunable. Diagnostics use min(configured, this).
+DIAGNOSTICS_CONNECT_TIMEOUT_CAP_SECS: float = 15.0
+
 # How long (secs) to wait for the remote `kirocrew token` to return before
 # giving up on a mint attempt. The mint runs over the same ssh transport as the
 # tunnel itself, so a host behind a ProxyCommand or jump host pays the proxy

--- a/src/kiro_crew/instances/diagnostics.py
+++ b/src/kiro_crew/instances/diagnostics.py
@@ -35,8 +35,11 @@ from kiro_crew.instances.validation import (
 logger = logging.getLogger(__name__)
 
 _LOOPBACK = "127.0.0.1"
-_SSH_PROBE_TIMEOUT_SECS = 12.0
-_REMOTE_CURL_TIMEOUT_SECS = 15.0
+# Fallback ssh ConnectTimeout when a caller doesn't pass one (matches
+# token_mint._build_ssh_argv's own fallback default). Real callers pass the
+# configured instances.connect_timeout_secs, capped for diagnostics use — see
+# DIAGNOSTICS_CONNECT_TIMEOUT_CAP_SECS.
+_DEFAULT_PROBE_CONNECT_TIMEOUT_SECS = 10.0
 _LOCAL_CONNECT_TIMEOUT_SECS = 2.0
 # SSM probes call the AWS control plane (describe-instance-information) and then
 # run a remote command via send-command, both slower than a direct ssh spawn.
@@ -99,28 +102,48 @@ class DiagnosisResult:
         return {"code": self.code, "ok": self.ok, "reason": self.reason, "probes": self.probes}
 
 
-async def _probe_ssh(ssh_host: str) -> bool:
-    """Return True if ``ssh <host> true`` succeeds (host reachable + auth ok)."""
+async def _probe_ssh(
+    ssh_host: str, connect_timeout_secs: float = _DEFAULT_PROBE_CONNECT_TIMEOUT_SECS
+) -> bool:
+    """Return True if ``ssh <host> true`` succeeds (host reachable + auth ok).
+
+    ``connect_timeout_secs`` bounds the ssh ``ConnectTimeout`` option (on
+    OpenSSH >= 8.6 this also covers the banner/KEX exchange, where a slow
+    ProxyCommand spends its time — see token_mint._build_ssh_argv). A caller
+    behind a slow proxy that raised ``instances.connect_timeout_secs`` to
+    make CONNECT work must pass it here too, or this probe reports a
+    reachable-but-slow host as unreachable. The outer wait_for leaves a fixed
+    2s margin past the ssh-side timeout for auth + running ``true`` after
+    connect succeeds.
+    """
     argv = [
         "ssh",
         "-o",
         "BatchMode=yes",
         "-o",
-        "ConnectTimeout=10",
+        f"ConnectTimeout={max(1, round(connect_timeout_secs))}",
         "-o",
         "AddressFamily=inet",
         ssh_host,
         "true",
     ]
-    return await _run_ok(argv, _SSH_PROBE_TIMEOUT_SECS)
+    return await _run_ok(argv, connect_timeout_secs + 2.0)
 
 
-async def _probe_remote_dashboard(ssh_host: str, remote_port: int) -> bool:
+async def _probe_remote_dashboard(
+    ssh_host: str,
+    remote_port: int,
+    connect_timeout_secs: float = _DEFAULT_PROBE_CONNECT_TIMEOUT_SECS,
+) -> bool:
     """Return True if the remote dashboard answers on its loopback port.
 
     Runs ``curl`` on the *remote* host against ``127.0.0.1:<remote_port>``; any
     HTTP status (incl. an auth gate like 401/403/404) means it's listening. A
     ``000`` code or empty output means nothing is bound there.
+
+    ``connect_timeout_secs`` — see :func:`_probe_ssh`. The outer wait_for
+    leaves a 5s margin past the ssh-side timeout, matching the remote
+    ``curl --max-time 5`` this runs after connect succeeds.
     """
     remote_cmd = (
         f"curl -s -o /dev/null -w '%{{http_code}}' --max-time 5 "
@@ -131,13 +154,13 @@ async def _probe_remote_dashboard(ssh_host: str, remote_port: int) -> bool:
         "-o",
         "BatchMode=yes",
         "-o",
-        "ConnectTimeout=10",
+        f"ConnectTimeout={max(1, round(connect_timeout_secs))}",
         "-o",
         "AddressFamily=inet",
         ssh_host,
         remote_cmd,
     ]
-    out = await _run_stdout(argv, _REMOTE_CURL_TIMEOUT_SECS)
+    out = await _run_stdout(argv, connect_timeout_secs + 5.0)
     if out is None:
         return False
     code = out.strip().strip("'\"")
@@ -203,11 +226,17 @@ async def diagnose_instance(
     ssh_host: str,
     remote_port: int,
     local_port: int,
+    connect_timeout_secs: float = _DEFAULT_PROBE_CONNECT_TIMEOUT_SECS,
 ) -> DiagnosisResult:
     """Run the dependency-ordered probes and return the first broken link.
 
     Validates ``ssh_host`` first; an invalid host short-circuits to UNKNOWN with
     a clear reason rather than spawning ssh.
+
+    ``connect_timeout_secs`` is forwarded to the ssh-based probes — see
+    :func:`_probe_ssh`. Callers should pass the configured
+    ``instances.connect_timeout_secs``, capped at
+    ``DIAGNOSTICS_CONNECT_TIMEOUT_CAP_SECS``.
     """
     try:
         ssh_host = validate_ssh_host(ssh_host)
@@ -216,12 +245,12 @@ async def diagnose_instance(
 
     probes: list[dict] = []
 
-    ssh_ok = await _probe_ssh(ssh_host)
+    ssh_ok = await _probe_ssh(ssh_host, connect_timeout_secs)
     probes.append({"name": "ssh", "ok": ssh_ok})
     if not ssh_ok:
         return DiagnosisResult(SSH_UNREACHABLE, _REASONS[SSH_UNREACHABLE], probes)
 
-    remote_ok = await _probe_remote_dashboard(ssh_host, remote_port)
+    remote_ok = await _probe_remote_dashboard(ssh_host, remote_port, connect_timeout_secs)
     probes.append({"name": "remote_dashboard", "ok": remote_ok})
     if not remote_ok:
         return DiagnosisResult(REMOTE_DOWN, _REASONS[REMOTE_DOWN], probes)

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -87,6 +87,9 @@ from kiro_crew.instances.constants import DEFAULT_TOKEN_REFRESH_FRACTION as _REF
 from kiro_crew.instances.constants import (
     DEFAULT_TUNNEL_BASE_PORT,
 )
+from kiro_crew.instances.constants import (
+    DIAGNOSTICS_CONNECT_TIMEOUT_CAP_SECS as _DIAGNOSTICS_CONNECT_TIMEOUT_CAP_SECS,
+)
 from kiro_crew.instances.diagnostics import diagnose_instance, diagnose_instance_ssm
 from kiro_crew.instances.port_allocator import PortAllocator, _is_port_free
 from kiro_crew.instances.registry import _UNALLOCATED_PORT, Instance, InstancesRegistry
@@ -1546,7 +1549,14 @@ class SshTunnelManager:
                 ssm_run_as=inst.ssm_run_as,
             )
         else:
-            result = await diagnose_instance(inst.ssh_host, inst.remote_port, local_port)
+            result = await diagnose_instance(
+                inst.ssh_host,
+                inst.remote_port,
+                local_port,
+                connect_timeout_secs=min(
+                    self._connect_timeout_for("ssh"), _DIAGNOSTICS_CONNECT_TIMEOUT_CAP_SECS
+                ),
+            )
         diag = result.to_dict()
         # Re-fetch the tunnel (it may have changed during the probes) and attach.
         tunnel = self._tunnels.get(instance_id)
@@ -1590,6 +1600,7 @@ class SshTunnelManager:
                 "restart",
                 remote_bin=params.remote_bin,
                 marker_port=inst.remote_port,
+                connect_timeout_secs=self._mint_timeout_for(params.method),
             )
         if rc == 0:
             logger.info("Restarted remote gateway for %s", instance_id)

--- a/src/kiro_crew/instances/token_mint.py
+++ b/src/kiro_crew/instances/token_mint.py
@@ -482,6 +482,7 @@ async def run_remote_kirocrew(
     remote_bin: str = "",
     marker_port: int | None = None,
     timeout_secs: float = 60.0,
+    connect_timeout_secs: float = 10.0,
 ) -> tuple[int, str]:
     """Run ``kirocrew <subcommand>`` on *ssh_host* over SSH.
 
@@ -495,11 +496,21 @@ async def run_remote_kirocrew(
     (same fix as token mint), instead of the blind PATH candidate search. This
     is what makes the dashboard "restart remote" action work on a host whose
     ``~/.local/bin/kirocrew`` points at an uninstalled worktree.
+
+    *connect_timeout_secs* — this is the same one-shot ssh-exec shape as
+    :func:`mint_remote_token`, so it pays the same proxy handshake cost on
+    CONNECT (OpenSSH >= 8.6 counts banner/KEX against ``ConnectTimeout``).
+    Callers should pass the resolved ``instances.mint_timeout_secs`` budget
+    rather than leaving the 10s fail-fast default, or a restart on a
+    slow-proxy host fails on the connect even after the user tuned the
+    tunable for exactly this. Independent of *timeout_secs* (the overall
+    wait_for budget): the outer wait_for is still the ultimate bound
+    regardless of what ``ConnectTimeout`` allows internally.
     """
     remote_command = build_remote_command(
         remote_bin, subcommand, marker_port=_validate_port(marker_port)
     )
-    argv = _build_ssh_argv(ssh_host, remote_command)
+    argv = _build_ssh_argv(ssh_host, remote_command, connect_timeout_secs=connect_timeout_secs)
     logger.info("Running 'kirocrew %s' on %s", subcommand, ssh_host)
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -2797,6 +2797,31 @@ class TestTokenMintGeneric:
         rc, err = asyncio.run(tm.run_remote_kirocrew("cd-1", "restart"))
         assert rc == 0 and err == ""
 
+    def test_run_remote_kirocrew_honors_connect_timeout_secs(self, monkeypatch):
+        """#3579: the fail-fast 10s ConnectTimeout default must not silently
+        override a caller-supplied budget -- a restart on a slow-proxy host
+        needs the same connect budget the mint itself gets."""
+        from kiro_crew.instances import token_mint as tm
+
+        class FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+        captured = {}
+
+        async def fake_exec(*argv, **k):
+            captured["argv"] = argv
+            return FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        rc, _ = asyncio.run(
+            tm.run_remote_kirocrew("cd-1", "restart", connect_timeout_secs=45.0)
+        )
+        assert rc == 0
+        assert "ConnectTimeout=45" in captured["argv"]
+
     def test_run_remote_kirocrew_redacts_stderr(self, monkeypatch):
         # Proxy-controlled stderr carrying a credential is redacted before return,
         # so a caller logging the tail cannot leak it.
@@ -2822,10 +2847,10 @@ class TestDiagnostics:
     def _set_probes(self, monkeypatch, ssh, remote, local):
         from kiro_crew.instances import diagnostics as diag
 
-        async def _ssh(h):
+        async def _ssh(h, connect_timeout_secs=10.0):
             return ssh
 
-        async def _rem(h, p):
+        async def _rem(h, p, connect_timeout_secs=10.0):
             return remote
 
         async def _loc(p):
@@ -2909,6 +2934,39 @@ class TestDiagnostics:
         assert asyncio.run(diag._probe_remote_dashboard("cd-1", 7777)) is True
         monkeypatch.setattr(asyncio, "create_subprocess_exec", mk(0, b"000"))
         assert asyncio.run(diag._probe_remote_dashboard("cd-1", 7777)) is False
+
+    def test_probes_honor_connect_timeout_secs(self, monkeypatch):
+        """#3579: the hardcoded ConnectTimeout=10 must not silently override a
+        caller-supplied budget -- a diagnosis on a slow-proxy host the user
+        already tuned instances.connect_timeout_secs for must not be
+        misreported as unreachable just because the probe never saw that
+        tuning."""
+        from kiro_crew.instances import diagnostics as diag
+
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+            async def wait(self):
+                return 0
+
+            async def communicate(self):
+                return (b"200", b"")
+
+        async def fake_exec(*argv, **k):
+            captured["argv"] = argv
+            return FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        assert asyncio.run(diag._probe_ssh("cd-1", connect_timeout_secs=42.0)) is True
+        assert "ConnectTimeout=42" in captured["argv"]
+
+        assert (
+            asyncio.run(diag._probe_remote_dashboard("cd-1", 7777, connect_timeout_secs=42.0))
+            is True
+        )
+        assert "ConnectTimeout=42" in captured["argv"]
 
     def test_probe_local_forward(self):
         from kiro_crew.instances import diagnostics as diag
@@ -3312,20 +3370,54 @@ class TestSelfHealRefreshRestart:
         reg.add(name="Bad", ssh_host="-obadhost", instance_id="bad")
         calls = {}
 
-        async def fake_run(host, sub, *, remote_bin="", marker_port=None, timeout_secs=60.0):
-            calls["a"] = (host, sub, marker_port)
+        async def fake_run(
+            host, sub, *, remote_bin="", marker_port=None, timeout_secs=60.0,
+            connect_timeout_secs=10.0,
+        ):
+            calls["a"] = (host, sub, marker_port, connect_timeout_secs)
             return (0, "")
 
         monkeypatch.setattr(stm, "run_remote_kirocrew", fake_run)
         r = asyncio.run(mgr.restart_remote("cd-1"))
         # remote_port defaults to 7777 → threaded so restart uses the marker resolver.
-        assert r["ok"] and calls["a"] == ("cd-1-alias", "restart", 7777)
+        # connect_timeout_secs comes from the configured mint budget (unset here,
+        # so the ssh default from constants.DEFAULT_MINT_TIMEOUT_SECS), not the
+        # 10s ssh-exec fail-fast fallback -- this is the fix for #3579: a restart
+        # on a slow-proxy host must reuse the same budget the mint itself gets.
+        assert r["ok"] and calls["a"] == ("cd-1-alias", "restart", 7777, 30.0)
         # validation failure
         r = asyncio.run(mgr.restart_remote("bad"))
         assert not r["ok"] and "invalid ssh settings" in r["message"]
         # unknown
         r = asyncio.run(mgr.restart_remote("ghost"))
         assert not r["ok"]
+
+    def test_diagnose_caps_connect_timeout_at_the_diagnostics_ceiling(
+        self, tmp_path, monkeypatch
+    ):
+        """#3579: a user who raised instances.connect_timeout_secs for a
+        genuinely slow proxy still wants a diagnosis to resolve in well
+        under a minute, not silently inherit the full tunable -- diagnose()
+        must cap what it forwards, not pass the configured value straight
+        through."""
+        from kiro_crew.instances import ssh_tunnel_manager as stm
+
+        reg, mgr = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        mgr._connect_timeout = 90.0  # well above the diagnostics cap
+        captured = {}
+
+        async def fake_diagnose(ssh_host, remote_port, local_port, connect_timeout_secs=10.0):
+            captured["connect_timeout_secs"] = connect_timeout_secs
+            from kiro_crew.instances.diagnostics import OK, DiagnosisResult
+
+            return DiagnosisResult(OK, "ok", [])
+
+        monkeypatch.setattr(stm, "diagnose_instance", fake_diagnose)
+        result = asyncio.run(mgr.diagnose("cd-1"))
+        assert result is not None
+        assert captured["connect_timeout_secs"] == stm._DIAGNOSTICS_CONNECT_TIMEOUT_CAP_SECS
+        assert captured["connect_timeout_secs"] < 90.0
 
     def test_probe_loop_tears_down_after_threshold(self, tmp_path, monkeypatch):
         from kiro_crew.instances import ssh_tunnel_manager as stm


### PR DESCRIPTION
## Problem / Motivation

PR #3571 made the token mint's ssh `ConnectTimeout` follow the configurable `instances.mint_timeout_secs` budget, because on OpenSSH >= 8.6 `ConnectTimeout` also bounds the banner/KEX exchange — which is where a slow ProxyCommand/jump-host handshake spends its time. Three sibling call sites still carry a hardcoded ~10s connect bound, so the same slow-proxy host that fix helps for the mint still fails or is misdiagnosed elsewhere:

- `token_mint.run_remote_kirocrew` (the dashboard "restart remote" action) — falls back to `_build_ssh_argv`'s 10s default.
- `diagnostics._probe_ssh` (`ssh <host> true`) — hardcodes `ConnectTimeout=10` directly in its argv.
- `diagnostics._probe_remote_dashboard` (the remote-dashboard `curl` check) — same hardcoded value.

## Why it matters

A user behind a slow ProxyCommand/jump host who raised `instances.connect_timeout_secs` or `instances.mint_timeout_secs` so their tunnel and mint would actually work still hits a wall on these three paths: restart fails on the proxy handshake even after tuning both timeouts, and the diagnostics panel reports a reachable-but-slow host as unreachable — actively misleading the user who's trying to figure out why their tunnel won't come up.

## What changed (motivation → approach → change)

Symptom: three ssh call sites ignore the user's configured connect/mint budget. Root cause: `_build_ssh_argv`'s `connect_timeout_secs=10.0` default and `diagnostics.py`'s two probes' hardcoded `"ConnectTimeout=10"` strings were never updated when #3571 added the configurable budget — they were written before the tunable existed and nothing since has threaded it through.

**Restart** (`run_remote_kirocrew`): added a `connect_timeout_secs` parameter, threaded into `_build_ssh_argv`. At the call site in `SshTunnelManager.restart_remote`, passed `self._mint_timeout_for(params.method)` — restart is the same one-shot ssh-exec shape as the mint (not the tunnel-CONNECT shape `connect_timeout_secs` governs), so it should reuse the mint budget, matching the issue's own "restart is a mint-shaped exec" framing.

**Diagnostics** (`_probe_ssh`, `_probe_remote_dashboard`, `diagnose_instance`): all three now accept `connect_timeout_secs`, threaded into the ssh argv. Their outer `asyncio.wait_for` bounds are recomputed from it rather than left as fixed constants (`connect_timeout_secs + 2.0` for `_probe_ssh`'s auth+`true` overhead after connect, `connect_timeout_secs + 5.0` for `_probe_remote_dashboard`'s own `curl --max-time 5` after connect) — otherwise a higher `ConnectTimeout` would just get preempted by the old fixed outer bound firing first, silently defeating the point. At the call site in `SshTunnelManager.diagnose`, passed `min(self._connect_timeout_for("ssh"), DIAGNOSTICS_CONNECT_TIMEOUT_CAP_SECS)` — a new constant (15s, added to `instances/constants.py`) — deliberately choosing to cap rather than pass the configured value straight through: a diagnosis has its own UX budget independent of how long a real connect is allowed to take, so a user who tuned `connect_timeout_secs` up to 90s for a genuinely slow proxy still gets a diagnosis back in well under a minute.

Not touched: the SSM-transport probes (`_probe_remote_dashboard_ssm`, etc.) — they dispatch via `aws ssm send-command`, not ssh, so `ConnectTimeout` doesn't apply to them at all; out of scope, matching the issue's explicit 3-site list.

## Tests

New:
- `TestTokenMintGeneric::test_run_remote_kirocrew_honors_connect_timeout_secs` — asserts `ConnectTimeout=45` reaches the real ssh argv when passed.
- `TestSelfHealRefreshRestart::test_restart_remote` (extended) — asserts `restart_remote` passes the resolved mint budget (`30.0`, the unset-config SSH default) through to `run_remote_kirocrew`, not the 10s fallback.
- `TestDiagnostics::test_probes_honor_connect_timeout_secs` — asserts `ConnectTimeout=42` reaches both probes' real ssh argv.
- `TestSelfHealRefreshRestart::test_diagnose_caps_connect_timeout_at_the_diagnostics_ceiling` — sets a configured connect timeout (90s) well above the diagnostics cap and asserts `diagnose()` forwards the capped 15s, not the raw 90s.

Also updated two pre-existing tests (`TestDiagnostics::test_ladder_first_broken_link`'s `_set_probes` helper, `TestSelfHealRefreshRestart::test_restart_remote`'s `fake_run`) whose fixed-arity monkeypatch signatures broke against the new keyword parameters — mechanical, no behavior change.

Verified all 4 new tests fail against pre-fix code (`git stash` on the four touched source files): `TypeError: unexpected keyword argument 'connect_timeout_secs'` for the two signature-based tests, `AttributeError: module ... has no attribute '_DIAGNOSTICS_CONNECT_TIMEOUT_CAP_SECS'` for the cap test, and a value mismatch (`10.0` vs. the expected `30.0`) for the restart test — restored after.

`test/test_instances.py` + `test/test_ssh_tunnel_manager_cov80.py` + `test/test_diagnostics.py`: 302 passed. `flake8` / `isort` clean on touched files. `mypy` clean except the 3 pre-existing, unrelated `hooks.py` Linux-xattr errors present on unmodified `main`.

## Manual verification

N/A — unit coverage sufficient. The tests drive the real ssh argv construction and the real `SshTunnelManager` timeout-resolution methods (`_mint_timeout_for`, `_connect_timeout_for`) directly; reproducing an actual slow-proxy handshake end-to-end would need a real jump host.

## Related Issues

Fixes #3579

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — CHANGELOG entry added
- [x] No secrets, credentials, or internal references in the diff
