### PR TITLE
fix(instances): pair the internal-API credential with the port it guards

### DIFF
--- a/.github/coverage-baselines/backend.txt
+++ b/.github/coverage-baselines/backend.txt
@@ -23,7 +23,6 @@ src/kiro_crew/apps/builtins/auto_improvement/spine/bug_gate.py 20.7   # 12/58
 src/kiro_crew/apps/builtins/auto_improvement/spine/gate.py 19.1   # 22/115
 src/kiro_crew/apps/builtins/auto_improvement/spine/git_safety.py 46.4   # 45/97
 src/kiro_crew/apps/builtins/auto_improvement/spine/pr_pipeline.py 28.7   # 35/122
-src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py 77.1   # 330/428
 src/kiro_crew/apps/builtins/code_review_sage/tests/fixtures.py 0.0   # 0/6
 src/kiro_crew/apps/builtins/crew_companion/backend/routes.py 62.9   # 112/178
 src/kiro_crew/apps/builtins/file_explorer/server.py 71.9   # 396/551

--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -856,9 +856,80 @@ file-permission argument does not hold, so Windows users keep `--port` /
 `KIROCREW_PORT`. This module deliberately offers no bare "is something
 listening" helper, so no caller can mistake reachability for identity.
 
-The live gateway prunes markers naming other ports on startup: a gateway is a
-singleton per data home, so any other marker belongs to a crashed earlier run,
-and each stale one costs a future client command a listener lookup.
+The live gateway prunes markers naming other ports on startup, EXCEPT any whose
+gateway passes the same ownership proof its readers use. `gateway.lock` makes a
+gateway a singleton per data home only when every start goes through it, and in
+practice one machine runs several that share a home (a second gateway launched by
+hand, one started from another checkout that inherits the default data home, a
+cutover overlapping its predecessor). A blanket prune deletes a LIVE gateway's
+marker and pid sidecar, which makes it undiscoverable to `token` / `status` /
+`stop` and destroys the evidence section 12.1 depends on. The ownership check fails
+closed by RETURNING FALSE rather than raising -- non-POSIX returns False outright,
+and a missing or throwing listener-lookup tool is folded into False as well -- so a
+False answer means "ownership not proven", NOT "process gone", and the two cases are
+indistinguishable from the caller. Such a marker still prunes, so markers do not
+accumulate forever -- but the prune removes only the marker and pid sidecar, never
+the credential, because treating False as death would strip a LIVE incumbent's
+credential on every Windows host and push its clients onto a shared file a newcomer
+may have replaced. `clear_marker()` owns credential deletion.
+
+### 12.1 The internal-API credential is keyed by port
+
+`<data-home>/run/gateway-<port>.secret` holds the internal-API credential of the
+gateway serving that port, written `0600` beside the marker and removed by
+`clear_marker()` with it.
+
+The credential is generated per gateway start (`os.urandom(16).hex()`) and kept in
+memory as the value the auth middleware compares against, so it identifies ONE
+generation. Published only to the single shared `<data-home>/.local_secret`, it
+was last-writer-wins per home: a second gateway starting in the same home replaced
+the file while the first kept serving the port, the incumbent went on comparing
+against its own in-memory value, and every internal caller then sent the
+newcomer's credential to the incumbent. The whole internal channel answers 403
+with a body of exactly `Forbidden` until one of them restarts: `learn_add`,
+`spawn`, `session-keepalive`, artifact writes, the task runner, all at once, with
+no warning and no metric.
+
+Two rules keep the two halves paired:
+
+- **The writer** (`dashboard.server._write_instance_credentials`) always writes the
+  per-port file, and writes the shared `.local_secret` only when no other gateway
+  in the home is verifiably alive on a different port. The shared file is still
+  written in the single-instance case because pre-per-port readers (an older CLI,
+  a cron script from a previous install) know only that path.
+- **The reader** is ONE shared helper, `config.loader.read_local_secret(port)`: it
+  returns the credential for the port the caller is about to dial and falls back to
+  `.local_secret` when no per-port file exists. It lives there rather than in each
+  reader because every surface that implements its own read reintroduces the bug for
+  itself. **`port` is required.** An optional port would resolve the dial target from
+  process context, so a converted call site could read the credential for one gateway
+  while dialing another -- the same desync, reintroduced one call site at a time and
+  invisible in the hunk under review. A caller with no port resolves one explicitly
+  and passes it, where the choice is reviewable. `mcp_core`, `mcp_shared`,
+  `cron_script`, `computer_use/screencast` and the Sage review driver each name their
+  dial target; a test greps for a no-argument call so the shape cannot come back.
+- **The dialed port's own credential outranks any path a caller names.**
+  `cron_trigger.trigger_cron_job` reads the per-port credential for the port it posts
+  to FIRST, and falls back to the `secret_path` its caller named only when that is
+  absent. The order is deliberate and is dictated by the callers: both of them pass
+  `config_dir() / ".local_secret"`, the home-wide file, which is exactly the file a
+  second gateway generation replaces -- so preferring the named path would reinstate
+  the defect this module exists to prevent.
+  The cost of that order, stated rather than hidden: a crash-orphaned
+  `run/gateway-<port>.secret` (the prune never deletes credentials, see section 12)
+  is preferred over a correct named path, so a caller that genuinely names another
+  home's credential for a port this home once served would send the stale one and get
+  a 403. No caller does that today -- both name the ambient home-wide file -- and
+  closing it properly means the credential-path parameter going away rather than the
+  order flipping.
+
+A denial carries a machine-readable `code` (`internal_auth_mismatch`) beside the
+prose, because a genuine permission denial produces the same `Forbidden` body and a
+consumer matching on text misdiagnoses one as the other. It also names both sides by
+fingerprint (a short SHA-256 prefix plus length, never the value), so a
+cross-generation mismatch is distinguishable from a forged header and from a caller
+that had no credential at all; without it a real desync is unattributable from the
+log.
 
 ### Why `run/` is on the sensitive-path floor
 

