### PR TITLE
fix(heartbeat): warn and count SEL prune failures instead of failing silent

### DIFF
--- a/src/kiro_crew/heartbeat.py
+++ b/src/kiro_crew/heartbeat.py
@@ -21,6 +21,7 @@ from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.executors import maintenance_executor
 from kiro_crew.memory import MemoryStore, workspace_dir
+from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.sel import sel
 
 if TYPE_CHECKING:
@@ -183,11 +184,31 @@ class HeartbeatService:
                 functools.partial(self._memory.prune_history, keep_days=max_days),
             )
 
-            # Prune security event log per retention policy
+            # Prune security event log per retention policy.
+            #
+            # maintenance_executor is deliberate, despite this pool's "fast
+            # periodic sweeps" charter and prune taking seconds on a large log.
+            # The three pools split on what makes a worker UN-RECLAIMABLE, not
+            # on duration: subprocess_executor is for work that can hang
+            # indefinitely on a wedged kernel resource, discovery_executor for
+            # work whose concurrency is set by remote callers.  prune is
+            # neither -- it terminates, it is awaited so it never overlaps
+            # itself, and it fires once per _PRUNE_TICKS, so one of four
+            # mc-maint workers once a day cannot starve the orphan-reaping
+            # sweeps this pool protects.  prune_history above is the same
+            # retention work on the same pool.
             try:
                 await loop.run_in_executor(maintenance_executor(), sel().prune)
             except Exception:
-                logger.debug("SEL prune failed", exc_info=True)
+                # WARNING, not debug: a dead prune means retention silently
+                # stops -- the unbounded-growth failure prune exists to
+                # prevent.  Counter so it is alarmable; guarded so a telemetry
+                # fault cannot take the heartbeat loop down with it.
+                logger.warning("SEL prune failed", exc_info=True)
+                try:
+                    get_recorder().counter("kirocrew.sel.prune_failed.count")
+                except Exception:
+                    pass
 
         # Check for idle sessions needing history consolidation (every tick)
         if self._consolidator:

--- a/test/test_heartbeat_sel_prune_offload.py
+++ b/test/test_heartbeat_sel_prune_offload.py
@@ -1,0 +1,169 @@
+"""Regression guards for the heartbeat's SEL-prune tick.
+
+Two things are pinned here.
+
+1. Which thread pool prune runs on.  ``sel().prune()`` does blocking file IO
+   (it streams the log to a temp file and ``os.replace``s it), so it must not
+   run on the event loop.  It runs on ``maintenance_executor`` -- deliberately,
+   even though that pool's charter is "fast periodic sweeps" -- because the
+   three pools are split on what makes a worker un-reclaimable rather than on
+   duration.  See the comment at the call site in ``heartbeat.py``.  These
+   tests assert on the NAME OF THE THREAD prune actually ran on, so an inline
+   call (``MainThread``) and a move to another pool (``mc-subproc``,
+   ``mc-discovery``) both fail here.
+
+2. That a failed prune is loud.  A silently-dead prune means retention stops,
+   which is the unbounded-growth failure prune exists to prevent.  It must log
+   at WARNING and bump an alarmable counter, without killing the heartbeat.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+import kiro_crew.heartbeat as hb_mod
+from kiro_crew.heartbeat import HeartbeatService
+
+_PRUNE_COUNTER = "kirocrew.sel.prune_failed.count"
+
+
+def _service(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    prune_error: BaseException | None = None,
+    consolidator: MagicMock | None = None,
+) -> tuple[HeartbeatService, MagicMock, list[str]]:
+    """A HeartbeatService parked on a tick where the prune branch fires.
+
+    Returns the service, the fake ``sel()`` singleton, and a list that receives
+    the name of the thread ``prune`` ran on.  Only the prune tick
+    is exercised: ``_processing`` short-circuits the HEARTBEAT.md branch, and
+    memory/config are stubbed so the surviving IO is prune's alone.
+    """
+    memory = MagicMock()
+    memory.rebuild_index.return_value = 0
+    svc = HeartbeatService(memory=memory, on_task=None, consolidator=consolidator)
+    svc._processing = True
+    svc._tick = 0  # 0 % _PRUNE_TICKS == 0 -> prune branch runs
+
+    monkeypatch.setattr(
+        hb_mod.KiroCrewConfig, "load", classmethod(lambda cls: MagicMock())
+    )
+    ran_on: list[str] = []
+
+    def _prune() -> None:
+        # Record where the work landed BEFORE raising, so the failure cases
+        # still report their thread.  This list is the positive field the pool
+        # assertions read: the real executor names its threads "mc-maint".
+        ran_on.append(threading.current_thread().name)
+        if prune_error is not None:
+            raise prune_error
+
+    fake_sel = MagicMock()
+    fake_sel.prune.side_effect = _prune
+    monkeypatch.setattr(hb_mod, "sel", lambda: fake_sel)
+    return svc, fake_sel, ran_on
+
+
+class TestSelPrunePool:
+    """The pool choice is an exemption; keep it pinned so it is re-decided
+    on purpose rather than drifting."""
+
+    @pytest.mark.asyncio
+    async def test_prune_runs_off_the_event_loop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        svc, _, ran_on = _service(monkeypatch)
+        loop_thread = threading.current_thread().name
+
+        await svc._beat()
+
+        # Indexing is deliberate: if prune never ran at all this raises rather
+        # than passing vacuously.
+        assert ran_on[0] != loop_thread
+
+    @pytest.mark.asyncio
+    async def test_prune_runs_on_the_maintenance_pool(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        svc, _, ran_on = _service(monkeypatch)
+
+        await svc._beat()
+
+        # "mc-maint" is maintenance_executor's thread_name_prefix; mc-subproc /
+        # mc-discovery / mc-cron would each fail this.
+        assert ran_on[0].startswith("mc-maint")
+
+
+class TestSelPruneFailureIsLoud:
+    @pytest.mark.asyncio
+    async def test_failure_logs_at_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        svc, _, _ran = _service(monkeypatch, prune_error=OSError("no space left on device"))
+        monkeypatch.setattr(hb_mod, "get_recorder", lambda: MagicMock())
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.heartbeat"):
+            await svc._beat()
+
+        assert any(
+            rec.levelno == logging.WARNING and "SEL prune failed" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_failure_increments_alarmable_counter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        svc, _, _ran = _service(monkeypatch, prune_error=OSError("no space left on device"))
+        recorder = MagicMock()
+        monkeypatch.setattr(hb_mod, "get_recorder", lambda: recorder)
+
+        await svc._beat()
+
+        # Core metric names must live under the kirocrew.* namespace -- an
+        # off-namespace name is rejected inside counter(), which swallows the
+        # error, so the counter would never fire and nothing would say so.
+        recorder.counter.assert_called_once_with(_PRUNE_COUNTER)
+
+    @pytest.mark.asyncio
+    async def test_failure_does_not_stop_the_heartbeat(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        consolidator = MagicMock()
+        svc, _, _ran = _service(
+            monkeypatch,
+            prune_error=OSError("no space left on device"),
+            consolidator=consolidator,
+        )
+        monkeypatch.setattr(hb_mod, "get_recorder", lambda: MagicMock())
+
+        await svc._beat()
+
+        # Work after the prune branch still ran, so the failure was swallowed
+        # rather than propagated out of the cycle.
+        consolidator.check_idle_sessions.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_telemetry_fault_does_not_stop_the_heartbeat(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The counter is guarded: a broken recorder must not escalate a
+        logged prune failure into a dead heartbeat loop."""
+        consolidator = MagicMock()
+        svc, _, _ran = _service(
+            monkeypatch,
+            prune_error=OSError("no space left on device"),
+            consolidator=consolidator,
+        )
+        recorder = MagicMock()
+        recorder.counter.side_effect = RuntimeError("metrics backend down")
+        monkeypatch.setattr(hb_mod, "get_recorder", lambda: recorder)
+
+        await svc._beat()
+
+        consolidator.check_idle_sessions.assert_called_once_with()


### PR DESCRIPTION
## What

`HeartbeatService._beat()` prunes the security event log (SEL) once a day. Until now a failed prune was logged at `logger.debug` and otherwise swallowed. This makes that failure visible and records why the prune runs on the pool it does.

Two changes to the same `try`/`except` block in `src/kiro_crew/heartbeat.py`:

1. **A failed prune is now loud.** It logs at `WARNING` and increments a `kirocrew.sel.prune_failed.count` counter. The counter call is wrapped in its own `try`/`except` so a broken metrics backend cannot escalate a logged prune failure into a dead heartbeat loop.
2. **A comment records the executor choice** as a deliberate exemption rather than an oversight.

