### PR TITLE
fix(chat): pin the header rename editor to the session it opened on

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -4729,7 +4729,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     return !isNaN(v) && v >= SIDEBAR_MIN && v <= SIDEBAR_MAX ? v : 260
   })
   const [sidebarDragging, setSidebarDragging] = useState(false)
-  const [editingTitle, setEditingTitle] = useState(false)
+  // Pinned to the slot the rename opened on: activeSlot moves the instant the user
+  // switches sessions, and a live-resolved commit would rename the wrong session.
+  const [editingTitleSlot, setEditingTitleSlot] = useState<string | null>(null)
+  const editingTitle = editingTitleSlot !== null && editingTitleSlot === activeSlot
+  // Leaving abandons the draft. The pin alone closes the editor but keeps it, so a
+  // return would revive stale text and a blur could overwrite a newer title.
+  useEffect(() => { setEditingTitleSlot(null) }, [activeSlot])
   // Native session grid "split mode": an in-place tiling of the chat surface (NOT an
   // overlay). The flag is EPHEMERAL per mount — nav/refresh lands on single chat —
   // but the LAYOUT persists per anchor slot (splitLayoutStore). So a split is
@@ -6257,7 +6263,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                     else if (!sidebarPinned) setSidebarPinned(true)
                     dispatch(requestSlotReveal(activeSlot))
                   } : undefined}
-                  onRename={activeSlot ? () => { setEditingTitle(true); setTitleDraft(title) } : undefined}
+                  onRename={activeSlot ? () => { setEditingTitleSlot(activeSlot); setTitleDraft(title) } : undefined}
                   mode={effectiveMode}
                 />
                 </div>
@@ -6265,11 +6271,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 <div className="flex min-w-0 flex-1 items-center gap-1 px-1.5 py-0.5 rounded-l-[2px] rounded-r-md bg-bg-hover">
                   {currentSlot?.memory_mode === 'incognito' && <span title={i18nT('pages.chatPage.incognito_memory_writes_disabled')}><EyeOff size={13} className="shrink-0 text-warn" /></span>}
                   {currentSlot?.memory_mode === 'temporary' && <span title={i18nT('pages.chatPage.temporary_no_memory_reads_or_writes')}><VenetianMask size={13} className="shrink-0 text-aim" /></span>}
