### PR TITLE
fix: stop a mid-turn steer from stranding the reasoning block below the answer

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -993,6 +993,26 @@ export const switchSlot = createAsyncThunk(
 )
 
 /** Re-fetch messages for a slot without changing activeSlot. Only applies if still active. */
+/**
+ * True when a `user` row ends the turn before it.
+ *
+ * A steered message is injected INTO the running turn, so a CONFIRMED steer is
+ * not a boundary. An OPTIMISTIC steer bubble (`meta.optimistic`, set at dispatch
+ * and cleared when the server's `steer_push` echo reconciles it) IS treated as a
+ * boundary, because it may not be a steer at all: the backend's steer branch is
+ * gated on `slot.running or slot._in_stage_execution`, so text sent while
+ * `chat_done` is still in flight takes the NEW TURN path instead, and no echo
+ * ever arrives to clear the flag. Exempting that row would splice the new turn's
+ * reasoning onto the previous turn's block — corrupting content rather than
+ * merely misplacing it.
+ *
+ * `selectSlotPendingApproval`'s scan deliberately does NOT use this: it exempts
+ * every steer row, optimistic included, because the distinction can only hide or
+ * show an approval bar there, never corrupt one.
+ */
+const isTurnBoundaryUser = (m: { role: string; meta?: Record<string, unknown> }): boolean =>
+  m.role === 'user' && !(m.meta?.steer && !m.meta?.optimistic)
+
 /** Re-insert client-only reasoning (`thinking`) messages into a server-refreshed
  *  message list. The backend never persists reasoning, so a refresh (e.g. the
  *  one fired on chat_done) would otherwise drop the thinking block the instant a
@@ -1002,7 +1022,7 @@ export const switchSlot = createAsyncThunk(
  *  block whose anchor isn't found is appended so it is never silently lost.
  *  Returns `incoming` unchanged (reference-equal) when there is nothing to
  *  preserve. */
