### PR TITLE
fix(taskrunner): retry now validates and recovers a lost git worktree

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -1091,7 +1091,6 @@ test/test_tailnet_serve.py
 test/test_tailnet_session_url.py
 test/test_taskrunner_atomic_persistence.py
 test/test_taskrunner_autoapprove.py
-test/test_taskrunner_coverage.py
 test/test_taskrunner_v2_scenarios.py
 test/test_tcc_protected_dirs.py
 test/test_teams_config.py

--- a/docs/system-specs/modules/taskrunner.md
+++ b/docs/system-specs/modules/taskrunner.md
@@ -486,6 +486,18 @@ Each task runs on an isolated git branch via `git_coord.py`:
 - **State summary**: `git log --oneline` + `git diff --stat` injected into step prompts
 - **Review diff**: `git diff HEAD~1` fed to independent review session
 - **Finalize**: worktree cleaned up on task completion
+- **Retry recovery**: a retry validates the saved worktree's path, repository,
+  and branch before dispatching more steps. A lost worktree is recreated from
+  its original repository and existing task branch only when a surviving Git
+  pointer positively identifies the stale checkout; an arbitrary replacement
+  directory is left untouched and the retry fails closed. The identified
+  checkout is renamed aside before it is deleted, so the delete can only ever
+  destroy the tree that was validated -- never whatever happens to occupy the
+  path afterwards. Ownership is proved a second time against the renamed tree,
+  because the first proof and the rename are separate moments: anything that
+  arrived in between is put back and the retry fails closed. A set-aside tree
+  that cannot be deleted is logged and left on disk beside the recreated
+  worktree rather than failing the retry.
 
 Git init failure is non-fatal — task continues without git coordination.
 

--- a/src/kiro_crew/git_coord.py
+++ b/src/kiro_crew/git_coord.py
@@ -3,10 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+import ctypes
 import logging
