### PR TITLE
feat: ACP backend logging + shell command tool-pill fallback

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -320,7 +320,7 @@ def make_unified_diff(old: str, new: str, path: str, max_len: int = 6000) -> str
     return "".join(udiff).rstrip()[:max_len]
 
 
-def select_tool_title(title: object, raw_input: object) -> str | None:
+def select_tool_title(title: object, raw_input: object, kind: object = None) -> str | None:
     """Pick the pill label, preferring a human-readable ``description`` when present.
 
     Some backends' Bash tool emits a ``description`` field alongside ``command``
@@ -334,8 +334,19 @@ def select_tool_title(title: object, raw_input: object) -> str | None:
         desc = raw_input.get("description")
         if isinstance(desc, str) and desc.strip():
             return desc
-    if isinstance(title, str) and title:
+    # The flat title field defaults to an "unknown" sentinel when a backend
+    # omits it; treat that (and blanks) as absent rather than surfacing it.
+    if isinstance(title, str) and title and title != "unknown":
         return title
+    # Some backends omit the SDK title for a shell/exec tool and carry only the
+    # command in rawInput. Surface it for shell kinds only (so an fs tool's
+    # operation name is never mistaken for a command) instead of a bare kind
+    # label like "Run Command".
+    kind_str = kind if isinstance(kind, str) else None
+    if is_shell_kind(kind_str) and isinstance(raw_input, dict):
+        cmd = raw_input.get("command")
+        if isinstance(cmd, str) and cmd.strip():
+            return cmd
     return None
 
 
@@ -709,7 +720,7 @@ def _build_tool_call_event(
         tool_input_cache[tool_call_id] = input_str
     if purpose:
         purpose = _redact(purpose)
-    title = select_tool_title(title, raw_input) or ""
+    title = select_tool_title(title, raw_input, kind) or ""
     if title:
         title = _redact(title)
     if kind:
@@ -977,7 +988,7 @@ def _build_tool_refinement_event(
         input_str = _redact(input_str)
         if tool_input_cache is not None:
             tool_input_cache[tool_use_id] = input_str
-    title_source = select_tool_title(title, raw_input)
+    title_source = select_tool_title(title, raw_input, kind)
     title_str = _redact(title_source) if title_source else ""
     kind_str = _redact(kind) if isinstance(kind, str) and kind else ""
     # The refinement's rawInput is the COMPLETE params object, so it carries the

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1863,7 +1863,7 @@ def _make_unified_diff(old: str, new: str, path: str, max_len: int = 6000) -> st
     return "".join(udiff).rstrip()[:max_len]
 
 
-def _select_tool_title(title: object, raw_input: object) -> str | None:
+def _select_tool_title(title: object, raw_input: object, kind: object = None) -> str | None:
     """Pick the pill label, preferring a human-readable `description` when present.
 
     Some backends' Bash tool emits a `description` field alongside `command`
@@ -1878,8 +1878,19 @@ def _select_tool_title(title: object, raw_input: object) -> str | None:
         desc = raw_input.get("description")
         if isinstance(desc, str) and desc.strip():
             return desc
-    if isinstance(title, str) and title:
+    # The flat title field defaults to an "unknown" sentinel when a backend
+    # omits it; treat that (and blanks) as absent rather than surfacing it.
+    if isinstance(title, str) and title and title != "unknown":
         return title
+    # Some backends omit the SDK title for a shell/exec tool and carry only the
+    # command in rawInput. Surface it for shell kinds only (so an fs tool's
+    # operation name is never mistaken for a command) instead of a bare kind
+    # label like "Run Command".
+    kind_str = kind if isinstance(kind, str) else None
+    if _is_shell_kind(kind_str) and isinstance(raw_input, dict):
+        cmd = raw_input.get("command")
+        if isinstance(cmd, str) and cmd.strip():
+            return cmd
     return None
 
 
@@ -5129,7 +5140,7 @@ class AcpClient:
                 # Cache the trusted tool name too, so the permission event can
                 # rebuild mcp__<server>__<tool> for per-tool governance.
                 self._tool_call_tool_name[tool_call_id] = _kiro_tool_name(update)
