### PR TITLE
fix(dev-fleet): reclaim a stopped pod's isolated HOME on worktree removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **Removing a worktree in Dev Fleet no longer strands its pod's isolated
+  HOME.** Reclamation was gated on the pod's unit still being ACTIVE, which the
+  ordinary path never is: you stop the pod when testing ends and prune days
+  later once the PR merges. So the delete path that reclaims the HOME was
+  effectively never called, and every removal leaked a full isolated
+  `KIROCREW_HOME` — dominated by a per-instance copy of the embedding model, so
+  ~0.6 GB each — with the directory becoming unattributable the moment the
+  worktree's env pin went away. Removal now reclaims the HOME whether or not the
+  pod is running, using the same `orphan_homes` predicate as `pod ls` / `pod
+  prune` (so symlinks are skipped, and a macOS name mid-`up` is treated as
+  installed rather than orphaned). Attribution and teardown are ONE transaction
+  held under `pod_name_mutex`: pod identities are global basenames, so checking
+  ownership in one process and tearing down in another leaves a window where a
+  concurrent `pod up` from a different checkout claims the same name and the
+  teardown would stop that pod and delete its HOME. Both call sites — the
+  live-unit path and the orphaned-HOME path — go through the one locked helper,
+  which is necessarily in-process: the mutex is held per open-file-description
+  and `stop_pod` re-acquires it, so holding it around a `pod down` shell-out
+  would block the child being waited on. Because the delete needs positive
+  attribution, an ABSENT checkout pin refuses rather than assuming ownership
+  (`pod prune` still reclaims those), and a name handed to a new pod mid-teardown
+  refuses the removal outright, since that pod may be running out of the very
+  worktree about to be deleted.
+  The two outcomes are reported separately (`stopped_pod` vs
+  `reclaimed_pod_home`) rather than conflated into a shutdown that never
+  happened. Liveness checks keep failing CLOSED — they guard against deleting a
+  checkout under a live pod — while a reclamation that cannot run now degrades
+  to a logged leftover instead of refusing the removal, and a provably absent
+  pod backend logs the HOME it is leaving behind at WARNING with the verb that
+  reclaims it, replacing a debug-level line that hid the residue entirely.
+
 - **The one-time config migration no longer leaves a `.json.bak` orphan beside a
   config path it does not own.** `KiroCrewConfig.load()` copied the
   pre-migration config to `<path>.bak`, where `<path>` is whatever
@@ -18,6 +49,7 @@ All notable changes to KiroCrew are documented in this file.
   copy aside is not rewritten either. The name is also built by
   appending rather than `with_suffix(".json.bak")`, which REPLACED the final
   suffix and so renamed a non-`*.json` config instead of backing it up.
+
 
 - **A knowledge source that errored during ingestion is no longer re-synced on
   every sweep.** `KnowledgeIngestion` marks failure in the `sync_status`

--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -128,7 +128,7 @@ verification. Route names below are relative to that prefix.
 | Route | Body | Description |
 |-------|------|-------------|
 | `/apps/dev-fleet/api/sync` | — | Pull main + rebuild (single-flight; a concurrent call is refused **409**) |
