### PR TITLE
feat(knowledge): isolate workload effort pools

### DIFF
--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -973,7 +973,10 @@ async def sync_source(request: web.Request) -> web.Response:
     pipeline = _pipeline(request)
     if not pipeline:
         return web.json_response({"error": "pipeline not configured"}, status=503)
-    pool = request.app["knowledge_llm_pool"]
+    pool = request.app.get("knowledge_fetch_pool")
+    if pool is None:
+        # Compatibility for minimal callers that predate workload-isolated pools.
+        pool = request.app["knowledge_llm_pool"]
     task = asyncio.create_task(_background_agent_sync(source_id, url, source["name"], store, pipeline, pool))
     app_tasks = request.app.setdefault("_bg_tasks", set())
     app_tasks.add(task)
@@ -1764,16 +1767,51 @@ async def add_agent_document_route(request: web.Request) -> web.Response:
     return web.json_response(result)
 
 
+async def _shutdown_knowledge_pools(app: web.Application) -> None:
+    """Shut down each workload pool once, including the legacy alias."""
+    seen: set[int] = set()
+    for key in (
+        "knowledge_extraction_pool",
+        "knowledge_fetch_pool",
+        "knowledge_llm_pool",
+    ):
+        pool = app.get(key)
+        if pool is None or id(pool) in seen:
+            continue
+        seen.add(id(pool))
+        try:
+            await pool.shutdown()
+        except Exception:
+            logger.exception("Knowledge pool shutdown failed: %s", key)
+
+
 def setup_knowledge_routes(app: web.Application) -> None:
     # Initialize pipeline and sync scheduler if not already set
     if "knowledge_pipeline" not in app:
         store = app["state"].knowledge_store
-        pool = LLMPool()
+        cfg = KiroCrewConfig.load()
+        extraction_pool = LLMPool(
+            pool_size=cfg.knowledge.extraction_pool_size,
+            effort=cfg.agent.resolve_effort("background"),
+            use_config_pool_size=False,
+        )
+        fetch_pool = LLMPool(
+            pool_size=1,
+            use_config_pool_size=False,
+        )
         embedder = _create_embedder(app)
-        pipeline = IngestionPipeline(store=store, extractor=EntityExtractor(pool=pool),
-                                     chunker=HeadingAwareChunker(), reader=FileReader(),
-                                     embedder=embedder)
-        app["knowledge_llm_pool"] = pool
+        pipeline = IngestionPipeline(
+            store=store,
+            extractor=EntityExtractor(pool=extraction_pool),
+            chunker=HeadingAwareChunker(),
+            reader=FileReader(),
+            embedder=embedder,
+        )
+        app["knowledge_extraction_pool"] = extraction_pool
+        app["knowledge_fetch_pool"] = fetch_pool
+        # Keep the old key as an extraction-only compatibility alias. Production
+        # URL sync uses knowledge_fetch_pool above.
+        app["knowledge_llm_pool"] = extraction_pool
         app["knowledge_embedder"] = embedder
         connectors: dict[str, "BaseConnector"] = {}
         # Local folder connector (always available)
@@ -1849,12 +1887,7 @@ def setup_knowledge_routes(app: web.Application) -> None:
     app.router.add_get("/api/knowledge/search-for-context", search_for_context)
 
     # Pool lifecycle: lazy start on first request, shutdown on app exit
-    async def _shutdown_pool(app: web.Application) -> None:
-        pool = app.get("knowledge_llm_pool")
-        if pool:
-            await pool.shutdown()
-
-    app.on_cleanup.append(_shutdown_pool)
+    app.on_cleanup.append(_shutdown_knowledge_pools)
 
     async def _stop_watcher(app: web.Application) -> None:
         watcher = app.get("knowledge_watcher")

