### PR TITLE
fix: scope busy-send Steer/Queue mode to the session slot (#3821)

### DIFF
--- a/docs/system-specs/modules/side.md
+++ b/docs/system-specs/modules/side.md
@@ -71,8 +71,10 @@ so the two surfaces cannot drift.
 | `steer` (default) | `POST .../side/turn` with `{"steer": true}` injects the text into the RUNNING turn via the isolated session's `steer()` RPC. |
 | `queue` | The text is held on `SideState.queue` and dispatched as the next turn when the current one ends. |
 
-Which mode Enter takes is ONE user preference (`mc-busy-send-mode` in
-localStorage), shared live between the main composer and the side panel.
+Which mode Enter takes is a PER-SLOT preference (`mc-busy-send-mode:<slot>` in
+localStorage), shared live between one session's main composer and its side
+panel; other sessions keep their own mode. A slot that has never chosen a mode
+inherits the legacy unscoped `mc-busy-send-mode` value.
 
 Fall-through, not rejection: a steer is attempted only when the isolated session
 exists, reports `supports_steer`, and `has_active_turn()` is true. Any of those

--- a/website/src/components/BusySendButton.tsx
+++ b/website/src/components/BusySendButton.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { ArrowUpFromLine, Check, ChevronDown, Target } from 'lucide-react'
 import { useListboxKeyboard } from '../hooks/useListboxKeyboard'
-import { safeSetItem } from '../utils/safeStorage'
+import { safeGetItem, safeSetItem } from '../utils/safeStorage'
 
 import { i18nT } from '../i18n/t'
 
@@ -41,28 +41,62 @@ const BUSY_SEND_MODES: Array<{ mode: BusySendMode; icon: React.ReactNode }> = [
   { mode: 'queue', icon: <ArrowUpFromLine size={15} /> },
 ]
 
-export function readBusySendMode(): BusySendMode {
-  try { return localStorage.getItem(BUSY_SEND_MODE_LS_KEY) === 'queue' ? 'queue' : 'steer' } catch { return 'steer' }
+/** Storage key for one slot's preference. A slot-less consumer gets a scoped
+ *  sentinel key rather than the legacy unscoped one: the legacy key is a READ-ONLY
+ *  migration source (see readBusySendMode), because a live write to it would
+ *  change the inherited default of every slot that never chose a mode — the exact
+ *  cross-session leak this scoping exists to prevent. */
+function busySendModeKey(slotKey?: string | null): string {
+  return `${BUSY_SEND_MODE_LS_KEY}:${slotKey || 'no-slot'}`
 }
 
-/** Live subscribers to the persisted mode. "What does Enter do while busy" is
- *  ONE user preference, so every composer showing this button (main chat and the
- *  side panel) must move together the moment it changes — localStorage alone
- *  only syncs across tabs, never within one. */
-const modeListeners = new Set<(m: BusySendMode) => void>()
+export function readBusySendMode(slotKey?: string | null): BusySendMode {
+  const scoped = safeGetItem(busySendModeKey(slotKey))
+  if (scoped !== null) return scoped === 'queue' ? 'queue' : 'steer'
+  // Migration fallback: before per-slot scoping the preference lived under the
+  // unscoped key. A slot that has never chosen a mode inherits that value, so
+  // an existing "queue" user keeps their default instead of being reset.
+  return safeGetItem(BUSY_SEND_MODE_LS_KEY) === 'queue' ? 'queue' : 'steer'
+}
 
-/** Read + write the shared busy-send preference. Every mounted consumer updates
- *  on a change from any other consumer. */
-export function useBusySendMode(): [BusySendMode, (m: BusySendMode) => void] {
-  const [mode, setMode] = useState<BusySendMode>(readBusySendMode)
+/** Live subscribers to the persisted mode, grouped by storage key. "What does
+ *  Enter do while busy" is a PER-SLOT preference: the composers sharing one slot
+ *  (main chat and its side panel) must move together the moment it changes —
+ *  localStorage alone only syncs across tabs, never within one — while composers
+ *  bound to OTHER slots must not move at all. */
+const modeListeners = new Map<string, Set<(m: BusySendMode) => void>>()
+
+/** Read + write one slot's busy-send preference. Every mounted consumer of the
+ *  SAME slot updates on a change from any other; other slots are untouched. */
+export function useBusySendMode(slotKey?: string | null): [BusySendMode, (m: BusySendMode) => void] {
+  const storageKey = busySendModeKey(slotKey)
+  const [mode, setMode] = useState<BusySendMode>(() => readBusySendMode(slotKey))
+  // Rebind (a mounted composer switching slots when activeSlot changes) is
+  // resolved DURING render — React's adjust-state-on-prop-change pattern — so
+  // the previous slot's mode is never painted, not even for the one frame an
+  // effect-based re-read would leave it visible (and clickable).
+  const [boundKey, setBoundKey] = useState(storageKey)
+  if (boundKey !== storageKey) {
+    setBoundKey(storageKey)
+    setMode(readBusySendMode(slotKey))
+  }
   useEffect(() => {
-    modeListeners.add(setMode)
-    return () => { modeListeners.delete(setMode) }
-  }, [])
+    let subs = modeListeners.get(storageKey)
+    if (!subs) {
+      subs = new Set()
+      modeListeners.set(storageKey, subs)
+    }
+    subs.add(setMode)
+    return () => {
+      subs.delete(setMode)
+      if (subs.size === 0) modeListeners.delete(storageKey)
+    }
+  }, [storageKey])
   const publish = useCallback((m: BusySendMode) => {
-    safeSetItem(BUSY_SEND_MODE_LS_KEY, m)
-    for (const fn of modeListeners) fn(m)
-  }, [])
+    safeSetItem(storageKey, m)
+    const subs = modeListeners.get(storageKey)
+    if (subs) for (const fn of subs) fn(m)
+  }, [storageKey])
   return [mode, publish]
 }
 

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -970,8 +970,8 @@ function ChatInput({
     setPlusOpen(false)
   }
   // Split send button while the composer is BUSY: 'steer' (default) vs 'queue'.
-  // The mode is a shared, persisted preference — see BusySendButton.
-  const [busySendMode, setBusySendMode] = useBusySendMode()
+  // The mode is a persisted PER-SLOT preference — see BusySendButton.
+  const [busySendMode, setBusySendMode] = useBusySendMode(slotId)
   // Steer is the active Enter/send action only while the composer is busy and
   // not stopping, on a steer-capable slot, and the user hasn't switched the
   // split button to Queue. Everywhere else the composer falls back to onSend

--- a/website/src/pages/chat/SideChat.tsx
+++ b/website/src/pages/chat/SideChat.tsx
@@ -76,7 +76,9 @@ export default function SideChat({ slot }: { slot: string }) {
   const messages = reduxSide?.messages ?? []
   const isPending = reduxSide?.pending ?? false
   const queue = reduxSide?.queue ?? []
-  const [busySendMode, setBusySendMode] = useBusySendMode()
+  // Same slot key as the main composer, so the side panel and the main chat of
+  // ONE session share the mode while other sessions keep their own.
+  const [busySendMode, setBusySendMode] = useBusySendMode(slot)
   // A turn is in flight, so a submit can no longer just start one. Derived from
   // the same signal the thinking indicator uses, so the composer's affordance and
   // what the server will actually do can't disagree.

--- a/website/src/test/BusySendButton.slotScope.test.tsx
+++ b/website/src/test/BusySendButton.slotScope.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useBusySendMode, readBusySendMode, BUSY_SEND_MODE_LS_KEY } from '../components/BusySendButton'
+
+/**
+ * Per-slot scoping of the busy-send (Steer/Queue) preference.
+ *
+ * The mode is a PER-SLOT preference: composers sharing one slot (main chat and
+ * its side panel) move together, while composers bound to other slots keep
+ * their own mode. A slot-less consumer keeps the unscoped legacy key.
+ */
+describe('useBusySendMode per-slot scoping', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('changing mode for one slot does not affect another slot', () => {
+    const a = renderHook(() => useBusySendMode('slot-a'))
+    const b = renderHook(() => useBusySendMode('slot-b'))
+    expect(a.result.current[0]).toBe('steer')
+    expect(b.result.current[0]).toBe('steer')
+
+    act(() => { a.result.current[1]('queue') })
+
+    expect(a.result.current[0]).toBe('queue')
+    // The other slot's live mode AND stored value are untouched.
+    expect(b.result.current[0]).toBe('steer')
+    expect(localStorage.getItem(`${BUSY_SEND_MODE_LS_KEY}:slot-a`)).toBe('queue')
+    expect(localStorage.getItem(`${BUSY_SEND_MODE_LS_KEY}:slot-b`)).toBeNull()
+    expect(readBusySendMode('slot-b')).toBe('steer')
+  })
+
+  it('broadcasts within one slot: two consumers of the same slot move together', () => {
+    const main = renderHook(() => useBusySendMode('slot-a'))
+    const side = renderHook(() => useBusySendMode('slot-a'))
+
+    act(() => { main.result.current[1]('queue') })
+
+    expect(main.result.current[0]).toBe('queue')
+    expect(side.result.current[0]).toBe('queue')
+  })
+
+  it('inherits the legacy unscoped value for a slot that never chose a mode', () => {
+    localStorage.setItem(BUSY_SEND_MODE_LS_KEY, 'queue')
+    const { result } = renderHook(() => useBusySendMode('slot-a'))
+    expect(result.current[0]).toBe('queue')
+    // A scoped choice then overrides the inherited legacy value for that slot only.
+    act(() => { result.current[1]('steer') })
+    expect(result.current[0]).toBe('steer')
+    expect(readBusySendMode('slot-b')).toBe('queue')
+  })
+
+  it('never writes the unscoped legacy key: a slot-less consumer uses a scoped sentinel', () => {
+    const { result } = renderHook(() => useBusySendMode(null))
+    act(() => { result.current[1]('queue') })
+    // The legacy key is a read-only migration source; a live write to it would
+    // change the inherited default of every slot that never chose a mode.
+    expect(localStorage.getItem(BUSY_SEND_MODE_LS_KEY)).toBeNull()
+    expect(localStorage.getItem(`${BUSY_SEND_MODE_LS_KEY}:no-slot`)).toBe('queue')
+    expect(readBusySendMode(null)).toBe('queue')
+  })
+
+  it('re-reads the mode when a mounted consumer rebinds to a different slot', () => {
+    localStorage.setItem(`${BUSY_SEND_MODE_LS_KEY}:slot-a`, 'queue')
+    const { result, rerender } = renderHook(
+      ({ slot }: { slot: string }) => useBusySendMode(slot),
+      { initialProps: { slot: 'slot-a' } },
+    )
+    expect(result.current[0]).toBe('queue')
+
+    rerender({ slot: 'slot-b' })
+    expect(result.current[0]).toBe('steer')
+
+    // After the rebind, publishes land on the NEW slot's key only.
+    act(() => { result.current[1]('queue') })
+    expect(localStorage.getItem(`${BUSY_SEND_MODE_LS_KEY}:slot-b`)).toBe('queue')
+    expect(readBusySendMode('slot-a')).toBe('queue')
+  })
+
+  it('does not leak broadcasts to a consumer that rebound away from the slot', () => {
+    const moved = renderHook(
+      ({ slot }: { slot: string }) => useBusySendMode(slot),
+      { initialProps: { slot: 'slot-a' } },
+    )
+    moved.rerender({ slot: 'slot-b' })
+
+    const stayed = renderHook(() => useBusySendMode('slot-a'))
+    act(() => { stayed.result.current[1]('queue') })
+
+    expect(stayed.result.current[0]).toBe('queue')
+    expect(moved.result.current[0]).toBe('steer')
+  })
+})

