### PR TITLE
fix(chat): render tag-like prose placeholders verbatim

### DIFF
--- a/website/src/apps/mochi/src/renderer/ChatPanel.tsx
+++ b/website/src/apps/mochi/src/renderer/ChatPanel.tsx
@@ -36,7 +36,7 @@ import { familyGrantIsDistinct, trustBasePattern, truncateCommandLabel } from '.
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
-import { rehypeSanitize } from '../../../../components/MarkdownRenderer'
+import { rehypeSanitize, remarkVerbatimUnknownTags } from '../../../../components/MarkdownRenderer'
 import { mdImageDestToPath } from '../../../../utils/fileTokens'
 import { classifyPlatform } from '../../../../hooks/useGatewayPlatform'
 import type { ApprovalRequest, ChatMessage } from '../shared/types'
@@ -1630,7 +1630,7 @@ function fixStreamingFences(s: string): string {
   return s
 }
 
-const MD_REMARK = [remarkGfm]
+const MD_REMARK = [remarkGfm, remarkVerbatimUnknownTags]
 /**
  * Raw HTML must be ADMITTED, then SANITIZED — in that order.
  *

--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -1236,6 +1236,91 @@ export function rehypeSanitize() {
   }
 }
 
+/** A whole mdast `html` node that is exactly ONE tag: `<x>`, `</x>`, `<x a b>`,
+ * `<x/>`. `[^>]*` forbids an interior `>`, and the leading `[a-zA-Z]` excludes
+ * comments (`<!-- -->`) and doctypes, which must keep their existing handling. */
+const SINGLE_TAG_RE = /^<\/?([a-zA-Z][a-zA-Z0-9-]*)(\s[^>]*)?\/?>$/
+
+/** Tag name of a single-tag html node, or undefined when it is not one. */
+function singleTagName(value: string): string | undefined {
+  return SINGLE_TAG_RE.exec(value)?.[1]?.toLowerCase()
+}
+
+/** Showable verbatim. Executable tags keep their `[unsupported: x]` marker; every
+ * other unknown tag diverts, because a text node is inert wherever it lands. */
+function divertibleTag(tag: string): boolean {
+  return !UNSAFE_RECONSTRUCT_TAGS.has(tag)
+}
+
+/** Index of the sibling that closes `tag`, tracking same-tag nesting; -1 if unclosed. */
+function matchingCloseIndex(kids: MdastNode[], start: number, tag: string): number {
+  let depth = 0
+  for (let j = start + 1; j < kids.length; j++) {
+    const k = kids[j]
+    if (k.type !== 'html' || typeof k.value !== 'string') continue
+    if (singleTagName(k.value) !== tag) continue
+    if (k.value.startsWith('</')) {
+      if (depth === 0) return j
+      depth--
+    } else if (!k.value.endsWith('/>')) depth++
+  }
+  return -1
+}
+
+/** Render non-allowlisted single tags VERBATIM instead of reconstructing them.
+ *
+ * Runs at the remark (mdast) stage, before rehypeRaw reaches the HTML parser. An
+ * mdast `html` node's `value` IS the author's original source substring, so
+ * converting it to `text` reproduces exactly what was typed: original case,
+ * original spacing, and no closing tag the author never wrote.
+ *
+ * Deliberately narrow — two things keep existing escapedNodeTree() handling:
+ * multi-tag raw HTML blocks, and UNSAFE_RECONSTRUCT_TAGS (script/style/iframe
+ * still collapse to `[unsupported: x]`). Everything else diverts, including a
+ * tag whose attribute value is a dangerous protocol — see frontend-security.
+ *
+ * Exported so every markdown surface that admits raw HTML shares this pass; a
+ * surface wiring rehypeSanitize without it keeps the lossy reconstruction.
+ *
+ * frontend-security: the tag never becomes an element and never reaches the HTML
+ * parser — it ends up a text node, which React escapes on render, so the React
+ * #290 guard still holds.
+ */
+export function remarkVerbatimUnknownTags() {
+  return (tree: MdastNode) => {
+    const walk = (node: MdastNode) => {
+      const kids = node.children
+      if (!kids) return
+      for (let i = 0; i < kids.length; i++) {
+        const child = kids[i]
+        if (child.type === 'html' && typeof child.value === 'string') {
+          const tag = singleTagName(child.value)
+          if (tag && !ALLOWED_TAGS.has(tag) && divertibleTag(tag)) {
+            const paired = child.value.startsWith('</') || child.value.endsWith('/>')
+              ? -1
+              : matchingCloseIndex(kids, i, tag)
+            if (paired > i) {
+              // A closed container: divert the whole span, so allowlisted tags
+              // inside it stay literal instead of rendering as live elements.
+              for (let j = i; j <= paired; j++) {
+                const k = kids[j]
+                if (k.type !== 'html' || typeof k.value !== 'string') continue
+                const kt = singleTagName(k.value)
+                if (kt && divertibleTag(kt)) k.type = 'text'
+              }
+            } else {
+              // Verbatim source text — no HTML string is built or re-parsed.
+              child.type = 'text'
+            }
+          }
+        }
+        walk(child)
+      }
+    }
+    walk(tree)
+  }
+}
+
 // CommonMark has a known emphasis defect (commonmark/commonmark-spec#650): a
 // closing `**` is only right-flanking when it is NOT preceded by punctuation, or
 // IS followed by whitespace/punctuation. `**中文（带括号）。**这句` fails both —
