### PR TITLE
fix(mcp): name the oauth_endpoints.json remedy in the OAuth rejection banner

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -1108,22 +1108,37 @@ def _emit_mcp_oauth_request(
         )
         return
     if oauth_url_contains_credential(oauth_url):
-        # Legitimate OAuth consent URLs carry state/code_challenge/client_id —
-        # never AKIA*/Bearer/etc.  Surface this so the user can ask the server
-        # owner to fix it instead of just seeing nothing happen.
+        # Two distinct causes reach this branch and the user cannot tell them
+        # apart from the banner alone:
+        #   1. A genuinely bogus URL — legitimate OAuth consent URLs carry
+        #      state/code_challenge/client_id, never AKIA*/Bearer/etc.
+        #   2. A legitimate consent URL at an endpoint outside
+        #      ``_OAUTH_AUTHORIZATION_ENDPOINTS``. The PKCE entropy carve-out
+        #      applies only at an approved (host, path), so an unlisted
+        #      self-hosted IdP has its ``code_challenge`` scanned as a bare
+        #      secret and fails closed.
+        # Case 2 has a remedy (the ``oauth_endpoints.json`` operator keystone,
+        # see security._load_operator_oauth_endpoints) but it is agent-fenced
+        # with no dashboard writer, so naming it here is the only way the user
+        # learns it exists. Without this the failure reads as unfixable.
         logger.warning(
             "ACP: rejecting MCP OAuth URL with credential/exfil pattern for %s",
             server_name or "(unknown)",
         )
         slot.append(
             "mcp_oauth",
-            f"🚫 {label} sent an authentication URL containing a credential pattern (rejected).",
+            f"🚫 {label} sent an authentication URL containing a credential "
+            "pattern (rejected). If this is a self-hosted or otherwise "
+            "unlisted identity provider, its authorization endpoint may need "
+            "adding to oauth_endpoints.json in the Kiro Crew data home; "
+            "otherwise ask the server owner to fix the URL.",
             "msg msg-warn",
             meta={
                 "server_name": safe_name,
                 "failed": True,
                 "rejected_url": True,
                 "error": "URL contained credential or exfiltration pattern",
+                "remedy": "oauth_endpoints.json",
             },
         )
         return

--- a/test/test_mcp_oauth_banner.py
+++ b/test/test_mcp_oauth_banner.py
@@ -188,6 +188,34 @@ class TestEmitMcpOAuthRequest:
         assert "AKIAIOSFODNN7EXAMPLE" not in m["content"]
         assert "credential" in m["meta"].get("error", "")
 
+    def test_rejection_banner_names_the_operator_remedy(self):
+        """A rejected URL must name ``oauth_endpoints.json``.
+
+        The endpoint allowlist means a legitimate consent URL at an unlisted
+        self-hosted IdP lands in this same branch, and its remedy — the
+        operator keystone extension — is agent-fenced with no dashboard
+        writer and is documented only in an internal spec. If the banner does
+        not name it, the failure is indistinguishable from unfixable: two
+        users independently root-caused this from source (#3310) rather than
+        finding the one-line config fix.
+        """
+        slot = _ChatSlot("s1")
+        state = MagicMock()
+        _emit_mcp_oauth_request(
+            state,
+            slot,
+            "self-hosted",
+            "https://evil.com/auth?key=AKIAIOSFODNN7EXAMPLE",
+        )
+        m = slot.messages[0]
+        assert "oauth_endpoints.json" in m["content"]
+        assert m["meta"]["remedy"] == "oauth_endpoints.json"
+        # The remedy hint must not soften the rejection itself.
+        assert m["meta"]["failed"] is True
+        assert m["meta"]["rejected_url"] is True
+        assert "oauth_url" not in m["meta"]
+        assert "AKIAIOSFODNN7EXAMPLE" not in m["content"]
+
     def test_accepts_real_github_oauth_pkce_url(self):
         """Regression: a legitimate GitHub OAuth + PKCE consent URL must be
         rendered, not rejected.  These URLs carry high-entropy params


### PR DESCRIPTION
## Problem

The MCP OAuth rejection banner names the symptom but never the remedy, so a legitimate consent URL at an unlisted identity provider reads as an unfixable failure.

Two different causes reach the `oauth_url_contains_credential` branch in `_emit_mcp_oauth_request`:

1. A genuinely bogus URL embedding a credential — the case the banner was written for.
2. A **legitimate** OAuth 2.1 + PKCE consent URL whose authorization endpoint is not in `_OAUTH_AUTHORIZATION_ENDPOINTS`. The entropy carve-out applies only at an approved `(host, path)`, so an unlisted self-hosted IdP has its 43-byte `code_challenge` scanned as a bare secret and fails closed.

Case 2 is documented and intended — `security.py` says a provider missing from the set "cannot be connected at all: its banner fails closed ... which is how the gap was found."

## Why it matters

Case 2 already has a remedy: the operator keystone extension `oauth_endpoints.json`, added in #2402 closing #1341, whose stated audience is "Okta orgs, Auth0, self-hosted OIDC, tenant-scoped Entra paths."

But nothing the user can see names it. The file is on `_CREW_SECRET_LEAVES` with deliberately no dashboard writer (correctly — an agent must not author its own OAuth exemption), and it is documented only in `docs/system-specs/modules/security.md`, an internal spec.

The result is in #3310: two people independently root-caused this from source rather than finding a one-line config fix. #2403 predicted precisely this, asking for "a migration story" for the behavioural change; I could not find one filed. This is the cheapest possible version of that migration story.

## Fix

Name the file in the banner text and add a `remedy` meta key.

The rejection itself is **unchanged**: still `failed`/`rejected_url`, `oauth_url` still withheld from meta, the offending URL still never rendered. HTTPS-only, no-explicit-port and exact-match stay enforced by the gate and are **not** relaxable via the file. This widens no trust boundary — it only tells the operator where the sanctioned lever is. The comment now also records both causes, since the branch serves two.

## Tests

`test_rejection_banner_names_the_operator_remedy` pins that the remedy is named **and** that the hint does not soften the rejection (failed/rejected_url still set, `oauth_url` still absent, credential still not echoed).

- `test_mcp_oauth_banner.py`: 76 passed
- `test_chat_runner_coverage.py` + `test_display_time_redaction.py`: 234 passed
- flake8, isort clean

## Manual verification

Root-caused against `kirocrew 0.3.0` on a self-hosted MCP server (Cognito-backed authorization server). Adding the endpoint to `oauth_endpoints.json` is what actually unblocked it — after a gateway restart, per failure mode 2 in #3310.

Refs #3310, #1341, #2402, #2403.