-            title = _select_tool_title(title, raw_input) or ""
+            title = _select_tool_title(title, raw_input, kind) or ""
             if title:
                 title, _ = redact_exfiltration_urls(title)
                 title, _ = redact_credentials(title)
@@ -5286,7 +5297,7 @@ class AcpClient:
         # Prefer rawInput.description over the SDK-supplied title (e.g.
         # Bash's "List KiroCrew ACP module files" rather than `ls /workplace/...`).
         # Same helper as `_extract_tool_event` so the rule is consistent.
-        title_source = _select_tool_title(title, raw_input)
+        title_source = _select_tool_title(title, raw_input, kind)
         title_str = ""
         if title_source:
             title_str, _ = redact_exfiltration_urls(title_source)

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -607,6 +607,10 @@ class AcpRuntime:
             str(mcp_gateway_settings_mcp_json) if mcp_gateway_settings_mcp_json else None
         )
         self._mcp_gateway_socket = str(mcp_gateway_socket) if mcp_gateway_socket else None
+        # First KAS auth callback per runtime is logged at INFO as a positive
+        # "KAS is actively serving this runtime" signal; later ones drop to
+        # DEBUG so a long-lived runtime does not spam the log on every refresh.
+        self._kas_auth_logged = False
         # Whether sessions on this runtime should hold drain_init() open for
         # slow MCP servers (the no-report ceiling). A runtime whose agent is
         # KNOWN to have zero MCP servers — the kirocrew-lite background runtime,
@@ -974,7 +978,12 @@ class AcpRuntime:
         self._start_time = _get_start_time(self._pid)
         self._spawn_monotonic = time.monotonic()
         self._last_activity = time.monotonic()
-        logger.info("AcpRuntime spawned kiro-cli acp (PID %d)", self._pid)
+        logger.info(
+            "AcpRuntime spawned backend=%s agent=%s (PID %d)",
+            self._acp_backend,
+            self._agent or "<none>",
+            self._pid,
+        )
 
         # Track the PID for orphan cleanup (mirrors AcpClient._spawn). Without
         # this, a kiro-cli process leaked by a gateway crash/restart is never
