### PR TITLE
refactor(messaging): dedupe two predicates and correct stale comments

### DIFF
--- a/src/kiro_crew/messaging/attachments.py
+++ b/src/kiro_crew/messaging/attachments.py
@@ -163,9 +163,7 @@ def classify(mimetype: str, name: str = "", audio_mimetypes: tuple[str, ...] = (
     mt = (mimetype or "").lower()
     if mt in IMAGE_MIMETYPES:
         return IMAGE
-    if any(mt.startswith(p) for p in audio_mimetypes):
-        return AUDIO
-    if any(mt.startswith(p) for p in _AUDIO_PREFIXES):
+    if any(mt.startswith(p) for p in (*audio_mimetypes, *_AUDIO_PREFIXES)):
         return AUDIO
     if any(mt.startswith(p) for p in _VIDEO_PREFIXES):
         return VIDEO
@@ -497,7 +495,7 @@ async def transcribe_audio_attachments(result: IngestResult, source: str) -> Ing
 
     Lives here rather than in each channel adapter so the transcript wording and
     the STT-unavailable handling cannot drift between channels — Discord and
-    Telegram previously carried byte-identical copies of this block.
+    Telegram would otherwise each carry a byte-identical copy of this block.
 
     ``source`` names the channel for log lines only; it does not change behaviour.
     """

--- a/src/kiro_crew/messaging/identity.py
+++ b/src/kiro_crew/messaging/identity.py
@@ -75,23 +75,19 @@ def _channel_inbound_permitted_sync(channel_type: str) -> bool:
             "channels", channel_type, session_key=HOST_SESSION_KEY, fail_closed=True
         )
         permitted = bool(getattr(decision, "permitted", False))
-        # Durable SEL audit. EVERY inbound decision is recorded (the codebase
-        # invariant: audit every permission decision). A GOVERNED ALLOW (layer ∈
-        # {policy,profile,both}) is AUDIT-OR-DENY, matching the host transport-start
-        # gate: the SEL write is ``critical=True`` (synchronous + raising), so if it
-        # can't be persisted (unwritable SEL / full disk) the exception propagates
-        # to the outer ``except`` and the inbound is DENIED — a governed message
-        # never drives a turn unaudited. A DENY (any layer) is logged BEST-EFFORT
-        # (``critical=False``): the message is dropped either way, so availability
-        # must not hinge on SEL disk health. The UNGOVERNED default-permit is not
-        # logged at all — see below. File-backed SEL, safe in this worker thread.
         layer = getattr(decision, "layer", "")
         governed = layer in ("policy", "profile", "both")
-        # Every GOVERNED decision, and every deny, leaves a SEL record. Disposition
+        # Durable SEL audit, on the codebase invariant that every permission
+        # DECISION is recorded — an ungoverned default-permit is not one, per the
+        # third bullet. File-backed SEL, safe in this worker thread. Every
+        # GOVERNED decision, and every deny, leaves a record; the disposition
         # splits on how a persistence failure is handled:
-        #   * GOVERNED ALLOW → AUDIT-OR-DENY (critical=True, synchronous+raising): a
-        #     SEL write failure raises to the outer except → the inbound is DENIED,
-        #     so a governed channel never receives unaudited.
+        #   * GOVERNED ALLOW (layer ∈ {policy,profile,both}) → AUDIT-OR-DENY
+        #     (critical=True, synchronous + raising), matching the host
+        #     transport-start gate: a SEL write that cannot be persisted
+        #     (unwritable SEL / full disk) raises to the outer ``except`` → the
+        #     inbound is DENIED, so a governed message never drives a turn
+        #     unaudited.
         #   * DENY (any layer) → best-effort (critical=False): the message is dropped
         #     either way, and availability must not hinge on SEL disk health.
         #   * UNGOVERNED ALLOW (the default build, no `channels` policy at all) →

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -64,6 +64,23 @@ _CHANNEL_SESSION_PREFIXES: tuple[str, ...] = tuple(
 )
 
 
+def _in_namespace(key: str, ns: str) -> bool:
+    """True when *key* sits in namespace *ns*, in either separator spelling.
+
+    Both separators must be accepted: a live session key uses ``:`` while the
+    persisted filename stem uses ``_`` (see :data:`_CHANNEL_SESSION_PREFIXES`).
+    This is the per-namespace form, for callers that need to know WHICH
+    namespace matched; :data:`_CHANNEL_SESSION_PREFIXES` is the flattened
+    equivalent for a yes/no over every CHANNEL namespace. Also called with the
+    ``_TELEMETRY_LOCAL_PREFIXES`` names, which that tuple deliberately excludes.
+
+    ``sel.py``'s audit-source attributor and ``context._runtime_display_name``
+    spell the same pair separately, on a LOWERCASED key over a narrower set and
+    with a ``"slack"`` fallback — do not consolidate them onto this helper.
+    """
+    return key.startswith((f"{ns}:", f"{ns}_"))
+
+
 def is_channel_session_key(key: str) -> bool:
     """True when *key* is a session started on a messaging channel.
 
@@ -81,7 +98,7 @@ def is_channel_session_key(key: str) -> bool:
 def channel_namespace_of(key: str) -> str:
     """Return the channel namespace of *key*, or ``""`` if it is not a channel key."""
     for ns in CHANNEL_SESSION_NAMESPACES:
-        if key.startswith((f"{ns}:", f"{ns}_")):
+        if _in_namespace(key, ns):
             return ns
     return ""
 
@@ -147,7 +164,7 @@ def telemetry_channel_of(key: str | None) -> str:
     if ns:
         return ns
     for prefix, label in _TELEMETRY_LOCAL_PREFIXES:
-        if key.startswith((f"{prefix}:", f"{prefix}_")):
+        if _in_namespace(key, prefix):
             return label
     if _TELEMETRY_CHAT_SLOT_RE.match(key):
         return "dashboard"
@@ -187,7 +204,7 @@ def session_key(channel_type: str, conversation_id: str) -> str:
     return f"{channel_type}:{conversation_id}"
 
 
-# ── Why an inbound resume binding was removed ────────────────────────────────
+# ── Unbind reasons: why an inbound resume binding was lost ───────────────────
 # The audited vocabulary, kept in this leaf module because both sides need it:
 # ``SessionMap`` stamps it on the audit event and normalizes to it, and the
 # transports that clear a binding pass it. Every clearing call site names one of

--- a/src/kiro_crew/messaging/registry.py
+++ b/src/kiro_crew/messaging/registry.py
@@ -1,7 +1,12 @@
-"""Channel registry: descriptors + the boot/shutdown loops (PR ③ of the RFC).
+"""Channel registry: descriptors + the boot/shutdown loops.
 
-One registry entry per channel replaces the hand-edited seams that adding a
-channel used to require in the host. This module owns the TYPES and the LOOPS
+One registry entry per channel carries the host's per-channel LIFECYCLE seams —
+the members tuple, the start call, the shutdown gather. The other per-channel
+seams (the ``orch._<channel>_*`` hoist in ``slack/gateway.py``, the ``loader.py``
+config dataclass, the ``sandbox.py`` credential denylist, the
+``dashboard/state.py`` connected fields) are still hand-edited.
+
+This module owns the TYPES and the LOOPS
 only — it must not import any channel package (``dispatch.py`` pins the
 dependency direction: ``<channel> -> messaging``, never the reverse). The one
 place that knows every builtin channel is :mod:`kiro_crew.channels`, which sits
@@ -17,11 +22,11 @@ Two views over the same descriptor list, because Slack is deliberately split:
   ``_connect_slack``), so the host starts it separately, after the others,
   preserving today's boot order.
 
-Descriptor honesty rule (learned from the capability truth pass): a field
-exists here ONLY if something consumes it in this change. Config schemas,
-credential field names for the sandbox denylist, and capability attachment are
-REAL parts of the RFC's descriptor design but land with their consumers (the
-config-schema PR), not as decorative fields nothing reads.
+Descriptor honesty rule: a field exists here ONLY if something consumes it.
+Config schemas, credential field names for the sandbox denylist, and capability
+attachment are REAL parts of the RFC's descriptor design, but each lands here
+only TOGETHER WITH its consumer, never ahead of it as a decorative field nothing
+reads.
 """
 
 from __future__ import annotations
@@ -35,11 +40,11 @@ logger = logging.getLogger(__name__)
 
 #: A channel start factory: takes the gateway orchestrator, returns the live
 #: client handle (or ``None`` when the channel is disabled/uncredentialed —
-#: every factory is a guarded no-op). The loose ``Any`` for the orchestrator is
-#: deliberate for this PR: the factories predate the registry and read
-#: pre-hoisted ``orch._<channel>_*`` attributes. The config-schema PR replaces
-#: this back-reference with a narrow ``ChannelBootContext``; widening the type
-#: now would freeze the wrong contract.
+#: every factory is a guarded no-op). The orchestrator is typed as a loose
+#: ``Any`` on purpose: the factories predate the registry and read pre-hoisted
+#: ``orch._<channel>_*`` attributes, so narrowing this to a
+#: ``ChannelBootContext`` has to wait until that back-reference goes — naming a
+#: type over the current shape would freeze the wrong contract.
 StartFactory = Callable[[Any], Awaitable[Any]]
 
 
@@ -98,8 +103,8 @@ async def start_channels(
         except Exception:
             logger.exception("channel registry: %s failed to start", desc.channel_type)
             client = None
-        # Legacy attribute kept in sync for existing readers/tests; the dict is
-        # the authority and the attributes retire with the config-schema PR.
+        # Legacy attribute kept in sync for existing readers/tests; the returned
+        # handles dict is the authority.
         setattr(orch, f"_{desc.channel_type}_client", client)
         if client is not None:
             handles[desc.channel_type] = client

--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -218,12 +218,13 @@ class Renderer(ABC):
         """Release whatever the renderer opened for this turn. Default no-op.
 
         Declared here because the shared pipeline's ``finally`` awaits it