-                  <Input className="session-header-title text-sm font-semibold text-muted font-body bg-transparent border-0 rounded-none p-0 m-0 min-w-0 flex-1 outline-none md:max-w-[50vw] focus:!shadow-none" size={Math.min(Math.max(titleDraft.length + 2, 6), 80)} autoFocus value={titleDraft} onChange={e => setTitleDraft(e.target.value)} onBlur={() => { if (!cancelTitleRef.current && titleDraft.trim() && activeSlot && titleDraft !== title) { dispatch(sseSlotTitle({ key: activeSlot, title: titleDraft.trim() })); api.renameSlot(activeSlot, titleDraft.trim()).catch(() => {}) } cancelTitleRef.current = false; setEditingTitle(false) }} onCompositionStart={() => { composingRef.current = true }} onCompositionEnd={() => { composingRef.current = true; setTimeout(() => { composingRef.current = false }, 50) }} onKeyDown={e => { if (e.key === 'Enter' && !e.nativeEvent.isComposing && !composingRef.current) (e.target as HTMLInputElement).blur(); if (e.key === 'Escape') { cancelTitleRef.current = true; setEditingTitle(false) } }} />
+                  <Input className="session-header-title text-sm font-semibold text-muted font-body bg-transparent border-0 rounded-none p-0 m-0 min-w-0 flex-1 outline-none md:max-w-[50vw] focus:!shadow-none" size={Math.min(Math.max(titleDraft.length + 2, 6), 80)} autoFocus value={titleDraft} onChange={e => setTitleDraft(e.target.value)} onBlur={() => { if (!cancelTitleRef.current && titleDraft.trim() && activeSlot && titleDraft !== title) { dispatch(sseSlotTitle({ key: activeSlot, title: titleDraft.trim() })); api.renameSlot(activeSlot, titleDraft.trim()).catch(() => {}) } cancelTitleRef.current = false; setEditingTitleSlot(null) }} onCompositionStart={() => { composingRef.current = true }} onCompositionEnd={() => { composingRef.current = true; setTimeout(() => { composingRef.current = false }, 50) }} onKeyDown={e => { if (e.key === 'Enter' && !e.nativeEvent.isComposing && !composingRef.current) (e.target as HTMLInputElement).blur(); if (e.key === 'Escape') { cancelTitleRef.current = true; setEditingTitleSlot(null) } }} />
                 </div>
               ) : (
                 <div className="cursor-text flex min-w-0 items-center gap-1 px-1.5 py-0.5 rounded-l-[2px] rounded-r-md group-hover/header:bg-bg-hover transition-colors">
-                  <Clickable className="flex min-w-0 items-center gap-1" onClick={() => { if (activeSlot && generatingTitleSlots.has(activeSlot)) return; setEditingTitle(true); setTitleDraft(title) }}>
+                  <Clickable className="flex min-w-0 items-center gap-1" onClick={() => { if (activeSlot && generatingTitleSlots.has(activeSlot)) return; setEditingTitleSlot(activeSlot); setTitleDraft(title) }}>
                     {currentSlot?.memory_mode === 'incognito' && <span title={i18nT('pages.chatPage.incognito_memory_writes_disabled')}><EyeOff size={13} className="shrink-0 text-warn" /></span>}
                     {currentSlot?.memory_mode === 'temporary' && <span title={i18nT('pages.chatPage.temporary_no_memory_reads_or_writes')}><VenetianMask size={13} className="shrink-0 text-aim" /></span>}
                     <TypewriterText text={title} className="session-header-title text-sm font-semibold text-muted font-body truncate min-w-0 md:max-w-[50vw]" />

--- a/website/src/test/ChatPage.titleRenamePin.test.tsx
+++ b/website/src/test/ChatPage.titleRenamePin.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Regression test: the header rename editor belongs to ONE session.
+ *
+ * Opening the editor stores the current title in a draft; the commit runs on
+ * blur. If the open flag were a bare boolean, switching sessions would leave the
+ * editor open holding the PREVIOUS session's text while the commit resolved its
+ * target from the live `activeSlot` — so a blur renamed the session now in front
+ * to the previous one's title, leaving two tabs with one name.
+ *
+ * `editingTitleSlot` pins the editor to the slot it opened on and it renders
+ * only while that slot is active, so a switch closes it and drops the draft.
+ * Deliberate renames are unaffected: tapping away inside one session blurs (and
+ * commits) before any switch, which the last case pins down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// The non-editing title renders through TypewriterText; keep the text visible
+// (and clickable) so the rename can be opened the way a user opens it.
+vi.mock('../components/TypewriterText', async () => {
+  const React = await import('react')
+  return { default: ({ text }: { text: string }) => React.createElement('span', { 'data-testid': 'header-title' }, text) }
+})
+
+vi.mock('../pages/chat', () => ({
+  ChatFooter: () => null,
+  McpInfoButton: () => null,
+  UserMessage: () => null,
+  AssistantMessage: () => null,
+}))
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
+  useVirtualChat: () => ({
+    virtualItems: [], isAtBottom: true, scrollToBottom: vi.fn(), scrollToIndexSmooth: vi.fn(),
+    mountIndex: vi.fn(), measureRef: () => () => {},
+    topSentinelRef: { current: null }, bottomSentinelRef: { current: null },
+    offsetBefore: 0, offsetAfter: 0,
+  }),
+}))
+vi.mock('../pages/ChatSidebar', () => ({ default: () => null, SIDEBAR_MIN: 200, SIDEBAR_MAX: 500 }))
+vi.mock('../components/ChatInput', () => ({ default: () => null }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/DiffPanel', () => ({ default: () => null }))
+vi.mock('../components/OverlayDrawer', () => ({ default: ({ children }: { children?: ReactNode }) => children }))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../pages/chat/CollapsibleToolGroup', () => ({ default: ({ children }: { children?: ReactNode }) => children }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ contentWidth: 'compact' }),
+  CONTENT_WIDTH: { compact: { messages: '900px', input: '916px' }, comfortable: { messages: '84%', input: '85%' }, full: { messages: '92%', input: '93%' } },
+}))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: null }) }))
+vi.mock('../hooks/useFilteredDropdown', () => ({ useFilteredDropdown: () => ({ filtered: [], query: '', setQuery: vi.fn(), selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn() }) }))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+
+const apiMocks: Record<string, ReturnType<typeof vi.fn>> = {}
+vi.mock('../api/client', () => ({
+  api: new Proxy({}, {
+    get: (_t, prop: string) => {
+      if (!(prop in apiMocks)) {
+        apiMocks[prop] = vi.fn().mockResolvedValue(
+          prop === 'chatSlotDetail' ? { messages: [], has_more: false, total: 0 } : {},
+        )
+      }
+      return apiMocks[prop]
+    },
+  }),
+  fileReadUrl: (p: string) => `/api/file?path=${encodeURIComponent(p)}`,
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve(''), json: () => Promise.resolve({}) }) as never
+
+import ChatPage from '../pages/ChatPage'
+
+const TITLE_A = 'Alpha session'
+const TITLE_B = 'Beta session'
+const mkSlot = (key: string, title: string) =>
+  ({ key, title, messages: 0, running: false, mode: '', created: '', last_ts: '' })
+
+const renderChatPage = () => {
+  const slots = [mkSlot('chat-a', TITLE_A), mkSlot('chat-b', TITLE_B)]
+  apiMocks.chatSlots = vi.fn().mockResolvedValue(slots)
+  apiMocks.chatSlotDetail = vi.fn().mockResolvedValue({ messages: [], has_more: false, total: 0 })
+  apiMocks.renameSlot = vi.fn().mockResolvedValue({})
+  const store = createTestStore({
+    dashboard: {
+      status: { platform: 'darwin' }, connected: false,
+      slots, slotsLoaded: true, approvalMode: 'normal', channelTrusted: false, refreshTrigger: 0,
+      unreadSlots: [], updateProgress: null,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as never,
+    chat: {
+      activeSlot: 'chat-a',
+      messages: [], slotRunning: false, slotStopping: false, slotState: 'idle',
+      slotStatusDetail: {}, slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+      lastChunkSeq: undefined, history: [], historyHasMore: false, historyOffset: 0,
+      pendingInput: null, slotContextPct: {}, voicePlaying: false, voiceAudio: null,
+      subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools', slotActivity: {}, slotHistory: [],
+    } as never,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat/chat-a']}>
+            <Routes>
+              <Route path="/chat/:slug?" element={<ChatPage mode="" />} />
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return store
+}
+
+const openRename = async () => {
+  const label = await screen.findByTestId('header-title')
+  act(() => { fireEvent.click(label) })
+  return screen.getByDisplayValue(TITLE_A) as HTMLInputElement
+}
+
+const switchToB = (store: ReturnType<typeof createTestStore>) => {
+  act(() => { store.dispatch({ type: 'chat/setActiveSlot', payload: 'chat-b' }) })
+}
+
+describe('ChatPage – header rename is pinned to the session it opened on', () => {
+  beforeEach(() => { Object.keys(apiMocks).forEach(k => delete apiMocks[k]) })
+
+  it('tapping the title opens an editor seeded with that session title', async () => {
+    renderChatPage()
+    const input = await openRename()
+    expect(input.value).toBe(TITLE_A)
+  })
+
+  it('switching sessions closes the editor instead of carrying the old draft over', async () => {
+    const store = renderChatPage()
+    await openRename()
+    switchToB(store)
+    expect(screen.queryByDisplayValue(TITLE_A)).toBeNull()
+  })
+
+  it('a commit arriving after a session switch renames nothing', async () => {
+    const store = renderChatPage()
+    const input = await openRename()
+    switchToB(store)
+    // Blur whatever survived the switch. With the editor pinned there is nothing
+    // left to blur, so the stale draft never reaches the newly active session.
+    act(() => { fireEvent.blur(input) })
+    expect(apiMocks.renameSlot).not.toHaveBeenCalled()
+  })
+
+  it('renaming within one session still commits on blur', async () => {
+    renderChatPage()
+    const input = await openRename()
+    act(() => { fireEvent.change(input, { target: { value: 'Renamed alpha' } }) })
+    act(() => { fireEvent.blur(input) })
+    expect(apiMocks.renameSlot).toHaveBeenCalledWith('chat-a', 'Renamed alpha')
+  })
+
+  it('returning to the session does not revive the abandoned draft', async () => {
+    const store = renderChatPage()
+    await openRename()
+    switchToB(store)
+    act(() => { store.dispatch({ type: 'chat/setActiveSlot', payload: 'chat-a' }) })
+    expect(screen.queryByDisplayValue(TITLE_A)).toBeNull()
+  })
+
+  it('an abandoned draft cannot overwrite a title that changed while away', async () => {
+    const store = renderChatPage()
+    await openRename()
+    switchToB(store)
+    // The session renames itself while the user is elsewhere — a generated title,
+    // or another client. The abandoned draft still holds the title it replaced.
+    act(() => { store.dispatch({ type: 'dashboard/sseSlotTitle', payload: { key: 'chat-a', title: 'Alpha regenerated' } }) })
+    act(() => { store.dispatch({ type: 'chat/setActiveSlot', payload: 'chat-a' }) })
+    // Blur whatever the return actually mounted, not the handle from before the
+    // switch: a detached node absorbs the event and proves nothing.
+    const revived = screen.queryByDisplayValue(TITLE_A)
+    if (revived) act(() => { fireEvent.blur(revived) })
+    expect(apiMocks.renameSlot).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The chat header's session title is editable in place: tapping it copies the current title into a draft, and the rename commits when the field loses focus. The flag that held the editor open was a bare boolean and the draft was plain component state, so neither was tied to a session. Two defects follow from that.

**Switching away renamed the wrong session.** Switching sessions with the editor open left it open, still showing the previous session's text, while the commit resolved its target from the live `activeSlot`. The next blur renamed whichever session was now in front to the previous one's title. The existing `titleDraft !== title` guard does not stop this — that comparison passes *precisely because* the two values belong to different sessions.

**Returning revived the abandoned draft.** Because nothing cleared the editor state on the way out, coming back to the session re-presented an old draft as if it were current. If the title had changed while the user was away — a generated title, or another client — a blur then wrote the stale draft over the newer one.

Both are the same root cause: editor state outliving the session it was opened against. The rename request's error is swallowed (`.catch(() => {})`), so neither path gives any signal, and there is no undo.

This is easy to reach on a phone: tapping the title is a common misfire, and switching sessions is one swipe away.

## Why it matters

This silently writes the wrong data and there is no way to notice or undo it. The rename request's error is swallowed, so a session retitled to another session's name gives no signal at the time and no trace afterwards — the user finds a mistitled session later with nothing to explain it. It is also easy to reach rather than a corner case: tapping the header title is a common misfire on a phone, and switching sessions is one swipe away, so the two actions that combine into the bug sit next to each other in ordinary use.

## What changed (motivation → approach → change)

`editingTitle` becomes `editingTitleSlot`, holding the slot the rename opened on. Two things follow from it:

```ts
const [editingTitleSlot, setEditingTitleSlot] = useState<string | null>(null)
const editingTitle = editingTitleSlot !== null && editingTitleSlot === activeSlot
useEffect(() => { setEditingTitleSlot(null) }, [activeSlot])
```

The derived flag **closes** the editor the moment `activeSlot` moves off the pinned slot, at render time, so there is no window in which a stale draft can reach a different session. The effect **discards** the pin on the way out, so a return cannot revive it.

A note on that split, since it invites the question of whether one of the two is redundant: with the derived comparison weakened to `editingTitleSlot !== null` and only the effect left, **all six tests still pass**. They cannot distinguish it, because `act()` flushes effects and so hides the window between commit and effect flush that the render-time guard covers. It is kept for that window, not because a test demands it — stated plainly here so a reviewer can weigh it rather than infer coverage that does not exist.

An earlier revision also carried `editingTitleSlot === activeSlot` inside the `onBlur` commit guard. It has been removed: the input renders only under `editingTitle`, so every blur closure it can carry was created in a render where that equality already held, making the clause tautologically true. Both values are render-scoped (`useState` / `useAppSelector`, not the `activeSlotRef` that exists at line 989), so the closure cannot observe a newer `activeSlot`. Instrumenting the clause to throw when false left the suite green while the same probe inverted to throw when reached did fire, confirming the site executes and never evaluates false. Dead weight that implied protection it did not provide.

The sidebar row rename already worked this way — it keys its commit on the row's own `s.key` and so was never affected by either defect. This brings the header in line with it.

Deliberate renames are unchanged. Tapping away inside one session blurs, and commits, before any switch happens, which the fourth test case pins down.

## Tests

New suite `website/src/test/ChatPage.titleRenamePin.test.tsx` (6 cases), driving the real ChatPage.

Negative control — with the fix reverted and the tests unchanged, the four regression cases fail and the two feature cases still pass, so they discriminate the fix rather than the harness:

| case                                                | without the fix                                    | with it |
| --------------------------------------------------- | -------------------------------------------------- | ------- |
| tapping the title opens an editor for that session   | pass                                               | pass    |
| switching sessions closes the editor                 | **fail** — `expected <input …> to be null`          | pass    |
| a commit after a switch renames nothing              | **fail** — `renameSlot('chat-b', 'Alpha session')`   | pass    |
| renaming within one session commits on blur          | pass                                               | pass    |
| returning does not revive the abandoned draft        | **fail** — `expected <input …> to be null`          | pass    |
| an abandoned draft cannot overwrite a newer title    | **fail** — `renameSlot('chat-a', 'Alpha session')`   | pass    |

Rows three and six are the two defects reproduced exactly: session B renamed to A's title, and A's draft overwriting the `Alpha regenerated` title it had been replaced by.

One correction worth recording: the sixth case initially passed against the unfixed code, which looked like a clean result and was not one. It blurred the input handle captured before the switch — a detached node that absorbs the event — so it could not fail for the intended reason. It now queries whatever the return actually mounted, and fails as it should.

Also run: `tsc --noEmit` clean; `eslint` on both changed files reports 0 errors (10 pre-existing warnings elsewhere in the file, unchanged in count); the `ChatPage.*` and `ChatSidebar.*` suites pass at 700 passed / 1 skipped across 85 files.

<!-- no-visual-delta -->

**Why no screenshot:** this change adds no UI and restyles nothing — it narrows *when* an existing editor is rendered. The only user-visible difference is the absence of a rename editor that previously lingered after a session switch, which a still image cannot demonstrate any better than the two regression cases that assert the field is gone. Nothing about the header's appearance in either state changes.


