### PR TITLE
refactor(acp): consolidate KAS wire parsing + declare provider H14 caps

### DIFF
--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -15,6 +15,7 @@ agent loads only the one it needs.
 | [acp-client.md](acp-client.md) | The ACP JSON-RPC client that drives `kiro-cli`: transport, framing, timeouts, and the backend seam. |
 | [providers.md](providers.md) | The `LLMProvider` interface and the KiroACP-only provider surface. |
 | [harness-parity.md](harness-parity.md) | The invariants keeping the Kiro harness first-class while other harnesses are adapted, and the test pinning each. |
+| [kas-backend.md](kas-backend.md) | The second, adapted ACP backend: how Crew selects and adapts it (the `kas_wire` seam, harness-parity, ABC defaults) and the deferred hooks / transport / `/clear` items. Crew-side only. |
 | [session.md](session.md) | Sessions, slots, session keys, the warm pool, and PID tracking. |
 | [history.md](history.md) | Conversation persistence, JSONL rotation, and transcript search. |
 | [session-summary.md](session-summary.md) | Intent-level session summaries: the sidecar cache, extraction, and the turn-end pass. |

--- a/docs/system-specs/modules/kas-backend.md
+++ b/docs/system-specs/modules/kas-backend.md
@@ -1,0 +1,54 @@
+# A second ACP backend
+
+Kiro Crew drives one first-class agent harness, `kiro-cli`, over ACP. It also
+supports a **second, adapted ACP backend** (`agent.acp_backend = "kas"`); the
+default and first-class path stays `kiro-cli`. `agent.provider` remains `"acp"`
+— the harness is never the provider selector (see
+[harness-parity.md](harness-parity.md)).
+
+**Scope.** This documents the Kiro Crew-side integration only. The second backend
+is not open source; its wire shapes, storage, auth, and process internals are
+not described here. Where its on-the-wire signals differ from `kiro-cli`'s, the
+difference is absorbed in one Crew module (below), which is the only place that
+needs editing if that backend changes.
+
+## How Crew runs it
+
+- It goes through the existing `AcpRuntime` (one process, multiplexed sessions)
+  via the established backend seam — no new runtime subclass, just a spawn-argv
+  branch plus adapters. `kiro-cli` keeps its own spawn path, per-harness
+  handshake literals, and session machinery unchanged (harness-parity H9/H10).
+- Backend-specific parsing (the display/telemetry frames whose shape differs
+  from `kiro-cli`'s) is localized in **`acp/kas_wire.py`** — a single module, so
+  an adjustment is a one-file edit. Backend-neutral logic (the context-meter
+  math) lives on `AcpPromptStats` and is shared by both paths, so they cannot
+  drift.
+- Capabilities the session layer reads off a provider are declared on the
+  `LLMProvider` ABC with safe defaults (harness-parity H14), so the adapted
+  backend never forces a `getattr` probe onto the `kiro-cli` path.
+
+## Identity is positive
+
+Every "is this the `kiro-cli` harness" test is a positive comparison against a
+named constant or membership in a named `ACP_BACKENDS_*` set — never
+`not is_<other>`, which would hand a branch to a later harness by default. The
+full invariant catalogue and its CI gate are in
+[harness-parity.md](harness-parity.md).
+
+## Switching backends
+
+```
+kirocrew config set agent.acp_backend kas   # then: kirocrew restart
+kirocrew config set agent.acp_backend ""     # back to kiro-cli; restart
+```
+
+A config change affects only new sessions; `restart` reaps the prior runtime
+process. `kirocrew doctor` reports the selected backend's readiness.
+
+## Deferred
+
+- **Hooks** are not wired for the second backend — a separate effort.
+- **`/clear`** currently maps to a `kiro-cli`-only notification, so on the second
+  backend it is a no-op today; a local reset is the intended parity fix.
+- An **alternative transport mode** is out of scope, pending its own design and
+  review.

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -5553,66 +5553,29 @@ class AcpClient:
         )
 
     def _backfill_context_window(self, pct: float) -> None:
-        """Derive window/used tokens when kiro-cli 2.10+ metadata gives only a
-        percentage (no usage_update {used, size}).
+        """Derive window/used tokens from a percentage-only reading.
 
