### PR TITLE
fix(memory): apply the session-recognition gate to the mutating memory routes

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1395,
+    "missing_code": 1393,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 794,
+  "_compliant": 800,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -91,7 +91,7 @@
     },
     "dashboard/handlers/cron.py": {
       "dynamic_status": 6,
-      "missing_code": 40
+      "missing_code": 38
     },
     "dashboard/handlers/discover.py": {
       "missing_code": 15

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -838,37 +838,34 @@ async def _recognize_session(
     operation: str,
     *,
     blocks_persisted_mode: Callable[[str], bool],
-    error_codes: bool = False,
 ) -> web.Response | None:
-    """Session-recognition gate shared by the lessons routes.
+    """Session-recognition gate shared by the lessons and memory routes.
 
     Applies one slot / restricted-key / channel-namespace / persisted-JSONL
-    cascade to every caller so the create and delete routes cannot diverge.
+    cascade to every caller so the mutating routes cannot diverge.
     Returns a refusal :class:`web.Response`, or ``None`` when the session is
     recognised. Every decision — allow or deny — emits a SEL audit event
     under *operation*.
 
     ``blocks_persisted_mode`` is the per-route policy for the
-    archived-session recovery path: create blocks every private mode (the
-    canonical ``history.is_incognito_transcript`` classifier); delete blocks
-    only ``temporary``. A ``None``
+    archived-session recovery path: writes block every private mode (the
+    canonical ``history.is_incognito_transcript`` classifier); lesson delete
+    blocks only ``temporary``. A ``None``
     (unreadable or ambiguous) persisted mode always fails closed regardless
-    of policy. ``error_codes`` controls whether the 400 refusal bodies carry
-    the machine-readable ``code`` field (the delete route's error contract;
-    the create route's 400 responses predate it and stay code-less); the 403
-    refusal carries ``restricted_session`` on both routes.
+    of policy. Every refusal body carries a machine-readable ``code`` field
+    (``missing_session_key`` / ``unknown_session`` on the 400s,
+    ``restricted_session`` on the 403), so clients dispatch on the
+    identifier rather than the prose.
     """
     if not sk:
         _sel().log_api_access(
             caller="anonymous", operation=operation, outcome="denied",
             source="dashboard", resources="missing_session_key",
         )
-        if error_codes:
-            return web.json_response(
-                {"error": "missing X-Session-Key", "code": "missing_session_key"},
-                status=400,
-            )
-        return web.json_response({"error": "missing X-Session-Key"}, status=400)
+        return web.json_response(
+            {"error": "missing X-Session-Key", "code": "missing_session_key"},
+            status=400,
+        )
     if sk == "dashboard:ui":
         # Browser UI's static key — implicitly trusted, but the allow
         # decision itself is still an authorization outcome and must be
@@ -932,12 +929,10 @@ async def _recognize_session(
                 caller=sk, operation=operation, outcome="denied",
                 source="dashboard", resources="unknown_session",
             )
-            if error_codes:
-                return web.json_response(
-                    {"error": "unknown session", "code": "unknown_session"},
-                    status=400,
-                )
-            return web.json_response({"error": "unknown session"}, status=400)
+            return web.json_response(
+                {"error": "unknown session", "code": "unknown_session"},
+                status=400,
+            )
         if persisted_mode is None or blocks_persisted_mode(persisted_mode):
             # Archiving a tab drops the slot AND discards its
             # ``_restricted_keys`` entry while leaving the transcript —
@@ -1142,7 +1137,6 @@ async def api_lessons_delete(request: web.Request) -> web.Response:
     refusal = await _recognize_session(
         state, sk, "lessons.delete",
         blocks_persisted_mode=_is_temporary_transcript,
-        error_codes=True,
     )
     if refusal is not None:
         return refusal

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -40,6 +40,7 @@ from kiro_crew.embeddings import (
     validate_custom_model_path,
 )
 from kiro_crew.executors import embed_executor, run_in_embed_pool
+from kiro_crew.history import is_incognito_transcript
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
     cgroup_scope_argv,
@@ -49,6 +50,7 @@ from kiro_crew.sandbox import (
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 from ._shared import _get_memory, _is_restricted_session
+from .cron import _recognize_session
 
 logger = logging.getLogger(__name__)
 
@@ -229,8 +231,20 @@ async def api_memory_semantic(request: web.Request) -> web.Response:
 
 async def api_memory_semantic_write(request: web.Request) -> web.Response:
     """PUT /api/memory/semantic — create/update a semantic entry."""
-    if _is_restricted_session(request.app["state"], request):
-        sk = request.headers.get("X-Session-Key", "")
+    state: DashboardState = request.app["state"]
+    # Session-recognition gate (shared with the lessons routes, #3226): the
+    # restricted-mode check below returns False for an unknown key, so before
+    # this gate a forged or never-established X-Session-Key could write
+    # semantic memory that create-style routes would refuse. Writes block
+    # every private persisted mode, mirroring ``api_lessons_create``.
+    sk = request.headers.get("X-Session-Key", "")
+    refusal = await _recognize_session(
+        state, sk, "semantic.write",
+        blocks_persisted_mode=is_incognito_transcript,
+    )
+    if refusal is not None:
+        return refusal
+    if _is_restricted_session(state, request):
         _sel().log_api_access(
             caller=sk, operation="semantic.write", outcome="denied",
             source="dashboard", resources="restricted_session_block",
@@ -280,8 +294,22 @@ async def api_memory_semantic_write(request: web.Request) -> web.Response:
 
 async def api_memory_semantic_delete(request: web.Request) -> web.Response:
     """DELETE /api/memory/semantic/{key} — tombstone a semantic entry."""
-    if _is_restricted_session(request.app["state"], request):
-        sk = request.headers.get("X-Session-Key", "")
+    state: DashboardState = request.app["state"]
+    # Same recognition gate as the write route: without it, this DELETE was
+    # LESS protected than the lessons delete #3226 fixed — an unknown key
+    # passed the restricted-mode check (False for unrecognised sessions) and
+    # could tombstone any semantic entry. Policy for known sessions is
+    # unchanged: this route keeps blocking incognito AND temporary (the
+    # ``_is_restricted_session`` check below), so the recovery-path probe
+    # blocks every private mode to match.
+    sk = request.headers.get("X-Session-Key", "")
+    refusal = await _recognize_session(
+        state, sk, "semantic.delete",
+        blocks_persisted_mode=is_incognito_transcript,
+    )
+    if refusal is not None:
+        return refusal
+    if _is_restricted_session(state, request):
         _sel().log_api_access(
             caller=sk, operation="semantic.delete", outcome="denied",
             source="dashboard", resources="restricted_session_block",
@@ -1062,7 +1090,32 @@ async def api_memory_episodic_list(request: web.Request) -> web.Response:
 
 async def api_memory_episodic_delete(request: web.Request) -> web.Response:
     """DELETE /api/memory/episodic/{id} — tombstone an episodic memory."""
-    store = _get_vector_store(request.app["state"])
+    state: DashboardState = request.app["state"]
+    # This route had NO session check at all — not even the restricted-mode
+    # one its semantic siblings carry — so any caller, restricted or forged,
+    # could tombstone episodic memories. Apply the shared recognition gate
+    # (#3226) plus the same live-slot restricted-mode policy as
+    # ``api_memory_semantic_delete``.
+    sk = request.headers.get("X-Session-Key", "")
+    refusal = await _recognize_session(
+        state, sk, "episodic.delete",
+        blocks_persisted_mode=is_incognito_transcript,
+    )
+    if refusal is not None:
+        return refusal
+    if _is_restricted_session(state, request):
+        _sel().log_api_access(
+            caller=sk, operation="episodic.delete", outcome="denied",
+            source="dashboard", resources="restricted_session_block",
+        )
+        return web.json_response(
+            {
+                "error": "Memory writes are not allowed in this session mode.",
+                "code": "restricted_session",
+            },
+            status=403,
+        )
+    store = _get_vector_store(state)
     mem_id = request.match_info["id"]
     # Offload: acquires _db_lock internally (#1947) — see api_memory_semantic.
     ok = await asyncio.to_thread(store.delete_episodic, mem_id)

--- a/test/test_ephemeral_sessions.py
+++ b/test/test_ephemeral_sessions.py
@@ -1936,8 +1936,8 @@ class TestSharedRecognitionGate:
     restricted-key / channel-namespace / persisted-JSONL cascade; these tests
     pin that both routes actually call it (so the cascades cannot silently
     diverge again) and that each passes its own policy: create blocks every
-    incognito mode and stays code-less on its 400s, delete blocks only
-    temporary and emits machine-readable codes.
+    incognito mode, delete blocks only temporary; every gate refusal emits
+    machine-readable codes.
     """
 
     @pytest.mark.asyncio
@@ -1979,16 +1979,14 @@ class TestSharedRecognitionGate:
         assert delete_blocks("temporary") is True
         assert delete_blocks("incognito") is False
         assert delete_blocks("persistent") is False
-        assert calls["lessons.delete"]["error_codes"] is True
-        assert calls["learn_add"].get("error_codes", False) is False
 
     @pytest.mark.asyncio
     async def test_delete_unknown_session_carries_machine_code(
         self, tmp_path, monkeypatch
     ):
-        """The delete route's 400 carries ``code: unknown_session`` (the
-        contract learn_remove dispatches on); create's equivalent stays
-        code-less (its pre-existing response shape)."""
+        """Every gate refusal carries ``code: unknown_session`` (the contract
+        learn_remove dispatches on) — the per-route ``error_codes`` knob was
+        dropped, so create's 400 carries it too."""
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         monkeypatch.setattr(
             "kiro_crew.dashboard.handlers._shared.config_dir", lambda: tmp_path
@@ -2013,7 +2011,7 @@ class TestSharedRecognitionGate:
             assert create.status == 400
             data = await create.json()
             assert data["error"] == "unknown session"
-            assert "code" not in data
+            assert data["code"] == "unknown_session"
 
     def test_http_error_body_preserves_machine_code(self):
         """``_http_error_body`` must carry the backend's ``code`` through the
@@ -2064,3 +2062,185 @@ class TestSharedRecognitionGate:
             lambda path, body=None: {"error": "boom"},
         )
         assert learn_remove("learn_remove", {"query": "x"}) == "Error: boom"
+
+
+# ── Memory-routes recognition gate (follow-up to #3226) ──
+
+
+class TestMemoryRoutesSessionGate:
+    """The three mutating memory routes must apply the SAME session
+    recognition as the lessons routes. Before the gate: DELETE
+    /api/memory/episodic/{id} had NO session check at all (even a restricted
+    session passed), and PUT /api/memory/semantic + DELETE
+    /api/memory/semantic/{key} gated only on ``_is_restricted_session`` —
+    which returns False for an unknown key, so a forged or never-established
+    X-Session-Key could mutate durable memory that the lessons routes refuse.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _persisted_history_dir_tracks_patched_home(self, monkeypatch):
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers._shared.config_dir",
+            lambda: Path.home() / ".kirocrew",
+        )
+
+    def _memory_state(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        store = MagicMock()
+        store.set_semantic = MagicMock(return_value=None)
+        store.delete_semantic = MagicMock(return_value=True)
+        store.delete_episodic = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.memory._get_vector_store",
+            MagicMock(return_value=store),
+        )
+        state = _make_state(tmp_path)
+        return state, store
+
+    def _make_memory_app(self, state):
+        from kiro_crew.dashboard.handlers import (
+            api_memory_episodic_delete,
+            api_memory_semantic_delete,
+            api_memory_semantic_write,
+        )
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_put("/api/memory/semantic", api_memory_semantic_write)
+        app.router.add_delete(
+            "/api/memory/semantic/{key:.+}", api_memory_semantic_delete
+        )
+        app.router.add_delete(
+            "/api/memory/episodic/{id}", api_memory_episodic_delete
+        )
+        return app
+
+    async def _call(self, client, route, headers):
+        if route == "semantic_write":
+            return await client.put(
+                "/api/memory/semantic",
+                json={"key": "k", "value": "v"},
+                headers=headers,
+            )
+        if route == "semantic_delete":
+            return await client.delete("/api/memory/semantic/k", headers=headers)
+        return await client.delete("/api/memory/episodic/42", headers=headers)
+
+    def _mutations(self, store) -> int:
+        return (
+            store.set_semantic.call_count
+            + store.delete_semantic.call_count
+            + store.delete_episodic.call_count
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route", ["semantic_write", "semantic_delete", "episodic_delete"]
+    )
+    async def test_rejected_without_session_header(self, tmp_path, monkeypatch, route):
+        state, store = self._memory_state(tmp_path, monkeypatch)
+        async with TestClient(TestServer(self._make_memory_app(state))) as client:
+            resp = await self._call(client, route, {})
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["code"] == "missing_session_key"
+        assert self._mutations(store) == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route", ["semantic_write", "semantic_delete", "episodic_delete"]
+    )
+    async def test_rejected_for_forged_unknown_session(
+        self, tmp_path, monkeypatch, route
+    ):
+        """Core regression: a forged/unknown key must NOT mutate memory."""
+        state, store = self._memory_state(tmp_path, monkeypatch)
+        (tmp_path / ".kirocrew" / "sessions").mkdir(parents=True, exist_ok=True)
+        async with TestClient(TestServer(self._make_memory_app(state))) as client:
+            resp = await self._call(
+                client, route, {"X-Session-Key": "dashboard:forged-slot"}
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["code"] == "unknown_session"
+        assert self._mutations(store) == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route,mode",
+        [
+            ("semantic_write", "incognito"),
+            ("semantic_write", "temporary"),
+            ("semantic_delete", "incognito"),
+            ("semantic_delete", "temporary"),
+            ("episodic_delete", "incognito"),
+            ("episodic_delete", "temporary"),
+        ],
+    )
+    async def test_blocked_for_live_restricted_slot(
+        self, tmp_path, monkeypatch, route, mode
+    ):
+        """Restricted live slots are refused on every route — episodic delete
+        previously had NO check and let a restricted session tombstone."""
+        state, store = self._memory_state(tmp_path, monkeypatch)
+        state.get_or_create_slot("r1", memory_mode=mode)
+        async with TestClient(TestServer(self._make_memory_app(state))) as client:
+            resp = await self._call(client, route, {"X-Session-Key": "dashboard:r1"})
+            assert resp.status == 403
+        assert self._mutations(store) == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route", ["semantic_write", "semantic_delete", "episodic_delete"]
+    )
+    async def test_allowed_for_browser_ui(self, tmp_path, monkeypatch, route):
+        state, store = self._memory_state(tmp_path, monkeypatch)
+        async with TestClient(TestServer(self._make_memory_app(state))) as client:
+            resp = await self._call(client, route, {"X-Session-Key": "dashboard:ui"})
+            assert resp.status == 200
+        assert self._mutations(store) == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route", ["semantic_write", "semantic_delete", "episodic_delete"]
+    )
+    async def test_allowed_for_live_persistent_slot(
+        self, tmp_path, monkeypatch, route
+    ):
+        state, store = self._memory_state(tmp_path, monkeypatch)
+        state.get_or_create_slot("p1")
+        async with TestClient(TestServer(self._make_memory_app(state))) as client:
+            resp = await self._call(client, route, {"X-Session-Key": "dashboard:p1"})
+            assert resp.status == 200
+        assert self._mutations(store) == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route", ["semantic_write", "semantic_delete", "episodic_delete"]
+    )
+    async def test_blocked_for_evicted_incognito_session_jsonl(
+        self, tmp_path, monkeypatch, route
+    ):
+        """Archived-session recovery fails closed for private modes: the
+        persisted memory_mode marker is the only remaining evidence once the
+        slot is evicted, and memory writes block every private mode."""
+        state, store = self._memory_state(tmp_path, monkeypatch)
+        sess_dir = tmp_path / ".kirocrew" / "sessions"
+        sess_dir.mkdir(parents=True, exist_ok=True)
+        meta = {
+            "_type": "metadata",
+            "created_at": "2026-01-01T00:00:00",
+            "memory_mode": "incognito",
+        }
+        (sess_dir / "dashboard_gone1.jsonl").write_text(
+            _json.dumps(meta) + "\n", encoding="utf-8"
+        )
+        async with TestClient(TestServer(self._make_memory_app(state))) as client:
+            resp = await self._call(
+                client, route, {"X-Session-Key": "dashboard:gone1"}
+            )
+            assert resp.status == 403
+            data = await resp.json()
+            assert data["code"] == "restricted_session"
+        assert self._mutations(store) == 0

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -434,14 +434,18 @@ class TestSemanticEndpoints:
     @pytest.mark.asyncio
     async def test_write_rejects_invalid_json(self) -> None:
         state = _make_state(vector_store=_store())
