### PR TITLE
fix(cron): validate the cron job name on update, not just create

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -53,7 +53,7 @@ from kiro_crew.constants import env_flag_enabled
 from kiro_crew.cron_history import CronHistoryStore, CronRunRecord
 from kiro_crew.executors import _CRON_QUEUE_WAIT_SECS, cron_gate_budget, subprocess_executor
 from kiro_crew.resource_status import admission_check
-from kiro_crew.validation import MAX_CRON_MESSAGE
+from kiro_crew.validation import MAX_CRON_MESSAGE, MAX_SHORT_STRING
 
 logger = logging.getLogger(__name__)
 
@@ -1620,6 +1620,17 @@ class CronService:
             raise ValueError("message must be a string")
         if len(message) > MAX_CRON_MESSAGE:
             raise ValueError(f"message exceeds max length {MAX_CRON_MESSAGE}")
+        # Same chokepoint argument for the name. The dashboard POST handler
+        # caps it at MAX_SHORT_STRING via validate_string_field, but the other
+        # create surfaces (MCP cron_add, the apps SDK, the CLI) reach this
+        # constructor directly, so the cap has to live here to actually bind
+        # them. Type first: len() succeeds on a list, which would then be
+        # persisted into crons.json and only surface as a render/log failure
+        # somewhere far from the request that wrote it.
+        if not isinstance(name, str):
+            raise ValueError("name must be a string")
+        if len(name) > MAX_SHORT_STRING:
+            raise ValueError(f"name exceeds max length {MAX_SHORT_STRING}")
         if timeout_secs and not 1 <= int(timeout_secs) <= 86400:
             raise ValueError(f"timeout_secs must be within 1..86400, got {timeout_secs}")
         if timeout_secs and (command or script):
@@ -1832,6 +1843,15 @@ class CronService:
                     if kwargs["approval_mode"] not in valid_approval_modes:
                         raise ValueError(f"Invalid approval_mode: {kwargs['approval_mode']!r}")
                 # Validate before any mutations
+                if "name" in kwargs and kwargs["name"]:
+                    # Mirrors the message check below and _build_job's create-side
+                    # cap: PATCH /api/crons/{id} copied `name` into kwargs raw, so
+                    # a non-string or oversize name was persisted verbatim while
+                    # POST rejected the identical value (#3831).
+                    if not isinstance(kwargs["name"], str):
+                        raise ValueError("name must be a string")
+                    if len(kwargs["name"]) > MAX_SHORT_STRING:
+                        raise ValueError(f"name exceeds max length {MAX_SHORT_STRING}")
                 if "message" in kwargs and kwargs["message"]:
                     # Same chokepoint rationale as _build_job: every update
                     # surface (MCP, dashboard PATCH, CLI) funnels here. Type

