### PR TITLE
test(dashboard): guard MCP call sites against the internal auth allowlists

### DIFF
--- a/test/test_mcp_call_site_auth_coverage.py
+++ b/test/test_mcp_call_site_auth_coverage.py
@@ -1,0 +1,724 @@
+"""Every internal-secret call site into the dashboard must be allowlisted.
+
+Registering a dashboard route and granting it internal access are two separate
+manual edits, and nothing couples them. When they disagree the failure only shows
+up at runtime: the caller sends ``X-Internal-Secret``, the middleware does not
+find the path in either internal allowlist, and the call 403s. Nothing fails at
+import, review, or build time. This test is the missing coupling.
+
+Callers reach the dashboard two ways, and BOTH are in scope. Most go through the
+``_post``/``_get``/``_put``/``_patch``/``_delete`` helpers in ``mcp_core``, which
+attach the secret centrally. A few build their own ``urllib.request.Request`` and
+set the header themselves (``mcp_computer``, ``cron_script``, the code-review-sage
+driver). The middleware grants any of them only for paths in
+``_STRICT_INTERNAL_API_PATHS`` or ``_MIXED_INTERNAL_API_PATHS``, matched by
+prefix. A path in neither set falls through to ordinary token auth and is
+unreachable for that caller. The population is therefore "sends the internal
+secret", not "is an MCP module" -- naming it after MCP is what let
+``mcp_computer.py`` sit outside an earlier revision of ``_SOURCES``.
+
+EXHAUSTIVENESS IS THE WHOLE POINT, so this file must never quietly skip a call
+site it cannot understand. A guard that skips the calls it cannot resolve reads
+green while those calls go unchecked, which is worse than no guard because it
+manufactures confidence. So every transport call must resolve to an ``/api``
+path, and ``test_every_transport_call_resolves_to_a_path`` FAILS on any that does
+not, except for the small reviewed set in ``_KNOWN_UNRESOLVED``.
+
+``_SOURCES`` is a hand-listed set, so the same reasoning applies to the list
+itself: ``test_no_secret_caller_is_unscanned`` fails if ANY module outside it
+reaches the dashboard, by any of the three routes (setting the secret header,
+bare-importing a helper, or calling one qualified). Keying that check on the
+capability rather than on one call shape is what makes it escape-proof, and it
+is why no same-name exemption list is needed: a module with its own private
+``_get`` neither imports ``mcp_core`` nor sets the header, so it never matches.
+
+Resolving the path argument therefore has to follow the shapes these modules
+really use, not just literals:
+
+* a literal, or an f-string whose interpolations are unknown at rest
+* a module-level constant, including one interpolated into an f-string
+  (``f"{_api_base()}{COMMAND_PATH}"`` in ``mcp_tools/browser.py``)
+* a local variable built earlier in the same function, including one assembled by
+  ``+`` concatenation (``"/api/apps/ops-mission-control" + _omc_path``) or
+  extended with ``+=``
+
+An unknown span becomes the marker ``{X}``. Where a marker occupies a whole path
+segment the path is still CONCRETE and is matched against the allowlists exactly
+as the middleware would. Where a marker is glued to the tail of a segment the
+runtime path is only known up to that point, so the path is treated as a PREFIX
+and the assertion weakens honestly: some allowlist entry must begin with the
+literal head. That is what covers the Ops Mission Control family, whose thirteen
+endpoints are allowlisted individually and deliberately not by bare prefix.
+
+Scope, and what this deliberately does not check:
+
+* Membership, not bucket choice. It asserts a path is in strict OR mixed, not
+  that it is in the RIGHT one. A browser-polled route wrongly placed in strict
+  passes here and still hard-denies forwarded browsers at runtime.
+* For a PREFIX path it proves the family is granted, not that the specific
+  endpoint is. An unallowlisted endpoint added under an already-granted prefix
+  would pass here.
+* Bucket disjointness already has its own guard in
+  ``test_internal_path_bucket_disjointness.py``. This file does not repeat it.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from kiro_crew.dashboard.server import (
+    _MIXED_INTERNAL_API_PATHS,
+    _STRICT_INTERNAL_API_PATHS,
+)
+from kiro_crew.dashboard.token_auth import _BYPASS_EXACT
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+_CORE = _SRC / "mcp_core.py"
+
+# The helpers that carry X-Internal-Secret. Defined in mcp_core; called either
+# bare (imported) or qualified as ``mcp_core._get(...)``.
+_TRANSPORT_HELPERS = frozenset({"_post", "_get", "_put", "_patch", "_delete"})
+
+# Stands in for a span of the path that is only known at runtime.
+_UNKNOWN = "{X}"
+
+# Modules that talk to the dashboard: the top-level MCP modules, plus the whole
+# mcp_tools package, where most tool implementations now live. Globbed rather
+# than listed so a new tool module is scanned the day it is added.
+_SOURCES = (
+    _CORE,
+    _SRC / "mcp_shared.py",
+    _SRC / "mcp_dashboard.py",
+    _SRC / "mcp_computer.py",
+    _SRC / "cli_commands.py",
+    _SRC / "cron_script.py",
+    _SRC / "cron_trigger.py",
+    _SRC / "apps/builtins/code_review_sage/sage_lib/review_driver.py",
+    _SRC / "computer_use/screencast.py",
+    *sorted((_SRC / "mcp_tools").glob("*.py")),
+)
+
+# Ceiling on how many possible values one expression may resolve to. Past it the
+# site is reported unresolved rather than silently narrowed to a subset.
+_MAX_CANDIDATES = 24
+
+# The header that makes a request an internal one. A module that sets it reaches
+# the dashboard without going through mcp_core's helpers at all. Matched with
+# either quote style AND via a constant holding the name, because
+# ``computer_use/screencast.py`` assigns it as ``headers[FRAME_SECRET_HEADER]``
+# and a literal-only pattern cannot see that.
+_SECRET_HEADER = "X-Internal-Secret"
+_SETS_SECRET = re.compile(
+    rf"""["']{_SECRET_HEADER}["']\s*:|headers\[\s*["']{_SECRET_HEADER}["']\s*\]\s*="""
+)
+
+# Call sites whose path genuinely cannot be known from the source, keyed by
+# module and enclosing function (not line number, which drifts). Every entry is a
+# generic wrapper taking the path as a PARAMETER, so the path belongs to its
+# callers -- and ``_wrapper_path_arg_index`` scans those callers, which is what
+# earns the exemption. That set is derived from the code, not from this list: a
+# wrapper is scanned because it forwards a path, whether or not its own site
+# resolves. RATCHET: may only shrink, and a stale entry fails the test. Do not add
+# a site here to silence it; a call whose path cannot be resolved is a call this
+# guard cannot vouch for.
+_KNOWN_UNRESOLVED = frozenset(
+    {
+        # ``_send(path)`` is the central helper every verb now delegates to; its
+        # nested ``_once(base)`` builds the Request, so the site is attributed here.
+        "mcp_core.py:_send",
+        "mcp_core.py:_post",
+        "mcp_core.py:_get",
+        "mcp_core.py:_put",
+        "mcp_core.py:_patch",
+        "mcp_core.py:_delete",
+        "mcp_dashboard.py:_get_rows",
+        "cron_script.py:_post",
+        "review_driver.py:_api_request",
+    }
+)
+
+# Secret-transport paths knowingly unreachable, as an explicit ratchet. Empty
+# here: every resolved call site matches an allowlist today. It is kept, empty,
+# so the exception set stays visible rather than implied.
+_KNOWN_UNREACHABLE: frozenset[str] = frozenset()
+
+
+def _normalise(path: str) -> str:
+    """Drop any query string and collapse interpolated segments to the marker."""
+    path = path.split("?", 1)[0]
+    return re.sub(r"\{[^}]*\}", _UNKNOWN, path)
+
+
+def _str_assignments(nodes: list[ast.stmt]) -> dict[str, list[str]]:
+    """Map ``NAME = "..."`` string constants from a list of statements."""
+    out: dict[str, list[str]] = {}
+    for node in nodes:
+        targets: list[ast.expr]
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+        value = node.value
+        if not (isinstance(value, ast.Constant) and isinstance(value.value, str)):
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name):
+                out.setdefault(target.id, [value.value])
+    return out
+
+
+class _TooManyCandidates(Exception):
+    """A name has more possible values than the ceiling allows.
+
+    Raised instead of truncating. Truncation would drop a real path and leave the
+    guard green, which is the silent skip this file exists to prevent.
+    """
+
+
+def _join(left: list[str], right: list[str]) -> list[str]:
+    if len(left) * len(right) > _MAX_CANDIDATES:
+        raise _TooManyCandidates
+    return [a + b for a in left for b in right]
+
+
+def _resolve(
+    node: ast.expr, scopes: list[dict[str, list[str]]], core: dict[str, list[str]]
+) -> list[str]:
+    """Resolve an expression to candidate strings, marking unknown spans.
+
+    Returns a list because a name reassigned on several branches has one possible
+    value per branch and every one of them is a real call path. Nothing is
+    truncated: past ``_MAX_CANDIDATES`` this raises and the site is reported
+    unresolved instead.
+    """
+    if isinstance(node, ast.Constant):
+        return [node.value] if isinstance(node.value, str) else [_UNKNOWN]
+    if isinstance(node, ast.JoinedStr):
+        joined = [""]
+        for value in node.values:
+            joined = _join(joined, _resolve(value, scopes, core))
+        return joined
+    if isinstance(node, ast.FormattedValue):
+        return _resolve(node.value, scopes, core)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return _join(
+            _resolve(node.left, scopes, core), _resolve(node.right, scopes, core)
+        )
+    if isinstance(node, ast.Name):
+        for scope in reversed(scopes):
+            if node.id in scope:
+                return scope[node.id]
+        return [_UNKNOWN]
+    if isinstance(node, ast.Attribute):
+        # ``mcp_core._CREW_READ_PATH`` -- resolve against mcp_core's constants.
+        return core.get(node.attr, [_UNKNOWN])
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and not node.args:
+        # A zero-arg URL builder, pre-resolved into scope under ``name()``.
+        for scope in reversed(scopes):
+            if f"{node.func.id}()" in scope:
+                return scope[f"{node.func.id}()"]
+    return [_UNKNOWN]
+
+
+def _url_builders(
+    tree: ast.Module, scopes: list[dict[str, list[str]]], core: dict[str, list[str]]
+) -> dict[str, list[str]]:
+    """Zero-arg module functions returning a URL, keyed ``name()``.
+
+    ``screencast.py`` passes ``Request(_ingress_url(), ...)``, so the path lives in
+    a builder's return rather than at the call -- invisible without this.
+    """
+    out: dict[str, list[str]] = {}
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.args.args or node.args.kwonlyargs:
+            continue
+        cands: list[str] = []
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Return) or inner.value is None:
+                continue
+            try:
+                cands.extend(_resolve(inner.value, scopes, core))
+            except _TooManyCandidates:
+                cands = [_UNKNOWN]
+                break
+        if cands:
+            out[f"{node.name}()"] = cands
+    return out
+
+
+def _function_locals(
+    fn: ast.AST, scopes: list[dict[str, list[str]]], core: dict[str, list[str]]
+) -> dict[str, list[str]]:
+    """Candidate string values for names assigned inside one function body.
+
+    A name whose candidates overflow is bound to the unknown marker rather than a
+    truncated list, so a call using it reports unresolved instead of passing on a
+    subset of its real paths.
+    """
+    local: dict[str, list[str]] = {}
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    try:
+                        found = _resolve(node.value, [*scopes, local], core)
+                    except _TooManyCandidates:
+                        local[target.id] = [_UNKNOWN]
+                        continue
+                    local.setdefault(target.id, []).extend(found)
+        elif isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Name):
+            base = local.get(node.target.id, [_UNKNOWN])
+            try:
+                local[node.target.id] = base + _join(
+                    base, _resolve(node.value, [*scopes, local], core)
+                )
+            except _TooManyCandidates:
+                local[node.target.id] = [_UNKNOWN]
+    return {k: v[:_MAX_CANDIDATES] if len(v) <= _MAX_CANDIDATES else [_UNKNOWN]
+            for k, v in local.items()}
+
+
+def _sends_secret(text: str, tree: ast.Module) -> bool:
+    """True when a module attaches the internal secret to an outgoing request.
+
+    Three spellings: the header name written literally, or held in a module
+    constant used either as a subscript target or as a dict-literal key.
+    """
+    if _SETS_SECRET.search(text):
+        return True
+    names = {
+        name
+        for name, values in _str_assignments(tree.body).items()
+        if values and values[0] == _SECRET_HEADER
+    }
+    if not names:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict) and any(
+            isinstance(key, ast.Name) and key.id in names for key in node.keys
+        ):
+            return True
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.slice, ast.Name)
+                and target.slice.id in names
+            ):
+                return True
+    return False
+
+
+def _wrapper_path_arg_index() -> dict[str, dict[str, int]]:
+    """Path-argument position for every wrapper that forwards a path to the wire.
+
+    Keyed by MODULE then function, because these names are not unique across the
+    tree: ``mcp_core._send(path)`` forwards a path, while ``cron_script._send(msg)``
+    is an unrelated JSON-RPC sender taking a dict. A flat name-keyed index treated
+    the latter as a transport call and reported its callers unresolved.
+
+    Derived from the CODE -- any function taking a ``path`` parameter that itself
+    performs a transport call -- and deliberately NOT from ``_KNOWN_UNRESOLVED``.
+    Those are two different questions, and conflating them left a hole: a wrapper
+    whose own site happens to resolve is absent from that list, so its callers went
+    unscanned and a literal they passed was never checked. ``cli_commands._request``
+    is exactly that shape, and its path sits at index 1, not 0.
+    """
+    index: dict[str, dict[str, int]] = {}
+    for src in _SOURCES:
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+        per_module = index.setdefault(src.name, {})
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            args = [a.arg for a in node.args.args]
+            if args and args[0] in ("self", "cls"):
+                args = args[1:]
+            if "path" not in args:
+                continue
+            forwards = any(
+                isinstance(inner, ast.Call)
+                and _plain_callee(inner.func) in (_TRANSPORT_HELPERS | {"Request"})
+                for inner in ast.walk(node)
+            )
+            if forwards:
+                per_module[node.name] = args.index("path")
+    return index
+
+
+def _plain_callee(func: ast.expr) -> str | None:
+    """The bare name a call targets, whether written plain or attribute-style."""
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+# The parameter every transport helper and path-forwarding wrapper names, so a
+# keyword-passed path is found whatever the call's positional shape.
+_PATH_PARAM = "path"
+
+
+def _path_expr(call: ast.Call, at_arg: int) -> ast.expr | None:
+    """The expression carrying the path, from either argument shape.
+
+    Recognition keys on the callee, not on the presence of positional args, so a
+    keyword-only call reaches the resolver instead of being skipped before it.
+    """
+    if at_arg < len(call.args):
+        return call.args[at_arg]
+    for kw in call.keywords:
+        if kw.arg == _PATH_PARAM:
+            return kw.value
+    return None
+
+
+def _called_helper_name(func: ast.expr, wrappers: dict[str, int]) -> str | None:
+    """The transport helper, ``Request``, or exempted wrapper this call targets."""
+    if isinstance(func, ast.Attribute):
+        name = func.attr
+    elif isinstance(func, ast.Name):
+        name = func.id
+    else:
+        return None
+    if name in _TRANSPORT_HELPERS or name == "Request" or name in wrappers:
+        return name
+    return None
+
+
+def _scan() -> tuple[dict[str, set[str]], set[str]]:
+    """Walk every source, returning (path -> call sites, unresolved site keys).
+
+    An unresolved site is keyed ``module.py:enclosing_function`` so the reviewed
+    exception list does not churn when line numbers move.
+    """
+    core = _str_assignments(ast.parse(_CORE.read_text(encoding="utf-8")).body)
+    wrapper_index = _wrapper_path_arg_index()
+    paths: dict[str, set[str]] = {}
+    unresolved: set[str] = set()
+
+    for src in _SOURCES:
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+        wrappers = wrapper_index.get(src.name, {})
+        module_scope = _str_assignments(tree.body)
+        module_scope.update(_url_builders(tree, [module_scope], core))
+
+        def visit(
+            node: ast.AST,
+            scopes: list[dict[str, list[str]]],
+            fname: str,
+            enclosing: list[ast.AST],
+        ) -> None:
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    inner = [*scopes, _function_locals(child, scopes, core)]
+                    visit(child, inner, child.name, [*enclosing, child])
+                    continue
+                if isinstance(child, ast.Call):
+                    called = _called_helper_name(child.func, wrappers)
+                    if called is not None:
+                        found = False
+                        expr = _path_expr(child, wrappers.get(called, 0))
+                        if expr is not None:
+                            try:
+                                cands = _resolve(expr, scopes, core)
+                            except _TooManyCandidates:
+                                cands = []
+                            for cand in cands:
+                                norm = _normalise(cand)
+                                at = norm.find("/api/")
+                                if at >= 0:
+                                    paths.setdefault(norm[at:], set()).add(
+                                        f"{src.name}:{child.lineno}"
+                                    )
+                                    found = True
+                        if not found:
+                            owner = next(
+                                (
+                                    fn.name
+                                    for fn in reversed(enclosing)
+                                    if isinstance(
+                                        fn, (ast.FunctionDef, ast.AsyncFunctionDef)
+                                    )
+                                    and fn.name in wrappers
+                                ),
+                                fname,
+                            )
+                            unresolved.add(f"{src.name}:{owner}")
+                visit(child, scopes, fname, enclosing)
+
+        visit(tree, [module_scope], "<module>", [])
+    return paths, unresolved
+
+
+def _call_sites() -> dict[str, set[str]]:
+    return _scan()[0]
+
+
+def _unresolved_sites() -> set[str]:
+    return _scan()[1]
+
+
+def _is_allowlisted(path: str) -> bool:
+    """Mirror the middleware's prefix-or-exact match over both internal sets."""
+    allow = _STRICT_INTERNAL_API_PATHS | _MIXED_INTERNAL_API_PATHS
+    return any(path == entry or path.startswith(entry + "/") for entry in allow)
+
+
+def _is_reachable(path: str) -> bool:
+    """Allowlisted, or auth-exempt outright via ``token_auth._BYPASS_EXACT``."""
+    return _is_allowlisted(path) or path in _BYPASS_EXACT
+
+
+def _is_prefix_path(path: str) -> bool:
+    """True when a marker is glued to a segment tail, so the path is a prefix.
+
+    A marker that occupies a whole segment (``/api/artifacts/{X}/comments``) is
+    an opaque id and the path is still concrete. A marker glued to text
+    (``/api/apps/ops-mission-control{X}``) means the rest of the segment is only
+    known at runtime.
+    """
+    at = path.find(_UNKNOWN)
+    return at > 0 and path[at - 1] != "/"
+
+
+def _is_granted(path: str) -> bool:
+    """Reachability for a concrete path; family-granted for a prefix path."""
+    if not _is_prefix_path(path):
+        return _is_reachable(path)
+    head = path[: path.find(_UNKNOWN)]
+    allow = _STRICT_INTERNAL_API_PATHS | _MIXED_INTERNAL_API_PATHS
+    return _is_reachable(head) or any(entry.startswith(head) for entry in allow)
+
+
+class TestMcpCallSiteAuthCoverage:
+    def test_every_transport_call_resolves_to_a_path(self):
+        """No transport call may be skipped just because it looks hard.
+
+        Skipping is the failure this file exists to prevent: the call goes
+        unchecked while the suite reads green. Resolve the indirection (a local
+        variable, a module constant, a concatenation are all handled), or route
+        the call through a wrapper whose callers pass a concrete path.
+        """
+        strays = sorted(_unresolved_sites() - _KNOWN_UNRESOLVED)
+        assert not strays, (
+            "transport call site(s) whose /api path could not be resolved, so "
+            f"this guard cannot vouch for them: {strays}. Resolve the "
+            "indirection rather than adding them to _KNOWN_UNRESOLVED."
+        )
+
+    def test_known_unresolved_ratchet_has_no_stale_entries(self):
+        """The wrapper exception list may only shrink."""
+        stale = sorted(_KNOWN_UNRESOLVED - _unresolved_sites())
+        assert not stale, (
+            f"_KNOWN_UNRESOLVED lists site(s) that now resolve: {stale}. "
+            "Remove them so the list keeps tightening."
+        )
+
+    def test_every_resolved_path_is_granted(self):
+        """A path in neither allowlist 403s for every MCP caller.
+
+        Fix by adding it to ``_STRICT_INTERNAL_API_PATHS`` (MCP-only) or
+        ``_MIXED_INTERNAL_API_PATHS`` (also polled by the browser) in
+        ``dashboard/server.py`` -- not by listing it as a known gap.
+        """
+        gaps = {
+            path: sorted(sites)
+            for path, sites in _call_sites().items()
+            if not _is_granted(path) and path not in _KNOWN_UNREACHABLE
+        }
+        assert not gaps, (
+            "MCP call site(s) reach a path that is in no internal allowlist, so "
+            f"every MCP call to them 403s: {sorted(gaps)}. Call sites: {gaps}"
+        )
+
+    def test_known_unreachable_ratchet_has_no_stale_entries(self):
+        """The known-gap ratchet may only shrink, so a fixed path is de-listed."""
+        unreachable = {p for p in _call_sites() if not _is_granted(p)}
+        stale = sorted(_KNOWN_UNREACHABLE - unreachable)
+        assert not stale, (
+            f"_KNOWN_UNREACHABLE lists path(s) that are now reachable: {stale}. "
+            "Remove them so the ratchet keeps tightening."
+        )
+
+    def test_extraction_is_not_vacuous(self):
+        """If extraction silently found nothing, the coverage test passes free."""
+        found = _call_sites()
+        assert len(found) >= 25, f"suspiciously few call sites found: {sorted(found)}"
+
+    def test_extraction_covers_every_call_shape(self):
+        """Pin one real path per argument shape and per source module.
+
+        A regression that blinded any single shape would otherwise just shrink
+        the set quietly, and the floor above is slack enough to absorb it.
+        """
+        found = _call_sites()
+        for path, shape in (
+            ("/api/spawn", "literal arg, qualified mcp_core._post"),
+            ("/api/chat/folders", "literal arg, bare imported _post"),
+            ("/api/apps/issue-radar/investigation", "the _put helper"),
+            ("/api/artifacts/{X}/comments", "f-string with an interpolation"),
+            ("/api/session-tool-policy", "direct urllib Request, leading f-string"),
+            ("/api/apps/issue-radar/crew", "path held in a module-level constant"),
+            ("/api/browser/command", "module constant interpolated into an f-string"),
+            ("/api/computer-use/invoke", "own Request + header, outside mcp_tools"),
+            ("/api/computer-use/frame", "path returned by a zero-arg URL builder"),
+            ("/api/chat/slots", "literal passed to an exempted wrapper's caller"),
+            ("/api/crons/{X}/run", "a non-MCP caller (cron_trigger)"),
+            ("/api/artifacts/{X}/versions/{X}", "local variable assigned in a branch"),
+            ("/api/apps/ops-mission-control{X}", "local built by + concatenation"),
+        ):
+            assert path in found, f"{path} not extracted -- {shape} is now blind"
+
+    def test_keyword_passed_paths_are_visited(self):
+        """A transport call with no positional args must still be resolved.
+
+        Recognition keys on the callee rather than on argument shape, so a
+        keyword-only call reaches the resolver instead of being skipped before
+        detection -- which would pass green with the call site unguarded.
+        """
+        kw = ast.parse('_post(path="/api/kw-shape-probe", body={})').body[0].value
+        expr = _path_expr(kw, 0)
+        assert expr is not None, (
+            "a keyword-passed path is invisible, so such a call would be "
+            "skipped before detection and read green while unguarded"
+        )
+        assert _resolve(expr, [{}], {}) == ["/api/kw-shape-probe"], (
+            "the keyword path expression did not resolve to its literal"
+        )
+        bare = ast.parse("_post()").body[0].value
+        assert _path_expr(bare, 0) is None, (
+            "a call carrying no path must yield no expression, so the walker "
+            "records it unresolved rather than silently finding nothing"
+        )
+
+    def test_the_walker_visits_a_keyword_only_transport_call(self, monkeypatch, tmp_path):
+        """End-to-end: shape must not decide whether a call is examined.
+
+        ``_path_expr`` is unit-pinned above, but the escape this closes lived in
+        the walker's entry condition, so it has to be asserted through ``_scan``.
+        """
+        mod = tmp_path / "kwshape.py"
+        mod.write_text(
+            "from kiro_crew.mcp_core import _post\n"
+            "def go():\n"
+            '    return _post(path="/api/kw-walker-probe", body={})\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setitem(globals(), "_SOURCES", (_CORE, mod))
+        paths, unresolved = _scan()
+        assert "/api/kw-walker-probe" in paths, (
+            "the walker skipped a transport call whose path is keyword-passed, "
+            f"so it is unguarded and nothing failed; unresolved={sorted(unresolved)}"
+        )
+
+    def test_secret_header_is_detected_in_a_dict_literal(self):
+        """A constant header key inside a dict literal marks a sender.
+
+        ``{FRAME_SECRET_HEADER: token}`` is neither literal header text nor a
+        subscript assignment, so without this a module sending the secret that
+        way would never be added to the scanned set.
+        """
+        src = 'H = "X-Internal-Secret"\ndef go(t):\n    return {H: t}\n'
+        assert _sends_secret(src, ast.parse(src)), (
+            "a dict-literal header key is invisible, so a sender spelled that "
+            "way would sit outside _SOURCES entirely"
+        )
+        # Must still DEFINE the header constant, or the predicate returns early
+        # at the empty-names guard and this passes without testing membership.
+        other = (
+            'H = "X-Internal-Secret"\nOTHER = "x-unrelated"\n'
+            "def go(t):\n    return {OTHER: t}\n"
+        )
+        assert not _sends_secret(other, ast.parse(other)), (
+            "an unrelated constant used as a dict key must not count as a sender"
+        )
+
+    def test_prefix_paths_are_distinguished_from_concrete_ones(self):
+        """Guard the classifier: reading a prefix as concrete would false-FAIL,
+        and reading a concrete path as a prefix would weaken a real check."""
+        assert _is_prefix_path("/api/apps/ops-mission-control{X}"), (
+            "a marker glued to a segment tail is a prefix, not a concrete path"
+        )
+        assert not _is_prefix_path("/api/artifacts/{X}/comments"), (
+            "a marker filling a whole segment is an opaque id, still concrete"
+        )
+        assert not _is_prefix_path("/api/spawn"), (
+            "a path with no marker at all is concrete"
+        )
+
+    def test_reachability_mirror_matches_the_middleware(self):
+        """Guard the mirror itself: a wrong mirror passes everything silently."""
+        entry = next(iter(_STRICT_INTERNAL_API_PATHS))
+        assert _is_allowlisted(entry), "exact match must be allowlisted"
+        assert _is_allowlisted(entry + "/child"), "prefix + / must be allowlisted"
+        assert not _is_allowlisted(entry + "-sibling"), (
+            "a shared string prefix is not a shared path prefix -- the / matters"
+        )
+
+    def test_no_secret_caller_is_unscanned(self):
+        """Any module reaching the dashboard must be in ``_SOURCES``.
+
+        Keyed on capability, not on one call shape: setting the secret header,
+        bare-importing a helper, or calling one qualified all count. Detecting
+        only qualified calls is what let ``mcp_computer.py`` (its own ``Request``
+        plus the header) and any bare-import caller escape unnoticed.
+        """
+        scanned = {p.resolve() for p in _SOURCES}
+        unscanned: dict[str, list[str]] = {}
+        for path in sorted(_SRC.rglob("*.py")):
+            rel = path.relative_to(_SRC).as_posix()
+            if path.resolve() in scanned:
+                continue
+            if "/tests/" in f"/{rel}" or path.name.startswith("test_"):
+                continue
+            text = path.read_text(encoding="utf-8")
+            tree = ast.parse(text)
+            reasons: list[str] = []
+            if _sends_secret(text, tree):
+                reasons.append(f"sets {_SECRET_HEADER}")
+            aliases = {"mcp_core", "core"}
+            imported: set[str] = set()
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and (node.module or "").endswith(
+                    "mcp_core"
+                ):
+                    for alias in node.names:
+                        if alias.name in _TRANSPORT_HELPERS:
+                            imported.add(alias.asname or alias.name)
+                        elif alias.name == "mcp_core":
+                            aliases.add(alias.asname or alias.name)
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name.endswith("mcp_core"):
+                            aliases.add(alias.asname or alias.name.split(".")[-1])
+            if imported:
+                reasons.append(f"imports {sorted(imported)}")
+            qualified = sorted(
+                {
+                    node.func.attr
+                    for node in ast.walk(tree)
+                    if isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr in _TRANSPORT_HELPERS
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id in aliases
+                }
+            )
+            if qualified:
+                reasons.append(f"calls {qualified}")
+            if reasons:
+                unscanned[rel] = reasons
+        assert not unscanned, (
+            "module(s) reach the dashboard with the internal secret but are not "
+            f"scanned by this guard, so their call sites are unchecked: "
+            f"{unscanned}. Add them to _SOURCES."
+        )


### PR DESCRIPTION
## Problem / Motivation

Registering a dashboard route and granting it MCP access are two separate manual edits, and nothing couples them. The MCP subprocess reaches the dashboard through the `_post`/`_get`/`_put`/`_patch`/`_delete` helpers in `mcp_core`, all of which send `X-Internal-Secret`. The middleware grants that secret only for paths in `_STRICT_INTERNAL_API_PATHS` or `_MIXED_INTERNAL_API_PATHS` (`dashboard/server.py`), matched by prefix. If a path is in neither set, the request falls through to ordinary token auth and returns 403 for every MCP caller.

The concrete failure is that the MCP tool simply does not work, and nothing catches it earlier: the code imports fine, the route exists, the tests pass, and the 403 only appears when someone invokes the tool. This test is the missing link between the two edits.

## Why it matters
Nothing is broken today: all 54 resolved call paths match an allowlist, so this prevents a regression rather than fixing one. When it does regress, the cost lands on whoever adds the next dashboard route and on every user of the MCP tool built on it — that tool returns 403 on every call, and since the import succeeds, the route exists and its own tests pass, the person who usually discovers it is a user hitting a broken tool rather than CI. The general shape is not hypothetical in this file: #11 was a security fix whose commit body names drift around these two sets as the root cause, and its remedy closed the duplicate-copy axis (hoisting the sets to shared module-level constants) while leaving the call-site axis unchecked.

## What changed (motivation → approach → change)
Adds one test file that asserts every internal-secret call site into the dashboard is covered by an internal auth allowlist. Test-only and add-only; no production code is touched.

The population is "sends `X-Internal-Secret`", not "is an MCP module". That distinction is load-bearing: naming it after MCP is exactly what let `mcp_computer.py` sit outside `_SOURCES` in an earlier revision, and review caught it. Most callers go through the `mcp_core` helpers, which attach the secret centrally; a few (`mcp_computer`, `cron_script`, the code-review-sage driver) build their own `Request` and set the header themselves. `_SOURCES` now covers all of them — 22 modules. Detecting the header has to see it written as a constant too: `computer_use/screencast.py` assigns `headers[FRAME_SECRET_HEADER]` (`screencast.py:76`, `:319`), which a literal-only pattern misses.

It walks the AST of the MCP modules, resolves the path argument of each transport call, and checks it against the allowlists imported from the shipped module rather than a copy kept in the test.

An AST walk rather than a text scan, because the path argument reaches these calls in several indirect shapes and a text scan cannot see through any of them: a module-level constant (`mcp_core._CREW_READ_PATH`), a constant interpolated into an f-string (`f"{_api_base()}{COMMAND_PATH}"` in `mcp_tools/browser.py`), a local variable assigned earlier in the function, and a local assembled by `+` concatenation (`"/api/apps/ops-mission-control" + _omc_path`). The resolver follows all of them, walking function scopes so a local's candidate values are known at the call. A name reassigned on two branches yields both paths rather than one.

Where a span of the path is only known at runtime it becomes the marker `{X}`. A marker filling a whole segment leaves the path CONCRETE and it is matched against the allowlists exactly as the middleware would. A marker glued to a segment tail means the path is only known up to that point, so it is treated as a PREFIX and the assertion weakens honestly to "some allowlist entry begins with this literal head". That is what covers the Ops Mission Control family, whose thirteen endpoints are allowlisted individually and deliberately not by bare prefix.

Crucially the guard FAILS on a transport call it cannot resolve, instead of skipping it — and, since the fourth review round, that holds for the call's SHAPE as well as for its path VALUE: recognition keys on the callee, so a call with no positional argument at all still has to resolve or fail. Skipping is the exact failure this file exists to prevent — the call goes unchecked while the suite reads green. Eight sites remain genuinely unresolvable, all generic wrappers that take the path as a parameter (`mcp_core`'s five helpers, `mcp_dashboard._get_rows`, `cron_script._post` and `review_driver._api_request`); they sit in a reviewed `_KNOWN_UNRESOLVED` list keyed by module and function, and their callers are scanned instead — a wrapper earns that by forwarding a path, derived from the code rather than from membership of this list. That list is ratcheted too: an entry that starts resolving fails the test.