-        req = _make_request(state, method="PUT", json_body=_BadJSON())
+        req = _make_request(
+            state, method="PUT", json_body=_BadJSON(), session_key="dashboard:ui"
+        )
         assert (await mem_mod.api_memory_semantic_write(req)).status == 400
 
     @pytest.mark.asyncio
     async def test_write_requires_key_and_value(self) -> None:
         state = _make_state(vector_store=_store())
         for body in ({"value": "v"}, {"key": "k"}, {}):
-            req = _make_request(state, method="PUT", json_body=body)
+            req = _make_request(
+                state, method="PUT", json_body=body, session_key="dashboard:ui"
+            )
             resp = await mem_mod.api_memory_semantic_write(req)
             assert resp.status == 400
             assert _body(resp)["error"] == "key and value required"
@@ -454,6 +458,7 @@ class TestSemanticEndpoints:
             state,
             method="PUT",
             json_body={"key": "k", "value": "v", "confidence": 0.5, "source": "agent"},
+            session_key="dashboard:ui",
         )
         assert _body(await mem_mod.api_memory_semantic_write(req)) == {"ok": True}
         store.set_semantic.assert_called_once_with("k", "v", 0.5, "agent")
@@ -463,7 +468,10 @@ class TestSemanticEndpoints:
         store = _store()
         state = _make_state(vector_store=store)
         req = _make_request(
-            state, method="PUT", json_body={"key": "k", "value": "v", "confidence": "high"}
+            state,
+            method="PUT",
+            json_body={"key": "k", "value": "v", "confidence": "high"},
+            session_key="dashboard:ui",
         )
         assert (await mem_mod.api_memory_semantic_write(req)).status == 200
         assert store.set_semantic.call_args[0][2] == 1.0
