### PR TITLE
fix(cron): give cron message its own 50k cap instead of shared 5k (#1682)

### DIFF
--- a/docs/architecture/security-deep-dive.md
+++ b/docs/architecture/security-deep-dive.md
@@ -249,7 +249,10 @@ before the handler sees it: NFC unicode normalization with hidden-character
 stripping (control, format, private-use and surrogate code points, preserving
 `\n`/`\r`/`\t`), enum allow-lists, regex patterns for identifiers, range checks,
 unknown-field rejection, tiered length caps (`MAX_TOOL_NAME_LEN` 256,
-`MAX_SHORT_STRING` 500, `MAX_MEDIUM_STRING` 5 000, `MAX_LONG_STRING` 50 000), and
+`MAX_SHORT_STRING` 500, `MAX_MEDIUM_STRING` 5 000, `MAX_LONG_STRING` 50 000, and
+the field-specific `MAX_CRON_MESSAGE` 50 000 for the cron `message` — a task
+prompt, enforced on the MCP schemas, both REST cron endpoints, and the
+`CronService` persistence chokepoint), and
 response truncation at `MAX_RESPONSE_LEN` (100 000 chars) so unbounded tool output
 cannot be a DoS vector.
 

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -76,6 +76,7 @@ Scheduled job execution with three schedule types: `every` (interval, min 60s), 
 - Handler intercepts cron commands before ACP (no LLM round-trip needed)
 - CLI: `kirocrew cron {list|add|update|remove|pause|resume|trigger}`. `add` and `update` accept `--every`, `--cron`, `--channel`, `--agent`, `--approval-mode`. CLI flags mirror the corresponding `cron_add`/`cron_update` MCP tool parameters.
 - Update: `CronService.update_job(job_id, **kwargs)` for partial updates (name, message, schedule, agent, channel, approval_mode, silent) with file locking and cron expression validation
+- Message cap: the cron `message` has its own `MAX_CRON_MESSAGE` (50 000) cap — a cron message is a task prompt, so it does not borrow the shared `MAX_MEDIUM_STRING` (5 000). Enforced on the MCP `cron_add`/`cron_update` schemas, `POST /api/crons` and `PATCH /api/crons/{id}` (PATCH routes `message` through `validate_string_field`, 400 `code: "invalid_message"` on non-string/oversize — it was previously unvalidated on that surface), and at the `CronService` persistence chokepoint (`_build_job`/`_update_job_locked` raise `ValueError`), so the CLI and apps-SDK paths cannot admit a value the validated surfaces would reject
 - Async stop: `stop()` is now async, cancels and awaits `_running_tasks` before returning
 
 ### Per-Job Timezone

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -52,6 +52,7 @@ from kiro_crew.constants import env_flag_enabled
 from kiro_crew.cron_history import CronHistoryStore, CronRunRecord
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.resource_status import admission_check
+from kiro_crew.validation import MAX_CRON_MESSAGE
 
 logger = logging.getLogger(__name__)
 
@@ -1366,6 +1367,18 @@ class CronService:
         valid_approval_modes = ("", "auto")
         if approval_mode not in valid_approval_modes:
             raise ValueError(f"Invalid approval_mode: {approval_mode!r}")
+        # Message cap enforced HERE, at the persistence owner, for the same
+        # reason as timezone/skip_dates below: every create path (MCP, apps
+        # SDK, dashboard, CLI) shares one check, so no surface can admit a
+        # message the others would reject. Uses the cron-specific cap, not
+        # MAX_MEDIUM_STRING — a cron message is a task prompt (see
+        # validation.MAX_CRON_MESSAGE). Type-checked first: len() succeeds on
+        # a list, and a non-str message would be persisted into crons.json and
+        # only blow up at fire time inside _build_prompt.
+        if not isinstance(message, str):
+            raise ValueError("message must be a string")
+        if len(message) > MAX_CRON_MESSAGE:
+            raise ValueError(f"message exceeds max length {MAX_CRON_MESSAGE}")
         if timeout_secs and not 1 <= int(timeout_secs) <= 86400:
             raise ValueError(f"timeout_secs must be within 1..86400, got {timeout_secs}")
         if timeout_secs and (command or script):
@@ -1578,6 +1591,15 @@ class CronService:
                     if kwargs["approval_mode"] not in valid_approval_modes:
                         raise ValueError(f"Invalid approval_mode: {kwargs['approval_mode']!r}")
                 # Validate before any mutations