-function mergePreservedThinking<M extends { role: string; content: string; cls?: string }>(
+function mergePreservedThinking<M extends { role: string; content: string; cls?: string; meta?: Record<string, unknown> }>(
   existing: M[],
   incoming: M[],
 ): M[] {
@@ -1014,7 +1034,12 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
     for (let j = i + 1; j < existing.length; j++) {
       const r = existing[j].role
       if (r === 'assistant' || r === 'streaming') { anchor = existing[j].content.trimEnd(); break }
-      if (r === 'user') break
+      // A confirmed steer does not end this block's turn, so the assistant row
+      // after it is still its anchor. Breaking here instead leaves `anchor`
+      // null, and an unanchored block is appended at the tail — below the answer
+      // and its footer — where the forward scan can never reach an assistant row
+      // again, so it stays there and is re-appended on every later refresh.
+      if (isTurnBoundaryUser(existing[j])) break
     }
     preserved.push({ msg: m, anchor })
   }
@@ -2831,13 +2856,17 @@ const chatSlice = createSlice({
      *  single content-bearing `thinking`-role message for the current turn.
      *  Reasoning normally arrives before the visible answer, so the block sits
      *  above the streamed assistant text. Scans back to the turn boundary (the
-     *  last user message) to keep one reasoning block per turn. */
+     *  last non-steer user message) to keep one reasoning block per turn. */
     sseThinkingChunk(state, action: PayloadAction<{ slot: string; content: string }>) {
       const { slot, content } = action.payload
       if (slot !== state.activeSlot || !content) return
       for (let i = state.messages.length - 1; i >= 0; i--) {
         if (state.messages[i].role === 'thinking') { state.messages[i].content += content; return }
-        if (state.messages[i].role === 'user') break
+        // A confirmed steer does not start a new turn, so reasoning after it
+        // belongs to this turn's existing block. Treating it as a boundary mints
+        // a second block for one answer, and that block lands at the end of the
+        // array, below the answer.
+        if (isTurnBoundaryUser(state.messages[i])) break
       }
       state.messages.push({ role: 'thinking', content, cls: '', meta: { clientTs: mintMsgId() } })
     },

--- a/website/src/test/chatThinkingSteerBoundary.test.ts
+++ b/website/src/test/chatThinkingSteerBoundary.test.ts
@@ -1,0 +1,151 @@
+/**
+ * A mid-turn steer must not be read as a turn boundary by the reasoning paths.
+ *
+ * A steered message is injected INTO the running turn and is stored as a
+ * `user` row carrying `meta.steer`. Two reasoning paths scan for a turn
+ * boundary by looking for a `user` row, and both must skip a steered one:
+ *
+ *  - `sseThinkingChunk` scans BACK for the turn's existing block. Reading the
+ *    steer as a boundary mints a second block for one turn.
+ *  - `mergePreservedThinking` (the refresh fired on `chat_done`) scans FORWARD
+ *    from a block for the assistant row that anchors it. Reading the steer as a
+ *    boundary leaves the anchor null, and an unanchored block is appended at
+ *    the tail — below the answer — from where the forward scan can never reach
+ *    an assistant row again, so it sticks there and re-appends on every
+ *    refresh.
+ *
+ * Both are asserted through the real reducer, so the guard cannot be satisfied
+ * by a test double that skips the scan.
+ */
+import { describe, it, expect } from 'vitest'
+import reducer, { sseThinkingChunk, sseChatMessage, refreshSlot } from '../store/chatSlice'
+
+type State = ReturnType<typeof reducer>
+
+const SLOT = 'default'
+
+/** A store with one committed user turn, ready to receive reasoning. */
+function withOpenTurn(): State {
+  let s = reducer(undefined, { type: '@@INIT' })
+  s = { ...s, activeSlot: SLOT }
+  s = reducer(s, sseChatMessage({ slot: SLOT, role: 'user', content: 'do the thing', ts: '100' }))
+  return s
+}
+
+const thinkingRows = (s: State) => s.messages.filter(m => m.role === 'thinking')
+
+describe('sseThinkingChunk turn-boundary scan', () => {
+  it('keeps one block when a steer lands mid-turn', () => {
+    let s = withOpenTurn()
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'first thought ' }))
+    // The steer arrives while the turn is still running.
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'user', content: 'also check X', ts: '101', meta: { steer: true } }))
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'second thought' }))
+
+    const rows = thinkingRows(s)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].content).toBe('first thought second thought')
+  })
+
+  it('still starts a new block on a real new turn', () => {
+    let s = withOpenTurn()
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'turn one' }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'assistant', content: 'answer one', ts: '102' }))
+    // A genuine user message — not a steer — IS a boundary.
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'user', content: 'next question', ts: '200' }))
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'turn two' }))
+
+    const rows = thinkingRows(s)
+    expect(rows).toHaveLength(2)
+    expect(rows.map(r => r.content)).toEqual(['turn one', 'turn two'])
+  })
+  it('treats an UNCONFIRMED steer as a boundary so a new turn cannot corrupt the old block', () => {
+    // The idle race: the turn finished but `chat_done` has not been handled, so
+    // the composer still reads busy and the text is sent as a steer. The backend
+    // gates its steer branch on `slot.running`, so it starts a REAL turn instead
+    // and no `steer_push` echo ever clears `meta.optimistic`. That row must count
+    // as a boundary — exempting it would splice this new turn's reasoning onto
+    // the finished turn's block.
+    let s = withOpenTurn()
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'turn one reasoning' }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'assistant', content: 'answer one', ts: '102' }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'user', content: 'raced text', ts: '103', meta: { steer: true, optimistic: true } }))
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'turn two reasoning' }))
+
+    const rows = thinkingRows(s)
+    expect(rows).toHaveLength(2)
+    // The finished turn's reasoning is untouched — no splice.
+    expect(rows[0].content).toBe('turn one reasoning')
+    expect(rows[1].content).toBe('turn two reasoning')
+  })
+
+  it('still merges once the server confirms the steer', () => {
+    // Same shape, but the echo has reconciled the bubble (optimistic cleared),
+    // so it is a real mid-turn steer and reasoning continues one block.
+    let s = withOpenTurn()
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'first ' }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'user', content: 'steered', ts: '101', meta: { steer: true } }))
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'second' }))
+
+    expect(thinkingRows(s)).toHaveLength(1)
+    expect(thinkingRows(s)[0].content).toBe('first second')
+  })
+})
+
+describe('mergePreservedThinking anchoring across a steer', () => {
+  /** Drive the refresh that fires on chat_done, returning the merged rows. */
+  function refreshWith(s: State, serverMessages: Array<Record<string, unknown>>): State {
+    return reducer(s, {
+      type: refreshSlot.fulfilled.type,
+      payload: { key: SLOT, messages: serverMessages, running: false, hasMore: false, queue: [], nextBefore: 0 },
+      meta: { arg: SLOT },
+    })
+  }
+
+  it('re-inserts the block above its answer when a steer sits between them', () => {
+    let s = withOpenTurn()
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'reasoning' }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'user', content: 'also check X', ts: '101', meta: { steer: true } }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'assistant', content: 'the answer', ts: '102' }))
+
+    // The server replays the turn without reasoning (it is never persisted).
+    s = refreshWith(s, [
+      { role: 'user', content: 'do the thing', ts: '100' },
+      { role: 'user', content: 'also check X', ts: '101', meta: { steer: true } },
+      { role: 'assistant', content: 'the answer', ts: '102' },
+    ])
+
+    const roles = s.messages.map(m => m.role)
+    const thinkingIdx = roles.indexOf('thinking')
+    const assistantIdx = roles.indexOf('assistant')
+    expect(thinkingIdx).toBeGreaterThanOrEqual(0)
+    // Anchored above its answer, NOT parked at the tail.
+    expect(thinkingIdx).toBeLessThan(assistantIdx)
+    expect(thinkingIdx).not.toBe(s.messages.length - 1)
+    expect(thinkingRows(s)).toHaveLength(1)
+  })
+
+  it('reproduces the reported shape: one row above the answer, none at the tail', () => {
+    // The screenshot's exact sequence: reasoning, a mid-turn steer, more
+    // reasoning, then the answer — followed by the refresh chat_done fires.
+    // Unfixed this yields TWO thinking rows sitting below the answer.
+    let s = withOpenTurn()
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'first thought ' }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'user', content: 'steered', ts: '101', meta: { steer: true } }))
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'second thought' }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'assistant', content: 'the answer', ts: '102' }))
+
+    s = refreshWith(s, [
+      { role: 'user', content: 'do the thing', ts: '100' },
+      { role: 'user', content: 'steered', ts: '101', meta: { steer: true } },
+      { role: 'assistant', content: 'the answer', ts: '102' },
+    ])
+
+    const rows = thinkingRows(s)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].content).toBe('first thought second thought')
+    const roles = s.messages.map(m => m.role)
+    expect(roles.indexOf('thinking')).toBeLessThan(roles.indexOf('assistant'))
+    expect(s.messages[s.messages.length - 1].role).not.toBe('thinking')
+  })
+})


