### PR TITLE
docs(skills): sharpen sage-review, browser-recording, worktree-dev, crystallize guidance

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/skills/sage-review/SKILL.md
+++ b/src/kiro_crew/apps/builtins/code_review_sage/skills/sage-review/SKILL.md
@@ -107,7 +107,14 @@ its own consequence chain, and only then settle on a verdict.
 - **Alternatives & proportionality.** Name the 1–2 strongest alternative
   designs and say why this one wins. Is the solution proportionate to the
   problem, or over-/under-engineered? "No alternative considered" on a
-  non-trivial change is itself a finding.
+  non-trivial change is itself a finding. **Anti-speculative-generality
+  lens:** flag any abstraction, option, or compatibility path with no
+  *current* production consumer. Map each to its contract and owning service;
+  an extension point, config knob, or generic seam that only a hypothetical
+  future caller would use is over-engineering — *cause* (added generality) →
+  *mechanism* (dead surface to maintain and test) → *consequence* (carrying
+  cost with no present payoff). Challenge it; prefer the concrete shape until
+  a real second consumer earns the abstraction.
 - **Failure modes.** How does the design behave when it is *wrong* — under load,
   partial failure, concurrent access, malformed input, or a dependency outage?
   A design with no failure story on a path that can fail is a design risk.
@@ -153,6 +160,27 @@ treat any divergence as a finding:
 - **"Why it matters":** the description SHOULD state *why* the change matters
   (the user-facing symptom), not just *what* changed. A "what" with no "why"
   is a 🟡 finding.
+
+### Docs & design-artifact fidelity (in-diff)
+
+> *Not just description↔diff — docs↔code, in the SAME change.*
+
+Documentation and design artifacts MUST move with the code that makes them
+true:
+
+- **Docs match the code in the same diff.** Any change to config, defaults,
+  errors, wire fields, events, or documented public behavior MUST update the
+  matching README / JSDoc / spec in the same change (for repos that keep
+  module specs, e.g. `docs/system-specs/modules/*.md`). A stale doc left
+  behind is 🟡 — or 🔴 when it is *load-bearing* for callers (they rely on it
+  to use the contract correctly, so the drift will mislead them).
+- **Design docs go to present-tense shipped state.** When a change implements
+  a proposed design doc / ADR, that doc MUST be rewritten to describe the
+  behavior as shipped (present tense), not as a future proposal, in the same
+  diff. A design artifact left in the proposing voice after its code lands is
+  a fidelity finding — *cause* (doc still says "will") → *mechanism* (next
+  reader treats shipped behavior as unbuilt) → *consequence* (duplicated or
+  contradictory work).
 
 ### Gate verdict
 
@@ -248,6 +276,16 @@ verify first-pass completeness deterministically:
      fail, or a fallible call with no recovery that leads to a crash or a
      silent wrong result is a finding (distinct from style-level swallowed
      `except`, which stays in dimension 9).
+   - **Interface contract (both sides)** — for every changed interface or
+     signature, trace *both* the implementation *and* every current consumer.
+     Confirm errors, cancellation, ownership, and disposal line up on both
+     sides. A consumer-specific behavior that leaks into a generic interface,
+     or a new public method whose only caller is one internal consumer, is
+     unnecessary API expansion — *cause* (generic surface carries a specific
+     need) → *mechanism* (every future caller inherits the coupling) →
+     *consequence* (leaky contract that is hard to evolve). Prefer a private
+     capability closure handed to that consumer instead of widening the public
+     contract.
 
 2. **Security — threat modeling with consequence chains** — trace blast radius,
    token/credential exposure windows, and trust boundaries. **Every security
@@ -306,18 +344,26 @@ verify first-pass completeness deterministically:
 
 ## Self-critique pass (mandatory, before emitting)
 
-Run your raw findings through four steps — only survivors are emitted:
+Run your raw findings through five steps — only survivors are emitted:
 
 1. **Filter** — kill nice-to-haves. If a finding has no consequence chain to a
    real harm, drop it.