+                if "message" in kwargs and kwargs["message"]:
+                    # Same chokepoint rationale as _build_job: every update
+                    # surface (MCP, dashboard PATCH, CLI) funnels here. Type
+                    # first — len() succeeds on a list, which would then be
+                    # persisted and only raise at fire time in _build_prompt.
+                    if not isinstance(kwargs["message"], str):
+                        raise ValueError("message must be a string")
+                    if len(kwargs["message"]) > MAX_CRON_MESSAGE:
+                        raise ValueError(f"message exceeds max length {MAX_CRON_MESSAGE}")
                 if (
                     "cron_expr" in kwargs
                     and kwargs["cron_expr"]

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -29,7 +29,7 @@ from kiro_crew.validation import (
     CHANNEL_ID_RE,
     CHANNEL_MAX_LEN,
     LEARN_ADD_SCHEMA,
-    MAX_MEDIUM_STRING,
+    MAX_CRON_MESSAGE,
     MAX_SHORT_STRING,
     SLACK_THREAD_TS_RE,
     ValidationError,
@@ -194,7 +194,7 @@ async def api_crons_create(request: web.Request) -> web.Response:
     # CRON_ADD_SCHEMA so the REST + tool paths validate identically.
     try:
         name = validate_string_field(body, "name", required=True, max_len=MAX_SHORT_STRING)
-        message = validate_string_field(body, "message", max_len=MAX_MEDIUM_STRING)
+        message = validate_string_field(body, "message", max_len=MAX_CRON_MESSAGE)
         schedule = validate_string_field(body, "schedule", max_len=100)
         cron_expr = validate_string_field(body, "cron", max_len=100) or None
         channel = validate_string_field(body, "channel", max_len=CHANNEL_MAX_LEN) or None
@@ -405,6 +405,19 @@ async def api_cron_update(request: web.Request) -> web.Response:
     ):
         if key in body:
             kwargs[key] = body[key]
+    # message routes through the same validator as POST (type check +
+    # sanitize_string + length cap) so the two REST surfaces cannot diverge:
+    # PATCH previously passed it through entirely unvalidated. Sanitizing here
+    # also keeps length measured post-normalization, matching create.
+    if "message" in kwargs:
+        try:
+            kwargs["message"] = validate_string_field(
+                body, "message", max_len=MAX_CRON_MESSAGE
+            )
+        except ValidationError as exc:
+            return web.json_response(
+                {"error": str(exc), "code": "invalid_message"}, status=400
+            )
     # folder_id must be a string (or null → ""): a non-string JSON value
     # would be persisted verbatim into the schema and corrupt reads.
     if "folder_id" in kwargs:

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -40,6 +40,14 @@ MAX_TOOL_NAME_LEN = 256
 MAX_SHORT_STRING = 500  # names, IDs, categories
 MAX_MEDIUM_STRING = 5_000  # messages, rules
 MAX_LONG_STRING = 50_000  # task specs, inline content
+# A cron job's message IS a task prompt (real dispatched task specs routinely
+# exceed 5k chars), so it gets its own cap at task-spec scale instead of
+# borrowing MAX_MEDIUM_STRING — raising that shared constant would widen ~20
+# unrelated fields. Enforced at every create/update surface (MCP schemas,
+# dashboard REST) AND at the CronService persistence chokepoint
+# (_build_job/update_job), so the CLI and apps SDK cannot admit a larger value
+# than the validated surfaces.
+MAX_CRON_MESSAGE = 50_000
 MAX_RESPONSE_LEN = 100_000  # truncate tool responses
 
 # Allowed categories for lessons
@@ -2080,7 +2088,7 @@ CRON_ADD_SCHEMA = ToolSchema(
     tool_name="cron_add",
     fields=[
         FieldSpec("name", str, required=True, max_len=MAX_SHORT_STRING),
-        FieldSpec("message", str, max_len=MAX_MEDIUM_STRING),
+        FieldSpec("message", str, max_len=MAX_CRON_MESSAGE),
         FieldSpec("every", int, min_val=60, max_val=86400 * 30),
         FieldSpec("cron_expr", str, max_len=100),
         FieldSpec("at", (int, float), min_val=0, max_val=4102444800),  # up to 2100
@@ -2460,7 +2468,7 @@ MCP_CRON_SCHEMAS: dict[str, ToolSchema] = {
         fields=[
             FieldSpec("job_id", str, required=True, max_len=16, pattern=_JOB_ID_RE),
             FieldSpec("name", str, max_len=MAX_SHORT_STRING),
-            FieldSpec("message", str, max_len=MAX_MEDIUM_STRING),
+            FieldSpec("message", str, max_len=MAX_CRON_MESSAGE),
             FieldSpec("cron_expr", str, max_len=100),
             FieldSpec("every", int, min_val=60, max_val=86400 * 30),
             FieldSpec("agent", str, max_len=MAX_SHORT_STRING, pattern=_AGENT_NAME_RE),

--- a/test/test_cron_message_cap.py
+++ b/test/test_cron_message_cap.py
@@ -1,0 +1,225 @@
+"""Tests for the cron-message character cap (issue #1682).
+
+A cron job's message is a task prompt, so it gets its own generous cap
+(``MAX_CRON_MESSAGE``) instead of borrowing the shared ``MAX_MEDIUM_STRING``
+(5000). Locks in:
+
+- messages longer than the old 5000-char limit are accepted on EVERY surface
+  (MCP schemas, dashboard POST/PATCH, CronService chokepoint) and round-trip
+  through create + disk reload intact;
+- the new cap is still enforced (oversize is rejected, not unbounded);
+- other fields sharing ``MAX_MEDIUM_STRING`` still reject at their old limit
+  (the shared constant was NOT raised).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.cron import CronService
+from kiro_crew.dashboard.handlers import api_cron_update, api_crons_create
+from kiro_crew.validation import (
+    CRON_ADD_SCHEMA,
+    MAX_CRON_MESSAGE,
+    MAX_MEDIUM_STRING,
+    MCP_CRON_SCHEMAS,
+    SPAWN_STEER_SCHEMA,
+    ValidationError,
+    validate_tool_args,
+)
+
+# Longer than the old shared cap, comfortably under the new cron cap.
+# No edge whitespace: validate_string_field/sanitize_string strip edges.
+LONG_MSG = ("task prompt " * 500).strip()  # 5999 chars
+assert MAX_MEDIUM_STRING < len(LONG_MSG) <= MAX_CRON_MESSAGE
+
+OVERSIZE_MSG = "x" * (MAX_CRON_MESSAGE + 1)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cron_store(monkeypatch, tmp_path):
+    monkeypatch.setattr("kiro_crew.cron._DEFAULT_DIR", tmp_path)
+    yield
+
+
+def test_cap_is_actually_more_generous():
+    assert MAX_CRON_MESSAGE > MAX_MEDIUM_STRING
+
+
+# ── MCP schema surface ──
+
+
+class TestMcpSchemas:
+    def test_cron_add_accepts_message_beyond_old_cap(self):
+        cleaned = validate_tool_args(
+            {"name": "big", "message": LONG_MSG, "every": 3600}, CRON_ADD_SCHEMA
+        )
+        assert cleaned["message"] == LONG_MSG
+
+    def test_cron_add_rejects_message_beyond_new_cap(self):
+        with pytest.raises(ValidationError):
+            validate_tool_args(
+                {"name": "big", "message": OVERSIZE_MSG, "every": 3600}, CRON_ADD_SCHEMA
+            )
+
+    def test_cron_update_accepts_message_beyond_old_cap(self):
+        cleaned = validate_tool_args(
+            {"job_id": "abc123", "message": LONG_MSG}, MCP_CRON_SCHEMAS["cron_update"]
+        )
+        assert cleaned["message"] == LONG_MSG
+
+    def test_cron_update_rejects_message_beyond_new_cap(self):
+        with pytest.raises(ValidationError):
+            validate_tool_args(
+                {"job_id": "abc123", "message": OVERSIZE_MSG},
+                MCP_CRON_SCHEMAS["cron_update"],
+            )
+
+    def test_other_medium_string_fields_still_reject_at_old_limit(self):
+        """Control: the shared MAX_MEDIUM_STRING cap was not raised globally."""
+        with pytest.raises(ValidationError):
+            validate_tool_args(
+                {"agent_id": "a1", "message": "y" * (MAX_MEDIUM_STRING + 1)},
+                SPAWN_STEER_SCHEMA,
+            )
+
+
+# ── CronService chokepoint (the path the CLI and apps SDK use) ──
+
+
+class TestServiceChokepoint:
+    def test_add_job_roundtrips_long_message(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="big", message=LONG_MSG, every_secs=3600)
+        assert job.message == LONG_MSG
+        # Round-trip: a fresh service instance reloads it from disk intact.
+        reloaded = CronService(base_dir=tmp_path)
+        jobs = reloaded.list_jobs()
+        assert len(jobs) == 1
+        assert jobs[0].message == LONG_MSG
+
+    def test_add_job_rejects_oversize_message(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        with pytest.raises(ValueError, match="max length"):
+            svc.add_job(name="big", message=OVERSIZE_MSG, every_secs=3600)
+        assert svc.list_jobs() == []
+
+    def test_add_job_accepts_message_at_exact_cap(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="edge", message="x" * MAX_CRON_MESSAGE, every_secs=3600)
+        assert len(job.message) == MAX_CRON_MESSAGE
+
+    def test_add_job_rejects_non_string_message(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        with pytest.raises(ValueError, match="must be a string"):
+            svc.add_job(name="bad", message=["not", "a", "str"], every_secs=3600)  # type: ignore[arg-type]
+        assert svc.list_jobs() == []
+
+    def test_update_job_rejects_non_string_message(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="j", message="short", every_secs=3600)
+        with pytest.raises(ValueError, match="must be a string"):
+            svc.update_job(job.id, message=["not", "a", "str"])
+        assert svc.list_jobs()[0].message == "short"
+
+    def test_update_job_accepts_long_message(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="j", message="short", every_secs=3600)
+        updated = svc.update_job(job.id, message=LONG_MSG)
+        assert updated is not None
+        assert updated.message == LONG_MSG
+
+    def test_update_job_rejects_oversize_and_leaves_job_unchanged(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="j", message="short", every_secs=3600)
+        with pytest.raises(ValueError, match="max length"):
+            svc.update_job(job.id, message=OVERSIZE_MSG)
+        assert svc.list_jobs()[0].message == "short"
+
+
+# ── Dashboard REST surface ──
+
+
+def _create_request(body: dict, crons: CronService) -> MagicMock:
+    state = MagicMock()
+    state.crons = crons
+    request = MagicMock()
+    request.app = {"state": state}
+    request.json = AsyncMock(return_value=body)
+    return request
+
+
+def _update_request(body: dict, crons: CronService, job_id: str) -> MagicMock:
+    request = _create_request(body, crons)
+    request.match_info = {"job_id": job_id}
+    return request
+
+
+class TestDashboardCreate:
+    @pytest.mark.asyncio
+    async def test_post_accepts_message_beyond_old_cap(self, tmp_path):
+        crons = CronService(base_dir=tmp_path)
+        resp = await api_crons_create(
+            _create_request({"name": "big", "message": LONG_MSG, "every": 3600}, crons)
+        )
+        assert resp.status == 200
+        assert crons.list_jobs()[0].message == LONG_MSG
+
+    @pytest.mark.asyncio
+    async def test_post_rejects_message_beyond_new_cap(self, tmp_path):
+        crons = CronService(base_dir=tmp_path)
+        resp = await api_crons_create(
+            _create_request({"name": "big", "message": OVERSIZE_MSG, "every": 3600}, crons)
+        )
+        assert resp.status == 400
+        assert crons.list_jobs() == []
+
+
+class TestDashboardUpdate:
+    @pytest.mark.asyncio
+    async def test_patch_accepts_message_beyond_old_cap(self, tmp_path):
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="j", message="short", every_secs=3600)
+        resp = await api_cron_update(_update_request({"message": LONG_MSG}, crons, job.id))
+        assert resp.status == 200
+        assert crons.list_jobs()[0].message == LONG_MSG
+
+    @pytest.mark.asyncio
+    async def test_patch_rejects_message_beyond_new_cap(self, tmp_path):
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="j", message="short", every_secs=3600)
+        resp = await api_cron_update(_update_request({"message": OVERSIZE_MSG}, crons, job.id))
+        assert resp.status == 400
+        assert crons.list_jobs()[0].message == "short"
+
+    @pytest.mark.asyncio
+    async def test_patch_rejects_non_string_message(self, tmp_path):
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="j", message="short", every_secs=3600)
+        resp = await api_cron_update(_update_request({"message": [1, 2]}, crons, job.id))
+        assert resp.status == 400
+        assert crons.list_jobs()[0].message == "short"
+
+    @pytest.mark.asyncio
+    async def test_patch_rejects_falsy_non_string_message(self, tmp_path):
+        """A falsy non-string (0) must 400, not silently no-op with a 200."""
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="j", message="short", every_secs=3600)
+        resp = await api_cron_update(_update_request({"message": 0}, crons, job.id))
+        assert resp.status == 400
+        assert b"invalid_message" in resp.body
+        assert crons.list_jobs()[0].message == "short"
+
+    @pytest.mark.asyncio
+    async def test_patch_sanitizes_message_like_post(self, tmp_path):
+        """PATCH routes through the same sanitizer as POST: hidden unicode
+        (zero-width space) is stripped before persistence, matching create."""
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="j", message="short", every_secs=3600)
+        resp = await api_cron_update(
+            _update_request({"message": "new\u200bplan"}, crons, job.id)
+        )
+        assert resp.status == 200
+        assert crons.list_jobs()[0].message == "newplan"


### PR DESCRIPTION
## Problem / Motivation

A cron job's `message` — the task prompt handed to the scheduled agent — was capped at 5,000 characters because it borrowed the shared `MAX_MEDIUM_STRING` validator. Real dispatched task prompts routinely exceed that (this repository's own auto-fix pipeline dispatch specs are 8–12k chars), so long prompts had to be squeezed through workarounds. Separately, the caps were inconsistent per surface: `POST /api/crons` enforced 5,000, the MCP schemas enforced 5,000, the dashboard `PATCH /api/crons/{id}` did not validate `message` at all, and the CLI/apps-SDK paths had no cap.

## Why it matters

Anyone scheduling a substantial agent task hits an arbitrary 5,000-char wall on some surfaces — while a different surface (PATCH) silently accepted anything, including non-strings that would be persisted verbatim into `crons.json` and only blow up at fire time. The limit and its enforcement should be one decision, made once.

## What changed (motivation → approach → change)

The message field needed its own, generous cap — not a raised shared one. `MAX_MEDIUM_STRING` is used by **24 other `FieldSpec`s** in `validation.py` (spawn tasks, steer messages, send_message text, register_hook context, issue-radar fields, ...); raising it globally would be unrelated blast radius. So:

- New `MAX_CRON_MESSAGE = 50_000` in `src/kiro_crew/validation.py` — task-spec scale, matching `MAX_LONG_STRING` semantics, as its own constant so it can evolve independently.
- Applied on **every** surface so the limit cannot differ by entry point:
  - MCP `cron_add` / `cron_update` schemas (was 5,000);
  - `POST /api/crons` (was 5,000);
  - `PATCH /api/crons/{id}` — `message` now routes through the same `validate_string_field` as POST (it was previously **entirely unvalidated** on this surface): type check, unicode sanitization, and length cap, returning 400 `code: "invalid_message"` on violation;
  - `CronService._build_job` / `_update_job_locked` as the **persistence chokepoint** (same pattern as the existing timezone/skip_dates validation there), so the CLI and apps-SDK create/update paths cannot admit a value the validated surfaces would reject. Type-checked before `len()` — a non-str message would otherwise persist and only raise at fire time.
- Specs updated in the same commit: `docs/architecture/security-deep-dive.md` (caps enumeration) and `docs/system-specs/modules/learn-cron-dashboard.md` (cap + new PATCH 400).

**Deliberately out of scope — the timeout half of the issue.** The 1800s `_JOB_TIMEOUT_SECS` default is untouched: a maintainer comment agreed the character-cap argument is fair but treated the default-timeout change as a separate, contested decision, and a per-job `timeout_secs` override (1..86400) already exists on every surface.

**Worst-case store bound (reviewer-raised, acknowledged):** `crons.json` can now hold up to 50 KB per message-carrying job; every mutation rewrites the file under the store lock, so lock-hold time scales with total message bytes (cap × job count). The message is never logged or posted to Slack, and cron ticks reload off-loop (`asyncio.to_thread`), so there is no event-loop or log-flood exposure.

**Known pre-existing gap (unchanged by this PR):** settings-archive import (`portability.py`) and snapshot restore (`snapshot.py`) write `crons.json` directly and bypass field validation — they bypassed the old 5,000 cap identically. Those are trusted operator-restore surfaces; tightening them is a separate concern.

## Tests

`test/test_cron_message_cap.py` (20 tests):

- **MCP schemas**: `cron_add`/`cron_update` accept a message beyond the old 5,000 cap; both reject beyond `MAX_CRON_MESSAGE`; control test that another `MAX_MEDIUM_STRING` field (`spawn_steer.message`) still rejects at 5,000 — proving the shared cap was not raised.
- **Service chokepoint**: `add_job` accepts >5k and **round-trips through create + a fresh-instance disk reload intact**; rejects oversize and non-str (nothing persisted); exact-cap boundary accepted; `update_job` same, with the job left unchanged on rejection.
- **Dashboard REST**: POST accepts >5k / rejects oversize; PATCH accepts >5k, rejects oversize, rejects non-string and **falsy non-string** (`0` → 400, not a silent 200 no-op), and sanitizes hidden unicode identically to POST.

All tests fail on base (the constant does not exist there). Full backend suite: 54,323 passed; 111 failures verified pre-existing/environmental by re-running the same files on unmodified base (sandbox/gh/jq-dependent, zero in cron/validation/dashboard areas).

## Manual verification

N/A — unit coverage exercises all four surfaces end-to-end including disk round-trip; no UI change.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend validation-only change; no frontend files touched and no rendered pixel changes.

## Related Issues

Closes #1682
