### PR TITLE
fix(install): don't build the frontend against an under-floor Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **`install.sh` no longer builds the dashboard against an unsupported
+  Node, leaving a "Dashboard HTML not found" page.** The Node ladder's
+  first branch tested `has node` alone, so a system Node below the
+  supported floor satisfied it and every install branch — apt/dnf/brew AND
+  nvm — was skipped. On Amazon Linux 2023 (Node 18) the frontend build then
+  ran under an unsupported interpreter, emitted only `EBADENGINE` warnings,
+  and produced no usable `dist/`; the launch still reported success because
+  the Python gateway answers `/api/health` without a frontend, so the first
+  symptom was a broken dashboard at first open. Detection now consults the
+  floor via a `node_supported()` helper: an under-floor Node falls through
+  to the install ladder (distro package first, then nvm) instead of being
+  accepted. The bundle build also sets a default
+  `NODE_OPTIONS=--max-old-space-size=8192`, since V8's ~2 GB default is not
+  enough for this module graph and the OOM surfaces as a build that dies
+  with no clear cause. (#3220)
+
 - **Opted-in MCP servers no longer silently fall back to unpooled backends.**
   On one live host, 988 degradations accrued in 15 hours with no signal: 79%
   were guaranteed-ENOENT pooled spawns of bare commands the gateway daemon's

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,10 @@ KIROCREW_APP_DIR="$(cd "$(dirname "$0")" && pwd)"
 # pre-move ~/.kirocrew, which the one-time data-home migration deletes).
 KIROCREW_DATA_DIR="${KIROCREW_HOME:-$HOME/.kiro/crew}"
 NODE_VERSION="24"
+# Minimum Node major the frontend build actually supports. Defined here
+# (not just at the post-install check) because DETECTION consults it: a
+# pre-existing but too-old node must not short-circuit the install ladder.
+NODE_MIN_MAJOR=22
 PYTHON_VERSION="3.12"
 KIROCREW_PORT="${KIROCREW_PORT:-5476}"
 ACP_NPM_PKG="@agentclientprotocol/claude-agent-acp"
@@ -116,6 +120,18 @@ spinner() {
 }
 
 has() { command -v "$1" >/dev/null 2>&1; }
+
+# True only when a usable node is on PATH: present AND at or above the build's
+# supported floor. `has node` alone was not enough -- Amazon Linux 2023 ships
+# node 18, so the "already installed" branch matched, every install branch
+# (including nvm) was skipped, and the frontend build then ran under an
+# unsupported node and produced no usable dist. A broken binary reports v0 and
+# fails the comparison, which is the intended answer.
+node_supported() {
+    has node || return 1
+    _n="$( { node --version 2>/dev/null || echo v0; } | sed 's/^v//' | cut -d. -f1)"
+    [ -n "$_n" ] && [ "$_n" -ge "$NODE_MIN_MAJOR" ] 2>/dev/null
+}
 
 # ── Pre-flight ──
 
@@ -238,9 +254,36 @@ fi
 # ── Node.js ──
 if [ "$USE_MISE" -eq 0 ]; then
 info "Checking Node.js…"
-if has node; then
+if node_supported; then
     _node_ver=$(node --version 2>/dev/null || echo "v0")
     ok "Node.js $_node_ver ($( which node ))"
+elif has node; then
+    # Present but below the floor: say so, then fall through to the install
+    # ladder below rather than building against it.
+    info "Node.js $(node --version 2>/dev/null || echo v0) is below the supported floor (>= $NODE_MIN_MAJOR) — installing a supported Node…"
+    if has apt-get; then
+        sudo apt-get install -y nodejs npm >/dev/null 2>&1 || true
+    elif has dnf; then
+        sudo dnf install -y nodejs >/dev/null 2>&1 || true
+    elif has brew; then
+        brew install node >/dev/null 2>&1 || true
+    fi
+    if ! node_supported; then
+        # Distro package still too old (the common case on AL2023/Debian):
+        # nvm is the only channel that reliably provides a current Node.
+        info "Installing Node.js $NODE_VERSION via nvm…"
+        if [ ! -d "$HOME/.nvm" ]; then
+            curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash 2>/dev/null
+        fi
+        export NVM_DIR="$HOME/.nvm"
+        # shellcheck disable=SC1091
+        [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+        nvm install "$NODE_VERSION" >/dev/null 2>&1
+        nvm alias default "$NODE_VERSION" >/dev/null 2>&1
+    fi
+    node_supported \
+        && ok "Node.js $(node --version) now active" \
+        || warn "Node.js is still below v$NODE_MIN_MAJOR — the frontend build will fail"
 elif has apt-get; then
     info "Installing nodejs via apt…"
     sudo apt-get install -y nodejs npm >/dev/null 2>&1
@@ -275,7 +318,6 @@ fi # USE_MISE -eq 0 (Node.js)
 # The apt/dnf/brew branches above accept whatever Node the distro ships, which
 # can be older than the supported floor (Debian/Ubuntu in particular). Catch
 # that here rather than as a confusing frontend-build failure later.
-NODE_MIN_MAJOR=22
 if has node; then
     # `|| echo v0` keeps a broken node binary (loader error) from killing the
     # installer under `set -e`; v0 then trips the floor warning below.
@@ -329,7 +371,11 @@ if has node && [ -d "$KIROCREW_APP_DIR/website" ]; then
         else
             npm install --no-audit --no-fund --loglevel=error 2>"$_fe_log"
         fi &&
-        npm run build 2>>"$_fe_log"
+        # Raise V8's heap ceiling for the bundle build. The default (~2 GB on
+        # 64-bit) is not enough for this app's 6k+ module graph, and the OOM
+        # surfaces as a build that dies without a clear cause -- leaving no
+        # dist/ and a "Dashboard HTML not found" page at first launch.
+        NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=8192}" npm run build 2>>"$_fe_log"
     ) &
     spinner $! "Installing npm packages & building React app…"
     _fe_ok=0

