### PR TITLE
fix(slack): fail closed when the enterprise-origin allowlist cannot be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
+- **A corrupt `config.json` no longer silently reopens the Slack
+  enterprise-origin allowlist.** `KiroCrewConfig.load()` degrades rather than
+  raises on a malformed or torn config: it catches the parse error, warns, and
+  returns DEFAULTS. So an operator's `slack.allowed_enterprise_ids` came back
+  empty, `_allowlist_configured` flipped to False, and `check_message_origin()`
+  took its documented default-open path — admitting every origin — while the
+  `except` branch written for exactly this case never fired, because `load()`
+  never raises. The operator's restriction just stopped applying, with nothing
+  surfaced, until the file was repaired; the loader's own docs name torn reads
+  as the common case. Both places `slack.enterprise` reads the allowlist now
+  ask whether the config on disk actually parses and fail CLOSED when it does
+  not — the allowlist stays active with only the validated `team_id` admitted,
+  and the degradation is logged and SEL-audited — instead of inferring
+  "unconfigured" from an empty value. Same root cause as the publish allowlist
+  fixed in #3615, and it now shares that fix's primitive:
+  `unreadable_config_paths()` moves next to the fail-closed read it delegates
+  to, so the two gates cannot drift. (#3945)
 
 - **Switching Kiro accounts mid-session no longer leaves the chat showing a raw
   `The bearer token included in the request is invalid.` with no way out.** A

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -730,6 +730,41 @@ def read_config_for_update(path: Path | None = None) -> dict:
     return raw
 
 
+def unreadable_config_paths() -> list[Path]:
+    """Return the config files that EXIST on disk but do not parse.
+
+    The question a security gate has to ask before trusting a value read out of
+    :meth:`KiroCrewConfig.load`. ``load()`` deliberately DEGRADES — it catches
+    ``json.JSONDecodeError``/``OSError``, logs a warning and returns DEFAULTS —
+    which is right for an ordinary consumer and wrong for anything deciding
+    access: the degraded object is indistinguishable from "the operator
+    configured nothing", so an allowlist the operator narrowed silently reopens.
+    Because ``load()`` cannot raise, a ``try/except`` around it never fires and
+    the gate has to ask separately.
+
+    It asks through :func:`read_config_for_update`, which already IS this
+    repo's fail-closed config read, rather than hand-rolling a second spelling
+    of "a config parse must not degrade" that could drift from the first.
+    The name reads oddly at a read-only call site only because nothing is being
+    updated.
+
+    BOTH files are reported: the overlay ``config.local.json`` is deep-merged
+    over the base and swallows its own parse errors the same way, so a corrupt
+    overlay hides a setting just as effectively as a corrupt base.
+
+    An ABSENT file is not unreadable — that is the ordinary unconfigured state,
+    and a gate should treat it as such.
+    """
+    bad: list[Path] = []
+    for path in (config_path(), config_local_path()):
+        try:
+            read_config_for_update(path)
+        except ConfigReadError as e:
+            logger.warning("config unreadable: %s", e)
+            bad.append(path)
+    return bad
+
+
 def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> None:
     """Write a config dict to *path* atomically, PRESERVING its permissions.
 

--- a/src/kiro_crew/publish_governance.py
+++ b/src/kiro_crew/publish_governance.py
@@ -41,11 +41,8 @@ from aiohttp import web
 
 from kiro_crew import sel as _sel_mod
 from kiro_crew.config.loader import (
-    ConfigReadError,
     KiroCrewConfig,
-    config_local_path,
-    config_path,
-    read_config_for_update,
+    unreadable_config_paths,
 )
 
 logger = logging.getLogger(__name__)
@@ -96,16 +93,12 @@ def _unparseable_config_reason() -> str | None:
     the operator closed. Because ``load()`` cannot fail, a ``try/except`` around
     it never fires, so this chokepoint has to ask the question itself.
 
-    It asks through :func:`read_config_for_update`, which already IS the repo's
-    fail-closed config read (absent → ``{}``, unreadable or non-object →
-    ``ConfigReadError``, ``UnicodeDecodeError`` named explicitly because it is a
-    ``ValueError`` rather than an ``OSError``). Hand-rolling a second spelling of
-    "a config parse must not degrade" would give the invariant two homes and let
-    them drift; the name reads oddly here only because nothing is being updated.
-
-    Both files are checked: the overlay ``config.local.json`` is deep-merged over
-    the base and swallows its own parse errors the same way, so a corrupt overlay
-    hides an allowlist just as effectively as a corrupt base.
+    The asking lives in :func:`unreadable_config_paths` — the shared predicate
+    next to the fail-closed read it delegates to — because this is not the only
+    gate that has to ask (the Slack enterprise-origin allowlist has the same
+    shape, see ``slack.enterprise``), and two spellings of "a config parse must
+    not degrade" would drift. This function only turns its answer into the
+    denial string this module's callers expect.
 
     A file that is simply ABSENT is not an error — that is the standalone default,
     and an unnamed publish is ungoverned and permitted.
@@ -115,12 +108,9 @@ def _unparseable_config_reason() -> str | None:
     module-scope dependency of this file (``KiroCrewConfig``), so the CPP
     import-direction invariant has nothing to say about importing more of it.
     """
-    for path in (config_path(), config_local_path()):
-        try:
-            read_config_for_update(path)
-        except ConfigReadError as e:
-            logger.warning("publish denied: %s", e)
-            return f"publishing denied: {path.name} could not be read as a JSON object"
+    for path in unreadable_config_paths():
+        logger.warning("publish denied: %s could not be read as a JSON object", path)
+        return f"publishing denied: {path.name} could not be read as a JSON object"
     return None
 
 

--- a/src/kiro_crew/slack/enterprise.py
+++ b/src/kiro_crew/slack/enterprise.py
@@ -13,13 +13,21 @@ Two layers of defence:
    event's ``team`` field against the cached value (zero-cost in-memory
    check, no API call).  Catches hot-swap of ``.env`` tokens while the
    gateway is running.  Allows everything when no allowlist is set.
