### PR TITLE
refactor(memory): consolidate lesson category validation and field redaction into shared helpers

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -74,7 +74,13 @@ from kiro_crew.security import (
     scan_memory,
 )
 from kiro_crew.sel import sel
-from kiro_crew.validation import _AGENT_NAME_RE, CHANNEL_ID_RE, CHANNEL_MAX_LEN, WORKSPACE_NAME_RE
+from kiro_crew.validation import (
+    _AGENT_NAME_RE,
+    CHANNEL_ID_RE,
+    CHANNEL_MAX_LEN,
+    WORKSPACE_NAME_RE,
+    normalize_lesson_category,
+)
 from kiro_crew.vector_memory import VectorMemoryStore, _lesson_display_text
 
 # Workspace dirs are confined to the data home: a workspace is agent-writable
@@ -1444,10 +1450,12 @@ def _learn(args: argparse.Namespace) -> None:
                     #
                     # The label reads the row's own category so this surface agrees
                     # with the dashboard's lessons panel; a legacy string row
-                    # carries none, and "knowledge" is the store's own default.
-                    category = val.get("category") if isinstance(val, dict) else None
-                    if not isinstance(category, str) or not category.strip():
-                        category = "knowledge"
+                    # carries none, and the shared helper supplies the store's
+                    # own "knowledge" default (display policy, strict=False).
+                    category = normalize_lesson_category(
+                        val.get("category") if isinstance(val, dict) else None,
+                        strict=False,
+                    )
                     text = _TERMINAL_CTRL_RE.sub("", _lesson_display_text(val) or str(val))
                     print(f"  [{_TERMINAL_CTRL_RE.sub('', category)}] {text}")
             else:
@@ -1457,7 +1465,11 @@ def _learn(args: argparse.Namespace) -> None:
                     return
                 for le in lessons:
                     neg = f" — {_TERMINAL_CTRL_RE.sub('', str(le.negative))}" if le.negative else ""