--- a/src/kiro_crew/knowledge/agent_fetch.py
+++ b/src/kiro_crew/knowledge/agent_fetch.py
@@ -1,6 +1,6 @@
 """Agent-assisted content fetch for Knowledge Library.
 
-Fetches content from URLs using the unified LLM pool. The pool worker uses
+Fetches content from URLs using the dedicated URL-fetch LLM pool. The pool worker uses
 whatever web/URL-fetch tool its backend exposes (configure the allowed tools
 via KIROCREW_KNOWLEDGE_FETCH_TOOLS). If the backend has no fetch tool available,
 the fetch fails gracefully and the caller falls back to local readers.
@@ -40,11 +40,12 @@ _ERROR_INDICATORS = (
 
 
 async def fetch_url_content(url: str, pool: "LLMPool") -> str:
-    """Fetch content from a URL using the shared LLM pool.
+    """Fetch content from a URL using the dedicated URL-fetch pool.
 
-    Acquires a worker, sends the fetch prompt, releases the worker. The worker
-    uses whatever URL-fetch tool its backend exposes (configurable via
-    KIROCREW_KNOWLEDGE_FETCH_TOOLS); if none is available the fetch fails.
+    Acquires a worker from the caller-supplied URL-fetch pool, sends the fetch
+    prompt, and releases the worker. The worker uses whatever URL-fetch tool its
+    backend exposes (configurable via KIROCREW_KNOWLEDGE_FETCH_TOOLS); if none is
+    available the fetch fails.
 
     Returns the fetched text content.
     Raises RuntimeError on failure.

--- a/src/kiro_crew/knowledge/llm_pool.py
+++ b/src/kiro_crew/knowledge/llm_pool.py
@@ -15,6 +15,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from kiro_crew.config.paths import config_dir
+from kiro_crew.effort import EFFORT_LEVELS, is_valid_effort
 from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 
 try:
@@ -179,6 +180,34 @@ def _get_pool_size(config: Optional[dict] = None) -> int:
     return DEFAULT_POOL_SIZE
 
 
+def _normalize_effort(value: object) -> Optional[str]:
+    """Return a valid explicit effort level, or ``None`` for provider default."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, str) and is_valid_effort(value):
+        return value
+    logger.warning("Ignoring invalid Knowledge worker effort: %r", value)
+    return None
+
+
+def _select_effort_level(requested: str, supported: list[str]) -> Optional[str]:
+    """Select the highest advertised effort no higher than ``requested``."""
+    supported_levels = {
+        level for level in supported
+        if isinstance(level, str) and is_valid_effort(level)
+    }
+    if not supported_levels:
+        # An advertised option without a usable level is treated like a lazy
+        # backend: attempt the requested value and let ACP confirm it.
+        return requested
+    requested_index = EFFORT_LEVELS.index(requested)
+    eligible = [
+        level for level in EFFORT_LEVELS
+        if level in supported_levels and EFFORT_LEVELS.index(level) <= requested_index
+    ]
+    return eligible[-1] if eligible else None
+
+
 class Worker(ABC):
     """Abstract base for a long-lived LLM worker."""
 
@@ -225,11 +254,18 @@ class Worker(ABC):
 class AcpWorker(Worker):
     """Long-lived AcpClient session with kirocrew-knowledge agent."""
 
-    def __init__(self, *, sandbox_mode: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        *,
+        sandbox_mode: Optional[str] = None,
+        effort: Optional[str] = None,
+    ) -> None:
         self._client: Optional[AcpClient] = None
         # Pre-resolved by the caller (off the event loop). ``None`` -> resolve
         # lazily in ``start`` (direct construction outside the pool / tests).
         self._sandbox_mode = sandbox_mode
+        self._effort = _normalize_effort(effort)
+        self._effective_effort: Optional[str] = None
         # PID currently shielded from the gateway orphan sweep (see module note).
         self._protected_pid: Optional[int] = None
 
@@ -262,7 +298,9 @@ class AcpWorker(Worker):
         self._client = AcpClient(
             agent=AGENT_NAME, sandbox_mode=sandbox_mode, audit_source="subagent"
         )
