### PR TITLE
refactor: flatten nested guards and drop dead code in toplevel

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2932,10 +2932,9 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         ]
         for mcp_name in _register_names:
             ref = f"@{mcp_name}"
-            if mcp_name in valid_servers:
-                if ref not in config.get("tools", []):
-                    config.setdefault("tools", []).append(ref)
-                    added_refs.append(ref)
+            if mcp_name in valid_servers and ref not in config.get("tools", []):
+                config.setdefault("tools", []).append(ref)
+                added_refs.append(ref)
         if added_refs:
             sel().log_api_access(
                 caller="system",

--- a/src/kiro_crew/cli_chat.py
+++ b/src/kiro_crew/cli_chat.py
@@ -162,8 +162,6 @@ async def _interactive(provider: LLMProvider, cfg: KiroCrewConfig) -> None:
 
     print("Type your message (Ctrl+D or 'exit' to quit)\n")
 
-    prompt_count = 0
-
     while True:
         try:
             message = input("you> ").strip()
@@ -178,7 +176,6 @@ async def _interactive(provider: LLMProvider, cfg: KiroCrewConfig) -> None:
             break
 
         await _send_and_print(provider, message)
-        prompt_count += 1
 
         # Check context usage — compact and restart if needed
         pct = provider.context_usage_pct()
@@ -193,7 +190,6 @@ async def _interactive(provider: LLMProvider, cfg: KiroCrewConfig) -> None:
                 pass
             await provider.shutdown()
             await provider.start()
-            prompt_count = 0
         elif pct >= 75.0:
             print(f"\n⚠️  Context at {pct:.0f}%", file=sys.stderr)
 

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -844,13 +844,11 @@ def _cron(args: argparse.Namespace) -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
-        if channel:
-
-            if len(channel) > CHANNEL_MAX_LEN or not CHANNEL_ID_RE.match(channel):
-                print(
-                    f"Error: invalid channel ID format (expected {CHANNEL_ID_RE.pattern.strip('^$')})"
-                )
-                return
+        if channel and (len(channel) > CHANNEL_MAX_LEN or not CHANNEL_ID_RE.match(channel)):
+            print(
+                f"Error: invalid channel ID format (expected {CHANNEL_ID_RE.pattern.strip('^$')})"
+            )
+            return
         if cron_expr:
             job = svc.add_job(
                 name=args.name,

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -2274,8 +2274,6 @@ def safe_copy_file_nolink(raw: str, dest_dir: str) -> str | None:
     the inode actually opened and copied, so no check-to-use window remains.
     If the fd's real path cannot be determined, fail closed.
     """
-    import tempfile
-
     path = validate_file_path(raw)
     if path is None:
         return None

--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -217,10 +217,9 @@ def refresh_kiro_windows(rows: list[dict[str, Any]]) -> bool:
         if not isinstance(win, int) or isinstance(win, bool) or win <= 0:
             continue
         for key in (row.get("model_id"), row.get("model_name")):
-            if isinstance(key, str) and key:
-                if _KIRO_WINDOWS.get(key) != win:
-                    _KIRO_WINDOWS[key] = win
-                    updated = True
+            if isinstance(key, str) and key and _KIRO_WINDOWS.get(key) != win:
+                _KIRO_WINDOWS[key] = win
+                updated = True
     return updated
 
 

--- a/src/kiro_crew/portability.py
+++ b/src/kiro_crew/portability.py
@@ -360,17 +360,16 @@ def _sanitize_imported_crons(crons_path: Path) -> tuple[list[str], list[str]]:
                 continue
 
         # Rule 3: anything that EXECUTES arrives paused, awaiting a human.
-        if command or script:
-            if not job.get("user_paused", False):
-                job["user_paused"] = True
-                job["enabled"] = False
-                changed = True
-                paused.append(_name_of(job))
-                _log_cron_denial(
-                    "settings_import",
-                    "Error: an imported job that runs a command or script is "
-                    "restored paused until it is enabled by hand",
-                )
+        if (command or script) and not job.get("user_paused", False):
+            job["user_paused"] = True
+            job["enabled"] = False
+            changed = True
+            paused.append(_name_of(job))
+            _log_cron_denial(
+                "settings_import",
+                "Error: an imported job that runs a command or script is "
+                "restored paused until it is enabled by hand",
+            )
         kept.append(job)
 
     if changed:

--- a/src/kiro_crew/tips.py
+++ b/src/kiro_crew/tips.py
@@ -658,9 +658,10 @@ def _sanitize_tip_links(t: dict) -> None:  # type: ignore[type-arg]
     """
     for link_field in ("doc", "doc_link"):
         val = t.get(link_field, "")
-        if isinstance(val, str) and val:
-            if not (re.match(r"^https?://", val) or re.match(r"^[\w./-]+\.md$", val)):
-                t[link_field] = ""
+        if isinstance(val, str) and val and not (
+            re.match(r"^https?://", val) or re.match(r"^[\w./-]+\.md$", val)
+        ):
+            t[link_field] = ""
 
 
 def _sanitize_persisted_tip(t: object) -> dict | None:  # type: ignore[type-arg]
@@ -799,9 +800,8 @@ def _is_eligible(
         snooze_ts = st.snoozed[tid]
         if now - snooze_ts < snooze_hours * 3600:
             return False
-    if doc and doc in st.snoozed_docs:
-        if now - st.snoozed_docs[doc] < snooze_hours * 3600:
-            return False
+    if doc and doc in st.snoozed_docs and now - st.snoozed_docs[doc] < snooze_hours * 3600:
+        return False
     return True
 
 


### PR DESCRIPTION
<!-- no-visual-delta --> Backend-only readability sweep; no rendered UI surface is touched.

## Problem
The top-level `kiro_crew` module carries small readability drag: a redundant
in-function `import tempfile` shadow, a write-only local, and five
single-branch `if A: if B:` nests that add indentation without adding logic.

## Why it matters
These read as accidental complexity. Flattening them lowers the cost of the
next reader and shrinks the surface the security-sensitive files present,
without changing any behavior.

## Fix (symptom → root cause → change)
The module-simplification detector's mechanical queue held one shadow-import;
the rest is the judgment classes the campaign scopes to the module you are
already in. Each change is behavior-preserving:

- **hooks.py** — drop the in-function `import tempfile` in
  `safe_copy_file_nolink`. `tempfile` is already imported at module scope
  (line 17) and the surviving `tempfile.mkstemp` call resolves to the same
  module object, so this is the safe shadow-import class, not a lazy-import
  hoist. hooks.py is a keystone file; deleting a shadow there is permitted and
  no matcher, guard, `O_NOFOLLOW`/fd-real-path check, or audit was touched.
- **cli_chat.py** — remove the `prompt_count` local in `_interactive`; it was
  assigned and incremented but never read.
- **agent.py, cli_commands.py, model_registry.py, portability.py, tips.py (×2)**
  — collapse `if A: if B:` to `if A and B:`, preserving short-circuit order and
  parenthesizing every folded `or`. The `agent.py` audit emit is guarded by a
  separate unchanged `if added_refs:` block and fires in identical cases.

## Tests
No new tests — this is a behavior-preserving refactor with no new branches.
Ran the existing suites covering every touched path on the Python 3.12
CI-parity venv:
`test_model_registry`, `test_model_registry_parity`, `test_portability`,
`test_tips`, `test_cli_chat`, `test_hooks_coverage`, `test_cli_commands_coverage`,
`test_agent`, `test_hooks`, `test_mcp_sync_agent`, `test_capability_agents_plugins`
— all green.

## Manual verification
N/A — unit coverage sufficient. Static gates all pass locally: flake8, isort,
mypy, brand, harness-parity, docs-lint, per-file-coverage, vendor-manifest, and
scrub-lint (`--no-history`). A fleet of two independent read-only reviewers
(behavior-preservation lens and AUTOSDE/security/keystone lens) each confirmed
all eight hunks equivalent with no findings.

## Screenshots
N/A — backend-only, no visual delta (see marker above).