-        Resolves the window through the central ``model_registry.model_window``
-        authority (kiro-list cache > static registry > [1m] heuristic). This now
-        works for non-Anthropic kiro models too (GPT 272k, DeepSeek 164k, …) once
-        the kiro-list cache is seeded, instead of no-op'ing. Only backfills a
-        window from a KNOWN source (``has_known_window``): a genuinely-unknown
-        model returns None and we leave the window 0 so the frontend's own
-        authoritative window (from /api/models) drives the meter rather than a
-        guess. kiro's real ``usage_update.size`` always wins when present (this
-        no-ops once it has set the window).
-
-        A surviving ``context_window_tokens`` outranks the registry: after a
-        compaction reset the counts are dropped but the SERVED window is kept
-        (the model did not change), and the served size can differ from the
-        registry's static entry (e.g. opus served at [1m] vs a 200K registry
-        row). Deriving against the kept window keeps the post-compaction
-        numbers consistent with what the adapter actually serves.
+        Thin wrapper binding this client's resolved model id; the shared logic
+        lives on ``AcpPromptStats.backfill_context_window`` (the AcpSessionHandle
+        path delegates to the same method, so the two can no longer drift).
         """
-        if self.last_prompt_stats.context_tokens_from_usage:
-            return  # a real usage_update already set authoritative counts
-        win = self.last_prompt_stats.context_window_tokens
-        if not win or win <= 0:
-            model_id = self._resolved_model_id or self._model
-            if not model_id or not model_registry.has_known_window(model_id):
-                return
-            reg_win = model_registry.model_window(model_id)
-            if not reg_win or reg_win <= 0:
-                return
-            win = int(reg_win)
-            self.last_prompt_stats.context_window_tokens = win
-        # A malformed metadata percentage (NaN, ±inf, or a huge finite value
-        # like 1e308) would overflow ``round(win * pct / 100)`` and abort the
-        # turn. Sanitize to a sane [0, 100] before deriving used tokens (NaN
-        # -> 0); this also keeps used <= window.
-        safe_pct = 0.0 if pct != pct else min(max(pct, 0.0), 100.0)
-        self.last_prompt_stats.context_used_tokens = round(win * safe_pct / 100.0)
+        self.last_prompt_stats.backfill_context_window(
+            pct, self._resolved_model_id or self._model
+        )
 
     def _track_metadata(self, msg: JsonRpcMessage) -> None:
         params = msg.params or {}
-        pct = params.get("contextUsagePercentage")
         # A real usage_update is authoritative for both the token counts AND the
         # pct derived from them. kiro's metadata percentage can measure a
         # different window, so applying it here would desync the headline % from
         # the "used / total" token text (e.g. 73% shown next to 408K / 1000K).
-        if pct is not None and not self.last_prompt_stats.context_tokens_from_usage:
-            try:
-                pct_f = float(pct)
-                # Sanitize a malformed metadata percentage (NaN/±inf/out-of-range,
-                # e.g. 1e308) at the source so context_pct is always a real
-                # [0, 100] value: keeps compaction comparisons sane and the
-                # diagnostic /api/sessions JSON standard (Infinity/NaN are not
-                # valid JSON). NaN is caught by its self-inequality.
-                pct_f = 0.0 if pct_f != pct_f else min(max(pct_f, 0.0), 100.0)
-                self.last_prompt_stats.context_pct = pct_f
-                self.last_prompt_stats.note_pct_reported()
-                self._backfill_context_window(pct_f)
-            except (TypeError, ValueError):
-                pass
+        # sanitize_pct is the shared coercion (the KAS usagePercentage path uses
+        # it too): it clamps NaN/±inf/out-of-range and returns None when absent.
+        pct_f = self.last_prompt_stats.sanitize_pct(params.get("contextUsagePercentage"))
+        if pct_f is not None and not self.last_prompt_stats.context_tokens_from_usage:
+            self.last_prompt_stats.context_pct = pct_f
+            self.last_prompt_stats.note_pct_reported()
+            self._backfill_context_window(pct_f)
         # kiro streams per-turn billing as meteringUsage entries (unit="credit").
         # Accumulate across the turn's metadata notifications; reset per turn by
         # the AcpPromptStats re-init in _dispatch_events/send_message_stream.

--- a/src/kiro_crew/acp/kas_wire.py
+++ b/src/kiro_crew/acp/kas_wire.py
@@ -1,0 +1,90 @@
+"""Localized parsing for the second ACP backend's ``session/update`` frames.
+
+Some of that backend's display/telemetry signals arrive in a different shape
+than ``kiro-cli``'s. This module is the ONE place Crew reads that shape, so an
+adjustment is a single-file edit; the handlers that act on a parsed frame live
+in :mod:`kiro_crew.acp.session_handle`. The literals below are only what Crew
+must match to route a frame — the backend's own internals are not documented
+here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ── Envelope keys ──
+# Where a frame's discriminant blob sits; both hops are guarded on read.
+META_KEY = "_meta"
+KIRO_KEY = "kiro"
+
+# ── Frame discriminants Crew matches on ──
+KIND_CONTEXT_USAGE = "context_usage"
+KIND_TURN_COMPLETION = "turn_completion"
+KIND_SUMMARIZATION_STARTED = "summarization_started"
+KIND_SUMMARIZATION_COMPLETED = "summarization_completed"
+KIND_SUMMARIZATION_FAILED = "summarization_failed"
+KIND_STEERING_QUEUED = "steering_queued"
+KIND_STEERING_INJECTED = "steering_injected"
+KIND_STEERING_CLEARED = "steering_cleared"
+KIND_AGENT_SUBTASK = "agent-subtask"  # hyphenated, not underscored
+
+# Summarization maps to Crew's compaction status; steering to mid-turn steer.
+SUMMARIZATION_KINDS = frozenset(
+    {KIND_SUMMARIZATION_STARTED, KIND_SUMMARIZATION_COMPLETED, KIND_SUMMARIZATION_FAILED}
+)
+STEERING_KINDS = frozenset(
+    {KIND_STEERING_QUEUED, KIND_STEERING_INJECTED, KIND_STEERING_CLEARED}
+)
+
+# ── Payload fields Crew reads ──
+FIELD_KIND = "kind"
+FIELD_USAGE_PERCENTAGE = "usagePercentage"
+FIELD_CONVERSATION_SUMMARY = "conversationSummary"
+FIELD_CONTENT = "content"
+FIELD_PROMPT_TURN_SUMMARIES = "promptTurnSummaries"
+FIELD_AGENT_SUBTASK_ID = "agentSubtaskId"
+FIELD_PIPELINE = "pipeline"
+FIELD_STAGES = "stages"
+FIELD_UNIT = "unit"
+FIELD_USAGE = "usage"
+UNIT_CREDIT = "credit"
+
+
+def kiro_meta(update: dict) -> dict[str, Any] | None:
+    """Return the frame's discriminant blob, or ``None`` when absent.
+
+    Both hops are ``isinstance``-guarded so a frame without it (a different
+    backend, or a malformed one) falls through to the shared parser rather than
+    raising. The single extraction step every handler shares — do not inline the
+    two-step ``.get`` elsewhere.
+    """
+    meta = update.get(META_KEY)
+    kiro = meta.get(KIRO_KEY) if isinstance(meta, dict) else None
+    return kiro if isinstance(kiro, dict) else None
+
+
+def turn_credits(kiro: dict) -> float | None:
+    """Sum the per-turn credit cost from a ``turn_completion`` frame.
+
+    Only ``credit``-unit entries contribute (the acp provider bills in credits).
+    Returns the total to ASSIGN — the frame carries the whole turn's summary, so
+    a replayed/duplicate frame reports the same total and must not accumulate —
+    or ``None`` when there is no summaries list, so the caller leaves the prior
+    value untouched rather than zeroing it.
+    """
+    summaries = kiro.get(FIELD_PROMPT_TURN_SUMMARIES)
+    if not isinstance(summaries, list):
+        return None
+    # Deferred import: _token_count lives in the dispatch module, which imports
+    # types; importing it at module scope would risk an import cycle once
+    # session_handle imports this module.
+    from kiro_crew.acp._dispatch import _token_count
+
+    total = 0.0
+    for entry in summaries:
+        if not isinstance(entry, dict) or entry.get(FIELD_UNIT) != UNIT_CREDIT:
+            continue
+        value = _token_count(entry.get(FIELD_USAGE))
+        if value is not None:
+            total += float(value)
+    return total

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -27,8 +27,8 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 from kiro_crew import model_registry
+from kiro_crew.acp import kas_wire
 from kiro_crew.acp._dispatch import (
-    _token_count,
     build_permission_event,
     classify_notification,
     parse_metadata,
@@ -2182,40 +2182,16 @@ class AcpSessionHandle:
         self.last_prompt_stats.credits += credits
 
     def _backfill_context_window(self, pct: float) -> None:
-        """Derive window/used tokens from the model registry when kiro-cli 2.10+
-        metadata gives only a percentage (no usage_update {used, size}).
+        """Derive window/used tokens from a percentage-only reading.
 
-        Mirrors AcpClient._backfill_context_window so the shared-runtime path
-        reports the same context-meter token counts. No-op once a real
-        usage_update has set the window. Keys on ``_resolved_model_id`` (kiro's
-        ``currentModelId`` from the session/new|load response, also synced by
-        set_model) first, then falls back to ``_model`` (the user-picked alias).
-        Resolves through the central ``model_registry.model_window`` authority
-        (kiro-list cache > registry > heuristic); only backfills a KNOWN window,
-        leaving 0 for a genuinely-unknown model so the frontend's own
-        authoritative window drives the meter. kiro's real usage_update.size
-        always wins when present. A surviving ``context_window_tokens`` (e.g.
-        kept across a compaction reset — the model did not change) outranks the
-        registry, since the served size can differ from the static entry.
+        Thin wrapper binding this handle's resolved model id (kiro-agent
+        ``currentModelId``, else the user-picked alias); the shared logic lives
+        on ``AcpPromptStats.backfill_context_window`` (the AcpClient path
+        delegates to the same method, so the two can no longer drift).
         """
-        if self.last_prompt_stats.context_tokens_from_usage:
-            return  # a real usage_update already set authoritative counts
-        win = self.last_prompt_stats.context_window_tokens
-        if not win or win <= 0:
-            model_id = self._resolved_model_id or self._model
-            if not model_id or not model_registry.has_known_window(model_id):
-                return
-            reg_win = model_registry.model_window(model_id)
-            if not reg_win or reg_win <= 0:
-                return
-            win = int(reg_win)
-            self.last_prompt_stats.context_window_tokens = win
-        # A malformed metadata percentage (NaN, ±inf, or a huge finite value
-        # like 1e308) would overflow ``round(win * pct / 100)`` and abort the
-        # turn. Sanitize to a sane [0, 100] before deriving used tokens (NaN
-        # -> 0); this also keeps used <= window.
-        safe_pct = 0.0 if pct != pct else min(max(pct, 0.0), 100.0)
-        self.last_prompt_stats.context_used_tokens = round(win * safe_pct / 100.0)
+        self.last_prompt_stats.backfill_context_window(
+            pct, self._resolved_model_id or self._model
+        )
 
     def _emit_tool_interrupted_sel(self, site: str) -> None:
         """Emit a SEL audit + WARNING when kiro-cli's security filter cancels tools.