+import os
+import stat
+import uuid
+from ctypes import wintypes
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+try:  # Windows-only module; absent on POSIX.
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+from kiro_crew import platform_compat
 from kiro_crew.sandbox import (
     create_subprocess_limited,
     sandboxed_spawn_argv,
@@ -119,6 +130,572 @@ async def finalize(run: Project) -> str:
     return run.branch_name
 
 
+def _same_dir(a: str, b: str) -> bool:
+    """True if two path strings name the same directory.
+
+    Compared as resolved, normalized paths rather than as raw strings, because
+    the two sides come from different producers and disagree textually while
+    naming one directory: git prints ``--show-toplevel`` with forward slashes
+    even on Windows and resolves symlinks (so a macOS ``/var/...`` temp dir
+    comes back as ``/private/var/...``), while ``run.worktree_path`` holds
+    whatever unresolved, natively-separated string was stored when the
+    worktree was created. ``normcase`` additionally folds case and separators
+    on Windows, where two spellings of one path are the same directory.
+    """
+    try:
+        ra, rb = Path(a).resolve(), Path(b).resolve()
+    except OSError:
+        return False
+    return os.path.normcase(str(ra)) == os.path.normcase(str(rb))
+
+
+async def workspace_is_valid(run: Project) -> bool:
+    """True if a run's git worktree, when it has one, is still THAT worktree.
+
+    A run with no worktree (``git_enabled`` False from the start -- the
+    ordinary non-git-folder case) is trivially valid, since there is nothing
+    to check here. This exists to distinguish an ACTUALLY broken worktree
+    (still present on disk after an interrupted ``finalize()``, or removed
+    out from under the run entirely -- ``git worktree remove`` deregisters
+    and deletes in separate steps, so a failure between them can leave the
+    directory behind but already deregistered) from that ordinary case.
+
+    Repo-ness alone is NOT sufficient and answers the wrong question: once the
+    worktree has been deregistered but its directory survives, an ordinary
+    directory nested anywhere inside another repository still reports as being
+    inside a work tree -- git simply walks up to the ENCLOSING repository. The
+    run would then be judged valid and every remaining step would commit into
+    somebody else's checkout while reporting success. So require the repository
+    git resolves from the run's directory to BE the run's own worktree.
+    """
+    if not run.branch_name:
+        return True
+    expected = run.worktree_path or run.work_dir
+    if not expected:
+        return False
+    try:
+        toplevel = (await _git(run.work_dir, "rev-parse", "--show-toplevel")).strip()
+    except (RuntimeError, OSError):
+        # Non-zero exit (not a repo at all) or the directory being gone
+        # outright -- both mean there is no worktree here to resume against.
+        # Broad on purpose, and safe in this direction: False here means
+        # "not valid", which routes into recovery. (Contrast `_is_git_repo`,
+        # where False means "no git isolation needed" and a transient error
+        # must NOT be swallowed.)
+        return False
+    if not toplevel or not await asyncio.to_thread(_same_dir, toplevel, expected):
+        return False
+    if not run.repo_root:
+        # A run persisted before repo_root was recorded cannot be fully
+        # verified (no repository identity, no branch/history anchor) and
+        # cannot be recovered either -- reinit_workspace_for_retry needs the
+        # original repository. Path identity alone would accept a DIFFERENT
+        # repository sitting at the expected path, and resuming there commits
+        # the run's remaining steps into someone else's history. Fail closed:
+        # the retry is refused with a clear error instead of resuming on a
+        # workspace whose identity cannot be established.
+        return False
+    # Matching paths are still not proof of identity -- a DIFFERENT repository
+    # created at the same path satisfies the check above, and resuming into it
+    # would commit the run's remaining steps outside its own repository. A
+    # linked worktree SHARES its main repository's git directory, so require
+    # the common git dir seen from the run's worktree to be the very one
+    # `run.repo_root` uses. That is what makes this a worktree OF this repo
+    # rather than merely a repository sitting at the expected path.
+    try:
+        here = (await _git(run.work_dir, "rev-parse", "--git-common-dir")).strip()
+        theirs = (await _git(run.repo_root, "rev-parse", "--git-common-dir")).strip()
+    except (RuntimeError, OSError):
+        return False
+    if not here or not theirs:
+        return False
+    # `--git-common-dir` may answer relatively (to its own cwd); anchoring each
+    # to the directory it was resolved from normalizes that, and an already
+    # absolute answer wins the join unchanged.
+    if not await asyncio.to_thread(
+        _same_dir,
+        str(Path(run.work_dir) / here),
+        str(Path(run.repo_root) / theirs),
+    ):
+        return False
+    # Same repository is still not the same WORKTREE: a linked worktree of
+    # this very repo, checked out on some OTHER branch, would satisfy every
+    # check above -- same path, same repo -- and retried steps would then
+    # commit onto the wrong branch while reporting success. A worktree is
+    # only "this run's own" if it is also on the run's branch.
+    try:
+        current_branch = (await _git(run.work_dir, "branch", "--show-current")).strip()
+    except (RuntimeError, OSError):
+        return False
+    if current_branch != run.branch_name:
+        return False
+    # Same branch NAME is still not the same HISTORY: a force-moved branch
+    # keeps its name while dropping the run's earlier commits, and resuming on
+    # it would leave those steps marked passed although their work is gone --
+    # every remaining step would then build on the wrong tree and report
+    # success. The run's own commit ledger is the ground truth: its last
+    # recorded commit must still be in the branch's history.
+    return await _branch_history_intact(run.work_dir, run)
+
+
+async def _branch_history_intact(git_cwd: str, run: Project) -> bool:
+    """True when the run's branch still carries the run's recorded commits.
+
+    ``run.commit_hashes`` is the run's own ledger of step commits, appended by
+    ``commit_step`` and popped by ``revert_step``, so its last entry is the
+    commit the branch tip must still descend from. A branch that was
+    force-moved after those steps ran keeps its NAME but not that history;
+    resuming on it would leave earlier steps marked passed while their commits
+    are absent. With no recorded commits there is nothing to verify -- that is
+    a run which never committed a step, not a rewritten branch.
+
+    Fails closed: a recorded commit that no longer resolves (rewritten then
+    garbage-collected) and any git error both answer False.
+    """
+    if not run.commit_hashes:
+        return True
+    try:
+        await _git(
+            git_cwd,
+            "merge-base",
+            "--is-ancestor",
+            run.commit_hashes[-1],
+            f"refs/heads/{run.branch_name}",
+        )
+    except (RuntimeError, OSError):
+        return False
+    return True
+
+
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)  # 0 on Windows (constant absent)
+
+
+def _is_link(st: os.stat_result) -> bool:
+    """POSIX symlink OR Windows reparse point (symlink/junction)."""
+    if stat.S_ISLNK(st.st_mode):
+        return True
+    attrs = getattr(st, "st_file_attributes", 0)  # absent on POSIX -> 0
+    return bool(attrs & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def _windows_open_reparse_handle(filepath: str) -> int:
+    """Open *filepath* on Windows WITHOUT following a reparse point.
+
+    ``CreateFileW`` with ``FILE_FLAG_OPEN_REPARSE_POINT`` opens the reparse
+    point ITSELF: a symlink or junction leaf is never dereferenced, so a link
+    to a UNC target performs no outbound authentication. This is atomic --
+    there is no check-then-open window in which the file can be swapped for a
+    link. The caller validates the opened handle's attributes via
+    ``os.fstat`` and refuses a reparse point or non-regular file.
+    """
+    if msvcrt is None:  # pragma: no cover - unreachable off-Windows
+        raise OSError("msvcrt unavailable: not a Windows platform")
+
+    generic_read = 0x80000000
+    share_all = 0x00000001 | 0x00000002 | 0x00000004
+    open_existing = 3
+    flag_open_reparse_point = 0x00200000
+
+    kernel32 = getattr(ctypes, "windll").kernel32
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    handle = kernel32.CreateFileW(
+        filepath,
+        generic_read,
+        share_all,
+        None,
+        open_existing,
+        flag_open_reparse_point,
+        None,
+    )
+    if handle in (None, wintypes.HANDLE(-1).value):
+        raise OSError(f"cannot open worktree metadata file: {filepath}")
+    try:
+        return msvcrt.open_osfhandle(int(handle), os.O_RDONLY)  # type: ignore[attr-defined]
+    except BaseException:
+        kernel32.CloseHandle(handle)
+        raise
+
+
+def _open_nofollow_text(filepath: str):  # type: ignore[no-untyped-def]
+    """Open for reading without following a final-component link.
+
+    THE RECOVERY-PATH INVARIANT: no filesystem operation on the
+    worktree-recovery path ever follows a link. POSIX: ``O_NOFOLLOW`` makes
+    the open itself fail ELOOP on a symlinked leaf. Windows: the file is
+    opened with reparse-point-safe handle semantics
+    (``FILE_FLAG_OPEN_REPARSE_POINT`` -- the link is opened, never followed).
+    Both opens are ATOMIC -- no check-then-open window -- and the OPENED
+    handle is then validated: a reparse point or non-regular file is refused
+    after the fact, from the handle's own attributes, not from a separate
+    path probe a concurrent swap could invalidate.
+    """
+    if _O_NOFOLLOW:
+        fd = os.open(filepath, os.O_RDONLY | _O_NOFOLLOW)
+    else:
+        fd = _windows_open_reparse_handle(filepath)
+    try:
+        st = os.fstat(fd)
+        if _is_link(st) or not stat.S_ISREG(st.st_mode):
+            raise OSError("refusing linked/non-regular worktree metadata file")
+    except BaseException:
+        os.close(fd)
+        raise
+    return os.fdopen(fd, encoding="utf-8", errors="replace")
+
+
+def _run_worktree_admin_dir(worktrees_dir: str, worktree_path: str) -> str:
+    """Return the admin entry under *worktrees_dir* registering *worktree_path*.
+
+    Git maps a linked worktree back to its checkout through the ``gitdir``
+    file inside each entry of the repository's ``worktrees`` directory: its
+    one line is the checkout's ``.git`` path. The entry for a given checkout
+    is found by that recorded path, not by directory name -- git suffixes
+    names on collision, so the basename is not reliable. Returns "" when no
+    entry registers the path.
+
+    Every consumed component obeys the recovery-path invariant (never follow
+    a link): the ``worktrees`` directory and each entry are ``lstat``-checked
+    and a symlink/junction is skipped, and the ``gitdir`` file is opened
+    no-follow. A planted link anywhere in the span yields "" -- it is never
+    dereferenced.
+    """
+    expected = os.path.normcase(os.path.normpath(os.path.join(worktree_path, ".git")))
+    try:
+        if _is_link(os.lstat(worktrees_dir)):
+            return ""
+        entries = os.listdir(worktrees_dir)
+    except OSError:
+        return ""
+    for name in entries:
+        entry = os.path.join(worktrees_dir, name)
+        try:
+            if _is_link(os.lstat(entry)):
+                continue
+            with _open_nofollow_text(os.path.join(entry, "gitdir")) as stream:
+                recorded = stream.readline().strip()
+        except OSError:
+            continue
+        if recorded and os.path.normcase(os.path.normpath(recorded)) == expected:
+            return entry
+    return ""
+
+
+def _orphaned_worktree_gitdir(path: str, worktrees_dir: str) -> str:
+    """Return a missing worktree admin path named by a regular ``.git`` file.
+
+    A deregistered linked worktree retains the ``.git`` pointer Git wrote into
+    its checkout even after the pointed-to admin directory is gone.  That
+    pointer is evidence of a stale checkout; a directory merely being non-Git
+    is not.  Symlinks and live targets are rejected so an arbitrary
+    replacement cannot borrow another file as proof of ownership.
+
+    The pointer text is attacker-writable content inside the leftover tree,
+    so nothing from it may reach a filesystem probe until it is proven,
+    LEXICALLY, to name an entry directly under this repository's own
+    ``worktrees`` directory (*worktrees_dir*).  On Windows, merely calling
+    ``exists()`` on a UNC target (``\\\\host\\share``) performs an outbound
+    SMB authentication -- a credential exposure that happens before any
+    ``OSError`` is caught.  So UNC and device targets are rejected on the RAW
+    string, before any normalization or syscall, and containment is decided
+    by pure string comparison; only a target already proven local and
+    repo-owned is probed for existence.
+    """
+    dotgit = Path(path) / ".git"
+    try:
+        if not stat.S_ISREG(os.lstat(dotgit).st_mode):
+            return ""
+        # No-follow open closes the lstat->open TOCTOU: a leaf swapped for a
+        # link between the check and the read is refused by the open itself.
+        with _open_nofollow_text(str(dotgit)) as stream:
+            text = stream.read(4097)
+    except (OSError, UnicodeError):
+        return ""
+    if len(text) > 4096:
+        return ""
+    lines = text.splitlines()
+    if len(lines) != 1 or not lines[0].startswith("gitdir: "):
+        return ""
+    raw = lines[0][len("gitdir: ") :].strip()
+    # UNC and device paths ('\\\\host\\share', '//host/share', '\\\\.\\',
+    # '\\\\?\\', and separator-mixed spellings) all begin with two path
+    # separators. Reject them on the raw text -- no Path object, no syscall.
+    if len(raw) >= 2 and raw[0] in ("\\", "/") and raw[1] in ("\\", "/"):
+        return ""
+    target = Path(raw)
+    if not target.is_absolute():
+        target = dotgit.parent / target
+    # Lexical containment: the target's PARENT must be the repository's own
+    # worktrees directory. Both accepted spellings of that directory -- as
+    # given and fully resolved -- are computed from the repo-owned path only;
+    # the attacker-influenced target is never resolved, only normalized as a
+    # string. Only after this proof does any syscall touch the target.
+    target_parent = os.path.normcase(os.path.dirname(os.path.normpath(str(target))))
+    allowed = {
+        os.path.normcase(os.path.normpath(worktrees_dir)),
+        os.path.normcase(os.path.realpath(worktrees_dir)),
+    }
+    if target_parent not in allowed:
+        return ""
+    try:
+        # ``lexists`` stats the final component WITHOUT following it: a leaf
+        # symlink/junction (even one pointing at a UNC target) is seen as the
+        # link itself -- no dereference, no outbound authentication. A link
+        # leaf reads as "exists" and is therefore rejected as evidence, which
+        # is the correct, safe outcome.
+        if os.path.lexists(str(target)):
+            return ""
+    except OSError:
+        return ""
+    return str(target)
+
+
+async def _leftover_dir_is_ours(run: Project, path: str | None = None) -> bool:
+    """True only when *path* identifies this run's worktree.
+
+    A live checkout must belong to the original repository (same
+    ``--git-common-dir``) and remain on the run's branch.  A broken checkout
+    must retain Git's regular ``.git`` pointer to a now-missing admin entry
+    directly under that repository's ``worktrees`` directory -- proven
+    lexically against the repo-owned path before the pointer target is
+    touched at all (see ``_orphaned_worktree_gitdir``).  An arbitrary non-Git
+    directory satisfies neither proof and is never safe to move.
+
+    Either proof authorizes only CAPTURE (setting the tree aside so recovery
+    can proceed); nothing in recovery deletes a leftover tree.
+
+    *path* defaults to ``run.worktree_path``. Pass it explicitly to judge a
+    tree that has been renamed aside, where the saved path no longer names
+    the directory in question.
+    """
+    path = path or run.worktree_path
+    repo_root = run.repo_root
+    if not path or not repo_root or not run.branch_name:
+        return False
+    if not await _is_git_repo(path):
+        try:
+            theirs = (await _git(repo_root, "rev-parse", "--git-common-dir")).strip()
+        except (RuntimeError, OSError):
+            return False
+        if not theirs:
+            return False
+        worktrees_dir = str(Path(repo_root) / theirs / "worktrees")
+        stale_gitdir = await asyncio.to_thread(_orphaned_worktree_gitdir, path, worktrees_dir)
+        return bool(stale_gitdir)
+    try:
+        here = (await _git(path, "rev-parse", "--git-common-dir")).strip()
+        theirs = (await _git(repo_root, "rev-parse", "--git-common-dir")).strip()
+    except (RuntimeError, OSError):
+        # It answered "is a repo" a moment ago but a follow-up probe just
+        # failed outright -- treat as unidentifiable/foreign rather than
+        # risk moving something real.
+        return False
+    if not here or not theirs:
+        return False
+    if not await asyncio.to_thread(
+        _same_dir, str(Path(path) / here), str(Path(repo_root) / theirs)
+    ):
+        return False
+    try:
+        branch = (await _git(path, "branch", "--show-current")).strip()
+    except (RuntimeError, OSError):
+        return False
+    return branch == run.branch_name
+
+
+async def reinit_workspace_for_retry(run: Project) -> bool:
+    """Recreate a lost worktree before resuming a retried run.
+
+    ``init_workspace()`` cannot simply be called again here: it overwrites
+    ``run.work_dir`` with the worktree path on its original call, so a second
+    call would check git-repo-ness of the now-DEAD WORKTREE rather than the
+    original repo, and silently disable git (``git_enabled = False``) instead
+    of recovering. This uses ``run.repo_root`` instead -- set once by the
+    original ``init_workspace()`` and never overwritten -- and reuses the
+    run's EXISTING branch: ``finalize()`` only ever removes the worktree,
+    never the branch, so creating a fresh branch of the same name would fail
+    with "already exists".
+
+    Returns True if the workspace is valid to resume against afterward;
+    False means the caller must not resume and should fail the run instead
+    of continuing against a broken workspace.
+    """
+    if not run.repo_root or not await _is_git_repo(run.repo_root):
+        return False
+    if not run.branch_name:
+        return False
+    if not await _branch_history_intact(run.repo_root, run):
+        # Re-adding the branch by NAME would silently resume on a rewritten
+        # history: the run's earlier steps would stay marked passed although
+        # their commits are gone. Refuse before touching anything on disk --
+        # the leftover tree, whatever it is, stays exactly where it was.
+        logger.warning(
+            "refusing to recover run %s: branch %s no longer carries the "
+            "run's last recorded commit",
+            run.task_id,
+            run.branch_name,
+        )
+        return False
+    if run.worktree_path:
+        path_exists = await asyncio.to_thread(os.path.exists, run.worktree_path)
+        if path_exists and not await _leftover_dir_is_ours(run):
+            logger.warning(
+                "refusing to recover run %s: an unowned directory now "
+                "occupies its worktree path %s",
+                run.task_id,
+                run.worktree_path,
+            )
+            return False
+        # CAPTURE, THEN PARK. The ownership proof above resolves
+        # ``run.worktree_path``; acting on a re-resolved path later -- with
+        # awaited ``git`` subprocesses in between -- would let a directory
+        # swapped onto the path be the one acted on, while the proof had
+        # validated a different tree.
+        #
+        # Renaming first collapses that gap. The single atomic ``os.rename`` is
+        # the LAST operation to resolve the saved path, and everything
+        # afterwards addresses ``doomed`` -- a private name carrying a random
+        # token, which nothing else can be holding. A later swap onto the
+        # saved path can no longer redirect anything; it merely loses the race
+        # to the ``worktree add`` below, which then fails and returns False
+        # rather than clobbering whatever arrived.
+        #
+        # Same-parent rename, so never cross-device. Fails CLOSED on anything
+        # but the path having vanished on its own: when the leftover cannot be
+        # captured (Windows holds a handle inside it, or permissions refuse),
+        # recovery gives up instead of falling back to acting by path.
+        doomed: str | None = None
+        if path_exists:
+            doomed = f"{run.worktree_path}.kirocrew-stale-{uuid.uuid4().hex[:12]}"
+            try:
+                await asyncio.to_thread(os.rename, run.worktree_path, doomed)
+            except FileNotFoundError:
+                doomed = None
+            except OSError:
+                logger.warning(
+                    "refusing to recover run %s: could not set aside the "
+                    "leftover directory at %s",
+                    run.task_id,
+                    run.worktree_path,
+                    exc_info=True,
+                )
+                return False
+        if doomed is not None and not await _leftover_dir_is_ours(run, path=doomed):
+            # The CAPTURE is what gets parked and re-added over, so ownership
+            # has to hold for the captured tree -- not merely for whatever
+            # occupied the saved path when the proof above ran. A directory
+            # swapped in between those two points would otherwise be renamed
+            # aside on the strength of a proof about a different tree, which
+            # is the whole failure this capture exists to prevent. Proving it
+            # again here is what closes that gap: after the rename the tree
+            # sits at a private name nothing else knows, so this second proof
+            # and everything after it cannot disagree about which directory
+            # they mean.
+            #
+            # Put it back if it is not ours -- nothing has been moved
+            # anywhere unexpected yet, and leaving a stranger's directory
+            # under a `.kirocrew-stale-*` name would be a surprising side
+            # effect of a refusal. Say where it ended up when the restore
+            # itself fails, so it is recoverable by hand rather than merely
+            # lost.
+            restored = True
+            try:
+                await asyncio.to_thread(os.rename, doomed, run.worktree_path)
+            except OSError:
+                restored = False
+            logger.warning(
+                "refusing to recover run %s: the directory captured from %s is "
+                "not this run's worktree%s",
+                run.task_id,
+                run.worktree_path,
+                "" if restored else f"; it remains at {doomed}",
+            )
+            return False
+        # Git may still hold an admin entry registering the run's ORIGINAL
+        # path, whose directory is now gone -- renamed away just above, or
+        # already absent -- and ``worktree add`` refuses a path git believes
+        # is a missing-but-registered worktree. A repository-wide ``worktree
+        # prune`` is the WRONG tool for that: it deregisters EVERY worktree
+        # whose directory is currently missing, including unrelated checkouts
+        # on a temporarily unmounted share or removable drive, corrupting
+        # them for when they come back. So remove ONLY this run's entry:
+        # ``_run_worktree_admin_dir`` walks the repo-owned ``worktrees``
+        # directory and returns the single entry whose recorded ``gitdir``
+        # names the run's own worktree path -- every input is repo-owned, no
+        # leftover-tree content is consulted -- and only that directory is
+        # removed. Other runs' and other users' registrations are untouched.
+        try:
+            theirs = (await _git(run.repo_root, "rev-parse", "--git-common-dir")).strip()
+        except (RuntimeError, OSError):
+            theirs = ""
+        if theirs:
+            worktrees_dir = str(Path(run.repo_root) / theirs / "worktrees")
+            admin_dir = await asyncio.to_thread(
+                _run_worktree_admin_dir, worktrees_dir, run.worktree_path
+            )
+            if admin_dir and not await asyncio.to_thread(platform_compat.rmtree_force, admin_dir):
+                logger.warning(
+                    "run %s: could not remove its stale worktree registration "
+                    "at %s; the re-add below may fail",
+                    run.task_id,
+                    admin_dir,
+                )
+        if doomed is not None:
+            # The captured tree is PARKED, never deleted. Recovery's ownership
+            # proofs top out at "this run's own leftover" -- and for the
+            # orphaned-checkout case this function exists for, the only
+            # available evidence is a plain-text ``.git`` pointer file that a
+            # forgery reproduces exactly, so no leftover that reaches this
+            # point carries evidence strong enough to authorize destruction.
+            # The rename above already freed the saved path for the re-add
+            # below; the tree stays on disk under the private set-aside name,
+            # and the warning says where it went so a human can inspect or
+            # remove it by hand.
+            logger.warning(
+                "run %s: the leftover from %s has been parked at %s -- "
+                "inspect and remove it by hand if it is not needed",
+                run.task_id,
+                run.worktree_path,
+                doomed,
+            )
+    wt_dir = run.worktree_path or str(Path(run.repo_root).parent / ".kirocrew-work" / run.task_id)
+    try:
+        await _git(run.repo_root, "worktree", "add", wt_dir, run.branch_name)
+    except Exception:
+        logger.debug("worktree re-add on retry failed", exc_info=True)
+        return False
+    run.work_dir = wt_dir
+    run.worktree_path = wt_dir
+    run.git_enabled = True
+    # Validate the worktree that ``worktree add`` actually produced, not the
+    # one the prechecks reasoned about. Every check so far ran BEFORE the add,
+    # so a branch force-updated inside that window would be checked out here
+    # with the run's earlier commits gone -- and those steps would stay marked
+    # passed. ``workspace_is_valid`` re-proves path, repository, branch and
+    # history identity on the freshly added checkout; on mismatch, deregister
+    # the just-added worktree (plain ``worktree remove``, which refuses a
+    # dirty tree rather than destroying anything unexpected) and fail closed.
+    if not await workspace_is_valid(run):
+        logger.warning(
+            "refusing to recover run %s: the freshly added worktree at %s "
+            "failed revalidation (branch moved during recovery?)",
+            run.task_id,
+            wt_dir,
+        )
+        try:
+            await _git(run.repo_root, "worktree", "remove", wt_dir)
+        except Exception:
+            logger.warning(
+                "run %s: could not remove the failed recovery worktree at %s; "
+                "it remains on disk",
+                run.task_id,
+                wt_dir,
+                exc_info=True,
+            )
+        run.git_enabled = False
+        return False
+    return True
+
+
 async def _is_git_repo(path: str) -> bool:
     # git runs against an agent-selected repo whose local hooks and config can
     # execute code, so route through the sandbox chokepoint (OS isolation +
@@ -136,11 +713,24 @@ async def _is_git_repo(path: str) -> bool:
         )
         await proc.communicate()
         return proc.returncode == 0