-        (``messaging/dispatch.py``) — before this existed, that await reached
-        through an ``Any`` for a method the contract never mentioned, so a
-        channel could change its signature without anything noticing. Telegram
-        did: its override takes an extra optional ``failure_reason``, which is a
-        legal widening of this contract and stays a channel-local concern until
-        the pipeline has a reason to carry one.
+        (``messaging/dispatch.py``, through a ``ChannelTurn.renderer`` still typed
+        ``Any``). Naming it in the contract is what makes a channel's override
+        signature checked, rather than a method the ABC never mentions that a
+        channel could reshape with nothing noticing. Telegram's override takes an
+        extra optional ``failure_reason``, which is a legal widening of this
+        contract and stays a channel-local concern until the pipeline has a
+        reason to carry one.
 
         Two rules for implementers:
 
@@ -309,16 +310,17 @@ class SilentRenderer(Renderer):
     gates in the dashboard turn loop. Every OTHER channel drives its turns
     through the shared inbound pipeline instead, where the reply is written by
     the channel's own :class:`Renderer` — a path the dashboard never touches. So
-    a stored pause for a non-Slack conversation had nothing to gate, and a
-    disconnected channel kept answering as if it were still connected.
+    without this substitution a stored pause for a non-Slack conversation has
+    nothing to gate, and a disconnected channel keeps answering as if it were
+    still connected.
 
     ``dispatch.drive_turn`` substitutes this for the real renderer when the
     conversation is disconnected. The turn STILL RUNS and the inbound message
     still lands in the session: the binding is retained by design, and the
     dashboard is where that user is now working. Only the writes back to the
