### PR TITLE
fix(ci): require the current-head marker before honouring an advisory verdict

### DIFF
--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -390,6 +390,19 @@ jobs:
           # Machine-parse the verdict header the prompt requires (case-insensitive).
           verdict="$(printf '%s\n' "$summary" | grep -iE '^Design-Verdict:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:lower:]' '[:upper:]')"
           [ -z "$verdict" ] && verdict="UNKNOWN"
+          # Require the CURRENT-HEAD proof marker before honouring that verdict.
+          # The prompt emits `[DESIGN-REVIEWED] <sha>`, but parsing the
+          # `Design-Verdict:` header alone made the marker decorative: a reply
+          # carrying a stale or rewritten marker still scored as a verdict for
+          # THIS revision, so a design verdict earned on older code could be
+          # presented as current. Absent or mismatched -> fall through to the
+          # existing non-blocking "could not complete" path rather than
+          # inventing a verdict. Here-string, not `printf | grep`, so a long
+          # summary cannot manufacture a SIGPIPE status under `pipefail`.
+          if ! grep -qF "[DESIGN-REVIEWED] $HEAD" <<< "$summary"; then
+            echo "verdict header present but no [DESIGN-REVIEWED] $HEAD marker; treating as UNKNOWN"
+            verdict="UNKNOWN"
+          fi
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
           MARKER="<!-- design-review -->"
           case "$verdict" in

--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -466,6 +466,7 @@ jobs:
         if: always()
         env:
           EXEC_FILE: ${{ steps.review.outputs.execution_file }}
+          HEAD: ${{ steps.pr.outputs.head_sha }}
         run: |
           set -uo pipefail
           summary=""
@@ -480,6 +481,20 @@ jobs:
           if [ -s "$RUNNER_TEMP/design-review-output.md" ]; then
             v="$(printf '%s\n' "$summary" | grep -iE '^Design-Verdict:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:lower:]' '[:upper:]')"
             [ -n "$v" ] && verdict="$v"
+          fi
+          # Require the CURRENT-HEAD proof marker before honouring that verdict.
+          # The prompt emits `[DESIGN-REVIEWED] <sha>`, but parsing the
+          # `Design-Verdict:` header alone made the marker decorative: a reply
+          # carrying a stale or rewritten marker still scored as a verdict for
+          # THIS revision, so a design verdict earned on older code could be
+          # presented as current. Absent or mismatched -> back to UNKNOWN, the
+          # existing non-blocking path, rather than inventing a verdict.
+          # Here-string, not `printf | grep`, so a long summary cannot
+          # manufacture a SIGPIPE status under `pipefail`.
+          if [ "$verdict" != "UNKNOWN" ] \
+             && ! grep -qF "[DESIGN-REVIEWED] ${HEAD:-}" <<< "$summary"; then
+            echo "verdict header present but no [DESIGN-REVIEWED] ${HEAD:-} marker; treating as UNKNOWN"
+            verdict="UNKNOWN"
           fi
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
           echo "Design review verdict: $verdict"

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -687,6 +687,19 @@ jobs:
           # Machine-parse the verdict header the prompt requires (case-insensitive).
           verdict="$(printf '%s\n' "$summary" | grep -iE '^UX-Verdict:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:lower:]' '[:upper:]')"
           [ -z "$verdict" ] && verdict="UNKNOWN"
+          # Require the CURRENT-HEAD proof marker before honouring that verdict.
+          # The prompt emits `[UX-REVIEWED] <sha>`, but parsing the
+          # `UX-Verdict:` header alone made the marker decorative: a reply
+          # carrying a stale or rewritten marker still scored as a verdict for
+          # THIS revision, so a UX verdict earned on older code could be
+          # presented as current. Absent or mismatched -> fall through to the
+          # existing non-blocking "could not complete" path rather than
+          # inventing a verdict. Here-string, not `printf | grep`, so a long
+          # summary cannot manufacture a SIGPIPE status under `pipefail`.
+          if ! grep -qF "[UX-REVIEWED] $HEAD" <<< "$summary"; then
+            echo "verdict header present but no [UX-REVIEWED] $HEAD marker; treating as UNKNOWN"
+            verdict="UNKNOWN"
+          fi
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
           case "$verdict" in
             PASS) badge="✅ PASS" ;;

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -548,6 +548,19 @@ jobs:
           # Machine-parse the verdict header the prompt requires (case-insensitive).
           verdict="$(printf '%s\n' "$summary" | grep -iE '^UX-Verdict:' | head -n1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | tr '[:lower:]' '[:upper:]')"
           [ -z "$verdict" ] && verdict="UNKNOWN"
