### PR TITLE
docs: add greysonevins to contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ make this tool possible:
 <a href="https://github.com/gragollier" title="Grant Gollier"><img src="https://github.com/gragollier.png?size=64" width="64" height="64" alt="Grant Gollier" /></a>
 <a href="https://github.com/greatfighter" title="Spencer"><img src="https://github.com/greatfighter.png?size=64" width="64" height="64" alt="Spencer" /></a>
 <a href="https://github.com/gregory-chapman" title="Gregory Chapman"><img src="https://github.com/gregory-chapman.png?size=64" width="64" height="64" alt="Gregory Chapman" /></a>
+<a href="https://github.com/greysonevins" title="Greyson Nevins"><img src="https://github.com/greysonevins.png?size=64" width="64" height="64" alt="Greyson Nevins" /></a>
 <a href="https://github.com/haozihong" title="haozihong"><img src="https://github.com/haozihong.png?size=64" width="64" height="64" alt="haozihong" /></a>
 <a href="https://github.com/harpreetmultani1994" title="Harpreet Singh"><img src="https://github.com/harpreetmultani1994.png?size=64" width="64" height="64" alt="Harpreet Singh" /></a>
 <a href="https://github.com/hazlijohar95" title="Hazli Johar"><img src="https://github.com/hazlijohar95.png?size=64" width="64" height="64" alt="Hazli Johar" /></a>


### PR DESCRIPTION
## Problem / Motivation

I'm missing from the Contributors list in the README. I worked on a few changes to
Kiro Crew before leaving Amazon, so I wasn't captured when the list was assembled.

## Why it matters

The Contributors section is how the project credits the people who worked on it.
The README invites anyone who contributed and isn't listed to open a PR to be added.

## What changed

Added a single entry for `@greysonevins` to the Contributors section, using the same
`<a>`/`<img>` markup as every other entry and inserted in alphabetical order by GitHub
username, between `gregory-chapman` and `haozihong`. One added line, no code changes.

## Tests

N/A — documentation-only change, no code paths affected.

## Manual verification

Confirmed the new entry matches the surrounding entries in structure (link target,
avatar URL, `size=64`, width/height, `title`/`alt`), the avatar URL resolves, and
alphabetical ordering is preserved. Diff is a single added line.

## Related Issues

N/A

## Checklist

- [x] Single commit with a Conventional Commits title (`docs: ...`)
- [x] Existing tests pass and new tests added for new functionality — N/A, docs only
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
