### PR TITLE
fix(knowledge): skip ingestion-errored sources in sync_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **A knowledge source that errored during ingestion is no longer re-synced on
+  every sweep.** `KnowledgeIngestion` marks failure in the `sync_status`
+  **column**, but `SyncScheduler.sync_all`'s skip predicate read only the
+  `sync_status` copy inside the properties JSON, which the ingestion path never
+  sets. So an ingestion-errored source (bad credentials, deleted remote,
+  unparseable content) was retried on every sweep forever, flooding logs with
+  the same failing network call and giving the user no way to quiesce it short
+  of deleting the source. `sync_all` now treats an `'error'` value in EITHER
+  store as errored (legacy JSON-only rows are still skipped), and
+  `_record_failure` writes the column alongside the properties copy it keeps for
+  `consecutive_failures`.
+
 - **`test_redaction_timing_scales_linearly` no longer fails CI
   intermittently** (observed "Redaction scaled super-linearly: 3.2x, limit
   3.0x" on an otherwise-healthy matcher). The test took ONE

--- a/src/kiro_crew/knowledge/sync.py
+++ b/src/kiro_crew/knowledge/sync.py
@@ -71,15 +71,23 @@ class SyncScheduler:
         updates = {"properties": props}
         if failures >= MAX_FAILURES:
             props["sync_status"] = "error"
+            # Write the column too, so the reader below (and the dashboard, which
+            # reads the column) observes the error regardless of which store it checks.
+            updates["sync_status"] = "error"
             logger.warning("Source %s reached %d failures, marking as error", source_id, failures)
         self.store.update_source(source_id, **updates)
 
     async def sync_all(self) -> list[dict]:
-        rows = self.store.db.execute("SELECT id, properties FROM sources").fetchall()
+        rows = self.store.db.execute(
+            "SELECT id, properties, sync_status FROM sources").fetchall()
         results = []
         for row in rows:
+            # sync_status lives in two stores: KnowledgeIngestion writes the COLUMN,
+            # while _record_failure historically wrote only the properties JSON. Treat
+            # an 'error' value in EITHER store as errored so both writers are observed
+            # and legacy JSON-only rows are still skipped.
             props = json.loads(row["properties"] or "{}")
-            if props.get("sync_status") == "error":
+            if row["sync_status"] == "error" or props.get("sync_status") == "error":
                 continue
             results.append(await self.sync_source(row["id"]))
         return results

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -19,6 +19,7 @@ from kiro_crew.knowledge.extractor import EntityExtractor
 from kiro_crew.knowledge.readers import FileReader
 from kiro_crew.knowledge.retrieval import HybridRetriever, _bytes_to_floats
 from kiro_crew.knowledge.store import KnowledgeStore, SimpleDiGraph
+from kiro_crew.knowledge.sync import SyncScheduler
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1888,3 +1889,59 @@ class TestEntityExtractorNonceDelimiters:
             nonces.append(nonce)
         # Per-chunk uuid: the two chunks must NOT share a nonce.
         assert nonces[0] != nonces[1], "each chunk must get a distinct per-chunk nonce"
+
+
+# ---------------------------------------------------------------------------
+# SyncScheduler.sync_all -- errored sources must be quiesced (issue #3946)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSyncAllSkipsErroredSources:
+    """sync_all must skip a source marked errored by EITHER writer.
+
+    KnowledgeIngestion marks failure in the sync_status COLUMN, while
+    SyncScheduler._record_failure historically wrote only the properties JSON.
+    sync_all must observe both so an errored source is never re-synced forever.
+    """
+
+    def _scheduler(self, store):
+        scheduler = SyncScheduler(store, pipeline=None, connectors={})
+        attempted: list[str] = []
+
+        async def _spy(source_id: str) -> dict:
+            attempted.append(source_id)
+            return {"synced": False, "items_created": 0, "error": None}
+
+        scheduler.sync_source = _spy  # type: ignore[method-assign]
+        return scheduler, attempted
+
+    async def test_column_only_error_is_skipped(self, store):
+        # A healthy source that should still be attempted.
+        ok_id = store.add_source("Healthy", "local_file", "/tmp/ok")
+        # A source errored the way ingestion.py does it: COLUMN only, no
+        # sync_status entry in the properties JSON.
+        err_id = store.add_source("Dead", "local_file", "/tmp/dead")
+        store.db.execute("UPDATE sources SET sync_status = 'error' WHERE id = ?", (err_id,))
+        store.db.commit()
+        # Guard: the failing writer really left the JSON untouched.
+        row = store.db.execute("SELECT properties FROM sources WHERE id = ?", (err_id,)).fetchone()
+        assert json.loads(row["properties"] or "{}").get("sync_status") is None
+
+        scheduler, attempted = self._scheduler(store)
+        await scheduler.sync_all()
+
+        assert err_id not in attempted, "column-only errored source must be skipped"
+        assert ok_id in attempted, "healthy source must still be synced"
+
+    async def test_legacy_json_only_error_is_still_skipped(self, store):
+        # A source errored the old way: sync_status lives only in the
+        # properties JSON, column falls back to its 'pending' default.
+        err_id = store.add_source("LegacyDead", "local_file", "/tmp/legacy",
+                                  properties={"sync_status": "error"})
+        col = store.db.execute("SELECT sync_status FROM sources WHERE id = ?", (err_id,)).fetchone()
+        assert col["sync_status"] != "error", "column should be pending for the legacy case"
+
+        scheduler, attempted = self._scheduler(store)
+        await scheduler.sync_all()
+
+        assert err_id not in attempted, "legacy JSON-only errored source must still be skipped"


### PR DESCRIPTION
## What is the problem?

An errored knowledge source is never skipped by the sync loop, so it is
re-attempted on every sweep forever. The writer and the reader of `sync_status`
use two different stores. `KnowledgeIngestion` marks failure in the `sync_status`
**column** (`UPDATE sources SET sync_status = 'error'`), while
`SyncScheduler.sync_all` read its skip predicate from the `sync_status` copy
inside the **properties JSON**, which the ingestion path never sets.

## Why this issue matters to the user

A remote or connector source whose ingestion fails (bad credentials, deleted
remote, unparseable content) is retried on every sync sweep instead of being
quiesced. The user gets repeated failing network calls against the same dead
source, a log full of the same error, and no way to make it stop short of
deleting the source. The `error` state they see in the UI does not actually
mean "we stopped trying".

## How our fix solves it

- Symptom: an errored source never stops syncing.
- Immediate cause: `sync_all`'s skip predicate reads a field (`props["sync_status"]`)
  that the failing ingestion writer never sets; it only sets the column.
- Root cause: `sync_status` is written to two stores by different code paths, so
  no single read answers "is this source errored".

Minimal fix, scoped to this bug:

1. `sync_all` now selects the `sync_status` column and treats an `'error'` value
   in EITHER the column OR the properties JSON as errored. This observes both
   writers and still skips legacy rows that were marked errored only in the JSON.
2. `_record_failure` now writes the `sync_status` column alongside the properties
   copy it keeps for `consecutive_failures`, so a failure recorded inside `sync.py`
   is visible to any column reader (including the dashboard).

Deliberately out of scope: retiring the properties copy of `sync_status` across
all sites, and the ~20 column-only UPDATE sites elsewhere. That wider dual-store
convergence needs its own decision.

## What tests we did

Added `TestSyncAllSkipsErroredSources` in `test/test_knowledge.py`:

- `test_column_only_error_is_skipped` marks a source errored the way
  `ingestion.py` does (column only, no properties JSON entry) and asserts
  `sync_all` skips it while a healthy source is still synced. This test FAILS on
  the pre-fix predicate (`AssertionError: column-only errored source must be
  skipped`) and PASSES with the fix.
- `test_legacy_json_only_error_is_still_skipped` marks a source errored the old
  way (properties JSON only, column left at its `pending` default) and asserts
  `sync_all` still skips it, guarding against regressing existing errored rows.

Gates run locally, all green:

- `pytest -q` on every knowledge test module (`test/test_knowledge*.py`,
  `test/test_mcp_knowledge*.py`): 794 passed, 1 xfailed.
- `isort --check-only src/kiro_crew test`: pass.
- `flake8 src/kiro_crew test`: pass.
- `mypy src/kiro_crew/`: Success, no issues in 976 source files.

## Any other suggestions on the work

The same column/JSON split means an ingestion failure is invisible to
`consecutive_failures` accounting, and a `sync.py` failure is invisible to any
column reader that does not also parse the JSON. The narrow fix here removes the
user-visible symptom; converging the two stores (a single source of truth for
`sync_status`, retiring the properties copy) is the durable answer and should be
tracked separately.

Closes #3946