@@ -2451,43 +2427,46 @@ class AcpSessionHandle:
         are KAS's mid-turn steer echo (kiro-cli: ``session/update`` steer
         discriminants, handled by the "steer" action).
         """
-        meta = update.get("_meta")
-        kiro = meta.get("kiro") if isinstance(meta, dict) else None
-        if not isinstance(kiro, dict):
+        kiro = kas_wire.kiro_meta(update)
+        if kiro is None:
             return []
-        kind = kiro.get("kind")
-        if kind == "context_usage":
-            self._apply_kas_context_pct(kiro.get("usagePercentage"))
+        kind = kiro.get(kas_wire.FIELD_KIND)
+        if kind == kas_wire.KIND_CONTEXT_USAGE:
+            self._apply_kas_context_pct(kiro.get(kas_wire.FIELD_USAGE_PERCENTAGE))
             return []
-        if kind == "turn_completion":
+        if kind == kas_wire.KIND_TURN_COMPLETION:
             self._apply_kas_turn_completion(kiro)
             return []
-        if kind in ("summarization_started", "summarization_completed", "summarization_failed"):
-            if kind == "summarization_completed":
+        if kind in kas_wire.SUMMARIZATION_KINDS:
+            if kind == kas_wire.KIND_SUMMARIZATION_COMPLETED:
                 # Pre-compaction counts no longer describe the session — drop
                 # them so the meter resets and fresh telemetry re-derives real
                 # numbers (parity with the kiro-cli compaction handler).
                 self.last_prompt_stats.reset_after_compaction()
                 status_type = "completed"
-            elif kind == "summarization_failed":
+            elif kind == kas_wire.KIND_SUMMARIZATION_FAILED:
                 status_type = "failed"
             else:
                 status_type = "started"
             # conversationSummary is backend-echoed, LLM-influenced text that
             # reaches the dashboard — redact exfil URLs/credentials first.
-            summary = redact_text(str(kiro.get("conversationSummary", "") or ""))
+            summary = redact_text(str(kiro.get(kas_wire.FIELD_CONVERSATION_SUMMARY, "") or ""))
             return [AcpEvent(kind=EVENT_COMPACTION_STATUS, text=status_type, title=summary)]
-        if kind in ("steering_queued", "steering_injected", "steering_cleared"):
+        if kind in kas_wire.STEERING_KINDS:
             # KAS mid-turn steer echo. kiro-cli sends these as `session/update`
             # discriminants (handled by the "steer" action); KAS instead puts the
             # kind under `_meta.kiro`, so route it here. `injected` is the
             # settling signal (→ EVENT_STEER_CONSUMED, which _settle_consumed_steers
             # consumes); queued/cleared mirror the kiro path. Never trust
             # backend-echoed steer text — redact before it reaches any surface.
-            if kind == "steering_cleared":
+            if kind == kas_wire.KIND_STEERING_CLEARED:
                 return [AcpEvent(kind=EVENT_STEER_CLEARED)]
-            text = redact_text(str(kiro.get("content") or ""))
-            steer_kind = EVENT_STEER_CONSUMED if kind == "steering_injected" else EVENT_STEER_QUEUED
+            text = redact_text(str(kiro.get(kas_wire.FIELD_CONTENT) or ""))
+            steer_kind = (
+                EVENT_STEER_CONSUMED
+                if kind == kas_wire.KIND_STEERING_INJECTED
+                else EVENT_STEER_QUEUED
+            )
             return [AcpEvent(kind=steer_kind, text=text)]
         return []
 
@@ -2499,25 +2478,24 @@ class AcpSessionHandle:
         a child nested tool or an ordinary frame that should fall through to the
         shared parser (so caches populate and tool events render).
         """