--- a/test/test_installer_node_floor.py
+++ b/test/test_installer_node_floor.py
@@ -1,0 +1,138 @@
+"""The installer must not build the frontend against an unsupported Node.
+
+Amazon Linux 2023 ships node 18. ``install.sh`` gated its "already installed"
+branch on ``has node`` alone, so that system node matched, EVERY install branch
+(apt/dnf/brew and nvm) was skipped, and the frontend build then ran under an
+unsupported interpreter -- emitting only ``EBADENGINE`` warnings and no usable
+``dist/``. The launch still reported success (the Python gateway answers
+``/api/health`` without a frontend), so the first symptom a user saw was
+"Dashboard HTML not found" (#3220).
+
+The floor is now consulted at DETECTION time via ``node_supported()``. These
+tests extract that helper from the real ``install.sh`` and run it against fake
+``node`` binaries, rather than executing the whole installer (which would
+install packages).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="POSIX shell installer; not exercised on native Windows"
+)
+
+
+def _helper_source() -> str:
+    """The floor constant plus `has`/`node_supported`, lifted verbatim.
+
+    Extracted rather than duplicated so the test cannot drift from the shipped
+    definition -- a copy would keep passing after the real helper regressed.
+    """
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    floor = next(
+        line for line in text.splitlines() if line.startswith("NODE_MIN_MAJOR=")
+    )
+    has_start = text.index("has() {")
+    fn_start = text.index("node_supported() {")
+    fn_end = text.index("\n}", fn_start) + len("\n}")
+    return f"{floor}\n{text[has_start:text.index(chr(10), has_start)]}\n{text[fn_start:fn_end]}\n"
+
+
+def _run_with_node(tmp_path: Path, version: str | None) -> int:
+    """Return `node_supported`'s exit status with a fake `node` reporting *version*.
+
+    ``version=None`` means no node on PATH at all.
+    """
+    binbox = tmp_path / "bin"
+    binbox.mkdir(exist_ok=True)
+    if version is not None:
+        node = binbox / "node"
+        node.write_text(f'#!/bin/sh\n[ "$1" = "--version" ] && echo "{version}"\n')
+        node.chmod(0o755)
+    # Isolated PATH: only the fake node plus the shell utilities the helper
+    # itself calls, so a host node can never satisfy the check.
+    tools = binbox / "tools"
+    tools.mkdir(exist_ok=True)
+    for util in ("sed", "cut", "sh", "env"):
+        real = shutil.which(util)
+        if real:
+            link = tools / util
+            if not link.exists():
+                link.symlink_to(real)
+    script = _helper_source() + "node_supported\n"
+    bash = shutil.which("bash")
+    if bash is None:  # pragma: no cover - POSIX hosts always have bash
+        pytest.skip("bash not available")
+    # Absolute bash: the isolated PATH below deliberately excludes it, and
+    # execvp would otherwise resolve argv[0] against that same stripped PATH.
+    return subprocess.run(
+        [bash, "-c", script],
+        env={"PATH": f"{binbox}:{tools}"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    ).returncode
+
+
+class TestNodeFloorIsAuthoritative:
+    @pytest.mark.parametrize("version", ["v18.20.8", "v20.11.0", "v16.0.0"])
+    def test_an_under_floor_node_is_refused(self, tmp_path: Path, version: str) -> None:
+        """The AL2023 case: node exists, so the old `has node` gate accepted it
+        and skipped every install branch."""
+        assert _run_with_node(tmp_path, version) != 0, (
+            f"{version} was accepted; the installer would build against it"
+        )
+
+    @pytest.mark.parametrize("version", ["v22.0.0", "v24.5.1", "v25.0.0"])
+    def test_a_supported_node_is_accepted(self, tmp_path: Path, version: str) -> None:
+        """Equally important: a usable node must NOT trigger a reinstall."""
+        assert _run_with_node(tmp_path, version) == 0, f"{version} was rejected"
+
+    def test_no_node_at_all_is_refused(self, tmp_path: Path) -> None:
+        assert _run_with_node(tmp_path, None) != 0
+
+    def test_a_broken_node_binary_is_refused_not_crashed_on(
+        self, tmp_path: Path
+    ) -> None:
+        """A node that errors instead of printing a version reports v0 and
+        fails the comparison -- it must not abort the installer."""
+        binbox = tmp_path / "bin"
+        binbox.mkdir()
+        node = binbox / "node"
+        node.write_text('#!/bin/sh\necho "loader error" >&2\nexit 1\n')
+        node.chmod(0o755)
+        script = _helper_source() + "node_supported\n"
+        bash = shutil.which("bash")
+        out = subprocess.run(
+            [bash or "/bin/bash", "-c", script],
+            env={"PATH": str(binbox) + ":" + os.environ.get("PATH", "")},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert out.returncode != 0, "a broken node binary was treated as supported"
+
+
+class TestFrontendBuildHeadroom:
+    def test_the_build_raises_the_v8_heap_ceiling(self) -> None:
+        """V8's ~2 GB default is not enough for this bundle; the OOM shows up
+        as a build that dies with no clear cause and no dist/ (#3220)."""
+        text = INSTALL_SH.read_text(encoding="utf-8")
+        assert "--max-old-space-size" in text
+        # Set only as a default so an operator can still override it.
+        assert 'NODE_OPTIONS="${NODE_OPTIONS:-' in text
+
+    def test_the_floor_is_defined_once(self) -> None:
+        """The constant is consulted by both detection and the post-install
+        check; two definitions could disagree."""
+        text = INSTALL_SH.read_text(encoding="utf-8")
+        assert text.count("NODE_MIN_MAJOR=") == 1


### PR DESCRIPTION
## Problem / Motivation

`kirocrew cloud launch` completes successfully — `CREATE_COMPLETE`, health check green — but the dashboard shows **"Dashboard HTML not found"**, because the frontend was never built.

## Why it matters

The launch *reports success*: the Python gateway answers `/api/health` without a frontend, so nothing fails during provisioning. The first symptom is a broken dashboard at first open, on a fresh install, with no error to point at. On Amazon Linux 2023 this reproduces every time.

## What changed (motivation → approach → change)

**Correcting the issue's stated cause.** #3220 attributes this to nvm-installed Node 20 not being active for the build subshell. Reading the script, nvm never runs at all on that host: the Node ladder opens with

```bash
if has node; then
    ok "Node.js $_node_ver"
elif has apt-get; then …
else
    # nvm branch — never reached
fi
```

`has node` accepts **any** node on PATH. AL2023 ships node 18, so the first branch matches and every install branch — apt/dnf/brew *and* nvm — is skipped. The frontend build then runs under an unsupported interpreter, emits only `EBADENGINE` warnings, and produces no usable `dist/`.

The post-install floor check (`NODE_MIN_MAJOR=22`) *did* notice, but only `warn`ed — the build proceeded anyway. Its own comment says "the apt/dnf/brew branches above accept whatever Node the distro ships", which is true but misses that the **first** branch has the same problem.

**The fix.** Detection now consults the floor through a `node_supported()` helper (present *and* major ≥ `NODE_MIN_MAJOR`). An under-floor node falls through to the install ladder — distro package first, then nvm, which is the only channel that reliably provides a current Node on AL2023/Debian — and the result is re-checked before continuing. `NODE_MIN_MAJOR` moves up beside `NODE_VERSION` so detection and the post-install check share one definition.

The bundle build additionally sets a **default** `NODE_OPTIONS=--max-old-space-size=8192` (still overridable), the issue's second suggestion: V8's ~2 GB default isn't enough for this module graph, and that OOM also surfaces as a build that dies with no clear cause and no `dist/`.

I did **not** implement the issue's suggestions 3 (`engine-strict`) and 4 (assert `static/dist/index.html` before signalling success). Both are reasonable, but they change failure semantics for every install path rather than fixing this cause, and the WaitCondition lives in the EC2 template rather than `install.sh` — better as their own change.

## Tests

New `test/test_installer_node_floor.py` **extracts the real `node_supported` helper from `install.sh`** — rather than duplicating it, so the test cannot keep passing after the shipped helper regresses — and runs it under an isolated PATH against fake `node` binaries:

- v16 / v18 / v20 refused (v18 is the AL2023 case);
- v22 / v24 / v25 accepted — equally important, a usable node must not trigger a pointless reinstall;
- no node at all refused; a **broken** node binary refused rather than aborting the installer;
- the heap ceiling is set as an overridable default, and the floor constant is defined exactly once.

**9 of the 10 fail against pre-fix `install.sh`.**

`test_installer_distro.py` + `test_cloud_install.py` + `test_installer_shim_and_cleanup.py` + the new file: **48 passed, 1 failed** — `test_cli_fails_over_from_a_wedged_interpreter_candidate`, which exercises `cli.sh` (untouched here) and times out identically with my change stashed, so it's pre-existing and unrelated. `bash -n install.sh` clean; `flake8` clean.

## Manual verification

Not run end-to-end against a live AL2023 EC2 instance — I don't have one to launch. The behaviour is pinned by the extracted-helper tests above, which reproduce the exact version matrix (including v18) that causes the reported failure.

## Screenshots / video

N/A — installer shell script, no user-visible surface in this diff.

## Related Issues

Refs #3220

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — CHANGELOG entry added
- [x] No secrets, credentials, or internal references in the diff
