### PR TITLE
fix(test): preserve the terminal report when xdist dies with INTERNALERROR (#2803)

### DIFF
--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -175,6 +175,13 @@ silently gone, and two of the defaults are load-bearing:
   20 minutes of zero progress and an empty log. Two replacements absorb a genuine
   one-off crash; past that the run is not going to finish.
 
+When worker replacement itself ends in an xdist INTERNALERROR (exit 3, no
+`short test summary info` at all -- the scheduler can die with a `KeyError` on a
+replaced node), `test/conftest.py`'s `pytest_internalerror` hook prints an
+`xdist run ABANDONED` banner to stderr replaying the crashed workers and the
+tests they were running, so the red stays diagnosable. The run still exits
+non-zero; the banner only preserves the report the crash would otherwise erase.
+
 So any override that still runs MANY tests must carry
 `-n auto --dist loadgroup --max-worker-restart=2`:
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import shutil
 import socket
+import sys
 import warnings
 
 import pytest
@@ -437,6 +438,112 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             os.close(fd)
         except OSError:
             pass
+
+
+# ── xdist INTERNALERROR terminal report (issue #2803) ───────────────────
+# When TWO pytest-timeout worker kills land in the same ``--dist loadgroup``
+# shard, xdist's loadscope scheduler can die with ``KeyError:
+# <WorkerController gwN>`` (a replaced node present in ``assigned_work`` but
+# absent from ``registered_collections``). pytest then exits 3 WITHOUT a
+# ``short test summary info`` section, so the red names no failing test at
+# all. The upstream defect is xdist's to fix; what this repo preserves is the
+# REPORT: record every crashed worker and the test it was running (the
+# pytest-timeout victim), and replay them from ``pytest_internalerror`` --
+# a hook that fires only on the already-broken path, so healthy runs pay
+# nothing. The run still exits non-zero: nothing here suppresses the
+# INTERNALERROR traceback or touches the exit status.
+#
+# State lives at module level on the controller only: ``pytest_testnodedown``
+# and ``pytest_handlecrashitem`` are controller-side xdist hooks that never
+# fire inside a worker, and ``pytest_internalerror`` only emits when a crash
+# was recorded, so a non-xdist internal error is reported exactly as before.
+
+_crashed_workers: list[tuple[str, str]] = []  # (worker id, error text)
+_crash_victims: list[str] = []  # test nodeids running when their worker died
+
+
+def _reset_xdist_crash_state() -> None:
+    """Test seam: clear the recorded crashes (module state is process-global)."""
+    _crashed_workers.clear()
+    _crash_victims.clear()
+
+
+def pytest_testnodedown(node, error) -> None:
+    """Record a crashed worker (controller only; ``error`` is None on clean exit)."""
+    if error is None:
+        return
+    worker_id = getattr(getattr(node, "gateway", None), "id", None) or "<unknown worker>"
+    _crashed_workers.append((str(worker_id), str(error)))
+
+
+def pytest_handlecrashitem(crashitem, report, sched) -> None:
+    """Record the test a crashed worker was running -- the timeout victim."""
+    _crash_victims.append(str(crashitem))
+
+
+def _format_abandoned_run_report(
+    crashes: list[tuple[str, str]], victims: list[str]
+) -> str:
+    """Build the terminal report for a run abandoned after worker crashes.
+
+    Wording is deliberately non-causal: worker replacement is routine here
+    (``--max-worker-restart=2`` exists because workers die under memory
+    pressure), so a later INTERNALERROR is not necessarily caused by the
+    recorded crashes. The block replays what was RECORDED earlier in this
+    run and leaves attribution to the reader.
+    """
+    lines = [
+        "",
+        "=" * 72,
+        f"xdist run ABANDONED: INTERNALERROR after {len(crashes)} crashed-worker "
+        f"replacement{'s' if len(crashes) != 1 else ''}",
+        "=" * 72,
+        "pytest hit an INTERNALERROR after replacing crashed workers, so the",
+        "normal 'short test summary info' section was never written. The worker",
+        "crashes recorded earlier in this run are replayed here so this red",
+        "stays diagnosable:",
+        "",
+        "Crashed workers:",
+    ]
+    for worker_id, error in crashes:
+        # The error is commonly a remote traceback: its FIRST line is the
+        # constant "Traceback (most recent call last):", so the last
+        # non-empty line (the exception itself) is the informative one.
+        stripped = [ln for ln in error.strip().splitlines() if ln.strip()]
+        summary = stripped[-1].strip() if stripped else error
+        lines.append(f"    {worker_id}: {summary}")
+    if victims:
+        lines.append("")
+        lines.append("Tests running when their worker died (recorded earlier in this run):")
+        for victim in victims:
+            lines.append(f"    {victim}")
+    else:
+        lines.append("")
+        lines.append("No in-flight test was recorded for the crashed workers.")
+    lines.append("")
+    lines.append("The run still fails (INTERNALERROR, non-zero exit); this block only")
+    lines.append("preserves the report that the crash would otherwise erase.")
+    lines.append("=" * 72)
+    return "\n".join(lines)
+
+
+def pytest_internalerror(excrepr, excinfo) -> None:
+    """Replay recorded worker crashes when an INTERNALERROR kills the run.
+
+    Written to ``sys.stderr`` directly rather than through the terminal
+    reporter: this hook runs on a path where pytest's own reporting machinery
+    has already failed, and stderr is the one sink that cannot depend on it.
+    Returns ``None`` (never ``True``) so pytest still prints the
+    ``INTERNALERROR>`` traceback and exits 3 -- the goal is a diagnosable red,
+    not a green.
+    """
+    if not _crashed_workers:
+        return
+    print(
+        _format_abandoned_run_report(list(_crashed_workers), list(_crash_victims)),
+        file=sys.stderr,
+        flush=True,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_xdist_internalerror_report.py
+++ b/test/test_xdist_internalerror_report.py
@@ -1,0 +1,114 @@
+"""Regression tests for the xdist INTERNALERROR terminal report (issue #2803).
+
+When a second pytest-timeout worker kill lands in one ``--dist loadgroup``
+shard, xdist's loadscope scheduler can die with an INTERNALERROR at exit 3
+and no ``short test summary info`` section -- the whole shard's report is
+erased. ``test/conftest.py`` preserves the report by recording each crashed
+worker (``pytest_testnodedown``) and its in-flight test
+(``pytest_handlecrashitem``) and replaying them from ``pytest_internalerror``.
+
+The real crash needs two timeout kills in the same shard and is a flake, so
+these tests drive the hooks directly with synthetic state instead of trying
+to reproduce it. They fail on base with ImportError: the hooks did not exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from conftest import (
+    _crash_victims,
+    _crashed_workers,
+    _format_abandoned_run_report,
+    _reset_xdist_crash_state,
+    pytest_handlecrashitem,
+    pytest_internalerror,
+    pytest_testnodedown,
+)
+
+
+class _FakeGateway:
+    def __init__(self, gw_id: str) -> None:
+        self.id = gw_id
+
+
+class _FakeNode:
+    def __init__(self, gw_id: str) -> None:
+        self.gateway = _FakeGateway(gw_id)
+
+
+@pytest.fixture(autouse=True)
+def _clean_crash_state():
+    """Isolate the module-level crash record from other tests in this worker."""
+    _reset_xdist_crash_state()
+    yield
+    _reset_xdist_crash_state()
+
+
+def test_internalerror_report_names_victims_and_replacement_count(capsys):
+    """The abandoned-run report names every victim and the replacement count."""
+    pytest_testnodedown(_FakeNode("gw1"), "worker gw1 crashed (pytest-timeout)")
+    pytest_handlecrashitem("test/test_slow_a.py::test_hangs", report=None, sched=None)
+    pytest_testnodedown(_FakeNode("gw2"), "worker gw2 crashed (pytest-timeout)")
+    pytest_handlecrashitem("test/test_slow_b.py::test_also_hangs", report=None, sched=None)
+
+    result = pytest_internalerror(excrepr="INTERNALERROR> KeyError: gw2", excinfo=None)
+
+    # MUST NOT swallow the failure: returning True would suppress pytest's own
+    # INTERNALERROR traceback. The hook only adds output.
+    assert result is None
+    err = capsys.readouterr().err
+    assert "ABANDONED: INTERNALERROR after 2 crashed-worker replacements" in err
+    assert "gw1" in err
+    assert "gw2" in err
+    assert "test/test_slow_a.py::test_hangs" in err
+    assert "test/test_slow_b.py::test_also_hangs" in err
+
+
+def test_internalerror_without_worker_crashes_is_silent(capsys):
+    """A non-xdist internal error must be reported exactly as before."""
+    result = pytest_internalerror(excrepr="INTERNALERROR> boom", excinfo=None)
+
+    assert result is None
+    # Substring check, not exact equality: unrelated stderr noise (GC-time
+    # asyncio warnings, first-use library warnings) must not flake this test.
+    assert "ABANDONED" not in capsys.readouterr().err
+
+
+def test_traceback_error_is_summarized_by_its_last_line():
+    """A multi-line remote traceback yields its exception line, not the
+    constant 'Traceback (most recent call last):' header."""
+    traceback_text = (
+        "Traceback (most recent call last):\n"
+        '  File "dsession.py", line 273, in worker_collectionfinish\n'
+        "    self.sched.schedule()\n"
+        "KeyError: <WorkerController gw5>\n"
+    )
+    report = _format_abandoned_run_report([("gw5", traceback_text)], [])
+
+    assert "gw5: KeyError: <WorkerController gw5>" in report
+    assert "gw5: Traceback" not in report
+
+
+def test_clean_worker_shutdown_is_not_recorded():
+    """``pytest_testnodedown`` with error=None (normal exit) records nothing."""
+    pytest_testnodedown(_FakeNode("gw0"), None)
+
+    assert _crashed_workers == []
+    assert _crash_victims == []
+
+
+def test_singular_replacement_count_and_missing_victim():
+    """One crash reads 'replacement' (singular); no victim gets an explicit line."""
+    report = _format_abandoned_run_report([("gw3", "worker gw3 crashed")], [])
+
+    assert "after 1 crashed-worker replacement" in report
+    assert "replacements" not in report
+    assert "No in-flight test was recorded" in report
+
+
+def test_node_without_gateway_id_is_still_recorded():
+    """A node whose gateway id cannot be read still yields a report entry."""
+    pytest_testnodedown(object(), "worker crashed hard")
+
+    assert _crashed_workers == [("<unknown worker>", "worker crashed hard")]


### PR DESCRIPTION
## Problem / Motivation

When a **second** pytest-timeout worker kill lands in the same xdist `--dist loadgroup` shard, xdist's loadscope scheduler can die with `INTERNALERROR> KeyError: <WorkerController gwN>` and pytest exits 3 **without a `short test summary info` section at all**. The job reports "2 failed" and then names neither failure — the whole shard's report is erased, and the operator is left with an uninterpretable red (observed on `Backend Tests (Windows) (1)`, run 31477872732).

## Why it matters

A single-timeout shard exits 1 and names its victim; a double-timeout shard degrades to a red with no starting point. That is a CI-trust problem independent of whatever caused the timeouts. Context on frequency: PR #2777 landing should cut the timeout supply sharply (today's timeouts come from a single flake), but the report-loss fragility is independent of its current cause, so it stays worth fixing even at low frequency — this PR deliberately does not oversell the impact.

## What changed (motivation → approach → change)

Symptom: the INTERNALERROR pre-empts terminal reporting, so everything the run knew about the crashed workers dies with the scheduler. Root cause is an upstream xdist defect (a replaced node present in `assigned_work` but missing from `registered_collections`); the repo-side fix worth having is **report preservation**, not a scheduler patch.

Intervention point: the **`pytest_internalerror` hook**, chosen over a scheduler wrapper or a `--dist` change because it fires ONLY on the already-broken path — a healthy run never reaches it, so scheduling and grouping for every passing shard are untouched. It lives in `test/conftest.py`, where the repo's xdist knowledge already is (`pytest_xdist_auto_num_workers`, worker-slot `pytest_sessionfinish`).

Mechanics: two controller-side xdist hooks record state as the run progresses — `pytest_testnodedown` records each crashed worker (id + error, summarized by the last non-empty line, where the exception lives in a remote traceback) and `pytest_handlecrashitem` records the test each crashed worker was running. When an INTERNALERROR then kills the run, `pytest_internalerror` replays them to stderr as an `xdist run ABANDONED` banner naming the replacement count, the crashed workers, and the in-flight tests. The wording is deliberately non-causal (the recorded crashes may not be what killed the scheduler), and the block is emitted only when a worker crash was actually recorded, so a non-xdist internal error is reported exactly as before.

**The failure is NOT swallowed**: the hook returns `None`, so pytest still prints its own `INTERNALERROR>` traceback and exits 3. The goal is turning an uninterpretable red into a diagnosable red — a change that made this scenario look green would be a regression.

Explicitly out of scope (deliberate, per the triage routing on the issue): the `pytest-xdist>=3` version constraint (`setup.cfg`) and the repo-wide `--dist` strategy — both are shared-CI decisions with their own blast radius.

`docs/system-specs/common/testing-conventions.md` gains a short paragraph in the xdist-flags section so a maintainer hitting the unfamiliar banner has something to grep.

## Tests

`test/test_xdist_internalerror_report.py` (new) drives the hooks directly with synthetic state — the real crash needs two timeout kills in one shard and is a flake, so it is deliberately not reproduced in CI:

- `test_internalerror_report_names_victims_and_replacement_count` — the report names every victim test, every crashed worker, and the replacement count; and the hook returns `None` (never `True`), locking in that pytest's own INTERNALERROR handling still runs.
- `test_internalerror_without_worker_crashes_is_silent` — a non-xdist internal error emits nothing.
- `test_clean_worker_shutdown_is_not_recorded` — `pytest_testnodedown` with `error=None` (normal exit) records nothing.
- `test_singular_replacement_count_and_missing_victim` — grammar + explicit no-victim line.
- `test_traceback_error_is_summarized_by_its_last_line` — a multi-line remote traceback is summarized by its exception line, not the constant `Traceback (most recent call last):` header.
- `test_node_without_gateway_id_is_still_recorded` — a node with no readable gateway id still yields an entry.

Proven to fail on base: without the conftest hooks the test file dies at collection with ImportError.

## Manual verification

N/A — unit coverage sufficient: the hook is driven directly with the same synthetic state xdist would feed it, and reproducing the real double-timeout crash requires a flaky two-kill race that cannot be forced deterministically.

## Related Issues

Closes #2803

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
