### PR TITLE
fix(chat): drive optimistic-timeout sweep from a client-side timer

### DIFF
--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -1179,10 +1179,6 @@ export function useWebSocket() {
             break
           }
           case 'heartbeat':
-            // Piggyback the optimistic-timeout sweep on the server heartbeat
-            // (~30s interval) so stale unconfirmed bubbles get marked without
-            // a dedicated client-side timer (#3898).
-            dispatch(sweepStaleOptimistic())
             break
           case 'context_usage':
             dispatch(sseContextUsage(data as { slot: string; pct: number; used_tokens?: number; window_tokens?: number; reset?: boolean }))
@@ -1523,6 +1519,16 @@ export function useWebSocket() {
       sendSlotFocusedImpl = () => {}
     }
   }, [connect, stopVoice, flushSlotActivity])
+
+  // Client-side optimistic-timeout sweep (#3973).  The server heartbeat only
+  // fires while the WebSocket is alive — but a dead connection is exactly the
+  // scenario where stale optimistic bubbles matter most.  This interval drives
+  // the sweep independently so the "message not confirmed" indicator appears
+  // even when the socket is down.
+  useEffect(() => {
+    const id = setInterval(() => dispatch(sweepStaleOptimistic()), 10_000)
+    return () => clearInterval(id)
+  }, [dispatch])
 
   /** Subscribe to log events — call with callback on mount, null on unmount. */
   const subscribeLogs = useCallback((cb: LogCallback) => {

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1984,7 +1984,8 @@ const chatSlice = createSlice({
     removeThinking(state) { state.messages = state.messages.filter(m => m.role !== 'thinking') },
     /** Mark optimistic bubbles older than OPTIMISTIC_TIMEOUT_MS as stale so the
      *  UI can show a "retry" affordance. Called periodically from useWebSocket's
-     *  heartbeat timer. Does not remove — the bubble stays in place. (#3898) */
+     *  client-side interval timer (10s). Does not remove — the bubble stays in
+     *  place. (#3898, #3973) */
     sweepStaleOptimistic(state) {
       const now = Date.now()
       const sweep = (msgs: ChatMessage[]) => {

--- a/website/src/test/UseWebSocketCoverage.test.tsx
+++ b/website/src/test/UseWebSocketCoverage.test.tsx
@@ -27,7 +27,7 @@ import {
 } from '../hooks/useWebSocket'
 import { api } from '../api/client'
 import { store as globalStore } from '../store'
-import chatReducer, { setActiveSlot, clearMessages, sseChatMessage, sseActivityEvent, setQuestionCard, resolveQuestionCard } from '../store/chatSlice'
+import chatReducer, { setActiveSlot, clearMessages, sseChatMessage, sseActivityEvent, setQuestionCard, resolveQuestionCard, sweepStaleOptimistic, appendMessage, OPTIMISTIC_TIMEOUT_MS } from '../store/chatSlice'
 import { sseSlots } from '../store/dashboardSlice'
 import { addNotification, removeNotificationByTs } from '../store/notificationsSlice'
 import type { ChatSlot } from '../types'
@@ -1755,5 +1755,50 @@ describe('useWebSocket slots reconcile', () => {
     testStore.dispatch(sseChatMessage({ slot: BACKGROUND, role: 'assistant', content: 'keep me', ts: '1' }))
     testStore.dispatch(sseSlots([]))
     expect(testStore.getState().chat.slotMessages[BACKGROUND]).toBeDefined()
+  })
+})
+
+describe('useWebSocket client-side optimistic timeout sweep (#3973)', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('dispatches sweepStaleOptimistic on a 10s interval independent of the heartbeat', () => {
+    const testStore = createTestStore({
+      chat: { ...chatReducer(undefined, { type: '@@INIT' }), activeSlot: ACTIVE },
+    })
+    // Inject an optimistic message with a backdated timestamp so the sweep can mark it stale
+    const oldTs = Date.now() - (OPTIMISTIC_TIMEOUT_MS + 5_000)
+    testStore.dispatch(appendMessage({
+      role: 'user', content: 'pending msg', cls: '', ts: '2026-08-16T14:00:00.000Z',
+      meta: { sendId: 's-timer', optimistic: true, optimisticTs: oldTs },
+    }))
+    expect(testStore.getState().chat.messages[0].meta?.stale).toBeUndefined()
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(QueryClientProvider, { client: new QueryClient({ defaultOptions: { queries: { retry: false } } }) },
+        createElement(Provider, { store: testStore }, children))
+
+    renderHook(() => useWebSocket(), { wrapper })
+
+    // The WebSocket may or may not have connected — the timer fires regardless.
+    // Advance past the 10s interval.
+    act(() => { vi.advanceTimersByTime(10_000) })
+
+    expect(testStore.getState().chat.messages[0].meta?.stale).toBe(true)
+  })
+
+  it('cleans up the interval on unmount', () => {
+    const testStore = createTestStore({
+      chat: { ...chatReducer(undefined, { type: '@@INIT' }), activeSlot: ACTIVE },
+    })
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(QueryClientProvider, { client: new QueryClient({ defaultOptions: { queries: { retry: false } } }) },
+        createElement(Provider, { store: testStore }, children))
+
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    const clearSpy = vi.spyOn(global, 'clearInterval')
+    act(() => { unmount() })
+    expect(clearSpy).toHaveBeenCalled()
+    clearSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Problem / Motivation

The `sweepStaleOptimistic` dispatch — which marks unconfirmed user messages as stale after 30s so the UI can show a "message not confirmed" indicator — was piggybacked on the server `heartbeat` WebSocket event (~30s interval). When the WebSocket connection is dead, the heartbeat stops firing and the sweep never runs. This is exactly the failure mode the indicator is meant to surface.

## Why it matters

Users on a dead connection see no visual feedback that their message was never confirmed by the server — the stale indicator only appears once the WebSocket reconnects (via `refreshSlot`). For connections that stay down for extended periods (network changes, laptop wake from sleep), the user gets no signal until reconnection.

## What changed (motivation → approach → change)

The server heartbeat is inherently connection-dependent, so any connection-independent sweep needs its own timer.

Added a dedicated `useEffect` in `useWebSocket` with a 10-second `setInterval` that dispatches `sweepStaleOptimistic()` regardless of WebSocket state. The 10s interval is shorter than the 30s timeout so stale bubbles are detected within one interval of expiry.

The previous heartbeat-driven dispatch was removed entirely — the 10s client timer strictly supersedes the ~30s heartbeat (it is always faster), so the heartbeat dispatch was redundant. The `case 'heartbeat':` handler remains as a valid no-op frame handler (the server still sends heartbeat frames for connection keepalive), it just no longer dispatches the sweep. The `chatSlice.ts` docstring was updated accordingly.

## Tests

- `dispatches sweepStaleOptimistic on a 10s interval independent of the heartbeat` — injects a backdated optimistic message, advances fake timers by 10s, asserts it becomes stale without any WebSocket event.
- `cleans up the interval on unmount` — verifies `clearInterval` is called when the hook unmounts (no leaked timers).

## Manual verification

N/A — unit coverage sufficient. The change is a single `setInterval`/`clearInterval` pair whose behavior is fully exercised by the two new tests under fake timers.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** No visible UI change — the stale indicator already exists from PR #3963; this PR only ensures the sweep fires when the connection is down.

## Related Issues

Fixes #3973

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER -->