-                    print(f"  [{_TERMINAL_CTRL_RE.sub('', str(le.category))}] {_TERMINAL_CTRL_RE.sub('', str(le.rule))}{neg}")
+                    # Same display policy as the vector-store branch above and
+                    # the dashboard's JSONL path: a blank/legacy category gets
+                    # the store's own "knowledge" default instead of printing [].
+                    category = normalize_lesson_category(le.category, strict=False)
+                    print(f"  [{_TERMINAL_CTRL_RE.sub('', category)}] {_TERMINAL_CTRL_RE.sub('', str(le.rule))}{neg}")
 
         elif action == "remove":
             if vs.get_lessons() and vs.delete_lesson(args.query):

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -19,7 +19,7 @@ from kiro_crew.agent_discovery import (
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.dashboard.state import VALID_MEMORY_MODES, DashboardState
-from kiro_crew.security import is_sensitive_path
+from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 from kiro_crew.skills import skills_dir
 from kiro_crew.slack.handler import (
     _hydrate_conv_flags,
@@ -31,6 +31,26 @@ if TYPE_CHECKING:
     from kiro_crew.platform.interfaces import CapabilityManager
 
 logger = logging.getLogger(__name__)
+
+
+def _redact_memory_field(val: object) -> object:
+    """Redact credentials and exfiltration URLs from a memory field.
+
+    Lives here (not in ``memory.py``) so handlers that ``memory.py`` itself
+    imports from -- e.g. ``cron.py`` -- can share the chain without an import
+    cycle.
+    """
+    if isinstance(val, (bytes, memoryview)):
+        return None
+    if isinstance(val, str):
+        val, _ = redact_exfiltration_urls(val)
+        val, _ = redact_credentials(val)
+        return val
+    if isinstance(val, list):
+        return [_redact_memory_field(item) for item in val]
+    if isinstance(val, dict):
+        return {k: _redact_memory_field(v) for k, v in val.items()}
+    return val
 
 
 # Shared body cap for the small JSON-object endpoints that must bound the

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -38,6 +38,7 @@ from kiro_crew.validation import (
     MAX_SHORT_STRING,
     SLACK_THREAD_TS_RE,
     ValidationError,
+    normalize_lesson_category,
     validate_string_field,
     validate_tool_args,
 )
@@ -49,6 +50,7 @@ from ._shared import (
     _get_memory,
     _is_restricted_session,
     _probe_persisted_session,
+    _redact_memory_field,
 )
 
 logger = logging.getLogger(__name__)
@@ -1383,21 +1385,21 @@ async def api_lessons(request: web.Request) -> web.Response:
     def _safe_lesson(rule: object, category: object, ts: object) -> dict:
         """One sanitization chokepoint for every branch of this endpoint.
 
-        Lesson rows can carry consolidation (LLM) or import output: enforce a
-        string category so a malformed row cannot ship an object to the React
-        panel, and redact BOTH prose fields like every other agent-derived
+        Lesson rows can carry consolidation (LLM) or import output: normalize
+        the category through the shared helper (display policy, strict=False)
+        so this surface cannot drift from the write-path rules, and redact
+        BOTH prose fields via the shared chain like every other agent-derived
         string this handler returns -- an imported row can carry a credential
         in either field. The JSONL store loads ``rule`` without type
         validation, so a malformed row can carry a non-string here; stringify
-        before the regex redaction rather than crashing the endpoint.
+        before the redaction rather than crashing the endpoint.
         """
         if not isinstance(rule, str):
             rule = str(rule)
-        safe_rule = redact_credentials(redact_exfiltration_urls(rule)[0])[0]
-        if isinstance(category, str) and category.strip():
-            safe_category = redact_credentials(redact_exfiltration_urls(category)[0])[0]
-        else:
-            safe_category = "knowledge"
+        safe_rule = _redact_memory_field(rule)
+        safe_category = _redact_memory_field(
+            normalize_lesson_category(category, strict=False)
+        )
         return {"rule": safe_rule, "category": safe_category, "ts": ts}
 
     # Read from vector store if it has lessons, else JSONL

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -49,7 +49,7 @@ from kiro_crew.sandbox import (
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
-from ._shared import _get_memory, _is_restricted_session
+from ._shared import _get_memory, _is_restricted_session, _redact_memory_field
 from .cron import _recognize_session
 
 logger = logging.getLogger(__name__)
@@ -163,21 +163,6 @@ async def api_memory_settings(request: web.Request) -> web.Response:
             "migrated": cfg.memory.migrated,
         }
     )
-
-
-def _redact_memory_field(val: object) -> object:
-    """Redact credentials and exfiltration URLs from a memory field."""
-    if isinstance(val, (bytes, memoryview)):
-        return None
-    if isinstance(val, str):
-        val, _ = redact_exfiltration_urls(val)
-        val, _ = redact_credentials(val)
-        return val
-    if isinstance(val, list):
-        return [_redact_memory_field(item) for item in val]
-    if isinstance(val, dict):
-        return {k: _redact_memory_field(v) for k, v in val.items()}
-    return val
 
 
 def _get_vector_store(state: DashboardState):

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -778,6 +778,10 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # egress boundary; the modules that CALL it (mochi routes/hooks) are the
         # registered sinks.
         "apps/builtins/mochi/redact.py",
+        # Same shape: hosts _redact_memory_field, the shared recursive scrubber
+        # for memory fields. It owns no output of its own — the handler modules
+        # that call it (memory.py, cron.py) are the covered surfaces.
+        "dashboard/handlers/_shared.py",
         # Same shape: applies a redactor the CALLER injects, to scan the form a
         # platform will actually render (markup collapsed, ANSI stripped). It owns
         # no output of its own -- the registered sinks are the modules that call

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -53,6 +53,29 @@ MAX_RESPONSE_LEN = 100_000  # truncate tool responses
 # Allowed categories for lessons
 ALLOWED_LESSON_CATEGORIES = frozenset({"tool", "preference", "knowledge"})
 
+
+def normalize_lesson_category(value: object, *, strict: bool) -> str:
+    """Normalize a lesson category to a usable string label.
+
+    The single source of the category rules for every surface that labels a
+    lesson, so write-time and display-time policy cannot drift apart:
+
+    - ``strict=True`` (write path): clamp to ``ALLOWED_LESSON_CATEGORIES`` --
+      an unrecognized or non-string label is not a category, and "knowledge"
+      is the default every other writer uses. The ``isinstance`` check runs
+      first so an unhashable label (a dict or list from an LLM) cannot make
+      the set membership test raise.
+    - ``strict=False`` (display surfaces): only default non-string or blank
+      values, passing any other non-blank string through -- a category
+      accepted at write time keeps its own label when rendered.
+    """
+    if not isinstance(value, str):
+        return "knowledge"
+    if strict:
+        return value if value in ALLOWED_LESSON_CATEGORIES else "knowledge"
+    return value if value.strip() else "knowledge"
+
+
 # Allowed scopes for lessons (mirrors the learn_add MCP inputSchema enum).
 ALLOWED_LESSON_SCOPES = frozenset({"global", "workspace"})
 

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -56,7 +56,7 @@ from kiro_crew import platform_compat
 from kiro_crew.config.loader import config_dir
 from kiro_crew.metrics.db_metrics import timed
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-from kiro_crew.validation import ALLOWED_LESSON_CATEGORIES
+from kiro_crew.validation import ALLOWED_LESSON_CATEGORIES, normalize_lesson_category
 
 # Consolidation caps live in vector_memory_constants (a light module with no
 # heavy transitive deps) so prompt-building callers can import them at top
@@ -2167,13 +2167,11 @@ class VectorMemoryStore:
         # bad label into lost guidance. Consolidation passes the LLM's own
         # item.get("category") straight through (history.py) with no validation,
         # unlike the REST and MCP paths, which are enum-restricted by
-        # LEARN_ADD_SCHEMA. Clamp to that same enum: an unrecognized or non-string
-        # label is not a category, and "knowledge" is what every other caller
-        # defaults to. The isinstance check runs first: an unhashable label (a
-        # dict or list from the LLM) would make the set membership test itself
-        # raise, aborting consolidation instead of clamping.
-        if not isinstance(category, str) or category not in ALLOWED_LESSON_CATEGORIES:
-            category = "knowledge"
+        # LEARN_ADD_SCHEMA. The shared helper clamps to that same enum
+        # (write policy, strict=True), safely handling unhashable labels
+        # (a dict or list from the LLM) that would make a raw set membership
+        # test raise and abort consolidation instead of clamping.
+        category = normalize_lesson_category(category, strict=True)
         rule_words = self._lesson_keywords(rule_lower)
         # Same reasoning as write_episodic: carry the space generation to the write
         # so a swap landing between the embed and the lock cannot commit a vector

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -1240,6 +1240,22 @@ class TestLearnCli:
             cc._learn(_ns(learn_action="list"))
         assert "[tool] r — n" in capsys.readouterr().out
 
+    def test_list_jsonl_fallback_normalizes_blank_category(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The JSONL fallback branch applies the same display policy as the
+        vector-store branch and the dashboard: a blank/legacy category renders
+        the store's own "knowledge" default, never a bare []."""
+        with _LearnHarness() as h:
+            h.vs.get_lessons.return_value = []
+            h.jsonl.load_all.return_value = [
+                SimpleNamespace(category="", rule="legacy row", negative=None)
+            ]
+            cc._learn(_ns(learn_action="list"))
+        out = capsys.readouterr().out
+        assert "[knowledge] legacy row" in out
+        assert "[]" not in out
+
     def test_list_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
         with _LearnHarness() as h:
             h.vs.get_lessons.return_value = []

--- a/test/test_lesson_contradiction.py
+++ b/test/test_lesson_contradiction.py
@@ -1425,3 +1425,49 @@ class TestLessonStorageShape:
             assert decoded["category"] == "preference"
         finally:
             store.close()
+
+
+class TestNormalizeLessonCategory:
+    """Direct coverage of the shared helper both policies delegate to.
+
+    The write path (strict=True) and the display surfaces (strict=False) pin
+    their behavior through the call sites above and in the handler tests;
+    these lock the helper's own contract so a change here fails fast.
+    """
+
+    def test_strict_clamps_unknown_label_to_knowledge(self):
+        from kiro_crew.validation import normalize_lesson_category
+
+        assert normalize_lesson_category("banana", strict=True) == "knowledge"
+
+    def test_strict_preserves_enum_member(self):
+        from kiro_crew.validation import normalize_lesson_category
+
+        assert normalize_lesson_category("preference", strict=True) == "preference"
+
+    def test_strict_clamps_unhashable_label_without_raising(self):
+        from kiro_crew.validation import normalize_lesson_category
+
+        assert normalize_lesson_category({"a": 1}, strict=True) == "knowledge"
+        assert normalize_lesson_category(["tool"], strict=True) == "knowledge"
+
+    def test_display_passes_through_non_enum_string(self):
+        """strict=False must NOT clamp: a category accepted at write time
+        after the enum grows keeps its own label on display surfaces."""
+        from kiro_crew.validation import normalize_lesson_category
+
+        assert normalize_lesson_category("future-category", strict=False) == "future-category"
+
+    def test_display_defaults_blank_and_non_string(self):
+        from kiro_crew.validation import normalize_lesson_category
+
+        assert normalize_lesson_category("   ", strict=False) == "knowledge"
+        assert normalize_lesson_category(None, strict=False) == "knowledge"
+        assert normalize_lesson_category(123, strict=False) == "knowledge"
+
+    def test_both_policies_agree_on_enum_members(self):
+        from kiro_crew.validation import ALLOWED_LESSON_CATEGORIES, normalize_lesson_category
+
+        for cat in ALLOWED_LESSON_CATEGORIES:
+            assert normalize_lesson_category(cat, strict=True) == cat
+            assert normalize_lesson_category(cat, strict=False) == cat


### PR DESCRIPTION
## Problem / Motivation

Lesson category validity rules were duplicated across three sites that can silently drift: `dashboard/handlers/cron.py` `_safe_lesson` (non-string/blank defaulted to "knowledge"), `cli_commands.py` learn-list labeling (same defaulting, re-spelled), and `vector_memory.py` `write_lesson` (strict clamp to `ALLOWED_LESSON_CATEGORIES`). `_safe_lesson` also re-spelled the redaction chain (`redact_exfiltration_urls` then `redact_credentials`) that `_redact_memory_field` already performs.

## Why it matters

Three independent spellings of one policy are a divergence bug waiting to happen: a change to the category rules or the redaction chain landing at one site but not the others produces inconsistent labeling between the write path and the display surfaces, and a weakened redaction copy on one surface could leak a credential an imported lesson row carries.

## What changed (motivation -> approach -> change)

Consolidation with one deliberate output change: the `learn list` JSONL fallback branch now renders a blank/legacy category as `[knowledge]` instead of `[]`, aligning it with the vector-store branch and the dashboard (that inconsistency is the drift this PR exists to eliminate). All other rewired sites are behavior-preserving.

- Added `normalize_lesson_category(value, *, strict: bool)` in `kiro_crew/validation.py` next to `ALLOWED_LESSON_CATEGORIES` as the single source of the category rules: `strict=True` clamps to the enum (write path; the isinstance check short-circuits so an unhashable LLM label cannot make the set membership test raise), `strict=False` only defaults non-string/blank values (display surfaces pass any other non-blank string through unchanged). Rewired all four display/write sites: `vector_memory.write_lesson` (strict=True), the dashboard lessons endpoint's `_safe_lesson` (strict=False), and both CLI learn-list branches -- the vector-store path and the JSONL fallback path (strict=False), so a blank/legacy category renders `[knowledge]` on every surface instead of `[]` in one of them.
- Moved `_redact_memory_field` from `dashboard/handlers/memory.py` to `dashboard/handlers/_shared.py` -- `memory.py` imports from `cron.py`, so `cron.py` could not import it from `memory.py` without a cycle. `memory.py` re-imports it from `_shared`, so every existing caller (and test access via the module attribute) is unchanged. `_safe_lesson` now calls it on the stringified rule and the normalized category instead of inlining the chain; the redaction order (exfiltration URLs, then credentials) is identical.
- Added `dashboard/handlers/_shared.py` to `NON_EGRESS_REDACTION_MODULES` in `security_posture.py`: the move makes `_shared.py` a redactor call site, and the posture ratchet requires every such module to be a registered egress sink or an explicitly allowlisted pure scrubber helper. `_shared.py` owns no output path of its own (it only shapes/redacts values returned to the existing handler sinks), the same classification as the already-listed `mochi/redact.py`.

Both pre-push reviewers (GPT and Opus mirrors of the CI gates) verified call-site equivalence across string/non-string/blank/enum/non-enum/unhashable inputs with zero findings.

## Tests

- New `TestNormalizeLessonCategory` in `test/test_lesson_contradiction.py` locks the helper's contract directly: strict clamping of unknown and unhashable labels, enum preservation, display pass-through of non-enum strings (the anti-drift property), blank/non-string defaulting, and strict/display agreement on every enum member.
- New `test_list_jsonl_fallback_normalizes_blank_category` in `test/test_cli_commands_coverage.py` pins the JSONL fallback branch of `learn list` to the same display policy: a blank/legacy category renders `[knowledge]`, never a bare `[]`.
- Existing pins stay green unchanged: category defaulting, redaction, and enum-clamp tests in `test_lesson_contradiction.py` (494 pass), `_redact_memory_field` type-dispatch tests in `test_handlers_memory_coverage.py`, plus `test_validation.py`, `test_cli_commands_coverage.py`, `test_vector_memory.py` (162 pass), and `test_validation_user_actions.py` (45 pass).

## Manual verification

N/A -- unit coverage sufficient: the change is a behavior-preserving extraction pinned by the pre-existing tests at all three call sites plus direct coverage of the new helper.

no visual delta: backend-only refactor, no UI change.

## Related Issues

Closes #3694

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