--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1392,
+    "missing_code": 1391,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 806,
+  "_compliant": 807,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -200,9 +200,6 @@
     },
     "dashboard/openai_compat.py": {
       "missing_code": 19
-    },
-    "dashboard/token_auth.py": {
-      "missing_code": 1
     },
     "deploy/handlers.py": {
       "dynamic_status": 5,

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
@@ -119,7 +119,17 @@ DEFAULT_REPORT_RETENTION = 20    # keep the N most-recent report artifacts; prun
 
 def _api_request(method: str, path: str, body: dict | None = None, timeout: int = 30) -> dict:
     """Authenticated loopback call to the gateway API. Never raises."""
-    base, secret = _gateway_base(), _local_secret()
+    base = _gateway_base()
+    # The credential belongs to the gateway this call DIALS, so it is read for the
+    # port carried by the resolved base rather than from the home-wide file, which
+    # names whichever generation wrote it last. An unparseable base leaves no dial
+    # target to name, and a credential for an unknown gateway is not a thing that
+    # exists -- so that is an error, not a reason to fall back to a home-wide read.
+    try:
+        base_port = int(base.rsplit(":", 1)[1])
+    except (IndexError, ValueError):
+        return {"error": f"could not read a port from the gateway base {base!r}"}
+    secret = _local_secret(base_port)
     if not secret:
         return {"error": "gateway IPC secret unavailable"}
     headers = {"X-Internal-Secret": secret}
@@ -522,8 +532,23 @@ _RESOLVED_BASE: str | None = None
 
 
 def _candidate_ports() -> list[int]:
-    """Ports to try for the live gateway: KIROCREW_PORT, config.json dashboard.url,
-    then the common gateway range (the gateway may be on 5477+ if 5476 was taken)."""
+    """Ports this process can claim as ITS OWN gateway, in order of authority.
+
+    Only self-declared sources are eligible: ``KIROCREW_BOUND_PORT`` (exported by
+    the parent gateway once its listener is bound), then ``KIROCREW_PORT``, then this
+    home's ``config.json`` ``dashboard.url``. The bound port leads because it carries
+    the port actually held: a gateway asked for 5476 but given 5477 has the truth
+    only there, and a ``--port auto`` gateway has no other numeric source at all.
+    A pod deliberately drops it so it never inherits its parent's listener.
+
+    A blind sweep of the common gateway range is deliberately NOT included, because
+    every probe carries that port's own credential -- so a sweep would authenticate
+    against whichever sibling gateway answered first and this app would then create
+    and delete review artifacts in that instance's store. A port we cannot justify
+    as ours is not a discovery candidate; when no source names one the caller falls
+    back to the default and the request errors clearly, which fails closed instead
+    of writing to a stranger.
+    """
     out: list[int] = []
 
     def _add(v) -> None:
@@ -534,6 +559,7 @@ def _candidate_ports() -> list[int]:
         if 1 <= p <= 65535 and p not in out:
             out.append(p)
 
+    _add(os.environ.get("KIROCREW_BOUND_PORT"))
     _add(os.environ.get("KIROCREW_PORT"))
     try:
         cfg = store.crew_home() / "config.json"
@@ -545,8 +571,6 @@ def _candidate_ports() -> list[int]:
                 _add(m.group(1))
     except Exception:
         pass
-    for p in (5476, 5477, 5478, 5479, 5480, 5486):
-        _add(p)
     return out
 
 
@@ -575,19 +599,50 @@ def _gateway_base() -> str:
     global _RESOLVED_BASE
     if _RESOLVED_BASE:
         return _RESOLVED_BASE
-    secret = _local_secret()
     ports = _candidate_ports()
     for port in ports:
         base = f"http://localhost:{port}"
-        if _probe(base, secret):
+        # Each candidate is probed with ITS OWN credential. A single secret read
+        # before the loop comes from the home-wide file, which holds one slot per
+        # data home: on a host running more than one gateway that names whichever
+        # generation wrote last, so every probe against the others 403s and the
+        # resolution falls through to a guess.
+        if _probe(base, _local_secret(port)):
             _RESOLVED_BASE = base
             return base
-    # best guess; the request will error clearly if wrong
-    return f"http://localhost:{ports[0] if ports else '5476'}"
+    # No candidate answered. Fall back only to a port a source positively NAMED
+    # (ports[0]); do NOT invent 5476. An unnamed default is a guess, and dialing it
+    # with its own credential is how a report write lands in whatever SIBLING gateway
+    # happens to own that port. When no source names a port at all, there is no base
+    # to justify -- return empty so _api_request fails closed with a clear error
+    # rather than authenticating against a stranger.
+    return f"http://localhost:{ports[0]}" if ports else ""
 
 
-def _local_secret() -> str:
-    """Read the gateway IPC secret (same mechanism the MCP server uses)."""
+def _local_secret(port: int) -> str:
+    """Credential for the gateway on *port*, via the shared resolver.
+
+    The per-port-then-shared order lives in ``config.loader.read_local_secret``;
+    duplicating it here would give this surface its own copy to drift. Only the
+    fallback differs: this app addresses its data home through ``store.crew_home()``,
+    so a home-wide read is retried against that when the shared resolver finds
+    nothing.
+
+    *port* is required for the same reason it is required there: the credential is
+    only valid for the gateway it belongs to, so the dial target is never inferred.
+    """
+    try:
+        # Optional dependency, so function-local: this app also runs STANDALONE,
+        # outside the Kiro Crew package, where this import raises and the
+        # crew_home() read below is the only resolution available. A module-scope
+        # import would make the module itself unimportable there.
+        from kiro_crew.config.loader import read_local_secret
+
+        secret = read_local_secret(port)
+        if secret:
+            return secret
+    except Exception:
+        pass
     try:
         return (store.crew_home() / ".local_secret").read_text(encoding="utf-8").strip()
     except Exception:

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -44,7 +44,6 @@ from kiro_crew.apps.scaffold import scaffold_app
 from kiro_crew.cli_server import _marker_port, resolve_client_port
 from kiro_crew.config import config_dir
 from kiro_crew.config.loader import (
-    DASHBOARD_PORT,
     ConfigReadError,
     KiroCrewAgentConfig,
     KiroCrewConfig,
@@ -65,6 +64,7 @@ from kiro_crew.eval.scenario import AssertionType, load_scenario, load_scenarios
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.learn import Lesson, LessonStore
 from kiro_crew.loopback_http import loopback_urlopen
+from kiro_crew.port_resolution import resolve_client_port_ex
 from kiro_crew.security import (
     BUILTIN_DENIED_RULES,
     BUILTIN_DENY_PATTERNS,
@@ -974,7 +974,10 @@ def _cron(args: argparse.Namespace) -> None:
             print(f"Job not found: {args.job_id}")
 
     elif action == "trigger":
-        port = DASHBOARD_PORT
+        # Instance-aware, for the same reason as the MCP trigger: DASHBOARD_PORT reads
+        # KIROCREW_PORT only, so on a --port auto gateway it names a sibling, and the
+        # paired credential would let that sibling run the job.
+        port, _evidence_backed = resolve_client_port_ex(None)
         secret_path = config_dir() / ".local_secret"
         ok, msg = trigger_cron_job(args.job_id, port, secret_path)
         print(msg)

--- a/src/kiro_crew/computer_use/screencast.py
+++ b/src/kiro_crew/computer_use/screencast.py
@@ -60,7 +60,6 @@ from dataclasses import dataclass
 from typing import Any, Iterator
 
 from kiro_crew.computer_use.types import MAX_SCREENSHOT_MAX_PX, OBS_SCREENSHOT, Snapshot
-from kiro_crew.config.paths import config_dir
 from kiro_crew.loopback_http import loopback_urlopen
 
 logger = logging.getLogger(__name__)
@@ -74,7 +73,6 @@ FRAME_INGRESS_PATH = "/api/computer-use/frame"
 
 # Header the ingress authenticates with (the gateway's own per-run local secret).
 FRAME_SECRET_HEADER = "X-Internal-Secret"
-_LOCAL_SECRET_FILE = ".local_secret"
 
 # Seconds to wait on the POST. The mirror is best-effort decoration on a tool
 # call that has already produced its result; a slow or dead gateway must cost the
@@ -291,16 +289,19 @@ def _post_frame(payload: dict[str, Any]) -> None:
 def _ingress_url() -> str:
     """Loopback URL of the frame ingress on the gateway this install serves.
 
-    Resolved through ``parse_dashboard_url`` (which honours ``KIROCREW_PORT`` and
-    then ``dashboard.url``) so a dev instance on 6777 mirrors to itself rather
-    than to a production gateway on 5476. Imported lazily: ``dashboard.origin``
-    pulls in aiohttp, and this module is reachable from the capture path.
-    """
-    from kiro_crew.config.loader import KiroCrewConfig
-    from kiro_crew.dashboard.origin import parse_dashboard_url
+    Resolved through :func:`resolve_serving_port`, which prefers the port this
+    process actually bound over an inherited ``KIROCREW_PORT``, so an auto-port
+    instance mirrors to itself instead of to a sibling.
 
-    _host, port = parse_dashboard_url(KiroCrewConfig.load().dashboard.url)
-    return f"http://127.0.0.1:{port}{FRAME_INGRESS_PATH}"
+    The import is function-local ON PURPOSE, against the advisory ``top-level-imports``
+    guideline: ``port_resolution`` imports ``dashboard.origin`` at module scope, which
+    pulls in aiohttp, and this module sits on the screen-capture path that must not pay
+    that cost at import time. This is the same lazy-import discipline the module used
+    before the shared resolver existed; the resolver did not change the constraint.
+    """
+    from kiro_crew.port_resolution import resolve_serving_port
+
+    return f"http://127.0.0.1:{resolve_serving_port()}{FRAME_INGRESS_PATH}"
 
 
 def _headers() -> dict[str, str]:
@@ -309,11 +310,30 @@ def _headers() -> dict[str, str]:
     An unreadable secret yields no header, the ingress refuses the POST, and the
     frame is dropped — which is the correct outcome: the mirror is not worth
     weakening the ingress for.
+
+    The credential is read for the port this module POSTS to (resolved the same way
+    :func:`_ingress_url` resolves it), not from the home-wide file alone: that file
+    holds one slot per data home, so a second gateway generation replaces it and the
+    ingress would refuse every frame from the instance that is actually serving.
+
+    Pairing the read to that resolution is the whole guard, and it is enough. The
+    hazard was an auto-port instance resolving to a SIBLING's port and credentialing
+    its ingress, which then accepted the frame and broadcast the capture.
+    :func:`resolve_serving_port` prefers the port this process actually bound, so the
+    sibling is never reached -- including when an inherited ``KIROCREW_PORT`` names
+    it, which the generic client resolver would otherwise honour first.
     """
+    # Function-local for the same reason as _ingress_url: keep the capture path off
+    # the import cost.
+    from kiro_crew.config.loader import read_local_secret
+    from kiro_crew.port_resolution import resolve_serving_port
+
     headers = {"Content-Type": "application/json"}
     try:
-        secret = (config_dir() / _LOCAL_SECRET_FILE).read_text(encoding="utf-8").strip()
-    except OSError:
+        # The SAME resolution _ingress_url uses, so the credential is always read
+        # for the port this module actually POSTs to -- the two cannot diverge.
+        secret = read_local_secret(resolve_serving_port())
+    except Exception:
         return headers
     if secret:
         headers[FRAME_SECRET_HEADER] = secret

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -593,13 +593,37 @@ def oauth_endpoints_path() -> Path:
     return config_dir() / "oauth_endpoints.json"
 
 
-def read_local_secret() -> str:
-    """Read ``<config_dir>/.local_secret`` (the gateway IPC secret), or ``""``.
+def read_local_secret(port: int) -> str:
+    """Read the internal-API credential for the gateway on *port*.
 
-    Single home for the secret-file read that callers (cron scripts, MCP tool
-    bridges, CLI) need to authenticate to the gateway's internal API. Returns
-    empty string if the file is absent/unreadable.
+    Single home for the secret read that callers (cron scripts, MCP tool bridges,
+    CLI) need to authenticate to the gateway's internal API. Returns empty string
+    when no credential can be read.
+
+    Resolution is per LISTENER first: ``run/gateway-<port>.secret``, then the
+    shared ``.local_secret``. That order is the invariant, and it lives here rather
+    than in each reader because the credential identifies ONE gateway generation
+    while the shared file has one slot per data home, last-writer-wins. A caller
+    that reads the shared file while a different generation owns the port it dials
+    gets 403 on every internal call.
+
+    *port* is REQUIRED, and deliberately so: the credential is a function of the
+    dial target, so inferring the target here would let a caller dial one gateway
+    while authenticating for another -- the exact desync this helper exists to
+    close, reintroduced one call site at a time and invisible at the call site. A
+    caller with no port must resolve one explicitly and pass it, where the choice
+    is reviewable.
     """
+    # Function-local: port_resolution imports this module, so a module-level
+    # import would be circular.
+    from kiro_crew.instances import run_marker
+
+    try:
+        per_port = run_marker.read_secret(int(port))
+    except Exception:
+        per_port = ""
+    if per_port:
+        return per_port
     try:
         return (config_dir() / ".local_secret").read_text().strip()
     except OSError:

--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -39,6 +39,7 @@ from kiro_crew import platform_compat
 from kiro_crew.config.loader import config_dir, read_local_secret
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.loopback_http import loopback_urlopen
+from kiro_crew.port_resolution import resolve_serving_port
 from kiro_crew.sandbox import (
     _AGENT_DENIED_ENV_KEYS,
     SandboxUnavailableError,
@@ -247,7 +248,14 @@ class ScriptContext:
     _secret: str = ""
 
     def __post_init__(self) -> None:
-        self._port = int(os.environ.get("KIROCREW_PORT", "5476"))
+        # The parent injects the port it minted the credential for. Preferring it
+        # keeps credential and dial target from one resolution; KIROCREW_PORT is the
+        # fallback for a directly-constructed context and is 5476 on a --port auto
+        # gateway, which is a SIBLING rather than this instance.
+        self._port = int(
+            os.environ.pop("_KIROCREW_DIAL_PORT", "")
+            or os.environ.get("KIROCREW_PORT", "5476")
+        )
         # Secret injected via temp file (not inherited env) to prevent privilege escalation.
         # Pop env var and unlink file immediately so fn(ctx) cannot access the secret directly.
         secret_file = os.environ.pop("_KIROCREW_SECRET_FILE", "")
@@ -548,17 +556,46 @@ def resolve_script_path(script_path: str) -> tuple[str, str]:
     return str(file_path), func_name
 
 
-def _resolve_internal_secret() -> str:
+def _resolve_internal_secret(port: int) -> str:
     """Internal secret for ScriptContext HTTP calls (e.g. notify -> /api/send-message).
 
-    The gateway generates its secret at startup and writes it to
-    ``config_dir()/.local_secret``; the ``KIROCREW_INTERNAL_SECRET`` env var is
-    normally unset, so fall back to the file via the shared
-    ``config.loader.read_local_secret`` helper (single home for that read).
-    Without this the sandbox sends an empty ``X-Internal-Secret`` and every
-    code-cron notify gets HTTP 403.
+    The gateway generates its secret at startup and publishes it per listener as
+    ``run/gateway-<port>.secret`` (with ``config_dir()/.local_secret`` as the
+    home-wide fallback); the ``KIROCREW_INTERNAL_SECRET`` env var is normally unset,
+    so fall back to the file via the shared ``config.loader.read_local_secret``
+    helper (single home for that read). Without this the sandbox sends an empty
+    ``X-Internal-Secret`` and every code-cron notify gets HTTP 403.
+
+    Takes the ALREADY-RESOLVED dial port rather than resolving its own. The caller
+    resolves the port ONCE and passes the same value here and into
+    ``_KIROCREW_DIAL_PORT``. Resolving twice -- once for the credential, once for the
+    child -- is a TOCTOU: a ``--port auto`` gateway that binds between the two calls
+    would mint the credential for one port and tell the child to dial another, and
+    the mismatched credential 403s the callback. One resolution makes that
+    unrepresentable, which is what the ``_KIROCREW_DIAL_PORT`` mechanism promised.
     """
-    return os.environ.get("KIROCREW_INTERNAL_SECRET", "") or read_local_secret()
+    env_secret = os.environ.get("KIROCREW_INTERNAL_SECRET", "")
+    if env_secret:
+        return env_secret
+    return read_local_secret(port)
+
+
+def _resolve_dial_port() -> int:
+    """The ONE port this cron dials, used for both the credential and the child.
+
+    The parent mints the credential and the child sends it, so a second independent
+    resolution in the child is exactly how the two diverge: ``ScriptContext`` reads
+    ``KIROCREW_PORT``, which is 5476 on a ``--port auto`` gateway, while the parent
+    would have minted for the real ephemeral port -- credential for one gateway,
+    request to another. One resolution, injected as ``_KIROCREW_DIAL_PORT``, makes
+    that mismatch unrepresentable.
+
+    Delegates to :func:`resolve_serving_port`, the shared gateway-side resolver that
+    prefers ``KIROCREW_BOUND_PORT`` over an inherited ``KIROCREW_PORT`` -- the cron
+    scheduler runs inside the gateway, so the bound port is ground truth and a
+    sibling-naming ``KIROCREW_PORT`` must not win.
+    """
+    return resolve_serving_port()
 
 
 def run_script_sandboxed(
@@ -607,6 +644,11 @@ def run_script_sandboxed(
 
     fd, launcher_path = tempfile.mkstemp(suffix=".py", prefix="kirocrew_cron_")
     sandbox_cleanup: str | None = None
+    # Resolve the dial port ONCE: the credential written below and the
+    # _KIROCREW_DIAL_PORT the child dials must come from the same resolution, or a
+    # --port auto bind between two resolutions would pair a credential with the
+    # wrong port and 403 the callback.
+    dial_port = _resolve_dial_port()
     # Write secret to temp file for ScriptContext (scrubbed from env)
     secret_fd, secret_path = tempfile.mkstemp(prefix="kirocrew_secret_")
     try:
@@ -624,7 +666,7 @@ def run_script_sandboxed(
             # unlinks the secret + launcher (otherwise the fd leaks and temp
             # files persist).
             platform_compat.restrict_to_owner(secret_path)
-            os.write(secret_fd, _resolve_internal_secret().encode())
+            os.write(secret_fd, _resolve_internal_secret(dial_port).encode())
         finally:
             os.close(secret_fd)
         try:
@@ -639,6 +681,9 @@ def run_script_sandboxed(
         # are never inherited; the internal secret is passed via the 0600 file.
         clean_env = _clean_cron_env()
         clean_env["_KIROCREW_SECRET_FILE"] = secret_path
+        # The child must dial the gateway the credential above was minted for:
+        # same dial_port, resolved once above, not a second resolution here.
+        clean_env["_KIROCREW_DIAL_PORT"] = str(dial_port)
 
         sandboxed_argv = cgroup_scope_argv(sandboxed_argv)  # cgroup DoS ceiling
         proc = popen_limited(

--- a/src/kiro_crew/cron_trigger.py
+++ b/src/kiro_crew/cron_trigger.py
@@ -8,6 +8,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from kiro_crew.instances import run_marker
 from kiro_crew.loopback_http import loopback_urlopen
 
 _JOB_ID_RE = re.compile(r"[a-f0-9]{6,12}")
@@ -24,8 +25,25 @@ def trigger_cron_job(job_id: str, port: int, secret_path: Path) -> tuple[bool, s
 
     url = f"http://127.0.0.1:{port}/api/crons/{job_id}/run"
     headers: dict[str, str] = {}
-    if secret_path.exists():
-        headers["X-Internal-Secret"] = secret_path.read_text().strip()
+    # Credential for the LISTENER first: the shared file has one slot per data
+    # home and a second gateway generation replaces it, so reading a home-wide
+    # file while another generation owns *port* is a guaranteed 403.
+    #
+    # The named *secret_path* is the FALLBACK, not an override, and that order is
+    # dictated by the callers: both pass the home-wide file, which is precisely the
+    # file the per-port read exists to outrank. Preferring the named path would
+    # reinstate the defect.
+    #
+    # The cost, stated rather than hidden: a crash-orphaned per-port credential is
+    # preferred over a correct named path, so a caller naming another home's
+    # credential for a port this home once served would send the stale one. No
+    # caller does that; closing it means this parameter going away, not the order
+    # flipping.
+    secret = run_marker.read_secret(port)
+    if not secret and secret_path.exists():
+        secret = secret_path.read_text().strip()
+    if secret:
+        headers["X-Internal-Secret"] = secret
     try:
         # data=b"" is required by urllib to send a POST (not GET)
         req = urllib.request.Request(url, method="POST", data=b"", headers=headers)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -16,7 +16,7 @@ from urllib.parse import quote
 
 from aiohttp import web
 
-from kiro_crew import platform_compat
+from kiro_crew import platform_compat, port_resolution
 from kiro_crew.apps.backend import start_enabled_app_backends
 from kiro_crew.apps.hooks_integration import (
     init_hooks_system,
@@ -138,6 +138,7 @@ from kiro_crew.deploy import _register_core_skills as _register_deploy_skills
 from kiro_crew.deploy.handlers import register_routes as _register_deploy_routes
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.hooks import ScriptHookStore, set_global_hook_store
+from kiro_crew.instances import run_marker
 from kiro_crew.instances.registry import InstancesRegistry
 from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager, TunnelState
 from kiro_crew.mcp_gateway.socketsec import chmod_socket_0600
@@ -1226,14 +1227,7 @@ def _export_bound_port(runner: web.AppRunner, port: int) -> None:
     Best-effort: when no TCP address is readable the environment is left
     untouched, which is exactly the pre-export behavior.
     """
-    bound = port
-    if not bound:
-        for addr in runner.addresses:
-            # TCP socknames are (host, port[, flowinfo, scope_id]) tuples; a
-            # unix socket's would be a bare str path.
-            if isinstance(addr, (tuple, list)) and len(addr) >= 2 and isinstance(addr[1], int):
-                bound = addr[1]
-                break
+    bound = _resolved_bound_port(runner, port)
     if bound:
         os.environ["KIROCREW_BOUND_PORT"] = str(bound)
         logger.debug("Exported KIROCREW_BOUND_PORT=%d for child processes", bound)
@@ -1242,6 +1236,29 @@ def _export_bound_port(runner: web.AppRunner, port: int) -> None:
             "Could not read the bound dashboard port; child processes will "
             "re-derive it from config and the run-marker"
         )
+
+
+def _resolved_bound_port(runner: web.AppRunner, port: int) -> int:
+    """The port actually bound: *port*, or the OS-assigned one when it is ``0``.
+
+    ``0`` means an ephemeral bind (``--port auto``, which ``--test-mode`` also
+    implies), so the declared value names no listener and anything keyed by it
+    would name the wrong one. Shared by the child-env export and the credential
+    publication, which must agree: a credential filed under port ``0`` is
+    unreachable for every client, and they would fall back to the shared file --
+    which is exactly what the live-sibling guard deliberately leaves pointing at
+    the sibling, so the ephemeral gateway would 403 every internal call.
+
+    Returns ``0`` only when no TCP address is readable at all.
+    """
+    if port:
+        return port
+    for addr in runner.addresses:
+        # TCP socknames are (host, port[, flowinfo, scope_id]) tuples; a
+        # unix socket's would be a bare str path.
+        if isinstance(addr, (tuple, list)) and len(addr) >= 2 and isinstance(addr[1], int):
+            return addr[1]
+    return 0
 
 
 async def _start_site(
@@ -1396,6 +1413,66 @@ def _register_unix_socket_cleanup(app: web.Application, holder: dict[str, Path |
             logger.debug("dashboard unix socket cleanup failed", exc_info=True)
 
     app.on_cleanup.append(_unlink_unix_socket)
+
+
+def _live_sibling_port(own_port: int) -> int | None:
+    """A DIFFERENT port in this data home whose gateway is verifiably alive.
+
+    ``None`` when this start is the only live gateway in the home, which is the
+    normal single-instance case. Uses the same ownership proof the client port
+    discovery already trusts (recorded pid, actually holds the port, same uid,
+    argv looks like a gateway), so a stale marker left by a crash does not count
+    as a sibling and never blocks a legitimate credential write.
+
+    Blocking (/proc + filesystem); call from the executor, never the loop.
+    """
+    try:
+        for port in run_marker.marker_ports():
+            if int(port) == int(own_port):
+                continue
+            if port_resolution._gateway_owns_port(int(port)):
+                return int(port)
+    except Exception:
+        # Discovery failing must not block startup: fall through to the write.
+        # A missed sibling degrades to the pre-existing last-writer-wins
+        # behaviour, never to a gateway that cannot start.
+        logger.debug("live-sibling discovery failed", exc_info=True)
+    return None
+
+
+def _write_instance_credentials(secret_path: Path, port: int, secret: str) -> None:
+    """Publish this gateway's internal-API credential.
+
+    Writes two files with different lifetimes:
+
+    * ``run/gateway-<port>.secret`` -- ALWAYS. Paired with the listener, so a
+      client that resolved a port reads the credential of the process that owns
+      that port rather than whichever gateway wrote the shared file last.
+    * ``.local_secret`` -- only when no other gateway in this data home is
+      verifiably alive on a different port. Overwriting it while a sibling is
+      serving is the desync this guard exists to prevent: the sibling keeps
+      comparing against its own in-memory value, every internal caller then
+      sends the newcomer's credential, and the whole internal channel answers
+      403 with a bare ``Forbidden`` until one of them restarts. The shared file
+      is still written in the single-instance case because pre-per-port clients
+      (an older CLI, a cron script from a previous install) read only that path.
+
+    Blocking fs I/O; the caller offloads this whole function.
+    """
+    _write_secret_file(run_marker.secret_path(int(port)), secret)
+    sibling = _live_sibling_port(int(port))
+    if sibling is not None:
+        logger.warning(
+            "Not overwriting %s: another gateway in this data home is live on port %d. "
+            "This instance's credential is published as %s; clients that resolve port %d "
+            "will authenticate against it.",
+            secret_path,
+            sibling,
+            run_marker.secret_path(int(port)).name,
+            port,
+        )
+        return
+    _write_secret_file(secret_path, secret)
 
 
 def _write_secret_file(secret_path: Path, secret: str) -> None:
@@ -2920,10 +2997,16 @@ async def start_dashboard(
     # Port bind succeeded — now safe to write the secret file. Offloaded:
     # _write_secret_file does blocking fs I/O (os.open/os.close and, on Windows,
     # an icacls subprocess via restrict_to_owner), so it must not run on the
-    # event loop (no-blocking-call-on-event-loop).
+    # event loop (no-blocking-call-on-event-loop). The port is passed so the
+    # credential is published per listener, not only into the shared file every
+    # gateway in this data home writes (see _write_instance_credentials).
     try:
         await asyncio.get_running_loop().run_in_executor(
-            subprocess_executor(), _write_secret_file, _secret_path, _internal_secret
+            subprocess_executor(),
+            _write_instance_credentials,
+            _secret_path,
+            _resolved_bound_port(runner, port),
+            _internal_secret,
         )
     except OSError:
         await runner.cleanup()
@@ -3568,10 +3651,16 @@ async def start_api_server(
     # start_dashboard: write deferred so a failed bind can't poison it).
     # Offloaded: _write_secret_file does blocking fs I/O (os.open/os.close and,
     # on Windows, an icacls subprocess via restrict_to_owner), so it must not run
-    # on the event loop (no-blocking-call-on-event-loop).
+    # on the event loop (no-blocking-call-on-event-loop). Same per-listener
+    # publication as start_dashboard: both surfaces must pair the credential
+    # with the port or a client cannot tell which generation it reached.
     try:
         await asyncio.get_running_loop().run_in_executor(
-            subprocess_executor(), _write_secret_file, _secret_path, _internal_secret
+            subprocess_executor(),
+            _write_instance_credentials,
+            _secret_path,
+            _resolved_bound_port(runner, port),
+            _internal_secret,
         )
     except OSError:
         await runner.cleanup()

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -1734,10 +1734,15 @@ def token_auth_middleware(
                     outcome="denied",
                     source="token_auth",
                     resources=path,
-                    error="wrong secret",
+                    error=f"wrong secret ({_credential_mismatch_detail(internal_secret, _provided_secret)})",
                 )
-                _log_auth(request, "internal", "denied", "wrong secret")
-                return _deny(request, "Forbidden")
+                _log_auth(
+                    request,
+                    "internal",
+                    "denied",
+                    f"wrong secret ({_credential_mismatch_detail(internal_secret, _provided_secret)})",
+                )
+                return _deny(request, "Forbidden", "internal_auth_mismatch")
             # No secret header (browser request) → verify cookie/query-param auth
             # inline to satisfy deny-by-default: positively confirm auth
             # at the decision point rather than deferring to downstream.
@@ -2196,10 +2201,46 @@ def token_auth_middleware(
     return middleware
 
 
-def _deny(request: web.Request, reason: str) -> web.Response:
+def _credential_fingerprint(value: str) -> str:
+    """Identify a credential without disclosing it: short digest + length.
+
+    ``absent`` for an empty value, which is a distinct and common case (a caller
+    that could not read any credential file at all) and must not be confused with
+    a caller holding the wrong one.
+
+    Eight hex characters of a SHA-256 is an identifier, not the credential: it
+    does not survive inversion for a 128-bit random value, and it goes only to the
+    SEL audit log, which already sits on the keystone floor. Without it a
+    cross-generation mismatch is indistinguishable from a forged header, which is
+    what made a real desync take hours to attribute -- the log said only
+    "wrong secret" and named no side.
+    """
+    if not value:
+        return "absent"
+    return f"{hashlib.sha256(value.encode()).hexdigest()[:8]}/len={len(value)}"
+
+
+def _credential_mismatch_detail(expected: str, provided: str) -> str:
+    """Both fingerprints, for the one log line that has to explain a 403."""
+    return (
+        f"expected={_credential_fingerprint(expected)} "
+        f"received={_credential_fingerprint(provided)}"
+    )
+
+
+def _deny(request: web.Request, reason: str, code: str = "") -> web.Response:
     headers = {"X-Auth-Required": "true"}
     if request.path.startswith("/api/"):
-        return web.json_response({"error": reason}, status=403, headers=headers)
+        # A machine-readable code alongside the prose: a caller cannot distinguish
+        # a credential desync from a genuine permission denial by matching the
+        # body text, and a tool that guesses from prose misdiagnoses the other one.
+        # Written as a dict LITERAL with the key present so the error-code ratchet
+        # can still read this sink statically -- handing it a prebuilt variable
+        # would trade a `missing_code` for an `opaque_body`, which is the bucket
+        # that hides every future regression here.
+        return web.json_response(
+            {"error": reason, "code": code or "forbidden"}, status=403, headers=headers
+        )
     return web.Response(
         text=_403_HTML.format(reason=reason),
         status=403,

--- a/src/kiro_crew/instances/run_marker.py
+++ b/src/kiro_crew/instances/run_marker.py
@@ -62,6 +62,7 @@ logger = logging.getLogger(__name__)
 _MARKER_PREFIX = "gateway-"
 _MARKER_SUFFIX = ".bin"
 _PID_SUFFIX = ".pid"
+_SECRET_SUFFIX = ".secret"
 
 
 def _run_dir() -> Path:
@@ -93,6 +94,42 @@ def pid_path(port: int) -> Path:
     ``gateway-<port>.pid``.
     """
     return _run_dir() / f"{_MARKER_PREFIX}{int(port)}{_PID_SUFFIX}"
+
+
+def secret_path(port: int) -> Path:
+    """Path of the internal-API credential for the gateway serving *port*.
+
+    The credential is a property of ONE gateway generation: it is generated at
+    startup and held in memory as the value the auth middleware compares
+    against. Keying its file by port keeps it paired with the listener a client
+    actually dials, which the single shared ``.local_secret`` cannot do -- that
+    file is last-writer-wins per data home, so a second gateway starting in the
+    same home silently replaces the credential of the process that owns the
+    port, and every internal call then fails 403 until something restarts.
+
+    Lives beside the marker and the pid sidecar, inside the ``0700`` ``run/``
+    dir on the ``is_sensitive_path`` floor, and is written ``0600``.
+    """
+    return _run_dir() / f"{_MARKER_PREFIX}{int(port)}{_SECRET_SUFFIX}"
+
+
+def read_secret(port: int) -> str:
+    """Internal-API credential recorded for *port*, or ``""`` when absent.
+
+    Read-only: never creates ``run/`` (mirrors :func:`read_pid`, so a client
+    merely looking for a gateway materialises no state). An empty return means
+    "no per-port credential here" -- the caller falls back to the shared
+    ``.local_secret`` for gateways predating the per-port file. Presence is NOT
+    proof the recorded gateway still owns the port; that remains
+    ``port_resolution._gateway_owns_port``'s job.
+    """
+    try:
+        raw = (config_dir() / "run" / f"{_MARKER_PREFIX}{int(port)}{_SECRET_SUFFIX}").read_text(
+            encoding="utf-8"
+        )
+    except (OSError, ValueError):
+        return ""
+    return raw.strip()
 
 
 def read_pid(port: int) -> int | None:
@@ -243,24 +280,59 @@ def write_marker(port: int) -> None:
 
 
 def prune_markers(*, keep_port: int) -> None:
-    """Remove run-markers for every port except *keep_port*.
+    """Remove run-markers for every port except *keep_port* and any LIVE sibling.
 
-    A gateway is a singleton per data home (``gateway.lock``), so any marker
-    naming a *different* port belongs to an earlier run that crashed before
-    :func:`clear_marker` could fire. Left alone they accumulate one per port ever
-    used, and each one costs a client command a listener lookup — making
-    discovery slower the longer a dev box churns ports. The live gateway is the
-    right place to reap them: it knows which port is current, and it is the only
-    writer.
+    Stale markers accumulate one per port ever used, and each one costs a client
+    command a listener lookup, so the live gateway reaps them: it knows which port
+    is current, and it is the only writer.
+
+    What it must NOT reap is a sibling that is still serving. ``gateway.lock``
+    makes a gateway a singleton per data home only when every start goes through
+    it; in practice one machine runs several -- a second gateway launched by hand,
+    one started from another checkout that inherits the default data home, a
+    cutover overlapping its predecessor -- and those really do share a home. A
+    blanket prune then deletes a LIVE gateway's marker and pid sidecar, which
+    makes it undiscoverable to `token` / `status` / `stop` and removes the very
+    evidence the credential writer uses to avoid clobbering that gateway's
+    credential. So each candidate is checked against the same ownership proof its
+    readers use (recorded pid, holds the port, same uid, argv looks like a
+    gateway) and skipped when it passes.
 
     Best-effort and never raises: a marker we fail to remove only costs a future
     lookup, and the ownership check still rejects it.
+
+    It removes the marker and pid sidecar but NEVER the credential, because
+    ``_gateway_owns_port`` cannot tell a dead gateway from an unprovable one. It
+    fails closed by RETURNING FALSE -- non-POSIX returns False outright, and a
+    missing or throwing listener-lookup tool is folded into False as well -- so
+    False means "ownership not proven", not "process gone". Deleting on False
+    would therefore delete a LIVE incumbent's credential on every Windows host
+    and on any host without listener tooling; its clients would fall back to the
+    shared ``.local_secret`` that a newcomer may have replaced, and the prune
+    would CAUSE the 403 the per-port credential exists to prevent.
+
+    A credential left behind is the safe residue: it is only reachable for a port
+    whose gateway is gone, which is already unreachable. Deletion belongs to
+    :func:`clear_marker`, where the gateway is authoritatively done with the port.
     """
+    # Function-local: port_resolution imports this module, so a module-level
+    # import would be circular.
+    from kiro_crew import port_resolution
+
     try:
         stale = [p for p in marker_ports() if p != int(keep_port)]
     except Exception:
         return
     for port in stale:
+        try:
+            if port_resolution._gateway_owns_port(int(port)):
+                logger.info(
+                    "Keeping gateway run-marker for port %s: that gateway is still live",
+                    port,
+                )
+                continue
+        except Exception:
+            logger.debug("Ownership check failed for port %s", port, exc_info=True)
         for path in (marker_path(port), pid_path(port)):
             try:
                 path.unlink(missing_ok=True)
@@ -270,8 +342,14 @@ def prune_markers(*, keep_port: int) -> None:
 
 
 def clear_marker(port: int) -> None:
-    """Best-effort removal of the run-marker + pid sidecar (on graceful shutdown)."""
-    for path in (marker_path(port), pid_path(port)):
+    """Best-effort removal of the run-marker, pid sidecar and credential.
+
+    The credential goes with them: it names a generation that no longer owns the
+    port, so leaving it behind would let a client authenticate with a value the
+    next owner never had. A crash still leaves all three (nothing runs), which is
+    why every consumer verifies ownership rather than trusting presence.
+    """
+    for path in (marker_path(port), pid_path(port), secret_path(port)):
         try:
             path.unlink(missing_ok=True)
         except OSError:

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -39,6 +39,7 @@ from kiro_crew.config.loader import (
     KiroCrewConfig,
     config_dir,
     outbox_dir,
+    read_local_secret,
     resolve_agent_bindings,
 )
 from kiro_crew.context_management import summarize_result
@@ -291,9 +292,14 @@ def _list_tools() -> list[dict[str, Any]]:
 
 
 def _internal_secret() -> str:
-    """Read the per-session secret for IPC authentication."""
+    """Credential for the gateway this client will dial, paired to its port.
+
+    Thin wrapper over ``config.loader.read_local_secret``, which owns the
+    per-listener-then-shared order. The port is passed rather than re-resolved
+    because ``_api_port`` already resolved and cached it for this process.
+    """
     try:
-        return (config_dir() / ".local_secret").read_text().strip()
+        return read_local_secret(_api_port())
     except Exception:
         return ""
 
@@ -990,6 +996,23 @@ def _http_error_body(exc: urllib.error.HTTPError) -> dict:
             pass
     message, _ = redact_exfiltration_urls(message)
     message, _ = redact_credentials(message)
+    if code == "internal_auth_mismatch":
+        # Every internal tool receives the auth layer's bare "Forbidden", which
+        # reads as a permission decision about the tool's own subject and sends
+        # the reader after the wrong bug. It is an instance mix-up: the credential
+        # this client read does not belong to the gateway generation that owns the
+        # port it dialled. Rewritten HERE because all tool call sites already flow
+        # through this decoder, so one mapping covers them instead of one branch
+        # per tool -- and it is keyed on the CODE, since a genuine permission
+        # denial produces the same body and must not be given this explanation.
+        message = (
+            "this client authenticated against the wrong Kiro Crew instance. "
+            "The credential it read does not match the gateway now serving that "
+            "port, usually because a second gateway started on this machine and "
+            "replaced the shared credential file. Restart the gateway (or target "
+            "the instance you meant) and retry; the gateway's security event log "
+            "records both credential fingerprints for the mismatch."
+        )
     out: dict = {"error": message}
     if counted:
         out["counted"] = True

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew import model_registry
-from kiro_crew.config.loader import DASHBOARD_PORT, config_dir
+from kiro_crew.config.loader import config_dir
 from kiro_crew.cron import (
     CronJob,
     CronService,
@@ -41,6 +41,7 @@ from kiro_crew.mcp_core import _resolve_session_key
 from kiro_crew.mcp_shared import call_tool_with_logging, run_mcp_stdio_loop
 from kiro_crew.platform import current_context
 from kiro_crew.platform import redact_via_context as redact
+from kiro_crew.port_resolution import resolve_serving_port
 from kiro_crew.sandbox import _AGENT_DENIED_ENV_KEYS
 from kiro_crew.security import (
     _SENSITIVE_HOME_DIRS,
@@ -1824,7 +1825,12 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         own_err = _check_cron_job_ownership(svc, jid)
         if own_err:
             return own_err
-        port = DASHBOARD_PORT
+        # Resolve through the gateway-side serving resolver, not DASHBOARD_PORT and
+        # not the client resolver: DASHBOARD_PORT reads KIROCREW_PORT only, and the
+        # client resolver reads it FIRST -- both give 5476 on a --port auto gateway,
+        # a SIBLING. resolve_serving_port prefers the bound port, so the credential
+        # is paired to the instance actually serving and the job runs here.
+        port = resolve_serving_port()
         secret_path = config_dir() / ".local_secret"
         ok, msg = trigger_cron_job(jid, port, secret_path)
         sel().log_api_access(

--- a/src/kiro_crew/mcp_shared.py
+++ b/src/kiro_crew/mcp_shared.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from kiro_crew import platform_compat
-from kiro_crew.config.loader import KiroCrewConfig, config_dir
+from kiro_crew.config.loader import KiroCrewConfig, config_dir, read_local_secret
 from kiro_crew.dashboard.origin import parse_dashboard_url
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.mcp_caller import (
@@ -363,10 +363,12 @@ def _resolve_excluded_tools(caller_session: str = "") -> set[str]:
         _host, port = parse_dashboard_url(cfg.dashboard.url)
         api_base = f"http://localhost:{port}"
 
-        # Read internal secret for auth
+        # Credential for the port this function DIALS (parsed just above), not for
+        # whichever gateway an ambient lookup would name -- those can differ on a
+        # multi-gateway host, which is the desync being closed.
         secret = ""
         try:
-            secret = (config_dir() / ".local_secret").read_text().strip()
+            secret = read_local_secret(port)
         except Exception:
             pass
 

--- a/src/kiro_crew/mcp_tools/learn.py
+++ b/src/kiro_crew/mcp_tools/learn.py
@@ -155,7 +155,10 @@ def learn_add(name: str, args: dict[str, Any]) -> str:
                 "from this session automatically."
             )
         # ``err_val`` is already redacted at the trust boundary by
-        # ``_http_error_body`` (HTTP bodies are untrusted external content).
+        # ``_http_error_body`` (HTTP bodies are untrusted external content), and
+        # an internal-auth mismatch has already been rewritten there into a
+        # sentence naming the instance mix-up -- so every tool gets that copy,
+        # not just this one.
         return f"Error: {err_val}"
     return f"Saved lesson ({scope}): {rule}"
 

--- a/src/kiro_crew/port_resolution.py
+++ b/src/kiro_crew/port_resolution.py
@@ -295,6 +295,42 @@ def resolve_client_port_ex(cli_port: int | None) -> tuple[int, bool]:
     return _DEFAULT_PORT, False
 
 
+def resolve_serving_port() -> int:
+    """The port THIS gateway process is serving, for its own in-process callers.
+
+    Distinct from :func:`resolve_client_port_ex` in ONE way that matters:
+    ``KIROCREW_BOUND_PORT`` is consulted BEFORE ``KIROCREW_PORT``. The client
+    resolver reads ``KIROCREW_PORT`` first, which is correct for a CLI client --
+    there the variable means "talk to that instance". This resolver is for code
+    running INSIDE the gateway (the frame relay, cron dial-port minting, the cron
+    trigger endpoint): there the port the process actually bound is ground truth,
+    and ``KIROCREW_PORT`` is a request that may be stale or merely inherited. A
+    shell that exported ``KIROCREW_PORT=5476`` and then started a second gateway
+    with ``--port auto`` leaves both set; the client order would pick 5476, a
+    SIBLING, and an in-gateway caller pairing a credential with that port
+    authenticates against the wrong instance.
+
+    Reordering the client resolver instead would fix these callers by breaking
+    every CLI client's ability to aim at a chosen instance, so the two resolvers
+    stay separate. After the bound port, the remaining precedence (``KIROCREW_PORT``
+    -> configured -> marker -> default) is shared with the client resolver, so a
+    gateway with no bound port exported still honours a dev instance's
+    ``KIROCREW_PORT``.
+
+    Returns the port only. Every in-gateway caller reads a per-port credential for
+    the returned value, and an unresolved credential reads empty and is refused by
+    the strict ingress (fail-closed), so no separate evidence flag is needed.
+    """
+    bound_port = os.environ.get("KIROCREW_BOUND_PORT")
+    if bound_port:
+        try:
+            return int(bound_port)
+        except ValueError:
+            pass  # malformed value is no evidence; fall through to the client order
+    port, _evidence_backed = resolve_client_port_ex(None)
+    return port
+
+
 # Subcommands that launch a long-running Kiro Crew *server* process which
 # ``kirocrew stop`` may need to terminate. These mirror the entry-point
 # subcommands dispatched in ``cli.py`` (``gateway`` / ``dashboard``; ``start``

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -1468,7 +1468,7 @@ class TestResolveInternalSecret:
             "kiro_crew.config.loader.config_dir", return_value=tmp_path
         ):
             (tmp_path / ".local_secret").write_text("fromfile")
-            assert _resolve_internal_secret() == "fromenv"
+            assert _resolve_internal_secret(5476) == "fromenv"
 
     def test_falls_back_to_local_secret_file(self, tmp_path):
         (tmp_path / ".local_secret").write_text("filesecret\n")
@@ -1476,21 +1476,21 @@ class TestResolveInternalSecret:
         with patch.dict(os.environ, env, clear=True), patch(
             "kiro_crew.config.loader.config_dir", return_value=tmp_path
         ):
-            assert _resolve_internal_secret() == "filesecret"
+            assert _resolve_internal_secret(5476) == "filesecret"
 
     def test_empty_when_neither_present(self, tmp_path):
         env = {k: v for k, v in os.environ.items() if k != "KIROCREW_INTERNAL_SECRET"}
         with patch.dict(os.environ, env, clear=True), patch(
             "kiro_crew.config.loader.config_dir", return_value=tmp_path
         ):
-            assert _resolve_internal_secret() == ""
+            assert _resolve_internal_secret(5476) == ""
 
     def test_env_empty_string_falls_back_to_file(self, tmp_path):
         (tmp_path / ".local_secret").write_text("filesecret")
         with patch.dict(os.environ, {"KIROCREW_INTERNAL_SECRET": ""}), patch(
             "kiro_crew.config.loader.config_dir", return_value=tmp_path
         ):
-            assert _resolve_internal_secret() == "filesecret"
+            assert _resolve_internal_secret(5476) == "filesecret"
 
     def test_run_script_writes_local_secret_to_sandbox_when_env_unset(self, tmp_path):
         """End-to-end: run_script_sandboxed hands the sandbox the .local_secret value."""

--- a/test/test_cron_script_more_coverage.py
+++ b/test/test_cron_script_more_coverage.py
@@ -917,13 +917,29 @@ class TestPathAndSecretResolution:
 
     def test_internal_secret_prefers_the_environment(self, monkeypatch):
         monkeypatch.setenv("KIROCREW_INTERNAL_SECRET", "env-secret")
-        monkeypatch.setattr(cron_script, "read_local_secret", lambda: "file-secret")
-        assert _resolve_internal_secret() == "env-secret"
+        monkeypatch.setattr(cron_script, "read_local_secret", lambda port: "file-secret")
+        assert _resolve_internal_secret(5476) == "env-secret"
 
     def test_internal_secret_falls_back_to_the_local_secret_file(self, monkeypatch):
         monkeypatch.delenv("KIROCREW_INTERNAL_SECRET", raising=False)
-        monkeypatch.setattr(cron_script, "read_local_secret", lambda: "file-secret")
-        assert _resolve_internal_secret() == "file-secret"
+        monkeypatch.setattr(cron_script, "read_local_secret", lambda port: "file-secret")
+        assert _resolve_internal_secret(5476) == "file-secret"
+
+    def test_internal_secret_reads_the_port_it_is_given(self, monkeypatch):
+        # The credential is only valid for the gateway it belongs to, and the caller
+        # resolves the dial port ONCE and passes it here, so the same port reaches
+        # both the credential read and the child env -- a mid-startup --port auto
+        # bind cannot split them into a mismatched pair that 403s the callback.
+        monkeypatch.delenv("KIROCREW_INTERNAL_SECRET", raising=False)
+        seen = {}
+
+        def _fake_read(port):
+            seen["port"] = port
+            return "file-secret"
+
+        monkeypatch.setattr(cron_script, "read_local_secret", _fake_read)
+        assert _resolve_internal_secret(7811) == "file-secret"
+        assert seen["port"] == 7811
 
 
 # ── run_script_sandboxed ──
@@ -939,7 +955,7 @@ def script_run(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(cron_script, "wrap_argv", lambda argv, **k: (list(argv), None))
     monkeypatch.setattr(cron_script, "cgroup_scope_argv", lambda argv: list(argv))
-    monkeypatch.setattr(cron_script, "_resolve_internal_secret", lambda: "unit-secret")
+    monkeypatch.setattr(cron_script, "_resolve_internal_secret", lambda port: "unit-secret")
     restricted: list[str] = []
     monkeypatch.setattr(
         cron_script.platform_compat, "restrict_to_owner", restricted.append
@@ -960,6 +976,29 @@ def script_run(monkeypatch, tmp_path):
 
 
 class TestRunScriptSandboxed:
+    def test_the_dial_port_is_resolved_exactly_once(self, script_run, monkeypatch):
+        # The credential write and the child's _KIROCREW_DIAL_PORT must come from
+        # ONE resolution. Two calls are a TOCTOU: a --port auto gateway binding
+        # between them would pair a credential with the wrong port and 403 the
+        # callback. So run_script_sandboxed must call _resolve_dial_port once and
+        # thread the value through, not resolve independently at each use.
+        calls = []
+        real = cron_script._resolve_dial_port
+
+        def _counting():
+            calls.append(1)
+            return real()
+
+        monkeypatch.setattr(cron_script, "_resolve_dial_port", _counting)
+        # Do NOT stub _resolve_internal_secret here (the fixture does): we want the
+        # real credential path so a second internal resolution would be counted.
+        monkeypatch.setattr(cron_script, "_resolve_internal_secret", lambda port: "s")
+        script_run.proc = _FakeProc(comm_results=[('{"status": "ok"}\n', "")])
+
+        run_script_sandboxed("spec:run", "job-once")
+
+        assert len(calls) == 1, f"_resolve_dial_port called {len(calls)} times, expected 1"
+
     def test_ok_result_and_temp_file_cleanup(self, script_run):
         script_run.proc = _FakeProc(comm_results=[('{"status": "ok"}\n', "")])
 

--- a/test/test_cron_trigger.py
+++ b/test/test_cron_trigger.py
@@ -214,7 +214,9 @@ class TestCronTriggerMCP:
         monkeypatch.setenv("KIROCREW_HOME", str(cfg_dir))
         from kiro_crew import mcp_cron
         with patch.object(mcp_cron, "config_dir", return_value=cfg_dir), \
-             patch.object(mcp_cron, "DASHBOARD_PORT", port):
+             patch.object(
+                 mcp_cron, "resolve_serving_port", lambda: port
+             ):
             result = _call_tool_inner("cron_trigger", {"job_id": "abc12345"})
         assert "test-job-name" in result
         assert "abc12345" in result
@@ -266,7 +268,10 @@ class TestCronTriggerCLI:
         from unittest.mock import patch as _patch
 
         with _patch("kiro_crew.cli_commands.config_dir", return_value=cfg_dir), \
-             _patch("kiro_crew.cli_commands.DASHBOARD_PORT", port):
+             _patch(
+                 "kiro_crew.cli_commands.resolve_client_port_ex",
+                 lambda _cli: (port, True),
+             ):
             _cron(args)
 
         captured = capsys.readouterr()

--- a/test/test_instance_credential_pairing.py
+++ b/test/test_instance_credential_pairing.py
@@ -1,0 +1,895 @@
+"""The internal-API credential must stay paired with the port it guards.
+
+The defect these cover: the credential is generated per gateway start and held in
+memory as the value the auth middleware compares against, but it was published
+only to one shared ``.local_secret`` per data home. A second gateway starting in
+the same home replaced that file while the first kept serving, so every internal
+caller then sent the newcomer's credential to the incumbent and the whole internal
+channel answered 403 with a bare ``Forbidden`` until something restarted.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from kiro_crew.dashboard import server as dashboard_server
+from kiro_crew.dashboard import token_auth
+from kiro_crew.instances import run_marker
+
+
+@pytest.fixture()
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    # config_dir memoises on (env value, resolved home); clear it so the temp
+    # home is honoured rather than a value cached by an earlier test.
+    from kiro_crew.config import paths
+
+    monkeypatch.setattr(paths, "_config_dir_memo", None, raising=False)
+    return tmp_path
+
+
+class TestPerPortCredentialFile:
+    def test_path_is_keyed_by_port_and_sits_beside_the_marker(self, home: Path) -> None:
+        assert run_marker.secret_path(5476).name == "gateway-5476.secret"
+        assert run_marker.secret_path(5476).parent == run_marker.marker_path(5476).parent
+
+    def test_read_returns_empty_when_absent(self, home: Path) -> None:
+        assert run_marker.read_secret(5476) == ""
+
+    def test_read_does_not_create_the_run_dir(self, home: Path) -> None:
+        run_marker.read_secret(5476)
+        assert not (home / "run").exists()
+
+    def test_round_trip(self, home: Path) -> None:
+        dashboard_server._write_secret_file(run_marker.secret_path(7811), "deadbeef")
+        assert run_marker.read_secret(7811) == "deadbeef"
+
+    def test_written_owner_only(self, home: Path) -> None:
+        dashboard_server._write_secret_file(run_marker.secret_path(7811), "deadbeef")
+        path = run_marker.secret_path(7811)
+        # The value must land whatever the platform's permission model is.
+        assert path.read_text(encoding="utf-8").strip() == "deadbeef"
+        if os.name == "nt":
+            # Windows does not honour POSIX mode bits: chmod only toggles the
+            # read-only attribute, so a 0600 write reports back as 0666 and the
+            # assertion below would describe the platform, not the code. The
+            # credential is protected there by the ACL on the user-profile data
+            # home instead.
+            pytest.skip("POSIX mode bits are not honoured on Windows")
+        mode = path.stat().st_mode & 0o777
+        assert mode == 0o600, oct(mode)
+
+    def test_cleared_with_the_marker_so_a_dead_generation_leaves_no_credential(
+        self, home: Path
+    ) -> None:
+        run_marker.write_marker(5476)
+        dashboard_server._write_secret_file(run_marker.secret_path(5476), "deadbeef")
+        run_marker.clear_marker(5476)
+        assert run_marker.read_secret(5476) == ""
+
+
+class TestSharedFileIsNotClobberedWhileASiblingServes:
+    def test_shared_file_written_when_this_is_the_only_gateway(self, home: Path) -> None:
+        shared = home / ".local_secret"
+        with mock.patch.object(dashboard_server, "_live_sibling_port", return_value=None):
+            dashboard_server._write_instance_credentials(shared, 5476, "mine")
+        assert shared.read_text() == "mine"
+        assert run_marker.read_secret(5476) == "mine"
+
+    def test_shared_file_preserved_when_another_gateway_is_live(self, home: Path) -> None:
+        shared = home / ".local_secret"
+        shared.write_text("incumbent")
+        with mock.patch.object(dashboard_server, "_live_sibling_port", return_value=5476):
+            dashboard_server._write_instance_credentials(shared, 7811, "newcomer")
+        # The incumbent keeps comparing against "incumbent"; clients that resolve
+        # its port must keep reading it.
+        assert shared.read_text() == "incumbent"
+        # The newcomer is still reachable, under its own port.
+        assert run_marker.read_secret(7811) == "newcomer"
+
+    def test_a_stale_marker_is_not_a_sibling(self, home: Path) -> None:
+        # A crashed gateway leaves its marker behind. Treating that as a live
+        # sibling would stop every subsequent gateway from publishing the shared
+        # credential at all -- the guard must key on the ownership proof, not on
+        # the file's presence.
+        run_marker.write_marker(5476)
+        with mock.patch(
+            "kiro_crew.port_resolution._gateway_owns_port", return_value=False
+        ):
+            assert dashboard_server._live_sibling_port(7811) is None
+
+    def test_a_verified_live_marker_is_a_sibling(self, home: Path) -> None:
+        run_marker.write_marker(5476)
+        with mock.patch(
+            "kiro_crew.port_resolution._gateway_owns_port", return_value=True
+        ):
+            assert dashboard_server._live_sibling_port(7811) == 5476
+
+    def test_own_port_is_never_its_own_sibling(self, home: Path) -> None:
+        run_marker.write_marker(5476)
+        with mock.patch(
+            "kiro_crew.port_resolution._gateway_owns_port", return_value=True
+        ):
+            assert dashboard_server._live_sibling_port(5476) is None
+
+    def test_discovery_failure_does_not_block_startup(self, home: Path) -> None:
+        with mock.patch.object(
+            run_marker, "marker_ports", side_effect=OSError("boom")
+        ):
+            assert dashboard_server._live_sibling_port(5476) is None
+
+
+class TestClientReadsTheCredentialForThePortItDials:
+    def test_per_port_beats_the_shared_file(self, home: Path) -> None:
+        from kiro_crew import mcp_core
+
+        (home / ".local_secret").write_text("newcomer-that-replaced-the-file")
+        dashboard_server._write_secret_file(run_marker.secret_path(5476), "owner-of-5476")
+        with mock.patch.object(mcp_core, "_api_port", return_value=5476):
+            assert mcp_core._internal_secret() == "owner-of-5476"
+
+    def test_falls_back_to_shared_file_for_a_gateway_without_a_per_port_file(
+        self, home: Path
+    ) -> None:
+        from kiro_crew import mcp_core
+
+        (home / ".local_secret").write_text("older-gateway")
+        with mock.patch.object(mcp_core, "_api_port", return_value=5476):
+            assert mcp_core._internal_secret() == "older-gateway"
+
+    def test_no_credential_anywhere_yields_empty_not_an_exception(self, home: Path) -> None:
+        from kiro_crew import mcp_core
+
+        with mock.patch.object(mcp_core, "_api_port", return_value=5476):
+            assert mcp_core._internal_secret() == ""
+
+    def test_two_generations_in_one_home_no_longer_collide(self, home: Path) -> None:
+        """End-to-end of the reported failure, at the credential layer.
+
+        Incumbent owns 5476. A second gateway starts in the same home on 7811.
+        Before the fix the client read the shared file and sent the newcomer's
+        credential to the incumbent; now each port resolves to its own owner.
+        """
+        from kiro_crew import mcp_core
+
+        shared = home / ".local_secret"
+        with mock.patch.object(dashboard_server, "_live_sibling_port", return_value=None):
+            dashboard_server._write_instance_credentials(shared, 5476, "incumbent")
+        with mock.patch.object(dashboard_server, "_live_sibling_port", return_value=5476):
+            dashboard_server._write_instance_credentials(shared, 7811, "newcomer")
+
+        with mock.patch.object(mcp_core, "_api_port", return_value=5476):
+            assert mcp_core._internal_secret() == "incumbent"
+        with mock.patch.object(mcp_core, "_api_port", return_value=7811):
+            assert mcp_core._internal_secret() == "newcomer"
+
+
+class TestPruneKeepsALiveSibling:
+    def test_a_false_ownership_answer_does_not_take_the_credential_with_it(
+        self, home: Path
+    ) -> None:
+        """False from the ownership check means UNPROVEN, never "process gone".
+
+        ``_gateway_owns_port`` fails closed by returning False: non-POSIX returns
+        False outright, and a missing or throwing listener-lookup tool is folded
+        into False too. Treating False as death would delete a LIVE incumbent's
+        credential on every Windows host, drop its clients onto a shared file a
+        newcomer may have replaced, and make the prune cause the 403 this whole
+        change exists to prevent. The marker may go; the credential may not.
+        """
+        run_marker.write_marker(5476)
+        dashboard_server._write_secret_file(run_marker.secret_path(5476), "incumbent")
+        with mock.patch(
+            "kiro_crew.port_resolution._gateway_owns_port", return_value=False
+        ):
+            run_marker.prune_markers(keep_port=7811)
+        assert run_marker.marker_ports() == []
+        assert run_marker.read_secret(5476) == "incumbent"
+
+    def test_an_unverifiable_host_also_keeps_the_credential(self, home: Path) -> None:
+        run_marker.write_marker(5476)
+        dashboard_server._write_secret_file(run_marker.secret_path(5476), "incumbent")
+        with mock.patch(
+            "kiro_crew.port_resolution._gateway_owns_port",
+            side_effect=OSError("no listener tooling"),
+        ):
+            run_marker.prune_markers(keep_port=7811)
+        assert run_marker.read_secret(5476) == "incumbent"
+
+    def test_live_sibling_is_kept(self, home: Path) -> None:
+        # A blanket prune here deletes a serving gateway's marker + pid, which
+        # makes it undiscoverable to client commands AND removes the evidence the
+        # credential writer needs to leave its credential alone.
+        run_marker.write_marker(5476)
+        dashboard_server._write_secret_file(run_marker.secret_path(5476), "alive")
+        with mock.patch(
+            "kiro_crew.port_resolution._gateway_owns_port", return_value=True
+        ):
+            run_marker.prune_markers(keep_port=7811)
+        assert run_marker.marker_ports() == [5476]
+        assert run_marker.read_secret(5476) == "alive"
+
+    def test_unverifiable_ownership_still_prunes(self, home: Path) -> None:
+        run_marker.write_marker(5476)
+        with mock.patch(
+            "kiro_crew.port_resolution._gateway_owns_port",
+            side_effect=OSError("no /proc"),
+        ):
+            run_marker.prune_markers(keep_port=7811)
+        assert run_marker.marker_ports() == []
+
+    def test_unverifiable_ownership_never_takes_a_live_credential(
+        self, home: Path
+    ) -> None:
+        """The prune must not be able to break a serving gateway.
+
+        On a host where ownership cannot be reported the check fails open to the
+        prune, so if the credential went with the marker a starting sibling would
+        strip the incumbent's credential, its clients would fall back to a shared
+        file the sibling may have replaced, and every incumbent internal call
+        would 403 -- this PR's own bug, reintroduced from the other direction.
+        """
+        run_marker.write_marker(5476)
+        dashboard_server._write_secret_file(run_marker.secret_path(5476), "incumbent")
+        with mock.patch(
+            "kiro_crew.port_resolution._gateway_owns_port",
+            side_effect=OSError("ownership unverifiable on this host"),
+        ):
+            run_marker.prune_markers(keep_port=7811)
+        assert run_marker.read_secret(5476) == "incumbent"
+
+
+class TestEphemeralBindPublishesUnderTheRealPort:
+    """`--port auto` binds port 0; the credential must not be filed under it.
+
+    A credential at `gateway-0.secret` is unreachable for every client, and they
+    would fall back to the shared file -- which the live-sibling guard
+    deliberately leaves pointing at the sibling, so the ephemeral gateway would
+    403 every internal call. `--test-mode` implies `--port auto`, so this is the
+    default shape for a throwaway instance.
+    """
+
+    class _Runner:
+        def __init__(self, addresses: object) -> None:
+            self.addresses = addresses
+
+    def test_declared_port_is_used_when_non_zero(self) -> None:
+        runner = self._Runner([("127.0.0.1", 5476)])
+        assert dashboard_server._resolved_bound_port(runner, 5476) == 5476
+
+    def test_os_assigned_port_is_read_back_when_declared_is_zero(self) -> None:
+        runner = self._Runner([("127.0.0.1", 41234)])
+        assert dashboard_server._resolved_bound_port(runner, 0) == 41234
+
+    def test_a_unix_socket_address_is_not_mistaken_for_a_port(self) -> None:
+        runner = self._Runner(["/run/user/1000/kirocrew/gateway.sock", ("127.0.0.1", 41234)])
+        assert dashboard_server._resolved_bound_port(runner, 0) == 41234
+
+    def test_zero_when_no_tcp_address_is_readable(self) -> None:
+        runner = self._Runner(["/run/user/1000/kirocrew/gateway.sock"])
+        assert dashboard_server._resolved_bound_port(runner, 0) == 0
+
+    def test_credential_lands_under_the_assigned_port_not_zero(self, home: Path) -> None:
+        shared = home / ".local_secret"
+        with mock.patch.object(dashboard_server, "_live_sibling_port", return_value=5476):
+            dashboard_server._write_instance_credentials(shared, 41234, "ephemeral")
+        assert run_marker.read_secret(41234) == "ephemeral"
+        assert run_marker.read_secret(0) == ""
+
+
+class TestDenialNamesTheMismatchWithoutDisclosingTheCredential:
+    def test_absent_is_distinguished_from_wrong(self) -> None:
+        assert token_auth._credential_fingerprint("") == "absent"
+        assert token_auth._credential_fingerprint("abc") != "absent"
+
+    def test_fingerprint_does_not_contain_the_credential(self) -> None:
+        secret = os.urandom(16).hex()
+        fp = token_auth._credential_fingerprint(secret)
+        assert secret not in fp
+        assert len(fp.split("/")[0]) == 8
+
+    def test_same_value_same_fingerprint_different_value_different(self) -> None:
+        a = token_auth._credential_fingerprint("aaaa")
+        b = token_auth._credential_fingerprint("bbbb")
+        assert a == token_auth._credential_fingerprint("aaaa")
+        assert a != b
+
+    def test_detail_names_both_sides(self) -> None:
+        detail = token_auth._credential_mismatch_detail("expected-one", "received-one")
+        assert "expected=" in detail and "received=" in detail
+        assert "expected-one" not in detail and "received-one" not in detail
+
+    def test_detail_marks_a_caller_that_had_no_credential_at_all(self) -> None:
+        detail = token_auth._credential_mismatch_detail("expected-one", "")
+        assert "received=absent" in detail
+
+
+class TestEveryToolGetsTheExplanation:
+    """The copy lives in the shared decoder, so no tool needs its own branch."""
+
+    def _body(self, payload: bytes, code: int = 403) -> dict:
+        import urllib.error
+
+        exc = urllib.error.HTTPError(
+            "http://127.0.0.1/api/x", code, "Forbidden", {}, io.BytesIO(payload)
+        )
+        from kiro_crew import mcp_core
+
+        return mcp_core._http_error_body(exc)
+
+    def test_auth_mismatch_is_rewritten_for_every_caller(self) -> None:
+        out = self._body(b'{"error": "Forbidden", "code": "internal_auth_mismatch"}')
+        assert "wrong Kiro Crew instance" in out["error"]
+        assert out["error"] != "Forbidden"
+
+    def test_a_plain_forbidden_is_not_misdiagnosed(self) -> None:
+        # A genuine permission denial carries the same body; explaining it as a
+        # credential desync would send that user after a bug they do not have.
+        out = self._body(b'{"error": "Forbidden"}')
+        assert "wrong Kiro Crew instance" not in out["error"]
+        assert out["error"] == "Forbidden"
+
+    def test_learn_add_surfaces_the_rewritten_message(self) -> None:
+        from kiro_crew.mcp_tools import learn
+
+        rewritten = self._body(
+            b'{"error": "Forbidden", "code": "internal_auth_mismatch"}'
+        )
+        with mock.patch.object(
+            learn.mcp_core, "_post", return_value=rewritten
+        ), mock.patch.object(
+            learn.mcp_core, "_vet_memory_writes_governance", return_value=""
+        ), mock.patch.object(
+            learn.mcp_core, "_resolve_session_key", return_value="dashboard:chat-1"
+        ):
+            out = learn.learn_add("learn_add", {"rule": "always check the port"})
+        assert "wrong Kiro Crew instance" in out
+        assert out.strip() != "Error: Forbidden"
+
+
+class TestTheSharedHelperOwnsThePairing:
+    """The invariant lives at one chokepoint, and the dial target is never inferred.
+
+    An optional port would let a converted call site read a credential for one
+    gateway while dialing another -- the desync this helper exists to close,
+    reintroduced one call site at a time and invisible at the call site. So the
+    parameter is required, and these tests pin that.
+    """
+
+    def test_helper_prefers_the_per_port_credential(self, home: Path) -> None:
+        from kiro_crew.config.loader import read_local_secret
+
+        (home / ".local_secret").write_text("shared-replaced-by-newcomer")
+        dashboard_server._write_secret_file(run_marker.secret_path(5476), "owner-of-5476")
+        assert read_local_secret(5476) == "owner-of-5476"
+
+    def test_helper_falls_back_to_the_shared_file(self, home: Path) -> None:
+        from kiro_crew.config.loader import read_local_secret
+
+        (home / ".local_secret").write_text("older-gateway")
+        assert read_local_secret(5476) == "older-gateway"
+
+    def test_helper_returns_empty_when_nothing_is_readable(self, home: Path) -> None:
+        from kiro_crew.config.loader import read_local_secret
+
+        assert read_local_secret(5476) == ""
+
+    def test_port_is_required_so_a_call_site_cannot_omit_the_dial_target(self) -> None:
+        import inspect
+
+        from kiro_crew.config.loader import read_local_secret
+
+        param = inspect.signature(read_local_secret).parameters["port"]
+        assert param.default is inspect.Parameter.empty, (
+            "read_local_secret(port) must stay required: a default would let a "
+            "caller dial one gateway and authenticate for another"
+        )
+        with pytest.raises(TypeError):
+            read_local_secret()  # type: ignore[call-arg]
+
+    def test_no_caller_relies_on_ambient_port_resolution(self) -> None:
+        """Every call site names its dial target.
+
+        Grep-level because the failure is a MISSING argument: a reviewer reading one
+        hunk cannot see that the port came from somewhere else, and the runtime
+        symptom is a 403 on a different machine shape than the developer's.
+        """
+        import pathlib
+
+        src = pathlib.Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+        offenders = []
+        for path in src.rglob("*.py"):
+            for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if "read_local_secret()" in line and "def " not in line:
+                    offenders.append(f"{path.relative_to(src)}:{i}")
+        assert not offenders, f"read_local_secret called with no port: {offenders}"
+
+    def test_only_the_shared_helper_spells_the_resolution_order(self) -> None:
+        """No module re-implements per-port-then-shared under its own name.
+
+        The previous test matches one call NAME, so a surface that copies the
+        ORDER into a private helper escapes it -- which is how a duplicate spelling
+        got into this change's own diff. This matches on the behaviour instead: a
+        module that reads a per-port credential must not also read the shared file,
+        unless it is the shared helper itself (or this test).
+        """
+        import pathlib
+
+        src = pathlib.Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+        allowed = {pathlib.Path("config/loader.py")}
+        offenders = []
+        for path in src.rglob("*.py"):
+            rel = path.relative_to(src)
+            if rel in allowed:
+                continue
+            text = path.read_text(encoding="utf-8")
+            reads_per_port = "run_marker.read_secret(" in text
+            reads_shared = '".local_secret"' in text
+            if reads_per_port and reads_shared:
+                offenders.append(str(rel))
+        assert not offenders, (
+            "these modules re-implement the per-port-then-shared order instead of "
+            f"calling config.loader.read_local_secret: {offenders}"
+        )
+
+    def test_mcp_core_delegates_rather_than_reimplementing(self, home: Path) -> None:
+        from kiro_crew import mcp_core
+
+        with mock.patch.object(mcp_core, "_api_port", return_value=7811), mock.patch(
+            "kiro_crew.mcp_core.read_local_secret", return_value="from-helper"
+        ) as helper:
+            assert mcp_core._internal_secret() == "from-helper"
+        helper.assert_called_once_with(7811)
+
+    def test_cron_trigger_pairs_its_credential_with_the_port(self, home: Path) -> None:
+        from kiro_crew import cron_trigger
+
+        shared = home / ".local_secret"
+        shared.write_text("shared-replaced-by-newcomer")
+        dashboard_server._write_secret_file(run_marker.secret_path(7811), "owner-of-7811")
+        seen: dict[str, str] = {}
+
+        class _Resp:
+            def __enter__(self) -> _Resp:
+                return self
+
+            def __exit__(self, *_a: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return b'{"ok": true, "name": "job"}'
+
+        def _fake_urlopen(req, timeout=0):  # type: ignore[no-untyped-def]
+            seen["secret"] = req.headers.get("X-internal-secret", "")
+            return _Resp()
+
+        with mock.patch.object(cron_trigger, "loopback_urlopen", _fake_urlopen):
+            ok, _msg = cron_trigger.trigger_cron_job("abc123", 7811, shared)
+        assert ok
+        assert seen["secret"] == "owner-of-7811"
+
+    def test_sage_probe_only_considers_ports_this_process_can_claim(self) -> None:
+        """An authenticated probe must never sweep for a stranger's gateway.
+
+        Each candidate is probed with THAT port's own credential, so a blind range
+        sweep would authenticate against whichever sibling answered first and this
+        app would then create and delete review artifacts in that instance's store.
+        With no self-declared port the list is empty and the caller falls back to a
+        default whose request errors clearly -- failing closed rather than writing to
+        a stranger.
+        """
+        from kiro_crew.apps.builtins.code_review_sage.sage_lib import review_driver
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch.object(
+                review_driver.store, "crew_home", return_value=Path("/nonexistent")
+            ):
+                assert review_driver._candidate_ports() == []
+
+        with mock.patch.dict(os.environ, {"KIROCREW_PORT": "7811"}, clear=True):
+            with mock.patch.object(
+                review_driver.store, "crew_home", return_value=Path("/nonexistent")
+            ):
+                assert review_driver._candidate_ports() == [7811]
+
+        # The parent gateway exports its ACTUAL bound port, which is the only numeric
+        # source a `--port auto` instance has and the correct one when the requested
+        # port was taken. It therefore leads, and remains self-declared: a pod drops
+        # it precisely so it never inherits its parent's listener.
+        with mock.patch.dict(
+            os.environ,
+            {"KIROCREW_BOUND_PORT": "7899", "KIROCREW_PORT": "5476"},
+            clear=True,
+        ):
+            with mock.patch.object(
+                review_driver.store, "crew_home", return_value=Path("/nonexistent")
+            ):
+                assert review_driver._candidate_ports() == [7899, 5476]
+
+    def test_cron_child_dials_the_port_its_credential_was_minted_for(self) -> None:
+        """One resolution owns both, so credential and dial target cannot diverge.
+
+        The parent mints the credential and the child sends it. If the child resolves
+        its own port it reads KIROCREW_PORT, which is 5476 on a `--port auto` gateway
+        -- a SIBLING -- so it would present a valid credential for one gateway to a
+        different one and the call would 403. The parent therefore injects the port it
+        minted for, and the child prefers it.
+        """
+        from kiro_crew import cron_script
+
+        job = mock.Mock()
+
+        with mock.patch.dict(
+            os.environ, {"_KIROCREW_DIAL_PORT": "7899", "KIROCREW_PORT": "5476"}
+        ):
+            ctx = cron_script.ScriptContext(job=job)
+            assert ctx._port == 7899
+
+        # Without the injection the fallback still holds for a directly-constructed
+        # context, so this is a preference and not a hard dependency.
+        with mock.patch.dict(os.environ, {"KIROCREW_PORT": "5476"}, clear=True):
+            assert cron_script.ScriptContext(job=job)._port == 5476
+
+    def test_cron_trigger_prefers_a_named_path_over_the_home_wide_file(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """With no per-port credential, the named path beats the home-wide file.
+
+        This is the arm the named ``secret_path`` genuinely wins: the home-wide file
+        is the one a second gateway generation replaces, so falling back to it when
+        the caller named a file would authenticate with whichever generation wrote
+        last. It does NOT outrank the per-port read -- see the companion test.
+        """
+        from kiro_crew import cron_trigger
+
+        (home / ".local_secret").write_text("ambient-home-of-this-process")
+        explicit = tmp_path / "pod-home-secret"
+        explicit.write_text("explicitly-named-home")
+        seen: dict[str, str] = {}
+
+        class _Resp:
+            def __enter__(self) -> _Resp:
+                return self
+
+            def __exit__(self, *_a: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return b'{"ok": true, "name": "job"}'
+
+        def _fake_urlopen(req, timeout=0):  # type: ignore[no-untyped-def]
+            seen["secret"] = req.headers.get("X-internal-secret", "")
+            return _Resp()
+
+        with mock.patch.object(cron_trigger, "loopback_urlopen", _fake_urlopen):
+            ok, _msg = cron_trigger.trigger_cron_job("abc123", 9999, explicit)
+        assert ok
+        assert seen["secret"] == "explicitly-named-home"
+
+    def test_cron_trigger_prefers_the_dialed_ports_credential_over_a_named_path(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """The per-port credential wins, and this test states the cost of that.
+
+        Both real callers pass the home-wide file as ``secret_path``, so the per-port
+        read MUST outrank it or the original defect returns. The consequence, pinned
+        here so it cannot be discovered as a surprise: a per-port credential left
+        behind by a crashed gateway (the prune never deletes credentials) is also
+        preferred over a named path. Closing that means removing the parameter, not
+        flipping this order -- flipping it would make both callers prefer the
+        home-wide file and reinstate the bug.
+        """
+        from kiro_crew import cron_trigger
+
+        dashboard_server._write_secret_file(run_marker.secret_path(9999), "per-port")
+        named = tmp_path / "named-secret"
+        named.write_text("named-home")
+        seen: dict[str, str] = {}
+
+        class _Resp:
+            def __enter__(self) -> _Resp:
+                return self
+
+            def __exit__(self, *_a: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return b'{"ok": true, "name": "job"}'
+
+        def _fake_urlopen(req, timeout=0):  # type: ignore[no-untyped-def]
+            seen["secret"] = req.headers.get("X-internal-secret", "")
+            return _Resp()
+
+        with mock.patch.object(cron_trigger, "loopback_urlopen", _fake_urlopen):
+            ok, _msg = cron_trigger.trigger_cron_job("abc123", 9999, named)
+        assert ok
+        assert seen["secret"] == "per-port"
+
+
+class TestFrameRelayNeverCredentialsASiblingGateway:
+    """A desktop frame must not be POSTed, credentialed, to another instance.
+
+    ``screencast`` mirrors captures to its own gateway's ingress, which is strict:
+    no credential means the POST is refused and the frame is dropped. The hazard is
+    the opposite case. ``parse_dashboard_url`` reads ``KIROCREW_PORT`` then
+    ``dashboard.url``, and on a ``--port auto`` gateway neither names the port that
+    was actually bound -- only ``KIROCREW_BOUND_PORT`` does. So both the ingress URL
+    and the credential resolved to 5476, a SIBLING on a multi-gateway host, and the
+    sibling then ACCEPTED the frame and broadcast somebody else's desktop to its own
+    owners.
+
+    Both halves are pinned here: the URL follows the bound port, and a port that is
+    only a guess gets no credential at all.
+    """
+
+    def test_ingress_follows_the_bound_port_not_the_configured_one(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.computer_use import screencast
+
+        # The shape of the bug: config names the sibling, the bound port is ours.
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7811")
+        monkeypatch.delenv("KIROCREW_PORT", raising=False)
+        (home / "config.json").write_text('{"dashboard": {"url": "http://127.0.0.1:5476"}}')
+
+        url = screencast._ingress_url()
+        assert ":7811" in url, f"frames still aim at the configured port: {url}"
+        assert ":5476" not in url
+
+    def test_the_credential_matches_the_port_the_frame_is_posted_to(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.computer_use import screencast
+
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7811")
+        monkeypatch.delenv("KIROCREW_PORT", raising=False)
+        dashboard_server._write_secret_file(run_marker.secret_path(5476), "sibling-secret")
+        dashboard_server._write_secret_file(run_marker.secret_path(7811), "our-secret")
+
+        headers = screencast._headers()
+        assert headers.get(screencast.FRAME_SECRET_HEADER) == "our-secret"
+        assert "sibling-secret" not in headers.values()
+
+    def test_a_default_port_install_still_gets_its_credential(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The common install must keep mirroring, not be sacrificed to the fix.
+
+        With no port evidence at all the resolver returns the default and reports
+        ``evidence_backed=False``. An earlier draft of this fix withheld the
+        credential in that case, reasoning that a guessed port might be a sibling's.
+        It was the wrong trade twice over: a ``--port auto`` gateway always has
+        ``KIROCREW_BOUND_PORT`` to offer, so the guard never fired in the scenario
+        it was written for, and it silently stopped every ordinary default-port
+        install from mirroring. ``test_computer_use_api`` caught it.
+        """
+        from kiro_crew.computer_use import screencast
+        from kiro_crew.port_resolution import resolve_client_port_ex
+
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+        monkeypatch.delenv("KIROCREW_PORT", raising=False)
+        port, evidence_backed = resolve_client_port_ex(None)
+        if evidence_backed:  # pragma: no cover - environment-dependent guard
+            pytest.skip("this environment supplies positive port evidence")
+        dashboard_server._write_secret_file(run_marker.secret_path(port), "default-port-secret")
+
+        headers = screencast._headers()
+        assert headers.get(screencast.FRAME_SECRET_HEADER) == "default-port-secret"
+
+    def test_url_and_credential_cannot_diverge(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both read the same resolver, so no input can split them apart."""
+        from kiro_crew.computer_use import screencast
+
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7811")
+        monkeypatch.delenv("KIROCREW_PORT", raising=False)
+        (home / "config.json").write_text('{"dashboard": {"url": "http://127.0.0.1:5476"}}')
+        dashboard_server._write_secret_file(run_marker.secret_path(7811), "our-secret")
+
+        url = screencast._ingress_url()
+        headers = screencast._headers()
+        assert ":7811" in url
+        assert headers.get(screencast.FRAME_SECRET_HEADER) == "our-secret"
+
+    def test_an_inherited_kirocrew_port_does_not_win_over_the_bound_port(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The generic client resolver's own ordering is the hazard here.
+
+        ``resolve_client_port_ex`` reads ``KIROCREW_PORT`` BEFORE
+        ``KIROCREW_BOUND_PORT``, which is right for a CLI client aiming at a chosen
+        instance and wrong for code running inside the gateway. A shell that
+        exported ``KIROCREW_PORT=5476`` and then started a second gateway with
+        ``--port auto`` leaves both set, and the frame would carry 5476's own valid
+        credential -- so that sibling ACCEPTS the capture rather than refusing it.
+        """
+        from kiro_crew.computer_use import screencast
+
+        monkeypatch.setenv("KIROCREW_PORT", "5476")  # inherited, names the sibling
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7811")  # what we actually bound
+        dashboard_server._write_secret_file(run_marker.secret_path(5476), "sibling-secret")
+        dashboard_server._write_secret_file(run_marker.secret_path(7811), "our-secret")
+
+        url = screencast._ingress_url()
+        headers = screencast._headers()
+        assert ":7811" in url, f"frames aim at the sibling: {url}"
+        assert headers.get(screencast.FRAME_SECRET_HEADER) == "our-secret", (
+            "the frame carries the sibling's credential, so its ingress accepts the "
+            "capture and broadcasts this desktop to its owners"
+        )
+
+    def test_kirocrew_port_still_decides_when_no_port_was_bound(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Preferring the bound port must not disable the dev-instance override."""
+        from kiro_crew.computer_use import screencast
+
+        monkeypatch.setenv("KIROCREW_PORT", "6777")
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+        dashboard_server._write_secret_file(run_marker.secret_path(6777), "dev-secret")
+
+        assert ":6777" in screencast._ingress_url()
+        assert screencast._headers().get(screencast.FRAME_SECRET_HEADER) == "dev-secret"
+
+    def test_a_malformed_bound_port_falls_through_instead_of_raising(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.computer_use import screencast
+
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "not-a-port")
+        monkeypatch.setenv("KIROCREW_PORT", "6777")
+        assert ":6777" in screencast._ingress_url()
+
+
+class TestCronDialsTheGatewayItRunsUnderNotASibling:
+    """A startup cron must not mint-and-send a credential to a sibling gateway.
+
+    ``_resolve_dial_port`` is the single resolution the parent injects as
+    ``_KIROCREW_DIAL_PORT`` so credential and dial target cannot diverge. The
+    hazard is the same one screencast had: the generic resolver reads
+    ``KIROCREW_PORT`` before ``KIROCREW_BOUND_PORT``, so an inherited
+    ``KIROCREW_PORT=5476`` beside a ``--port auto`` gateway dials 5476 -- a
+    SIBLING -- and an overdue cron then authenticates a real callback against it.
+
+    Deliberately NOT tested: a "refuse until the per-port credential exists" gate.
+    There is none, on purpose -- an unresolved secret reads empty and the ingress
+    refuses the empty header, so fail-closed already holds, and an explicit gate
+    would only reintroduce the default-port regression a sibling fix already hit.
+    """
+
+    def test_bound_port_wins_over_an_inherited_kirocrew_port(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import cron_script
+
+        monkeypatch.setenv("KIROCREW_PORT", "5476")  # inherited, the sibling
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7811")  # what we actually bound
+        assert cron_script._resolve_dial_port() == 7811
+
+    def test_the_credential_is_read_for_the_dialed_port(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import cron_script
+
+        monkeypatch.setenv("KIROCREW_PORT", "5476")
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7811")
+        dashboard_server._write_secret_file(run_marker.secret_path(5476), "sibling-secret")
+        dashboard_server._write_secret_file(run_marker.secret_path(7811), "our-secret")
+        # The caller resolves the dial port once and passes it in; the credential
+        # must be the one for that port, never the inherited-KIROCREW_PORT sibling.
+        assert cron_script._resolve_internal_secret(cron_script._resolve_dial_port()) == "our-secret"
+
+    def test_kirocrew_port_still_decides_when_no_port_was_bound(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import cron_script
+
+        monkeypatch.setenv("KIROCREW_PORT", "6777")
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+        assert cron_script._resolve_dial_port() == 6777
+
+    def test_a_malformed_bound_port_falls_through(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import cron_script
+
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "not-a-port")
+        monkeypatch.setenv("KIROCREW_PORT", "6777")
+        assert cron_script._resolve_dial_port() == 6777
+
+
+class TestTheServingResolverIsTheOneGatewaySideChokepoint:
+    """One shared resolver for every in-gateway caller, bound-port-first.
+
+    The client resolver reads KIROCREW_PORT first, which is right for a CLI client
+    and wrong for code inside the gateway. Rather than each in-gateway module
+    carrying its own bound-port-first override (screencast, cron_script did, and
+    mcp_cron was missed entirely), resolve_serving_port is the single chokepoint they
+    all delegate to, so a new consumer cannot silently reintroduce the sibling bug by
+    reaching for the client resolver.
+    """
+
+    def test_bound_port_beats_an_inherited_kirocrew_port(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.port_resolution import resolve_serving_port
+
+        monkeypatch.setenv("KIROCREW_PORT", "5476")
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7811")
+        assert resolve_serving_port() == 7811
+
+    def test_kirocrew_port_still_decides_with_no_bound_port(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.port_resolution import resolve_serving_port
+
+        monkeypatch.setenv("KIROCREW_PORT", "6777")
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+        assert resolve_serving_port() == 6777
+
+    def test_a_malformed_bound_port_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.port_resolution import resolve_serving_port
+
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "not-a-port")
+        monkeypatch.setenv("KIROCREW_PORT", "6777")
+        assert resolve_serving_port() == 6777
+
+    def test_every_in_gateway_consumer_routes_through_it(self) -> None:
+        # A grep-level guard: the three in-gateway consumers must not reach for the
+        # client resolver directly, or the sibling bug returns one file at a time.
+        src = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+        offenders = []
+        for rel in (
+            "computer_use/screencast.py",
+            "cron_script.py",
+            "mcp_cron.py",
+        ):
+            text = (src / rel).read_text(encoding="utf-8")
+            if "resolve_client_port_ex" in text:
+                offenders.append(rel)
+        assert not offenders, (
+            "these in-gateway modules still reference the client resolver; they must "
+            f"use resolve_serving_port so credentials pair with the bound port: {offenders}"
+        )
+
+
+class TestReviewDriverDoesNotGuessASiblingPort:
+    """The report-write base must be a port a source NAMED, never an invented 5476.
+
+    _gateway_base probes candidate ports, each with its own credential. When none
+    answers it may fall back only to a port _candidate_ports positively named; when
+    NO source names one, guessing 5476 and dialing it with 5476's credential is how a
+    review artifact gets created or pruned in whatever sibling owns that port.
+    """
+
+    def test_no_named_port_fails_closed_instead_of_guessing_5476(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.apps.builtins.code_review_sage.sage_lib import review_driver
+
+        monkeypatch.setattr(review_driver, "_RESOLVED_BASE", "", raising=False)
+        monkeypatch.setattr(review_driver, "_candidate_ports", lambda: [])
+        # If _gateway_base returned a base anyway, _api_request would read a
+        # credential for it; assert it refuses instead.
+        assert review_driver._gateway_base() == ""
+        result = review_driver._api_request("GET", "/whatever")
+        assert "error" in result
+        assert "5476" not in review_driver._gateway_base()
+
+    def test_a_named_port_is_still_used_as_the_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.apps.builtins.code_review_sage.sage_lib import review_driver
+
+        monkeypatch.setattr(review_driver, "_RESOLVED_BASE", "", raising=False)
+        monkeypatch.setattr(review_driver, "_candidate_ports", lambda: [7811])
+        monkeypatch.setattr(review_driver, "_probe", lambda base, secret: False)
+        assert review_driver._gateway_base() == "http://localhost:7811"

--- a/test/test_review_driver_loopback.py
+++ b/test/test_review_driver_loopback.py
@@ -109,7 +109,7 @@ class TestReviewDriverLoopbackCallsIgnoreTheProxy:
 
     def test_api_request_does_not_proxy_the_secret(self, monkeypatch, listeners):
         monkeypatch.setattr(review_driver, "_gateway_base", lambda: listeners["gateway_base"])
-        monkeypatch.setattr(review_driver, "_local_secret", lambda: CANARY)
+        monkeypatch.setattr(review_driver, "_local_secret", lambda *_a: CANARY)
 
         # A real parse of the gateway's body proves the request landed there and
         # was not merely swallowed by _api_request's blanket except.


### PR DESCRIPTION
## 1. What is the problem?

The internal-API credential is generated per gateway start
(`dashboard/server.py`, `os.urandom(16).hex()`) and kept in memory as the value the
auth middleware compares against -- so it identifies ONE generation. But it was
published only to a single shared `<data-home>/.local_secret`, which is
last-writer-wins per home. The port it guards is a machine-wide resource. Nothing
paired the two.

So on a machine running more than one gateway -- a supported setup: a second
gateway launched by hand, one started from another checkout that inherits the
default data home, a cutover overlapping its predecessor -- the process that OWNS
the port and the process that WROTE the credential can be different. The
incumbent keeps comparing against its own in-memory value, every internal caller
now reads the newcomer's value out of the shared file, and every internal call is
refused.

Measured on the reporting host:

| when | observation |
| --- | --- |
| 02:12 | `.local_secret` mtime `2026-08-14T15:03:03` (the start that still owned the port) |
| 02:44 | same file mtime `2026-08-16T02:23:32` -- rewritten that morning |
| process table | `kirocrew gateway --no-open` (same repo, no isolated home) started `02:23:28`, four seconds before that write |
| process table | a second gateway from an unrelated git worktree started `02:06:17` |
| `/proc/net/tcp` | exactly ONE listener on the port, so the extra gateways only competed for it and rewrote the shared credential |
| same session, same client process | POST `/api/spawn` denied `wrong secret` at `02:09:56`; GET `/api/lessons` granted at `02:41` |

The last row is the decisive one: the client, its process and the file it reads did
not change between those calls, so what changed is the value the server compares
against.

A second, smaller defect sits behind the same assumption: `run_marker.write_marker`
prunes every marker naming a different port, documented as safe because "a gateway
is a singleton per data home". When that is false the prune deletes a LIVE
sibling's marker and pid sidecar, making it undiscoverable to `token` / `status` /
`stop`.

## 2. Why this issue matters to the user

The refusal reaches the user as a bare `Forbidden`. `learn_add` had friendly copy
for an unknown session but nothing for an authentication failure, so saving a
lesson printed exactly:

```
Error: Forbidden
```

Nothing points at a cross-generation mix-up, so the natural reading is that the
feature, or the approval mode, is broken.

It is never one tool either -- the caller's whole internal channel dies at once and
stays dead until something restarts. On the reporting host the security event log
holds 2457 distinct `internal_auth ... denied ... wrong secret` events across
several days, including a client whose `/api/session-keepalive` was refused once a
minute for 35 minutes while `/api/taskrunner` and `/api/lessons` failed alongside
it. Those refusals appear ONLY in the security event log: no warning, no metric,
and the log named neither side of the mismatch, which is why attributing one took
hours.

## 3. How our fix solves it

Symptom (`Error: Forbidden` on every internal call) -> the middleware compares the
caller's header against this process's in-memory credential -> the caller read a
different generation's credential out of the shared per-home file -> the file has
one slot per data home while the credential belongs to one listener. So the fix is
to key the credential by port, and to stop destroying the evidence that says a
sibling is alive:

- `run_marker.secret_path()` / `read_secret()` -- the credential for a port lives at
  `run/gateway-<port>.secret`, `0600`, beside the marker and pid sidecar it already
  keeps there, and `clear_marker()` removes it with them so a dead generation
  leaves no usable credential behind.
- `server._write_instance_credentials()` -- always writes the per-port file; writes
  the shared `.local_secret` only when `_live_sibling_port()` finds no other gateway
  in the home verifiably alive on a different port. The shared file is still written
  in the single-instance case, because pre-per-port readers (an older CLI, a cron
  script from a previous install) know only that path. Both startup surfaces
  (`start_dashboard` and the headless path) go through it.
- `mcp_core._internal_secret()` -- reads the credential for the port it resolved and
  falls back to the shared file when no per-port file exists.
- `run_marker.prune_markers()` -- skips a marker whose gateway passes the same
  ownership proof its readers use (recorded pid, holds the port, same uid, argv
  looks like a gateway). Unverifiable ownership still prunes, so markers cannot
  accumulate forever on a non-POSIX host.
- `token_auth._credential_fingerprint()` -- a denial records a short SHA-256 prefix
  plus length for both the expected and the received value, and marks `absent`
  distinctly, so the next occurrence names its two sides. Eight hex characters of a
  128-bit random value is an identifier, not the credential, and it goes only to the
  SEL log, which is already on the keystone floor.
- `learn_add` -- maps the auth refusal to a sentence naming the instance mix-up and
  the recovery, instead of printing the auth layer's body.

Reused rather than reinvented: the ownership proof is `port_resolution._gateway_owns_port`,
already trusted for exactly this decision (it gates handing the local secret to a
discovered listener).

## 4. What tests we did

New `test/test_instance_credential_pairing.py`, 25 cases in six groups: the
per-port file (path, absent-read, no directory creation as a side effect,
round-trip, `0600`, cleared with the marker); the no-clobber guard (shared file
written when alone, preserved when a sibling is live, a stale marker is not a
sibling, a verified one is, own port is never its own sibling, discovery failure
does not block startup); the client preference (per-port beats shared, falls back
for an older gateway, empty rather than raising when neither exists, and an
end-to-end two-generations-in-one-home case); the prune (stale pruned, live kept,
unverifiable still pruned); the fingerprints (absent distinguished, credential not
present in its own fingerprint, stable and discriminating, both sides named); and
the `learn_add` copy.

- Mutation-verified rather than assumed: disabling the per-port preference in
  `_internal_secret` fails exactly the two pairing tests
  (`test_per_port_beats_the_shared_file`,
  `test_two_generations_in_one_home_no_longer_collide`) and nothing else.
- 345 passed across the new file plus the existing suites covering every touched
  module: `test_instances.py`, `test_dashboard_peer_auth.py`,
  `test_mcp_api_port_resolution.py`, `test_learn.py`, `test_mcp_core.py`.
- `isort --check-only src/kiro_crew test`, `flake8 src/kiro_crew`, and
  `mypy src/kiro_crew/` (976 files) all clean. No frontend files touched.
- Diff scanned for the inclusive-language gate and for non-ASCII on added lines:
  both clean.

## 5. Any other suggestions on the work

- **Deliberately not in scope: making the client refuse to send on a guessed
  port.** `resolve_client_port_ex` returns `(port, positive)` where `positive=False`
  means "no evidence, this is the hardcoded default", and `_post` currently sends
  anyway. Refusing there is the right end state and closes the remaining case this
  PR does not: a stale per-port credential in home A for a port whose new owner
  lives in home B. It also has a wide test blast radius, so it belongs in its own
  PR rather than riding along with a credential-storage change.
- **Deferred with a measured reason: the five CLI credential readers**
  (`cli_commands.py:169`, `:963`, `cli_server.py:147`/`:275`/`:774`). The pairing now
  lives in one shared helper, `config.loader.read_local_secret(port)`, and the MCP,
  cron-trigger and cron-script surfaces adopt it. The CLI sites were converted and
  then reverted: their tests patch a MODULE-LOCAL `config_dir`, so moving the read
  into the shared helper moves it out from under that patch point and 19 existing
  tests fail on the moved seam rather than on behaviour. Converting them means
  editing test files unrelated to this defect, so it is a separable refactor. The
  gap that remains is `kirocrew token --port <newcomer>` reading the shared file,
  and the `cli_commands.py:162` docstring claiming to mirror
  `mcp_core._internal_secret` is true again only once that lands.
- **Related open PR:** #2671 touches `mcp_core.py` in the same region (it added
  run-marker discovery to the client port path). It is CONFLICTING today; whichever
  lands second rebases.
- **A silent wrong-instance WRITE is the other face of this bug:** when a caller
  resolves one instance's home and another's port and the two happen to agree, it
  authenticates against the wrong gateway and its lesson or artifact lands in that
  instance's data. Worth its own test once the refusal above exists.
- **Superseded hypothesis, recorded so nobody re-runs it:** this was first diagnosed
  as a child process losing `KIROCREW_HOME`. It is not that. Stripping the instance
  environment entirely still resolves the correct home (legacy-home migration finds
  it), MCP tools read the credential fresh per call rather than inheriting a stale
  one, and the daemon socket is per-home, so none of those three paths explains the
  failure.

Closes #3869

