### PR TITLE
fix(apps): stack the meetings and pptx-maker splits at phone widths

### DIFF
--- a/website/src/apps/meetings/MeetingView.tsx
+++ b/website/src/apps/meetings/MeetingView.tsx
@@ -120,8 +120,13 @@ export default function MeetingView({
   }
 
   return (
-    <div className="flex h-full overflow-hidden">
-      <div className="flex-1 flex flex-col h-full overflow-hidden">
+    // Stacks below `lg`, the same shape MeetingWorkspace and TaskReviewView
+    // already use in this app: a 340px task sidebar beside the meeting left the
+    // content 49px at 390px. `min-w-0`/`min-h-0` on the content column is what
+    // lets it actually shrink -- without it the row overflowed sideways instead,
+    // pushing the meeting off-screen rather than narrowing it.
+    <div className="flex flex-col lg:flex-row h-full overflow-hidden">
+      <div className="flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden">
         <div className="flex-none px-6 py-4 border-b border-border flex items-center justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
             <Btn onClick={onBack} aria-label={i18nT('apps.meetings.meeting.back')}>

--- a/website/src/apps/meetings/components/TaskSidebar.tsx
+++ b/website/src/apps/meetings/components/TaskSidebar.tsx
@@ -42,8 +42,12 @@ export default function TaskSidebar({ tasks, onClose, onAdd, onUpdate, onDelete 
   const open = tasks.filter(task => task.review_status !== 'archived')
 
   return (
+    // Full width below `lg`, stacked under the meeting with a bounded height --
+    // the same shape MeetingWorkspace's transcript pane uses. The divider turns
+    // with the layout: a left border between two stacked blocks draws a line down
+    // the side of the sidebar instead of between the two.
     <aside
-      className="flex-none w-[340px] border-l border-border bg-bg flex flex-col overflow-hidden"
+      className="flex-none w-full h-[42%] min-h-[260px] border-t border-border lg:h-full lg:w-[340px] lg:border-t-0 lg:border-l bg-bg flex flex-col overflow-hidden"
       aria-label={i18nT('apps.meetings.taskSidebar.title')}
     >
       <div className="flex items-center gap-2 px-4 py-3 border-b border-border">

--- a/website/src/apps/pptx-maker/LibraryPanel.tsx
+++ b/website/src/apps/pptx-maker/LibraryPanel.tsx
@@ -294,8 +294,10 @@ export default function LibraryPanel({ kind }: { kind: LibraryKind }) {
       )}
       {notice && <div className="mb-3 text-[13px] text-muted">{notice}</div>}
 
-      <div className="flex gap-4 flex-1 min-h-0">
-        <div className="w-56 shrink-0 overflow-y-auto border-r border-border pr-3">
+      <div className="flex flex-col sm:flex-row gap-4 flex-1 min-h-0">
+        {/* Stacked while narrow, same reason as the deck split above: a 224px
+            template list beside the detail left it too little to read. */}
+        <div className="w-full sm:w-56 shrink-0 max-h-[40vh] sm:max-h-none overflow-y-auto border-b sm:border-b-0 sm:border-r border-border pb-3 sm:pb-0 sm:pr-3">
           {loading && (
             <div className="text-sm text-muted px-1">
               {i18nT('apps.pptxMaker.libraryPanel.loading')}

--- a/website/src/apps/pptx-maker/PptxMakerPage.tsx
+++ b/website/src/apps/pptx-maker/PptxMakerPage.tsx
@@ -418,8 +418,12 @@ export default function PptxMakerPage() {
                 />
               )}
               {filtered.length > 0 && (
-                <div className="flex gap-4 flex-1 min-h-0">
-                  <div className="w-60 shrink-0 overflow-y-auto border-r border-border pr-3">
+                <div className="flex flex-col sm:flex-row gap-4 flex-1 min-h-0">
+                  {/* Stacked while narrow: a 240px deck list beside the viewer left
+                      it 86px of a 390px viewport -- 44px once the surrounding Card
+                      padding is counted. The list is bounded when stacked, or its
+                      `shrink-0` natural height would push the viewer out. */}
+                  <div className="w-full sm:w-60 shrink-0 max-h-[40vh] sm:max-h-none overflow-y-auto border-b sm:border-b-0 sm:border-r border-border pb-3 sm:pb-0 sm:pr-3">
                     {filtered.map((deck) => (
                       <Clickable
                         key={deck.deckId}

--- a/website/src/test/appSplitsNarrowA.test.ts
+++ b/website/src/test/appSplitsNarrowA.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Two builtin apps whose desktop left/right splits had no narrow-viewport branch
+ * at all. Measured at a 390px viewport before this change:
+ *
+ *   meetings MeetingView   340px task sidebar  -> content   49px (or the row
+ *                                                 overflowed: the content column
+ *                                                 lacked `min-w-0`, so it refused
+ *                                                 to shrink and pushed the meeting
+ *                                                 off-screen instead)
+ *   pptx-maker decks       240px deck list     -> viewer    86px, 44px once the
+ *                                                 surrounding Card padding counts
+ *   pptx-maker library     224px template list -> detail    too little to read
+ *
+ * Nothing overflowed in the pptx-maker cases, which is why an overflow-based check
+ * reports them as fine: the list simply took its fixed width and the content took
+ * what was left. This is a body-text rule in every language -- the measure is how
+ * much width the prose column gets, and script only changes the symptom.
+ *
+ * meetings follows ITS OWN existing shape (`flex-col lg:flex-row`, already used by
+ * MeetingWorkspace and TaskReviewView) rather than a new one; only MeetingView's
+ * outer split lacked it. pptx-maker has no precedent of its own, so it takes the
+ * same stacked form as the rest of this series.
+ *
+ * Asserted over source: jsdom performs no layout, so a render cannot measure the
+ * widths this is about.
+ */
+import { describe, it, expect } from 'vitest'
+
+const read = async (p: string): Promise<string> =>
+  (await import(`../apps/${p}?raw`)).default as string
+
+describe('meetings MeetingView at narrow widths', () => {
+  it('stacks the split, using the shape this app already uses twice', async () => {
+    const s = await read('meetings/MeetingView.tsx')
+    expect(s, 'expected the outer split to stack below lg')
+      .toMatch(/className="flex flex-col lg:flex-row h-full overflow-hidden"/)
+    // The app's own convention is the `lg` breakpoint, not `sm` -- matching it
+    // keeps one app from having two answers to the same question.
+    const workspace = await read('meetings/components/MeetingWorkspace.tsx')
+    expect(workspace, 'the precedent this copies must still exist').toMatch(/flex flex-col lg:flex-row/)
+  })
+
+  it('lets the content column actually shrink', async () => {
+    const s = await read('meetings/MeetingView.tsx')
+    // Without `min-w-0` a flex child refuses to go below its content width, so the
+    // row overflowed sideways instead of resolving to 49px -- a different symptom
+    // with the same cause, and the reason stacking alone was not the whole fix.
+    expect(s, 'the content column needs min-w-0/min-h-0')
+      .toMatch(/className="flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden"/)
+  })
+
+  it('gives the task sidebar the full width when stacked, with a bound', async () => {
+    const s = await read('meetings/components/TaskSidebar.tsx')
+    expect(s, 'sidebar must release its 340px while narrow').toMatch(/w-full[^"]*lg:w-\[340px\]/)
+    // Bounded height when stacked, or a `flex-none` sidebar at natural height
+    // would push the meeting out of view -- the same shape the transcript pane
+    // uses in MeetingWorkspace.
+    expect(s, 'sidebar needs a bounded height when stacked').toMatch(/h-\[42%\][^"]*min-h-\[260px\]/)
+    // The divider turns with the layout: a left border between two stacked blocks
+    // draws a line down the side of the sidebar, not between the two.
+    expect(s).toMatch(/border-t border-border[^"]*lg:border-t-0 lg:border-l/)
+    expect(s, 'no ungated 340px width').not.toMatch(/className="flex-none w-\[340px\]/)
+  })
+})
+
+describe('pptx-maker splits at narrow widths', () => {
+  const cases: [string, string, string][] = [
+    ['decks', 'pptx-maker/PptxMakerPage.tsx', 'sm:w-60'],
+    ['library', 'pptx-maker/LibraryPanel.tsx', 'sm:w-56'],
+  ]
+
+  it('stacks both splits and releases both list widths', async () => {
+    for (const [name, path, gated] of cases) {
+      const s = await read(path)
+      expect(s, `${name}: expected the split to stack while narrow`)
+        .toMatch(/className="flex flex-col sm:flex-row gap-4 flex-1 min-h-0"/)
+      expect(s, `${name}: the list must take the full width while narrow`)
+        .toMatch(new RegExp(`w-full ${gated.replace(':', ':')}`))
+      // Bounded when stacked: the list is `shrink-0`, so its natural height would
+      // otherwise push the content pane out of the column.
+      // A viewport unit, not a percentage: these splits sit inside a Card inside a
+      // page scroller, and no ancestor has a definite height, so a percentage
+      // max-height never resolves -- measured on the Releases panel, where a 10%
+      // cap left a 289px list untouched while 10vh brought it to 84px.
+      expect(s, `${name}: the list needs a height bound when stacked`)
+        .toContain('max-h-[40vh] sm:max-h-none')
+      expect(s, `${name}: the bound must use a definite unit`).not.toContain('max-h-[38%]')
+      // Divider on the axis the columns now sit on.
+      expect(s, `${name}: the divider must turn with the layout`)
+        .toMatch(/border-b sm:border-b-0 sm:border-r border-border/)
+    }
+  })
+
+  it('leaves no ungated fixed list width behind', async () => {
+    for (const [name, path, gated] of cases) {
+      const s = await read(path)
+      const bare = gated.replace('sm:', '')
+      expect(s, `${name}: no ungated ${bare}`).not.toMatch(new RegExp(`className="${bare}\\b`))
+    }
+  })
+})


### PR DESCRIPTION
First of the remaining builtin-app splits, after #3840 / #3842 / #3844 / #3849 did
the same for Issue Radar, Code Review Sage, Task Runner, Webhooks, Spec Builder and
Settings → Releases.

## Three splits, no narrow branch at all

| split | fixed sibling | primary column at 390px |
|---|---|---|
| `meetings` MeetingView | 340px task sidebar | **49px** — or the row overflowed |
| `pptx-maker` decks | 240px deck list | **86px**, **44px** with Card `p-5` |
| `pptx-maker` library | 224px template list | same shape |

Nothing overflowed in the pptx-maker cases, which is why an overflow check reports
them as fine: the list took its fixed width and the content took what was left.

**meetings has a second symptom with the same cause.** Its content column is
`flex-1` with **no `min-w-0`**, so it refused to shrink below its content and the
row overflowed sideways instead of resolving to 49px — the meeting was pushed
off-screen rather than narrowed. Stacking alone would not have fixed that.

## meetings copies its own answer

`MeetingWorkspace.tsx:28` and `TaskReviewView.tsx:62` already use
`flex flex-col lg:flex-row`; only `MeetingView`'s outer split lacked it. So this
follows the app's own convention — including the `lg` breakpoint rather than `sm`,
and the bounded stacked height its transcript pane uses
(`w-full h-[42%] min-h-[260px] lg:h-full`). One app should not have two answers to
the same question.

`pptx-maker` has no precedent of its own, so it takes the stacked form used
elsewhere in this series.

## The stacked bounds are `vh`, and that was a correction

A stacked list is `shrink-0`, so without a bound it takes its natural height and
pushes the content pane down. My first version bounded it with `max-h-[38%]` — which
does **nothing**: these splits sit inside a Card inside a page scroller and no
ancestor has a definite height, so a percentage max-height never resolves. Measured
by injecting caps on a live page (the Releases panel, same ancestor shape):

| cap | computed | list height | scrolls |
|---|---|---|---|
| `10%` | stays `10%` | **289px** (unchanged) | no |
| `10vh` | `84.4px` | 84px | yes |

So the bounds here are `max-h-[40vh] sm:max-h-none`, and the assertions pin the
absence of the percentage form so the inert version cannot come back.

## Tests

New `website/src/test/appSplitsNarrowA.test.ts`. Each assertion falsified by a
mutation, every mutation confirmed applied to the file before its result was read:

| mutation | caught |
|---|---|
| meetings row no longer stacks | yes |
| content column loses `min-w-0` | yes |
| sidebar keeps its ungated 340px | yes |
| deck list keeps its ungated `w-60` | yes |
| a list loses its height bound | yes |

`tsc` clean; 14 meetings/pptx test files, **322 tests** passing.

## Evidence gap, stated plainly

**No 390px screenshot.** I seeded a meeting (`session.json`, credential-free) and
enabled both apps in an isolated pod, and the meeting page renders — but the task
sidebar's toggle never appears, so the split it belongs to cannot be brought on
screen: `sidebarOpen` starts `false` and the control seems to require a started
meeting. pptx-maker's split is gated on `filtered.length > 0`, i.e. it needs decks,
which live under the app's data dir in a layout I did not reproduce.

So this rests on the arithmetic above plus the falsified assertions, not on pixels.
Anyone with a real meeting or a deck can see both in one click, and the two riders
worth a look there are the stacked sidebar's `h-[42%]` (copied from this app's own
pane, so it should behave the same) and whether the bounded lists feel too short.