-| `/apps/dev-fleet/api/worktree/remove` | `{name, force?}` | Remove a worktree (stops pod first) |
+| `/apps/dev-fleet/api/worktree/remove` | `{name, force?}` | Remove a worktree (stops its pod and reclaims that pod's isolated HOME first) |
 | `/apps/dev-fleet/api/prune-run` | `{names[]}` | Batch-remove eligible worktrees |
 | `/apps/dev-fleet/api/pod/up` | `{name}` | Start isolated pod instance (re-verifies the unit is active) |
 | `/apps/dev-fleet/api/pod/down` | `{name}` | Stop pod instance (re-verifies the unit is gone before reporting success) |
@@ -226,6 +226,80 @@ running" bug, issue #220). As defence-in-depth, `_pod_up` and `_pod_down` both
 re-check `runtime.active_names` after the CLI returns and fail closed
 (`pod not active after start` / `pod still active after shutdown`) — a CLI exit 0
 is never taken as proof of the state change, in either direction.
+
+### Pod HOME reclamation on worktree removal
+
+Removing a worktree reclaims the isolated `KIROCREW_HOME` of that worktree's pod
+whether or not the pod is still running, because a stopped pod still owns its
+HOME and this is the last moment anything can attribute that directory to this
+checkout — afterwards the per-pod env pin naming it is gone and only a bulk
+`pod prune` could find it. Reclaiming only a LIVE unit would therefore reclaim
+nothing on the ordinary path: the operator stops the pod when testing ends and
+prunes days later once the PR merges, so the unit is inactive by then and every
+removal stranded a full isolated HOME (a per-instance embedding-model copy
+dominates its size).
+
+Which directories qualify is decided by `runtime.orphan_homes`, the same
+predicate `pod ls` and `pod prune` use, rather than a bare directory probe — so
+symlinks are skipped and, on macOS, a name whose per-pod plist exists counts as
+*installed* rather than orphaned and is never reclaimed from underneath a
+concurrent `up`. That predicate keys on the pod root, liveness and plist and
+never on the checkout pin, so attribution is not its job.
+
+Attribution and teardown are ONE locked transaction. `_reclaim_pod_locked` runs
+entirely inside `runtime.pod_name_mutex` — the cross-process flock every mutating
+pod path cooperates on — and reads the checkout pin, decides ownership, calls
+`runtime.stop_pod`, and clears the per-pod env file without ever releasing it.
+Splitting those halves is what the lock exists to prevent: pod identities are
+global basenames, so between an ownership check in one process and a teardown in
+another, a concurrent `pod up` from a DIFFERENT checkout can claim the same name
+and the teardown would stop that pod and delete its isolated HOME. Both call
+sites in `_worktree_remove` — the live-unit path and the orphaned-HOME path — go
+through this one helper, so neither carries that window.
+
+That is also why the reclaim is in-process rather than a `pod down` shell-out:
+the mutex is held per open-file-description and `stop_pod` re-acquires it, so a
+caller holding it around a subprocess would block the child it waits on. The
+mutex is reentrant *within a thread* and the helper is submitted to the executor
+as a single callable, so `stop_pod`'s own acquisition nests instead of
+deadlocking. The helper mirrors `_pod_checkout_guard`'s attribution rules with one deliberate
+tightening: an ABSENT pin is a refusal here. The guard allows an unpinned name
+when no unit is live, which is right for operating on a pod the caller located,
+but this path DELETES the HOME and a same-basename leftover from another checkout
+is indistinguishable from here, so deletion demands positive attribution. The
+cost is that an unpinned orphan is not reclaimed automatically — `pod prune`
+still takes it — which is the cheaper side of the trade. It also mirrors the
+CLI's post-teardown env-file clear, and leaves that file alone when `stop_pod`
+reports the name was handed to a new pod mid-teardown (it now pins the new pod's
+checkout).
+
+`handed_over` is a REFUSAL at both call sites, not a success: a new pod holds the
+name, which checkout it belongs to is unknowable here, and it may be running out
+of the very worktree about to be deleted. The post-stop liveness recheck is not a
+substitute, since it can miss a unit that is still bootstrapping.
+
+The two fail directions are scoped separately on the orphan path. The
+ENUMERATION is best-effort cleanup — an orphan scan says nothing about liveness,
+so its failure degrades to a named leftover rather than turning a lost directory
+into a lost removal. The RECLAIM is teardown and fails CLOSED: a returned failure
+refuses the removal, and a RAISED one is deliberately not caught there either,
+because a teardown that died mid-flight (a stop that timed out against a
+still-activating unit) is exactly the state in which removing the checkout is
+unsafe.
+
+The result reports the two outcomes separately: `stopped_pod` for a unit that was
+running, `reclaimed_pod_home` for a HOME reclaimed with nothing running.
+
+Two failure directions are deliberately different. A **liveness** check that
+cannot run fails CLOSED and refuses the removal, because it guards against
+deleting a checkout out from under a running pod. A **reclamation** step that
+cannot run degrades: the orphan scan says nothing about liveness, so an
+enumeration error logs the leftover (pointing at `pod prune`) and the removal
+proceeds, rather than turning a lost directory into a lost removal. When the pod
+backend is provably absent the HOME is left in place on purpose — liveness is
+then unprovable and deleting a HOME that may belong to a live gateway is the one
+outcome teardown must never risk — but the path is logged at WARNING with the
+`pod down` verb that reclaims it, so the residue is visible instead of silent.
 
 ### Provisioning Dependency Install
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -2608,6 +2608,92 @@ async def _pod_checkout_guard(name: str) -> str | None:
     return None
 
 
+def _reclaim_pod_locked(cfg, name: str, expected_checkout: str) -> tuple[str, str]:
+    """Attribute pod *name* and tear it down as ONE locked transaction.
+
+    Runs entirely inside ``rt.pod_name_mutex``, which is the cross-process flock
+    every mutating pod path cooperates on. That is the whole point of this
+    helper: checking the checkout pin in one process and then tearing down in
+    another leaves a window where a concurrent ``pod up`` from a DIFFERENT
+    checkout claims the same global basename, so the teardown would stop that
+    pod and delete its isolated HOME. Reading the pin under the same lock the
+    teardown holds closes it.
+
+    Necessarily in-process rather than via the ``pod down`` CLI: the lock is held
+    per open-file-description and ``stop_pod`` re-acquires it, so a caller that
+    held it around a shell-out would block the very child it waits on.
+    ``pod_name_mutex`` is reentrant WITHIN A THREAD, and this function is
+    submitted to the executor as one callable, so ``stop_pod``'s own acquisition
+    nests instead of deadlocking.
+
+    *expected_checkout* is this repo's worktree path for *name*, resolved by the
+    caller before the lock -- it is not the racy half, since a foreign ``up``
+    moves the PIN, never our own worktree.
+
+    Mirrors :func:`_pod_checkout_guard`'s attribution rules, and the CLI's
+    post-teardown env-file clear, so behaviour matches the paths it replaces.
+
+    Returns ``(outcome, detail)`` with outcome one of:
+      ``reclaimed``  -- ours, torn down, HOME verified gone
+      ``handed_over`` -- a new pod claimed the name mid-teardown; its state (and
+                        its pin) is deliberately left untouched. Callers treat
+                        this as a REFUSAL, not a success: a live pod may now be
+                        running out of the very checkout they are about to
+                        delete, and which pod holds the name is unknowable here.
+      ``foreign``    -- not attributable to this checkout; nothing was touched
+      ``failed``     -- attribution or teardown could not be completed
+    """
+    with rt.pod_name_mutex(cfg, name):
+        try:
+            env_exists, pinned = _read_pin_strict(cfg, name)
+        except Exception as exc:  # noqa: BLE001
+            # Pin state exists but cannot be positively read -> never treat as
+            # "unpinned"; that ambiguity is the cross-repo hole itself.
+            return "failed", f"cannot verify pod checkout pin: {_redact(str(exc))}"
+        if not env_exists:
+            # No pin means the HOME cannot be attributed to ANY checkout, and
+            # this path deletes it. ``_pod_checkout_guard`` allows an unpinned
+            # name when no unit is live, which is right for OPERATING on a pod
+            # the caller located; deletion is the stricter case and demands
+            # POSITIVE attribution, because a same-basename leftover from
+            # another checkout looks identical from here. Refusing costs an
+            # unpinned orphan an automatic reclaim -- `pod prune` still takes
+            # it -- while allowing it risks deleting another repo's data.
+            return "foreign", (
+                f"pod {name!r} has no checkout pin, so its HOME cannot be "
+                "attributed to this checkout (unattributable pod identity)"
+            )
+        if not pinned:
+            return "foreign", (
+                f"pod {name!r} has a pin file without a verifiable CHECKOUT "
+                "(ambiguous pod identity)"
+            )
+        try:
+            mine = Path(pinned).resolve() == Path(expected_checkout).resolve()
+        except OSError as exc:
+            return "failed", f"cannot resolve checkout paths: {_redact(str(exc))}"
+        if not mine:
+            return "foreign", (
+                f"pod {name!r} is pinned to a different checkout "
+                "(basename collision)"
+            )
+        cp = rt.stop_pod(cfg, name)
+        if cp.returncode != 0:
+            # Redacted like every other detail this helper returns: it reaches the
+            # worktree-remove response and therefore the dashboard, and teardown
+            # stderr can carry a path or credential from the pod's own output.
+            err = _redact((cp.stderr or "").strip())
+            return "failed", err or f"stop rc={cp.returncode}"
+        if rt.RECLAIMED_MARKER in (cp.stdout or ""):
+            # The env file now pins the NEW pod's checkout -- clearing it would
+            # strip that pod's identity.
+            return "handed_over", f"pod {name!r} was reclaimed by a new pod mid-teardown"
+        # Clear the pinned CHECKOUT=/SEED= so a later `up` re-resolves cleanly,
+        # the same post-reclaim step the CLI performs.
+        cfg.env_file(name).unlink(missing_ok=True)
+        return "reclaimed", ""
+
+
 async def _pod_up(name: str) -> dict:
     guard = await _pod_checkout_guard(name)
     if guard:
@@ -3081,6 +3167,10 @@ async def _worktree_remove(
         progress("stopping_pod")
     cfg = _load_cfg()
     stopped_pod = False
+    # Distinct from ``stopped_pod``: nothing was running, an already-stopped
+    # pod's isolated HOME was reclaimed. Conflating the two would report a
+    # shutdown that never happened.
+    reclaimed_pod_home = False
     if _POD_AVAILABLE and cfg is None:
         return {"ok": False, "error": "cannot load pod configuration to verify pod state"}
     if _POD_AVAILABLE and cfg:
@@ -3108,9 +3198,23 @@ async def _worktree_remove(
                     }
             except Exception:
                 pass  # unit_state also fails → backend truly gone
-            logger.debug(
-                "dev-fleet worktree_remove: pod backend absent; "
-                "skipping pod-state check for %r",
+            # Name the residue instead of hiding the skip at debug level. The
+            # HOME cannot be reclaimed here — without a backend the pod's
+            # liveness is unprovable, and deleting a HOME that may belong to a
+            # live gateway is the one outcome teardown must never risk — but an
+            # operator who is told the path can reclaim it with `pod down`.
+            # Resolving the path is itself best-effort: a diagnostic must never
+            # be the reason a removal fails.
+            try:
+                residue: object = rt.pod_home(cfg, name)
+            except Exception:  # noqa: BLE001
+                residue = "its isolated HOME under the pod root"
+            logger.warning(
+                "dev-fleet worktree_remove: pod backend absent, so %r's pod state "
+                "cannot be verified and %s is left in place; reclaim it with "
+                "`kirocrew pod down %s` once the backend is back",
+                name,
+                residue,
                 name,
             )
         else:
@@ -3120,10 +3224,26 @@ async def _worktree_remove(
                     subprocess_executor(), rt.active_names, cfg
                 )
                 if name in active:
-                    r = await _pod_down(name)
-                    if not r.get("ok"):
-                        return {"ok": False, "error": f"pod shutdown failed: {r.get('error')}"}
+                    outcome, detail = await loop.run_in_executor(
+                        subprocess_executor(), _reclaim_pod_locked, cfg, name, path
+                    )
+                    if outcome == "foreign":
+                        return {"ok": False, "error": f"refusing pod shutdown: {detail}"}
+                    if outcome == "handed_over":
+                        # A new pod holds this name. Which checkout it belongs to
+                        # is unknowable from here, and it may be running out of
+                        # THIS worktree -- removing the files under a live pod is
+                        # exactly what the liveness gate exists to prevent, and
+                        # the post-stop recheck below cannot be relied on to see
+                        # a unit that is still bootstrapping.
+                        return {"ok": False, "error": f"refusing removal: {detail}"}
+                    if outcome == "failed":
+                        return {"ok": False, "error": f"pod shutdown failed: {detail}"}
                     stopped_pod = True
+                    # ``reclaimed_pod_home`` deliberately stays False here: the
+                    # teardown did reclaim the HOME, but the flag's job is to
+                    # distinguish a leftover reclaimed with NOTHING running from a
+                    # real shutdown, and ``stopped_pod`` already reports this one.
                     try:
                         active2 = await loop.run_in_executor(
                             subprocess_executor(), rt.active_names, cfg
@@ -3135,6 +3255,80 @@ async def _worktree_remove(
                             "ok": False,
                             "error": f"cannot verify pod shutdown: {_redact(str(exc))}",
                         }
+                else:
+                    # A STOPPED pod still owns its isolated HOME, and removing the
+                    # worktree is the last moment anything can attribute that
+                    # directory to this checkout: afterwards the pin naming it is
+                    # gone and only a bulk sweep could find it. Real usage stops
+                    # the pod when testing ends and prunes days later once the PR
+                    # merges, so gating reclamation on a LIVE unit meant the common
+                    # path never reclaimed anything — each removal stranded a full
+                    # isolated HOME (a per-instance model copy dominates it) for
+                    # good.
+                    #
+                    # ``orphan_homes`` is the authoritative predicate rather than a
+                    # bare directory probe, so this agrees with `pod ls` / `pod
+                    # prune` by construction: it skips symlinks, and on macOS it
+                    # treats a per-pod plist as "installed, not orphaned" so a name
+                    # mid-``up`` is never reclaimed underneath itself. It keys on
+                    # the pod root, liveness and plist and never on the checkout
+                    # pin, so attribution is the locked helper's job, not its.
+                    #
+                    # Two different fail directions, so two different scopes. The
+                    # ENUMERATION is best-effort cleanup: an orphan scan says
+                    # nothing about liveness, so its failure degrades to a named
+                    # leftover rather than turning a lost directory into a lost
+                    # removal. The RECLAIM is teardown, so it fails CLOSED -- a
+                    # returned failure refuses the removal, and a raised one is
+                    # deliberately left to the liveness handler below rather than
+                    # swallowed here, because a teardown that died mid-flight
+                    # (a stop that timed out against a still-activating unit) is
+                    # exactly the state in which removing the checkout is unsafe.
+                    try:
+                        # Probe the pod root FIRST: ``orphan_homes`` swallows an
+                        # enumeration OSError and answers ``[]``, which is
+                        # indistinguishable from "nothing to reclaim" -- so an
+                        # unreadable pod root would silently skip the HOME without
+                        # the warning this block promises. Reading it here puts the
+                        # error on a path that reaches that warning.
+                        await loop.run_in_executor(
+                            subprocess_executor(), lambda: list(cfg.pod_root.iterdir())
+                        )
+                        orphans = await loop.run_in_executor(
+                            subprocess_executor(), rt.orphan_homes, cfg
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "dev-fleet worktree_remove: could not look for %r's pod "
+                            "HOME (%s); the worktree is still removed — sweep the "
+                            "leftover with `kirocrew pod prune`",
+                            name,
+                            _redact(str(exc)),
+                        )
+                        orphans = []
+                    if name in orphans:
+                        outcome, detail = await loop.run_in_executor(
+                            subprocess_executor(), _reclaim_pod_locked, cfg, name, path
+                        )
+                        if outcome == "reclaimed":
+                            reclaimed_pod_home = True
+                        elif outcome == "foreign":
+                            # Not ours to delete, which is a reason to leave it --
+                            # never a reason to refuse this checkout's own removal,
+                            # since nothing of ours is at risk.
+                            logger.warning(
+                                "dev-fleet worktree_remove: left a pod HOME named "
+                                "%r in place (%s); continuing the removal",
+                                name,
+                                _redact(detail),
+                            )
+                        else:
+                            # failed, or handed_over -- a new pod now holds this
+                            # name and may be running out of this worktree.
+                            return {
+                                "ok": False,
+                                "error": f"pod home reclaim failed: {detail}",
+                            }
             except Exception as exc:
                 return {
                     "ok": False,
@@ -3245,7 +3439,13 @@ async def _worktree_remove(
         (verdict_oid or "").strip()[:12] if verdict_oid else "none",
     )
     _fleet_forget(name)
-    return {"ok": True, "removed": True, "stopped_pod": stopped_pod, "pr": _redact_pr(pr)}
+    return {
+        "ok": True,
+        "removed": True,
+        "stopped_pod": stopped_pod,
+        "reclaimed_pod_home": reclaimed_pod_home,
+        "pr": _redact_pr(pr),
+    }
 
 
 # --- sync (pull + build) ---

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -14,6 +14,7 @@ import threading
 import time
 from contextlib import ExitStack
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -351,6 +352,492 @@ async def test_remove_still_fails_on_non_pod_exceptions():
         result = await mod._worktree_remove("feat-x", force=False)
     assert result["ok"] is False
     assert "cannot verify pod state" in result["error"]
+
+
+# --- stopped-pod HOME reclamation on worktree removal ---
+def _remove_stubs(pod_root, **extra):
+    """The guard stack every ``_worktree_remove`` pod-path test needs.
+
+    *pod_root* is the test's own ``tmp_path``-derived pod root: the code reads it
+    to tell an unreadable root from "nothing to reclaim", so it has to exist and
+    be readable, and it must be per-test so nothing is left on disk afterwards.
+
+    Returns the context managers so each test only states the pod-state patches
+    it is actually about. A key present in *extra* REPLACES the default of the
+    same name rather than stacking a second patch on the same attribute, so a
+    test that overrides ``backend`` gets exactly one ``require_backend`` patch.
+    """
+    base = {
+        "find": patch.object(mod, "_find_worktree", new_callable=AsyncMock,
+                             return_value=({"path": "/fake/wt", "branch": "feat-x",
+                                            "is_main": False}, None)),
+        "dirty": patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        "pr": patch.object(mod, "_pr_status_cached", new_callable=AsyncMock,
+                           return_value={"state": "MERGED"}),
+        "own": patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=1),
+        "git": patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        "head": patch.object(mod, "_fetch_pr_head_oid", new_callable=AsyncMock,
+                             return_value="aaa1111"),
+        "cfg": patch.object(mod, "_load_cfg",
+                            return_value=SimpleNamespace(pod_root=pod_root)),
+        "avail": patch.object(mod, "_POD_AVAILABLE", True),
+        "backend": patch.object(mod.rt, "require_backend", return_value=None),
+        "run": patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "", "")),
+        "upstream": patch.object(mod, "_upstream_remote", new_callable=AsyncMock,
+                                 return_value="origin"),
+    }
+    base.update(extra)
+    return list(base.values())
+
+
+@pytest.mark.asyncio
+async def test_remove_reclaims_home_of_a_stopped_pod(tmp_path):
+    """A pod that is DOWN still owns its isolated HOME, so removal reclaims it.
+
+    Gating reclamation on a live unit stranded the HOME on the common path:
+    the operator stops the pod when testing ends and prunes days later once the
+    PR merges, so the unit is never active at removal time.
+    """
+    reclaim = MagicMock(return_value=("reclaimed", ""))
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            active=patch.object(mod.rt, "active_names", return_value=set()),
+            orphans=patch.object(mod.rt, "orphan_homes", return_value=["feat-x"]),
+            reclaim=patch.object(mod, "_reclaim_pod_locked", reclaim),
+        ):
+            stack.enter_context(cm)
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    # The worktree path is handed in as the expected checkout, so attribution
+    # inside the lock compares against THIS repo's worktree.
+    assert reclaim.call_args.args[1:] == ("feat-x", "/fake/wt")
+    # Reported as a reclaim, never as a shutdown that did not happen.
+    assert result["reclaimed_pod_home"] is True
+    assert result["stopped_pod"] is False
+
+
+@pytest.mark.asyncio
+async def test_remove_leaves_a_non_orphan_home_alone(tmp_path):
+    """``orphan_homes`` is the authority: a name it omits is never reclaimed.
+
+    Covers the HOME that does not exist at all and the macOS name mid-``up``
+    whose per-pod plist marks it installed rather than orphaned.
+    """
+    reclaim = MagicMock(return_value=("reclaimed", ""))
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            active=patch.object(mod.rt, "active_names", return_value=set()),
+            orphans=patch.object(mod.rt, "orphan_homes", return_value=["other-wt"]),
+            reclaim=patch.object(mod, "_reclaim_pod_locked", reclaim),
+        ):
+            stack.enter_context(cm)
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    reclaim.assert_not_called()
+    assert result["reclaimed_pod_home"] is False
+
+
+@pytest.mark.asyncio
+async def test_remove_refuses_when_home_reclaim_fails(tmp_path):
+    """A HOME that survives teardown must not be reported as a clean removal."""
+    reclaim = MagicMock(return_value=("failed", "a process is still writing there"))
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            active=patch.object(mod.rt, "active_names", return_value=set()),
+            orphans=patch.object(mod.rt, "orphan_homes", return_value=["feat-x"]),
+            reclaim=patch.object(mod, "_reclaim_pod_locked", reclaim),
+        ):
+            stack.enter_context(cm)
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is False
+    assert "pod home reclaim failed" in result["error"]
+    assert "still writing" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_remove_of_active_pod_reports_a_stop_not_a_reclaim(tmp_path):
+    """The live-unit path keeps its own reporting; the two flags never conflate."""
+    reclaim = MagicMock(return_value=("reclaimed", ""))
+    # Stateful rather than a fixed side_effect list: the live-unit path queries
+    # liveness three times (pre-stop, post-stop, and the TOCTOU recheck under
+    # the git lock), so a length-pinned list breaks on an unrelated change to
+    # how often the code verifies.
+    calls = {"n": 0}
+
+    def _liveness(_cfg):
+        calls["n"] += 1
+        return {"feat-x"} if calls["n"] == 1 else set()
+
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            active=patch.object(mod.rt, "active_names", side_effect=_liveness),
+            reclaim=patch.object(mod, "_reclaim_pod_locked", reclaim),
+        ):
+            stack.enter_context(cm)
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    assert result["stopped_pod"] is True
+    assert result["reclaimed_pod_home"] is False
+
+
+@pytest.mark.asyncio
+async def test_remove_of_an_active_foreign_pod_is_refused(tmp_path):
+    """A LIVE pod that is not this checkout's must not be stopped."""
+    reclaim = MagicMock(return_value=("foreign", "pinned to a different checkout"))
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            active=patch.object(mod.rt, "active_names", return_value={"feat-x"}),
+            reclaim=patch.object(mod, "_reclaim_pod_locked", reclaim),
+        ):
+            stack.enter_context(cm)
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is False
+    assert "refusing pod shutdown" in result["error"]
+    assert "different checkout" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_remove_skips_a_pod_home_that_is_another_checkouts(tmp_path, caplog):
+    """A same-basename HOME belonging to ANOTHER checkout is left, not refused.
+
+    Pod identities are global basenames and ``orphan_homes`` keys on the pod
+    root, liveness and plist -- never on the checkout pin -- so another repo's
+    stale HOME of the same name shows up here. Leaving it is correct; refusing
+    this checkout's own removal over it is not.
+    """
+    reclaim = MagicMock(return_value=("foreign", "pinned to a different checkout"))
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            active=patch.object(mod.rt, "active_names", return_value=set()),
+            orphans=patch.object(mod.rt, "orphan_homes", return_value=["feat-x"]),
+            reclaim=patch.object(mod, "_reclaim_pod_locked", reclaim),
+        ):
+            stack.enter_context(cm)
+        with caplog.at_level("WARNING"):
+            result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    assert result["reclaimed_pod_home"] is False
+    assert "left a pod HOME named" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_remove_refuses_when_the_pod_name_was_handed_over(tmp_path):
+    """A new pod holding this name blocks the removal, on BOTH reclaim branches.
+
+    Which checkout the new pod belongs to is unknowable here, and it may be
+    running out of this very worktree -- so the files must not be deleted, and the
+    post-stop liveness recheck cannot be relied on to see a unit that is still
+    bootstrapping.
+    """
+    reclaim = MagicMock(return_value=("handed_over", "was reclaimed by a new pod"))
+
+    # Live-unit branch.
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            active=patch.object(mod.rt, "active_names", return_value={"feat-x"}),
+            reclaim=patch.object(mod, "_reclaim_pod_locked", reclaim),
+        ):
+            stack.enter_context(cm)
+        live = await mod._worktree_remove("feat-x", force=False)
+
+    assert live["ok"] is False
+    assert "refusing removal" in live["error"]
+
+    # Orphaned-HOME branch.
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            active=patch.object(mod.rt, "active_names", return_value=set()),
+            orphans=patch.object(mod.rt, "orphan_homes", return_value=["feat-x"]),
+            reclaim=patch.object(mod, "_reclaim_pod_locked", reclaim),
+        ):
+            stack.enter_context(cm)
+        orphan = await mod._worktree_remove("feat-x", force=False)
+
+    assert orphan["ok"] is False
+    assert "reclaim failed" in orphan["error"]
+
+
+@pytest.mark.asyncio
+async def test_remove_refuses_when_the_reclaim_itself_raises(tmp_path):
+    """A teardown that DIES mid-flight must not be read as a cleanup miss.
+
+    The enumeration's failure degrades, but a raising reclaim (a stop that timed
+    out against a still-activating unit) is the state in which removing the
+    checkout is unsafe, so it must reach the fail-closed handler.
+    """
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            active=patch.object(mod.rt, "active_names", return_value=set()),
+            orphans=patch.object(mod.rt, "orphan_homes", return_value=["feat-x"]),
+            reclaim=patch.object(mod, "_reclaim_pod_locked",
+                                 MagicMock(side_effect=TimeoutError("stop timed out"))),
+        ):
+            stack.enter_context(cm)
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is False
+    assert "cannot verify pod state" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_remove_survives_a_failing_home_enumeration(tmp_path, caplog):
+    """A cleanup that cannot even enumerate must not refuse the removal.
+
+    Liveness failures fail CLOSED (they guard against deleting a checkout under
+    a live pod), but an orphan scan says nothing about liveness -- so it degrades
+    to a named leftover instead of turning a lost directory into a lost removal.
+    """
+    reclaim = MagicMock(return_value=("reclaimed", ""))
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            active=patch.object(mod.rt, "active_names", return_value=set()),
+            orphans=patch.object(mod.rt, "orphan_homes", side_effect=OSError("pod root gone")),
+            reclaim=patch.object(mod, "_reclaim_pod_locked", reclaim),
+        ):
+            stack.enter_context(cm)
+        with caplog.at_level("WARNING"):
+            result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    assert result["reclaimed_pod_home"] is False
+    reclaim.assert_not_called()
+    assert "could not look for" in caplog.text
+    assert "pod prune" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_remove_warns_when_the_pod_root_is_unreadable(tmp_path, caplog):
+    """An unreadable pod root must reach the warning, not read as "no orphans".
+
+    ``orphan_homes`` answers ``[]`` on an enumeration error, which is
+    indistinguishable from "nothing to reclaim", so the root is read here first.
+    """
+    reclaim = MagicMock(return_value=("reclaimed", ""))
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path / "never-created",
+            active=patch.object(mod.rt, "active_names", return_value=set()),
+            orphans=patch.object(mod.rt, "orphan_homes", return_value=[]),
+            reclaim=patch.object(mod, "_reclaim_pod_locked", reclaim),
+        ):
+            stack.enter_context(cm)
+        with caplog.at_level("WARNING"):
+            result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    reclaim.assert_not_called()
+    assert "pod prune" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_remove_names_the_home_it_cannot_reclaim(tmp_path, caplog):
+    """Backend absent: the HOME is unprovable, so it is NAMED, not silently skipped.
+
+    Reclaiming here would risk deleting a live gateway's HOME, so the residue
+    stays -- but at a level the operator sees, carrying the path and the verb
+    that reclaims it.
+    """
+    from kiro_crew.pod.runtime import PodBackendAbsent
+
+    with ExitStack() as stack:
+        for cm in _remove_stubs(
+            tmp_path,
+            backend=patch.object(mod.rt, "require_backend",
+                                 side_effect=PodBackendAbsent("no session bus")),
+            unit=patch.object(mod.rt, "unit_state", return_value=("inactive", 0)),
+            home=patch.object(mod.rt, "pod_home", return_value=Path("/pods/feat-x")),
+        ):
+            stack.enter_context(cm)
+        with caplog.at_level("WARNING"):
+            result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    assert "/pods/feat-x" in caplog.text
+    assert "pod down feat-x" in caplog.text
+
+
+# --- _reclaim_pod_locked: attribution and teardown share the per-name lock ---
+class _RecordingMutex:
+    """Records lock enter/exit against a shared event log."""
+
+    def __init__(self, log):
+        self.log = log
+
+    def __call__(self, cfg, name):
+        return self
+
+    def __enter__(self):
+        self.log.append("lock-enter")
+        return self
+
+    def __exit__(self, *exc):
+        self.log.append("lock-exit")
+        return False
+
+
+def _reclaim_cfg(tmp_path):
+    """A cfg whose ``env_file`` names a path inside the test's own tmp dir."""
+    return SimpleNamespace(env_file=lambda name: tmp_path / f"{name}.env")
+
+
+def test_reclaim_reads_the_pin_and_tears_down_inside_the_lock(tmp_path):
+    """The whole point of the helper: no window between attribution and teardown.
+
+    Checking the pin in one process and tearing down in another leaves a gap in
+    which a concurrent ``pod up`` from a DIFFERENT checkout claims the same
+    global basename, so the teardown would stop that pod and delete its HOME.
+    Both halves must land between the same lock enter and exit.
+    """
+    log = []
+    cp = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def _pin(_cfg, _name):
+        log.append("read-pin")
+        return True, "/fake/wt"
+
+    def _stop(_cfg, _name):
+        log.append("stop")
+        return cp
+
+    with patch.object(mod.rt, "pod_name_mutex", _RecordingMutex(log)), \
+         patch.object(mod, "_read_pin_strict", _pin), \
+         patch.object(mod.rt, "stop_pod", _stop):
+        outcome, detail = mod._reclaim_pod_locked(_reclaim_cfg(tmp_path), "feat-x", "/fake/wt")
+
+    assert (outcome, detail) == ("reclaimed", "")
+    assert log == ["lock-enter", "read-pin", "stop", "lock-exit"]
+
+
+def test_reclaim_refuses_a_foreign_pin_without_tearing_down(tmp_path):
+    """A pin naming another checkout stops the transaction before any teardown."""
+    log = []
+    stop = MagicMock()
+
+    with patch.object(mod.rt, "pod_name_mutex", _RecordingMutex(log)), \
+         patch.object(mod, "_read_pin_strict", lambda c, n: (True, "/other/repo/wt")), \
+         patch.object(mod.rt, "stop_pod", stop):
+        outcome, detail = mod._reclaim_pod_locked(_reclaim_cfg(tmp_path), "feat-x", "/fake/wt")
+
+    assert outcome == "foreign"
+    assert "basename collision" in detail
+    stop.assert_not_called()
+    assert log == ["lock-enter", "lock-exit"]
+
+
+def test_reclaim_refuses_an_unpinned_pod(tmp_path):
+    """No pin at all means the HOME is unattributable -- never torn down.
+
+    Stricter than ``_pod_checkout_guard``, deliberately: the guard allows an
+    unpinned name when no unit is live, which is right for operating on a pod the
+    caller located, but this path DELETES the HOME and a same-basename leftover
+    from another checkout is indistinguishable from here. Liveness is not even
+    consulted, so the refusal holds whether or not a unit is up.
+    """
+    stop = MagicMock()
+    active = MagicMock(return_value=set())
+
+    with patch.object(mod.rt, "pod_name_mutex", _RecordingMutex([])), \
+         patch.object(mod, "_read_pin_strict", lambda c, n: (False, None)), \
+         patch.object(mod.rt, "active_names", active), \
+         patch.object(mod.rt, "stop_pod", stop):
+        outcome, detail = mod._reclaim_pod_locked(_reclaim_cfg(tmp_path), "feat-x", "/fake/wt")
+
+    assert outcome == "foreign"
+    assert "no checkout pin" in detail
+    stop.assert_not_called()
+    active.assert_not_called()
+
+
+def test_reclaim_leaves_the_env_file_when_the_name_was_handed_over(tmp_path):
+    """A name claimed mid-teardown keeps the NEW pod's pin: never clear it."""
+    env = tmp_path / "feat-x.env"
+    env.write_text("CHECKOUT=/other/repo/wt\n")
+    cfg = SimpleNamespace(env_file=lambda name: env)
+    cp = SimpleNamespace(returncode=0, stdout=mod.rt.RECLAIMED_MARKER, stderr="")
+
+    with patch.object(mod.rt, "pod_name_mutex", _RecordingMutex([])), \
+         patch.object(mod, "_read_pin_strict", lambda c, n: (True, "/fake/wt")), \
+         patch.object(mod.rt, "stop_pod", lambda c, n: cp):
+        outcome, detail = mod._reclaim_pod_locked(cfg, "feat-x", "/fake/wt")
+
+    assert outcome == "handed_over"
+    assert env.exists()
+
+
+def test_reclaim_clears_the_env_file_after_a_clean_reclaim(tmp_path):
+    """A reclaimed pod's pin is cleared so a later ``up`` re-resolves cleanly."""
+    env = tmp_path / "feat-x.env"
+    env.write_text("CHECKOUT=/fake/wt\n")
+    cfg = SimpleNamespace(env_file=lambda name: env)
+    cp = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with patch.object(mod.rt, "pod_name_mutex", _RecordingMutex([])), \
+         patch.object(mod, "_read_pin_strict", lambda c, n: (True, "/fake/wt")), \
+         patch.object(mod.rt, "stop_pod", lambda c, n: cp):
+        outcome, _ = mod._reclaim_pod_locked(cfg, "feat-x", "/fake/wt")
+
+    assert outcome == "reclaimed"
+    assert not env.exists()
+
+
+def test_reclaim_reports_a_teardown_that_left_the_home_behind(tmp_path):
+    """``stop_pod`` reports a surviving HOME as non-zero; that is a failure.
+
+    The detail reaches the worktree-remove response and so the dashboard, so it
+    goes through ``_redact`` like every other detail this helper returns.
+    """
+    cp = SimpleNamespace(returncode=1, stdout="", stderr="isolated HOME is still at /pods/feat-x")
+
+    with patch.object(mod.rt, "pod_name_mutex", _RecordingMutex([])), \
+         patch.object(mod, "_read_pin_strict", lambda c, n: (True, "/fake/wt")), \
+         patch.object(mod.rt, "stop_pod", lambda c, n: cp):
+        outcome, detail = mod._reclaim_pod_locked(_reclaim_cfg(tmp_path), "feat-x", "/fake/wt")
+
+    assert outcome == "failed"
+    assert "still at /pods/feat-x" in detail
+
+
+def test_reclaim_redacts_the_teardown_stderr(tmp_path):
+    """Teardown stderr can carry a secret from the pod's own output."""
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    cp = SimpleNamespace(returncode=1, stdout="", stderr=f"stop failed: {secret}")
+
+    with patch.object(mod.rt, "pod_name_mutex", _RecordingMutex([])), \
+         patch.object(mod, "_read_pin_strict", lambda c, n: (True, "/fake/wt")), \
+         patch.object(mod.rt, "stop_pod", lambda c, n: cp):
+        outcome, detail = mod._reclaim_pod_locked(_reclaim_cfg(tmp_path), "feat-x", "/fake/wt")
+
+    assert outcome == "failed"
+    assert secret not in detail
+    assert detail == mod._redact(f"stop failed: {secret}")
+
+
+def test_reclaim_falls_back_to_the_return_code_when_stderr_is_empty(tmp_path):
+    """An empty stderr still names a cause rather than an empty error string."""
+    cp = SimpleNamespace(returncode=3, stdout="", stderr="   ")
+
+    with patch.object(mod.rt, "pod_name_mutex", _RecordingMutex([])), \
+         patch.object(mod, "_read_pin_strict", lambda c, n: (True, "/fake/wt")), \
+         patch.object(mod.rt, "stop_pod", lambda c, n: cp):
+        outcome, detail = mod._reclaim_pod_locked(_reclaim_cfg(tmp_path), "feat-x", "/fake/wt")
+
+    assert (outcome, detail) == ("failed", "stop rc=3")
 
 
 # --- _upstream_remote fallback + override ---


