### PR TITLE
docs(kas): KAS backend spec + post-summarization context-usage test (Group E)

### DIFF
--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -15,6 +15,7 @@ agent loads only the one it needs.
 | [acp-client.md](acp-client.md) | The ACP JSON-RPC client that drives `kiro-cli`: transport, framing, timeouts, and the backend seam. |
 | [providers.md](providers.md) | The `LLMProvider` interface and the KiroACP-only provider surface. |
 | [harness-parity.md](harness-parity.md) | The invariants keeping the Kiro harness first-class while other harnesses are adapted, and the test pinning each. |
+| [kas-backend.md](kas-backend.md) | The second, adapted ACP backend: how Crew selects and adapts it (the `kas_wire` seam, harness-parity, ABC defaults) and the deferred hooks / transport / `/clear` items. Crew-side only. |
 | [session.md](session.md) | Sessions, slots, session keys, the warm pool, and PID tracking. |
 | [history.md](history.md) | Conversation persistence, JSONL rotation, and transcript search. |
 | [session-summary.md](session-summary.md) | Intent-level session summaries: the sidecar cache, extraction, and the turn-end pass. |

--- a/docs/system-specs/modules/kas-backend.md
+++ b/docs/system-specs/modules/kas-backend.md
@@ -1,0 +1,54 @@
+# A second ACP backend
+
+KiroCrew drives one first-class agent harness, `kiro-cli`, over ACP. It also
+supports a **second, adapted ACP backend** (`agent.acp_backend = "kas"`); the
+default and first-class path stays `kiro-cli`. `agent.provider` remains `"acp"`
+— the harness is never the provider selector (see
+[harness-parity.md](harness-parity.md)).
+
+**Scope.** This documents the KiroCrew-side integration only. The second backend
+is not open source; its wire shapes, storage, auth, and process internals are
+not described here. Where its on-the-wire signals differ from `kiro-cli`'s, the
+difference is absorbed in one Crew module (below), which is the only place that
+needs editing if that backend changes.
+
+## How Crew runs it
+
+- It goes through the existing `AcpRuntime` (one process, multiplexed sessions)
+  via the established backend seam — no new runtime subclass, just a spawn-argv
+  branch plus adapters. `kiro-cli` keeps its own spawn path, per-harness
+  handshake literals, and session machinery unchanged (harness-parity H9/H10).
+- Backend-specific parsing (the display/telemetry frames whose shape differs
+  from `kiro-cli`'s) is localized in **`acp/kas_wire.py`** — a single module, so
+  an adjustment is a one-file edit. Backend-neutral logic (the context-meter
+  math) lives on `AcpPromptStats` and is shared by both paths, so they cannot
+  drift.
+- Capabilities the session layer reads off a provider are declared on the
+  `LLMProvider` ABC with safe defaults (harness-parity H14), so the adapted
+  backend never forces a `getattr` probe onto the `kiro-cli` path.
+
+## Identity is positive
+
+Every "is this the `kiro-cli` harness" test is a positive comparison against a
+named constant or membership in a named `ACP_BACKENDS_*` set — never
+`not is_<other>`, which would hand a branch to a later harness by default. The
+full invariant catalogue and its CI gate are in
+[harness-parity.md](harness-parity.md).
+
+## Switching backends
+
+```
+kirocrew config set agent.acp_backend kas   # then: kirocrew restart
+kirocrew config set agent.acp_backend ""     # back to kiro-cli; restart
+```
+
+A config change affects only new sessions; `restart` reaps the prior runtime
+process. `kirocrew doctor` reports the selected backend's readiness.
+
+## Deferred
+
+- **Hooks** are not wired for the second backend — a separate effort.
+- **`/clear`** currently maps to a `kiro-cli`-only notification, so on the second
+  backend it is a no-op today; a local reset is the intended parity fix.
+- An **alternative transport mode** is out of scope, pending its own design and
+  review.

--- a/test/test_kas_display_mapping.py
+++ b/test/test_kas_display_mapping.py
@@ -237,6 +237,35 @@ def test_summarization_completed_emits_compaction_and_resets() -> None:
     assert handle.last_prompt_stats.context_tokens_from_usage is False
 
 
+def test_context_usage_reapplies_after_summarization_completed() -> None:
+    # Sequencing (the KAS analog of the kiro-cli post-compaction metadata
+    # re-apply): summarization_completed resets and clears the authoritative
+    # flag, so a FOLLOWING context_usage frame must re-derive the meter. Were the
+    # reset missing, context_tokens_from_usage would stay True and the fresh
+    # percentage would be ignored — the dashboard bar frozen at the
+    # pre-compaction value forever.
+    handle = _handle(ACP_BACKEND_KAS)
+    handle.last_prompt_stats.context_pct = 80.0
+    handle.last_prompt_stats.context_tokens_from_usage = True
+    _update(
+        handle,
+        {
+            "sessionUpdate": "session_info_update",
+            "_meta": {"kiro": {"kind": "summarization_completed", "conversationSummary": ""}},
+        },
+    )
+    assert handle.last_prompt_stats.context_tokens_from_usage is False
+    assert handle.last_prompt_stats.context_pct == 0.0
+    _update(
+        handle,
+        {
+            "sessionUpdate": "session_info_update",
+            "_meta": {"kiro": {"kind": "context_usage", "usagePercentage": 12.0}},
+        },
+    )
+    assert handle.last_prompt_stats.context_pct == 12.0
+
+
 def test_summarization_started_emits_started_status() -> None:
     handle = _handle(ACP_BACKEND_KAS)
     events = _update(handle, {"sessionUpdate": "session_info_update", "_meta": {"kiro": {"kind": "summarization_started"}}})


### PR DESCRIPTION
## What

The **Group E tail**: a Crew-side spec doc for the second ACP backend + one KAS mapping test. Stacked on #3823; retargets to `main` when it merges.

**Scope note:** the second backend is not open source. This PR documents the **KiroCrew-side** integration only — its wire shapes, auth, storage, and process internals are deliberately not restated.

## Docs

- **`docs/system-specs/modules/kas-backend.md`** (new) — Crew-side integration: it runs through the existing `AcpRuntime` seam (no new subclass; `kiro-cli` keeps its own path), backend-specific parsing is localized in the single `acp/kas_wire.py` module, provider capabilities are declared on the `LLMProvider` ABC with safe defaults (harness-parity H14), harness identity is positive, how to switch backends, and the deferred items (hooks, `/clear` parity, an alternative transport mode).
- Indexed in the modules `README.md`.

## Test

- `test_kas_display_mapping`: adds the **sequencing** case a prior audit flagged as the one genuine gap — a completed summarization resets and clears the authoritative flag, so a *following* context-usage frame re-derives the meter (otherwise the meter freezes at the pre-reset value). The other flagged "variants" were validated as not genuine: routing already runs through the real dispatch in the existing mapping tests, and the provider compact-result cache is backend-neutral.

## Verification

`test_kas_display_mapping` green including the new test; `isort`/`flake8` clean. Docs + one test — no production code touched.