`_SOURCES` globs `mcp_tools/*.py` rather than listing modules, and `test_no_transport_module_is_unscanned` fails if any module outside `_SOURCES` calls the transport helpers. That second check is the part that keeps this from rotting: the tool implementations already moved out of `mcp_core` into `mcp_tools` once, and a guard with a hand-listed source set would have gone quietly blind at that point instead of reporting anything.

54 distinct paths resolve on this tree and all 54 are granted today, so the `_KNOWN_UNREACHABLE` ratchet ships empty. It is kept, empty, so that the exception set is visible rather than implied: adding an entry is a reviewable act, and a companion test fails if an entry is listed that has since become reachable, so the list can only shrink.

## How this differs from #3256

#3256 (`test_internal_path_bucket_disjointness.py`) asserts a property of the two allowlists themselves: that `_STRICT_INTERNAL_API_PATHS` and `_MIXED_INTERNAL_API_PATHS` do not overlap, because an entry in both has two contradictory auth policies.

This PR asserts a property of the call sites relative to those allowlists: that every path the MCP modules actually call appears in one of them.

Neither implies the other, in either direction. The buckets can be perfectly disjoint while a call site sits in neither and 403s, and every call site can be covered while the two buckets overlap and pick the wrong policy. There is no overlap in files or assertions: this PR adds a new file and does not modify #3256's, and it does not re-check disjointness — the module docstring points at #3256 for that so a later reader does not think the check is missing.

