### PR TITLE
refactor(acp): route AcpSessionHandle metadata pct through sanitize_pct

### DIFF
--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -2165,20 +2165,14 @@ class AcpSessionHandle:
         # A real usage_update is authoritative for context_pct + token counts;
         # kiro's metadata percentage can measure a different window, so applying
         # it here would desync the headline % from the "used / total" token text.
-        if pct is not None and not self.last_prompt_stats.context_tokens_from_usage:
-            try:
-                pct_f = float(pct)
-                # Sanitize a malformed metadata percentage (NaN/±inf/out-of-range,
-                # e.g. 1e308) at the source so context_pct is always a real
-                # [0, 100] value: keeps compaction comparisons sane and the
-                # diagnostic /api/sessions JSON standard (Infinity/NaN are not
-                # valid JSON). NaN is caught by its self-inequality.
-                pct_f = 0.0 if pct_f != pct_f else min(max(pct_f, 0.0), 100.0)
-                self.last_prompt_stats.context_pct = pct_f
-                self.last_prompt_stats.note_pct_reported()
-                self._backfill_context_window(pct_f)
-            except (TypeError, ValueError):
-                pass
+        # sanitize_pct is the shared coercion (the AcpClient path uses it too),
+        # so the two metadata paths cannot drift: it clamps NaN/±inf/out-of-range
+        # and returns None for a missing or unparseable value.
+        pct_f = self.last_prompt_stats.sanitize_pct(pct)
+        if pct_f is not None and not self.last_prompt_stats.context_tokens_from_usage:
+            self.last_prompt_stats.context_pct = pct_f
+            self.last_prompt_stats.note_pct_reported()
+            self._backfill_context_window(pct_f)
         self.last_prompt_stats.credits += credits
 
     def _backfill_context_window(self, pct: float) -> None:


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only refactor with identical rendered output — no watched frontend path changes.

## Problem / Motivation

`AcpSessionHandle._track_metadata` still carried a third verbatim copy of the context-usage percentage sanitize logic (inline `try` / `float` / NaN-and-range clamp), duplicating the coercion that already lives on `AcpPromptStats.sanitize_pct` and is used by the `AcpClient._track_metadata` path. The two metadata paths could therefore drift, which is exactly the drift the shared helper was introduced to prevent.

## Why it matters

The percentage sanitize is subtle (NaN via self-inequality, ±inf/out-of-range clamp so `context_pct` stays valid JSON and never overflows the downstream `round(win * pct / 100)`). A verbatim second copy means a future fix to one path silently diverges from the other. Consolidating removes that footgun and makes the "both paths delegate" invariant actually true.

## What changed (motivation → approach → change)

The shared `AcpPromptStats.sanitize_pct` already exists and the `AcpClient` path already delegates to it; only the handle path still inlined the block. Replaced the inline `try`/`float`/clamp in `AcpSessionHandle._track_metadata` with a single `self.last_prompt_stats.sanitize_pct(pct)` call, mirroring the client path.

Behavior-equivalent, and strictly safer: `sanitize_pct` additionally absorbs `OverflowError` (a JSON integer beyond float range degrades to "absent" rather than propagating), matching the already-shipped client path. `None`/unparseable → the meter is left untouched, same as before.

## Tests

No new tests — this is a behavior-preserving consolidation onto an already-tested helper. Existing coverage of the handle metadata path and `sanitize_pct` (`test/test_acp_metadata_fields.py`, `test/test_kas_wire.py`, `test/test_acp_runtime.py`, `test/test_context_bar_reopen.py`, `test/test_cron_context_meter_seed.py`) exercises the change; all pass locally (270).

## Manual verification

N/A — unit coverage sufficient; the delegated helper is unchanged and already tested for the NaN/±inf/out-of-range/OverflowError/None cases.

## Related Issues

no linked issue: follow-up cleanup surfaced by the advisory First Principles review on the merged #3823 (the sanitize dedup that landed after that PR was already merged).

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
