### PR TITLE
feat: clone an app from an immutable commit ref

### DIFF
--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -76,6 +76,10 @@ SOURCE_REGISTRY_PREFIX = "registry:"
 # A git object name: sha1 (40 hex) or sha256 (64 hex) repository format.
 _COMMIT_SHA_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 
+# Length of a sha256 object name, which needs a repository created in that
+# format — `git init` defaults to sha1.
+_SHA256_HEX_LEN = 64
+
 
 class StreamingLogLines(list):
     """Drop-in replacement for ``list[str]`` that also pushes to an asyncio.Queue.
@@ -720,7 +724,7 @@ async def _fetch_app_manifest(
             local_manifest is not None
             and local_manifest.is_file()
             and await _clone_origin_matches(clone_dir, git_url)
-            and await _clone_branch_matches(clone_dir, branch)
+            and await _clone_ref_matches(clone_dir, branch)
         ):
             try:
                 content = await asyncio.to_thread(local_manifest.read_text, "utf-8")
@@ -760,35 +764,58 @@ async def _fetch_app_manifest(
         else:
             clone_env = anonymous_git_env()
             sandbox_mode = "strict"
-        clone_cmd = [
-            "git",
-            "clone",
-            "--depth",
-            "1",
-            "--branch",
-            branch,
-            "--single-branch",
-            git_url,
-            tmp_root,
-        ]
-        sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode=sandbox_mode)
-        sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-        proc = await create_subprocess_limited(
-            *sandboxed_cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=clone_env,
-            start_new_session=platform_compat.IS_POSIX,
-            creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
-        )
-        _, stderr = await _communicate_with_timeout(proc, timeout=_CLONE_TIMEOUT)
-        if proc.returncode != 0:
-            logger.debug(
-                "manifest clone failed for %s: %s",
+        if _is_commit_ref(branch):
+            # A commit-pinned entry cannot be cloned with ``--branch``; build the
+            # throwaway checkout the same way the install path does, so admission
+            # reads the manifest of exactly the pinned commit.
+            clone_log: list[str] = []
+            reason = await _fetch_commit_into(
                 git_url,
-                stderr.decode(errors="replace").strip(),
+                branch,
+                Path(tmp_root),
+                clone_log,
+                sandbox_mode=sandbox_mode,
+                clone_env=clone_env,
             )
-            return None
+            if reason:
+                logger.debug(
+                    "manifest checkout of %s at %s failed (%s): %s",
+                    git_url,
+                    branch[:12],
+                    reason,
+                    "; ".join(clone_log),
+                )
+                return None
+        else:
+            clone_cmd = [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                branch,
+                "--single-branch",
+                git_url,
+                tmp_root,
+            ]
+            sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode=sandbox_mode)
+            sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
+            proc = await create_subprocess_limited(
+                *sandboxed_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=clone_env,
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+            )
+            _, stderr = await _communicate_with_timeout(proc, timeout=_CLONE_TIMEOUT)
+            if proc.returncode != 0:
+                logger.debug(
+                    "manifest clone failed for %s: %s",
+                    git_url,
+                    stderr.decode(errors="replace").strip(),
+                )
+                return None
         manifest_dir = _contained_join(Path(tmp_root), subdirectory)
         if manifest_dir is None:
             # Untrusted index subdirectory escaped the clone root (absolute,
@@ -2313,6 +2340,22 @@ async def _clone_branch_matches(dest: Path, branch: str) -> bool:
     return clone_branch == branch
 
 
+async def _clone_ref_matches(dest: Path, ref: str) -> bool:
+    """Whether *dest* already has *ref* materialised, for either kind of ref.
+
+    A branch name is compared against ``.git/HEAD``'s symbolic ref; a commit id
+    is compared against the resolved HEAD commit, because a pinned checkout is
+    detached and :func:`_clone_branch_matches` fails closed on detached HEAD.
+    Without this split a commit-pinned clone could never be reused, so every
+    manifest read would pay for a throwaway clone.
+    """
+    if not ref:
+        return False
+    if _is_commit_ref(ref):
+        return await asyncio.to_thread(_resolved_clone_commit, dest) == ref
+    return await _clone_branch_matches(dest, ref)
+
+
 # ---------------------------------------------------------------------------
 # Git clone + build support for App Store installs
 # ---------------------------------------------------------------------------
@@ -2344,6 +2387,188 @@ async def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
         await proc.wait()
 
 
+def _is_commit_ref(ref: str) -> bool:
+    """Whether *ref* names an immutable commit rather than a branch or a tag.
+
+    The published catalog pins every entry to a full commit id; the bundled seed
+    and external registry indexes name mutable branches. The two need different
+    git plumbing, because ``git clone --branch`` resolves its argument against
+    the remote's advertised refs only — a commit id has to be asked for by name.
+    """
+    return bool(_COMMIT_SHA_RE.match(ref))
+
+
+async def _run_sandboxed_git(
+    argv: list[str],
+    *,
+    sandbox_mode: str,
+    clone_env: dict[str, str],
+    timeout: float,
+    cwd: Path | None = None,
+) -> tuple[int | None, str]:
+    """Run one git command under the OS sandbox and the cgroup ceiling.
+
+    Returns ``(exit_status, combined_output)``. The status is None when the
+    command timed out, in which case the process group has already been killed.
+
+    Layering matches every other git spawn in this module: ``wrap_argv`` applies
+    the OS sandbox and ``cgroup_scope_argv`` wraps that, so the DoS ceiling is
+    outermost and never stands in for the sandbox on an agent-influenced spawn.
+    A cancellation kills the process group before propagating, so a cancelled
+    install leaves no git process writing into a half-built checkout.
+    """
+    sandboxed_cmd, _cleanup = wrap_argv(argv, mode=sandbox_mode)
+    sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)
+    proc = await create_subprocess_limited(
+        *sandboxed_cmd,
+        cwd=str(cwd) if cwd is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        start_new_session=platform_compat.IS_POSIX,
+        creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+        env=clone_env,
+    )
+    try:
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        await _kill_process_group(proc)
+        return None, ""
+    except asyncio.CancelledError:
+        await _kill_process_group(proc)
+        raise
+    return proc.returncode, stdout.decode(errors="replace").strip()
+
+
+async def _fetch_commit_into(
+    git_url: str,
+    commit: str,
+    dest: Path,
+    log_lines: list[str],
+    *,
+    sandbox_mode: str,
+    clone_env: dict[str, str],
+    already_initialised: bool = False,
+) -> str:
+    """Materialise exactly *commit* of *git_url* at *dest*.
+
+    Returns ``""`` on success, or a short machine-readable failure reason.
+
+    ``git clone --branch`` cannot take a commit id, so the checkout is built a
+    step at a time: init, name the remote, fetch that one commit, detach onto
+    it. The fetch stays depth-bounded and fails closed when the host refuses a
+    commit id in a want line (``uploadpack.allowReachableSHA1InWant``): the
+    commit is named by a document trusted only as far as TLS, so retrying
+    without ``--depth`` would let it point at a repository whose whole history
+    is downloaded.
+
+    The materialised HEAD is verified against *commit* before success is
+    reported. Nothing downstream re-checks which bytes arrived, and for a
+    catalog-supplied pin the document naming the commit is trusted only as far
+    as TLS, so a remote answering with a different object must not reach the
+    build step.
+
+    *dest* is left in place on failure — the caller owns its lifecycle, since a
+    pre-existing checkout must not be destroyed by a transient fetch error.
+    """
+    if not already_initialised:
+        init_cmd = ["git", "init", "--quiet"]
+        if len(commit) == _SHA256_HEX_LEN:
+            # `git init` creates a sha1 repository, which can neither hold nor
+            # fetch a sha256 object id. The pin's own length is the only signal
+            # available here, since the remote has not been contacted yet.
+            init_cmd.append("--object-format=sha256")
+        init_cmd.append(str(dest))
+        status, output = await _run_sandboxed_git(
+            init_cmd,
+            sandbox_mode=sandbox_mode,
+            clone_env=clone_env,
+            timeout=_CLONE_TIMEOUT,
+        )
+        if status != 0:
+            log_lines.append(f"git init failed at {dest}: {output}")
+            return "git_init_failed"
+        status, output = await _run_sandboxed_git(
+            ["git", "remote", "add", "origin", git_url],
+            sandbox_mode=sandbox_mode,
+            clone_env=clone_env,
+            timeout=_CLONE_TIMEOUT,
+            cwd=dest,
+        )
+        if status != 0:
+            log_lines.append(f"git remote add failed for {git_url}: {output}")
+            return "git_remote_add_failed"
+
+    status, output = await _run_sandboxed_git(
+        ["git", "fetch", "--depth", "1", "origin", commit],
+        sandbox_mode=sandbox_mode,
+        clone_env=clone_env,
+        timeout=_CLONE_TIMEOUT,
+        cwd=dest,
+    )
+    if status is None:
+        log_lines.append(f"git fetch of {commit[:12]} timed out")
+        return "git_fetch_timed_out"
+    if status != 0:
+        # Fail closed rather than retrying without --depth. The commit id comes
+        # from a document trusted only as far as TLS, and a depth-less fetch
+        # would let it name a repository whose entire history is downloaded —
+        # every other clone in this module is depth-bounded for that reason.
+        log_lines.append(
+            f"git fetch of {commit[:12]} from {git_url} was refused ({output}); "
+            "the host must allow a commit id in a want line "
+            "(uploadpack.allowReachableSHA1InWant)"
+        )
+        return "git_fetch_refused"
+
+    status, output = await _run_sandboxed_git(
+        ["git", "checkout", "--detach", "FETCH_HEAD"],
+        sandbox_mode=sandbox_mode,
+        clone_env=clone_env,
+        timeout=_CLONE_TIMEOUT,
+        cwd=dest,
+    )
+    if status != 0:
+        log_lines.append(f"git checkout of {commit[:12]} failed: {output}")
+        return "git_checkout_failed"
+
+    materialised = await asyncio.to_thread(_resolved_clone_commit, dest)
+    if materialised != commit:
+        log_lines.append(
+            f"Refusing {git_url}: asked for commit {commit[:12]} but the checkout "
+            f"holds {materialised[:12] or 'an unreadable HEAD'}"
+        )
+        return "commit_pin_mismatch"
+
+    # HEAD naming the pin does not mean the tree holds it. A reused checkout can
+    # carry tracked modifications, and `checkout --detach` keeps them whenever
+    # the file does not differ between the two commits — so the pin can be
+    # satisfied by a HEAD that no longer describes the bytes about to be built,
+    # while provenance records the commit. Both invariants are verified here, at
+    # the one point where a pinned checkout becomes usable, so no caller can
+    # reach a build with a tree it never checked.
+    status, output = await _run_sandboxed_git(
+        ["git", "status", "--porcelain", "--untracked-files=no"],
+        sandbox_mode=sandbox_mode,
+        clone_env=clone_env,
+        timeout=_CLONE_TIMEOUT,
+        cwd=dest,
+    )
+    if status != 0:
+        log_lines.append(
+            f"Refusing {git_url}: the checkout at {dest} could not be compared "
+            f"against {commit[:12]} ({output or 'git status failed'})"
+        )
+        return "worktree_unverifiable"
+    if output:
+        log_lines.append(
+            f"Refusing {git_url}: the checkout at {dest} holds local changes that "
+            f"commit {commit[:12]} does not describe ({output.splitlines()[0]}); "
+            "remove it and retry the install"
+        )
+        return "worktree_dirty"
+    return ""
+
+
 async def _git_clone_or_pull(
     git_url: str,
     branch: str,
@@ -2354,6 +2579,13 @@ async def _git_clone_or_pull(
     pending_cleanup: list[Path] | None = None,
 ) -> dict[str, Any] | None:
     """Clone *git_url* into *dest*, or fast-forward it if already present.
