### PR TITLE
perf(dashboard): offload SEL audit-log reads off the event loop

### DIFF
--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -41,6 +41,7 @@ from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.dashboard.stt_stream import _STREAMING_PROVIDERS
 from kiro_crew.dashboard.token_auth import MAX_SESSION_TTL_SECS, generate_token, parse_duration
 from kiro_crew.effort import EFFORT_LEVELS
+from kiro_crew.executors import discovery_executor
 from kiro_crew.metrics import provider as _metrics_provider
 from kiro_crew.security_posture import build_posture_snapshot_async, posture_counts_async
 from kiro_crew.transcribe import BREW_PATH_DIRS, ensure_ffmpeg_in_path, find_brew, is_available
@@ -1196,14 +1197,31 @@ async def api_sel_events(request: web.Request) -> web.Response:
         limit = min(int(request.query.get("limit", "100")), 1000)
     except (TypeError, ValueError):
         limit = 100
-    events = _sel().recent(limit=limit)
+    # recent() reads the WHOLE audit-log file with blocking IO: it is one JSONL
+    # file pruned by age, so `limit` bounds the rows returned, not the bytes
+    # read. Called inline it stalls the whole event loop, so it must be
+    # offloaded. Use the DISCOVERY pool, not maintenance_executor: this handler
+    # is browser-triggerable, so multiple tabs or pollers could otherwise occupy
+    # the workers the orphan-reaping sweeps need to recover from an event-loop
+    # wedge.
+    # _sel() is called INSIDE the callable, not while building it: the first
+    # call constructs the singleton, which reads/creates the HMAC key and scans
+    # the log tail. Evaluating it here would leave that IO on the loop.
+    events = await asyncio.get_running_loop().run_in_executor(
+        discovery_executor(), lambda: _sel().recent(limit=limit)
+    )
     return web.json_response({"events": events, "count": len(events)})
 
 
 async def api_sel_verify(request: web.Request) -> web.Response:
     """GET /api/sel/verify — verify HMAC chain integrity."""
 