-    muted conversation are dropped. ``on_turn_start`` and ``close`` inherit the
-    base no-ops, so no typing indicator is ever opened and there is nothing to
-    finalize.
+    muted conversation are dropped. ``on_turn_start`` inherits the base no-op, so
+    no typing indicator is ever opened; ``close`` overrides only to tolerate a
+    widened signature, because there is nothing to finalize either way.
 
     ``on_prompt_choice`` is dropped like the rest, matching the Slack gate that
     withholds the linked approval prompt from a disconnected thread: the


### PR DESCRIPTION
<!-- no-visual-delta -->
Backend-only: the diff touches five files under `src/kiro_crew/messaging/` and nothing under `website/`, `.github/` or `scripts/`, so there is no rendered surface to screenshot and the `changes` job reports `only_backend=true`.

## Problem

`messaging/` carries two predicates that spell the same test twice, and five comments that a reader cannot trust:

- `attachments.classify` tests `audio_mimetypes` and `_AUDIO_PREFIXES` in two consecutive branches that both `return AUDIO`.
- `link.py` spells the `:`/`_` two-separator namespace test inline in `channel_namespace_of` and again in `telemetry_channel_of`.
- `registry.py` cites a PR ordinal (`PR ③ of the RFC`), "in this change", and "the config-schema PR" — process artifacts `AGENTS.md` § Comments forbids because they go stale silently.
- `identity.py` states its three-way SEL audit disposition **twice**, in two adjacent comment blocks (~26 lines where 17 say it once), and the first copy asserts "EVERY inbound decision is recorded" while the second explains that an ungoverned default-permit is not logged.
- `link.py`'s unbind-reason section header, and two `renderer.py` docstrings, make claims that are false of the current code (details under *Fix*).

