### PR TITLE
fix(kas): emit context_window_update in SSE stream for API consumers

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1832,6 +1832,23 @@ class _ChatSlot:
             # The frozen prefix grew → its cached bytes are stale.
             self._frozen_prefix_cache = None
 
+    def push_wire_frame(self, cls: str, content: str) -> None:
+        """Queue an ephemeral wire-only frame for live SSE readers.
+
+        Unlike ``append_message`` this touches NOTHING durable: the frame is
+        not added to ``messages``, not counted in ``total_messages``, not
+        persisted, and not WS-broadcast. It only lands in ``_pending`` so an
+        attached HTTP stream reader drains it before the turn's ``done``.
+        Use for out-of-band signals (e.g. the context meter) that a WebSocket
+        client gets via a typed broadcast but an SSE-only client would miss.
+        The queue/ordering contract lives here so callers never hand-roll a
+        raw ``_pending`` append at a distance.
+        """
+        self._pending.append(
+            {"role": cls, "content": content, "cls": cls, "ts": ""}
+        )
+        self.event.set()
+
     def drain(self) -> list[dict[str, str]]:
         """Return and clear pending messages."""
         out = self._pending[:]
@@ -6017,6 +6034,17 @@ class DashboardState:
         slot = self.get_slot(slot_key)
         if slot is None:
             return
+        # SSE-only consumers (API clients, soak harness) never open a
+        # WebSocket, so the broadcast above is invisible to them. Mirror the
+        # SAME payload into the slot's live stream queue as an ephemeral
+        # wire-only frame under the SAME ``context_usage`` name the WS
+        # transport uses. Done HERE, inside the single writer, so every
+        # producer (end-of-turn, compaction, cron injection, reset) feeds the
+        # SSE channel identically and it cannot drift from the WS channel.
+        try:
+            slot.push_wire_frame("context_usage", json.dumps(payload))
+        except (TypeError, ValueError):
+            pass  # non-serializable payload (e.g. a test mock) — skip the SSE mirror
         # Ephemeral tabs (incognito/temporary) leave no memory behind by
         # contract — same filter as _persist_open_slots.
         if getattr(slot, "memory_mode", "persistent") != "persistent":

