### PR TITLE
fix(config): stop the migration backup leaking a .bak beside a foreign path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **The one-time config migration no longer leaves a `.json.bak` orphan beside a
+  config path it does not own.** `KiroCrewConfig.load()` copied the
+  pre-migration config to `<path>.bak`, where `<path>` is whatever
+  `config_path()` resolved to -- so every caller that redirects the loader at
+  its own `tempfile` entry (tests and embedders do) silently accumulated one
+  orphan per load, since the caller unlinks the path it created and never learns
+  a sibling appeared. One dev host reached 72,327 such files in `/tmp`, 7% of a
+  tmpfs inode budget whose exhaustion fails every process on the box. The copy
+  is now gated on the config living in `config_dir()`, the one directory whose
+  contents we own; the production backup is unchanged, and a copy that fails
+  still aborts the migration save exactly as before, so a config we could not
+  copy aside is not rewritten either. The name is also built by
+  appending rather than `with_suffix(".json.bak")`, which REPLACED the final
+  suffix and so renamed a non-`*.json` config instead of backing it up.
+
 - **A knowledge source that errored during ingestion is no longer re-synced on
   every sweep.** `KnowledgeIngestion` marks failure in the `sync_status`
   **column**, but `SyncScheduler.sync_all`'s skip predicate read only the

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -17,6 +17,7 @@ import logging
 import math
 import os
 import re as _re
+import shutil
 import stat as _stat
 import threading
 import uuid
@@ -485,6 +486,46 @@ def config_path() -> Path:
 def config_local_path() -> Path:
     """Return path to config.local.json — user overrides that survive upgrades."""
     return config_dir() / "config.local.json"
+
+
+def _write_migration_backup(path: Path) -> None:
+    """Copy the pre-migration config aside, but ONLY inside our own data home.
+
+    ``load()`` reads whatever ``config_path()`` resolves to, and callers can
+    redirect that at a file they own — tests and embedders point it at a
+    ``tempfile`` entry in the shared ``TMPDIR``. Writing ``<path>.bak`` beside
+    such a path leaks a file nobody collects: the caller unlinks the path it
+    created and never learns a sibling appeared. One dev host accumulated 72k
+    orphaned ``tmpXXXXXXXX.json.bak`` files this way, 7% of a tmpfs inode
+    budget whose exhaustion fails every process on the box.
+
+    So the copy is gated on the config living in ``config_dir()``, the one
+    directory whose contents we own. In production that is always true
+    (``config_path()`` is ``config_dir() / "config.json"``), which keeps the
+    real backup exactly where it has always been; for a redirected path we
+    write nothing rather than litter a directory belonging to someone else.
+
+    Only the LOCATION decision is contained here. A failing copy still
+    propagates, because the caller's ``except`` is what skips the migration
+    ``save()`` -- so a config we could not copy aside is not rewritten either,
+    and the migration retries on the next load.
+    """
+    try:
+        inside_data_home = path.parent.resolve() == config_dir().resolve()
+    except OSError:
+        # Containment is unprovable (symlink loop, vanished parent): treat the
+        # path as foreign, since writing on a failed check is the worse error.
+        inside_data_home = False
+    if not inside_data_home:
+        # info, not debug: the migration save that follows rewrites this
+        # caller-owned file in place, and that now happens with no backup.
+        logger.info("Config migrated; no backup written for %s (outside the data home)", path)
+        return
+    # NOT with_suffix(".json.bak"): that REPLACES the final suffix, so a
+    # config path which is not *.json would be renamed rather than backed up.
+    backup = Path(str(path) + ".bak")
+    shutil.copy2(path, backup)
+    logger.info("Config migrated — backup saved to %s", backup)
 
 
 def denied_commands_path() -> Path:
@@ -6682,14 +6723,7 @@ class KiroCrewConfig:
                 needs_migration = True
 
             if needs_migration:
-                backup = path.with_suffix(".json.bak")
-                import shutil
-
-                shutil.copy2(path, backup)
-                logger.info(
-                    "Config migrated — backup saved to %s",
-                    backup,
-                )
+                _write_migration_backup(path)
                 cfg.save()
         except Exception as e:
             # Migration write-back is best-effort; never block startup.

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -4846,3 +4846,99 @@ class TestUpdateConfigLocked:
 
         assert result == {"repaired": True}
         assert json.loads(cfg.read_text()) == {"repaired": True}