@@ -475,7 +483,12 @@ class TestSemanticEndpoints:
         store = _store()
         store.set_semantic.return_value = (SemanticRejectCode.CONFLICT, "already set")
         state = _make_state(vector_store=store)
-        req = _make_request(state, method="PUT", json_body={"key": "k", "value": "v"})
+        req = _make_request(
+            state,
+            method="PUT",
+            json_body={"key": "k", "value": "v"},
+            session_key="dashboard:ui",
+        )
         resp = await mem_mod.api_memory_semantic_write(req)
         assert resp.status == 409
         assert _body(resp)["error"] == "already set"
@@ -490,7 +503,12 @@ class TestSemanticEndpoints:
             f"value too large for {_CRED}",
         )
         state = _make_state(vector_store=store)
-        req = _make_request(state, method="PUT", json_body={"key": "k", "value": "v"})
+        req = _make_request(
+            state,
+            method="PUT",
+            json_body={"key": "k", "value": "v"},
+            session_key="dashboard:ui",
+        )
         resp = await mem_mod.api_memory_semantic_write(req)
         assert resp.status == 422
         assert _CRED not in _body(resp)["error"]
@@ -509,7 +527,9 @@ class TestSemanticEndpoints:
     async def test_delete_missing_key_is_404(self) -> None:
         store = _store(delete_semantic=MagicMock(return_value=False))
         state = _make_state(vector_store=store)
