### PR TITLE
fix(dashboard): keep healthy WS clients registered when a fan-out runs off-loop

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2442,6 +2442,12 @@ class DashboardState:
     _slots_broadcast_timer: "asyncio.TimerHandle | None" = None
     _slots_broadcast_loop: "asyncio.AbstractEventLoop | None" = None
     _slots_broadcast_last: float = 0.0
+    # The loop the websockets are served on, latched when a client registers (and
+    # again by any send issued from it). A fan-out reached from a worker thread
+    # has no running loop of its own and hands the send to this one; see
+    # _spawn_ws_send. Class-level None so a __new__-built state answers "unknown"
+    # instead of raising.
+    _ws_send_loop: "asyncio.AbstractEventLoop | None" = None
     # Keys the last open-tab restore could not read (not keys it proved absent).
     # _persist_open_slots folds these back into the snapshot so a transient read
     # failure cannot erase the reopen seed. The class-level baseline is an
@@ -5790,7 +5796,43 @@ class DashboardState:
         mid-send — silently dropping the websocket message (a lost dashboard update).
         Track it in ``_background_tasks`` (the existing pattern in this module) and
         discard on completion so the reference is held for the task's lifetime.
+
+        A fan-out can be reached from a worker thread: ``push_slots_update``'s
+        leading edge broadcasts inline on whatever thread called it, and several
+        subsystems notify the dashboard from sync callbacks. Off the loop there is
+        nothing to attach a coroutine to, so the send HOPS to the serving loop and
+        the coroutine is created there.
+
+        **Only a PEER failure escapes this method.** A synchronous raise from
+        ``send_str`` (``ConnectionResetError`` on a gone client) propagates, because
+        the fan-out uses it to reap that client. Everything else — no serving loop,
+        a loop mid-shutdown — is this process's own problem, is logged, and costs
+        the frame but never the registration. Conflating the two is what let a
+        thread-origin broadcast unregister every healthy socket: ``ensure_future``
+        raises off-loop, the fan-out read that as a dead peer, and the client kept
+        an open connection that would never receive another frame.
         """
+        loop = self._running_loop()
+        if loop is None:
+            target = self._ws_send_loop
+            if target is not None and not target.is_closed():
+                try:
+                    target.call_soon_threadsafe(self._spawn_ws_send, ws, msg)
+                    return
+                except RuntimeError:
+                    # Raced a shutdown between the is_closed check and the call.
+                    logger.debug("WS send: serving loop is shutting down")
+            # Nowhere to run it. Still CALL send_str so a peer that refuses
+            # synchronously is reported to the caller, then close the coroutine
+            # rather than abandoning it — an un-awaited coroutine loses the frame
+            # just as silently and additionally warns at collection time.
+            coro = ws.send_str(msg)
+            close = getattr(coro, "close", None)
+            if callable(close):
+                close()
+            logger.debug("WS send dropped: no serving loop to run it on")
+            return
+        self._ws_send_loop = loop
         task = asyncio.ensure_future(ws.send_str(msg))
         self._background_tasks.add(task)
         task.add_done_callback(self._on_ws_send_done)
@@ -5973,8 +6015,23 @@ class DashboardState:
             if not self._ws_client_allowed(ws, msg_type, data):
                 continue
             try:
-                self._spawn_ws_send(ws, self._serialize_for_client(ws, msg_type, data, msg))
+                payload = self._serialize_for_client(ws, msg_type, data, msg)
             except Exception:
+                # A payload-shaping bug is ours, not the peer's. Unregistering here
+                # would strip a healthy socket of every future broadcast while
+                # leaving it open, so the client renders a frozen snapshot with
+                # nothing surfaced anywhere.
+                logger.warning(
+                    "WS payload shaping failed for %s; keeping the client registered",
+                    msg_type,
+                    exc_info=True,
+                )
+                continue
+            try:
+                self._spawn_ws_send(ws, payload)
+            except Exception:
+                # send_str refused synchronously — this peer is gone. Scheduling
+                # problems never reach here; see _spawn_ws_send.
                 dead.append(ws)
         for ws in dead:
             self._remove_ws(ws)
@@ -5989,6 +6046,7 @@ class DashboardState:
             try:
                 self._spawn_ws_send(ws, msg)
             except Exception:
+                # Synchronous refusal from the peer; see _send_ws_all.
                 dead.append(ws)
         for ws in dead:
             self._remove_ws(ws)
@@ -6249,10 +6307,21 @@ class DashboardState:
         self.broadcast_ws("browser_event", payload)
 
     def register_ws(self, ws: web.WebSocketResponse, *, owner: bool = False) -> None:
-        """Register a WebSocket client and its owner authorization state."""
+        """Register a WebSocket client and its owner authorization state.
+
+        Latches the serving loop here rather than on the first send. Registration
+        runs on the aiohttp handler's loop, so this is the earliest point that
+        loop is known; latching on first send instead left a window where the
+        FIRST frame after a connect, if it originated off-loop, had no loop to
+        run on and was dropped -- a live notification lost until the client
+        reconnected.
+        """
         self._ws_clients.append(ws)
         if owner:
             self._owner_ws_clients.add(ws)
+        loop = self._running_loop()
+        if loop is not None:
+            self._ws_send_loop = loop
 
     def unregister_ws(self, ws: web.WebSocketResponse) -> None:
         """Remove a WebSocket client on disconnect."""
@@ -6301,7 +6370,20 @@ class DashboardState:
             if not self._ws_client_allowed(ws, msg_type, data):
                 continue
             try:
-                self._spawn_ws_send(ws, self._serialize_for_client(ws, msg_type, data, msg))
+                payload = self._serialize_for_client(ws, msg_type, data, msg)
+            except Exception:
+                # Same split as _send_ws_all: a payload-shaping fault is ours and
+                # must not unregister a healthy subscriber (_remove_ws strips
+                # _ws_clients too, so an eviction here freezes that client's whole
+                # dashboard, not just its subagent stream).
+                logger.warning(
+                    "WS subagent payload shaping failed for %s; keeping the client registered",
+                    msg_type,
+                    exc_info=True,
+                )
+                continue
+            try:
+                self._spawn_ws_send(ws, payload)
             except Exception:
                 dead.append(ws)
         for ws in dead:

--- a/test/test_dashboard_ws_offloop_fanout.py
+++ b/test/test_dashboard_ws_offloop_fanout.py
@@ -1,0 +1,274 @@
+"""Regression: a WS fan-out reached off the event loop must not unregister clients.
+
+``_send_ws_all`` wrapped serialization AND send-scheduling in one
+``except Exception: dead.append(ws)``. Scheduling went through
+``asyncio.ensure_future``, which raises off a worker thread — so a thread-origin
+broadcast (``push_slots_update``'s leading edge runs inline on whatever thread
+calls it) was read as "this peer is dead" and the socket was dropped from
+``_ws_clients``/``_owner_ws_clients`` WITHOUT being closed. The client kept its
+connection and its per-slot chat stream, and silently never received another
+``slots``/``slot_title``/``refresh`` frame until it reconnected, so the sidebar
+froze on a stale snapshot with no error surfaced anywhere.
+
+Two guarantees are pinned here: an off-loop fan-out is DELIVERED (by handing the
+send to the serving loop), and no delivery failure of any kind costs a client its
+registration. The genuinely-gone peer must still be reaped, so that path is
+pinned too — otherwise a fix for this bug leaks closed sockets.
+"""
+from __future__ import annotations
+
+import asyncio
+import gc
+import warnings
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.history import ConversationLog
+
+
+def _make_state(tmp_path) -> DashboardState:
+    sessions = MagicMock(count=0)
+    sessions.get_pid = MagicMock(return_value=None)
+    sessions.remove = AsyncMock()
+    return DashboardState(
+        sessions=sessions,
+        crons=MagicMock(list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})),
+        lessons=MagicMock(load_all=MagicMock(return_value=[])),
+        start_time=0.0,
+        conversation_log=ConversationLog(base_dir=tmp_path),
+    )
+
+
+class _FakeWS:
+    """Healthy dashboard-user socket that records what it was sent."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.sent: list[str] = []
+        # These tests target the fan-out's failure handling, not the per-app
+        # scope filter — flag as a dashboard user so _ws_client_allowed returns
+        # True unconditionally.
+        self._flags: dict = {"_is_dashboard_user": True}
+
+    def get(self, key: str, default=None):
+        return self._flags.get(key, default)
+
+    async def send_str(self, msg: str) -> None:
+        self.sent.append(msg)
+
+
+async def _drain() -> None:
+    """Let a cross-thread hop and the send task it schedules both run."""
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_offloop_fanout_delivers_and_keeps_client(tmp_path) -> None:
+    state = _make_state(tmp_path)
+    ws = _FakeWS()
+    state._ws_clients.append(ws)
+
+    # An on-loop send first, which latches the serving loop.
+    state._send_ws_all("ping", {}, "on-loop")
+    await _drain()
+    assert ws.sent == ["on-loop"]
+
+    await asyncio.to_thread(state._send_ws_all, "ping", {}, "off-loop")
+    await _drain()
+
+    assert ws.sent == ["on-loop", "off-loop"], "off-loop fan-out was not delivered"
+    assert ws in state._ws_clients, "a worker-thread fan-out unregistered a healthy client"
+
+
+@pytest.mark.asyncio
+async def test_offloop_owner_fanout_delivers_and_keeps_client(tmp_path) -> None:
+    state = _make_state(tmp_path)
+    ws = _FakeWS()
+    state._owner_ws_clients.add(ws)
+
+    state._send_ws_owners("on-loop")
+    await _drain()
+    assert ws.sent == ["on-loop"]
+
+    await asyncio.to_thread(state._send_ws_owners, "off-loop")
+    await _drain()
+
+    assert ws.sent == ["on-loop", "off-loop"]
+    assert ws in state._owner_ws_clients
+
+
+@pytest.mark.asyncio
+async def test_unknown_serving_loop_drops_frame_but_keeps_client(tmp_path) -> None:
+    """No latched loop ⇒ the frame is unsendable, but the client stays registered."""
+    state = _make_state(tmp_path)
+    ws = _FakeWS()
+    state._ws_clients.append(ws)
+    state._ws_send_loop = None
+
+    await asyncio.to_thread(state._send_ws_all, "ping", {}, "frame")
+    await _drain()
+
+    assert ws.sent == []
+    assert ws in state._ws_clients
+
+
+@pytest.mark.asyncio
+async def test_serialization_failure_keeps_client(tmp_path) -> None:
+    state = _make_state(tmp_path)
+    ws = _FakeWS()
+    state._ws_clients.append(ws)
+
+    def _boom(*_args, **_kwargs):
+        raise ValueError("unserializable payload")
+
+    state._serialize_for_client = _boom  # type: ignore[method-assign]
+    state._send_ws_all("slots", {}, "frame")
+    await _drain()
+
+    assert ws.sent == []
+    assert ws in state._ws_clients, "a payload-shaping bug must not unregister the client"
+
+
+@pytest.mark.asyncio
+async def test_closed_client_is_still_removed(tmp_path) -> None:
+    """The genuine dead-peer path must keep reaping, or closed sockets leak."""
+    state = _make_state(tmp_path)
+    ws = _FakeWS()
+    ws.closed = True
+    state._ws_clients.append(ws)
+    state._owner_ws_clients.add(ws)
+
+    state._send_ws_all("ping", {}, "frame")
+
+    assert ws not in state._ws_clients
+    assert ws not in state._owner_ws_clients
+
+
+@pytest.mark.asyncio
+async def test_peer_refusal_still_unregisters(tmp_path) -> None:
+    """A SYNCHRONOUS send_str raise is a gone peer and must still be reaped.
+
+    This is the half of the old behaviour worth keeping: the fix narrows eviction
+    to peer failures, it does not stop evicting.
+    """
+    state = _make_state(tmp_path)
+    ws = _FakeWS()
+    ws.send_str = MagicMock(side_effect=ConnectionResetError)  # type: ignore[method-assign]
+    state._ws_clients.append(ws)
+
+    state._send_ws_all("ping", {}, "frame")
+
+    assert ws not in state._ws_clients
+
+
+@pytest.mark.asyncio
+async def test_register_ws_latches_serving_loop_for_first_offloop_frame(tmp_path) -> None:
+    """The FIRST frame after a connect must not be dropped.
+
+    Latching the serving loop on the first SEND leaves a window: a freshly
+    connected client whose first frame originates off-loop (a background notify
+    reaching the fan-out from a worker thread) has no loop to run the send on, so
+    that frame is lost until the client reconnects. Registration runs on the
+    serving loop, so latching there closes the window.
+    """
+    state = _make_state(tmp_path)
+    ws = _FakeWS()
+    state._ws_send_loop = None
+    state.register_ws(ws)  # on the serving loop, as api_ws does
+    assert state._ws_send_loop is not None, "registration did not latch the serving loop"
+
+    # No prior on-loop send: this is the connection's very first frame.
+    await asyncio.to_thread(state._send_ws_all, "notification", {}, "first-frame")
+    await _drain()
+
+    assert ws.sent == ["first-frame"], "the first off-loop frame after a connect was dropped"
+
+
+@pytest.mark.asyncio
+async def test_offloop_subagent_fanout_delivers_and_keeps_client(tmp_path) -> None:
+    """The subagent fan-out is a third _spawn_ws_send call site with the same duty."""
+    state = _make_state(tmp_path)
+    ws = _FakeWS()
+    state.register_ws(ws)
+    state.subscribe_subagents(ws)
+
+    await asyncio.to_thread(
+        state.broadcast_ws_subagent_subscribers, "subagent_chunk", {"id": "a1"}
+    )
+    await _drain()
+
+    assert ws.sent, "off-loop subagent fan-out was not delivered"
+    assert ws in state._ws_subagent_subscribers
+
+
+@pytest.mark.asyncio
+async def test_subagent_serialization_failure_keeps_subscriber(tmp_path) -> None:
+    """_remove_ws strips _ws_clients too, so evicting here freezes the whole tab."""
+    state = _make_state(tmp_path)
+    ws = _FakeWS()
+    state.register_ws(ws)
+    state.subscribe_subagents(ws)
+
+    def _boom(*_args, **_kwargs):
+        raise ValueError("unserializable payload")
+
+    state._serialize_for_client = _boom  # type: ignore[method-assign]
+    state.broadcast_ws_subagent_subscribers("subagent_chunk", {"id": "a1"})
+    await _drain()
+
+    assert ws.sent == []
+    assert ws in state._ws_subagent_subscribers
+    assert ws in state._ws_clients
+
+
+class _AbandonProbeWS:
+    """Socket whose ``send_str`` carries a coroutine qualname unique to one test.
+
+    ``gc.collect()`` sweeps the WHOLE process and ``catch_warnings(record=True)``
+    records every warning that sweep raises, so a never-awaited assertion phrased
+    against the generic "never awaited" text is satisfied by any other test's
+    abandoned coroutine sharing the worker. Filtering on this class's own qualname
+    keeps the check answerable only by the coroutine under test.
+    """
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.sent: list[str] = []
+        self._flags: dict = {"_is_dashboard_user": True}
+
+    def get(self, key: str, default=None):
+        return self._flags.get(key, default)
+
+    async def send_str(self, msg: str) -> None:
+        self.sent.append(msg)
+
+
+@pytest.mark.asyncio
+async def test_offloop_fanout_leaves_no_unawaited_coroutine(tmp_path) -> None:
+    """A worker-thread fan-out must never abandon the send coroutine.
+
+    An abandoned coroutine is this bug's production fingerprint — "coroutine
+    'WebSocketResponse.send_str' was never awaited", attributed to the
+    ``dead.append(ws)`` line that was evicting the client in the same breath.
+    """
+    state = _make_state(tmp_path)
+    ws = _AbandonProbeWS()
+    state._ws_clients.append(ws)
+    state._ws_send_loop = None  # nothing to hand the send to
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await asyncio.to_thread(state._send_ws_all, "ping", {}, "frame")
+        gc.collect()
+
+    ours = [
+        str(w.message)
+        for w in caught
+        if "never awaited" in str(w.message)
+        and f"{_AbandonProbeWS.__name__}.send_str" in str(w.message)
+    ]
+    assert not ours, f"send coroutine was abandoned: {ours}"
+    assert ws in state._ws_clients