@@ -1576,6 +1585,23 @@ class AcpRuntime:
         positive ``== ACP_BACKEND_KAS`` check (harness-parity H5); this body is
         only ever reached on the KAS path.
         """
+        # Positive liveness signal: this callback fires ONLY when a running
+        # KAS process asks Kiro Crew for a token, so reaching here is direct
+        # proof KAS is serving this runtime. No token is logged — only the
+        # fact of the callback, deduped to once-per-runtime at INFO.
+        if not self._kas_auth_logged:
+            self._kas_auth_logged = True
+            logger.info(
+                "KAS auth callback served — backend=kas agent=%s (PID %s)",
+                self._agent or "<none>",
+                self._pid,
+            )
+        else:
+            logger.debug(
+                "KAS auth callback served — agent=%s (PID %s)",
+                self._agent or "<none>",
+                self._pid,
+            )
         try:
             result = await resolve_kas_access_token()
         except KasAuthCallbackError as exc:

--- a/test/test_tool_purpose_key.py
+++ b/test/test_tool_purpose_key.py
@@ -19,7 +19,12 @@ from __future__ import annotations
 
 import pytest
 
-from kiro_crew.acp._dispatch import extract_tool_purpose, is_tool_purpose_key, parse_session_update
+from kiro_crew.acp._dispatch import (
+    extract_tool_purpose,
+    is_tool_purpose_key,
+    parse_session_update,
+    select_tool_title,
+)
 from kiro_crew.acp.types import EVENT_TOOL_CALL_UPDATE, TOOL_PURPOSE_KEYS
 
 
@@ -180,3 +185,34 @@ def test_refinement_purpose_is_redacted() -> None:
     assert event.tool_purpose.startswith("Use ")
     assert event.tool_purpose.endswith("to list buckets")
     assert "AKIAIOSFODNN7EXAMPLE" not in event.tool_purpose
+
+
+class TestSelectToolTitle:
+    """The pill label falls back sensibly when a backend omits the SDK title."""
+
+    def test_description_is_preferred(self) -> None:
+        raw = {"description": "List temp", "command": "ls /tmp"}
+        assert select_tool_title("ls /tmp", raw) == "List temp"
+
+    def test_title_preferred_over_command(self) -> None:
+        assert select_tool_title("ls /tmp", {"command": "ls /tmp"}, "execute") == "ls /tmp"
+
+    def test_unknown_sentinel_falls_through_to_command_for_shell(self) -> None:
+        # A backend that omits the title leaves the flat field at the "unknown"
+        # sentinel; a shell call still shows its command instead of a bare kind.
+        assert select_tool_title("unknown", {"command": "git status"}, "execute") == "git status"
+
+    def test_none_title_falls_through_to_command_for_shell(self) -> None:
+        assert select_tool_title(None, {"command": "git status"}, "execute") == "git status"
+
+    def test_command_not_used_for_non_shell_kind(self) -> None:
+        # For an fs edit tool, rawInput.command is the operation name
+        # ("strReplace"), not a shell command — it must not become the label.
+        assert select_tool_title("unknown", {"command": "strReplace"}, "edit") is None
+
+    def test_command_ignored_without_kind(self) -> None:
+        # Without a kind we cannot confirm a shell tool, so no command fallback.
+        assert select_tool_title("unknown", {"command": "ls"}) is None
+
+    def test_blank_title_no_command_returns_none(self) -> None:
+        assert select_tool_title("", {}, "execute") is None


### PR DESCRIPTION
Two related observability/UX fixes for confirming and reading which ACP backend actually served a session.

## 1. Backend logging (confirm which backend is live)

`config get agent.acp_backend` and `kirocrew doctor` show which backend is *configured* and reachable, but neither proves the running session is routing through it. Two low-volume signals close that gap:

- **Runtime spawn log.** The spawn line previously read `AcpRuntime spawned kiro-cli acp` unconditionally, which is misleading now that the same runtime path also spawns other backends. It now reads `AcpRuntime spawned backend=<backend> agent=<agent> (PID …)` — one line per runtime, so `grep backend=` over the gateway log shows the backend→agent mapping directly (and surfaces a per-agent backend mismatch at a glance).
- **Token-callback liveness.** The token callback Kiro Crew already handles for the KAS backend now emits a positive `KAS auth callback served — backend=kas agent=… (PID …)` line. It fires only when a live KAS process asks Kiro Crew for a token, so it is direct evidence KAS is *serving* a runtime, not merely installed. **No token/credential is logged** — only the fact of the callback, deduped to once-per-runtime at INFO (later refreshes drop to DEBUG so a long-lived runtime never spams).

## 2. Tool-pill title fallback (show what ran)

`select_tool_title` picked the pill label from `rawInput.description` then the SDK `title`, and showed a bare kind label (e.g. "Run Command") when both were absent. Some backends omit the SDK title for a shell/exec tool and carry only the command in `rawInput`, so the pill lost all detail. Two backend-neutral changes:

- Treat the `"unknown"` title sentinel (the default when a backend omits the flat field) and blanks as absent, so the fallback can engage.
- Fall back to `rawInput.command` **for shell kinds only**, so an fs edit tool's operation name (`rawInput.command == "strReplace"`, etc.) is never mistaken for a command.

Both synced copies (`_dispatch.py` and `client.py`) are updated identically.

## Tests

- New `TestSelectToolTitle` (7 cases) in `test/test_tool_purpose_key.py` — description preferred, title preferred over command, `"unknown"`/`None` title falling through to the command for shell kinds, and the fs-operation-name guard (non-shell kind and missing kind both suppress the command fallback).
- Full backend suite: 54522 passed. Failures are pre-existing/environmental only: `TestRunProbe` (subprocess spawn needs user-namespace support this host lacks; reproduces on `origin/main`) and one `@caplog_dev_fleet` xdist log-capture race that passes in isolation.
- isort / flake8 / mypy (976 files) clean. No frontend changes (tsc / vitest unaffected).