+
+Default-open means *no allowlist configured*, which is not the same as
+*the allowlist could not be read*.  ``KiroCrewConfig.load()`` degrades to
+defaults on a corrupt or torn ``config.json`` rather than raising, so both
+places this module reads the allowlist ask :func:`unreadable_config_paths`
+first and fail CLOSED on an unreadable config — admitting only the
+validated ``team_id`` — instead of inferring "unconfigured" from an empty
+value (#3945).
 """
 
 from __future__ import annotations
 
 import logging
 
-from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.config.loader import KiroCrewConfig, unreadable_config_paths
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -60,6 +68,24 @@ def _load_allowed_team_ids() -> None:
     any ``slack.allowed_enterprise_ids`` entries.  When none are
     configured the module stays default-open.
 
+    **A config that cannot be read is not "unconfigured".**
+    ``KiroCrewConfig.load()`` degrades on a corrupt or torn ``config.json``:
+    it catches the parse error, logs a warning and returns DEFAULTS.  So an
+    operator's ``allowed_enterprise_ids`` came back as the empty default,
+    ``_allowlist_configured`` flipped to False, and ``check_message_origin``
+    took its default-open path — accepting every origin — while the
+    ``except`` branch below, written for exactly this case, never fired
+    because ``load()`` never raises (#3945).  Torn reads are documented as
+    the common case in ``read_config_for_update``, so this is not
+    hypothetical.
+
+    :func:`unreadable_config_paths` asks the question ``load()`` swallows.
+    When a config file exists but does not parse, this fails CLOSED: the
+    allowlist stays ACTIVE with only the validated ``team_id`` admitted, so
+    the restriction narrows rather than disappearing until the file is
+    repaired.  Same shape and same primitive as the publish allowlist fix in
+    #3615.
+
     Config load failures are logged and SEL-audited but do not raise —
     the cache falls back to just the validated team_id.
     """
@@ -67,6 +93,8 @@ def _load_allowed_team_ids() -> None:
     allowed: set[str] = set()
     if _validated_team_id:
         allowed.add(_validated_team_id)
+    # Asked BEFORE load(), because load() cannot report it afterwards.
+    unreadable = unreadable_config_paths()
     try:
         cfg = KiroCrewConfig.load()
         configured = set(cfg.slack.allowed_enterprise_ids)
@@ -83,6 +111,27 @@ def _load_allowed_team_ids() -> None:
             outcome="error",
             source="startup",
             error="config_load_failed",
+        )
+    if unreadable:
+        # Deliberately NOT `or`-ed into the bool above: an unreadable config
+        # forces the allowlist ON even when the parsed (defaulted) value is
+        # empty. That is the whole point — empty-because-unknown must not read
+        # as empty-because-unconfigured.
+        _allowlist_configured = True
+        names = ", ".join(p.name for p in unreadable)
+        logger.error(
+            "Slack enterprise allowlist failing CLOSED: %s could not be read, "
+            "so slack.allowed_enterprise_ids is unknown; admitting only the "
+            "validated team_id until the config is repaired",
+            names,
+        )
+        sel().log_api_access(
+            caller="gateway",
+            operation="slack.allowed_team_ids_load",
+            outcome="denied",
+            source="startup",
+            resources=f"unreadable={names}",
+            error="config_unreadable_failing_closed",
         )
     _allowed_team_ids = allowed
 