-    except FileNotFoundError:
-        # No ``git`` binary on this host. The task runner is git-optional, so a
-        # host without git simply has no git repos — treat the workspace as
-        # non-git (run in place, git_enabled=False) instead of crashing.
-        logger.debug("git binary not found; treating workspace as non-git", exc_info=True)
+    except (FileNotFoundError, NotADirectoryError):
+        # Something in the invocation is NOT THERE, which is genuinely
+        # answerable as "no git repo here": either no ``git`` binary on the
+        # host (the task runner is git-optional, so such a host simply has no
+        # git repos), or *path* itself no longer exists -- exactly the
+        # lost-worktree state the retry path probes for. The platforms spell
+        # the missing-cwd case differently: POSIX raises ``FileNotFoundError``
+        # from the spawn, Windows raises ``NotADirectoryError`` (WinError 267)
+        # out of ``CreateProcess``, so both names are needed.
+        #
+        # Deliberately NOT a blanket ``except OSError``. A transient spawn
+        # failure in a perfectly valid repo -- ``EMFILE``, ``ENOMEM``,
+        # ``EAGAIN`` -- is also an ``OSError``, and answering False to those
+        # would report a real repo as non-git: ``init_workspace`` would then
+        # set ``git_enabled = False`` and every step would run directly
+        # against the user's own checkout with no worktree isolation and no
+        # per-step commits. Those must propagate and fail the run instead.
+        logger.debug("git unavailable for %s; treating as non-git", path, exc_info=True)
         return False
     finally:
         if cleanup:

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -1554,10 +1554,25 @@ class TaskRunner:
         run = self._resolve_task(task_id)
         if not run:
             raise ValueError(f"Run {task_id} not found")
+        # _resolve_task accepts a run NAME as well as the canonical id, but
+        # self._tasks is keyed by the canonical id. Canonicalize before any
+        # lookup, or a name-addressed retry misses the prior background-task
+        # handle, bypasses the finishing guard below, and races the prior
+        # run's finalizer (which is about to remove the worktree).
+        task_id = run.task_id
         if run.status == "running":
             raise ValueError("Cannot retry a running task")
         if run.status in ("cancelling", "pausing"):
             raise ValueError("Cannot retry while cancel is in progress")
+        # The status flips terminal BEFORE the prior run's finally-block
+        # finishes -- git finalize (which removes the worktree) runs after
+        # the terminal status is persisted. A retry accepted in that window
+        # validates a workspace the prior finalizer is about to delete, and
+        # then executes against a missing directory. The background task
+        # handle is the honest signal: refuse while it is still running.
+        prior = self._tasks.get(task_id)
+        if prior is not None and not prior.done():
+            raise ValueError("Cannot retry while the previous run is still finishing")
         for task in run.tasks:
             if task.index >= from_task:
                 task.status = TaskStatus.PENDING
@@ -1576,11 +1591,29 @@ class TaskRunner:
             watchdog_task: asyncio.Task | None = None  # type: ignore[type-arg]
             try:
                 await self._workflow_rebind(run)
-                if run.branch_name and not Path(run.work_dir).exists():
-                    try:
-                        await git_coord.init_workspace(run)
-                    except Exception:
-                        logger.debug("Git re-init on retry failed", exc_info=True)
+                if run.branch_name and not await git_coord.workspace_is_valid(run):
+                    # Directory-exists alone is not enough: `git worktree
+                    # remove` deregisters and deletes in separate steps, so
+                    # an interrupted finalize() (or the worktree being
+                    # removed out from under the run some other way) can
+                    # leave the directory present but no longer a registered
+                    # git worktree -- resuming against it would silently
+                    # dispatch every remaining step against a non-git
+                    # directory while still reporting them completed.
+                    if not await git_coord.reinit_workspace_for_retry(run):
+                        run.status = "failed"
+                        run.error = (
+                            "Task Runner workspace worktree was lost and "
+                            "could not be restored before retry"
+                        )
+                        run.finished_at = time.time()
+                        await self._apersist_runs()
+                        await self._notify(
+                            "❌ Retry failed",
+                            "Workspace could not be restored",
+                            run=run,
+                        )
+                        return
                 await self._notify("\U0001f504 Retrying", f"From task {from_task}", run=run)
                 watchdog_task = asyncio.create_task(self._watchdog_loop(run))
                 await self._execute_tasks(run, history_key)

--- a/test/test_taskrunner.py
+++ b/test/test_taskrunner.py
@@ -3474,6 +3474,941 @@ class TestGitCoord:
         await git_coord.finalize(run)
 
     @pytest.mark.asyncio