+
+
+class TestMigrationBackupContainment:
+    """``load()`` must not create files beside a config path it does not own.
+
+    The one-time agents migration copies the pre-migration config aside. The
+    copy landed next to whatever ``config_path()`` resolved to, so every caller
+    that redirects the loader at its own temp file (this module's own helpers do
+    exactly that) silently accumulated a ``<tmpname>.json.bak`` orphan it never
+    cleaned up -- 72k of them on one dev host, against a tmpfs inode cap.
+    """
+
+    # A config with neither "agents" nor "default_agent" is what makes
+    # load() take the migration write-back branch that writes the backup.
+    _LEGACY = {"telegram": {"allow_forum": True}}
+
+    def _load_with(self, home: Path, cfg_file: Path) -> KiroCrewConfig:
+        with unittest.mock.patch(
+            "kiro_crew.config.loader.config_dir", return_value=home
+        ), unittest.mock.patch(
+            "kiro_crew.config.loader.config_path", return_value=cfg_file
+        ):
+            return KiroCrewConfig.load()
+
+    def test_no_sibling_left_beside_a_redirected_config(self, tmp_path: Path) -> None:
+        """A caller-owned directory gains nothing from a migrating load()."""
+        caller_dir = tmp_path / "caller-owned"
+        caller_dir.mkdir()
+        cfg_file = caller_dir / "tmpdeadbeef.json"
+        cfg_file.write_text(json.dumps(self._LEGACY), encoding="utf-8")
+        home = tmp_path / "home"
+        home.mkdir()
+
+        before = {p.name for p in caller_dir.iterdir()}
+        cfg = self._load_with(home, cfg_file)
+        after = {p.name for p in caller_dir.iterdir()}
+
+        # Guard the guard: assert the migration branch actually ran, otherwise
+        # this test would pass for the wrong reason if that branch stops firing.
+        assert cfg.agents, "migration write-back did not run, test is vacuous"
+        assert after == before, (
+            "load() left orphans beside the caller's config: %s" % sorted(after - before)
+        )
+
+    def test_real_config_in_the_data_home_is_still_backed_up(self, tmp_path: Path) -> None:
+        """The production path keeps its backup exactly where it always was."""
+        home = tmp_path / "home"
+        home.mkdir()
+        cfg_file = home / "config.json"
+        cfg_file.write_text(json.dumps(self._LEGACY), encoding="utf-8")
+
+        cfg = self._load_with(home, cfg_file)
+
+        assert cfg.agents, "migration write-back did not run, test is vacuous"
+        assert (home / "config.json.bak").exists()
+
+    def test_backup_appends_the_suffix_instead_of_replacing_it(self, tmp_path: Path) -> None:
+        """A config whose name is not ``*.json`` is backed up, not renamed.
+
+        ``Path.with_suffix(".json.bak")`` REPLACES the final suffix, so
+        ``settings.conf`` would have produced ``settings.json.bak``.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        cfg_file = home / "settings.conf"
+        cfg_file.write_text(json.dumps(self._LEGACY), encoding="utf-8")
+
+        self._load_with(home, cfg_file)
+
+        assert (home / "settings.conf.bak").exists()
+        assert not (home / "settings.json.bak").exists()
+
+    def test_failed_backup_still_aborts_the_migration_save(self, tmp_path: Path) -> None:
+        """A config we could not copy aside is not rewritten either.
+
+        The caller's ``except`` is what skips ``cfg.save()``, so containing the
+        LOCATION decision must not also swallow a failing copy: otherwise the
+        only pre-migration copy is overwritten with no backup anywhere.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        cfg_file = home / "config.json"
+        original = json.dumps(self._LEGACY)
+        cfg_file.write_text(original, encoding="utf-8")
+
+        with unittest.mock.patch(
+            "kiro_crew.config.loader.shutil.copy2",
+            side_effect=OSError("backup target is read-only"),
+        ):
+            cfg = self._load_with(home, cfg_file)
+
+        # load() still returns a usable config -- the write-back is best-effort.
+        assert cfg.agents
+        # But the on-disk config is untouched, so the migration retries next load.
+        assert json.loads(cfg_file.read_text(encoding="utf-8")) == json.loads(original)
+        assert not (home / "config.json.bak").exists()


### PR DESCRIPTION
## What is the problem?

`KiroCrewConfig.load()` writes a backup file **next to whatever config path it
was given** when it decides a migration is needed:

```python
if needs_migration:
    backup = path.with_suffix(".json.bak")
    import shutil

    shutil.copy2(path, backup)
```

`path` is `config_path()`, and callers can redirect that at a file they own.
Six test modules do exactly that -- `NamedTemporaryFile(suffix=".json",
delete=False)` plus a patched `config_path` -- so each load left a
`<tmpname>.json.bak` sibling in the shared `TMPDIR` that nobody collected: the
caller unlinks the path it created and never learns a sibling appeared.

One dev host reached **72,327 orphaned `tmpXXXXXXXX.json.bak` files** in `/tmp`,
all byte-identical to one test fixture.

## Why this issue matters to the user

Three costs, none visible at the call site:

1. **Inode exhaustion on tmpfs hosts.** `/tmp` on that host is a 62G tmpfs with
   a hard cap of 1,048,576 inodes. This leak alone held 7% of the budget and was
   still growing; at the cap *every* process on the box starts failing with
   ENOSPC, unrelated sessions included. That host has five recorded exhaustion
   incidents.
2. **Slower runtime cold-start.** The sandbox pre-exec hardlink scan walks `/tmp`
   and truncates at 100,000 files, so an inflated `/tmp` taxes every agent
   runtime spawn.
