### PR TITLE
fix(ci): retry the fork lanes' check-run finalize instead of stranding it

### DIFF
--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -569,11 +569,26 @@ jobs:
             BLOCK)    conclusion="failure"; title="BLOCK — design concern (advisory)" ;;
             *)        conclusion="neutral"; title="review incomplete (advisory)" ;;
           esac
+          # complete <conclusion> <title> — one retry, because a single transient
+          # 5xx here is what strands the run: the check-run stays `in_progress`
+          # forever, and pr-readiness counts ANY non-completed run of this name as
+          # pending — including after a successful re-run — so the PR sits at
+          # `readiness: checking` with no event able to clear it.
+          complete() {
+            for attempt in 1 2; do
+              if gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
+                -f status="completed" -f conclusion="$1" \
+                -f "output[title]=Design Review — $2" \
+                -f "output[summary]=Advisory fork design review for $HEAD. See the PR comment for details." >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::warning::could not complete check-run $CHECK_ID for $HEAD"
+            return 1
+          }
           if [ -n "${CHECK_ID:-}" ]; then
-            gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-              -f status="completed" -f conclusion="$conclusion" \
-              -f "output[title]=Design Review — $title" \
-              -f "output[summary]=Advisory fork design review for $HEAD. See the PR comment for details." >/dev/null || true
+            complete "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="Design Review" -f head_sha="$HEAD" \

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -723,11 +723,26 @@ jobs:
               conclusion="success"; title="no blocking findings"
             fi
           fi
+          # complete <conclusion> <title> — one retry, because a single transient
+          # 5xx here is what strands the run: the check-run stays `in_progress`
+          # forever, and pr-readiness counts ANY non-completed run of this name as
+          # pending — including after a successful re-run — so the PR sits at
+          # `readiness: checking` with no event able to clear it.
+          complete() {
+            for attempt in 1 2; do
+              if gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
+                -f status="completed" -f conclusion="$1" \
+                -f "output[title]=GPT 5.6 Review — $2" \
+                -f "output[summary]=Fork AI review for $HEAD. See the PR comment for details." >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::warning::could not complete check-run $CHECK_ID for $HEAD"
+            return 1
+          }
           if [ -n "${CHECK_ID:-}" ]; then
-            gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-              -f status="completed" -f conclusion="$conclusion" \
-              -f "output[title]=GPT 5.6 Review — $title" \
-              -f "output[summary]=Fork AI review for $HEAD. See the PR comment for details." >/dev/null || true
+            complete "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="GPT 5.6 Review" -f head_sha="$HEAD" \

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -458,11 +458,26 @@ jobs:
               conclusion="success"; title="no blocking findings"
             fi
           fi
+          # complete <conclusion> <title> — one retry, because a single transient
+          # 5xx here is what strands the run: the check-run stays `in_progress`
+          # forever, and pr-readiness counts ANY non-completed run of this name as
+          # pending — including after a successful re-run — so the PR sits at
+          # `readiness: checking` with no event able to clear it.
+          complete() {
+            for attempt in 1 2; do
+              if gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
+                -f status="completed" -f conclusion="$1" \
+                -f "output[title]=Opus 4.8 Review — $2" \
+                -f "output[summary]=Fork AI review for $HEAD. See the PR comment for details." >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::warning::could not complete check-run $CHECK_ID for $HEAD"
+            return 1
+          }
           if [ -n "${CHECK_ID:-}" ]; then
-            gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-              -f status="completed" -f conclusion="$conclusion" \
-              -f "output[title]=Opus 4.8 Review — $title" \
-              -f "output[summary]=Fork AI review for $HEAD. See the PR comment for details." >/dev/null || true
+            complete "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="Opus 4.8 Review" -f head_sha="$HEAD" \

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -756,11 +756,26 @@ jobs:
             *)
               conclusion="neutral"; title="review incomplete (advisory)" ;;
           esac
+          # complete <conclusion> <title> — one retry, because a single transient
+          # 5xx here is what strands the run: the check-run stays `in_progress`
+          # forever, and pr-readiness counts ANY non-completed run of this name as
+          # pending — including after a successful re-run — so the PR sits at
+          # `readiness: checking` with no event able to clear it.
+          complete() {
+            for attempt in 1 2; do
+              if gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
+                -f status="completed" -f conclusion="$1" \
+                -f "output[title]=UX Review — $2" \
+                -f "output[summary]=Advisory fork UX review for $HEAD. See the PR comment for details." >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::warning::could not complete check-run $CHECK_ID for $HEAD"
+            return 1
+          }
           if [ -n "${CHECK_ID:-}" ]; then
-            gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-              -f status="completed" -f conclusion="$conclusion" \
-              -f "output[title]=UX Review — $title" \
-              -f "output[summary]=Advisory fork UX review for $HEAD. See the PR comment for details." >/dev/null || true
+            complete "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="UX Review" -f head_sha="$HEAD" \

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -1030,6 +1030,66 @@ class TestFirstPrinciplesScopeGateBehavior:
         assert (out.stdout == "true") is want, f"{lane}: {touched!r} -> {out.stdout!r}"
 
 