@@ -1252,6 +1337,7 @@ const REMARK_PLUGINS: PluggableList = [
   remarkGfm,
   remarkCjkFriendlyGfmStrikethrough,
   [remarkMath, { singleDollarTextMath: false }],
+  remarkVerbatimUnknownTags,
 ]
 
 /**

--- a/website/src/test/MarkdownRenderer.sanitize.test.tsx
+++ b/website/src/test/MarkdownRenderer.sanitize.test.tsx
@@ -12,8 +12,9 @@ describe('rehypeSanitize allowlist (React #290 fix)', () => {
       <MarkdownRenderer content={'The client is <dynamoDBClient> and it handles requests.'} />
     )
     // Should render as literal text, not crash
-    // Note: HTML parser lowercases tag names before they reach rehype
-    expect(container.textContent).toContain('<dynamodbclient>')
+    // Rendered verbatim: the tag is diverted to a text node at the remark stage,
+    // so it never reaches the HTML parser that used to lowercase it.
+    expect(container.textContent).toContain('<dynamoDBClient>')
     // Should NOT produce an actual dynamoDBClient element
     expect(container.querySelector('dynamoDBClient' as any)).toBeNull()
     expect(container.querySelector('dynamodbclient' as any)).toBeNull()
@@ -23,10 +24,10 @@ describe('rehypeSanitize allowlist (React #290 fix)', () => {
     const { container } = render(
       <MarkdownRenderer content={'<myCustomTag>inner content</myCustomTag>'} />
     )
-    // HTML parser lowercases tag names before they reach rehype
-    expect(container.textContent).toContain('<mycustomtag>')
+    // Verbatim, including the closing tag the author actually typed.
+    expect(container.textContent).toContain('<myCustomTag>')
     expect(container.textContent).toContain('inner content')
-    expect(container.textContent).toContain('</mycustomtag>')
+    expect(container.textContent).toContain('</myCustomTag>')
   })
 
   it('still renders allowed HTML tags normally', () => {
@@ -94,11 +95,17 @@ describe('rehypeSanitize allowlist (React #290 fix)', () => {
     expect(container.innerHTML).toContain('&lt;')
   })
 
-  it('drops dangerous-protocol attribute values when serializing unknown tags', () => {
+  it('renders an unknown tag with a dangerous-protocol value as inert text', () => {
     const { container } = render(
       <MarkdownRenderer content={'<customLink href="javascript:alert(1)">x</customLink>'} />
     )
-    expect(container.textContent).not.toContain('javascript:')
+    // Unknown tags are no longer serialized; they divert to a text node, so the
+    // protocol is displayed rather than parsed. No anchor, no handler, no href.
+    expect(container.querySelectorAll('a')).toHaveLength(0)
+    expect(Array.from(container.querySelectorAll('*')).filter(el =>
+      Array.from(el.attributes).some(a => /^on/i.test(a.name) || /javascript:/i.test(a.value))
+    )).toHaveLength(0)
+    expect(container.textContent).toContain('<customLink href="javascript:alert(1)">')
   })
 
   it('GFM footnotes render as real elements, not escaped text', () => {

--- a/website/src/test/MarkdownRenderer.verbatimTags.test.tsx
+++ b/website/src/test/MarkdownRenderer.verbatimTags.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import MarkdownRenderer, { remarkVerbatimUnknownTags } from '../components/MarkdownRenderer'
+
+/** No live sink: a diverted tag is a React text node, so a protocol string in it
+ * is displayed, never parsed. Asserts that rather than the string's absence. */
+function expectInert(container: HTMLElement) {
+  const strip = (v: string) => v.replace(/[\s\u0000-\u001f]/g, '').toLowerCase()
+  const els = Array.from(container.querySelectorAll('*'))
+  for (const tag of ['script', 'iframe', 'object', 'embed', 'a', 'img']) {
+    expect(container.querySelectorAll(tag)).toHaveLength(0)
+  }
+  expect(els.filter(el => Array.from(el.attributes)
+    .some(a => /^on/i.test(a.name)))).toHaveLength(0)
+  expect(els.filter(el => Array.from(el.attributes)
+    .some(a => /^(javascript|vbscript):/.test(strip(a.value))))).toHaveLength(0)
+}
+
+/**
+ * Unknown (non-allowlisted) tags used as prose placeholders must render
+ * VERBATIM — same case, same spacing, and with no closing tag the author
+ * never typed.
+ *
+ * Regression: escapedNodeTree() rebuilt the tag from the post-parse hast
+ * node, so it inherited every normalisation parse5 applied:
+ *   - tagName was already lowercased      -> <Widget-id>  became <widget-id>
+ *   - bare attributes became value ''     -> <a b c>  became <a b="" c="">
+ *   - a close tag was appended uncondi-   -> unclosed placeholders grew a
+ *     tionally, and parse5 had nested        stack of </...> at the very end
+ *     the unclosed elements
+ * The displayed bubble was therefore not a faithful copy of what the user
+ * typed, which made copy-paste out of chat lossy.
+ */
+describe('verbatim rendering of unknown tags used as prose placeholders', () => {
+  it('preserves original case and injects no closing tag', () => {
+    const { container } = render(<MarkdownRenderer content={'config has <Widget-id>.json so it loads default'} />)
+    expect(container.textContent).toContain('<Widget-id>.json')
+    expect(container.textContent).not.toContain('<widget-id>')
+    expect(container.textContent).not.toContain('</Widget-id>')
+    expect(container.textContent).not.toContain('</widget-id>')
+  })
+
+  it('does not turn bare words inside a placeholder into empty attributes', () => {
+    const { container } = render(<MarkdownRenderer content={'like <Widget-id>.<some optional variant id>.json instead'} />)
+    expect(container.textContent).toContain('<some optional variant id>')
+    expect(container.textContent).not.toContain('=""')
+  })
+
+  it('reproduces a multi-placeholder message with no appended close-tag stack', () => {
+    // Two unclosed placeholders in one paragraph append a run of closing tags.
+    const content = 'For ex. if the config has <Widget-id>.json it will load the default, '
+      + 'but if it has like <Widget-id>.<some optional variant id>.json it will '
+      + 'load that one instead of the default'
+    const { container } = render(<MarkdownRenderer content={content} />)
+    const text = container.textContent || ''
+    expect(text).toContain('<Widget-id>.json')
+    expect(text).toContain('<some optional variant id>')
+    // The exact corruption users saw appended to the end of their own message.
+    expect(text).not.toContain('</some>')
+    expect(text).not.toContain('</widget-id>')
+    expect(text).not.toContain('=""')
+  })
+
+  it('keeps a closing tag the author actually typed, in its original case', () => {
+    const { container } = render(<MarkdownRenderer content={'<myCustomTag>inner content</myCustomTag>'} />)
+    const text = container.textContent || ''
+    expect(text).toContain('<myCustomTag>')
+    expect(text).toContain('inner content')
+    expect(text).toContain('</myCustomTag>')
+  })
+
+  it('still renders no element for the unknown tag (React #290 guard holds)', () => {
+    const { container } = render(<MarkdownRenderer content={'The client is <dynamoDBClient> and it handles requests.'} />)
+    expect(container.querySelector('dynamoDBClient' as never)).toBeNull()
+    expect(container.querySelector('dynamodbclient' as never)).toBeNull()
+    expect(container.textContent).toContain('<dynamoDBClient>')
+  })
+
+  it('renders a block-level lone placeholder with no escaped-tag wrapper', () => {
+    // A placeholder alone in a block takes a different mdast position from an
+    // inline one and emits a bare text node rather than a wrapper span.
+    const { container } = render(<MarkdownRenderer content={'<Widget-id>'} />)
+    expect(container.querySelector('span.escaped-tag')).toBeNull()
+    expect(container.querySelector('Widget-id' as never)).toBeNull()
+    expect(container.textContent).toContain('<Widget-id>')
+  })
+
+  it('still collapses executable tags to an unsupported marker', () => {
+    const { container } = render(<MarkdownRenderer content={'before <script>alert(1)</script> after'} />)
+    const text = container.textContent || ''
+    expect(container.querySelector('script')).toBeNull()
+    expect(text).not.toContain('alert(1)')
+    expect(text).toContain('[unsupported: script]')
+  })
+
+  it('leaves allowlisted inline HTML working', () => {
+    const { container } = render(<MarkdownRenderer content={'<strong>bold</strong> and <em>italic</em>'} />)
+    expect(container.querySelector('strong')).not.toBeNull()
+    expect(container.querySelector('em')).not.toBeNull()
+    expect(container.textContent).toContain('bold')
+  })
+
+  it('does not escape tag-like text inside code spans or fences', () => {
+    const { container } = render(<MarkdownRenderer content={'inline `<Widget-id>` and\n\n```\n<Widget-id>.json\n```\n'} />)
+    const text = container.textContent || ''
+    expect(text).toContain('<Widget-id>')
+    expect(text).not.toContain('&lt;')
+  })
+
+  it('renders a placeholder containing a protocol-like word verbatim', () => {
+    // `data:` is an ordinary English word plus a colon, so a bare word inside a
+    // placeholder must not be read as a dangerous attribute VALUE.
+    const { container } = render(<MarkdownRenderer content={'paste <Some data: Thing> below'} />)
+    const text = container.textContent || ''
+    expect(text).toContain('<Some data: Thing>')
+    expect(text).not.toContain('<some data:')
+    expect(text).not.toContain('=""')
+    expect(text).not.toContain('</some>')
+  })
+
+  it('keeps fidelity uniform across neighbouring placeholders in one message', () => {
+    const { container } = render(<MarkdownRenderer content={'<Alpha-id> then <Beta data: id> then <Gamma-id>'} />)
+    const text = container.textContent || ''
+    expect(text).toContain('<Alpha-id>')
+    expect(text).toContain('<Beta data: id>')
+    expect(text).toContain('<Gamma-id>')
+  })
+
+  it('shows a protocol-bearing placeholder verbatim and inert', () => {
+    const { container } = render(<MarkdownRenderer content={'<customLink href="javascript:alert(1)">x</customLink>'} />)
+    expect(container.textContent).toContain('<customLink href="javascript:alert(1)">')
+    expectInert(container)
+  })
+
+  it('keeps a paired unknown container literal, including nested allowed HTML', () => {
+    const { container } = render(<MarkdownRenderer content={'<customBlock>see <b>this</b> ok</customBlock>'} />)
+    const text = container.textContent || ''
+    expect(text).toContain('<customBlock>')
+    expect(text).toContain('<b>this</b>')
+    expect(text).toContain('</customBlock>')
+    expect(container.querySelectorAll('b')).toHaveLength(0)
+  })
+
+  it('still collapses an executable tag nested in a paired container', () => {
+    const { container } = render(<MarkdownRenderer content={'<customBlock>a <script>alert(1)</script> b</customBlock>'} />)
+    const text = container.textContent || ''
+    expect(container.querySelectorAll('script')).toHaveLength(0)
+    expect(text).not.toContain('alert(1)')
+    expect(text).toContain('[unsupported: script]')
+  })
+
+  it('shows a protocol-bearing anchor inside a paired container verbatim and inert', () => {
+    const { container } = render(<MarkdownRenderer content={'<customBlock>a <a href="javascript:alert(1)">x</a> b</customBlock>'} />)
+    expect(container.textContent).toContain('<a href="javascript:alert(1)">')
+    expectInert(container)
+  })
+
+  it('shows an unquoted protocol value verbatim and inert', () => {
+    const { container } = render(<MarkdownRenderer content={'<customLink href=javascript:alert(1)>x</customLink>'} />)
+    expect(container.textContent).toContain('<customLink href=javascript:alert(1)>')
+    expectInert(container)
+  })
+})
+
+/**
+ * The pass is exported and wired by every surface that admits raw HTML, so it is
+ * tested as a unit rather than only through one component: a second consumer
+ * (the mochi chat panel) composes it into its own remark list.
+ */
+describe('remarkVerbatimUnknownTags as a shared unit', () => {
+  const run = (src: string) => {
+    const tree = unified().use(remarkParse).use(remarkVerbatimUnknownTags).runSync(
+      unified().use(remarkParse).parse(src)
+    ) as { children: { children?: { type: string; value?: string }[] }[] }
+    return tree.children[0]?.children ?? []
+  }
+
+  it('converts an unknown single tag from an html node to a text node', () => {
+    const kids = run('a <Widget-id> b')
+    expect(kids.some(k => k.type === 'html')).toBe(false)
+    expect(kids.some(k => k.type === 'text' && k.value === '<Widget-id>')).toBe(true)
+  })
+
+  it('converts a tag carrying a dangerous attribute value to a text node', () => {
+    const kids = run('a <customLink href="javascript:alert(1)"> b')
+    expect(kids.some(k => k.type === 'html')).toBe(false)
+    expect(kids.some(k => k.type === 'text'
+      && k.value === '<customLink href="javascript:alert(1)">')).toBe(true)
+  })
+
+  it('converts a placeholder whose bare word merely looks like a protocol', () => {
+    const kids = run('a <Some data: Thing> b')
+    expect(kids.some(k => k.type === 'text' && k.value === '<Some data: Thing>')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

A tag-like prose placeholder in a chat message does not render faithfully. Typing this:

```
For ex. if the config has <Widget-id>.json it will load the default, but if it has like <Widget-id>.<some optional variant id>.json it will load that one instead
```

displayed this (captured from the test run on `main` before the fix):

```
For ex. if the config has <widget-id>.json it will load the default, but if it has like <widget-id>.<some optional="" variant="" id="">.json it will load that one instead</some></widget-id></widget-id>
```

Three separate corruptions: tag names lowercased, bare words turned into empty attributes (`optional=""`), and a run of closing tags the author never typed (`</some></widget-id></widget-id>`) appended at the very end of the message.

## Why it matters

Anyone who types an angle-bracket placeholder while describing a config key, a filename pattern, or a template — ordinary in a technical chat — sees their own words come back altered, with a run of closing tags they never wrote appended to the end of the message. The severity is modest and worth stating plainly: nothing is lost from the stored message, the agent receives exactly what was typed, and no security boundary is involved, so this is a fidelity and trust problem rather than a correctness or safety one. The concrete cost is that copy-pasting text back out of a chat bubble silently returns something different from what was entered.

## Scope: display only, ingest was never affected

The stored message is byte-clean, so the agent received exactly what was typed. The cost is that copy-paste out of a chat bubble is lossy, and the user sees their own words mangled.

## Root cause

`escapedNodeTree()` in `website/src/components/MarkdownRenderer.tsx`. Non-allowlisted tags are deliberately reconstructed as visible text so that they do not silently vanish; that intent is right and is preserved. The flaw is that the reconstruction is built from the **post-parse hast node** rather than from the original source, so it inherits everything the HTML parser (parse5) normalised:

| Symptom | Mechanism |
| ---------------------------------- | ------------------------------------------------------------------------- |
| `<Widget-id>` renders as `<widget-id>` | `node.tagName` arrives already lowercased; the original case is unrecoverable |
| bare words become `attr=""` | parse5 gives a bare attribute the value `''`, and the serializer emits `k="v"` |
| closing tags appended at the end | the close tag is emitted unconditionally, and parse5 had nested the unclosed elements |

## What changed (motivation → approach → change)

A new remark plugin, `remarkVerbatimUnknownTags`, diverts non-allowlisted **single** tags to a verbatim text node at the remark (mdast) stage, before `rehypeRaw` hands anything to the HTML parser. An mdast `html` node's `value` is the original source substring, so for every input the diverter accepts the output is byte-identical to what was typed, and no closing tag is invented. An author's own closing tag is just another `html` node and is handled identically.

Scope is deliberately narrow. These all keep their existing `escapedNodeTree()` handling:

- multi-tag raw HTML blocks, so intentional raw HTML is unaffected;
- `UNSAFE_RECONSTRUCT_TAGS` (`script`, `style`, `iframe`, ...), which still collapse to their `[unsupported: x]` marker rather than being echoed back.

There is now exactly **one** exclusion, and that is deliberate. An earlier revision also excluded any tag whose attribute value began with a dangerous protocol, which meant `<customLink href="javascript:alert(1)">` typed in prose was still mangled. That exclusion has been removed: such a tag now diverts to a text node like any other, and is displayed exactly as typed. The reasoning is in the Security posture section — a text node is inert, so nothing was being defended, while the exclusion cost a second rendering path and one more inconsistency in the fidelity this change exists to provide.

A **closed** unknown container diverts as a whole span, not tag-by-tag. The pass walks siblings, and an opening tag plus its matching closing tag arrive as two independent single-tag nodes, so converting each on its own left everything between them untouched — an allowlisted tag nested in a placeholder then rendered as a live element and the author's `<b>`/`</b>` markers disappeared. When a matching close is found (tracking same-tag nesting), every divertible node in that span is converted, so the container's contents display literally. The one exclusion is preserved inside the span as well as outside it: `UNSAFE_RECONSTRUCT_TAGS` keep their `[unsupported: x]` marker, so a `<script>` nested inside a placeholder is still collapsed rather than echoed back.

**Severity of that defect was fidelity, not injection**, and this was measured rather than assumed. Inside `<customBlock>…</customBlock>`: a nested `<script>` still collapsed to `[unsupported: script]` with 0 script elements; `<a href="javascript:alert(1)">` still rendered with the `href` stripped; `<img src=x onerror=alert(1)>` still rendered with `onerror` stripped. Every nested element continued through `rehypeSanitize`, so nothing dangerous became reachable — what was lost was the literal display of allowlisted markup the author typed.

**Both consumers of the shared sanitizer are wired.** `escapedNodeTree()` is reached
through the exported `rehypeSanitize`, which has two real consumers:
`website/src/components/MarkdownRenderer.tsx` and the mochi chat panel at
`website/src/apps/mochi/src/renderer/ChatPanel.tsx`. The pass cannot live inside
`rehypeSanitize` itself — by then parse5 has already destroyed the original case and
attribute spelling, which is the whole defect — so it is a remark-stage pass that each
surface composes. It is therefore exported, and mochi's own `MD_REMARK` list now
includes it. A surface that wires `rehypeSanitize` without it keeps the lossy
reconstruction, which is why that constraint is stated on the function itself.

## Security posture

This tightens rather than relaxes. The tag never becomes an element and never reaches the HTML parser: it lands in a React text node, which React escapes at the sink. Encoding at the sink rather than building markup from untrusted input is the intended posture for this path.

`on*` handler attributes need no exclusion from the verbatim path even though `escapedNodeTree()` filters them via `!/^on/i.test(k)`. Because the tag becomes a text node, the value never becomes an attribute and no handler is ever installed. The same reasoning is why dangerous **protocol** values need no exclusion either, and an earlier revision's carve-out for them has been removed.

That claim is measured, not asserted. Across 20 adversarial inputs — quoted, unquoted and single-quoted `javascript:`, mixed case, an HTML entity in the middle of the protocol, tab / newline / NUL inside it, leading whitespace, `vbscript:`, a non-image `data:` URL, `srcdoc`, bare `onclick` / `onerror` attributes, and `a` / `img` / `script` / `iframe` nested inside a paired placeholder — the rendered output contains 0 anchors, 0 images, 0 scripts, 0 iframes, 0 objects, 0 embeds, 0 elements carrying an `on*` attribute, and 0 elements carrying a dangerous-protocol attribute value. The same harness was positive-controlled: it reports 1 anchor for an ordinary allowlisted `<a href="https://example.com">`, and its attribute detector reports 1 on a synthetic dangerous-protocol anchor, so those zeros are real absences rather than a blind check.

Removing the carve-out also removed a live element. Under the old behaviour, `<customBlock>a <a href="javascript:alert(1)">x</a> b</customBlock>` rendered a real `<a target="_blank">` (with `href` stripped) inside the placeholder; it now renders as inert text with no element at all. So the subtraction is not merely security-neutral, it reduces the number of live elements built from untrusted input.

This also matches Amazon's own XSS guidance, which prefers escaping over sanitisation precisely because sanitisation damages legitimate content — its worked example of an inappropriate mitigation is refusing to let an author title a book `My favorite <script>s`. Mangling `<customLink href="javascript:...">` that someone typed into a chat message is the same shape of harm.

The React #290 guard (an unknown tag name must never be handed to React as an element) remains covered by tests.

## Known limitations

Three entries that previously appeared here are now CLOSED: the broader-than-its-sibling protocol check, the paired-container behaviour (both described under What changed), and the asymmetry between this path's exclusion set and `escapedNodeTree()`'s — that asymmetry is gone because the protocol exclusion is gone, leaving one exclusion on each side of a different axis and no protocol carve-out to be inconsistent about.

One narrower limitation remains, and it is not a regression: it behaves identically before and after this change. It is recorded because the section above advertises verbatim fidelity, and this is the reachable input where it does not hold. It was verified by running it against this branch, not inferred from reading the code.

1. **A tag whose attribute value legitimately contains `>` never matches.** `SINGLE_TAG_RE` uses `[^>]*` for the attribute span, which forbids an interior `>`, so such a tag silently keeps the lossy handling. Measured: `<Foo bar="a>b">` renders `<foo bar="a>b">` plus a trailing `</foo>`.

## Three changed assertions in an existing test

Three assertions across two tests in `MarkdownRenderer.sanitize.test.tsx` encoded the old lossy output and now assert the verbatim form: `<dynamodbclient>` to `<dynamoDBClient>`, `<mycustomtag>` to `<myCustomTag>`, and `</mycustomtag>` to `</myCustomTag>`.

All three were asserting the bug rather than guarding a regression — the original comment on each test ("HTML parser lowercases tag names before they reach rehype") documents the corruption as the expected result. What those tests exist to protect (an unknown tag must not reach React as an element, and the inner content must survive) is unchanged and still asserted by the same tests.

## Reviewer dispositions on this revision

Each claim was checked at source before deciding, and the two substantive ones are now **fixed in code** rather than argued away.

**Nested allowed HTML in a paired container (GPT 5.6) — CONFIRMED and FIXED.** The mechanism was real: the pass walked siblings, so an unknown opening tag and its matching close arrived as two independent nodes and everything between them was left untouched, rendering nested allowlisted markup live and dropping the author's own `<b>`/`</b>`. It is fixed by span diversion, described under What changed. Note this is not the literal remedy the review proposed — skipping conversion for matched pairs would have sent the whole container back to the old path, lowercasing an author's own `</myCustomTag>` again and failing the existing test `keeps a closing tag the author actually typed, in its original case`. Diverting the matched span instead keeps the subtree literal *and* preserves case, which is what the finding's stated goal, preserving the literal subtree, actually asks for. Severity was fidelity rather than injection, and that was measured: nested `<script>` still collapsed to `[unsupported: script]`, and a nested anchor and image had `href` and `onerror` stripped respectively.

**Delete the dangerous-protocol carve-out (First Principles) — ACCEPTED and DONE, reversing an earlier decision on this PR.** An earlier revision declined this on the grounds that removal broke five test assertions. That count was correct but it was the wrong reason, and the reviewer was right to press it a second time. Re-examined, all five assertions were of the form "the substring `javascript:` must not appear in the output", or in one case a direct assertion that the carve-out existed — none of them pinned a live sink. The security property they appeared to protect is provided by React escaping the text node, which holds with the carve-out gone, so the assertions were pinning the old lossy rendering rather than any user-visible protection.

So the carve-out is removed: `hasDangerousAttrValue` and `ATTR_VALUE_RE` are gone, `divertibleTag` no longer takes the tag source, and roughly 25 lines and the second rendering path go with them.

The five assertions were not simply relaxed to expect verbatim text, because a substring-absence assertion is the weaker form of what they were trying to say. Each now asserts the property that actually matters — no anchor, image, script, iframe, object or embed element; no `on*` attribute; no dangerous-protocol attribute value — *and* that the tag is displayed verbatim. That is strictly stronger than what they asserted before. This includes the **pre-existing** `drops dangerous-protocol attribute values when serializing unknown tags`, which is renamed to `renders an unknown tag with a dangerous-protocol value as inert text`: unknown tags are no longer serialized at all, so its old premise no longer describes the code, and it is re-pointed at the sink property rather than deleted.

The one honest caveat: inertness rests on a diverted mdast `text` node never being re-parsed into markup. That is verified through the real pipeline rather than assumed — `rehypeRaw` re-parses only `raw` nodes, which come from mdast `html` nodes, and the 20-input census above runs the full `rehypeRaw` → `rehypeSanitize` chain. If a future consumer introduced a re-parse of text nodes, that would be a defect for every diverted placeholder in this PR, not only the protocol-bearing ones, so the carve-out was never the thing holding that line.

**Export one shared remark/rehype plugin-list pair (Design) — agreed in principle, out of scope here.** The pairing genuinely can be half-wired, which is why the constraint is now stated on the exported function itself and both real consumers are wired and counted. Turning it into a single exported pair changes the wiring contract for every markdown surface, including ones this PR does not touch, and belongs in its own change rather than riding along with a rendering fix.

## Tests

- 19 new tests in `website/src/test/MarkdownRenderer.verbatimTags.test.tsx`, 3 of which exercise the exported pass as a unit because two surfaces compose it.
- **Negative control, this round:** restoring the old carve-out behaviour fails exactly the five rewritten assertions and nothing else, so each is non-vacuous and precisely attributable. The inertness helper was controlled separately, because sibling assertions in one test are masked by whichever fails first: with the verbatim check removed so the helper runs alone, it fails on the live `<a target="_blank">` the old path produced. The 20-input adversarial census was positive-controlled in both directions, as described under Security posture.
- **Earlier round:** `keeps a paired unknown container literal, including nested allowed HTML` failed for the intended reason before the span fix — `expected '<customBlock>see this ok</customBlock>' to contain '<b>this</b>'` — and disabling only the span branch (`if (false && paired > i)`) failed that one test alone.
- **Earlier rounds:** 6 of the first 9 failed on unpatched `main`; all 28 assertions were split into individual tests against unpatched `main` (15 fail, 13 pass); and every assertion added in each round was individually falsified against the patched tree and failed, so none is vacuous.
- Full run: the entire `website` suite, 1315 files / 20877 tests, 0 unexpected failures (2 expected-fail, 3 skipped). The markdown-specific set — `MarkdownRenderer`, both `ChatPanel` suites, the mochi suites, autolink boundaries, PR/issue ref links, session-ref markdown, knowledge detail view — is 54 files / 662 tests, re-run green after the rebase.
- `tsc --noEmit`: 0 errors. `eslint`: 0 errors and 0 new warnings — 51 problems across the four touched files, byte-identical to the count on the same files at the base commit, positive-controlled by linting the base versions in place.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** the delta is entirely character-level inside one text node, and it is already reproduced verbatim under Problem / Motivation — a screenshot of that same text would be strictly less precise than the before/after strings quoted there. There is no layout or styling change to photograph: the only structural difference is that a lone placeholder no longer gets a `<span class="escaped-tag">` wrapper, and `escaped-tag` has zero CSS rules anywhere in `website/` (it occurs twice in the tree, both in `MarkdownRenderer.tsx` — the doc comment and the `className` assignment), so nothing styles it and its removal is visually inert. This is a text-fidelity fix, not a visual one; if a reviewer would still rather see it rendered, say so and I will attach a capture.