## Why it matters

A duplicated predicate invites the next editor to update one copy — in `classify` that would change which attachment class reaches the model, and the second branch is what makes Slack's `video/webm` voice memos classify as AUDIO instead of being rejected as VIDEO. A comment that is confidently wrong is worse than one that is obviously stale: `identity.py`'s two copies can drift apart on a governance audit path, and `renderer.py` currently tells a reader that `SilentRenderer.close` inherits a no-op when it in fact overrides it.

## Fix (symptoms → root cause → change)

**Root cause of both structural items:** the same predicate was written at each use site instead of once, so each site is independently editable.

- **`attachments.classify`** — merged to `any(mt.startswith(p) for p in (*audio_mimetypes, *_AUDIO_PREFIXES))`. Equivalence: `any(f(p) for p in A) or any(f(p) for p in B)` ≡ `any(f(p) for p in (*A, *B))` because unpacking preserves order, so the first truthy element *and* the first raising element are the same and short-circuiting stops at the same position. The merged branch still sits before the `_VIDEO_PREFIXES` branch, preserving the AUDIO-before-VIDEO precedence Slack depends on. The only production caller passing the parameter is `slack/files.py:108` with a module-level `tuple[str, ...]`; the other three adapters take the `()` default, which reduces the expression to exactly the old second branch.
- **`link.py`** — extracted `_in_namespace(key, ns)`. `_CHANNEL_SESSION_PREFIXES` and `is_channel_session_key` are deliberately **left alone**: they use one flattened C-level `startswith`, and routing them through a Python loop would cost the dashboard's session-classification path.

**Root cause of the comment items:** each was written as a note to the reviewer of the change that introduced it, not to the next reader. Corrected only where a comment named a process artifact, duplicated an adjacent block, or was false of the current code — that criterion is why `transport.py`'s "History:" paragraph and the two "lands with the approval-ladder work" forward pointers are **left as they are**: they are accurate rationale and cite no process artifact.

- `registry.py` — dropped the PR ordinal and the two "this change"/"config-schema PR" references. The docstring's claim that the registry replaced the host's per-channel seams was also an over-claim, contradicted 14 lines below by Slack's `start=None`: only the **lifecycle** seams (members tuple, start call, shutdown gather) are registry-derived, so the remaining hand-edited ones (`orch._<channel>_*` in `slack/gateway.py`, the `loader.py` config dataclass, the `sandbox.py` credential denylist, the `dashboard/state.py` connected fields) are now named.
- `identity.py` — collapsed the duplicate. Every claim in the original survives; the surviving copy scopes the invariant to a permission *decision* so it no longer reads as if an ungoverned default-permit were logged.
- `link.py` header — was "why an inbound resume binding was **removed**"; `UNBIND_REASON_ENTRY_DELETED` / `_SESSION_DESTROYED` reach `_remove_entry`, which pops the whole entry, so the binding is **lost** as a consequence rather than cleared. Kept "inbound resume binding" — that is the term `session_map._note_inbound_unbind` and `dashboard/state.py` use, and `ChannelLink`'s own docstring distinguishes it from the mirror binding.
- `renderer.py` — no longer implies the `close` declaration types the pipeline's await (`ChannelTurn.renderer` is annotated `Any`, so it does not); what the declaration buys is that a channel's override is signature-checked. And `SilentRenderer` no longer claims `close` inherits the base no-op when it overrides it at `renderer.py:340`.

