### PR TITLE
fix(detail-panel): give the panel the full width at phone widths

### DIFF
--- a/website/src/components/DetailPanel.tsx
+++ b/website/src/components/DetailPanel.tsx
@@ -1,4 +1,5 @@
 import { safeSetItem } from '../utils/safeStorage'
+import { useIsMobile } from '../hooks/useIsMobile'
 import React, { useState, useEffect, useLayoutEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { X } from 'lucide-react'
@@ -83,6 +84,7 @@ const clampPanelWidth = (w: number, minWidth: number, rowWidth: number, reserveW
   Math.max(minWidth, Math.min(w, maxPanelWidth(rowWidth, reserveWidth)))
 
 export default function DetailPanel({ title, icon, onClose, footer, headerActions, secondaryHeaderActions, initialWidth = 380, minWidth = 300, reserveWidth, storageKey, children, noPadding = false, headerClassName, embedded = false, customHeader }: DetailPanelProps) {
+  const isMobile = useIsMobile()
   // Outer wrapper ref, used to measure the panel's flex row (its parent) so the
   // width cap tracks the actual available room rather than the whole viewport.
   const wrapperRef = useRef<HTMLDivElement>(null)
@@ -215,7 +217,17 @@ export default function DetailPanel({ title, icon, onClose, footer, headerAction
 
   // Embedded: fill the parent (SidePanel tab body) — no resize handle, no left
   // border, no width animation. Only the header + content contribute.
-  if (embedded) {
+  // While narrow, take the same full-width path `embedded` callers already use.
+  // The alternative -- keeping the pixel width and lowering the floor -- cannot
+  // work: `minWidth` is applied AFTER every cap in `clampPanelWidth`, so no
+  // caller can configure its way below it.
+  //
+  // This alone is NOT sufficient, and that is the point of the caller-side
+  // change that ships with it: dropping the pixel width means a caller that
+  // wraps this panel in its OWN content-sized box (an animated `width: 'auto'`
+  // with `shrink-0`) gets a box that hugs its content, and the panel comes out
+  // NARROWER than the floor it replaced. Measured at a 390px row: 42px.
+  if (embedded || isMobile) {
     return (
       <div className="h-full w-full min-w-0 bg-bg flex flex-col overflow-hidden relative">
         {body}

--- a/website/src/pages/ProjectDetailPage.tsx
+++ b/website/src/pages/ProjectDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useIsMobile } from '../hooks/useIsMobile'
 import { useNavigate } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -44,6 +45,7 @@ export default function ProjectDetailPage({ run, onRetry, onRefresh }: Props) {
 
   const tasks = useMemo(() => (run.task_details || []).map(t => savedOverrides[t.index] ? { ...t, ...savedOverrides[t.index] } : t), [run.task_details, savedOverrides]);
   const idea = run.spec_content || run.original_input || '';
+  const isMobile = useIsMobile()
   const selected = selectedTask !== null ? tasks.find(t => t.index === selectedTask) : null;
 
   // Poll pending approvals for force_approval gates
@@ -161,7 +163,10 @@ export default function ProjectDetailPage({ run, onRetry, onRefresh }: Props) {
 
   return (
     <div className="flex flex-1 min-h-0 overflow-hidden">
-      <div className="flex-1 min-w-0 flex flex-col min-h-0">
+      {/* The panel owns the pane while narrow, so the task view steps aside.
+          Hidden rather than unmounted: the view holds scroll position and the
+          DAG's own layout, and rotating a phone crosses the breakpoint. */}
+      <div className={`flex-1 min-w-0 flex flex-col min-h-0 ${isMobile && selected ? 'hidden' : ''}`}>
         {/* Tab bar */}
         <div className="px-4 py-2 border-b border-border flex gap-1 items-center shrink-0">
           <button onClick={() => setTab('idea')} className={tabCls(tab === 'idea')}>{i18nT('pages.projectDetailPage.idea')}</button>
@@ -237,10 +242,13 @@ export default function ProjectDetailPage({ run, onRetry, onRefresh }: Props) {
           <motion.div
             key="task-panel"
             initial={{ width: 0, opacity: 0 }}
-            animate={{ width: 'auto', opacity: 1 }}
+            animate={{ width: isMobile ? '100%' : 'auto', opacity: 1 }}
             exit={{ width: 0, opacity: 0 }}
             transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
-            className="shrink-0 overflow-hidden h-full"
+            // This wrapper is the other half of the fix. `width: 'auto'` with
+            // `shrink-0` is a box that hugs its content, so the panel's own
+            // full-width class would resolve against a 42px box at a 390px row.
+            className={`overflow-hidden h-full ${isMobile ? 'flex-1 min-w-0' : 'shrink-0'}`}
           >
             <TaskDetailPanel task={selected} allTasks={tasks} onClose={() => setSelectedTask(null)} onRetry={onRetry} onApprove={approvalMap[selected.index] ? handleApprove : undefined} onToggleApproval={editable ? handleToggleApproval : undefined} editable={editable && ((run.status === 'running' || run.status === 'paused') ? selected.status === 'pending' : true)} onSave={handleSaveTask} pendingEdits={pendingEdits} onEdit={handleEdit} />
           </motion.div>

--- a/website/src/test/detailPanelNarrow2.test.ts
+++ b/website/src/test/detailPanelNarrow2.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const read = (p: string) => readFile(join(__dirname, '..', p), 'utf8')
+
+// `DetailPanel` sets its own pixel width with a `minWidth` floor applied AFTER
+// every cap, so no caller can configure below it. Dropping that width is only
+// half a fix: a caller that wraps the panel in its OWN content-sized box (an
+// animated `width: 'auto'` with `shrink-0`) then hands it a box that hugs its
+// content, and the panel comes out NARROWER than the floor it replaced.
+//
+// Measured in isolation at a 390px row:
+//   before (pixel + 300px floor)      panel 380px, task view  10px
+//   panel only, caller untouched      panel  71px  <-- collapses
+//   caller only, panel still pixel    panel clipped to 195px
+//   both + content steps aside        panel 390px  <-- correct
+describe('DetailPanel at phone widths', () => {
+  it('takes the existing full-width path instead of a pixel width', async () => {
+    const s = await read('components/DetailPanel.tsx')
+    expect(s, 'expected the viewport hook').toContain('useIsMobile')
+    expect(s, 'the narrow branch must reuse the embedded early return')
+      .toMatch(/if \(embedded \|\| isMobile\) \{/)
+    // The floor is the documented root cause: lowering it cannot work, because
+    // `clampPanelWidth` applies `minWidth` last.
+    expect(s).toMatch(/Math\.max\(minWidth, Math\.min\(w, maxPanelWidth\(rowWidth, reserveWidth\)\)\)/)
+  })
+
+  it('is not left to fend for itself: the one caller with its own width wrapper moves too', async () => {
+    const s = await read('pages/ProjectDetailPage.tsx')
+    expect(s, 'expected the viewport hook').toContain('useIsMobile')
+    expect(s, 'the animated wrapper width must move')
+      .toMatch(/animate=\{\{ width: isMobile \? '100%' : 'auto', opacity: 1 \}\}/)
+    expect(s, 'the wrapper must stop hugging its content while narrow')
+      .toMatch(/\$\{isMobile \? 'flex-1 min-w-0' : 'shrink-0'\}/)
+  })
+
+  it('steps the task view aside so the panel owns the pane', async () => {
+    const s = await read('pages/ProjectDetailPage.tsx')
+    expect(s).toMatch(/\$\{isMobile && selected \? 'hidden' : ''\}/)
+    // Hidden, not unmounted: the view holds scroll position and the DAG layout,
+    // and rotating a phone crosses the breakpoint.
+    expect(s, 'the task view must not be unmounted by a responsive branch')
+      .not.toMatch(/\{!\(isMobile && selected\) && \(/)
+  })
+
+  it('no other caller wraps the panel in its own width box', async () => {
+    // The two-sided fix is only safe because the caller set is small and known.
+    // If another caller grows a width wrapper, this pins that it must be handled.
+    const files = [
+      'components/ArtifactPanel.tsx', 'components/MarkdownPanel.tsx',
+      'components/GitPanel.tsx', 'pages/chat/FolderPanel.tsx',
+      'pages/chat/SidePanel.tsx', 'pages/aidlc/TaskDetailPanel.tsx',
+    ]
+    for (const f of files) {
+      const s = await read(f)
+      const own = /animate=\{\{[^}]*width:\s*'auto'/.test(s)
+      expect(own, `${f} grew its own animated width wrapper -- it needs the narrow branch too`).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
Replaces #3850, which I am closing. That branch shipped two revisions of a
**one-sided** fix, and both were inert — the second one measurably worse than doing
nothing. This is the same objective with the missing half, and with each half
falsifiable on its own.

## Why one side was never enough

`DetailPanel` sets its own pixel width, and `clampPanelWidth` applies the 300px
`minWidth` floor **after** every cap:

```ts
Math.max(minWidth, Math.min(w, maxPanelWidth(rowWidth, reserveWidth)))
```

So no caller can configure below the floor. At 390px the panel took 380px and left
the task view 10px.

Dropping that width alone makes it **worse**. `ProjectDetailPage` wraps the panel in
its own animated `width: 'auto'` box with `shrink-0` — a box that hugs its content —
so a panel that no longer emits a width resolves its full-width class against that box.
Measured in isolation at a 390px row, each combination separately:

| combination | panel | task view |
|---|---|---|
| before — pixel width + 300px floor | 380px | **10px** |
| **panel only, caller untouched** (what #3850 shipped) | **71px** | 319px |
| caller only, panel still pixel | clipped to 195px | 195px |
| **both, and the task view steps aside** (this PR) | **390px** | 0 |

## The fix

- `DetailPanel`: while narrow, take the same full-width path its `embedded` callers
  already use — no pixel width, no `shrink-0`.
- `ProjectDetailPage`: its own wrapper animates to `100%` and stops hugging its
  content, and the task view is hidden so the panel owns the pane.

The task view is **hidden, not unmounted** — it holds scroll position and the DAG's own
layout, and rotating a phone crosses the breakpoint.

## The assumption is now enforced, not assumed

A two-sided fix on a shared primitive is only safe while the caller set is small and
known. I checked all ten call sites: exactly one owns a width wrapper. A test asserts
that none of the other six library callers has grown an animated `width: 'auto'`
wrapper, so the next one to do so fails here instead of silently reintroducing the
defect. (`ChannelPage`'s thread panel is excluded on purpose: that page is not routed.)

## Tests

`src/test/detailPanelNarrow2.test.ts` — each half falsified independently:

| mutation | caught |
|---|---|
| revert the caller's animated width (panel-only fix) | yes |
| let the caller's wrapper keep hugging its content | yes |
| revert the panel's narrow branch (caller-only fix) | yes |
| stop the task view stepping aside | yes |

`tsc` clean; 22 panel/project suites, 335 tests; `eslint` 0 errors; `i18n:check` PASS.

## Evidence note

No screenshots. I could not reach a `DetailPanel` surface at 390px in an isolated pod
across the four routes I tried, which is what let both earlier revisions ship inert —
so the evidence here is the isolated four-way measurement above, which reproduces the
real DOM shape (row → animated `width:'auto'` + `shrink-0` wrapper → panel) and is the
same probe that caught the original bug. It answers the width question more directly
than a frame would.