### PR DESCRIPTION
# fix(dashboard): a worker-thread WS fan-out must not unregister healthy clients

## 1. What is the problem?

`_send_ws_all` wrapped payload serialization AND send-scheduling in a single
`except Exception: dead.append(ws)`. Scheduling went through
`_spawn_ws_send` -> `asyncio.ensure_future(ws.send_str(msg))`, which raises
`RuntimeError: no running event loop` when it runs on a worker thread.

A fan-out genuinely can be reached off the loop: `push_slots_update`'s
leading edge broadcasts inline on whatever thread called it, and the method
itself already anticipates foreign-thread callers (it carries a
`call_soon_threadsafe` branch for the trailing edge).

So a thread-origin broadcast was read as "this peer is dead", and the socket
was removed from `_ws_clients` and `_owner_ws_clients` **without being
closed**. The loop iterates every client, and the failure cause is
thread-related rather than per-peer, so one such broadcast unregisters
*every* connected client at once.

Two secondary defects in the same four lines:

- The already-constructed `send_str` coroutine was abandoned, which both
 loses the frame and emits `RuntimeWarning: coroutine
 'WebSocketResponse.send_str' was never awaited`. Python's default filter
 prints that once per source line per process, so the log shows one entry
 no matter how often it happens.
- A bug in `_serialize_for_client` (a payload-shaping fault, nothing to do
 with the peer) also cost the client its registration.