--- a/test/test_cron_name_cap.py
+++ b/test/test_cron_name_cap.py
@@ -1,0 +1,150 @@
+"""Tests for the cron-job ``name`` cap at the persistence owner (issue #3831).
+
+``POST /api/crons`` caps ``name`` at ``MAX_SHORT_STRING`` through
+``validate_string_field``, and ``PATCH /api/crons/{id}`` gained the same
+validation when #3831's REST half landed (locked by
+``test/test_cron_patch_name_validation.py``). One layer down the divergence
+remained: ``_build_job`` capped ``message`` but not ``name``, and
+``_update_job_locked`` assigned ``name`` with only a truthiness guard -- so
+the non-REST create and update paths (MCP ``cron_add``/``cron_update``, the
+CLI, the apps SDK) could still persist a non-string or oversize name verbatim
+into ``crons.json``, to surface later far from the call that wrote it.
+
+Locks in that the persistence owner now binds every caller:
+
+- ``_build_job`` / ``_update_job_locked`` reject a non-string or oversize
+  name, so the CLI/MCP/SDK paths share REST's cap instead of each surface
+  deciding for itself;
+- a rejected update leaves the job unchanged in memory and on disk;
+- a name at the exact cap is still accepted (the check is a cap, not an
+  off-by-one rejection);
+- REST boundary cases not pinned elsewhere: POST rejects an oversize name,
+  PATCH accepts a name at the exact cap, and a ``null`` name stays a no-op
+  rather than blanking the job's name.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.cron import CronService
+from kiro_crew.dashboard.handlers import api_cron_update, api_crons_create
+from kiro_crew.validation import MAX_SHORT_STRING
+
+OVERSIZE_NAME = "x" * (MAX_SHORT_STRING + 1)
+EXACT_NAME = "x" * MAX_SHORT_STRING
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cron_store(monkeypatch, tmp_path):
+    monkeypatch.setattr("kiro_crew.cron._DEFAULT_DIR", tmp_path)
+    yield
+
+
+# ── CronService chokepoint (the path the CLI, MCP and apps SDK use) ──
+
+
+class TestServiceChokepoint:
+    def test_add_job_rejects_oversize_name(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        with pytest.raises(ValueError, match="max length"):
+            svc.add_job(name=OVERSIZE_NAME, message="m", every_secs=3600)
+        assert svc.list_jobs() == []
+
+    def test_add_job_rejects_non_string_name(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        with pytest.raises(ValueError, match="must be a string"):
+            svc.add_job(name=["not", "a", "str"], message="m", every_secs=3600)  # type: ignore[arg-type]
+        assert svc.list_jobs() == []
+
+    def test_add_job_accepts_name_at_exact_cap(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name=EXACT_NAME, message="m", every_secs=3600)
+        assert len(job.name) == MAX_SHORT_STRING
+
+    def test_update_job_rejects_oversize_and_leaves_job_unchanged(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="j", message="m", every_secs=3600)
+        with pytest.raises(ValueError, match="max length"):
+            svc.update_job(job.id, name=OVERSIZE_NAME)
+        assert svc.list_jobs()[0].name == "j"
+
+    def test_update_job_rejects_non_string_name(self, tmp_path):
+        """A list is truthy, so the old `if kwargs["name"]:` guard let it
+        through and `job.name` became a list on disk."""
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="j", message="m", every_secs=3600)
+        with pytest.raises(ValueError, match="must be a string"):
+            svc.update_job(job.id, name=["not", "a", "str"])
+        assert svc.list_jobs()[0].name == "j"
+
+    def test_update_job_accepts_name_at_exact_cap(self, tmp_path):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="j", message="m", every_secs=3600)
+        updated = svc.update_job(job.id, name=EXACT_NAME)
+        assert updated is not None
+        assert updated.name == EXACT_NAME
+
+    def test_rejected_update_does_not_reach_disk(self, tmp_path):
+        """Validation runs before any mutation, so a reload sees the old name
+        -- not a half-applied update that only looks right in memory."""
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="j", message="m", every_secs=3600)
+        with pytest.raises(ValueError):
+            svc.update_job(job.id, name=OVERSIZE_NAME)
+        assert CronService(base_dir=tmp_path).list_jobs()[0].name == "j"
+
+
+# ── Dashboard REST surface ──
+
+
+def _create_request(body: dict, crons: CronService) -> MagicMock:
+    state = MagicMock()
+    state.crons = crons
+    request = MagicMock()
+    request.app = {"state": state}
+    request.json = AsyncMock(return_value=body)
+    return request
+
+
+def _update_request(body: dict, crons: CronService, job_id: str) -> MagicMock:
+    request = _create_request(body, crons)
+    request.match_info = {"job_id": job_id}
+    return request
+
+
+class TestDashboardCreate:
+    @pytest.mark.asyncio
+    async def test_post_rejects_oversize_name(self, tmp_path):
+        crons = CronService(base_dir=tmp_path)
+        resp = await api_crons_create(
+            _create_request({"name": OVERSIZE_NAME, "message": "m", "every": 3600}, crons)
+        )
+        assert resp.status == 400
+        assert crons.list_jobs() == []
+
+
+class TestDashboardUpdate:
+    """PATCH rejection/sanitization paths are pinned by
+    ``test/test_cron_patch_name_validation.py``; here only the boundary
+    cases that file does not cover."""
+
+    @pytest.mark.asyncio
+    async def test_patch_accepts_name_at_exact_cap(self, tmp_path):
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="j", message="m", every_secs=3600)
+        resp = await api_cron_update(_update_request({"name": EXACT_NAME}, crons, job.id))
+        assert resp.status == 200
+        assert crons.list_jobs()[0].name == EXACT_NAME
+
+    @pytest.mark.asyncio
+    async def test_patch_with_null_name_leaves_it_unchanged(self, tmp_path):
+        """`null` sanitizes to "" and the mutation site skips empty names, so
+        a PATCH cannot blank a job's name -- unchanged from before the fix."""
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="j", message="m", every_secs=3600)
+        resp = await api_cron_update(_update_request({"name": None, "silent": True}, crons, job.id))
+        assert resp.status == 200
+        assert crons.list_jobs()[0].name == "j"


