### PR TITLE
docs: add uninstall and clean reinstall steps

### DIFF
--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -13,6 +13,25 @@ Builds use plain `pip` + `npm`/Vite + `pytest`, driven by the repo-root
 > `kiro_crew.platform_compat`. See
 > [windows-install.md](windows-install.md) for the Windows walkthrough.
 
+---
+
+- [Prerequisites](#prerequisites)
+- [Install paths](#install-paths)
+- [Build targets](#build-targets)
+- [First run](#first-run)
+- [Configuration](#configuration)
+- [Verify the install](#verify-the-install)
+- [Running as a service](#running-as-a-service)
+- [Linux: the agent sandbox and unprivileged user namespaces](#linux-the-agent-sandbox-and-unprivileged-user-namespaces)
+- [Troubleshooting](#troubleshooting)
+- [Uninstalling](#uninstalling)
+- [Removing user data](#removing-user-data)
+- [Clean reinstall](#clean-reinstall)
+- [Data retention details](#data-retention-details)
+- [Next steps](#next-steps)
+
+---
+
 ## Prerequisites
 
 | Requirement | Needed for | Floor |
@@ -769,11 +788,163 @@ kirocrew doctor
 kirocrew gateway --port auto   # bind an OS-assigned port if 5476 is taken
 ```
 
-## Uninstall and data retention
+## Uninstalling
 
-Uninstalling Kiro Crew preserves `$KIROCREW_HOME` (`~/.kiro/crew` by default).
-That directory holds configuration, credentials, memory, sessions, apps, and the
-audit chain, and none of the repository-controlled uninstall paths remove it:
+Uninstalling removes the Kiro Crew binary and its runtime but **preserves your
+data home** (`~/.kiro/crew`) — configuration, credentials, memory, sessions,
+apps, and the audit chain remain intact. This is intentional: reinstalling picks
+up where you left off without re-running setup or losing history.
+
+Before uninstalling, stop any running gateway and remove the system service if
+one is installed:
+
+```bash
+kirocrew stop                # stop a running foreground gateway
+kirocrew service uninstall   # removes the systemd unit / launchd plist
+```
+
+Then follow the section matching your install method.
+
+### One-line install via `cli.sh` (pipx)
+
+If `cli.sh` used `pipx` (the default when pipx is on `PATH`):
+
+```bash
+pipx uninstall kirocrew
+```
+
+### One-line install via `cli.sh` (managed venv)
+
+If `pipx` was not available, `cli.sh` created a managed venv and a symlink.
+Remove both:
+
+```bash
+rm -f ~/.local/bin/kirocrew
+rm -rf "${KIROCREW_VENV:-${KIROCREW_HOME:-$HOME/.kiro/crew}-venv}"
+```
+
+If you set `KIROCREW_VENV` to a custom path, verify its contents before
+removing it — `cli.sh` overlays that directory with venv files, and an `rm -rf`
+on a path you already used for something else will take that too.
+
+### pip / pip wheel install
+
+```bash
+pip uninstall kirocrew
+```
+
+If installed in a dedicated virtualenv:
+
+```bash
+rm -rf /path/to/your/venv
+```
+
+### From source (development)
+
+Remove the editable install and the build artifacts:
+
+```bash
+# Chained so a failed `cd` (wrong path) can never run `rm -rf` in your current directory:
+cd /path/to/KiroCrew \
+  && pip uninstall kirocrew \
+  && rm -rf .venv build dist   # editable install, local venv, and build outputs
+```
+
+### macOS desktop app (DMG / zip)
+
+1. Quit Kiro Crew from the menu bar or Dock.
+2. Drag **KiroCrew.app** from `/Applications` to the Trash (or `rm -rf`).
+
+There is no installer package or receipt to clean — the DMG is a drag-install.
+
+### Linux AppImage
+
+Delete the AppImage file wherever you placed it:
+
+```bash
+rm -f ~/Applications/KiroCrew-x86_64.AppImage   # or wherever you saved it
+```
+
+### Windows (NSIS installer)
+
+Use **Settings → Apps → Installed apps**, find "Kiro Crew", and click
+**Uninstall**. The NSIS uninstaller removes the application directory and
+shortcuts but does not touch `~/.kiro/crew`.
+
+### Docker
+
+```bash
+docker stop kirocrew && docker rm kirocrew   # graceful stop, then remove
+docker rmi ghcr.io/kirodotdev/kirocrew:stable # remove the image (match the tag you pulled)
+```
+
+`docker stop` sends SIGTERM and gives the gateway time to run its shutdown
+flush; `docker rm -f` sends SIGKILL immediately, which can drop up to one
+5-second flush interval of recent session state.
+
+## Removing user data
+
+Uninstalling via any method above leaves your data home intact. To also remove
+all user data:
+
+```bash
+# Back up first — this is irreversible. `kirocrew snapshot` only captures
+# memory/config/skills/workspace, not `.env`, credentials, or installed apps,
+# so a full copy of the data home is the only complete backup. Chained with
+# `&&` so a failed copy (e.g. disk full) blocks the delete rather than racing
+# ahead of it. Point the copy at a location you control OUTSIDE the data home:
+cp -a "${KIROCREW_HOME:-$HOME/.kiro/crew}" ~/kirocrew-backup \
+  && rm -rf "${KIROCREW_HOME:-$HOME/.kiro/crew}"
+```
+
+The backup is a full copy of your credentials (`.env`), signing keys, and
+session data, and it does NOT inherit the agent's path protections that guard
+the live data home — store it somewhere the agent cannot reach and delete it
+once the reinstall is confirmed good.
+
+This deletes configuration, credentials (`.env`), session history, memory
+databases, installed apps, and the embedding model cache.
+
+> **Docker:** the commands above target a host data home. A Docker install keeps
+> everything in the `kirocrew-home` named volume instead, so remove that rather
+> than `~/.kiro/crew`: `docker volume rm kirocrew-home` (or `docker compose down -v`).
+
+> **Note:** App Kit data is preserved per-app by default. To remove an
+> individual app's data before or instead of purging the whole home:
+> `kirocrew app uninstall NAME --purge-data`
+
+## Clean reinstall
+
+A clean reinstall removes both the binary and the data home, then installs
+fresh. Use this when `kirocrew doctor` reports issues that setup cannot fix,
+or when you want a completely fresh start.
+
+```bash
+# 1. Stop any running gateway, then remove the service
+kirocrew stop                        # stop a foreground gateway (service uninstall won't)
+kirocrew service uninstall 2>/dev/null
+
+# 2. Uninstall the binary (use the matching command from above)
+pipx uninstall kirocrew          # or: pip uninstall kirocrew, rm the AppImage, etc.
+
+# 3. Back up and remove the data home (chained so a failed copy blocks the delete)
+cp -a "${KIROCREW_HOME:-$HOME/.kiro/crew}" ~/kirocrew-backup \
+  && rm -rf "${KIROCREW_HOME:-$HOME/.kiro/crew}"
+
+# 4. Reinstall
+curl -fsSL https://download.crew.kiro.dev/cli.sh | sh
+
+# 5. Run first-time setup
+kirocrew setup
+kirocrew doctor
+```
+
+Replace step 4 with your preferred install method (pip wheel, source build,
+desktop app) as described in the [Install paths](#install-paths) section above.
+
+## Data retention details
+
+For reference, the data home structure and what each uninstall path touches:
 
 - `kirocrew service uninstall` removes only the systemd unit (plus the AppArmor
   profile it installed) or the launchd plist.
@@ -786,15 +957,11 @@ audit chain, and none of the repository-controlled uninstall paths remove it:
   `kirocrew app uninstall NAME --purge-data`, or unchecking **Keep app data** in
   the confirmation dialog.
 
-There is intentionally no implicit whole-home purge. Back up with `kirocrew
-snapshot` before manually removing a data home you no longer need.
-
-**External certification dependency.** Windows desktop releases use an NSIS
-installer, whose uninstaller electron-builder generates. `nsis.oneClick` is false
-and `nsis.deleteAppDataOnUninstall` is left false, so the uninstaller removes only
+**Windows NSIS uninstaller behavior.** `nsis.oneClick` is false and
+`nsis.deleteAppDataOnUninstall` is left false, so the uninstaller removes only
 the application install directory and its shortcuts; it never resolves or removes
 the Kiro Crew home, which lives outside the install directory. Each signed Windows
-installer must nevertheless pass an install, create-sentinel-under-`~/.kiro/crew`,
+installer must pass an install, create-sentinel-under-`~/.kiro/crew`,
 uninstall, verify-sentinel smoke test before release. A separate Kiro-family
 uninstaller could remove the parent `~/.kiro/` directory; it must exclude
 `~/.kiro/crew` or prompt explicitly. That release-blocking cross-product


### PR DESCRIPTION
## Description

Adds step-by-step uninstall commands for every install method (pipx, managed venv, pip, source, macOS DMG, Linux AppImage, Windows NSIS, Docker), a dedicated "Removing user data" section, and a complete clean reinstall recipe, plus a table of contents for the install guide.

## Provenance

This is a same-repo re-open of #1497 by @pilami (Sai Chaitanya Manchikatla). The original commit authorship is preserved (`git author = smanchik@amazon.com`) and credited via `Co-authored-by`. It was re-opened from a repo-owned branch **only** to work around a tooling gap: the `/ai-review override` mechanism does not function on fork PRs (the override workflow re-runs the same-repo `codex-review.yml`, which skips on forks), so a fully-reviewed fork PR could not clear a single residual GPT finding. See #1497 for the full history. All credit for the content belongs to @pilami.

## What changed vs the original

Same docs content, plus the review-driven refinements accumulated on #1497:
- Brand Name Gate fix (`Kiro Crew`, two words)
- `cd … && rm -rf` chained so a wrong path can't delete the current directory
- `docker stop` before `docker rm` (graceful shutdown flush)
- Docker named-volume note (`docker volume rm kirocrew-home`)
- Backup copied to a location outside the data home, with a caveat that the copy holds credentials outside the agent's path protections

## Related Issues

Closes #1485
Closes #1416

## Testing

Docs-only change. Verified locally: `scripts/check_brand_name.py`, `scripts/check_harness_parity.py`, and `scripts/docs-lint.sh` all pass; markdown fences balanced.