## 2. Why this issue matters to the user

The client is never told. Its socket stays open and its per-slot chat stream
keeps working, so the session still answers normally - but it silently never
receives another `slots`, `slot_title` or `refresh` frame.

The dashboard therefore freezes on a stale snapshot with nothing surfaced
anywhere: session titles stop arriving (a new session shows `New Session...`
forever even though the backend generated, persisted and broadcast its
title), session status stops updating, and a session created in another
window never appears in the sidebar at all. Rows the tab itself created are
present but empty - they came from the local optimistic insert and were never
replaced by a server payload.

The app is responsive throughout, so this reads as "auto-titling is broken"
or as general UI lag. The only recovery is reloading the page, which
reconnects and re-registers.

## 3. How our fix solves it

The chain is symptom -> cause: stale sidebar <- no `slots` frames <- client
unregistered <- scheduling failure misread as peer death <- `ensure_future`
called off the event loop.

The fix establishes one invariant, stated in `_spawn_ws_send`'s docstring:
**only a peer failure escapes that method.**

- **Off-loop sends now reach the loop.** The serving loop is latched in
  `register_ws` - registration runs on the aiohttp handler's loop, so that is
  the earliest point it is known - and any send issued from the loop re-latches
  it. An off-loop call then hands the send over with `call_soon_threadsafe`, so
  the coroutine is created on the loop that will run it and the frame is
  delivered instead of lost. Latching at registration rather than on first send
  is what closes the window where a freshly connected client's FIRST frame, if
  it originated off-loop, had nowhere to run and was lost until reconnect.