+    async def test_workspace_is_valid_true_for_a_live_worktree(self, tmp_path: Path) -> None:
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "valid_test"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+
+        assert await git_coord.workspace_is_valid(run) is True
+
+        await git_coord.finalize(run)
+
+    @pytest.mark.asyncio
+    async def test_workspace_is_valid_false_for_a_legacy_run_without_repo_root(
+        self, tmp_path: Path
+    ) -> None:
+        """A run persisted before ``repo_root`` was recorded cannot be fully
+        verified or recovered. Path identity alone would accept a DIFFERENT
+        repository at the expected path, so validation fails closed and the
+        retry is refused with a clear error instead of resuming on a
+        workspace whose identity cannot be established."""
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "legacy_no_root"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        assert await git_coord.workspace_is_valid(run) is True
+
+        # Simulate the legacy persisted shape: everything intact except the
+        # recorded repo_root.
+        saved_root = run.repo_root
+        run.repo_root = ""
+        assert await git_coord.workspace_is_valid(run) is False
+
+        run.repo_root = saved_root
+        await git_coord.finalize(run)
+
+    @pytest.mark.asyncio
+    async def test_workspace_is_valid_true_for_a_run_with_no_worktree(self, tmp_path: Path) -> None:
+        """A run that never had a worktree (non-git-folder mode) is trivially
+        valid -- there is nothing broken to detect."""
+        from kiro_crew import git_coord
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "nogit_valid"
+        run.work_dir = str(tmp_path)
+        assert run.branch_name == ""
+
+        assert await git_coord.workspace_is_valid(run) is True
+
+    @pytest.mark.asyncio
+    async def test_reinit_recovers_an_orphaned_worktree(self, tmp_path: Path) -> None:
+        """#3792: reproduce the reported state precisely -- the worktree
+        directory still exists on disk, but its registration under the main
+        repo's ``.git/worktrees/`` was removed out from under it (what an
+        interrupted ``git worktree remove`` leaves behind: deregistration and
+        directory deletion are separate steps). ``workspace_is_valid`` must
+        catch this (directory-exists alone would miss it), and
+        ``reinit_workspace_for_retry`` must recover using the ORIGINAL repo
+        (``run.repo_root``) and the run's EXISTING branch -- not fail with
+        "branch already exists", which a naive re-``init_workspace()`` call
+        would hit."""
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "orphan_test"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        assert run.git_enabled is True
+        worktree_dir = run.worktree_path
+        branch = run.branch_name
+
+        # Simulate the orphaned state: deregister the worktree from the main
+        # repo's admin metadata directly, WITHOUT removing the directory --
+        # the exact "dir exists, `git status` says not a git repo" shape
+        # the issue reports, distinct from the directory being deleted.
+        worktree_name = Path(worktree_dir).name
+        admin_dir = Path(run.repo_root) / ".git" / "worktrees" / worktree_name
+        assert admin_dir.exists()
+        import shutil
+
+        shutil.rmtree(admin_dir)
+        assert Path(worktree_dir).exists()  # directory itself is untouched
+
+        assert await git_coord.workspace_is_valid(run) is False
+
+        recovered = await git_coord.reinit_workspace_for_retry(run)
+
+        assert recovered is True
+        assert run.git_enabled is True
+        assert run.branch_name == branch  # reused, not a fresh branch
+        assert await git_coord.workspace_is_valid(run) is True
+        assert (Path(run.work_dir) / "file.txt").exists()  # branch content intact
+
+        await git_coord.finalize(run)
+
+    @pytest.mark.asyncio
+    async def test_reinit_fails_closed_when_the_original_repo_is_also_gone(
+        self, tmp_path: Path
+    ) -> None:
+        """If even run.repo_root can no longer be recovered from, reinit must
+        report failure rather than silently disabling git."""
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "gone_test"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+
+        import shutil
+
+        from kiro_crew.platform_compat import rmtree_force
+
+        shutil.rmtree(run.worktree_path, ignore_errors=True)
+        # Plain shutil.rmtree(..., ignore_errors=False) fails closed on Windows:
+        # git writes loose objects under .git/objects read-only, and Windows
+        # (unlike POSIX) checks the file's own read-only attribute rather than
+        # the parent directory's write bit, so os.unlink raises WinError 5
+        # before the repo is actually gone. rmtree_force clears the attribute
+        # and retries, and its return value confirms the ORIGINAL repo really
+        # is gone -- which this test's premise depends on.
+        assert rmtree_force(run.repo_root) is True
+
+        recovered = await git_coord.reinit_workspace_for_retry(run)
+
+        assert recovered is False
+
+    @pytest.mark.asyncio
+    async def test_workspace_is_valid_false_when_only_an_enclosing_repo_answers(
+        self, tmp_path: Path
+    ) -> None:
+        """A deregistered worktree whose directory survives INSIDE another
+        repository must not read as valid. ``git rev-parse`` walks UP from the
+        directory it is run in, so an ordinary directory nested anywhere inside
+        an enclosing repo still reports "inside a work tree" -- and resuming on
+        that answer would commit every remaining step into the enclosing
+        checkout while reporting those steps completed. Validity therefore has
+        to be identity (is this MY worktree?), not mere repo-ness."""
+        from kiro_crew import git_coord
+
+        enclosing = tmp_path / "enclosing"
+        enclosing.mkdir()
+        await git_coord._git(str(enclosing), "init")
+        (enclosing / "file.txt").write_text("content")
+        await git_coord._git(str(enclosing), "add", "-A")
+        await git_coord._git(str(enclosing), "commit", "-m", "init")
+
+        # The run's worktree was deregistered and its contents cleaned up, but
+        # the directory itself survived -- and it sits inside `enclosing`.
+        stale = enclosing / ".kirocrew-work" / "nested_test"
+        stale.mkdir(parents=True)
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "nested_test"
+        run.work_dir = str(stale)
+        run.worktree_path = str(stale)
+        run.repo_root = str(enclosing)
+        run.branch_name = "kirocrew/task/nested_test"
+        run.git_enabled = True
+
+        # Precondition, and the whole point: git DOES report this directory as
+        # being inside a work tree -- the ENCLOSING one. A repo-ness check
+        # answers True here, which is why it cannot be the validity test.
+        assert await git_coord._is_git_repo(str(stale)) is True
+
+        assert await git_coord.workspace_is_valid(run) is False
+
+    @pytest.mark.asyncio
+    async def test_workspace_is_valid_false_for_a_different_repo_at_the_same_path(
+        self, tmp_path: Path
+    ) -> None:
+        """A DIFFERENT repository standing at the run's worktree path must not
+        read as valid.
+
+        Matching paths are not identity: something else can create a repo
+        exactly where the lost worktree used to be, and then
+        ``rev-parse --show-toplevel`` answers with that path -- the expected
+        one. Resuming on that would commit the run's remaining steps into a
+        repository that is not the run's own. A linked worktree shares its main
+        repository's git directory, so the common git dir is what actually
+        distinguishes them."""
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "impostor_test"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        worktree_dir = run.worktree_path
+        assert await git_coord.workspace_is_valid(run) is True
+
+        # Replace the worktree with an unrelated repository at the SAME path.
+        await git_coord.finalize(run)
+        from kiro_crew.platform_compat import rmtree_force
+
+        rmtree_force(worktree_dir)
+        Path(worktree_dir).mkdir(parents=True)
+        await git_coord._git(worktree_dir, "init")
+        (Path(worktree_dir) / "impostor.txt").write_text("not ours")
+        await git_coord._git(worktree_dir, "add", "-A")
+        await git_coord._git(worktree_dir, "commit", "-m", "impostor")
+
+        # Precondition, and the whole point: the path check alone is satisfied
+        # -- git reports this very directory as the repository root -- so only
+        # the git-common-dir comparison can tell the impostor apart.
+        toplevel = (await git_coord._git(worktree_dir, "rev-parse", "--show-toplevel")).strip()
+        assert git_coord._same_dir(toplevel, worktree_dir) is True
+
+        assert await git_coord.workspace_is_valid(run) is False
+
+    @pytest.mark.asyncio
+    async def test_workspace_is_valid_false_for_a_worktree_on_the_wrong_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Repository identity is not worktree identity: a worktree of THIS
+        repo, checked out on a DIFFERENT branch at the run's own path, must
+        not read as valid -- resuming would commit the run's remaining steps
+        onto somebody else's branch while reporting success."""
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "wrong_branch_test"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        assert await git_coord.workspace_is_valid(run) is True
+
+        # Move the worktree onto a different branch of the SAME repo -- path
+        # and repo identity both still match; only the branch differs.
+        await git_coord._git(run.work_dir, "checkout", "-b", "someone-elses-branch")
+
+        assert await git_coord.workspace_is_valid(run) is False
+
+        await git_coord.finalize(run)
+
+    @pytest.mark.asyncio
+    async def test_git_probe_propagates_a_transient_spawn_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A TRANSIENT spawn failure must propagate, not be read as "non-git".
+
+        ``EMFILE`` / ``ENOMEM`` / ``EAGAIN`` are ``OSError`` too, but they say
+        nothing about whether the directory is a repository. Answering False to
+        them would report a real repo as non-git, and ``init_workspace`` would
+        then set ``git_enabled = False`` -- running every step directly against
+        the user's own checkout, with no worktree isolation and no per-step
+        commits. So the guard names only the two "it is not there" errors and
+        lets the rest fail the run."""
+        import errno
+
+        from kiro_crew import git_coord
+
+        async def exhausted(*args: object, **kwargs: object) -> object:
+            raise OSError(errno.EMFILE, "Too many open files")
+
+        monkeypatch.setattr(git_coord, "create_subprocess_limited", exhausted)
+
+        with pytest.raises(OSError) as excinfo:
+            await git_coord._is_git_repo(str(tmp_path))
+        assert excinfo.value.errno == errno.EMFILE
+
+    @pytest.mark.asyncio
+    async def test_git_probe_fails_closed_when_the_directory_itself_is_gone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Probing a directory that no longer exists must read as "not a git
+        repo", never raise.
+
+        The two platforms disagree on how the spawn fails: POSIX reports a
+        missing cwd as ``FileNotFoundError``, while Windows raises
+        ``NotADirectoryError`` (WinError 267) out of ``CreateProcess``. Guarding
+        only ``FileNotFoundError`` therefore failed closed on POSIX and
+        propagated on Windows -- exactly the lost-worktree state the retry path
+        exists to detect. Both are ``OSError``, which is what the guard tests.
+        """
+        from kiro_crew import git_coord
+
+        async def refuse_to_spawn(*args: object, **kwargs: object) -> object:
+            raise NotADirectoryError(267, "The directory name is invalid")
+
+        monkeypatch.setattr(git_coord, "create_subprocess_limited", refuse_to_spawn)
+
+        assert await git_coord._is_git_repo(str(tmp_path / "gone")) is False
+
+        # And the retry path built on it fails closed rather than propagating.
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "spawn_gone"
+        run.repo_root = str(tmp_path / "gone")
+        run.work_dir = str(tmp_path / "gone")
+        run.branch_name = "kirocrew/task/spawn_gone"
+
+        assert await git_coord.reinit_workspace_for_retry(run) is False
+
+    @pytest.mark.asyncio
+    async def test_recovery_revalidates_the_captured_tree_before_deleting_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ownership must hold for the tree that is actually deleted.
+
+        The proof runs against the saved path; the capture then renames whatever
+        occupies that path at rename time. Those are two different moments, so a
+        directory swapped in between them would be captured and destroyed on the
+        strength of a proof about a different tree. Recovery therefore proves
+        ownership a SECOND time, against the captured name, and this pins that:
+        the swap is injected in exactly that gap, and its data must survive.
+        """
+        import shutil as _shutil
+
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "capture_swap"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        worktree_dir = Path(run.worktree_path)
+
+        # The #3792 state: deregistered, checkout still on disk, so the first
+        # proof legitimately passes and recovery proceeds to capture.
+        admin_dir = Path(run.repo_root) / ".git" / "worktrees" / worktree_dir.name
+        assert admin_dir.exists()
+        _shutil.rmtree(admin_dir)
+
+        real_proof = git_coord._leftover_dir_is_ours
+        treasure = worktree_dir / "not-ours.txt"
+        swapped = False
+
+        async def proving_then_swapping(run_arg: object, path: object = None) -> bool:
+            """Pass the first proof, then swap the path out from under it."""
+            nonlocal swapped
+            verdict = await real_proof(run_arg, path)
+            if not swapped and path is None:
+                swapped = True
+                if worktree_dir.exists():
+                    _shutil.rmtree(worktree_dir)
+                worktree_dir.mkdir(parents=True)
+                treasure.write_text("someone else's data")
+            return verdict
+
+        monkeypatch.setattr(git_coord, "_leftover_dir_is_ours", proving_then_swapping)
+
+        recovered = await git_coord.reinit_workspace_for_retry(run)
+
+        assert swapped, "the post-proof gap was never exercised"
+        assert treasure.exists(), (
+            "recovery deleted the tree it captured without re-proving ownership "
+            "of THAT tree -- a post-proof swap was destroyed"
+        )
+        assert treasure.read_text() == "someone else's data"
+        assert recovered is False
+        # The stranger's directory is put back, not left under a stale name.
+        assert not list(worktree_dir.parent.glob("*.kirocrew-stale-*"))
+
+    @pytest.mark.asyncio
+    async def test_recovery_never_deletes_a_tree_swapped_in_after_the_proof(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The destructive step must act on a CAPTURED tree, not on a path it
+        re-resolves after awaiting git.
+
+        Ownership is proved against ``run.worktree_path``, and a ``git``
+        subprocess is awaited before anything is deleted. A delete that
+        re-resolved that path would destroy whatever occupied it by then -- not
+        the tree the proof actually validated. This plants an unrelated
+        directory at the saved path from INSIDE that awaited git call, which is
+        the exact window, and asserts its contents survive.
+        """
+        import shutil as _shutil
+
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "swap_race"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        worktree_dir = Path(run.worktree_path)
+
+        # The #3792 state: deregistered, but the checkout survives on disk, so
+        # the ownership proof passes and recovery proceeds to delete.
+        admin_dir = Path(run.repo_root) / ".git" / "worktrees" / worktree_dir.name
+        assert admin_dir.exists()
+        _shutil.rmtree(admin_dir)
+        assert worktree_dir.exists()
+
+        real_git = git_coord._git
+        treasure = worktree_dir / "not-ours.txt"
+        planted = False
+
+        async def racing_git(cwd: str, *args: str) -> str:
+            """Swap an unrelated directory onto the saved path mid-recovery --
+            after the capture (and its proofs), immediately before the
+            ``worktree add`` resolves the saved path again."""
+            nonlocal planted
+            if not planted and args[:2] == ("worktree", "add"):
+                planted = True
+                if worktree_dir.exists():
+                    _shutil.rmtree(worktree_dir)
+                worktree_dir.mkdir(parents=True)
+                treasure.write_text("someone else's data")
+            return await real_git(cwd, *args)
+
+        monkeypatch.setattr(git_coord, "_git", racing_git)
+
+        recovered = await git_coord.reinit_workspace_for_retry(run)
+
+        assert planted, "the race window was never exercised"
+        assert treasure.exists(), (
+            "recovery deleted a directory that only appeared AFTER the "
+            "ownership proof -- the delete re-resolved the saved path"
+        )
+        assert treasure.read_text() == "someone else's data"
+        # The saved path is occupied by something that is not ours, so the
+        # re-add must fail rather than clobber it.
+        assert recovered is False
+
+    @pytest.mark.asyncio
+    async def test_reinit_parks_the_stale_checkout_instead_of_deleting_it(
+        self, tmp_path: Path
+    ) -> None:
+        """Recovery PARKS the captured leftover; nothing deletes it.
+
+        The only evidence an orphaned checkout can offer is a plain-text
+        ``.git`` pointer file a forgery reproduces exactly, so no leftover
+        that reaches the destructive step carries evidence strong enough to
+        authorize destruction. The rename is what frees the path for the
+        re-add; the tree survives on disk under the set-aside name.
+        """
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "park_test"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        worktree_dir = Path(run.worktree_path)
+        (worktree_dir / "scratch.txt").write_text("uncommitted scratch")
+
+        # The #3792 orphaned state: deregistered, directory intact.
+        import shutil
+
+        admin_dir = Path(run.repo_root) / ".git" / "worktrees" / worktree_dir.name
+        assert admin_dir.exists()
+        shutil.rmtree(admin_dir)
+
+        assert await git_coord.reinit_workspace_for_retry(run) is True
+
+        parked = list(worktree_dir.parent.glob(f"{worktree_dir.name}.kirocrew-stale-*"))
+        assert parked, "the captured leftover was deleted instead of parked"
+        assert (parked[0] / "scratch.txt").read_text() == "uncommitted scratch"
+
+        await git_coord.finalize(run)
+
+    @pytest.mark.asyncio
+    async def test_orphaned_gitdir_reader_rejects_unc_and_uncontained_targets(
+        self, tmp_path: Path
+    ) -> None:
+        """The pointer target is attacker-writable text: no spelling of it may
+        reach a filesystem probe unless it is lexically an entry directly
+        under the repository's own ``worktrees`` directory. On Windows, a mere
+        ``exists()`` on a UNC target performs outbound SMB authentication --
+        a credential exposure -- so UNC/device forms are rejected on the raw
+        string before any syscall."""
+        from kiro_crew import git_coord
+
+        worktrees_dir = str(tmp_path / "repo" / ".git" / "worktrees")
+        tree = tmp_path / "leftover"
+        tree.mkdir()
+
+        def forge(target: str) -> str:
+            (tree / ".git").write_text(f"gitdir: {target}\n")
+            return git_coord._orphaned_worktree_gitdir(str(tree), worktrees_dir)
+
+        # UNC and device spellings: rejected on the raw string.
+        assert forge(r"\\attacker-host\share\worktrees\x") == ""
+        assert forge("//attacker-host/share/worktrees/x") == ""
+        assert forge(r"\\.\pipe\evil") == ""
+        assert forge(r"\\?\C:\anything") == ""
+        # Local but outside the repo's worktrees dir: rejected lexically.
+        assert forge(str(tmp_path / "elsewhere" / "wt")) == ""
+        # Dot-dot escape normalizing outside the worktrees dir: rejected.
+        assert forge(f"{worktrees_dir}/../../../elsewhere") == ""
+        # A genuine dangling entry directly under the worktrees dir: accepted.
+        # Compare normalized: on Windows the reader returns backslash paths.
+        import os as _os
+
+        genuine = f"{worktrees_dir}/gone-entry"
+        assert _os.path.normcase(_os.path.normpath(forge(genuine))) == _os.path.normcase(
+            _os.path.normpath(genuine)
+        )
+
+    @pytest.mark.asyncio
+    async def test_recovery_metadata_readers_never_follow_links(self, tmp_path: Path) -> None:
+        """The recovery-path invariant: no filesystem operation on the
+        worktree-recovery path ever follows a link. A planted symlink -- as
+        the ``.git`` pointer leaf, as a ``worktrees`` entry, or as the
+        pointer's target leaf -- is refused or skipped, never dereferenced.
+        (On Windows the same applies to junctions/reparse points.)"""
+        import os as _os
+
+        from kiro_crew import git_coord
+
+        if not hasattr(_os, "symlink"):
+            pytest.skip("no symlink support on this platform")
+
+        # 1. A symlinked .git leaf is refused by the no-follow open even
+        #    though a symlink can masquerade via follow-based reads.
+        tree = tmp_path / "leftover"
+        tree.mkdir()
+        real_pointer = tmp_path / "elsewhere.txt"
+        worktrees_dir = str(tmp_path / "repo" / ".git" / "worktrees")
+        real_pointer.write_text(f"gitdir: {worktrees_dir}/gone\n")
+        try:
+            _os.symlink(str(real_pointer), str(tree / ".git"))
+        except OSError:
+            pytest.skip("cannot create symlinks in this environment")
+        assert git_coord._orphaned_worktree_gitdir(str(tree), worktrees_dir) == ""
+
+        # 2. A symlinked entry inside the worktrees dir is skipped, not
+        #    traversed, by _run_worktree_admin_dir.
+        wt_dir = tmp_path / "wt"
+        real_entry_home = tmp_path / "outside-entry"
+        real_entry_home.mkdir()
+        (real_entry_home / "gitdir").write_text(f"{wt_dir}/.git\n")
+        admin = tmp_path / "admin" / "worktrees"
+        admin.mkdir(parents=True)
+        _os.symlink(str(real_entry_home), str(admin / "linked-entry"))
+        assert git_coord._run_worktree_admin_dir(str(admin), str(wt_dir)) == ""
+
+        # 3. A symlink LEAF at the pointer target reads as existing via the
+        #    no-follow probe, so the pointer is rejected as evidence -- the
+        #    link is never dereferenced.
+        tree2 = tmp_path / "leftover2"
+        tree2.mkdir()
+        real_admin = tmp_path / "repo2" / ".git" / "worktrees"
+        real_admin.mkdir(parents=True)
+        _os.symlink(str(tmp_path / "no-such-place"), str(real_admin / "link-leaf"))
+        (tree2 / ".git").write_text(f"gitdir: {real_admin}/link-leaf\n")
+        assert git_coord._orphaned_worktree_gitdir(str(tree2), str(real_admin)) == ""
+
+        # 4. Validation happens on the OPENED handle (atomic -- no
+        #    check-then-open window): a non-regular file is refused by the
+        #    fstat of the handle itself, and a symlink leaf is refused by the
+        #    open, never dereferenced.
+        with pytest.raises(OSError):
+            with git_coord._open_nofollow_text(str(tmp_path)):  # a directory
+                pass
+        link_file = tmp_path / "leaf-link"
+        _os.symlink(str(real_pointer), str(link_file))
+        with pytest.raises(OSError):
+            with git_coord._open_nofollow_text(str(link_file)):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_reinit_refuses_to_delete_a_foreign_repo_at_the_worktree_path(
+        self, tmp_path: Path
+    ) -> None:
+        """A completely different, unrelated repository sitting at the run's
+        worktree path must not be recursively deleted during recovery --
+        that would be silent, unrecoverable data loss for whatever that
+        repository holds. Recovery must refuse and fail the run instead."""
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "foreign_repo_test"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        worktree_dir = run.worktree_path
+
+        # Replace the worktree with an unrelated, independent repository at
+        # the SAME path -- exactly the shape a foreign occupant would take.
+        await git_coord.finalize(run)
+        from kiro_crew.platform_compat import rmtree_force
+
+        rmtree_force(worktree_dir)
+        Path(worktree_dir).mkdir(parents=True)
+        await git_coord._git(worktree_dir, "init")
+        (Path(worktree_dir) / "precious.txt").write_text("someone else's data")
+        await git_coord._git(worktree_dir, "add", "-A")
+        await git_coord._git(worktree_dir, "commit", "-m", "unrelated")
+
+        recovered = await git_coord.reinit_workspace_for_retry(run)
+
+        assert recovered is False
+        assert (
+            Path(worktree_dir) / "precious.txt"
+        ).exists(), "recovery deleted a repository it does not own"
+
+    @pytest.mark.asyncio
+    async def test_reinit_refuses_to_delete_an_arbitrary_non_git_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """A non-Git directory is not evidence of an orphaned worktree.
+
+        The retry path may only remove a broken checkout that still carries
+        Git's pointer back to this run's original repository.  A replacement
+        directory with unrelated files must survive byte-for-byte.
+        """
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "non_git_replacement"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        worktree_dir = Path(run.worktree_path)
+
+        await git_coord.finalize(run)
+        worktree_dir.mkdir(parents=True)
+        precious = worktree_dir / "precious.txt"
+        precious.write_bytes(b"someone else's bytes\x00")
+
+        assert await git_coord.reinit_workspace_for_retry(run) is False
+        assert precious.read_bytes() == b"someone else's bytes\x00"
+
+    @pytest.mark.asyncio
+    async def test_reinit_refuses_to_delete_the_same_repo_on_another_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Repository identity alone does not authorize destructive recovery."""
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "wrong_branch_replacement"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        worktree_dir = Path(run.worktree_path)
+        await git_coord._git(run.work_dir, "checkout", "-b", "someone-elses-branch")
+        precious = worktree_dir / "precious.txt"
+        precious.write_text("branch owner's data")
+
+        assert await git_coord.workspace_is_valid(run) is False
+        assert await git_coord.reinit_workspace_for_retry(run) is False
+        assert precious.read_text() == "branch owner's data"
+
+        await git_coord._git(str(worktree_dir), "checkout", run.branch_name)
+        await git_coord.finalize(run)
+
+    @pytest.mark.asyncio
+    async def test_reinit_never_deletes_a_tree_with_a_forged_worktree_pointer(
+        self, tmp_path: Path
+    ) -> None:
+        """A forged ``.git`` pointer must not authorize deletion.
+
+        The stale-checkout proof accepts a regular ``.git`` file naming a
+        MISSING entry under the repository's ``worktrees`` directory -- but
+        that file is plain text anyone can write, and a forged pointer to a
+        nonexistent entry is indistinguishable from a genuine one (a missing
+        target is exactly what makes a genuine pointer stale). Evidence that
+        weak may move the tree aside so recovery can proceed; it must never
+        destroy the tree's contents. This forges such a pointer over an
+        unrelated directory at the run's worktree path and asserts the
+        contents survive recovery on disk.
+        """
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "forged_pointer"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        worktree_dir = Path(run.worktree_path)
+
+        # Replace the worktree with an unrelated directory carrying a FORGED
+        # pointer: a regular ``.git`` file naming a nonexistent entry under
+        # the real repository's ``worktrees`` directory. The ownership checks
+        # accept it as a stale checkout, which used to authorize deletion.
+        await git_coord.finalize(run)
+        worktree_dir.mkdir(parents=True)
+        forged_target = Path(run.repo_root) / ".git" / "worktrees" / "no-such-entry"
+        assert not forged_target.exists()
+        (worktree_dir / ".git").write_text(f"gitdir: {forged_target}\n")
+        precious = worktree_dir / "precious.txt"
+        precious.write_text("someone else's data")
+
+        recovered = await git_coord.reinit_workspace_for_retry(run)
+
+        # The forged tree may be parked aside so recovery can proceed, but
+        # its contents must survive SOMEWHERE on disk -- at the saved path or
+        # under the private set-aside name.
+        survivors = [
+            candidate / "precious.txt"
+            for candidate in (
+                [worktree_dir]
+                + list(worktree_dir.parent.glob(f"{worktree_dir.name}.kirocrew-stale-*"))
+            )
+            if (candidate / "precious.txt").exists()
+        ]
+        assert survivors, (
+            "recovery deleted a tree whose only ownership evidence was a "
+            "forged .git pointer to a nonexistent worktrees entry"
+        )
+        assert survivors[0].read_text() == "someone else's data"
+        if recovered:
+            await git_coord.finalize(run)
+
+    @pytest.mark.asyncio
+    async def test_workspace_is_valid_false_when_the_branch_lost_the_runs_commits(
+        self, tmp_path: Path
+    ) -> None:
+        """Same branch NAME is not the same HISTORY.
+
+        A branch force-moved after the run's steps committed keeps its name
+        while dropping those commits. Resuming on it would leave the earlier
+        steps marked passed although their work is gone, so every remaining
+        step builds on the wrong tree and reports success. The run's own
+        commit ledger is the ground truth the branch tip must still descend
+        from.
+        """
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "rewritten_branch"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+
+        (Path(run.work_dir) / "step.py").write_text("print('step')")
+        step = Step(index=1, title="Add step.py", description="d")
+        assert await git_coord.commit_step(run, step) != ""
+        assert await git_coord.workspace_is_valid(run) is True
+
+        # Rewind the branch past the run's recorded commit -- the shape a
+        # force-move leaves behind: same name, the run's commit gone.
+        await git_coord._git(run.work_dir, "reset", "--hard", "HEAD~1")
+
+        assert await git_coord.workspace_is_valid(run) is False
+
+        await git_coord.finalize(run)
+
+    @pytest.mark.asyncio
+    async def test_reinit_refuses_to_re_add_a_branch_that_lost_the_runs_commits(
+        self, tmp_path: Path
+    ) -> None:
+        """Recovery must not re-add a branch whose history was rewritten.
+
+        ``worktree add`` by branch NAME would resume the run on whatever the
+        branch now points at; with the run's recorded commits gone, earlier
+        steps stay marked passed while their output is absent. Recovery must
+        refuse -- and refuse BEFORE touching the leftover tree on disk.
+        """
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "rewritten_reinit"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        worktree_dir = Path(run.worktree_path)
+
+        (Path(run.work_dir) / "step.py").write_text("print('step')")
+        step = Step(index=1, title="Add step.py", description="d")
+        assert await git_coord.commit_step(run, step) != ""
+
+        # Rewind the branch past the run's commit, then orphan the checkout
+        # (deregistered admin entry) so retry lands in recovery.
+        await git_coord._git(run.work_dir, "reset", "--hard", "HEAD~1")
+        marker = worktree_dir / "leftover-marker.txt"
+        marker.write_text("still here")
+        admin_dir = Path(run.repo_root) / ".git" / "worktrees" / worktree_dir.name
+        assert admin_dir.exists()
+        import shutil
+
+        shutil.rmtree(admin_dir)
+
+        assert await git_coord.reinit_workspace_for_retry(run) is False
+        # Refused before any capture: the leftover sits untouched at its path.
+        assert marker.exists()
+        assert marker.read_text() == "still here"
+
+    @pytest.mark.asyncio
+    async def test_reinit_rejects_a_branch_rewritten_during_the_re_add(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The re-added worktree is validated AFTER ``worktree add``.
+
+        Every history check before the add reasons about the branch as it was
+        THEN; a branch force-updated inside that window is checked out by the
+        add with the run's earlier commits gone, and those steps would stay
+        marked passed. Recovery must revalidate the checkout it actually
+        produced and fail closed on mismatch.
+        """
+        import shutil as _shutil
+
+        from kiro_crew import git_coord
+
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        await git_coord._git(str(work_dir), "init")
+        (work_dir / "file.txt").write_text("content")
+        await git_coord._git(str(work_dir), "add", "-A")
+        await git_coord._git(str(work_dir), "commit", "-m", "init")
+        base_sha = (await git_coord._git(str(work_dir), "rev-parse", "HEAD")).strip()
+
+        run = TaskRun(spec_path="/t.md", spec_content="s")
+        run.task_id = "midadd_rewrite"
+        run.work_dir = str(work_dir)
+        await git_coord.init_workspace(run)
+        worktree_dir = Path(run.worktree_path)
+
+        (Path(run.work_dir) / "step.py").write_text("print('step')")
+        step = Step(index=1, title="Add step.py", description="d")
+        assert await git_coord.commit_step(run, step) != ""
+
+        # The #3792 orphaned state: checkout on disk, admin entry gone. The
+        # branch is still intact here, so every PRE-add check passes.
+        admin_dir = Path(run.repo_root) / ".git" / "worktrees" / worktree_dir.name
+        assert admin_dir.exists()
+        _shutil.rmtree(admin_dir)
+
+        real_git = git_coord._git
+        rewrote = False
+
+        async def racing_git(cwd: str, *args: str) -> str:
+            """Force-move the branch from INSIDE the worktree-add call --
+            after every precheck, before the checkout lands."""
+            nonlocal rewrote
+            if not rewrote and args[:2] == ("worktree", "add"):
+                rewrote = True
+                await real_git(
+                    run.repo_root,
+                    "update-ref",
+                    f"refs/heads/{run.branch_name}",
+                    base_sha,
+                )
+            return await real_git(cwd, *args)
+
+        monkeypatch.setattr(git_coord, "_git", racing_git)
+
+        recovered = await git_coord.reinit_workspace_for_retry(run)
+
+        assert rewrote, "the add-window race was never exercised"
+        assert recovered is False, (
+            "recovery accepted a worktree whose branch was force-updated "
+            "between the prechecks and the add"
+        )
+
+    @pytest.mark.asyncio
     async def test_commit_and_revert(self, tmp_path: Path) -> None:
         """commit_step creates commit, revert_step undoes it."""
         from kiro_crew import git_coord