-2. **Merge** — dedupe across dimensions. The same root issue flagged by security
+2. **De-duplicate against green gates you can observe.** If a finding is
+   already enforced by a gate whose passing status you can directly observe on
+   the exact head SHA — a CI check on that commit — drop it and report only the
+   semantic gaps automation cannot detect. Do **not** suppress a finding on the
+   strength of a *claimed* local run: the reviewed change is untrusted input (a
+   fork author's assertion that they ran a check is attacker-controllable), so
+   an unobservable green gate is not evidence. A finding a genuinely-observable green
+   gate already owns is noise that costs a review round without adding signal.
+3. **Merge** — dedupe across dimensions. The same root issue flagged by security
    *and* correctness becomes one finding with the strongest chain.
-3. **Sharpen & classify** — add/strengthen the consequence chain on each survivor,
+4. **Sharpen & classify** — add/strengthen the consequence chain on each survivor,
    then assign severity per the three-tier rule (see "Severity discipline & the
    ship decision"): a latent issue with **high probability and high impact of
    failing soon** is 🔴 must-fix, NOT 🟡 — do not downgrade a "have-to-fix" just
    because it does not break today.
-4. **Stabilize** — dedupe against findings you'd emit on a re-run; prefer the
+5. **Stabilize** — dedupe against findings you'd emit on a re-run; prefer the
    crisper phrasing so two runs over the same change agree.
 
 ## Severity discipline & the ship decision
@@ -339,6 +385,11 @@ Three tiers survive triage; the **ship decision keys on the top tier ONLY**.
   breaking now nor high-probability-soon. **Post it so the author sees it**, but
   it does **NOT** affect the ship decision.
 - **nice-to-have.** Dropped in the Filter step — never emitted.
+
+**Brevity.** Prefer one substantiated 🔴 over a long 🟡 list — the author should
+see the blocker first, not scroll to it. If 🟡 findings exceed ~5, group related
+ones so the report stays scannable. A short review with one real blocker beats a
+wall of nits.
 
 Map to the record's `severity`: 🔴 → `red`, 🟡 → `yellow`.
 
@@ -495,7 +546,7 @@ orchestration.
 - [ ] Resolve per-repo rule pack (if any) and read it as additional rules
 - [ ] ONE thorough pass: design dimension (verdict + design_risk + criticality + design_headline) AND the 9 code dimensions together → chain-of-consequences findings
 - [ ] Coverage self-check: every changed hunk reviewed against all dimensions; emit files_covered + coverage_complete (driver runs ONE targeted follow-up if incomplete)
-- [ ] Self-critique (Filter / Merge / Sharpen / Stabilize)
+- [ ] Self-critique (Filter / De-dup against green gates / Merge / Sharpen / Stabilize)
 - [ ] Post surviving findings as DRAFT comments (publish=false), each quoting the snippet
 - [ ] If the change is a fix, run INLINE miss-analysis (learn-from-sage) → STAGE the learning into the candidate file
 - [ ] Write the result record JSON

--- a/src/kiro_crew/builtin_skills/browser-recording/SKILL.md
+++ b/src/kiro_crew/builtin_skills/browser-recording/SKILL.md
@@ -11,6 +11,34 @@ involves **animation, transitions, or a multi-step flow** (wizard steps, a
 modal opening, drag interactions), record it. This skill is the *how* for the
 evidence rule in the `frontend-design-workflow` skill's Phase 3.
 
+## Recording evidence for GUI PRs (provenance)
+
+`frontend-design-workflow` Phase 3 owns *which* evidence a GUI change needs: a
+still screenshot for a static layout or styling change, a **recording** for
+motion, a transition, or a multi-step flow a still frame cannot prove. This
+section does not widen that rule — do not record a change a screenshot already
+covers — it adds the one thing Phase 3 leaves open: how to make a recording
+*reproducible and honest about how it was produced*.
+
+When a change does need a recording, it must come from the **real server and
+model flow**: the actual dev/preview server running the branch, driven through
+a real interaction, never a fixture, a mock, or a hand-faked event stream. A
+recording of a stubbed surface proves nothing about the code under review.
+
+Embed the recording with a provenance line beside it disclosing how it was
+produced:
+
+```
+recorded from <full-SHA> · <tree/origin> · mode: <flags> · real server + model, no fixtures
+```
+
+State the commit SHA, the tree or origin it came from, any mode flags that
+change behaviour, and an explicit real-vs-fixture disclosure. The line is
+written by the same agent that made the recording, so it discloses provenance
+rather than proving it — the real check is the SHA-pinned embed a reviewer can
+open and a re-record from that SHA. A recording with no provenance line leaves
+how it was produced unstated.
+
 ## What it does
 
 `scripts/record_browser.py` drives a headless Chromium through the **target
@@ -55,13 +83,76 @@ GIF /tmp/rec/settings-flow.gif
    ~30 seconds of wall time.
 3. **Run the recorder** (command above). `--project` must point at a
    directory whose `node_modules` has Playwright with Chromium installed.
-4. **Look at the result** before presenting: read the GIF/mp4 (or key frames)
-   to confirm the flow actually shows what you claim.
-5. **Deliver**: embed the GIF in chat with `![what it shows](/abs/path.gif)`;
-   for PRs follow the repository's screenshot-embedding convention (in this
-   repo: commit under `.github/screenshots/<feature>/`, embed with
-   commit-SHA-pinned `github.com/<owner>/<repo>/raw/<sha>/...` URLs). Attach
-   the mp4 as a file when higher fidelity matters.
+4. **Verify the encoded artifact, not the source frames.** Decode
+   representative frames back out of the *final GIF/mp4* you are about to
+   ship — not the raw webm or an intermediate capture — and confirm the flow
+   actually shows what you claim. An encode step can drop frames, crush
+   colours, or truncate; only the encoded artifact is what the reviewer sees.
+   When a scenario asserts a completion state, match on **exact text** through
+   a precise locator (`getByText('Saved', { exact: true })`), never a
+   substring — a substring predicate silently passes on the wrong element.
+   While you have those frames decoded, **check them for anything the flow was
+   not meant to expose** — secrets, tokens, real names or emails, other users'
+   data — because publishing a recording sends real UI pixels to an
+   outward-facing, often permanent place. If any is present, sanitize the
+   *source* (scrub the fixture, mask the field, record against throwaway data)
+   and re-record; do not crop or blur the encoded artifact, which leaves the
+   data recoverable underneath.
+5. **Deliver**: embed the GIF in chat with `![what it shows](/abs/path.gif)`.
+   If a GIF is too large to embed, trim the scenario or lower the frame rate
+   and re-record rather than shipping a blob no one can open.
+   For a PR, follow the repository's own screenshot/media convention when it
+   has one — many repos commit PR media on the feature branch under a known
+   path so their review lanes and cleanup workflows can see it. Only when a
+   repo has no such convention (and you have push access), publish the binary
+   to a dedicated assets branch instead of bloating the feature branch or main
+   (see *Publishing to an assets branch* below). Then embed the raw blob URL
+   and attach the mp4 as a file when higher fidelity matters.
+
+## Publishing to an assets branch
+
+This is the **fallback for a repo that has no media convention of its own** —
+prefer the repository's documented path when one exists. Recordings are
+binaries. Committing them onto the feature branch — or worse, main — bloats
+history permanently, since git keeps every revision of every blob forever.
+When a repo offers no place for media, publish them to a throwaway **assets
+branch** instead so main's history stays text-only. **Get the user's explicit OK
+before creating or pushing an assets branch — on any repo, owned or not.** An
+orphan assets branch is a permanent, outward-facing side effect, so it is a push
+like any other, and this repo's standing rule is that committing and pushing each
+require explicit user authorization and are never done proactively. On a repo you
+do not own you need the owner's OK as well, since some orgs restrict branch
+creation outright.
+
+1. Shallow-clone the repo into a scratch directory and create (or check out)
+   an **orphan** `<series>-assets` branch — one branch per recording series,
+   holding only media, sharing no history with main.
+2. Copy the encoded GIF/mp4 in, commit, and push to that branch through an
+   **authenticated** remote. Never force-push an assets branch: appends only,
+   so previously embedded URLs never break.
+3. Embed in the PR body with the raw-blob form (`...?raw=true`) pinned to the
+   commit you just pushed.
+4. Verify the embed resolves: fetch the raw URL through the authenticated
+   remote and confirm a 200, the expected content-type, and a byte count or
+   checksum matching the local file. A GitHub-rendered Markdown preview
+   confirms it displays. Re-read the PR head SHA before and after editing the
+   body so the embed stays pinned to the right commit.
+
+## State isolation
+
+A recording is only trustworthy evidence for a specific commit if nothing
+outside that commit leaked into it. Record from an isolated, throwaway
+context:
+
+- Use a **fresh scratch home / session / browser context** per recording — no
+  reused cookies, cached state, or ambient config from a prior run — so the
+  flow reflects the branch alone.
+- **Record the exact SHA** the server is running (the same SHA that goes in
+  the provenance line), and check the working tree is clean before capture so
+  no uncommitted change sneaks into the frames.
+
+This is what lets a GIF provably attribute to one commit rather than to
+whatever happened to be on the machine.
 
 ## Dependencies (probe-first, never auto-installed)
 
@@ -79,3 +170,12 @@ to a screenshot sequence and say explicitly that motion could not be captured.
 - Static changes — a screenshot is cheaper and clearer (`web-verify` skill).
 - Live interactive browsing for the user — that is the Browser panel /
   `web-browse` path, not an offline recording.
+
+## Related skills
+
+- `feature-demo-recording` — a cinematic, narrated mp4 demo for Slack
+  (auto-zoom, caption cards, camera polish). Use it for showing off a
+  finished feature. (Ships with the dev_fleet app, not as a built-in skill,
+  so it is only available where that app is installed.)
+- `browser-recording` (this skill) — the GIF-for-PR evidence gate. Use it to
+  prove a GUI change works, embedded in the PR from the real server flow.

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
@@ -160,6 +160,38 @@ python3 -m venv ~/.kiro/crew/venvs/mypy-ci
 **Order matters:** if you changed frontend code, rebuild the dist (Rule 3)
 before running backend tests that import static assets.
 
+### Two tiers: a diff-scoped fast inner loop, one full floor at push
+
+The full gate above is the **push gate** and never moves. But running all six
+gates on every fix→re-verify round is what produces the 45-minute timeouts — the
+cost lands during *iteration*, not at the push. So split verification into two
+tiers with different jobs:
+
+- **Iteration model (fast tier).** During the fix→re-verify loop, run
+  `scripts/local-gate.py` instead of the six gates by hand. It classifies the
+  diff into the same buckets `ci.yml`'s `changes` job uses and runs only the
+  surfaces the diff can affect, so an iteration costs what the diff costs rather
+  than what the repo costs. `--dry-run` prints the plan without running,
+  `--base REF` sets the base, `--full` forces both surfaces. Its narrowing is
+  deliberately **fail-open** — a meta path, both surfaces touched, or an
+  unreadable diff all fall back to the full gate — so a classification miss
+  costs local time, never a skipped test. Do NOT re-derive that bucket list as
+  your own prose or scope selection: `test/test_local_gate.py` pins the script's
+  rules to `ci.yml`, and a hand-maintained copy silently drifts out of that
+  ratchet.
+- **Gate model (full floor).** The full blocking floor — `pytest` + `isort` +
+  `flake8` + `mypy` + `tsc -b` + `vitest`, all green — **still runs once before
+  you push**, exactly as specified above. It is never skipped, never replaced,
+  and never satisfied by a fast-tier run. The fast tier is a strict *subset* of
+  the floor chosen for iteration speed only; it earns you quick rounds, it does
+  not earn you the push.
+
+This is what mitigates the documented full-suite timeout *during iteration*
+without loosening anything: the pre-push full floor plus the `ci.yml` ratchet
+(the profile test that fails when CI gains a gate the floor lacks) keep the
+determinism guarantee fully intact. Fast tier = how you iterate; full floor =
+the gate that lets you push.
+
 ## Rule 3 — The served frontend is a built `dist`, not a dev server
 
 - The gateway serves the frontend from `src/kiro_crew/static/dist/` (a compiled


### PR DESCRIPTION
## What is the problem?

Four agent-facing skills carry gaps that cost real review rounds and agent time:

- **sage-review** re-flags findings a green CI gate already owns, does not trace both sides of a changed interface, and does not require docs/design artifacts to move with the code in the same diff.
- **browser-recording** produces a recording but has no rule tying that evidence to GUI PRs, no publishing model that keeps binaries out of `main` history, no deterministic byte-capped encode step, and no provenance/anti-fake discipline.
- **kirocrew-worktree-dev** mandates the full blocking floor (pytest + isort + flake8 + mypy + tsc + vitest) on every iteration, which the skill itself documents can exceed 45 minutes and time out agent sessions -- even though the repo already ships `scripts/local-gate.py` for exactly that iteration cost, which no skill mentions (0 references under `builtin_skills/`).

## Why this issue matters to the user

These are the surfaces agents touch on nearly every PR. A reviewer that re-flags lint-owned nits or misses a consumer of a changed interface produces noise and misses; a recording with no PR-evidence rule or provenance lets unproven UI claims ship; a 45-minute floor on every fix-verify cycle burns session budget and causes timeouts; and skill duplication silently degrades the skill corpus the agent relies on.

## How our fix solves it

Each change targets the exact symptom above:

- **sage-review**: adds a "de-duplicate against green gates" step in the self-critique pass (5 steps now); both-sides interface-contract tracing in the Correctness dimension; an in-diff docs/design-artifact fidelity check; an anti-speculative-generality lens on the design dimension; and a brevity rule (one substantiated blocker over a wall of nits). All new findings keep sage's cause -> mechanism -> consequence format.
- **browser-recording**: adds a "recording mandatory for GUI PRs, from the real server+model flow" rule with a provenance line; an orphan assets-branch publishing workflow for repos with no media convention (keeps binaries out of `main`, and defers to an existing `.github/screenshots/` convention where one exists); a "verify the encoded artifact, not source frames" rule with exact-text completion predicates; state-isolation guidance so a recording provably attributes to one commit; and a cross-link separating it (GIF-for-PR evidence) from feature-demo-recording (cinematic Slack demo).
- **kirocrew-worktree-dev**: names the two tiers explicitly and points the fix-verify iteration loop at the repo's existing `scripts/local-gate.py` (whose bucket rules `test/test_local_gate.py` already pins to `ci.yml`, and whose narrowing is fail-open) instead of restating a scope classifier as prose that would drift out of that ratchet, while keeping the full floor mandatory once before push.
- **crystallize**: withdrawn. A consolidation clause was drafted here, but retiring a live skill other things may reference is a genuinely destructive multi-reference operation that does not belong in a prose addendum -- four successive review rounds each surfaced a new reachable hazard (delete-before-approval, unrecoverable delete, an archive group the loader still walks, and archival bypassing the pinned / cron-reference exemptions that `run_skill_lifecycle` enforces). The clause was removed rather than fenced a fifth time; `crystallize/SKILL.md` is byte-identical to `main` and is not part of this change. If retiring superseded skills is worth doing, the right shape is making `archive_auto_skill` perform the same pinned / cron-reference checks `run_skill_lifecycle` already does -- enforcement in code with tests, in its own PR.

## What tests we did

Markdown-only change; the Python/TS lint and type gates are no-ops for this diff. Ran the affected content tests locally: `test_browser_recording_skill.py`, `test_frontmatter.py`, `test_brand_name_gate.py` -- 215 passed, 1 skipped. No frontmatter descriptions changed, so length gates are unaffected.

## Any other suggestions on the work

Three companion skills were drafted separately for local review (trim-cot-leakage, writing-standard, ai-discover-simplify); if they prove useful they can be promoted into the repo in a follow-up.
