### PR TITLE
fix(dashboard): carry the stall idle span on the subagent reconnect frame

### DIFF
--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -233,7 +233,7 @@ The slow-command record (`record_slow_command`, `subagent_persistence.py`) is ap
 
 ### Running-card progress events
 
-`subagent_tool` is fired on **`EVENT_TOOL_CALL`** (not only `EVENT_PERMISSION_REQUEST`) — kiro-auto-allowed tools surface only as informational `tool_call` updates, so this is the sole progress signal a simple/read-only task emits. Payload carries `{tool, tool_kind, turns, tool_count}`; `info.tool_count` increments per observed tool call. The `subagent_snapshot` reconnect payload (`dashboard/ws.py`) also carries `tool_count` and `stalled` so a reloading client recovers progress/stall state (a transition-only WS signal always needs a matching snapshot field).
+`subagent_tool` is fired on **`EVENT_TOOL_CALL`** (not only `EVENT_PERMISSION_REQUEST`) — kiro-auto-allowed tools surface only as informational `tool_call` updates, so this is the sole progress signal a simple/read-only task emits. Payload carries `{tool, tool_kind, turns, tool_count}`; `info.tool_count` increments per observed tool call. The `subagent_snapshot` reconnect payload (`dashboard/ws.py`, built by `build_subagent_snapshot()`) also carries `tool_count`, `stalled`, and — only while stalled — `idle_secs`, recomputed at replay time from `last_activity` (clamped at 0, omitted entirely for a healthy agent) so a reloading client recovers progress/stall state including the span that justifies the stall badge (a transition-only WS signal always needs a matching snapshot field).
 
 
 ### Model Provenance (#3582)

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -7,6 +7,7 @@ import json
 import logging
 import sys
 import time
+from typing import Any
 
 from aiohttp import WSCloseCode, WSMsgType, web
 
@@ -38,6 +39,52 @@ SUBAGENT_REPLAY_BATCH_THRESHOLD = 8
 SIDE_RESULT_EVENT = "chat.side_result"
 SIDE_QUEUE_EVENT = "chat.side_queue"
 SIDE_KIND = "side"
+
+
+def build_subagent_snapshot(a: Any, *, now: float | None = None) -> dict:
+    """Build the ``subagent_snapshot`` replay frame's ``data`` for one agent.
+
+    Extracted from the reconnect handler so the frame's CONTENTS can be
+    asserted directly — the handler around it needs a live aiohttp WS, which is
+    why the omission this fixes went unnoticed.
+
+    ``idle_secs`` is the span that justifies the stall badge. The live
+    ``subagent_stalled`` event carries it; this replay frame did not, so ANY
+    reconnect during an active stall degraded the row to the plain
+    "no activity" wording that was only ever meant for a gateway too old to
+    send the field (#3929).
+
+    It is computed at replay time rather than replaying the original transition
+    value: by reconnect the agent has usually been idle longer than it was when
+    flagged, and ``last_activity`` is already the field the reaper itself
+    measures. Clamped at 0 so a clock adjustment cannot produce a negative span.
+
+    The key is OMITTED entirely when the agent is not stalled, so a client
+    cannot attach an idle span to a healthy row — the reducer pairs the span
+    with the flag and would otherwise have to defend against the mismatch.
+    """
+    ts = time.time() if now is None else now
+
+    def _r(t: str) -> str:
+        t, _ = redact_exfiltration_urls(t)
+        t, _ = redact_credentials(t)
+        return t
+
+    data: dict = {
+        "id": a.id,
+        "slot": subagent_event_slot(a.parent_session_key),
+        "task": _r(a.task),
+        "agent": _r(a.agent),
+        "model": a.resolved_model,
+        "streaming": _r(a.streaming_text),
+        "last_tool": _r(a.last_tool),
+        "tool_count": a.tool_count,
+        "stalled": a.stalled,
+    }
+    if a.stalled:
+        data["idle_secs"] = max(0, int(ts - a.last_activity))
+    data["started"] = a.started
+    return data
 
 
 def _audit_grant_quietly(app: str, event: str) -> None:
@@ -646,22 +693,10 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                         if state.subagents:
                             for a in state.subagents.running:
                                 try:
-                                    slot = subagent_event_slot(a.parent_session_key)
                                     _replay.append(
                                         {
                                             "type": "subagent_snapshot",
-                                            "data": {
-                                                "id": a.id,
-                                                "slot": slot,
-                                                "task": _r(a.task),
-                                                "agent": _r(a.agent),
-                                                "model": a.resolved_model,
-                                                "streaming": _r(a.streaming_text),
-                                                "last_tool": _r(a.last_tool),
-                                                "tool_count": a.tool_count,
-                                                "stalled": a.stalled,
-                                                "started": a.started,
-                                            },
+                                            "data": build_subagent_snapshot(a),
                                         }
                                     )
                                 except Exception:

--- a/test/test_subagent_snapshot_idle_secs.py
+++ b/test/test_subagent_snapshot_idle_secs.py
@@ -1,0 +1,95 @@
+"""The subagent_snapshot replay frame must carry the stall idle span (#3929).
+
+The live ``subagent_stalled`` event sends ``idle_secs`` on the not-stalled →
+stalled transition, and the stalled row renders "possibly stalled at <tool> —
+no activity for Ns" when it has that span, falling back to a plain
+"no activity" wording when it does not. That fallback exists for a gateway too
+old to send the field -- but the reconnect replay frame omitted ``idle_secs``
+too, so in practice ANY reconnect during an active stall took it. The user saw
+a strictly less informative badge purely because their socket blipped.
+
+These assert the frame's contents directly, via the extracted
+``build_subagent_snapshot``: the handler that wraps it needs a live aiohttp WS,
+which is why the omission survived.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+# ``ws.py`` imports ``handlers.updates`` mid-module, and ``handlers/__init__``
+# imports ``handlers.side``, which imports back from ``ws`` — so importing
+# ``ws`` FIRST in a fresh interpreter dies on the partially-initialized module.
+# Importing the handlers package first resolves the cycle in the direction
+# every green consumer uses, and keeps this file collectable when a
+# pytest-xdist worker imports it before any other dashboard module.
+import kiro_crew.dashboard.handlers  # noqa: F401
+from kiro_crew.dashboard.ws import build_subagent_snapshot
+
+
+def _agent(**over):
+    """A minimal stand-in for the SubagentInfo fields the frame reads."""
+    base = dict(
+        id="a1",
+        parent_session_key="dashboard:main",
+        task="do a thing",
+        agent="kirocrew",
+        resolved_model="model-1",
+        streaming_text="",
+        last_tool="Running: sleep 600",
+        tool_count=3,
+        stalled=False,
+        started=1000.0,
+        last_activity=1000.0,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def test_a_stalled_agent_replays_with_its_idle_span():
+    a = _agent(stalled=True, last_activity=1000.0)
+    data = build_subagent_snapshot(a, now=1117.0)
+    assert data["stalled"] is True
+    assert data["idle_secs"] == 117
+
+
+def test_the_span_is_measured_at_replay_time_not_at_the_transition():
+    """By reconnect the agent has usually been idle longer than it was when
+    flagged, and last_activity is the field the reaper itself measures -- so a
+    later replay must report a larger span, not the frozen transition value."""
+    a = _agent(stalled=True, last_activity=1000.0)
+    assert build_subagent_snapshot(a, now=1200.0)["idle_secs"] == 200
+    assert build_subagent_snapshot(a, now=1800.0)["idle_secs"] == 800
+
+
+def test_a_healthy_agent_carries_no_idle_span():
+    """Omitted rather than zero: the reducer pairs the span with the flag, so a
+    healthy row must not be able to acquire an idle figure at all."""
+    data = build_subagent_snapshot(_agent(stalled=False), now=9999.0)
+    assert data["stalled"] is False
+    assert "idle_secs" not in data
+
+
+def test_a_backwards_clock_cannot_produce_a_negative_span():
+    a = _agent(stalled=True, last_activity=2000.0)
+    assert build_subagent_snapshot(a, now=1000.0)["idle_secs"] == 0
+
+
+def test_the_rest_of_the_frame_is_unchanged():
+    """The added key must not disturb the fields clients already read."""
+    data = build_subagent_snapshot(_agent(stalled=True), now=1000.0)
+    assert data["id"] == "a1"
+    assert data["task"] == "do a thing"
+    assert data["agent"] == "kirocrew"
+    assert data["model"] == "model-1"
+    assert data["last_tool"] == "Running: sleep 600"
+    assert data["tool_count"] == 3
+    assert data["started"] == 1000.0
+    assert data["slot"]
+
+
+def test_the_frame_still_redacts_credentials():
+    """The extraction must not drop the redaction the inline builder applied."""
+    a = _agent(stalled=True, task="curl -H 'Authorization: Bearer sk-ant-api03-SECRETVALUE'")
+    data = build_subagent_snapshot(a, now=1000.0)
+    assert "sk-ant-api03-SECRETVALUE" not in data["task"]

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -3200,7 +3200,7 @@ const chatSlice = createSlice({
       if (idx >= 0) side.messages.splice(idx, 1)
       side.pending = false
     },
-    sseSubagentSnapshot(state, action: PayloadAction<{ id: string; slot: string; task: string; agent: string; model?: string; streaming: string; last_tool: string; started: number; tool_count?: number; stalled?: boolean }>) {
+    sseSubagentSnapshot(state, action: PayloadAction<{ id: string; slot: string; task: string; agent: string; model?: string; streaming: string; last_tool: string; started: number; tool_count?: number; stalled?: boolean; idle_secs?: number }>) {
       const d = action.payload
       if (isUnsafeKey(d.slot) || isUnsafeKey(d.id)) return
       const subs = d.slot && d.slot !== state.activeSlot
@@ -3210,6 +3210,7 @@ const chatSlice = createSlice({
       // Live events can interleave with replay because subscription starts before
       // snapshots are sent. Never let a stale running snapshot demote a terminal card.
       if (existing?.status === 'done' || existing?.status === 'error') return
+      const stalled = d.stalled ?? false
       subs[safeKey(d.id)] = {
         id: d.id, task: d.task, agent: d.agent || 'kirocrew',
         // Prefer the snapshot's model; fall back to any id a live frame already
@@ -3217,7 +3218,15 @@ const chatSlice = createSlice({
         model: d.model || existing?.model || '',
         status: d.last_tool ? 'tool' : 'running', streaming: d.streaming, lastTool: d.last_tool,
         startedAt: d.started * 1000, elapsed: 0,
-        toolCount: d.tool_count ?? 0, stalled: d.stalled ?? false,
+        toolCount: d.tool_count ?? 0, stalled,
+        // Same pairing rule as sseSubagentStalled: the idle span lives and dies
+        // with the flag it justifies, so a non-stalled snapshot can never carry
+        // one. `stalledAt` is the receipt instant — the row advances the figure
+        // from here rather than freezing it beside a live elapsed counter.
+        // Both stay undefined when the gateway omits `idle_secs`, which keeps
+        // the plain "no activity" fallback reachable for an older gateway.
+        idleSecs: stalled ? d.idle_secs : undefined,
+        stalledAt: stalled && typeof d.idle_secs === 'number' ? Date.now() : undefined,
         approval_id: existing?.approval_id, approving: existing?.approving,
       }
     },

--- a/website/src/test/SubagentProgress.reducers.test.tsx
+++ b/website/src/test/SubagentProgress.reducers.test.tsx
@@ -5,10 +5,12 @@
  *    simple/auto-approved task shows live tool activity) and clears stalled.
  *  - sseSubagentStalled toggles the idle/stalled flag surfaced by the reaper,
  *    and retains the `idle_secs` span that justifies it.
+ *  - sseSubagentSnapshot (the reconnect replay path) carries that same span, so
+ *    a socket blip during an active stall does not degrade the badge.
  */
 import { describe, it, expect } from 'vitest'
 import { createTestStore } from './helpers'
-import { sseSubagentSpawn, sseSubagentTool, sseSubagentStalled } from '../store/chatSlice'
+import { sseSubagentSpawn, sseSubagentTool, sseSubagentStalled, sseSubagentSnapshot } from '../store/chatSlice'
 
 const ID = 'a1b2c3d4'
 
@@ -63,5 +65,51 @@ describe('subagent progress reducers', () => {
     store.dispatch(sseSubagentStalled({ slot: SLOT, id: ID, stalled: true, idle_secs: 300 }))
     store.dispatch(sseSubagentTool({ slot: SLOT, id: ID, tool: 'grep', tool_count: 5 }))
     expect(sub(store).idleSecs).toBeUndefined()
+  })
+
+  // ── Reconnect replay (#3929) ────────────────────────────────────────────
+  // The snapshot frame carries `stalled` but used to omit the idle span, so a
+  // reconnect during an active stall dropped the row to the plain fallback
+  // wording that was only ever meant for a gateway too old to send the field.
+
+  const snap = (over: Record<string, unknown> = {}) => ({
+    id: ID, slot: '', task: 'do a thing', agent: 'kirocrew',
+    streaming: '', last_tool: 'Running: sleep 600', started: 1000,
+    tool_count: 3, ...over,
+  })
+
+  it('sseSubagentSnapshot keeps the idle span across a reconnect', () => {
+    const store = createTestStore()
+    const SLOT = store.getState().chat.activeSlot
+    store.dispatch(sseSubagentSnapshot(snap({ slot: SLOT, stalled: true, idle_secs: 117 })))
+    const a = sub(store)
+    expect(a.stalled).toBe(true)
+    expect(a.idleSecs).toBe(117)
+    // stalledAt is the receipt instant the row advances the figure from, the
+    // same way the live frame sets it.
+    expect(typeof a.stalledAt).toBe('number')
+  })
+
+  it('sseSubagentSnapshot leaves a healthy row without an idle span', () => {
+    const store = createTestStore()
+    const SLOT = store.getState().chat.activeSlot
+    store.dispatch(sseSubagentSnapshot(snap({ slot: SLOT, stalled: false, idle_secs: 117 })))
+    const a = sub(store)
+    expect(a.stalled).toBe(false)
+    expect(a.idleSecs).toBeUndefined()
+    expect(a.stalledAt).toBeUndefined()
+  })
+
+  it('a gateway that omits idle_secs still reaches the plain fallback', () => {
+    // The fallback wording must stay reachable: an older gateway sends
+    // `stalled` with no span, and the row should say "no activity" rather than
+    // "no activity for undefineds".
+    const store = createTestStore()
+    const SLOT = store.getState().chat.activeSlot
+    store.dispatch(sseSubagentSnapshot(snap({ slot: SLOT, stalled: true })))
+    const a = sub(store)
+    expect(a.stalled).toBe(true)
+    expect(a.idleSecs).toBeUndefined()
+    expect(a.stalledAt).toBeUndefined()
   })
 })


### PR DESCRIPTION
Closes #3929.

## Problem / Motivation

The live `subagent_stalled` event sends `idle_secs` on the not-stalled → stalled transition, and the stalled row renders `possibly stalled at <tool> — no activity for Ns` when it has that span. The `subagent_snapshot` frame replayed on WebSocket reconnect carried `stalled` but **not** the span, so a reconnecting client fell back to the plain `— no activity` wording.

That fallback was intended for a gateway too old to send the field. In practice **any** reconnect during an active stall took it, because the current gateway's snapshot omitted it too — the user lost the number that justifies the warning purely because their socket blipped. Same root cause as #3919 ("the justifying figure is dropped in transit"), one layer further back.

## Why it matters

The idle span is the evidence behind the stall badge — "no activity for 117s" tells the user whether to worry; a bare "no activity" does not. Reconnects are routine (laptop sleep, network blips, gateway restarts), so the degraded wording was the *common* case during a stall, and it silently misrepresented gateway capability: the UI treated a current gateway as a legacy one.

## What changed (motivation → approach → change)

**Backend** — the frame now carries `idle_secs`, computed at replay time as `int(now - last_activity)` rather than replaying the original transition value: by reconnect the agent has usually been idle longer than it was when flagged, and `last_activity` is already the field the reaper measures. Clamped at 0 so a clock adjustment cannot produce a negative span, and **omitted entirely** when the agent is not stalled — the reducer pairs the span with the flag it justifies, so a healthy row must not be able to acquire an idle figure at all.

**Reducer** — `sseSubagentSnapshot` sets `idleSecs` + `stalledAt` the same way `sseSubagentStalled` does, and only when stalled. `stalledAt` is set only when a span actually arrived, so a gateway that omits the field still reaches the plain fallback rather than rendering against a bare receipt instant.

**Testability** — the frame builder is extracted from the reconnect handler into `build_subagent_snapshot()`. The handler around it needs a live aiohttp WS, which is precisely why this omission went unnoticed: nothing could assert the frame's contents. Behavior is unchanged apart from the new key; the redaction pass moves with it and is pinned by a test, and the extracted builder keeps main's `model` field so the reconnect frame keeps feeding the model pill.

## Tests

- **`test/test_subagent_snapshot_idle_secs.py`** (new, 6 tests): a stalled agent replays with its span; the span is measured at replay time rather than frozen at the transition; a healthy agent carries no key at all; a backwards clock cannot go negative; the rest of the frame (including `model`) is untouched; credentials are still redacted. **Errors on main** — the symbol does not exist there.
- **`website/src/test/SubagentProgress.reducers.test.tsx`**: 3 new tests — the span survives a reconnect, a healthy snapshot gets neither `idleSecs` nor `stalledAt`, and a gateway that omits `idle_secs` still reaches the plain fallback. 1 fails on main.
- Local gates: backend full suite 67652 passed (82 failures + 2 errors reproduced identically on clean main — host-environment, list-diffed empty); frontend `tsc -b` clean, vitest 23949 passed; isort/flake8 (touched files)/mypy/black ratchet clean.

## Manual verification

N/A — the change is data plumbing into an existing row rendering; both wording variants and the reducer pairing rule are pinned by unit tests on the exact frame/action shapes the wire carries.

## Screenshots / video

Waived: no new or changed UI surface — the stalled-row component and both of its wording variants already exist and are untouched; this PR only preserves the data that selects between them across a reconnect. The rendering itself is covered by the existing component tests plus the 3 new reducer tests.
