### PR TITLE
fix(knowledge): apply ACP extraction effort

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -14,6 +14,26 @@ files / uploads / artifacts / URLs
    → local_knowledge_search (MCP) / dashboard Knowledge tab
 ```
 
+### LLM worker-pool policy
+
+Knowledge ingestion and URL-content acquisition use separate long-lived worker
+pools. The extraction pool uses `knowledge.extraction_pool_size` and requests
+Knowledge-specific reasoning effort `high`; the URL-fetch pool has one worker and
+sends no explicit effort, so it retains the provider default. Both pools drive the
+same `kirocrew-knowledge` agent and preserve the existing model resolution:
+`knowledge.extraction_model` → `agent.model` → provider/`auto`.
+
+The extraction effort is a Knowledge policy, independent of
+`agent.role_efforts.background`, which controls other background workers. For the
+Kiro ACP backend, the worker applies the requested level through the `/effort`
+command; Claude ACP uses its advertised session config option. Capability
+negotiation may select the highest supported level at or below `high`, while an
+unsupported model or rejected command falls back to provider default.
+
+Separate pools make the different workload policies structural for long-lived
+sessions rather than relying on a worker being reused by only one workload by
+convention.
+
 ## Role & boundary
 
 The Knowledge Library is the agent's **precise-recall complement to memory** — it is defined as much by the two things it is *not*:

--- a/src/kiro_crew/knowledge/llm_pool.py
+++ b/src/kiro_crew/knowledge/llm_pool.py
@@ -1,7 +1,8 @@
 """Unified LLM worker pool for Knowledge Library.
 
 Provider-agnostic bounded pool of long-lived workers (CC or ACP).
-Both entity extraction and URL fetch acquire workers from this pool.
+Knowledge extraction and URL fetch use separate instances of this pool so their
+workload policies and session state remain isolated.
 """
 from __future__ import annotations
 
@@ -321,7 +322,8 @@ class AcpWorker(Worker):
         if client is None or requested is None:
             return
         try:
-            if not client.supports_config_option("effort"):
+            is_claude = bool(getattr(client, "_is_claude", False))
+            if is_claude and not client.supports_config_option("effort"):
                 logger.warning(
                     "AcpWorker: effort=%s unsupported; using provider default",
                     requested,
@@ -338,7 +340,10 @@ class AcpWorker(Worker):
                     requested,
                 )
                 return
-            await client.set_config_option("effort", effective)
+            if is_claude:
+                await client.set_config_option("effort", effective)
+            else:
+                await client.send_command("/effort", args={"level": effective})
         except Exception:
             logger.warning(
                 "AcpWorker: could not apply effort=%s; using provider default",

--- a/test/test_llm_pool.py
+++ b/test/test_llm_pool.py
@@ -718,31 +718,48 @@ class TestAcpWorker:
         assert unregistered == [100]
 
 
-def _mock_effort_client(levels: list[str], *, supports: bool = True) -> AsyncMock:
+def _mock_effort_client(
+    levels: list[str], *, supports: bool = True, claude: bool = False
+) -> AsyncMock:
     client = AsyncMock()
     client.is_ready = True
     client._pid = None
+    client._is_claude = claude
     client.is_process_alive = lambda: True
     client.supports_config_option = MagicMock(return_value=supports)
     client.get_valid_effort_levels = MagicMock(return_value=levels)
+    client.send_command = AsyncMock()
     client.set_config_option = AsyncMock()
     return client
 
 
 class TestAcpWorkerEffort:
     @pytest.mark.asyncio
-    async def test_applies_effort_after_ready_before_use(self, tmp_path):
+    async def test_applies_kiro_effort_after_ready_before_use(self, tmp_path):
         client = _mock_effort_client(["low", "medium", "high"])
         events: list[str] = []
         client.ensure_ready.side_effect = lambda: events.append("ready")
-        client.set_config_option.side_effect = lambda *_args: events.append("set")
+        client.send_command.side_effect = lambda *_args, **_kwargs: events.append("set")
         with patch("pathlib.Path.home", return_value=tmp_path), \
              patch("kiro_crew.knowledge.llm_pool.AcpClient", return_value=client):
             worker = AcpWorker(effort="high")
             await worker.start()
 
         assert events == ["ready", "set"]
+        client.send_command.assert_awaited_once_with("/effort", args={"level": "high"})
+        client.set_config_option.assert_not_awaited()
+        assert worker._effective_effort == "high"
+
+    @pytest.mark.asyncio
+    async def test_applies_claude_effort_via_config_option(self, tmp_path):
+        client = _mock_effort_client(["low", "medium", "high"], claude=True)
+        with patch("pathlib.Path.home", return_value=tmp_path), \
+             patch("kiro_crew.knowledge.llm_pool.AcpClient", return_value=client):
+            worker = AcpWorker(effort="high")
+            await worker.start()
+
         client.set_config_option.assert_awaited_once_with("effort", "high")
+        client.send_command.assert_not_awaited()
         assert worker._effective_effort == "high"
 
     @pytest.mark.asyncio
@@ -755,8 +772,8 @@ class TestAcpWorkerEffort:
             await worker.start()
             await worker.start()
 
-        first.set_config_option.assert_awaited_once_with("effort", "high")
-        second.set_config_option.assert_awaited_once_with("effort", "high")
+        first.send_command.assert_awaited_once_with("/effort", args={"level": "high"})
+        second.send_command.assert_awaited_once_with("/effort", args={"level": "high"})
 
     @pytest.mark.asyncio
     async def test_downgrades_to_highest_supported_lower_level(self, tmp_path, caplog):
@@ -766,21 +783,39 @@ class TestAcpWorkerEffort:
             worker = AcpWorker(effort="high")
             await worker.start()
 
-        client.set_config_option.assert_awaited_once_with("effort", "medium")
+        client.send_command.assert_awaited_once_with("/effort", args={"level": "medium"})
         assert worker._effective_effort == "medium"
         assert "downgraded" in caplog.text
 
     @pytest.mark.asyncio
-    async def test_uses_provider_default_when_effort_is_unsupported(self, tmp_path, caplog):
-        client = _mock_effort_client([], supports=False)
+    async def test_uses_provider_default_when_claude_effort_is_unsupported(
+        self, tmp_path, caplog
+    ):
+        client = _mock_effort_client([], supports=False, claude=True)
         with patch("pathlib.Path.home", return_value=tmp_path), \
              patch("kiro_crew.knowledge.llm_pool.AcpClient", return_value=client):
             worker = AcpWorker(effort="high")
             await worker.start()
 
         client.set_config_option.assert_not_awaited()
+        client.send_command.assert_not_awaited()
         assert worker._effective_effort is None
         assert "unsupported" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_uses_provider_default_when_kiro_effort_command_fails(
+        self, tmp_path, caplog
+    ):
+        client = _mock_effort_client(["low", "medium", "high"])
+        client.send_command.side_effect = RuntimeError("effort command rejected")
+        with patch("pathlib.Path.home", return_value=tmp_path), \
+             patch("kiro_crew.knowledge.llm_pool.AcpClient", return_value=client):
+            worker = AcpWorker(effort="high")
+            await worker.start()
+
+        client.send_command.assert_awaited_once_with("/effort", args={"level": "high"})
+        assert worker._effective_effort is None
+        assert "could not apply effort=high" in caplog.text
 
 
 class TestLLMPoolEffort:


### PR DESCRIPTION
## Problem / Motivation

The Knowledge effort-pool implementation requests extraction effort `high`, but its ACP worker applied that level through `session/set_config_option` for every ACP backend. Kiro ACP applies reasoning effort through the `/effort` command, so the config-option request can be rejected and extraction can silently fall back to provider-default effort.

## Why it matters

When the Kiro command path is not used, the Knowledge extraction policy is not actually enforced on supported models. The resulting extraction quality, latency, and cost differ from the intended Knowledge-specific policy, while the worker reports only a warning and continues.

## What changed

- Route Kiro ACP effort application through `send_command("/effort", args={"level": ...})`.
- Preserve Claude ACP's `session/set_config_option` path and its advertised-option capability check.
- Keep capability negotiation: select the highest supported level at or below requested `high`; rejected or unsupported effort falls back to provider default.
- Re-apply the same backend-specific effort path after worker respawn.
- Add regression coverage for Kiro command routing, Claude config routing, downgrade, respawn, and both fallback paths.
- Document the separate Knowledge extraction/fetch pools, the intentional Knowledge-specific `high` policy, unchanged model resolution, and backend-specific effort handling.

The Knowledge policy remains intentionally independent of `agent.role_efforts.background`. Model selection is unchanged:

`knowledge.extraction_model` -> `agent.model` -> provider/`auto`

## Tests

- 92 targeted tests passed serially across `test_llm_pool.py` and `test_knowledge_effort_pools.py`.
- Effort-focused regression tests passed: 6 tests covering Kiro `/effort`, Claude config-option routing, respawn, downgrade, and fallback.
- `isort`, `flake8`, `compileall`, `git diff --check`, and documentation lint passed.
- Targeted mypy with imports isolated from the pre-existing platform typing issue passed for `src/kiro_crew/knowledge/llm_pool.py`.
- A normal local mypy run still reports the same three pre-existing macOS xattr typing errors in unchanged `src/kiro_crew/hooks.py`; no hooks code is included here.

## Manual verification

N/A — the changed backend dispatch is covered by mocked ACP regression tests, and no live gateway was reloaded. The existing mixed-workload runtime evidence remains recorded on the merged pool-isolation change.

<!-- no-visual-delta -->
**Why no screenshot:** This is a backend-only correction and documentation update; it changes no rendered frontend surface.

## Related Issues

no issue closed: this follow-up addresses review-identified backend behavior with no tracked issue.