-        meta = update.get("_meta")
-        kiro = meta.get("kiro") if isinstance(meta, dict) else None
-        if not isinstance(kiro, dict):
+        kiro = kas_wire.kiro_meta(update)
+        if kiro is None:
             return None
 
-        agent_subtask_id = kiro.get("agentSubtaskId")
-        pipeline = kiro.get("pipeline")
+        agent_subtask_id = kiro.get(kas_wire.FIELD_AGENT_SUBTASK_ID)
+        pipeline = kiro.get(kas_wire.FIELD_PIPELINE)
 
         if not agent_subtask_id and not pipeline:
             return None
 
         # Pipeline frame: one entry per stage.
         if isinstance(pipeline, dict):
-            stages = pipeline.get("stages")
+            stages = pipeline.get(kas_wire.FIELD_STAGES)
             if isinstance(stages, list):
                 for stage in stages:
                     if not isinstance(stage, dict):
                         continue
-                    s_id = stage.get("agentSubtaskId")
+                    s_id = stage.get(kas_wire.FIELD_AGENT_SUBTASK_ID)
                     if not isinstance(s_id, str) or not s_id:
                         continue
                     s_status = str(stage.get("status") or "in_progress")
@@ -2535,7 +2513,7 @@ class AcpSessionHandle:
             )]
 
         # Individual agent-subtask frame (kind == "agent-subtask") → PARENT.
