### PR TITLE
fix(chat): keep board column panning from closing the mobile pane

### DIFF
--- a/website/src/hooks/useSwipeEdge.ts
+++ b/website/src/hooks/useSwipeEdge.ts
@@ -8,6 +8,23 @@ interface SwipeEdgeOptions {
   onSwipe: () => void
 }
 
+/**
+ * Nearest ancestor of `from`, up to and including `root`, that scrolls
+ * horizontally. Returns null when the touch did not start inside one.
+ */
+function findHorizontalScroller(from: EventTarget | null, root: HTMLElement): HTMLElement | null {
+  let node: Element | null = from instanceof Element ? from : null
+  while (node) {
+    if (node instanceof HTMLElement && node.scrollWidth - node.clientWidth > 1) {
+      const overflowX = getComputedStyle(node).overflowX
+      if (overflowX === 'auto' || overflowX === 'scroll') return node
+    }
+    if (node === root) break
+    node = node.parentElement
+  }
+  return null
+}
+
 export function useSwipeEdge(
   ref: React.RefObject<HTMLElement | null>,
   { enabled, edge = 'left', edgeZone = 30, threshold = 60, onSwipe }: SwipeEdgeOptions,
@@ -15,6 +32,8 @@ export function useSwipeEdge(
   const startX = useRef(0)
   const startY = useRef(0)
   const tracking = useRef(false)
+  const scroller = useRef<HTMLElement | null>(null)
+  const scrollerLeft = useRef(0)
 
   useEffect(() => {
     const el = ref.current
@@ -29,23 +48,35 @@ export function useSwipeEdge(
         startX.current = x
         startY.current = touch.clientY
         tracking.current = true
+        scroller.current = findHorizontalScroller(e.target, el)
+        scrollerLeft.current = scroller.current ? scroller.current.scrollLeft : 0
       }
     }
 
     const onTouchEnd = (e: TouchEvent) => {
       if (!tracking.current) return
       tracking.current = false
+      const sc = scroller.current
+      scroller.current = null
       const touch = e.changedTouches[0]
       const dx = touch.clientX - startX.current
       const dy = Math.abs(touch.clientY - startY.current)
       if (dy > Math.abs(dx)) return
+      // A horizontal scroller under the finger owns the gesture; take it over
+      // only once that scroller has not moved and cannot reveal more this way.
+      if (sc) {
+        if (sc.scrollLeft !== scrollerLeft.current) return
+        const maxScrollLeft = sc.scrollWidth - sc.clientWidth
+        const canReveal = dx < 0 ? sc.scrollLeft < maxScrollLeft - 1 : sc.scrollLeft > 1
+        if (canReveal) return
+      }
       const swipedRight = dx > threshold
       const swipedLeft = dx < -threshold
       if (edge === 'left' && swipedRight) onSwipe()
       if (edge === 'right' && swipedLeft) onSwipe()
     }
 
-    const onTouchCancel = () => { tracking.current = false }
+    const onTouchCancel = () => { tracking.current = false; scroller.current = null }
 
     el.addEventListener('touchstart', onTouchStart, { passive: true })
     el.addEventListener('touchend', onTouchEnd, { passive: true })

--- a/website/src/test/useSwipeEdge.test.ts
+++ b/website/src/test/useSwipeEdge.test.ts
@@ -104,4 +104,74 @@ describe('useSwipeEdge', () => {
     el.dispatchEvent(createTouchEvent('touchend', 100))
     expect(onSwipe).not.toHaveBeenCalled()
   })
+
+  /**
+   * A horizontally scrollable child of the swipe root, mirroring the sidebar's
+   * board-view column strip (`overflow-x-auto` with off-screen columns).
+   */
+  function appendScroller(scrollLeft: number, scrollWidth = 900, clientWidth = 300): HTMLDivElement {
+    const sc = document.createElement('div')
+    sc.style.overflowX = 'auto'
+    Object.defineProperty(sc, 'scrollWidth', { configurable: true, value: scrollWidth })
+    Object.defineProperty(sc, 'clientWidth', { configurable: true, value: clientWidth })
+    Object.defineProperty(sc, 'scrollLeft', { configurable: true, writable: true, value: scrollLeft })
+    el.appendChild(sc)
+    return sc
+  }
+
+  it('does not close the pane when panning a horizontal scroller that can reveal more', () => {
+    const onSwipe = vi.fn()
+    const sc = appendScroller(0)
+    renderHook(() => useSwipeEdge(ref, { enabled: true, edge: 'right', edgeZone: 9999, threshold: 50, onSwipe }))
+
+    expect(sc.scrollWidth - sc.clientWidth).toBe(600)
+    sc.dispatchEvent(createTouchEvent('touchstart', 200))
+    sc.dispatchEvent(createTouchEvent('touchend', 100))
+    expect(onSwipe).not.toHaveBeenCalled()
+  })
+
+  it('does not close the pane when the scroller consumed the gesture', () => {
+    const onSwipe = vi.fn()
+    const sc = appendScroller(600)
+    renderHook(() => useSwipeEdge(ref, { enabled: true, edge: 'right', edgeZone: 9999, threshold: 50, onSwipe }))
+
+    sc.dispatchEvent(createTouchEvent('touchstart', 200))
+    sc.scrollLeft = 540
+    sc.dispatchEvent(createTouchEvent('touchend', 100))
+    expect(onSwipe).not.toHaveBeenCalled()
+  })
+
+  it('closes the pane when the scroller is already at its end and did not move', () => {
+    const onSwipe = vi.fn()
+    const sc = appendScroller(600)
+    renderHook(() => useSwipeEdge(ref, { enabled: true, edge: 'right', edgeZone: 9999, threshold: 50, onSwipe }))
+
+    expect(sc.scrollLeft).toBe(sc.scrollWidth - sc.clientWidth)
+    sc.dispatchEvent(createTouchEvent('touchstart', 200))
+    sc.dispatchEvent(createTouchEvent('touchend', 100))
+    expect(onSwipe).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the pane from a child that does not scroll horizontally', () => {
+    const onSwipe = vi.fn()
+    const plain = document.createElement('div')
+    el.appendChild(plain)
+    renderHook(() => useSwipeEdge(ref, { enabled: true, edge: 'right', edgeZone: 9999, threshold: 50, onSwipe }))
+
+    expect(plain.scrollWidth - plain.clientWidth).toBe(0)
+    plain.dispatchEvent(createTouchEvent('touchstart', 200))
+    plain.dispatchEvent(createTouchEvent('touchend', 100))
+    expect(onSwipe).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens the pane from the left edge over a scroller already at its start', () => {
+    const onSwipe = vi.fn()
+    const sc = appendScroller(0)
+    renderHook(() => useSwipeEdge(ref, { enabled: true, edge: 'left', edgeZone: 0.35, threshold: 60, onSwipe }))
+
+    expect(sc.scrollLeft).toBe(0)
+    sc.dispatchEvent(createTouchEvent('touchstart', 20))
+    sc.dispatchEvent(createTouchEvent('touchend', 140))
+    expect(onSwipe).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
## What breaks today

On a phone, the sessions pane's board view cannot be panned. Swiping left to bring the next tag column into view closes the whole pane instead. The columns and the pane share one gesture, and the pane always wins, so the board is effectively unusable on mobile.

## Why

`useSwipeEdge` decides "is this touch a swipe?" from the start position and the straight-line delta between `touchstart` and `touchend`. It has no notion of a scroller underneath the finger.

The close gesture is registered with `edgeZone: 9999` (`website/src/pages/ChatPage.tsx:5844`). The hook turns that into an in-zone test of `x >= window.innerWidth - 9999`, which is true for every touch on any real phone, so swipe tracking begins on every touch anywhere in the chat container. At `touchend` the only rejection is `if (dy > Math.abs(dx)) return` — a gesture is discarded only when it travelled further vertically than horizontally. Any leftward pan past the 50px threshold therefore calls `closeSidebar()`.

The sidebar's board view is a horizontal strip of `min-w-[220px]` columns inside an `overflow-x-auto` container (`website/src/pages/ChatSidebar.tsx:4078`). It is gated only on `tagColumnsEnabled` (`website/src/pages/ChatSidebar.tsx:1593`), not on viewport, so it renders on mobile — where panning it is exactly the gesture that closes the pane.

## The fix

Teach the hook to recognise when a scroller owns the gesture. At `touchstart` it records the nearest horizontally scrollable ancestor of the touch target (walking up to the swipe root, requiring both `scrollWidth > clientWidth` and a computed `overflow-x` of `auto` or `scroll`). At `touchend`, if such a scroller exists, the swipe is declined when either the scroller moved during the gesture (`scrollLeft` changed — the user was panning) or it still has content to reveal in the direction the finger pushed.

This is a gesture-ownership rule rather than a timing or threshold tweak, so it does not require tuning a duration or velocity constant that would be right on one device and wrong on another.

## What still works

Swipe-to-close is not removed. It fires from any surface that does not scroll horizontally, and it fires from a scroller that is already at its end and did not move — so once the board has nothing left to pan, a further left swipe still dismisses the pane. Opening the pane from the left edge is unaffected for the mirrored reason: at `scrollLeft: 0` a scroller cannot reveal anything further left, so it does not claim a rightward swipe.

## Testing

Five cases added to `website/src/test/useSwipeEdge.test.ts`, with a fixture that mirrors the board strip's geometry (900px of content in a 300px viewport):

- panning a scroller that can reveal more does not close the pane
- a gesture the scroller consumed (its `scrollLeft` moved) does not close the pane
- a scroller at its end that did not move does close the pane
- a child that does not scroll horizontally does close the pane
- the left-edge open swipe still fires over a scroller at `scrollLeft: 0`

Negative control: reverting only the hook and re-running the same file fails exactly the first two cases and leaves the other three green, so the new tests detect the real defect rather than passing vacuously. Verified locally: 14/14 pass with the fix, `tsc --noEmit` clean, `eslint` clean on both files.

Not verified here: how the hand-off feels on a physical phone. The `maxScrollLeft - 1` boundary means a hard left flick at the far right end of the board still closes the pane, which is the intended hand-off, but it is worth a thumb test before merge.
