### PR TITLE
fix(chat): scope Steer/Queue mode per session instead of globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **Steer / Queue mode is now a per-session preference instead of a global
+  one.** Switching a session's composer to Queue via the split-button
+  dropdown immediately flipped every other open session to Queue too:
+  `useBusySendMode` persisted to a single global `mc-busy-send-mode`
+  localStorage key and broadcast every change to one flat set of listeners
+  holding every mounted composer. A user who habitually queues for a
+  long-running task, then switches to Steer for a quick question in another
+  session, silently changed the long-running session's send behavior. The
+  key is now scoped per session slot (`mc-busy-send-mode:<slot>`) and the
+  listener fanout is keyed by slot, so the two composers that legitimately
+  share a session (main chat and its side panel) still move together
+  instantly — the behavior the global set existed for — while a different
+  session is never touched. A pane reassigned to a different slot re-reads
+  that slot's own stored mode rather than carrying the previous session's
+  value over. (#3821)
+
 - **Opted-in MCP servers no longer silently fall back to unpooled backends.**
   On one live host, 988 degradations accrued in 15 hours with no signal: 79%
   were guaranteed-ENOENT pooled spawns of bare commands the gateway daemon's

--- a/website/src/components/BusySendButton.tsx
+++ b/website/src/components/BusySendButton.tsx
@@ -41,28 +41,49 @@ const BUSY_SEND_MODES: Array<{ mode: BusySendMode; icon: React.ReactNode }> = [
   { mode: 'queue', icon: <ArrowUpFromLine size={15} /> },
 ]
 
-export function readBusySendMode(): BusySendMode {
-  try { return localStorage.getItem(BUSY_SEND_MODE_LS_KEY) === 'queue' ? 'queue' : 'steer' } catch { return 'steer' }
+/** Per-session storage key. Empty ``slotKey`` (no session yet — a fresh,
+ *  unsaved composer) falls into its own consistent bucket rather than
+ *  reading/writing a real session's key. */
+function busySendModeLsKey(slotKey: string): string {
+  return `${BUSY_SEND_MODE_LS_KEY}:${slotKey}`
 }
 
-/** Live subscribers to the persisted mode. "What does Enter do while busy" is
- *  ONE user preference, so every composer showing this button (main chat and the
- *  side panel) must move together the moment it changes — localStorage alone
- *  only syncs across tabs, never within one. */
-const modeListeners = new Set<(m: BusySendMode) => void>()
+export function readBusySendMode(slotKey: string): BusySendMode {
+  try {
+    return localStorage.getItem(busySendModeLsKey(slotKey)) === 'queue' ? 'queue' : 'steer'
+  } catch { return 'steer' }
+}
 
-/** Read + write the shared busy-send preference. Every mounted consumer updates
- *  on a change from any other consumer. */
-export function useBusySendMode(): [BusySendMode, (m: BusySendMode) => void] {
-  const [mode, setMode] = useState<BusySendMode>(readBusySendMode)
+/** Live subscribers to the persisted mode, keyed by session slot. "What does
+ *  Enter do while busy" is ONE preference PER SESSION, so every composer
+ *  showing this button for the SAME slot (main chat and the side panel) must
+ *  move together the moment it changes — localStorage alone only syncs
+ *  across tabs, never within one — but a change in one session's slot must
+ *  never leak into a different session's composer (#3821). */
+const modeListeners = new Map<string, Set<(m: BusySendMode) => void>>()
+
+/** Read + write the busy-send preference for one session. Every mounted
+ *  consumer sharing that session's slot updates on a change from any other
+ *  consumer of the SAME slot. */
+export function useBusySendMode(slotKey: string): [BusySendMode, (m: BusySendMode) => void] {
+  const [mode, setMode] = useState<BusySendMode>(() => readBusySendMode(slotKey))
   useEffect(() => {
-    modeListeners.add(setMode)
-    return () => { modeListeners.delete(setMode) }
-  }, [])
+    // Re-sync on mount AND whenever the pane is reassigned to a different
+    // slot (e.g. the session grid recycling a pane) — the mode captured at
+    // the PREVIOUS slot must not linger as this slot's displayed value.
+    setMode(readBusySendMode(slotKey))
+    let listeners = modeListeners.get(slotKey)
+    if (!listeners) { listeners = new Set(); modeListeners.set(slotKey, listeners) }
+    listeners.add(setMode)
+    return () => {
+      listeners!.delete(setMode)
+      if (listeners!.size === 0) modeListeners.delete(slotKey)
+    }
+  }, [slotKey])
   const publish = useCallback((m: BusySendMode) => {
-    safeSetItem(BUSY_SEND_MODE_LS_KEY, m)
-    for (const fn of modeListeners) fn(m)
-  }, [])
+    safeSetItem(busySendModeLsKey(slotKey), m)
+    for (const fn of modeListeners.get(slotKey) ?? []) fn(m)
+  }, [slotKey])
   return [mode, publish]
 }
 

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -970,8 +970,8 @@ function ChatInput({
     setPlusOpen(false)
   }
   // Split send button while the composer is BUSY: 'steer' (default) vs 'queue'.
-  // The mode is a shared, persisted preference — see BusySendButton.
-  const [busySendMode, setBusySendMode] = useBusySendMode()
+  // The mode is a per-session, persisted preference — see BusySendButton.
+  const [busySendMode, setBusySendMode] = useBusySendMode(slotId || '')
   // Steer is the active Enter/send action only while the composer is busy and
   // not stopping, on a steer-capable slot, and the user hasn't switched the
   // split button to Queue. Everywhere else the composer falls back to onSend

--- a/website/src/pages/chat/SideChat.tsx
+++ b/website/src/pages/chat/SideChat.tsx
@@ -76,7 +76,7 @@ export default function SideChat({ slot }: { slot: string }) {
   const messages = reduxSide?.messages ?? []
   const isPending = reduxSide?.pending ?? false
   const queue = reduxSide?.queue ?? []
-  const [busySendMode, setBusySendMode] = useBusySendMode()
+  const [busySendMode, setBusySendMode] = useBusySendMode(slot)
   // A turn is in flight, so a submit can no longer just start one. Derived from
   // the same signal the thinking indicator uses, so the composer's affordance and
   // what the server will actually do can't disagree.

--- a/website/src/test/ChatInput.test.tsx
+++ b/website/src/test/ChatInput.test.tsx
@@ -1279,7 +1279,9 @@ describe('ChatInput', () => {
       renderWithProviders(<ChatInput {...p} />)
       fireEvent.click(screen.getByTestId('busy-send-caret'))
       fireEvent.click(screen.getByTestId('busy-send-mode-queue'))
-      expect(localStorage.getItem('mc-busy-send-mode')).toBe('queue')
+      // Per-session key (#3821): the store's default activeSlot is null, so
+      // ChatInput binds to the empty-slot bucket here.
+      expect(localStorage.getItem('mc-busy-send-mode:')).toBe('queue')
       const main = screen.getByTestId('busy-send-button')
       expect(main).toHaveAttribute('aria-label', 'Queue message')
       fireEvent.click(main)
@@ -1290,9 +1292,29 @@ describe('ChatInput', () => {
     })
 
     it('restores persisted queue mode from localStorage', () => {
-      safeSetItem('mc-busy-send-mode', 'queue')
+      safeSetItem('mc-busy-send-mode:', 'queue')
       renderWithProviders(<ChatInput {...runningProps()} />)
       expect(screen.getByTestId('busy-send-button')).toHaveAttribute('aria-label', 'Queue message')
+    })
+
+    it('does not inherit another session slot\'s persisted mode (#3821)', () => {
+      // A DIFFERENT session was switched to queue. This composer (bound to the
+      // default/empty slot) must still open in steer: the preference is
+      // per-session, so one session's choice cannot silently change another's
+      // send behavior.
+      safeSetItem('mc-busy-send-mode:some-other-slot', 'queue')
+      renderWithProviders(<ChatInput {...runningProps()} />)
+      expect(screen.getByTestId('busy-send-button')).toHaveAttribute('aria-label', 'Steer')
+    })
+
+    it('switching to Queue writes only this session\'s key (#3821)', () => {
+      safeSetItem('mc-busy-send-mode:some-other-slot', 'steer')
+      renderWithProviders(<ChatInput {...runningProps()} />)
+      fireEvent.click(screen.getByTestId('busy-send-caret'))
+      fireEvent.click(screen.getByTestId('busy-send-mode-queue'))
+      expect(localStorage.getItem('mc-busy-send-mode:')).toBe('queue')
+      // The other session is untouched — the original bug was this flipping too.
+      expect(localStorage.getItem('mc-busy-send-mode:some-other-slot')).toBe('steer')
     })
 
     it('dropdown is keyboard operable: focus on open, arrows roam, Escape returns to caret', async () => {

--- a/website/src/test/ChatPage.steerWithSubagents.test.tsx
+++ b/website/src/test/ChatPage.steerWithSubagents.test.tsx
@@ -175,7 +175,8 @@ describe('steer default while sub-agents run', { timeout: 20_000 }, () => {
   })
 
   it('honours an explicit Queue choice and leaves the flag off', async () => {
-    localStorage.setItem('mc-busy-send-mode', 'queue')
+    // Per-session key (#3821) — this harness renders with activeSlot 'slot-a'.
+    localStorage.setItem('mc-busy-send-mode:slot-a', 'queue')
     const { input } = await renderChat({ subagentsRunning: true, turnRunning: false })
     await typeAndSubmit(input, 'run this after the wave')
 


### PR DESCRIPTION
## Problem / Motivation

Switching the Steer / Queue mode on one session's composer immediately changes the mode on **every other open session**. Open two chat sessions, set one to Queue via the split-button dropdown, switch to the other — it is in Queue mode too. Every session flips simultaneously.

## Why it matters

A user who habitually uses Queue mode for a long-running task, then switches back to Steer for a quick question in another session, silently changes the original long-running session's behavior — it no longer queues the next delivery. There is no indication this happened, and Steer vs Queue is exactly the kind of setting a user reasonably assumes is scoped to the conversation they set it on.

## What changed (motivation → approach → change)

Root cause (as the issue correctly identified): `useBusySendMode` in `website/src/components/BusySendButton.tsx` persisted to a single global `mc-busy-send-mode` localStorage key, and broadcast every change to one flat `Set` holding every mounted composer:

```ts
const modeListeners = new Set<(m: BusySendMode) => void>()
// ...
const publish = useCallback((m: BusySendMode) => {
  safeSetItem(BUSY_SEND_MODE_LS_KEY, m)   // single global key
  for (const fn of modeListeners) fn(m)   // fires ALL mounted composers
}, [])
```

The file's own comment explains the global fanout: *"ONE user preference, so every composer showing this button (main chat and the side panel) must move together the moment it changes"*. That rationale is genuinely correct — but only for the two composers that share **one** session (a pane and its side panel). It was implemented at process scope, so it also applied across unrelated sessions.

Fix: the storage key is now scoped per slot (`mc-busy-send-mode:<slot>`), and `modeListeners` becomes a `Map<slotKey, Set<...>>`. The within-session instant sync is preserved exactly — the two composers sharing a session still move together on the same tick — while a change can no longer cross sessions. `useBusySendMode` takes the slot key from its two call sites, both of which already had it in scope (`ChatInput`'s `useSlotId()`, `SideChat`'s `slot` prop), so no new plumbing was needed.

One subtlety handled: the mount effect re-reads on `slotKey` change, not just on mount. Panes get reassigned to different slots (the session grid recycles them), and without the re-read the mode captured under the *previous* slot would linger as the new slot's displayed value.

Disclosed behavior change: this drops any previously-stored global preference, since the old unscoped key is no longer read — every session starts from the `steer` default once after upgrading. Migrating the old value would require picking one session to apply it to, which is precisely the ambiguity this fix exists to remove.

## Tests

- `website/src/test/ChatInput.test.tsx`: 2 new tests — a composer must **not** inherit a different slot's persisted queue mode; and switching to Queue writes only this session's key while leaving another session's key untouched (the original bug, asserted directly).
- Verified the second new test fails against the pre-fix code (it writes the global key, so the session-scoped key reads `null`) and passes after.
- Updated the 2 existing tests that asserted against the old global key (`ChatInput.test.tsx`, `ChatPage.steerWithSubagents.test.tsx`) to use the slot-scoped key their harnesses' `activeSlot` resolves to.
- `vitest` on both files: 143 passed. `tsc --noEmit` clean. `eslint` on the 3 changed source files: 0 errors, 7 warnings — byte-identical to the pre-change baseline on the same files (verified by re-running eslint against the stashed changes), so nothing new was introduced.

## Manual verification

N/A — unit coverage sufficient. The behavior is pure client state (a localStorage key and an in-process listener registry); the new tests assert the cross-session isolation directly, which is the property that was broken.

## Related Issues

Fixes #3821

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — CHANGELOG entry added