--- a/test/test_context_usage_sse_frame.py
+++ b/test/test_context_usage_sse_frame.py
@@ -1,0 +1,104 @@
+"""SSE-only consumers must see the context meter via ``broadcast_context_usage``.
+
+A WebSocket client gets the context reading through the typed
+``broadcast_ws("context_usage", ...)`` frame, but an SSE-only consumer (an API
+client or the KAS soak harness) never opens a WebSocket. The single writer
+``broadcast_context_usage`` therefore ALSO mirrors the same payload into the
+slot's live stream queue as an ephemeral wire-only frame, under the same
+``context_usage`` name — so every producer (end-of-turn, compaction, cron
+injection, reset) feeds the SSE channel identically and it cannot drift.
+
+The mirror must be ephemeral: it lands in ``_pending`` for the live reader to
+drain, but is never persisted, never added to ``messages``, and never counted
+in ``total_messages``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard.state import _ChatSlot
+
+
+def _register_slot(state, key="dashboard:chat-1", **kw):
+    slot = _ChatSlot(key=key, **kw)
+    state._slots[key] = slot
+    return slot
+
+
+def test_broadcast_pushes_context_usage_sse_frame(tmp_path):
+    """A single broadcast enqueues one ephemeral ``context_usage`` frame."""
+    state = _make_state(tmp_path)
+    slot = _register_slot(state)
+    payload = {"slot": slot.key, "pct": 42.5, "used_tokens": 85000, "window_tokens": 200000}
+
+    state.broadcast_context_usage(slot.key, payload)
+
+    drained = slot.drain()
+    frames = [m for m in drained if m.get("cls") == "context_usage"]
+    assert len(frames) == 1
+    frame = frames[0]
+    # Reuses the wire's existing name — NOT a second "context_window_update" spelling.
+    assert frame["role"] == "context_usage"
+    assert json.loads(frame["content"]) == payload
+
+
+def test_sse_mirror_is_ephemeral_not_persisted(tmp_path):
+    """The frame is live-only: transcript and lifetime count stay untouched."""
+    state = _make_state(tmp_path)
+    slot = _register_slot(state)
+
+    state.broadcast_context_usage(slot.key, {"slot": slot.key, "pct": 10.0})
+
+    assert slot.messages == []  # not appended to the transcript
+    assert slot.total_messages == 0  # not counted toward lifetime messages
+
+
+def test_every_producer_feeds_sse_via_single_writer(tmp_path):
+    """Any call site reaching broadcast_context_usage emits the SSE frame.
+
+    Guards the single-writer invariant: producers do NOT hand-roll their own
+    ``_pending`` push, so covering the writer covers all of them.
+    """
+    state = _make_state(tmp_path)
+    slot = _register_slot(state)
+
+    # A reset frame (post-compaction) carries no token counts — still mirrored.
+    state.broadcast_context_usage(slot.key, {"slot": slot.key, "pct": 0.0, "reset": True})
+    drained = slot.drain()
+    frames = [m for m in drained if m.get("cls") == "context_usage"]
+    assert len(frames) == 1
+    assert json.loads(frames[0]["content"])["reset"] is True
+
+
+def test_missing_slot_is_a_noop(tmp_path):
+    """An unknown slot key must not raise (WS broadcast still fires upstream)."""
+    state = _make_state(tmp_path)
+    state.broadcast_context_usage("dashboard:does-not-exist", {"slot": "x", "pct": 1.0})
+
+
+def test_non_serializable_payload_skips_sse_mirror(tmp_path):
+    """A non-JSON-serializable payload must not raise or enqueue a frame."""
+    state = _make_state(tmp_path)
+    slot = _register_slot(state)
+
+    state.broadcast_context_usage(slot.key, {"slot": slot.key, "pct": object()})
+
+    assert [m for m in slot.drain() if m.get("cls") == "context_usage"] == []
+
+
+def test_push_wire_frame_is_live_only(tmp_path):
+    """The slot-owned helper queues for SSE without persisting."""
+    state = _make_state(tmp_path)
+    slot = _register_slot(state)
+
+    slot.push_wire_frame("context_usage", json.dumps({"pct": 5.0}))
+
+    drained = slot.drain()
+    assert len(drained) == 1
+    assert drained[0]["cls"] == "context_usage"
+    assert drained[0]["role"] == "context_usage"
+    assert slot.messages == []
+    assert slot.total_messages == 0


### PR DESCRIPTION
## Summary

The KAS `context_usage` payload was only broadcast via WebSocket, so SSE-only
consumers never received context-window updates. The **dashboard SSE stream**
(`GET /api/chat`) — read by API clients and the KAS soak harness — carried the
assistant tokens but no context-meter reading.

## Fix

Emit the SSE mirror **inside `broadcast_context_usage`** — the documented SINGLE
writer for context-meter state — so every producer (end-of-turn, compaction,
cron injection, reset) feeds the SSE channel identically and it cannot drift
from the WS channel. The frame:

- reuses the wire's existing **`context_usage`** name (no second spelling);
- is queued through a new slot-owned `_ChatSlot.push_wire_frame()` helper, so no
  caller hand-rolls a raw `_pending` append at a distance;
- is **ephemeral** — lands in `_pending` for a live reader to drain before the
  turn's `done`, but is never persisted, never added to `messages`, never
  counted in `total_messages`.

### Scope note (OpenAI-compat)

The OpenAI-compatible endpoint deliberately still filters this frame (`role not
in assistant/chunk`): a context-meter frame is not part of the OpenAI
chat-completion schema, so injecting it there would break format compliance. The
fixed surface is the dashboard SSE stream, not `/v1/chat/completions`.

### Format independence

The mirror operates purely on the already-normalized `{slot, pct, used_tokens?,
window_tokens?, reset?}` payload. KAS-specific wire parsing (`_meta.kiro` shapes)
is upstream in `kas_wire` → `AcpPromptStats` → the backend-neutral provider
accessors → `_context_usage_payload`. This change adds **no** new KAS-format
dependency.

## Review feedback addressed

Both Design Review and First Principles Review flagged the prior approach (a
second SSE-only emission at 1 of ~7 producer sites, hand-rolling half of
`append_message`, and a new `context_window_update` name with 0 in-repo
consumers). This revision routes through the single writer, reuses the
`context_usage` name, and centralizes the queue write on the slot.

## Changes

- `src/kiro_crew/dashboard/state.py`: `broadcast_context_usage` mirrors the
  payload into the slot's SSE queue; new `_ChatSlot.push_wire_frame()` helper.
- `test/test_context_usage_sse_frame.py`: 6 regression tests.

## Testing

- `test_context_usage_sse_frame.py` (6) ✅
- `test_cron_context_meter_seed.py` + `test_context_bar_reopen.py` +
  `test_dashboard_chat.py` + `test_chat_runner_coverage.py` (806) ✅
- isort / flake8 / mypy clean