-        req = _make_request(state, method="DELETE", match_info={"key": "nope"})
+        req = _make_request(
+            state, method="DELETE", match_info={"key": "nope"}, session_key="dashboard:ui"
+        )
         resp = await mem_mod.api_memory_semantic_delete(req)
         assert resp.status == 404
         assert _body(resp) == {"error": "not found"}
@@ -518,7 +538,9 @@ class TestSemanticEndpoints:
     async def test_delete_success(self) -> None:
         store = _store()
         state = _make_state(vector_store=store)
-        req = _make_request(state, method="DELETE", match_info={"key": "k"})
+        req = _make_request(
+            state, method="DELETE", match_info={"key": "k"}, session_key="dashboard:ui"
+        )
         assert _body(await mem_mod.api_memory_semantic_delete(req)) == {"ok": True}
         store.delete_semantic.assert_called_once_with("k", source="user_explicit")
 
@@ -625,7 +647,9 @@ class TestEpisodicEndpoints:
     async def test_delete_missing_id_is_404(self) -> None:
         store = _store(delete_episodic=MagicMock(return_value=False))
         state = _make_state(vector_store=store)
-        req = _make_request(state, method="DELETE", match_info={"id": "42"})
+        req = _make_request(
+            state, method="DELETE", match_info={"id": "42"}, session_key="dashboard:ui"
+        )
         resp = await mem_mod.api_memory_episodic_delete(req)
         assert resp.status == 404
         assert _body(resp) == {"error": "not found"}