-        is_parent = kiro.get("kind") == "agent-subtask"
+        is_parent = kiro.get(kas_wire.FIELD_KIND) == kas_wire.KIND_AGENT_SUBTASK
 
         if is_parent:
             subtask_id = str(agent_subtask_id)
@@ -2566,15 +2544,17 @@ class AcpSessionHandle:
         Returns a list when the chunk belongs to a child sub-agent, else None
         (fall through to normal chunk handling).
         """
-        meta = update.get("_meta")
-        kiro = meta.get("kiro") if isinstance(meta, dict) else None
-        if not isinstance(kiro, dict):
+        kiro = kas_wire.kiro_meta(update)
+        if kiro is None:
             return None
-        subtask_id = kiro.get("agentSubtaskId")
+        subtask_id = kiro.get(kas_wire.FIELD_AGENT_SUBTASK_ID)
         if not isinstance(subtask_id, str) or not subtask_id:
             return None
         # Must NOT have kind:"agent-subtask" or pipeline — those are parent frames
-        if kiro.get("kind") == "agent-subtask" or kiro.get("pipeline"):
+        if (
+            kiro.get(kas_wire.FIELD_KIND) == kas_wire.KIND_AGENT_SUBTASK
+            or kiro.get(kas_wire.FIELD_PIPELINE)
+        ):
             return None
         text, _thinking = parse_text_chunk(update)
         if not text or _thinking:
@@ -2595,11 +2575,10 @@ class AcpSessionHandle:
         activity attribution is emitted BEFORE the tool events from
         ``parse_session_update``.
         """
-        meta = update.get("_meta")
-        kiro = meta.get("kiro") if isinstance(meta, dict) else None
-        if not isinstance(kiro, dict):
+        kiro = kas_wire.kiro_meta(update)
+        if kiro is None:
             return []
-        subtask_id = kiro.get("agentSubtaskId")
+        subtask_id = kiro.get(kas_wire.FIELD_AGENT_SUBTASK_ID)
         if not isinstance(subtask_id, str) or not subtask_id:
             return []
         tool_call_id = str(update.get("toolCallId") or "")
@@ -2616,21 +2595,15 @@ class AcpSessionHandle:
     def _apply_kas_context_pct(self, pct: object) -> None:
         """Apply a KAS ``context_usage`` percentage to the context meter.
 
-        Mirrors ``_track_metadata``'s pct path: a real ``usage_update`` is
-        authoritative (``context_tokens_from_usage``) and must not be clobbered,
-        and the value is sanitized to a real [0, 100] before use.
+        A real ``usage_update`` is authoritative (``context_tokens_from_usage``)
+        and must not be clobbered. ``sanitize_pct`` (shared with the kiro-cli
+        metadata path) clamps NaN/±inf/out-of-range and returns None when the
+        value is absent or unparseable, so malformed telemetry degrades to
+        "no reading" rather than aborting the active turn.
         """
-        if pct is None or self.last_prompt_stats.context_tokens_from_usage:
+        pct_f = self.last_prompt_stats.sanitize_pct(pct)
+        if pct_f is None or self.last_prompt_stats.context_tokens_from_usage:
             return
-        try:
-            pct_f = float(pct)  # type: ignore[arg-type]
-        except (TypeError, ValueError, OverflowError):
-            # OverflowError: a JSON integer beyond float range (int->float
-            # conversion) — malformed telemetry must degrade to "absent", never
-            # abort the active turn's dispatch.
-            return
-        # NaN is caught by self-inequality; ±inf/out-of-range are clamped.
-        pct_f = 0.0 if pct_f != pct_f else min(max(pct_f, 0.0), 100.0)
         self.last_prompt_stats.context_pct = pct_f
         self.last_prompt_stats.note_pct_reported()
         self._backfill_context_window(pct_f)
@@ -2638,27 +2611,17 @@ class AcpSessionHandle:
     def _apply_kas_turn_completion(self, kiro: dict) -> None:
         """Set per-turn credits from a KAS ``turn_completion`` frame.
 
-        ``promptTurnSummaries`` entries are ``{usage, unit, unitPlural}``; only
-        ``unit == "credit"`` contributes, mirroring the kiro-cli ``meteringUsage``
-        credit sum (value validation shared via ``_token_count``). The acp
-        provider bills in credits.
-
-        The frame carries the whole turn's summary, so the total is ASSIGNED, not
-        accumulated: a duplicate or resume-replayed ``turn_completion`` reports
-        the same total and must not inflate the displayed cost. A malformed frame
-        (no summaries list) leaves the prior value untouched rather than zeroing.
+        Delegates the ``promptTurnSummaries`` credit sum (only ``unit ==
+        "credit"`` entries count; the acp provider bills in credits) to
+        ``kas_wire.turn_credits``. The frame carries the whole turn's summary, so
+        the total is ASSIGNED, not accumulated: a duplicate or resume-replayed
+        ``turn_completion`` reports the same total and must not inflate the
+        displayed cost. A malformed frame (``turn_credits`` returns ``None``)
+        leaves the prior value untouched rather than zeroing.
         """