+        self._effective_effort = None
         await self._client.ensure_ready()
+        await self._apply_effort()
         # Shield the live worker PID from the periodic orphan sweep for as long
         # as it runs. Paired with unregister in shutdown() and on respawn above.
         pid = getattr(self._client, "_pid", None)
@@ -272,6 +310,46 @@ class AcpWorker(Worker):
         else:
             self._protected_pid = None
         logger.info("AcpWorker: ready (agent=%s, pid=%s)", AGENT_NAME, getattr(self._client, '_pid', 'unknown'))
+
+    async def _apply_effort(self) -> None:
+        """Apply the requested effort without breaking provider-default fallback."""
+        client = self._client
+        requested = self._effort
+        if client is None or requested is None:
+            return
+        try:
+            if not client.supports_config_option("effort"):
+                logger.warning(
+                    "AcpWorker: effort=%s unsupported; using provider default",
+                    requested,
+                )
+                return
+            supported = client.get_valid_effort_levels()
+            if not isinstance(supported, list):
+                supported = []
+            effective = _select_effort_level(requested, supported)
+            if effective is None:
+                logger.warning(
+                    "AcpWorker: no supported effort at or below %s; "
+                    "using provider default",
+                    requested,
+                )
+                return
+            await client.set_config_option("effort", effective)
+        except Exception:
+            logger.warning(
+                "AcpWorker: could not apply effort=%s; using provider default",
+                requested,
+                exc_info=True,
+            )
+            return
+        self._effective_effort = effective
+        if effective != requested:
+            logger.warning(
+                "AcpWorker: effort=%s downgraded to supported effort=%s",
+                requested,
+                effective,
+            )
 
     async def send_message(self, prompt: str, timeout: float = DEFAULT_TIMEOUT) -> str:
         if self._client is None or not self._client.is_ready:
@@ -464,13 +542,22 @@ class CCWorker(Worker):
 class LLMPool:
     """Bounded pool of long-lived LLM workers.
 
-    Both extraction and URL fetch acquire workers from this pool.
+    Callers may bind a pool to one workload's effort profile. Extraction and URL
+    fetch use separate instances so an effort setting cannot leak between them.
     If all workers are busy, callers wait on the semaphore.
     Dead workers are replaced transparently on acquire.
     """
 
-    def __init__(self, pool_size: int = DEFAULT_POOL_SIZE):
+    def __init__(
+        self,
+        pool_size: int = DEFAULT_POOL_SIZE,
+        *,
+        effort: Optional[str] = None,
+        use_config_pool_size: bool = True,
+    ):
         self._pool_size = pool_size
+        self._effort = _normalize_effort(effort)
+        self._use_config_pool_size = use_config_pool_size
         self._semaphore = asyncio.Semaphore(pool_size)
         self._workers: list[Worker] = []
         self._available: asyncio.Queue[int] = asyncio.Queue()
@@ -511,7 +598,11 @@ class LLMPool:
             configured_size = _get_pool_size(config)
             explicit = "extraction_pool_size" in (_section(
                 config, "knowledge") if config else {})
-            if explicit and configured_size != self._pool_size:
+            if (
+                self._use_config_pool_size
+                and explicit
+                and configured_size != self._pool_size
+            ):
                 self._pool_size = configured_size
                 self._semaphore = asyncio.Semaphore(configured_size)
             self._idle_ttl = _get_idle_ttl(config)
@@ -545,7 +636,10 @@ class LLMPool:
         if self._provider_type == "claude_code":
             worker: Worker = CCWorker()
         else:
-            worker = AcpWorker(sandbox_mode=self._sandbox_mode)
+            worker = AcpWorker(
+                sandbox_mode=self._sandbox_mode,
+                effort=self._effort,
+            )
         await worker.start()
         return worker
 

