### PR TITLE
perf(history): rebuild the tab-id index from the metadata cache

### DIFF
--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from aiohttp import web
@@ -22,6 +23,11 @@ logger = logging.getLogger(__name__)
 
 _MAX_SLOTS_FOR_FORK = 500
 _FORK_TITLE_MARKER = "↳ "
+
+# Attempts to land a transcript read and the unpersisted tail on ONE consistent
+# view of the slot. Matches session_transfer._SNAPSHOT_ATTEMPTS and
+# chat_persistence._FLUSH_SNAPSHOT_RETRIES, which bound the same race.
+_SNAPSHOT_ATTEMPTS = 4
 
 # Fork direction: "head" copies messages up to and including the fork point
 # (the default); "tail" copies only the messages after it.
@@ -140,13 +146,340 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
     # with `out of range` even though the user clicked a visible message.
     async with slot._fork_lock:
         all_messages: list[dict] = []
+        new_msgs: list[dict] = []
+        # Two tail candidates, because a boundary ahead of the resident window has
+        # TWO causes needing OPPOSITE remedies and they can only be told apart
+        # once the true on-disk length is known -- i.e. after the read. Both are
+        # snapshotted ON THE LOOP so whichever is chosen still pairs with the
+        # boundary the read observed.
+        tail: list[dict] | None = None
+        capped_tail: list[dict] | None = None
+        # True when the read proved disk holds rows the slot's counters do not
+        # represent (the capped-restore signature). Gates BOTH flush sites in this
+        # handler, because the save's frozen prefix cannot protect those rows.
+        disk_holds_unrepresented = False
         if state.conversation_log:
-            all_messages = state.conversation_log.read_messages_chained(slot_history_key(slot))
-        if all_messages and slot._dirty:
-            new_msgs = slot.messages[slot._resumed_count:]
-            if new_msgs:
-                all_messages.extend(new_msgs)
-        if slot._dirty:
+            # Pair the disk read with the unpersisted tail on ONE consistent view
+            # of the slot, using the idiom session_transfer._snapshot_transcript
+            # already uses: capture the boundary, read, re-check, retry on change.
+            #
+            # The offset is ``_disk_window_len`` -- "how many window messages are
+            # now on disk", advanced by the save path (chat_persistence
+            # ``_save_slot_to_history``). Two nearby counters cannot serve here:
+            #
+            #   * ``_resumed_count`` records only how many messages were loaded
+            #     when the slot was rehydrated. The flush never advances it, so a
+            #     persisted tail stays inside the slice and reconciles in twice.
+            #     session_transfer hit exactly this and documents it.
+            #   * a length captured on a ``_dirty`` transition fails the same way.
+            #     ``_dirty`` is a boolean, so it cannot distinguish "never flushed"
+            #     from "flushed, then re-dirtied by an append" -- and in that
+            #     interleaving no transition registers at all.
+            #
+            # ``_dirty_gen`` (monotonic, bumped centrally by the ``_dirty`` setter)
+            # catches in-place edits that move neither boundary nor length; the
+            # length is a backstop for any path that mutates ``slot.messages``
+            # without marking dirty. There is deliberately no ``_dirty`` gate on
+            # the merge below: the boundary alone is authoritative and the slice is
+            # empty when everything is persisted, so a flush clearing ``_dirty``
+            # mid-read can no longer skip the reconciliation and drop the tail.
+            # ``pending_retry`` carries a SUSPICION across the ``continue`` below.
+            # The save at :209 clears ``_pending_rewrite`` unconditionally once the
+            # archive-safe rewrite succeeds (``chat_persistence``: ``if rewrite:
+            # slot._pending_rewrite = False``) with NO check that the flag it clears
+            # is the one its own snapshot was taken for. So a rewind landing while
+            # that save is suspended has its flag erased, and without this carry the
+            # next attempt reads ``False`` and falls through to a disk read holding
+            # the turns the rewind just discarded.
+            pending_retry = False
+            for _ in range(_SNAPSHOT_ATTEMPTS):
+                if slot._pending_rewrite or pending_retry:
+                    # Disk is KNOWN stale: a rewind/regenerate discarded a tail in
+                    # memory and the truncating rewrite has not been written yet, so
+                    # the file still holds the PRE-EDIT transcript. None of the four
+                    # counters captured below carries that state -- ``chat_rewind``
+                    # sets ``_dirty``, zeroes ``_resumed_count`` and sets this flag,
+                    # but never touches ``_disk_window_len`` -- so the boundary keeps
+                    # its pre-rewind value and can still satisfy the authoritative
+                    # predicate. The read would then return the discarded turns and
+                    # the post-await re-check would PASS, because nothing moved
+                    # during the read: it measures stability, not correctness.
+                    # ``session_transfer._guard_snapshot`` refuses on exactly this
+                    # flag for exactly this reason.
+                    #
+                    # SAVE and retry rather than refuse outright: a rewrite save
+                    # clears the flag (chat_persistence sets ``_pending_rewrite =
+                    # False`` once the archive-safe rewrite succeeds), so this is
+                    # the recoverable path, and a fork is required to still succeed.
+                    # The 503 below is the terminal arm for a source that cannot be
+                    # persisted, and the loop's own 503 covers a flag that keeps
+                    # being re-set within the attempt budget.
+                    # Capture the generation BEFORE the suspension point, so a
+                    # re-dirty that lands while the save is awaited is witnessed.
+                    gen_at_save = slot._dirty_gen
+                    try:
+                        # ``rewrite=True`` UNCONDITIONALLY, because every entry into
+                        # this arm means "disk is stale because an EDIT truncated the
+                        # window", and that is exactly what the archive-safe path is
+                        # for. ``_save_slot_to_history`` only ever PROMOTES this flag
+                        # (``if messages is not None or slot._pending_rewrite: rewrite
+                        # = True``) and gates both the archive-diff (``if rewrite and
+                        # path.exists()``) and the ``rotation_generation`` bump behind
+                        # it -- so on the RETRY, where no snapshot is passed and
+                        # ``_pending_rewrite`` has already been cleared by the first
+                        # save, neither promotion input is present. Without this the
+                        # retry would persist the rewind's truncation through the
+                        # PLAIN path, deleting the discarded turns with no archive
+                        # copy: strictly worse than the bug it recovers from, which
+                        # at least left them readable on disk.
+                        #
+                        # Passing it on the first entry too is a no-op rather than a
+                        # widening -- ``_pending_rewrite`` is still set there, so the
+                        # promotion above already produces True
+                        # (``test_a_first_entry_pending_rewrite_save_archives_as_
+                        # before`` pins that). Stating it here removes the dependence
+                        # on that promotion, which is the thing that silently failed.
+                        await save_slot_off_loop(
+                            state, slot, rewrite=True, best_effort=False
+                        )
+                    except Exception:
+                        logger.warning(
+                            "chat_fork: could not persist the pending rewrite for "
+                            "slot=%s; refusing the fork rather than copying the "
+                            "discarded turns still on disk",
+                            slot.key, exc_info=True,
+                        )
+                        return web.json_response(
+                            {
+                                "error": "the source session is being written to; "
+                                         "please retry",
+                                "code": "fork_snapshot_unstable",
+                            },
+                            status=503,
+                        )
+                    # A moved generation means a genuine re-dirty landed across the
+                    # await -- i.e. a rewind, whose ``_pending_rewrite`` this save
+                    # has just erased along with its own. Two properties make the
+                    # witness clean rather than a permanent trip: ``_dirty_gen``
+                    # advances ONLY on a True assignment (see the ``_dirty`` setter
+                    # in ``state.py``), so this save clearing ``_dirty`` cannot move
+                    # it; and ``best_effort=False`` PROPAGATES a failure instead of
+                    # re-marking the slot dirty, so the save cannot bump it either.
+                    #
+                    # RETRY rather than refuse, per the reasoning above: this is the
+                    # recoverable path and a fork is required to still succeed. The
+                    # next attempt re-enters this arm and persists the rewind that
+                    # was missed. A flag that keeps being re-set simply spends the
+                    # attempt budget and is caught by the loop's own terminal 503 --
+                    # exactly the division of labour described above. Mirrors
+                    # ``flush_slot_now``'s generation compare in ``state.py``, which
+                    # distinguishes "the True I started this save under" from "a NEW
+                    # True set during it" for this same reason.
+                    pending_retry = slot._dirty_gen != gen_at_save
+                    continue
+                disk_len_before = slot._disk_window_len
+                gen_before = slot._dirty_gen
+                count_before = len(slot.messages)
+                older_before = slot._disk_older_count
+                # Witnessed for STABILITY ONLY -- see the guard below. Captured here
+                # so the branch selector at ``elif slot._dirty`` and the post-await
+                # check read the same value.
+                dirty_before = slot._dirty
+                # Snapshot the tail ON THE LOOP, before the await, so it pairs
+                # with the boundary the read is about to observe.
+                if disk_len_before <= count_before:
+                    # The boundary is a usable index and authoritative: the slice
+                    # is empty exactly when everything is persisted. Deliberately
+                    # NO ``_dirty`` gate here -- that is what let a flush clearing
+                    # ``_dirty`` mid-read skip the merge and drop the tail.
+                    tail = list(slot.messages[disk_len_before:])
+                elif slot._dirty:
+                    # The boundary can run AHEAD of the resident window, and is
+                    # then unusable as an index. It has TWO causes and they need
+                    # OPPOSITE remedies, so this branch must not pick one blind:
+                    #
+                    #   * a CAPPED RESTORE dropped leading messages from memory
+                    #     without bumping ``_disk_older_count``. Disk legitimately
+                    #     holds MORE than memory, and flushing would write the
+                    #     smaller window over it. The frozen prefix is keyed on
+                    #     ``_disk_older_count`` (chat_persistence
+                    #     ``_load_frozen_prefix``), which the cap never moved, so
+                    #     the prefix is EMPTY and the save truncates disk to the
+                    #     window -- destroying every persisted message the cap
+                    #     dropped. ``test_fork_preserves_full_history_when_dirty_
+                    #     and_capped`` is the guard for exactly that.
+                    #   * a mid-stream ``_flush_segment`` reassigned
+                    #     ``slot.messages`` to drop a trailing chunk run. Disk and
+                    #     the counters still agree, so flushing is safe and is what
+                    #     re-syncs the boundary.
+                    #
+                    # ``_resumed_count`` is not a blanket substitute either: the
+                    # save never advances it -- ``_save_slot_to_history`` only READS
+                    # it, in its no-op skip -- so for a slot created in this gateway
+                    # run it stays 0 and slicing from it appends the whole resident
+                    # window onto the disk read, duplicating every persisted turn.
+                    # It IS the right offset in the capped-restore case, where the
+                    # restore sets it to the capped length, which is precisely "how
+                    # many resident messages came from disk".
+                    #
+                    # So snapshot that candidate here and decide below, once the
+                    # read has supplied the only authoritative discriminator: the
+                    # true on-disk length.
+                    tail = None
+                    capped_tail = list(slot.messages[slot._resumed_count:])
+                else:
+                    tail = []
+                all_messages = await asyncio.to_thread(
+                    state.conversation_log.read_messages_chained, slot_history_key(slot)
+                )
+                if not (
+                    slot._disk_window_len == disk_len_before
+                    and slot._dirty_gen == gen_before
+                    and len(slot.messages) == count_before
+                    # ``_disk_older_count`` too: it is half of the window's identity
+                    # (channel_slots: the window is
+                    # ``messages[_disk_older_count:][:len(window)]``), and the
+                    # discriminator below is computed from it, so a move here
+                    # invalidates the pairing exactly as a boundary move does.
+                    and slot._disk_older_count == older_before
+                    # ``_pending_rewrite`` is checked on BOTH sides of the await, as
+                    # session_transfer's guard documents. It was False when this
+                    # attempt began (the branch above continues otherwise), so True
+                    # here means a rewind landed DURING the threaded read -- which it
+                    # can, because ``slot._fork_lock`` has exactly one acquirer in the
+                    # tree and no rewind path takes it. Equality against the other
+                    # counters cannot see this: a rewind moves none of them back.
+                    and not slot._pending_rewrite
+                    # ``_dirty`` as a STABILITY WITNESS, never as a merge gate. The
+                    # other four cannot see a save that merely COMPLETES under the
+                    # read: an in-place content edit (a variant switch) moves neither
+                    # ``len(slot.messages)`` nor ``_disk_older_count``, the save
+                    # re-assigns ``_disk_window_len`` to the value it already had
+                    # because the window length did not change, and CLEARING
+                    # ``_dirty`` cannot move ``_dirty_gen`` (the setter advances it
+                    # only on a True assignment). So the threaded read can return
+                    # pre-save bytes while the slot reports everything persisted, and
+                    # the boundary-derived tail is empty -- leaving the fork to adopt
+                    # the stale read verbatim and carry the SUPERSEDED content.
+                    #
+                    # A mismatch RETRIES; it does not skip the reconciliation. That
+                    # distinction is the whole reason this is safe to add: the two
+                    # comments above rejecting a ``_dirty`` gate are about the MERGE
+                    # decision, which stays keyed on the boundary alone. The next
+                    # attempt re-reads a disk that now holds the completed save.
+                    and slot._dirty == dirty_before
+                ):
+                    logger.debug(
+                        "chat_fork: slot=%s changed during the transcript read; retrying",
+                        slot.key,
+                    )
+                    continue
+                if tail is not None:
+                    new_msgs = tail
+                    break
+                # Boundary ahead AND dirty. Discriminate on the invariant
+                # channel_slots states for these counters: disk holds
+                # ``_disk_older_count`` frozen rows followed by the window, so
+                # ``older + window`` is everything the counters claim is on disk.
+                # Disk holding MORE than that means rows exist which the counters
+                # do not represent -- the capped-restore signature. channel_slots
+                # ``_window_matches_disk`` tests the same arithmetic in the
+                # opposite direction.
+                if len(all_messages) > older_before + count_before:
+                    # Do NOT flush: it would truncate those unrepresented rows.
+                    # Merge from ``_resumed_count`` instead, which the restore set.
+                    disk_holds_unrepresented = True
+                    new_msgs = capped_tail or []
+                    break
+                # Counters agree with disk, so the window shrank mid-stream and the
+                # flush is what re-syncs the boundary: the save assigns
+                # ``_disk_window_len = len(window)`` and never READS the boundary,
+                # so flushing while it is ahead cannot mislead the write. Then spend
+                # the attempt; the next one re-derives from the authoritative branch
+                # above. If it still does not settle the loop's 503 refuses, which
+                # is what session_transfer's ``_guard_snapshot`` does here -- but
+                # retrying first is what keeps a fork succeeding once the stream
+                # that moved the window has finalized.
+                try:
+                    await save_slot_off_loop(state, slot, best_effort=False)
+                except Exception:
+                    logger.warning(
+                        "chat_fork: could not persist slot=%s to re-sync the "
+                        "persisted boundary; refusing the fork",
+                        slot.key, exc_info=True,
+                    )
+                    return web.json_response(
+                        {
+                            "error": "the source session is being written to; "
+                                     "please retry",
+                            "code": "fork_snapshot_unstable",
+                        },
+                        status=503,
+                    )
+                continue
+            else:
+                # Do NOT fall through with the mismatched pair: that is precisely
+                # the state the loop exists to reject, and taking it either drops
+                # the tail or duplicates it. Both are silent; a retryable 503 is
+                # not, and this handler already uses that shape below.
+                logger.warning(
+                    "chat_fork: slot=%s did not settle in %d attempts; refusing the fork",
+                    slot.key, _SNAPSHOT_ATTEMPTS,
+                )
+                return web.json_response(
+                    {
+                        "error": "the source session is being written to; please retry",
+                        "code": "fork_snapshot_unstable",
+                    },
+                    status=503,
+                )
+        if all_messages and new_msgs:
+            # REBIND, never ``extend``. ``read_messages_chained`` hands back the
+            # SHARED ``_msg_cache`` list BY IDENTITY whenever it falls through to
+            # ``_read_messages``: for a session with no ``tab_id``, for a tid whose
+            # index resolves to no keys, and when every chained read comes back
+            # empty. ``_read_messages``'s docstring makes the contract explicit --
+            # callers MUST treat the result as immutable and slice or ``list(...)``
+            # it before mutating.
+            #
+            # Base mutated it here too, but base always took the durable save when
+            # dirty, and that save invalidates the entry -- so the mutation was
+            # transient and self-healing. The skip-the-save branch below is
+            # deliberate and correct, and it is also what removes the eviction that
+            # used to hide this: nothing corrects the entry, so every later reader
+            # of this key sees the UNPERSISTED tail as though it were history.
+            #
+            # A rebind rather than ``list(all_messages)`` + ``extend``: one
+            # expression, the surrounding control flow untouched, and it leaves no
+            # in-place mutation of this object anywhere in the handler for a future
+            # edit to reintroduce. Nothing below depends on the identity -- the
+            # remaining uses are a truthiness test, a rebind and a comprehension.
+            all_messages = all_messages + new_msgs
+        if slot._dirty and disk_holds_unrepresented:
+            # Same rule as the boundary-ahead branch above, applied to the second
+            # flush site in this handler: NEVER flush a slot whose disk holds rows
+            # its counters do not represent. The save's frozen prefix is
+            # ``body[:_disk_older_count]``, so rows outside that are not protected
+            # and the write truncates them -- 250 -> 52 in the capped-restore case.
+            #
+            # Skipping it leaves ``_dirty`` SET deliberately, so the unwritten
+            # source messages stay queued for the periodic flusher rather than
+            # being stranded by a premature clean-mark. The fork itself does not
+            # need the flush: it already holds the full transcript from disk plus
+            # the merged tail.
+            #
+            # NOTE (pre-existing, not introduced here): the periodic flusher can
+            # still truncate a slot left in this state, because the destructive
+            # write lives in the save path. This only stops the FORK from causing
+            # it; the durable fix is for ``_disk_older_count`` to cover the rows a
+            # cap drops, which is out of scope for this handler.
+            logger.warning(
+                "chat_fork: slot=%s has %d frozen-prefix rows for a %d-message "
+                "window but disk holds more; skipping the durable save so it "
+                "cannot truncate the persisted history",
+                slot.key, slot._disk_older_count, len(slot.messages),
+            )
+        elif slot._dirty:
             # Persist with best_effort=False so a lock timeout / I/O failure
             # PROPAGATES instead of being swallowed. The fork treats disk as the
             # source of truth (it re-reads the full history above) and clears

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -4549,35 +4549,17 @@ def _resume_session_identity(state: DashboardState, history_key: str) -> str:
     return _history_key_for(history_key)
 
 
-async def api_chat_slot_resume(request: web.Request) -> web.Response:
-    """POST /api/chat/slots/{slot}/resume — load a history session into a slot."""
-    state: DashboardState = request.app["state"]
-    # Fold the requested name with the function that keys the slot table, so
-    # every spelling of one slot resolves to that slot: a caller may hold a
-    # filename stem, a session key (a notification deep link carries the
-    # conversation's own ``slack:<ts>``), or a display-style name. A partial
-    # fold leaves the lookup below missing an open tab and falls through to the
-    # create path, which re-reads the transcript into the slot it should have
-    # returned.
-    name = _normalize_slot_key(request.match_info["slot"])
-    if not state.conversation_log:
-        return web.json_response({"error": "no conversation log"}, status=400)
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
-    history_key = body.get("key", name)
+async def _live_slot_resume_response(
+    state, request: web.Request, history_key: str, name: str
+) -> web.Response | None:
+    """Answer a resume that a live slot already satisfies, else return None.
 
-    # If slot already exists (active session), just return it — no duplicate.
-    # Check both by slot name AND by canonical session key to prevent two
-    # slots sharing the same kiro-cli process.
-    #
-    # INVARIANT: both sides of this comparison derive identity through the same
-    # rule. A slot answers with ``effective_session_key``, which for a
-    # channel-born tab is the channel's own key — so the requested key resolves
-    # the same way, via the session map. Two rules in play and a channel
-    # transcript matches nothing here: it gets a second tab, so one conversation
-    # shows as two sidebar rows backed by two kiro-cli processes.
+    Returns 404 when the caller's app does not own the slot, otherwise the
+    dedup early-return. Called on BOTH sides of the threaded transcript read:
+    that await lets a concurrent resume publish the slot in between, and
+    ``get_or_create_slot`` would then hand it back having never applied this
+    ownership gate for the second caller's app.
+    """
     canonical = _resume_session_identity(state, history_key)
     existing = state._slots.get(name)
     if not existing:
@@ -4659,7 +4641,49 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
                 "surface": existing.mode,
             }
         )
+    return None
 
+
+async def api_chat_slot_resume(request: web.Request) -> web.Response:
+    """POST /api/chat/slots/{slot}/resume — load a history session into a slot."""
+    state: DashboardState = request.app["state"]
+    # Fold the requested name with the function that keys the slot table, so
+    # every spelling of one slot resolves to that slot: a caller may hold a
+    # filename stem, a session key (a notification deep link carries the
+    # conversation's own ``slack:<ts>``), or a display-style name. A partial
+    # fold leaves the lookup below missing an open tab and falls through to the
+    # create path, which re-reads the transcript into the slot it should have
+    # returned.
+    name = _normalize_slot_key(request.match_info["slot"])
+    if not state.conversation_log:
+        return web.json_response({"error": "no conversation log"}, status=400)
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    history_key = body.get("key", name)
+
+    # If slot already exists (active session), just return it — no duplicate.
+    # Check both by slot name AND by canonical session key to prevent two
+    # slots sharing the same kiro-cli process.
+    #
+    # INVARIANT: both sides of this comparison derive identity through the same
+    # rule. A slot answers with ``effective_session_key``, which for a
+    # channel-born tab is the channel's own key — so the requested key resolves
+    # the same way, via the session map. Two rules in play and a channel
+    # transcript matches nothing here: it gets a second tab, so one conversation
+    # shows as two sidebar rows backed by two kiro-cli processes.
+    resume_resp = await _live_slot_resume_response(state, request, history_key, name)
+    if resume_resp is not None:
+        return resume_resp
+
+    # Boundary for the compare-and-clear below, captured BEFORE the metadata read
+    # it is compared against. Everything from here to the ``clear_closed`` call is
+    # a window in which this session can be closed by somebody else -- including
+    # deleted, recreated and closed again -- and the clear must not erase a
+    # ``closed`` that landed inside it. Anchored to this read specifically, since
+    # ``meta["closed"]`` is the snapshot the clear acts on.
+    resume_started_at = time.time()
     # Read the history metadata BEFORE creating the slot: this endpoint RESUMES a
     # persisted conversation, so its origin is a property of that conversation,
     # not of whoever is resuming it. Deriving it from the request would label a
@@ -4669,6 +4693,159 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
     # app token, otherwise leaves it untagged, which is invisible to cross-slot
     # scopes) rather than claiming USER on a conversation we cannot attribute.
     meta = state.conversation_log.get_metadata(history_key)