## Tests

Nine tests, all passing, run against this branch.

**Review round: two items, both accepted, one root cause.** `_SOURCES` omitted `mcp_computer.py`, whose `/api/computer-use/invoke` call sets the secret header directly (`mcp_computer.py:117` and `:645-650`). Separately, the completeness check only matched qualified `mcp_core._x(...)` calls, so a bare-import caller — the style `mcp_dashboard.py` already uses — escaped it. Both are the same defect: the check was keyed on one call SHAPE rather than on the capability. It is now keyed on capability and fails on any of the three routes (sets the header, bare-imports a helper, calls one qualified, alias included). That change also removed the `_NOT_TRANSPORT_CALLERS` same-name exemption list: a module with its own private `_get` neither imports `mcp_core` nor sets the header, so it no longer needs an exemption. Widening `_SOURCES` found four further uncovered senders beyond the one reported (`cli_commands`, `cron_script`, `cron_trigger`, the sage driver); every path they contribute was already allowlisted, so nothing was suppressed to keep this green.

Every assertion was negative-controlled separately rather than as a group, because the runner stops at the first failing assertion and one control would otherwise "validate" siblings that never executed. **Second review round: three more real gaps, all fixed; one item deferred with reasons.**

1. `_SETS_SECRET` matched only a literal header key, so `screencast.py` — which sets it through the `FRAME_SECRET_HEADER` constant and imports no `mcp_core` helper — escaped all three detection routes. Detection now resolves a constant key, and the module is scanned. Its path `/api/computer-use/frame` needed one more resolver shape to become visible: the URL comes from a zero-argument builder (`Request(_ingress_url(), ...)`, path baked in at `screencast.py:303`), so zero-arg builders are now resolved through their `return`.

