### PR TITLE
refactor(dashboard): resolve one serving loop instead of latching three copies

### DIFF
--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -1364,30 +1364,28 @@ class _RingLogHandler(logging.Handler):
         self._ring = ring
         self._max = max_size
         self._state: DashboardState | None = None
-        self._loop: asyncio.AbstractEventLoop | None = None
 
     def set_state(self, state: DashboardState) -> None:
         """Attach DashboardState for WS log broadcasting."""
         self._state = state
-        try:
-            self._loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self._loop = None
 
     def emit(self, record: logging.LogRecord) -> None:
         try:
             msg = self.format(record)
             data = json.dumps({"level": record.levelname, "msg": msg})
             self._ring.append(data)
-            # Push to WS log subscribers (thread-safe via call_soon_threadsafe)
-            if self._state and self._loop and self._state._ws_log_subscribers:
+            # Push to WS log subscribers. emit() runs on ARBITRARY threads (any
+            # logger call anywhere), so the send is handed to the dashboard's one
+            # serving loop rather than to a copy latched by this handler.
+            loop = self._state.serving_loop if self._state else None
+            if self._state and loop and self._state._ws_log_subscribers:
                 ws_msg = json.dumps(
                     {"type": "log", "data": {"level": record.levelname, "msg": msg}}
                 )
                 for ws in list(self._state._ws_log_subscribers):
                     try:
-                        self._loop.call_soon_threadsafe(
-                            self._loop.create_task,
+                        loop.call_soon_threadsafe(
+                            loop.create_task,
                             _safe_ws_send(ws, ws_msg, self._state),
                         )
                     except RuntimeError:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2082,11 +2082,6 @@ async def start_dashboard(
         # call ``asyncio.ensure_future``, which RAISES off-loop — and
         # ``_send_ws_all`` treats that raise as a dead socket and EVICTS every
         # connected client. Marshal the emit back onto the loop instead.
-        try:
-            _gw_loop: "asyncio.AbstractEventLoop | None" = asyncio.get_running_loop()
-        except RuntimeError:  # pragma: no cover - sync/embedded launch
-            _gw_loop = None
-
         def _on_pending_skill_staged(info: dict) -> None:
             try:
                 name = str(info.get("name") or info.get("slug") or "skill")
@@ -2154,11 +2149,12 @@ async def start_dashboard(
                     except Exception:
                         logger.debug("pending-skill notification failed", exc_info=True)
 
-                if _gw_loop is not None and not _gw_loop.is_closed():
+                loop = state.serving_loop
+                if loop is not None and not loop.is_closed():
                     # Safe from the loop thread too — call_soon_threadsafe just
                     # schedules. RuntimeError means the loop is shutting down.
                     try:
-                        _gw_loop.call_soon_threadsafe(_emit)
+                        loop.call_soon_threadsafe(_emit)
                     except RuntimeError:  # pragma: no cover - loop closing
                         pass
                 else:
@@ -2193,9 +2189,10 @@ async def start_dashboard(
                     except Exception:
                         logger.debug("pending-skill notification resolve failed", exc_info=True)
 
-                if _gw_loop is not None and not _gw_loop.is_closed():
+                loop = state.serving_loop
+                if loop is not None and not loop.is_closed():
                     try:
-                        _gw_loop.call_soon_threadsafe(_resolve)
+                        loop.call_soon_threadsafe(_resolve)
                     except RuntimeError:  # pragma: no cover - loop closing
                         pass
                 # Without a loop there is no serving dashboard (sync/embedded
@@ -2350,6 +2347,12 @@ async def start_dashboard(
         client_max_size=60 * 1024 * 1024
     )  # 60 MB: covers 50 MB upload + multipart overhead
     app["state"] = state
+    # Bind the serving loop once, here: this runs ON that loop, so every
+    # surface that later hands work in from a foreign thread -- slots
+    # coalescing, an off-loop websocket send, the log handler's fan-out --
+    # resolves the same loop instead of each latching its own copy from
+    # whichever thread happens to arrive first.
+    state.bind_serving_loop(asyncio.get_running_loop())
     # Voice settings live in slack/handler's module state and are otherwise
     # loaded only on the Slack startup path (set_orch_cfg) — without this a
     # dashboard-only gateway (no Slack tokens) resets TTS to defaults on
@@ -3312,6 +3315,12 @@ async def start_api_server(
         client_max_size=60 * 1024 * 1024
     )  # 60 MB: covers 50 MB upload + multipart overhead
     app["state"] = state
+    # Bind the serving loop once, here: this runs ON that loop, so every
+    # surface that later hands work in from a foreign thread -- slots
+    # coalescing, an off-loop websocket send, the log handler's fan-out --
+    # resolves the same loop instead of each latching its own copy from
+    # whichever thread happens to arrive first.
+    state.bind_serving_loop(asyncio.get_running_loop())
     # Voice settings live in slack/handler's module state and are otherwise
     # loaded only on the Slack startup path (set_orch_cfg) — without this a
     # dashboard-only gateway (no Slack tokens) resets TTS to defaults on

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2440,14 +2440,15 @@ class DashboardState:
     # __init__ installs the real per-instance lock.
     _slots_broadcast_lock: "threading.Lock | None" = None
     _slots_broadcast_timer: "asyncio.TimerHandle | None" = None
-    _slots_broadcast_loop: "asyncio.AbstractEventLoop | None" = None
     _slots_broadcast_last: float = 0.0
-    # The loop the websockets are served on, latched when a client registers (and
-    # again by any send issued from it). A fan-out reached from a worker thread
-    # has no running loop of its own and hands the send to this one; see
-    # _spawn_ws_send. Class-level None so a __new__-built state answers "unknown"
-    # instead of raising.
-    _ws_send_loop: "asyncio.AbstractEventLoop | None" = None
+    # The one loop this dashboard is served on. Every surface that hands work in
+    # from a foreign thread -- the coalesced slots broadcast, an off-loop
+    # websocket send, the log handler's fan-out -- resolves it through
+    # :attr:`serving_loop` rather than keeping a copy of its own: two copies are
+    # two answers to one question and can disagree, and a caller that finds its
+    # own copy unset drops the work silently. Bound at app startup; the property
+    # latches lazily so a ``__new__``-built state still resolves one.
+    _serving_loop: "asyncio.AbstractEventLoop | None" = None
     # Keys the last open-tab restore could not read (not keys it proved absent).
     # _persist_open_slots folds these back into the snapshot so a transient read
     # failure cannot erase the reopen seed. The class-level baseline is an
@@ -5527,8 +5528,9 @@ class DashboardState:
             return
 
         with lock:
-            if self._slots_broadcast_loop is None:
-                self._slots_broadcast_loop = self._running_loop()
+            # Resolved once here, at the top of the lock, so the timer branch
+            # below and any later cross-thread caller agree on one loop.
+            serving = self.serving_loop
 
             elapsed = now - self._slots_broadcast_last
             if elapsed >= _SLOTS_BROADCAST_INTERVAL_S:
@@ -5538,9 +5540,9 @@ class DashboardState:
                     self._slots_broadcast_timer = None
                 broadcast_now = True
             elif self._slots_broadcast_timer is None:
-                # Scheduling onto the captured loop is preferred over broadcasting
+                # Scheduling onto the serving loop is preferred over broadcasting
                 # from a foreign thread; a closed loop falls back to an immediate send.
-                loop = self._slots_broadcast_loop
+                loop = serving
                 remaining = _SLOTS_BROADCAST_INTERVAL_S - elapsed
                 try:
                     if loop is None:
@@ -5568,6 +5570,33 @@ class DashboardState:
             return asyncio.get_running_loop()
         except RuntimeError:
             return None
+
+    def bind_serving_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Record the loop this dashboard is served on, before any request runs.
+
+        Called from an app startup hook: that is the earliest point the loop
+        exists, so every later reader finds it already bound instead of racing to
+        latch a copy from whichever thread happens to arrive first.
+        """
+        self._serving_loop = loop
+
+    @property
+    def serving_loop(self) -> "asyncio.AbstractEventLoop | None":
+        """The loop to hand cross-thread work to, or None when it is unknowable.
+
+        Prefers the loop bound at startup. When nothing bound one -- a
+        ``__new__``-built state, a unit test, a process whose startup hook has not
+        run -- it latches the running loop the first time it is read FROM that
+        loop, so an off-loop caller arriving later still has a target. ``None``
+        means this state has never seen a loop, and the caller owns the decision
+        about what to do with the work rather than being handed a guess.
+        """
+        loop = self._serving_loop
+        if loop is None:
+            loop = self._running_loop()
+            if loop is not None:
+                self._serving_loop = loop
+        return loop
 
     def _schedule_trailing_flush(self, delay: float) -> None:
         """Arm the trailing flush. Must run ON the event loop."""
@@ -5814,7 +5843,7 @@ class DashboardState:
         """
         loop = self._running_loop()
         if loop is None:
-            target = self._ws_send_loop
+            target = self.serving_loop
             if target is not None and not target.is_closed():
                 try:
                     target.call_soon_threadsafe(self._spawn_ws_send, ws, msg)
@@ -5832,7 +5861,11 @@ class DashboardState:
                 close()
             logger.debug("WS send dropped: no serving loop to run it on")
             return
-        self._ws_send_loop = loop
+        # Latch through the accessor, never by assigning the field: the read
+        # records this loop only when nothing bound one, so a loop bound at
+        # startup stays authoritative and bind_serving_loop remains the only
+        # writer that can override. The send below runs on the loop we are on.
+        self.serving_loop
         task = asyncio.ensure_future(ws.send_str(msg))
         self._background_tasks.add(task)
         task.add_done_callback(self._on_ws_send_done)
@@ -6319,9 +6352,9 @@ class DashboardState:
         self._ws_clients.append(ws)
         if owner:
             self._owner_ws_clients.add(ws)
-        loop = self._running_loop()
-        if loop is not None:
-            self._ws_send_loop = loop
+        # Same one-sink rule as _spawn_ws_send: reading the accessor latches
+        # this loop when nothing bound one and leaves a startup bind alone.
+        self.serving_loop
 
     def unregister_ws(self, ws: web.WebSocketResponse) -> None:
         """Remove a WebSocket client on disconnect."""

--- a/test/test_dashboard_updates_coverage.py
+++ b/test/test_dashboard_updates_coverage.py
@@ -780,11 +780,19 @@ class TestSafeWsSend:
 class TestRingLogHandler:
     """The always-on ring buffer plus its WebSocket fan-out."""
 
-    def test_set_state_off_the_loop_records_no_loop(self):
-        """Installed at import time on some paths, where no loop is running yet."""
+    def test_set_state_keeps_no_loop_of_its_own(self):
+        """The handler defers to the dashboard's one serving loop.
+
+        Its `emit()` runs on arbitrary threads while `set_state` captured a loop
+        ONCE, so any caller attaching the state from a non-loop context latches
+        None permanently and every later fan-out is dropped with nothing
+        surfaced. Today's only production caller runs inside `start_dashboard`,
+        so the capture did succeed -- this pins the shape, not a live bug.
+        Resolving through the state at emit time removes the latch entirely.
+        """
         handler = updates._RingLogHandler(collections.deque(maxlen=4))
         handler.set_state(MagicMock())
-        assert handler._loop is None
+        assert not hasattr(handler, "_loop")
 
     def test_emit_appends_to_the_ring_and_honours_maxlen(self):
         ring: collections.deque[str] = collections.deque(maxlen=2)
@@ -816,8 +824,8 @@ class TestRingLogHandler:
         ws.send_str = AsyncMock()
         state = MagicMock()
         state._ws_log_subscribers = {ws}
+        state.serving_loop = asyncio.get_running_loop()
         handler.set_state(state)
-        assert handler._loop is asyncio.get_running_loop()
 
         handler.emit(_record("broadcast me"))
         # The fan-out is scheduled via call_soon_threadsafe, so it lands on a
@@ -862,8 +870,10 @@ class TestRingLogHandler:
         state = MagicMock()
         state._ws_log_subscribers = {MagicMock()}
         handler._state = state
-        handler._loop = MagicMock()
-        handler._loop.call_soon_threadsafe.side_effect = RuntimeError("event loop is closed")
+        state.serving_loop = MagicMock()
+        state.serving_loop.call_soon_threadsafe.side_effect = RuntimeError(
+            "event loop is closed"
+        )
 
         handler.emit(_record("during shutdown"))
 

--- a/test/test_dashboard_ws_offloop_fanout.py
+++ b/test/test_dashboard_ws_offloop_fanout.py
@@ -106,7 +106,7 @@ async def test_unknown_serving_loop_drops_frame_but_keeps_client(tmp_path) -> No
     state = _make_state(tmp_path)
     ws = _FakeWS()
     state._ws_clients.append(ws)
-    state._ws_send_loop = None
+    state._serving_loop = None
 
     await asyncio.to_thread(state._send_ws_all, "ping", {}, "frame")
     await _drain()
@@ -176,9 +176,9 @@ async def test_register_ws_latches_serving_loop_for_first_offloop_frame(tmp_path
     """
     state = _make_state(tmp_path)
     ws = _FakeWS()
-    state._ws_send_loop = None
+    state._serving_loop = None
     state.register_ws(ws)  # on the serving loop, as api_ws does
-    assert state._ws_send_loop is not None, "registration did not latch the serving loop"
+    assert state._serving_loop is not None, "registration did not latch the serving loop"
 
     # No prior on-loop send: this is the connection's very first frame.
     await asyncio.to_thread(state._send_ws_all, "notification", {}, "first-frame")
@@ -257,7 +257,7 @@ async def test_offloop_fanout_leaves_no_unawaited_coroutine(tmp_path) -> None:
     state = _make_state(tmp_path)
     ws = _AbandonProbeWS()
     state._ws_clients.append(ws)
-    state._ws_send_loop = None  # nothing to hand the send to
+    state._serving_loop = None  # nothing to hand the send to
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")

--- a/test/test_serving_loop_unified.py
+++ b/test/test_serving_loop_unified.py
@@ -1,0 +1,264 @@
+"""One serving loop, resolved through one accessor.
+
+The dashboard latched "the loop to hand cross-thread work to" in four separate
+places under four names: a field for the coalesced slots broadcast, a second for
+off-loop websocket sends, a third inside the ring-log handler, and a startup
+closure in ``server.py`` that marshalled the skill-staging hooks. They held the
+same loop, so nothing was broken -- but they are four answers to one question,
+they can be updated independently, and a caller that finds ITS copy unset drops
+the work silently rather than raising.
+
+These tests pin the collapsed shape: ``DashboardState.serving_loop`` is the single
+resolver, and the three ratchets at the bottom fail if a second latched copy
+reappears -- as an instance attribute, as a loop held across a closure, or as a
+second writer of the field that would clobber the startup bind.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import collections
+import logging
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.dashboard import state as state_mod
+from kiro_crew.dashboard.handlers import updates
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.history import ConversationLog
+
+
+def _make_state(tmp_path) -> DashboardState:
+    sessions = MagicMock(count=0)
+    sessions.get_pid = MagicMock(return_value=None)
+    sessions.remove = AsyncMock()
+    return DashboardState(
+        sessions=sessions,
+        crons=MagicMock(list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})),
+        lessons=MagicMock(load_all=MagicMock(return_value=[])),
+        start_time=0.0,
+        conversation_log=ConversationLog(base_dir=tmp_path),
+    )
+
+
+@pytest.mark.asyncio
+async def test_bind_wins_over_lazy_latching(tmp_path) -> None:
+    """A bound loop is authoritative: the accessor never re-derives one."""
+    state = _make_state(tmp_path)
+    sentinel = MagicMock(name="loop-bound-at-startup")
+    state.bind_serving_loop(sentinel)
+
+    # Read from a real running loop; the bound value must still win, otherwise
+    # startup's authoritative answer could be overwritten by whoever reads first.
+    assert state.serving_loop is sentinel
+
+
+@pytest.mark.asyncio
+async def test_lazy_latch_when_nothing_bound(tmp_path) -> None:
+    """A state whose startup never ran still resolves a loop when read from one."""
+    state = _make_state(tmp_path)
+    state._serving_loop = None
+
+    assert state.serving_loop is asyncio.get_running_loop()
+    # And it sticks, so a later off-loop caller has a target.
+    assert state._serving_loop is asyncio.get_running_loop()
+
+
+def test_unknowable_loop_is_none_not_a_guess(tmp_path) -> None:
+    """Off the loop with nothing bound, the accessor admits it does not know."""
+    state = _make_state(tmp_path)
+    state._serving_loop = None
+
+    assert state.serving_loop is None
+
+
+@pytest.mark.asyncio
+async def test_ws_hop_and_slots_coalescer_share_one_loop(tmp_path) -> None:
+    """The two in-state consumers resolve the SAME object, not two copies."""
+    state = _make_state(tmp_path)
+    state._serving_loop = None
+    ws = MagicMock(closed=False)
+    ws.send_str = AsyncMock()
+    ws.get = MagicMock(return_value=True)
+
+    state.register_ws(ws)  # on the loop
+    latched = state._serving_loop
+    assert latched is asyncio.get_running_loop()
+
+    # The slots coalescer must read that same field rather than latch its own.
+    state.push_slots_update()
+    assert state._serving_loop is latched
+
+
+@pytest.mark.asyncio
+async def test_log_handler_uses_the_states_loop(tmp_path) -> None:
+    """The ring-log handler keeps no loop; it asks the state at emit time.
+
+    emit() runs on arbitrary threads, so this is the surface most likely to
+    re-grow its own copy.
+    """
+    ring: collections.deque[str] = collections.deque(maxlen=4)
+    handler = updates._RingLogHandler(ring)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    ws = MagicMock()
+    ws.send_str = AsyncMock()
+    state = MagicMock()
+    state._ws_log_subscribers = {ws}
+    state.serving_loop = MagicMock()
+    handler.set_state(state)
+
+    handler.emit(
+        logging.LogRecord("kiro_crew", logging.INFO, __file__, 1, "hello", None, None)
+    )
+
+    assert state.serving_loop.call_soon_threadsafe.called, (
+        "the handler did not route its fan-out through the state's serving loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_and_send_do_not_clobber_the_startup_bind(tmp_path) -> None:
+    """The two on-loop consumers must not overwrite the authoritative bind.
+
+    Both ``register_ws`` and the on-loop branch of ``_spawn_ws_send`` run while a
+    loop IS current, so a direct ``self._serving_loop = loop`` there would silently
+    replace whatever startup bound -- making "bind wins" true only until the first
+    websocket connects. Reading the accessor instead latches only when nothing is
+    bound, which is what keeps the invariant a property of the code rather than a
+    claim in a docstring.
+    """
+    state = _make_state(tmp_path)
+    sentinel = MagicMock(name="loop-bound-at-startup")
+    state.bind_serving_loop(sentinel)
+    ws = MagicMock(closed=False)
+    ws.send_str = AsyncMock()
+    ws.get = MagicMock(return_value=True)
+
+    state.register_ws(ws)
+    assert state.serving_loop is sentinel, "register_ws clobbered the startup bind"
+
+    state._spawn_ws_send(ws, "{}")
+    assert state.serving_loop is sentinel, "_spawn_ws_send clobbered the startup bind"
+
+    pending = list(state._background_tasks)
+    if pending:
+        await asyncio.gather(*pending)
+
+
+def test_only_bind_and_the_accessor_write_the_field() -> None:
+    """Ratchet: "bind wins" must be structural, not merely asserted.
+
+    Any other writer of ``_serving_loop`` overwrites the loop bound at startup, so
+    the accessor's promise would hold only until whichever call site got there
+    first. Exactly two writers are permitted: ``bind_serving_loop``, the
+    authoritative one, and the lazy latch inside the ``serving_loop`` property.
+    A third reintroduces the many-writers shape this change removed -- a reader
+    that wants the loop recorded should READ the accessor, which latches for it.
+    """
+    tree = ast.parse(Path(state_mod.__file__).read_text(encoding="utf-8"))
+    allowed = {"bind_serving_loop", "serving_loop"}
+    offenders: list[str] = []
+
+    def scan(node: ast.AST, fn: str | None) -> None:
+        for child in ast.iter_child_nodes(node):
+            inner = (
+                child.name
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                else fn
+            )
+            if isinstance(child, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+                targets = child.targets if isinstance(child, ast.Assign) else [child.target]
+                for target in targets:
+                    if (
+                        isinstance(target, ast.Attribute)
+                        and target.attr == "_serving_loop"
+                        and isinstance(target.value, ast.Name)
+                        and target.value.id == "self"
+                        and inner not in allowed
+                    ):
+                        offenders.append(f"{inner or '<module>'}:{child.lineno}")
+            scan(child, inner)
+
+    scan(tree, None)
+    assert not offenders, (
+        "something other than bind_serving_loop and the accessor writes "
+        f"_serving_loop: {offenders} -- read DashboardState.serving_loop instead, "
+        "which latches without overwriting a loop bound at startup"
+    )
+
+
+def test_only_one_latched_serving_loop_field_remains() -> None:
+    """Ratchet: a second latched copy of the loop must not reappear.
+
+    Matches assignments of a running loop into an instance attribute across the
+    two modules that had them. `_serving_loop` is the one permitted sink; anything
+    else means the duplication this collapsed has grown back, which is invisible
+    until two copies disagree at runtime.
+
+    The match must END at the loop call: ``self._x = get_running_loop()`` stores
+    the loop, whereas ``self._timer = get_running_loop().call_later(...)`` stores
+    a timer handle and is not a second copy of the loop.
+    """
+    pattern = re.compile(
+        r"self\.(_[A-Za-z0-9_]+)\s*=\s*(?:self\._running_loop\(\)"
+        r"|asyncio\.get_running_loop\(\)"
+        r"|asyncio\.get_event_loop\(\))\s*(?:#.*)?$",
+        re.MULTILINE,
+    )
+    offenders: dict[str, set[str]] = {}
+    for mod in (state_mod, updates):
+        src = Path(mod.__file__).read_text(encoding="utf-8")
+        names = {m.group(1) for m in pattern.finditer(src)} - {"_serving_loop"}
+        if names:
+            offenders[Path(mod.__file__).name] = names
+
+    assert not offenders, (
+        "a second latched serving-loop field reappeared: "
+        f"{offenders} -- route it through DashboardState.serving_loop instead"
+    )
+
+
+def test_no_latched_loop_held_across_a_closure() -> None:
+    """Ratchet: a loop latched into a LOCAL and held for later must not reappear.
+
+    The instance-attribute ratchet above cannot see this shape, which is exactly
+    how one copy survived the first pass: a startup closure captured the loop in a
+    local, then marshalled onto it from hook callbacks that fire much later.
+
+    The tell is the annotation. A transient local reads
+    ``loop = asyncio.get_running_loop()`` and is used immediately; a copy meant to
+    outlive its statement is annotated Optional so the ``except RuntimeError``
+    branch can set it to None. Matching only the annotated form keeps ordinary
+    transient locals free while pinning the smell.
+
+    That makes this ratchet deliberately incomplete: an UNANNOTATED captured local
+    slips past it. It is kept anyway because neither other ratchet can see a local
+    at all -- one matches ``self.<attr> =``, the other only writes of
+    ``_serving_loop`` -- so dropping this one would leave the exact shape that
+    escaped the first pass with no guard. Widening it to every
+    ``get_running_loop()`` assignment would flag dozens of legitimate transient
+    locals and get muted, which is worse than a narrow guard that fires rarely.
+    """
+    annotated = re.compile(
+        r"[A-Za-z_][A-Za-z0-9_]*\s*:\s*\"?asyncio\.AbstractEventLoop\s*\|\s*None\"?\s*"
+        r"=\s*asyncio\.get_running_loop\(\)"
+    )
+    from kiro_crew.dashboard import server as server_mod
+
+    offenders: dict[str, list[str]] = {}
+    for mod in (server_mod, state_mod, updates):
+        name = Path(mod.__file__).name
+        hits = [
+            line.strip()
+            for line in Path(mod.__file__).read_text(encoding="utf-8").splitlines()
+            if annotated.search(line)
+        ]
+        if hits:
+            offenders[name] = hits
+    assert not offenders, (
+        "a loop was latched into a local and held for later use: "
+        f"{offenders} -- read DashboardState.serving_loop at dispatch time instead"
+    )

--- a/test/test_slots_broadcast_coalesce.py
+++ b/test/test_slots_broadcast_coalesce.py
@@ -38,7 +38,7 @@ def state(monkeypatch, tmp_path, loop):
     s.is_yolo_active = lambda: False
     # Production captures this on the first call from the loop thread; pinning it
     # here keeps each test's timing independent of construction order.
-    s._slots_broadcast_loop = loop
+    s._serving_loop = loop
     return s
 
 
@@ -170,7 +170,7 @@ class TestNonEventLoopThread:
 
         dead = asyncio.new_event_loop()
         dead.close()
-        state._slots_broadcast_loop = dead
+        state._serving_loop = dead
         state._slots_broadcast_last = time.monotonic()
 
         state.push_slots_update()


### PR DESCRIPTION
# refactor(dashboard): resolve one serving loop instead of latching four copies

## 1. What is the problem?

The dashboard latched "the loop to hand cross-thread work to" in four
independent places, under four names:

| where | field | latched | used for |
|---|---|---|---|
| `state.py` | `_slots_broadcast_loop` | inside `push_slots_update` | arming the trailing coalesced slots flush |
| `state.py` | `_ws_send_loop` | `register_ws` + any on-loop send | hopping an off-loop websocket send |
| `handlers/updates.py` | `_loop` on the ring-log handler | its own `set_state` | `call_soon_threadsafe` for the log fan-out |
| `server.py` | `_gw_loop` (a startup CLOSURE, not an attribute) | inside `start_dashboard` | marshalling the skill-staging hooks back onto the loop |

All four hold the same gateway loop, so nothing misbehaves today. They are still
four answers to one question: each can be updated without the others, and a
caller that finds ITS copy unset drops the work silently rather than raising.

That silent-drop shape is not hypothetical. It is the same shape as the defect
fixed in #3961, where a surface that could not resolve a loop discarded the frame
with nothing surfaced anywhere. The log handler is the clearest instance: its
`emit()` runs on arbitrary threads while `set_state` captured the loop ONCE, so
any caller attaching the state off-loop latches `None` permanently and every
later fan-out is dropped with nothing surfaced. To be precise about what is NOT
claimed: today's only production `set_state` caller runs inside
`start_dashboard`, so that capture did succeed and the fan-out worked. What this
removes is the latch, not an observed drop.

## 2. Why this issue matters to the user

Nothing is broken right now, so the honest framing is risk rather than symptom:
the next surface that needs to hand work to the loop has three fields to choose
from and no rule saying which, and picking the one that happens to be unset in
its call path loses the work with no error. Two reviewers independently flagged
the duplication on #3962 for exactly that reason.

## 3. How our fix solves it

One concept, one resolver, bound once.

- **`DashboardState.serving_loop`** is the single resolver. It prefers a loop
  bound at startup, and otherwise latches the running loop the first time it is
  read FROM that loop, so a `__new__`-built state and the unit tests still
  resolve one. `None` means this state has never seen a loop, and the caller owns
  that decision instead of being handed a guess.
- **`bind_serving_loop` is called where the app is built**, in both entry points
  (`start_dashboard` and `start_api_server`). That code already runs on the
  serving loop, so binding there is authoritative and needs no `on_startup` hook -
  which also avoids the frozen-signal-list hazard `server.py` documents. Every
  later reader finds the loop already bound rather than racing to latch it.
- **`bind_serving_loop` and the accessor's lazy latch are the ONLY writers of
  the field.** `register_ws` and the on-loop branch of `_spawn_ws_send` used to
  assign `_serving_loop` directly; they now READ the accessor, which records a
  loop only when nothing bound one. That makes "a bound loop wins" a property of
  the code rather than a claim a test happens to cover - previously the first
  websocket connect could replace the loop startup had bound. Same loop in
  practice today, so no behaviour change, but three writers of one field is the
  shape this PR exists to remove.
- **All four consumers read the accessor** and keep no copy. The two `state.py`
  fields are gone, the log handler's `_loop` is gone with them, and the
  skill-staging hooks resolve the loop at FIRE time instead of capturing it at
  startup - they are registered during startup but cannot fire until a skill is
  staged, which is necessarily after the bind.

Behaviour is deliberately unchanged, and no behaviour fix is claimed: same
coalescing semantics (the loop is now resolved once at the top of the same lock,
so the timer branch and any later cross-thread caller agree), same off-loop hop,
same eviction rules. The ring-log handler's fan-out worked before and works now;
only its private latch is gone.

## 4. What tests we did

New `test/test_serving_loop_unified.py`:

- a bound loop wins over lazy latching, so startup's answer is not overwritten by
  whichever reader arrives first;
- an unbound state latches when read from a loop, and the value sticks so a later
  off-loop caller has a target;
- off the loop with nothing bound, the accessor returns `None` rather than
  guessing;
- the websocket hop and the slots coalescer resolve the SAME object;
- the ring-log handler routes its fan-out through the state's loop and keeps none
  of its own;
- `register_ws` and `_spawn_ws_send`, called while a loop IS current, leave a
  startup bind alone instead of overwriting it;
- **three ratchets**: one fails if a second latched instance attribute reappears,
  one if a loop is latched into a LOCAL and held for later, and one (an AST walk)
  if anything other than `bind_serving_loop` and the accessor writes the field.
  The second exists because the first structurally cannot see a closure - which is
  how `_gw_loop` survived the first pass of this change; the third closes the
  same gap for a direct assignment. The closure ratchet is deliberately narrow -
  it matches only the Optional-annotated form, so an unannotated captured local
  evades it - and is kept because neither other ratchet can see a local at all,
  which would leave the escaped shape with no guard.

Each ratchet is proven to discriminate. Injecting a second
`self._sneaky_loop = asyncio.get_running_loop()` makes it fail naming that field,
and removing it makes it pass. It matches only assignments that END at the loop
call, so a timer handle from `get_running_loop().call_later(...)` is not a false
positive - that over-match was caught while building it. Re-introducing a direct
`self._serving_loop = self._running_loop()` in `register_ws` fails the AST ratchet
AND the behaviour test that pins the bind, and restoring the file makes both pass.

Existing suites that referenced the removed fields were updated rather than
weakened: the WS fan-out tests and the slots-coalescing tests are a rename onto
the unified field, and the three ring-log handler tests now drive the loop
through the state. Those had to be explicit about it - their `state` is a
`MagicMock`, so leaving `serving_loop` as an auto-Mock would be truthy and turn
`call_soon_threadsafe` into a no-op that asserts nothing.

Gates: 150 passed across the changed surface (the new file plus
`test_dashboard_ws_offloop_fanout`, `test_slots_broadcast_coalesce`,
`test_dashboard_updates_coverage`, `test_dashboard_state_ws`,
`test_dashboard_ws_task_tracking`). `isort` and `flake8` clean; `mypy` clean over
976 files at the `pyproject.toml` pin, in a venv without `faiss` for CI parity.

This host carries pre-existing failures unrelated to the dashboard. Rather than
label them, they were compared like-for-like: the 21 files involved were run with
identical flags on this branch and on pristine `main`, giving **9 failed / 1983
passed on both, with no difference in the failing set**. A full-suite run shows
more failures than that subset on either tree, which is parallel-load noise on a
busy box, not a branch difference.

## 5. Any other suggestions on the work

- `_broadcast` still runs its SSE `put_nowait` / `_notify_event.set` and
  `serialize_slots` on whatever thread calls it. This PR unifies who owns the
  loop, not which work is allowed off it; that remains open.
- While reading the log handler I noticed its `_safe_ws_send` coroutine is built
  BEFORE the scheduling call, so a `RuntimeError` from a closed loop abandons it
  un-awaited - the same "coroutine was never awaited" shape #3961 removed from the
  websocket fan-out. An existing test documents it as harmless. Left alone here
  deliberately: it is a behaviour change in a surface this PR only re-points, and
  it deserves its own change with its own test rather than riding along.

- **The same latch-a-copy shape exists outside the dashboard and is NOT fixed
  here.** Grepping `self._<name> = asyncio.get_running_loop()` plus the
  module-level binds finds five siblings: `computer_use/overlay.py:538`
  (`_bound_loop`, with its own `bind_gateway_loop` at :541 - a second spelling of
  the bind this PR adds), `slack/handler.py:342`, `cron.py:766` and `:782`, and
  `history.py:4891`. In the gateway process they all hold the same loop, so
  nothing misbehaves. Collapsing them is a process-level change that crosses
  deliberate module boundaries and would make this diff about two things, so it
  is deferred on purpose rather than overlooked - naming it here so a reviewer
  does not have to rediscover it. The `*_lock_loop` fields in `handlers/mcp.py`,
  `handlers/agents.py` and `handlers/cron.py` are a different question again
  (whether an `asyncio.Lock` needs rebinding), not copies of this one.

Closes #3969