--- a/test/test_knowledge_effort_pools.py
+++ b/test/test_knowledge_effort_pools.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.handlers import knowledge as kh
+from kiro_crew.knowledge.store import KnowledgeStore
+
+
+class _FakePool:
+    def __init__(
+        self,
+        *,
+        pool_size: int,
+        effort: str | None = None,
+        use_config_pool_size: bool = True,
+    ) -> None:
+        self.pool_size = pool_size
+        self.effort = effort
+        self.use_config_pool_size = use_config_pool_size
+        self.shutdown = AsyncMock()
+
+
+@pytest.fixture()
+def store(tmp_path):
+    value = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    yield value
+    value.close()
+
+
+def _config():
+    return SimpleNamespace(
+        knowledge=SimpleNamespace(extraction_pool_size=3),
+        agent=SimpleNamespace(resolve_effort=lambda role: "high"),
+    )
+
+
+class TestKnowledgePoolSetup:
+    def test_setup_creates_isolated_extraction_and_fetch_pools(self, monkeypatch):
+        app = web.Application()
+        app["state"] = SimpleNamespace(knowledge_store=object())
+        pools: list[_FakePool] = []
+        extractor_calls: list[dict[str, object]] = []
+        extractor = object()
+        pipeline = object()
+
+        def _pool_factory(**kwargs):
+            pool = _FakePool(**kwargs)
+            pools.append(pool)
+            return pool
+
+        def _extractor_factory(**kwargs):
+            extractor_calls.append(kwargs)
+            return extractor
+
+        monkeypatch.setattr(kh.KiroCrewConfig, "load", _config)
+        monkeypatch.setattr(kh, "LLMPool", _pool_factory)
+        monkeypatch.setattr(kh, "EntityExtractor", _extractor_factory)
+        monkeypatch.setattr(kh, "IngestionPipeline", lambda **kwargs: pipeline)
+        monkeypatch.setattr(kh, "HeadingAwareChunker", lambda: object())
+        monkeypatch.setattr(kh, "FileReader", lambda: object())
+        monkeypatch.setattr(kh, "SyncScheduler", lambda **kwargs: object())
+        monkeypatch.setattr(kh, "_create_embedder", lambda _app: None)
+
+        kh.setup_knowledge_routes(app)
+
+        assert len(pools) == 2
+        extraction, fetch = pools
+        assert extraction.pool_size == 3
+        assert extraction.effort == "high"
+        assert extraction.use_config_pool_size is False
+        assert fetch.pool_size == 1
+        assert fetch.effort is None
+        assert fetch.use_config_pool_size is False
+        assert extractor_calls[0]["pool"] is extraction
+        assert app["knowledge_extraction_pool"] is extraction
+        assert app["knowledge_fetch_pool"] is fetch
+        assert app["knowledge_llm_pool"] is extraction
+
+
+class TestKnowledgeFetchPoolWiring:
+    @pytest.mark.asyncio
+    async def test_agent_sync_prefers_fetch_pool(self, store, monkeypatch):
+        source_id = store.add_source(
+            name="source",
+            source_type="web",
+            uri="https://example.com/source",
+        )
+        extraction_pool = object()
+        fetch_pool = object()
+        app = web.Application()
+        app["state"] = SimpleNamespace(knowledge_store=store)
+        app["knowledge_pipeline"] = object()
+        app["knowledge_sync"] = SimpleNamespace(get_connector=lambda _type: None)
+        app["knowledge_extraction_pool"] = extraction_pool
+        app["knowledge_fetch_pool"] = fetch_pool
+        app["knowledge_llm_pool"] = extraction_pool
+        app.router.add_post("/api/knowledge/sources/{id}/sync", kh.sync_source)
+        observed: dict[str, object] = {}
+        done = asyncio.Event()
+
+        async def _fake_sync(source_id, url, name, store, pipeline, pool):
+            observed["pool"] = pool
+            done.set()
+
+        monkeypatch.setattr(kh, "_background_agent_sync", _fake_sync)
+        monkeypatch.setattr(kh, "_sel_log", lambda *args, **kwargs: None)
+
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(f"/api/knowledge/sources/{source_id}/sync")
+            assert response.status == 200
+            await asyncio.wait_for(done.wait(), timeout=5)
+
+        assert observed["pool"] is fetch_pool
+
+
+class TestKnowledgePoolCleanup:
+    @pytest.mark.asyncio
+    async def test_shutdowns_each_pool_once(self):
+        extraction = _FakePool(pool_size=3, effort="high")
+        fetch = _FakePool(pool_size=1)
+        app = web.Application()
+        app["knowledge_extraction_pool"] = extraction
+        app["knowledge_fetch_pool"] = fetch
+        app["knowledge_llm_pool"] = extraction
+
+        await kh._shutdown_knowledge_pools(app)
+
+        extraction.shutdown.assert_awaited_once()
+        fetch.shutdown.assert_awaited_once()

