### PR TITLE
fix(apps): resolve the adopted backend's port owner cross-platform

### DIFF
--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -135,7 +135,8 @@ def _survived_spawn(proc: Any, port: int | None = None) -> bool:
     established at all (no port to observe, or no port->PID tool on the host), it
     degrades to polling the full budget exactly as before.
 
-    The ownership probe shells out to lsof (~150ms), so it is gated behind a cheap
+    The ownership probe shells out to the port->PID tool (lsof on POSIX, netstat
+    on Windows; ~150ms), so it is gated behind a cheap
     loopback connect and is not run on every poll: the deadline below stays honest
     about wall-clock rather than adding the probe's cost to each interval, which
     would otherwise make the failure path take LONGER than the original budget.
@@ -631,23 +632,34 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                 except Exception as exc:
                     logger.debug("SEL audit failed for app %s backend adopt: %s", app_name, exc)
                 # Record PIDs listening on this port at adoption time
-                adopted_pids: list[int] = []
-                try:
-                    lsof_result = subprocess.run(
-                        ["lsof", "-ti", f":{port}", "-sTCP:LISTEN"],
-                        capture_output=True, text=True, timeout=5,
-                    )
-                    if lsof_result.returncode == 0 and lsof_result.stdout.strip():
-                        for pid_str in lsof_result.stdout.strip().split("\n"):
-                            try:
-                                adopted_pids.append(int(pid_str.strip()))
-                            except ValueError:
-                                pass
-                except (OSError, subprocess.TimeoutExpired):
-                    pass
+                # Through the module's own helper, never a bare ``lsof``: that
+                # tool does not exist on Windows, where only the *exec* launcher
+                # branch is POSIX-gated — Python and Node backends run there, so
+                # a POSIX-only probe records no owner and refuses every
+                # adoption. find_listening_pids parses ``netstat -ano`` instead,
+                # and resolves the binary through trusted_system_bin rather than
+                # a PATH that can lead with a same-uid-writable directory.
+                #
+                # Ownership recorded here is port-wide, not address-scoped: the
+                # probe reports every listener on the port whatever its local
+                # address, so a process bound to a different address on the same
+                # port is adopted alongside the backend we health-checked and is
+                # signalled with it by stop's adopted path. That breadth is not
+                # introduced here — the inline probe this call replaced selected
+                # the same set — and it is deliberately left alone: the address a
+                # listener is bound to is not part of find_listening_pids' return
+                # shape, and the two obvious narrowings are both wrong. Owning
+                # only the loopback listener would refuse adoption for an
+                # externally-managed backend bound to 0.0.0.0, which is what
+                # adoption exists for, and refusing when several PIDs answer
+                # would refuse every pre-fork or multi-worker backend, where
+                # sharing one listening socket is normal. Narrowing it means
+                # changing that helper for all of its callers. Tracked in #5261.
+                adopted_pids = _listening_pids(port)
                 if not adopted_pids:
                     logger.warning(
-                        "App %s: cannot record PIDs on port %d (lsof unavailable?) — skipping adoption",
+                        "App %s: cannot record PIDs on port %d (port->PID probe "
+                        "unavailable?) — skipping adoption",
                         app_name, port,
                     )
                     return None
@@ -664,7 +676,8 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                 # If the gateway dies, the external instance keeps running and is
                 # simply re-probed and re-adopted on the next start — so reaping it
                 # would kill a healthy service we would immediately re-adopt. stop's
-                # adopted path kills only the lsof-revalidated PIDs for this reason.
+                # adopted path kills only the PIDs still revalidated as holding
+                # this port, for this reason.
                 with _lock:
                     _processes[app_name] = ap
                     _allocated_ports[app_name] = port
@@ -1134,25 +1147,24 @@ def stop_app_backend(app_name: str) -> bool:
             target_pids: set[int] = set(ap.adopted_pids)
 
             # Verify adopted PIDs still belong to this port (guards against