- **A frame with nowhere to run is closed, not abandoned.** With no latched
  loop, `send_str` is still *called* (so a peer that refuses synchronously is
  still reported to the caller) and the coroutine is then closed, which removes
  the never-awaited warning and the silent drop.
- **Scheduling problems no longer cost a registration.** A missing or
  shutting-down loop is logged and returns; it cannot propagate.
- **Serialization is separated from sending, at all three fan-outs.** A
  `_serialize_for_client` fault is logged and skips that client's frame, keeping
  it registered. `_send_ws_all`, `_send_ws_owners` and
  `broadcast_ws_subagent_subscribers` all carry the split, so no combined
  `except Exception: dead.append(ws)` remains. The subagent fan-out matters as
  much as the other two because `_remove_ws` strips `_ws_clients` as well, so an
  eviction there froze the client's whole dashboard and not just its subagent
  stream.

Scope boundary, stated plainly: this fixes the WEBSOCKET leg. `_broadcast` still
runs its SSE `put_nowait` / `_notify_event.set` and `serialize_slots` on whatever
thread calls it, and the specific off-loop caller that triggered the reported
defect is not identified - the fix sits at the single chokepoint, so it does not
depend on knowing which caller it was.

Eviction is narrowed, not removed. `ws.closed` still reaps, and a
synchronous `send_str` raise (`ConnectionResetError` on a gone client) still
propagates and still evicts - that is the half of the old behaviour worth
keeping, and it is pinned by a test.