--- a/test/test_llm_pool.py
+++ b/test/test_llm_pool.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -716,6 +716,116 @@ class TestAcpWorker:
             await worker.start()     # stale-drop: unregister 100, then register 200
         assert registered == [100, 200]
         assert unregistered == [100]
+
+
+def _mock_effort_client(levels: list[str], *, supports: bool = True) -> AsyncMock:
+    client = AsyncMock()
+    client.is_ready = True
+    client._pid = None
+    client.is_process_alive = lambda: True
+    client.supports_config_option = MagicMock(return_value=supports)
+    client.get_valid_effort_levels = MagicMock(return_value=levels)
+    client.set_config_option = AsyncMock()
+    return client
+
+
+class TestAcpWorkerEffort:
+    @pytest.mark.asyncio
+    async def test_applies_effort_after_ready_before_use(self, tmp_path):
+        client = _mock_effort_client(["low", "medium", "high"])
+        events: list[str] = []
+        client.ensure_ready.side_effect = lambda: events.append("ready")
+        client.set_config_option.side_effect = lambda *_args: events.append("set")
+        with patch("pathlib.Path.home", return_value=tmp_path), \
+             patch("kiro_crew.knowledge.llm_pool.AcpClient", return_value=client):
+            worker = AcpWorker(effort="high")
+            await worker.start()
+
+        assert events == ["ready", "set"]
+        client.set_config_option.assert_awaited_once_with("effort", "high")
+        assert worker._effective_effort == "high"
+
+    @pytest.mark.asyncio
+    async def test_reapplies_effort_after_respawn(self, tmp_path):
+        first = _mock_effort_client(["low", "medium", "high"])
+        second = _mock_effort_client(["low", "medium", "high"])
+        with patch("pathlib.Path.home", return_value=tmp_path), \
+             patch("kiro_crew.knowledge.llm_pool.AcpClient", side_effect=[first, second]):
+            worker = AcpWorker(effort="high")
+            await worker.start()
+            await worker.start()
+
+        first.set_config_option.assert_awaited_once_with("effort", "high")
+        second.set_config_option.assert_awaited_once_with("effort", "high")
+
+    @pytest.mark.asyncio
+    async def test_downgrades_to_highest_supported_lower_level(self, tmp_path, caplog):
+        client = _mock_effort_client(["low", "medium"])
+        with patch("pathlib.Path.home", return_value=tmp_path), \
+             patch("kiro_crew.knowledge.llm_pool.AcpClient", return_value=client):
+            worker = AcpWorker(effort="high")
+            await worker.start()
+
+        client.set_config_option.assert_awaited_once_with("effort", "medium")
+        assert worker._effective_effort == "medium"
+        assert "downgraded" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_uses_provider_default_when_effort_is_unsupported(self, tmp_path, caplog):
+        client = _mock_effort_client([], supports=False)
+        with patch("pathlib.Path.home", return_value=tmp_path), \
+             patch("kiro_crew.knowledge.llm_pool.AcpClient", return_value=client):
+            worker = AcpWorker(effort="high")
+            await worker.start()
+
+        client.set_config_option.assert_not_awaited()
+        assert worker._effective_effort is None
+        assert "unsupported" in caplog.text
+
+
+class TestLLMPoolEffort:
+    @pytest.mark.asyncio
+    async def test_passes_effort_to_acp_worker(self):
+        pool = LLMPool(pool_size=1, effort="high")
+        pool._provider_type = "acp"
+        pool._sandbox_mode = "auto"
+        fake_worker = AsyncMock()
+        with patch("kiro_crew.knowledge.llm_pool.AcpWorker", return_value=fake_worker) as worker_type:
+            result = await pool._create_worker()
+
+        worker_type.assert_called_once_with(sandbox_mode="auto", effort="high")
+        assert result is fake_worker
+
+    @pytest.mark.asyncio
+    async def test_default_pool_does_not_pass_effort(self):
+        pool = LLMPool(pool_size=1)
+        pool._provider_type = "acp"
+        pool._sandbox_mode = "auto"
+        fake_worker = AsyncMock()
+        with patch("kiro_crew.knowledge.llm_pool.AcpWorker", return_value=fake_worker) as worker_type:
+            await pool._create_worker()
+
+        worker_type.assert_called_once_with(sandbox_mode="auto", effort=None)
+
+    @pytest.mark.asyncio
+    async def test_fetch_sized_pool_ignores_extraction_size_config(self):
+        pool = LLMPool(pool_size=1, use_config_pool_size=False)
+        created: list[FakeWorker] = []
+
+        async def _mock_create():
+            worker = FakeWorker()
+            created.append(worker)
+            return worker
+
+        pool._create_worker = _mock_create  # type: ignore[assignment]
+        with patch(
+            "kiro_crew.knowledge.llm_pool._read_config",
+            return_value={"knowledge": {"extraction_pool_size": 3}},
+        ):
+            await pool.start()
+
+        assert pool._pool_size == 1
+        assert len(created) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation
Knowledge extraction and URL-content acquisition share one long-lived LLM pool, so the two workloads cannot independently select their effort behavior. Applying the extraction background profile to the shared pool would also affect URL fetching.