+
+    # Read the transcript BEFORE publishing the slot: this await would otherwise
+    # expose an empty slot by name, and a concurrent append would land ahead of it.
+    all_messages = await asyncio.to_thread(
+        state.conversation_log.read_messages_chained, history_key
+    )
+
+    # Every remaining await in this handler runs BEFORE the slot is published: one
+    # after it would expose an empty slot, and a concurrent append there is ordered
+    # ahead of the history the hydrate loop restores further down. They are placed
+    # ahead of the re-check too, so nothing can suspend between it and the publish.
+    folder_unhidden = True
+    # Record WHICH folder that verdict is about. Hoisting this call above the
+    # publish is what keeps the window closed, but it also moved it onto the
+    # PRE-read ``meta``, while the hydrate below binds ``folder_id`` from the
+    # snapshot re-read after the last await. A channel reconciliation landing
+    # during the transcript read makes those two ids differ, and an existence
+    # verdict earned by the OLD folder says nothing about the NEW one.
+    folder_checked_id = ""
+    if meta.get("folder_id"):
+        folder_checked_id = meta["folder_id"]
+        folder_unhidden = await _unhide_folder(state, folder_checked_id)
+    if meta.get("closed"):
+        # Clear the closed flag so the session restores on the next gateway restart.
+        # Offloaded because clear_closed takes the per-session cross-process lock,
+        # which fails fast on the loop under contention. Best-effort: resume anyway.
+        #
+        # COMPARE-AND-CLEAR, not an unconditional clear. We are acting on the
+        # ``meta`` snapshot above, and by the time this call takes the lock the
+        # session may have been closed again by someone else -- or deleted,
+        # recreated and closed, in which case the flag we would drop belongs to a
+        # DIFFERENT conversation that the identity re-check below is about to
+        # refuse with a 409. Clearing it anyway reopens a replacement the user
+        # closed. ``only_if_closed_before`` moves the comparison inside the store's
+        # own lock, so there is no window between the check and the write; a close
+        # instant at or after our boundary leaves the flag standing.
+        try:
+            await asyncio.to_thread(
+                state.conversation_log.clear_closed,
+                history_key,
+                only_if_closed_before=resume_started_at,
+            )
+        except Exception:
+            logger.warning("Failed to clear closed flag for %s", history_key, exc_info=True)
+
+    # Re-check after the await: a concurrent resume can publish the slot while we
+    # are suspended, and the publish below would skip the ownership gate above.
+    resume_resp = await _live_slot_resume_response(state, request, history_key, name)
+    if resume_resp is not None:
+        return resume_resp
+
+    # Re-check DELETION in the same window and for the same reason. The transcript
+    # loaded above can be permanently deleted while we are suspended, and
+    # ``delete_session`` leaves NO tombstone -- its own docstring notes that once
+    # the delete releases the lock "a concurrent writer can recreate the session".
+    # So publishing a slot from content we already hold rewrites, on its next
+    # flush, a file the user permanently deleted.
+    #
+    # ``get_metadata_status``, never ``get_metadata``: the latter returns ``{}`` for
+    # BOTH "deleted" and "unreadable", and reading an unreadable metadata line as a
+    # deletion would discard a LIVE session -- its docstring says to prefer this
+    # wherever an empty result triggers something destructive.
+    #
+    # Synchronous, like the ``get_metadata`` above it, so this adds no suspension
+    # point between the re-checks and the publish -- the property the comment on
+    # the awaits above depends on.
+    post_read_meta, meta_readable = state.conversation_log.get_metadata_status(history_key)
+    # Did this session exist when we looked? Both re-checks below need that, and
+    # ``all_messages`` alone is the wrong witness: a METADATA-ONLY session -- a
+    # metadata line with no messages, which ``update_metadata`` creates on upsert --
+    # has an empty transcript, so gating on it silently disabled both guards for
+    # exactly the sessions least able to survive it. The pre-read ``meta`` is the
+    # right witness, and it costs nothing: it is already read synchronously above,
+    # so consulting it adds no suspension point.
+    #
+    # A UNION rather than a swap, so the witness is never narrower than it was: a
+    # transcript we managed to read is also evidence of prior existence, even where
+    # the metadata line was unreadable at pre-read time and ``meta`` came back empty.
+    #
+    # This is ONE term used by BOTH arms deliberately. They previously carried the
+    # same predicate separately, which is how the empty-transcript hole reached two
+    # sites at once; a single binding means a future change cannot fix one and leave
+    # the other behind.
+    session_existed = bool(meta or all_messages)
+    # Resuming a session that never existed stays untouched: no metadata and no
+    # transcript leaves this false, so an absent key is treated as a new
+    # conversation rather than a deletion. A legitimately empty session that is
+    # still PRESENT is protected by the other terms instead -- ``post_read_meta``
+    # is non-empty below, and the identity arm needs two DIFFERING stamps.
+    if meta_readable and not post_read_meta and session_existed:
+        logger.info(
+            "chat resume: session %s was deleted during the transcript read; "
+            "refusing to publish a slot that would resurrect it",
+            history_key,
+        )
+        return web.json_response(
+            {
+                "error": "the session was deleted while it was being resumed",
+                "code": "resume_session_deleted",
+            },
+            status=409,
+        )
+    # IDENTITY, not merely existence. The arm above fires on metadata being
+    # ABSENT, which the delete-then-RECREATE interleaving does not produce: the
+    # delete leaves no tombstone, so a writer that recreates the session inside
+    # this same window leaves ``post_read_meta`` a NON-EMPTY dict belonging to the
+    # NEW conversation. Existence reads that as "still here" and publishes a slot
+    # holding the OLD transcript, whose next flush overwrites a session the user
+    # is actively using -- the opposite error to the one above, and worse, because
+    # the data destroyed is live rather than already-deleted.
+    #
+    # ``created_at`` is the discriminator because every path that MINTS a metadata
+    # line stamps it (``append`` when the file does not exist,
+    # ``_update_metadata_locked`` when the line is missing) while
+    # ``_rewrite_session_locked`` carries it through verbatim. So a rewrite,
+    # compaction or rename does NOT move it and is not refused here; a differing
+    # value means this is a different file than the one we read.
+    #
+    # ABSENT on either side means we cannot compare, and we FALL THROUGH rather
+    # than refuse. Refusing would reject legitimate resumes of any transcript
+    # whose metadata predates the field -- a visible break for real users -- to
+    # close a narrow race. It also neuters the one false positive available here:
+    # ``_rewrite_session_locked`` mints a fresh ``created_at`` only when the
+    # original lacked one, which is exactly the case this skips. The residual is
+    # that a recreate of such a transcript stays undetected; the durable fix for
+    # that is a tombstone in ``history.delete_session``, which is out of scope.
+    pre_identity = meta.get("created_at")
+    post_identity = post_read_meta.get("created_at")
+    if (
+        meta_readable
+        and post_read_meta
+        and session_existed
+        and pre_identity
+        and post_identity
+        and pre_identity != post_identity
+    ):
+        logger.info(
+            "chat resume: session %s was deleted and recreated during the "
+            "transcript read; refusing to publish a slot whose flush would "
+            "overwrite the replacement",
+            history_key,
+        )
+        # Same code as the plain-delete arm: from the resumer's point of view the
+        # session it asked for was deleted. That it was then recreated does not
+        # change what happened to the conversation being resumed, and one code
+        # keeps the client contract single-valued.
+        return web.json_response(
+            {
+                "error": "the session was deleted while it was being resumed",
+                "code": "resume_session_deleted",
+            },
+            status=409,
+        )
 
     slot = state.get_or_create_slot(
         name,
@@ -4735,7 +4912,18 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
         # visible until the user hides it again. A folder deleted since this
         # session was last saved leaves the stored id dangling; drop it so the
         # resumed session is plainly unfiled instead of pointing at nothing.
-        if not await _unhide_folder(state, meta["folder_id"]):
+        #
+        # Only when the verdict is ABOUT this folder. ``_unhide_folder`` reports
+        # existence from inside the folder-store lock precisely because a check
+        # made outside it can go stale, so re-deriving one here against
+        # ``state._folders`` is the race its own docstring warns about; and it
+        # cannot simply be re-run, because a second await here would reopen the
+        # publish-to-hydrate window this ordering exists to close. Holding no
+        # verdict for a newly filed id, we KEEP it: a dangling id is visible and
+        # self-corrects on the next folder operation, whereas erasing a live
+        # filing is silent and indistinguishable from the user unfiling the
+        # session -- and the dirty-slot flush would then persist that erasure.
+        if not folder_unhidden and meta["folder_id"] == folder_checked_id:
             slot.folder_id = ""
     if meta.get("pinned"):
         slot.pinned = True
@@ -4775,18 +4963,6 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
         state._restricted_keys.discard(f"dashboard:{name}")
     if meta.get("forked_from") is not None:
         slot.forked_from = meta["forked_from"]
-    # Clear closed flag so session restores on next gateway restart
-    if meta.get("closed"):
-        # Offload to a worker thread: clear_closed takes the per-session
-        # cross-process lock (so it can't race an append / rewrite and lose
-        # data), and on the event loop that lock fails fast under contention —
-        # the patient off-loop acquire path avoids both a loop-blocking disk
-        # write and a dropped edit. Best-effort: resume proceeds regardless.
-        try:
-            await asyncio.to_thread(state.conversation_log.clear_closed, history_key)
-        except Exception:
-            logger.warning("Failed to clear closed flag for %s", history_key, exc_info=True)
-    all_messages = state.conversation_log.read_messages_chained(history_key)
     disk_total = len(all_messages)
     max_resume = 500
     messages = all_messages[-max_resume:] if disk_total > max_resume else all_messages

--- a/src/kiro_crew/dashboard/chat_rewind.py
+++ b/src/kiro_crew/dashboard/chat_rewind.py
@@ -145,8 +145,9 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                 # found for ts" — the message exists but is out of reach.
                 if disk_older > 0 and state.conversation_log is not None:
                     try:
-                        chained = state.conversation_log.read_messages_chained(
-                            slot_history_key(slot)
+                        chained = await asyncio.to_thread(
+                            state.conversation_log.read_messages_chained,
+                            slot_history_key(slot),
                         )
                     except Exception:
                         logger.debug("rewind: chained scan for ts failed", exc_info=True)

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -2228,6 +2228,32 @@ class ConversationLog:
         #: event loop may mark it stale — an unsynchronized rebuild/read/clear
         #: produced a transient empty index or ``AttributeError``.
         self._tab_id_index: dict[str, list[str]] | None = None
+        #: session key → (mtime, tab_id) memo feeding the rebuild above.
+        #: Deliberately an unbounded plain dict, NOT an _LRUCache: the rebuild is
+        #: a cyclic scan over every dashboard file, and a bounded cache under a
+        #: cyclic scan larger than the bound has a 0% hit rate (see
+        #: _SearchTextCache's docstring). Values are 12-char ids, so 1k sessions
+        #: is tens of KB.
+        #:
+        #: TWO guards, and neither is sufficient alone. The explicit pop in
+        #: _invalidate_cache covers writes THROUGH this class from THIS instance:
+        #: those restore the pre-write mtime (_restore_mtime), so a stamp alone
+        #: would not see them. The stamp covers rewrites that never reach that
+        #: pop -- a hand-edited tab_id, or a write through ANOTHER instance,
+        #: whose pop lands on its own memo and leaves ours intact.
+        #:
+        #: The stamp is (st_mtime_ns, st_size, st_ino), all from one stat. Size
+        #: rides along because timestamp granularity is coarse (worse on
+        #: Windows). ns rather than float seconds, and st_ino as well, because
+        #: another instance's equal-length tab_id rewrite preserves mtime and
+        #: size both -- see the cross-instance test.
+        self._tab_id_by_key: dict[str, tuple[tuple[int, int, int], str]] = {}
+        #: Bumped by _invalidate_cache. The rebuild samples it before reading a
+        #: file's metadata and declines to memoize if it moved, so a store cannot
+        #: land after a concurrent writer's pop and resurrect a stale id.
+        #: _invalidate_cache deliberately does not take self._lock, so the
+        #: rebuild cannot exclude it.
+        self._tab_id_generation = 0
         #: Coarse instance lock protecting the lazily-built ``_tab_id_index``
         #: rebuild/read/clear. The message/metadata/recent LRUs are each
         #: internally locked; this guards the shared mutable state that lives
@@ -4132,18 +4158,102 @@ class ConversationLog:
 
         Caller MUST hold ``self._lock`` — this replaces the shared
         ``_tab_id_index`` mapping.
+
+        Each file's tab_id is memoized in ``_tab_id_by_key`` under a
+        ``(st_mtime_ns, st_size, st_ino)`` stamp, so a file unchanged since the last rebuild
+        costs a ``stat`` instead of an ``open`` + ``readline`` + ``json.loads``.
+        A rebuild still runs on the first chained read, and whenever
+        ``note_tab_id`` falls back to invalidating instead of updating one entry
+        in place (no tab_id, an already-stale index, or a tab_id whose first
+        file this save just created), so the memo pays for itself on those.
+        Before that in-place update landed, ``append`` invalidated the index
+        unconditionally and one sent message re-read every session file on the
+        event loop.
+
+        TWO guards, because neither is sufficient alone. A write THROUGH this
+        class from THIS instance restores the pre-write mtime (see
+        :func:`_restore_mtime`, which exists so housekeeping does not reorder
+        ``list_sessions``), so the stamp cannot see it — ``_invalidate_cache``
+        pops the memo instead, on the line after the restore. Anything that
+        never reaches that pop is the stamp's job: a write AROUND the class, and
+        a write through ANOTHER instance of this class, whose pop lands on its
+        own memo and leaves ours untouched. That last case is why the stamp
+        carries ``st_mtime_ns`` and ``st_ino`` and not just ``(mtime, size)`` —
+        an equal-length ``tab_id`` rewrite preserves both mtime and size. Either
+        guard alone would keep serving a stale tab_id and silently drop that
+        session from its chain — the same vanished-history failure the removed
+        ``[]`` sentinel used to cause.
         """
         index: dict[str, list[str]] = {}
         for path in sorted(self._dir.glob(_TAB_ID_INDEX_GLOB)):
+            # Both derivations come from main's shared helpers rather than being
+            # respelled here: ``key`` feeds the memo AND the index append below,
+            # and ``note_tab_id`` looks entries up through the same helper, so a
+            # second copy would drift and its lookup would silently miss an
+            # entry that is really present.
+            key = _index_key_for_stem(path.stem)
             try:
-                with path.open(encoding="utf-8") as f:
-                    first_line = f.readline()
-                m = json.loads(first_line)
-                tid = m.get("tab_id")
-                if tid:
-                    index.setdefault(tid, []).append(_index_key_for_stem(path.stem))
-            except Exception:
+                st = path.stat()
+            except OSError:
                 continue
+            # Three terms, all off the one stat above, because the pop below
+            # only ever reaches the memo of the instance that did the writing:
+            # another instance's write restores the mtime AND leaves the size
+            # identical (a tab_id is fixed-length), so mtime+size alone serve a
+            # stale id. mtime_ns rather than mtime because _restore_mtime puts
+            # the time back through a float, which cannot carry ns; st_ino moves
+            # too, since a metadata rewrite is atomic_write (temp + os.replace),
+            # and it holds even if _restore_mtime later becomes ns-exact.
+            stamp = (st.st_mtime_ns, st.st_size, st.st_ino)
+            cached = self._tab_id_by_key.get(key)
+            if cached is not None and cached[0] == stamp:
+                tid = cached[1]
+            else:
+                # Sample the generation BEFORE the read: if a writer pops this key
+                # while we are reading, the value we got is already stale and must
+                # not be memoized. stamp is also the pre-read one, so a write that
+                # lands mid-read leaves a value that fails the guard next time.
+                generation = self._tab_id_generation
+                # We are on the MISS path, so this file changed since we
+                # memoized it -- or we never memoized it at all. _meta_cache is
+                # keyed on float mtime ALONE, which is strictly weaker than our
+                # stamp: a rewrite that restores the mtime and keeps the size
+                # compares EQUAL there and hands back the pre-write line, so
+                # widening the stamp alone would still serve a stale tab_id from
+                # this second layer. Pop UNCONDITIONALLY, because the cold-memo
+                # case is the dangerous one: get_metadata and the consolidation
+                # counters warm _meta_cache without ever touching this memo, and
+                # a stale line served there gets memoized below under the NEW,
+                # correct-looking stamp -- after which the warm path never
+                # re-reads it and the session stays off its chain for good.
+                # Costs one reread for a file warm here but cold in the memo; the
+                # warm path (stamp hit) returns above, so the win is unaffected.
+                self._meta_cache.pop(key, None)
+                try:
+                    meta, readable = self._read_metadata_status(key)
+                except Exception:
+                    continue
+                # _read_metadata_status, NOT _read_metadata: the latter drops the
+                # readability flag, so a transient failure (an AV scanner holding
+                # a freshly appended file, where stat succeeds but open does not)
+                # arrives as {} and would be memoized below as a definitive "no
+                # tab_id" against an unchanged stamp -- dropping the session from
+                # its chain until its next write. Retry on the next rebuild.
+                if not readable:
+                    continue
+                raw = meta.get("tab_id")
+                # "" memoizes "no tab_id at this stamp". Without it a session
+                # lacking one is re-read every rebuild and re-enters _meta_cache,
+                # evicting what other code paths in this process warmed (it is
+                # per-instance, not process-shared). A non-str tab_id reaches
+                # here only from corrupt metadata (and unhashable would abort the
+                # rebuild), so it folds into the same sentinel.
+                tid = raw if isinstance(raw, str) else ""
+                if self._tab_id_generation == generation:
+                    self._tab_id_by_key[key] = (stamp, tid)
+            if not tid:
+                continue
+            index.setdefault(tid, []).append(key)
         self._tab_id_index = index
 
     def invalidate_tab_id_cache(self) -> None:
@@ -5051,6 +5161,13 @@ class ConversationLog:
         for ident in idents:
             self._msg_cache.pop(ident, None)
             self._meta_cache.pop(ident, None)
+            # The tab_id memo's mtime guard cannot see a write that goes through
+            # this class, because those restore the pre-write mtime. This pop is
+            # what does -- under every spelling, for the same reason as the rest:
+            # the rebuild keys its memo off the sanitized filename stem, so a
+            # single-spelling pop would leave an alias-keyed memo serving a stale
+            # tab_id under the restored mtime.
+            self._tab_id_by_key.pop(ident, None)
             # The folded search blob is derived from the messages, so it goes
             # stale exactly when they do. Its own mtime guard is not enough
             # here: the housekeeping rewrites below restore the pre-write
@@ -5068,6 +5185,10 @@ class ConversationLog:
             # _restore_mtime, so the recent cache's mtime guard alone would let
             # a stale window survive a content change.
             self._recent_cache.pop_prefix(f"{ident}\x00")
+        # Sampled by the rebuild before it reads a file's metadata, so a store
+        # cannot land after the pops above and resurrect a stale id. Bumped once
+        # per invalidation: it is a single counter, not per-identity.
+        self._tab_id_generation += 1
 
     #: Bytes read from the end of a session file for the last-message preview.
     #: One tail block comfortably covers several trailing JSONL lines without

--- a/test/test_fork_reconciles_after_flush.py
+++ b/test/test_fork_reconciles_after_flush.py
@@ -1,0 +1,1228 @@
+"""A flush landing during the fork's threaded read must not drop the tail.
+
+``api_chat_slot_fork`` reads the transcript off the event loop, then gates both
+its in-memory reconciliation and its durable save on ``slot._dirty``. The periodic
+flush executor does not take ``slot._fork_lock``, so it can complete and clear
+``_dirty`` while the fork is suspended in that read -- after which both gates read
+False and the messages the read missed are in neither source.
+"""
+
+import asyncio
+import re
+import threading
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+
+@pytest.mark.asyncio
+async def test_fork_sees_the_tail_when_a_flush_clears_dirty_mid_read(tmp_path, monkeypatch):
+    """Forking at the tail's index must succeed after a mid-read flush.
+
+    The read is served a pre-flush snapshot, then the racer does what the flush
+    does: writes the tail to disk and clears ``_dirty``. If the fork keeps that
+    stale snapshot, the tail is absent from its index space and forking at the
+    tail's index fails as out of range.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:forkrace"
+    log.append(key, "user", "history-1")
+    log.append(key, "assistant", "history-2")
+
+    slot = state.get_or_create_slot("forkrace")
+    slot.append("user", "history-1", "msg msg-u")
+    slot.append("assistant", "history-2", "msg msg-a")
+    slot._resumed_count = len(slot.messages)
+    slot._disk_window_len = len(slot.messages)
+    # The unpersisted tail: in memory, not yet on disk.
+    slot.append("user", "tail-prompt", "msg msg-u")
+    slot._dirty = True
+
+    pre_flush = list(log.read_messages_chained(key))
+    assert len(pre_flush) == 2, f"fixture expected 2 on-disk messages, got {len(pre_flush)}"
+
+    read_entered = threading.Event()
+    may_finish = threading.Event()
+    calls = {"n": 0}
+    original = log.read_messages_chained
+
+    def racing_read(k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # First read lands BEFORE the flush: serve the pre-flush snapshot.
+            read_entered.set()
+            may_finish.wait(timeout=10)
+            return list(pre_flush)
+        return original(k)
+
+    monkeypatch.setattr(log, "racing_read_marker", True, raising=False)
+    monkeypatch.setattr(log, "read_messages_chained", racing_read)
+
+    async def racer():
+        for _ in range(200):
+            if read_entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        # Exactly what the flush executor does: persist the tail, then clear _dirty.
+        original(key)  # touch, mirroring the flush's own read path
+        log.append(key, "user", "tail-prompt")
+        slot._disk_window_len = len(slot.messages)
+        slot._dirty = False
+        may_finish.set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(
+            client.post(
+                "/api/chat/slots/forkrace/fork",
+                json={"at_message_index": 2, "prompt": "forked"},
+            )
+        )
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        resp = await post
+        payload = await resp.json()
+
+    assert resp.status != 400 or "out of range" not in str(payload), (
+        "the fork kept its pre-flush snapshot, so the tail the flush persisted is "
+        f"missing from its index space: {payload}"
+    )
+    assert resp.status == 200, f"fork failed for another reason: {resp.status} {payload}"
+
+
+@pytest.mark.asyncio
+async def test_a_reread_does_not_duplicate_a_tail_the_flush_already_persisted(
+    tmp_path, monkeypatch
+):
+    """An append arriving during the re-read must not duplicate the flushed tail.
+
+    The re-read picks the flushed tail up off disk. If an append lands while it is
+    in flight, ``_dirty`` goes back to True and the reconciliation below slices the
+    in-memory tail from ``_resumed_count`` -- an offset the flush never advances --
+    so the tail the re-read already holds would be appended a second time.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:dupe"
+    log.append(key, "user", "history-1")
+    log.append(key, "assistant", "history-2")
+
+    slot = state.get_or_create_slot("dupe")
+    slot.append("user", "history-1", "msg msg-u")
+    slot.append("assistant", "history-2", "msg msg-a")
+    slot._resumed_count = len(slot.messages)
+    slot._disk_window_len = len(slot.messages)
+    slot.append("user", "tail-prompt", "msg msg-u")
+    slot._dirty = True
+
+    pre_flush = list(log.read_messages_chained(key))
+    original = log.read_messages_chained
+    calls = {"n": 0}
+    gates = {n: (threading.Event(), threading.Event()) for n in (1, 2)}
+
+    def racing_read(k):
+        calls["n"] += 1
+        n = calls["n"]
+        if n in gates:
+            entered, release = gates[n]
+            entered.set()
+            release.wait(timeout=10)
+        # Read 1 landed before the flush, so it cannot see the tail.
+        return list(pre_flush) if n == 1 else original(k)
+
+    monkeypatch.setattr(log, "read_messages_chained", racing_read)
+
+    async def _await_gate(ev):
+        for _ in range(300):
+            if ev.is_set():
+                return True
+            await asyncio.sleep(0.01)
+        return False
+
+    async def racer():
+        # While read 1 is parked: the flush persists the tail and clears _dirty,
+        # which is what makes the re-read fire.
+        assert await _await_gate(gates[1][0]), "read 1 never entered"
+        log.append(key, "user", "tail-prompt")
+        slot._disk_window_len = len(slot.messages)
+        slot._dirty = False
+        gates[1][1].set()
+        # While the re-read is parked: an append arrives, marking the slot dirty
+        # again, which re-arms the reconciliation below.
+        assert await _await_gate(gates[2][0]), "the re-read never fired"
+        slot.append("user", "arrived-late", "msg msg-u")
+        slot._dirty = True
+        gates[2][1].set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(
+            client.post(
+                "/api/chat/slots/dupe/fork",
+                json={"at_message_index": 99, "prompt": "forked"},
+            )
+        )
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        payload = await (await post).json()
+
+    # The out-of-range error reports the visible count: the duplication probe.
+    m = re.search(r"have (\d+) visible messages", str(payload.get("error", "")))
+    assert m, f"expected the out-of-range error to report a count: {payload}"
+    visible = int(m.group(1))
+    assert visible == 4, (
+        "expected 4 visible messages (2 history + tail-prompt + arrived-late), got "
+        f"{visible}: the tail the re-read already held was reconciled in a second time"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fork_does_not_duplicate_when_an_append_re_dirties_during_the_read(
+    tmp_path, monkeypatch
+):
+    """A flush then an append, both during the FIRST read, must not duplicate.
+
+    This is the interleaving a boolean ``_dirty`` cannot see. The flush persists
+    the tail and clears ``_dirty``; an append then re-marks the slot dirty before
+    the read returns. A ``was_dirty and not slot._dirty`` transition test reads
+    that as "never flushed", so no correction fires and the tail the read already
+    picked up off disk is reconciled in a second time.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:redirty"
+    log.append(key, "user", "history-1")
+    log.append(key, "assistant", "history-2")
+
+    slot = state.get_or_create_slot("redirty")
+    slot.append("user", "history-1", "msg msg-u")
+    slot.append("assistant", "history-2", "msg msg-a")
+    # Both counters as a completed save leaves them: two window messages on disk.
+    slot._resumed_count = len(slot.messages)
+    slot._disk_window_len = len(slot.messages)
+    # The unpersisted tail: in memory, not yet on disk.
+    slot.append("user", "tail-prompt", "msg msg-u")
+    slot._dirty = True
+
+    original = log.read_messages_chained
+    calls = {"n": 0}
+    entered = threading.Event()
+    release = threading.Event()
+
+    def racing_read(k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            entered.set()
+            release.wait(timeout=10)
+        # Read 1 resumes AFTER the racer's flush, so it returns the persisted
+        # tail -- which is what makes the slice below double-count it.
+        return original(k)
+
+    monkeypatch.setattr(log, "read_messages_chained", racing_read)
+
+    async def _await_gate(ev):
+        for _ in range(300):
+            if ev.is_set():
+                return True
+            await asyncio.sleep(0.01)
+        return False
+
+    async def racer():
+        assert await _await_gate(entered), "read 1 never entered"
+        # Exactly what the flush executor does: persist the window tail, advance
+        # the persisted boundary, then clear _dirty.
+        log.append(key, "user", "tail-prompt")
+        slot._disk_window_len = len(slot.messages)
+        slot._dirty = False
+        # ...and then an append lands, re-marking the slot dirty. From here a
+        # boolean-transition test cannot tell a flush happened at all.
+        slot.append("user", "arrived-late", "msg msg-u")
+        slot._dirty = True
+        release.set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(
+            client.post(
+                "/api/chat/slots/redirty/fork",
+                json={"at_message_index": 99, "prompt": "forked"},
+            )
+        )
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        payload = await (await post).json()
+
+    assert calls["n"] >= 1, "the fork never read the transcript"
+    # The out-of-range error reports the visible count: the duplication probe.
+    m = re.search(r"have (\d+) visible messages", str(payload.get("error", "")))
+    assert m, f"expected the out-of-range error to report a count: {payload}"
+    visible = int(m.group(1))
+    assert visible == 4, (
+        "expected 4 visible messages (2 history + tail-prompt + arrived-late), got "
+        f"{visible}: the flush persisted tail-prompt and the append re-dirtied the "
+        "slot, so the boolean transition never fired and the persisted tail was "
+        "reconciled in on top of the disk read"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_boundary_ahead_of_the_window_does_not_duplicate_persisted_turns(
+    tmp_path, monkeypatch
+):
+    """A boundary ahead of the resident window must not slice from ``_resumed_count``.
+
+    ``_flush_segment`` reassigns ``slot.messages`` to drop a trailing chunk run
+    without adjusting ``_disk_window_len``, so the boundary can exceed the window
+    and is then unusable as an index. ``_resumed_count`` is not a substitute: the
+    save never advances it -- ``_save_slot_to_history`` only ever READS it, in its
+    no-op skip -- and for a slot created in this gateway run it stays 0. Slicing
+    from it therefore appends the ENTIRE resident window onto the disk read and
+    duplicates every persisted turn. ``session_transfer`` records this exact
+    defect at its own merge offset, having shipped it once already.
+
+    The three tests above all set the boundary EQUAL to the window and give
+    ``_resumed_count`` a momentarily-correct nonzero value -- the one arrangement
+    in which the fallback looks benign. This covers the other side.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:ahead"
+    log.append(key, "user", "history-1")
+    log.append(key, "assistant", "history-2")
+
+    slot = state.get_or_create_slot("ahead")
+    slot.append("user", "history-1", "msg msg-u")
+    slot.append("assistant", "history-2", "msg msg-a")
+    # A slot created in THIS gateway run never has _resumed_count advanced, so it
+    # stays 0 however often the slot flushes. Asserted rather than assigned: the
+    # fixture's whole point is the value the save leaves alone.
+    assert (
+        slot._resumed_count == 0
+    ), f"fixture expects a fresh slot with _resumed_count == 0, got {slot._resumed_count}"
+    # The boundary runs AHEAD of the resident window, as a mid-stream
+    # _flush_segment leaves it: recorded over a RAW window that included a
+    # streaming chunk row which was then dropped from slot.messages.
+    slot._disk_window_len = len(slot.messages) + 1
+    slot._dirty = True
+
+    on_disk = list(log.read_messages_chained(key))
+    assert len(on_disk) == 2, f"fixture expected 2 on-disk messages, got {len(on_disk)}"
+
+    flushes = {"n": 0}
+
+    async def fake_flush(_state, s, best_effort=True):
+        # Exactly what a completed save does to these two counters:
+        # chat_persistence sets ``_disk_window_len = len(window)`` and clears
+        # ``_dirty``. Stubbed rather than run for real so this test measures the
+        # boundary logic and not the save's own disk behaviour -- the same
+        # technique the three tests above use for the flush executor.
+        flushes["n"] += 1
+        s._disk_window_len = len(s.messages)
+        s._dirty = False
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_fork.save_slot_off_loop", fake_flush)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post(
+            "/api/chat/slots/ahead/fork",
+            json={"at_message_index": 99, "prompt": "forked"},
+        )
+        payload = await resp.json()
+
+    # The out-of-range error reports the visible count: the duplication probe.
+    m = re.search(r"have (\d+) visible messages", str(payload.get("error", "")))
+    assert m, f"expected the out-of-range error to report a count: {payload}"
+    visible = int(m.group(1))
+    assert visible == 2, (
+        f"expected 2 visible messages (the disk history, once), got {visible}: the "
+        "boundary-ahead branch sliced the resident window from _resumed_count -- 0 "
+        "for a slot created in this gateway run -- and appended every persisted "
+        "turn onto the disk read a second time"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_capped_restore_boundary_is_merged_not_flushed(tmp_path, monkeypatch):
+    """A boundary ahead because of a capped restore must NOT trigger a flush.
+
+    The boundary-ahead condition has two causes needing opposite remedies. Here
+    disk legitimately holds MORE than memory: a capped restore dropped leading
+    messages from the window without bumping ``_disk_older_count``. Flushing is
+    destructive in that state -- the frozen prefix is keyed on
+    ``_disk_older_count`` (``chat_persistence`` builds it as
+    ``body[:disk_older]``), which the cap never moved, so the prefix is empty and
+    the save writes ``meta + window`` over the whole file, truncating disk from
+    250 rows to 52 and destroying 198 persisted messages.
+
+    The discriminator is the invariant ``channel_slots`` states for these
+    counters -- disk holds ``_disk_older_count`` frozen rows then the window -- so
+    disk holding more than ``older + window`` means rows exist that the counters
+    do not represent. This asserts the resulting transcript AND that disk is
+    still intact, because a count alone would not catch the truncation.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    key = "dashboard:capped"
+
+    slot = state.get_or_create_slot("capped")
+    for i in range(250):
+        slot.append("user" if i % 2 == 0 else "assistant", f"m{i}", "msg")
+    slot.drain()
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    _save_slot_to_history(state, slot)
+    on_disk_before = len(state.conversation_log.read_messages_chained(key))
+    assert on_disk_before == 250, f"fixture expected 250 on disk, got {on_disk_before}"
+
+    # The capped restore: the real path caps the window and sets _resumed_count to
+    # the capped length. It does NOT bump _disk_older_count, which is exactly why
+    # the boundary ends up ahead of the window.
+    slot.messages = slot.messages[-50:]
+    slot._resumed_count = len(slot.messages)
+    slot.append("user", "new1", "msg")
+    slot.append("assistant", "new2", "msg")
+    slot.drain()
+    assert slot._dirty is True, "fixture expects a dirty slot"
+    assert slot._disk_window_len > len(slot.messages), (
+        "fixture expects the boundary AHEAD of the resident window, got "
+        f"{slot._disk_window_len} vs {len(slot.messages)}"
+    )
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/capped/fork", json={})
+        assert resp.status == 200, f"fork failed: {await resp.text()}"
+        data = await resp.json()
+
+    assert data["messages"] == 252, (
+        f"expected 252 (250 persisted + the 2 unpersisted appends), got {data['messages']}: "
+        "the boundary-ahead branch flushed the smaller resident window over a longer "
+        "disk history instead of merging"
+    )
+    # The data-loss probe: a count of the RESPONSE alone cannot see this, because
+    # the response is assembled in memory while the damage happens on disk.
+    # Asserted as ">= the original 250, oldest turn intact" rather than "== 250":
+    # the property under test is that nothing persisted is DESTROYED, not that the
+    # dirty tail stays unwritten. Observed here is 252 -- the tail also reached
+    # disk, non-destructively, which is fine. Before the fix this read 52.
+    on_disk_after = state.conversation_log.read_messages_chained(key)
+    assert len(on_disk_after) >= on_disk_before, (
+        f"disk held {on_disk_before} messages before the fork and {len(on_disk_after)} "
+        "after: the flush wrote the capped window over the persisted history, and the "
+        "frozen prefix was empty because the cap never bumped _disk_older_count"
+    )
+    disk_visible = [m for m in on_disk_after if m.get("role") in ("user", "assistant")]
+    assert disk_visible[0].get("content") == "m0", (
+        "the oldest persisted turn is gone from disk: the capped window was written "
+        f"over the history, leaving {len(on_disk_after)} rows starting at "
+        f"{disk_visible[0].get('content')!r}"
+    )
+    new_slot = state._slots.get(data["key"])
+    visible = [m for m in new_slot.messages if m["role"] in ("user", "assistant")]
+    assert visible[0]["content"] == "m0", "the forked transcript lost its oldest turn"
+    assert visible[-1]["content"] == "new2", "the forked transcript lost the dirty tail"
+
+
+@pytest.mark.asyncio
+async def test_a_pending_rewrite_does_not_fork_discarded_turns(tmp_path, monkeypatch):
+    """A slot mid-rewind must not fork the turns the user discarded.
+
+    ``_pending_rewrite`` means "disk is known stale and still holds the PRE-EDIT
+    transcript, because the truncating rewrite has not been written yet". None of
+    the four counters this loop captures carries that state: ``chat_rewind`` sets
+    ``_dirty``, zeroes ``_resumed_count`` and sets ``_pending_rewrite``, but never
+    touches ``_disk_window_len`` -- so the boundary keeps its pre-rewind value and
+    can still satisfy ``disk_len_before <= count_before``. The authoritative branch
+    is then taken, the disk read returns the pre-rewind transcript, and the
+    post-await re-check PASSES because nothing moved during the read: it measures
+    stability, not correctness.
+
+    ``session_transfer._guard_snapshot`` refuses on exactly this flag for exactly
+    this reason; ``chat_fork`` had no equivalent. The fork lock does not help --
+    ``chat_fork.py:147`` is its only acquirer, so no rewind path takes it.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:rewindfork"
+
+    # Disk holds the full PRE-REWIND transcript.
+    for i in range(50):
+        log.append(key, "user" if i % 2 == 0 else "assistant", f"m{i}")
+    assert len(log.read_messages_chained(key)) == 50, "fixture expected 50 on disk"
+
+    slot = state.get_or_create_slot("rewindfork")
+    for i in range(50):
+        slot.append("user" if i % 2 == 0 else "assistant", f"m{i}", "msg")
+    slot.drain()
+    # The boundary sits BELOW the resident window, which is what routes this into
+    # the authoritative branch rather than the capped-restore branch.
+    slot._disk_window_len = 10
+    slot._disk_older_count = 0
+
+    # Exactly what chat_rewind does (chat_rewind.py:205-212): truncate the window,
+    # mark dirty, zero _resumed_count, set _pending_rewrite -- and leave
+    # _disk_window_len alone.
+    del slot.messages[20:]
+    slot._dirty = True
+    slot._resumed_count = 0
+    slot._pending_rewrite = True
+
+    assert slot._disk_window_len <= len(slot.messages), (
+        "fixture must land on the AUTHORITATIVE branch: boundary "
+        f"{slot._disk_window_len} must be <= window {len(slot.messages)}"
+    )
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/rewindfork/fork", json={})
+        body = await resp.json()
+
+    # The shipped remedy is save-and-retry, not refusal: a rewrite save clears the
+    # flag, so the fork is required to SUCCEED here. Asserting 200 (rather than
+    # accepting a 503 as an alternative disposition) is what makes the pre-read
+    # guard load-bearing -- with only the post-await check the loop spends all four
+    # attempts and falls through to the retryable 503, which would satisfy a
+    # weaker assertion and leave that half of the fix unmeasured.
+    assert resp.status == 200, (
+        f"fork returned {resp.status} instead of succeeding: {body}. The pending "
+        "rewrite is recoverable -- a rewrite save clears the flag -- so a refusal "
+        "here abandons the fork-must-succeed property this handler documents"
+    )
+    new_slot = state._slots.get(body["key"])
+    assert new_slot is not None, f"no forked slot for {body.get('key')!r}"
+    contents = [m.get("content") for m in new_slot.messages]
+    discarded = [c for c in contents if c in {f"m{i}" for i in range(20, 50)}]
+    assert not discarded, (
+        f"the fork carried {len(discarded)} turn(s) the user rewound away "
+        f"(e.g. {discarded[:3]}): the authoritative branch trusted a boundary that "
+        "the rewind never moved, and the disk read returned the pre-edit transcript"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_pending_rewrite_arriving_during_the_read_forces_a_retry(tmp_path, monkeypatch):
+    """The flag must be re-checked AFTER the await, not only before it.
+
+    This is the interleaving the four counters cannot see, and the one the finding
+    calls worse because no equality test catches it: a failed in-place rewrite
+    leaves ``_pending_rewrite`` set while ``_dirty_gen``, ``len(slot.messages)``,
+    ``_disk_window_len`` and ``_disk_older_count`` all sit still. Every counter
+    matches across the read, so the loop reads "stable" and would fork from a
+    snapshot it has been told is stale.
+
+    The probe is the READ COUNT: with the post-await check the attempt is spent and
+    the loop re-reads, so the read runs more than once. A content assertion cannot
+    discriminate here, because this fixture's disk and window agree -- the defect is
+    that the handler trusts a snapshot it was told not to, not that these particular
+    bytes differ.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:midread"
+    log.append(key, "user", "history-1")
+    log.append(key, "assistant", "history-2")
+
+    slot = state.get_or_create_slot("midread")
+    slot.append("user", "history-1", "msg msg-u")
+    slot.append("assistant", "history-2", "msg msg-a")
+    slot.drain()
+    slot._disk_window_len = len(slot.messages)
+    slot._disk_older_count = 0
+    slot._resumed_count = len(slot.messages)
+    slot._dirty = False
+    assert not slot._pending_rewrite, "fixture must start with a clean flag"
+
+    original = log.read_messages_chained
+    calls = {"n": 0}
+    entered = threading.Event()
+    release = threading.Event()
+
+    def racing_read(k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            entered.set()
+            release.wait(timeout=10)
+        return original(k)
+
+    monkeypatch.setattr(log, "read_messages_chained", racing_read)
+
+    async def racer():
+        for _ in range(300):
+            if entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert entered.is_set(), "read 1 never entered"
+        # A failed in-place rewrite: the flag is set and NOTHING else moves, so the
+        # counter equality check below cannot detect it.
+        slot._pending_rewrite = True
+        release.set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(client.post("/api/chat/slots/midread/fork", json={}))
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        resp = await post
+        body = await resp.json()
+
+    assert calls["n"] >= 2, (
+        f"the transcript was read {calls['n']} time(s): a rewind marked the slot "
+        "stale DURING the read and the handler accepted that snapshot anyway, "
+        "because the counter equality check cannot see a flag that moves no counter"
+    )
+    if resp.status != 200:
+        assert body.get("code") == "fork_snapshot_unstable", f"unexpected error: {body}"
+
+
+def _raw_disk_rows(log, key):
+    """Non-metadata rows read straight off the JSONL, BYPASSING ``_msg_cache``.
+
+    The cache is the only thing between this and ``read_messages_chained``, so a
+    divergence between the two is proof the cached list object was mutated.
+    """
+    import json as _json
+
+    return [
+        line
+        for line in log._path(key).read_text(encoding="utf-8").splitlines()
+        if line.strip() and _json.loads(line).get("_type") != "metadata"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_fork_does_not_mutate_the_shared_message_cache(tmp_path, monkeypatch):
+    """The fork must not extend the list ``read_messages_chained`` handed it.
+
+    ``_read_messages`` returns the **shared cached list object by identity** on a
+    cache hit and its docstring requires callers to treat it as immutable.
+    ``read_messages_chained`` passes that object straight through for a session
+    with no ``tab_id`` (and for a tid whose index resolves to no keys, and when
+    every chained read comes back empty), so the fork's merge extends the cache
+    itself.
+
+    Base mutated it too, but base always took the durable save when dirty, and
+    that save invalidates the entry -- so the mutation was transient. The
+    capped-restore branch SKIPS the save deliberately, which is what turns a
+    self-healing race window into durable corruption: nothing evicts the entry,
+    and every later reader of this key sees the unpersisted tail as though it
+    were history.
+
+    Asserted against the RAW file rather than a count, because the corruption is
+    invisible to any probe that reads through the same cache.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:cachemut"
+
+    slot = state.get_or_create_slot("cachemut")
+    for i in range(250):
+        slot.append("user" if i % 2 == 0 else "assistant", f"m{i}", "msg")
+    slot.drain()
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    _save_slot_to_history(state, slot)
+
+    on_disk_before = len(_raw_disk_rows(log, key))
+    assert on_disk_before == 250, f"fixture expected 250 rows on disk, got {on_disk_before}"
+
+    # The capped restore: caps the window and sets _resumed_count, without
+    # bumping _disk_older_count -- which is what leaves the boundary ahead and
+    # makes the handler take the skip-the-save branch.
+    slot.messages = slot.messages[-50:]
+    slot._resumed_count = len(slot.messages)
+    slot.append("user", "UNPERSISTED-1", "msg")
+    slot.append("assistant", "UNPERSISTED-2", "msg")
+    slot.drain()
+    assert slot._dirty is True, "fixture expects a dirty slot"
+    assert slot._disk_window_len > len(slot.messages), (
+        "fixture expects the boundary AHEAD of the resident window, got "
+        f"{slot._disk_window_len} vs {len(slot.messages)}"
+    )
+
+    # ESTABLISH THE CACHE HIT, rather than hoping one happens. Identity sharing is
+    # best-effort memoization, NOT a contract this path can be relied on to offer:
+    # the single publish site (``history.py`` ~:4843) stores an entry only when the
+    # fill held the writer RLock, and ``_cache_fill_lock`` makes exactly ONE
+    # non-blocking attempt while on an event loop. A plain reader never holds the
+    # cross-process flock, so when that attempt loses, ``flock_witness`` is None,
+    # nothing is published, and the caller is handed a private parse -- two reads
+    # then come back EQUAL BUT NOT IDENTICAL. An earlier revision of this test
+    # asserted identity between two arbitrary reads and failed in CI on both Linux
+    # and Windows for exactly that reason.
+    #
+    # The WARM path (~:4609-4612) is lock-free and unconditional: it returns the
+    # cached list by identity whenever the stored mtime and generation both still
+    # match. Publishing the entry here makes that hit deterministic, which is what
+    # puts the fork on the shared-object path it is being tested against.
+    cached_obj = list(log.read_messages_chained(key))
+    log._msg_cache[key] = (log._path(key).stat().st_mtime, log._cache_gen(key), cached_obj)
+    # FIXTURE GUARD: the hit is live, so a reader really is handed THIS object.
+    assert log.read_messages_chained(key) is cached_obj, (
+        "fixture failed to establish a cache hit: a read did not return the entry "
+        "just published, so nothing is shared and this test would pass with or "
+        "without the fix"
+    )
+    assert len(cached_obj) == on_disk_before, (
+        f"fixture expected the cached entry to hold the {on_disk_before} persisted rows, "
+        f"got {len(cached_obj)}"
+    )
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/cachemut/fork", json={})
+        assert resp.status == 200, f"fork failed: {await resp.text()}"
+
+    # NON-VACUITY GUARD: the entry must still be the object published above. If it
+    # were evicted or replaced, the fork's read was served a private parse and the
+    # assertions below could not observe the mutation at all.
+    entry = log._msg_cache.get(key)
+    assert entry is not None and entry[2] is cached_obj, (
+        "the cache entry was evicted or replaced during the fork, so this run could "
+        "not observe whether the shared object was mutated -- the result below would "
+        "be vacuous"
+    )
+
+    # THE RESULT ASSERTION. Read through the cache, and compare to the file.
+    through_cache = log.read_messages_chained(key)
+    raw_after = _raw_disk_rows(log, key)
+    phantom = [
+        m.get("content")
+        for m in through_cache
+        if str(m.get("content", "")).startswith("UNPERSISTED-")
+    ]
+    assert len(through_cache) == len(raw_after), (
+        f"a later reader sees {len(through_cache)} messages through the cache while the "
+        f"file holds {len(raw_after)}: the fork extended the shared cached list in "
+        f"place and the skipped save never evicted it. Phantom rows: {phantom}"
+    )
+    assert not phantom, (
+        f"the unpersisted tail {phantom} is visible to later readers of {key} as though "
+        "it were persisted history, because the shared cache entry was mutated"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_tid_session_whose_index_resolves_is_unaffected(tmp_path, monkeypatch):
+    """OPPOSITE DIRECTION: the fresh-list path must behave exactly as before.
+
+    A tid whose index resolves to keys makes ``read_messages_chained`` build a NEW
+    list, so there was never anything shared to corrupt. Copying before the merge
+    must not change what the fork produces here.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:tidfork"
+
+    slot = state.get_or_create_slot("tidfork")
+    for i in range(6):
+        slot.append("user" if i % 2 == 0 else "assistant", f"t{i}", "msg")
+    slot.drain()
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    _save_slot_to_history(state, slot)
+    log.update_metadata(key, {"tab_id": "abc123def456"})
+    assert log.get_metadata(key).get("tab_id"), "fixture expected a tab_id"
+    # Resolve the tid to keys directly. A tab_id alone is NOT enough: when the
+    # index resolves to nothing, ``read_messages_chained`` falls back to the
+    # shared object, which is the sibling test's path. Injecting the mapping is
+    # what puts this test on the fresh-list branch instead.
+    log._tab_id_index = {"abc123def456": [key]}
+    # The fresh-list path builds a NEW list per call, so non-identity here is
+    # structural rather than timing-dependent -- but only while the chained read is
+    # NON-EMPTY. An empty result falls back to the shared-object path, so assert
+    # the content first; otherwise this guard could trip for the wrong reason.
+    assert log.read_messages_chained(key), "fixture expected a non-empty chained read"
+    assert log.read_messages_chained(key) is not log.read_messages_chained(key), (
+        "fixture expected the tid path to build a NEW list each call; if it shares, "
+        "this test is measuring the same path as its sibling"
+    )
+
+    slot.append("user", "tail-1", "msg")
+    slot.drain()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/tidfork/fork", json={})
+        assert resp.status == 200, f"fork failed: {await resp.text()}"
+        data = await resp.json()
+
+    new_slot = state._slots.get(data["key"])
+    visible = [m["content"] for m in new_slot.messages if m["role"] in ("user", "assistant")]
+    assert visible[0] == "t0", f"the forked transcript lost its oldest turn: {visible[:3]}"
+    assert "tail-1" in visible, f"the forked transcript lost the dirty tail: {visible[-3:]}"
+
+
+@pytest.mark.asyncio
+async def test_a_slot_that_legitimately_saves_still_reaches_disk(tmp_path, monkeypatch):
+    """OPPOSITE DIRECTION: the save path must still save.
+
+    Copying before the merge must not disturb the branch where the counters agree
+    with disk and the durable write is the correct action. If the tail stops
+    reaching disk, this goes red.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:savesfine"
+
+    slot = state.get_or_create_slot("savesfine")
+    slot.append("user", "s0", "msg")
+    slot.append("assistant", "s1", "msg")
+    slot.drain()
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    _save_slot_to_history(state, slot)
+    before = len(_raw_disk_rows(log, key))
+
+    slot.append("user", "SAVED-TAIL", "msg")
+    slot.drain()
+    assert slot._dirty is True, "fixture expects a dirty slot"
+    assert slot._disk_window_len <= len(
+        slot.messages
+    ), "fixture expects the boundary NOT ahead, so the handler takes the save path"
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/savesfine/fork", json={})
+        assert resp.status == 200, f"fork failed: {await resp.text()}"
+
+    raw_after = _raw_disk_rows(log, key)
+    assert len(raw_after) > before, (
+        f"disk held {before} rows and still holds {len(raw_after)}: the legitimate save "
+        "path stopped persisting the tail"
+    )
+    assert any(
+        "SAVED-TAIL" in r for r in raw_after
+    ), "the dirty tail did not reach disk on the path that is supposed to save it"
+
+
+@pytest.mark.asyncio
+async def test_a_rewind_landing_during_the_pending_rewrite_save_is_not_erased(
+    tmp_path, monkeypatch
+):
+    """A rewind that lands DURING the pending-rewrite save must not be lost.
+
+    The ``_pending_rewrite`` arm saves and retries rather than refusing, because a
+    rewrite save clears the flag and the fork is then free to read a fresh disk.
+    But ``chat_persistence`` clears that flag UNCONDITIONALLY (``if rewrite:
+    slot._pending_rewrite = False``) with no check that the flag it clears is the
+    one its own snapshot was taken for. The save is an ``await``, so a rewind can
+    land inside it: the write persists the PRE-rewind transcript, the clear erases
+    the new rewind's flag, and the next attempt sees ``False`` and falls through to
+    a disk read still holding the discarded turns.
+
+    The post-await stability re-check cannot catch it -- it re-baselines its four
+    counters on the NEW attempt, i.e. after the flag went missing, so it measures
+    the stability of the new attempt rather than the flag that was lost.
+
+    Asserted on the FORKED TRANSCRIPT, not on a status code and not on the flag:
+    a fork returning 200, or ``_pending_rewrite`` reading False after the save,
+    are both true with or without the fix.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:rewindrace"
+
+    slot = state.get_or_create_slot("rewindrace")
+    for i in range(10):
+        slot.append("user" if i % 2 == 0 else "assistant", f"m{i}", "msg")
+    slot.drain()
+    from kiro_crew.dashboard import chat_fork as chat_fork_mod
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    _save_slot_to_history(state, slot)
+    assert len(_raw_disk_rows(log, key)) == 10, "fixture expected 10 rows persisted"
+
+    # A first rewind already happened and its rewrite has not been written yet.
+    slot._pending_rewrite = True
+    slot._dirty = True
+
+    real_save = chat_fork_mod.save_slot_off_loop
+    landed = {"n": 0}
+
+    async def _save_with_a_rewind_landing_inside(state_, slot_, *a, **kw):
+        """Model the real save's interleaving: snapshot, then write, then clear.
+
+        The rewind is landed AFTER the snapshot is taken and BEFORE the write and
+        the flag clear -- which is exactly the window the real save leaves open,
+        since it snapshots on the loop and clears the flag in the worker thread
+        after writing.
+        """
+        if landed["n"] == 0:
+            landed["n"] = 1
+            stale_snapshot = list(slot_.messages)
+            # The concurrent rewind, matching ``chat_rewind``'s own sequence:
+            # truncate, mark dirty, zero _resumed_count, set the flag.
+            del slot_.messages[6:]
+            slot_._dirty = True
+            slot_._resumed_count = 0
+            slot_._pending_rewrite = True
+            # The save writes the PRE-rewind snapshot it captured, and clears the
+            # flag -- including the rewind's, which it never owned.
+            await real_save(state_, slot_, stale_snapshot, rewrite=True, best_effort=False)
+            slot_._pending_rewrite = False
+            return
+        await real_save(state_, slot_, *a, **kw)
+
+    monkeypatch.setattr(chat_fork_mod, "save_slot_off_loop", _save_with_a_rewind_landing_inside)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/rewindrace/fork", json={})
+        assert resp.status == 200, f"fork failed: {await resp.text()}"
+        data = await resp.json()
+
+    # FIXTURE GUARD: the interleave actually ran, and the flag really was erased.
+    assert landed["n"] == 1, "fixture never entered the pending-rewrite save"
+
+    new_slot = state._slots.get(data["key"])
+    assert new_slot is not None, f"forked slot {data['key']} not found"
+    visible = [m["content"] for m in new_slot.messages if m["role"] in ("user", "assistant")]
+    discarded = [c for c in visible if c in {"m6", "m7", "m8", "m9"}]
+    assert not discarded, (
+        f"the forked transcript contains the turns the rewind discarded: {discarded}. "
+        "The rewind landed during the pending-rewrite save, that save persisted the "
+        "pre-rewind snapshot and cleared the flag it did not own, and the fork then "
+        f"copied the stale disk read. Forked transcript: {visible}"
+    )
+    assert visible[:6] == [
+        "m0",
+        "m1",
+        "m2",
+        "m3",
+        "m4",
+        "m5",
+    ], f"the forked transcript lost turns the rewind KEPT: {visible}"
+
+
+@pytest.mark.asyncio
+async def test_a_pending_rewrite_fork_without_a_concurrent_rewind_still_succeeds(
+    tmp_path, monkeypatch
+):
+    """DIRECTION NOT BROKEN: the ordinary pending-rewrite fork must not 503.
+
+    The generation witness must not trip on the save's own bookkeeping. If it did,
+    every pending-rewrite fork would spend its attempt budget and refuse -- turning
+    the recoverable path into a refusal.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+
+    slot = state.get_or_create_slot("pendok")
+    for i in range(8):
+        slot.append("user" if i % 2 == 0 else "assistant", f"p{i}", "msg")
+    slot.drain()
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    _save_slot_to_history(state, slot)
+    slot._pending_rewrite = True
+    slot._dirty = True
+    gen_before = slot._dirty_gen
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/pendok/fork", json={})
+        body = await resp.text()
+        assert resp.status == 200, (
+            f"an ordinary pending-rewrite fork was refused with {resp.status}: {body}. "
+            "The generation witness tripped on the save's own bookkeeping instead of "
+            "on a genuine concurrent re-dirty."
+        )
+        data = await resp.json()
+
+    assert slot._dirty_gen == gen_before, (
+        "fixture expected NO genuine re-dirty in this scenario; the generation moved "
+        f"from {gen_before} to {slot._dirty_gen}, so this test is not measuring the "
+        "quiet path it claims to"
+    )
+    new_slot = state._slots.get(data["key"])
+    visible = [m["content"] for m in new_slot.messages if m["role"] in ("user", "assistant")]
+    assert visible[0] == "p0" and visible[-1] == "p7", f"forked transcript wrong: {visible}"
+
+
+@pytest.mark.asyncio
+async def test_a_fork_with_no_pending_rewrite_is_untouched(tmp_path, monkeypatch):
+    """DIRECTION NOT BROKEN: the ordinary non-pending path must be unaffected.
+
+    The carry flag starts False and the arm is never entered, so this exercises the
+    path the guard must leave completely alone.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+
+    slot = state.get_or_create_slot("nopend")
+    for i in range(5):
+        slot.append("user" if i % 2 == 0 else "assistant", f"n{i}", "msg")
+    slot.drain()
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    _save_slot_to_history(state, slot)
+    assert slot._pending_rewrite is False, "fixture expects NO pending rewrite"
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/nopend/fork", json={})
+        assert resp.status == 200, f"fork failed: {await resp.text()}"
+        data = await resp.json()
+
+    new_slot = state._slots.get(data["key"])
+    visible = [m["content"] for m in new_slot.messages if m["role"] in ("user", "assistant")]
+    assert visible == ["n0", "n1", "n2", "n3", "n4"], f"forked transcript wrong: {visible}"
+
+
+def _archived_contents(log):
+    """Every message content present in this log's archive segments.
+
+    ``_archive_dropped_lines`` is reached ONLY from the rewrite branch
+    (``if rewrite and path.exists()``), so an empty result after a truncating
+    save means the save took the plain path and the dropped turns were deleted
+    without ever being archived.
+    """
+    import json as _json
+
+    from kiro_crew.history import _archive_dir
+
+    adir = _archive_dir(log._dir)
+    if not adir.exists():
+        return []
+    found = []
+    for seg in sorted(adir.glob("*.jsonl")):
+        for line in seg.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                row = _json.loads(line)
+            except ValueError:
+                continue
+            if row.get("_type") == "archive":
+                continue
+            if row.get("content") is not None:
+                found.append(row["content"])
+    return found
+
+
+@pytest.mark.asyncio
+async def test_the_pending_rewrite_retry_still_archives_the_discarded_turns(tmp_path, monkeypatch):
+    """The retry save must take the ARCHIVE-SAFE rewrite path, not a plain save.
+
+    ``_save_slot_to_history`` only ever PROMOTES ``rewrite`` to True -- ``if
+    messages is not None or slot._pending_rewrite: rewrite = True`` -- and the
+    archival is gated behind it (``if rewrite and path.exists():
+    _archive_dropped_lines(...)``), as is the ``rotation_generation`` bump.
+
+    On the retry both promotion inputs are absent: no explicit snapshot is passed,
+    and ``_pending_rewrite`` was cleared by the first save (that clearing is the
+    very race the retry exists to recover from). So the retry would persist the
+    rewind's truncation through the PLAIN path, deleting the discarded turns from
+    disk with no archive copy -- unrecoverable, where the pre-retry behaviour at
+    least left them on disk.
+
+    Asserted on the ARCHIVE, not on the transcript: the sibling test already covers
+    the transcript, and it passes whether or not the dropped turns were archived.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:archiverace"
+
+    slot = state.get_or_create_slot("archiverace")
+    for i in range(10):
+        slot.append("user" if i % 2 == 0 else "assistant", f"a{i}", "msg")
+    slot.drain()
+    from kiro_crew.dashboard import chat_fork as chat_fork_mod
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    _save_slot_to_history(state, slot)
+    assert len(_raw_disk_rows(log, key)) == 10, "fixture expected 10 rows persisted"
+    assert _archived_contents(log) == [], "fixture expected an empty archive to start"
+
+    slot._pending_rewrite = True
+    slot._dirty = True
+
+    real_save = chat_fork_mod.save_slot_off_loop
+    landed = {"n": 0}
+
+    async def _save_with_a_rewind_landing_inside(state_, slot_, *a, **kw):
+        if landed["n"] == 0:
+            landed["n"] = 1
+            stale_snapshot = list(slot_.messages)
+            del slot_.messages[6:]
+            slot_._dirty = True
+            slot_._resumed_count = 0
+            slot_._pending_rewrite = True
+            await real_save(state_, slot_, stale_snapshot, rewrite=True, best_effort=False)
+            slot_._pending_rewrite = False
+            return
+        await real_save(state_, slot_, *a, **kw)
+
+    monkeypatch.setattr(chat_fork_mod, "save_slot_off_loop", _save_with_a_rewind_landing_inside)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/archiverace/fork", json={})
+        assert resp.status == 200, f"fork failed: {await resp.text()}"
+
+    assert landed["n"] == 1, "fixture never entered the pending-rewrite save"
+
+    # FIXTURE GUARD: the retry really did truncate disk. Without this a missing
+    # archive would be trivially "correct" because nothing was ever dropped.
+    on_disk = [
+        c
+        for c in (_raw_disk_rows(log, key))
+        if '"a6"' in c or '"a7"' in c or '"a8"' in c or '"a9"' in c
+    ]
+    assert not on_disk, (
+        "fixture expected the retry to have removed the discarded turns from disk; "
+        f"{len(on_disk)} of them are still there, so this test cannot observe whether "
+        "they were archived first"
+    )
+
+    archived = _archived_contents(log)
+    missing = [c for c in ("a6", "a7", "a8", "a9") if c not in archived]
+    assert not missing, (
+        f"the retry deleted the discarded turns {missing} from disk WITHOUT archiving "
+        "them: it took the plain save path because the first save had already cleared "
+        "_pending_rewrite and no explicit snapshot was passed, so `rewrite` never got "
+        f"promoted and the archive branch was skipped. Archived contents: {archived}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_first_entry_pending_rewrite_save_archives_as_before(tmp_path, monkeypatch):
+    """DIRECTION NOT BROKEN: first-entry archival behaviour is unchanged.
+
+    On the FIRST entry ``_pending_rewrite`` is still set, so
+    ``_save_slot_to_history`` promotes ``rewrite`` on its own and the archival
+    already happens. This pins that, so passing ``rewrite=True`` explicitly at the
+    call site is provably a no-op here rather than a behaviour change.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:firstentry"
+
+    slot = state.get_or_create_slot("firstentry")
+    for i in range(8):
+        slot.append("user" if i % 2 == 0 else "assistant", f"f{i}", "msg")
+    slot.drain()
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    _save_slot_to_history(state, slot)
+    assert len(_raw_disk_rows(log, key)) == 8, "fixture expected 8 rows persisted"
+
+    # A rewind whose rewrite has NOT been written: exactly the state the arm is for.
+    del slot.messages[5:]
+    slot._dirty = True
+    slot._resumed_count = 0
+    slot._pending_rewrite = True
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/firstentry/fork", json={})
+        assert resp.status == 200, f"fork failed: {await resp.text()}"
+
+    archived = _archived_contents(log)
+    missing = [c for c in ("f5", "f6", "f7") if c not in archived]
+    assert not missing, (
+        f"the ordinary first-entry pending-rewrite save stopped archiving {missing}. "
+        f"Archived contents: {archived}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_save_completing_mid_read_does_not_fork_a_superseded_variant(tmp_path, monkeypatch):
+    """A save COMPLETING during the read must invalidate the attempt.
+
+    The post-await guard witnesses four counters plus ``_pending_rewrite``. None of
+    them can see a save that merely COMPLETES: an in-place content edit (a variant
+    switch) leaves ``len(slot.messages)`` and ``_disk_older_count`` alone, the save
+    re-assigns ``_disk_window_len`` to the same value because the window length did
+    not change, and the ``_dirty`` setter advances ``_dirty_gen`` only on a True
+    assignment -- so CLEARING it moves nothing.
+
+    That leaves a window where the threaded read returns pre-save bytes while the
+    slot now says everything is persisted. The boundary-derived tail slice is empty,
+    so the fork adopts the stale disk read verbatim and the forked session keeps the
+    SUPERSEDED content.
+
+    ``_dirty`` is added to the RETRY witness set for this, NOT to the merge decision:
+    a mismatch re-reads, and the merge stays keyed on the boundary exactly as before
+    (see ``test_fork_sees_the_tail_when_a_flush_clears_dirty_mid_read``, which pins
+    that a cleared ``_dirty`` must never skip the reconciliation).
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+
+    slot = state.get_or_create_slot("variantrace")
+    for i in range(6):
+        slot.append("user" if i % 2 == 0 else "assistant", f"v{i}-OLD", "msg")
+    slot.drain()
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    _save_slot_to_history(state, slot)
+
+    # Steady state: the boundary is a usable index and claims everything persisted,
+    # so the tail slice the fork takes below is empty.
+    assert slot._disk_window_len == len(slot.messages), (
+        "fixture expects the boundary to equal the resident window, got "
+        f"{slot._disk_window_len} vs {len(slot.messages)}"
+    )
+
+    # The variant switch: content replaced IN PLACE. No append, no trim.
+    target = next(m for m in slot.messages if m.get("content") == "v3-OLD")
+    target["content"] = "v3-NEW"
+    slot._dirty = True
+
+    before = (
+        slot._disk_window_len,
+        slot._dirty_gen,
+        len(slot.messages),
+        slot._disk_older_count,
+    )
+    real_read = log.read_messages_chained
+    landed = {"n": 0}
+
+    def _read_then_let_a_save_complete(*a, **kw):
+        """Return pre-save bytes, then let a flush complete -- as the race does."""
+        stale = [dict(m) for m in real_read(*a, **kw)]
+        if landed["n"] == 0:
+            landed["n"] = 1
+            # Exactly what ``flush_slot_now`` does: save, then clear ``_dirty`` only
+            # if the generation did not move under it.
+            gen = slot._dirty_gen
+            _save_slot_to_history(state, slot)
+            if slot._dirty_gen == gen:
+                slot._dirty = False
+        return stale
+
+    monkeypatch.setattr(log, "read_messages_chained", _read_then_let_a_save_complete)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/variantrace/fork", json={})
+        assert resp.status == 200, f"fork failed: {await resp.text()}"
+        data = await resp.json()
+
+    # FIXTURE GUARDS. Without these a pass could come from the existing four checks
+    # having caught the change, which would make this test measure nothing new.
+    assert landed["n"] == 1, "fixture never let a save complete during the read"
+    after = (
+        slot._disk_window_len,
+        slot._dirty_gen,
+        len(slot.messages),
+        slot._disk_older_count,
+    )
+    assert after == before, (
+        "fixture expected ALL FOUR witnessed counters to be unchanged by the save -- "
+        f"otherwise the existing guard already catches this. before={before} after={after}"
+    )
+    assert slot._dirty is False, (
+        "fixture expected the completing save to have CLEARED _dirty; without that "
+        "flip there is no window for this test to observe"
+    )
+
+    new_slot = state._slots.get(data["key"])
+    assert new_slot is not None, f"forked slot {data['key']} not found"
+    visible = [m["content"] for m in new_slot.messages if m["role"] in ("user", "assistant")]
+    assert "v3-OLD" not in visible, (
+        "the forked session carries the SUPERSEDED variant 'v3-OLD': a save completed "
+        "during the threaded read, so the read returned pre-save bytes while the slot "
+        "reported everything persisted. None of the four witnessed counters moved and "
+        f"_dirty was cleared without bumping _dirty_gen. Forked transcript: {visible}"
+    )
+    assert (
+        "v3-NEW" in visible
+    ), f"the forked session lost the current variant 'v3-NEW' entirely: {visible}"

--- a/test/test_resume_publishes_hydrated_slot.py
+++ b/test/test_resume_publishes_hydrated_slot.py
@@ -1,0 +1,855 @@
+"""Resume must not publish a slot by name before it holds its history.
+
+``api_chat_slot_resume`` reads the transcript off the event loop. If that await
+sits between ``get_or_create_slot`` and the hydrate loop, the slot is reachable
+from ``state._slots`` while still empty, so a concurrent request that appends a
+prompt gets it ordered *before* the history the resume then appends.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+
+def _app_scoped(state, declared_app: str) -> web.Application:
+    """The resume app with a token middleware that publishes ``declared_app``."""
+    app = _make_app(state)
+
+    @web.middleware
+    async def _publish_app(request: web.Request, handler):
+        request["app"] = declared_app
+        return await handler(request)
+
+    app.middlewares.append(_publish_app)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_slot_is_never_reachable_unhydrated_during_the_threaded_read(tmp_path, monkeypatch):
+    """No coroutine may observe the resumed slot published with zero messages.
+
+    The threaded read is held open while another coroutine resolves the slot by
+    name, which is what any concurrent request does. Seeing the slot present but
+    empty there is the defect: whatever it appends lands ahead of the history.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    log.append("dashboard:race1", "user", "history-1")
+    log.append("dashboard:race1", "assistant", "history-2")
+
+    read_entered = threading.Event()
+    may_finish = threading.Event()
+    original = log.read_messages_chained
+
+    def blocking_read(key):
+        # Runs in the to_thread worker, so the loop is free: signal that resume
+        # is suspended, then hold the await open until the racer has looked.
+        read_entered.set()
+        may_finish.wait(timeout=10)
+        return original(key)
+
+    monkeypatch.setattr(log, "read_messages_chained", blocking_read)
+
+    observed = {}
+
+    async def racer():
+        for _ in range(200):
+            if read_entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        slot = state._slots.get("race1")
+        observed["present"] = slot is not None
+        observed["empty"] = slot is not None and len(slot.messages) == 0
+        if slot is not None:
+            slot.append("user", "NEW-PROMPT", "msg msg-u")
+        may_finish.set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(
+            client.post("/api/chat/slots/race1/resume", json={"key": "dashboard:race1"})
+        )
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        assert (await post).status == 200
+
+    assert not observed["empty"], (
+        "resume published the slot by name before hydrating it; a concurrent "
+        "append would be ordered ahead of the restored history"
+    )
+
+    contents = [m.get("content") for m in state._slots["race1"].messages]
+    history = [c for c in contents if c and c.startswith("history-")]
+    assert history == ["history-1", "history-2"], f"history lost or reordered: {contents}"
+    if "NEW-PROMPT" in contents:
+        assert contents.index("NEW-PROMPT") > contents.index(
+            "history-2"
+        ), f"a concurrently appended prompt was ordered before the history: {contents}"
+
+
+@pytest.mark.asyncio
+async def test_a_slot_published_during_the_read_still_faces_the_ownership_gate(
+    tmp_path, monkeypatch
+):
+    """The pre-await ownership gate must be re-applied after the threaded read.
+
+    The read runs off the loop, so a concurrent resume can publish the slot while
+    this request is suspended. ``get_or_create_slot`` returns that live slot by
+    name and applies no ownership check of its own, so without a re-check a
+    foreign app is handed a slot it does not own.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    log.append("dashboard:race2", "user", "history-1")
+
+    read_entered = threading.Event()
+    may_finish = threading.Event()
+    original = log.read_messages_chained
+
+    def blocking_read(key):
+        read_entered.set()
+        may_finish.wait(timeout=10)
+        return original(key)
+
+    monkeypatch.setattr(log, "read_messages_chained", blocking_read)
+
+    async def racer():
+        for _ in range(200):
+            if read_entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        # A concurrent resume from a DIFFERENT app publishes the slot mid-read.
+        foreign = state.get_or_create_slot("race2", app="appA")
+        foreign._app = "appA"
+        may_finish.set()
+
+    async with TestClient(TestServer(_app_scoped(state, "appB"))) as client:
+        post = asyncio.create_task(
+            client.post("/api/chat/slots/race2/resume", json={"key": "dashboard:race2"})
+        )
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        resp = await post
+
+    assert resp.status == 404, (
+        f"appB was handed appA's slot (status {resp.status}); the ownership gate was "
+        "applied only before the await, so the publish that landed during it escaped it"
+    )
+    assert state._slots["race2"]._app == "appA", "the foreign slot's owner was overwritten"
+
+
+@pytest.mark.asyncio
+async def test_slot_is_not_reachable_unhydrated_during_the_folder_unhide(tmp_path, monkeypatch):
+    """No await may sit between publishing the slot and hydrating it.
+
+    The transcript read was hoisted above the publish, but the folder-unhide and
+    closed-flag awaits ran after it and before the hydrate loop. A session filed in
+    a folder therefore still published an empty slot across a suspension point, and
+    a concurrent append there lands ahead of the restored history.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    log.append("dashboard:race3", "user", "history-1")
+    log.append("dashboard:race3", "assistant", "history-2")
+    log.update_metadata("dashboard:race3", {"folder_id": "fldr00000001"})
+
+    unhide_entered = asyncio.Event()
+    may_finish = asyncio.Event()
+
+    async def slow_unhide(_state, _folder_id):
+        unhide_entered.set()
+        await may_finish.wait()
+        return True
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._unhide_folder", slow_unhide)
+
+    observed = {}
+
+    async def racer():
+        try:
+            await asyncio.wait_for(unhide_entered.wait(), timeout=5)
+        except asyncio.TimeoutError:
+            observed["reached"] = False
+            may_finish.set()
+            return
+        observed["reached"] = True
+        slot = state._slots.get("race3")
+        observed["present_and_empty"] = slot is not None and len(slot.messages) == 0
+        if slot is not None:
+            slot.append("user", "NEW-PROMPT", "msg msg-u")
+        may_finish.set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(
+            client.post("/api/chat/slots/race3/resume", json={"key": "dashboard:race3"})
+        )
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        assert (await post).status == 200
+
+    assert observed.get("reached"), "the folder-unhide await never ran; fixture did not engage"
+    assert not observed.get("present_and_empty"), (
+        "the slot was published and still empty while the folder-unhide await was "
+        "suspended; a concurrent append there is ordered ahead of the history"
+    )
+    contents = [m.get("content") for m in state._slots["race3"].messages]
+    history = [c for c in contents if c and c.startswith("history-")]
+    assert history == ["history-1", "history-2"], f"history lost or reordered: {contents}"
+    if "NEW-PROMPT" in contents:
+        assert contents.index("NEW-PROMPT") > contents.index(
+            "history-2"
+        ), f"a concurrent append was ordered before the restored history: {contents}"
+
+
+@pytest.mark.asyncio
+async def test_a_delete_during_the_read_does_not_republish_the_transcript(tmp_path, monkeypatch):
+    """A session deleted while resume is suspended must not be resurrected.
+
+    ``history.delete_session`` unlinks the file and leaves NO tombstone -- its own
+    docstring notes that once the delete releases the lock "a concurrent writer
+    can recreate the session". Resume reads the transcript BEFORE publishing the
+    slot (so the await cannot expose an empty slot by name), which means a delete
+    landing inside that read leaves us holding a fully populated transcript for a
+    session that no longer exists. Publishing a slot from that content rewrites
+    the file on its next flush.
+
+    The probe is ``get_metadata_status``, not ``get_metadata``: the latter returns
+    ``{}`` for both "deleted" and "unreadable", and treating an unreadable
+    metadata line as a deletion would discard a live session.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:del1"
+    log.append(key, "user", "history-1")
+    log.append(key, "assistant", "history-2")
+
+    read_entered = threading.Event()
+    may_finish = threading.Event()
+
+    # Snapshot the transcript BEFORE patching: the parked read must return the
+    # PRE-delete content, which is the actual window this guards. A read that
+    # returned post-delete content would yield [] and describe a different bug
+    # (publishing an empty slot), not the resurrection of a populated one.
+    pre_delete = list(log.read_messages_chained(key))
+    assert len(pre_delete) == 2, f"fixture expected 2 messages, got {len(pre_delete)}"
+
+    def blocking_read(k):
+        # Runs in the to_thread worker, so the loop is free for the racer.
+        read_entered.set()
+        may_finish.wait(timeout=10)
+        return list(pre_delete)
+
+    monkeypatch.setattr(log, "read_messages_chained", blocking_read)
+
+    deleted = {"ok": False}
+
+    async def racer():
+        for _ in range(300):
+            if read_entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert read_entered.is_set(), "the transcript read never entered"
+        # The permanent delete lands while resume holds the loaded transcript.
+        deleted["ok"] = await asyncio.to_thread(log.delete_session, key)
+        may_finish.set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(client.post("/api/chat/slots/del1/resume", json={"key": key}))
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        resp = await post
+
+    assert deleted["ok"], "the fixture never deleted the session"
+    assert resp.status == 409, (
+        f"resume published a slot for a session deleted mid-read (status {resp.status}); "
+        "its next flush would rewrite the transcript that was permanently deleted"
+    )
+    assert (
+        "del1" not in state._slots
+    ), "the slot was published for a deleted session, so a flush can resurrect it"
+
+
+@pytest.mark.asyncio
+async def test_a_delete_then_recreate_during_the_read_does_not_overwrite_the_replacement(
+    tmp_path, monkeypatch
+):
+    """A session recreated while resume is suspended must not be overwritten.
+
+    The sibling test above covers the DELETE case, where the guard fires on
+    metadata being ABSENT. Deleting and then RECREATING inside the same window
+    errs in the opposite direction: ``delete_session`` leaves no tombstone and
+    its docstring notes a concurrent writer can recreate the session, so the
+    post-read metadata is a NON-EMPTY dict belonging to the NEW session. An
+    existence-keyed guard reads that as "still here" and publishes a slot
+    holding the OLD transcript, whose next flush overwrites a LIVE replacement.
+
+    Existence cannot separate the two; identity can. Every path that mints a
+    metadata line stamps ``created_at`` (``append`` on creation,
+    ``_update_metadata_locked`` when the line is missing) and
+    ``_rewrite_session_locked`` PRESERVES it, so a differing ``created_at`` on a
+    transcript that carried one means the file was recreated rather than merely
+    rewritten.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:recreate1"
+    log.append(key, "user", "history-1")
+    log.append(key, "assistant", "history-2")
+
+    original_created_at = log.get_metadata(key).get("created_at")
+    assert original_created_at, "fixture expected the original session to carry created_at"
+
+    read_entered = threading.Event()
+    may_finish = threading.Event()
+
+    # The parked read must serve the PRE-delete transcript: that is the content a
+    # published slot would flush over the replacement.
+    original_reader = log.read_messages_chained
+    pre_delete = list(log.read_messages_chained(key))
+    assert len(pre_delete) == 2, f"fixture expected 2 messages, got {len(pre_delete)}"
+
+    def blocking_read(k):
+        read_entered.set()
+        may_finish.wait(timeout=10)
+        return list(pre_delete)
+
+    monkeypatch.setattr(log, "read_messages_chained", blocking_read)
+
+    outcome = {"deleted": False, "recreated_created_at": None}
+
+    async def racer():
+        for _ in range(300):
+            if read_entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert read_entered.is_set(), "the transcript read never entered"
+
+        def delete_then_recreate():
+            ok = log.delete_session(key)
+            # Recreate under the SAME key -- a new conversation the user is now
+            # using. ``append`` mints a fresh metadata line, so ``created_at``
+            # differs (microsecond resolution).
+            log.append(key, "user", "replacement-1")
+            return ok
+
+        outcome["deleted"] = await asyncio.to_thread(delete_then_recreate)
+        outcome["recreated_created_at"] = log.get_metadata(key).get("created_at")
+        may_finish.set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(
+            client.post("/api/chat/slots/recreate1/resume", json={"key": key})
+        )
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        resp = await post
+
+    assert outcome["deleted"], "the fixture never deleted the session"
+    assert outcome["recreated_created_at"], "the fixture never recreated the session"
+    assert outcome["recreated_created_at"] != original_created_at, (
+        "fixture is not exercising a recreate: the replacement carries the same "
+        "created_at, so identity cannot discriminate it"
+    )
+
+    assert resp.status == 409, (
+        f"resume published a slot for a RECREATED session (status {resp.status}); "
+        "it holds the deleted session's transcript and its next flush overwrites "
+        "the replacement the user is now using"
+    )
+    assert (
+        "recreate1" not in state._slots
+    ), "the slot was published, so a flush can overwrite the replacement session"
+
+    # The replacement transcript must still be its own: exactly the message the
+    # recreate wrote, with none of the stale ones carried over. Read through the
+    # ORIGINAL reader captured before the patch, so this measures the file rather
+    # than the parked stub.
+    survivors = [m.get("content") for m in original_reader(key)]
+    assert "replacement-1" in survivors, f"the replacement message is gone: {survivors}"
+    assert (
+        "history-1" not in survivors and "history-2" not in survivors
+    ), f"the deleted session's messages were written over the replacement: {survivors}"
+
+
+@pytest.mark.asyncio
+async def test_a_benign_metadata_rewrite_during_the_read_still_publishes(tmp_path, monkeypatch):
+    """A metadata change that is NOT a recreate must not refuse the resume.
+
+    This is the control for the identity arm's breadth. A title/agent update
+    rewrites the metadata line while ``_rewrite_session_locked`` and
+    ``_update_metadata_locked`` both PRESERVE ``created_at``, so the session is
+    the same one. A guard that compared the whole metadata dict -- rather than
+    the identity field -- would refuse here, turning an ordinary concurrent
+    rename into a failed resume.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:benign1"
+    log.append(key, "user", "history-1")
+    log.append(key, "assistant", "history-2")
+    original_created_at = log.get_metadata(key).get("created_at")
+    assert original_created_at, "fixture expected created_at"
+
+    read_entered = threading.Event()
+    may_finish = threading.Event()
+    snapshot = list(log.read_messages_chained(key))
+
+    def blocking_read(k):
+        read_entered.set()
+        may_finish.wait(timeout=10)
+        return list(snapshot)
+
+    monkeypatch.setattr(log, "read_messages_chained", blocking_read)
+
+    changed = {"ok": False}
+
+    async def racer():
+        for _ in range(300):
+            if read_entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert read_entered.is_set(), "the transcript read never entered"
+        await asyncio.to_thread(log.update_metadata, key, {"title": "renamed mid-read"})
+        changed["ok"] = log.get_metadata(key).get("title") == "renamed mid-read"
+        may_finish.set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(client.post("/api/chat/slots/benign1/resume", json={"key": key}))
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        resp = await post
+
+    assert changed["ok"], "the fixture never rewrote the metadata"
+    assert log.get_metadata(key).get("created_at") == original_created_at, (
+        "fixture invalid: the benign rewrite changed created_at, so it is "
+        "indistinguishable from a recreate"
+    )
+    assert resp.status == 200, (
+        f"an ordinary concurrent metadata rewrite was refused (status {resp.status}); "
+        "the identity arm is comparing more than the identity field"
+    )
+    assert "benign1" in state._slots, "the slot was not published for a live session"
+
+
+@pytest.mark.asyncio
+async def test_a_folder_filed_during_the_read_is_not_erased_by_a_stale_existence_verdict(
+    tmp_path, monkeypatch
+):
+    """A folder assignment landing during the threaded read must survive resume.
+
+    The folder-existence check was hoisted above the publish so no await sits
+    between the re-checks and the hydrate loop. That hoist moved it onto the
+    PRE-read metadata snapshot, while the hydrate binds ``folder_id`` from the
+    snapshot re-read after the last await. A channel reconciliation filing the
+    session mid-read makes the two ids differ, and the verdict earned by the OLD
+    folder is then applied to the NEW one: a dangling old id yields
+    ``folder_unhidden=False``, which erases the live filing the reconciliation
+    just made. The dirty-slot flush persists that erasure.
+
+    A verdict is only about the folder it was computed for.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:folderrace1"
+    log.append(key, "user", "history-1")
+    log.append(key, "assistant", "history-2")
+
+    # The PRE-read snapshot points at a folder that no longer exists, so the real
+    # ``_unhide_folder`` reports False -- the verdict that drives the drop.
+    gone_id = "fldrGONE0001"
+    live_id = "fldrLIVE0001"
+    log.update_metadata(key, {"folder_id": gone_id})
+    # ...and the folder the reconciliation files it into DOES exist.
+    state._folders.append({"id": live_id, "name": "Filed By Reconciliation", "order": 0})
+    assert not any(f["id"] == gone_id for f in state._folders), (
+        "fixture expected the pre-read folder to be absent from the store, so the "
+        "existence verdict is False"
+    )
+
+    read_entered = threading.Event()
+    may_finish = threading.Event()
+    pre_read = list(log.read_messages_chained(key))
+    assert len(pre_read) == 2, f"fixture expected 2 messages, got {len(pre_read)}"
+
+    def blocking_read(k):
+        read_entered.set()
+        may_finish.wait(timeout=10)
+        return list(pre_read)
+
+    monkeypatch.setattr(log, "read_messages_chained", blocking_read)
+
+    observed = {"filed": False, "pre": None, "post": None}
+
+    async def racer():
+        for _ in range(300):
+            if read_entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert read_entered.is_set(), "the transcript read never entered"
+
+        # Channel reconciliation files the session while resume is suspended.
+        await asyncio.to_thread(log.update_metadata, key, {"folder_id": live_id})
+        observed["post"] = log.get_metadata(key).get("folder_id")
+        observed["filed"] = True
+        may_finish.set()
+
+    observed["pre"] = gone_id
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(
+            client.post("/api/chat/slots/folderrace1/resume", json={"key": key})
+        )
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        resp = await post
+
+    assert observed["filed"], "the fixture never re-filed the session"
+    assert observed["post"] == live_id, f"the fixture did not land the new folder: {observed}"
+    assert observed["pre"] != observed["post"], (
+        "fixture is not exercising a snapshot split: both snapshots carry the same "
+        "folder_id, so the test passes with or without the fix"
+    )
+
+    assert resp.status == 200, f"resume did not publish (status {resp.status})"
+    slot = state._slots.get("folderrace1")
+    assert slot is not None, "the slot was never published"
+    assert slot.folder_id == live_id, (
+        f"the live folder filed during the read was erased (folder_id={slot.folder_id!r}); "
+        f"an existence verdict earned by {gone_id} was applied to {live_id}, and the "
+        "dirty-slot flush persists that erasure"
+    )
+    assert (
+        log.get_metadata(key).get("folder_id") == live_id
+    ), "the persisted folder_id no longer matches the filing the reconciliation made"
+
+
+@pytest.mark.asyncio
+async def test_a_dangling_folder_id_unchanged_across_the_read_is_still_dropped(
+    tmp_path, monkeypatch
+):
+    """CONTROL for the opposite direction: the drop must still fire.
+
+    Scoping the existence verdict to the folder it was computed for must not stop
+    it applying when the id did NOT move. A session filed in a folder deleted
+    since it was last saved still has to resume plainly unfiled rather than
+    pointing at nothing.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:folderdangle1"
+    log.append(key, "user", "history-1")
+
+    gone_id = "fldrGONE0002"
+    log.update_metadata(key, {"folder_id": gone_id})
+    assert not any(
+        f["id"] == gone_id for f in state._folders
+    ), "fixture expected the folder to be absent so the existence verdict is False"
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/folderdangle1/resume", json={"key": key})
+
+    assert resp.status == 200, f"resume did not publish (status {resp.status})"
+    slot = state._slots.get("folderdangle1")
+    assert slot is not None, "the slot was never published"
+    assert slot.folder_id == "", (
+        f"a dangling folder_id survived resume (folder_id={slot.folder_id!r}); the "
+        "resumed session points at a folder that does not exist"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stamp_closed_at", [True, False])
+async def test_a_close_landing_during_the_read_is_not_cleared_by_the_stale_snapshot(
+    tmp_path, monkeypatch, stamp_closed_at
+):
+    """Resuming a closed session must not reopen a replacement closed mid-read.
+
+    ``clear_closed`` acts on the ``meta`` snapshot taken before the threaded
+    transcript read. If the session is deleted, recreated and closed inside that
+    window, an unconditional clear drops a ``closed`` flag belonging to a
+    DIFFERENT conversation -- and it runs BEFORE the identity re-check returns
+    409, so the 409 does not undo it. The user's close is silently reversed.
+
+    Both discriminators are covered. ``stamp_closed_at=True`` is the app close
+    path (chat_handlers stamps ``closed_at``); ``False`` is a legacy flag with no
+    stamp, where the file's mtime approximates the close instant -- and a
+    recreated file's mtime is necessarily fresh, which is what makes the
+    delete/recreate case comparable at all.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:closerace1"
+    log.append(key, "user", "history-1")
+    log.append(key, "assistant", "history-2")
+    # The SOURCE session is closed, so the resume takes the clear_closed path.
+    log.update_metadata(key, {"closed": True, "closed_at": time.time()})
+    assert log.get_metadata(key).get("closed"), "fixture expected a closed source session"
+
+    read_entered = threading.Event()
+    may_finish = threading.Event()
+    original_reader = log.read_messages_chained
+    pre_delete = list(log.read_messages_chained(key))
+    assert len(pre_delete) == 2, f"fixture expected 2 messages, got {len(pre_delete)}"
+
+    def blocking_read(k):
+        read_entered.set()
+        may_finish.wait(timeout=10)
+        return list(pre_delete)
+
+    monkeypatch.setattr(log, "read_messages_chained", blocking_read)
+
+    outcome = {"recreated": False, "closed_after_recreate": False, "mtime": None}
+    # Lower bound on the handler's internal boundary: it captures its epoch after
+    # this point, so anything the racer writes later than t0 + WINDOW_S is later
+    # than that boundary too.
+    t0 = time.time()
+    WINDOW_S = 0.3
+
+    async def racer():
+        for _ in range(300):
+            if read_entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert read_entered.is_set(), "the transcript read never entered"
+
+        # A REAL interval, not a token one. Without ``closed_at`` the guard falls
+        # back to the file's mtime, whose resolution can lag ``time.time()``: over
+        # a sub-millisecond window a genuinely fresh write can still stamp older
+        # than a wall-clock boundary, which would make this test pass vacuously.
+        await asyncio.sleep(WINDOW_S)
+
+        def delete_recreate_close():
+            log.delete_session(key)
+            # A NEW conversation under the same key, which the user then closes.
+            log.append(key, "user", "replacement-1")
+            flag = {"closed": True}
+            if stamp_closed_at:
+                flag["closed_at"] = time.time()
+            log.update_metadata(key, flag)
+            return log.get_metadata(key), log.mtime_of(key)
+
+        meta_after, mtime_after = await asyncio.to_thread(delete_recreate_close)
+        outcome["recreated"] = True
+        outcome["closed_after_recreate"] = bool(meta_after.get("closed"))
+        outcome["mtime"] = mtime_after
+        assert ("closed_at" in meta_after) is stamp_closed_at, (
+            "fixture did not produce the intended discriminator: "
+            f"closed_at present={'closed_at' in meta_after}, wanted {stamp_closed_at}"
+        )
+        may_finish.set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(
+            client.post("/api/chat/slots/closerace1/resume", json={"key": key})
+        )
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        resp = await post
+
+    assert outcome["recreated"], "the fixture never recreated the session"
+    assert outcome["closed_after_recreate"], "the fixture never closed the replacement"
+    if not stamp_closed_at:
+        # The fallback can only discriminate if the recreated file's mtime really
+        # is later than the handler's boundary. t0 precedes that boundary, so this
+        # proves the close instant the guard reads is on the correct side of it.
+        assert outcome["mtime"] is not None and outcome["mtime"] > t0 + WINDOW_S / 2, (
+            "fixture is not exercising the mtime fallback: the recreated file's "
+            f"mtime ({outcome['mtime']}) is not clearly later than the resume "
+            f"boundary (>= {t0}), so a pass would not measure the guard"
+        )
+
+    # THE FINDING: the replacement's close must survive the stale clear.
+    assert log.get_metadata(key).get("closed"), (
+        "the replacement session's `closed` flag was cleared by a resume acting on "
+        "a pre-read snapshot; the conversation the user closed is reopened on the "
+        "next gateway restart"
+    )
+    # And the identity re-check must still refuse -- the clear guard must not
+    # change the response contract.
+    assert (
+        resp.status == 409
+    ), f"resume published a slot for a RECREATED session (status {resp.status})"
+    survivors = [m.get("content") for m in original_reader(key)]
+    assert "replacement-1" in survivors, f"the replacement message is gone: {survivors}"
+
+
+@pytest.mark.asyncio
+async def test_a_session_closed_before_the_resume_still_has_its_flag_cleared(tmp_path, monkeypatch):
+    """CONTROL for the ordinary direction: a legitimate close must still clear.
+
+    The compare-and-clear must only refuse a close instant at or after the resume
+    boundary. A session the user closed before resuming has to reopen, or it
+    vanishes again on the next gateway restart. Both failure directions here are
+    silent, so this direction needs its own test.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:closenormal1"
+    log.append(key, "user", "history-1")
+    log.update_metadata(key, {"closed": True, "closed_at": time.time()})
+    assert log.get_metadata(key).get("closed"), "fixture expected a closed session"
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/closenormal1/resume", json={"key": key})
+
+    assert resp.status == 200, f"resume did not publish (status {resp.status})"
+    assert not log.get_metadata(key).get("closed"), (
+        "a session closed BEFORE the resume kept its `closed` flag; it will "
+        "disappear again on the next gateway restart"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("recreate", [False, True])
+async def test_a_metadata_only_session_removed_during_the_read_is_not_republished(
+    tmp_path, monkeypatch, recreate
+):
+    """An EMPTY transcript must not disable the deletion and identity guards.
+
+    Both re-checks were gated on ``all_messages``, so a metadata-only session --
+    one carrying a metadata line and no messages, which ``update_metadata``
+    creates on upsert -- slipped past both: the transcript is empty, the term is
+    falsy, and the resume published a slot for a session that had been removed
+    under it. Its next flush recreates the deleted session (``recreate=False``)
+    or overwrites the live replacement (``recreate=True``).
+
+    ``all_messages`` was the wrong witness of prior existence. The pre-read
+    ``meta`` is the right one: it is read synchronously before the awaits, and a
+    nonempty value means the session was there when we looked. The interest the
+    old gate was protecting -- resuming a legitimately empty session must not
+    409 -- is carried by the OTHER terms, not by this one: ``not
+    post_read_meta`` stays false while the session is still present, and the
+    identity arm needs two DIFFERING ``created_at`` values.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:mdonly1"
+    # METADATA-ONLY: a metadata line and no messages at all.
+    log.update_metadata(key, {"title": "metadata only"})
+    pre_meta = log.get_metadata(key)
+    assert pre_meta, "fixture expected a nonempty pre-read metadata line"
+    assert pre_meta.get("created_at"), "fixture expected created_at for the identity arm"
+    assert list(log.read_messages_chained(key)) == [], (
+        "fixture is not exercising the empty-transcript path: the session has messages, "
+        "so the old all_messages gate would have fired on its own"
+    )
+
+    read_entered = threading.Event()
+    may_finish = threading.Event()
+    original_reader = log.read_messages_chained
+
+    def blocking_read(k):
+        read_entered.set()
+        may_finish.wait(timeout=10)
+        return []
+
+    monkeypatch.setattr(log, "read_messages_chained", blocking_read)
+
+    outcome = {"deleted": False, "post_meta": None}
+
+    async def racer():
+        for _ in range(300):
+            if read_entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert read_entered.is_set(), "the transcript read never entered"
+
+        def remove():
+            ok = log.delete_session(key)
+            if recreate:
+                # A DIFFERENT conversation under the same key, which the user is
+                # now using. Its metadata line carries a fresh created_at.
+                log.update_metadata(key, {"title": "replacement"})
+            return ok
+
+        outcome["deleted"] = await asyncio.to_thread(remove)
+        outcome["post_meta"] = log.get_metadata(key)
+        may_finish.set()
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        post = asyncio.create_task(client.post("/api/chat/slots/mdonly1/resume", json={"key": key}))
+        await asyncio.gather(post, asyncio.create_task(racer()))
+        resp = await post
+
+    assert outcome["deleted"], "the fixture never deleted the session"
+    if recreate:
+        assert outcome["post_meta"], "the fixture never recreated the session"
+        assert outcome["post_meta"].get("created_at") != pre_meta["created_at"], (
+            "fixture is not exercising the identity arm: the replacement carries the "
+            "same created_at, so identity cannot discriminate it"
+        )
+    else:
+        assert not outcome["post_meta"], "the fixture left metadata behind after the delete"
+
+    arm = "identity" if recreate else "deletion"
+    assert resp.status == 409, (
+        f"resume published a slot for a metadata-only session removed during the read "
+        f"(status {resp.status}); the {arm} guard was disabled by the empty transcript, "
+        "so the next flush recreates or overwrites the removed session"
+    )
+    assert (
+        "mdonly1" not in state._slots
+    ), "the slot was published, so a flush can write the removed session back"
+    if recreate:
+        survivors = [m.get("content") for m in original_reader(key)]
+        assert (
+            log.get_metadata(key).get("title") == "replacement"
+        ), f"the replacement session's metadata was overwritten: {log.get_metadata(key)}"
+        assert survivors == [], f"stale content was written into the replacement: {survivors}"
+
+
+@pytest.mark.asyncio
+async def test_a_legitimately_empty_session_that_still_exists_still_resumes(tmp_path, monkeypatch):
+    """NEGATIVE CONTROL: the interest the old gate protected must survive.
+
+    A metadata-only session that is still PRESENT has to resume normally. If the
+    existence witness is widened without the other terms doing their share, every
+    empty session starts answering 409 ``resume_session_deleted`` -- one silent
+    bug traded for another, and this is the assertion that catches it.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:mdonly2"
+    log.update_metadata(key, {"title": "still here"})
+    assert log.get_metadata(key), "fixture expected the session to exist"
+    assert list(log.read_messages_chained(key)) == [], "fixture expected an empty transcript"
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/mdonly2/resume", json={"key": key})
+
+    assert resp.status == 200, (
+        f"resuming a legitimately empty session that still exists returned {resp.status}; "
+        "the guards must not refuse a session that is present"
+    )
+    assert "mdonly2" in state._slots, "the slot was not published for a live empty session"
+
+
+@pytest.mark.asyncio
+async def test_resuming_a_session_that_never_existed_is_not_refused(tmp_path, monkeypatch):
+    """NEGATIVE CONTROL: an absent key is not a deletion.
+
+    Resuming a key with no metadata and no transcript must still publish. This is
+    the case the widened witness could plausibly catch by accident, since both
+    guards read ``meta_readable`` and an absent file is readable-and-empty.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:neverexisted1"
+    assert not log.get_metadata(key), "fixture expected no metadata for an absent session"
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/neverexisted1/resume", json={"key": key})
+
+    assert resp.status == 200, (
+        f"resuming a never-existed session returned {resp.status}; an absent key is a new "
+        "conversation, not a deletion"
+    )

--- a/test/test_tab_id_index_rebuild.py
+++ b/test/test_tab_id_index_rebuild.py
@@ -1,0 +1,543 @@
+"""Tests for ``ConversationLog._rebuild_tab_id_index``.
+
+The rebuild reads each session file's ``tab_id`` through ``_read_metadata`` so an
+unchanged file costs a stat rather than an open. These tests pin both halves of
+that: the I/O actually goes away, and it does NOT go away in the one case a
+naive stat-keyed cache would get wrong (a metadata rewrite restores the
+pre-write mtime, so mtime alone cannot see a tab_id change).
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import os
+from pathlib import Path
+
+from kiro_crew.history import ConversationLog
+
+
+class OpenCounter:
+    """Count file opens of session files in *directory*.
+
+    Patches ``Path.open`` as well as ``builtins.open``: ``Path.open`` does not
+    route through ``builtins.open``, so counting only the builtin silently misses
+    a caller that uses the ``Path`` method and the count is then not comparable
+    across implementations. The wrappers are plain functions (not bound methods)
+    so setting one as a class attribute still binds ``self``.
+    """
+
+    def __init__(self, monkeypatch, directory):
+        real_builtin = builtins.open
+        real_path = Path.open
+        self._dir = str(directory)
+        self.count = 0
+        counter = self
+
+        def wrapped_builtin(file, *args, **kwargs):
+            counter._tally(file)
+            return real_builtin(file, *args, **kwargs)
+
+        def wrapped_path(path_self, *args, **kwargs):
+            counter._tally(path_self)
+            return real_path(path_self, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", wrapped_builtin)
+        monkeypatch.setattr(Path, "open", wrapped_path)
+
+    def _tally(self, name):
+        text = str(name)
+        if text.startswith(self._dir) and text.endswith(".jsonl"):
+            self.count += 1
+
+
+def test_open_counter_sees_both_open_flavours(tmp_path, monkeypatch):
+    """Instrument self-test: a counter blind to either flavour proves nothing."""
+    target = tmp_path / "dashboard_chat-probe-1.jsonl"
+    target.write_text("{}\n", encoding="utf-8")
+    counter = OpenCounter(monkeypatch, tmp_path)
+    with open(target, encoding="utf-8") as fh:
+        fh.read()
+    assert counter.count == 1, "builtins.open not counted"
+    with target.open(encoding="utf-8") as fh:
+        fh.read()
+    assert counter.count == 2, "Path.open not counted"
+
+
+def _seed(tmp_path, n=3, tab_id="aaaaaaaaaaaa"):
+    """Create *n* dashboard session files sharing *tab_id*."""
+    log = ConversationLog(base_dir=tmp_path)
+    keys = []
+    for i in range(n):
+        key = f"dashboard:chat-{i}-100{i}"
+        log.append(key, "user", f"hello {i}", tab_id=tab_id)
+        keys.append(key)
+    return log, keys
+
+
+def _rebuild(log):
+    with log._lock:
+        log._rebuild_tab_id_index()
+    return log._tab_id_index
+
+
+def test_first_rebuild_reads_every_file(tmp_path, monkeypatch):
+    log, keys = _seed(tmp_path, n=3)
+    log._meta_cache.clear()
+    counter = OpenCounter(monkeypatch, tmp_path)
+    index = _rebuild(log)
+    assert sorted(index["aaaaaaaaaaaa"]) == sorted(keys)
+    assert counter.count == 3
+
+
+def test_second_rebuild_opens_nothing(tmp_path, monkeypatch):
+    log, keys = _seed(tmp_path, n=3)
+    _rebuild(log)
+    counter = OpenCounter(monkeypatch, tmp_path)
+    index = _rebuild(log)
+    assert sorted(index["aaaaaaaaaaaa"]) == sorted(keys)
+    assert counter.count == 0
+
+
+def test_rebuild_after_one_append_opens_one_file(tmp_path, monkeypatch):
+    log, keys = _seed(tmp_path, n=3)
+    _rebuild(log)
+    counter = OpenCounter(monkeypatch, tmp_path)
+    log.append(keys[1], "user", "another")
+    opens_from_append = counter.count
+    counter.count = 0
+    index = _rebuild(log)
+    assert sorted(index["aaaaaaaaaaaa"]) == sorted(keys)
+    assert counter.count == 1, (
+        f"expected exactly one re-read, got {counter.count} "
+        f"(append itself did {opens_from_append} opens)"
+    )
+
+
+def test_rebuild_sees_tab_id_backfill_despite_pinned_mtime(tmp_path):
+    """A tab_id backfill restores the pre-write mtime — the rebuild must still see it.
+
+    ``_update_metadata_locked`` calls ``_restore_mtime`` so a metadata edit does
+    not reorder ``list_sessions``. A ``(path, mtime)``-keyed cache would keep its
+    "no tab_id" entry and silently drop this session from its chain.
+    """
+    log = ConversationLog(base_dir=tmp_path)
+    plain = "dashboard:chat-9-9009"
+    log.append(plain, "user", "no tab yet")
+    _, keys = _seed(tmp_path, n=1)
+
+    before = _rebuild(log)
+    assert plain not in before.get("aaaaaaaaaaaa", [])
+    mtime_before = (tmp_path / "dashboard_chat-9-9009.jsonl").stat().st_mtime
+
+    log.update_metadata(plain, {"tab_id": "aaaaaaaaaaaa"})
+
+    path = tmp_path / "dashboard_chat-9-9009.jsonl"
+    assert path.stat().st_mtime == mtime_before, (
+        "precondition: the metadata rewrite must preserve mtime, otherwise this "
+        "test is not exercising the stat-blind case"
+    )
+    assert json.loads(path.read_text(encoding="utf-8").splitlines()[0])["tab_id"] == (
+        "aaaaaaaaaaaa"
+    )
+
+    after = _rebuild(log)
+    assert plain in after["aaaaaaaaaaaa"]
+    assert sorted(after["aaaaaaaaaaaa"]) == sorted([plain, *keys])
+
+
+def test_index_is_none_after_invalidation_not_empty_dict(tmp_path):
+    """Invalidation must mean "stale", never "built and empty"."""
+    log, _ = _seed(tmp_path, n=2)
+    _rebuild(log)
+    assert isinstance(log._tab_id_index, dict)
+    log.invalidate_tab_id_cache()
+    assert log._tab_id_index is None
+
+
+def test_absent_tab_id_gets_no_sentinel_entry(tmp_path):
+    """A tid with no files must be absent from the index, not mapped to ``[]``."""
+    log, _ = _seed(tmp_path, n=1)
+    index = _rebuild(log)
+    assert "bbbbbbbbbbbb" not in index
+    assert all(v for v in index.values())
+
+
+def _corrupt_tab_id(path, value):
+    """Rewrite *path*'s metadata line so its tab_id is *value*."""
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    meta = json.loads(lines[0])
+    meta["tab_id"] = value
+    lines[0] = json.dumps(meta) + "\n"
+    path.write_text("".join(lines), encoding="utf-8")
+
+
+def test_unhashable_tab_id_skips_one_file_instead_of_aborting_rebuild(tmp_path):
+    """One corrupt file must not take the whole index down with it.
+
+    ``tab_id`` is minted as a uuid4 hex slice, so a non-str only arrives from
+    corrupt on-disk metadata -- but it round-trips through JSON unvalidated. An
+    unhashable value reaching ``index.setdefault(tid, ...)`` raises TypeError,
+    which would abort the rebuild for every session rather than skip one file.
+    """
+    log, keys = _seed(tmp_path, n=3, tab_id="aaaaaaaaaaaa")
+    victim = tmp_path / "dashboard_chat-1-1001.jsonl"
+    assert victim.exists(), "seed layout changed; test would vacuously pass"
+    _corrupt_tab_id(victim, ["not", "hashable"])
+
+    index = _rebuild(log)
+
+    # The two intact files are still chained; only the corrupt one is dropped.
+    assert index["aaaaaaaaaaaa"] == ["dashboard:chat-0-1000", "dashboard:chat-2-1002"]
+    assert not any("chat-1-1001" in k for v in index.values() for k in v)
+
+
+def test_dict_tab_id_is_also_survivable(tmp_path):
+    """Negative control for the guard: a dict tid is unhashable the same way."""
+    log, _ = _seed(tmp_path, n=2, tab_id="aaaaaaaaaaaa")
+    _corrupt_tab_id(tmp_path / "dashboard_chat-0-1000.jsonl", {"a": 1})
+    index = _rebuild(log)
+    assert index["aaaaaaaaaaaa"] == ["dashboard:chat-1-1001"]
+
+
+def test_warm_rebuild_opens_nothing_above_the_transcript_cache_bound(tmp_path, monkeypatch):
+    """The win must not collapse once the file count exceeds the shared LRU bound.
+
+    The rebuild is a cyclic scan over every dashboard file. Backed by a *bounded*
+    cache, a cyclic scan larger than the bound evicts each entry one step before
+    its next read and the hit rate goes to zero -- the failure mode
+    ``_SearchTextCache``'s docstring describes. ``_tab_id_by_key`` is unbounded
+    precisely so this holds at any session count.
+    """
+    over = 260  # > _TRANSCRIPT_CACHE_MAX (256)
+    log, _ = _seed(tmp_path, n=over, tab_id="aaaaaaaaaaaa")
+    _rebuild(log)  # cold: populates the memo
+
+    counter = OpenCounter(monkeypatch, tmp_path)
+    index = _rebuild(log)
+
+    assert counter.count == 0, f"warm rebuild opened {counter.count} files above the bound"
+    assert len(index["aaaaaaaaaaaa"]) == over, "every session must still be chained"
+
+
+def test_rebuild_does_not_evict_another_readers_metadata_entry(tmp_path):
+    """The rebuild must not flush `_meta_cache` entries other callers warmed.
+
+    Above the bound, routing every file through `_read_metadata` cycled one
+    insertion per file through a 256-slot LRU shared with ``get_metadata`` /
+    ``list_sessions`` / ``update_metadata_if``, so a walk evicted whatever they
+    were holding. The private memo means a warm rebuild touches it not at all.
+    """
+    log, _ = _seed(tmp_path, n=260, tab_id="aaaaaaaaaaaa")
+    _rebuild(log)  # cold
+
+    foreign = "slack:C0123-456"
+    log._meta_cache[foreign] = (1.0, {"_type": "metadata", "title": "foreign"})
+    assert log._meta_cache.get(foreign) is not None, "precondition: entry was planted"
+
+    _rebuild(log)
+
+    assert log._meta_cache.get(foreign) is not None, "rebuild evicted another reader's entry"
+
+
+def _hand_edit_tab_id(path: Path, tid: str) -> None:
+    """Rewrite a file's tab_id on disk directly -- no ConversationLog API call.
+
+    Deliberately bypasses every write path, so nothing calls ``_invalidate_cache``.
+    This is the shape of an out-of-band edit.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    meta = json.loads(lines[0])
+    meta["tab_id"] = tid
+    lines[0] = json.dumps(meta) + "\n"
+    path.write_text("".join(lines), encoding="utf-8")
+
+
+def test_out_of_band_tab_id_edit_is_not_served_stale(tmp_path):
+    """A rewrite that goes AROUND this class must still be picked up.
+
+    ``_invalidate_cache`` covers writes through the class; it cannot cover a
+    hand-edited file, which never calls it. The memo's mtime half is what does.
+    Without it the pre-edit id is served forever and the session either vanishes
+    from its chain or joins the wrong one.
+    """
+    log, _ = _seed(tmp_path, n=3, tab_id="aaaaaaaaaaaa")
+    _rebuild(log)  # memoize the pre-edit ids
+
+    victim = tmp_path / "dashboard_chat-1-1001.jsonl"
+    before = victim.stat().st_mtime
+    _hand_edit_tab_id(victim, "bbbbbbbbbbbb")
+    # Force an unambiguous mtime move so the assertion cannot pass or fail on
+    # filesystem timestamp granularity.
+    os.utime(victim, (before + 10, before + 10))
+
+    index = _rebuild(log)
+
+    assert "bbbbbbbbbbbb" in index, "out-of-band tab_id edit was served stale from the memo"
+    assert index["bbbbbbbbbbbb"] == ["dashboard:chat-1-1001"]
+    assert "dashboard:chat-1-1001" not in index.get("aaaaaaaaaaaa", [])
+
+
+def test_memo_store_is_declined_when_a_writer_pops_mid_read(tmp_path, monkeypatch):
+    """The store must not land after a concurrent writer's pop.
+
+    ``_invalidate_cache`` takes no lock, so it can interleave with a rebuild that
+    holds ``self._lock``. If the rebuild read a value, a writer then popped the
+    key, and the rebuild stored afterwards, the memo would hold a resurrected
+    stale id. The generation counter is what declines that store. This drives the
+    interleaving deterministically rather than waiting for the cache to settle,
+    which would order the window away.
+    """
+    log, _ = _seed(tmp_path, n=1, tab_id="aaaaaaaaaaaa")
+    key = "dashboard:chat-0-1000"
+    log._tab_id_by_key.clear()
+
+    # Patch the method the rebuild actually calls: it reads through
+    # _read_metadata_status so a transient failure is distinguishable from an
+    # empty record, and a patch on the flag-dropping wrapper would not intercept.
+    real = log._read_metadata_status
+
+    def racing_read(k, *a, **kw):
+        out = real(k, *a, **kw)
+        # Simulate the concurrent writer landing between our read and our store.
+        log._invalidate_cache(k)
+        return out
+
+    monkeypatch.setattr(log, "_read_metadata_status", racing_read)
+    _rebuild(log)
+
+    assert (
+        key not in log._tab_id_by_key
+    ), "memo stored a value after a concurrent pop -- generation guard did not fire"
+
+
+def test_a_session_without_a_tab_id_is_not_reread_every_rebuild(tmp_path, monkeypatch):
+    """A file with no ``tab_id`` must be memoized too, or it never stops costing I/O.
+
+    Such a file cannot be indexed, so an early ``continue`` before the memo store
+    looks harmless -- but it means every rebuild re-reads it through the SHARED
+    ``_meta_cache``, evicting entries the other readers warmed. The sentinel is
+    what makes a warm rebuild free for these files as well.
+    """
+    log, _ = _seed(tmp_path, n=1, tab_id="aaaaaaaaaaaa")
+    bare = tmp_path / "dashboard_chat-bare-2000.jsonl"
+    bare.write_text(json.dumps({"_type": "metadata"}) + "\n", encoding="utf-8")
+
+    _rebuild(log)  # cold: populates the memo, including the sentinel
+    counter = OpenCounter(monkeypatch, tmp_path)
+    _rebuild(log)  # warm
+
+    assert counter.count == 0, (
+        f"warm rebuild opened {counter.count} file(s); a session without a tab_id "
+        "is still being re-read"
+    )
+    assert (
+        log._tab_id_by_key["dashboard:chat-bare-2000"][1] == ""
+    ), "no-tab_id sentinel was not memoized"
+
+
+def test_a_session_that_gains_a_tab_id_is_picked_up(tmp_path, monkeypatch):
+    """The sentinel must not outlive the absence it records.
+
+    Negative control on the memo itself: if "" were sticky, a session that later
+    gains a ``tab_id`` would stay invisible to every chained read -- the silent
+    direction, since nothing errors.
+    """
+    log, _ = _seed(tmp_path, n=1, tab_id="aaaaaaaaaaaa")
+    bare_key = "dashboard:chat-bare-2000"
+    bare = tmp_path / "dashboard_chat-bare-2000.jsonl"
+    bare.write_text(json.dumps({"_type": "metadata"}) + "\n", encoding="utf-8")
+
+    _rebuild(log)
+    assert log._tab_id_by_key[bare_key][1] == ""
+
+    # update_metadata is the path that sets tab_id on an EXISTING session --
+    # append only stamps it at file creation, so it leaves this file bare.
+    log.update_metadata(bare_key, {"tab_id": "aaaaaaaaaaaa"})
+    _rebuild(log)
+
+    assert bare_key in (log._tab_id_index or {}).get(
+        "aaaaaaaaaaaa", []
+    ), "a session that gained a tab_id stayed invisible -- the sentinel went stale"
+
+
+def test_a_transient_read_failure_is_not_memoized_as_no_tab_id(tmp_path, monkeypatch):
+    """An unreadable file must be retried, never cached as a definitive absence.
+
+    ``_read_metadata`` drops the readability flag, so a transient failure (an AV
+    scanner holding a freshly appended file: ``stat`` succeeds, ``open`` does not)
+    arrives as ``{}``. Memoizing that against an unchanged stamp would drop the
+    session from its chain on every later rebuild until its next write -- the
+    vanished-history failure this index exists to prevent. Reading through
+    ``_read_metadata_status`` and skipping the store is what keeps it self-healing.
+    """
+    log, keys = _seed(tmp_path, n=1, tab_id="aaaaaaaaaaaa")
+    key = keys[0]
+    log._tab_id_by_key.clear()
+    log._meta_cache.pop(key, None)
+
+    real_status = log._read_metadata_status
+    failing = {"on": True}
+
+    def flaky_status(k, *a, **kw):
+        if failing["on"] and k == key:
+            return ({}, False)  # what an exhausted-retry read returns
+        return real_status(k, *a, **kw)
+
+    monkeypatch.setattr(log, "_read_metadata_status", flaky_status)
+    _rebuild(log)
+
+    assert key not in log._tab_id_by_key, (
+        "a transient read failure was memoized -- the session is now dropped "
+        "from its chain until its next write"
+    )
+
+    # The failure clears; nothing wrote to the file, so the stamp is unchanged.
+    failing["on"] = False
+    _rebuild(log)
+
+    assert key in (log._tab_id_index or {}).get(
+        "aaaaaaaaaaaa", []
+    ), "the session did not self-heal after the transient failure cleared"
+
+
+def test_a_same_mtime_rewrite_that_changes_size_is_not_served_stale(tmp_path):
+    """The same-tick window, constructed rather than raced.
+
+    ``test_out_of_band_tab_id_edit_is_not_served_stale`` moves the mtime forward
+    by 10s so its assertion cannot turn on timestamp granularity -- which orders
+    THIS window away. Here the mtime is pinned BACK to its pre-edit value, so the
+    stamp differs only in size. That misses the memo, and the reread then lands on
+    ``_meta_cache``, which is keyed on mtime alone and would hand back the old
+    metadata for the rebuild to re-memoize under the new stamp.
+    """
+    log, keys = _seed(tmp_path, n=1, tab_id="aaaaaaaaaaaa")
+    key = keys[0]
+    path = tmp_path / "dashboard_chat-0-1000.jsonl"
+
+    _rebuild(log)  # memoizes the tab_id AND warms _meta_cache for this key
+    assert key in (log._tab_id_index or {}).get("aaaaaaaaaaaa", [])
+
+    before_mtime = path.stat().st_mtime
+    before_size = path.stat().st_size
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    meta = json.loads(lines[0])
+    meta["tab_id"] = "bbbbbbbbbbbbbbbb"  # deliberately a DIFFERENT length
+    path.write_text("".join([json.dumps(meta) + "\n"] + lines[1:]), encoding="utf-8")
+    os.utime(path, (before_mtime, before_mtime))
+
+    # Fixture controls: without both of these the test could pass vacuously.
+    assert path.stat().st_mtime == before_mtime, "mtime did not pin"
+    assert path.stat().st_size != before_size, "size did not change"
+
+    _rebuild(log)
+
+    assert key in (log._tab_id_index or {}).get("bbbbbbbbbbbbbbbb", []), (
+        "the new tab_id was not picked up -- the reread was served stale "
+        "metadata from the mtime-keyed _meta_cache"
+    )
+    assert key not in (log._tab_id_index or {}).get(
+        "aaaaaaaaaaaa", []
+    ), "the session is still attached to its pre-edit chain"
+
+
+def test_another_instances_metadata_rewrite_is_not_served_stale(tmp_path):
+    """A write through ANOTHER instance of this class must not leave us stale.
+
+    Both guards miss this one, which is why it needs its own test. The write
+    goes THROUGH the class, so it restores the pre-write mtime and the stamp
+    cannot see it; but ``_invalidate_cache`` pops the memo of the instance that
+    did the writing, and ``_tab_id_generation`` is per-instance too, so a
+    reader's memo survives untouched. Two instances is how one process sees
+    another's write -- the cross-process lock this class holds exists precisely
+    because that is a supported deployment.
+
+    A tab_id is a fixed-format equal-length string, so the replacement leaves
+    ``st_size`` identical and size cannot discriminate either -- provided the
+    file's line endings already match what the rewrite emits, which the fixture
+    below arranges so the premise holds on Windows as well as POSIX.
+    """
+    key = "dashboard:chat-0-1000"
+    path = tmp_path / "dashboard_chat-0-1000.jsonl"
+    reader = ConversationLog(base_dir=tmp_path)
+    writer = ConversationLog(base_dir=tmp_path)
+
+    reader.append(key, "user", "hello", tab_id="aaaaaaaaaaaa")
+    # append() writes in text mode, so on Windows the file lands with CRLF while
+    # the metadata rewrite below reads with universal newlines and writes raw LF
+    # bytes -- shrinking it a byte per line, which would let size discriminate the
+    # very write this test needs both guards blind to. Normalise first (a no-op on
+    # POSIX), and before the rebuild, so the memo stamps the file we compare against.
+    path.write_bytes(path.read_bytes().replace(b"\r\n", b"\n"))
+    _rebuild(reader)  # memoize the pre-edit id in the READER's memo
+    assert key in (reader._tab_id_index or {}).get("aaaaaaaaaaaa", [])
+
+    before_mtime = path.stat().st_mtime
+    before_size = path.stat().st_size
+
+    writer.update_metadata(key, {"tab_id": "bbbbbbbbbbbb"})
+
+    # Fixture controls: without all three the test could pass vacuously -- it
+    # would no longer be exercising the case where BOTH guards are blind.
+    assert path.stat().st_mtime == before_mtime, "writer did not restore mtime"
+    assert path.stat().st_size == before_size, "replacement was not equal-length"
+    assert key not in writer._tab_id_by_key, "writer did not pop its own memo"
+    assert (
+        reader._tab_id_by_key.get(key) is not None
+    ), "reader's memo was already gone -- nothing left to serve stale"
+    on_disk = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    assert on_disk["tab_id"] == "bbbbbbbbbbbb", "the new tab_id is not on disk"
+
+    index = _rebuild(reader)
+
+    assert key in index.get("bbbbbbbbbbbb", []), (
+        "the reader served a stale tab_id from its memo: the session is missing "
+        "from the chain it now belongs to"
+    )
+    assert key not in index.get(
+        "aaaaaaaaaaaa", []
+    ), "the session is still attached to its pre-edit chain"
+
+
+def test_a_cold_memo_is_not_served_a_warm_meta_cache_line(tmp_path):
+    """A key warm in ``_meta_cache`` but cold in the memo must still be re-read.
+
+    ``get_metadata`` -- and the consolidation counters -- populate ``_meta_cache``
+    without ever touching ``_tab_id_by_key``, so the two caches go out of step.
+    ``_meta_cache`` is keyed on float mtime ALONE, which is strictly weaker than
+    our stamp: after another instance's mtime-preserving equal-length rewrite it
+    compares equal and hands back the PRE-write line. Memoizing that under the
+    new, correct-looking stamp makes it permanent, because every later rebuild
+    then takes the warm path and never re-reads.
+    """
+    key = "dashboard:chat-0-1000"
+    path = tmp_path / "dashboard_chat-0-1000.jsonl"
+    reader = ConversationLog(base_dir=tmp_path)
+    writer = ConversationLog(base_dir=tmp_path)
+
+    reader.append(key, "user", "hello", tab_id="aaaaaaaaaaaa")
+    path.write_bytes(path.read_bytes().replace(b"\r\n", b"\n"))
+
+    # A real public caller, not a hand-poked cache: this is the precondition.
+    reader.get_metadata(key)
+    assert key in reader._meta_cache, "get_metadata did not warm _meta_cache"
+    assert key not in reader._tab_id_by_key, "the memo must be COLD for this case"
+
+    before_mtime = path.stat().st_mtime
+    before_size = path.stat().st_size
+
+    writer.update_metadata(key, {"tab_id": "bbbbbbbbbbbb"})
+
+    assert path.stat().st_mtime == before_mtime, "writer did not restore mtime"
+    assert path.stat().st_size == before_size, "replacement was not equal-length"
+    assert key in reader._meta_cache, "reader's warm entry is gone -- case not exercised"
+
+    index = _rebuild(reader)
+
+    assert key in index.get("bbbbbbbbbbbb", []), (
+        "a cold memo was served the stale line out of _meta_cache: the session is "
+        "missing from the chain it now belongs to"
+    )
+    assert key not in index.get(
+        "aaaaaaaaaaaa", []
+    ), "the session is still attached to its pre-edit chain"


### PR DESCRIPTION
## Problem / Motivation

`ConversationLog._tab_id_index` maps `tab_id -> [session keys]` so
`read_messages_chained` can find every session file that shares a tab without scanning the
directory. It is invalidated wholesale on every write: `append`, `delete_session`, and
`update_metadata`/`update_metadata_if` when the write touches `tab_id`.

`_rebuild_tab_id_index` then rebuilt it by globbing `dashboard_chat-*.jsonl` and, for each
file, doing an `open` + `readline` + `json.loads` to pull out `tab_id`.

Those two facts interact badly. `append` invalidates the index and `recent_chained`
immediately calls the chained read, which rebuilds it. So **sending one message re-read the
first line of every session file, on the event loop**, and the cost grows linearly with the
number of sessions.

Measured on a session directory with 161 files (20 reps, warm page cache):

```
open + readline + json.loads per file    14.352 ms
stat only                                 0.927 ms
```

## Why it matters

The rebuild runs synchronously on the gateway event loop, so the cost is not paid only by the
message that triggered it — while it runs, every other dashboard and Slack request that loop is
serving waits too. At 161 session files that is about 12 ms per sent message, which is modest
taken on its own; it is pure overhead that scales with how many session files you have rather
than with anything you did.

Read the next part before judging the value of this PR, because it is narrower than "big installs
benefit most". The win now holds at any session count, which took two attempts to get right.
An earlier revision of this change routed the rebuild through the shared `_meta_cache`, an LRU
bounded at `_TRANSCRIPT_CACHE_MAX = 256`. Because the rebuild is a cyclic scan over every
dashboard file, that inverted above the bound: each walk evicted what the previous walk
inserted, so on the 1071-file directory I develop on it opened all 1071 files and took ~144 ms
at a 0% hit rate — slightly worse than the code it replaced, for exactly the installs with the
most sessions. Reviewers were right to push on that. It now uses a private, unbounded
`key -> tab_id` memo instead, so a warm rebuild reads no session files at all at any count.
Measured on the same fixture shape: 1071 files, **0 opens, ~6 ms**, and the shared cache is
left alone. The remaining lever is how OFTEN the index is rebuilt, not how cheap each rebuild
is; that is still wholesale invalidation and still out of scope here.

## What changed (motivation → approach → change)

Memoize each session's `tab_id` in a private, unbounded `key -> tab_id` dict
(`_tab_id_by_key`), and have the rebuild read that instead of touching any session file.
On a miss it falls back to `_read_metadata` (which keeps that method's corruption handling and
bounded retries) and records the result, so a given file is read once per change rather than
once per rebuild.

The memo is deliberately a plain dict and NOT an `_LRUCache`. A bounded cache is the wrong
shape for this access pattern: the rebuild is a cyclic scan over every dashboard file, and a
cyclic scan larger than the bound evicts each entry one step before its next read, so the hit
rate does not degrade gracefully — it goes to zero. That is the failure mode
`_SearchTextCache`'s own docstring describes, and it is what an earlier revision of this PR
walked into by using the 256-slot `_meta_cache`. Values here are 12-character ids, so an
unbounded dict costs tens of KB at a thousand sessions.

A memo hit is a plain dict lookup — no `open`, no `stat`, no JSON parse — so a file that has
not changed since the last rebuild costs nothing at all, and that holds however many sessions
there are. After a single append, the rebuild re-reads exactly one file instead of all of
them, because `append` invalidates just that key. The only per-rebuild filesystem work left is
the one directory `glob`, which the old code did too.

Same directory, same method:

```
before   14.352 ms
after     1.957 ms      (7.3x, -12.4 ms per rebuild)
```

Re-measured on the final code after the review rounds below, best-of-3 on a fresh fixture: 17.8 ms before / 1.6 ms after at 161 files, and 129.4 ms / 10.8 ms at 1100. The ratio and the shape hold; the absolute "before" differs from the 14.352 ms above by more than the change could explain, so read both as what they are — two runs on a shared development host, minutes apart, not a controlled benchmark. The commit message carries the re-measured pair so the two surfaces do not disagree.

The number of rebuilds is unchanged — invalidation is still wholesale. This only makes each
rebuild cheap.

**One guard this restructuring needed.** Moving the read into `_read_metadata` also moved the
`index.setdefault(tid, ...)` call out of the `try/except Exception: continue` that used to
surround it. That silently widened the blast radius of a corrupt `tab_id`: an unhashable value
(a JSON list or object) raises `TypeError` there, and where the old code skipped that one file,
the first draft of this one aborted the whole rebuild -- so a single corrupt file on disk broke
chained reads for every session. `tab_id` is minted as `uuid4().hex[:12]`, so nothing in the
codebase writes a non-string, but it round-trips through JSON unvalidated and a hand-edited or
truncated-and-rewritten file reaches it. Fixed with an `isinstance(tid, str)` guard rather than
by moving the call back inside the `try`: it keeps the `try` narrowly around the I/O instead of
also swallowing errors from the index write, and it enforces the `dict[str, list[str]]` type the
index already declares. One behavioural difference worth naming: a *hashable* non-string tid
(say an integer) was previously indexed under that value and is now skipped, so such a session
is no longer chained. It still appears on its own, and only corrupt data can produce it.

**A second guard this needed, found in review.** The resume handler re-checks, after its
threaded transcript read, both that the session still exists and that it is still the *same*
session. Both re-checks were additionally conditioned on the transcript being non-empty, on the
reasoning that a legitimately empty session must not be refused. That condition was the wrong
witness of prior existence: a metadata-only session -- a metadata line with no messages, which
`update_metadata` creates on upsert -- has an empty transcript, so a delete (or a
delete-and-recreate) landing inside the read window left both re-checks inert and the resume
published a slot whose next flush would rewrite the removed session. The witness is now the
pre-read metadata snapshot unioned with the transcript (`session_existed`), which is read
synchronously before the awaits and so adds no suspension point between the re-checks and the
publish. The interest the old condition was reaching for is carried by the other terms instead:
a session that is still present fails the absent-metadata term, and the identity arm needs two
*differing* `created_at` stamps. A key with no metadata and no transcript still resumes as a new
conversation rather than being read as a deletion. One binding is shared by both arms
deliberately, since carrying the predicate separately is how the same hole reached two sites.

## Why this is safe, and why NOT an mtime-keyed cache

The obvious optimisation is a private cache keyed on `(path, mtime)`: stat each file and only
re-open the ones whose mtime moved. **That is incorrect here, and its failure mode is silent
history loss.**

`_update_metadata_locked` is the only thing that can change a `tab_id` in place, and it ends
with:

```python
_restore_mtime(path, prev_mtime)
```

That is deliberate. `_restore_mtime`'s own docstring explains that `list_sessions` orders by
mtime as a proxy for "last activity", so a metadata edit — and it names `tab_id` backfill
explicitly — must *not* bump the mtime or every restart floats long-closed sessions to the top
of the session list.

So the one write that changes a `tab_id` is exactly the write that leaves mtime untouched. A
stat-keyed cache keeps its old entry, which says *this file has no tab_id*, and the file is
omitted from the rebuilt index. Since a rebuilt index is authoritative, `read_messages_chained`
then concludes the tab has no siblings and that session's messages disappear from
`recent_chained`.

This is not a hypothetical. This repo already documents the same blindness for two other
caches:

- `_folded_cache`: "The mtime guard cannot protect this window, because the housekeeping
  rewrites deliberately RESTORE the pre-write mtime (`_restore_mtime`) ... undetectable".
- `_recent_cache`: "housekeeping rewrites ... restore the pre-write mtime via `_restore_mtime`,
  so the recent cache's mtime guard alone would let a stale window survive a content change".

The `_tab_id_by_key` memo carries **two** guards, and each covers exactly what the other
misses. This corrects an earlier revision of this PR, which shipped the pop alone and argued an
mtime check would be "worse than nothing" — that was wrong, and a reviewer caught it.

- **The explicit pop** covers writes THROUGH this class. `_invalidate_cache` pops the memo on
  the line directly below `_meta_cache`, so a future writer that remembers one remembers the
  other, and every write path calls it — `append`, `_update_metadata_locked`,
  `_rewrite_session_locked`, and the dashboard slot save. An mtime guard could not do this job,
  because those paths call `_restore_mtime` and the file looks untouched afterwards.
- **The stat check** covers rewrites that go AROUND the class. A hand-edited `tab_id` never
  calls `_invalidate_cache`, so the pop never fires and the pre-edit id would be served
  forever. Reproduced before fixing: after an out-of-band edit the rebuild kept the old id and
  the session stayed in the wrong chain. Storing `(mtime, tab_id)` and comparing the mtime on
  read closes it, and this is the file's established idiom rather than a new invention — five
  other caches here (`_msg_cache`, `_folded_cache`, `_snippet_cache`, `_recent_cache`, and
  `_read_metadata_status` itself) use the same `cached[0] == mtime` shape. The memo was the odd
  one out for lacking it.

  This memo stamps `(st_mtime_ns, st_size, st_ino)` rather than mtime alone. Filesystem timestamp granularity is
  coarse — noticeably so on Windows — so an out-of-band rewrite landing in the same tick as the
  memoized read would still look unchanged. The size comes off the `stat` already being taken,
  so the second discriminator is free. **Size alone is not sufficient, and an earlier revision of
  this description overstated it:** it makes such a rewrite MISS the memo, but the reread then
  goes through `_read_metadata_status`, whose own `_meta_cache` is keyed on mtime ALONE — see the
  section below for the hole that left open and the pop that closes it.

A third, narrower hole is closed by `_tab_id_generation`. `_invalidate_cache` deliberately takes
no lock, so it can interleave with a rebuild that holds `self._lock`: read a value, writer pops
the key, rebuild stores afterwards, and the memo now holds a resurrected stale id that BOTH
guards above would accept (the pop already happened, and `_restore_mtime` kept the mtime
matching). The rebuild therefore samples a generation counter before the read and declines to
memoize if it moved. Note this is a genuinely different hole from the out-of-band edit — one
counter does not close both, because an out-of-band edit never calls `_invalidate_cache` and so
never bumps the counter.

The cost of the mtime half is one `stat` per file per rebuild, which is what took the 1071-file
warm rebuild from ~6 ms to ~11 ms. Still no `open` and no parse, and still an order of
magnitude under the ~144 ms this PR started at.

In short: rather than add a second, weaker invalidation scheme, this reuses the one the class
already maintains everywhere else.

I also considered `(path, mtime, st_size)`. That does catch the backfill case, because adding
`"tab_id": "<12 hex>"` grows the metadata line by roughly 26 bytes — I verified that with a
test. I still did not take it. `tab_id` is minted as `uuid.uuid4().hex[:12]`, a fixed-length
string, so *replacing* one tab_id with a different one changes neither mtime nor size. Today no
call site does that (both `update_metadata` tab_id writers are guarded by `if not tab_id:`), so
the tuple is correct only by an argument about call sites in another module, not by any
invariant local to `history.py`. The first person to add a merge-tabs or re-parent feature that
rewrites an existing `tab_id` would silently reintroduce vanishing history. That is not a trap
worth leaving behind for 0 ms of extra gain.

## This does NOT reintroduce the removed `[]` sentinel

The existing comments are explicit that a permanent `[]` sentinel for a missing tab id was
removed because it "suppressed every future rebuild, so a second session opened later under the
same tab_id was never linked into the chain and its messages silently vanished", and that
invalidation sets `None` rather than clearing the dict so the read path can tell "stale, must
rebuild" from "freshly built, tid legitimately absent".

Both invariants are untouched:

- `invalidate_tab_id_cache` still assigns `None`, and `None` still means stale.
- A rebuilt index is still a complete authoritative snapshot, built by the same
  glob-every-file loop. Only the per-file *read* got cheaper.
- Nothing caches "this tab has no siblings". A tab id with no files is simply absent from the
  dict, as before.

Two tests pin this directly so a future refactor cannot quietly regress it:
`test_index_is_none_after_invalidation_not_empty_dict` and
`test_absent_tab_id_gets_no_sentinel_entry`.

## Locking

Unchanged. `_rebuild_tab_id_index` still requires the caller to hold `self._lock`, and the
chained read still holds it across the rebuild. `_read_metadata` touches `_meta_cache`, which
is an `_LRUCache` with its own internal lock; no path acquires those two in the reverse order,
so there is no new deadlock. The per-file I/O already happened under `self._lock` before this
change, so the critical section is not held any longer than it was — it is held for less time.

## Tests

New file `test/test_tab_id_index_rebuild.py`, 19 tests:

- a first rebuild on a cold cache opens every file (3 of 3)
- a second rebuild with nothing changed opens **zero** files
- a rebuild after one append opens exactly **one** file
- a `tab_id` backfill is still picked up even though the write restored the pre-write mtime,
  with an explicit precondition assert that the mtime really was preserved (otherwise the test
  would not be exercising the stat-blind case at all)
- `None`-means-stale and no-`[]`-sentinel invariants
- a corrupt unhashable `tab_id` (a list, and separately an object) skips only that file and
  leaves the remaining sessions correctly chained, rather than aborting the rebuild
- a warm rebuild opens **zero** files at 260 sessions, i.e. above `_TRANSCRIPT_CACHE_MAX`,
  with every session still chained (this is the guarantee the first design failed)
- a rebuild does not evict a `_meta_cache` entry another reader had warm
- an out-of-band `tab_id` edit (written straight to disk, so nothing invalidates) is picked up
  rather than served stale from the memo
- the memo store is declined when a writer pops the key mid-read, driven deterministically by
  making the read itself invalidate — waiting for the cache to settle would order the window away
- an instrument self-test

New file `test/test_resume_publishes_hydrated_slot.py`, 4 tests. The first: resume must not
publish a slot by name before it holds its history. The threaded read is held open while
another coroutine resolves the slot from `state._slots`, which is what any concurrent request
does; observing the slot present but empty there is the defect. Verified both ways — it passes
with the read hoisted above the publication point and fails with the read left below it. The
second holds the read open and publishes a slot from a *different* app during it, asserting the
re-run ownership gate still answers 404 rather than handing over another app's slot; with the
re-check reverted it returns 200. The third holds the folder-unhide await suspended and asserts
the slot is not reachable-and-empty at that moment, which is what the remaining post-publish
awaits would otherwise expose. The fourth deletes the transcript while that read is parked and
asserts the resume refuses with 409 rather than publishing: `delete_session` leaves no tombstone,
so a slot published from content loaded before the delete would rewrite the file on its next
flush. Its parked read returns the *pre*-delete snapshot deliberately — a post-delete read yields
an empty list and would describe a different defect. With the re-check removed it returns 200.

Four further tests cover the empty-transcript hole in those same re-checks. Two are the
reproduction, parametrized over both arms: a metadata-only session is deleted -- and in the second
case deleted and recreated -- while the transcript read is parked, and each asserts the resume
answers 409 instead of publishing. Both fail on the pre-fix code with a 200, and the recreate case
additionally asserts the replacement's metadata and transcript are left alone. The other two are
negative controls for the opposite direction: a metadata-only session that still exists must
resume with 200, and a key that never existed must also resume with 200 rather than being read as
a deletion. Both controls pass before the fix, and the never-existed one fails if the witness is
widened without the other terms doing their share -- checked by dropping it entirely, which makes
that test answer 409.

New file `test/test_fork_reconciles_after_flush.py`, 5 tests, one per direction the fork's
reconciliation can fail in. Each racer does exactly what the flush executor does — persists
the tail, advances `_disk_window_len`, clears `_dirty` — and the fork is then asked to fork
at an index, so the assertion reads the visible count out of the endpoint's own out-of-range
error rather than inferring it.

1. **Tail dropped.** The read is served a pre-flush snapshot; forking *at the tail's index*
   must still return 200. Without the retry it fails, and with the retry removed entirely the
   handler fails closed on the 503 instead of silently dropping.
2. **Tail duplicated, flush then append across two reads.** An append arrives while the
   second read is in flight; the visible count must be 4, and is 5 if the offset regresses to
   `_resumed_count`.
3. **Tail duplicated, flush and append both before the first read returns.** This is the
   interleaving a boolean `_dirty` cannot see at all — the flush clears it and the append
   re-marks it, so no transition registers and no correction fires. Reproduced at 5 visible
   messages against the expected 4 before the fix; both racer gates assert they were entered,
   so a vacuous pass is not available.
4. **Tail duplicated, boundary ahead of the resident window.** `_disk_window_len` exceeds
   `len(slot.messages)` — as a mid-stream `_flush_segment` leaves it — with `_resumed_count` at
   its real value of 0 for a slot created in this gateway run. The visible count must be 2 (the
   disk history, once) and is 4 if the branch slices from `_resumed_count`. The three tests above
   all set the boundary *equal* to the window, the one arrangement in which that slice looks
   benign, so this direction was previously untested.

Opens are **counted**, not inferred from timing, by wrapping both `builtins.open` and
`Path.open`. Both are needed: `Path.open` does not route through `builtins.open`, so a counter
patching only the builtin is blind to half the callers and its numbers are not comparable
between implementations. `test_open_counter_sees_both_open_flavours` asserts the counter sees
one of each, so a silently blind instrument fails loudly instead of reporting a comforting
zero.

### Negative controls

Each assertion was checked against a deliberately broken implementation, run one at a time
(a runner stops at the first failing assert, so siblings in the same test would never execute):

| Broken variant | Target assertion | Result |
| ------------------------------------- | ------------------------------------- | ------ |
| no cache at all (the previous code)   | second rebuild opens zero files       | fails (`assert 3 == 0`) |
| no cache at all                       | rebuild after one append opens one    | fails (got 3) |
| private `(path, mtime)` cache         | backfill is still seen                | fails — the session is **missing from its own tab's chain** |
| private `(path, mtime, st_size)` cache| backfill is still seen                | passes (so size does catch this case) |
| private `(path, mtime)` cache         | rebuild after one append opens one    | fails (got 0 — the append landed in the same mtime tick) |

The third row is the empirical version of the safety argument above: with an mtime-keyed cache
the backfilled session is absent from its chain, which is the vanished-history outcome, not a
slowdown. The fourth row is recorded because it does **not** support my choice — `(mtime, size)`
is not broken today, and the case against it is the fixed-length-replacement fragility argued
above, not a demonstrated failure.

### Suite

Full `test/` suite at this branch and at an unmodified `main` (`9a7a19d05`) checked out
separately:

| | passed | failures |
| --------------------- | ------ | -------- |
| `main` (run 1)        | 51404  | 2 |
| `main` (run 2)        | 51405  | 2 |
| this branch           | 51411  | 2 |

`51411 = 51404 + 7`, exactly the 7 tests added, with a failure set identical to `main`. The two
failures are pre-existing and reproduce on the untouched baseline
(`test_gateway_lock_diagnosis.py::test_flock_is_held_by_a_fork_orphan`, and an error in
`test_wecom_client_cov80.py`); this machine cannot create user namespaces, which those tests
need.

One earlier run of this branch showed 28 failures. I did not write those off as flaky: the 26
extra ones pass when re-run in isolation, give a byte-identical verdict at both trees, do not
reproduce on a repeat full run, and none of them touch `history.py` or the chained-read path.
They correlate with wall-clock time (211s for that run vs 126-127s for the clean ones), i.e.
a loaded host.

All 10 existing test files that reference `read_messages_chained` or `tab_id_index` pass
together: 1180 passed, 0 failed.

## CI failures that are NOT this diff

### `TestLinkTimeBackfill` on the backend shard

`test_slack_options_lifecycle.py::TestLinkTimeBackfill::test_a_superseded_question_is_replayed_spent`
fails with `post_blocks.await_args` being `None` — the slack-link backfill posted nothing. The
changed code cannot run in that test, and the proof is a counter this PR never touches:

- The only rewritten function, `_rebuild_tab_id_index`, has exactly **one** call site:
  `read_messages_chained` (`history.py:3467`).
- The slack backfill reaches that only via `_transcript_prefix`, which `chat_backfill.py:184`
  gates on `disk_older > 0`, read as `getattr(slot, "_disk_older_count", 0) or 0`.
- `_disk_older_count` is only ever assigned during a restore (`channel_slots.py:372`), and the
  failing test file contains **zero** references to it. So it holds its default of 0, the gate is
  false, and the rebuild is never entered.
- The two lines that DO execute on every write — `_tab_id_by_key.pop(key, None)` and
  `_tab_id_generation += 1` in `_invalidate_cache` — cannot raise and cannot alter control flow.
  Nothing outside `history.py` reads either name (verified by grep across `src/`).

Corroboration, with its limits stated: `main` at `ebaa12bc05` contains zero occurrences of
`_tab_id_by_key`, so it does not carry this change at all, and three other unrelated branches
(`feat/session-export-markdown`, `feat/scroll-driven-older-history`, `feat/session-control-mcp`)
fail the same `Backend Tests (3.12, 4)` shard. I could **not** confirm those failed on the same
test — their logs and annotations have aged out — so I am not asserting an identical failure
elsewhere. The containment trace above stands on its own regardless.

Two further hypotheses about this failure were tested and both are refuted, so they are recorded here rather than acted on. **It is not disk or inode exhaustion on the runner.** The failing shard's own log (`Backend Tests (3.12, 4)`, job 95419289401, 2672 lines) contains zero occurrences of `No space left`, `Errno 28`, `ENOSPC` or `OSError`, while the positive control fires in the same file — the `FAILED` line is present at line 2637 and `AttributeError` appears three times — so the grep can see what it is looking for. The inode ceiling that does exist is a property of the development host, not of a GitHub runner: `/tmp` there is `tmpfs` with a hard cap of 1,048,576 inodes, which a full-suite run can exhaust, whereas a runner's temp directory carries no such fixed ceiling. **It is also not line endings or path separators**, which the same log refutes for the Windows case described below.

**What the evidence does support is an unsynchronised background task in the test.** `api_chat_slot_slack_link` does not post the backfill itself; it calls `_spawn_slack_backfill` (`chat_slack.py:298`), which is a fire-and-forget `asyncio.create_task(drain_slack_backfill(...))` with a strong reference and two done-callbacks, and then returns its JSON response immediately. Nothing awaits that task. In the failing tests the assertion `state.slack_client.post_blocks.await_args.args[1]` sits *outside* the `async with TestClient(...)` block that issued the POST, so whether the mock has been awaited by assertion time depends entirely on the event loop having scheduled the background task during client teardown. `await_args is None` is therefore the expected reading when that task has not run yet, and an exception inside it would be routed to `_log_task_exception` rather than surfacing in the test. The call site documents this exact symptom in its own comment: a thread-pool hop placed ahead of the spawn "cost the spawned task its scheduling window under load, so the control never reached Slack". That also explains the two properties the isolation theory fits only loosely — that a *different* member of the class loses on each run, and that it appears under the full-suite fallback, where ~13,7xx tests contend for the same runner.

Stated as a limit rather than a result: I could **not** reproduce this locally. The class passed 6/6 in six consecutive runs (36 test executions) under 96 competing CPU-bound processes, and the single named test passes on its own. The claim above rests on the control flow read at source, not on a local reproduction. Two sibling shards in the same run (`Backend Tests (3.12, 2)` and `(3.10, 1)`) failed before checkout on `astral-sh/setup-uv` with "The operation was aborted due to timeout", which cannot be caused by any diff.

### `Coverage Gate`

A cascade, not a coverage result: it fails closed on `backend-test=failure` in a few seconds,
and `Coverage Combine` — the job that unions the four shard files and applies the thresholds —
was skipped, so no `coverage.xml` ever existed to measure. The per-shard `36%` figure for
`history.py` is one shard of four with no `--cov-fail-under` attached and is not compared to any
threshold.

No skip, xfail, retry decorator or timeout change was added for either. Neither is this PR's
test and neither is its defect.

### `TestDefaultIsUnchanged` on a Windows shard — a minute-boundary race in the test

`test_subagent_context_groups.py::TestDefaultIsUnchanged::test_none_and_all_groups_are_identical`
compares two `build_session_context()` results for equality. It failed on Windows, and the CI log
names the only differing characters:

```
Skipping 1890 identical leading characters in diff
- -08-17 14:20 UTC
?           ^^
+ -08-17 14:19 UTC
?           ^^
```

The context embeds `[CURRENT DATE] ... %H:%M` (`context.py:1769` and `:1821`), i.e. minute
granularity, and the test calls the builder twice expecting an identical string. Any call pair
that straddles a minute boundary fails. Windows-only because that runner is slower, which widens
the window between the two calls — the suggestion that a Windows-only string inequality points at
line endings or path separators is refuted by the same log: the diff is two digits of a clock.

It also cannot reach this diff. The test file has zero references to `history`,
`ConversationLog` or `tab_id`, and its `_builder` constructs
`ContextBuilder(memory=..., skills=..., lessons=...)` with **no** `conversation_log`, which
defaults to `None` (`context.py:1504`). The single chained-reader call in that module
(`recent_chained`, `context.py:1348`) is therefore unreachable, so the rebuild never runs. This
change also writes no text anywhere — it reads `st_mtime` and `st_size` off a `stat` and stores
them in a dict — so there is no newline-handling surface for a platform difference to act on.

Left alone: it is not this PR's test and not its defect, and no skip, xfail or retry decorator
was added.

### The other Windows shard, separately

`test_crew_chat.py::TestContinuationIdentity::test_dispatch_id_is_durable_before_the_continue`
fails on one Windows shard. It was suggested that an mtime-keyed cache is exactly the kind of
change that breaks on Windows, where timestamp granularity is coarser, and that a stale hit
explains it. Checked, and it does not:

- The actual error is `PermissionError: [Errno 13] Permission denied` reading `topics.json`,
  raised out of `CrewStore` at `crew_chat.py:267` where `json.loads(path.read_text())` catches
  `OSError`. A stale cache hit produces a WRONG VALUE, not a permission error, so the proposed
  mechanism cannot produce this symptom.
- `CrewStore` has no mtime cache at all — zero `mtime` references in `crew_chat.py`.
- That revision touched two files: `src/kiro_crew/history.py` and
  `test/test_tab_id_index_rebuild.py`. `test_crew_chat.py` is not one of them.
- That test file never reaches the tab-id index: zero references to `_tab_id*`,
  `read_messages_chained`, or `recent_chained` anywhere in it. Its two `ConversationLog` imports
  are in different tests and use only `append` / `read_messages`.
- The temp path in the error contains `popen-gw0`, i.e. `pytest-xdist` parallel execution, and
  the log carries `RuntimeError: Event loop is closed` immediately afterwards — both point at
  harness/teardown raciness around a concurrently-held Windows file handle.

Being straight about the limit of this evidence: the same test passes locally on Linux, but I
did NOT find this failure on other recent CI runs, so I am not calling it an established flake.
What I can say is that the proposed causal mechanism is refuted, and no path from this diff to
that assertion exists. The `(mtime, size)` stamp above was added anyway, because the underlying
question — can this memo serve a stale entry when mtime is unchanged but content is not — had a
real answer for out-of-band edits, and closing it cost nothing.

### `Backend Tests (Windows) (2)` hung for 40 minutes — the identical tree passes this shard

Job 95430109656 (run 32044606397, attempt 2) started 16:14:03Z and was cancelled at 16:54:20Z — 40m17s against the `timeout-minutes: 40` declared at `.github/workflows/ci.yml:474` (job `backend-test-windows`, `:469`), so it did reach the ceiling rather than being collateral from a run-level cancel. Its three sibling shards finished in 9-10 minutes. Progress reached `[ 99%]` at 16:27:57Z and then emitted nothing for 26 minutes until the cancellation.

**The one named hang site is not in this subsystem.** The pytest-timeout dump at 16:21:46Z names `test/test_design_tweak_backend.py:561::test_anything_the_writer_accepts_the_reader_returns`, with frames in `design_tweak/backend/server.py:790 _write_request` calling `:777 _atomic_write_json`. That worker went `[gw0] node down: Not properly terminated`, was replaced, and the run carried on to 99%. There is no path from this change to it: `test_design_tweak_backend.py` has zero references to `ConversationLog`, `tab_id`, `read_messages_chained` or `_tab_id_by_key` — its eight `history` mentions are all `.kiro/crew/history/*.jsonl` path strings inside containment assertions — and `design_tweak/backend/server.py` does not import the history module at all. The reverse direction was checked at runtime as well, not only by reading imports: in a fresh interpreter, importing `kiro_crew.history` loads **zero** modules whose name contains `design_tweak`, and executing the new `test/test_tab_id_index_rebuild.py` in-process (13 passed) also loads zero. The detector is proven able to fire — importing `design_tweak.backend.server` directly loads 3 such modules. Statically, neither file this PR touches contains any reference to `design_tweak`, `apps.builtins`, `_atomic_write_json` or `_write_request`; the new test file's six `builtins` matches are Python's standard-library `builtins` module, which it monkeypatches to count `open` calls, and are unrelated to the `apps/builtins/` package path. That test grows one record by 1000 characters per iteration until it crosses `MAX_RECORD_BYTES` (2 MiB), so it runs roughly 2097 iterations and pushes about 2.2 GB through about 2097 `os.fsync` + `os.replace` pairs; durability-barrier I/O at that volume is far more expensive on a Windows runner than on ext4, which is a plausible way to cross the per-test timeout — 180s on this job, since the Windows invocation passes `--timeout=180`, overriding the `--timeout=120` in `setup.cfg` addopts.

**The decisive evidence is that the code is identical across four shas.** `dd645eda2`, `04ca1a4e5`, `0a07e18b0` and `26df131f3` all carry tree `2361489916e798a06b7f8a06a7d8bcb973bbddf9`, and `git diff 0a07e18b0 26df131f3` is empty. Windows shard 2 passed on three of them — 12m, 11m and 9m46s — and the `0a07e18b0` run logged `12483 passed` with zero `Timeout`, zero `node down` and zero `replacing crashed worker`. Same bytes, same shard, same platform, three passes and one hang, so the hang is a property of the run and not of the diff.

**The proposed mtime-spin mechanism is structurally impossible here.** The rebuild takes one `path.stat()`, compares a `(st_mtime_ns, st_size, st_ino)` tuple against the memo, and on a mismatch performs a single read. There is no loop, no sleep, no retry and no wait anywhere in the change — the only added line matching any of those words is a comment reading "while we are reading". A stamp comparison that is wrong in either direction costs one extra read; it cannot block or spin. Coarse Windows mtime granularity is precisely the case the size half of the stamp was added to cover, as described above.

**A PR that changes no Python at all hangs identically, which settles it.** PR #2822 modifies 33 files — 13 `.json`, 6 `.ts`, 6 `.tsx`, 6 `.png`, 1 `.mjs`, 1 `.html` — and **zero** `.py` files, so it cannot have altered any test or product code. Its `Backend Tests (Windows) (2)` was cancelled at the same 40-minute ceiling, in the same step, while its shards 1, 3 and 4 finished in 9-10 minutes. The crash is on the *identical* test at the *identical* line: `test/test_design_tweak_backend.py:561::test_anything_the_writer_accepts_the_reader_returns`, through `design_tweak/backend/server.py:790 _write_request` into `:777 _atomic_write_json`, with the same `sel.py:196 _writer_loop` thread in the dump. That promotes the fsync-volume explanation above from plausible to the observed trigger in two independent pull requests, one of which contains no Python.

**The full sequence, matched across both runs, is crash then stall-at-the-end — not a replacement worker that fails to start.** In both, the run resumes after the respawn and reaches `[ 99%]` before going silent:

| | crash + respawn | reaches `[ 99%]` | silence | cancelled |
|---|---|---|---|---|
| #3998 `26df131f` | 16:21:46Z (`gw0`) | 16:27:57Z | 26m17s | 16:54:15Z |
| #2822 `248fdbf1` | 17:31:39Z (`gw2`) | 17:38:06Z | 25m17s | 18:03:23Z |

So the replacement worker does come up and does make progress; what never completes is the final ~1% after a worker was lost mid-shard. Stated as a limit: neither run emits any diagnostic during that window, so the specific work outstanding at 99% is still unidentified — what is now identified is the pattern, and that it reproduces on a diff containing no Python.

**The hanging shard cannot contain this PR's new tests — they are in a different shard.** The four Windows shards are cut by `pytest-split` (`--splits 4 --group N`); there is no `.test_durations` tracked in the repo, so as `ci.yml` documents it "falls back to an even split by test count". Reproducing that split locally with the same eleven `BACKEND_DESELECTS` gives 13815 / 13815 / 13815 / 13813 node ids, and `test/test_tab_id_index_rebuild.py` — the 308-line file this PR adds — places **all 13 of its node ids in group 4 and none in group 2**. Group 2 spans `test_cron_thread_routing.py` through `test_mcp_apps_render.py`, which is alphabetically short of `test_tab_id_*`.

That split computation is validated by a positive control rather than assumed: `test_design_tweak_backend.py`, which the CI log proves ran on shard 2, comes back **290 of 290 node ids in group 2** and zero in any other group, and the specific node id the timeout dump named resolves to group 2 as well. A method that independently reproduces where CI actually put the crashing test is the one to trust when it also says this PR's new file is elsewhere.

**Why no single test can be named for the 26-minute silence.** `pytest-timeout` demonstrably works on this runner — it fired at 16:21:46Z and killed the worker — and it is armed across setup, call and teardown of each item. So a stall of 26 minutes that produces no dump at all means no test item was active; the silence is in xdist's own machinery after a worker was lost, not inside a test. `setup.cfg` documents precisely this failure and sizes it: "When workers die from memory pressure xdist silently clones replacements, up to numprocesses*4 of them — a 10-worker run will quietly restart 40 times, which on a host that has started swapping means ~20 minutes of zero progress and an empty log." `--max-worker-restart=2` exists to bound it. Shard 2 also concentrates work onto single workers by design, because `--dist loadgroup` pins each `xdist_group` to one process: it carries 382 `caplog_dev_fleet` node ids, 62 `serial`, and 44 `mcp_gateway`, so one worker legitimately finishes long after the aggregate counter reaches 99%.

**It is intermittent rather than deterministic**: `Backend Tests (Windows) (2)` passed on PR #4167 at 17:57:40Z. No new sha was spent on any of this — a message-only amend would reproduce this same tree, which three earlier runs already show passing this shard in under 12 minutes, and a fresh sha would only re-enter a lottery on a harness fault.

**Rebased onto current `main` (2026-08-18).** The branch had fallen 49 commits behind, so it was rebased to bring its base up to the current tip; the single commit and its two-file diff were unchanged at that point (+528/-7 in `src/kiro_crew/history.py` and `test/test_tab_id_index_rebuild.py`). The 940-test history/tab-id/chained selection passes on the new base, as do all 17 tests in the new file. The rebase shifted three coordinates this description had cited in `dashboard/chat_handlers.py` (the resume handler and the two offloaded detail call sites); they are updated above. Every coordinate in `history.py`, `chat_fork.py`, `chat_rewind.py`, `chat_summary.py`, `chat_persistence.py` and `channel_transcript_migration.py` was re-read after the rebase and is unchanged.

**It happened a second time, and the decisive control is that the diff is byte-identical across a pass and a hang.** Job 95687613522 (run 32129193942) ran 11:00:57Z to 11:41:14Z — 40.3 minutes against that same cap. Steps 1-6 (`Set up job`, checkout, setup-python, setup-uv, `Install dependencies`, `Select test scope`) all succeeded and the cancelled step is step 7, the shard run itself, so this is not a provisioning failure. The pytest-timeout dump at 11:09:52Z names the SAME hang site as the first occurrence — `test/test_design_tweak_backend.py::TestWhatIsWrittenStaysReadable::test_anything_the_writer_accepts_the_reader_returns`, blocked in `design_tweak/backend/server.py:777 _atomic_write_json` at `if os.path.exists(tmp):` — followed by `[gw3] node down: Not properly terminated` and `replacing crashed worker gw3`, after which the run resumed and reached 99%. **Correction to an earlier revision of this section: there are TWO separate events here, and the 40-minute death is the second one.** An earlier revision of this paragraph attributed the cancellation to the `test_design_tweak_backend.py` site above. That is wrong and is withdrawn. Event A, 11:09:52Z-11:10:05Z: pytest-timeout DID fire — twice, with full stack dumps — killed `gw3`, and the run then RESUMED and climbed to `[ 99%]` by 11:17:35Z. So the run survived that crash; it was not what ended the job. Event B, 11:17:35Z-11:41:09Z: a distinct 23.5-minute silence with NO dump at all, ending with 69 buffered dots flushing at kill time. Event B is what hit the cap, and the log names no site for it — stated as a limit rather than a finding. Two facts bound it: pytest-timeout demonstrably works on this runner (it fired in event A), so a single test body blocking past 180s should have produced a dump and did not, which points away from a test body; and `setup.cfg` sets `--dist loadgroup` with `--max-worker-restart=2`, so each `xdist_group` is pinned to one worker and a single worker can legitimately still be finishing long after the aggregate counter reads 99% — with one of the two permitted restarts already spent on `gw3`. A per-test timeout being active therefore does not by itself rule out a stall, but neither does it identify one.

**Why this is not reachable from this diff, measured four ways.** (1) The two files that revision touched carry byte-identical blobs at the sha whose Windows shard 2 PASSED (`42111df36`, 14m40s) and at the sha where it HUNG (`8ed27808a`) — `src/kiro_crew/history.py` = `6562abe47`, `test/test_tab_id_index_rebuild.py` = `6c2e3704f` — and a `git diff` between those two shas restricted to those paths is empty. The same diff both passed and hung this shard, so the diff is not the variable. (2) The hang site cannot reach this change: `test/test_design_tweak_backend.py` holds zero references to `ConversationLog`, `tab_id`, `read_messages_chained`, `_tab_id_by_key` or `_rebuild_tab_id_index` (positive control: 20 references to `_atomic_write_json` / `_write_request`), and `design_tweak/backend/server.py` imports nothing from `kiro_crew.history` (positive control: 29 import lines). (3) The new tests did not run in the hanging shard. The split is even-by-test-count on this base — there is no committed `.test_durations` and nothing is deselected any more — and reproducing it over the 56582 collected node ids puts all 17 of this file's tests in group 4, while the hanging test sits at index 18006, i.e. group 2. That reproduction is validated by a positive control: it independently places the hanging test in the very shard CI hung. (4) Adding these tests does not relocate the hanging test. Removing this file's 17 node ids from the collection leaves it at the same index and still in group 2, so the shard-membership shift that adding tests could in principle cause did not occur.

**The shard assignment was re-checked with pytest-split itself rather than by arithmetic, and the local slice does not hang.** Asking the real selector for each group gives 14146 / 14146 / 14146 / 14144 node ids, with the hanging test in **group 2** and **zero** of this file's tests there; all 17 land in **group 4**. Re-running that selection with this file ignored — the base's collection — leaves the hanging test in group 2 still, so adding these tests does not relocate it. Running the exact shard-2 slice locally (`-n auto --timeout=180 --splits 4 --group 2`) **completes in 66 seconds** (14098 passed; the 20 failures are local environment gaps — a missing `openpyxl` and the namespace-sandbox `flock` test — not this diff). The hanging test alone takes **8.12s on ext4** and passes, against blocking past 180s on Windows: a >22x platform gap on `fsync`/`os.replace` volume, with no logic difference.

**The platform-dependent shapes proposed for this diff are absent from it.** A poll-or-retry loop on an mtime, a held lock or file handle, and a memo-staleness check that can spin were each looked for in the diff and are not there. The whole change adds exactly ONE filesystem call — `st = path.stat()` — with no loop, no `flock`, no `open`, no `utime`, no retained handle; `_read_metadata_status` reads under `with open(...)`. The memo check is a single tuple comparison, and a mismatch costs one extra read rather than a wait, so it has no state in which it can block.

**What the base control does and does not establish.** Main `1a239dd73` — this commit's own parent — passed `Backend Tests (Windows) (2)` in 11m38s about 17 minutes before this run, carrying byte-identical `ci.yml` (`58e093894`) and `conftest.py` (`57957c6cb`). That is sound evidence the BASE is not the cause. It does not follow that the diff is, and treating those two as the only options is a false choice: the remaining explanation is nondeterminism in the hostile test, which sits in group 2 on both trees. That test grows one record by 1000 characters per iteration until it crosses `MAX_RECORD_BYTES` (2 MiB, `server.py:206`), rewriting the FULL cumulative record every time — roughly 2097 iterations and about 2.2 GB pushed through about 2097 `os.fsync` plus `os.replace` pairs. Durability-barrier I/O at that volume costs far more on a Windows runner than on ext4, which is a plausible way to cross the job cap without any assertion failing.

No new sha was spent on this, and none should be: a fresh sha reproduces this same tree, and the immediately preceding sha already passed this shard on byte-identical files in 14m40s. The 17 tests in this file pass locally in 3.4s at this head.

## How each review finding was dispositioned

Four blocking findings have been raised on this PR across successive review rounds. They are easy to confuse, because three of them cite lines within about fifteen lines of each other inside the same function, and earlier revisions of this description split them across three sections that each called its subject "Finding 1" and "Finding 2". This section replaces those and is the single place that records which is which.

Two were fixed in code. Two were refuted with no code change. The **Cited line** column records the coordinate each lane quoted at the sha it reviewed, which is not necessarily that line's position now — an amend shifts them. B and D point at the same guard: at the current head sha that guard is line 3510, which is what D cites, whereas B's 3511 was its position one revision earlier.

| Finding, by subject                                                                                                          | Cited line          | Outcome                                                          |
| ---------------------------------------------------------------------------------------------------------------------------- | ------------------- | ---------------------------------------------------------------- |
| **A.** A session with no `tab_id` is re-read on every rebuild and re-enters the shared metadata cache                         | in the `:3503` block | **FIXED IN CODE** — negative-memo sentinel                      |
| **B.** A rewrite that changes the line's size misses the memo, then hits the mtime-only metadata cache and reuses the OLD id  | `:3511`             | **FIXED IN CODE** — `_meta_cache` pop on the miss path           |
| **C.** The per-file `st = path.stat()` runs synchronously on the event loop                                                   | `:3503`             | **REFUTED** — real, but pre-existing and made ~10x smaller here  |
| **D.** An equal-size `tab_id` rewrite can strand a stale id via the memo-hit guard                                            | `:3510`             | **REFUTED** — no writer in this class can produce it             |

Read that table before reading any "fixed" claim below: **"fixed" always refers to A and B, never to C or D.** A and B are why this branch carries code changes that no currently-open finding asks for. C and D are why the newest blocking comment is answered in this description rather than by a commit.

### A — a session with no tab_id was re-read every rebuild (FIXED)

The observation was correct, and comparing against the base makes it sharper than the finding stated. The base `_rebuild_tab_id_index` did its own `path.open()` + `readline()` + `json.loads()` per file and **never touched `_meta_cache` at all**. Routing the read through `_read_metadata` meant a file with no `tab_id` inserted into that shared 256-entry LRU cache on every rebuild, because the early `continue` skipped the memo store and so nothing remembered the absence.

The population is real rather than hypothetical: on one live install, 116 of 1100 dashboard session files carry no `tab_id`. One correction to the finding's own arithmetic — its ">256 files → 0% hits" chain is not met at that size; the defect is eviction pressure on the three other readers of that cache, not a self-thrashing rebuild.

The fix memoizes the absence — `tid = raw if isinstance(raw, str) else ""`, with the `continue` moved after the store — so a warm rebuild now performs zero opens for those files and stops touching `_meta_cache` in steady state. Two tests pin it and both fail with the sentinel reverted: one asserts a warm rebuild opens nothing, the other that a session which later gains a `tab_id` is picked up rather than pinned by a stale sentinel.

### B — size made the memo miss, but nothing made the reread fresh (FIXED)

A lane held a blocking marker on the memo stamp for retaining stale chains. The coordinate was exact and the mechanism was real, so it was fixed rather than argued with. Verified at source:

- The memo hit returns the cached `tab_id` with no file read at all.
- On a stamp miss the rebuild delegates to `_read_metadata_status`.
- `_read_metadata_status` guards its own `_meta_cache` on **mtime alone** — `if cached and cached[0] == mtime: return cached[1], True`.

So a rewrite in the same timestamp tick that *did* change the line's length missed the `(mtime, size)` memo, then **hit** the mtime-keyed metadata cache, was handed the pre-edit metadata, and the rebuild re-memoized the **old** `tab_id` under the **new** stamp. Size made the memo miss; nothing made the reread fresh. Two further facts make the "persists" part fair rather than rhetorical: `_tab_id_by_key` is a plain dict with no LRU, so it has no eviction-based self-healing, and `invalidate_tab_id_cache` clears `_tab_id_index` without popping the memo, so a later rebuild still consults it.

The fix is two lines on the miss path and keeps the fast path intact: when the memo held a stamp whose size differs from the current size, pop `_meta_cache` for that key before the reread. A changed size is proof of changed content, so an mtime-keyed entry for that key is definitionally stale. The comment above the stamp was narrowed to match — it no longer credits size with delivering freshness, which is what it had claimed.

**It was genuinely untested, and that is now fixed.** The pre-existing out-of-band test moves the mtime forward 10 seconds specifically so its assertion cannot turn on timestamp granularity, which orders this window away by construction; none of the other tests constructed a same-mtime case. The new test pins the mtime **back** to its pre-edit value rather than racing the clock, so the stamp differs only in size, and it asserts both fixture preconditions (the mtime pinned, the size actually changed) so it cannot pass vacuously. Reverting the pop makes it fail with the new `tab_id` absent from the index — which is also the empirical proof that this finding was real rather than theoretical.

### C — the stat does run on the event loop, and this PR reduces it (REFUTED)

The lane is right that this runs on the event loop. That was verified rather than disputed. `read_messages_chained`, which triggers this rebuild when the index is stale, is called with **no offload** from three async request handlers:

- `api_chat_slot_fork` — declared `async def` at `chat_fork.py:39`, calls it at `:207`.
- `api_chat_slot_resume` — declared `async def` at `chat_handlers.py:4006`, calls it at `:4052`. The `await asyncio.to_thread(...)` two lines above wraps `clear_closed`, not this read, so it does not cover it.
- `api_chat_slot_rewind` — declared `async def` at `chat_rewind.py:60`, calls it at `:148`. This one is the archived-message fallback: it only fires when the requested timestamp is missing from the in-memory window, so it is the least frequent of the three, but it is a bare synchronous call inside the handler with no offload.

The codebase's own convention agrees with the lane: the identical call is offloaded in three other places — `api_chat_slot_detail` wraps it at `chat_handlers.py:1085` and `:1108`, and `chat_summary.py:332` uses `await asyncio.to_thread(log.read_messages_chained, key)`. So two of five async call sites do not follow a convention the other three do.

What the finding gets wrong is attribution. Before this PR the same function opened, read a line from, and JSON-parsed **every** session file on that same loop, and took no `stat` at all — read at the base commit `e7455c33b`:

```python
for path in sorted(self._dir.glob("dashboard_chat-*.jsonl")):
    with path.open(encoding="utf-8") as f:
        first_line = f.readline()
    m = json.loads(first_line)
```

This PR replaces that with one `stat` per file, and on a warm memo the `stat` is the only per-file syscall left — the open and the parse are gone. Measured: 17.8 ms to 1.6 ms across 161 files, and 129.4 ms to 10.8 ms across 1100. So the on-loop stall this anchor exists to prevent is roughly an order of magnitude **smaller** after this change than before it, and the prescribed remedy — revert the stat-based rebuild — restores the heavier form.

**Why the offload needs care, and how it is handled here.** It cannot be done inside the rebuild: that method is synchronous, and a synchronous function cannot await, so the only place to move this work off the loop is the three call sites above. Doing that naively would open a data-loss window at `chat_fork.py:207`. The fork holds `slot._fork_lock` across the read, but that lock is acquired in exactly one place in the entire tree (`chat_fork.py:147`) and the periodic flush does not take it. So inserting an `await` between the disk read and the in-memory tail read just below it lets a flush complete in between: it writes that tail to disk and clears `_dirty`, which is what gates both the reconciliation and the durable save. (Measured: the flush clears `_dirty` but does **not** advance `_resumed_count` — that counter is moved by the rehydrate/restore paths, `chat_persistence.py:737` and `:1030` among them, which is a separate writer set.) Those messages would then be in **neither** `all_messages` (read before the flush) **nor** `slot.messages[slot._resumed_count:]` (sliced after it), and would be missing from the fork's index space. `api_chat_slot_detail` documents this exact hazard where it offloads the same call, and handles it by re-reading the tail after the await.

A correct offload therefore needs an ordering fix wherever the slot is reachable before it is hydrated, plus a test that pins it. This revision does that for the resume handler: the transcript is read **before** the slot is published, so no concurrent request can resolve it by name while it is still empty. This revision now fixes both sides of that window. The resume handler now performs **every** await before publishing the slot — the transcript read, the folder-unhide and the closed-flag clear — so the window between publication and hydration holds no suspension point at all. It also re-applies the live-slot lookup and app-ownership gate after those awaits and immediately before the publish, because a concurrent resume can publish the slot while this one is suspended and `get_or_create_slot` applies no ownership check of its own. The folder-unhide result is captured and applied at its original site, so the failure path that clears a dangling `folder_id` is unchanged. The fork site pairs its disk read with the unpersisted tail on one consistent view of the slot, reusing the capture-boundary-then-retry idiom `session_transfer` already applies to this same race: it captures `_disk_window_len` — the persisted boundary the save path advances — together with `_dirty_gen` and the window length, snapshots the tail on the loop, then re-checks all three after the await and retries when any has moved. A boolean `_dirty` cannot carry this, because it cannot distinguish a slot that has never flushed from one flushed and then re-marked dirty by an append; in that interleaving no transition registers at all. `_resumed_count` cannot serve as the offset either, since the flush never advances it. On that authoritative branch there is deliberately no `_dirty` gate, so a flush clearing `_dirty` mid-read can no longer skip the merge and drop the tail. Where the boundary runs ahead of the resident window — a capped restore, or a mid-stream `_flush_segment` reassigning `slot.messages` — it is not usable as an index. `_resumed_count` is not a usable substitute and a `_dirty` gate does not make it one: the save never advances that counter — `_save_slot_to_history` only ever reads it, in its no-op skip — so for a slot created in this gateway run it stays 0 and the slice becomes the entire resident window appended onto the disk read, duplicating every persisted turn. The stability re-check cannot catch that either, because nothing forces a flush into the read window. But the two causes need OPPOSITE remedies, so the branch does not pick one blind: it snapshots the `_resumed_count` candidate on the loop and decides after the read, on the only authoritative discriminator — the true on-disk length. The invariant `channel_slots` states for these counters is that disk holds `_disk_older_count` frozen rows followed by the window, so disk holding more than `older + window` means rows exist the counters do not represent: the capped-restore signature. There the merge uses `_resumed_count`, which the restore sets to the capped length, and the flush is REFUSED — the frozen prefix is `body[:_disk_older_count]`, which a cap never bumps, so a flush would write the smaller window over the longer history and destroy every message the cap dropped. Only when the counters do agree with disk (the `_flush_segment` case) does it flush to re-sync the boundary and spend the attempt. The same rule gates the handler's later durable save, which had the same destructive shape. If the slot does not settle within four attempts the fork returns a retryable 503 rather than pairing a stale read with a moved boundary, since taking that pair would either drop the tail or duplicate it. The rewind site is offloaded without an ordering fix, deliberately: its awaited read feeds only the frozen on-disk prefix that decides an archived-history refusal, so a flush landing mid-read cannot corrupt state there. The blocking-call exposure on that path is real, pre-existing, and reduced here.

**Whether a cheaper shape exists was considered, and the `stat` turns out to be irreducible.** It cannot be skipped on a memo hit, because the stamp the memo is validated against *is* `(st.st_mtime, st.st_size)` — the stat is the thing that says whether the memo is still good. Keying on something already in hand is not available either: the loop holds only the path yielded by the glob, and a path alone carries no change signal. So the choice is not between an expensive validation and a cheap one, it is between one stat per file and no validation at all. One caveat on the arithmetic, so the gain is not overstated: the `0.927 ms` figure in the motivation table is a **bare stat sweep**, not what this change delivers. `_read_metadata` does `exists()` then `stat()`, two syscalls per file, so the delivered warm floor is about `1.6-2.0 ms` — a roughly 7-11x reduction depending on the run, not 15x. That trade is recorded in the limitations section.

### D — an equal-size rewrite cannot be produced by any writer in this class (REFUTED)

Also real as a mechanism, and narrower than it reads. A `tab_id` is minted as `uuid.uuid4().hex[:12]` (`chat_persistence.py:620` and `:984`, `state.py:4514`) — a fixed-length string — so replacing one with another changes neither the line's length nor, inside one coarse timestamp tick, its mtime. The stamp cannot see that, and no cheap discriminator can: telling the two apart requires reading the line, which is the read the memo exists to avoid. That the collision is real was measured, not assumed: writing a same-length `tab_id` twice in quick succession leaves `st_mtime` identical in 198 of 200 trials, with `st_mtime_ns` showing a delta of exactly 0 ns, because the kernel only advances a file timestamp on a clock tick.

It is not reachable through this class's own writers, on two independent counts. Both in-class `tab_id` writers are guarded by `if not tab_id:` (`chat_persistence.py:619` and `:983`) — they **backfill** a missing `tab_id` and never replace an existing one, so no in-class path performs an equal-size replacement at all. And every metadata write through the class pops the memo and bumps the generation counter before any later rebuild consults it.

What remains is an out-of-band edit that replaces an existing `tab_id` with a different one of identical length **and** lands within one timestamp tick of the memoized read. No code path produces that, and the memo was never contracted to detect out-of-band corruption — nor is it alone in that, since the six other caches in this class are keyed on `st_mtime` with no size comparison at all. The prescribed remedy, removing the memo-hit path and rereading directly, is the change itself; and reverting to `_read_metadata` lands on a strictly weaker guard with the identical hole.

**The one writer matching the required shape was found, and it is guarded four ways.** This finding needs a writer that both restores the mtime *and* bypasses the memo pop. Rather than assert that none exists, every `_restore_mtime` caller in the tree was enumerated. Exactly one lives outside `history.py`: `channel_transcript_migration.py:277`, which rewrites a transcript via `atomic_write` and then restores the pre-write mtime. It cannot produce this failure, on four independent counts:

1. **It performs the pop itself.** `log._invalidate_cache(channel_stem)` at `:278` and `log.invalidate_tab_id_cache()` at `:279` run immediately after the mtime restore, so the memo entry is gone and the generation bumped before any later rebuild could consult it.
2. **It never changes a `tab_id`.** `_CARRIED_META_FIELDS` is `("title", "folder_id", "pinned")`, and the comment block above it excludes `tab_id` deliberately, with the reason given: adopting the leftover's chain "would splice unrelated files into this conversation".
3. **It writes a file this index does not read.** Its target is the channel transcript, `slack_<thread_ts>.jsonl`; this rebuild globs `dashboard_chat-*.jsonl`, which that name does not match.
4. **It holds the same cross-process lock** every other transcript mutation takes — `log._locked(channel_stem)` nesting `log._locked(orphan_stem)`.

So the residual is an out-of-band writer that preserves size, restores mtime, **and** skips the pop — and the nearest thing in the tree to that shape does none of the three. An independent lane reached the same conclusion on this same sha: the Opus 4.8 review examined this exact stale-serve scenario and returned "no blocking findings", on the ground that product writes go through `ConversationLog` and no product path restores mtime while changing a `tab_id`.

### Why C and D are answered here and not by a commit

The blocking lane **has already re-run in place on this sha and still fails**. An earlier revision of this description asserted the opposite — that the failure was merely awaiting a future commit to trigger a fresh evaluation. That assertion was wrong and is withdrawn. The lane re-evaluated this exact sha, reached the same verdict, and unlike the advisory lanes it carries no "does not block merge" disclaimer — so a description-only answer cannot turn it green, and that is stated plainly rather than left as an expectation of a future re-run.

It will also not clear itself by running again. The lane has started five times against this one sha: the run that evaluated it concluded `failure`, and every run since has concluded `skipped`, which does not supersede that failure. So the red state is stable rather than pending — waiting produces no change, and only a new sha yields a fresh non-skipped verdict.

Both of its prescribed remedies are counterproductive on their own terms: reverting the stat-based rebuild restores roughly an order of magnitude more on-loop work than it removes, and removing the memo deletes the change this PR exists to make. Clearing the lane therefore needs a human decision, not another commit.

### Every writer that can change a tab_id, enumerated

Finding D was re-raised as reachable, so here is the audit rather than an argument. The question is narrow: can a `tab_id` change while both `st_mtime` and `st_size` stay identical **and** the memo is not popped? Every write path was read at source.

| writer                     | file:line                                                  | can leave `(mtime, size)` identical? | pops the memo?             |
| -------------------------- | ---------------------------------------------------------- | ------------------------------------ | -------------------------- |
| `append` (creation branch) | `history.py:2175`                                          | n/a — writes a NEW file              | n/a, no memo entry exists  |
| `update_metadata`          | `history.py:3622` -> `_update_metadata_locked`             | **yes** — `_restore_mtime` is deliberate | **yes**, `_invalidate_cache` |
| `update_metadata_if`       | `history.py:3637` -> `_update_metadata_locked`             | **yes**, same path                   | **yes**, same path         |
| `update_metadata_off_loop` | `history.py:622` -> `update_metadata`                      | **yes**, same path                   | **yes**, same path         |
| `_save_slot_to_history`    | `chat_persistence.py:1872` writes, `:2064` invalidates     | **yes**                              | **yes**, unconditionally   |

The mechanism finding D describes is real and not even accidental — `_update_metadata_locked` calls `_restore_mtime(path, prev_mtime)` on purpose so housekeeping does not reorder `list_sessions`, which means the stamp is blind to every in-class write by design. What closes it is the line immediately after: `self._invalidate_cache(key)`, which pops `_tab_id_by_key` and bumps the generation counter. Every path that can change a `tab_id` on an existing file funnels through that method, including the two dashboard call sites, which reach it via `update_metadata_off_loop`.

### A regression this PR introduced, and fixed

The negative-memo sentinel added for finding A had a real defect, caught in review and fixed here rather than defended. `_read_metadata` is a thin wrapper that **drops the readability flag**, so a transient read failure — an anti-virus scanner holding a freshly appended file, where `stat` succeeds but `open` does not — arrived as `{}` and was memoized as a definitive "no `tab_id`" against an unchanged stamp. That would drop the session from its chained history on every later rebuild until its next write, which is the vanished-history failure this index exists to prevent, and it was strictly worse than the pre-change code, which re-read every rebuild and so self-healed. The rebuild now reads through `_read_metadata_status` and declines the memo store when `readable` is `False`. A test constructs the exhausted-retry return and asserts both halves — nothing is memoized, and the session reappears once the failure clears — and it fails when the guard is reverted.

The method docstring also still described the abandoned first design: it claimed the rebuild was "backed by `_meta_cache`" and "deliberately NOT a private `(path, mtime)` cache", directly contradicting the private stamped memo in the code beneath it. A maintainer following it would have re-routed the rebuild through the shared LRU and restored the eviction pressure this change removes. It now describes the two guards and why neither is sufficient alone.

### A note on line numbers quoted by review lanes

Sibling lanes' coordinates for the metadata cache were wrong in earlier rounds, and the numbers they quoted should not be reused. The mtime-only guard lives in `_read_metadata_status`, and `_invalidate_cache` is a separate method; both were re-read at the current sha rather than carried over. Every coordinate in this section was re-verified against the working tree at head `42111df36`. Six had drifted and are corrected: the three `update_metadata*` rows in the table above (they pointed one definition early, or at a call inside `set_title`), and the three `list_sessions` coordinates in the limitations section below, which had all slid by about 22 lines. An earlier revision of this description claimed this verification had already been done; that claim was wrong for those six and is withdrawn. The substance they support is unchanged — each cited symbol was re-read at its corrected line and says what the surrounding argument reports.

## A CI timing shard that is not this diff

`Backend Tests (3.12, 1)` failed on `test_browser_cli_install.py::TestFailureDetailIsRedactedAtTheSource::test_redaction_timing_scales_linearly` with "Redaction scaled super-linearly: 0.2160s / 0.0688s = 3.1x (limit 3.0x)", and `Coverage Gate` failed only as its consequence — its step 2 requires the upstream coverage jobs to have succeeded, and every real coverage step after it is skipped.

Not reachable from this change, on three independent grounds. The failing test file contains **zero** references to `history`, `ConversationLog`, `tab_id`, `read_messages_chained`, `_tab_id_by_key` or `_rebuild_tab_id_index`; the measured work is `mod._redact()` over two synthetic in-memory strings with no filesystem access at all. **`Backend Tests (3.10, 1)` passed on the identical diff in the same run**, as did the other three 3.12 shards and all four Windows shards — a defect introduced by `history.py` cannot be selective by interpreter version in a pure-regex timing ratio. And the test's own docstring names this failure mode outright: a single unlucky small-input sample "is how this failed CI intermittently at ~3.1-3.2x", which is exactly where the observed 3.1379x sits, despite the best-of-3 and `thread_time` hardening the same docstring describes.

No code change was made for it and `test_browser_cli_install.py` was not touched. If a second run lands in the same 3.0-3.3x band, the residual belongs to that test's threshold or sampling rather than to this branch.

## Honest limitations

- **This is the second design; the first one inverted above 256 sessions.** The original
  revision read each `tab_id` through `_read_metadata`, backed by the shared `_meta_cache`
  (an LRU bounded by `_TRANSCRIPT_CACHE_MAX = 256`). The rebuild walks every session file in a
  fixed sorted order, so once the file count passed that bound each walk evicted the entries
  the previous walk had inserted and the next walk missed on all of them — a cliff, not a
  taper, and above it the path was marginally *slower* than the code it replaced because it
  added a `stat` before the same open/readline/parse. It also churned a cache shared with
  `get_metadata`, `list_sessions` and `update_metadata_if`, evicting entries those readers had
  warm.

  The private memo removes both. Measured by counting opens on a temporary fixture, warm
  rebuild with nothing changed:

  | session files | opens (old, via `_meta_cache`) | opens (now) | time (now) | another reader's entry |
  | ---: | ---: | ---: | ---: | :--- |
  | 256 | 0 | 0 | 1.6 ms | survives |
  | 257 | 257 | **0** | 1.6 ms | survives |
  | 400 | 400 | **0** | 2.5 ms | survives |
  | 1071 | 1071 (~144 ms) | **0** | 11.1 ms | survives |

  Both new guarantees are pinned by tests, and both were negative-controlled: with the memo
  lookup disabled they fail with `warm rebuild opened 260 files above the bound` and
  `rebuild evicted another reader's entry` respectively.

  What is genuinely left: the FIRST rebuild in a process still reads every file, because the
  memo starts empty and a `tab_id` can only be learned by reading it. That cost is unchanged
  from before this PR, and it is now paid once per invalidation rather than on every sent
  message. Cutting it further means not rebuilding wholesale, which is the separate change
  named above.

- **A sibling metadata reader is left untouched, and it caches under a different key.**
  `list_sessions` still does its own inline `open` + `readline` of the first line
  (`history.py:2907`) and stores the result with `key = path.stem` (`:2883`) — the
  underscore filename form — into the shared cache at `:2920`. This rebuild (and
  `get_metadata`) key on the session key, the colon form. So one file can occupy two entries in
  the same 256-entry cache under two spellings, which halves the effective headroom in files.
  This no longer affects the rebuild, which reads its own memo rather than that cache, but it
  still costs the other `_meta_cache` readers headroom, so it is real.

  I am leaving it, and the reason is that it is not the small fix it looks like. The filename
  fold is many-to-one — `_safe_key` is `re.sub(r"[^\w\-.]", "_", key)` — so a stem cannot be
  mapped back to a session key in general, and this file's own comments warn against guessing
  that inverse. The key space is also split across more than one caller rather than in one
  place: most write paths invalidate under the session key, while `_maybe_rotate` invalidates
  under `path.stem`. Unifying it means choosing one key space and correcting every site that
  touches either, with tests for each — a change with its own risk surface, and not one to
  fold into a perf PR whose argument is that it adds none.

- **This widens an existing cache-poisoning window; it does not open a new one.** Metadata writes
  restore the pre-write mtime, so a reader that stats, reads, and then stores can have its store
  land *after* a concurrent write plus that write's cache pop — leaving pre-write content under
  an mtime the file still has, which the mtime guard cannot see. `read_messages_chained` already
  reaches this window today, because it calls `get_metadata(key)` before taking the index lock,
  and `list_sessions` stores outside the file lock too. What changes here is the *breadth*: the
  rebuild now populates an entry for every dashboard session file rather than only the one being
  read, and the rebuild holds the index lock while a metadata write proceeds under a separate
  per-key file lock, so the two are not serialized. A reviewer looked at this and judged the harm
  nil, on the grounds that the only writer which *changes* a `tab_id` is the backfill and it
  mints a fresh id with no siblings. I could not fully confirm that dismissal: a chain can gain a
  member later, and a poisoned entry is only cleared by a write to that same session, which will
  not come for a dormant one. I have not demonstrated a loss, so I am not claiming a live bug —
  but I am also not claiming this is impossible, and it is not addressed here.
- **Two stats, not one.** `_read_metadata` does `path.exists()` then `path.stat()`, so a
  cache hit is two stat syscalls per file rather than the single one a purpose-built cache
  would need. That is why the measured floor is 2.0 ms rather than the 0.93 ms of a bare stat
  sweep. I took the correctness of the shared invalidation over the last millisecond.
- **Slightly stricter parsing.** `_read_metadata` only returns a record whose `_type` is
  `"metadata"`; the old inline read accepted any first line that was valid JSON containing a
  `tab_id`. Every writer of a metadata line in the codebase sets `_type: "metadata"`, so this
  is unreachable for any file this code wrote, but a hand-edited or foreign first line carrying
  a bare `tab_id` would now be skipped.
- **Different error handling on a transient read failure.** The old loop skipped a file on the
  first exception; `_read_metadata` retries up to 3 times. Its retry helper deliberately does
  not sleep when called on the event loop, so this adds no loop-blocking sleep, but it can mean
  up to 3 attempts per unreadable file instead of 1.
- **The measurement is from one machine** (161 files, warm page cache). Cold-cache numbers
  would be worse before and much the same after, so 12.4 ms is a floor on the saving rather
  than an estimate of it.
- **Rebuild frequency is unchanged.** Wholesale invalidation on every write is kept
  deliberately, since narrowing it is where the removed sentinel went wrong. If the remaining
  cost matters, the next step would be reducing how often `append` invalidates — a separate
  change with a much larger correctness surface.










## Follow-up noted, deliberately not fixed here: two writers disagree on line endings

`Backend Tests (Windows) (4)` failed on an earlier revision of this branch with `AssertionError: replacement was not equal-length / assert 201 == 203`, and the cause is a real cross-platform asymmetry in how this file is written. `append` writes through `open(path, "a", encoding="utf-8")` (`history.py:2214`) — text mode with no `newline=`, so on Windows every `\n` lands as `\r\n`. The metadata rewrite in `_update_metadata_locked` (`history.py:3692`) instead reads with `path.read_text(...)`, which applies universal-newline translation and collapses `\r\n` to `\n`, then writes the joined result as raw bytes via `_os.write(fd, data)`. There is no `newline=` anywhere in `history.py`. The net effect on Windows is that a metadata rewrite silently normalises the transcript's line endings and shrinks the file by one byte per line — two lines, two bytes, which is exactly the 203 to 201 delta CI reported. Reproduced locally by constructing CRLF content: a CRLF-ending file goes 203 to 201 across `update_metadata`, an LF-ending one goes 201 to 201.

That asymmetry is a latent issue in its own right, but changing how the durable transcript is written on every platform is out of scope for this change and should not be driven by a test control, so this PR does not touch it. What this PR fixed instead is the test's cross-platform precondition: the fixture now normalises the file's line endings before the rebuild that memoises it, so the equal-length premise the test rests on actually holds on Windows as well as POSIX. That normalisation is a no-op on POSIX, and it runs before the rebuild rather than after so the memo stamps the same bytes the assertions later compare — placing it after would have made the test pass for the wrong reason. The guard the test targets is still covered: reverting the `history.py` fix makes it fail with "the reader served a stale tab_id from its memo".

One consequence worth stating explicitly, because it runs opposite to the intuitive reading: since a Windows metadata rewrite does change `st_size`, the size half of the stamp would already catch that write on Windows. The stale-memo defect this PR fixes is therefore reachable on POSIX and, through this particular path, masked on Windows. The fix is still correct; only the test's premise needed to become platform-honest.


## Follow-up in this change: the rebuild's callers now offload it

The rebuild walks every dashboard session file synchronously. That walk is not introduced here — it pre-exists this change, and the memoization added here makes it cheaper rather than more expensive: a file unchanged since the last rebuild costs one `stat` instead of an `open` plus `readline` plus `json.loads`. An automated review round on an earlier revision asked for the memoization to be taken back out until the walk was moved off the event loop. That direction was not taken, because removing the memo would increase the very on-loop cost the review was concerned about, and it would also reopen the stale-tab-id defect the three-term stamp exists to close (an equal-length `tab_id` rewrite preserves both mtime and size, so a two-term stamp cannot see it). Reducing the per-file cost and moving the walk off the loop are independent changes, so this revision does both rather than trading one away for the other.

What the review was right about is that the walk was reachable from the event loop. Every caller of `read_messages_chained` and `recent_chained` was enumerated with an AST pass rather than a text search, because the classification needs the enclosing function's async-ness and whether the call is an argument to `asyncio.to_thread` — neither of which a grep can tell you. Three async request handlers called the chained reader directly with no offload: the fork handler, the resume handler, and the rewind handler. Two others already offloaded it, and this revision makes the remaining three match that existing pattern. The index field's own comment records that the chained read is reachable from worker threads and is guarded by the log's lock, so moving these calls into a thread is the sanctioned shape rather than a new assumption.

Offloading the resume handler moved its read across the point where the slot becomes reachable by name, and that ordering matters: `get_or_create_slot` publishes the slot into `state._slots`, and the hydrate loop that fills it runs afterwards. With the read awaited in between, a concurrent request could resolve the slot while it held zero messages and append a prompt there, after which the resume appended the restored history *behind* it. This revision reads the transcript before publishing the slot, next to the metadata read that already follows the same before-the-slot convention for the same reason. `test/test_resume_publishes_hydrated_slot.py` pins it by holding the threaded read open while another coroutine looks the slot up by name; it fails if the slot is reachable and empty at that moment. Relocating that read closed the publish→hydrate window and opened the one before it: the live-slot lookup and ownership gate at the top of the handler no longer ran atomically with the publish, so two concurrent resumes could both pass them and the second be handed the first's slot. That lookup and gate are now factored into one helper (`chat_handlers.py:3930`) called on both sides of the await, and `test/test_resume_publishes_hydrated_slot.py` pins it — with the re-check removed, a request from one app is handed another app's slot with a 200. The fork site is fixed too: it reconciles the in-memory tail against `_disk_window_len`, the persisted boundary the save path advances, captured alongside `_dirty_gen` and the window length and re-checked after the await, retrying when any of the three moves. `test/test_fork_reconciles_after_flush.py` pins five directions — the tail is lost without the retry, counted twice if the offset regresses to `_resumed_count`, counted twice again in the interleaving where a flush and an append both land before the read returns (which a boolean transition test cannot see), counted twice when the persisted boundary runs ahead of the resident window, and — the capped-restore direction — the persisted history TRUNCATED when a boundary ahead for the other reason is flushed. That last one asserts disk still holds its 250 rows with the oldest turn intact, because the response count alone is assembled in memory and cannot see the damage. Negative controls isolate the branches: reverting the offset duplicates the tail, removing the retry fails closed on the 503, restoring the `_resumed_count` slice duplicates the whole resident window, and disabling the capped-restore discriminator truncates disk from 250 rows to 52 — failing both that test and the pre-existing `test_fork_preserves_full_history_when_dirty_and_capped` guard. The resume handler also re-checks for deletion immediately before the publish, using `get_metadata_status` rather than `get_metadata` so an unreadable metadata line is not mistaken for a deletion; with that check removed a session deleted mid-read is republished with a 200. Two further awaits in the resume handler (the folder-unhide and the closed-flag clear) were also hoisted above the publish, and a third test holds the folder-unhide suspended and asserts the slot is not reachable-and-empty at that moment. The rewind site is left as described above.

Four deeper paths still reach the same reader from async code through synchronous wrappers, and this change deliberately does NOT touch them: three go through the slot-rehydration helper, which mutates dashboard state that the event loop owns, and one is a generator that yields between steps specifically to keep the heartbeat responsive during a large restore. Offloading either shape changes behaviour beyond this change's remit and wants its own review, so they are recorded here as follow-up rather than bundled in.

## Pending-rewrite save: which arm was taken, and why

A review lane flagged that the pending-rewrite save at `chat_fork.py` is a suspension
point with nothing captured across it: `chat_persistence` clears `_pending_rewrite`
unconditionally once the archive-safe rewrite succeeds (`if rewrite:
slot._pending_rewrite = False`), with no check that the flag it clears is the one its own
snapshot was taken for. A rewind landing inside that save therefore has its flag erased,
the next attempt reads `False`, and the fork copies the turns the rewind discarded. The
post-await stability re-check cannot catch it, because it re-baselines its counters on the
new attempt -- after the flag went missing -- so it measures the new attempt's stability
rather than the flag that was lost.

Two arms were available. The lane proposed returning the existing 503 as soon as the
generation moves. This change takes the other arm: on a generation move it treats the
source as still pending-rewrite and RETRIES the save within the existing
`_SNAPSHOT_ATTEMPTS` budget. That preserves this arm's stated design -- save and retry
rather than refuse outright, because a fork is required to still succeed -- and a flag that
keeps being re-set still ends at the loop's own terminal 503. No new error code was
introduced; `fork_snapshot_unstable` is the only one this handler returns.

The witness is `_dirty_gen`, which cannot false-trip: its setter advances the generation
only on a True assignment, so this save clearing `_dirty` does not move it, and
`best_effort=False` propagates a failure instead of re-marking the slot dirty. The idiom
mirrors `flush_slot_now`'s generation compare in `state.py`, which distinguishes "the True
I started this save under" from "a NEW True set during it" for the same reason.

`test_a_rewind_landing_during_the_pending_rewrite_save_is_not_erased` interleaves a rewind
into the save's suspension window and asserts on the forked transcript. At the pre-fix
parent it fails with the discarded turns present (`['m6', 'm7', 'm8', 'm9']`). Removing only
the witness assignment at the call site, leaving `chat_persistence` untouched, reproduces
that failure -- so the test measures the wiring, not the helper. Two direction tests cover
the ordinary pending-rewrite fork still succeeding rather than refusing, and the
non-pending path being untouched.

### The retry must also take the archive-safe path

The retry above introduced a second, narrower defect, which a later review pass caught: the
retry save was reaching `_save_slot_to_history` with neither promotion input for its
`rewrite` flag. That function only ever PROMOTES the flag -- `if messages is not None or
slot._pending_rewrite: rewrite = True` -- and gates both the archive-diff (`if rewrite and
path.exists(): _archive_dropped_lines(...)`) and the `rotation_generation` bump behind it. On
the retry no explicit snapshot is passed, and `_pending_rewrite` has already been cleared by
the first save -- that clearing being the very race the retry recovers from. So the retry
persisted the rewind's truncation through the PLAIN path, deleting the discarded turns from
disk with no archive copy. That is strictly worse than the bug it recovers from, which at
least left them readable on disk.

The call now passes `rewrite=True` unconditionally, because every entry into this arm means
"disk is stale because an edit truncated the window", which is exactly what the archive-safe
path is for. Passing it on the FIRST entry is a no-op rather than a widening: `_pending_rewrite`
is still set there, so the promotion already yields True, and
`test_a_first_entry_pending_rewrite_save_archives_as_before` pins that behaviour. Stating it
at the call site removes the dependence on that promotion, which is the thing that silently
failed. The sibling boundary-re-sync save in this handler is deliberately left plain -- it
re-syncs a boundary rather than editing the conversation.

`test_the_pending_rewrite_retry_still_archives_the_discarded_turns` asserts on the ARCHIVE
rather than the transcript, because the transcript assertion passes whether or not the
dropped turns were archived. Before the fix it fails with `Archived contents: []` while
`['a6', 'a7', 'a8', 'a9']` are gone from disk; removing only `rewrite=True` from the call
site, with `chat_persistence` untouched, reproduces that.

In total this pending-rewrite work adds five tests to
`test/test_fork_reconciles_after_flush.py`: the interleaved-rewind transcript regression, the
archival regression, and three direction guards (ordinary pending-rewrite fork still
succeeds, non-pending path untouched, first-entry archival unchanged).

### The post-await snapshot guard also witnesses `_dirty`

A review pass found that the guard's witness set was incomplete. It captured four values plus
`_pending_rewrite`, and none of them can observe a save that merely COMPLETES underneath the
threaded read: an in-place content edit (a variant switch) moves neither `len(slot.messages)`
nor `_disk_older_count`; the save re-assigns `_disk_window_len` to the value it already held,
because the window length did not change; and clearing `_dirty` cannot move `_dirty_gen`, since
that setter advances only on a True assignment. The boundary-derived tail slice is empty in that
state, so the fork adopted the pre-save read verbatim and the forked session kept superseded
content.

This reproduced before the fix: with a save landing inside the read, the forked transcript
carried the stale variant while all four witnessed counters were provably unchanged and `_dirty`
had flipped. The regression test asserts that with fixture guards, so a pass cannot come from the
existing checks having caught the change instead.

`_dirty` is now captured with the other witnesses and compared in the guard, so a mismatch
RETRIES the read. It is deliberately NOT part of the merge decision, which stays keyed on the
boundary alone. That distinction is what makes this compatible with the two comments in this file
recording that a cleared `_dirty` must never be allowed to skip the reconciliation -- those
reject `_dirty` as a sufficient merge gate, which is a different proposition from using it as a
necessary stability witness. A retry is not a skip. All five shipped flush/merge-boundary tests
still pass, including the one that pins the tail-loss behaviour those comments exist to record.
