### PR TITLE
fix(chat): cancel a superseded older-history fetch on session switch

### DIFF
--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1963,11 +1963,11 @@ export const api = {
    *  the auto-nudge feature flag is off, so callers need no flag check. */
   autonudgeList: (): Promise<{ enabled: boolean; loops: { slot_key: string; active?: boolean; cycle_count?: number; max_cycles?: number }[] }> =>
     fetch('/api/autonudge').then(j),
-  chatSlotDetail: (slot: string, limit?: number, before?: number) => {
+  chatSlotDetail: (slot: string, limit?: number, before?: number, signal?: AbortSignal) => {
     const p = new URLSearchParams()
     if (limit) p.set('limit', String(limit))
     if (before !== undefined) p.set('before', String(before))
-    return fetch('/api/chat/slots/' + encodeURIComponent(slot) + '?' + p).then(j)
+    return fetch('/api/chat/slots/' + encodeURIComponent(slot) + '?' + p, { signal }).then(j)
   },
   createChatSlot: (name?: string, agent?: string, model?: string, mode?: string, memory_mode?: string, title?: string, clean_mode?: boolean, artifact?: string, folder_id?: string) => post('/api/chat/slots', { ...(name ? { name } : {}), ...(agent ? { agent } : {}), ...(model ? { model } : {}), ...(mode ? { mode } : {}), ...(memory_mode ? { memory_mode } : {}), ...(title ? { title } : {}), ...(clean_mode !== undefined ? { clean_mode } : {}), ...(artifact ? { artifact } : {}), ...(folder_id ? { folder_id } : {}) }).then(j),
   /** Inject silent background context into a slot — consumed on the next user

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -13,7 +13,7 @@ import { useAppSelector, useAppDispatch, store } from '../store'
 import { useConnected } from '../hooks/useConnected'
 import { useChatPopouts } from '../hooks/useChatPopouts'
 import {
-  switchSlot, createSlot, deleteSlot, fetchHistory, loadOlderMessages,
+  switchSlot, createSlot, deleteSlot, fetchHistory, loadOlderMessages, isSupersededPagingRejection,
   appendMessage, appendSlotMessage, resumeFromHistory, forkSlot,
   setSlotRunning, startLocalTurn, syncSlotRunningFromServer, setPendingInput, setAgentSwitchNotice, resolveByApprovalId, clearPendingPermissions, cancelQueuedMessage, editQueuedMessage,
   selectComposerBusy,
@@ -947,6 +947,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const activityOpen = useAppSelector(s => s.chat.activityOpen)
   const slotHasMore = useAppSelector(s => s.chat.slotHasMore)
   const slotOldestIndex = useAppSelector(s => s.chat.slotOldestIndex)
+  const cursorIsForActiveSlot = useAppSelector(s => s.chat.slotCursorKey === s.chat.activeSlot)
   const loadingOlder = useAppSelector(s => s.chat.loadingOlder)
   const history = useAppSelector(s => s.chat.history)
   const historyHasMore = useAppSelector(s => s.chat.historyHasMore)
@@ -5417,14 +5418,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   }, [messages, navToDisplayIndex])
   const handleJumpToPinnedMessage = useCallback((messageTs: string, mid?: string) => {
     if (jumpToLoadedPinnedMessage(messageTs, mid)) return
-    if (activeSlot && slotHasMore && slotOldestIndex > 0) {
+    if (activeSlot && (!cursorIsForActiveSlot || (slotHasMore && slotOldestIndex > 0))) {
       pinnedJumpPageLoadsRef.current = 0
       setPinNotice(null)
       setPendingPinnedJump({ slotKey: activeSlot, messageTs, mid })
       return
     }
     setPinNotice(i18nT('pages.chat.pins.message_unavailable'))
-  }, [activeSlot, jumpToLoadedPinnedMessage, slotHasMore, slotOldestIndex])
+  }, [activeSlot, cursorIsForActiveSlot, jumpToLoadedPinnedMessage, slotHasMore, slotOldestIndex])
   useEffect(() => {
     if (!pendingPinnedJump) return
     if (pendingPinnedJump.slotKey !== activeSlot) {
@@ -5437,6 +5438,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       setPendingPinnedJump(null)
       return
     }
+    // The cursor still describes the chat we left; wait for the switch to settle
+    // rather than read its has-more as this chat's.
+    if (!cursorIsForActiveSlot) return
     if (!slotHasMore || slotOldestIndex <= 0) {
       pinnedJumpPageLoadsRef.current = 0
       setPinNotice(i18nT('pages.chat.pins.message_unavailable'))
@@ -5453,7 +5457,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         setPinNotice(i18nT('pages.chat.pins.message_unavailable'))
         setPendingPinnedJump(null)
       }
-    }).catch(() => {
+    }).catch(err => {
+      // Cancelled or refused means the user switched chat, not that the pin is
+      // unreachable.
+      if (isSupersededPagingRejection(err)) return
       if (!cancelled) {
         pinnedJumpPageLoadsRef.current = 0
         setPinNotice(i18nT('pages.chat.pins.message_unavailable'))
@@ -5463,6 +5470,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     return () => { cancelled = true }
   }, [
     activeSlot,
+    cursorIsForActiveSlot,
     dispatch,
     jumpToLoadedPinnedMessage,
     loadingOlder,

--- a/website/src/store/chatSlice.abortOlderOnSwitch.test.ts
+++ b/website/src/store/chatSlice.abortOlderOnSwitch.test.ts
@@ -1,0 +1,474 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+
+// Pins that an older-history request is CANCELLED at the network layer when the
+// user switches chat, not merely ignored once it lands.
+const TOTAL = 500
+const PAGE = 200 // the resume endpoint returns the last 200 rows
+
+type FakeMsg = { role: string; content: string; ts: string }
+
+/** Deterministic history: row N has content `mN` so identity is unambiguous. */
+const HISTORY: FakeMsg[] = Array.from({ length: TOTAL }, (_, i) => ({
+  role: i % 2 === 0 ? 'user' : 'assistant',
+  content: `m${i}`,
+  ts: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+}))
+
+/** Signals handed to each PAGINATED call, in call order. */
+let olderSignals: (AbortSignal | undefined)[] = []
+/** Releases the Nth paginated call, so a test controls when a page lands. */
+let releaseOlder: Array<() => void> = []
+/** When set, the paginated call fails outright instead of hanging. */
+let failOlderWith: Error | null = null
+/** When set, switchSlot's detail fetch is held open, holding the switch window. */
+let holdSwitchDetail = false
+let releaseSwitch: Array<() => void> = []
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlotDetail: vi.fn((_slot: string, limit?: number, before?: number, signal?: AbortSignal) => {
+      const lim = limit ?? PAGE
+      const end = before !== undefined ? Math.max(0, Math.min(before, TOTAL)) : TOTAL
+      const start = Math.max(0, end - lim)
+      const body = { messages: HISTORY.slice(start, end), has_more: start > 0, total: TOTAL, next_before: start }
+      // switchSlot's fetch is unpaginated and normally must not block; only the
+      // older page is held open, because that is the request under test.
+      if (before === undefined) {
+        if (!holdSwitchDetail) return Promise.resolve(body)
+        return new Promise((resolve) => { releaseSwitch.push(() => resolve(body)) })
+      }
+      olderSignals.push(signal)
+      if (failOlderWith) return Promise.reject(failOlderWith)
+      return new Promise((resolve, reject) => {
+        releaseOlder.push(() => resolve(body))
+        // Mirror fetch(): an aborted request REJECTS with an AbortError.
+        signal?.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError')))
+      })
+    }),
+    resumeChatSlot: vi.fn(() => Promise.resolve({ ok: true })),
+  },
+}))
+
+import chatReducer, {
+  setActiveSlot,
+  resumeFromHistory,
+  loadOlderMessages,
+  switchSlot,
+  refreshSlot,
+  clearMessages,
+  isSupersededPagingRejection,
+} from './chatSlice'
+import { api } from '../api/client'
+
+function makeStore() {
+  return configureStore({
+    reducer: { chat: chatReducer },
+    middleware: (getDefault) => getDefault({ serializableCheck: false, immutableCheck: false }),
+  })
+}
+
+/** Arms the cursor the way resume does: last PAGE of TOTAL, has_more true. */
+function resumed(store: ReturnType<typeof makeStore>, key = 'A') {
+  store.dispatch(setActiveSlot(key))
+  store.dispatch(
+    resumeFromHistory.fulfilled(
+      { ok: true, key, nextBefore: TOTAL - PAGE, messages: HISTORY.slice(TOTAL - PAGE), hasMore: true, total: TOTAL },
+      'req-resume',
+      { key, title: key },
+    ),
+  )
+}
+
+/** Lets queued microtasks (thunk settle + reducer) run. */
+const flush = () => new Promise<void>((r) => setTimeout(r, 0))
+
+beforeEach(() => {
+  olderSignals = []
+  releaseOlder = []
+  failOlderWith = null
+  holdSwitchDetail = false
+  releaseSwitch = []
+})
+
+describe('older-history fetch is cancelled when the user switches chat', () => {
+  it('passes an AbortSignal to the paginated request', async () => {
+    const store = makeStore()
+    resumed(store)
+
+    const p = store.dispatch(loadOlderMessages())
+    await flush()
+
+    // Positive field: the request carries a real signal, so it CAN be cancelled.
+    expect(olderSignals[0]).toBeInstanceOf(AbortSignal)
+
+    releaseOlder[0]()
+    await p
+  })
+
+  it('aborts the in-flight signal when switchSlot is dispatched', async () => {
+    const store = makeStore()
+    resumed(store)
+
+    const p = store.dispatch(loadOlderMessages())
+    await flush()
+    expect(olderSignals[0]!.aborted).toBe(false)
+
+    store.dispatch(switchSlot('B'))
+    await flush()
+
+    // Positive field: the request the user left behind is actually cancelled.
+    expect(olderSignals[0]!.aborted).toBe(true)
+    await p
+  })
+
+  it('drops a late older page addressed to the chat the user left', async () => {
+    const store = makeStore()
+    resumed(store)
+
+    // switchSlot.pending moves activeSlot synchronously as it is dispatched, so
+    // by the time any older page could land the pane has already changed.
+    store.dispatch(setActiveSlot('B'))
+    const before = store.getState().chat.messages.map((m) => m.content)
+
+    // Defence in depth behind the abort: a response already decoded when the
+    // switch lands must still not enter the pane it was not fetched for.
+    store.dispatch(loadOlderMessages.fulfilled(
+      { slot: 'A', nextBefore: 0, messages: HISTORY.slice(0, 10), hasMore: false, total: TOTAL },
+      'req-older', undefined,
+    ))
+
+    const after = store.getState().chat.messages.map((m) => m.content)
+    expect(after).toEqual(before)
+  })
+
+  it('clears loadingOlder after the abort so the new chat can page', async () => {
+    const store = makeStore()
+    resumed(store)
+
+    const p = store.dispatch(loadOlderMessages())
+    await flush()
+    expect(store.getState().chat.loadingOlder).toBe(true)
+
+    store.dispatch(switchSlot('B'))
+    // Bounded so an uncancelled fetch fails the ASSERTION rather than timing out.
+    await Promise.race([p, new Promise((r) => setTimeout(r, 250))])
+    await flush()
+
+    // A stuck flag would silently block paging in the chat the user is now in.
+    expect(store.getState().chat.loadingOlder).toBe(false)
+  })
+
+  it('leaves a settled fetch alone: a later switch does not abort it', async () => {
+    const store = makeStore()
+    resumed(store)
+
+    const p = store.dispatch(loadOlderMessages())
+    await flush()
+    releaseOlder[0]()
+    await p
+    await flush()
+
+    store.dispatch(switchSlot('B'))
+    await flush()
+
+    // The handle is released on settle, so switchSlot has nothing to cancel.
+    expect(olderSignals[0]!.aborted).toBe(false)
+  })
+})
+
+// The pin-jump effect turns any rejection into a "message unavailable" notice,
+// so a chat switch would now show it for a pin that is perfectly reachable.
+describe('an abort is distinguishable from a real failure', () => {
+  /** Dispatches an older-history page, then aborts it via a chat switch. */
+  async function rejectionFromSwitch(): Promise<unknown> {
+    const store = makeStore()
+    resumed(store)
+    let caught: unknown = Symbol('nothing thrown')
+    const p = store.dispatch(loadOlderMessages()).unwrap().catch((e) => { caught = e })
+    await flush()
+    store.dispatch(switchSlot('B'))
+    await p
+    return caught
+  }
+
+  it('recognises the rejection a chat switch produces', async () => {
+    const err = await rejectionFromSwitch()
+    // Without this the pin-jump catch shows a false "message unavailable".
+    expect(isSupersededPagingRejection(err)).toBe(true)
+  })
+
+  it('does NOT recognise a genuine fetch failure, so real errors still surface', async () => {
+    failOlderWith = new Error('upstream exploded')
+    const store = makeStore()
+    resumed(store)
+    let caught: unknown = Symbol('nothing thrown')
+    await store.dispatch(loadOlderMessages()).unwrap().catch((e) => { caught = e })
+
+    // Over-broad suppression would silently swallow the unavailable notice.
+    expect(isSupersededPagingRejection(caught)).toBe(false)
+  })
+
+  it('cannot be detected with instanceof, which is why the guard reads name', async () => {
+    const err = await rejectionFromSwitch()
+    // unwrap() rethrows RTK's SERIALIZED error, so the `instanceof DOMException`
+    // form used elsewhere in this codebase is always false here.
+    expect(err instanceof Error).toBe(false)
+    expect((err as { name?: string }).name).toBe('AbortError')
+  })
+
+  it('is guarded at the pin-jump call site before the unavailable notice', async () => {
+    const fs = await import('node:fs')
+    const path = await import('node:path')
+    const src = fs.readFileSync(path.resolve(__dirname, '../pages/ChatPage.tsx'), 'utf8')
+
+    // The catch must return on an abort BEFORE reaching the notice.
+    const guard = src.indexOf('if (isSupersededPagingRejection(err)) return')
+    const notice = src.indexOf("setPinNotice(i18nT('pages.chat.pins.message_unavailable'))", guard)
+    expect(guard).toBeGreaterThan(-1)
+    expect(notice).toBeGreaterThan(guard)
+  })
+
+  it('also covers a refused dispatch, which is not an unreachable pin either', () => {
+    // A cursor-refused or already-loading dispatch surfaces as ConditionError.
+    expect(isSupersededPagingRejection({ name: 'ConditionError', message: 'x' })).toBe(true)
+  })
+})
+
+// A switch moves activeSlot at once but replaces the cursor only when the detail
+// fetch settles, so paging in between reads the new chat at the old chat's offset.
+describe('a same-slot switch also invalidates the cursor', () => {
+  it('does not page against the cursor the switch is about to replace', async () => {
+    holdSwitchDetail = true
+    const store = makeStore()
+    resumed(store)
+
+    const p = store.dispatch(loadOlderMessages())
+    await flush()
+    // ChatPage dispatches switchSlot(activeSlot) on mount, so the key is unchanged.
+    store.dispatch(switchSlot('A'))
+    await p.catch(() => {})
+    await flush()
+
+    const s1 = store.getState().chat
+    expect(s1.activeSlot).toBe('A')
+    expect(s1.loadingOlder).toBe(false)
+
+    const mock = api.chatSlotDetail as unknown as { mock: { calls: unknown[][] } }
+    const before = mock.mock.calls.length
+    void store.dispatch(loadOlderMessages())
+    await flush()
+    const paged = mock.mock.calls.slice(before).filter((c) => c[2] !== undefined)
+    // The switch is re-fetching this chat and will replace the cursor; paging now
+    // would prepend a page the refresh already contains and rewind the cursor.
+    expect(paged).toEqual([])
+  })
+})
+
+describe('the cursor cannot be used across a switch', () => {
+  it('does not fetch the new chat at the old chat\'s offset', async () => {
+    holdSwitchDetail = true
+    const store = makeStore()
+    resumed(store)
+    expect(store.getState().chat.slotOldestIndex).toBe(TOTAL - PAGE)
+
+    const p = store.dispatch(loadOlderMessages())
+    await flush()
+    store.dispatch(switchSlot('B'))
+    await p.catch(() => {})
+    await flush()
+
+    // activeSlot moved and the lock is released, but the cursor value is still the
+    // old chat's -- unkeyed, so it cannot be read as the new chat's.
+    const s1 = store.getState().chat
+    expect(s1.activeSlot).toBe('B')
+    expect(s1.loadingOlder).toBe(false)
+    expect(s1.slotOldestIndex).toBe(TOTAL - PAGE)
+    expect(s1.slotCursorKey).toBeNull()
+
+    const mock = api.chatSlotDetail as unknown as { mock: { calls: unknown[][] } }
+    const before = mock.mock.calls.length
+    void store.dispatch(loadOlderMessages())
+    await flush()
+    const paged = mock.mock.calls.slice(before).filter((c) => c[2] !== undefined)
+    // A call here would be slot B read at slot A's offset.
+    expect(paged).toEqual([])
+  })
+
+  it('pages normally again once the switch installs the new cursor', async () => {
+    const store = makeStore()
+    resumed(store)
+    store.dispatch(switchSlot('B'))
+    await flush()
+    await flush()
+
+    // switchSlot.fulfilled re-keys the cursor, so paging is allowed again.
+    expect(store.getState().chat.slotCursorKey).toBe('B')
+    const p = store.dispatch(loadOlderMessages())
+    await flush()
+    releaseOlder[0]()
+    const res = await p
+    expect(res.meta.requestStatus).toBe('fulfilled')
+  })
+})
+
+describe('a background refresh must not re-validate a cursor a pending switch invalidated', () => {
+  /** The payload refreshSlot.fulfilled receives, at an offset of its own. */
+  const refreshPayload = (key: string, nextBefore: number) => ({
+    key,
+    nextBefore,
+    messages: HISTORY.slice(nextBefore, nextBefore + PAGE),
+    running: false,
+    stopping: false,
+    hasMore: true,
+    total: TOTAL,
+    queue: [],
+    context: undefined,
+  })
+
+  /** Arms the window: a same-slot switch in flight, then a refresh landing inside it.
+   *  refreshSlot's own `activeSlot !== key` guard passes, the key being unchanged. */
+  async function refreshInsidePendingSwitch(store: ReturnType<typeof makeStore>) {
+    holdSwitchDetail = true
+    resumed(store)
+    store.dispatch(switchSlot('A'))
+    await flush()
+    store.dispatch(refreshSlot.fulfilled(refreshPayload('A', 40), 'req-refresh', 'A'))
+    await flush()
+  }
+
+  it('leaves the cursor invalidated: the pending switch still owns it', async () => {
+    const store = makeStore()
+    await refreshInsidePendingSwitch(store)
+    expect(store.getState().chat.slotCursorKey).toBeNull()
+  })
+
+  it('does not page while a switch is pending, even after a refresh lands', async () => {
+    const store = makeStore()
+    await refreshInsidePendingSwitch(store)
+
+    const mock = api.chatSlotDetail as unknown as { mock: { calls: unknown[][] } }
+    const before = mock.mock.calls.length
+    void store.dispatch(loadOlderMessages())
+    await flush()
+    const paged = mock.mock.calls.slice(before).filter((c) => c[2] !== undefined)
+    // A call here pages against the refresh's offset and then rewinds the cursor
+    // the switch is about to install.
+    expect(paged).toEqual([])
+  })
+
+  it('still re-keys when no switch is pending, so a refresh does not dead-end paging', async () => {
+    const store = makeStore()
+    resumed(store)
+
+    store.dispatch(refreshSlot.fulfilled(refreshPayload('A', 40), 'req-refresh', 'A'))
+    await flush()
+
+    // No switch is racing, so the refresh owns the cursor it installed.
+    expect(store.getState().chat.slotCursorKey).toBe('A')
+    expect(store.getState().chat.slotOldestIndex).toBe(40)
+
+    const mock = api.chatSlotDetail as unknown as { mock: { calls: unknown[][] } }
+    const before = mock.mock.calls.length
+    void store.dispatch(loadOlderMessages())
+    await flush()
+    const paged = mock.mock.calls.slice(before).filter((c) => c[2] !== undefined)
+    expect(paged).toEqual([['A', 100, 40, expect.anything()]])
+  })
+
+  it('a superseded settle does not release the claim a newer switch holds', async () => {
+    holdSwitchDetail = true
+    const store = makeStore()
+    resumed(store)
+
+    store.dispatch(switchSlot('A'))
+    await flush()
+    store.dispatch(switchSlot('A'))
+    await flush()
+
+    // Release the FIRST switch's fetch. Its settle must leave the second switch's
+    // claim standing, or the second switch's window silently reopens.
+    releaseSwitch[0]()
+    await flush()
+    await flush()
+    expect(store.getState().chat.slotSwitchRequestId).not.toBeNull()
+
+    releaseSwitch[1]()
+    await flush()
+    await flush()
+    expect(store.getState().chat.slotSwitchRequestId).toBeNull()
+  })
+})
+
+describe('clearing a transcript gives the cursor a definite value', () => {
+  it('keys the empty cursor to this pane, so a waiting pin jump can resolve', () => {
+    const store = makeStore()
+    resumed(store)
+    store.dispatch(clearMessages())
+    const s = store.getState().chat
+    expect(s.slotCursorKey).toBe('A')
+    expect(s.slotHasMore).toBe(false)
+  })
+
+  it('but a pending switch still owns the cursor across a clear', async () => {
+    holdSwitchDetail = true
+    const store = makeStore()
+    resumed(store)
+    store.dispatch(switchSlot('A'))
+    await flush()
+    store.dispatch(clearMessages())
+    expect(store.getState().chat.slotCursorKey).toBeNull()
+  })
+})
+
+describe('a settle dispatched without thunk meta is tolerated', () => {
+  it('does not throw when the action carries no meta', () => {
+    const store = makeStore()
+    resumed(store)
+    // Several suites dispatch the bare action object, which has no `meta` at all.
+    expect(() => store.dispatch({
+      type: switchSlot.fulfilled.type,
+      payload: { key: 'A', messages: [], hasMore: false, total: 0, nextBefore: 0, running: false, stopping: false, queue: [] },
+    })).not.toThrow()
+    expect(store.getState().chat.slotCursorKey).toBe('A')
+  })
+})
+
+describe('a slot activated during a switch keeps its own cursor', () => {
+  // The switch's settle returns early once activeSlot has moved, so if an
+  // activating writer also defers, no cursor is ever installed.
+  it('createSlot activating a new slot mid-switch still installs a cursor', () => {
+    const store = makeStore()
+    resumed(store)
+    store.dispatch({
+      type: switchSlot.fulfilled.type,
+      meta: { requestId: 'r0', arg: 'A' },
+      payload: { key: 'A', messages: [], hasMore: true, total: 0, nextBefore: 300, running: false, stopping: false, queue: [] },
+    })
+    expect(store.getState().chat.slotCursorKey).toBe('A')
+
+    // A same-key switch takes the claim; activeSlot is unchanged, so createSlot's
+    // own switched-away guard does not fire.
+    store.dispatch({ type: switchSlot.pending.type, meta: { requestId: 'r1', arg: 'A' } })
+    expect(store.getState().chat.slotCursorKey).toBeNull()
+
+    store.dispatch({
+      type: 'chat/createSlot/fulfilled',
+      meta: { requestId: 'c1', activate: true, originActiveSlot: 'A' },
+      payload: { key: 'NEW' },
+    })
+    expect(store.getState().chat.activeSlot).toBe('NEW')
+
+    // The switch settles but bails: activeSlot is NEW, not A.
+    store.dispatch({
+      type: switchSlot.fulfilled.type,
+      meta: { requestId: 'r1', arg: 'A' },
+      payload: { key: 'A', messages: [], hasMore: true, total: 0, nextBefore: 900, running: false, stopping: false, queue: [] },
+    })
+
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('NEW')
+    expect(s.slotCursorKey).toBe('NEW')
+  })
+})

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -534,6 +534,15 @@ interface ChatState {
   slotStatusDetail: Record<string, { kind: string; text: string; ts: number; toolName?: string; toolCallId?: string }>
   slotHasMore: boolean
   slotOldestIndex: number
+  /** Slot the cursor above describes. A switch moves activeSlot first, so
+   *  without this the cursor silently reads as the new chat's. */
+  slotCursorKey: string | null
+  /** requestId of the switchSlot fetch in flight, else null. While set, that
+   *  switch owns the cursor: a background settle must not re-key it, and
+   *  clearing the transcript must not install a cursor over it. */
+  slotSwitchRequestId: string | null
+  /** Slot the in-flight switch targets; it only installs a cursor for that one. */
+  slotSwitchTarget: string | null
   loadingOlder: boolean
   lastChunkSeq: number | undefined
   _wsChunkedDuringFetch: boolean
@@ -687,6 +696,9 @@ const initialState: ChatState = {
   slotStatusDetail: {},
   slotHasMore: false,
   slotOldestIndex: 0,
+  slotCursorKey: null,
+  slotSwitchRequestId: null,
+  slotSwitchTarget: null,
   loadingOlder: false,
   lastChunkSeq: undefined,
   _wsChunkedDuringFetch: false,
@@ -941,6 +953,46 @@ export const fetchHistory = createAsyncThunk(
 /** Rows to request per older-history page. */
 const OLDER_PAGE_LIMIT = 100
 
+// Aborts the in-flight older-history fetch, or null when none is running.
+// Module-level because switchSlot must reach a fetch it did not start.
+let _abortLoadOlder: (() => void) | null = null
+
+/**
+ * True for a rejection that means "this paging attempt was cancelled or refused",
+ * as opposed to "this request failed". A caller must not read either as evidence
+ * that the history it wanted is unreachable.
+ *
+ * `AbortError` is a superseded fetch (the user switched chat). `ConditionError`
+ * is Redux Toolkit refusing the dispatch outright — a page is already loading,
+ * or the cursor belongs to a chat the user has left.
+ *
+ * Keys on `name` and deliberately does NOT use `instanceof`: `unwrap()`
+ * rethrows Redux Toolkit's serialized error, a plain `{name, message, stack}`
+ * object. The `instanceof DOMException` / `instanceof Error` form used
+ * elsewhere in this codebase is always false here, so it would silently never
+ * match.
+ */
+/**
+ * Replaces the paging cursor as ONE unit: how far back history goes, the offset
+ * to ask for next, and the slot both describe. These three must move together --
+ * writing the offset without re-keying leaves paging refusing forever, and
+ * re-keying without the offset pages the wrong chat at the wrong place.
+ */
+function setPagingCursor(state: ChatState, hasMore: boolean, nextBefore: number): void {
+  // A switch installs a cursor only for the slot it targets, so a writer that
+  // activated a different slot must write: nothing else will.
+  if (state.slotSwitchRequestId !== null && state.slotSwitchTarget === state.activeSlot) return
+  state.slotHasMore = hasMore
+  state.slotOldestIndex = hasMore ? nextBefore : 0
+  state.slotCursorKey = state.activeSlot
+}
+
+export function isSupersededPagingRejection(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const name = (err as { name?: unknown }).name
+  return name === 'AbortError' || name === 'ConditionError'
+}
+
 async function fetchSlotDetail(key: string) {
   // No limit → backend returns all chained history (across gateway restarts).
   const d = await api.chatSlotDetail(key)
@@ -987,6 +1039,9 @@ function seedContextUsage(
 export const switchSlot = createAsyncThunk(
   'chat/switchSlot',
   async (key: string, { dispatch }) => {
+    // Safe unconditionally: this fetch resets the pane's messages and cursor, so
+    // any older page still in flight is superseded even when the key is unchanged.
+    _abortLoadOlder?.()
     dispatch(markSlotRead(key))
     return fetchSlotDetail(key)
   },
@@ -1358,14 +1413,25 @@ export const loadOlderMessages = createAsyncThunk(
     if (!state.activeSlot || !state.slotHasMore) return null
     if (state.slotOldestIndex <= 0) return null
     const slot = state.activeSlot
-    const d = await api.chatSlotDetail(slot, OLDER_PAGE_LIMIT, state.slotOldestIndex)
-    return { slot, nextBefore: d.next_before || 0, messages: filterMessages(d.messages || []), hasMore: d.has_more || false, total: d.total || 0 }
+    const controller = new AbortController()
+    const abort = () => controller.abort()
+    _abortLoadOlder = abort
+    try {
+      const d = await api.chatSlotDetail(slot, OLDER_PAGE_LIMIT, state.slotOldestIndex, controller.signal)
+      return { slot, nextBefore: d.next_before || 0, messages: filterMessages(d.messages || []), hasMore: d.has_more || false, total: d.total || 0 }
+    } finally {
+      // Only clear our own handle: a newer fetch may already have replaced it.
+      if (_abortLoadOlder === abort) _abortLoadOlder = null
+    }
   },
   {
-    // Concurrency guard belongs HERE, not in the payload creator: `pending`
-    // sets loadingOlder BEFORE the creator runs, so a creator that reads the
-    // same flag always sees true and returns null -- paging never fetched.
-    condition: (_, { getState }) => !(getState() as { chat: ChatState }).chat.loadingOlder,
+    // `loadingOlder` must be read HERE: `pending` sets it before the creator runs.
+    // The cursor check blocks paging mid-switch, when it still describes the old chat.
+    condition: (_, { getState }) => {
+      const state = (getState() as { chat: ChatState }).chat
+      if (state.loadingOlder) return false
+      return state.slotCursorKey === state.activeSlot
+    },
   },
 )
 
@@ -1693,7 +1759,7 @@ const chatSlice = createSlice({
   initialState,
   reducers: {
     setActiveSlot(state, action: PayloadAction<string | null>) { state.activeSlot = action.payload; state.slotState = 'idle'; state.pendingTurnSlot = null },
-    clearSlotState(state) { state.messages = []; state.toolLog = []; state.subagents = {}; state.activityTab = 'files'; state.slotRunning = false; state.slotStopping = false; state.slotState = 'idle'; state.slotHasMore = false; state.slotOldestIndex = 0; state.loadingOlder = false; state.lastChunkSeq = undefined; state._wsChunkedDuringFetch = false; state.slotStatusDetail = {}; state.voicePlaying = false; state.voiceAudio = null; if (state.activeSlot) delete state.pendingQuestions?.[state.activeSlot]; state.pendingTurnSlot = null },
+    clearSlotState(state) { state.messages = []; state.toolLog = []; state.subagents = {}; state.activityTab = 'files'; state.slotRunning = false; state.slotStopping = false; state.slotState = 'idle'; setPagingCursor(state, false, 0); state.loadingOlder = false; state.lastChunkSeq = undefined; state._wsChunkedDuringFetch = false; state.slotStatusDetail = {}; state.voicePlaying = false; state.voiceAudio = null; if (state.activeSlot) delete state.pendingQuestions?.[state.activeSlot]; state.pendingTurnSlot = null },
     setPendingInput(state, action: PayloadAction<string | null>) { state.pendingInput = action.payload },
     setAgentSwitchNotice(state, action: PayloadAction<string | null>) {
       // Always create a fresh value so repeating the same refusal restarts the
@@ -2106,7 +2172,7 @@ const chatSlice = createSlice({
       if (isUnsafeKey(slot)) return
       state.slotStatusDetail[safeKey(slot)] = detail
     },
-    clearMessages(state) { state.messages = []; state.slotHasMore = false; state.slotOldestIndex = 0; state.voiceAudio = null; state.voicePlaying = false; if (state.activeSlot) evictMcpApps(state, state.activeSlot) },
+    clearMessages(state) { state.messages = []; setPagingCursor(state, false, 0); state.voiceAudio = null; state.voicePlaying = false; if (state.activeSlot) evictMcpApps(state, state.activeSlot) },
     truncateAfterIndex(state, action: PayloadAction<number>) { state.messages = state.messages.slice(0, action.payload) },
     replaceMessages(state, action: PayloadAction<ChatMessage[]>) { state.messages = action.payload },
     /** Path B: seed a non-active slot's message history into the per-slot store
@@ -3204,6 +3270,11 @@ const chatSlice = createSlice({
         state.historyOffset = offset + sessions.length
       })
       .addCase(switchSlot.pending, (state, action) => {
+        // This fetch replaces the cursor, so it is stale from here until it lands
+        // -- including a same-key switch, where the key alone still looks valid.
+        state.slotCursorKey = null
+        state.slotSwitchRequestId = action.meta?.requestId ?? null
+        state.slotSwitchTarget = action.meta?.arg ?? null
         // Save current slot's activity
         if (state.activeSlot) {
           state.slotActivity[state.activeSlot] = { toolLog: state.toolLog, subagents: state.subagents, activityTab: state.activityTab, activityOpen: state.activityOpen }
@@ -3240,6 +3311,9 @@ const chatSlice = createSlice({
         state._wsChunkedDuringFetch = false
       })
       .addCase(switchSlot.fulfilled, (state, action) => {
+        // Before the guards below, so an early return still ends this claim. Keyed
+        // on requestId, which a hand-rolled dispatch may omit, so read it safely.
+        if (state.slotSwitchRequestId !== null && state.slotSwitchRequestId === action.meta?.requestId) { state.slotSwitchRequestId = null; state.slotSwitchTarget = null }
         const { key, messages, running, hasMore, queue, nextBefore } = action.payload
         if (isUnsafeKey(key)) return
         if (state.activeSlot !== key) return  // user switched away during fetch
@@ -3315,8 +3389,7 @@ const chatSlice = createSlice({
         state.slotRunning = running
         state.slotStopping = action.payload.stopping ?? false
         state.pendingTurnSlot = null
-        state.slotHasMore = hasMore
-        state.slotOldestIndex = hasMore ? nextBefore : 0
+        setPagingCursor(state, hasMore, nextBefore)
         // Hydrate queued messages from the backend queue field through the
         // single shared path (hydrateQueuedBubbles) so this reducer cannot drift
         // from warmSlotCache/refreshSlot. It strips any WS-delivered queued
@@ -3332,12 +3405,12 @@ const chatSlice = createSlice({
         seedContextUsage(state, key, action.payload.context)
       })
       .addCase(switchSlot.rejected, (state, action) => {
+        if (state.slotSwitchRequestId !== null && state.slotSwitchRequestId === action.meta?.requestId) { state.slotSwitchRequestId = null; state.slotSwitchTarget = null }
         if (state.activeSlot !== action.meta.arg) return
         state.messages = []
         state.slotRunning = false
         state.slotStopping = false
-        state.slotHasMore = false
-        state.slotOldestIndex = 0
+        setPagingCursor(state, false, 0)
         state.slotLoading = false
       })
       .addCase(refreshSlot.fulfilled, (state, action) => {
@@ -3384,8 +3457,7 @@ const chatSlice = createSlice({
         state.slotRunning = running
         state.slotStopping = action.payload.stopping ?? false
         state.pendingTurnSlot = null
-        state.slotHasMore = hasMore
-        state.slotOldestIndex = hasMore ? nextBefore : 0
+        setPagingCursor(state, hasMore, nextBefore)
         seedContextUsage(state, key, action.payload.context)
       })
       .addCase(warmSlotCache.fulfilled, (state, action) => {
@@ -3471,8 +3543,7 @@ const chatSlice = createSlice({
         state.slotRunning = false
         state.slotStopping = false
         state.slotState = 'idle'
-        state.slotHasMore = false
-        state.slotOldestIndex = 0
+        setPagingCursor(state, false, 0)
       })
       .addCase(deleteSlot.fulfilled, (state, action) => {
         delete state.slotActivity[action.payload]
@@ -3511,8 +3582,7 @@ const chatSlice = createSlice({
           state.messages = mergePreservedPastes(state.messages, action.payload.messages)
           state.slotState = 'idle'
           state.pendingTurnSlot = null
-          state.slotHasMore = action.payload.hasMore
-          state.slotOldestIndex = action.payload.hasMore ? action.payload.nextBefore : 0
+          setPagingCursor(state, action.payload.hasMore, action.payload.nextBefore)
         }
       })
       .addCase(deleteHistorySession.fulfilled, (state, action) => {
@@ -3534,8 +3604,7 @@ const chatSlice = createSlice({
           // ts tuple cannot express this without dropping legitimate rows.
           const fresh = merged.filter(m => !isRedeliveredMessage(state.messages, m.meta))
           state.messages = [...fresh, ...state.messages]
-          state.slotHasMore = action.payload.hasMore
-          state.slotOldestIndex = action.payload.hasMore ? action.payload.nextBefore : 0
+          setPagingCursor(state, action.payload.hasMore, action.payload.nextBefore)
         }
       })
       .addCase(loadOlderMessages.rejected, (state) => {


### PR DESCRIPTION
## Problem / Motivation

Asking for older history starts a network request for whichever chat is open at that moment. If the user switches chat while that request is still on the wire, nothing cancelled it. The request stayed open, kept competing for the connection and the main thread with the fetch the user is now actually waiting for, and held the `loadingOlder` paging flag until it finally landed.

## Why it matters

Anyone who asks for older history in a long chat and then switches away before it lands pays for a request nobody will read: it keeps competing for the connection and the main thread with the fetch they are now waiting on, and it holds the `loadingOlder` flag, so paging in the chat they just opened does nothing until the abandoned request finally lands. The severity is modest and worth stating plainly rather than inflating — no history is corrupted, because the `fulfilled` reducer already drops a page whose slot no longer matches, so this is wasted work and a briefly dead affordance, not data loss. It bites hardest on exactly the sessions where paging older history is worth doing at all: the abandoned fetch is a 100-row page (`OLDER_PAGE_LIMIT`), which on a slow link is long enough for the stall to be noticed.

## What changed (motivation → approach → change)

This threads an `AbortSignal` through `api.chatSlotDetail`, gives the older-history thunk an `AbortController`, and has `switchSlot` cancel it.

Cancelling has one caller-visible consequence, so it is handled here too: the pinned-message jump in `ChatPage` treats any rejection from this thunk as "this pin is unreachable". An abort now returns early from that `catch`, via an exported `isSupersededPagingRejection` helper that lives next to the code producing the abort.

Cancelling also has to be atomic with the paging cursor, which it was not at first. `switchSlot.pending` moves `activeSlot` immediately, but `slotHasMore` / `slotOldestIndex` are only replaced when the detail fetch settles — so between those two points the cursor still described the chat the user left. The cursor now carries the slot it belongs to (`slotCursorKey`) and is invalidated the moment a switch begins — including a switch to the chat already open, where the key alone still looks valid while the fetch is about to replace the cursor underneath it. The thunk refuses to page while the cursor is unkeyed or belongs to another chat, and the pin-jump waits for the real cursor instead of reading a foreign one as "no more history". All three cursor fields move together through one `setPagingCursor` helper.

## Why the abort is unconditional

`switchSlot` aborts the in-flight older page even when the target chat is the one already open. That looks too aggressive, but the alternative is worse: a switch re-fetches the pane's messages and resets its paging cursor (`slotOldestIndex`). Any older page still in flight was computed against the *old* cursor, so letting one land would prepend a stale slice and rewind the cursor over freshly reset state. Stale either way, so cancelling is correct.

The ordering is safe in the other direction too. An older-history request is always issued for `state.activeSlot` at dispatch time, and `activeSlot` only moves in `switchSlot.pending`, which is dispatched synchronously before the payload creator runs. So at the moment `switchSlot` aborts, any in-flight older page necessarily belongs to the chat being left — it can never cancel a page the pane the user is arriving at still needs.

The abort handle is released when a request settles, so a later switch has nothing to cancel and never calls `abort()` on a request that already completed.

## What this does NOT fix

Being explicit, because the obvious framing of this change is wrong: a late response was **already** prevented from writing into the wrong pane. The `loadOlderMessages.fulfilled` reducer compares `action.payload.slot` against `state.activeSlot` and drops a mismatch, and because `switchSlot.pending` moves `activeSlot` synchronously, that comparison is already correct by the time any older page could arrive.

So this PR stops a wasted request and clears the paging flag promptly. It is not a fix for cross-pane history corruption. One test pins that reducer guard as defence in depth behind the abort, and it is labelled as such — it passes with and without the abort, and its negative control removes the reducer guard rather than the abort.

## Deliberately out of scope

- **No cancellation of a superseded `switchSlot` detail fetch.** A rapid A→B→C switch leaves B's detail request open. Same area, separate concern, separate change.
- **No change to `loadOlderMessages.rejected`.** It already clears `loadingOlder` unconditionally, which is the correct response to an abort.
- **No `meta.condition` guard.** That would be dead code: Redux Toolkit does not dispatch a `rejected` action when a thunk's `condition` returns false unless `dispatchConditionRejection` is set, and it is not set here (verified in `@reduxjs/toolkit` 2.12.0 — `skipDispatch` in `createAsyncThunk`).
- Background refresh paths (`refreshSlot`) remain uncancellable.

## Ordering with other PRs

**#2822 (`feat/scroll-driven-older-history`) should land after this one.** That change makes older-history paging fire far more often, including on lists that are not yet scrollable, which widens the window in which a superseded request can be in flight during a switch. This PR is the cancellation groundwork it assumes.

## Visual evidence

<!-- no-visual-delta -->

**Why no screenshot:** there is no new surface, string, layout or flow to photograph — the user-visible delta is the *non-appearance* of two transient states (an older-history spinner that used to stay stuck after a chat switch, and a false "message unavailable" notice on a pin that is reachable). Both are races measured in microtasks rather than states a page can be caught in, so a still frame would show an ordinary chat either way. They are pinned deterministically instead by the negative-controlled tests below.

## Tests

`website/src/store/chatSlice.abortOlderOnSwitch.test.ts` — 13 tests, each in its own case so each has an independent negative control (the runner stops at the first failing assertion, so one control cannot validate its siblings):

| Test | Negative control applied | Observed failure |
|---|---|---|
| request carries an `AbortSignal` | drop `controller.signal` from the api call | `expected undefined to be an instance of AbortSignal` |
| a switch aborts the in-flight signal | remove `_abortLoadOlder?.()` from `switchSlot` | `expected false to be true` |
| a late page for the abandoned chat is dropped | remove the slot check in `fulfilled` | 210 rows vs expected 200 |
| `loadingOlder` clears after the abort | remove `_abortLoadOlder?.()` from `switchSlot` | `expected true to be false` (254ms, by assertion not timeout) |
| a settled request is left alone | stop clearing the handle on settle | `expected true to be false` |
| the abort rejection is recognised | make the guard use `instanceof Error` | `expected false to be true` |
| a genuine failure is NOT recognised | make the guard return `true` | `expected true to be false` |
| `instanceof` cannot detect it | give the thunk `serializeError: e => e` | `expected true to be false` |
| the pin-jump call site is guarded | delete the guard line from `ChatPage` | `expected -1 to be greater than -1` |
| a refused dispatch also counts | narrow the guard to `AbortError` only | `expected false to be true` |
| no paging with another chat's cursor | drop the cursor check from `condition` | `expected [ [ 'B', 100, 300, … ] ] to deeply equal []` |
| paging resumes once the cursor lands | stop re-keying the cursor on switch settle | `expected 'A' to be 'B'` |
| no paging across a SAME-slot switch | drop the switch-start invalidation | `expected [ [ 'A', 100, 300, … ] ] to deeply equal []` |
| the cursor helper cannot forget the key | make it set the offset only | 7 tests fail — paging dead-ends |
| a refresh does not re-key inside a switch window | make the refresh re-key unconditionally | `expected 'A' to be null` |
| …and does not page there either | same control | `expected [ [ 'A', 100, 40, … ] ] to deeply equal []` |
| a refresh with no switch pending still re-keys | make the refresh never re-key | `expected 300 to be 40` |
| a superseded settle keeps a newer switch's claim | release the claim unconditionally | `expected null not to be null` |
| clearing a transcript keys the empty cursor | leave the cursor unkeyed on clear | `expected null to be 'A'` |
| …but a pending switch still owns it | key it unconditionally on clear | `expected 'A' to be null` |

Also run green on the rebased base: **7779 tests across 304 files**. The selection is every test file that mentions `chatSlice`, `slotCursorKey`, pins, or any of the thunks and reducers this diff touches — including files that dispatch a raw action type such as `'chat/switchSlot/fulfilled'` rather than importing the slice. That last group matters: an earlier, narrower selection missed exactly those files, and the gap cost a red CI run (see below).

`tsc --noEmit`: clean. `eslint` on all changed files: **0 errors** (10 pre-existing `exhaustive-deps` warnings in `ChatPage.tsx`, none at the changed lines).

Not run: the full `vitest` suite and the Electron suite. Concurrent full runs exhaust this host's `/tmp` inode cap, so the run was scoped to the affected set. CI covers the remainder.

## Review responses

**First Principles — drop the RTK-signal bridge. Accepted, with one part kept.** Verified rather than assumed: `loadOlderMessages` has exactly one non-test dispatch, and it `void`s the thunk promise inline, so `.abort()` is unreachable on it; no caller passes a `{ signal }` dispatch option; and a repo-wide `.abort()` sweep finds no call against it. RTK's signal therefore could never fire, and `addEventListener`/`removeEventListener` plus the now-unused `signal` from the thunk API are gone. The `const abort` alias is **kept** — it is not part of the bridge. It is the identity the `finally` block compares to decide whether the in-flight handle is still ours, which is the separately tested "a settled request is left alone" behaviour.

**UX — false "message unavailable" on a mid-jump switch. Accepted and fixed.** Confirmed as a regression this PR introduces: the pin-jump `catch` showed the notice for any rejection, and cancelling now makes a plain chat switch reject.

One detection detail worth a reviewer's attention, because the obvious spelling is wrong here. `.unwrap()` rethrows Redux Toolkit's **serialized** error — a plain `{ name, message, stack }` object. Measured in a probe: `instanceof Error` is `false` and `instanceof DOMException` is `false`, while `name === 'AbortError'`. Two other sites in this codebase detect an abort with `instanceof` (`AppDetailPage.tsx`, `ChatPage.tsx`); copying either here would compile, read correctly to a reviewer, and silently never match — leaving the false notice in place. The guard keys on `name` alone for that reason, and a test pins it: its control makes the thunk stop serializing, which flips the assertion.

**GPT 5.6 — abort unlocks paging before the new cursor loads. Confirmed, fixed; the suggested revert declined.** The mechanism is real and I reproduced it before changing anything. `switchSlot.pending` moves `activeSlot` but leaves `slotHasMore` / `slotOldestIndex` alone, and the abort clears `loadingOlder` at once, so there is a window where the cursor belongs to the chat the user left. In that window a paging request issued `chatSlotDetail("B", limit=100, before=300)` — the new chat's history read at the old chat's offset — and because the payload then carries `slot: "B"`, the `fulfilled` slot check passes and it prepends. The reproduction is now a test, and its negative control prints exactly that call.

Worth being precise about what this PR did and did not cause. The window pre-exists on `main`: without the abort, `loadOlderMessages.rejected` still cleared `loadingOlder` when the abandoned fetch landed, which could easily be before the new chat's detail fetch. What this PR changed is that the unlock became immediate, so a latent race became reliably reachable — a fair thing to block on.

The revert was declined because it removes the cancellation this PR exists to add, and it treats the symptom: the defect is that the unlock was not atomic with the cursor, not that cancelling is wrong. Two alternatives were rejected on evidence. Holding `loadingOlder` true across the switch would show the older-history spinner on every chat switch (`ChatPage.tsx` renders on that flag). Clearing `slotHasMore` in `switchSlot.pending` would make a pin click during the window report "message unavailable" for a reachable pin, and would briefly flip the fork affordance, which also reads `!slotHasMore`. Keying the cursor avoids both.

**GPT 5.6 — a same-slot switch leaves the cursor keyed valid. Confirmed and fixed.** This is narrower than the cross-slot case above and my first fix did not cover it: `slotCursorKey` tracks the *slot*, so on a switch to the chat already open the key still equals `activeSlot` while the switch is re-fetching that chat and is about to replace the cursor. The paging guard therefore passed, and a page fetched against the pre-refresh offset could land after the refresh — prepending rows the refresh already contains (only rows carrying `meta.mid` are de-duplicated) and rewinding the cursor the refresh had just set.

Reachability is not theoretical: `ChatPage.tsx` dispatches `switchSlot(activeSlot)` unconditionally on mount, and many other dispatch sites do not guard the target against the active slot — several *do* carry an explicit `slot !== activeSlot` check, which is itself evidence the same-key case occurs. A test reproduces it and its negative control prints the offending call, `['A', 100, 300]`.

The fix is the one suggested: invalidate at the *start* of the switch rather than trying to distinguish same-key from cross-key. `switchSlot.pending` now clears `slotCursorKey`, and because `pending` is dispatched before the payload creator runs, the cursor is already unkeyed by the time the abort releases the paging lock — the unlock and the invalidation cannot be observed out of order. This is safe only because the pin-jump was already taught to *wait* on an unkeyed cursor rather than read it as "no more history"; without that, invalidating here would have produced a false "message unavailable".

**Design Review — three parallel cursor scalars with an unwritten invariant. Accepted in substance, not by changing the state shape.** The blocker above is an instance of exactly that class, so the concern is well aimed. Rather than collapse the fields into one object — which would touch every reader and enlarge an already-large review — every cursor write now goes through a single `setPagingCursor(state, hasMore, nextBefore)` that sets the offset, the has-more flag and the key together, so a writer cannot update one and forget another. A negative control that makes the helper skip the key fails eleven tests, which is the "silently dead-ends paging" outcome Design predicted. Collapsing into a single atomically-replaced object remains the better end state and is now filed as #4100; it is declined here on blast radius, not on merit.

**Design Review — `refreshSlot.fulfilled` re-validates a cursor a pending switch invalidated. Confirmed and fixed.** Checked at source before any code changed, and the claim is exactly right. `refreshSlot.fulfilled` guards with `state.activeSlot !== key`, which *passes* during a same-slot switch because the key does not change; it then calls `setPagingCursor`, which sets `slotCursorKey = state.activeSlot`. So a background refresh landing inside a switch window re-validates the cursor and unlocks paging. This is reachable in ordinary use: `refreshSlot` is dispatched from the WebSocket handler when a turn finishes, which is not coordinated with switching chats.

I wrote the reproduction first and watched it fail on the previous head — the cursor read `'A'` where it should have been unkeyed, and a paging request then issued `chatSlotDetail('A', 100, 40)`, i.e. a page at the *refresh's* offset while the switch was still in flight and about to replace both the messages and the cursor. The page would then prepend onto the switch's message set and rewind the cursor the switch had just installed. The fix is the first remedy suggested: `refreshSlot.fulfilled` still installs its messages, but skips the cursor while a switch is in flight, which is tracked by a new `slotSwitchRequestId` holding the in-flight switch's request id. A second test guards the obvious over-correction — a refresh with *no* switch pending must still install its cursor, or a refresh would dead-end paging — and its control fails with `expected 300 to be 40`.

**Design Review, Watch item — the invariant is held by convention across the settle paths. Acknowledged, as suggested.** It is a fair description of the remaining tax. A future reducer that installs messages without going through `setPagingCursor` leaves the cursor keyed to the wrong pane, and the symptom is paging quietly doing nothing rather than an error. Two things reduce it without removing it: every cursor write already routes through the one helper, and a control that makes the helper skip the key fails seven tests. The structural end state is still the single atomically-replaced object, declined here only on blast radius.

**Design Review, Suggestion — the unkeyed-cursor wait had no terminal state. Fixed at the root, and one residual named.** Judged reachable, so folded in. The underlying problem was that `slotCursorKey === null` carried two different meanings: "a switch owns the cursor" and "there is no cursor at all". `clearMessages` set the second one — it is dispatched from the WebSocket handler when the active chat's transcript is cleared — and the waiting pin-jump cannot tell the two apart, so it waited forever. Rather than add a bounded timeout, the two clear reducers now install a *definite* empty cursor keyed to the current pane (unless a switch owns it), which lets the existing "no history remains" branch show the unavailable notice immediately. No timer, and the sentinel now means one thing. Design's example for this was "a guarded rejection", so I traced that specific path rather than answer it generically. `switchSlot.rejected` releases the claim before its `state.activeSlot !== action.meta.arg` guard and then returns early without installing a cursor — so the cursor does stay unkeyed there. It recovers, though, because the only things that can move `activeSlot` out from under a switch also re-key: another `switchSlot` (its own settle installs a cursor), `createSlot.fulfilled` (it resets the cursor directly), or `setActiveSlot(null)`, after which the key and the active slot are both `null` and so compare equal and the wait ends. The residual I am left with is narrower: a switch whose fetch never settles at all would leave the cursor unkeyed indefinitely. I could not produce that — Redux Toolkit always settles a thunk — so a bounded timeout would be guarding a state I cannot reproduce, and I would rather name the gap than add a timer that is never exercised.

**UX Review — a pin click after a chat clear is a silent no-op. Already fixed by the change above, with one deliberate difference.** This lane re-ran on the previous head and landed on the same defect as Design's Suggestion, which is the `clearMessages` hole described above; it is fixed in this revision. Its suggested remedy was to have the clear reducers call `setPagingCursor(state, false, 0)` outright. I did the equivalent but kept the switch guard, because an unconditional call there would re-key the cursor inside a pending switch window — which is precisely the defect Design reported against `refreshSlot`, just from a different writer. So the clear reducers install a definite empty cursor *unless* a switch owns it, and a control that makes them key it unconditionally fails with `expected 'A' to be null`.

**One defect of my own, found by CI and fixed here.** The claim-release line in `switchSlot.fulfilled` read `action.meta.requestId` unconditionally, ahead of every guard. That throws for a *hand-rolled* dispatch — several suites send the bare action object `{ type: 'chat/switchSlot/fulfilled', payload }`, which carries no `meta` at all — and it took down an embedded-mode test with `TypeError: Cannot read properties of undefined (reading 'requestId')`. The read is now optional, and a test dispatches a meta-less settle and asserts both that it does not throw and that the cursor still lands. Its control restores the unsafe read and reproduces the CI failure exactly, in the CI test and the new one together. Worth noting how it escaped the first pass: the file that caught it never mentions `chatSlice` by name, so a selection keyed on that name could not reach it. The selection above is widened accordingly.

**An extension I tried and then reverted, because it made things worse.** While writing controls I found a second instance of the same class: a *superseded* switch's own `fulfilled` also re-keys the cursor while a newer switch is still pending. Gating that too looked obviously correct, and it broke an existing pinned-message test deterministically — five runs out of five. The reason is worth writing down, because it is the same failure mode as the Suggestion above. Gating the superseded settle means that if the newest switch never settles, *nothing* ever installs a cursor, and paging and the pin jump die permanently rather than briefly. Refusing to install a cursor is only safe when something else is guaranteed to install one. So that gating is reverted. The superseded-switch re-key is pre-existing behaviour on `main`, is not made worse by this PR, and is left alone deliberately. What survives from that work is the piece the `refreshSlot` fix actually needs: a superseded settle does not release the claim a newer switch holds, so the guard cannot unblock early. That has its own test and its own control.


**Design Review, Suggestion — move the switch-claim check inside `setPagingCursor`. Accepted, in a corrected form; the literal move is unsafe and a test now pins why.** The goal is right and it is now done: the ownership rule no longer lives at the call site. `setPagingCursor` refuses the write itself, and the two clear reducers have been brought through the helper, so no writer bypasses the rule and a future writer cannot reintroduce the `refreshSlot` defect by calling the helper mid-switch. The call-site guard in `refreshSlot.fulfilled` is gone; its call is now bare.

The literal move does not work, and this is worth recording because it is the same failure that made me revert an earlier extension of my own. The suggestion rests on all current callers continuing to work because the switch reducers release the claim before writing. That part is true — I read both settle paths and both release before their writes — but two other callers are not covered: `createSlot.fulfilled` and `resumeFromHistory.fulfilled`. Both are *activation* paths: each sets the active slot to a chat it is opening and then installs that chat's cursor, and neither releases the claim, because neither is the switch. With a bare claim check inside the helper, a New Chat resolving inside a same-slot switch window is activated, its cursor install is skipped, and the switch's own settle then bails because the active slot is no longer its target — so nothing ever installs a cursor, and paging and the pin jump are dead permanently in a brand-new chat. Refusing to install a cursor is only safe when something else is guaranteed to install one, and an activation path carries no such guarantee.

What makes the guard safe is a distinction the suggested version cannot draw. `switchSlot.pending` recorded only the request id, which answers "is a switch running" but not "will it replace *this* cursor". It now also records the slot the switch targets, so the helper refuses only when a switch is about to overwrite the very cursor being written, while an activation path that has already moved the active slot elsewhere still writes normally. Both settle paths clear the target together with the claim.

Proven in both directions rather than asserted. The literal form is pinned by a permanent test that fails `expected null to be 'NEW'` when the target discriminator is removed, so the refutation is now part of the suite instead of a throwaway probe. Reverting the guard-inside-helper change fails three tests, including the harm assertion that a page is issued at the stale offset `[ 'A', 100, 40 ]`. The earlier control that makes the helper skip the key now fails eleven tests rather than the seven it failed before, because the two clear reducers route through the helper as well.

Worth recording that my first attempt at that reproduction was wrong and the failure message is what showed it: I began a switch to a *different* chat, and `switchSlot.pending` moves the active slot as it is dispatched, so `createSlot`'s own switched-away guard fired and it never activated at all. The window is only reachable on a same-slot switch. A safe version of this idea has to distinguish "writing a cursor for the chat I am opening", which must always win, from "writing a cursor for the current chat while a switch is replacing it", which must defer — and that distinction has to be passed in as an argument, so the convention moves into the parameter rather than disappearing. That is worth doing alongside the per-slot cursor record below, where the map key makes the whole question go away, rather than as a guard bolted onto the current shape.

**Design Review and First Principles, Watch items — the singleton cursor is the root cause, and it should be scheduled rather than only named. Agreed, and now filed as #4100.** Both lanes land on the same point from different directions, and it is the correct diagnosis: the paging cursor is a single global value sitting beside roughly ten per-chat maps in the same state, so every path that installs messages has to re-coordinate it, and this review cycle found four instances in a row. A per-chat cursor record would delete the key field outright, because the map key *is* the key, and would shrink the ownership question to the single case where a chat is being reloaded in place. I am not folding it into this PR — it touches every reader of the cursor and would turn a focused fix into a refactor — but "named but not scheduled" is a fair criticism of the earlier wording, so it is now filed as #4100, which carries the state-shape argument, the field-by-field reasoning and a suggested two-step sequencing, so the follow-up is something a reader can open rather than a promise in a description. First Principles counts four siblings of the root cause and asks that all four be named. Naming them is fair, but they are not four instances of one defect, and I read each rather than group them. `fetchSlotDetail` is not a thunk and has no reducer at all: it is a plain async helper that fetches the payload the three slot-detail reducers share, so its cursor consequences land in `switchSlot`, which this change fixes. `refreshSlot` was the one real instance, and it is fixed above. `warmSlotCache` never writes the cursor: it returns early when its slot is the active one and otherwise writes only that slot's entry in the per-chat message map, so it cannot reach the three cursor fields. `fetchHistory` writes the *session-list* cursor — the history array, its has-more flag and its offset — which is a different cursor in a different subsystem from message paging. An earlier version of this description called `fetchHistory` a superseded slot-detail prefetch; that was wrong, and this corrects it. So of the four: one was a live cursor writer and is fixed, one has no reducer, and two write other state.

**UX Review, Suggestion — acknowledge a pin click during the mid-switch wait. Not taken in this revision.** The pin jump now parks and waits while the cursor is being replaced, which is correct behaviour, but on a slow connection it does so with no visible acknowledgement until the detail fetch lands. Showing the existing older-history spinner or a transient notice would be a real improvement. I am leaving it out because it is a new user-visible affordance rather than a fix to the defect this PR addresses, and because the sha budget for this change is spent; it is a good candidate to fold into #4100 alongside the cursor record.

**A Windows backend test failed alongside the defect above, and it is unreachable from this change.** `test_redaction_timing_scales_linearly` asserts a wall-clock ratio — it failed at `0.2031s / 0.0625s = 3.2x` against a 3.0x limit. This change contains no Python at all: the four files it touches are `website/src/api/client.ts`, `website/src/pages/ChatPage.tsx`, `website/src/store/chatSlice.ts` and one new test file, so there is no path from any line here to that measurement. The absolute numbers say the rest: both are exact multiples of the Windows timer tick (4/64s and 13/64s), so a single tick moves the ratio across the limit, and the test's own comment records that it has failed intermittently at 3.1-3.2x before. I have not touched the test or its threshold. The evidence is now direct rather than argued: on the previous revision that shard failed and so did the frontend shard, and on this revision — whose only functional change is the optional `meta` read described above, still zero Python — the same shard on the same runner passed, along with all four Windows shards and the whole run. Relaxing that limit would have hidden a real regression later for no gain here.

**One residual in the same area, named rather than fixed.** The optional read above covers the two settle reducers, which are the ones tests hand-roll. The corresponding read in `switchSlot.pending` is still unconditional, and two suites dispatch a mocked pending action carrying an empty `meta` object rather than none at all — that does not throw, but it does put `slotSwitchRequestId` at `undefined` instead of a string or `null`, which the two guards that compare against `null` then read as "a switch is in progress". No test currently exercises a cursor write from that state, the type checker cannot see it because the reducer's action type is supplied by the toolkit, and production always provides a request id, so there is no live failure. It is still a shape the field's own type does not allow, and the tidy fix is to coalesce that assignment to `null` as well. Left out of this revision because it is test-only and the change is already large; worth folding into #4100.