Plus `test/test_heartbeat_sel_prune_offload.py`, a new file that pins both.

## Why the warning matters

Prune is the only thing bounding SEL growth. If it starts failing — a full disk, a permissions change, a partially-renamed temp file — retention stops and never restarts, and at `debug` level nothing says so. The log then grows without limit, which is exactly the condition prune exists to prevent. `WARNING` plus a counter makes it something an operator can alarm on.

## Why prune stays on `maintenance_executor`

This was raised as a possible mismatch: `maintenance_executor()`'s docstring reserves it for "the fast periodic sweeps", and `prune()` can run for seconds on a large log. Reading all three pool docstrings, the split is not on how slow or how destructive the work is — it is on **what can make a worker un-reclaimable**:

| Pool | The property it isolates |
| --------------------- | ----------------------------------------------------------------------------------------------- |
| `maintenance_executor` | Nothing — it is the pool being protected. The orphan-reaping sweeps live here and are the recovery action for an event-loop wedge, so nothing may occupy its 4 workers for long. |
| `subprocess_executor`  | Work that can hang **indefinitely** on a wedged kernel resource: `os.close` on a PTY master fd whose far-end shell is in uninterruptible sleep, `ps`/`pgrep` spawns. |
| `discovery_executor`   | Work whose **concurrency is set by remote callers**: a dashboard list endpoint that N browser tabs can fire at once, each pinning a worker for a full `os.walk`. |

`prune()` is neither of the isolated cases:

- **It terminates.** It streams the log line-by-line to a temp file and `os.replace`s it, under a lock, on the local filesystem. Bounded and slow is not the same as unbounded — `subprocess_executor` exists for calls that may never return, not for calls that take a while.
- **It cannot overlap itself.** It is `await`ed, and it fires once every `_PRUNE_TICKS` (1440 ticks ≈ once a day). Peak occupancy is 1 of 4 `mc-maint` workers, once a day, so it cannot starve the orphan sweeps this pool exists to keep responsive.

That also resolves what looks at first like a contradiction: the two **read-only** SEL dashboard handlers use `discovery_executor()` while the more destructive prune does not. They were sorted there because they are browser-triggerable and N-concurrent, not because they touch the SEL. Destructiveness is not a criterion in any of the three docstrings; arrival rate and un-reclaimability are.

Corroborating: `self._memory.prune_history` on the two lines directly above is the same kind of work — a destructive retention sweep doing blocking IO — and already runs on `maintenance_executor`. Moving only the SEL prune elsewhere would split two adjacent retention prunes across two pools for no stated reason.

So the right output here was a comment plus a test, not a change of pool.

## Testing

`test/test_heartbeat_sel_prune_offload.py`, 6 cases, all passing. They assert on **the name of the thread `prune` actually ran on** rather than on a mock sentinel, so the real pool is exercised: `mc-maint` passes, `MainThread` (an inline call) and `mc-subproc` / `mc-discovery` (a moved call) each fail.

Every assertion was negative-controlled **separately**, since the runner stops at the first failing assertion and one control cannot vouch for its siblings:

| Assertion | Control applied | Result |
| ------------------------------------- | ---------------------------------------------- | ------ |
| prune runs off the event loop | call `sel().prune()` inline | fails |
| prune runs on the maintenance pool | switch to `subprocess_executor()` | fails |
| failure logs at WARNING | revert to `logger.debug` | fails |
| failure increments the counter | delete the counter call | fails |
| counter name is `kirocrew.*` | use an off-namespace name | fails |
| failure does not stop the heartbeat | remove the `except Exception` | fails |
| telemetry fault does not stop it | remove the inner `try`/`except` | fails |

The `subprocess_executor` control is the one that shows the two pool tests are not redundant: under it the off-loop test still passes and only the pool test fails.

The metric-name control is worth calling out. `validate_name` requires core metrics to start with `kirocrew.`, and `counter()` deliberately swallows its own exceptions so telemetry can never break a caller. An off-namespace name therefore produces a counter that silently never fires — so the exact name is pinned by a test rather than left to review.

Also run: `test_heartbeat_retention.py`, `test_heartbeat_cov80.py`, `test_sel.py`, `test_sel_prune_streaming.py` — 171 passed together with the new file. `flake8`, `isort --check-only` and `mypy src/kiro_crew/heartbeat.py` are all clean.