### PR DESCRIPTION
## 1. What is the problem?

Removing a worktree in Dev Fleet deleted the worktree but stranded the isolated
`KIROCREW_HOME` of that worktree's pod, permanently.

`_worktree_remove` reclaimed the pod HOME only when the pod's unit was still
running:

```python
if name in active:            # active = currently-running pod units
    r = await _pod_down(name) # the only path that deletes the HOME
```

The ordinary workflow never satisfies that condition. You stop the pod when
testing ends, then prune the worktree days later once the PR merges, so by prune
time the unit is inactive, `name in active` is false, and the reclaim is never
called. `pod down` and `runtime.cleanup_home` were already correct and
idempotent; nothing called them.

The leftover also became unattributable at that moment: removing the worktree
drops the per-pod env pin naming its checkout, so afterwards only a bulk sweep
could find it.

Two further holes sat in the same block. When `rt.require_backend()` raised
`PodBackendAbsent` the code logged one `debug` line and skipped all pod handling,
so the residue was invisible. And ownership was checked in the Dev Fleet process
while the teardown ran in a `pod down` child, leaving a window with no lock over
it.

## 2. Why this issue matters to the user

Each stranded HOME is a full isolated data home, and roughly 0.6 GB of it is a
per-instance copy of the embedding model, so the leak was per-worktree-removal and
large rather than incidental. On a host whose pod root lives on a memory-backed
filesystem it consumes RAM rather than disk.