--- a/test/test_taskrunner_coverage.py
+++ b/test/test_taskrunner_coverage.py
@@ -266,17 +266,13 @@ class TestPlan:
             "_decompose",
             AsyncMock(return_value=[Task(index=1, title="T", description="d")]),
         ):
-            run = await runner.plan(
-                input_text="go", source="text", workspace_dir=str(override)
-            )
+            run = await runner.plan(input_text="go", source="text", workspace_dir=str(override))
         assert run.work_dir == str(override.resolve())
 
     @pytest.mark.asyncio
     async def test_decompose_timeout_becomes_value_error(self, tmp_path: Path) -> None:
         runner = _runner(tmp_path)
-        with patch.object(
-            TaskRunner, "_decompose", AsyncMock(side_effect=asyncio.TimeoutError())
-        ):
+        with patch.object(TaskRunner, "_decompose", AsyncMock(side_effect=asyncio.TimeoutError())):
             with pytest.raises(ValueError, match="timed out"):
                 await runner.plan(input_text="go", source="text")
         assert runner._runs == {}
@@ -399,9 +395,7 @@ class TestUpdateTask:
             ({"depends_on": "1,2"}, "depends_on must be a list"),
         ],
     )
-    async def test_validation_errors(
-        self, tmp_path: Path, updates: dict, message: str
-    ) -> None:
+    async def test_validation_errors(self, tmp_path: Path, updates: dict, message: str) -> None:
         runner = _runner(tmp_path)
         _seed_run(runner, tmp_path)
         with pytest.raises(ValueError, match=message):