-        summaries = kiro.get("promptTurnSummaries")
-        if not isinstance(summaries, list):
-            return
-        total = 0.0
-        for entry in summaries:
-            if not isinstance(entry, dict) or entry.get("unit") != "credit":
-                continue
-            value = _token_count(entry.get("usage"))
-            if value is not None:
-                total += float(value)
-        self.last_prompt_stats.credits = total
+        total = kas_wire.turn_credits(kiro)
+        if total is not None:
+            self.last_prompt_stats.credits = total
 
     def _handle_update(self, msg: JsonRpcMessage) -> list[AcpEvent]:
         """Process a session/update notification and return events."""

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -648,6 +648,67 @@ class AcpPromptStats:
         """
         self.context_pct_unknown = False
 
+    @staticmethod
+    def sanitize_pct(value: object) -> float | None:
+        """Coerce a raw context-usage percentage to a real [0, 100] float.
+
+        Both the kiro-cli ``contextUsagePercentage`` and the KAS
+        ``usagePercentage`` fields feed this. Returns ``None`` for a missing or
+        unparseable value (the caller leaves the meter untouched). A malformed
+        number (NaN, ±inf, or a huge finite like 1e308) is clamped — NaN via its
+        self-inequality — so ``context_pct`` is always valid JSON and never
+        overflows the downstream ``round(win * pct / 100)``.
+        """
+        if value is None:
+            return None
+        try:
+            pct = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError, OverflowError):
+            # OverflowError: a JSON integer beyond float range — malformed
+            # telemetry must degrade to "absent", never abort the active turn.
+            return None
+        return 0.0 if pct != pct else min(max(pct, 0.0), 100.0)
+
+    def backfill_context_window(self, pct: float, model_id: str) -> None:
+        """Derive window/used tokens from the model registry when only a
+        percentage is available.
+
+        kiro-cli 2.10+ metadata and KAS ``context_usage`` both give a percentage
+        with no ``usage_update {used, size}``. Shared by the AcpClient and
+        AcpSessionHandle paths (previously two verbatim copies) so both report
+        the same context-meter token counts. No-op once a real usage_update has
+        set authoritative counts. ``model_id`` is the caller's resolved id (the
+        kiro-agent ``currentModelId``, else the user-picked alias). Resolves the
+        window through ``model_registry.model_window`` (kiro-list cache >
+        registry > heuristic) and only backfills a KNOWN window, leaving 0 for a
+        genuinely-unknown model so the frontend's own authoritative window drives
+        the meter. A real ``usage_update.size`` always wins. A surviving
+        ``context_window_tokens`` (e.g. kept across a compaction reset — the
+        model did not change) outranks the registry, since the served size can
+        differ from the static entry.
+        """
+        if self.context_tokens_from_usage:
+            return  # a real usage_update already set authoritative counts
+        win = self.context_window_tokens
+        if not win or win <= 0:
+            if not model_id:
+                return
+            # Deferred import: model_registry is a leaf module, but importing it
+            # at module scope would drag it into the very early types import.
+            from kiro_crew import model_registry
+
+            if not model_registry.has_known_window(model_id):
+                return
+            reg_win = model_registry.model_window(model_id)
+            if not reg_win or reg_win <= 0:
+                return
+            win = int(reg_win)
+            self.context_window_tokens = win
+        # sanitize_pct already clamps live telemetry, but a caller may pass a raw
+        # pct here; guard the multiply so a stray NaN/inf can never overflow.
+        safe_pct = 0.0 if pct != pct else min(max(pct, 0.0), 100.0)
+        self.context_used_tokens = round(win * safe_pct / 100.0)
+
     def reset_after_compaction(self) -> None:
         """Drop the usage counts after a successful compaction.
 