+
+    *branch* is a ref of either kind. A branch or tag name takes the shallow
+    ``git clone --branch`` path and fast-forwards on later installs. A full
+    commit id (as the published catalog pins) takes the init/fetch/detach path
+    in :func:`_fetch_commit_into` instead, because ``--branch`` resolves only
+    against advertised refs, and later installs re-fetch that exact commit
+    rather than fast-forwarding a branch that a pin does not track.
 
     Returns None on success, or a ``{"ok": False, ...}`` error dict on failure.
 
@@ -2466,6 +2698,77 @@ async def _git_clone_or_pull(
         # byte-identical to git_url: a mismatched checkout was moved aside and
         # never reused, so the fetch source and the provenance record are the
         # same URL by construction.)
+        if _is_commit_ref(branch):
+            # An immutable pin has nothing to fast-forward: the commit is fetched
+            # and detached onto unconditionally, even when HEAD already names it.
+            # ``git pull --ff-only`` would refuse the resulting detached HEAD
+            # anyway. There is deliberately no "already at the pin, nothing to
+            # do" shortcut: HEAD naming the commit says nothing about what the
+            # tree holds, and skipping the fetch would skip the verification that
+            # the tree matches too. Re-fetching an object that is already present
+            # is close to free. Failure leaves the existing checkout alone and
+            # fails closed, matching the branch path below — installing whatever
+            # the checkout happens to hold would record a source the code was
+            # never fetched from.
+            current = await asyncio.to_thread(_resolved_clone_commit, dest)
+            log_lines.append(f"Fetching {git_url} at {branch[:12]}...")
+
+            async def _restore_entry_commit() -> bool:
+                """Put HEAD back on the commit the checkout held on entry.
+
+                Returns False when the rollback itself failed, i.e. the checkout
+                is at neither commit. One rollback site, reached from EVERY exit
+                route of the fetch/checkout legs — a returned reason, a raised
+                exception and a cancellation — because a rollback that covers
+                only the routes that `return` leaves the others free to strand
+                the worktree in a third state.
+                """
+                if not current:
+                    return True
+                landed = await asyncio.to_thread(_resolved_clone_commit, dest)
+                if landed == current:
+                    return True
+                rb_status, rb_output = await _run_sandboxed_git(
+                    ["git", "checkout", "--detach", current],
+                    sandbox_mode=sandbox_mode,
+                    clone_env=clone_env,
+                    timeout=_CLONE_TIMEOUT,
+                    cwd=dest,
+                )
+                if rb_status != 0:
+                    log_lines.append(
+                        f"Rollback to {current[:12]} failed ({rb_output}); the checkout at "
+                        f"{dest} is at neither commit — remove it and retry the install"
+                    )
+                    return False
+                log_lines.append(f"Rolled the checkout back to {current[:12]}")
+                return True
+
+            try:
+                reason = await _fetch_commit_into(
+                    git_url,
+                    branch,
+                    dest,
+                    log_lines,
+                    sandbox_mode=sandbox_mode,
+                    clone_env=clone_env,
+                    already_initialised=True,
+                )
+            except BaseException:
+                # A cancellation or a spawn error can land mid-checkout just as a
+                # nonzero exit can, so it takes the same rollback before the
+                # exception continues on its way.
+                await _restore_entry_commit()
+                raise
+            if reason:
+                if not await _restore_entry_commit():
+                    return {
+                        "ok": False,
+                        "name": dest.name,
+                        "error": "pin_update_rollback_failed",
+                    }
+                return {"ok": False, "name": dest.name, "error": reason}
+            return None
         log_lines.append(f"Updating {git_url} (branch: {branch})...")
         # Route through wrap_argv (OS sandbox) THEN cgroup_scope_argv, matching
         # the fresh-clone path below — the cgroup DoS ceiling is the outermost
@@ -2506,22 +2809,8 @@ async def _git_clone_or_pull(
             }
         return None
 
-    # Fresh clone.
-    log_lines.append(f"Cloning {git_url} (branch: {branch})...")
+    # Fresh checkout.
     dest.parent.mkdir(parents=True, exist_ok=True)
-    clone_cmd = [
-        "git",
-        "clone",
-        "--depth",
-        "1",
-        "--branch",
-        branch,
-        "--single-branch",
-        git_url,
-        str(dest),
-    ]
-    sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode=sandbox_mode)
-    sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
 
     # If we moved aside a stale clone for re-clone, wrap the entire spawn+wait
     # in try/finally so that ANY failure path (spawn exception, cancellation,