2. The wrapper exemptions claimed "the path belongs to its callers and those callers are checked instead". That was **false** for two of the eight: `_get_rows` and `_api_request` are not transport helpers, so calls to them were never scanned, and `/api/chat/slots` (`mcp_dashboard.py:571`, `:617`) was consequently unchecked. Wrapper calls are now scanned, with the path-argument position read from each wrapper's own signature — which matters, because `_api_request(method, path, ...)` carries it at index 1, not 0. The comment's rationale is now true rather than aspirational.

3. The `[:2]` candidate cap silently discarded a name's third-and-later values. That was live, not theoretical: `cli_commands.py::_artifact` resolves **six** `/api` candidates for one name, so four were being dropped. Nothing is truncated now — past a ceiling of 24 the site is reported unresolved and the test fails loud, which is what the file's own invariant demands. All six are retained and granted today.

**Third round: one more real hole, closed.** A wrapper was scanned only if it appeared in `_KNOWN_UNRESOLVED`, because the wrapper index was derived from that list. Those are two different questions, and conflating them left `cli_commands._request` — a nested wrapper taking `path` at index 1 (`cli_commands.py:1643`) — unscanned, because its own site happens to resolve and so it is legitimately absent from the exemption list. Measured on a copy of the real module with one added caller: an un-allowlisted literal passed to it was NOT extracted, was NOT granted, and the suite stayed **green** — the precise failure this file exists to prevent. The wrapper set is now derived from the code (any function taking a `path` parameter that forwards it to a transport call), independent of the exemption ratchet. The same fixture now fails naming that path, and the clean tree stays green with the ratchet unstale, so nothing was suppressed to get there.

