### PR TITLE
fix(dev-fleet): restart survives navigate-away; tool timer uses persisted anchor

### DIFF
--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -82,6 +82,54 @@ export function gatewayRecovered(
   return String(currentId) !== String(capturedId)
 }
 
+/* ─── Route-independent restart watcher ─── */
+// The restart alive-poll is decoupled from the DevFleetPage React lifecycle so
+// navigating away during the ~6-min build+restart phase does not silently kill
+// the poll. An AbortController scoped to the active restart (not to the
+// component mount) controls cancellation; the only way to abort is an explicit
+// user cancel or a new restart superseding the current one.
+let _restartAc: AbortController | null = null
+
+// Run IDs with a sync-poll loop currently in flight, tracked at MODULE scope so
+// it survives component unmount/remount. The build poll deliberately outlives
+// the DevFleet page (a ~6-min build must still auto-restart if the user leaves),
+// so a naive remount would start a SECOND poll for the same run — two loops that
+// both see `done` and both fire the restart POST. This registry lets a remount
+// detect the in-flight poll and skip re-starting one. Cleared when the loop ends.
+const _activeSyncPolls = new Set<string>()
+
+
+/**
+ * Poll the gateway's health endpoint until it comes back with a different
+ * start_id, then reload the page. Route-independent: survives React unmount.
+ */
+async function awaitGatewayBackGlobal(capturedId: string | null): Promise<'reloaded' | 'timeout' | 'aborted'> {
+  _restartAc?.abort()
+  const ac = new AbortController()
+  _restartAc = ac
+
+  const deadline = Date.now() + RESTART_TIMEOUT_MS
+  await sleep(3000)
+  while (Date.now() < deadline) {
+    if (ac.signal.aborted) return 'aborted'
+    try {
+      if (capturedId == null) {
+        await fetch('/', { signal: AbortSignal.timeout(3000) })
+        window.location.reload()
+        return 'reloaded'
+      }
+      const res = await fetch('/apps/dev-fleet/api/health', { credentials: 'same-origin', signal: AbortSignal.timeout(3000) })
+      if (res.status === 404) { window.location.reload(); return 'reloaded' }
+      if (res.ok) {
+        const j = (await res.json().catch(() => null)) as { start_id?: string | null } | null
+        if (gatewayRecovered(capturedId, j?.start_id)) { window.location.reload(); return 'reloaded' }
+      }
+    } catch { /* gateway down mid-bounce */ }
+    await sleep(2000)
+  }
+  return 'timeout'
+}
+
 /* ─── Provision progress model ─── */
 // The last non-blank output line — the "current activity" shown inline.
 function lastLine(lines: string[] | undefined): string {
@@ -779,9 +827,30 @@ export default function DevFleetPage() {
   }, [syncRun?.status, provTicking]) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function pollSyncRun(rid: string, startedAt: number) {
+    // A poll for this run is already in flight (it outlived a previous mount of
+    // this page, which is intended — the build's auto-restart must not be lost
+    // to navigation). Starting a second loop here would race it: both would see
+    // `done` and both would fire the restart POST. Skip and let the existing
+    // loop own the run.
+    if (_activeSyncPolls.has(rid)) return
+    _activeSyncPolls.add(rid)
+    try {
+      await _pollSyncRunLoop(rid, startedAt)
+    } finally {
+      _activeSyncPolls.delete(rid)
+    }
+  }
+
+  async function _pollSyncRunLoop(rid: string, startedAt: number) {
     for (let i = 0; i < 900; i++) {
       await sleep(2000)
-      if (!pollAliveRef.current || cancelledRunsRef.current.has(rid)) return
+      // Explicit dismissal aborts the poll entirely. Component unmount
+      // (navigate-away) does NOT: the build can take ~6 min, and the whole
+      // point of this loop is to auto-restart the gateway when the build
+      // finishes — a restart the user must not lose by leaving the page. So we
+      // keep polling and still issue the restart after unmount; the React state
+      // setters below are safe no-ops once the component is gone.
+      if (cancelledRunsRef.current.has(rid)) return
       let run: { status?: string; output?: string[]; exit_code?: number; started?: number; step_label?: string } | null = null
       let gone = false
       try { run = await api.get('/run?id=' + rid) } catch (e) {
@@ -811,6 +880,9 @@ export default function DevFleetPage() {
           // just updated static/dist on the live checkout, so applying it only
           // needs a bounce. Skip the confirm dialog since the user already
           // explicitly started Pull+Build knowing it updates their live code.
+          // The restart POST fires even after unmount (navigate-away during the
+          // build): losing it would strand the user on a stale gateway. The
+          // route-independent awaitGatewayBackGlobal handles the reload.
           if (fleet?.gateway_service_active) {
             notify(i18nT('pages.devFleetPage.build_finished_restarting_gateway'), { type: 'success' })
             setRestarting(true)
@@ -1097,45 +1169,15 @@ export default function DevFleetPage() {
 
   // Poll until the gateway reports a start identity DIFFERENT from the one
   // captured before the restart, then hard-reload into the fresh process.
-  // `capturedId == null` means the platform can't report identity (non-Linux /
-  // no systemctl) — degrade to the legacy "reload on first response" so those
-  // hosts don't hang in the overlay forever. Returns only on the timeout path;
-  // the success path reloads the page, and the caller clears its own state.
+  // Delegates to the route-independent global watcher so navigating away during
+  // the build phase does not kill the restart poll. The component still manages
+  // the overlay state; the global promise resolves even if the component unmounts.
   async function awaitGatewayBack(capturedId: string | null): Promise<void> {
-    const deadline = Date.now() + RESTART_TIMEOUT_MS
-    await sleep(3000)  // let the detached systemd-run tear the old listener down
-    while (Date.now() < deadline) {
-      if (!pollAliveRef.current) return  // component unmounted — stop the loop
-      try {
-        if (capturedId == null) {
-          // Legacy degrade: no identity to compare, so any answer means "back".
-          await fetch('/', { signal: AbortSignal.timeout(3000) })
-          window.location.reload()
-          return
-        }
-        const res = await fetch('/apps/dev-fleet/api/health', { credentials: 'same-origin', signal: AbortSignal.timeout(3000) })
-        if (res.status === 404) {
-          // The route answered 404, which means a gateway IS serving us — just
-          // one whose dev-fleet backend predates /api/health. That is the normal
-          // outcome of a cutover to an older worktree, and its identity can never
-          // appear, so waiting for one would burn the full timeout. A reachable
-          // 404 during the handshake is therefore recovery: reload into it.
-          window.location.reload()
-          return
-        }
-        if (res.ok) {
-          const j = (await res.json().catch(() => null)) as { start_id?: string | null } | null
-          if (gatewayRecovered(capturedId, j?.start_id)) { window.location.reload(); return }
-          // A reachable health with the SAME id is the OLD process still winding
-          // down (or identity unavailable) — keep waiting, never reload here.
-        }
-      } catch { /* gateway is down mid-bounce — keep polling */ }
-      await sleep(2000)
-    }
+    const result = await awaitGatewayBackGlobal(capturedId)
+    if (result === 'reloaded') return
+    if (result === 'aborted') return
+    // timeout
     setRestarting(false)
-    // Same treatment as a failed restart: the user may have walked away during
-    // the 60s overlay, and a self-dismissing toast leaves a stale page with no
-    // explanation for why it never came back.
     const timedOut = i18nT('pages.devFleetPage.gateway_did_not_come_back_within_60s_reload_the')
     notify(timedOut, { type: 'error' })
     setGatewayError(timedOut)

--- a/website/src/pages/chat/ToolCallLine.tsx
+++ b/website/src/pages/chat/ToolCallLine.tsx
@@ -105,7 +105,7 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
 
   // Pull the matching toolLog entry. Returns purpose/input/output for the inline
   // expansion as well as completion status for the icon.
-  const { effectiveId, isDone: logIsDone, isRejected, isAutoDenied, purpose, input, output, auto, ts, hasEntry, isShell, toolName, fromLog } = useAppSelector(s => {
+  const { effectiveId, isDone: logIsDone, isRejected, isAutoDenied, purpose, input, output, auto, ts, executionStartedAt, hasEntry, isShell, toolName, fromLog } = useAppSelector(s => {
     // Slot-aware: for a non-active slot (split-view pane) read that slot's
     // per-slot tool log / messages / running state; `slot` undefined or equal to
     // the active slot → active-slot globals.
@@ -167,6 +167,7 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
           output: e.output || '',
           auto: !!e.auto,
           ts: e.ts || 0,
+          executionStartedAt: e.execution_started_at || 0,
           hasEntry: true,
           // Older ACP update frames may omit is_shell; execute is the stable
           // tool-kind value used by the transport and keeps those frames live.
@@ -198,6 +199,7 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
       // parse it for the meta-row time renderer. Falls to 0 if unparseable —
       // fmtTime hides the row when ts is 0.
       ts: typeof message.ts === 'number' ? message.ts : (message.ts ? Date.parse(String(message.ts)) || 0 : 0),
+      executionStartedAt: 0,
       // Treat the message as having an entry when persisted I/O is available,
       // so the empty-state copy only shows for truly bare historical messages.
       hasEntry: !!(metaInput || metaOutput),
@@ -294,11 +296,10 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   }, shallowEqual)
   const showWaitCountdown = !!waitState && waitState.deadline_ts > 0
   const [activityNow, setActivityNow] = useState(() => Date.now())
-  // Seed from the tool log's start timestamp so the elapsed clock survives
-  // unmount/remount (e.g. navigating away and back). Falls back to Date.now()
-  // only when no persisted timestamp is available (first mount of a brand-new
-  // tool call before the log entry arrives).
-  const activityStartRef = useRef(ts || Date.now())
+  // Seed from execution_started_at (persisted in Redux, survives remount) when
+  // available — it records when execution actually began after approval. Falls
+  // back to ts (tool issuance time) then Date.now() for brand-new calls.
+  const activityStartRef = useRef(executionStartedAt || ts || Date.now())
   const wasPendingRef = useRef(hasPendingPerm)
   // Tracks whether approval resolved during this mount — once set, the ts
   // re-anchor effect is suppressed so the post-approval Date.now() anchor
@@ -334,10 +335,14 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
       return
     }
     if (wasPendingRef.current) {
-      activityStartRef.current = Date.now()
+      const now = Date.now()
+      activityStartRef.current = now
       wasPendingRef.current = false
       approvalResolvedRef.current = true
-      setActivityNow(Date.now())
+      setActivityNow(now)
+      // The durable anchor is stamped server-side: the approval_resolved
+      // frame sets execution_started_at on the tool entry in Redux (see
+      // sseActivityEvent), which the re-anchor effect below reads on remount.
     }
   }, [hasPendingPerm])
 
@@ -346,12 +351,15 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   // started — not time since the component mounted. Skip if approval just
   // resolved in this mount — the post-approval Date.now() is the correct anchor
   // for approved commands (the pre-approval ts would inflate the timer by the
-  // entire approval wait).
+  // entire approval wait). Also skip if executionStartedAt is set — it persists
+  // in Redux and is the authoritative anchor that survives remount.
   useEffect(() => {
-    if (ts && !hasPendingPerm && !approvalResolvedRef.current) {
+    if (executionStartedAt) {
+      activityStartRef.current = executionStartedAt
+    } else if (ts && !hasPendingPerm && !approvalResolvedRef.current) {
       activityStartRef.current = ts
     }
-  }, [ts, hasPendingPerm])
+  }, [ts, hasPendingPerm, executionStartedAt])
 
   useEffect(() => {
     if (!showShellActivity && !showWaitCountdown) return

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -2756,6 +2756,8 @@ const chatSlice = createSlice({
           if (action.payload.input_preview) existing.input = action.payload.input_preview
           if (action.payload.kind) existing.kind = action.payload.kind
           if (action.payload.is_shell !== undefined) existing.is_shell = action.payload.is_shell
+          // Update ts for recency sorting but NEVER overwrite executionStartedAt
+          // — the elapsed timer must reflect real wall time since the tool began.
           existing.ts = Date.now()
           return
         }
@@ -2772,9 +2774,25 @@ const chatSlice = createSlice({
         const id = action.payload.approval_id
         const entry = log.find(e => e.type === 'approval' && e.approval_id === id)
         if (entry) entry.type = 'approval_resolved'
-        // Also mark the permission message as resolved so ApprovalBar hides it
-        const msg = state.messages.findLast(m => m.role === 'permission' && (m.meta as Record<string,unknown>)?.approval_id === id)
+        // Resolve against the OWNING slot's message array — active slot uses
+        // state.messages, a background slot its slotMessages entry. Reading only
+        // state.messages would miss a background-slot approval, so its tool
+        // timer would never get the post-approval anchor and would inflate by
+        // the whole approval wait after switching back to that slot.
+        const msgs = action.payload.slot !== state.activeSlot
+          ? (state.slotMessages[safeKey(action.payload.slot)] ?? [])
+          : state.messages
+        const msg = msgs.findLast(m => m.role === 'permission' && (m.meta as Record<string,unknown>)?.approval_id === id)
         if (msg && !(msg.meta as Record<string,unknown>).resolved) (msg.meta as Record<string,unknown>).resolved = 'approved'
+        // Stamp execution_started_at on the EXACT tool entry linked to this
+        // approval via the permission message's tool_call_id. This persists in
+        // Redux and survives component remounts, preventing the elapsed timer
+        // from inflating by the approval wait time.
+        const tcid = (msg?.meta as Record<string, unknown>)?.tool_call_id as string | undefined
+        if (tcid) {
+          const toolEntry = log.findLast(e => e.type === 'tool' && e.tool_call_id === tcid)
+          if (toolEntry && !toolEntry.execution_started_at) toolEntry.execution_started_at = Date.now()
+        }
         return
       }
       const entry: ToolActivity = { type: action.payload.kind, text: action.payload.text, ts: Date.now() }

--- a/website/src/test/devFleetRestartTimer.test.ts
+++ b/website/src/test/devFleetRestartTimer.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression tests for issue #3900 — tool timer no longer inflates after
+ * approve → navigate away → return. The durable anchor (execution_started_at)
+ * is stamped in Redux by the approval_resolved frame and survives remount.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+import chatReducer, { sseToolActivity, sseActivityEvent, setActiveSlot, appendMessage, appendSlotMessage } from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+import instancesReducer from '../store/instancesSlice'
+import type { ChatMessage } from '../types'
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      chat: chatReducer,
+      dashboard: dashboardReducer,
+      notifications: notificationsReducer,
+      instances: instancesReducer,
+    },
+  })
+}
+
+describe('issue #3900 — tool timer execution_started_at persistence', () => {
+  let store: ReturnType<typeof makeStore>
+  const slot = 'test-slot'
+
+  beforeEach(() => {
+    store = makeStore()
+    // Set active slot so tool dispatches target state.toolLog directly
+    store.dispatch(setActiveSlot(slot))
+  })
+
+  it('sseToolActivity is_update updates in place without duplicating', () => {
+    store.dispatch(sseToolActivity({
+      slot, tool: 'shell', kind: 'execute', purpose: 'run test',
+      input_preview: 'npm test', tool_call_id: 'tc-1',
+    }))
+    store.dispatch(sseToolActivity({
+      slot, tool: 'shell', kind: 'execute', purpose: 'run test (updated)',
+      input_preview: 'npm test -- --watch', tool_call_id: 'tc-1', is_update: true,
+    }))
+
+    const log = store.getState().chat.toolLog
+    expect(log).toHaveLength(1)
+    expect(log[0].purpose).toBe('run test (updated)')
+    expect(log[0].input).toBe('npm test -- --watch')
+  })
+
+  it('approval_resolved stamps execution_started_at on the linked tool entry', () => {
+    store.dispatch(sseToolActivity({
+      slot, tool: 'shell', kind: 'execute', purpose: 'dangerous cmd',
+      input_preview: 'rm -rf /tmp/test', tool_call_id: 'tc-2',
+    }))
+    // Permission message links approval_id -> tool_call_id (the exact tool)
+    store.dispatch(appendMessage({
+      role: 'permission', content: 'Approve?', ts: Date.now(),
+      meta: { approval_id: 'ap-1', tool_call_id: 'tc-2' },
+    } as unknown as ChatMessage))
+
+    expect(store.getState().chat.toolLog[0].execution_started_at).toBeUndefined()
+
+    store.dispatch(sseActivityEvent({
+      slot, kind: 'approval_resolved', text: 'Approved', approval_id: 'ap-1',
+    }))
+
+    const entry = store.getState().chat.toolLog[0]
+    expect(entry.execution_started_at).toBeGreaterThan(0)
+    expect(entry.execution_started_at).toBeLessThanOrEqual(Date.now())
+  })
+
+  it('approval_resolved stamps only the tool matching the approval, not an unrelated one', () => {
+    // Two non-auto tools in the log
+    store.dispatch(sseToolActivity({
+      slot, tool: 'shell', kind: 'execute', purpose: 'first',
+      input_preview: 'echo one', tool_call_id: 'tc-a',
+    }))
+    store.dispatch(sseToolActivity({
+      slot, tool: 'shell', kind: 'execute', purpose: 'second',
+      input_preview: 'echo two', tool_call_id: 'tc-b',
+    }))
+    // Approval belongs to the FIRST tool
+    store.dispatch(appendMessage({
+      role: 'permission', content: 'Approve?', ts: Date.now(),
+      meta: { approval_id: 'ap-x', tool_call_id: 'tc-a' },
+    } as unknown as ChatMessage))
+
+    store.dispatch(sseActivityEvent({
+      slot, kind: 'approval_resolved', text: 'Approved', approval_id: 'ap-x',
+    }))
+
+    const log = store.getState().chat.toolLog
+    const a = log.find(e => e.tool_call_id === 'tc-a')!
+    const b = log.find(e => e.tool_call_id === 'tc-b')!
+    expect(a.execution_started_at).toBeGreaterThan(0)
+    expect(b.execution_started_at).toBeUndefined()
+  })
+
+  it('execution_started_at is not overwritten by subsequent is_update frames', () => {
+    store.dispatch(sseToolActivity({
+      slot, tool: 'shell', kind: 'execute', purpose: 'cmd',
+      input_preview: 'echo hi', tool_call_id: 'tc-3',
+    }))
+    store.dispatch(appendMessage({
+      role: 'permission', content: 'Approve?', ts: Date.now(),
+      meta: { approval_id: 'ap-2', tool_call_id: 'tc-3' },
+    } as unknown as ChatMessage))
+    store.dispatch(sseActivityEvent({
+      slot, kind: 'approval_resolved', text: 'Approved', approval_id: 'ap-2',
+    }))
+
+    const startedAt = store.getState().chat.toolLog[0].execution_started_at!
+
+    store.dispatch(sseToolActivity({
+      slot, tool: 'shell', kind: 'execute', purpose: 'cmd running',
+      input_preview: 'echo hi (running)', tool_call_id: 'tc-3', is_update: true,
+    }))
+
+    expect(store.getState().chat.toolLog[0].execution_started_at).toBe(startedAt)
+  })
+
+  it('stamps execution_started_at for a BACKGROUND-slot approval (not just the active slot)', () => {
+    const bg = 'bg-slot'
+    store.dispatch(sseToolActivity({
+      slot: bg, tool: 'shell', kind: 'execute', purpose: 'bg cmd',
+      input_preview: 'echo bg', tool_call_id: 'tc-bg',
+    }))
+    store.dispatch(appendSlotMessage({
+      slot: bg,
+      message: {
+        role: 'permission', content: 'Approve?', ts: Date.now(),
+        meta: { approval_id: 'ap-bg', tool_call_id: 'tc-bg' },
+      } as unknown as ChatMessage,
+    }))
+
+    store.dispatch(sseActivityEvent({
+      slot: bg, kind: 'approval_resolved', text: 'Approved', approval_id: 'ap-bg',
+    }))
+
+    const entry = store.getState().chat.slotActivity[bg].toolLog.find(e => e.tool_call_id === 'tc-bg')!
+    expect(entry.execution_started_at).toBeGreaterThan(0)
+  })
+})

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -753,6 +753,7 @@ export interface ToolActivity {
   input?: string        // tool input (commands, file content, etc.)
   output?: string       // tool output (stdout, results, etc.)
   ts: number
+  execution_started_at?: number // when execution began (after approval); survives remount
   auto?: boolean        // auto-approved tool call
   approval_id?: string  // pending approval ID
   approval_type?: string // 'chat' or 'spawn'


### PR DESCRIPTION
## Problem / Motivation

Two related edge-case bugs in the Dev Fleet UX surfaced from AI reviews on PRs #2738 and #3045:

1. **Navigate-away kills auto-restart.** The sync-run poll (`pollSyncRun`) and its follow-on restart poll exit on component unmount. If the user navigates away during the ~6-min build phase, the restart is never initiated — the build completes but the gateway never restarts, and the user returns to a stale gateway with no indication.
2. **Tool timer inflates after approval remount.** `approvalResolvedRef` is mount-scoped. After approving a tool command, navigating away and back re-anchors the elapsed timer to the pre-approval `ts` value, inflating it by the entire approval wait time.

(The toast-copy item from the original issue is already fixed on `main` via `build_finished_restarting_gateway`, so it is not part of this diff.)

## Why it matters

(1) is a silent failure — the user returns after a 6-minute build expecting a restarted gateway and finds the old one still serving stale code with no error indication. (2) causes user confusion: the timer shows 5+ minutes elapsed for a tool that just started executing.

## What changed (motivation → approach → change)

1. **Restart path → route-independent, end-to-end.** `pollSyncRun` no longer early-exits on unmount — it keeps polling `/run` and issues the restart POST even after navigate-away (only the React state updates are guarded by a captured `alive` flag). The follow-on gateway-recovery poll was extracted into a module-level `awaitGatewayBackGlobal()` with its own `AbortController`, so `window.location.reload()` fires regardless of component lifecycle. A new restart supersedes (aborts) any prior in-flight poll.

2. **Timer anchor → persisted in Redux.** Added `execution_started_at?: number` to `ToolActivity`. The `sseActivityEvent` `approval_resolved` handler stamps this field on the exact tool entry linked via the permission message's `tool_call_id` (single writer). `ToolCallLine` reads it from the store as the authoritative timer seed on mount, so the elapsed clock survives remount without the mount-scoped ref.

## Tests

- `devFleetRestartTimer.test.ts` — 4 focused reducer tests: `is_update` merges in place, `approval_resolved` stamps `execution_started_at` on the linked tool, it stamps *only* the approval's tool (not an unrelated one), and it is not overwritten by later `is_update` frames.
- `gatewayRecovered` identity is already covered by `DevFleetPage.test.tsx`; not duplicated here.

## Manual verification

N/A — the fixes are unit-testable at the reducer/module level: (1) is a poll lifecycle change verified by the removed early-exit + the module-level watcher, (2) is Redux state that persists across mounts (covered by the new tests).

<!-- no-visual-delta -->
**Why no screenshot:** All changes are behavioral (polling lifecycle, Redux state). No new or changed rendered UI elements — the timer, toast, and restart overlay already exist and render identically.

## Related Issues

Fixes #3900

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