## Tests

No new tests: this PR adds no behavior to lock in, and the equivalence of both rewrites is already pinned by existing coverage — `test_messaging_attachments.py` exercises `classify` including the Slack `video/webm` override, and `test_messaging_link.py` plus `test/metrics/test_startup_channel_attrs.py` and `test_cost_breakdown.py` pin `channel_namespace_of` / `telemetry_channel_of` behaviorally. Writing a test that passes equally before and after would assert nothing this diff could break.

**Ran green on a Python 3.12 CI-parity venv:** `flake8`, `isort --check-only`, `mypy` (976 files), `check_brand_name.py`, `check_harness_parity.py`, `docs_lint.py --test`, `docs-lint.sh`, `check_per_file_coverage.py --test`, `verify_vendor_manifest.py`, `scrub-lint.sh --no-history`, and 1,780 targeted tests across the module and its downstream consumers (messaging, slack, discord, telegram, weixin, teams, dashboard sessions, metrics).

`black --check` reports pre-existing deviations in `link.py`, `attachments.py` and `renderer.py` on lines this PR does not touch; the same files fail identically on `origin/main`. It is not a CI gate here, and reformatting unrelated lines is out of scope.

## Manual verification

N/A — no runtime behavior changes, and equivalence was established mechanically rather than by observation: an AST comparison with docstrings stripped shows `identity.py`, `registry.py` and `renderer.py` are **AST-identical** to base (proving those three are comment-only and that no statement crossed a `try`/`except`/`await` boundary), `attachments.py` has exactly one AST hunk, and `link.py` exactly three. The two rewrites were additionally differential-tested against reconstructed pre-change implementations: 2,805 + 210 `classify` cases (including `()`, `("",)`, uppercase, `video/webm;codecs=opus`, and hostile non-tuple arguments) and 782 `link.py` keys — zero divergences.

## Review fleet

Five independent read-only reviewers ran against `AUTOSDE.yaml`, `AGENTS.md` and the CI review contracts before this PR opened: AUTOSDE blocking rules, behavior preservation, import semantics, security keystone, and comment accuracy.

**No behavior, security, or import finding.** `no-new-work-on-gateway-boot-path`, `harness-parity` and `no-test-side-effects` match no changed file; `backend-security-controls` and `no-blocking-call-on-event-loop` match but are unaffected (no redaction call, `sel()` emit, `critical=` flag, deny-by-default fallthrough, or import changed shape or order). The diff contains **zero** import lines, so the in-function-import and lazy-hoist prohibitions are untriggered.

Six comment-accuracy findings were raised — all against wording introduced by this PR — and all six were **confirmed against the code and fixed** before opening: the `_in_namespace` "one place" claim (refuted by `sel.py:1086` and `context.py:683`), the unbind header's noun and verb, the registry seam over-claim, an inverted descriptor-honesty rule, the `close` typing counterfactual, and `SilentRenderer`'s "inherits" claim. Nothing was dropped as a false positive.

Two observations recorded but deliberately **not** acted on here: `weixin/attachments.py` is a third caller of `transcribe_audio_attachments`, so naming Discord and Telegram slightly undersells the dedup (accurate as written); and two reviewers independently noted that `messaging/identity.py` (a fail-closed policy evaluator with an audit-or-deny SEL emit) and `messaging/attachments.py` (the CWE-434 magic-byte content gate) would qualify as keystone security files by the campaign's own criterion. That is a change to the sweep tooling's keystone set, not to this repo, and belongs in a follow-up rather than widening this diff.