Worth noting for anyone reading the review thread: the suggested remedy — adding the wrapper to `_KNOWN_UNRESOLVED` — did close the hole mechanically, but it also broke `test_known_unresolved_ratchet_has_no_stale_entries`, since that list may only contain sites that genuinely do not resolve. Decoupling the two roles is what satisfies both.

**Lane currency.** All three review lanes — GPT 5.6, Opus 4.8 and Design — name the current head sha, so their verdicts are live: GPT and Opus report no findings, and Design reports CONCERNS carrying two Watch items and no `FINDING` line. This corrects an earlier revision of this paragraph, which claimed every lane named `c84ea45cb` and that fork lanes could not re-read until the PR was published. Both were wrong — the lanes re-read this sha while it is still a draft. The same-repo `GPT 5.6 Review` and `Design Review` workflow runs do report `skipped`, but that is the same-repo variant standing down; the fork pipeline is what posted the comments. Re-verified at this sha: zero `[:2]` occurrences remain in the file, and tightening the candidate ceiling below the real count makes the guard report the site unresolved rather than pass on a subset.

**Tracked as #4103**, not merely deferred: extracting the strict/mixed predicate out of the middleware so this file can import it instead of mirroring it, and the root-cause fix of declaring internal access at route registration and deriving the allowlist from it. The design review asked for a tracked follow-up rather than a description paragraph, so that issue tracks both, and this test is explicitly the interim gate. To be accurate about the follow-up's status rather than implying one: #4103 is open but has no assignee, so nobody is committed to the extraction yet -- treat the mirror below as unowned interim state, not as work already scheduled. The reasoning below stands as the record of why it is not done in this PR. The suggestion is right about the drift axis, and I verified the shape: the logic is inlined inside a closure at `token_auth.py:1664-1670` (`_matches_strict = internal_paths and (...)`) with no importable function, so adopting it means a production change and this PR is test-only. To be precise about that claim, since a near-miss exists: `token_auth.py:1238 _api_pattern_matches` is importable and its non-wildcard branch is the identical rule -- measured equivalent to this mirror over all 47 entries (141 probes, 0 disagreements, no wildcard entries) -- but it is not the middleware's predicate. Its only caller is the per-app `permissions.api` check at line 1329, so importing it would couple this guard to an unrelated subsystem's rule while leaving the middleware drift it is meant to track untouched. #4103 is what exports the right predicate. What that costs while #4103 is open is worth stating plainly, because it is the one failure here that does not announce itself: if the middleware's matching rule changes, nothing breaks loudly — the mirror keeps answering the old question, this suite stays green, and the guard then vouches for a rule the middleware no longer applies. So the mirror is the part of this design that can rot into false confidence rather than into a visible failure, and because #4103 currently has no owner, the trigger for escalating it is an owner not being found rather than a long silence -- an unowned extraction is what lets this mirror age quietly. Two things bound the risk meanwhile — the mirror is pinned by three predicate self-tests (exact, prefix-plus-slash, and sibling-prefix), and the one middleware behaviour my mirror does not model, the `local_only=False` strict→mixed promotion, cannot change the answer this guard asks, since it moves a path between the two sets without changing membership of their union.