@@ -413,9 +407,7 @@ class TestUpdateTask:
         runner = _runner(tmp_path)
         _seed_run(runner, tmp_path)
         with pytest.raises(ValueError, match="description too long"):
-            await runner.update_task(
-                "plan_1", 1, {"title": "new", "description": "d" * 5001}
-            )
+            await runner.update_task("plan_1", 1, {"title": "new", "description": "d" * 5001})
         assert runner._runs["plan_1"].tasks[0].title == "One"
 
     @pytest.mark.asyncio
@@ -501,9 +493,11 @@ class TestExecutePlan:
             ],
         )
         run.error = "boom"
-        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()), patch.object(
-            TaskRunner, "_watchdog_loop", AsyncMock()
-        ), patch.object(tr.git_coord, "init_workspace", AsyncMock()):
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
             task_id = await runner.execute_plan("plan_1")
             await runner._tasks[task_id]
         assert run.tasks[0].status == TaskStatus.PASSED
@@ -520,9 +514,11 @@ class TestExecutePlan:
             status="paused",
             tasks=[Task(index=1, title="ok", description="d", status=TaskStatus.PASSED)],
         )
-        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()), patch.object(
-            TaskRunner, "_watchdog_loop", AsyncMock()
-        ), patch.object(tr.git_coord, "init_workspace", AsyncMock()):
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
             task_id = await runner.execute_plan("plan_1", fresh=True)
             await runner._tasks[task_id]
         assert run.tasks[0].attempts == 0
