### PR TITLE
fix(detail-panel): drop the width contract at phone widths

### DIFF
--- a/website/src/components/DetailPanel.tsx
+++ b/website/src/components/DetailPanel.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 import { X } from 'lucide-react'
 import { Btn } from './ui'
 import { usePointerDrag } from '../hooks/usePointerDrag'
+import { useIsMobile } from '../hooks/useIsMobile'
 
 import { i18nT } from '../i18n/t'
 interface DetailPanelProps {
@@ -86,6 +87,9 @@ export default function DetailPanel({ title, icon, onClose, footer, headerAction
   // Outer wrapper ref, used to measure the panel's flex row (its parent) so the
   // width cap tracks the actual available room rather than the whole viewport.
   const wrapperRef = useRef<HTMLDivElement>(null)
+  // Narrow viewports drop the whole width contract (see the render below), so the
+  // panel becomes a drill-down rather than a side-by-side that cannot fit.
+  const isMobile = useIsMobile()
   // Measured width of the panel's flex row (its parent). A non-positive measure
   // means the row isn't laid out yet (initial mount, or jsdom) — return Infinity
   // so the row term drops out and the cap degrades to the viewport-only bound
@@ -177,10 +181,12 @@ export default function DetailPanel({ title, icon, onClose, footer, headerAction
 
   const body = (
     <>
-      {!embedded && (
+      {!embedded && !isMobile && (
         /* Drag-to-resize splitter: pointer-only affordance (no meaningful
             keyboard gesture for a 6px handle); role="separator" is the correct
-            ARIA role. */
+            ARIA role. Dropped while narrow: the panel owns the whole width there,
+            so there is nothing to resize it against, and a drag handle does
+            nothing on touch. */
         <div role="separator" aria-orientation="vertical" aria-label={i18nT('components.detailPanel.resize_panel')} className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-20 group/drag" style={{ touchAction: 'none' }} {...drag}>
           <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent resize-accent" />
         </div>
@@ -215,7 +221,16 @@ export default function DetailPanel({ title, icon, onClose, footer, headerAction
 
   // Embedded: fill the parent (SidePanel tab body) — no resize handle, no left
   // border, no width animation. Only the header + content contribute.
-  if (embedded) {
+  //
+  // A narrow viewport takes the SAME path. It is already exactly the shape the
+  // narrow case needs -- full width, no divider, no width contract, and (through
+  // the `!embedded` gate in `body`) no resize handle -- so the panel becomes a
+  // drill-down by reusing a rendering that exists rather than by forking the
+  // width style. Setting `width: 100%` on the inner div instead would do nothing:
+  // its parent is the motion wrapper, `shrink-0` with an animated `width: 'auto'`,
+  // so a percentage resolves against a content-sized box. Measured in isolation at
+  // a 390px row: wrapper 42px, panel 42px -- narrower than before, not full width.
+  if (embedded || isMobile) {
     return (
       <div className="h-full w-full min-w-0 bg-bg flex flex-col overflow-hidden relative">
         {body}

--- a/website/src/test/detailPanelNarrow.test.tsx
+++ b/website/src/test/detailPanelNarrow.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * `DetailPanel` applies a `minWidth` FLOOR after every cap, and its own comment
+ * documents the residual: once the row cannot afford the floor, the floor wins and
+ * the panel overflows its row — "only reachable on a viewport narrower than
+ * minWidth + reserveWidth where the layout is already unusable".
+ *
+ * A phone is not already unusable; it is the target. Computed from the clamp at a
+ * 390px viewport:
+ *
+ *   Project Detail task panel  max(300, min(420, 234)) = 300  -> content  90px
+ *   ChatPage search panel      max(320, min(400, 234)) = 320  -> chat     70px
+ *
+ * No caller can configure its way out, because the floor is applied last.
+ *
+ * The narrow case reuses the EXISTING `embedded` rendering rather than forking the
+ * width style: that path is already full width, no divider, no width animation,
+ * and its `!embedded` gate drops the resize handle too. A style fork was tried and
+ * measured wrong — `width: 100%` on the inner div resolves against the motion
+ * wrapper, which is `shrink-0` with an animated `width: 'auto'`, i.e. content-sized.
+ * In an isolated 390px row that produced a 42px panel: narrower than before.
+ *
+ * These are RENDER assertions on the DOM the component produces. jsdom performs no
+ * layout, so what they pin is the width CONTRACT the browser then resolves.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+const mobile = { value: false }
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => mobile.value }))
+
+const { default: DetailPanel } = await import('../components/DetailPanel')
+
+afterEach(() => { cleanup(); mobile.value = false })
+
+describe('DetailPanel at narrow widths', () => {
+  it('renders the frameless full-width form while narrow', () => {
+    mobile.value = true
+    const { container } = render(
+      <DetailPanel title="t" onClose={() => {}} initialWidth={420} minWidth={300}>x</DetailPanel>,
+    )
+    const root = container.firstElementChild as HTMLElement
+    // `w-full`, and NO inline width: the width contract is gone rather than
+    // overridden, so no floor can reassert itself.
+    expect(root.className).toMatch(/\bw-full\b/)
+    expect(root.getAttribute('style') ?? '').not.toMatch(/width/)
+    // No motion wrapper to resolve a percentage against -- this IS the root.
+    expect(container.querySelector('div[style*="width"]')).toBeNull()
+  })
+
+  it('keeps the pixel width contract on a desktop', () => {
+    mobile.value = false
+    const { container } = render(
+      <DetailPanel title="t" onClose={() => {}} initialWidth={420} minWidth={300}>x</DetailPanel>,
+    )
+    const el = container.querySelector('div.border-l') as HTMLElement | null
+    expect(el, 'expected the bordered panel root on desktop').not.toBeNull()
+    expect(el!.style.width).toMatch(/^\d+px$/)
+    expect(el!.style.minWidth).toBe('300px')
+  })
+
+  it('drops the divider while narrow and keeps it on a desktop', () => {
+    mobile.value = true
+    const { container: narrow } = render(<DetailPanel title="t" onClose={() => {}}>x</DetailPanel>)
+    // Nothing sits to its left once it owns the width.
+    expect(narrow.querySelector('div.border-l')).toBeNull()
+    cleanup()
+    mobile.value = false
+    const { container: wide } = render(<DetailPanel title="t" onClose={() => {}}>x</DetailPanel>)
+    expect(wide.querySelector('div.border-l')).not.toBeNull()
+  })
+
+  it('drops the resize handle on touch and keeps it on a desktop', () => {
+    mobile.value = true
+    const { container: narrow } = render(<DetailPanel title="t" onClose={() => {}}>x</DetailPanel>)
+    // Pointer-only affordance, and there is nothing to resize against.
+    expect(narrow.querySelector('[role="separator"][aria-orientation="vertical"]')).toBeNull()
+    cleanup()
+    mobile.value = false
+    const { container: wide } = render(<DetailPanel title="t" onClose={() => {}}>x</DetailPanel>)
+    expect(wide.querySelector('[role="separator"][aria-orientation="vertical"]')).not.toBeNull()
+  })
+
+  it('still offers a way back out while narrow', () => {
+    // The panel owns the whole width, so its own close control is the ONLY route
+    // back to the content it covers.
+    mobile.value = true
+    const { container } = render(<DetailPanel title="t" onClose={() => {}}>x</DetailPanel>)
+    expect(container.querySelector('[aria-label]'), 'expected a labelled close control').not.toBeNull()
+  })
+
+  it('reuses the embedded rendering rather than forking it', () => {
+    // The two paths must stay ONE path: a second full-width branch would drift.
+    mobile.value = true
+    const { container: narrow } = render(<DetailPanel title="t" onClose={() => {}}>x</DetailPanel>)
+    const narrowCls = (narrow.firstElementChild as HTMLElement).className
+    cleanup()
+    mobile.value = false
+    const { container: emb } = render(<DetailPanel title="t" onClose={() => {}} embedded>x</DetailPanel>)
+    expect((emb.firstElementChild as HTMLElement).className).toBe(narrowCls)
+  })
+})


### PR DESCRIPTION
Same rule as #3840 / #3842 / #3849, applied at the SHARED primitive rather than one
page — `DetailPanel` is used by seven surfaces, and the defect is in its width
contract, not in any one caller.

## The defect is documented in the component's own comment

`DetailPanel` applies a `minWidth` **floor after every cap**. Its comment names the
consequence and the reasoning behind accepting it:

> Residual: when `rowWidth - reserveWidth < minWidth`, the `minWidth` floor in
> `clampPanelWidth` wins, so the panel can be wider than its row and overflow
> again. Only reachable on a viewport narrower than `minWidth + reserveWidth`
> **where the layout is already unusable**; the floor is preferred over an
> unreadably narrow panel.

A phone is not already unusable — it is the target. Computed from the clamp at a
390px viewport:

| caller | clamp | primary column |
|---|---|---|
| Project Detail task panel | `max(300, min(420, 234))` = **300px** | **90px** |
| ChatPage search panel | `max(320, min(400, 234))` = **320px** | **70px** of chat |

**No caller can configure its way out**, because the floor is applied last.
ChatPage is the one caller that tries: it passes `reserveWidth: undefined` while
narrow, which *removes* the row cap and leaves only the 60%-viewport bound — so the
floor wins there too, and the attempt makes it worse rather than better.

## The change

While narrow the width contract is dropped entirely — `100%`, no floor — so the
panel becomes a drill-down instead of a side-by-side that does not fit. Two riders
travel with the axis change: the left border goes (nothing sits to its left to
divide it from) and so does the resize handle (a pointer-only affordance, with
nothing left to resize against). The panel's own close control is the way back.

Desktop is untouched — the clamp, the row cap and the floor all still apply.

## Evidence, and one gap stated plainly

**What is verified.** Five RENDER assertions on the DOM the component actually
produces (not source greps): the inline `width: 100%` / `minWidth: 0` while narrow,
a pixel width and a `300px` floor on desktop, the divider present on desktop and
absent while narrow, the separator likewise, and a labelled close control while
narrow. Each falsified by a mutation, every mutation confirmed applied to the file
before its result was read:

| mutation | caught |
|---|---|
| don't release the width contract | yes |
| give `100%` but keep the `minWidth` floor | yes |
| let the resize handle back onto touch | yes |
| keep `border-l` while narrow | yes |

`tsc` clean. **All 26 test files that touch `DetailPanel` pass — 223 tests**,
including the 49 existing `DetailPanel` / `TaskDetailPanel` cases unchanged, which
is what shows the desktop contract really is untouched.

**What is NOT verified: there is no 390px screenshot.** I could not reach a single
`DetailPanel` caller at that width in an isolated pod, and I would rather say so
than pin a frame that shows something else. What I tried:

- **ChatPage search** — needs messages to search; a fresh session renders the hero
  instead, and `Ctrl+F` opened nothing.
- **Dev Fleet** — the pod's isolated HOME lists no worktrees, so no row to select.
- **Task Runner / Project Detail** — needs a run; runs live in the DB, so unlike
  issue-radar's `issues-cache.json` there is no credential-free file to seed.
- **Git / Markdown / Artifact panels** — all mounted inside the chat activity
  panel, which ChatPage does not mount at all while narrow (`activitySlot` is
  `null` when `isMobile`).

That last bullet is also the reason the blast radius is smaller than "seven
callers" sounds: on a phone the three chat-embedded panels are not rendered, so the
change lands on Project Detail, Dev Fleet, the aidlc task panel, and chat search.

**Where a reviewer should look:** ChatPage's search panel is the one caller where
full-width is a judgement call rather than obviously right — search results are the
content while searching, and jump-to-message still works with the chat behind it,
but I have not seen it. Anyone with a chat that has messages can check it in one
click. If it reads wrong there, the fix is a declared opt-out on that one call site
rather than reverting the primitive.



## Round 2 — the fix did not work, and both advisory reviews caught it

**Design and First Principles independently flagged that `width: 100%` on the
inner div cannot fill the row**, because its parent is the motion wrapper —
`shrink-0` with an animated `width: 'auto'`, i.e. content-sized. They were right. I
reproduced the exact DOM shape in isolation at a 390px row:

| shape | wrapper | panel | content |
|---|---|---|---|
| **what this PR shipped**: wrapper `auto` + `shrink-0`, panel `100%` | **42px** | **42px** | 348px |
| wrapper also `100%` | 390px | 390px | 0px |

So the panel collapsed to its own content width — **narrower than the 300px floor
it was meant to replace**. The fix was inert in the wrong direction, and the reason
I did not catch it is stated in the section above: no reachable surface, so no
rendered evidence. A reading review found what my missing screenshot would have.

**Taken First Principles' alternative rather than patching the fork.** A narrow
viewport now takes the same path as `embedded`, which was already exactly the
needed shape — full width, no divider, no width animation, and no resize handle
through its existing `!embedded` gate. The diff is now smaller than before: one
condition widened, no style fork, no conditional border. A test pins that the two
paths stay ONE path (the narrow root's className must equal the embedded root's),
so a future full-width branch cannot drift from it.

**Correcting a false claim in this PR body: Dev Fleet is NOT affected.** Both
reviews caught it. `DevFleetPage` defines its own local `DetailPanel`
(`DevFleetPage.tsx:442`) and does not import the shared one, so the earlier
"lands on ... Dev Fleet" was wrong.

**Accepted and deferred, with a reason:** First Principles found the pinned-messages
panel (`ChatPage.tsx:7012`) animating to a fixed 300px beside chat — the same defect
this fixes, but it does not go through `DetailPanel`, so it is a separate change
rather than something to widen this one into.