### PR DESCRIPTION
## What breaks

A finished turn renders **two collapsed "Thinking" rows sitting below the
answer and its footer** — under the model/credits line, under the action icons,
next to the follow-up chips. It reads as if the agent were still working when
its turn is over and nothing further is coming.

The trigger is a **mid-turn steer**.

## Why

A steered message is injected INTO the running turn and is stored as a `user`
row carrying `meta.steer`. Two reasoning paths looked for a turn boundary by
testing `role === 'user'` with no exclusion for a steered one, so a steer read
as the start of a new turn.

**1. A second block is minted.** `sseThinkingChunk` scans back for the turn's
existing block and stops at the steer, so it pushes a new `thinking` message —
to the end of the array.

**2. The block is stranded below the answer.** Reasoning is never persisted
server-side (`chat_runner.py`: *"Thinking is ephemeral, broadcast-only"*), so
the `refreshSlot` that `chat_done` fires is what re-inserts it, via
`mergePreservedThinking`. That anchors each block by scanning **forward** for
the assistant row it belongs to — and stops at the steer, leaving the anchor
`null`. An unanchored block is then deliberately appended at the tail, a
documented choice: *"Any block whose anchor isn't found is appended so it is
never silently lost."* Never-lost was chosen over never-misplaced.

That lands it below the answer, and it is **not recoverable**: from the tail the
forward scan can never reach an assistant row again, so the anchor stays `null`
and the block is re-appended on every later refresh.

## The fix

Both scans now share one named predicate, `isTurnBoundaryUser`, which exempts
only a **confirmed** steer:

```ts
const isTurnBoundaryUser = (m) => m.role === 'user' && !(m.meta?.steer && !m.meta?.optimistic)
```