Measured on one host, both worktrees long gone:

| Size | Orphaned pod HOME |
|---|---|
| 626M | `kc-fix-2887` |
| 627M | `kc-fix-3493` |

Linux (systemd) and macOS (launchd) are both affected, since both are real pod
backends. Windows has neither service manager, so pods cannot run there and it is
unaffected.

## 3. How our fix solves it

Chain from symptom to root cause: leaked 0.6 GB directories -> nothing ever called
the reclaim path -> the call was gated on a LIVE unit -> the gate is wrong, because
a stopped pod still owns its HOME and worktree removal is the last moment anything
can attribute that directory to this checkout.

**Reclaim regardless of liveness.** The `else` branch of the same liveness check
now reclaims the HOME of a pod that is already down.

**Reuse the existing predicate.** `runtime.orphan_homes` decides what qualifies,
rather than a bare directory probe, so this agrees with `pod ls` and `pod prune`
by construction: symlinks are skipped, and on macOS a name whose per-pod plist
exists counts as installed rather than orphaned, so a name mid-`up` is never
reclaimed underneath itself.

**Attribution and teardown are ONE locked transaction.** A new helper,
`_reclaim_pod_locked`, runs entirely inside `runtime.pod_name_mutex` and, without
releasing it, reads the checkout pin, decides ownership, calls `runtime.stop_pod`,
and clears the per-pod env file. Splitting those halves is what the lock exists to
prevent: pod identities are global basenames, so between an ownership check in one
process and a teardown in another, a concurrent `pod up` from a DIFFERENT checkout
can claim the same name and the teardown would stop that pod and delete its HOME.
BOTH call sites in `_worktree_remove` -- the live-unit path and the orphaned-HOME
path -- go through this one helper, so the window is gone from the pre-existing
path too, not only from the branch this PR adds.