### PR DESCRIPTION
Closes #3831.

## Problem / Motivation

`POST /api/crons` caps `name` at `MAX_SHORT_STRING` through `validate_string_field`, and — since #3831's REST half landed on main separately — `PATCH /api/crons/{id}` now does too. But the divergence sat one layer down as well, which the issue's "and/or add a check at the `_update_job_locked` chokepoint" line points at: `_build_job` enforces the *message* cap at the persistence owner precisely so every surface shares it — but it never checked `name` at all, and the mutation site in `_update_job_locked` guarded it with truthiness alone:

```python
if "name" in kwargs and kwargs["name"]:
    job.name = kwargs["name"]
```

A JSON list is truthy, so `job.name = ["x"]` was persisted verbatim into `crons.json` — as was any name past the cap — on the paths that reach `CronService` directly. Same surface-divergence class fixed for `message` in #3829.

## Why it matters

The surfaces genuinely unguarded at base were the **apps SDK** (`cron_sdk.py` passes kwargs straight through), the **CLI** (oversize only — argparse can't produce a non-string), and any direct in-process caller: a non-string or oversize name written there lands in `crons.json` silently and only surfaces later as a render/log failure far from the call that wrote it. (The MCP `cron_add`/`cron_update` schemas already bind `name` with `FieldSpec(..., str, max_len=MAX_SHORT_STRING)` at their own boundary — for those the chokepoint turns a per-surface convention into a structural guarantee rather than closing a live hole.) Whether a value is accepted should not depend on which surface the caller reached for.

## What changed (motivation → approach → change)

Root cause: the cap lived only at per-surface boundaries (REST validators, MCP schemas), so surfaces without their own validator were never bound by it. The fix places the check at the persistence owner — the one chokepoint every surface funnels through — mirroring how the `message` cap already works:

- **`_build_job` and `_update_job_locked`** type- and length-check `name`, so REST, MCP, the CLI, the apps SDK and direct callers are all bound by the same cap instead of each surface deciding for itself.

Type is checked before length in both places, for the reason the neighbouring message check already documents: `len()` succeeds on a list, so a length-first check would pass a non-string straight through to disk.

A `null`/empty name remains a no-op rather than blanking the job's name — unchanged behavior (matching the `message` check's falsy-skip idiom one line below), now pinned by a test.

(The PR originally also added the PATCH-handler validation; main absorbed an equivalent hunk while this PR was open, locked by `test/test_cron_patch_name_validation.py`, so after rebase this PR carries only the chokepoint layer. Sibling fields at the same chokepoint that still lack checks are tracked in #5782.)

## Tests

`test/test_cron_name_cap.py` (new, 10 tests, mirroring `test_cron_message_cap.py`):

- chokepoint rejection of non-string and oversize names on both add and update (the 4 defect reproductions — all fail on main);
- acceptance at the exact cap on both add and update (the check is a cap, not an off-by-one rejection);
- a rejected update leaves the job unchanged in memory **and on disk** (validation precedes mutation);
- REST boundary cases not pinned elsewhere: POST rejects an oversize name, PATCH accepts a name at the exact cap, and a `null` name stays a no-op.

PATCH rejection/sanitization paths are pinned by `test/test_cron_patch_name_validation.py` on main. Full local run: `test_cron_name_cap` + `test_cron_patch_name_validation` + `test_cron_message_cap` + `test_api_input_validation` → 47 passed; all cron + contract/ratchet suites → 1257 passed; `flake8` / `isort` / `mypy` / black gate clean on touched files.

## Manual verification

N/A — unit coverage sufficient: the change is two guard clauses at a single chokepoint, and the tests exercise both REST and service-level callers end to end.