--- a/src/kiro_crew/providers/base.py
+++ b/src/kiro_crew/providers/base.py
@@ -180,3 +180,52 @@ class LLMProvider(ABC):
         real values. Base returns (None, None) which disables abort push.
         """
         return (None, None)
+
+    # ── Turn-control and capability surface (harness-parity H14) ──
+    # The session, shutdown-drain, steer, and dashboard layers read these off a
+    # provider. Declaring them here with a safe default means a provider that
+    # lacks the capability (a non-ACP backend, a warm-pool stub) returns the
+    # default instead of forcing a ``getattr`` probe onto the Kiro path or
+    # AttributeError-ing. Concrete providers override; the caller-side
+    # ``getattr``/``hasattr`` guards remain where they additionally defend
+    # against test doubles (AsyncMock) that are not LLMProvider instances.
+
+    def has_active_turn(self) -> bool:
+        """True if a prompt is in flight and not yet cancelled. Default False."""
+        return False
+
+    def has_unfinished_turn(self) -> bool:
+        """True if a native turn has not reached its done boundary, independent
+        of cancel state (drives the shutdown drain). Default False."""
+        return False
+
+    async def wait_turn_done(self, timeout: float) -> str:
+        """Wait for the current native turn's done boundary and return its stop
+        reason. Default: no turn to wait for — return immediately with ``""``."""
+        return ""
+
+    async def steer(self, message: str) -> bool:
+        """Inject a mid-turn steer; return True if accepted. Default False for a
+        provider with no steer extension (granted by opt-in, never inherited)."""
+        return False
+
+    @property
+    def supports_steer(self) -> bool:
+        """True when the provider implements mid-turn steer. Default False."""
+        return False
+
+    @property
+    def is_session_sharing_eligible(self) -> bool:
+        """True when the provider can host multiplexed sub-agent sessions on one
+        process. Default False — session sharing is opt-in, never inherited."""
+        return False
+
+    def available_models(self) -> list[dict[str, str]]:
+        """Backend-advertised models (``[{modelId, name, ...}]``) for the model
+        picker. Default empty for a provider that advertises none."""
+        return []
+
+    def get_valid_effort_levels(self) -> list[str]:
+        """Reasoning-effort levels the provider accepts. Default empty for a
+        provider with no effort control."""
+        return []

--- a/test/test_kas_display_mapping.py
+++ b/test/test_kas_display_mapping.py
@@ -237,6 +237,35 @@ def test_summarization_completed_emits_compaction_and_resets() -> None:
     assert handle.last_prompt_stats.context_tokens_from_usage is False
 
 
+def test_context_usage_reapplies_after_summarization_completed() -> None:
+    # Sequencing (the KAS analog of the kiro-cli post-compaction metadata
+    # re-apply): summarization_completed resets and clears the authoritative
+    # flag, so a FOLLOWING context_usage frame must re-derive the meter. Were the
+    # reset missing, context_tokens_from_usage would stay True and the fresh
+    # percentage would be ignored — the dashboard bar frozen at the
+    # pre-compaction value forever.
+    handle = _handle(ACP_BACKEND_KAS)
+    handle.last_prompt_stats.context_pct = 80.0
+    handle.last_prompt_stats.context_tokens_from_usage = True
+    _update(
+        handle,
+        {
+            "sessionUpdate": "session_info_update",
+            "_meta": {"kiro": {"kind": "summarization_completed", "conversationSummary": ""}},
+        },
+    )
+    assert handle.last_prompt_stats.context_tokens_from_usage is False
+    assert handle.last_prompt_stats.context_pct == 0.0
+    _update(
+        handle,
+        {
+            "sessionUpdate": "session_info_update",
+            "_meta": {"kiro": {"kind": "context_usage", "usagePercentage": 12.0}},
+        },
+    )
+    assert handle.last_prompt_stats.context_pct == 12.0
+
+
 def test_summarization_started_emits_started_status() -> None:
     handle = _handle(ACP_BACKEND_KAS)
     events = _update(handle, {"sessionUpdate": "session_info_update", "_meta": {"kiro": {"kind": "summarization_started"}}})

--- a/test/test_kas_wire.py
+++ b/test/test_kas_wire.py
@@ -1,0 +1,118 @@
+"""Unit tests for the consolidated KAS wire-shape helpers.
+
+Pins :mod:`kiro_crew.acp.kas_wire` (the single home for KAS ``_meta.kiro``
+parsing) and the shared ``AcpPromptStats`` context-meter helpers that both the
+AcpClient and AcpSessionHandle paths now delegate to, so a future change to
+either cannot silently drift the two backends apart.
+"""
+
+from __future__ import annotations
+
+import math
+
+from kiro_crew.acp import kas_wire
+from kiro_crew.acp.types import AcpPromptStats
+
+
+class TestKiroMeta:
+    def test_extracts_the_kiro_blob(self):
+        assert kas_wire.kiro_meta({"_meta": {"kiro": {"kind": "x"}}}) == {"kind": "x"}
+
+    def test_missing_meta_is_none(self):
+        assert kas_wire.kiro_meta({}) is None
+
+    def test_meta_not_a_dict_is_none(self):
+        assert kas_wire.kiro_meta({"_meta": "nope"}) is None
+
+    def test_kiro_not_a_dict_is_none(self):
+        assert kas_wire.kiro_meta({"_meta": {"kiro": []}}) is None
+
+    def test_missing_kiro_is_none(self):
+        assert kas_wire.kiro_meta({"_meta": {"other": {}}}) is None
+
+
+class TestTurnCredits:
+    def test_sums_only_credit_units(self):
+        kiro = {
+            "promptTurnSummaries": [
+                {"usage": 3, "unit": "credit"},
+                {"usage": 100, "unit": "token"},  # ignored — not a credit
+                {"usage": 2, "unit": "credit"},
+            ]
+        }
+        assert kas_wire.turn_credits(kiro) == 5.0
+
+    def test_no_summaries_list_returns_none(self):
+        # None signals "leave the prior value untouched", not "zero it".
+        assert kas_wire.turn_credits({}) is None
+        assert kas_wire.turn_credits({"promptTurnSummaries": "nope"}) is None
+
+    def test_empty_list_is_zero_not_none(self):
+        assert kas_wire.turn_credits({"promptTurnSummaries": []}) == 0.0
+
+    def test_malformed_entries_are_skipped(self):
+        kiro = {"promptTurnSummaries": ["x", {"unit": "credit"}, {"usage": 4, "unit": "credit"}]}
+        assert kas_wire.turn_credits(kiro) == 4.0
+
+
+class TestKindConstants:
+    def test_summarization_set_membership(self):
+        assert kas_wire.KIND_SUMMARIZATION_COMPLETED in kas_wire.SUMMARIZATION_KINDS
+        assert kas_wire.KIND_CONTEXT_USAGE not in kas_wire.SUMMARIZATION_KINDS
+
+    def test_steering_set_membership(self):
+        assert kas_wire.KIND_STEERING_INJECTED in kas_wire.STEERING_KINDS
+        assert kas_wire.KIND_AGENT_SUBTASK not in kas_wire.STEERING_KINDS
+
+    def test_agent_subtask_kind_is_hyphenated(self):
+        # The wire value is ``agent-subtask`` (hyphen), NOT ``agent_subtask``.
+        assert kas_wire.KIND_AGENT_SUBTASK == "agent-subtask"
+
+
+class TestSanitizePct:
+    def test_none_is_none(self):
+        assert AcpPromptStats.sanitize_pct(None) is None
+
+    def test_unparseable_is_none(self):
+        assert AcpPromptStats.sanitize_pct("abc") is None
+        assert AcpPromptStats.sanitize_pct([]) is None
+
+    def test_plain_value(self):
+        assert AcpPromptStats.sanitize_pct("50") == 50.0
+        assert AcpPromptStats.sanitize_pct(42) == 42.0
+
+    def test_nan_becomes_zero(self):
+        assert AcpPromptStats.sanitize_pct(math.nan) == 0.0
+
+    def test_out_of_range_is_clamped(self):
+        assert AcpPromptStats.sanitize_pct(150) == 100.0
+        assert AcpPromptStats.sanitize_pct(-5) == 0.0
+        assert AcpPromptStats.sanitize_pct(math.inf) == 100.0
+        assert AcpPromptStats.sanitize_pct(1e308) == 100.0
+
+
+class TestBackfillContextWindow:
+    def test_noop_when_counts_from_usage(self):
+        stats = AcpPromptStats()
+        stats.context_tokens_from_usage = True
+        stats.context_window_tokens = 1000
+        stats.backfill_context_window(50.0, "some-model")
+        assert stats.context_used_tokens == 0  # left untouched
+
+    def test_derives_used_from_kept_window(self):
+        stats = AcpPromptStats()
+        stats.context_window_tokens = 1000  # a surviving window (e.g. post-compaction)
+        stats.backfill_context_window(25.0, "some-model")
+        assert stats.context_used_tokens == 250
+
+    def test_no_model_and_no_window_leaves_zero(self):
+        stats = AcpPromptStats()
+        stats.backfill_context_window(50.0, "")
+        assert stats.context_window_tokens == 0
+        assert stats.context_used_tokens == 0
+
+    def test_malformed_pct_does_not_overflow(self):
+        stats = AcpPromptStats()
+        stats.context_window_tokens = 1000
+        stats.backfill_context_window(math.nan, "some-model")
+        assert stats.context_used_tokens == 0


### PR DESCRIPTION
## What

Finishes KAS Group C — the getattr/H14 bucket and consolidating the second ACP backend's `session/update` parsing into one module.

**Scope note:** the second backend is not open source. This describes the **Crew-side** handling only; the backend's own wire/auth/process internals are not restated.

## Wire-shape consolidation

- **New `acp/kas_wire.py`** is the single place Crew parses the second backend's `session/update` frames whose shape differs from `kiro-cli`'s — the discriminant literals, the extractor, and the turn-credit sum. `session_handle` reads the shape THROUGH it, so an adjustment is a one-file edit.
- The verbatim-duplicated `_backfill_context_window` (`AcpClient` AND `AcpSessionHandle`) and the duplicated context-pct sanitize move onto **`AcpPromptStats`** as backend-neutral methods; both paths delegate so they cannot drift.

## Provider capability surface (harness-parity H14)

- The `LLMProvider` ABC declares the probed capabilities (`has_active_turn`, `has_unfinished_turn`, `wait_turn_done`, `steer`, `supports_steer`, `is_session_sharing_eligible`, `available_models`, `get_valid_effort_levels`) with safe defaults, so a non-ACP provider returns the default instead of forcing a `getattr` probe onto the `kiro-cli` path. Concrete providers override; the caller-side guards that defend `AsyncMock` test doubles are unchanged (no `MagicMock(spec=)` fallout — full suite confirms).

## Tests

`test_kas_wire.py` pins the extractor, credit sum, discriminants, and the `AcpPromptStats` `sanitize_pct`/`backfill` helpers.

## Verification

`isort`/`flake8`/`mypy` (976) + harness scanner green; targeted suite 1206 + 21 pass; full-suite failures are all host-environment (userns/gh/git), none in acp/session/providers.