**Necessarily in-process, and that is why the old shape could not simply be
wrapped in the lock.** `pod_name_mutex` is a cross-process flock held per
open-file-description and `stop_pod` re-acquires it, so a caller holding it around
a `pod down` shell-out would block the very child it waits on. The mutex is
reentrant *within a thread* (`_MUTEX_STATE` is a `threading.local`) and the helper
is submitted to the executor as a single callable, so `stop_pod`'s own acquisition
nests instead of deadlocking. The helper therefore re-implements
`_pod_checkout_guard`'s attribution rules under the lock, and mirrors the CLI's
post-teardown env-file clear.

**Deletion demands positive attribution.** One deliberate tightening over the
guard: an ABSENT pin is a refusal. The guard allows an unpinned name when no unit
is live, which is right for OPERATING on a pod the caller located, but this path
DELETES the HOME and a same-basename leftover from another repo is
indistinguishable from here. Named cost: an unpinned orphan loses its automatic
reclaim and waits for `kirocrew pod prune` -- a directory kept, rather than
another repo's data deleted.

**A handed-over name refuses the removal.** When `stop_pod` reports the name was
claimed by a new pod mid-teardown, that pod may be running out of the very
worktree about to be deleted and which checkout owns it is unknowable here, so
both branches refuse rather than proceed. The post-stop liveness recheck is not a
substitute, since it can miss a unit that is still bootstrapping.

