### PR TITLE
fix(tests): use absolute paths via _REPO_ROOT instead of relative Path('src/...')

### DIFF
--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -219,6 +219,15 @@ custom-rules:
       ignore_errors=True)`. The rule is: if you create it, you must register
       its destruction in the same scope.
 
+      NEVER use relative `Path("src/...")` or bare string paths to read source
+      files from a test. Under pytest-xdist, workers may change CWD, making
+      relative paths non-deterministic. Always anchor to the repo root via
+      `_REPO_ROOT = Path(__file__).resolve().parents[1]` (for test/ files) or
+      the equivalent number of parent hops for deeper test directories, then
+      use `_REPO_ROOT / "src/kiro_crew/..."`. This pattern is already
+      established in test_builtin_app_assets.py, test_platform_compat.py, and
+      test_skill_home_paths.py.
+
   - id: top-level-imports
     blocking: false
     file-patterns:

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -36,6 +36,9 @@ from kiro_crew.apps.bridges import (
 from kiro_crew.apps.manager import APP_MANIFEST_FILENAME, install_app
 from kiro_crew.apps.manifest import AppManifest
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -2575,7 +2578,6 @@ class TestBuiltinAgentNamesAreNamespaced:
     """
 
     def _builtin_dirs(self):
-        from pathlib import Path
 
         import kiro_crew.apps.builtins as builtins_pkg
 
@@ -2725,7 +2727,6 @@ class TestUserAgentEditsSurviveRefresh:
         anywhere says so.
         """
         import json
-        from pathlib import Path
 
         from kiro_crew.apps.bridges import _FRAMEWORK_OWNED_AGENT_KEYS
 
@@ -2743,7 +2744,7 @@ class TestUserAgentEditsSurviveRefresh:
         preferences = {
             "description", "model", "toolsSettings", "$schema", "welcomeMessage", "skills",
         }
-        root = Path("src/kiro_crew/apps/builtins")
+        root = _REPO_ROOT / "src/kiro_crew/apps/builtins"
         templates = sorted(root.glob("*/agents/*.json"))
         if not templates:
             # Same reasoning as the namespacing guard above: nothing ships an
@@ -3173,9 +3174,8 @@ class TestMcpEnableHandlersOffloadTheSync:
 
     def test_handlers_offload_sync_to_agent(self) -> None:
         import re
-        from pathlib import Path
 
-        src = Path("src/kiro_crew/dashboard/handlers/mcp.py").read_text(encoding="utf-8")
+        src = (_REPO_ROOT / "src/kiro_crew/dashboard/handlers/mcp.py").read_text(encoding="utf-8")
         # No bare synchronous call to a PUBLIC sync-to-agent function inside an
         # async handler: every such invocation is wrapped in asyncio.to_thread.
         # The `_unlocked` variants are the sync locking-wrapper's own delegation

--- a/test/test_app_denial_code.py
+++ b/test/test_app_denial_code.py
@@ -24,6 +24,9 @@ import pytest
 
 from kiro_crew.apps.manager import AppResult
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
 DENIAL_CODE = "app_execution_denied"
 
 
@@ -152,5 +155,5 @@ def test_denial_code_matches_the_open_command_route():
     place, this fails rather than leaving the affordance silently dead on the
     other paths.
     """
-    src = Path("src/kiro_crew/apps/routes.py").read_text(encoding="utf-8")
+    src = (_REPO_ROOT / "src/kiro_crew/apps/routes.py").read_text(encoding="utf-8")
     assert f'"code": "{DENIAL_CODE}"' in src

--- a/test/test_app_manifest.py
+++ b/test/test_app_manifest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from hypothesis import given, settings
@@ -16,6 +17,9 @@ from kiro_crew.apps.manifest import (
     SetupConfig,
 )
 from kiro_crew.constants import WINDOWS_DEVICE_STEMS
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -707,11 +711,10 @@ class TestDependencies:
         silent, so the useful thing to pin is the general property.
         """
         import json
-        from pathlib import Path
 
         from kiro_crew.apps.manifest import AppManifest
 
-        builtins = Path("src/kiro_crew/apps/builtins")
+        builtins = _REPO_ROOT / "src/kiro_crew/apps/builtins"
         for app_json in sorted(builtins.glob("*/app.json")):
             raw = json.loads(app_json.read_text(encoding="utf-8"))
             declared = raw.get("dependencies") or {}
@@ -981,7 +984,6 @@ class TestRequiresDesktopApp:
 
     def test_mochi_builtin_declares_it(self):
         """Mochi is the first consumer: its panel needs the Electron shell."""
-        from pathlib import Path
 
         import kiro_crew.apps.builtins as builtins_pkg
 

--- a/test/test_mcp_sync_agent.py
+++ b/test/test_mcp_sync_agent.py
@@ -17,6 +17,8 @@ from kiro_crew.dashboard.handlers.agents import (
 )
 from kiro_crew.mcp_provenance import without_marker
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 @pytest.fixture()
 def mcp_env(tmp_path: Path):
@@ -1260,10 +1262,9 @@ class TestOffloadedSyncHoldsTheConfigLock:
     """
 
     def test_every_offloaded_sync_is_under_the_config_lock(self) -> None:
-        from pathlib import Path
 
         lines = (
-            Path("src/kiro_crew/dashboard/handlers/mcp.py").read_text(encoding="utf-8").splitlines()
+            (_REPO_ROOT / "src/kiro_crew/dashboard/handlers/mcp.py").read_text(encoding="utf-8").splitlines()
         )
         offenders: list[str] = []
         for i, ln in enumerate(lines):

--- a/test/test_mochi_routes.py
+++ b/test/test_mochi_routes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextlib
 import json
 import threading
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -16,6 +17,8 @@ from aiohttp.test_utils import make_mocked_request
 
 from kiro_crew.apps.builtins.mochi import hooks
 from kiro_crew.apps.builtins.mochi.backend import routes
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class _Ctx:
@@ -897,7 +900,6 @@ class TestNoLockingCallRunsOnTheEventLoop:
 
     def test_every_locking_call_in_async_code_is_offloaded(self) -> None:
         import ast
-        from pathlib import Path
 
         locking = {
             "add_pin",
@@ -914,7 +916,7 @@ class TestNoLockingCallRunsOnTheEventLoop:
             "cancel_watch_item",
             "remove_watch_item",
         }
-        root = Path("src/kiro_crew/apps/builtins/mochi")
+        root = _REPO_ROOT / "src/kiro_crew/apps/builtins/mochi"
         offenders: list[str] = []
         scanned = 0
         for path in sorted(root.rglob("*.py")):
@@ -967,10 +969,9 @@ class TestTheOwnerLoopNeverBlocksOnDisk:
 
     def test_every_disk_bound_tick_is_offloaded(self) -> None:
         import ast
-        from pathlib import Path
 
         tree = ast.parse(
-            Path("src/kiro_crew/apps/builtins/mochi/hooks.py").read_text(encoding="utf-8")
+            (_REPO_ROOT / "src/kiro_crew/apps/builtins/mochi/hooks.py").read_text(encoding="utf-8")
         )
 
         def receiver(call: ast.Call) -> tuple[str, str] | None:
@@ -1018,10 +1019,9 @@ class TestSettingsAndDisplayWritesAreOffloaded:
 
     def test_no_bare_blocking_write_on_an_async_route(self) -> None:
         import re
-        from pathlib import Path
 
         lines = (
-            Path("src/kiro_crew/apps/builtins/mochi/backend/routes.py")
+            (_REPO_ROOT / "src/kiro_crew/apps/builtins/mochi/backend/routes.py")
             .read_text(encoding="utf-8")
             .splitlines()
         )
@@ -1194,7 +1194,6 @@ class TestQueueFilenameHasOneDefinition:
 
     def test_no_module_redefines_the_literal(self):
         """A future copy-paste must fail here rather than drift silently."""
-        from pathlib import Path
 
         from kiro_crew.apps.builtins.mochi import queue_file
 

--- a/test/test_stub_bridge_liveness.py
+++ b/test/test_stub_bridge_liveness.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 
 import pytest
 
@@ -20,6 +21,8 @@ from kiro_crew.mcp_gateway.stub import (
     BridgeLivenessFailure,
     run_bridge,
 )
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # Pin to one xdist worker (requires --dist loadgroup) alongside the other
 # mcp_gateway suites.
@@ -393,9 +396,7 @@ class TestLivenessIsNegotiated:
         session's tools are lost either way, and exec would additionally discard
         the socket a future reconnect could reuse.
         """
-        from pathlib import Path
-
-        src = Path("src/kiro_crew/mcp_gateway/stub.py").read_text(encoding="utf-8")
+        src = (_REPO_ROOT / "src/kiro_crew/mcp_gateway/stub.py").read_text(encoding="utf-8")
         marker = "if liveness_failure is not None:"
         assert marker in src
         tail = src[src.index(marker):]

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -29,6 +29,8 @@ from kiro_crew.tips import (
 )
 from kiro_crew.tips_text import truncate_summary
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 class TestCatalogParsing:
     def test_scan_docs_catalog_finds_entries(self) -> None:
@@ -719,7 +721,7 @@ class TestCatalogAllowlist:
         """Catch allowlist drift: every listed doc must exist in the docs dir."""
         from kiro_crew.tips_allowlist import TIP_DOC_ALLOWLIST
 
-        docs_dir = Path("src/kiro_crew/docs")
+        docs_dir = _REPO_ROOT / "src/kiro_crew/docs"
         if not docs_dir.is_dir():  # running from an installed package
             import kiro_crew
 


### PR DESCRIPTION
## Problem

7 test files use `Path('src/...')` relative paths to read source files for structural assertions. Under pytest-xdist, workers may shift CWD, causing `FileNotFoundError` (observed on release.yml's full-suite run, insider.9/10).

## Fix

Anchor all source-reading paths to:
```python
_REPO_ROOT = Path(__file__).resolve().parents[1]
```

Files fixed: test_mcp_sync_agent.py, test_mochi_routes.py, test_stub_bridge_liveness.py, test_app_bridges.py, test_app_manifest.py, test_tips.py, test_app_denial_code.py.

AUTOSDE rule: `no-test-side-effects` now explicitly prohibits `Path('src/...')` patterns.

## Tests

All 7 fixed files pass (554 tests). Verified on v0.3.0-insider.11 release pipeline: Test Release Candidate SHA passed.

<!-- no-visual-delta -->
**Why no screenshot:** Test infrastructure, no UI.

no linked issue: addresses release pipeline test failures