### PR TITLE
refactor: measure the follow-up row's edges with the shared hook

### DIFF
--- a/website/src/components/FollowUpBar.tsx
+++ b/website/src/components/FollowUpBar.tsx
@@ -1,4 +1,5 @@
-import { memo, useRef, useState, useEffect, useCallback } from 'react'
+import { memo, useRef, useEffect, useCallback } from 'react'
+import { useScrollEdges } from '../hooks/useScrollEdges'
 import { ChevronLeft, ChevronRight, ArrowUp } from 'lucide-react'
 
 import { i18nT } from '../i18n/t'
@@ -219,16 +220,39 @@ function Chip({ option, isPicked, picked, quickSend, onSelect, onSend, className
 }
 
 function ScrollLayout({ options, picked, onSelect, onSend, quickSend }: Omit<FollowUpBarProps, 'layout'>) {
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const [canScrollL, setCanScrollL] = useState(false)
-  const [canScrollR, setCanScrollR] = useState(false)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const [attachEdges, edges, remeasure] = useScrollEdges<HTMLDivElement>()
+  const detachWheel = useRef<(() => void) | null>(null)
 
-  const updateScroll = useCallback(() => {
-    const el = scrollRef.current
-    if (!el) return
-    setCanScrollL(el.scrollLeft > 2)
-    setCanScrollR(el.scrollLeft + el.clientWidth < el.scrollWidth - 2)
+  // One ref callback owns everything bound to the scroller: the shared edge
+  // measurement plus this row's own wheel translation. Binding from the
+  // callback rather than a mount effect keeps the two in step — the node's
+  // arrival is what both depend on, not a render.
+  const setScroller = useCallback((node: HTMLDivElement | null) => {
+    detachWheel.current?.()
+    detachWheel.current = null
+    scrollRef.current = node
+    attachEdges(node)
+    if (!node) return
+    // Vertical wheel scrolls the row horizontally, but only while the row
+    // actually overflows — otherwise the page loses its own scroll.
+    const onWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return
+      if (node.scrollWidth <= node.clientWidth) return
+      e.preventDefault()
+      node.scrollLeft += e.deltaY
+    }
+    node.addEventListener('wheel', onWheel, { passive: false })
+    detachWheel.current = () => node.removeEventListener('wheel', onWheel)
+  }, [attachEdges])
+
+  useEffect(() => () => {
+    detachWheel.current?.()
+    detachWheel.current = null
   }, [])
+
+  // Chips changing keeps the row's own box, so no observer reports it.
+  useEffect(() => { remeasure() }, [options, remeasure])
 
   // Scroll by ~80% of the visible width in the given direction, so a click
   // reveals the next set of chips while keeping one in view for continuity.
@@ -238,28 +262,6 @@ function ScrollLayout({ options, picked, onSelect, onSend, quickSend }: Omit<Fol
     el.scrollBy({ left: dir * Math.max(el.clientWidth * 0.8, 120), behavior: 'smooth' })
   }, [])
 
-  useEffect(() => {
-    const el = scrollRef.current
-    if (!el) return
-    updateScroll()
-    el.addEventListener('scroll', updateScroll, { passive: true })
-    const ro = new ResizeObserver(updateScroll)
-    ro.observe(el)
-    const onWheel = (e: WheelEvent) => {
-      if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return
-      if (el.scrollWidth <= el.clientWidth) return
-      e.preventDefault()
-      el.scrollLeft += e.deltaY
-    }
-    el.addEventListener('wheel', onWheel, { passive: false })
-
-    return () => {
-      el.removeEventListener('scroll', updateScroll)
-      el.removeEventListener('wheel', onWheel)
-      ro.disconnect()
-    }
-  }, [updateScroll, options])
-
   // Small solid, vertically-centered pill button so the arrow reads as a
   // distinct control instead of a transparent icon colliding with the chip
   // text underneath it. The opaque background masks the faded edge chip.
@@ -268,9 +270,9 @@ function ScrollLayout({ options, picked, onSelect, onSend, quickSend }: Omit<Fol
   return (
     <div className="pt-1">
       <div className="relative">
-      {canScrollL && <div className="absolute left-0 top-0 bottom-0 w-10 z-10 pointer-events-none bg-gradient-to-r from-bg to-transparent" />}
-      {canScrollR && <div className="absolute right-0 top-0 bottom-0 w-10 z-10 pointer-events-none bg-gradient-to-l from-bg to-transparent" />}
-      {canScrollL && (
+      {edges.left && <div className="absolute left-0 top-0 bottom-0 w-10 z-10 pointer-events-none bg-gradient-to-r from-bg to-transparent" />}
+      {edges.right && <div className="absolute right-0 top-0 bottom-0 w-10 z-10 pointer-events-none bg-gradient-to-l from-bg to-transparent" />}
+      {edges.left && (
         <button
           type="button"
           aria-label={i18nT('components.followUpBar.scroll_suggestions_left')}
@@ -282,7 +284,7 @@ function ScrollLayout({ options, picked, onSelect, onSend, quickSend }: Omit<Fol
           <ChevronLeft size={16} />
         </button>
       )}
-      {canScrollR && (
+      {edges.right && (
         <button
           type="button"
           aria-label={i18nT('components.followUpBar.scroll_suggestions_right')}
@@ -294,7 +296,7 @@ function ScrollLayout({ options, picked, onSelect, onSend, quickSend }: Omit<Fol
           <ChevronRight size={16} />
         </button>
       )}
-      <div ref={scrollRef} className="flex gap-1.5 overflow-x-auto items-center" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
+      <div ref={setScroller} className="flex gap-1.5 overflow-x-auto items-center" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
         {options.map(o => {
           const isPicked = picked.has(o)
           return (

--- a/website/src/test/FollowUpBar.scrollEdges.test.tsx
+++ b/website/src/test/FollowUpBar.scrollEdges.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * The scroll layout's arrows and edge fades are driven by a MEASUREMENT, and
+ * that measurement is now the shared `useScrollEdges` hook rather than a
+ * hand-rolled copy. These tests pin the behaviour the conversion has to
+ * preserve, since the hand-rolled version shipped with none:
+ *
+ *   - a row that fits shows no arrow and no fade,
+ *   - a clipped row offers the arrow pointing at the hidden side only,
+ *   - the arrows follow the row as it is scrolled (which needs a listener bound
+ *     to the node, not a one-shot read),
+ *   - the wheel translation still rides on the same node after the binding moved
+ *     into the ref callback.
+ *
+ * jsdom does no layout, so scroll geometry is stubbed — that stub is what makes
+ * the derivation testable at all.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import FollowUpBar from '../components/FollowUpBar'
+
+/** `hidden` px of content beyond the right edge, `scrolled` px already past the left. */
+function stubGeometry({ hidden, scrolled = 0 }: { hidden: number; scrolled?: number }) {
+  const proto = window.HTMLElement.prototype
+  vi.spyOn(proto, 'clientWidth', 'get').mockReturnValue(320)
+  vi.spyOn(proto, 'scrollWidth', 'get').mockReturnValue(320 + hidden)
+  vi.spyOn(proto, 'scrollLeft', 'get').mockReturnValue(scrolled)
+}
+
+const OPTIONS = ['Ship it', 'Explain the diff', 'Run the tests']
+
+function renderScroll(options = OPTIONS) {
+  return render(<FollowUpBar options={options} picked={new Set()} onSelect={() => {}} layout="scroll" />)
+}
+
+const leftArrow = () => screen.queryByRole('button', { name: /scroll suggestions left/i })
+const rightArrow = () => screen.queryByRole('button', { name: /scroll suggestions right/i })
+
+describe('FollowUpBar scroll layout edges', () => {
+  beforeEach(() => {
+    if (!window.ResizeObserver) {
+      window.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      } as unknown as typeof ResizeObserver
+    }
+  })
+  afterEach(() => { vi.restoreAllMocks(); cleanup() })
+
+  it('offers no arrow and no fade when every chip fits', () => {
+    stubGeometry({ hidden: 0 })
+    const { container } = renderScroll()
+    expect(leftArrow()).toBeNull()
+    expect(rightArrow()).toBeNull()
+    expect(container.querySelector('.bg-gradient-to-l')).toBeNull()
+  })
+
+  it('offers only the arrow pointing at the hidden side', () => {
+    stubGeometry({ hidden: 240 })
+    const { container } = renderScroll()
+    expect(rightArrow()).toBeTruthy()
+    // Nothing is hidden to the left at offset 0, so an arrow there would scroll
+    // to content that does not exist.
+    expect(leftArrow()).toBeNull()
+    expect(container.querySelector('.bg-gradient-to-l')).toBeTruthy()
+  })
+
+  it('follows the row as it scrolls', () => {
+    stubGeometry({ hidden: 240 })
+    const { container } = renderScroll()
+    const scroller = container.querySelector('.overflow-x-auto') as HTMLElement
+    expect(leftArrow()).toBeNull()
+
+    // Scrolled to the far end: the hidden side flips.
+    stubGeometry({ hidden: 240, scrolled: 240 })
+    fireEvent.scroll(scroller)
+    expect(leftArrow()).toBeTruthy()
+    expect(rightArrow()).toBeNull()
+  })
+
+  it('translates a vertical wheel into horizontal scrolling only while clipped', () => {
+    stubGeometry({ hidden: 240 })
+    const { container } = renderScroll()
+    const scroller = container.querySelector('.overflow-x-auto') as HTMLElement
+    // scrollLeft is stubbed as a getter, so observe the preventDefault contract
+    // instead: the row claims the gesture exactly when it can act on it.
+    const clipped = new WheelEvent('wheel', { deltaY: 40, deltaX: 0, cancelable: true })
+    scroller.dispatchEvent(clipped)
+    expect(clipped.defaultPrevented).toBe(true)
+
+    vi.restoreAllMocks()
+    stubGeometry({ hidden: 0 })
+    const fits = new WheelEvent('wheel', { deltaY: 40, deltaX: 0, cancelable: true })
+    scroller.dispatchEvent(fits)
+    // A row that fits must leave the gesture to the page.
+    expect(fits.defaultPrevented).toBe(false)
+  })
+})


### PR DESCRIPTION
**Stacked on #3851** — its base is `fix/scroll-edges-late-mount`, not `main`, because it consumes the callback-ref form of `useScrollEdges` that #3851 introduces. GitHub retargets the base to `main` automatically when #3851 merges. Review #3851 first; the diff shown here is only this change.

## Why

First Principles Review on #3843 flagged that `useScrollEdges` was a third spelling of a measurement already hand-rolled twice. #3851 converted the first duplicate (the file-explorer tab strip). This converts the last one, so the answer to "is content hidden past this edge?" has one implementation instead of three — and these had already drifted: 2px of slack here, 4px in the tab strip, 1px in the hook.

I deliberately left this out of #3851 and said so there: it is not a like-for-like conversion, so it earns its own change.

## What stays local to this row

Only the measurement is shared. The row keeps the arrow buttons, the 80%-of-visible-width scroll step, and the wheel translation that turns a vertical gesture into horizontal movement — none of that belongs in a measurement hook.

The wheel listener moves into the same ref callback that binds the measurement. Both depend on the node arriving rather than on a render, and that is exactly the failure #3851 fixes: a mount effect binds nothing when the node is not there yet. Keeping them in one place means they cannot disagree about which node they are attached to.

## Behaviour change to be aware of

Slack narrows from 2px to 1px on this surface. It decides only how close to an edge an arrow stops being offered; a click still clamps at the end of the row. I chose convergence over preserving a magic number that no test or comment justified.

## Tests

The hand-rolled version shipped with no coverage for arrows, fades or the wheel path, so the conversion adds four tests, each falsified:

- a row that fits offers no arrow and no fade
- a clipped row offers only the arrow pointing at hidden content — forcing the flags off reds this and the next one
- the arrows follow the row as it is scrolled, which only passes with a listener bound to the node rather than a one-shot read
- the wheel claims the gesture (`preventDefault`) only while the row is clipped, and leaves it to the page otherwise — dropping the `wheel` binding reds exactly this one

No visual change on a row that was already correct: the fades and arrows render from the same flags, at the same positions, with the same classes.


<!-- no-visual-delta -->

**Why no screenshot:** this is a measurement swap with a byte-identical render — the fades and arrows come from the same two flags, at the same positions, with the same classes, so a before/after pair would be two identical frames and captioning them as a change would be misleading. The behaviour that IS observable (arrows appearing on the hidden side, following the row as it scrolls, the wheel claiming the gesture only while clipped) is pinned by four falsified tests, which the hand-rolled version had none of. The one deliberate behaviour change — slack 2px → 1px — is sub-pixel-adjacent by definition and cannot be photographed.