-    total, valid = _sel().verify_integrity()
+    # Same offload rationale as api_sel_events, including deferring _sel() into
+    # the callable: verify_integrity() reads the whole log file to check the HMAC
+    # chain end to end and must not run on the event loop.
+    total, valid = await asyncio.get_running_loop().run_in_executor(
+        discovery_executor(), lambda: _sel().verify_integrity()
+    )
     return web.json_response(
         {
             "total": total,

--- a/test/test_sel_dashboard_offload.py
+++ b/test/test_sel_dashboard_offload.py
@@ -1,0 +1,166 @@
+"""Regression guard: SEL dashboard handlers must not block the event loop.
+
+``recent()`` and ``verify_integrity()`` both read the WHOLE audit-log file with
+blocking IO (``sel.py`` reads it via ``read_text()`` in both). The log is a single
+JSONL file pruned by age, so ``limit`` bounds the rows ``recent()`` returns, not
+the bytes it reads. Called inline from an aiohttp handler either one stalls the
+entire event loop for the duration of the read.
+These tests assert both handlers dispatch through ``run_in_executor`` on the
+bounded DISCOVERY pool -- not ``maintenance_executor``. Both handlers are
+browser-triggerable, so routing them through the maintenance pool would let
+dashboard tabs occupy the workers the orphan-reaping sweeps need. They FAIL
+against an inline ``_sel().recent(...)`` / ``_sel().verify_integrity()`` call,
+because ``run_in_executor`` is then never reached.
+
+They also pin WHERE ``_sel()`` is called. Constructing the singleton reads or
+creates the HMAC key and scans the log tail, so evaluating ``_sel()`` while
+building the callable would leave that IO on the event loop even though the
+read itself is offloaded. This is checked at two strengths: the ordering tests
+record "callable submitted" against "``_sel()`` called" and require submission
+first, and the thread-identity tests submit to a real executor through the real
+running loop and require the constructing thread to differ from the loop's.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock
+
+import pytest
+
+import kiro_crew.dashboard.handlers.core as core_mod
+
+
+class _FakeLoop:
+    """Records the pool + callable handed to run_in_executor, then runs it."""
+
+    def __init__(self, captured: dict, order: list[str]) -> None:
+        self._captured = captured
+        self._order = order
+
+    async def run_in_executor(self, pool, fn, *args):  # type: ignore[no-untyped-def]
+        self._captured["pool"] = pool
+        self._captured["fn"] = fn
+        self._order.append("submitted")
+        return fn(*args)
+
+
+def _request(query: dict | None = None) -> MagicMock:
+    req = MagicMock()
+    req.query = query or {}
+    return req
+
+
+def _tracking_sel(fake_sel: MagicMock, order: list[str]):
+    """Stand-in for ``_sel`` that records when construction happens."""
+
+    def _call():
+        order.append("sel")
+        return fake_sel
+
+    return _call
+
+
+class TestSelHandlerOffload:
+    @pytest.mark.asyncio
+    async def test_events_handler_offloads_recent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict = {}
+        order: list[str] = []
+        fake_sel = MagicMock()
+        fake_sel.recent.return_value = [{"event_id": "e1"}]
+        sentinel_pool = object()
+        monkeypatch.setattr(core_mod, "_sel", _tracking_sel(fake_sel, order))
+        monkeypatch.setattr(core_mod, "discovery_executor", lambda: sentinel_pool)
+        monkeypatch.setattr(
+            core_mod.asyncio, "get_running_loop", lambda: _FakeLoop(captured, order)
+        )
+
+        resp = await core_mod.api_sel_events(_request({"limit": "7"}))
+
+        assert captured["pool"] is sentinel_pool  # bounded discovery pool
+        assert order == ["submitted", "sel"]  # singleton built off the loop
+        fake_sel.recent.assert_called_once_with(limit=7)
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_verify_handler_offloads_verify_integrity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict = {}
+        order: list[str] = []
+        fake_sel = MagicMock()
+        fake_sel.verify_integrity.return_value = (5, 5)
+        sentinel_pool = object()
+        monkeypatch.setattr(core_mod, "_sel", _tracking_sel(fake_sel, order))
+        monkeypatch.setattr(core_mod, "discovery_executor", lambda: sentinel_pool)
+        monkeypatch.setattr(
+            core_mod.asyncio, "get_running_loop", lambda: _FakeLoop(captured, order)
+        )
+
+        resp = await core_mod.api_sel_verify(_request())
+
+        assert captured["pool"] is sentinel_pool
+        assert order == ["submitted", "sel"]
+        fake_sel.verify_integrity.assert_called_once_with()
+        assert resp.status == 200
+
+
+class TestSelConstructionRunsOffTheLoop:
+    """Thread-identity guards, run against a REAL loop and a REAL executor.
+
+    ``TestSelHandlerOffload`` substitutes the loop, so its ordering assertion
+    shows only that ``_sel()`` is called after submission -- the callable still
+    runs inline in the test's own thread. These two tests submit to a real
+    ``ThreadPoolExecutor`` through the real running loop and compare the thread
+    that calls ``_sel()`` against the test's thread, which is the loop's thread.
+    That is the property the offload exists for: singleton construction, which
+    reads or creates the HMAC key and scans the log tail, must not run on the
+    event loop. They fail if ``_sel()`` is evaluated while building the callable.
+    """
+
+    @staticmethod
+    def _recording_sel(fake_sel: MagicMock, seen: dict):
+        def _call():
+            seen["ident"] = threading.get_ident()
+            return fake_sel
+
+        return _call
+
+    @pytest.mark.asyncio
+    async def test_events_handler_builds_sel_on_a_worker_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: dict = {}
+        fake_sel = MagicMock()
+        fake_sel.recent.return_value = []
+        pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test-disc")
+        monkeypatch.setattr(core_mod, "_sel", self._recording_sel(fake_sel, seen))
+        monkeypatch.setattr(core_mod, "discovery_executor", lambda: pool)
+        try:
+            resp = await core_mod.api_sel_events(_request({"limit": "3"}))
+        finally:
+            pool.shutdown(wait=True)
+
+        assert seen["ident"] != threading.get_ident()  # off the loop's thread
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_verify_handler_builds_sel_on_a_worker_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: dict = {}
+        fake_sel = MagicMock()
+        fake_sel.verify_integrity.return_value = (2, 2)
+        pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test-disc")
+        monkeypatch.setattr(core_mod, "_sel", self._recording_sel(fake_sel, seen))
+        monkeypatch.setattr(core_mod, "discovery_executor", lambda: pool)
+        try:
+            resp = await core_mod.api_sel_verify(_request())
+        finally:
+            pool.shutdown(wait=True)
+
+        assert seen["ident"] != threading.get_ident()
+        assert resp.status == 200


### PR DESCRIPTION
## Problem / Motivation

Two SEL (security event log) dashboard endpoints read the audit log with blocking file IO directly on the aiohttp event loop:

| Endpoint | Blocking call | Was |
|--------------------------|--------------------------------------|-------------------|
| `GET /api/sel/events`    | `SecurityEventLog.recent(limit=...)` | inline on the loop |
| `GET /api/sel/verify`    | `SecurityEventLog.verify_integrity()` | inline on the loop |

The audit log is a single JSONL file, pruned by age (`_RETENTION_DAYS = 365`, `sel.py:56`) — there is no rotation into segments in this tree. Both calls read that file **whole** via `read_text()` (`sel.py:965` for `recent()`, `sel.py:937` for `verify_integrity()`). So `limit` bounds the rows `recent()` returns, not the bytes it reads, and `verify_integrity()` has no limit at all because it must check the HMAC chain end to end. None of that read is awaited.

## Why it matters

The stall is gateway-wide, not request-scoped: while one of these reads is in flight, no other HTTP request is served, no SSE frame is flushed, and every background task waiting on the loop is starved. Nothing unusual is needed to trigger it — opening the dashboard's security page does, and a tab polling that page does it repeatedly. Being honest about severity: the cost scales with how far the audit log has grown, so on a fresh install it is negligible and on a long-lived one it is a read of the entire accumulated log, which makes this a latent stall that gets worse with uptime rather than a constant outage.

## What changed (motivation → approach → change)

Both handlers now dispatch through `run_in_executor` on `discovery_executor()`, so the read happens on a worker thread and the loop stays free.

The callable submitted to the executor is a `lambda` that calls `_sel()` **inside** the worker, not a partial built around an already-constructed instance. That matters because constructing the singleton is itself blocking: `SecurityEventLog._init_locked` runs `_load_or_create_hmac_key()` and `_read_last_hash()`, both filesystem IO. Deferring the whole expression means nothing touches the filesystem until a worker picks the job up.

## Why the discovery pool and not the maintenance pool

This is the one non-obvious decision in the change, so it is also recorded as a comment in the code.

Both handlers are **browser-triggerable**. The maintenance pool's workers are what the orphan-reaping sweeps use to recover from an event-loop wedge. If browser traffic were routed there, several open dashboard tabs (or one polling tab) could occupy exactly the workers that recovery depends on — turning a slow page into a stuck gateway.

`discovery_executor()` already exists for this precise case; its own docstring says it is kept separate from `maintenance_executor()` so that "browser-triggerable, seconds-long read-only filesystem scans ... can never occupy the workers the orphan-reaping sweeps need". These two handlers are that same shape of work, so they belong in that pool.

## Tests

New file `test/test_sel_dashboard_offload.py` (4 tests, in two classes). The first pair asserts each handler dispatches through `run_in_executor` **and** that the pool it is handed is the discovery pool specifically — a sentinel object is substituted for `discovery_executor()`, so a switch to any other pool fails the identity check rather than passing silently. The second pair is described under "Two strengths of proof" below.

Every assertion was negative-controlled separately, because pytest stops at the first failing assertion in a test and one control therefore cannot validate the assertions after it. Each control below mutates only the handler code, leaving earlier assertions passing so the target assertion is actually reached:

| Control | Mutation | Result |
|-----------------------|--------------------------------------------|------------------------------------------------------|
| defect (both tests)   | restore the original inline calls          | both fail, `KeyError: 'pool'` — executor never reached |
| events: pool identity | hand the work to a different pool          | fails, pool identity mismatch                        |
| events: deferred `_sel()` | evaluate `_sel()` while building the callable | fails, `['sel', 'submitted'] == ['submitted', 'sel']` |
| events: `limit`       | hardcode `limit=100`                       | fails, "expected call not found"                     |
| events: status        | respond `500`                              | fails, `assert 500 == 200`                            |
| verify: pool identity | hand the work to a different pool          | fails, pool identity mismatch                        |
| verify: deferred `_sel()` | evaluate `_sel()` while building the callable | fails, `['sel', 'submitted'] == ['submitted', 'sel']` |
| verify: call count    | add a second call inside the callable      | fails, "called once ... Called 2 times"              |
| verify: status        | respond `500`                              | fails, `assert 500 == 200`                            |
| events / verify: thread identity (2 controls) | evaluate `_sel()` while building the callable | fails, `assert <ident> != <ident>` — same thread twice |
| events / verify: status on the thread tests (2 controls) | respond `500` | fails, `assert 500 == 200`                            |

Suite results, run sequentially:

- `test_sel_dashboard_offload.py` — 4 passed
- with the two existing files that cover these endpoints (`test_dashboard_handlers_core_coverage.py`, `test_pptx_maker_routes.py`) — **237 passed**, no regressions
- `isort --check-only`, `flake8` — clean on both files
- `mypy src/kiro_crew/` — "no issues found in 979 source files"

## Not in scope

Only these two call sites are changed. The `log_api_access()` calls elsewhere in the same module are appends, not whole-file reads, and are left alone.

**Deliberately deferred: `recent()` still reads the whole file.** This change moves the read off the event loop; it does not make the read smaller. `GET /api/sel/events?limit=100` still reads the entire log to return 100 rows, so a polling dashboard tab now occupies a bounded discovery worker for a full-file read instead of stalling the loop. That is a real remaining cost and it is not fixed here. The cause-level fix is to make `recent()` tail-read from the end of the file — the bounded backward scan already exists in the same class (`_read_last_hash`, `sel.py:608`) — after which `limit` would bound the IO and only `verify_integrity()` would still need the executor hop. That is a behavioural change to `sel.py`, which this PR deliberately does not touch: a separate change is porting rotation/retention work to that module, and overlapping edits there would conflict.

### Review dispositions

Both advisory lanes (Design, First Principles) flagged that the comments and test docstring described a log-rotation mechanism this tree does not have. That was correct and is fixed in this revision, not argued with. The offending prose came from an internal change against a tree where rotation does exist; carried over verbatim, it pointed a future maintainer at a `backup_count`/`max_bytes` knob that is absent from `sel.py` (the only 2 MB/3-backup rotation in the repo is `gateway.log`, `cli.py:847`) and cited a "v3.2.3 hotfix" that matches no release (CHANGELOG runs 0.1.2–0.2.0). Both the code comment and the test docstring now describe the actual mechanism: one file, read whole, pruned by age. The unmeasured "~600 MB" figure is gone rather than restated, because it was imported from the other tree and never measured here.

## Where `_sel()` is called (review round 2)

An earlier revision built the offloaded callable with `functools.partial(_sel().recent, limit=limit)`. That evaluates `_sel()` **eagerly, on the event loop** — only the `recent()` call was deferred. So the first SEL request after startup still did blocking IO on the loop, for the reason given under "What changed".

To be accurate about magnitude: this residual block is much smaller than the read it guards. `_read_last_hash()` scans backward in bounded chunks rather than reading the whole file, so the init cost is a key-file read plus a tail scan, not the whole-file read it precedes. It is still real blocking IO on the loop, and deferring it costs nothing.

The tests pin this directly rather than trusting the shape of the call. Each records the order of two events — "callable submitted to the executor" and "`_sel()` called" — and requires submission to come first. The negative control reproduces the exact prior code (eager `_sel()`, deferred method) and the assertion fails with `['sel', 'submitted'] == ['submitted', 'sel']`.

An earlier assertion that the submitted callable **is** the bound `verify_integrity` method was removed: it pinned the very shape that caused this bug, so keeping it would have made the correct fix fail.

### Two strengths of proof, and what each does not show

An ordering test alone is weak: it substitutes the event loop, so the callable still runs inline in the test's own thread. It shows only that `_sel()` is called *after* submission — not that construction leaves the loop. So there is a second pair of tests (`TestSelConstructionRunsOffTheLoop`) that submits to a real `ThreadPoolExecutor` through the real running loop and asserts the thread that calls `_sel()` differs from the loop's thread. Against the eager shape both fail with `assert <ident> != <ident>` — the same thread id twice.

Remaining limit, stated plainly rather than papered over: all four tests substitute `_sel` with a recorder, so none of them executes the real `SecurityEventLog.__init__`. They prove *where* construction is invoked, not that the real key-read and tail-scan are themselves thread-safe. Driving the genuine singleton would mean constructing a process-wide object with class-level `_instance` state inside a unit test, which leaks across tests; that was judged the wrong trade for this change.

