### PR TITLE
refactor(dashboard): flatten the turn-metric exhausted ternary

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -6390,18 +6390,18 @@ async def _run_chat(
                 # turn (depth > 0), which the branches below never re-queue —
                 # it dies with "please retry", a user-visible fault that must
                 # reach fault_rate.
+                if event.stop_reason == STOP_REASON_STALE_RECOVER:
+                    _turn_exhausted = _prompt_depth > 0 or slot._stale_recovery_retries >= 3
+                elif event.stop_reason == STOP_REASON_TOOL_STALL:
+                    _turn_exhausted = _prompt_depth > 0 or slot._tool_stall_retries >= 3
+                else:
+                    _turn_exhausted = False
                 _emit_turn_metric(
                     event.usage.duration_ms,
                     event.stop_reason,
                     slot.key,
                     elapsed_ms=_turn_elapsed_ms,
-                    exhausted=(
-                        (_prompt_depth > 0 or slot._stale_recovery_retries >= 3)
-                        if event.stop_reason == STOP_REASON_STALE_RECOVER
-                        else (_prompt_depth > 0 or slot._tool_stall_retries >= 3)
-                        if event.stop_reason == STOP_REASON_TOOL_STALL
-                        else False
-                    ),
+                    exhausted=_turn_exhausted,
                 )
                 _stop_reason = event.stop_reason
                 # Recorded on the slot so post-turn consumers reached later


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only, one hunk in `dashboard/chat_runner.py`; the
computed value feeds an OTel metric attribute, and nothing renders differently.

no linked issue: routine readability sweep, one module per PR.

## Problem

`_emit_turn_metric`'s `exhausted=` argument was a ternary chained inside another
ternary, spread over six lines of keyword argument:

```python
exhausted=(
    (_prompt_depth > 0 or slot._stale_recovery_retries >= 3)
    if event.stop_reason == STOP_REASON_STALE_RECOVER
    else (_prompt_depth > 0 or slot._tool_stall_retries >= 3)
    if event.stop_reason == STOP_REASON_TOOL_STALL
    else False
),
```

To learn which of the three outcomes applies, a reader has to unpack precedence in a
chained conditional whose conditions sit below their results — inside an argument list,
in a 4200-line function.

## Why it matters

This value is not cosmetic: it decides the `stall_exhausted` label on
`kirocrew.turn.duration`, which is what separates a re-driven turn from a terminal
user-visible fault in the fault-rate metric. The comment above it needs eight lines to
explain the rule. Code that takes that much explaining should at least be shaped so the
three cases are visibly three cases.

## Fix (symptom → root cause → change)

**Symptom:** a three-way decision is unreadable at the call site.
**Root cause:** it is expressed as nested ternaries in a keyword argument, so precedence
carries the logic instead of structure.
**Change:** hoist it to a local computed by if/elif/else immediately above the call.

Equivalence was checked on every axis rather than assumed:

- **Branch precedence** — stale-recovery first, then tool-stall, else `False`; unchanged.
- **Operands per branch** — the stale-recovery path still never reads
  `_tool_stall_retries`, and vice versa. No cross-reads were introduced.
- **Short-circuiting** — every operand is side-effect free, so evaluation order is
  unobservable: `_prompt_depth` is an `int` parameter, `_stale_recovery_retries` and
  `_tool_stall_retries` are plain `int` attributes assigned in `__init__`, and
  `stop_reason` is a plain `str` dataclass field, not a property.
- **Position** — the computation did not move across an `await` or into or out of a
  `try`/`except`.
- **Type inference** — every branch assigns `bool`, so mypy needs no annotation.

**The local is named `_turn_exhausted`, not `_exhausted`, deliberately.** `_run_chat`
already binds `_exhausted` roughly 800 lines below (pipe-death / prompt-busy retry
budget) and reads it in an `elif`. Reusing the name would not misbehave today — both
branches there assign it unconditionally before the read — but it would leave one name
meaning two different things in one function, where a later edit to either branch would
silently let this value reach that `elif`. Verified by AST that `_turn_exhausted` is
otherwise unused in the function.

## Tests

No test changes: the diff is behavior-preserving, so the existing tests are the
assertion. 326 passed across the files that cover this code and these stop reasons —
`metrics/test_turn_metric.py`, `test_turn_duration_recorded.py`,
`test_turn_duration_subagent.py`, `test_chat_runner_coverage.py`,
`test_acp_stale_recovery.py`, `test_stuck_turn_watchdog.py`. A precedence slip or a
wrong operand would change the emitted `exhausted` attribute and fail
`metrics/test_turn_metric.py`.

## Manual verification

Gates on a CI-parity venv (Python 3.12.13, dependency-group pins, no `faiss`), run with
`PYTHONPATH=$PWD/src` so they test this worktree:

| Gate | Result |
|---|---|
| `flake8 src/kiro_crew test` | pass |
| `isort --check-only src/kiro_crew test` | pass |
| `mypy src/kiro_crew/` | pass |
| `check_brand_name.py` (`--test` + diff vs merge-base) | pass |
| `check_harness_parity.py` (diff vs merge-base) | pass |
| `docs_lint.py --test` / `docs-lint.sh` | pass |
| `check_per_file_coverage.py --test` | pass |
| `verify_vendor_manifest.py` | pass |
| `scrub-lint.sh --no-history` | pass |

Reviewed before opening by four parallel subagents grounded in `AUTOSDE.yaml` and the
`codex-review.yml` / `claude-review.yml` / `code-review.yml` contracts — one per lens
(equivalence, scope and shadowing, blocking AUTOSDE rules, comment truth), each finding
subject to three adversarial refuters. **Zero findings raised.**

Frontend gates were not run: the diff touches nothing under `website/`, `.github/` or
`scripts/`, so CI's `changes` job reports `only_backend=true`.
