### PR TITLE
fix(electron): route updater logging into gateway-launch.log

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -20,6 +20,7 @@ const {
 const { createWindowOpenHandler, openExternalSafely } = require("./external-scheme");
 const { resolveThemeSource } = require("./native-theme");
 const { initAutoUpdate } = require("./auto-update");
+const { makeUpdaterLogger } = require("./update-logger");
 const {
   classifyBundleLocation,
   containingDirForBundle,
@@ -3538,6 +3539,7 @@ app.whenReady().then(async () => {
       recoverWedgedGateway(mainWindow).catch((e) => glog(`post-install-failure recovery failed: ${e && e.message}`));
     },
     onUpdateState: broadcastUpdateState,
+    log: makeUpdaterLogger(glog),
     });
   } catch (e) {
     glog(`auto-update init failed — continuing WITHOUT auto-update: ${(e && e.stack) || e}`);

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -69,6 +69,7 @@
       "find-bin.js",
       "data-home.js",
       "auto-update.js",
+      "update-logger.js",
       "bundle-location.js",
       "gateway-auth-hint.js",
       "blocking-prompt.js",

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -259,6 +259,19 @@ function makeDeps(opts = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// Logger wiring contract: a provided `log` dep must become autoUpdater.logger,
+// verbatim. This is what routes electron-updater's own lifecycle/error output
+// through the caller's sink -- if the assignment drifts, a packaged app's
+// update diagnostics silently fall back to console and are lost.
+// ---------------------------------------------------------------------------
+
+test("initAutoUpdate wires the provided log dep as autoUpdater.logger", () => {
+  const { deps } = makeDeps();
+  initAutoUpdate(deps);
+  assert.strictEqual(deps.autoUpdater.logger, deps.log);
+});
+
+// ---------------------------------------------------------------------------
 // #709 regression guard: every state that renders a version must report the
 // PENDING one. emit() defaults `version` to app.getVersion(), so a
 // "downloading" event that forgets to pass it makes the update card claim the

--- a/website/electron/test/update-logger.test.js
+++ b/website/electron/test/update-logger.test.js
@@ -1,0 +1,102 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { makeUpdaterLogger, MAX_ARG_CHARS } = require("../update-logger");
+
+function makeSink() {
+  const lines = [];
+  const sink = (line) => lines.push(line);
+  return { sink, lines };
+}
+
+// ---------------------------------------------------------------------------
+// One call, one tagged line. The launch log is grepped line-by-line, so a
+// level that emitted zero lines (or several) would corrupt that contract.
+// ---------------------------------------------------------------------------
+
+test("each level emits exactly one line tagged with its level", () => {
+  const { sink, lines } = makeSink();
+  const log = makeUpdaterLogger(sink);
+  log.info("checking", "feed");
+  log.warn("slow feed");
+  log.error("boom");
+  log.debug("probe");
+  assert.deepStrictEqual(lines, [
+    "[update:info] checking feed",
+    "[update:warn] slow feed",
+    "[update:error] boom",
+    "[update:debug] probe",
+  ]);
+});
+
+test("multi-line string args are collapsed to a single line", () => {
+  const { sink, lines } = makeSink();
+  makeUpdaterLogger(sink).info("first\nsecond\n  third");
+  assert.strictEqual(lines.length, 1);
+  assert.ok(!lines[0].includes("\n"), "emitted line must not contain newlines");
+  assert.strictEqual(lines[0], "[update:info] first second third");
+});
+
+// ---------------------------------------------------------------------------
+// Error serialization: message + FIRST stack frame only. electron-updater's
+// HttpError dumps are multi-line; the first frame carries the signal and the
+// rest floods the log.
+// ---------------------------------------------------------------------------
+
+test("Error serializes to message + first stack frame only", () => {
+  const { sink, lines } = makeSink();
+  const err = new Error("feed unreachable");
+  err.stack = "Error: feed unreachable\n    at fetchFeed (auto-update.js:1:1)\n    at deeper (auto-update.js:2:2)";
+  makeUpdaterLogger(sink).error("[update] check failed", err);
+  assert.strictEqual(lines.length, 1);
+  assert.ok(lines[0].includes("Error: feed unreachable"), "must carry the message");
+  assert.ok(lines[0].includes("at fetchFeed (auto-update.js:1:1)"), "must carry the first frame");
+  assert.ok(!lines[0].includes("at deeper"), "must drop every frame after the first");
+  assert.ok(!lines[0].includes("\n"), "must stay a single line");
+});
+
+test("Error with no stack still serializes its message", () => {
+  const { sink, lines } = makeSink();
+  const err = new Error("bare");
+  err.stack = undefined;
+  makeUpdaterLogger(sink).error(err);
+  assert.strictEqual(lines[0], "[update:error] Error: bare");
+});
+
+// ---------------------------------------------------------------------------
+// Truncation: any single argument is bounded so one giant HttpError body
+// cannot flood the launch log.
+// ---------------------------------------------------------------------------
+
+test("an over-long argument is truncated with a marker", () => {
+  const { sink, lines } = makeSink();
+  const huge = "x".repeat(MAX_ARG_CHARS * 4);
+  makeUpdaterLogger(sink).info(huge);
+  assert.strictEqual(lines.length, 1);
+  assert.ok(lines[0].includes("…[truncated]"), "must mark the cut");
+  assert.ok(
+    lines[0].length < MAX_ARG_CHARS + 50,
+    `line stayed bounded (got ${lines[0].length} chars)`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Never throw: the logger sits inside updater lifecycle callbacks, where a
+// throw would break the one subsystem it exists to observe.
+// ---------------------------------------------------------------------------
+
+test("a throwing sink does not propagate out of any level", () => {
+  const log = makeUpdaterLogger(() => { throw new Error("disk full"); });
+  assert.doesNotThrow(() => log.info("a"));
+  assert.doesNotThrow(() => log.warn("b"));
+  assert.doesNotThrow(() => log.error("c", new Error("inner")));
+  assert.doesNotThrow(() => log.debug("d"));
+});
+
+test("unserializable args do not throw (circular object falls back to String)", () => {
+  const { sink, lines } = makeSink();
+  const circular = {};
+  circular.self = circular;
+  assert.doesNotThrow(() => makeUpdaterLogger(sink).info(circular));
+  assert.strictEqual(lines.length, 1);
+  assert.ok(lines[0].startsWith("[update:info] "));
+});

--- a/website/electron/update-logger.js
+++ b/website/electron/update-logger.js
@@ -1,0 +1,69 @@
+/**
+ * Updater -> launch-log bridge, kept pure for testability.
+ *
+ * electron-updater (and auto-update.js's own lifecycle lines) log through a
+ * {info, warn, error, debug} object. When main.js passes no `log` dep,
+ * auto-update.js defaults to `console` AND assigns it as autoUpdater.logger --
+ * and in a packaged app console output goes nowhere durable, so update
+ * failures leave no trace on disk. main.js already owns a durable
+ * single-line sink (glog -> gateway-launch.log); this module adapts the
+ * updater's logger interface onto such a sink.
+ *
+ * Contract:
+ * - Each call becomes exactly ONE line, tagged with its level
+ *   ("[update:error] ..."), so the launch log stays greppable line-by-line.
+ * - An Error serializes as its message plus the FIRST stack frame only:
+ *   electron-updater's HttpError dumps are multi-line monsters that would
+ *   otherwise flood the log while the first frame carries the signal.
+ * - Any single argument is truncated to MAX_ARG_CHARS for the same reason.
+ * - Never throws: logging must never be able to break the updater (the
+ *   mirror of glog's own "never let logging break launch" rule).
+ * - `debug` is included because electron-updater probes its logger for it.
+ */
+
+const MAX_ARG_CHARS = 500;
+
+/** Render one logger argument as single-line text, bounded in length. */
+function formatArg(arg) {
+  let text;
+  if (arg instanceof Error) {
+    const stack = typeof arg.stack === "string" ? arg.stack.split("\n") : [];
+    // stack[0] repeats "Name: message"; the first real frame is stack[1].
+    const frame = stack.length > 1 ? ` ${stack[1].trim()}` : "";
+    text = `${arg.name || "Error"}: ${arg.message}${frame}`;
+  } else if (typeof arg === "string") {
+    text = arg;
+  } else {
+    try { text = JSON.stringify(arg); } catch { text = String(arg); }
+    if (text === undefined) text = String(arg);
+  }
+  // One call, one line -- collapse any embedded newlines.
+  text = String(text).replace(/\s*\r?\n\s*/g, " ");
+  if (text.length > MAX_ARG_CHARS) {
+    text = `${text.slice(0, MAX_ARG_CHARS)}…[truncated]`;
+  }
+  return text;
+}
+
+/**
+ * Build an electron-updater-compatible logger that writes tagged single
+ * lines through `sink` (a function taking one string, e.g. main.js's glog).
+ *
+ * @param {(line: string) => void} sink
+ * @returns {{info: Function, warn: Function, error: Function, debug: Function}}
+ */
+function makeUpdaterLogger(sink) {
+  const emit = (level) => (...args) => {
+    try {
+      sink(`[update:${level}] ${args.map(formatArg).join(" ")}`);
+    } catch { /* logging must never break the updater */ }
+  };
+  return {
+    info: emit("info"),
+    warn: emit("warn"),
+    error: emit("error"),
+    debug: emit("debug"),
+  };
+}
+
+module.exports = { makeUpdaterLogger, MAX_ARG_CHARS };


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

In a packaged .app, the auto-update subsystem's diagnostics are unrecoverable. `website/electron/main.js` calls `initAutoUpdate()` without a `log` dep, so `auto-update.js` falls back to `console` for its own `[update]` lifecycle lines and classified errors, and also installs `console` as `autoUpdater.logger`, which routes electron-updater's internal output the same way — and console output from a packaged app is not persisted anywhere. I hit this diagnosing a real update error on my own install: `gateway-launch.log` faithfully records every gateway launch decision via `glog()`, but the one subsystem the report was actually about had written nothing to it, and I had to reconstruct the update timeline from disk forensics instead of reading a log.

## Why it matters

Update failures happen almost exclusively in the field, on packaged builds, where console is exactly the sink that does not exist. Anyone triaging a user's "the update failed" report has `gateway-launch.log` as the natural first artifact to ask for — it already carries the adjacent lines like `update install dispatched — liveness recovery disarmed` — but none of the updater's own checking/found/downloaded/error output lands there, so the log answers every question except the one being asked.

## What changed (motivation → approach → change)

The symptom is missing update diagnostics in packaged builds; the root cause is that the updater's logger defaults to console because no `log` dep is passed; the fix is to bridge the updater's logger interface onto the durable sink main.js already owns. I added a small pure module, `website/electron/update-logger.js`, exporting `makeUpdaterLogger(sink)` which returns the `{info, warn, error, debug}` shape electron-updater expects (`debug` included because the library probes its logger for it). Each call becomes exactly one level-tagged line (`[update:error] ...`) so the launch log stays greppable line-by-line; an `Error` serializes as its message plus the first stack frame only, and any single argument is truncated at 500 chars, because electron-updater's HttpError dumps are multi-line and would otherwise flood the log; the sink call is wrapped in try/catch so logging can never break the updater, mirroring glog's own "never let logging break launch" rule. main.js changes by exactly two lines — the require and `log: makeUpdaterLogger(glog)` in the `initAutoUpdate` deps — deliberately kept minimal because several open PRs touch main.js. `update-logger.js` is also added to the electron-builder `files` allowlist so it ships in the packaged app (the packaging tests enforce this).

## Tests

`website/electron/test/update-logger.test.js` (node:test, matching its neighbors): each level emits exactly one line tagged with its level; multi-line string args collapse to a single line; an Error serializes to message + first stack frame only (later frames dropped, no embedded newlines); a stackless Error still serializes its message; an over-long argument is truncated with a visible marker and the line stays bounded; a throwing sink does not propagate out of any level; a circular (unserializable) object does not throw. `website/electron/test/auto-update.test.js` gains a wiring-contract test asserting that a provided `log` dep becomes `autoUpdater.logger` verbatim, so the assignment that routes electron-updater's internal output cannot silently drift.

## Manual verification

N/A — unit coverage sufficient: the module is pure (sink injected), the wiring contract is pinned by the new initAutoUpdate test, and glog's append-to-`gateway-launch.log` behavior is untouched by this diff.

<!-- no-visual-delta -->
**Why no screenshot:** main-process logging plumbing; no rendered UI is touched.

## Related Issues

no linked issue: diagnosed from a field report on my own install.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