+          # Require the CURRENT-HEAD proof marker before honouring that verdict.
+          # The prompt emits `[UX-REVIEWED] <sha>`, but parsing the
+          # `UX-Verdict:` header alone made the marker decorative: a reply
+          # carrying a stale or rewritten marker still scored as a verdict for
+          # THIS revision, so a UX verdict earned on older code could be
+          # presented as current. Absent or mismatched -> fall through to the
+          # existing non-blocking "could not complete" path rather than
+          # inventing a verdict. Here-string, not `printf | grep`, so a long
+          # summary cannot manufacture a SIGPIPE status under `pipefail`.
+          if ! grep -qF "[UX-REVIEWED] $HEAD" <<< "$summary"; then
+            echo "verdict header present but no [UX-REVIEWED] $HEAD marker; treating as UNKNOWN"
+            verdict="UNKNOWN"
+          fi
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
           case "$verdict" in
             PASS) badge="✅ PASS" ;;

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -1203,6 +1203,81 @@ class TestUxScopeGateSurvivesAWideDiff:
         assert "printf" not in gate, f"{lane}: writer is back in the pipeline"
 
 
+ADVISORY_LANES = {
+    "design-review.yml": "DESIGN-REVIEWED",
+    "fork-design-review.yml": "DESIGN-REVIEWED",
+    "ux-review.yml": "UX-REVIEWED",
+    "fork-ux-review.yml": "UX-REVIEWED",
+}
+
+
+class TestAdvisoryVerdictRequiresCurrentHeadMarker:
+    """#3447 defect 2: the advisory lanes emitted a `[<LANE>-REVIEWED] <sha>`
+    proof marker but scored the verdict off the header ALONE, so the marker was
+    decorative -- a reply carrying a stale or rewritten marker still counted as
+    a verdict for the current revision.
+
+    These lanes are non-blocking, so the failure is not a bad merge gate; it is
+    a badge that asserts "reviewed at this sha" without that being checked.
+    """
+
+    @pytest.mark.parametrize(("lane", "marker"), sorted(ADVISORY_LANES.items()))
+    def test_the_head_marker_is_verified_not_just_emitted(
+        self, lane: str, marker: str
+    ) -> None:
+        flat = _flat(_workflow(lane))
+        assert f'grep -qF "[{marker}] $HEAD"' in flat or (
+            f'grep -qF "[{marker}] ${{HEAD:-}}"' in flat
+        ), f"{lane}: verdict is accepted without proving the marker matches HEAD"
+        assert 'verdict="UNKNOWN"' in flat, (
+            f"{lane}: a missing marker must degrade to the existing "
+            "non-blocking UNKNOWN path, not invent a verdict"
+        )
+
+    @pytest.mark.parametrize(("lane", "marker"), sorted(ADVISORY_LANES.items()))
+    def test_the_marker_check_does_not_reintroduce_the_pipe_bug(
+        self, lane: str, marker: str
+    ) -> None:
+        """The check must not be `printf … | grep -q`: under `pipefail` a long
+        summary lets grep exit first, and the SIGPIPE status would silently
+        turn every verdict into UNKNOWN (same defect as #3447's defect 3)."""
+        flat = _flat(_workflow(lane))
+        i = flat.index(f"[{marker}] $")
+        window = flat[max(0, i - 200):i]
+        assert "printf" not in window.split("if ")[-1], (
+            f"{lane}: marker check pipes a writer into grep"
+        )
+
+    @pytest.mark.parametrize("marker", ["DESIGN-REVIEWED", "UX-REVIEWED"])
+    def test_marker_matching_is_literal_and_head_scoped(self, marker: str) -> None:
+        """Behavioural: the guard accepts only the CURRENT head's marker.
+
+        `grep -qF` matters -- the marker is bracketed, and those are regex
+        metacharacters, so a non-fixed match would not mean what it reads as.
+        """
+        bash = shutil.which("bash")
+        if bash is None:
+            pytest.skip("the guard runs only under Bash")
+        script = (
+            "set -uo pipefail\n"
+            'if ! grep -qF "[%s] $HEAD" <<< "$SUMMARY"; then\n'
+            '  echo UNKNOWN\nelse\n  echo KEPT\nfi'
+        ) % marker
+        cases = {
+            f"Verdict: PASS\n[{marker}] abc123": "KEPT",
+            f"Verdict: PASS\n[{marker}] deadbeef": "UNKNOWN",
+            "Verdict: PASS": "UNKNOWN",
+        }
+        for summary, want in cases.items():
+            out = subprocess.run(
+                [bash, "-c", script],
+                check=False, capture_output=True, text=True, encoding="utf-8",
+                env={**os.environ, "HEAD": "abc123", "SUMMARY": summary},
+            )
+            assert out.returncode == 0, out.stderr
+            assert out.stdout.strip() == want, f"{summary!r} -> {out.stdout!r}"
+
+
 class TestPreparePrPreSubmitReview:
     def test_two_read_only_reviewers_run_before_the_first_push(self) -> None:
         skill = _prepare_pr_skill()