**Accepted trade-off: the resolver is a partial evaluator, and extending it is the price.** The design review is right that this test constrains how production code composes paths, and that is worth naming here rather than discovered in a failing build. Measured, not assumed: `.format()`, `%`-formatting, a dict lookup and a path read from the environment each fail `test_every_transport_call_resolves_to_a_path`, checked by adding a synthetic sender using each idiom to the scanned set. `_SOURCES` globs `mcp_tools/*.py`, so a new tool module is scanned the day it lands and whoever adds it absorbs that cost even if their change has nothing to do with auth. The trade is taken deliberately: the alternative is skipping the call, which is the failure this file exists to prevent and which reads green. In exchange the failure names the exact site and leaves two documented exits — resolve the indirection, or route the call through a wrapper whose callers pass a concrete path. One correction to the review's framing: the evaluator is 272 lines across 18 helpers, not ~600. The 611-line file is 272 lines of resolver, 159 of assertions, and 180 of imports, constants and the reviewed exception lists. The mirror-extraction item above is tracked in #4103, as stated further up; it is not done here because it is a production change and this PR is test-only.

That came to 15 controls this round, re-run from scratch against the widened guard. Four of them exercise the completeness check's escape routes one at a time, including a repro of the reported omission: dropping `mcp_computer.py` back out of `_SOURCES` makes the check name it. One is the positive control — perturbing a module that IS listed turns the suite red, so the check discriminates rather than passing vacuously. Each fix above carries its own control: dropping `screencast.py` back out is reported; removing `_get_rows` from the wrapper index makes `/api/chat/slots` vanish from the pinned set; disabling builder resolution makes `/api/computer-use/frame` vanish; and tightening the ceiling to 3 makes the overflowing site report unresolved instead of passing on a subset.

