### PR TITLE
fix(i18n): list the per-app stylesheet exemptions as exact paths

### DIFF
--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -142,9 +142,19 @@ export default [
       // Stated as a false-negative class, per this file's convention: user-visible
       // copy added to one of these modules will not be reported -- keep them
       // stylesheet-only, and put anything a person reads in the component with
-      // `i18nT`. Verified copy-free rather than assumed: none of them imports
-      // `i18nT` or `useTranslation`.
-      'src/apps/*/styles.ts',
+      // `i18nT`. Verified copy-free rather than assumed: none of these four
+      // imports `i18nT` or `useTranslation`.
+      //
+      // Listed as EXACT PATHS, not a `src/apps/*/styles.ts` glob, for the reason
+      // stated above for the srcdoc pair: the false-negative note is only true of
+      // files that exist today. A glob would put every future app's stylesheet
+      // outside this gate sight-unseen, including one where someone later writes
+      // `content: "…"` copy or misfiles a string. One config line per new app is
+      // the cost of keeping the ratchet's shape.
+      'src/apps/crew-companion/styles.ts',
+      'src/apps/design-critique/styles.ts',
+      'src/apps/file-explorer/styles.ts',
+      'src/apps/md-notebook/styles.ts',
       // The PPTX Maker board-preview builder — the same category as
       // `sketchSrcdoc.ts` directly above, and listed by the same exact-path rule
       // rather than a shared glob. Every literal in it is handed to a PARSER: the


### PR DESCRIPTION
Follow-up to #3868, which merged with the wider form. Design flagged it there and was
right.

That PR needed per-app `styles.ts` exempted from the i18n gate — each is one template
literal of stylesheet text, and the diff-scoped `added-lines` check reports the whole
template against whoever edits a rule inside it, so any narrow-viewport or theming edit
to an app's CSS tripped a zero-tolerance gate it could never satisfy. That part is right.

What shipped was a **glob**: `src/apps/*/styles.ts`. This file's own recorded convention
is exact paths, and it states the reason directly above, for the srcdoc pair:

> A path this narrow cannot exempt a future file that does hold copy.

The "verified copy-free" note is only ever true of files that exist **today**. Four apps
have a `styles.ts`; there are twenty-three apps. The glob therefore pre-exempts nineteen
files that do not exist yet, including any where an author later writes `content: "…"`
copy or misfiles a string.

The four are enumerated instead, with the reason for not globbing written where the next
person adding an app will read it. One config line per future app is the cost of keeping
the ratchet's shape.

No behaviour change for the files that exist — `npm run i18n:check` still reports
**16 checks · PASS**, and `eslint src/ --max-warnings 1116` is clean.

I did not try to gate this with a test: the check that matters is the i18n job itself,
and a unit test asserting the contents of an ignore list would just restate the file.
