### PR TITLE
fix(apps): read process start time through a cross-platform shim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,7 @@ Kiro Crew runs on macOS, Linux (x86_64 and ARM), and Windows (native). `fcntl`,
 | Kill a tree | `kill_process_tree(pid, sig)` | `os.killpg(os.getpgid(pid), sig)` |
 | Parent PID | `get_ppid(pid)` | `/proc` read / libproc |
 | Match process cmdline | `process_matches(pid, needles)` | `/proc/<pid>/cmdline` / `ps` |
+| Process start time (PID-reuse guard) | `process_start_time(pid)` | `/proc/<pid>/stat` / `ps -o lstart=` (both answer `None` on Windows, so the guard silently never confirms) |
 | Signals | `platform_compat.SIGKILL` / `SIGTERM` | `signal.SIGKILL` (undefined on Windows) |
 | Spawn isolation | `start_new_session=IS_POSIX` + `creationflags=CREATE_NEW_PROCESS_GROUP` | bare `start_new_session=True` |
 | File mode | `chmod_safe(path, mode)` / `fchmod_safe(fd, mode)` | `os.chmod` / `os.fchmod` (no `os.fchmod` on Windows) |

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -76,7 +76,6 @@ _BOOT_SPAWN_MAX_WORKERS = 8
 # applied PER orphan, not shared across the batch.
 _REAP_SIGTERM_GRACE = 3.0  # seconds to wait for an orphan to exit after SIGTERM
 _REAP_POLL_INTERVAL = 0.1  # liveness re-poll cadence during the grace window
-_PS_TIMEOUT = 2  # seconds before a `ps` start-time probe is abandoned
 
 
 # ---------------------------------------------------------------------------
@@ -1385,25 +1384,14 @@ def _proc_start_time(pid: int) -> str | None:
     prior generation against one read now), so it cannot use ``hash()`` — that
     is salted per interpreter by ``PYTHONHASHSEED``.
 
-    Linux reads ``/proc/<pid>/stat`` field 22 (start time in clock ticks since
-    boot): monotonic, locale-independent, and far finer than 1s, so same-second
-    PID reuse cannot alias. macOS falls back to ``ps -o lstart=`` (1s resolution,
-    locale/TZ-formatted); a format/resolution drift there can only make the guard
-    FAIL SAFE (decline to reap → orphan leaks), never kill the wrong process.
+    Per-platform sources live in ``platform_compat.process_start_time``: Linux
+    reads ``/proc/<pid>/stat`` field 22, Windows the process creation FILETIME
+    through a query-only handle, and other POSIX ``ps -o lstart=``. Resolving it
+    there is what keeps the guard alive on Windows — a ``/proc``-or-``ps`` probe
+    answers None for every pid there, and a recorded None makes the reap decline
+    to confirm ANY backend, so nothing is ever reaped and the entries accumulate.
     """
-    try:
-        if sys.platform == "linux":
-            stat = Path(f"/proc/{pid}/stat").read_text()
-            # The comm field can contain spaces/parens; split after the last ')'.
-            fields = stat.rsplit(")", 1)[1].split()
-            return fields[19]  # field 22 (1-based) = starttime in clock ticks
-        out = subprocess.check_output(
-            ["ps", "-o", "lstart=", "-p", str(pid)],
-            stderr=subprocess.DEVNULL, timeout=_PS_TIMEOUT,
-        )
-        return out.decode().strip() or None
-    except (OSError, ValueError, IndexError, subprocess.SubprocessError):
-        return None
+    return platform_compat.process_start_time(pid)
 
 
 def _pid_alive(pid: int) -> bool:
@@ -1452,11 +1440,12 @@ def _record_app_pid(app_name: str, pid: int, port: int) -> None:
     if pid <= 0:
         return
     try:
-        # Compute start_time BEFORE taking the lock: on macOS _proc_start_time
-        # shells out to `ps` (up to _PS_TIMEOUT), and holding _pidfile_lock
-        # across that slow IO would serialize concurrent enable/stop/uninstall
-        # ops behind it. Mirrors the reap path's validate-lock-free /
-        # store-under-lock discipline.
+        # Compute start_time BEFORE taking the lock: the probe is slow on the
+        # platforms that cannot answer from memory (a `ps` spawn on macOS, an
+        # OpenProcess round trip on Windows), and holding _pidfile_lock across
+        # that IO would serialize concurrent enable/stop/uninstall ops behind
+        # it. Mirrors the reap path's validate-lock-free / store-under-lock
+        # discipline.
         start_time = _proc_start_time(pid)
         with _pidfile_lock:
             data = _read_pidfile()
@@ -1536,9 +1525,24 @@ def _reap_stale_app_backends() -> int:
             )
             continue
         try:
-            platform_compat.kill_process_tree(pid, platform_compat.SIGTERM)
+            # Identity-PINNED: on Windows the handle that re-verifies the start
+            # time stays open across the terminate, so the pid taskkill resolves
+            # cannot have been recycled between the check above and the signal.
+            # False means the identity could not be pinned -- keep the entry
+            # (omit from ``handled``) and retry on a later start, exactly as the
+            # unconfirmed-start_time branch above does. POSIX delegates straight
+            # through and is unchanged.
+            signalled = platform_compat.kill_process_tree_pinned(
+                pid, recorded_st, platform_compat.SIGTERM
+            )
         except (ProcessLookupError, OSError):
             handled[app_name] = entry  # gone between the probe and the signal
+            continue
+        if not signalled:
+            logger.info(
+                "Skipping stale-reap of %s pid %d: identity could not be pinned for the kill",
+                app_name, pid,
+            )
             continue
         handled[app_name] = entry
         # Carry recorded_st so the delayed SIGKILL can re-confirm identity before
@@ -1574,7 +1578,17 @@ def _reap_stale_app_backends() -> int:
             )
             continue
         try:
-            platform_compat.kill_process_tree(pid, platform_compat.SIGKILL)
+            # Same pinning as the SIGTERM path, and it matters more here: this is
+            # the destructive escalation, and the grace window above is exactly
+            # the interval in which the pid can be recycled.
+            if not platform_compat.kill_process_tree_pinned(
+                pid, recorded_st, platform_compat.SIGKILL
+            ):
+                logger.info(
+                    "Skipping stale-reap SIGKILL of %s pid %d: identity could not be pinned",
+                    app_name, pid,
+                )
+                continue
         except (ProcessLookupError, OSError):
             continue
         try:

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -2021,6 +2021,78 @@ def pid_exists(pid: int) -> bool:
         return False
 
 
+#: Seconds before the ``ps`` start-time probe is abandoned. Only the BSD leg
+#: spawns anything; Linux reads /proc and Windows calls the kernel directly.
+_START_TIME_PS_TIMEOUT = 2
+
+
+def process_start_time(pid: int) -> str | None:
+    """Stable identity for WHEN *pid* started, or ``None`` when unreadable.
+
+    An opaque token whose only contract is that it compares equal across gateway
+    generations on the same host while the PID still names the same process
+    object, and unequal once that PID has been recycled onto another. Units
+    differ per platform and are deliberately not normalised -- nothing ever
+    compares one host's value against another's, and no caller parses it.
+
+    Callers use it as a PID-reuse guard before signalling, so an unreadable
+    value must fail SAFE: ``None`` means "identity unconfirmed", which every
+    caller treats as "do not kill".
+
+    * **Linux** -- ``/proc/<pid>/stat`` field 22 (start time in clock ticks
+      since boot): monotonic, locale-independent, and far finer than 1s, so
+      same-second reuse cannot alias.
+    * **Windows** -- the process creation ``FILETIME`` (100-ns units), read
+      through a QUERY-ONLY handle. Terminate rights are deliberately NOT
+      requested: this value is what decides whether a kill may happen at all, so
+      demanding the right to kill in order to read it would refuse the guard for
+      exactly the processes a caller must be most careful about.
+    * **macOS / other POSIX** -- ``ps -o lstart=`` (1s resolution, locale/TZ
+      formatted). Coarser, so a format or resolution drift can only make the
+      guard decline to act, never act on the wrong process.
+    """
+    if sys.platform == "linux":
+        try:
+            stat = Path(f"/proc/{pid}/stat").read_text()
+            # The comm field can contain spaces and parens; split after the
+            # LAST ')' so a process named "(evil) 1 2 3" cannot shift the index.
+            return stat.rsplit(")", 1)[1].split()[19]
+        except (OSError, ValueError, IndexError):
+            return None
+    if IS_WINDOWS:
+        # Opened and closed through the shared seams so this READ and the
+        # identity-pinned TERMINATE below cannot drift in how they acquire or
+        # release the handle -- the difference between the two is the handle's
+        # LIFETIME, and that is easier to reason about with one acquisition site.
+        handle = _open_process_query_handle(pid)
+        if handle is None:
+            return None
+        try:
+            identity = _windows_process_handle_identity(handle)
+        finally:
+            _close_process_handle(handle)
+        # (pid, creation_time, exit_time) -- only the creation half is an
+        # identity; exit_time moves as the process dies.
+        return str(identity[1]) if identity is not None else None
+    ps_bin = trusted_system_bin("ps")
+    if ps_bin is None:
+        return None
+    try:
+        out = subprocess.check_output(
+            [ps_bin, "-o", "lstart=", "-p", str(pid)],
+            stderr=subprocess.DEVNULL,
+            timeout=_START_TIME_PS_TIMEOUT,
+        )
+        # STRICT decode. A lossy one would turn unreadable bytes into a
+        # non-empty string, so the caller would accept garbage as a confirmed
+        # identity -- and two different processes whose output both decoded to
+        # replacement characters would compare equal. Undecodable output means
+        # the probe cannot be trusted, which is the None case.
+        return out.decode().strip() or None
+    except (OSError, UnicodeError, subprocess.SubprocessError):
+        return None
+
+
 def process_thread_count(pid: int) -> int | None:
     """Thread count of *pid*, or ``None`` when it cannot be determined.
 