One control earned its keep by failing. The header detector was written for a double-quoted key, so a module writing `'X-Internal-Secret':` would have escaped it — the same kind of hole the check exists to close, reintroduced in the check itself. The detector is now quote-agnostic, and the sender set it finds is unchanged at 9, so no receiver is falsely swept in.

One positive control on top of that: a synthetic module calling `mcp_core._post("/api/brand-new-route-nobody-allowlisted", ...)` was added to the scanned set, and the guard reported exactly that path and nothing else.

Correction to an earlier revision of this description, which claimed the extractor had "no silent blind spot ... zero transport calls have a first-argument shape it cannot resolve". That was wrong, and a review finding caught it. The check behind it treated an `ast.Name` argument as resolvable, when a name bound to a *local* variable resolved to nothing and the call was then skipped. Six sites were being skipped, two of them reaching paths no other call site covered: the Ops Mission Control family via a concatenated local, and `/api/browser/command` via a constant interpolated into an f-string. Neither was a live 403 — both are allowlisted — but both were invisible to the guard, so the exhaustiveness claim did not hold. The resolver above closes them, and the guard now fails rather than skips.

The fix carries its own repro control: the pre-fix guard PASSES a synthetic module whose transport path comes from `os.environ`, recording zero call sites from it, while the current guard fails and names the site. A control that only fires on the new code cannot show the old code was broken.