@@ -634,7 +658,9 @@ class TestEpisodicEndpoints:
     async def test_delete_success(self) -> None:
         store = _store()
         state = _make_state(vector_store=store)
-        req = _make_request(state, method="DELETE", match_info={"id": "42"})
+        req = _make_request(
+            state, method="DELETE", match_info={"id": "42"}, session_key="dashboard:ui"
+        )
         assert _body(await mem_mod.api_memory_episodic_delete(req)) == {"ok": True}
         store.delete_episodic.assert_called_once_with("42")
 


### PR DESCRIPTION
## Problem / Motivation

PR #3226 fixed DELETE /api/lessons accepting unrecognized session keys, and its First Principles review flagged that the sibling memory routes have the same hole. Verified in main:

- `DELETE /api/memory/episodic/{id}` has no session check at all — even a restricted (incognito/temporary) session can tombstone episodic memories.
- `PUT /api/memory/semantic` and `DELETE /api/memory/semantic/{key}` gate only on `_is_restricted_session`, which returns `False` for an unknown key — so a forged or never-established `X-Session-Key` can create, overwrite, or tombstone durable semantic memory that the lessons routes refuse with HTTP 400 `unknown session`.

The same review also flagged the gate's `error_codes` parameter: a per-caller knob that let refusal bodies diverge (create's 400s stayed code-less purely because they predated the delete route's error contract).