3. **Silent by design.** The write sits inside a bare `except Exception`, so a
   leaking (or failing) backup surfaces nowhere.

## How our fix solves it

Symptom to root cause:

- **Symptom:** 72,327 `tmpXXXXXXXX.json.bak` files in `TMPDIR`, contents
  identical to the fixture in `test/test_telegram.py`.
- Its helper writes that fixture to a `NamedTemporaryFile(delete=False)`,
  patches `kiro_crew.config.loader.config_path` at it, calls
  `KiroCrewConfig.load()`, and in `finally` unlinks **only** the path it made.
- The fixture has no `agents` and no `default_agent`, so `load()` sets
  `needs_migration = True` and copies the file to
  `path.with_suffix(".json.bak")` -- a sibling in a directory the loader does
  not own, under a name the caller cannot know about.
- **Root cause:** the backup's location is derived from a caller-supplied path.
  The test is what made it visible, not the defect.

**The fix gates the copy on the config living in `config_dir()`** -- the one
directory whose contents we own -- in a new `_write_migration_backup()` helper.
In production that is always true, since `config_path()` *is*
`config_dir() / "config.json"`, so the real backup stays exactly where it has
always been. For a redirected path we now write nothing rather than litter
someone else's directory.

Two smaller things in the same span:

- The name is built by appending, not `Path.with_suffix(".json.bak")`, which
  **replaces** the final suffix -- a config path that is not `*.json` was being
  renamed (`settings.conf` -> `settings.json.bak`) instead of backed up.
- The function-local `import shutil` is hoisted to module level, matching the
  direction `test_agent_import_hoist.py` already ratchets.

Deliberately NOT in this PR: converting the six leaking test helpers to
pytest's `tmp_path`. Fixing the single writer removes the leak at its source,
so changing six readers buys nothing here -- and those files are touched by
other open PRs (#3733, #2065, #2025), so the churn would only create conflicts.

The skip is logged at `info`: the migration `save()` that follows rewrites the
caller-owned file in place, and that now happens with no backup anywhere, so the
event has to be visible. Only the backup's LOCATION policy changes here -- a
failing copy still propagates, because the caller's `except` is what skips the
migration `save()`, so a config we could not copy aside is not rewritten either
and the migration retries on the next load.

## What tests we did

Four new tests in `test/test_config_loader.py::TestMigrationBackupContainment`,
covering the invariant that was missing (no new entry appears beside a
caller-owned config) plus the three behaviours that must not regress:

| test | asserts |
|---|---|
| `test_no_sibling_left_beside_a_redirected_config` | a caller-owned directory is byte-for-byte unchanged in its listing after a migrating load |
| `test_real_config_in_the_data_home_is_still_backed_up` | production still gets `config.json.bak` |
| `test_backup_appends_the_suffix_instead_of_replacing_it` | `settings.conf` -> `settings.conf.bak`, not `settings.json.bak` |
| `test_failed_backup_still_aborts_the_migration_save` | a `copy2` that raises leaves the on-disk config untouched, so the migration retries |

Each asserts `cfg.agents` first, so the test fails loudly rather than passing
vacuously if the migration branch ever stops firing.

**Mutation-verified, two separate mutants.** Restoring the original one-liner
(`shutil.copy2(path, path.with_suffix(".json.bak"))`) kills two of the first three:

```
E  AssertionError: load() left orphans beside the caller's config: ['tmpdeadbeef.json.bak']
E  AssertionError: assert False   # settings.conf.bak missing
2 failed, 1 passed
```

Re-introducing the `except OSError: ... return` swallow around the copy kills the
fourth -- the on-disk config comes back rewritten to its 38-key migrated form
with no backup anywhere:

```
E  AssertionError: assert {'agent': {...}, ...} == {'telegram': {'allow_forum': True}}
E    Left contains 38 more items
```

The third passing on the mutant is by design -- it is the no-regression guard on
the production backup.

Gates, all green on this head:

- `pytest test/test_config*.py test/test_agent*.py` -- 970 passed, 1 skipped
- plus `test_telegram.py test_teams_config.py` -- 647 passed in that subset
- `isort --check-only src/kiro_crew test` -- clean
- `flake8 src/kiro_crew test` (7.1.0, the CI pin) -- clean
- `mypy src/kiro_crew/` -- Success, no issues in 976 source files

No frontend change, so `tsc` / `vitest` are untouched surfaces.

## Any other suggestions on the work

The generalisable rule is that a best-effort write whose LOCATION is derived
from a caller-supplied path needs a containment check, not just a
`try/except`. Worth a sweep for other writes of that shape in the config and
startup paths.

Separately, the six `NamedTemporaryFile(..., delete=False)` config helpers are
still writing into the shared `TMPDIR` and relying on manual cleanup. They no
longer leak, but `tmp_path` would make them relocatable off tmpfs and
self-collecting. That is a test-hygiene sweep better done in one pass when those
files are otherwise quiet.

Fixes #3966