-            # PID recycling between adoption and stop).
-            try:
-                lsof_result = subprocess.run(
-                    ["lsof", "-ti", f":{ap.port}", "-sTCP:LISTEN"],
-                    capture_output=True, text=True, timeout=5,
-                )
-                if lsof_result.returncode == 0 and lsof_result.stdout.strip():
-                    current_pids: set[int] = set()
-                    for pid_str in lsof_result.stdout.strip().split("\n"):
-                        try:
-                            current_pids.add(int(pid_str.strip()))
-                        except ValueError:
-                            pass
-                    # Only kill PIDs that are both adopted AND still on this port
-                    target_pids = target_pids & current_pids
-            except (OSError, subprocess.TimeoutExpired):
-                # lsof unavailable at stop time — proceed with adopted PIDs
-                # (they were validated at adoption time)
-                pass
+            # PID recycling between adoption and stop). Same helper as adoption,
+            # so the check works on Windows instead of silently degrading there.
+            #
+            # Gate on the TOOL, not on the result. find_listening_pids folds
+            # "the probe could not run" and "the port genuinely has no listener"
+            # into one empty list, and those demand opposite actions: the first
+            # carries no identity information, while the second says the backend
+            # is gone and the recorded PID may already have been recycled onto an
+            # unrelated process. Nothing after this point re-checks identity
+            # before kill_pid, so an empty result from a WORKING probe must empty
+            # the kill set. listening_pid_tool_available exists to tell the two
+            # apart. A probe that is present but fails also collapses to [] and
+            # therefore kills nobody: at a process-termination boundary, leaking
+            # a backend beats signalling a stranger — the same rule
+            # _reap_stale_app_backends applies when it cannot confirm identity.
+            if platform_compat.listening_pid_tool_available():
+                # Only kill PIDs that are both adopted AND still on this port.
+                target_pids &= set(_listening_pids(ap.port))
 
             pids: list[int] = []
             for pid in target_pids:

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -1872,8 +1872,18 @@ def find_listening_pids(port: int) -> list[int]:
                 [lsof_bin, "-ti", f"TCP:{port}", "-sTCP:LISTEN"],
                 text=True,
                 stderr=subprocess.DEVNULL,
+                # Bounded like the Windows branch below. A wedged lsof (stale
+                # network mount, jammed process table) must not hang a caller:
+                # app-backend adoption and stop both run this on a request
+                # path, and an unbounded probe would block them indefinitely
+                # rather than degrading. SubprocessError — not just
+                # CalledProcessError — so the TimeoutExpired this introduces
+                # lands in the same "return []" degraded result an absent tool
+                # produces; listening_pid_tool_available() is what callers use
+                # to tell that apart from a genuinely empty port.
+                timeout=10,
             )
-        except (FileNotFoundError, subprocess.CalledProcessError, OSError):
+        except (FileNotFoundError, subprocess.SubprocessError, OSError):
             return []
         return list(dict.fromkeys(int(p) for p in out.split() if p.strip().isdigit()))
     # Windows: netstat -ano. Lines look like:

--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -158,6 +158,37 @@ def _capture_popen(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     return seen
 
 
+def _stub_listening_pids(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    pids: list[int] | None = None,
+    exc: BaseException | None = None,
+    available: bool = True,
+) -> None:
+    """Stub the port->PID probe at the seam the module actually uses.
+
+    ``_listening_pids`` wraps ``platform_compat.find_listening_pids``, which is
+    what makes the lookup answerable on Windows (``netstat -ano``) as well as
+    POSIX. Stubbing it here also keeps these tests hermetic: the real helper
+    spawns lsof/netstat and would otherwise report on whatever happens to be
+    listening on the developer's machine.
+
+    *available* drives ``listening_pid_tool_available``, which is the ONLY thing
+    that separates "the tool is absent" from "the tool ran and found no
+    listener" — ``find_listening_pids`` collapses both into ``[]``.
+    """
+
+    def _probe(_port: int) -> list[int]:
+        if exc is not None:
+            raise exc
+        return list(pids or [])
+
+    monkeypatch.setattr(bmod.platform_compat, "find_listening_pids", _probe)
+    monkeypatch.setattr(
+        bmod.platform_compat, "listening_pid_tool_available", lambda: available
+    )
+
+
 def _record_runs(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -654,11 +685,10 @@ class TestAdoptExistingInstance:
     ) -> None:
         port = bmod._MIN_PORT + 6
         monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
-        _record_runs(
-            monkeypatch,
-            # A non-numeric line must be skipped, not abort the adoption.
-            result=SimpleNamespace(returncode=0, stdout="111\nbogus\n222\n"),
-        )
+        # Parsing (non-numeric rows, dedup) is find_listening_pids' own
+        # contract and is covered in test_platform_compat; this test's subject
+        # is that a healthy occupant is adopted carrying the PIDs it reports.
+        _stub_listening_pids(monkeypatch, pids=[111, 222])
         ap = self._run(port)
         assert ap is not None
         assert ap.proc is None
@@ -666,6 +696,36 @@ class TestAdoptExistingInstance:
         assert ap.adopted_pids == [111, 222]
         assert bmod._processes["adoptee"] is ap
         assert bmod._allocated_ports["adoptee"] == port
+
+    def test_a_healthy_instance_is_adopted_where_lsof_does_not_exist(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Adoption must not depend on a POSIX-only tool.
+
+        Windows ships no ``lsof``, so the bare probe raises ``FileNotFoundError``
+        and no owning PID can be recorded — which makes adoption impossible on a
+        platform where Python and Node backends otherwise run (only the *exec*
+        launcher branch is POSIX-gated). ``platform_compat.find_listening_pids``
+        answers exactly this question there by parsing ``netstat -ano``, and this
+        module already routes every other process primitive through it —
+        including its own ``_listening_pids`` helper.
+        """
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        # What a bare ["lsof", ...] actually does on a host without lsof.
+        _record_runs(
+            monkeypatch,
+            exc=FileNotFoundError(2, "No such file or directory", "lsof"),
+        )
+        monkeypatch.setattr(bmod.platform_compat, "find_listening_pids", lambda _p: [4242])
+
+        ap = self._run(bmod._MIN_PORT + 11)
+
+        assert ap is not None, (
+            "a healthy backend on the port was refused because the port->PID "
+            "lookup shelled out to lsof; on Windows that can never succeed")
+        assert ap.adopted_pids == [4242]
+        assert ap.healthy is True
+        assert bmod._processes["adoptee"] is ap
 
     def test_adoption_survives_an_audit_sink_failure(
         self, occupied: Any, monkeypatch: pytest.MonkeyPatch
@@ -677,7 +737,7 @@ class TestAdoptExistingInstance:
 
         monkeypatch.setattr(bmod, "sel", _boom)
         monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
-        _record_runs(monkeypatch, result=SimpleNamespace(returncode=0, stdout="333\n"))
+        _stub_listening_pids(monkeypatch, pids=[333])
         ap = self._run(bmod._MIN_PORT + 7)
         assert ap is not None
         assert ap.adopted_pids == [333]
@@ -688,7 +748,7 @@ class TestAdoptExistingInstance:
         """Adopting without PIDs would leave a backend we can never stop."""
 
         monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
-        _record_runs(monkeypatch, result=SimpleNamespace(returncode=1, stdout=""))
+        _stub_listening_pids(monkeypatch, pids=[])
         with caplog.at_level(logging.WARNING):
             assert self._run(bmod._MIN_PORT + 8) is None
         assert any("cannot record PIDs" in r.message for r in caplog.records)
@@ -698,7 +758,7 @@ class TestAdoptExistingInstance:
         self, occupied: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _stub_listening_pids(monkeypatch, exc=OSError("no port->pid tool"))
         assert self._run(bmod._MIN_PORT + 9) is None
 
     def test_an_unhealthy_occupant_blocks_the_spawn_instead_of_colliding(
@@ -1116,15 +1176,38 @@ class TestStopAdoptedBackend:
         """Revalidation guards against a PID recycled since adoption."""
 
         self._track(adopted_pids=[111, 222], healthy=True)
-        _record_runs(monkeypatch, result=SimpleNamespace(returncode=0, stdout="111\n999\n"))
+        _stub_listening_pids(monkeypatch, pids=[111, 999])
         assert bmod.stop_app_backend("ext") is True
         assert kills == [(111, bmod.platform_compat.SIGTERM)]
+
+    def test_a_working_probe_finding_no_listener_signals_nobody(
+        self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty answer from a WORKING probe is a negative identity result.
+
+        The backend exited, the port has no listener, and the OS may already have
+        recycled the adopted PID onto an unrelated process. Nothing downstream
+        re-checks identity before ``kill_pid``, so treating "no listener" as "no
+        information" and falling back to the recorded PID is how an unrelated
+        process gets signalled. ``find_listening_pids`` cannot express the
+        difference — it folds a failed probe and a genuinely empty port into
+        ``[]`` — which is exactly why ``listening_pid_tool_available`` exists.
+        """
+        self._track(adopted_pids=[111], healthy=True)
+        _stub_listening_pids(monkeypatch, pids=[], available=True)
+
+        assert bmod.stop_app_backend("ext") is True
+
+        assert kills == [], (
+            "the adopted PID was signalled although a working probe reported no "
+            "listener on the port -- that PID may have been recycled onto an "
+            "unrelated process")
 
     def test_an_unavailable_pid_probe_falls_back_to_the_adopted_set(
         self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
     ) -> None:
         self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _stub_listening_pids(monkeypatch, available=False)
         assert bmod.stop_app_backend("ext") is True
         assert kills == [(111, bmod.platform_compat.SIGTERM)]
 
@@ -1132,7 +1215,7 @@ class TestStopAdoptedBackend:
         self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
     ) -> None:
         self._track(adopted_pids=[0, -1], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _stub_listening_pids(monkeypatch, available=False)
         assert bmod.stop_app_backend("ext") is True
         assert kills == []
 
@@ -1145,7 +1228,7 @@ class TestStopAdoptedBackend:
         )
         monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
         self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _stub_listening_pids(monkeypatch, available=False)
         assert bmod.stop_app_backend("ext") is True
         assert recorded == [
             (111, bmod.platform_compat.SIGTERM),
@@ -1161,7 +1244,7 @@ class TestStopAdoptedBackend:
         monkeypatch.setattr(bmod.platform_compat, "kill_pid", _denied)
         monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: False)
         self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _stub_listening_pids(monkeypatch, available=False)
         assert bmod.stop_app_backend("ext") is True
 
     def test_an_unexpected_stop_failure_restores_tracking(
@@ -1174,7 +1257,7 @@ class TestStopAdoptedBackend:
 
         monkeypatch.setattr(bmod.platform_compat, "kill_pid", _bad)
         ap = self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _stub_listening_pids(monkeypatch, available=False)
         with caplog.at_level(logging.WARNING):
             assert bmod.stop_app_backend("ext") is False
         assert any("Failed to stop adopted backend" in r.message for r in caplog.records)
@@ -1746,7 +1829,7 @@ class TestDefensiveBranches:
         assert bmod.stop_app_backend("ext") is False
         assert "ext" in bmod._processes
 
-    def test_a_garbled_pid_probe_line_is_skipped_during_an_adopted_stop(
+    def test_an_adopted_stop_escalates_despite_an_audit_sink_failure(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         def _no_sel() -> Any:
@@ -1759,7 +1842,7 @@ class TestDefensiveBranches:
             bmod.platform_compat, "kill_pid", lambda pid, sig: killed.append((pid, sig))
         )
         monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
-        _record_runs(monkeypatch, result=SimpleNamespace(returncode=0, stdout="111\nnope\n"))
+        _stub_listening_pids(monkeypatch, pids=[111])
         with bmod._lock:
             bmod._processes["ext"] = AppProcess(
                 app_name="ext", port=9100, pid=0, proc=None, adopted_pids=[111], healthy=True

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -2136,6 +2136,40 @@ class TestFindListeningPidsErrors:
         monkeypatch.setattr(pc.subprocess, "check_output", lambda *a, **k: "111\n111\n222\n")
         assert pc.find_listening_pids(7777) == [111, 222]
 
+    def test_posix_probe_is_bounded_by_a_timeout(self, monkeypatch):
+        # The POSIX branch must pass timeout= like the Windows branch does.
+        # Adoption and stop_app_backend both call this on a request path, so an
+        # unbounded lsof would hang the caller instead of degrading. Forced onto
+        # the POSIX branch so the guard is asserted on every platform: the
+        # sibling tests here skip off-POSIX, which would hide a regression from
+        # everyone developing on Windows.
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/usr/bin/lsof")
+        seen: dict = {}
+
+        def _capture(*_a, **kwargs):
+            seen.update(kwargs)
+            return "4242\n"
+
+        monkeypatch.setattr(pc.subprocess, "check_output", _capture)
+        assert pc.find_listening_pids(7777) == [4242]
+        assert seen.get("timeout"), "POSIX lsof probe must pass a timeout"
+
+    def test_posix_timeout_degrades_to_empty_rather_than_raising(self, monkeypatch):
+        # The timeout above is only safe if TimeoutExpired is caught: the except
+        # tuple originally listed CalledProcessError, which does NOT cover it,
+        # so a bare timeout= would have turned a hang into an uncaught crash on
+        # the app-start path. [] is the same degraded result an absent tool
+        # gives; listening_pid_tool_available() distinguishes the two.
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/usr/bin/lsof")
+
+        def _wedged(*_a, **_kw):
+            raise pc.subprocess.TimeoutExpired(cmd="lsof", timeout=10)
+
+        monkeypatch.setattr(pc.subprocess, "check_output", _wedged)
+        assert pc.find_listening_pids(7777) == []
+
     def _fake_netstat(self, blob: str):
         """Return a fake subprocess.check_output that returns *blob*."""
         def _run(*_a, **_kw):

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -293,7 +293,6 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # recorded, rendered through ``str()``. Nothing here is agent-influenced.
         "platform_compat.py::process_start_time",
         "apps/backend.py::_resolve_nvm_path",
-        "apps/backend.py::stop_app_backend",
         # py-spy attach for `kirocrew perf sample --pid`: fixed list-argv (no
         # shell=True), binary resolved via shutil.which rather than from input,
         # and every value is either a range-validated int (pid/seconds/rate) or a


### PR DESCRIPTION
## Problem / Motivation

App-backend **adoption** — taking over a healthy instance already listening on the
app's fixed port instead of colliding with it — recorded the owning PIDs by shelling
out to a bare `lsof`:

```python
adopted_pids: list[int] = []
try:
    lsof_result = subprocess.run(["lsof", "-ti", f":{port}", "-sTCP:LISTEN"], ...)
    ...
except (OSError, subprocess.TimeoutExpired):
    pass
if not adopted_pids:
    logger.warning("App %s: cannot record PIDs on port %d (lsof unavailable?) — skipping adoption", ...)
    return None
```

`lsof` does not exist on Windows. `subprocess.run` raises `FileNotFoundError`,
`adopted_pids` stays empty, and **adoption is refused every time**.

## Why it matters

The path is reachable on Windows. Only the **exec / shell-launcher** branch is
POSIX-gated (`backend.py:854`, which fails fast with an explicit message); Python
and Node app backends run there normally. So on Windows a healthy backend already
holding the port can never be adopted — the gateway logs `cannot record PIDs …
skipping adoption` and gives up.

This module already knows better everywhere else. It routes `pid_exists`,
`pid_liveness`, `kill_pid`, `kill_process_tree`, `get_ppid`,
`CREATE_NEW_PROCESS_GROUP` and `start_new_session=IS_POSIX` through
`platform_compat`, and it has its **own** port→PID wrapper ~460 lines above the
first offender:

```python
def _listening_pids(port: int) -> list[int]:
    """PIDs holding a LISTEN socket on *port* (best-effort, never raises)."""
    try:
        return platform_compat.find_listening_pids(port)
    except Exception:
        return []
```

`dashboard/port_reclaim.py` answers the identical question that way and says so:
"Windows has no `lsof` and parses `netstat -ano` through
`platform_compat.find_listening_pids` instead." `AGENTS.md` states the rule:

> | Port to PID | `find_listening_pids(port)` / `listening_pid_tool_available()` | `lsof` directly |

Two call sites in `apps/backend.py` were the outliers.

## What changed (motivation → approach → change)

**Motivation** — make the port→PID lookup answerable on every platform the app
backends actually run on, without inventing anything.

**Approach** — use the helper the module already defines. No new abstraction, no
new dependency, no behaviour change on POSIX (`find_listening_pids` runs the same
`lsof -ti TCP:<port> -sTCP:LISTEN` there, just resolved through
`trusted_system_bin`).

**Change** — one production file, two hunks:

1. **Adoption** — `adopted_pids = _listening_pids(port)`, replacing the inline
   `subprocess.run` + hand-rolled line parsing.
2. **Stop-path recycle guard** — `stop_app_backend` re-verifies adopted PIDs against
   the port before signalling them. Same bare probe, so on Windows the guard
   silently degraded to "proceed with adopted PIDs" and a recycled PID could be
   signalled. Its trigger is narrower today (adoption cannot populate
   `adopted_pids` on Windows in the first place) — but fixing adoption alone would
   make it reachable, so both move together.

**Gated on the tool, not on the result — this is the safety half.**
`find_listening_pids` folds "the probe could not run" and "the port genuinely has
no listener" into one empty list, and those two demand *opposite* actions. The
second means the backend is gone and its recorded PID may already have been
recycled onto an unrelated process; nothing downstream re-checks identity before
`kill_pid`. Preserving the old "only a positive reading narrows the set" shape
would therefore have carried a recycled-PID kill into a path this very PR makes
reachable on Windows:

```
adopt PID 1234 -> backend exits -> OS recycles 1234 onto an unrelated process
               -> port has no listener -> probe returns []
               -> kill set stays {1234} -> kill_pid(1234), then SIGKILL
```

`listening_pid_tool_available` exists precisely to tell the two apart ("Lets
callers distinguish 'tool absent' from 'no listener found'"), so the gate reads
the tool:

```python
target_pids = set(ap.adopted_pids)
if platform_compat.listening_pid_tool_available():
    target_pids &= set(_listening_pids(ap.port))
```

| situation | behaviour |
|---|---|
| tool absent | fall back to the adopted PIDs (unchanged) |
| tool available, PID still listening | signal the intersection only |
| tool available, port empty | **signal nobody** |
| tool available, probe fails (also `[]`) | signal nobody |

The last row does narrow the old POSIX error-path behaviour, deliberately. At a
process-termination boundary, leaking a backend beats signalling a stranger —
the rule `_reap_stale_app_backends` already states for itself: "if identity
cannot be confirmed the pid is [left alone]".

**Secondary, same edit:** both sites passed `["lsof", ...]` resolved through `PATH`.
`find_listening_pids` goes through `trusted_system_bin`, which `AGENTS.md` requires
because `PATH` can lead with a same-uid-writable directory — and `stop_app_backend`
**kills** the PIDs this probe returns.

The refusal log no longer names `lsof`, since the probe is no longer lsof-specific.

## Tests

New `test_a_healthy_instance_is_adopted_where_lsof_does_not_exist` in
`TestAdoptExistingInstance`. It models the Windows reality precisely: the bare probe
raises `FileNotFoundError` (what a host without `lsof` does) while
`platform_compat.find_listening_pids` reports a PID. It then asserts the healthy
occupant is adopted carrying that PID.

New `test_a_working_probe_finding_no_listener_signals_nobody` in
`TestStopAdoptedBackend` covers the safety half: a working probe reporting an empty
port must empty the kill set, because the adopted PID may have been recycled.

Two base controls, tests kept in both:

| production under test | result |
|---|---|
| `origin/main` (`fa30219bb`) | **5 fail** — both new tests, plus the 3 whose seam moved |
| this PR's previous head (`42fce17c4`) | **1 fail** — exactly `test_a_working_probe_finding_no_listener_signals_nobody`, i.e. the recycled-PID kill it still had |
| this head | all pass |

The second control is the isolated proof for the stop-path fix.

The stop path is covered in all three states: tool available + empty (signal
nobody), tool absent (fall back to the adopted set), tool available + a matching
PID (signal the intersection only).

**Ten existing tests moved seam, none weakened.** They stubbed `subprocess.run` to
stand in for the lsof probe; they now stub `find_listening_pids` — the seam the
module actually consults — through one shared `_stub_listening_pids` helper. Each
keeps its original subject: PIDs still listening are the only ones signalled, an
unavailable probe falls back to the adopted set, non-positive PIDs are never
signalled, adoption is refused when no owner can be recorded, and so on. The
stop-path ones now express "the probe cannot run" as tool *absence*, which is the
distinction the production gate reads. Row parsing and dedup are
`find_listening_pids`' own contract and are covered by `test_platform_compat`, so
the one test whose only subject was garbled-row parsing is retargeted to the
escalation it uniquely exercises.

That change also makes them **hermetic**: left as-is they would have called the real
helper, spawning `netstat`/`lsof` and reporting on whatever happened to be listening
on the machine running the suite.

```
pytest test/test_apps_backend_coverage.py -q                118 passed
pytest test/test_apps_backend_coverage.py \
       test/test_app_backend.py \
       test/test_platform_compat.py \
       test/test_platform_compat_coverage.py -q             302 passed, 320 skipped, 2 failed
```

The 2 are pre-existing local-Windows failures in `test_app_backend.py`
(`WinError 1314` symlink privilege, and a `cp950` decode of a UTF-8 repo file). Both
reproduce identically with this branch's changes reverted, so neither is caused
here; they do not occur on the CI runners.

**One repo-owned audit entry retired with the spawn it described.**
`test/test_spawn_audit.py`'s `BENIGN_SPAWNS` allowlisted
`apps/backend.py::stop_app_backend` because that function used to spawn a bare
`lsof`. Routing the probe through `find_listening_pids` removes the spawn, so the
entry went stale and the repo's own `test_benign_allowlist_has_no_stale_entries`
failed by design - its own message is "remove them or they mask future
regressions". Deleting that one line is the whole fix: measured on this base,
`1 failed` with the entry present and `1 passed` without it, and
`test/test_spawn_audit.py` is `9 passed`. This is exactly what the previous head's
CI red was, on all three shard-4 jobs (3.10, 3.12 and Windows).

Also green on the changed files: `flake8`, `isort --check-only`,
`mypy --platform linux` (no findings for `apps/backend.py`), `git diff --check`.

## Manual verification

N/A — no user-visible surface. The Windows half is exactly what cannot be exercised
from a POSIX CI runner, which is why the regression drives the platform seam rather
than the real tool.

## Screenshots / video

<!-- no-visual-delta -->

Backend process handling only.

## Related Issues

Fixes #3876.

`_proc_start_time` (`backend.py:1401`) also shells out to a bare `ps -o lstart=` for
PID-recycle identity. Different question (process start time, not port→PID) with its
own Windows story, so it is deliberately left for separate assessment rather than
swept in here.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — no documented behaviour changed; `AGENTS.md` already mandates this helper, the two call sites were the outliers
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