## Why it matters

Semantic and episodic memory are durable stores that shape every future agent session. With these routes ungated, any caller that can reach the dashboard port can mutate or tombstone them with a forged or absent session key, and restricted incognito/temporary sessions can delete episodic memories despite the product rule that restricted sessions must not touch durable state. It is the same defect class already judged worth closing for lessons in #3226 — leaving the memory siblings open makes that gate inconsistent and easy to bypass.

## What changed (motivation → approach → change)

- `api_memory_semantic_write`, `api_memory_semantic_delete`, and `api_memory_episodic_delete` now run the shared `_recognize_session` cascade (slot / restricted-key / channel-namespace / persisted-JSONL) before touching the store. Policy for known sessions is unchanged: the semantic routes keep blocking incognito and temporary; episodic delete gains the same restricted-mode check its semantic siblings already had (it previously had none).
- Dropped the `error_codes` parameter from `_recognize_session`: every refusal now carries the machine-readable `code` field (`missing_session_key` / `unknown_session` / `restricted_session`), so the lessons create route's 400s gain the code too. The error-code baseline was regenerated for the resulting legitimate drop (cron.py missing_code 40 → 38).
- Existing memory-handler coverage tests updated to send the browser UI's `dashboard:ui` key, matching the real frontend caller.

## Tests

21 regression tests across the three routes, locking in: forged/unknown key refused, missing key refused, restricted live slots refused (both incognito and temporary), evicted-incognito JSONL recovery fails closed, and browser-UI plus live persistent slots still allowed. 11 of them fail before the fix (mutation-verified).

Test results: 470 passed / 1 skipped across the lessons, ephemeral-session, memory-handler, and error-code-contract suites; isort/flake8/mypy clean on all touched files.

## Manual verification

N/A — unit coverage sufficient: the recognition cascade and per-route policies are exercised end-to-end at the handler level with the real session stores.

## Related Issues

Follow-up to the sibling-routes finding from PR #3226's First Principles review.
