### PR TITLE
fix(apps): reach the file tree and note list from the top at phone widths

### DIFF
--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -132,6 +132,19 @@ export default [
       // keep both modules parser-facing only.
       'src/lib/widgetSrcdoc.ts',
       'src/lib/mcpAppSrcdoc.ts',
+      // Per-app scoped CSS, injected as `<style>{APP_CSS}</style>`. Each module is
+      // ONE template literal of stylesheet text handed to the CSS parser -- selectors,
+      // lengths and `var(--…)` references. None of it is read as words, and the
+      // diff-scoped `added-lines` check reports the whole template against whoever
+      // touches a rule inside it, so any narrow-viewport or theming edit to an app's
+      // stylesheet trips a zero-tolerance gate it can never satisfy.
+      //
+      // Stated as a false-negative class, per this file's convention: user-visible
+      // copy added to one of these modules will not be reported -- keep them
+      // stylesheet-only, and put anything a person reads in the component with
+      // `i18nT`. Verified copy-free rather than assumed: none of them imports
+      // `i18nT` or `useTranslation`.
+      'src/apps/*/styles.ts',
       // The PPTX Maker board-preview builder — the same category as
       // `sketchSrcdoc.ts` directly above, and listed by the same exact-path rule
       // rather than a shared glob. Every literal in it is handed to a PARSER: the

--- a/website/src/apps/file-explorer/FileExplorerPage.tsx
+++ b/website/src/apps/file-explorer/FileExplorerPage.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useQuery, useQueryClient, useMutation, useQueries } from '@tanstack/react-query'
 import { usePointerDrag } from '../../hooks/usePointerDrag'
-import { AlertTriangle, MessageSquare, Eye, CornerDownRight, Copy, ArrowUpFromLine } from 'lucide-react'
+import { AlertTriangle, MessageSquare, Eye, CornerDownRight, Copy, ArrowUpFromLine, ChevronDown, ChevronUp } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useAppDispatch } from '../../store'
 import { setPendingInput } from '../../store/chatSlice'
-import { Skeleton } from '../../components/ui'
+import { Skeleton, Btn } from '../../components/ui'
+import { useIsMobile } from '../../hooks/useIsMobile'
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem } from '../../components/ui/context-menu'
 import { fileExplorerApi } from './api'
 import { basename, dirname, loadState, saveState, isShortcut } from './utils'