**Two fail directions, scoped separately.** Liveness checks fail CLOSED -- they
guard against deleting a checkout out from under a live pod. Reclamation degrades:
an orphan scan says nothing about liveness, so an enumeration error logs the
leftover, points at `pod prune`, and lets the removal proceed rather than turning
a lost directory into a lost removal. A teardown that RAISES is deliberately not
caught there, because a stop that died mid-flight against a still-activating unit
is exactly the state in which removing the checkout is unsafe. A pod root that
cannot be read is probed before the scan, because `orphan_homes` answers `[]` on
an enumeration error, which is otherwise indistinguishable from "nothing to
reclaim".

**Residue is named, never silently skipped.** The `PodBackendAbsent` branch still
declines to delete -- without a backend the pod's liveness is unprovable, and
deleting a HOME that may belong to a live gateway is the one outcome teardown must
never risk -- but now logs at WARNING with the HOME path and the `pod down` verb
that reclaims it.

**Honest reporting.** `stopped_pod` keeps its meaning (a unit was running and was
stopped) and a new `reclaimed_pod_home` covers a HOME reclaimed with nothing
running, so the response never claims a shutdown that did not happen. Teardown
stderr is redacted like every other detail the helper returns, since it reaches
this response and therefore the dashboard.

## 4. What tests we did

