### PR TITLE
fix(security): lock the revoked-nonce store down through restrict_to_owner

### DIFF
--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -177,18 +177,31 @@ class RevokedNonceStore:
             try:
                 self._state_path.parent.mkdir(parents=True, exist_ok=True)
                 tmp = self._state_path.with_suffix(self._state_path.suffix + ".tmp")
-                tmp.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
+                # Create the temp file EMPTY, lock it down, and only then write
+                # the nonces. On Windows restrict_to_owner shells out to icacls,
+                # so writing first would leave the denylist under the
+                # parent-inherited DACL for the length of that call. O_TRUNC also
+                # empties a stale temp file an earlier crash left behind, so the
+                # lockdown never applies on top of someone else's contents.
+                os.close(os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600))
                 try:
-                    os.chmod(tmp, 0o600)
+                    # restrict_to_owner (fail-loud), NOT a raw chmod: on Windows
+                    # os.chmod only toggles the read-only attribute and leaves the
+                    # inherited DACL intact, so the nonces stay readable by other
+                    # local accounts — and because that chmod SUCCEEDS, the
+                    # warning below never fires. Matches token_secret.py and the
+                    # app-token secret written further down this module.
+                    platform_compat.restrict_to_owner(tmp)
                 except OSError:
-                    # Security-sensitive state (revoked session nonces). A chmod
-                    # failure must be observable, matching token_secret.py.
+                    # Security-sensitive state (revoked session nonces). A
+                    # lockdown failure must be observable, matching token_secret.py.
                     logger.warning(
-                        "could not set 0600 on revoked-nonce store %s; "
+                        "could not restrict revoked-nonce store %s to its owner; "
                         "file may be readable by other users",
                         tmp,
                         exc_info=True,
                     )
+                tmp.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
                 os.replace(tmp, self._state_path)
             except OSError:
                 logger.warning("could not persist revoked-nonce store", exc_info=True)

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -2002,6 +2002,55 @@ def test_revoked_cookie_survives_store_reload(tmp_path) -> None:
     assert reloaded.is_revoked(nonce) is True
 
 
+def test_revoked_store_locks_the_file_down_to_its_owner(tmp_path, monkeypatch) -> None:
+    """The denylist is locked to its owner through the fail-loud helper.
+
+    A bare ``os.chmod(path, 0o600)`` only toggles the read-only ATTRIBUTE on
+    Windows: it leaves the parent-inherited DACL in place, so the file stays
+    readable by other local accounts, and because the call still succeeds the
+    warn-and-continue handler never fires. ``restrict_to_owner`` is the helper
+    that applies an owner-only DACL there and raises when it cannot — the same
+    one the app-token secret in this module and ``token_secret.py`` already use.
+    """
+    from kiro_crew import platform_compat
+    from kiro_crew.dashboard import token_auth as token_auth_mod
+
+    locked: list[tuple[str, int]] = []
+    real_restrict = platform_compat.restrict_to_owner
+
+    def _spy(path) -> None:
+        # Record the size at lockdown time: the nonce list must not be sitting
+        # in the file yet (see the ordering assertion below).
+        locked.append((str(path), os.path.getsize(str(path))))
+        real_restrict(path)
+
+    monkeypatch.setattr(token_auth_mod.platform_compat, "restrict_to_owner", _spy)
+
+    state_path = tmp_path / "token_revoked_nonces.json"
+    store = RevokedNonceStore(state_path=state_path)
+    store.revoke("nonce-locked", time.time() + 3600)
+
+    assert locked, (
+        "the revoked-nonce store was persisted without restrict_to_owner; a raw "
+        "chmod is a no-op on Windows and leaves the denylist readable by other "
+        "local accounts")
+    locked_path, size_at_lockdown = locked[0]
+    assert size_at_lockdown == 0, (
+        "the denylist was written before the lockdown applied; on Windows "
+        "restrict_to_owner shells out to icacls, so the nonces would sit under "
+        "the parent-inherited DACL for the length of that call")
+    assert locked_path.startswith(str(state_path)), (
+        f"locked down {locked_path}, which is not the store's own temp file")
+
+    # The store still works, and on POSIX the resulting mode is observable.
+    assert store.is_revoked("nonce-locked") is True
+    if platform_compat.IS_POSIX:
+        # Windows locks the file down via an owner DACL, which does not surface
+        # in st_mode (files report 0o666) — that path is covered by
+        # test_platform_compat::TestRestrictToOwner.
+        assert (state_path.stat().st_mode & 0o777) == 0o600
+
+
 def test_revoked_store_evicts_expired_entry() -> None:
     """An entry whose session_exp has passed is treated as not-revoked (the
     token is rejected by the expiry check anyway) and dropped lazily."""


### PR DESCRIPTION
## Problem / Motivation

`RevokedNonceStore._persist` (`src/kiro_crew/dashboard/token_auth.py`) locked its
state file with a raw `os.chmod(tmp, 0o600)`.

On Windows `os.chmod` only toggles the **read-only attribute**. It does not strip
the parent-inherited DACL, so `token_revoked_nonces.json` is left readable by other
local accounts. And because that chmod **succeeds**, the `except OSError`
warn-and-continue handler — which exists precisely so a failed lockdown is
observable — never fires. The failure is silent and settles on the permissive
result.

