### PR TITLE
fix(mobile): let the software keyboard resize the layout viewport

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -2,7 +2,16 @@
 <html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- `interactive-widget=resizes-content`: the default, `resizes-visual`, shrinks only
+       the VISUAL viewport when the software keyboard opens. The layout viewport keeps
+       its full height, so `vh`, `dvh` and `position:fixed; inset:0` all keep laying out
+       against a window the user can no longer see the bottom of -- a focused full-screen
+       overlay strands its own content below the keyboard with no gesture to reach it.
+       `resizes-content` resizes the layout viewport instead, so the shell (already
+       `h-dvh` with `overflow-hidden` and inner `min-h-0` scrollers) simply gets shorter
+       and the focused input stays on screen. `dvh` alone cannot do this: it tracks
+       collapsible browser UI, not the keyboard. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
   <link rel="icon" href="/logo.png" type="image/png" />
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#0d0f12" />

--- a/website/src/test/mobileKeyboardViewport.test.ts
+++ b/website/src/test/mobileKeyboardViewport.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const html = () => readFile(join(__dirname, '..', '..', 'index.html'), 'utf8')
+
+// Without this, the keyboard shrinks only the VISUAL viewport: the layout viewport
+// keeps its full height, so `vh` / `dvh` / `fixed inset-0` lay out against a window
+// whose bottom the user cannot see. A focused full-screen overlay then strands its
+// own content under the keyboard with no gesture to reach it -- measured on the
+// command palette, whose panel sits 101-692px of an 844px layout viewport while the
+// keyboard covers roughly the bottom 350px.
+describe('mobile software keyboard', () => {
+  it('resizes the layout viewport, not just the visual one', async () => {
+    const s = await html()
+    const m = s.match(/<meta name="viewport" content="([^"]*)"/)
+    expect(m, 'expected a viewport meta').not.toBeNull()
+    expect(m![1]).toContain('interactive-widget=resizes-content')
+  })
+
+  it('keeps the rest of the viewport contract intact', async () => {
+    const s = await html()
+    const m = s.match(/<meta name="viewport" content="([^"]*)"/)
+    expect(m![1]).toContain('width=device-width')
+    expect(m![1]).toContain('initial-scale=1')
+    // `resizes-visual` is the default this replaces; it must not be re-stated.
+    expect(m![1]).not.toContain('resizes-visual')
+  })
+})


### PR DESCRIPTION
Refs #3888 (deliberately NOT `Closes` -- see the platform note at the end). That issue laid out two levers and asked for a decision; this takes **A**.

## Why A

The default `interactive-widget=resizes-visual` shrinks only the **visual** viewport. The
layout viewport keeps its full height, so `vh`, `dvh` and `position:fixed; inset:0` all
keep laying out against a window whose bottom the user can no longer see. A focused
full-screen overlay then strands its own content under the keyboard: the overlay does not
scroll, and an internally-scrollable list does not help once its scrollable region is
itself hidden.

Measured on the command palette, which autofocuses its input so the keyboard is open every
time it is used on a phone: the panel occupies **101–692px** of an 844px layout viewport
while a keyboard covers roughly the bottom 350px.

A is one line and fixes the class **on Chromium** — the mobile sessions drawer, the artifact side
panels and every future full-screen overlay have the same exposure. B (a `visualViewport`
listener local to the palette) would leave all of those broken and become the first
instance of a pattern that then wants sharing.

The stated risk of A is a whole-layout reflow when the keyboard opens. That is the
behaviour this app wants: the shell is already `h-dvh` with `overflow-hidden` and inner
`min-h-0` scrollers, so a shorter layout viewport shrinks the scrollers and keeps the
focused input on screen — which for a chat app is the point.

`dvh` alone cannot substitute: it tracks collapsible browser UI, not the keyboard.

## Verified at the post-resize geometry

Headless cannot raise a real keyboard, so I measured at **390×494** — the state this
change produces when a ~350px keyboard opens:

| | full 390×844 | keyboard-open 390×494 |
|---|---|---|
| palette panel | 101 → 692 | **59 → 405** |
| result list bottom | 691 | **404** |
| chat composer bottom | 758 | **408** |
| everything inside the viewport | yes | **yes** |
| list still scrollable | yes | yes |

![layout at keyboard height, 390×494](https://github.com/kirodotdev/KiroCrew/raw/19527c15d2a69002c0f58415fee66131f292c995/temp-screenshots/mobile-keyboard/layout-at-keyboard-height-390x494.png)

Without the change the same keyboard leaves the panel laid out to 692px with ~494px
visible — 287px of it, including most of the list, unreachable.

## Tests

`mobileKeyboardViewport.test.ts`, both assertions falsified by mutation:

| mutation | caught |
|---|---|
| drop `interactive-widget` from the meta | yes |
| set it back to `resizes-visual` | yes |

The second assertion also pins that `width=device-width` and `initial-scale=1` survive, so
the fix cannot quietly replace the rest of the viewport contract.

## Honest limit

I never reproduced the original report (the search panel scrolls fine under real CDP touch
input at full height), so this ships as a fix for a **mechanism I could measure**, not a
symptom I could replay. If the panel still misbehaves on the reporter's phone after this,
the diagnosis was wrong and the issue should be reopened rather than patched around.



---

## Correction: this is Chromium-only, and my "fixes the class" claim was overstated

Design Review flagged it and is right. `interactive-widget` is **not supported by iOS
Safari** — confirmed against upstream discussion (MDN's compat data for Safari/iOS is itself
contested, and there is an active question specifically about polyfilling this key for iOS
Safari). The accurate scope:

| surface | before | after |
|---|---|---|
| Chromium / Android | overlay strands its lower half | **fixed** |
| desktop app (Electron/Chromium) | same | **fixed** |
| **iOS Safari** | strands | **unchanged** |

The body above said this "fixes the class". It fixes the class *where the key is honoured*.
The iOS mechanism is untouched, and is now tracked in #3895 rather than left implied by this
PR closing #3888.

I am not adding an iOS path here. The obvious `visualViewport` polyfill is specifically
unreliable on iOS — Safari extends document length around the focused input, which fights a
JS-driven height — and I have no iOS device in this environment, so I would be shipping
something I cannot verify. #3895 records the candidate approaches, and why `dvh` is not one
of them.

What this PR still earns on its own: one line, no JS, no platform detection, and it makes
the Android and desktop-app paths correct, verified at the post-resize geometry.


## Two residuals, stated rather than implied

**#3888 is left OPEN on purpose.** This PR no longer says `Closes`. If the original reporter
was on iOS Safari, this change does nothing for them, and auto-closing their issue would
bury that. #3888 should be closed by whoever can confirm the platform — or by #3895 if it
turns out to be iOS.

**The headless verification covers the post-resize layout, not the resize transition.**
Measuring at 390×494 proves the geometry the change produces; it does not exercise the
browser's actual reflow — scroll anchoring, or whether the focused input stays visible
*during* the transition. I have no Android device in this environment, so that residual is
real and unretired. One check on a real device before merge would close it.
