### PR TITLE
fix(ci): stop the UX scope gate misreading a wide diff as not-UI-relevant

### DIFF
--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -249,7 +249,14 @@ jobs:
           changed="$( { grep -E '^\+\+\+ b/' "$PATCH" | sed 's#^+++ b/##'; \
                         grep -E '^--- a/' "$PATCH" | sed 's#^--- a/##'; } \
                       2>/dev/null | grep -v '^/dev/null$' | sort -u || true )"
-          if printf '%s\n' "$changed" | grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)'; then
+          # Here-string, NOT `printf … | grep -q`: under `pipefail` a matching
+          # `grep -q` exits as soon as it has its answer, closing the pipe while
+          # `printf` is still writing. `printf` then dies on SIGPIPE and the
+          # pipeline reports 141 for input that DID match, so a UI change is
+          # silently classified as not-UI-relevant and this review skips green.
+          # A here-string takes the writer out of the pipeline entirely, so no
+          # exit status can be manufactured by pipe timing.
+          if grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)' <<< "$changed"; then
             echo "ui=true" >> "$GITHUB_OUTPUT"
             echo "UI-relevant changes detected; running UX review."
           else

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -67,7 +67,14 @@ jobs:
         run: |
           set -euo pipefail
           changed="$(git diff --name-only "$BASE_SHA"...HEAD)"
-          if printf '%s\n' "$changed" | grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)'; then
+          # Here-string, NOT `printf … | grep -q`: under `pipefail` a matching
+          # `grep -q` exits as soon as it has its answer, closing the pipe while
+          # `printf` is still writing. `printf` then dies on SIGPIPE and the
+          # pipeline reports 141 for input that DID match, so a UI change is
+          # silently classified as not-UI-relevant and this review skips green.
+          # A here-string takes the writer out of the pipeline entirely, so no
+          # exit status can be manufactured by pipe timing.
+          if grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)' <<< "$changed"; then
             echo "ui=true" >> "$GITHUB_OUTPUT"
             echo "UI-relevant changes detected; running UX review."
           else

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -1090,6 +1090,119 @@ class TestForkLaneFinalizeRetries:
             assert "sleep 5" in flat, f"{lane}: retry has no backoff"
 
 
