### PR TITLE
fix(ci): give the shared screenshot stub real config fixtures

### DIFF
--- a/website/scripts/lib/stub-dashboard-api.mjs
+++ b/website/scripts/lib/stub-dashboard-api.mjs
@@ -20,6 +20,53 @@ export const json = (route, body, status = 200) => route.fulfill({
 })
 
 /**
+ * The `/api/config/kirocrew` body, matching `KiroCrewCfg` in
+ * `website/src/pages/overview/KiroCrewCfgTab.tsx`.
+ *
+ * Named ahead of the catch-all because that tab does
+ * `Object.entries(cfg.agents)` on mount. Under the catch-all's `{}`,
+ * `cfg.agents` is `undefined`, `Object.entries(undefined)` throws, the app-shell
+ * error boundary catches it, and the WHOLE PAGE renders blank — while the
+ * harness still exits 0 and still writes a PNG. That failure mode fails toward
+ * a false pass: a PR can cite a screenshot of an error boundary as evidence.
+ *
+ * Exported so a harness that needs a variation can spread it rather than
+ * hand-rolling the shape again. Eighteen harnesses had already done exactly
+ * that, and they had drifted — several spelled a workspace's directory `path`
+ * where the component reads `dir`, so those rows rendered blank in the
+ * screenshots that were supposed to prove them.
+ */
+export const KIROCREW_CONFIG_FIXTURE = {
+  agents: {
+    kirocrew: { kiro_agent: 'kirocrew', workspace: 'default', memory_store: 'default' },
+  },
+  default_agent: 'kirocrew',
+  workspaces: { default: { dir: '~/.kiro/crew/workspace' } },
+  default_workspace: 'default',
+  memory_stores: {
+    default: { description: 'Default store', embedding_provider: '' },
+  },
+  default_memory_store: 'default',
+  agent: {
+    default_agent: 'kirocrew', provider: 'acp', model: 'auto',
+    approval_mode: 'interactive', sandbox: 'auto',
+    subagent_max_turns: 100, max_subagents: 3, subagent_auto_max: 16,
+    conductor_skill: false, tool_search: true,
+    max_channels: 8, max_channel_agents: 4, enforce_denied_commands: 'all',
+  },
+  session: { timeout_secs: 1800, pool_size: 2, pool_agent: 'kirocrew', pool_ttl_secs: 600 },
+  memory: { embedding_provider: 'local' },
+  auto_update: true,
+}
+
+/** The `/api/agent/config` body — the per-agent MCP view. */
+export const AGENT_CONFIG_FIXTURE = { name: 'kirocrew', mcpServers: {} }
+
+/** Whether an unmapped path should be guessed as an object rather than a list. */
+const objectish = path =>
+  /(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
+
+/**
  * Install the gateway-free API stub on a page.
  *
  * @param {import('playwright').Page} page
@@ -53,6 +100,10 @@ export async function stubDashboardApi(page, opts = {}) {
     botName = 'Kiro Crew',
     extra = null,
   } = opts
+
+  // Per-install, so a long harness reports each unmapped path once rather than
+  // once per poll of the same endpoint.
+  const announced = new Set()
 
   // Swallow the dashboard's websocket so it does not retry-storm with no gateway.
   await page.routeWebSocket(/\/api\/ws/, () => {})
@@ -94,10 +145,25 @@ export async function stubDashboardApi(page, opts = {}) {
     if (path === '/api/agents' || path === '/api/chat/agents') {
       return json(route, [{ name: 'kirocrew', source: 'builtin' }, { name: 'oncall', source: 'aim' }])
     }
+    // Named BEFORE the catch-all: both paths match its `config` test, and the
+    // `{}` it would return blanks the whole Developer > Config surface (see
+    // KIROCREW_CONFIG_FIXTURE for why).
+    if (path === '/api/config/kirocrew') return json(route, KIROCREW_CONFIG_FIXTURE)
+    if (path === '/api/agent/config') return json(route, AGENT_CONFIG_FIXTURE)
     // Endpoints not worth naming individually: anything object-shaped gets {},
-    // everything else gets []. Guessing wrong only costs an empty panel.
-    const objectish = /(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
-    return json(route, objectish ? {} : [])
+    // everything else gets []. Guessing wrong only costs an empty panel — in
+    // the cases where it does not, the endpoint belongs above this line.
+    //
+    // Announced once per path per run. The fixture gap this catch-all produced
+    // for /api/config/kirocrew was silent AND fatal, and a harness author with
+    // no reason to suspect the stub had nothing to go on: the page just came
+    // back blank. A guess is a reasonable default, but it should say so, so the
+    // NEXT unmapped endpoint is discoverable rather than mysterious.
+    if (!announced.has(path)) {
+      announced.add(path)
+      console.log(`STUB: no fixture for ${path} — guessing ${objectish(path) ? '{}' : '[]'}`)
+    }
+    return json(route, objectish(path) ? {} : [])
   })
 
   await page.addInitScript(([themeMode, keepStorage, entries]) => {

--- a/website/src/test/stubDashboardApiConfigFixture.test.tsx
+++ b/website/src/test/stubDashboardApiConfigFixture.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * The shared screenshot stub's /api/config/kirocrew fixture (#3696).
+ *
+ * `website/scripts/lib/stub-dashboard-api.mjs` used to answer every path
+ * matching /config/ from a catch-all that returns `{}`. `/api/config/kirocrew`
+ * matched, so `KiroCrewCfgTab` got `cfg.agents === undefined`,
+ * `Object.entries(undefined)` threw, the app-shell error boundary swallowed it,
+ * and the WHOLE PAGE rendered blank -- while the harness still exited 0 and
+ * still wrote a PNG. The failure fails toward a FALSE PASS: a PR can cite a
+ * screenshot of an error boundary as visual evidence.
+ *
+ * The stub is a Playwright-only module, so these assert the contract that
+ * actually matters: the fixture it now serves is a shape this component can
+ * render. A future field added to `KiroCrewCfg` and read unguarded (the exact
+ * shape of the original bug) fails here rather than silently blanking ~140
+ * capture harnesses.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import KiroCrewCfgTab from '../pages/overview/KiroCrewCfgTab'
+import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
+import {
+  KIROCREW_CONFIG_FIXTURE,
+  AGENT_CONFIG_FIXTURE,
+} from '../../scripts/lib/stub-dashboard-api.mjs'
+
+vi.mock('../api/client')
+
+vi.mock('../components/SimpleSelect', () => ({
+  default: ({ options, value, 'aria-label': ariaLabel }: {
+    options: string[]
+    value: string
+    'aria-label'?: string
+  }) => (
+    <div role="group" aria-label={ariaLabel}>
+      {options.map(o => (
+        <button key={o} type="button" role="option" aria-selected={o === value}>{o}</button>
+      ))}
+    </div>
+  ),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  const m = vi.mocked(api)
+  m.kirocrewConfig = vi.fn().mockResolvedValue(KIROCREW_CONFIG_FIXTURE)
+  m.patchConfig = vi.fn().mockResolvedValue(KIROCREW_CONFIG_FIXTURE)
+  m.saveKirocrewConfig = vi.fn().mockResolvedValue({ ok: true })
+  m.themeBoot = vi.fn().mockResolvedValue({})
+})
+
+describe('stub-dashboard-api config fixture', () => {
+  it('renders the config surface instead of blanking the page', async () => {
+    renderWithProviders(<KiroCrewCfgTab />)
+    // Reaching the first table means the three Object.entries() calls that
+    // threw under the catch-all's `{}` all survived.
+    expect(await screen.findByText('Kiro Crew Agents')).toBeInTheDocument()
+    expect(screen.getAllByRole('table').length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('populates every table the tab renders, not just the headers', async () => {
+    renderWithProviders(<KiroCrewCfgTab />)
+    await screen.findByText('Kiro Crew Agents')
+    // An empty-but-present object would still render three tables with zero
+    // rows -- a screenshot of empty tables is barely better evidence than a
+    // blank page, so the fixture has to carry actual entries.
+    const [agents, workspaces, stores] = screen.getAllByRole('table')
+    for (const table of [agents, workspaces, stores]) {
+      expect(table.querySelectorAll('tbody tr').length).toBeGreaterThan(0)
+    }
+  })
+
+  it('spells the workspace directory the way the component reads it', async () => {
+    // The hand-rolled per-harness copies of this fixture had drifted to `path`
+    // where WorkspaceCfg declares `dir`, so the directory cell rendered blank
+    // in screenshots meant to show it. One shared fixture is the fix; this
+    // pins the field name so the drift cannot silently return.
+    expect(Object.values(KIROCREW_CONFIG_FIXTURE.workspaces)[0]).toHaveProperty('dir')
+    renderWithProviders(<KiroCrewCfgTab />)
+    await screen.findByText('Kiro Crew Agents')
+    expect(screen.getByText('~/.kiro/crew/workspace')).toBeInTheDocument()
+  })
+
+  it('carries the nested objects the tab dereferences unguarded', () => {
+    // cfg.agent.*, cfg.session.* and cfg.memory.* are read without optional
+    // chaining, so a missing branch is a throw, not a blank row.
+    expect(KIROCREW_CONFIG_FIXTURE.agent).toBeTypeOf('object')
+    expect(KIROCREW_CONFIG_FIXTURE.session).toBeTypeOf('object')
+    expect(KIROCREW_CONFIG_FIXTURE.memory).toBeTypeOf('object')
+    expect(KIROCREW_CONFIG_FIXTURE.auto_update).toBeTypeOf('boolean')
+    for (const key of ['agents', 'workspaces', 'memory_stores'] as const) {
+      expect(KIROCREW_CONFIG_FIXTURE[key]).toBeTypeOf('object')
+      expect(KIROCREW_CONFIG_FIXTURE[key]).not.toBeNull()
+    }
+    for (const key of ['default_agent', 'default_workspace', 'default_memory_store'] as const) {
+      expect(KIROCREW_CONFIG_FIXTURE[key]).toBeTypeOf('string')
+    }
+  })
+
+  it('names each default as a key that actually exists', async () => {
+    // The tab badges the default row by matching name === cfg.default_*. A
+    // default naming a missing key renders three tables with no badge at all,
+    // which is exactly the detail a Config screenshot exists to show.
+    expect(KIROCREW_CONFIG_FIXTURE.agents).toHaveProperty(KIROCREW_CONFIG_FIXTURE.default_agent)
+    expect(KIROCREW_CONFIG_FIXTURE.workspaces).toHaveProperty(KIROCREW_CONFIG_FIXTURE.default_workspace)
+    expect(KIROCREW_CONFIG_FIXTURE.memory_stores).toHaveProperty(KIROCREW_CONFIG_FIXTURE.default_memory_store)
+    renderWithProviders(<KiroCrewCfgTab />)
+    await screen.findByText('Kiro Crew Agents')
+    expect(screen.getAllByText('default').length).toBeGreaterThan(0)
+  })
+
+  it('serves an agent-config fixture the MCP view can read', () => {
+    expect(AGENT_CONFIG_FIXTURE.name).toBeTypeOf('string')
+    expect(AGENT_CONFIG_FIXTURE.mcpServers).toBeTypeOf('object')
+  })
+})


### PR DESCRIPTION
Closes #3696.

> Original work by @adiarora06 (Aura1122). Rebased onto main and template-conformed by Kiro Crew (operator bolichen97); the CHANGELOG.md hunk was dropped per the repo's test-only-PR changelog rule.

## Problem / Motivation

`website/scripts/lib/stub-dashboard-api.mjs` ended with a catch-all answering any path matching `config` with an empty object. `/api/config/kirocrew` matched, so `KiroCrewCfgTab` received `cfg.agents === undefined`, `Object.entries(undefined)` threw, the app-shell error boundary swallowed it, and the **whole page** rendered blank.

## Why it matters

The failure fails toward a **false pass**: the harness still exits 0 and still writes a PNG, so a blank capture is indistinguishable from a working one and a PR can cite a picture of an error boundary as visual evidence. Confirmed directly — feeding `{}` to the component raises `TypeError: Cannot convert undefined or null to object`. ~140 screenshot harnesses share this stub, so every one of them can silently blank the same way.

## What changed (motivation → approach → change)

Observed symptom (blank page in captures) → root cause (the `config` catch-all served `{}` to `/api/config/kirocrew`, which `KiroCrewCfgTab` dereferences unguarded) → change:

- **Real fixtures for `/api/config/kirocrew` and `/api/agent/config`**, keyed by name *ahead of* the catch-all — the same treatment `/api/kiro-prerequisite` and `/api/dashboard/config` already get. The shape follows `KiroCrewCfg` exactly: `agents`/`workspaces`/`memory_stores`, their three `default_*` strings, and the `agent`/`session`/`memory`/`auto_update` branches the tab dereferences unguarded.
- **Both are exported**, so a harness needing a variation spreads them rather than hand-rolling the shape a nineteenth time. The existing copies had already drifted — several spell a workspace's directory `path` where `WorkspaceCfg` declares `dir`, so the directory cell rendered blank in the screenshots meant to show it.
- **The catch-all is now noisy**, announcing each unmapped path once per run (`STUB: no fixture for <path> — guessing {}`). This is the part that generalizes: the fixture gap is one instance, and the catch-all will keep producing this class as endpoints are added. A guess is a reasonable default, but it should say so.

**Deliberately not in this change:** step 2 of the issue — deleting the 18 harnesses' now-redundant local fixtures. A local `extra` handler still takes precedence and still works, so leaving them is harmless; removing them touches 18 capture scripts that each want their own verification run. Better as a follow-up sweep than bundled with the fix that makes them unnecessary.

## Tests

- **`website/src/test/stubDashboardApiConfigFixture.test.tsx`** (new, 6 tests): the fixture renders the config surface instead of blanking; every table gets real rows (empty-but-present tables are barely better evidence than a blank page); the workspace directory is spelled the way the component reads it; the nested objects the tab dereferences unguarded are all present; each `default_*` names a key that actually exists; and the agent-config fixture is readable by the MCP view. The stub is a Playwright-only module, so these assert the contract that matters — a future `KiroCrewCfg` field read unguarded fails here instead of silently blanking ~140 harnesses.
- Separately verified the defect itself: mocking the endpoint with the catch-all's `{}` makes the component throw `Cannot convert undefined or null to object`.
- Full frontend suite after rebase: **23902 passed** (1529 files), `npx tsc -b` clean, `eslint` clean on both touched files.

## Manual verification

`node` import of the stub module: OK — exports `KIROCREW_CONFIG_FIXTURE`, `AGENT_CONFIG_FIXTURE`, `stubDashboardApi`, `json`, `logPageProblems`. N/A beyond that — this is a Playwright-harness stub with unit coverage asserting its contract; no user-facing surface changes.

## Related Issues

Fixes #3696

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, test-infrastructure only
- [x] No secrets, credentials, or internal references in the diff