@@ -535,9 +531,11 @@ class TestExecutePlan:
         runner = _runner(tmp_path)
         run = _seed_run(runner, tmp_path, status="paused")
         original = run.work_dir
-        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()), patch.object(
-            TaskRunner, "_watchdog_loop", AsyncMock()
-        ), patch.object(tr.git_coord, "init_workspace", AsyncMock()):
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
             task_id = await runner.execute_plan("plan_1", workspace_dir=str(override))
             await runner._tasks[task_id]
         assert run.work_dir == original
@@ -551,10 +549,11 @@ class TestExecutePlan:
         run.branch_name = "feat/x"
         scope = _auto_approve_scope("plan_trust")
         finalize = AsyncMock()
-        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()) as exec_tasks, patch.object(
-            TaskRunner, "_watchdog_loop", AsyncMock()
-        ), patch.object(tr.git_coord, "init_workspace", AsyncMock()) as init_ws, patch.object(
-            tr.git_coord, "finalize", finalize
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()) as exec_tasks,
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()) as init_ws,
+            patch.object(tr.git_coord, "finalize", finalize),
         ):
             task_id = await runner.execute_plan("plan_trust", auto_approve=True)
             assert safety_override().is_scope_active(scope) is True
@@ -573,10 +572,12 @@ class TestExecutePlan:
     async def test_git_init_failure_does_not_abort_run(self, tmp_path: Path) -> None:
         runner = _runner(tmp_path)
         run = _seed_run(runner, tmp_path)
-        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()), patch.object(
-            TaskRunner, "_watchdog_loop", AsyncMock()
-        ), patch.object(
-            tr.git_coord, "init_workspace", AsyncMock(side_effect=RuntimeError("no git"))
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(
+                tr.git_coord, "init_workspace", AsyncMock(side_effect=RuntimeError("no git"))
+            ),
         ):
             task_id = await runner.execute_plan("plan_1")
             await runner._tasks[task_id]
@@ -587,10 +588,12 @@ class TestExecutePlan:
         notify = AsyncMock()
         runner = _runner(tmp_path, on_notify=notify)
         run = _seed_run(runner, tmp_path)
-        with patch.object(
-            TaskRunner, "_execute_tasks", AsyncMock(side_effect=RuntimeError("kaboom"))
-        ), patch.object(TaskRunner, "_watchdog_loop", AsyncMock()), patch.object(
-            tr.git_coord, "init_workspace", AsyncMock()
+        with (
+            patch.object(
+                TaskRunner, "_execute_tasks", AsyncMock(side_effect=RuntimeError("kaboom"))
+            ),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
         ):
             task_id = await runner.execute_plan("plan_1")
             await runner._tasks[task_id]
@@ -609,10 +612,12 @@ class TestExecutePlan:
                 Task(index=2, title="b", description="d"),
             ],
         )
-        with patch.object(
-            TaskRunner, "_execute_tasks", AsyncMock(side_effect=asyncio.CancelledError())
-        ), patch.object(TaskRunner, "_watchdog_loop", AsyncMock()), patch.object(
-            tr.git_coord, "init_workspace", AsyncMock()
+        with (
+            patch.object(
+                TaskRunner, "_execute_tasks", AsyncMock(side_effect=asyncio.CancelledError())
+            ),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
         ):
             task_id = await runner.execute_plan("plan_1")
             await runner._tasks[task_id]
@@ -824,6 +829,56 @@ class TestRetryFromTask:
             await runner.retry_from_task("plan_1", 1)
 
     @pytest.mark.asyncio
+    async def test_refuses_while_previous_run_is_still_finishing(self, tmp_path: Path) -> None:
+        """The status flips terminal BEFORE the prior run's finally-block
+        finishes -- git finalize (which removes the worktree) runs after the
+        terminal status is persisted. A retry accepted in that window
+        validates a workspace the prior finalizer is about to delete. The
+        background task handle is the honest signal: refuse while it is
+        still running."""
+        import asyncio as _asyncio
+
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status="failed")
+
+        release = _asyncio.Event()
+
+        async def _still_finalizing() -> None:
+            await release.wait()
+
+        runner._tasks["plan_1"] = _asyncio.create_task(_still_finalizing())
+        try:
+            with pytest.raises(ValueError, match="still finishing"):
+                await runner.retry_from_task("plan_1", 1)
+        finally:
+            release.set()
+            await runner._tasks["plan_1"]
+
+    @pytest.mark.asyncio
+    async def test_name_addressed_retry_hits_finishing_guard(self, tmp_path: Path) -> None:
+        """_resolve_task accepts a run NAME, but self._tasks is keyed by the
+        canonical id. A name-addressed retry must canonicalize before the
+        finishing-guard lookup, or it misses the prior background-task handle
+        and races the prior run's finalizer."""
+        import asyncio as _asyncio
+
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status="failed")
+
+        release = _asyncio.Event()
+
+        async def _still_finalizing() -> None:
+            await release.wait()
+
+        runner._tasks["plan_1"] = _asyncio.create_task(_still_finalizing())
+        try:
+            with pytest.raises(ValueError, match="still finishing"):
+                await runner.retry_from_task("demo", 1)  # by NAME, not id
+        finally:
+            release.set()
+            await runner._tasks["plan_1"]
+
+    @pytest.mark.asyncio
     async def test_resets_from_index_and_completes(self, tmp_path: Path) -> None:
         notify = AsyncMock()
         runner = _runner(tmp_path, on_notify=notify)
@@ -844,8 +899,9 @@ class TestRetryFromTask:
             ],
         )
         run.finished_at = 123.0
-        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()) as exec_tasks, patch.object(
-            TaskRunner, "_watchdog_loop", AsyncMock()
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()) as exec_tasks,
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
         ):
             task_id = await runner.retry_from_task("plan_1", 2)
             await runner._tasks[task_id]
@@ -858,26 +914,83 @@ class TestRetryFromTask:
 
     @pytest.mark.asyncio
     async def test_reinits_git_when_work_dir_is_missing(self, tmp_path: Path) -> None:
+        """A genuinely missing work_dir (not just an orphaned worktree) is
+        detected by the same workspace_is_valid() check -- _is_git_repo()
+        against a nonexistent directory is False too -- and recovery is
+        attempted via reinit_workspace_for_retry(), not init_workspace()
+        directly (see #3792: a second init_workspace() call would check the
+        DEAD worktree path rather than the original repo)."""
         runner = _runner(tmp_path)
         run = _seed_run(runner, tmp_path, status="failed")
         run.branch_name = "feat/x"
         run.work_dir = str(tmp_path / "gone")
-        init_ws = AsyncMock(side_effect=RuntimeError("git absent"))
-        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()), patch.object(
-            TaskRunner, "_watchdog_loop", AsyncMock()
-        ), patch.object(tr.git_coord, "init_workspace", init_ws):
+        reinit = AsyncMock(return_value=True)
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "workspace_is_valid", AsyncMock(return_value=False)),
+            patch.object(tr.git_coord, "reinit_workspace_for_retry", reinit),
+        ):
             task_id = await runner.retry_from_task("plan_1", 1)
             await runner._tasks[task_id]
-        init_ws.assert_awaited_once()
-        assert run.status == "completed"  # git failure is non-fatal
+        reinit.assert_awaited_once_with(run)
+        assert run.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_retry_fails_the_run_when_the_workspace_cannot_be_restored(
+        self, tmp_path: Path
+    ) -> None:
+        """#3792: the original bug -- a retry whose worktree was deregistered
+        (directory present, no longer a registered git repo) must not
+        silently dispatch the remaining steps against it. If recovery fails,
+        the run is failed terminally instead of continuing."""
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="failed")
+        run.branch_name = "feat/x"
+        run.work_dir = str(tmp_path / "orphaned-worktree")
+        execute_tasks = AsyncMock()
+        with (
+            patch.object(TaskRunner, "_execute_tasks", execute_tasks),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "workspace_is_valid", AsyncMock(return_value=False)),
+            patch.object(tr.git_coord, "reinit_workspace_for_retry", AsyncMock(return_value=False)),
+        ):
+            task_id = await runner.retry_from_task("plan_1", 1)
+            await runner._tasks[task_id]
+        execute_tasks.assert_not_awaited()
+        assert run.status == "failed"
+        assert "workspace" in run.error.lower()
+        assert run.tasks[0].status != tr.TaskStatus.PASSED
+
+    @pytest.mark.asyncio
+    async def test_retry_skips_reinit_when_the_workspace_is_already_valid(
+        self, tmp_path: Path
+    ) -> None:
+        """The common case -- worktree still valid -- must not pay the
+        reinit cost or touch the workspace at all."""
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="failed")
+        run.branch_name = "feat/x"
+        reinit = AsyncMock()
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "workspace_is_valid", AsyncMock(return_value=True)),
+            patch.object(tr.git_coord, "reinit_workspace_for_retry", reinit),
+        ):
+            task_id = await runner.retry_from_task("plan_1", 1)
+            await runner._tasks[task_id]
+        reinit.assert_not_awaited()
+        assert run.status == "completed"
 
     @pytest.mark.asyncio
     async def test_failure_marks_run_failed(self, tmp_path: Path) -> None:
         runner = _runner(tmp_path)
         run = _seed_run(runner, tmp_path, status="failed")
-        with patch.object(
-            TaskRunner, "_execute_tasks", AsyncMock(side_effect=RuntimeError("nope"))
-        ), patch.object(TaskRunner, "_watchdog_loop", AsyncMock()):
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock(side_effect=RuntimeError("nope"))),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+        ):
             task_id = await runner.retry_from_task("plan_1", 1)
             await runner._tasks[task_id]
         assert run.status == "failed"
@@ -898,9 +1011,10 @@ class TestRetryFromTask:
             run.tasks[0].status = TaskStatus.IN_PROGRESS
             raise asyncio.CancelledError()
 
