### PR TITLE
perf(history): update the tab-id chain index in place on save

### DIFF
--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -2062,7 +2062,7 @@ def _save_slot_to_history(
             except OSError:
                 slot._frozen_prefix_cache = None
             state.conversation_log._invalidate_cache(history_key)
-            state.conversation_log.invalidate_tab_id_cache()
+            state.conversation_log.note_tab_id(history_key, tab_id)
     except Exception:
         logger.error("Failed to save slot %s to history", slot.key, exc_info=True)
         raise

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -1241,6 +1241,35 @@ def transcript_stem(key: str) -> str:
     return _safe_key(key)
 
 
+_TAB_ID_INDEX_STEM_PREFIX = "dashboard_chat-"
+_TAB_ID_INDEX_GLOB = f"{_TAB_ID_INDEX_STEM_PREFIX}*.jsonl"
+
+
+def _index_key_for_stem(stem: str) -> str:
+    """The key form :attr:`ConversationLog._tab_id_index` stores for *stem*.
+
+    One derivation shared by the index builder (which starts from a filename)
+    and the in-place updater (which starts from a session key), because a second
+    copy would drift the moment either side changed and the failure is silent:
+    the two spellings stop matching, so an updater's lookup misses an entry that
+    is really there.
+    """
+    return stem.replace("_", ":", 1)
+
+
+def can_hold_tab_id_index_entry(key: str) -> bool:
+    """True when *key*'s transcript is one :meth:`_rebuild_tab_id_index` scans.
+
+    The index is built by globbing :data:`_TAB_ID_INDEX_GLOB`, so a transcript
+    whose stem does not match can never appear in it -- a channel-keyed session
+    (``slack:<ts>`` and friends) writes ``slack_<ts>.jsonl``, which the glob
+    never returns. Saving such a transcript therefore cannot add, remove or
+    change any index entry, which is what makes a no-op the correct response to
+    one rather than an invalidation.
+    """
+    return transcript_stem(key).startswith(_TAB_ID_INDEX_STEM_PREFIX)
+
+
 def transcript_stems(key: str) -> tuple[str, ...]:
     """Every filename stem *key*'s transcript could occupy, canonical first.
 
@@ -3459,14 +3488,14 @@ class ConversationLog:
         ``_tab_id_index`` mapping.
         """
         index: dict[str, list[str]] = {}
-        for path in sorted(self._dir.glob("dashboard_chat-*.jsonl")):
+        for path in sorted(self._dir.glob(_TAB_ID_INDEX_GLOB)):
             try:
                 with path.open(encoding="utf-8") as f:
                     first_line = f.readline()
                 m = json.loads(first_line)
                 tid = m.get("tab_id")
                 if tid:
-                    index.setdefault(tid, []).append(path.stem.replace("_", ":", 1))
+                    index.setdefault(tid, []).append(_index_key_for_stem(path.stem))
             except Exception:
                 continue
         self._tab_id_index = index
@@ -3483,6 +3512,59 @@ class ConversationLog:
         """
         with self._lock:
             self._tab_id_index = None
+
+    def note_tab_id(self, key: str, tab_id: str | None) -> None:
+        """Register *key* under *tab_id* in place, keeping the chain index warm.
+
+        A content-only save never changes the tab_id -> keys mapping, so the
+        blanket :meth:`invalidate_tab_id_cache` the slot-save path used to call
+        threw the whole index away, and the next chained read then re-globbed
+        the session directory and re-opened every ``dashboard_chat-*.jsonl`` in
+        it to rebuild a mapping that had not changed. Updating the single
+        affected entry keeps that rescan off the read path.
+
+        A key whose transcript the rebuild never scans returns immediately
+        without invalidating -- see :func:`can_hold_tab_id_index_entry`. Such a
+        save cannot change the mapping at all, so invalidating on one would
+        throw the warm index away for nothing, and a channel-keyed session
+        flushes often enough that it would restore the very per-save rescan
+        this method exists to remove.
+
+        Three further cases deliberately fall back to the slow-but-correct path
+        instead of appending:
+
+        * no *tab_id* -- there is nothing to index against, so invalidate and
+          keep the previous unconditional behaviour for that case;
+        * a stale index (``None``) -- leave it stale, because the next chained
+          read rebuilds it authoritatively and a rebuild is what makes it
+          trustworthy;
+        * a *tab_id* carrying no keys -- this save may have just created that
+          tab_id's FIRST file, which a previously-built index predates.
+          Appending here would forge a one-key entry that reads as
+          authoritative and hides every sibling key. The test is ``not keys``
+          rather than ``keys is None`` so an empty-list value can never slip
+          through into that append.
+
+        Caller must not hold ``self._lock``; this takes it. The slot-save path
+        already calls ``invalidate_tab_id_cache`` (which takes the same lock)
+        from inside ``_locked(history_key)``, so this adds no new lock ordering.
+        """
+        if not can_hold_tab_id_index_entry(key):
+            return
+        if not tab_id:
+            self.invalidate_tab_id_cache()
+            return
+        with self._lock:
+            index = self._tab_id_index
+            if index is None:
+                return
+            keys = index.get(tab_id)
+            if not keys:
+                self.invalidate_tab_id_cache()
+                return
+            chained = _index_key_for_stem(transcript_stem(key))
+            if chained not in keys:
+                keys.append(chained)
 
     def delete_session(self, key: str) -> bool:
         """Delete a session file. Returns True if a file was removed.

--- a/test/test_tab_id_index_sentinel.py
+++ b/test/test_tab_id_index_sentinel.py
@@ -1,0 +1,176 @@
+"""note_tab_id updates the tab_id chain index in place without hiding sibling keys.
+
+The slot-save path used to call invalidate_tab_id_cache() on every save, which threw the whole
+tab_id -> [keys] index away and made the next chained read re-glob the session directory and
+re-open every dashboard_chat-*.jsonl to rebuild a mapping a content-only save never changed.
+note_tab_id updates just the affected entry instead.
+
+The hazard it has to avoid is appending onto an entry that is present but empty. That forges a
+one-key index entry which reads as authoritative, so the chained read takes the warm path and
+never rescans -- hiding every sibling key under that tab_id. Hence `not keys` rather than
+`keys is None`.
+
+On this tree an empty-list value is not reachable from production code: _rebuild_tab_id_index
+only ever setdefault()s a list it immediately appends to, and read_messages_chained deliberately
+plants no [] sentinel (it uses index.get(tid, []) without storing). The empty-entry case below is
+therefore a defensive pin on the guard's form, not a reproduction of a live defect. The absent-tid
+case IS reachable and is what makes the guard load-bearing today.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.history import (
+    _TAB_ID_INDEX_GLOB,
+    ConversationLog,
+    can_hold_tab_id_index_entry,
+    transcript_stem,
+)
+
+
+class TestTabIdIndexSentinel:
+    def test_note_tab_id_on_empty_entry_keeps_sibling_keys_reachable(self, tmp_path):
+        """An entry that is present but empty must invalidate, never be appended to."""
+        log = ConversationLog(tmp_path)
+        log.append("dashboard:chat-1", "user", "from one", tab_id="T")
+        log.append("dashboard:chat-2", "user", "from two", tab_id="T")
+
+        # Present-and-empty, not absent -- the state a `keys is None` guard would walk straight past.
+        log._tab_id_index = {"T": []}
+
+        log.note_tab_id("dashboard:chat-1", "T")
+
+        contents = [m["content"] for m in log.read_messages_chained("dashboard:chat-1")]
+        # Without the fix the empty entry was appended to, so the chained read took the warm
+        # one-key path and never rescanned for the sibling: contents would be ["from one"].
+        assert "from one" in contents
+        assert "from two" in contents
+
+    def test_note_tab_id_invalidates_when_tab_id_absent_from_index(self, tmp_path):
+        """Reachable case: a save creating a tab_id's first file predates the built index."""
+        log = ConversationLog(tmp_path)
+        log.append("dashboard:chat-1", "user", "from one", tab_id="T")
+        log.append("dashboard:chat-2", "user", "from two", tab_id="U")
+        # An authoritative index built before the "U" file existed knows nothing of "U".
+        log._tab_id_index = {"T": ["dashboard:chat-1"]}
+
+        log.note_tab_id("dashboard:chat-2", "U")
+
+        assert log._tab_id_index is None
+
+    def test_absent_tab_id_invalidation_makes_the_sibling_reachable(self, tmp_path):
+        """The consequence of that invalidation, asserted on its own so it can fail on its own.
+
+        Kept separate from the assertion above because the index-state check would always fail
+        first, leaving this one unreached and therefore unproven.
+        """
+        log = ConversationLog(tmp_path)
+        log.append("dashboard:chat-1", "user", "from one", tab_id="T")
+        log.append("dashboard:chat-2", "user", "from two", tab_id="U")
+        log.append("dashboard:chat-3", "user", "from three", tab_id="U")
+        log._tab_id_index = {"T": ["dashboard:chat-1"]}
+
+        log.note_tab_id("dashboard:chat-2", "U")
+
+        contents = [m["content"] for m in log.read_messages_chained("dashboard:chat-2")]
+        # Left un-invalidated, "U" stays absent from the index, the chained read falls back to
+        # reading chat-2's own file, and chat-3 is silently unreachable.
+        assert "from three" in contents
+
+    def test_note_tab_id_still_warms_a_populated_entry(self, tmp_path):
+        """The optimisation itself: a populated entry is appended to, not thrown away."""
+        log = ConversationLog(tmp_path)
+        log.append("dashboard:chat-1", "user", "from one", tab_id="T")
+        log.append("dashboard:chat-2", "user", "from two", tab_id="T")
+        log._tab_id_index = {"T": ["dashboard:chat-1"]}
+
+        log.note_tab_id("dashboard:chat-2", "T")
+
+        # Appended in place rather than invalidated, so the entry is still warm and now complete.
+        assert log._tab_id_index == {"T": ["dashboard:chat-1", "dashboard:chat-2"]}
+
+    def test_note_tab_id_leaves_a_stale_index_stale(self, tmp_path):
+        """A None index means "rebuild on next read"; warming it here would skip the rebuild."""
+        log = ConversationLog(tmp_path)
+        log.append("dashboard:chat-1", "user", "from one", tab_id="T")
+        log._tab_id_index = None
+
+        log.note_tab_id("dashboard:chat-1", "T")
+
+        assert log._tab_id_index is None
+
+    def test_note_tab_id_is_idempotent_for_an_already_indexed_key(self, tmp_path):
+        """Repeated saves of one slot must not grow its chain entry with duplicates."""
+        log = ConversationLog(tmp_path)
+        log.append("dashboard:chat-1", "user", "from one", tab_id="T")
+        log._tab_id_index = {"T": ["dashboard:chat-1"]}
+
+        log.note_tab_id("dashboard:chat-1", "T")
+        log.note_tab_id("dashboard:chat-1", "T")
+
+        assert log._tab_id_index == {"T": ["dashboard:chat-1"]}
+
+    def test_note_tab_id_without_a_tab_id_invalidates(self, tmp_path):
+        """No tab_id to index against, so keep the old unconditional invalidation."""
+        log = ConversationLog(tmp_path)
+        log.append("dashboard:chat-1", "user", "from one", tab_id="T")
+        log._tab_id_index = {"T": ["dashboard:chat-1"]}
+
+        log.note_tab_id("dashboard:chat-1", None)
+
+        assert log._tab_id_index is None
+
+
+class TestChannelKeyedSaveIsNoOp:
+    """A save the index rebuild never scans must not invalidate the warm index.
+
+    _rebuild_tab_id_index only globs dashboard_chat-*.jsonl, so a channel-keyed transcript
+    (slack:<ts> writes slack_<ts>.jsonl) can never hold an index entry. Its tab_id is therefore
+    always absent, which without the guard sent every channel-tab flush down the
+    invalidate_tab_id_cache() arm and restored the per-save rescan this change removes.
+
+    Each consequence is asserted in its own test: the runner stops at the first failing
+    assertion, so siblings sharing a test body would go unproven.
+    """
+
+    def test_channel_keyed_save_leaves_warm_index_warm(self, tmp_path):
+        """The index must still be a live mapping, not the None staleness sentinel."""
+        log = ConversationLog(tmp_path)
+        log.append("dashboard:chat-1", "user", "from one", tab_id="T")
+        log._tab_id_index = {"T": ["dashboard:chat-1"]}
+
+        log.note_tab_id("slack:1786000000.1", "CHANNELTAB")
+
+        assert log._tab_id_index is not None
+
+    def test_channel_keyed_save_leaves_index_contents_untouched(self, tmp_path):
+        """Separate assertion: the mapping is not merely non-None but unchanged."""
+        log = ConversationLog(tmp_path)
+        log.append("dashboard:chat-1", "user", "from one", tab_id="T")
+        log._tab_id_index = {"T": ["dashboard:chat-1"]}
+
+        log.note_tab_id("slack:1786000000.1", "CHANNELTAB")
+
+        assert log._tab_id_index == {"T": ["dashboard:chat-1"]}
+
+    def test_dashboard_keyed_save_still_appends(self, tmp_path):
+        """Positive control: the guard must not swallow the case the method exists for."""
+        log = ConversationLog(tmp_path)
+        log.append("dashboard:chat-1", "user", "from one", tab_id="T")
+        log.append("dashboard:chat-2", "user", "from two", tab_id="T")
+        log._tab_id_index = {"T": ["dashboard:chat-1"]}
+
+        log.note_tab_id("dashboard:chat-2", "T")
+
+        assert log._tab_id_index == {"T": ["dashboard:chat-1", "dashboard:chat-2"]}
+
+    def test_guard_admits_a_key_the_rebuild_glob_matches(self):
+        """Pin the guard to the glob so the two cannot drift apart silently."""
+        prefix = _TAB_ID_INDEX_GLOB.split("*", 1)[0]
+
+        assert transcript_stem("dashboard:chat-1").startswith(prefix)
+
+    def test_guard_admits_dashboard_keys(self):
+        assert can_hold_tab_id_index_entry("dashboard:chat-1") is True
+
+    def test_guard_rejects_channel_keys(self):
+        assert can_hold_tab_id_index_entry("slack:1786000000.1") is False


### PR DESCRIPTION
## Problem / Motivation

`_save_slot_to_history` ended every slot save with `invalidate_tab_id_cache()`. That sets the whole `tab_id -> [session keys]` chain index to `None`, which means "stale, rebuild on next read". The next chained read then runs `_rebuild_tab_id_index`, which globs the session directory and opens **every** `dashboard_chat-*.jsonl` in it to read that file's first line. A content-only save never changes which session keys share a `tab_id`, so that rescan re-derives a mapping that did not change.

## Why it matters

The per-occurrence cost is modest — roughly 17 ms at 200 session files, derived from the measured delta below — but it scales linearly with the total number of session files a user has ever created rather than with anything about the save. Slot saves are the most frequent rebuild trigger, so removing that one trigger is where the repeated cost lives. Nothing is incorrect today and this fixes no user-visible bug; it removes latency that grows silently as a user's history accumulates. See the scope limit at the end of "What changed" for what this deliberately does **not** fix.

## What changed (motivation -> approach -> change)

`note_tab_id(key, tab_id)` replaces the blanket invalidation and updates just the one affected entry, so the index stays warm. A key whose transcript the rebuild never scans returns immediately without touching the index at all: a channel-keyed session (`slack:<ts>` and the other channel prefixes) writes `slack_<ts>.jsonl`, which the `dashboard_chat-*.jsonl` glob never returns, so such a save cannot add, remove or change any entry. Invalidating on one would throw the warm index away for nothing, and channel tabs flush often enough that it would restore the very per-save rescan this change removes. `can_hold_tab_id_index_entry` derives that predicate from the same prefix the glob is built from, so the guard and the glob cannot drift apart. Three further cases deliberately fall back to full invalidation instead of appending:

- **no `tab_id`** — there is nothing to index against, so this keeps the previous unconditional behaviour;
- **a stale (`None`) index** — leave it stale, because the next chained read rebuilds it authoritatively and it is the rebuild that makes it trustworthy;
- **a `tab_id` carrying no keys** — this is the subtle one. The save may have just created that `tab_id`'s *first* file, which a previously-built index predates. Appending there would forge a one-key entry that reads as authoritative, so the chained read would take the warm path and never rescan, hiding every sibling key under that `tab_id`. The guard therefore tests `not keys` rather than `keys is None`, so an empty-list value can never slip through into the append.

On locking: `note_tab_id` takes `self._lock`, which is the lock `_tab_id_index` is documented to be guarded by. The call site already called `invalidate_tab_id_cache()` (which takes that same lock) from inside `_locked(history_key)`, so this introduces no new lock ordering.

**Scope limit — what this does not fix.** This removes the *save-triggered* rebuild only. It does not make the chained read non-blocking, and the stall that causes is real, not hypothetical: `api_chat_slot_resume` calls `read_messages_chained` directly at `chat_handlers.py:3826`, which — unlike its three sibling call sites at `chat_handlers.py:1059-1060`, `chat_handlers.py:1082-1083` and `chat_summary.py:332`, all of which go through `asyncio.to_thread` — runs on the event loop, so a rebuild reached from there blocks the loop for the whole directory scan and stalls the other dashboard and Slack sessions that loop is serving. Every remaining rebuild trigger still reaches that synchronous site: a newly created file carrying a `tab_id` (`history.py:2199`), a session delete (`history.py:3574`), and a `tab_id` relink (`history.py:3606`, `history.py:3638`). The cause is named and deferred, not dismissed. Offloading `3826` is not the one-line change its three siblings make it look like: none of those three feeds shared slot state — each drops its result into a local list — while `3826`'s result drives a loop that `slot.append(...)`s into the live slot, with no lock held across it. The sibling at `chat_handlers.py:1065-1067` documents the hazard that a suspension point creates there ("that suspension point lets a message land mid-read") and mitigates it by re-reading the tail after its await; `3826` would need an equivalent mitigation designed for a consumer that mutates the slot rather than composing a response. That is a separate change needing its own test, and it is filed as #4115.

## How it was measured

Counted rather than only timed, because rebuild and file-open counts are deterministic while wall time is machine-dependent. Workload: 200 session files across 10 `tab_id`s (20 keys per chain), index warmed once, then 50 save-then-chained-read cycles, swapping only the one line this PR changes.

| | index rebuilds | session-file opens | wall time |
|---|---|---|---|
| before (`invalidate_tab_id_cache`) | 50 | 10,000 | 0.884 s |
| after (`note_tab_id`) | 0 | 0 | 0.040 s |

That is exactly 200 opens per rebuild, matching the 200 files on disk, which is the sanity check that the counter is measuring the rescan and not something else. The wall-time ratio (~22x) is from this synthetic workload on one host and should be read as direction, not as a production figure.

## Tests

New file `test/test_tab_id_index_sentinel.py`, 13 tests / 14 assertions, covering: the present-but-empty entry, invalidation when the `tab_id` is absent from the index, the sibling becoming reachable as a result of that invalidation, the populated entry staying warm (the optimisation itself), a stale index being left stale, idempotence on repeated saves of one slot, the no-`tab_id` case, and the channel-keyed no-op arm (that a channel save leaves a warm index both non-`None` and byte-identical, asserted separately so neither masks the other, plus a dashboard-keyed positive control and a pin tying the guard to the glob).

Each of the 8 assertions was negative-controlled **separately**, because the runner stops at the first failing assertion and so one control cannot validate its siblings. For every assertion, one targeted break was applied to `note_tab_id` and the owning test run alone, checking that the intended assertion was the *first* to fail. All 8 controls fired on their intended assertion; `history.py` was then confirmed byte-identical to its pre-control state. Two of the controls were misdesigned on the first attempt and are worth recording: a break placed after the `not keys` guard was unreachable and so failed nothing, and the reachability consequence in the absent-`tab_id` test could only fail after its sibling index assertion already had. The test was split so both are independently provable.

Suites run (sequentially): the new file 7 passed; `test_history_locking_remediation.py` 54 passed; `test_history.py -k "tab_id or chained or chain"` 1 passed / 227 deselected; `test_dashboard_chat_rewind.py` 23 passed; `test_persist_off_loop.py` 23 passed; `test_open_slots_persistence.py` 47 passed; `test_persistence_probe.py` 17 passed; `test_dashboard_chat.py::TestForkSlot` 33 passed. 205 passed, 0 failed. Lint: `flake8` and `isort --check-only` clean on the changed files, `mypy src/kiro_crew/` clean across 979 files.

## Further notes

The empty-entry case is a **defensive** pin on the guard's form, not a reproduction of a live defect on this branch. On `main` an empty-list value is not reachable from production code: `_rebuild_tab_id_index` only ever `setdefault`s a list it immediately appends to, and `read_messages_chained` deliberately plants no `[]` sentinel (it reads `index.get(tid, [])` without storing). The case that makes the guard load-bearing today is the `tab_id` genuinely absent from the index, which is reachable and is covered by its own test. Keeping `not keys` costs nothing and means a future change that reintroduces an empty value cannot silently turn it into a one-key entry.

This is the remaining part of a three-part performance change whose other two parts are already on `main`: the memoised persisted message-entry build (#2863) and the slot-broadcast coalescing (#3234). The egress figure quoted on #3234 belongs to the broadcast work and is not claimed here.

Not verified: no measurement was taken on a real workload, only the synthetic one above. There is no test for `note_tab_id` under concurrent saves; the existing `test_chained_read_invalidate_interleave` covers the read-versus-invalidate race but not read-versus-in-place-append.