## Why it matters
Extraction/chunk/entity work should use the configured background effort, while URL fetching must retain provider-default effort. Sharing workers couples those policies and allows workload state to leak across long-lived sessions.

## What changed
The shared `knowledge_llm_pool` made extraction and URL fetching use the same workers and lifecycle. The implementation now creates separate extraction and fetch pools: extraction uses `knowledge.extraction_pool_size` plus `agent.resolve_effort(\"background\")`, while the single-worker fetch pool uses provider defaults. URL sync prefers the fetch pool, the legacy key remains an extraction-only alias, both pools shut down exactly once, and effort is applied after readiness and reapplied after respawn with backend capability checks and safe downgrade/fallback behavior.

## Tests
- 253 targeted tests passed serially on Python 3.14.7, covering LLMPool, Knowledge handlers, Knowledge effort-pool wiring, and ACP dynamic configuration.
- Added coverage for effort application ordering, respawn reapplication, supported-level downgrade, unsupported-provider fallback, isolated pool sizing, fetch-pool routing, compatibility aliasing, and exactly-once cleanup.
- isort, flake8, mypy, compileall, diff check, brand-name, docs-lint, vendor-manifest, and scrub-lint checks passed.

## Manual verification
Not performed against a live ACP provider or gateway; this backend-only change has targeted unit coverage, and the live gateway was intentionally not reloaded.

## Related Issues
No related issue. no issue closed: this standalone behavior fix has no tracked issue provided.

## Checklist
- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (not applicable — no user-facing documentation changed)
- [x] No secrets, credentials, or internal references in the diff