@@ -194,6 +243,11 @@ def validate_enterprise(
         # config here cannot rely on auth.test having succeeded, so check
         # it directly.
         configured: set[str] = set()
+        # Same trap as _load_allowed_team_ids: load() degrades to defaults on a
+        # corrupt config instead of raising, so an empty `configured` here can
+        # mean "no allowlist" OR "the allowlist is unreadable" — and the
+        # difference decides whether this branch fails open or closed (#3945).
+        unreadable = unreadable_config_paths()
         try:
             cfg = KiroCrewConfig.load()
             configured = set(cfg.slack.allowed_enterprise_ids)
@@ -204,24 +258,33 @@ def validate_enterprise(
             )
         allowlist = extra | configured
 
-        if allowlist:
-            # FAIL CLOSED: an operator restriction is in force but the
-            # workspace identity could not be verified.  Accepting an
-            # unverifiable workspace against an explicit allowlist would
-            # silently bypass the restriction.  check_message_origin()
-            # also denies because no validated team_id was cached.
+        if allowlist or unreadable:
+            # FAIL CLOSED: an operator restriction is in force -- or may be,
+            # and we cannot tell -- but the workspace identity could not be
+            # verified.  Accepting an unverifiable workspace against an
+            # explicit allowlist would silently bypass the restriction, and an
+            # unreadable config is not evidence that no restriction exists.
+            # check_message_origin() also denies because no validated team_id
+            # was cached.
             _allowlist_configured = True
             _allowed_team_ids = set(allowlist)
+            reason = (
+                "auth_test_unavailable_with_unreadable_config"
+                if unreadable and not allowlist
+                else "auth_test_unavailable_with_allowlist"
+            )
             logger.error(
                 "Enterprise validation FAILED: auth.test unavailable and an "
-                "allowlist is configured; cannot verify workspace identity."
+                "allowlist is configured (or unreadable: %s); cannot verify "
+                "workspace identity.",
+                ", ".join(p.name for p in unreadable) or "none",
             )
             sel().log_api_access(
                 caller="gateway",
                 operation="slack.enterprise_validation",
                 outcome="denied",
                 source="startup",
-                error="auth_test_unavailable_with_allowlist",
+                error=reason,
             )
             return False
 

--- a/test/test_deploy_public_gate_3599.py
+++ b/test/test_deploy_public_gate_3599.py
@@ -482,11 +482,12 @@ def test_a_malformed_config_denies_instead_of_reopening_the_path(
     moment the file was corrupted. This module documents fail-CLOSED, so it checks
     parseability itself.
     """
+    import kiro_crew.config.loader as loader
     import kiro_crew.publish_governance as pg
     bad = tmp_path / "config.json"
     bad.write_text('{"publish": {"allowed_destinations": ["internal-registry"]')  # truncated
-    monkeypatch.setattr(pg, "config_path", lambda: bad)
-    monkeypatch.setattr(pg, "config_local_path", lambda: tmp_path / "config.local.json")
+    monkeypatch.setattr(loader, "config_path", lambda: bad)
+    monkeypatch.setattr(loader, "config_local_path", lambda: tmp_path / "config.local.json")
 
     reason = pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID)
 
@@ -501,13 +502,14 @@ def test_a_malformed_overlay_denies_too(tmp_path, monkeypatch, _quiet_sel):
     A corrupt overlay hides an allowlist exactly as effectively as a corrupt base,
     so checking only the base would leave half the hole open.
     """
+    import kiro_crew.config.loader as loader
     import kiro_crew.publish_governance as pg
     good = tmp_path / "config.json"
     good.write_text("{}")
     bad_overlay = tmp_path / "config.local.json"
     bad_overlay.write_text("}not json{")
-    monkeypatch.setattr(pg, "config_path", lambda: good)
-    monkeypatch.setattr(pg, "config_local_path", lambda: bad_overlay)
+    monkeypatch.setattr(loader, "config_path", lambda: good)
+    monkeypatch.setattr(loader, "config_local_path", lambda: bad_overlay)
 
     reason = pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID)
 
@@ -517,11 +519,12 @@ def test_a_malformed_overlay_denies_too(tmp_path, monkeypatch, _quiet_sel):
 
 def test_a_non_object_config_denies(tmp_path, monkeypatch, _quiet_sel):
     """Valid JSON that is not an object also degrades to defaults in the loader."""
+    import kiro_crew.config.loader as loader
     import kiro_crew.publish_governance as pg
     weird = tmp_path / "config.json"
     weird.write_text('["not", "an", "object"]')
-    monkeypatch.setattr(pg, "config_path", lambda: weird)
-    monkeypatch.setattr(pg, "config_local_path", lambda: tmp_path / "nope.json")
+    monkeypatch.setattr(loader, "config_path", lambda: weird)
+    monkeypatch.setattr(loader, "config_local_path", lambda: tmp_path / "nope.json")
 
     assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is not None
 
@@ -537,11 +540,12 @@ def test_a_config_load_failure_is_audited_too(tmp_path, monkeypatch, _quiet_sel)
     The parseability guard sits in front of this branch, so the config on disk has
     to be VALID while ``load()`` itself fails — hence a raising ``load``.
     """
+    import kiro_crew.config.loader as loader
     import kiro_crew.publish_governance as pg
     good = tmp_path / "config.json"
     good.write_text("{}")
-    monkeypatch.setattr(pg, "config_path", lambda: good)
-    monkeypatch.setattr(pg, "config_local_path", lambda: tmp_path / "absent.json")
+    monkeypatch.setattr(loader, "config_path", lambda: good)
+    monkeypatch.setattr(loader, "config_local_path", lambda: tmp_path / "absent.json")
 
     class _Raising:
         """Only publish_governance's binding is replaced, so the governance layer
@@ -570,9 +574,10 @@ def test_an_absent_config_still_permits(tmp_path, monkeypatch, _quiet_sel):
     merely MISSING would break every ordinary install, where an unnamed publish is
     ungoverned and permitted.
     """
+    import kiro_crew.config.loader as loader
     import kiro_crew.publish_governance as pg
-    monkeypatch.setattr(pg, "config_path", lambda: tmp_path / "absent.json")
-    monkeypatch.setattr(pg, "config_local_path", lambda: tmp_path / "absent.local.json")
+    monkeypatch.setattr(loader, "config_path", lambda: tmp_path / "absent.json")
+    monkeypatch.setattr(loader, "config_local_path", lambda: tmp_path / "absent.local.json")
 
     assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is None
     assert _quiet_sel == [], "a permitted publish must not audit"

--- a/test/test_enterprise.py
+++ b/test/test_enterprise.py
@@ -343,3 +343,129 @@ def test_governance_posture_empty_enterprise_id_ok_when_not_pinned():
             assert enterprise.validate_enterprise("xoxb-token") is True
     finally:
         ctx_mod.reset_context()
+
+
+# --------------------------------------------------------------------------
+# A config that cannot be READ is not a config that says "no allowlist" (#3945)
+# --------------------------------------------------------------------------
+#
+# KiroCrewConfig.load() catches JSONDecodeError/OSError, warns, and returns
+# DEFAULTS -- it never raises. So the `except Exception` in
+# _load_allowed_team_ids, written for exactly this case, never fired: a corrupt
+# or torn config.json handed back an empty allowed_enterprise_ids,
+# _allowlist_configured flipped to False, and check_message_origin took its
+# default-open path, accepting every origin. These tests drive the REAL loader
+# against a real corrupt file on disk rather than mocking load(), because the
+# whole defect is that the mock-visible failure path is not the one taken.
+
+
+@pytest.fixture
+def _config_on_disk(tmp_path, monkeypatch):
+    """Point the loader at a tmp config pair and return (base, overlay)."""
+    import kiro_crew.config.loader as loader
+
+    base = tmp_path / "config.json"
+    overlay = tmp_path / "config.local.json"
+    monkeypatch.setattr(loader, "config_path", lambda: base)
+    monkeypatch.setattr(loader, "config_local_path", lambda: overlay)
+    return base, overlay
+
+
+def test_corrupt_config_refuses_a_foreign_workspace_instead_of_admitting_it(
+    _config_on_disk,
+):
+    """The regression the issue asks for: a malformed config.json must not
+    reopen the allowlist for an origin the operator never listed."""
+    base, _ = _config_on_disk
+    base.write_text('{"slack": {"allowed_enterprise_ids": ["T_ALLOWED"]')  # truncated
+
+    resp = {"team_id": "T_HOME", "team": "Home Co", "url": "https://x"}
+    with _install_fake_slack_sdk(resp):
+        enterprise.validate_enterprise("xoxb-token")
+
+    assert enterprise._allowlist_configured is True
+    assert enterprise.check_message_origin("T_FOREIGN") is False
+    # The validated workspace itself still works -- this narrows, not bricks.
+    assert enterprise.check_message_origin("T_HOME") is True
+
+
+def test_a_corrupt_overlay_fails_closed_too(_config_on_disk):
+    """config.local.json is deep-merged and swallows its own parse errors, so
+    a corrupt overlay hides the allowlist just as effectively as a corrupt base."""
+    base, overlay = _config_on_disk
+    base.write_text('{"slack": {"allowed_enterprise_ids": ["T_ALLOWED"]}}')
+    overlay.write_text("}not json{")
+
+    resp = {"team_id": "T_HOME", "team": "Home Co", "url": "https://x"}
+    with _install_fake_slack_sdk(resp):
+        enterprise.validate_enterprise("xoxb-token")
+
+    assert enterprise._allowlist_configured is True
+    assert enterprise.check_message_origin("T_FOREIGN") is False
+
+
+def test_a_readable_config_with_no_allowlist_still_defaults_open(_config_on_disk):
+    """Control: the fail-closed path must key off UNREADABLE, not off empty.
+    An operator who configured nothing is still unrestricted."""
+    base, _ = _config_on_disk
+    base.write_text('{"slack": {}}')
+
+    resp = {"team_id": "T_HOME", "team": "Home Co", "url": "https://x"}
+    with _install_fake_slack_sdk(resp):
+        assert enterprise.validate_enterprise("xoxb-token") is True
+
+    assert enterprise._allowlist_configured is False
+    assert enterprise.check_message_origin("T_ANYTHING") is True
+
+
+def test_an_absent_config_still_defaults_open(_config_on_disk):
+    """Control: absent is the ordinary unconfigured state, not an error."""
+    resp = {"team_id": "T_HOME", "team": "Home Co", "url": "https://x"}
+    with _install_fake_slack_sdk(resp):
+        assert enterprise.validate_enterprise("xoxb-token") is True
+
+    assert enterprise._allowlist_configured is False
+    assert enterprise.check_message_origin("T_ANYTHING") is True
+
+
+def test_corrupt_config_is_sel_audited(_config_on_disk):
+    """The degradation must be visible to an operator, not silent."""
+    base, _ = _config_on_disk
+    base.write_text("}not json{")
+
+    fake_sel = MagicMock()
+    resp = {"team_id": "T_HOME", "team": "Home Co", "url": "https://x"}
+    with _install_fake_slack_sdk(resp), patch.object(
+        enterprise, "sel", return_value=fake_sel
+    ):
+        enterprise.validate_enterprise("xoxb-token")
+
+    errors = [
+        c.kwargs.get("error") for c in fake_sel.log_api_access.call_args_list
+    ]
+    assert "config_unreadable_failing_closed" in errors
+
+
+def test_auth_test_failure_with_corrupt_config_fails_closed(_config_on_disk):
+    """The other read of the allowlist in this module has the same shape: an
+    unverifiable workspace plus an unreadable config must not continue
+    default-open on the strength of an allowlist we could not read."""
+    base, _ = _config_on_disk
+    base.write_text('{"slack": {"allowed_enterprise_ids": ["T_ALLOWED"]')  # truncated
+
+    with _install_fake_slack_sdk(raise_exc=True):
+        assert enterprise.validate_enterprise("xoxb-token") is False
+    assert enterprise._allowlist_configured is True
+
+
+def test_auth_test_failure_with_readable_empty_config_still_defaults_open(
+    _config_on_disk,
+):
+    """Control for the above: a readable config with no allowlist keeps the
+    documented default-open behaviour when auth.test is unavailable."""
+    base, _ = _config_on_disk
+    base.write_text('{"slack": {}}')
+
+    with _install_fake_slack_sdk(raise_exc=True):
+        assert enterprise.validate_enterprise("xoxb-token") is True
+    assert enterprise._allowlist_configured is False


### PR DESCRIPTION
Closes #3945.

## Problem

`KiroCrewConfig.load()` **degrades instead of raising** on a corrupt or torn `config.json` — it catches `JSONDecodeError`/`OSError`, logs a warning, and returns a DEFAULTS object. `_load_allowed_team_ids` wrapped that call in a `try/except` written for exactly this case, but the `except` never fires, because `load()` never raises:

```python
try:
    cfg = KiroCrewConfig.load()
    configured = set(cfg.slack.allowed_enterprise_ids)
    _allowlist_configured = bool(configured)   # ← False, from the DEFAULTED value
    allowed.update(configured)
except Exception:
    ...  # never reached
```

`check_message_origin()` then hit its documented default-open path and returned `True` for any origin, recording only `error="no_allowlist_configured"`. An operator who restricted which Slack enterprise may reach their gateway lost that enforcement with nothing surfaced, until the file was repaired. `read_config_for_update`'s own docstring names torn reads as the common case, so this is not hypothetical.

## Fix

The break is at the inference: the module must be able to tell *"the operator configured no allowlist"* from *"we could not read the operator's configuration"*. Both reads of the allowlist in this module now ask that question directly and **fail closed** on an unreadable config — the allowlist stays ACTIVE with only the validated `team_id` admitted, and the degradation is logged and SEL-audited — instead of inferring "unconfigured" from an empty set:

- **`_load_allowed_team_ids`** — an unreadable config forces `_allowlist_configured` True even though the parsed (defaulted) value is empty. That is the whole point: empty-because-unknown must not read as empty-because-unconfigured.
- **`validate_enterprise`'s `auth.test`-failure branch** — same shape, found by the issue's "worth grepping for other call sites" note. An unreadable config made its `allowlist` empty and took the *"continuing default-open"* path. It fails closed there too now.

The question is asked through a new `unreadable_config_paths()`, placed beside `read_config_for_update` — the repo's existing fail-closed config read — and `publish_governance._unparseable_config_reason` (the #3615 fix, same root cause) now delegates to it rather than carrying its own copy of the loop. That function's docstring already warned that a second spelling of "a config parse must not degrade" would let the invariant drift; this is the second caller that would have caused it.

**Scope note:** the fail-closed trigger is *a config file that exists but does not parse*, **not** a raising `load()`. A `load()` that genuinely raises while the on-disk config is fine keeps its existing documented default-open behavior — `test_auth_test_failure_bad_config_no_allowlist_defaults_open` still passes unchanged.

`test_deploy_public_gate_3599`'s five config-parse tests monkeypatched `publish_governance.config_path`/`config_local_path`; that seam moved one module down with the loop, so they now patch `config.loader` directly — the more accurate seam either way. No assertions changed.

## Test plan

- **`test/test_enterprise.py`** — 7 new tests that drive the **real loader against real corrupt files on disk**. Mocking `load()` cannot reproduce this defect, since the whole point is that the mock-visible failure path is not the one taken. Covers: a corrupt base and a corrupt overlay each refusing a foreign `team_id` while still admitting the validated one; the degradation being SEL-audited; the `auth.test`-failure branch failing closed; plus controls proving readable-but-empty and absent configs still default open. **3 fail on main.**
- `test_enterprise` + `test_deploy_public_gate_3599` + `test_governance_chokepoints` + `test_config_loader` + `test_channel_activation`: **449 passed, 6 skipped**.
- Full `-k "slack or publish or enterprise or config_loader"` sweep: **2788 passed**. The 10 failures there are byte-identical before and after this change (verified against a stashed tree) — environment-only: no `gh` binary in the subprocess env, and a standalone-import subprocess.
- `flake8` / `isort` clean on touched files.