### PR TITLE
fix(artifacts): give the side panels the width at phone widths

### DIFF
--- a/website/src/components/ArtifactChatPanel.tsx
+++ b/website/src/components/ArtifactChatPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { useIsMobile } from '../hooks/useIsMobile'
 import { Plus, ExternalLink, X, Sparkles } from 'lucide-react'
 import { useAppDispatch } from '../store'
 import { switchSlot } from '../store/chatSlice'
@@ -50,6 +51,7 @@ export function ArtifactChatPanel({
   onOpenFull: () => void
   onClose: () => void
 }) {
+  const isMobile = useIsMobile()
   const dispatch = useAppDispatch()
   const prevSlotRef = useRef<string | null>(null)
 
@@ -62,9 +64,12 @@ export function ArtifactChatPanel({
     }
   }, [slotKey, dispatch])
 
+  // 480px cannot fit a phone viewport, and this row has no horizontal scroll,
+  // so the overhang was clipped rather than reachable. While narrow the panel
+  // takes the width and the artifact body steps aside.
   return (
     <aside
-      className="w-[480px] shrink-0 flex flex-col rounded-xl border border-border bg-card overflow-hidden"
+      className={`${isMobile ? 'w-full' : 'w-[480px] shrink-0'} flex flex-col rounded-xl border border-border bg-card overflow-hidden`}
       style={{ height: 'calc(100vh - 240px)', minHeight: 480 }}
       aria-label={i18nT('components.artifactChatPanel.artifact_companion_chat')}
     >

--- a/website/src/components/CommentsSidebar.tsx
+++ b/website/src/components/CommentsSidebar.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo, useRef, useState, useCallback, useEffect } from 'react'
+import { useIsMobile } from '../hooks/useIsMobile'
 import {
   MessageSquare, X, RefreshCw, Send, Bot, CheckCircle2, Eye, CornerDownRight,
   AlertTriangle, ChevronRight, Sparkles, Plus, RotateCcw, Link2, Pencil,
@@ -346,6 +347,7 @@ export interface CommentsSidebarProps {
 }
 
 const SIDEBAR_DEFAULT_CLASS = 'w-[340px] shrink-0 flex flex-col rounded-xl border border-border bg-card overflow-hidden'
+const SIDEBAR_NARROW_CLASS = 'w-full flex flex-col rounded-xl border border-border bg-card overflow-hidden'
 const SIDEBAR_DEFAULT_STYLE: React.CSSProperties = { height: 'calc(100vh - 240px)', minHeight: 480 }
 
 /** Collapsible right-hand comment sidebar. Threaded one level deep, with
@@ -354,6 +356,7 @@ const SIDEBAR_DEFAULT_STYLE: React.CSSProperties = { height: 'calc(100vh - 240px
  *  widget, where text-selection anchoring isn't available inside the
  *  sandboxed iframe — comments degrade to whole-artifact). */
 export const CommentsSidebar = memo(function CommentsSidebar(props: CommentsSidebarProps) {
+  const isMobile = useIsMobile()
   const {
     comments, loading, remoteSyncError, onAdd, onReply, onResolve,
     onMarkReview, onDelete, onRefresh, onAskAgent, onClose, restrictActions, hideResolve, hideDelete,
@@ -440,7 +443,9 @@ export const CommentsSidebar = memo(function CommentsSidebar(props: CommentsSide
   const visibleRoots = showResolved ? roots : roots.filter(r => r.status !== 'resolved')
 
   return (
-    <aside className={containerClassName ?? SIDEBAR_DEFAULT_CLASS} style={containerStyle ?? SIDEBAR_DEFAULT_STYLE}>
+    // A caller-supplied class still wins. Absent one, the default 340px leaves
+    // the artifact body 34px at 390px, so the panel takes the width instead.
+    <aside className={containerClassName ?? (isMobile ? SIDEBAR_NARROW_CLASS : SIDEBAR_DEFAULT_CLASS)} style={containerStyle ?? SIDEBAR_DEFAULT_STYLE}>
       {/* header */}
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-bg-elevated shrink-0">
         <MessageSquare size={14} className="text-accent" />

--- a/website/src/pages/ArtifactDetailPage.tsx
+++ b/website/src/pages/ArtifactDetailPage.tsx
@@ -1,4 +1,5 @@
 import { safeSetItem } from '../utils/safeStorage'
+import { useIsMobile } from '../hooks/useIsMobile'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import WebAppArtifactCard from '../components/WebAppArtifactCard'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -369,6 +370,7 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
   // show/hide applies to the current view only; we intentionally do NOT persist
   // it, so every artifact independently does the right thing instead of a
   // global pin re-opening empty panels everywhere.
+  const isMobile = useIsMobile()
   const [panel, setPanel] = useState<'none' | 'comments' | 'chat'>('none')
   // Flipped once the user manually toggles, so the comment-driven auto-reveal
   // below stops overriding an explicit choice — but only for the current
@@ -1822,7 +1824,12 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
             would let a click on a webapp artifact create/activate a session with
             nowhere to display. */}
         <div className="flex gap-4 items-start">
-          <div className="flex-1 min-w-0">
+          {/* An open panel owns the width while narrow, so the artifact body
+              steps aside -- giving the panel `w-full` alone would still leave the
+              two of them splitting 390px. Hidden rather than unmounted: the body
+              holds scroll position and, for markdown, an in-progress anchored
+              comment selection, and rotating a phone crosses the breakpoint. */}
+          <div className={`flex-1 min-w-0 ${isMobile && panel !== 'none' ? 'hidden' : ''}`}>
             {/* Copy raw source — its own right-aligned slot ABOVE the body (not
                 the header toolbar, which must not grow; not an overlay, which
                 could obscure a heading's trailing text or cover a top-right

--- a/website/src/test/artifactPanelsNarrow.test.ts
+++ b/website/src/test/artifactPanelsNarrow.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const read = (p: string) => readFile(join(__dirname, '..', p), 'utf8')
+
+// Both side panels on the artifact page are fixed-width `shrink-0` siblings of the
+// artifact body in a `flex gap-4` row, and the page consulted no viewport hook at
+// all. At 390px the 480px chat panel could not fit and was CLIPPED (the row has no
+// horizontal scroll, so the overhang was unreachable rather than off-screen), and
+// the 340px comments panel left the body 34px.
+describe('artifact side panels at phone widths', () => {
+  it('gives the companion chat panel the width instead of clipping it', async () => {
+    const s = await read('components/ArtifactChatPanel.tsx')
+    expect(s, 'expected the viewport hook').toContain('useIsMobile')
+    expect(s).toMatch(/\$\{isMobile \? 'w-full' : 'w-\[480px\] shrink-0'\}/)
+  })
+
+  it('gives the comments sidebar the width too, without breaking caller overrides', async () => {
+    const s = await read('components/CommentsSidebar.tsx')
+    expect(s, 'expected the viewport hook').toContain('useIsMobile')
+    expect(s).toMatch(/const SIDEBAR_NARROW_CLASS = 'w-full flex flex-col/)
+    // A caller-supplied class must still win, or embedders lose their layout.
+    expect(s).toMatch(/containerClassName \?\? \(isMobile \? SIDEBAR_NARROW_CLASS : SIDEBAR_DEFAULT_CLASS\)/)
+  })
+
+  it('steps the artifact body aside so an open panel is not splitting 390px', async () => {
+    const s = await read('pages/ArtifactDetailPage.tsx')
+    expect(s, 'expected the viewport hook').toContain('useIsMobile')
+    expect(s).toMatch(/\$\{isMobile && panel !== 'none' \? 'hidden' : ''\}/)
+    // Hidden, not unmounted: the body holds scroll position and, for markdown, an
+    // in-progress anchored comment selection.
+    expect(s, 'the body must not be unmounted by a responsive branch')
+      .not.toMatch(/\{!\(isMobile && panel !== 'none'\) && \(/)
+  })
+})


### PR DESCRIPTION
Fixes #3837 — and the sibling defect that issue did not name.

## Two panels, one row, no viewport hook

Both side panels are fixed-width `shrink-0` siblings of the artifact body in a
`flex gap-4 items-start` row, and `ArtifactDetailPage` consulted **no viewport hook at
all**. At 390px:

| panel | width | consequence |
|---|---|---|
| companion chat (`ArtifactChatPanel`) | **480px** | cannot fit; the row has no horizontal scroll, so the overhang is **clipped and unreachable** — including the panel's own close button |
| comments (`CommentsSidebar` default) | **340px** | artifact body left **34px** |

#3837 named only the chat panel. The comments sidebar is the same defect on the same
row, so it is fixed with it rather than left to be found again.

## The fix

Each panel takes the full width while narrow, and the artifact body steps aside.
`w-full` on the panel alone would **not** be enough — the two would still split 390px
between them, which is the mistake that cost two revisions on the `DetailPanel` PR.

The comments sidebar **keeps its caller override**: `containerClassName` still wins when
supplied, so embedders passing their own geometry are unaffected; only the default 340px
class is swapped. A test pins that, because silently ignoring the override would break
every other embedder to fix this page.

The body is hidden rather than unmounted — it holds scroll position and, for markdown
artifacts, an in-progress anchored comment selection, and rotating a phone crosses the
breakpoint.

## Tests

`src/test/artifactPanelsNarrow.test.ts`, each assertion falsified by mutation:

| mutation | caught |
|---|---|
| restore the chat panel's fixed 480px | yes |
| restore the sidebar's fixed 340px | yes |
| make the narrow class ignore `containerClassName` | yes |
| stop the artifact body stepping aside | yes |

`tsc` clean; 45 artifact/comment suites, 682 tests; `eslint` 0 errors; `i18n:check` PASS.