`AGENTS.md` names this exact anti-pattern in its cross-platform table:

> | Owner-only secret (fail-loud) | `restrict_to_owner(path)` | `os.chmod(path, 0o600)` under `if IS_POSIX` (silent no-op leaves secrets world-readable) |

## Why it matters

The store is the per-session logout denylist (CWE-613). The access cookie is a
self-contained HMAC token, so this file is the only thing keeping a revoked cookie
dead for up to its 20h `session_exp`. Its rows are the nonces of sessions a user
explicitly logged out. Another local account reading them is disclosure of
identifiers the product has already decided are owner-only — that decision *is* the
`0600` in the code.

The removed comment claimed parity with `token_secret.py`. It did not hold. Every
other owner-only write in this area already routes through the fail-loud helper:

| write | mechanism |
|---|---|
| `dashboard/token_secret.py:59` (signing key) | `platform_compat.restrict_to_owner` |
| `dashboard/token_auth.py:987` (app-token secret) | `platform_compat.restrict_to_owner` |
| `dashboard/server.py:1422` (gateway secret) | `platform_compat.restrict_to_owner` |
| `dashboard/session_transfer.py:427` | `restrict_to_owner` |
| `dashboard/refresh_tokens.py:361` | `atomic_write(..., restrict_to_owner=True)` |
| **`dashboard/token_auth.py:182` (revoked-nonce store)** | **raw `os.chmod`** ← this PR |

The app-token secret 800 lines further down this same module already spells out the
reason: an `IS_POSIX`-shaped no-op "would let per-app secrets land readable by other
local users".

## What changed

One production file, one hunk.

**1. Route the lockdown through `platform_compat.restrict_to_owner`.** POSIX
behaviour is unchanged — the helper is `os.chmod(path, 0o600)` there, including the
fail-loud `OSError` propagation the existing handler relies on. On Windows it
applies an owner-only DACL via `icacls` and raises when it cannot, so the warning
below it can finally fire.

**2. Lock the temp file down while it is still empty.** `restrict_to_owner` shells
out to `icacls` on Windows, so writing first would leave the nonce list under the
inherited DACL for the length of that subprocess. Create with
`O_WRONLY | O_CREAT | O_TRUNC, 0o600`, restrict, then write — the same ordering, and
for the same stated reason, as the app-token secret path in this module. `O_TRUNC`
additionally empties a stale temp file left by an earlier crash, so the lockdown is
never applied on top of foreign contents.

```
before:  write nonces -> chmod(0o600)          -> replace
after:   create empty -> restrict_to_owner     -> write nonces -> replace
```

**No new work reaches the event loop.** `_persist` is reached only from `revoke()`
and `clear_all()`, and the logout route already runs it off-loop
(`handlers/auth_refresh.py:599` — `await asyncio.to_thread(revoke_access_cookie, ...)`),
so the `icacls` subprocess cannot land on the gateway loop.

## Tests

New `test_revoked_store_locks_the_file_down_to_its_owner` in
`test/test_token_auth.py`. It spies on `restrict_to_owner` through the module the
production code actually calls, delegating to the real helper so the file really is
locked down, then drives the real `RevokedNonceStore.revoke()`.

Three assertions, in the order they can fail:

1. the helper was called at all — this is the defect;
2. the file size **at lockdown time was 0** — this is the ordering half, and it
   fails if someone reverts to write-then-restrict;
3. POSIX-only, the resulting mode is `0600` — end-to-end proof the behaviour on the
   CI platform is untouched. Windows locks down via a DACL that does not surface in
   `st_mode` (files report `0o666`), which is why that leg is gated; that path is
   covered by `test_platform_compat::TestRestrictToOwner`.

Fail-before / pass-after on `origin/main` (`c429cf558`):

| | before | after |
|---|---|---|
| `test_revoked_store_locks_the_file_down_to_its_owner` | **FAIL** — `assert []`, "persisted without restrict_to_owner" | PASS |

```
pytest test/test_token_auth.py -q                    242 passed, 3 skipped
pytest test/test_token_auth.py \
       test/test_platform_compat.py \
       test/test_platform_compat_coverage.py \
       test/test_auth_refresh_handlers_cov80.py \
       test/test_refresh_tokens.py -q                479 passed, 317 skipped
```

Also green on the changed files: `flake8`, `isort --check-only`,
`mypy --platform linux` (no findings for `token_auth.py`), `git diff --check`.

## Manual verification

N/A — no user-visible surface and no interactive flow. The Windows DACL half is not
observable through `st_mode` by design, which is why the regression asserts the
*mechanism* (the fail-loud helper is invoked, and invoked before the write) rather
than a mode bit that platform cannot report.

## Screenshots / video

<!-- no-visual-delta -->

Backend file-permission handling only.

## Related Issues

Fixes #3870.

Nine more raw `os.chmod(tmp, 0o600)` sites exist under
`apps/builtins/code_review_sage/`, plus one each in `sel.py`, `workflows/store.py`
and `mcp_gateway/apps.py`. Same family, but different call paths with their own
loop-safety and ownership questions, so they are deliberately left out of this PR
rather than swept in behind one regression test.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — no documented behaviour changed; `AGENTS.md` already mandates this helper, the code was the outlier
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