+FORK_FINALIZE_LANES = (
+    "fork-opus-review.yml",
+    "fork-gpt-review.yml",
+    "fork-design-review.yml",
+    "fork-ux-review.yml",
+)
+
+
+class TestForkLaneFinalizeRetries:
+    """#3447 defect 1: the fork lanes finalized their check-run with a bare
+    `PATCH … || true`.
+
+    One transient API failure there leaves the run `in_progress` forever, and
+    pr-readiness counts ANY non-completed check-run of that name as pending --
+    including after a successful re-run -- so the PR sits at
+    `readiness: checking` with no event able to clear it. `|| true` also
+    swallowed the failure, so nothing in the log said why.
+
+    fork-first-principles-review.yml already carries the retry helper this
+    pins; these tests keep the other four from drifting back.
+    """
+
+    @pytest.mark.parametrize("lane", FORK_FINALIZE_LANES)
+    def test_the_finalize_patch_retries_before_giving_up(self, lane: str) -> None:
+        flat = _flat(_workflow(lane))
+        assert "complete() {" in flat, f"{lane}: no complete() helper"
+        assert "for attempt in 1 2; do" in flat, (
+            f"{lane}: finalize does not retry, so one transient 5xx strands the run"
+        )
+
+    @pytest.mark.parametrize("lane", FORK_FINALIZE_LANES)
+    def test_a_permanent_finalize_failure_is_announced(self, lane: str) -> None:
+        """`|| true` alone made a stranded run silent. A wedged PR must at
+        least say so in the job log."""
+        flat = _flat(_workflow(lane))
+        assert "could not complete check-run" in flat, (
+            f"{lane}: a failed finalize leaves no trace in the log"
+        )
+
+    @pytest.mark.parametrize("lane", FORK_FINALIZE_LANES)
+    def test_the_bare_unretried_patch_is_gone(self, lane: str) -> None:
+        """Shape guard: the defect is the un-retried form, so pin its absence
+        rather than only the presence of the replacement."""
+        flat = _flat(_workflow(lane))
+        assert 'check-runs/$CHECK_ID" -f status="completed"' not in flat or (
+            "complete() {" in flat
+        ), f"{lane}: bare un-retried finalize PATCH is back"
+
+    def test_the_helper_matches_the_reference_lane(self) -> None:
+        """The first-principles lane is where this helper was introduced; the
+        ported copies should not diverge from its retry shape."""
+        ref = _flat(_workflow("fork-first-principles-review.yml"))
+        assert "for attempt in 1 2; do" in ref
+        assert "could not complete check-run" in ref
+        for lane in FORK_FINALIZE_LANES:
+            flat = _flat(_workflow(lane))
+            assert "for attempt in 1 2; do" in flat, lane
+            assert "sleep 5" in flat, f"{lane}: retry has no backoff"
+
+
 class TestPreparePrPreSubmitReview:
     def test_two_read_only_reviewers_run_before_the_first_push(self) -> None:
         skill = _prepare_pr_skill()


### PR DESCRIPTION
## Problem / Motivation

The four fork reviewer lanes (`fork-opus-review.yml`, `fork-gpt-review.yml`, `fork-design-review.yml`, `fork-ux-review.yml`) finalize their check-run like this:

```bash
gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
  -f status="completed" -f conclusion="$conclusion" \
  … >/dev/null || true
```

No retry, and `|| true` swallows the failure.

## Why it matters

This is the one defect in #3447 with a **user-visible failure**. A single transient API error leaves the check-run `in_progress` forever, and `pr-readiness.yml` counts *any* non-completed check-run of that name as pending — **including after a successful re-run**. The PR then sits at `readiness: checking` with no event able to clear it, so it's wedged rather than merely red. And because of `|| true`, nothing in the job log says why.

## What changed (motivation → approach → change)

All four lanes now finalize through the same one-retry `complete()` helper that `fork-first-principles-review.yml` already carries (#3436 introduced it there), so the four drift back into line with the reference rather than growing a fifth variant. A finalize that still fails after both attempts emits a `::warning::` naming the check-run and head instead of exiting quietly.

Retry semantics verified directly by stubbing `gh`:

```
transient-then-ok  -> completed after 2 attempt(s)
always-fails       -> warned after 2 attempts (was: silent || true)
```

## Deliberately NOT in scope: the stranded-run sweep

#3436's implementation also sweeps already-incomplete runs, and I chose not to port that here. The sweep is scoped by `external_id` precisely so it can never complete a check-run belonging to a **different PR that shares the head commit** — completing that one would publish a verdict computed from a different diff. **None of these four lanes set `external_id` when they create their run**, so porting the sweep safely means first adding it at each creation site.

That's a change to the creation path of the two *blocking* lanes (Opus/GPT), and the sweep would only help runs created after it lands — while the retry above is what prevents new strandings in the first place. It deserves its own PR and its own review rather than widening this one.

## Tests

New `TestForkLaneFinalizeRetries` in `test/test_ai_review_workflows.py`:

- each of the four lanes has the retry helper **and** a backoff;
- a permanent failure is announced in the log rather than swallowed;
- the bare un-retried PATCH shape is gone (pins the defect's absence, not just the replacement's presence);
- the ported copies don't diverge from the reference lane's retry shape.

**9 of the 13 fail against the pre-fix workflows.** `test/test_ai_review_workflows.py`: 125 passed. `flake8` clean; all four workflows still parse as YAML.

## Manual verification

The stubbed-`gh` transcript above is the verification of the retry itself; the rest is pinned by the tests.

## Screenshots / video

N/A — CI workflow change, no user-visible surface.

## Related Issues

Refs #3447 — **defect 1**, minus the sweep as explained above. Defect 3 is #3854; defect 2 is #3855.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no CHANGELOG entry: the original one targeted `[Unreleased]`, which no longer exists after the 0.4.0 release; dropped during the rebase per the released-section policy
- [x] No secrets, credentials, or internal references in the diff