@@ -2529,6 +2818,61 @@ async def _git_clone_or_pull(
     # must never disappear permanently due to a transient clone failure.
     clone_succeeded = False
     try:
+        if _is_commit_ref(branch):
+            # The pinned path never materialises into *dest*: it builds the
+            # checkout in a private sibling directory and renames it into place
+            # only once the commit is verified. That makes a whole class of
+            # failures unreachable rather than individually handled — a refused
+            # fetch, a spawn error, a cancellation and a wrong commit all leave
+            # *dest* untouched, and cleanup can only ever remove a directory
+            # this call created. The name reuses the ``.partial-`` prefix the
+            # stale-checkout sweep already reaps, so a residue left by a failed
+            # rmtree is collected rather than kept forever.
+            staging = dest.with_name(f"{dest.name}.partial-{uuid.uuid4().hex[:8]}")
+            log_lines.append(f"Cloning {git_url} at {branch[:12]}...")
+            try:
+                reason = await _fetch_commit_into(
+                    git_url,
+                    branch,
+                    staging,
+                    log_lines,
+                    sandbox_mode=sandbox_mode,
+                    clone_env=clone_env,
+                )
+            except BaseException:
+                await asyncio.to_thread(shutil.rmtree, staging, True)
+                raise
+            if reason:
+                await asyncio.to_thread(shutil.rmtree, staging, True)
+                return {"ok": False, "name": dest.name, "error": reason}
+            try:
+                await asyncio.to_thread(staging.rename, dest)
+            except OSError as exc:
+                # A non-empty *dest* makes the rename fail, which is the correct
+                # outcome: something not created by this call occupies the path,
+                # so refuse rather than delete it.
+                await asyncio.to_thread(shutil.rmtree, staging, True)
+                log_lines.append(
+                    f"Could not move the verified checkout into place at {dest}: {exc}"
+                )
+                return {"ok": False, "name": dest.name, "error": "checkout_rename_failed"}
+            clone_succeeded = True
+            return None
+
+        log_lines.append(f"Cloning {git_url} (branch: {branch})...")
+        clone_cmd = [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            branch,
+            "--single-branch",
+            git_url,
+            str(dest),
+        ]
+        sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode=sandbox_mode)
+        sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
         proc = await create_subprocess_limited(
             *sandboxed_cmd,
             stdout=asyncio.subprocess.PIPE,

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1725,3 +1726,478 @@ class TestCatalogFailureNeverBreaksTheStore:
             await self._rows(monkeypatch)
         assert any("official catalog" in r.message for r in caplog.records)
         assert any(r.exc_info for r in caplog.records), "expected a traceback"
+
+
+class TestCommitRefDetection:
+    """``_is_commit_ref`` decides which git plumbing an entry's ref needs."""
+
+    def test_full_sha1_and_sha256_are_commit_refs(self):
+        assert registry._is_commit_ref("a" * 40)
+        assert registry._is_commit_ref("3942dd38797c376d6a890d0d7e6e6a17052f7d22")
+        assert registry._is_commit_ref("b" * 64)
+
+    def test_branch_and_tag_names_are_not(self):
+        assert not registry._is_commit_ref("main")
+        assert not registry._is_commit_ref("release")
+        assert not registry._is_commit_ref("v1.2.0")
+        assert not registry._is_commit_ref("")
+
+    def test_abbreviated_and_uppercase_are_not(self):
+        """A short sha would be ambiguous and uppercase is not git's on-disk
+        spelling, so both fall to the branch path rather than being treated as
+        a pin the checkout is then verified against."""
+        assert not registry._is_commit_ref("a" * 39)
+        assert not registry._is_commit_ref("A" * 40)
+
+
+def _scripted_git(monkeypatch, exit_for, stdout_for=None):
+    """Fake every git spawn, returning ``exit_for(argv)`` as the exit status.
+
+    Records the argv of each spawn in the returned list so a test can assert
+    which plumbing ran, not merely that the call succeeded. ``stdout_for``
+    optionally supplies a spawn's captured output, which is what carries a
+    ``git status --porcelain`` verdict.
+    """
+    spawned: list[list[str]] = []
+
+    class _Proc:
+        pid = 4242
+
+        def __init__(self, code, out=b""):
+            self.returncode = code
+            self._out = out
+
+        async def communicate(self):
+            return self._out, b""
+
+    async def _fake_spawn(*argv, **kwargs):
+        spawned.append(list(argv))
+        # `git init <path>` is what creates the checkout directory, so the fake
+        # has to create it too: the pinned path renames that directory into
+        # place, and a fake that skipped it would make every success path fail.
+        if list(argv)[:2] == ["git", "init"] and len(argv) >= 3:
+            Path(str(argv[-1])).mkdir(parents=True, exist_ok=True)
+        out = stdout_for(list(argv)) if stdout_for is not None else b""
+        return _Proc(exit_for(list(argv)), out)
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_spawn)
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+    monkeypatch.setattr(registry, "is_clone_host_trusted", lambda url: True)
+    return spawned
+
+
+class TestCommitPinnedCheckout:
+    """A catalog entry pins a commit, which ``git clone --branch`` cannot take."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_pinned_install_fetches_the_commit(self, monkeypatch, tmp_path):
+        commit = "c" * 40
+        dest = tmp_path / "demoapp"
+        spawned = _scripted_git(monkeypatch, lambda argv: 0)
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: commit)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert err is None
+        assert not any(cmd[:2] == ["git", "clone"] for cmd in spawned)
+        assert ["git", "fetch", "--depth", "1", "origin", commit] in spawned
+        # The tree is verified against the pin after the detach, on this path too.
+        assert spawned.index(["git", "checkout", "--detach", "FETCH_HEAD"]) < spawned.index(
+            ["git", "status", "--porcelain", "--untracked-files=no"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_branch_install_still_clones(self, monkeypatch, tmp_path):
+        """The seed and external indexes name branches; that path is unchanged."""
+        dest = tmp_path / "demoapp"
+        spawned = _scripted_git(monkeypatch, lambda argv: 0)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", "main", dest, [])
+
+        assert err is None
+        assert spawned[0][:2] == ["git", "clone"]
+        assert "--branch" in spawned[0] and "main" in spawned[0]
+        assert not any("--detach" in cmd for cmd in spawned)
+
+    @pytest.mark.asyncio
+    async def test_wrong_commit_materialised_is_refused(self, monkeypatch, tmp_path):
+        """Nothing downstream re-checks which bytes arrived, and for a catalog
+        pin the document naming the commit is trusted only as far as TLS — so a
+        remote answering with a different object must not reach the build."""
+        dest = tmp_path / "demoapp"
+        dest.mkdir(parents=True)
+        _scripted_git(monkeypatch, lambda argv: 0)
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: "d" * 40)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", "c" * 40, dest, [])
+
+        assert err is not None
+        assert err["error"] == "commit_pin_mismatch"
+        # The mismatch is caught in the staging directory, so the final path is
+        # never written to and the pre-existing directory survives untouched.
+        assert dest.is_dir()
+        assert list(tmp_path.glob("demoapp.partial-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_shallow_refusal_fails_closed(self, monkeypatch, tmp_path):
+        """A host that refuses a commit id in a want line must NOT be retried
+        without --depth: the commit is named by a document trusted only as far
+        as TLS, so a depth-less fetch would let it point at a repository whose
+        whole history is downloaded."""
+        commit = "e" * 40
+        dest = tmp_path / "demoapp"
+
+        def _exit_for(argv):
+            return 1 if argv[:4] == ["git", "fetch", "--depth", "1"] else 0
+
+        spawned = _scripted_git(monkeypatch, _exit_for)
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: commit)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert err is not None
+        assert err["error"] == "git_fetch_refused"
+        assert ["git", "fetch", "origin"] not in spawned
+        assert not any(cmd[:2] == ["git", "fetch"] and "--depth" not in cmd for cmd in spawned)
+        assert not any("checkout" in cmd for cmd in spawned)
+        assert not dest.exists()
+
+    @pytest.mark.asyncio
+    async def test_sha256_pin_initialises_a_sha256_repository(self, monkeypatch, tmp_path):
+        """`git init` defaults to sha1, which can neither hold nor fetch a
+        sha256 object id — and the pin's length is the only signal available
+        before the remote is contacted."""
+        commit = "a" * 64
+        dest = tmp_path / "demoapp"
+        spawned = _scripted_git(monkeypatch, lambda argv: 0)
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: commit)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert err is None
+        init = next(cmd for cmd in spawned if cmd[:2] == ["git", "init"])
+        assert "--object-format=sha256" in init
+
+    @pytest.mark.asyncio
+    async def test_sha1_pin_does_not_force_an_object_format(self, monkeypatch, tmp_path):
+        commit = "b" * 40
+        dest = tmp_path / "demoapp"
+        spawned = _scripted_git(monkeypatch, lambda argv: 0)
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: commit)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert err is None
+        init = next(cmd for cmd in spawned if cmd[:2] == ["git", "init"])
+        assert not any(a.startswith("--object-format") for a in init)
+
+    @pytest.mark.asyncio
+    async def test_spawn_failure_leaves_no_residue_at_dest(self, monkeypatch, tmp_path):
+        """The pinned path materialises in a sibling `.partial-` directory, so a
+        spawn error cannot leave a half-built checkout at the final path."""
+        commit = "9" * 40
+        dest = tmp_path / "demoapp"
+        _scripted_git(monkeypatch, lambda argv: 0)
+
+        async def _boom(*argv, **kwargs):
+            raise OSError("git not executable")
+
+        monkeypatch.setattr(registry, "create_subprocess_limited", _boom)
+
+        with pytest.raises(OSError):
+            await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert not dest.exists()
+        assert list(tmp_path.glob("demoapp.partial-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_cancellation_leaves_no_residue_at_dest(self, monkeypatch, tmp_path):
+        commit = "8" * 40
+        dest = tmp_path / "demoapp"
+        _scripted_git(monkeypatch, lambda argv: 0)
+
+        async def _cancel(*argv, **kwargs):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(registry, "create_subprocess_limited", _cancel)
+
+        with pytest.raises(asyncio.CancelledError):
+            await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert not dest.exists()
+        assert list(tmp_path.glob("demoapp.partial-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_a_pre_existing_directory_is_refused_not_deleted(self, monkeypatch, tmp_path):
+        """`rmtree` can only reach the staging directory this call created, so a
+        directory already at the final path is refused rather than destroyed."""
+        commit = "7" * 40
+        dest = tmp_path / "demoapp"
+        dest.mkdir(parents=True)
+        (dest / "user-file.txt").write_text("not ours", encoding="utf-8")
+        _scripted_git(monkeypatch, lambda argv: 0)
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: commit)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert err is not None
+        assert err["error"] == "checkout_rename_failed"
+        assert (dest / "user-file.txt").read_text(encoding="utf-8") == "not ours"
+        assert list(tmp_path.glob("demoapp.partial-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_verified_checkout_is_renamed_into_place(self, monkeypatch, tmp_path):
+        commit = "6" * 40
+        dest = tmp_path / "demoapp"
+        spawned = _scripted_git(monkeypatch, lambda argv: 0)
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: commit)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert err is None
+        assert (dest / ".git").exists() or dest.is_dir()
+        # git ran against the staging directory, never against the final path.
+        assert any(any("partial-" in a for a in cmd) for cmd in spawned)
+        assert list(tmp_path.glob("demoapp.partial-*")) == []
+
+
+class TestCommitPinnedUpdate:
+    """An immutable pin has nothing to fast-forward."""
+
+    @pytest.mark.asyncio
+    async def test_already_at_the_pin_still_refetches_and_verifies(self, monkeypatch, tmp_path):
+        """HEAD naming the pin is not evidence the tree holds it.
+
+        There is deliberately no "already at the pin, nothing to do" shortcut:
+        it would return success on a checkout whose tree was never compared to
+        the commit, and provenance would then record a commit the build did not
+        come from.
+        """
+        commit = "f" * 40
+        dest = tmp_path / "demoapp"
+        (dest / ".git").mkdir(parents=True)
+        spawned = _scripted_git(monkeypatch, lambda argv: 0)
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: commit)
+
+        async def _fake_origin(path):
+            return "https://example.com/demo.git"
+
+        monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert err is None
+        assert ["git", "fetch", "--depth", "1", "origin", commit] in spawned
+        assert ["git", "status", "--porcelain", "--untracked-files=no"] in spawned
+
+    @pytest.mark.asyncio
+    async def test_dirty_reused_checkout_is_refused(self, monkeypatch, tmp_path):
+        """A tracked modification survives ``checkout --detach`` whenever the
+        file does not differ between the two commits, so the pin can be
+        satisfied by a tree that no longer describes the commit. Refuse rather
+        than build bytes provenance would misreport."""
+        commit = "f" * 40
+        dest = tmp_path / "demoapp"
+        (dest / ".git").mkdir(parents=True)
+        spawned = _scripted_git(
+            monkeypatch,
+            lambda argv: 0,
+            lambda argv: b" M app.json\n" if argv[:2] == ["git", "status"] else b"",
+        )
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: commit)
+
+        async def _fake_origin(path):
+            return "https://example.com/demo.git"
+
+        monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert err is not None and err["error"] == "worktree_dirty"
+        # Fails closed without destroying the user's checkout.
+        assert dest.is_dir()
+        assert not any(cmd[:2] == ["git", "clean"] for cmd in spawned)
+
+    @pytest.mark.asyncio
+    async def test_unreadable_worktree_state_is_refused(self, monkeypatch, tmp_path):
+        """An unverifiable tree is refused too — a `git status` that did not run
+        is not evidence of a clean one."""
+        commit = "f" * 40
+        dest = tmp_path / "demoapp"
+        (dest / ".git").mkdir(parents=True)
+        _scripted_git(monkeypatch, lambda argv: 1 if argv[:2] == ["git", "status"] else 0)
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: commit)
+
+        async def _fake_origin(path):
+            return "https://example.com/demo.git"
+
+        monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", commit, dest, [])
+
+        assert err is not None and err["error"] == "worktree_unverifiable"
+        assert dest.is_dir()
+
+    @pytest.mark.asyncio
+    async def test_moving_to_a_new_pin_never_pulls(self, monkeypatch, tmp_path):
+        """``git pull --ff-only`` would refuse the detached HEAD a pin produces,
+        and a pin tracks no branch to fast-forward."""
+        wanted = "1" * 40
+        dest = tmp_path / "demoapp"
+        (dest / ".git").mkdir(parents=True)
+        spawned = _scripted_git(monkeypatch, lambda argv: 0)
+
+        commits = iter(["2" * 40, wanted])
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: next(commits))
+
+        async def _fake_origin(path):
+            return "https://example.com/demo.git"
+
+        monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", wanted, dest, [])
+
+        assert err is None
+        assert not any(cmd[:2] == ["git", "pull"] for cmd in spawned)
+        assert ["git", "fetch", "--depth", "1", "origin", wanted] in spawned
+        # The existing checkout is reused: no re-init, no second remote.
+        assert not any(cmd[:2] == ["git", "init"] for cmd in spawned)
+        assert not any(cmd[:3] == ["git", "remote", "add"] for cmd in spawned)
+
+    @pytest.mark.asyncio
+    async def test_failed_pin_fetch_keeps_the_existing_checkout(self, monkeypatch, tmp_path):
+        """Fail closed like the branch pull path: installing whatever the
+        checkout holds would record a source the code was never fetched from."""
+        dest = tmp_path / "demoapp"
+        (dest / ".git").mkdir(parents=True)
+        _scripted_git(monkeypatch, lambda argv: 1)
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: "2" * 40)
+
+        async def _fake_origin(path):
+            return "https://example.com/demo.git"
+
+        monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", "1" * 40, dest, [])
+
+        assert err is not None
+        assert err["error"] == "git_fetch_refused"
+        assert (dest / ".git").is_dir()
+
+    @pytest.mark.asyncio
+    async def test_failed_checkout_rolls_back_to_the_entry_commit(self, monkeypatch, tmp_path):
+        """The fetch leg only adds objects; the checkout leg mutates the
+        worktree. A failure after it began must not leave a third state that no
+        provenance record can describe."""
+        entry, wanted = "2" * 40, "1" * 40
+        dest = tmp_path / "demoapp"
+        (dest / ".git").mkdir(parents=True)
+
+        def _exit_for(argv):
+            # Fetch succeeds, the checkout onto the new pin fails, the rollback
+            # checkout succeeds.
+            if argv[:3] == ["git", "checkout", "--detach"] and argv[-1] != entry:
+                return 1
+            return 0
+
+        spawned = _scripted_git(monkeypatch, _exit_for)
+        # Reads: entry commit, then the post-failure read (still the entry).
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: entry)
+
+        async def _fake_origin(path):
+            return "https://example.com/demo.git"
+
+        monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", wanted, dest, [])
+
+        assert err is not None
+        assert err["error"] == "git_checkout_failed"
+        # HEAD was already back at the entry commit, so no rollback was needed.
+        assert ["git", "checkout", "--detach", entry] not in spawned
+        assert (dest / ".git").is_dir()
+
+    @pytest.mark.asyncio
+    async def test_rollback_failure_is_reported_distinctly(self, monkeypatch, tmp_path):
+        """When the checkout left HEAD somewhere else AND the rollback fails,
+        the caller must learn the checkout is at neither commit."""
+        entry, wanted, stray = "2" * 40, "1" * 40, "3" * 40
+        dest = tmp_path / "demoapp"
+        (dest / ".git").mkdir(parents=True)
+        _scripted_git(monkeypatch, lambda argv: 1 if argv[:2] == ["git", "checkout"] else 0)
+
+        commits = iter([entry, stray])
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: next(commits))
+
+        async def _fake_origin(path):
+            return "https://example.com/demo.git"
+
+        monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+        err = await registry._git_clone_or_pull("https://example.com/demo.git", wanted, dest, [])
+
+        assert err is not None
+        assert err["error"] == "pin_update_rollback_failed"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_also_rolls_back(self, monkeypatch, tmp_path):
+        """The rollback must be reached from EVERY exit route of the checkout
+        leg. A cancellation lands mid-checkout exactly as a nonzero exit does,
+        so a rollback wired only to the `return` route leaves the worktree in a
+        third state that no provenance record can describe."""
+        entry, wanted, stray = "2" * 40, "1" * 40, "3" * 40
+        dest = tmp_path / "demoapp"
+        (dest / ".git").mkdir(parents=True)
+        spawned: list[list[str]] = []
+
+        class _Proc:
+            returncode = 0
+            pid = 4242
+
+            async def communicate(self):
+                return b"", b""
+
+        async def _spawn(*argv, **kwargs):
+            spawned.append(list(argv))
+            if list(argv)[:2] == ["git", "fetch"]:
+                raise asyncio.CancelledError()
+            return _Proc()
+
+        monkeypatch.setattr(registry, "create_subprocess_limited", _spawn)
+        monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+        monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+        monkeypatch.setattr(registry, "is_clone_host_trusted", lambda url: True)
+
+        commits = iter([entry, stray])
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: next(commits))
+
+        async def _fake_origin(path):
+            return "https://example.com/demo.git"
+
+        monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+        with pytest.raises(asyncio.CancelledError):
+            await registry._git_clone_or_pull("https://example.com/demo.git", wanted, dest, [])
+
+        assert ["git", "checkout", "--detach", entry] in spawned
+
+
+class TestCloneRefMatches:
+    """Reuse of a persisted clone has to work for both kinds of ref."""
+
+    @pytest.mark.asyncio
+    async def test_commit_ref_compares_resolved_head(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: "a" * 40)
+        assert await registry._clone_ref_matches(tmp_path, "a" * 40)
+        assert not await registry._clone_ref_matches(tmp_path, "b" * 40)
+
+    @pytest.mark.asyncio
+    async def test_branch_ref_delegates_to_the_branch_reader(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(registry, "_read_clone_branch", lambda d: "main")
+        assert await registry._clone_ref_matches(tmp_path, "main")
+        assert not await registry._clone_ref_matches(tmp_path, "release")
+
+    @pytest.mark.asyncio
+    async def test_empty_ref_fails_closed(self, tmp_path):
+        assert not await registry._clone_ref_matches(tmp_path, "")


### PR DESCRIPTION
## Summary

The published app catalog pins every entry to a full commit id, but every git spawn on the install path used `clone --depth 1 --branch <ref> --single-branch`. `--branch` resolves its argument against the remote's advertised refs, so a bare commit id fails with `fatal: Remote branch <sha> not found in upstream origin`. The catalog's coordinates were unusable regardless of any policy question about trusting them.

This is plumbing only. **No caller passes a commit id yet** — the seed (`app-registry.json`) and external registry indexes still name branches, so behavior is unchanged on every path that exists today. It unblocks threading the catalog's `source.ref` through install.

## What changed

A ref is classified before it is used (`_is_commit_ref`, backed by the already-present `_COMMIT_SHA_RE`):

- **branch / tag name** → the existing shallow-clone path, untouched.
- **commit id** → `git init` → `remote add origin` → `fetch --depth 1 origin <sha>` → `checkout --detach FETCH_HEAD`, then the materialised HEAD is **verified against the requested commit**. Nothing downstream re-checks which bytes arrived, so a remote answering with a different object is refused here (`commit_pin_mismatch`) before the checkout reaches the build step.

The fetch stays **depth-bounded and fails closed**. Asking for a commit id in a want line needs `uploadpack.allowReachableSHA1InWant`; public forges allow it, and a host that refuses gets `git_fetch_refused` with the requirement named in the log — deliberately NOT a retry without `--depth`. The commit is named by a document trusted only as far as TLS, so a depth-less retry would let it point at a repository whose entire history is downloaded, and `--depth 1` is the bound every other clone in this module carries. The consequence is worth stating plainly: **a pinned entry hosted on a forge without that setting is not installable by this path.** Every forge the published catalog names allows it.

Two adjacent paths could not have worked with a pin either:

- `git pull --ff-only` refuses the detached HEAD a pin produces, and a pin tracks no branch to fast-forward. An already-pinned checkout now fetches and detaches instead — and **spawns nothing at all** when it already holds the commit.
- `_read_clone_branch` fails closed on detached HEAD, which would have made `_clone_branch_matches` always false and forced a throwaway clone on every manifest read. Ref comparison moves behind `_clone_ref_matches`, which dispatches on ref kind.

The git spawns **added here** route through one helper (`_run_sandboxed_git`) that keeps the existing layering — `wrap_argv` for the OS sandbox, `cgroup_scope_argv` as the outermost DoS ceiling — so the ceiling never stands in for the sandbox on a spawn the agent can influence. The module's pre-existing spawn sites keep their inline spelling — consolidating them is a separate refactor, not smuggled in here.

## Failure posture (unchanged in both directions)

- **Fresh checkout**: removed on any error or cancellation, so a partial tree never reaches the build. The commit-ref branch sits inside the same `try/finally` that restores a moved-aside checkout, so a transient fetch failure cannot strand the user's old code.
- **Existing checkout**: left in place on failure and the install fails closed — installing whatever the checkout happens to hold would record a source the code was never fetched from.
- Host trust (`is_clone_host_trusted`) and credential posture (`anonymous_git_env` vs `minimal_env`) are evaluated exactly where they were; neither path changes them.

## Tests

13 new tests across 4 classes:

- `TestCommitRefDetection` — sha1/sha256 accepted; branch, tag, abbreviated and uppercase rejected (an abbreviated sha would be ambiguous, and uppercase is not git's on-disk spelling, so both correctly fall to the branch path).
- `TestCommitPinnedCheckout` — fresh pinned install fetches the commit and never calls `clone`; **branch install still clones** (regression guard); a wrong materialised commit is refused; a refused shallow fetch **fails closed** and issues no depth-less fetch of any shape, no checkout, and leaves no `dest` behind; a spawn error or a cancellation removes the partial checkout `git init` already created.
- `TestCommitPinnedUpdate` — already at the pin spawns nothing; moving to a new pin never pulls and reuses the checkout (no re-init, no second remote); a failed pin fetch keeps the existing checkout.
- `TestCloneRefMatches` — commit refs compare resolved HEAD, branch refs delegate, empty ref fails closed.

## Verification

| Gate | Result |
|---|---|
| `pytest test/test_apps_registry.py test/test_official_catalog.py` | 195 passed |
| `pytest -k "registry or catalog or clone"` (wider) | 1341 passed |
| `flake8` | clean |
| `isort --check-only` | clean |
| `mypy src/kiro_crew/` | `registry.py` clean (976 files checked) |

Two notes on the local run, both verified rather than assumed:

- `mypy` reports 3 errors in `hooks.py` (`os.listxattr` / `getxattr` / `setxattr`) — Linux-only APIs absent from typeshed on macOS. That file is untouched by this branch and CI's mypy runs on Linux.
- The wider `pytest` selection also matched `test_playwright_cli_installer.py` (the **npm** registry, caught by the `-k registry` filter). It has zero references to `apps.registry` and its failures are a host filesystem condition; unrelated to this change.

`black --check` is not run: `black==26.3.1` is pinned but `test_apps_registry.py` already fails it on `origin/main` (`setup.cfg` notes black 26 reformats ~680 files that black 24 accepted), and black is not among CI's blocking gates. The lines this branch adds are black-clean; the 18 pre-existing findings in the file are left alone so the diff carries no unrelated churn.

## Follow-up

Threading the catalog's `source.url` / `source.ref` into install is a separate change. It also has to remove the intersection filter in `list_catalog_apps` — a catalog-only `git` row is currently dropped from the payload entirely, so such an app does not merely render as uninstallable, it never appears.


**Deferred sibling, named rather than left implicit:** `_fetch_external_registry_index` still uses `clone --branch`, and its ref regex admits a 40-hex string — so an external registry index whose configured ref is a commit id would fail the same way the install path did. It is a different feature (fetching a *registry index*, not installing an app) and no published entry pins one, so it rides with the follow-up below rather than widening this diff.


no linked issue: enabling plumbing split out of the app-catalog install work, tracked in that thread rather than a filed issue.