@@ -2275,6 +2347,92 @@ def kill_process_tree(pid: int, sig: int = SIGTERM) -> bool:
     if r.returncode != 0:
         _raise_taskkill_error(pid, r.returncode, r.stderr or r.stdout)
     return True
+
+
+def _open_process_query_handle(pid: int) -> int | None:
+    """Open a QUERY-ONLY Windows handle to *pid*, or ``None``.
+
+    Terminate rights are deliberately NOT requested: the callers use this handle
+    to decide whether a kill may happen at all, so demanding the right to kill in
+    order to read the identity would refuse the guard for exactly the processes a
+    caller must be most careful about.
+
+    Returns ``None`` on every non-Windows platform, and on any failure -- an
+    unopenable process is one whose identity cannot be confirmed, which every
+    caller must treat as "do not kill".
+    """
+    if not IS_WINDOWS:
+        return None
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+        kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        handle = kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    except Exception:
+        return None
+    return int(handle) if handle else None
+
+
+def _close_process_handle(handle: int) -> None:
+    """Release a handle from :func:`_open_process_query_handle`. Never raises."""
+    if not IS_WINDOWS or type(handle) is not int or handle <= 0:
+        return
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        kernel32.CloseHandle(wintypes.HANDLE(handle))
+    except Exception:
+        logger.debug("CloseHandle failed for process handle %d", handle, exc_info=True)
+
+
+def kill_process_tree_pinned(
+    pid: int, expected_start_time: str, sig: int = SIGTERM
+) -> bool:
+    """Kill *pid*'s tree only while its verified identity is PINNED OPEN.
+
+    :func:`kill_process_tree` addresses the target by PID, and on Windows it
+    does so from a separate ``taskkill`` process. A caller that merely read the
+    start time first has released every handle by then, so between the check and
+    the terminate the process can exit and Windows can recycle the PID onto an
+    unrelated process -- which ``taskkill /T /F /PID`` would then tear down with
+    its whole tree. The check is only as good as the window after it.
+
+    Windows keeps a process ID reserved for as long as ANY handle to the process
+    object remains open, so holding the query handle that verified the identity
+    across the terminate is what makes the PID still mean the same process when
+    ``taskkill`` resolves it. That is the guarantee this function adds, and the
+    only reason it exists.
+
+    Returns ``False`` -- WITHOUT invoking any kill -- when the handle cannot be
+    opened or the identity does not match *expected_start_time*. Callers must
+    treat that as "identity unconfirmed, do not reap", the same fail-safe the
+    start-time comparison already gives them. On a match it delegates to
+    :func:`kill_process_tree` and propagates its exceptions unchanged, so
+    ``except (ProcessLookupError, OSError)`` handlers keep firing as before.
+
+    POSIX is deliberately untouched: it delegates straight through, because
+    ``os.killpg`` is issued in-process by the same interpreter that did the
+    check and there is no handle to hold. The residual probe-to-signal window
+    there is the pre-existing one the callers already mitigate by re-confirming
+    identity before the destructive escalation.
+    """
+    if not IS_WINDOWS:
+        return kill_process_tree(pid, sig)
+    handle = _open_process_query_handle(pid)
+    if handle is None:
+        return False
+    try:
+        identity = _windows_process_handle_identity(handle)
+        # (pid, creation_time, exit_time) -- the creation half is the identity.
+        if identity is None or str(identity[1]) != expected_start_time:
+            return False
+        # The handle stays open for the whole call: taskkill resolves the PID
+        # while this process object is still referenced, so the PID cannot have
+        # been recycled onto a different process in between.
+        return kill_process_tree(pid, sig)
+    finally:
+        _close_process_handle(handle)
 
 
 async def kill_pid_async(pid: int, sig: int = SIGTERM) -> bool:

--- a/test/test_app_backend_stale_reap.py
+++ b/test/test_app_backend_stale_reap.py
@@ -33,6 +33,64 @@ def test_record_read_forget_roundtrip(pidfile):
     assert "code_reviewer" not in backend_mod._read_pidfile()
 
 
+def _model_a_host_without_ps(monkeypatch, *, identity):
+    """Model a platform whose start-time probe is NOT `/proc` and NOT `ps`.
+
+    That is precisely Windows: `sys.platform` is not "linux", and there is no
+    standard `ps` for the fallback to reach. `platform_compat` is the layer that
+    can still answer there (process creation FILETIME through a query-only
+    handle) — its real per-platform behaviour is pinned in test_platform_compat.
+    """
+    monkeypatch.setattr(backend_mod.sys, "platform", "win32")
+
+    def _no_ps(*_a, **_k):
+        raise FileNotFoundError(2, "No such file or directory", "ps")
+
+    monkeypatch.setattr(backend_mod.subprocess, "check_output", _no_ps)
+    monkeypatch.setattr(
+        backend_mod.platform_compat, "process_start_time", lambda _pid: identity
+    )
+
+
+def test_a_host_without_ps_still_records_a_reapable_identity(pidfile, monkeypatch):
+    """The stale-reap must not be structurally dead on a `ps`-less platform.
+
+    `_record_app_pid` stores whatever the start-time probe returns, and the reap
+    refuses to signal when the recorded identity is falsy ("identity unconfirmed
+    -> do not kill", and the entry is KEPT). A probe that can only answer via
+    `/proc` or `ps` therefore records None on Windows, and every stale backend
+    there survives forever while its pidfile entry accumulates — the reap fails
+    safe into never reaping at all.
+    """
+    _model_a_host_without_ps(monkeypatch, identity="WIN-CREATION-8817")
+
+    backend_mod._record_app_pid("code_reviewer", 4321, 9100)
+
+    entry = backend_mod._read_pidfile()["code_reviewer"]
+    assert entry["start_time"] == "WIN-CREATION-8817", (
+        "no start-time identity was recorded on a host without /proc or ps, so "
+        "the stale-reap can never positively identify this backend")
+
+    # The consequence: with an identity on file, the reap can now confirm and act
+    # -- and the recorded identity is what the terminate is PINNED to, so the
+    # chain from probe to kill carries one value end to end.
+    killed: list[tuple[int, str, int]] = []
+    monkeypatch.setattr(
+        backend_mod.platform_compat, "pid_liveness",
+        lambda _pid: backend_mod.platform_compat.PID_ALIVE,
+    )
+    monkeypatch.setattr(
+        backend_mod.platform_compat, "kill_process_tree_pinned",
+        lambda pid, expected, sig: bool(killed.append((pid, expected, sig))) or True,
+    )
+    monkeypatch.setattr(backend_mod, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(backend_mod, "sel", lambda: None)
+
+    assert backend_mod._reap_stale_app_backends() == 1
+    assert killed and killed[0][:2] == (4321, "WIN-CREATION-8817")
+    assert backend_mod._read_pidfile() == {}, "the handled entry was not cleared"
+
+
 def test_record_ignores_nonpositive_pid(pidfile):
     backend_mod._record_app_pid("x", 0, 9100)
     assert backend_mod._read_pidfile() == {}
@@ -298,3 +356,71 @@ def test_reap_skips_sigkill_when_pid_recycled_during_grace(pidfile):
         n = backend_mod._reap_stale_app_backends()
     assert n == 1  # the SIGTERM was sent, so it counts as reaped
     assert sigkilled == []  # but the recycled pid must NOT be SIGKILLed
+
+
+def test_reap_keeps_the_entry_when_the_kill_identity_cannot_be_pinned(pidfile):
+    """The reap goes through the identity-PINNED terminate, and honours its refusal.
+
+    ``kill_process_tree_pinned`` returns False when the process cannot be opened
+    or its identity no longer matches, which on Windows is the pid having been
+    recycled between the start-time check and the signal. That must behave like
+    every other unconfirmed-identity case here: no kill, and the entry is KEPT so
+    a later start can retry -- leak-not-mis-kill.
+
+    Liveness is stubbed at ``platform_compat.pid_liveness`` rather than at
+    ``os.kill`` so the case is about the pin and runs identically on every host;
+    the Windows liveness probe is an ``OpenProcess``, not an ``os.kill``.
+    """
+    backend_mod._write_pidfile({"app": {"pid": 4321, "start_time": "ST-1", "port": 9100}})
+    with (
+        patch.object(backend_mod, "_proc_start_time", return_value="ST-1"),
+        patch.object(
+            backend_mod.platform_compat,
+            "pid_liveness",
+            return_value=backend_mod.platform_compat.PID_ALIVE,
+        ),
+        patch.object(
+            backend_mod.platform_compat, "kill_process_tree_pinned", return_value=False
+        ) as mock_pinned,
+        patch.object(backend_mod, "sel"),
+    ):
+        n = backend_mod._reap_stale_app_backends()
+
+    assert n == 0
+    mock_pinned.assert_called_once()
+    assert "app" in backend_mod._read_pidfile(), "an unpinnable entry must be retried"
+
+
+def test_reap_hands_the_recorded_identity_to_the_pinned_kill(pidfile):
+    """The pin must re-verify against the RECORDED baseline, not a fresh read.
+
+    Re-reading inside the pin would compare the process against itself and
+    confirm any pid, which is the check the window exists to survive.
+    """
+    backend_mod._write_pidfile({"app": {"pid": 4321, "start_time": "ST-1", "port": 9100}})
+    alive = {"v": True}
+
+    def fake_pinned(pid, expected, sig):
+        alive["v"] = False  # the terminate took effect
+        return True
+
+    with (
+        patch.object(backend_mod, "_proc_start_time", return_value="ST-1"),
+        patch.object(
+            backend_mod.platform_compat,
+            "pid_liveness",
+            return_value=backend_mod.platform_compat.PID_ALIVE,
+        ),
+        patch.object(backend_mod, "_pid_alive", side_effect=lambda pid: alive["v"]),
+        patch.object(
+            backend_mod.platform_compat,
+            "kill_process_tree_pinned",
+            side_effect=fake_pinned,
+        ) as mock_pinned,
+        patch.object(backend_mod, "sel"),
+    ):
+        n = backend_mod._reap_stale_app_backends()
+
+    assert n == 1
+    assert mock_pinned.call_args.args[:2] == (4321, "ST-1")
+    assert backend_mod._read_pidfile() == {}

--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -1287,73 +1287,26 @@ class TestPidfileHelpers:
 
 
 class TestProcStartTime:
-    def test_linux_reads_the_starttime_field_past_a_parenthesised_comm(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Splitting on the FIRST ')' would mis-index any comm containing one."""
+    """The wrapper must not re-implement the per-platform probe.
 
-        tail = " ".join(str(i) for i in range(4, 24))
-        stat = f"4242 (my (odd) proc) S 1 {tail}"
+    Every platform source (Linux /proc field 22, the Windows creation
+    FILETIME, the BSD ``ps`` leg) and its fail-safe behaviour is pinned in
+    test_platform_compat::TestProcessStartTime. What matters here is that this
+    module reads identity from that shim, because a /proc-or-ps probe answers
+    None for every pid on Windows and a recorded None makes the stale-reap
+    decline to confirm any backend at all.
+    """
 
-        class _FakeStatPath:
-            def __init__(self, _p: str) -> None:
-                pass
+    def test_it_delegates_to_the_platform_shim(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: list[int] = []
 
-            def read_text(self) -> str:
-                return stat
+        def _probe(pid: int) -> str:
+            seen.append(pid)
+            return "ST-FROM-SHIM"
 
-        monkeypatch.setattr(bmod.sys, "platform", "linux")
-        monkeypatch.setattr(bmod, "Path", _FakeStatPath)
-        assert bmod._proc_start_time(4242) == "21"
-
-    def test_a_malformed_stat_line_yields_no_identity(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        class _FakeStatPath:
-            def __init__(self, _p: str) -> None:
-                pass
-
-            def read_text(self) -> str:
-                return "no closing paren here"
-
-        monkeypatch.setattr(bmod.sys, "platform", "linux")
-        monkeypatch.setattr(bmod, "Path", _FakeStatPath)
-        assert bmod._proc_start_time(4242) is None
-
-    def test_non_linux_shells_out_to_ps(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(bmod.sys, "platform", "darwin")
-        monkeypatch.setattr(
-            bmod.subprocess, "check_output", lambda *_a, **_k: b" Mon Jan  1 00:00:00 2024\n"
-        )
-        assert bmod._proc_start_time(4242) == "Mon Jan  1 00:00:00 2024"
-
-    def test_empty_ps_output_yields_no_identity(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(bmod.sys, "platform", "darwin")
-        monkeypatch.setattr(bmod.subprocess, "check_output", lambda *_a, **_k: b"\n")
-        assert bmod._proc_start_time(4242) is None
-
-    def test_a_failed_ps_probe_yields_no_identity(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        def _boom(*_a: Any, **_k: Any) -> bytes:
-            raise OSError("no ps")
-
-        monkeypatch.setattr(bmod.sys, "platform", "darwin")
-        monkeypatch.setattr(bmod.subprocess, "check_output", _boom)
-        assert bmod._proc_start_time(4242) is None
-
-    def test_pid_alive_delegates_to_the_platform_shim(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
-        assert bmod._pid_alive(4242) is True
-
-
-# ---------------------------------------------------------------------------
-# Health-gated MCP registration
-# ---------------------------------------------------------------------------
+        monkeypatch.setattr(bmod.platform_compat, "process_start_time", _probe)
+        assert bmod._proc_start_time(4242) == "ST-FROM-SHIM"
+        assert seen == [4242]
 
 
 class TestGateMcpRegistration:
@@ -1853,21 +1806,25 @@ class TestReapDefensiveBranches:
                 "zero": {"pid": 0, "start_time": "ST", "port": 9101},
             }
         )
-        monkeypatch.setattr(
-            bmod.platform_compat,
-            "kill_process_tree",
-            lambda *_a: pytest.fail("signalled an unusable pidfile entry"),
-        )
+        for _name in ("kill_process_tree", "kill_process_tree_pinned"):
+            monkeypatch.setattr(
+                bmod.platform_compat,
+                _name,
+                lambda *_a: pytest.fail("signalled an unusable pidfile entry"),
+            )
         assert bmod._reap_stale_app_backends() == 0
         assert bmod._read_pidfile() == {}
 
     def test_a_pid_that_exits_before_the_signal_is_dropped(
         self, matched_orphan: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def _gone(_pid: int, _sig: int) -> None:
+        def _gone(_pid: int, _expected: str, _sig: int) -> bool:
             raise ProcessLookupError
 
-        monkeypatch.setattr(bmod.platform_compat, "kill_process_tree", _gone)
+        # Patched at the PINNED entry point, which is what the reap calls now.
+        # Patching the inner ``kill_process_tree`` would leave the real handle
+        # work in front of it and make the case host-dependent.
+        monkeypatch.setattr(bmod.platform_compat, "kill_process_tree_pinned", _gone)
         assert bmod._reap_stale_app_backends() == 0
         assert bmod._read_pidfile() == {}
 
@@ -1880,7 +1837,9 @@ class TestReapDefensiveBranches:
         signals: list[int] = []
         monkeypatch.setattr(bmod, "sel", _no_sel)
         monkeypatch.setattr(
-            bmod.platform_compat, "kill_process_tree", lambda _pid, sig: signals.append(sig)
+            bmod.platform_compat,
+            "kill_process_tree_pinned",
+            lambda _pid, _expected, sig: bool(signals.append(sig)) or True,
         )
         assert bmod._reap_stale_app_backends() == 1
         assert signals == [
@@ -1891,10 +1850,11 @@ class TestReapDefensiveBranches:
     def test_a_pid_that_exits_before_the_escalation_is_not_an_error(
         self, matched_orphan: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def _kill(_pid: int, sig: int) -> None:
+        def _kill(_pid: int, _expected: str, sig: int) -> bool:
             if sig == bmod.platform_compat.SIGKILL:
                 raise ProcessLookupError
+            return True
 
-        monkeypatch.setattr(bmod.platform_compat, "kill_process_tree", _kill)
+        monkeypatch.setattr(bmod.platform_compat, "kill_process_tree_pinned", _kill)
         assert bmod._reap_stale_app_backends() == 1
         assert bmod._read_pidfile() == {}

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -20,6 +20,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import types
 from pathlib import Path
@@ -933,6 +934,131 @@ class TestProcessIdentityPosix:
         assert isinstance(result, bool)
         if pc.IS_POSIX:
             assert result is False
+
+
+class TestProcessStartTime:
+    """The identity source every PID-reuse guard compares before signalling.
+
+    The value is opaque and its units differ per platform; the contract is only
+    that it is stable for one process object on one host and that an unreadable
+    answer is ``None`` — which every caller treats as "identity unconfirmed, do
+    not kill".
+    """
+
+    def test_this_process_has_a_stable_identity(self):
+        first = pc.process_start_time(os.getpid())
+        assert first, "no start-time identity for the running process"
+        assert pc.process_start_time(os.getpid()) == first, "identity is not stable"
+
+    def test_an_unreadable_pid_fails_safe(self):
+        # PID 0 is never a queryable user process on any supported platform.
+        assert pc.process_start_time(0) is None
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc contract")
+    def test_linux_reports_stat_field_22(self):
+        stat_text = Path(f"/proc/{os.getpid()}/stat").read_text()
+        expected = stat_text.rsplit(")", 1)[1].split()[19]
+        assert pc.process_start_time(os.getpid()) == expected
+
+    @pytest.mark.skipif(not pc.IS_WINDOWS, reason="Windows creation-FILETIME contract")
+    def test_windows_reports_a_positive_creation_filetime(self):
+        value = pc.process_start_time(os.getpid())
+        assert value is not None and value.isdigit()
+        assert int(value) > 0
+
+    def test_linux_reads_the_starttime_field_past_a_parenthesised_comm(self, monkeypatch):
+        """Splitting on the FIRST ')' would mis-index any comm containing one."""
+
+        tail = " ".join(str(i) for i in range(4, 24))
+
+        class _FakeStatPath:
+            def __init__(self, _p):
+                pass
+
+            def read_text(self):
+                return f"4242 (my (odd) proc) S 1 {tail}"
+
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        monkeypatch.setattr(pc, "Path", _FakeStatPath)
+        assert pc.process_start_time(4242) == "21"
+
+    def test_a_malformed_stat_line_fails_safe(self, monkeypatch):
+        class _FakeStatPath:
+            def __init__(self, _p):
+                pass
+
+            def read_text(self):
+                return "no closing paren here"
+
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        monkeypatch.setattr(pc, "Path", _FakeStatPath)
+        assert pc.process_start_time(4242) is None
+
+    def test_the_bsd_leg_resolves_ps_through_trusted_system_bin(self, monkeypatch):
+        """A PATH-resolved `ps` would let a planted binary forge process identity.
+
+        The value gates a kill, so its source binary must come from the pinned
+        lookup rather than whatever `PATH` leads with.
+        """
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/usr/bin/ps")
+        seen: list[list[str]] = []
+
+        def _check_output(argv, **_k):
+            seen.append(list(argv))
+            return b" Mon Jan  1 00:00:00 2024\n"
+
+        monkeypatch.setattr(pc.subprocess, "check_output", _check_output)
+
+        assert pc.process_start_time(4242) == "Mon Jan  1 00:00:00 2024"
+        assert seen and seen[0][0] == "/usr/bin/ps", "ps was not the pinned binary"
+
+    def test_an_absent_ps_fails_safe(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: None)
+        assert pc.process_start_time(4242) is None
+
+    def test_undecodable_ps_output_fails_safe(self, monkeypatch):
+        """Bytes that are not valid UTF-8 are not an identity.
+
+        A lossy decode would turn unreadable output into a NON-EMPTY string, so
+        the caller would treat garbage as a confirmed identity — the fail-OPEN
+        direction at a kill boundary, and two different processes whose output
+        both decoded to replacement characters would compare equal.
+        """
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/usr/bin/ps")
+        monkeypatch.setattr(
+            pc.subprocess, "check_output", lambda *_a, **_k: b"\xff\xfe not utf-8"
+        )
+        assert pc.process_start_time(4242) is None
+
+    def test_empty_ps_output_fails_safe(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/usr/bin/ps")
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: b"\n")
+        assert pc.process_start_time(4242) is None
+
+    @pytest.mark.skipif(not pc.IS_WINDOWS, reason="Windows handle-rights contract")
+    def test_windows_identity_does_not_require_terminate_rights(self, monkeypatch):
+        """Reading identity must not demand the right to kill.
+
+        This value is what DECIDES whether a kill may happen, so routing it
+        through the termination handle (PROCESS_TERMINATE + SYNCHRONIZE) would
+        deny the guard for exactly the processes a caller must be most careful
+        about — they would read as "identity unconfirmed" for a permissions
+        reason rather than a recycling one.
+        """
+
+        def _refuse(_pid):
+            raise AssertionError("start-time identity opened a termination handle")
+
+        monkeypatch.setattr(pc, "_open_process_termination_handle", _refuse)
+        assert pc.process_start_time(os.getpid())
 
 
 class TestPidLivenessPosix:
@@ -2802,3 +2928,217 @@ class TestIsBundledInterpreter:
             "platform_compat.BUNDLED_BACKEND_DIST_DIRNAME in sync with the "
             "packaging layer (see is_bundled_interpreter)."
         )
+
+
+class TestKillProcessTreePinned:
+    """The verified identity must stay PINNED for the whole terminate.
+
+    ``kill_process_tree`` addresses the target by PID, and on Windows it does so
+    from a separate ``taskkill`` process. A caller that only read the start time
+    first has released every handle by then, so the process can exit and Windows
+    can recycle the PID onto an unrelated one in between -- which
+    ``taskkill /T /F /PID`` would then tear down with its whole tree. Windows
+    keeps a process ID reserved while ANY handle to the process object is open,
+    so holding the query handle that verified the identity across the terminate
+    is what makes the PID still mean the same process when taskkill resolves it.
+
+    Driven through the module seams with ``IS_WINDOWS`` patched, so every case
+    runs on every platform: the invariant is about handle LIFETIME, not about
+    which OS the test host happens to be.
+    """
+
+    HANDLE = 4242
+
+    def _wire(self, monkeypatch, *, handle=HANDLE, identity=(4321, 777, None)):
+        """Patch the seams; return (opened, closed, killed) recorders."""
+        opened: list[int] = []
+        closed: list[int] = []
+        killed: list[tuple[int, int]] = []
+
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+
+        def _open(pid):
+            opened.append(pid)
+            return handle
+
+        def _identity(h):
+            assert h == handle, "the identity must be read from the handle just opened"
+            return identity
+
+        def _close(h):
+            closed.append(h)
+
+        def _kill(pid, sig):
+            killed.append((pid, sig))
+            return True
+
+        monkeypatch.setattr(pc, "_open_process_query_handle", _open)
+        monkeypatch.setattr(pc, "_windows_process_handle_identity", _identity)
+        monkeypatch.setattr(pc, "_close_process_handle", _close)
+        monkeypatch.setattr(pc, "kill_process_tree", _kill)
+        return opened, closed, killed
+
+    def test_a_matching_identity_kills_and_then_releases_the_handle(self, monkeypatch):
+        opened, closed, killed = self._wire(monkeypatch)
+
+        assert pc.kill_process_tree_pinned(4321, "777", pc.SIGTERM) is True
+
+        assert opened == [4321]
+        assert killed == [(4321, pc.SIGTERM)]
+        assert closed == [self.HANDLE]
+
+    def test_a_mismatched_identity_never_invokes_the_kill(self, monkeypatch):
+        """The pid was recycled: refuse, and do not spawn taskkill at all.
+
+        Asserting on "no kill" rather than on the return value is the point --
+        a terminate that ran and then failed would still have torn down whatever
+        now owns the pid.
+        """
+        _, closed, killed = self._wire(monkeypatch, identity=(4321, 999, None))
+
+        assert pc.kill_process_tree_pinned(4321, "777", pc.SIGKILL) is False
+
+        assert killed == []
+        assert closed == [self.HANDLE], "the handle must still be released"
+
+    def test_an_unopenable_process_never_invokes_the_kill(self, monkeypatch):
+        """No handle means no pin, and an unpinned pid must not be killed."""
+        _, closed, killed = self._wire(monkeypatch, handle=None)
+
+        assert pc.kill_process_tree_pinned(4321, "777", pc.SIGTERM) is False
+
+        assert killed == []
+        assert closed == [], "nothing was opened, so nothing may be closed"
+
+    def test_an_unreadable_identity_never_invokes_the_kill(self, monkeypatch):
+        """A handle that cannot answer WHO it is confirms nothing."""
+        _, closed, killed = self._wire(monkeypatch, identity=None)
+
+        assert pc.kill_process_tree_pinned(4321, "777", pc.SIGTERM) is False
+
+        assert killed == []
+        assert closed == [self.HANDLE]
+
+    def test_the_handle_is_still_open_while_the_kill_is_in_flight(self, monkeypatch):
+        """The invariant itself, observed rather than inferred.
+
+        The fake terminate is gated on an event, so the assertion runs at a
+        moment that is CAUSALLY inside the kill rather than at a moment chosen by
+        a sleep. The two ``wait`` calls are bounded hang guards; nothing asserts
+        on elapsed time.
+        """
+        closed: list[int] = []
+        entered = threading.Event()
+        release = threading.Event()
+        seen_closed_during_kill: list[list[int]] = []
+
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_open_process_query_handle", lambda pid: self.HANDLE)
+        monkeypatch.setattr(
+            pc, "_windows_process_handle_identity", lambda h: (4321, 777, None)
+        )
+        monkeypatch.setattr(pc, "_close_process_handle", closed.append)
+
+        def _gated_kill(pid, sig):
+            seen_closed_during_kill.append(list(closed))
+            entered.set()
+            assert release.wait(10), "the gate was never released"
+            return True
+
+        monkeypatch.setattr(pc, "kill_process_tree", _gated_kill)
+
+        result: list[bool] = []
+        worker = threading.Thread(
+            target=lambda: result.append(pc.kill_process_tree_pinned(4321, "777"))
+        )
+        worker.start()
+        try:
+            assert entered.wait(10), "the kill never started"
+            assert closed == [], (
+                "the handle was released while taskkill was still in flight -- "
+                "the pid is unpinned for exactly the window this exists to close"
+            )
+        finally:
+            release.set()
+            worker.join(10)
+
+        assert not worker.is_alive()
+        assert seen_closed_during_kill == [[]]
+        assert result == [True]
+        assert closed == [self.HANDLE], "released once the kill returned"
+
+    def test_the_handle_is_released_when_the_kill_raises(self, monkeypatch):
+        """A failing terminate must not leak the handle.
+
+        A leaked handle keeps the pid reserved for the life of the gateway, so
+        the failure mode is a slow resource leak rather than a loud one.
+        """
+        closed: list[int] = []
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_open_process_query_handle", lambda pid: self.HANDLE)
+        monkeypatch.setattr(
+            pc, "_windows_process_handle_identity", lambda h: (4321, 777, None)
+        )
+        monkeypatch.setattr(pc, "_close_process_handle", closed.append)
+
+        def _raising_kill(pid, sig):
+            raise ProcessLookupError("gone between the pin and the signal")
+
+        monkeypatch.setattr(pc, "kill_process_tree", _raising_kill)
+
+        with pytest.raises(ProcessLookupError):
+            pc.kill_process_tree_pinned(4321, "777")
+
+        assert closed == [self.HANDLE]
+
+    def test_posix_delegates_straight_through(self, monkeypatch):
+        """POSIX is unchanged: no handle exists to hold, so none is sought.
+
+        ``os.killpg`` is issued in-process by the same interpreter that did the
+        check. Introducing a Windows-shaped pin here would change a path this
+        finding is not about.
+        """
+        killed: list[tuple[int, int]] = []
+        opened: list[int] = []
+
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(pc, "_open_process_query_handle", opened.append)
+        monkeypatch.setattr(
+            pc, "kill_process_tree", lambda pid, sig: killed.append((pid, sig)) or True
+        )
+
+        assert pc.kill_process_tree_pinned(4321, "anything", pc.SIGTERM) is True
+
+        assert killed == [(4321, pc.SIGTERM)]
+        assert opened == [], "no handle work on POSIX"
+
+    def test_the_pinned_identity_is_the_same_half_process_start_time_returns(
+        self, monkeypatch
+    ):
+        """Both sides must read the CREATION half, or the comparison is nonsense.
+
+        ``process_start_time`` records ``str(identity[1])``; if the pin compared
+        a different element the guard would refuse every legitimate reap while
+        reporting itself as working.
+        """
+        # ``process_start_time`` checks ``sys.platform == "linux"`` BEFORE
+        # ``IS_WINDOWS``, so on a Linux runner the /proc arm answers None for a
+        # pid that does not exist and the patched Windows arm is never reached.
+        # Steering the platform too is what keeps this case host-independent --
+        # the same technique test_app_backend_stale_reap uses to model a
+        # ps-less host.
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_open_process_query_handle", lambda pid: self.HANDLE)
+        monkeypatch.setattr(pc, "_close_process_handle", lambda h: None)
+        monkeypatch.setattr(
+            pc, "_windows_process_handle_identity", lambda h: (4321, 777, 888)
+        )
+        monkeypatch.setattr(pc, "kill_process_tree", lambda pid, sig: True)
+
+        recorded = pc.process_start_time(4321)
+
+        assert recorded == "777"
+        assert pc.kill_process_tree_pinned(4321, recorded) is True
+        # The exit half moves as the process dies and must never be the identity.
+        assert pc.kill_process_tree_pinned(4321, "888") is False

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -239,7 +239,14 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # ``capabilities.tailnet_origin`` ceiling at the enforcement call, and
         # never reached from a tool dispatch path.
         "dashboard/tailnet_serve.py::_run",
-        "apps/backend.py::_proc_start_time",
+        # PID-reuse guard for the app-backend reap, moved out of
+        # ``apps/backend.py::_proc_start_time`` so Windows gets a real answer
+        # instead of a blanket None. Only the macOS/other-POSIX arm spawns, and
+        # it is the same fixed ``ps -o lstart= -p <pid>`` argv the backend used
+        # before: no shell, the binary comes from ``trusted_system_bin`` rather
+        # than PATH, and the sole interpolated value is a pid the gateway itself
+        # recorded, rendered through ``str()``. Nothing here is agent-influenced.
+        "platform_compat.py::process_start_time",
         "apps/backend.py::_resolve_nvm_path",
         "apps/backend.py::stop_app_backend",
         # py-spy attach for `kirocrew perf sample --pid`: fixed list-argv (no


### PR DESCRIPTION
## Problem / Motivation

The app-backend stale-reap identifies a recorded pid by its **start time** before
signalling it, so a recycled pid is never killed. That probe
(`apps/backend.py::_proc_start_time`) had two branches:

```python
if sys.platform == "linux":
    stat = Path(f"/proc/{pid}/stat").read_text()
    ...
out = subprocess.check_output(["ps", "-o", "lstart=", "-p", str(pid)], ...)
```

Its docstring described the second as the **macOS** fallback. The `else` in fact
covered every non-Linux platform — including Windows, which has no standard `ps`.
The call raised, the error was swallowed, and the probe returned `None` for every
pid there.

## Why it matters

`_record_app_pid` persists whatever the probe returns, and the reap refuses to act
on an unconfirmed identity:

```python
recorded_st = entry.get("start_time")      # None on Windows
live_st = _proc_start_time(pid)
if not recorded_st or live_st is None or live_st != recorded_st:
    # Identity unconfirmed ... Do NOT kill, and KEEP the entry
    continue
```

On Windows `not recorded_st` is always true, so **no app backend was ever reaped**
— and because unconfirmed entries are deliberately KEPT rather than dropped, the
pidfile accumulated them across every gateway generation. The fail-safe design is
correct; it was simply pinned in the safe state on a platform where app backends
do run (only the *exec* / shell-launcher branch is POSIX-gated, at
`backend.py:854`).

## What changed (motivation → approach → change)

**Motivation** — make the PID-reuse guard answerable on Windows so the reap can do
its job there, without weakening the fail-safe anywhere.

**Approach** — no new Windows process-identity design was needed. `platform_compat`
already had every piece: `_PROCESS_QUERY_LIMITED_INFORMATION` with several
query-only `OpenProcess` precedents (each closing its handle in a `finally`), and
`_windows_process_handle_identity(handle) -> (pid, creation_time, exit_time)`,
which reads the creation `FILETIME` through `GetProcessTimes` and already handles
the exited-process FILETIME publication race. The only missing piece was the
PID→handle bridge.

**Change** — add `platform_compat.process_start_time(pid) -> str | None` and make
`_proc_start_time` a thin delegation:

| platform | source |
|---|---|
| Linux | `/proc/<pid>/stat` field 22 — **unchanged** |
| macOS / other POSIX | `ps -o lstart=` — unchanged, but resolved through `trusted_system_bin` |
| Windows | query-only `OpenProcess` → `_windows_process_handle_identity` → creation FILETIME |
| unreadable | `None` — fail-safe preserved |

The `ps` binary now comes from the pinned lookup rather than `PATH`: this value
gates a kill, so a planted `ps` must not be able to forge process identity.

**Terminate rights are deliberately not requested.** Reusing
`_open_process_termination_handle` (which also asks for
`PROCESS_TERMINATE | SYNCHRONIZE`) would report "identity unconfirmed" for a
*permissions* reason rather than a recycling one — for exactly the processes a
caller must be most careful about. There is a regression test for that specifically.

The returned token stays opaque: stable and comparable across gateway generations
on one host, never parsed, never compared across hosts — so units differing per
platform is not a contract.

**Decoding stays strict**, for the same fail-safe reason. A lossy decode would turn
unreadable `ps` bytes into a non-empty string and hand the caller a
confirmed-looking identity — and two processes whose output both decoded to
replacement characters would compare *equal*. Undecodable output means the probe
cannot be trusted, which is the `None` case. This preserves the pre-move behaviour:
the old implementation decoded strictly inside a handler that caught `ValueError`,
of which `UnicodeDecodeError` is a subclass.

Housekeeping the change forces: the `ps`-only timeout constant and the comment
naming it moved with the code they described, and the shim table in `AGENTS.md`
gains the row, so the bare probe is not re-introduced.

## Tests

**Fail-before**, on pristine `origin/main` (`81e28b333`):

```
test_a_host_without_ps_still_records_a_reapable_identity
AssertionError: no start-time identity was recorded on a host without /proc or ps,
so the stale-reap can never positively identify this backend
assert None == 'WIN-CREATION-8817'
```

That test models Windows' exact situation (`sys.platform` not `linux`, no `ps`)
and asserts the **consequence**, not the call: the recorded identity is present,
and the reap then confirms and reaps the entry instead of keeping it forever.

**The Windows branch is verified for real, not stubbed.** This was developed on
Windows, so `TestProcessStartTime` exercises the actual `OpenProcess` /
`GetProcessTimes` path against the running process:

- a stable, positive creation FILETIME for `os.getpid()`, equal across two calls;
- `None` for a pid that cannot be opened (fail-safe);
- and — with `_open_process_termination_handle` monkeypatched to raise — identity
  still resolves, proving the query-only contract.

The BSD leg is pinned on both halves that gate a kill: `ps` is resolved through
`trusted_system_bin` (a `PATH`-planted binary must not be able to forge identity),
and undecodable output returns `None` rather than a replacement-character string.

The four existing `_proc_start_time` cases (field-22 past a parenthesised comm,
malformed stat, the `ps` leg, empty `ps` output) moved to `test_platform_compat`
where that behaviour now lives, plus a new one pinning that the `ps` leg uses the
pinned binary. The app-backend side keeps a delegation test. No subject was
dropped.

```
pytest test/test_platform_compat.py test/test_apps_backend_coverage.py \
       test/test_app_backend_stale_reap.py test/test_app_backend.py -q
   309 passed, 41 skipped, 13 failed
```

All 13 are **pre-existing local-Windows** failures, verified by re-running them
with this branch's changes reverted to `origin/main`:

- 11 in `test_app_backend_stale_reap.py` — they `patch.object(backend_mod.os, "getpgid"/"killpg")`, which do not exist on Windows (`11 failed, 3 passed` on pristine main; this branch is `11 failed, 4 passed` — the extra pass is the new test);
- 2 in `test_app_backend.py` — `WinError 1314` symlink privilege and a `cp950` decode of a UTF-8 repo file.

None occur on the CI runners, which are POSIX.

Also green: `flake8`, `isort --check-only`, `mypy --platform linux` (no findings
for either changed module), `git diff --check`, `scripts/docs_lint.py`,
`BRAND_BASE_REF=origin/main scripts/check_brand_name.py`,
`HARNESS_BASE_REF=origin/main scripts/check_harness_parity.py`.

## Manual verification

The Windows leg is covered by real (non-stubbed) tests above, executed on Windows.
No user-visible surface changes.

## Screenshots / video

<!-- no-visual-delta -->

Backend process identity only.

## Related Issues

Fixes #3930.

Follow-up from #3876 / #3877, which flagged this probe as out of scope at the time.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `AGENTS.md` shim table gains the start-time row; no module spec documents this probe, so none needed an update
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