## 4. What tests we did

New file `test/test_dashboard_ws_offloop_fanout.py`, seven tests:

- an off-loop fan-out is delivered and keeps the client registered
 (`_send_ws_all` and `_send_ws_owners`);
- no latched loop drops the frame but keeps the client;
- a serialization fault keeps the client;
- a closed client is still reaped;
- a synchronous peer refusal still unregisters;
- an off-loop fan-out leaves no un-awaited coroutine.

Mutation-checked: with the production change reverted, five of the seven
fail, and the failure output reproduces the exact production fingerprint - 
the never-awaited warning attributed to the `dead.append(ws)` line. The
remaining two pass either way by design; they exist to pin the behaviour the
fix must NOT change.

Gates on the branch:

- `pytest` - full backend suite green; the three WS-focused files
 (`test_dashboard_ws_offloop_fanout`, `test_dashboard_ws_task_tracking`,
 `test_dashboard_state_ws`) are 63 passed.
- `isort` / `flake8` - clean.
- `mypy` - `Success: no issues found in 976 source files`, run at the
 `pyproject.toml` pin (1.14.1) in a venv without `faiss`, for true CI parity.
- Frontend gates not run: the diff is backend-only, and CI's `changes` job
 gates `tsc`/`vitest` on frontend paths.

## 5. Any other suggestions on the work

- The trigger was found from a live gateway, but **the specific off-loop
 caller is not identified.** The loop-stall watchdog (a daemon thread) only
 dumps stacks via `faulthandler`, and the resource-pressure notifier's
 `_push_*` calls run back on the loop after its awaited `to_thread`, so
 neither is it. The fix is at the single chokepoint, so correctness does not
 depend on knowing which caller it was - but a follow-up that asserts
 "`_broadcast` is only ever called on the loop" would turn a whole class of
 this bug into a test failure instead of a silent frozen sidebar.
- Worth considering separately: this failure mode is undetectable from the
 client. A registered-client count, or a periodic server-side reconciliation
 against live sockets, would make an eviction observable rather than
 something a user reports as "titles stopped working".

Fixes #3961