+UX_LANES = ("ux-review.yml", "fork-ux-review.yml")
+
+
+class TestUxScopeGateSurvivesAWideDiff:
+    """Execute the ACTUAL UI-detection shell from both UX lanes against a diff
+    big enough to expose the pipe-timing bug (#3447, defect 3).
+
+    Under ``pipefail``, ``printf … | grep -q`` reports 141 when the match is
+    found early enough that ``grep`` exits while ``printf`` is still writing:
+    ``printf`` dies on SIGPIPE and the pipeline's status becomes the writer's.
+    The gate then reads a MATCHING diff as "not UI-relevant" and the reviewer
+    skips green -- a silent, invisible loss rather than a visible failure.
+
+    Parameterized on the size of the non-matching tail because the defect is
+    latent at small sizes (printf finishes before grep exits, status 0) and
+    only appears once the write blocks -- which is exactly why it survived
+    review and only bites on wide diffs.
+    """
+
+    def _gate(self, name: str) -> str:
+        script = _step_script(_workflow(name), "Detect UI-relevant changes")
+        start = script.index("if grep -qE")
+        end = script.index("fi", start)
+        return script[start:end] + "fi"
+
+    @pytest.mark.parametrize("lane", UX_LANES)
+    @pytest.mark.parametrize("tail_files", [1, 200_000])
+    def test_a_ui_change_is_detected_regardless_of_diff_width(
+        self, lane: str, tail_files: int, tmp_path: Path
+    ) -> None:
+        bash = shutil.which("bash")
+        if bash is None:
+            pytest.skip("the scope gate runs only under Bash")
+        # The UI file comes FIRST so `grep -q` can answer immediately -- the
+        # worst case for the writer, and the one that manufactured 141.
+        touched = "website/src/App.tsx\n" + "\n".join(
+            f"src/kiro_crew/module_{i}.py" for i in range(tail_files)
+        )
+        # Via a FILE, not the environment: a 200k-line value blows past the
+        # execve argument/environment limit (E2BIG) long before it reaches the
+        # gate, and the test would fail on the harness rather than the defect.
+        # Both scratch paths live under tmp_path so pytest owns the cleanup.
+        listing = tmp_path / "touched.txt"
+        listing.write_text(touched)
+        github_output = tmp_path / "github_output"
+        github_output.touch()  # the Actions runtime pre-creates $GITHUB_OUTPUT
+        script = (
+            "set -euo pipefail\n"
+            'changed="$(cat "$TOUCHED_FILE")"\n'
+            + self._gate(lane)
+            + '\ncat "$GITHUB_OUTPUT"'
+        )
+        out = subprocess.run(
+            [bash, "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=tmp_path,
+            env={
+                **os.environ,
+                "TOUCHED_FILE": str(listing),
+                "GITHUB_OUTPUT": str(github_output),
+            },
+        )
+        assert out.returncode == 0, f"{lane}: gate exited {out.returncode}: {out.stderr}"
+        assert "ui=true" in out.stdout, (
+            f"{lane}: a diff touching website/ was classified as not-UI-relevant "
+            f"with a {tail_files}-file tail -- the UX review would skip green"
+        )
+
+    @pytest.mark.parametrize("lane", UX_LANES)
+    def test_a_non_ui_diff_still_skips(self, lane: str, tmp_path: Path) -> None:
+        """The fix must not turn the gate into an always-true: a backend-only
+        diff still has to skip, or every PR pays for a UX review."""
+        bash = shutil.which("bash")
+        if bash is None:
+            pytest.skip("the scope gate runs only under Bash")
+        touched = "src/kiro_crew/session.py\ndocs/ci/ci-and-reviews.md"
+        github_output = tmp_path / "github_output"
+        github_output.touch()  # the Actions runtime pre-creates $GITHUB_OUTPUT
+        script = (
+            "set -euo pipefail\n"
+            'changed="$TOUCHED"\n'
+            + self._gate(lane)
+            + '\ncat "$GITHUB_OUTPUT"'
+        )
+        out = subprocess.run(
+            [bash, "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=tmp_path,
+            env={
+                **os.environ,
+                "TOUCHED": touched,
+                "GITHUB_OUTPUT": str(github_output),
+            },
+        )
+        assert out.returncode == 0, out.stderr
+        assert "ui=false" in out.stdout, f"{lane}: backend-only diff was read as UI"
+
+    @pytest.mark.parametrize("lane", UX_LANES)
+    def test_the_gate_keeps_the_writer_out_of_the_pipeline(self, lane: str) -> None:
+        """Pin the SHAPE, not just the behaviour: the behavioural test above
+        needs a 200k-line diff to fail, so a revert to the piped form would
+        pass every small-input check and only regress in production."""
+        gate = self._gate(lane)
+        assert "<<<" in gate, f"{lane}: expected a here-string feeding grep"
+        assert "printf" not in gate, f"{lane}: writer is back in the pipeline"
+
+
 class TestPreparePrPreSubmitReview:
     def test_two_read_only_reviewers_run_before_the_first_push(self) -> None:
         skill = _prepare_pr_skill()


### PR DESCRIPTION
## Problem / Motivation

`ux-review.yml` and `fork-ux-review.yml` decide whether a PR touches UI with:

```bash
set -o pipefail
if printf '%s\n' "$changed" | grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)'; then
```

A matching `grep -q` exits as soon as it has its answer, closing the pipe while `printf` is still writing. `printf` then dies on SIGPIPE and, under `pipefail`, the pipeline reports **141 for input that did match**.

## Why it matters

That status lands in an `if` condition, so it is not treated as an error — it simply takes the `else` branch. The gate answers `ui=false`, the step exits **0**, and the UX review **skips green** on a diff that touches `website/`.

So the failure mode isn't a red check someone investigates; it's a silently missing review that looks like a pass. And because the defect only appears once `printf`'s write blocks, it is latent on small diffs and shows up specifically on **wide** ones — the case where a UX review is most warranted.

Measured directly against the real gate, on a 200,000-line file list whose first entry is `website/src/App.tsx`:

```
OLD  printf | grep -q          rc=0  ui=false   <- wrong, and silent
NEW  grep -q <<< here-string   rc=0  ui=true
```

## What changed (motivation → approach → change)

Both gates now feed `grep` from a **here-string**, which takes the writer out of the pipeline entirely so no exit status can be manufactured by pipe timing. This is the fix shape #3447 prescribes for defect 3, applied to the two gates it names.

I checked the other `| grep -q` uses across `.github/workflows/`. Most pipe genuinely bounded values (a PR state, a title, a short error string) and cannot realistically block a writer. **Three do not**, and an earlier revision of this description wrongly claimed otherwise: `screenshot-evidence.yml:104,118,122` pipe `$body` — the PR description, which GitHub caps at 65,536 characters, i.e. past the 64 KiB pipe buffer as soon as any multi-byte character appears — under the same `set -uo pipefail`. Same root cause; the failure mode there is a false red (evidence or an accepted waiver in a large body goes unseen) rather than a silent skip.

They are deliberately **not** fixed here: this PR is scoped to defect 3 of #3447 in the two UX lanes, and those are a different file and a different lane. Tracked with the verified line numbers and the same here-string fix shape in #5918.

## Tests

New `TestUxScopeGateSurvivesAWideDiff` in `test/test_ai_review_workflows.py` executes the **actual gate shell extracted from both lanes** (same approach as the existing `TestFirstPrinciplesScopeGateBehavior`):

- a `website/` change is detected with both a 1-file and a **200,000-file** non-matching tail — the wide case is the one that regressed;
- a backend-only diff still skips, so the fix isn't an always-true;
- a shape assertion pins the here-string. This one matters: the behavioural test needs a 200k-line diff to fail, so a revert to the piped form would pass every small-input check and only regress in production.

The large listing is passed via a temp **file**, not the environment — a 200k-line env value exceeds the `execve` limit (`E2BIG`) and the test would fail on the harness rather than the defect.

`test/test_ai_review_workflows.py`: 125 passed. `flake8` clean; both workflows still parse as YAML.

## Manual verification

The before/after table above is the verification — run against the real gate text, not a paraphrase of it.

## Screenshots / video

N/A — CI workflow change, no user-visible surface.

## Related Issues

Refs #3447 — **defect 3 only**. Defects 1 (finalize retry + stranded-run sweep, 4 lanes) and 2 (current-head proof marker, advisory lanes) touch different files and are left for their own PRs, as the issue itself frames them.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no CHANGELOG entry: the repo writes the changelog at version-bump only
- [x] No secrets, credentials, or internal references in the diff