`flake8` and `isort` are clean on the new file. `mypy` in CI runs against `src/` only, so it does not cover this file.

**Fourth round: the invariant held only for shapes the walker visited.** The design review was right and I confirmed it at source before changing anything: callee recognition sat inside `if isinstance(child, ast.Call) and child.args:`, and `child.keywords` was never read anywhere in the file, so `_post(path="/api/x")` entered neither the coverage net nor the resolve-failure net. Measured on a copy of the real module: the keyword form was extracted=False AND unresolved=empty — escaping both — while the positional control was caught, and a `{FRAME_SECRET_HEADER: token}` dict literal returned False from the sender predicate while its literal-text twin returned True. The remedy is the structural one the review asked for rather than another per-idiom patch: recognition now keys on the callee, and the path is taken from the positional slot or from a `path=` keyword, with anything unresolved failing loud. Worth stating plainly — this was a LATENT hole, not a live unguarded call: no transport call in the 22 scanned modules currently uses either shape, so nothing was 403ing and no assertion was loosened to get green. Counts are unchanged at 22 sources, 54 paths, zero ungranted, and the unresolved set still equals the 8-entry reviewed list exactly; the sender set is byte-identical before and after, so the widened predicate introduced no false positive.

Six negative controls, one per added assertion, each reverting a different mechanism so the failure is attributable — the runner stops at the first failing assertion, so a single control cannot vouch for its siblings. Restoring the old walker guard, dropping the keyword branch, returning the wrong keyword, inventing an expression where none exists, dropping the dict-literal branch, and matching any constant key instead of the header's: all six fail, each with its own message. One of them initially did NOT fire, and that was a defect in my test rather than in the control — the "unrelated key" fixture never defined the header constant, so the predicate returned early at its empty-names guard and the assertion passed without ever exercising the membership check it was meant to test. The fixture now defines the constant and keys the dict on a different name.

**Windows CI note, and it is not this change.** `Backend Tests (Windows) (2)` was cancelled at its 40-minute cap (`ci.yml` sets `timeout-minutes: 40`). The hanging frame is named by the worker's own timeout dump, and it is in another test: `test/test_design_tweak_backend.py:561` (`test_anything_the_writer_accepts_the_reader_returns`), blocked inside `_atomic_write_json` at `apps/builtins/design_tweak/backend/server.py:777`, on `os.path.exists(tmp)`. That test grows one record and re-writes it atomically up to 4000 times, so it performs thousands of temp-file create-and-replace cycles — cheap on Linux, slow on Windows. Both of those files are byte-identical to `main`; this PR adds one file and touches neither. The same test wedged the same Windows shard earlier on this branch and passed on shas in between, which is the signature of a load-sensitive test rather than a defect introduced here. Checked on this side too, since a new test file can perturb a shard: this file's slowest test is 6.4s, its two regular expressions contain no nested quantifiers so they cannot backtrack catastrophically, and its only filesystem glob is a non-recursive `mcp_tools/*.py` under the repository's own `src` directory.

## Limits, stated explicitly

- It checks allowlist membership, not bucket choice. A browser-polled route wrongly placed in `strict` passes here and still hard-denies forwarded browsers at runtime. Choosing between `strict` and `mixed` remains a manual judgement.
- The allowlist rule is mirrored here, not imported. `_is_allowlisted` re-implements the middleware's prefix-or-exact match because the middleware's own copy is inlined inside a closure at `token_auth.py:1664-1670`, so there is nothing to import. The cost is that this is the one failure in the design that does not announce itself: if the middleware's matching rule changes and the mirror does not follow, no test breaks -- the suite stays green while vouching for a rule the middleware no longer applies. #4103 exports a shared predicate and retires the mirror; it is open and currently unassigned, so nobody is committed to it yet. Until it lands, three predicate self-tests pin the mirror's behaviour: an exact match, a prefix plus `/`, and a sibling prefix that must not match.
- `+` concatenation and f-string interpolation are resolved, but `.format()`, `%`, and a path read from config or the environment at runtime are not. Such a call is no longer skipped silently — it fails the resolve test and has to be either resolved or reviewed into `_KNOWN_UNRESOLVED`.
- Those are limits on resolving a path's VALUE. The separate class of limits on which call SHAPES get visited at all is closed: a keyword-passed path, a call with no positional arguments, and a header key held in a constant used as a dict-literal key are all handled, because detection keys on the callee and on the capability rather than on argument position. A shape nobody has used yet therefore fails loud rather than passing unseen.
- For a PREFIX path the guard proves the family is granted, not the specific endpoint. A new unallowlisted endpoint added under an already-granted prefix would pass.
- Run locally on CPython 3.12 only. CI covers 3.10 through 3.13, so the matrix is the cross-interpreter signal.