### PR DESCRIPTION
## Problem / Motivation

`design-review.yml`, `ux-review.yml` and their fork counterparts each emit a proof marker into the review body:

```
[DESIGN-REVIEWED] <sha>     /     [UX-REVIEWED] <sha>
```

…but they score the verdict off the `Design-Verdict:` / `UX-Verdict:` **header alone**. The marker is never compared to the current head, so it is decorative.

## Why it matters

A reply carrying a **stale or rewritten** marker still scores as a verdict for the current revision. These lanes are advisory, so this isn't a bad merge gate — the harm is subtler: the posted badge says *"Advisory design-level review of `<head sha>`"* while the verdict behind it may have been earned on older code. A marker that exists specifically to prove "this verdict is about this revision" should be checked, or it is worse than not having one.

Audited all four lanes — every one emits the marker, none verifies it:

| lane | emits marker | verifies vs HEAD |
|---|---|---|
| `design-review.yml` | yes | **no** |
| `ux-review.yml` | yes | **no** |
| `fork-design-review.yml` | yes | **no** |
| `fork-ux-review.yml` | yes | **no** |

## What changed (motivation → approach → change)

All four lanes now require the exact current-head marker and, when it is absent or mismatched, fall through to the **existing** non-blocking UNKNOWN / "could not complete" path rather than inventing a verdict. That's the fix shape #3447 prescribes for defect 2, and it reuses a path that already exists in each lane (which also keeps the leak-safe behaviour: the UNKNOWN branch deliberately does not post raw model text).

Two details worth flagging for review:

- **`fork-design-review.yml` needed one extra line.** Its `Capture design verdict` step didn't have the head sha in scope, so `HEAD: ${{ steps.pr.outputs.head_sha }}` is added to that step's `env`. I confirmed by parsing the workflow that the `pr` step is defined earlier in the same job (`['pr', 'check', 'review', 'verdict']`), so the reference resolves.
- **`grep -qF`, not `grep -q`.** The marker is bracketed, and `[` / `]` are regex metacharacters — a non-fixed match would not mean what it reads as.

The check is written as a here-string rather than `printf … | grep -q`, so a long summary can't manufacture a SIGPIPE status under `pipefail` — that's the same defect this issue records as defect 3, and it would have silently turned every verdict into UNKNOWN here.

## Tests

New `TestAdvisoryVerdictRequiresCurrentHeadMarker` in `test/test_ai_review_workflows.py`:

- all four lanes verify the marker against `HEAD` and retain an UNKNOWN degrade path;
- the marker check does not pipe a writer into `grep` (guards against reintroducing defect 3 here);
- **behavioural**, executing the real guard under Bash: current-head marker → verdict kept; **stale** marker → UNKNOWN; no marker → UNKNOWN.

Verified the four lane-shape cases **fail against the pre-fix workflows** and pass after. `test/test_ai_review_workflows.py`: 122 passed. `flake8` clean; all four workflows still parse as YAML.

## Manual verification

The behavioural test above runs the exact guard expression; the stale-marker case is the one the old code got wrong.

## Screenshots / video

N/A — CI workflow change, no user-visible surface.

## Related Issues

Refs #3447 — **defect 2 only**. Defect 3 is #3854. Defect 1 (finalize retry + stranded-run sweep) touches four other lanes and is left for its own PR, as the issue frames them.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — CHANGELOG entry added
- [x] No secrets, credentials, or internal references in the diff