--- a/website/src/test/ChatInput.test.tsx
+++ b/website/src/test/ChatInput.test.tsx
@@ -1279,7 +1279,9 @@ describe('ChatInput', () => {
       renderWithProviders(<ChatInput {...p} />)
       fireEvent.click(screen.getByTestId('busy-send-caret'))
       fireEvent.click(screen.getByTestId('busy-send-mode-queue'))
-      expect(localStorage.getItem('mc-busy-send-mode')).toBe('queue')
+      // The test store has no active slot, so the write lands on the slot-less
+      // sentinel key; the unscoped legacy key is a read-only migration source.
+      expect(localStorage.getItem('mc-busy-send-mode:no-slot')).toBe('queue')
       const main = screen.getByTestId('busy-send-button')
       expect(main).toHaveAttribute('aria-label', 'Queue message')
       fireEvent.click(main)


### PR DESCRIPTION
## Problem
Switching the composer's busy-send mode (Steer ↔ Queue) in one session changes it in **every** session. The preference is stored under a single global localStorage key (`mc-busy-send-mode`) and fanned out through a module-level listener set, so every mounted composer across all sessions moves together.

## Why it matters
A user running parallel sessions who flips one session to Queue silently changes what Enter does in every other session — a steer they intended elsewhere becomes a queued message (or vice versa), with no visible cause. Send semantics are the most consequential thing the composer does while a turn is running.

## Fix (symptom → root cause → change)
- **Symptom:** mode flips in sessions the user never touched.
- **Root cause:** `useBusySendMode` in `BusySendButton.tsx` reads/writes one unscoped key and broadcasts through one global `modeListeners` set — no slot identity anywhere in the mechanism, even though every render site has it.
- **Change:**
  - Storage key is scoped per slot: `mc-busy-send-mode:<slotKey>` (slot-less consumers get a scoped `:__noslot` sentinel).
  - `modeListeners` becomes a `Map<storageKey, Set<listener>>`; a publish notifies only consumers of the same key, so one session's main composer and side panel still move together while other sessions are untouched.
  - Both call sites pass their slot: `ChatInput` via `useSlotId()`, `SideChat` via its `slot` prop.
  - **Migration:** a slot that never chose a mode inherits the legacy unscoped value on read, so an existing "queue" user keeps their default. The legacy key is now a **read-only** migration source — writing it would change the inherited default of every never-chosen slot, i.e. reintroduce the bug.
  - Rebind (a mounted composer switching slots) is resolved during render (adjust-state-on-prop-change), so the previous slot's mode is never painted or clickable, not even for one frame.
  - `docs/system-specs/modules/side.md` updated in the same commit (it documented the mode as "ONE user preference").

## Tests
`website/src/test/BusySendButton.slotScope.test.tsx` (new):
- changing mode for one slot does not affect another slot's live mode or stored value
- two consumers of the same slot broadcast together
- legacy unscoped value is inherited by a never-chosen slot; a scoped choice then overrides it for that slot only
- a slot-less consumer never writes the legacy key (scoped sentinel instead)
- a rebound consumer re-reads the new slot's mode and publishes to the new key only
- no stale-listener leak after rebinding away from a slot

Updated: `ChatInput.test.tsx` (persistence assertion now targets the sentinel key — the test store has no active slot).

## Manual verification
N/A — unit coverage exercises the full mechanism (scoping, broadcast, migration, rebind); the button's rendering and interaction are unchanged and covered by the existing ChatInput/steerWithSubagents suites.

## Screenshots
N/A — no visual change; only which storage key backs the already-existing split button.

## Pre-push review
GPT (gpt-5.6-sol): NO FINDINGS. Opus (claude-opus-5): no blocking; both Low findings fixed pre-push (one-frame stale mode after rebind → render-phase resolution; legacy key as live write target → write-frozen), safeStorage accessor nit taken, key-accumulation nit acknowledged (~25 bytes per visited slot, reviewer: no change needed).

Closes #3821