Nineteen tests on this path in `test/test_dev_fleet_app.py`. The leak itself was
mutation-verified: without the fix the decisive test fails with
`Expected mock to have been awaited once. Awaited 0 times`.

The atomicity property is pinned directly rather than implied.
`test_reclaim_reads_the_pin_and_tears_down_inside_the_lock` records lock
enter/exit against pin-read and stop and asserts the exact order
`["lock-enter", "read-pin", "stop", "lock-exit"]`; moving the pin read outside the
`with` turns it red, and it returns green when restored.

Also pinned: a foreign pin refuses without calling `stop_pod` at all; an unpinned
pod is refused and `active_names` is never consulted, so the refusal cannot
regress into a liveness-conditional one; a handed-over name refuses on both
branches and never has its env file cleared; a clean reclaim does clear it; a
surviving HOME is reported as failed; teardown stderr is redacted and an empty
stderr still names a cause; a raising reclaim ends in `cannot verify pod state`
rather than a completed removal; an enumeration failure degrades with the leftover
named; and the live-unit path still reports `stopped_pod` without conflating the
two flags.

Full local floor green: `flake8`, `isort`, `mypy` (976 files, 0 issues), backend
`pytest` 54580 passed, `tsc -b`, `eslint` (0 errors), `vitest` 20460 passed,
`i18n:check` and `i18n:render`.