@@ -41,6 +42,15 @@ export default function FileExplorerPage() {
   const [activeFolderId, setActiveFolderId] = useState<string | null>(null)
   const [activeFileId, setActiveFileId] = useState<string | null>(null)
   const [leftWidth, setLeftWidth] = useState(280)
+  const isMobile = useIsMobile()
+  // The tree is a fixed 280px `flex-shrink:0` pane, so at 390px it left the
+  // viewer 106px inside a `overflow:hidden` split -- unreadable and impossible
+  // to scroll into view. While narrow it becomes a drawer reached from a bar at
+  // the TOP, so the viewer owns the full width. Drawer-only state: the desktop
+  // always shows the tree, and `leftWidth` stays the user's desktop preference.
+  const [treeOpen, setTreeOpen] = useState(false)
+  const treeBar = isMobile && !treeOpen
+  const treeFull = isMobile && treeOpen
   const [contextNode, setContextNode] = useState<TreeEntry | null>(null)
   const [initialized, setInitialized] = useState(false)
 
@@ -169,13 +179,16 @@ export default function FileExplorerPage() {
 
   const openFile = useCallback(async (path: string, _opts: { reveal?: boolean } = {}) => {
     if (!activeFolder) return
+    // Close the drawer on pick, or the full-width tree is a one-way door: the
+    // file opens behind it with nothing on screen to say so.
+    if (isMobile) setTreeOpen(false)
     const folderId = activeFolder.id
     const existing = fileTabsRef.current.find((ft) => ft.path === path && ft.folderId === folderId)
     if (existing) { setActiveFileId(existing.id); return }
     const ft = newFileTab(path, folderId)
     setFileTabs((tabs) => [...tabs, ft])
     setActiveFileId(ft.id)
-  }, [activeFolder])
+  }, [activeFolder, isMobile])
 
   const reloadFile = useCallback(() => {
     if (!activeFile) return
@@ -351,8 +364,25 @@ export default function FileExplorerPage() {
       />
       {healthError && <div className="mc-fe-banner"><AlertTriangle size={12} /> {i18nT('apps.fileExplorer.fileExplorerPage.backend_not_reachable')} {(healthError as Error).message}</div>}
       <PathBar rootPath={activeFolder.rootPath} gitInfo={rootGitInfo} onChangeRoot={changeRoot} onNavigate={openMaybe} />
-      <div className="mc-fe-split">
-        <div className="mc-fe-left" style={{ width: leftWidth }}>
+      <div className={`mc-fe-split${isMobile ? ' is-stacked' : ''}`}>
+        {/* Narrow: the control that reaches the tree sits at the TOP, so no
+            horizontal space is reserved for it and the viewer gets the full
+            width. Hidden rather than absent on a desktop, where the tree pane
+            is always on screen. */}
+        {isMobile && (
+          <Btn
+            onClick={() => setTreeOpen(!treeOpen)}
+            className="mc-fe-treebar"
+            aria-expanded={treeOpen}
+          >
+            {treeOpen ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+            {activeFolder.label || basename(activeFolder.rootPath) || activeFolder.rootPath}
+          </Btn>
+        )}
+        <div
+          className={`mc-fe-left${treeBar ? ' is-hidden' : ''}`}
+          style={{ width: treeFull ? '100%' : leftWidth }}
+        >
           <ContextMenu onOpenChange={(open) => { if (!open) setContextNode(null) }}>
             <ContextMenuTrigger asChild>
               {treeRoot ? (
@@ -396,10 +426,11 @@ export default function FileExplorerPage() {
           </ContextMenu>
         </div>
         {/* Pane splitter: mouse-drag-only resize affordance; role=separator is
-            correct for a window splitter but is non-interactive per jsx-a11y. */}
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-        <div className="mc-fe-resizer" aria-label={i18nT('apps.fileExplorer.fileExplorerPage.resize_panel')} aria-orientation="vertical" role="separator" tabIndex={-1} style={{ touchAction: 'none' }} {...leftResize} />
-        <div className="mc-fe-right">
+            correct for a window splitter but is non-interactive per jsx-a11y.
+            Absent while narrow -- it is pointer-only, so on touch it would cost
+            width and buy nothing. */}
+        {!isMobile && <div className="mc-fe-resizer" aria-label={i18nT('apps.fileExplorer.fileExplorerPage.resize_panel')} aria-orientation="vertical" role="separator" tabIndex={-1} style={{ touchAction: 'none' }} {...leftResize} />}
+        <div className={`mc-fe-right${treeFull ? ' is-hidden' : ''}`}>
           {showSearch ? (
             <SearchPanel
               rootPath={activeFolder.rootPath}

--- a/website/src/apps/file-explorer/FileViewer.tsx
+++ b/website/src/apps/file-explorer/FileViewer.tsx
@@ -1,4 +1,5 @@
 import { FileText, AlertTriangle, FileQuestion, RefreshCw, Download, Copy, ExternalLink, MoreHorizontal, ShieldAlert } from 'lucide-react'
+import { useIsMobile } from '../../hooks/useIsMobile'
 import MarkdownRenderer, { BasePathCtx } from '../../components/MarkdownRenderer'
 import { EmptyState, Skeleton } from '../../components/ui'
 import {
@@ -64,10 +65,11 @@ function renderViewerBody({ ext, fileMeta, content, openFile }: { ext: string; f
 }
 
 export default function FileViewer({ filePath, fileMeta, content, loading, error, onReload, onDownload }: FileViewerProps) {
+  const isMobile = useIsMobile()
   // Before the early returns: a hook cannot sit behind a conditional.
   const gatewayPlatform = useGatewayPlatform()
   if (!filePath) {
-    return <EmptyState icon={<FileText size={28} />} title={i18nT('apps.fileExplorer.fileViewer.select_a_file_to_view')} subtitle={i18nT('apps.fileExplorer.fileViewer.tip_ctrl_cmd_f_to_search')} />
+    return <EmptyState icon={<FileText size={28} />} title={i18nT('apps.fileExplorer.fileViewer.select_a_file_to_view')} subtitle={isMobile ? undefined : i18nT('apps.fileExplorer.fileViewer.tip_ctrl_cmd_f_to_search')} />
   }
   if (loading) return <Skeleton className="h-full w-full" />
   if (error) {

--- a/website/src/apps/file-explorer/styles.ts
+++ b/website/src/apps/file-explorer/styles.ts
@@ -32,6 +32,15 @@ export const FE_CSS = `
 .mc-fe-bc:hover { color:var(--text); background:color-mix(in srgb, var(--text) 10%, transparent); }
 .mc-fe-bc-sep { color:var(--muted); opacity:.4; font-family:var(--mono, ui-monospace, monospace); }
 .mc-fe-split { flex:1; display:flex; min-height:0; overflow:hidden; }
+/* Narrow: the tree becomes a drawer under a top bar, so the row turns into a
+   column and the divider turns with it. The left pane's border-right would draw
+   a stray vertical rule once stacked. */
+.mc-fe-split.is-stacked { flex-direction:column; }
+.mc-fe-split.is-stacked > .mc-fe-left { border-right:none; border-bottom:1px solid var(--border); }
+/* Hidden rather than unmounted: the pane keeps its scroll position across a
+   rotation that crosses the breakpoint. */
+.mc-fe-left.is-hidden, .mc-fe-right.is-hidden { display:none; }
+.mc-fe-treebar { flex-shrink:0; justify-content:flex-start; gap:6px; width:100%; border-radius:0; border-left:none; border-right:none; border-top:none; }
 .mc-fe-left { flex-shrink:0; min-height:0; overflow-y:auto; overflow-x:hidden; border-right:1px solid var(--border); background:var(--bg); }
 .mc-fe-resizer { width:4px; flex-shrink:0; background:transparent; cursor:col-resize; transition:background .15s; }
 .mc-fe-resizer:hover { background:var(--accent); opacity:.5; }

--- a/website/src/apps/md-notebook/MdNotebookPage.tsx
+++ b/website/src/apps/md-notebook/MdNotebookPage.tsx
@@ -5,6 +5,7 @@
  * Search swaps the tree for flat ranked results; clearing restores the tree.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useIsMobile } from '../../hooks/useIsMobile'
 import { useQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
 import type { CSSProperties } from 'react'
@@ -158,6 +159,18 @@ export default function MdNotebookPage() {
     loadPref<'folders' | 'list'>('mdnb-list-view', 'folders'),
   )
   const [panelOpen, setPanelOpen] = useState(() => loadPref<boolean>(LS.panelOpen, true))
+  const isMobile = useIsMobile()
+  // The panel is a fixed 260px `flexShrink: 0` column, so at 390px it left the
+  // editor 130px. `panelOpen` already exists but is a stored DESKTOP preference,
+  // so it arrives open on a phone. While narrow the panel is a drawer that starts
+  // closed and owns the pane when opened -- derived, never written back, or a
+  // phone visit would silently change what the desktop shows.
+  const [narrowPanelOpen, setNarrowPanelOpen] = useState(false)
+  // With no note open the pane has nothing to show but the list, and the empty
+  // state's copy points at the + button INSIDE the drawer -- so a closed drawer
+  // there instructs an action whose control is off-screen. Forced open until a
+  // note is picked, which is also when `openNote` closes it again.
+  const panelShown = isMobile ? (narrowPanelOpen || !activePath) : panelOpen
   const [panelW, setPanelW] = useState(() => {
     const w = loadPref<number>(LS.panelWidth, PANEL_DEFAULT_WIDTH)
     return w >= PANEL_MIN_WIDTH && w <= PANEL_MAX_WIDTH ? w : PANEL_DEFAULT_WIDTH
@@ -426,6 +439,8 @@ export default function MdNotebookPage() {
       if (dirtyRef.current) return
       pathRef.current = path
       setActivePath(path)
+      // Close the drawer on pick, or the full-width list is a one-way door.
+      if (isMobile) setNarrowPanelOpen(false)
       savePref(LS.openNote, path)
       setContent(doc.content)
       contentRef.current = doc.content
@@ -439,7 +454,7 @@ export default function MdNotebookPage() {
       if (openSeqRef.current !== seq) return
       setError(e instanceof Error ? e.message : String(e))
     }
-  }, [flushSave])
+  }, [flushSave, isMobile])
 
   // Load the note list whenever the vault changes, then restore the open note.
   useEffect(() => {
@@ -1110,11 +1125,12 @@ export default function MdNotebookPage() {
   )
 
   const togglePanel = useCallback(() => {
+    if (isMobile) { setNarrowPanelOpen(v => !v); return }
     setPanelOpen(v => {
       savePref(LS.panelOpen, !v)
       return !v
     })
-  }, [])
+  }, [isMobile])
 
   const startResize = useCallback(
     (e: React.PointerEvent) => {
@@ -1252,7 +1268,7 @@ export default function MdNotebookPage() {
         className="pi-morph mdnb-collapse"
         onClick={togglePanel}
         aria-label={
-          panelOpen
+          panelShown
             ? i18nT('apps.mdNotebook.panel.hide')
             : i18nT('apps.mdNotebook.panel.show')
         }
@@ -1281,13 +1297,13 @@ export default function MdNotebookPage() {
           transition: 'color .15s, background .15s',
         }}
       >
-        {panelOpen ? <PanelLeftLight size={16} /> : <PanelLeftSolid size={16} />}
+        {panelShown ? <PanelLeftLight size={16} /> : <PanelLeftSolid size={16} />}
       </button>
 
-      {panelOpen && (
+      {panelShown && (
         <div
           style={{
-            width: `${panelW}px`,
+            width: isMobile ? '100%' : `${panelW}px`,
             flexShrink: 0,
             position: 'relative',
             display: 'flex',

--- a/website/src/test/explorerNotebookNarrow.test.ts
+++ b/website/src/test/explorerNotebookNarrow.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const app = (p: string) => readFile(join(__dirname, '..', 'apps', p), 'utf8')
+
+// Both apps put a fixed-width navigator beside the pane that carries the primary
+// text, with nothing gating it on viewport width. At 390px that left the file
+// viewer 106px (inside an `overflow:hidden` split, so unreachable rather than
+// merely cramped) and the note editor 130px. The fix is the same in both: the
+// navigator becomes a drawer reached from a control at the TOP, so no horizontal
+// space is reserved for it and the reading pane owns the full width.
+describe('file-explorer at phone widths', () => {
+  it('reaches the tree from a top bar instead of a side pane', async () => {
+    const s = await app('file-explorer/FileExplorerPage.tsx')
+    expect(s, 'expected a viewport hook').toContain("useIsMobile")
+    expect(s, 'expected drawer state').toMatch(/const treeBar = isMobile && !treeOpen/)
+    expect(s, 'expected a full-width expanded tree').toMatch(/const treeFull = isMobile && treeOpen/)
+    expect(s, 'the bar must be a Btn primitive').toMatch(/<Btn[\s\S]{0,200}mc-fe-treebar/)
+    expect(s, 'the bar must announce its disclosure state').toMatch(/aria-expanded=\{treeOpen\}/)
+  })
+
+  it('turns the split into a column and drops the pointer-only handle', async () => {
+    const s = await app('file-explorer/FileExplorerPage.tsx')
+    expect(s, 'expected the row to stack').toMatch(/mc-fe-split\$\{isMobile \? ' is-stacked' : ''\}/)
+    // The resizer is mouse-drag-only. Rendered on touch it costs width and does nothing.
+    expect(s, 'the resizer must not render while narrow').toMatch(/\{!isMobile && <div className="mc-fe-resizer"/)
+    expect(s, 'the tree must take the whole width when open')
+      .toMatch(/width: treeFull \? '100%' : leftWidth/)
+  })
+
+  it('closes the drawer on pick, so the full-width tree is not a one-way door', async () => {
+    const s = await app('file-explorer/FileExplorerPage.tsx')
+    const fn = s.match(/const openFile = useCallback\([\s\S]*?\n  \}, \[[^\]]*\]\)/)
+    expect(fn, 'expected openFile').not.toBeNull()
+    expect(fn![0]).toContain('if (isMobile) setTreeOpen(false)')
+    expect(fn![0], 'the callback must depend on isMobile').toContain('isMobile]')
+  })
+
+  it('stacks the divider and hides panes without unmounting them', async () => {
+    const css = await app('file-explorer/styles.ts')
+    expect(css, 'expected a stacked modifier').toMatch(/\.mc-fe-split\.is-stacked \{ flex-direction:column; \}/)
+    // A border-right would draw a stray vertical rule once the row is a column.
+    expect(css).toMatch(/is-stacked > \.mc-fe-left \{ border-right:none; border-bottom:/)
+    expect(css, 'panes must be hidden, not removed').toMatch(/\.mc-fe-left\.is-hidden, \.mc-fe-right\.is-hidden \{ display:none; \}/)
+    // styles.ts is a template literal: a backtick in the CSS ends it early.
+    const body = css.split('`')[1] ?? ''
+    expect(body.includes('`'), 'no backtick may appear inside the CSS template').toBe(false)
+  })
+})
+
+describe('md-notebook at phone widths', () => {
+  it('drives the existing panel toggle from the viewport', async () => {
+    const s = await app('md-notebook/MdNotebookPage.tsx')
+    expect(s, 'expected a viewport hook').toContain('useIsMobile')
+    expect(s, 'expected a derived visibility').toMatch(/const panelShown = isMobile \? \(narrowPanelOpen \|\| !activePath\) : panelOpen/)
+    expect(s, 'the panel must render from the derived value').toMatch(/\{panelShown && \(/)
+    expect(s, 'the toggle icon must follow it').toMatch(/\{panelShown \? <PanelLeftLight/)
+    expect(s, 'the aria label must follow it').toMatch(/aria-label=\{\s*\n?\s*panelShown/)
+  })
+
+  it('never writes the narrow state into the stored desktop preference', async () => {
+    const s = await app('md-notebook/MdNotebookPage.tsx')
+    const fn = s.match(/const togglePanel = useCallback\([\s\S]*?\n  \}, \[[^\]]*\]\)/)
+    expect(fn, 'expected togglePanel').not.toBeNull()
+    // The narrow branch returns BEFORE savePref: a phone visit must not change
+    // what the desktop shows on the next load.
+    expect(fn![0]).toMatch(/if \(isMobile\) \{ setNarrowPanelOpen\(v => !v\); return \}/)
+    const narrow = fn![0].slice(0, fn![0].indexOf('setPanelOpen'))
+    expect(narrow.includes('savePref'), 'the narrow branch must not persist').toBe(false)
+  })
+
+  it('gives the open panel the full width and closes it on pick', async () => {
+    const s = await app('md-notebook/MdNotebookPage.tsx')
+    expect(s, 'expected a full-width panel while narrow')
+      .toMatch(/width: isMobile \? '100%' : `\$\{panelW\}px`/)
+    const fn = s.match(/const openNote = useCallback\([\s\S]*?\n  \}, \[[^\]]*\]\)/)
+    expect(fn, 'expected openNote').not.toBeNull()
+    expect(fn![0]).toContain('if (isMobile) setNarrowPanelOpen(false)')
+    expect(fn![0], 'the callback must depend on isMobile').toContain('isMobile')
+  })
+
+  it('does not leave the empty state pointing at a control it just hid', async () => {
+    const s = await app('md-notebook/MdNotebookPage.tsx')
+    // The empty state reads "Select a note, or create one with the + button" and
+    // that + lives INSIDE the drawer. Closed, it instructs an off-screen control.
+    expect(s).toMatch(/const panelShown = isMobile \? \(narrowPanelOpen \|\| !activePath\) : panelOpen/)
+  })
+
+  it('drops keyboard-only advice from what is now the mobile landing view', async () => {
+    const s = await app('file-explorer/FileViewer.tsx')
+    expect(s, 'expected the viewport hook').toContain('useIsMobile')
+    expect(s).toMatch(/subtitle=\{isMobile \? undefined : i18nT\('apps\.fileExplorer\.fileViewer\.tip_ctrl_cmd_f_to_search'\)\}/)
+  })
+})


### PR DESCRIPTION
Two more apps that reserve horizontal space for a navigator no matter how narrow the
viewport gets. Same defect class as #3840 / #3842 / #3846, and the same fix: the
control that reaches the navigator moves to the TOP, so the reading pane owns the
full width.

## file-explorer — the viewer was unreachable, not just cramped

`.mc-fe-left` is a `flex-shrink:0` pane at an inline `width: 280`, inside
`.mc-fe-split { overflow:hidden }`. At 390px that leaves the viewer 106px, and the
`overflow:hidden` means the remainder cannot be scrolled into view. The app had **no
collapse state at all** — only a drag-to-resize width, and the drag handle is
pointer-only, so on a touch device there was no way to get the width back.

Measured in the real build at 390px (isolated pod, DSF=2):

| element | before | after, drawer closed | after, drawer open |
|---|---|---|---|
| top bar | — | **390 × 29** | 390 × 29 |
| `.mc-fe-left` (tree) | 280px | **0 × 0**, hidden | **390px**, scrolls |
| `.mc-fe-right` (viewer) | **106px** | **390px** | 0 × 0, stepped aside |
| `.mc-fe-resizer` | 4px | **not rendered** | not rendered |
| split direction | row | column | column |

Picking a file closes the drawer, or the full-width tree is a one-way door — the file
would open behind it with nothing on screen to say so.

## md-notebook — the toggle existed, it just did not know about the viewport

The panel is a `flexShrink: 0` column at 260px, leaving the editor 130px. `panelOpen`
already exists with a working toggle, but it is loaded from a **stored preference that
defaults to open** — a desktop preference that arrives on the phone. So the fix is
wiring, not new machinery: while narrow the panel is a drawer that starts closed, takes
the whole pane when opened, and closes when a note is picked.

The narrow state is **derived, never written back**. Writing it would mean a phone
visit silently changes what the desktop shows on the next load, and the test asserts
the narrow branch returns before `savePref`.

## Details worth flagging

- **Hidden, not unmounted.** `display:none` on both panes, so the tree keeps its scroll
  position across a rotation that crosses 768px. (The tree's expansion state was
  already safe — it lives on the folder tab, not in the component.)
- **The divider turns with the axis**: `border-right` becomes `border-bottom` once
  stacked, or a stray vertical rule is left drawn across a column.
- **No new user-facing strings.** The bar is a disclosure button labelled with the
  folder it opens (`aria-expanded` carries the state), matching the collapsed-rail bars
  already shipped on the Projects and Webhooks pages. md-notebook reuses its existing
  `panel.show` / `panel.hide` labels.
- **A backtick in `styles.ts` ends the CSS template literal.** I hit this writing the
  new rules — `tsc` reported a syntax error two lines later. There is now an assertion
  that the CSS body contains no backtick.

## Tests

`src/test/explorerNotebookNarrow.test.ts`, every assertion falsified by mutation:

| mutation | caught |
|---|---|
| drop close-on-pick in file-explorer | yes |
| render the resize handle on touch | yes |
| stop giving the expanded tree full width | yes |
| drop the stacked-column modifier | yes |
| stop branching the md-notebook toggle on viewport | yes |
| stop giving the open panel full width | yes |
| drop close-on-pick in md-notebook | yes |

`tsc` clean; 14 file-explorer / md-notebook suites, 394 tests.

## Evidence gaps, stated rather than papered over

- **No committed screenshots.** The only reachable root in this environment is the real
  home directory, and the frames therefore carry the machine's directory layout. The
  repo's leak check is text-only and cannot see inside a PNG, so committing them would
  push that past the guard. The measured DOM geometry above is the stronger evidence for
  a width claim anyway. I tried repointing the root at a neutral tree and the path-bar
  interaction did not take; worth a second attempt if a reviewer wants frames.
- **md-notebook is verified at source level only.** The app shows its "Connect a vault"
  onboarding in the pod, so the split UI does not render and there was nothing to
  measure. Its arithmetic (260px fixed in a 390px row → 130px) and the derived-state
  behaviour are pinned by tests, not by a frame.


---

## The i18n gate caught a real trap (and the fix is a config entry, not a new key)

`Frontend Lint & Type Check` failed on `[added-lines] 1 untranslated literal · zero
tolerance`, pointing at `apps/file-explorer/styles.ts:1`. Not a missed string: that
module is ONE template literal of stylesheet text, and the diff-scoped check reports the
**whole template** against whoever edits a rule inside it. So any narrow-viewport or
theming change to an app's CSS trips a zero-tolerance gate it cannot satisfy — there is
no key to add, because none of it is read as words.

Per-app `styles.ts` now joins the ignore list beside `widgetSrcdoc.ts` and
`sketchSrcdoc.ts`, the same parser-facing category, with the false-negative stated as
this file's convention requires. Verified rather than assumed: no `src/apps/*/styles.ts`
imports `i18nT` or `useTranslation`.

All four frontend gates reproduced locally after the change:

| gate | result |
|---|---|
| `tsc -b` | clean |
| `eslint src/ --max-warnings 1116` | 0 errors, 12 warnings |
| `jscpd .` | 0 clones |
| `npm run i18n:check` | **16 checks · PASS** |

I also removed an eslint-disable directive that my own change made unused — wrapping the
resizer in `{!isMobile && …}` stopped the rule firing, and CI's warning ratchet counts a
stale directive.

Two process notes worth recording, since both made a reading meaningless rather than
wrong:

- `TSC=$?` after a pipe captures the **pipe's** status, not the compiler's. Every such
  reading in my own loop was noise until I fixed it.
- A backtick inside a `styles.ts` CSS comment **ends the template literal**; `tsc`
  reports the syntax error two lines later. There is now an assertion that the CSS body
  contains no backtick.


---

## UX round — the dead end it found was real

**md-notebook's drawer no longer starts closed when nothing is open.** The empty state
reads *"Select a note, or create one with the + button"* — and that `+` lives inside the
drawer. Closed, the copy instructed an action whose only control was off-screen, and
md-notebook has no labelled top bar to discover it with (only a 28px icon-only floating
toggle). `panelShown` is now `narrowPanelOpen || !activePath` while narrow: with no note
open the list is what the pane shows, and `openNote` already closes the drawer the moment
one is picked. It also cannot be closed into that dead end, because there is nothing else
to show there.

file-explorer has the same shape but does have the labelled full-width bar directly
above, so it was already discoverable — left as is rather than changed for symmetry.

**FileViewer's `Tip: Ctrl/Cmd+F to search` is dropped while narrow.** That empty state is
now the mobile landing view, and keyboard advice on a touch screen is noise.

Two more mutations, both caught:

| mutation | caught |
|---|---|
| let the drawer start closed with no note open | yes |
| restore the keyboard tip on a phone | yes |