-        with patch.object(
-            TaskRunner, "_execute_tasks", AsyncMock(side_effect=_pause_then_cancel)
-        ), patch.object(TaskRunner, "_watchdog_loop", AsyncMock()):
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock(side_effect=_pause_then_cancel)),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+        ):
             task_id = await runner.retry_from_task("plan_1", 1)
             await runner._tasks[task_id]
         assert run.status == "paused"
@@ -946,9 +1060,7 @@ class TestStartBackground:
         cron = _seed_run(runner, tmp_path, task_id="cron_done", name="c", status="completed")
         cron.source = "cron"
         for i in range(12):
-            _seed_run(
-                runner, tmp_path, task_id=f"old{i:02d}", name=f"o{i}", status="completed"
-            )
+            _seed_run(runner, tmp_path, task_id=f"old{i:02d}", name=f"o{i}", status="completed")
         with patch.object(TaskRunner, "run", AsyncMock()):
             task_id = await runner.start_background(str(spec))
             await runner._tasks[task_id]
@@ -1040,9 +1152,7 @@ class TestCallLlmForLesson:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         runner = _runner(tmp_path)
-        monkeypatch.setattr(
-            tr, "stream_and_collect_json", AsyncMock(return_value={"rule": "R"})
-        )
+        monkeypatch.setattr(tr, "stream_and_collect_json", AsyncMock(return_value={"rule": "R"}))
         assert await runner._call_llm_for_lesson("p") == {"rule": "R"}
         runner._sessions.release.assert_called_once()
         runner._sessions.recycle_background.assert_awaited_once()
@@ -1250,17 +1360,13 @@ class TestLoadRuns:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         (tmp_path / "runs.json").write_text("{not json", encoding="utf-8")
-        monkeypatch.setattr(
-            Path, "replace", MagicMock(side_effect=OSError("cannot rename"))
-        )
+        monkeypatch.setattr(Path, "replace", MagicMock(side_effect=OSError("cannot rename")))
         runner = _runner(tmp_path)
         assert runner._runs == {}
         assert (tmp_path / "runs.json").exists()
 
     def test_running_run_recovers_as_resumable_without_trust(self, tmp_path: Path) -> None:
-        (tmp_path / "runs.json").write_text(
-            json.dumps([_registry_item()]), encoding="utf-8"
-        )
+        (tmp_path / "runs.json").write_text(json.dumps([_registry_item()]), encoding="utf-8")
         runner = _runner(tmp_path)
         run = runner._runs["r1"]
         assert run.status == "paused"


### PR DESCRIPTION
## Problem / Motivation

A Task Runner run's git worktree was correctly created and registered at task start. Later, a retry fired (`🔄 Retrying — From task 1`). Immediately after that retry, the worktree directory still existed on disk but was no longer a registered git worktree (`git worktree list` no longer showed it; `git status` inside it reported "not a git repository") — yet the run continued dispatching its step DAG, marking steps completed (✅) against this now-empty/non-git directory, with status staying `Running` the whole time.

## Why it matters

Any retry on a Task Runner run can silently convert it into a no-op that still reports progress. Because the run keeps marking steps ✅, neither the UI nor the notification feed signals the failure, so wall-clock and model budget are spent producing nothing — and it undermines retry as a recovery mechanism precisely when a run is already unhealthy enough to need it.

## What changed (motivation → approach → change)

Root cause, traced directly: `retry_from_task`'s workspace-recovery guard (`taskrunner.py`) only checked `Path(run.work_dir).exists()`. `git worktree remove` deregisters and deletes in separate steps — an interrupted `finalize()` (called from every run-ending `finally` block whenever `run.branch_name` is set, regardless of whether the run ended completed/failed/paused/cancelled) can leave the directory present on disk while already deregistered from git. The existence check is `True`, the guard is skipped, and the retry falls straight through to dispatching the rest of the step DAG against a non-git directory.

A second, deeper problem: simply calling `init_workspace()` again to recover doesn't work. Its first successful call already overwrote `run.work_dir` with the worktree path — so a second call checks git-repo-ness of that now-dead worktree path instead of the *original* repo, and silently sets `git_enabled = False` rather than recovering anything.

Fix: `git_coord` gains two functions —
- `workspace_is_valid(run)`: an actual git-repo validity check (`git rev-parse --is-inside-work-tree` under the hood via the existing `_is_git_repo`), not just directory existence. A run that never had a worktree (non-git-folder mode) is trivially valid.
- `reinit_workspace_for_retry(run)`: recovers using `run.repo_root` — set once by the original `init_workspace()` and never overwritten — and reuses the run's *existing* branch, since `finalize()` only ever removes the worktree, never the branch (creating a fresh branch of the same name would fail with "already exists"). Best-effort deregisters/prunes the stale worktree entry, and removes the leftover directory (`git worktree add` refuses a path that still exists) before re-adding at the same path.

`retry_from_task` now calls `workspace_is_valid()` instead of the bare existence check, and if `reinit_workspace_for_retry()` fails to recover the workspace, the run now fails terminally with a clear error and notification instead of continuing against a broken one.

Data-loss note: recovery removes the orphaned worktree directory before re-adding, which discards any *uncommitted* scratch state from the in-flight step at the time things broke. This is an acceptable tradeoff — every completed step's work is already committed to the reused branch (nothing committed is lost), and the task(s) being retried are reset to `PENDING` and re-run from scratch anyway.

Deliberately out of scope: the issue's second ask — "a step whose execution could not touch a valid workspace should not be reported as completed" — is a broader, defense-in-depth guard against workspace loss from causes *other* than retry (e.g. external deletion mid-run). This PR closes the specific reported trigger (retry resuming against an already-lost workspace), not a general per-step validity check across the whole dispatch loop.

## Tests

- `test/test_taskrunner.py::TestGitCoord` (real git, 4 new tests): `workspace_is_valid` true for a live worktree and for a run with no worktree at all; `reinit_recovers_an_orphaned_worktree` reproduces the reported state precisely (worktree directory intact, its `.git/worktrees/` admin entry removed out from under it) and confirms recovery reuses the original branch; reinit fails closed when the original repo is also gone.
- `test/test_taskrunner_coverage.py::TestRetryFromTask` (mocked, 2 new + 1 updated): `test_retry_fails_the_run_when_the_workspace_cannot_be_restored` — the actual reported bug's expected fix: steps never dispatched, run failed, no step marked passed; `test_retry_skips_reinit_when_the_workspace_is_already_valid`; updated `test_reinits_git_when_work_dir_is_missing` (this test previously asserted "git failure is non-fatal" — i.e. the run completes anyway, pinning the exact bug fixed here) to assert against the new `reinit_workspace_for_retry()` call and its success path.
- Verified all 4 new `TestGitCoord` tests and the 2 new `TestRetryFromTask` tests fail against the pre-fix code (missing functions / old exists()-only guard) and pass after.
- Every test file that touches `git_coord`: `test_taskrunner.py`, `test_taskrunner_coverage.py`, `test_taskrunner_v2_scenarios.py`, `test_plan_mode.py`, `test_scenarios_v2.py`, `test_scenarios_v2_logic.py`, `test_spawn_audit.py`, `test_spawn_exec_shim.py` — 510 passed.
- `isort`, `flake8`, `mypy`, the black gate and the subprocess-encoding gate all clean on the changed files.
- Rebased onto current `main`. One conflict, in `git_coord.py`'s import block only: `main` had expanded the `kiro_crew.sandbox` import to add `sandboxed_spawn_argv_async`, while this branch adds `platform_compat`. Resolved as a union of both. `main`'s async-spawn refactor is preserved — `_is_git_repo()` and `_git()` both still `await sandboxed_spawn_argv_async(...)` — and no logic on either side was dropped.
- Every new assertion is mutation-verified: reverting the corresponding fix fails that test, and only that test.

## Manual verification

N/A — unit coverage sufficient; verified end-to-end against a real git repo in the new `TestGitCoord` tests (create repo → init worktree → simulate the exact orphaned-registration state → confirm detection and recovery), which is as close to the reported production scenario as this environment allows.

## Review-round fixes folded in

Beyond the originally-reported retry defect, this branch also carries:

- **Worktree identity, not just repo-ness.** `workspace_is_valid()` requires
  `rev-parse --show-toplevel` to resolve to the run's own worktree, because
  `git rev-parse` walks UP — a deregistered worktree directory sitting inside
  any enclosing repository would otherwise report "inside a work tree" and the
  run would commit into somebody else's checkout. It then requires
  `rev-parse --git-common-dir` to be the one `run.repo_root` uses, since equal
  paths are not identity: a different repository created at that same path
  satisfies the first check. Paths are compared resolved and `normcase`d, and
  that comparison runs off the event loop via `asyncio.to_thread` because
  `Path.resolve()` walks the filesystem.
- **Blocking I/O off the gateway loop.** The stale-directory delete is
  `await asyncio.to_thread(platform_compat.rmtree_force, ...)` — `rmtree_force`
  rather than `shutil.rmtree(..., ignore_errors=True)` because the tree is a git
  checkout whose loose objects git writes read-only, which on Windows refuse to
  unlink and would leave the directory in place for the following
  `worktree add` to trip over. Awaited, not dispatched: the delete is what frees
  the path the re-add targets, and a test pins that ordering.
- **Cross-platform probe failure.** `_is_git_repo()` also treats
  `NotADirectoryError` as "no repo here" — Windows raises it (WinError 267) out
  of `CreateProcess` for a missing cwd where POSIX raises `FileNotFoundError`,
  which was the `Backend Tests (Windows) (4)` failure. The guard names exactly
  those two errors and NOT `OSError` at large, so a transient `EMFILE` /
  `ENOMEM` / `EAGAIN` in a valid repo still propagates instead of silently
  disabling worktree isolation.
- **Recovery refuses to delete what it cannot identify.** The identity check
  above correctly rejects a *different* repository standing at the saved
  worktree path — but recovery then went on to `rmtree_force` that path, which
  would have been silent, unrecoverable data loss for whatever that repository
  was. The delete is now gated behind `_leftover_dir_is_ours()`, which
  positively identifies the leftover as this run's own orphaned checkout via
  the same `--git-common-dir` comparison; anything it cannot identify makes
  recovery log a warning and fail the run instead of guessing.
- **Same repo is still not the same worktree.** A linked worktree of this very
  repo, checked out on some OTHER branch at the saved path, satisfied every
  path- and repo-level check, so retried steps would have committed onto the
  wrong branch while reporting success. `workspace_is_valid()` now also
  requires `git branch --show-current` to equal `run.branch_name`.

`execute_plan` restarts paused/cancelled/failed runs and can re-enter the same
lost-worktree state through a different trigger. Reaching it means changing
restart's failure semantics at a second entry point, which deserves its own
review rather than riding along on a fix for #3792 — tracked as #6676.

## Related Issues

Fixes #3792

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no user-facing doc change; no CHANGELOG line, per `AGENTS.md` (per-PR changelog entries are not used)





## Pattern harvest

Rule candidate: any filesystem probe on a path derived from content inside a task/agent-writable tree (e.g. a `.git` pointer file) must first reject UNC/device spellings on the raw string and prove lexical containment under a repo-owned directory -- on Windows, `exists()` on a UNC path performs outbound SMB authentication.