Residual local failures were each reproduced on a clean `origin/main` checkout and
are host-environment specific, not regressions: TMPDIR/home-layout classification,
a local `gh` wrapper shadowing a test fixture, and sandbox `unshare` EPERM.

## 5. Any other suggestions on the work

- The reclaim machinery was already built and hardened (`orphan_homes`,
  `cleanup_home`, `pod prune` with its age gate, per-name mutex, strict liveness,
  SEL audit). This PR adds no new deletion primitive -- `_reclaim_pod_locked`
  composes those under the lock, which is the part that was missing.
- Existing orphans predating this fix are not retroactively cleaned; reclaim them
  with `kirocrew pod prune`.
- `_pod_down` is unchanged and still serves `POST /api/pod/down` and
  `_pod_restart`, so the check-then-act shape survives there. Those are operator
  actions naming a single pod rather than worktree teardown, so they were left out
  of this PR's scope rather than widened into it.
- `orphan_homes` swallowing an enumeration `OSError` as `[]` is pre-probed at this
  call site only; its two CLI callers still cannot tell "error" from "empty".
  Fixing that in the shared runtime function would change `pod ls` / `pod prune`
  output and belongs in its own change.
- Worth considering separately: `pod prune` is operator-driven only, so a host
  that crashes or reboots still accumulates orphans until someone runs it.

Closes #3964