An **optimistic** steer bubble stays a boundary. That is not caution, it is a
reachable case: the backend's steer branch is gated on `slot.running or
slot._in_stage_execution` (`chat_handlers.py:267`), so text sent while
`chat_done` is still in flight takes the **new turn** path instead, and no
`steer_push` echo ever arrives to clear `meta.optimistic` (set at
`ChatPage.tsx:5296`). Exempting that row would splice the new turn's reasoning
onto the finished turn's block — corrupting content, not merely misplacing it.
That window is the same one the composer-busy defect below keeps open, so it is
not rare.

Residual, stated plainly: during a genuine steer there is a one-round-trip
window before the echo reconciles the bubble, and reasoning arriving inside it
still mints a second block. That is the original symptom in a much narrower
window, and it is the deliberate trade for never corrupting a finished turn's
reasoning.

Exempting a steer is not a new rule — it is the one the module already applies in
`selectSlotPendingApproval` and the other last-non-steer-user scans, which mirror
`_is_interrupted` / `_has_conversation` in `chat_handlers.py`. These two scans
were the outliers. `selectSlotPendingApproval` keeps its own inline test on
purpose and is NOT migrated to the predicate: it exempts every steer row,
optimistic included, because there the distinction can only hide or show an
approval bar, never corrupt one.

The tail-append fallback is deliberately **left in place**. It still fires for
the other two anchor-miss causes — a server-side redaction that changes the
assistant row's bytes (`chat_utils._prepare_messages` redacts on emit while the
streamed copy is raw), and a turn stored as several assistant rows. Those are
separate questions and are not addressed here.

## Tests

`website/src/test/chatThinkingSteerBoundary.test.ts`, 6 cases driven through the
real reducer (including `refreshSlot.fulfilled`) rather than a double that would
skip the scan:

- one block, not two, when a confirmed steer lands mid-turn
- a genuine new user message still starts a new block *(control)*
- an **unconfirmed** steer counts as a boundary, so a new turn cannot splice onto
  the finished turn's block
- merging resumes once the server confirms the steer
- the block is re-inserted above its answer when a steer sits between them
- the reported end-to-end shape: reasoning → steer → reasoning → answer →
  refresh yields exactly one block, above the answer, not at the tail

**Falsified per guard, not just green.** Each half of the predicate is
independently pinned:

| mutation | result |
|---|---|
| drop the confirmation gate (the reported blocking defect) | exactly **1** fails — the idle-race case |
| drop the steer exemption entirely (the original bug) | **4** fail |
| both guards in place | 6 pass |

An earlier draft of one case passed in both states — it asserted "no accumulation
across repeated refreshes", which cannot fail because each refresh rebuilds from
the current message list and always sees one block. It was replaced with the
end-to-end repro above.

## Verification

- `npx tsc -b` — clean
- `npx vitest run` — **1310 files, 20780 passed**, 2 expected-fail, 3 skipped
- Frontend-only diff; no backend surface touched

## Same cause, deliberately not fixed here

Two more scans share the missing-steer-exclusion pattern, both
`// end of turn — show footer`: `ChatPage.tsx:5751` and
`app-sdk/messageRenderers.tsx:255`. `finalizeTrailingStreaming` freezes
streaming text into an `assistant` row *before* the steer bubble, so
`user → assistant → steer → assistant` is a real transcript shape and both scans
then render a footer mid-turn on the frozen segment — which is visible in the
report screenshot, where the footer sits above the stranded reasoning rows.

They are left out because they change rendered output rather than store state and
carry their own test surface; folding a visible footer change into a state-logic
fix would make both harder to review. Declared here rather than left silent.

## Not in scope

The same screenshot shows a second, **separate** defect: the composer keeps the
mid-turn steer affordance and the stop button after the turn ends, so the next
message is steered into a turn that is already over. That is governed by
`selectComposerBusy`, five OR'd signals that fail toward "busy" by design. Two
were ruled out by reading — `slotRunning` (derived from `task is not None and
not task.done()`, and `slot.task = None` precedes the `chat_done` broadcast) and
a trailing `thinking` row (`selectSlotStreamState` reads the `slotState` field,
not the message rows). The remaining suspects are the two sub-agent signals, one
of which self-heals only *"on sub-agent crash via the reaper's done event"* —
which an abnormal termination such as a turn-limit stop is not. That is a
hypothesis, not a finding: which signal latches cannot be settled by reading
alone, and guessing at a five-way busy predicate risks reporting idle while a
turn really is running. Left for a live repro.

