### PR TITLE
chore: list todo-txt in the app registry

### DIFF
--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -10,5 +10,11 @@
     "gitUrl": "https://github.com/qihang-dai/todo-ledger",
     "repo": "https://github.com/qihang-dai/todo-ledger",
     "branch": "release"
+  },
+  {
+    "name": "todo-txt",
+    "gitUrl": "https://github.com/LeTeutz/todo-txt",
+    "repo": "https://github.com/LeTeutz/todo-txt",
+    "branch": "main"
   }
 ]


### PR DESCRIPTION
## Problem / Motivation

The App Store's core registry — `src/kiro_crew/apps/app-registry.json` — is the
list a user browses in Discover and Library. An app that is not in it cannot be
found or installed from the store; the only route is a manual sideload against a
local path, which means nobody discovers the app and nobody gets updates.

**todo.txt** is a finished, tagged v1.0.0 app that is not in that list. This PR
adds the one row that makes it installable, following §10 of
`docs/app-kit/publishing-guide.md`.

## Why it matters

Users who keep tasks in a plain `todo.txt` file — the format has a large existing
following and a CLI ecosystem — currently have no way to reach an editor for it
from inside Kiro Crew. For the registry itself, this is the documented
third-party path exercised end to end by someone with no special access, which is
the case §10 is written for.

## What changed (motivation → approach → change)

**Goal:** make one existing, released app installable from the store.

**Approach:** §10's registry-pointer entry, not vendoring. The app lives in its
own repo with its own CI and release tags, so a pointer keeps its release cadence
independent and keeps this diff to data. `branch` tracks `main`, which is what
§13's update model assumes and what both existing entries do.

**Change:** a single object appended to the JSON array. No code, schema, or guard
is touched, and the two existing entries are byte-identical after the change.

```json
{
  "name": "todo-txt",
  "gitUrl": "https://github.com/LeTeutz/todo-txt",
  "repo": "https://github.com/LeTeutz/todo-txt",
  "branch": "main"
}
```

`repo` is set alongside `gitUrl` so the blob proxy can serve the app's committed
store art.

**What the app is:** an editor for a `todo.txt` file — one task per line, no
database. Priorities, projects, contexts and due dates colour as you type, and
the format's semantics run rather than just highlight: `rec:` rollover on
completion, `t:` thresholds, `h:1` hidden tasks. Palette verbs match the todo.txt
CLI. Apache-2.0, `minKiroCrewVersion: 0.1.2`, **no network access, no cron, no
MCP tools, and no install script**.

The format is Gina Trapani's [todo.txt
specification](https://github.com/todotxt/todo.txt); upstream's one-page visual
cheatsheet of the grammar is
[`description.svg`](https://github.com/todotxt/todo.txt/blob/master/description.svg),
which this app implements rather than reinterprets. It is linked and not
reproduced: that repository is GPL-3.0 and this app is Apache-2.0.

## Tests

No tests are added here, because the diff adds no code — it is one data row in a
JSON array, and `_load_registry_file` already validates shape and drops malformed
rows.

What the entry points at is tested, and that is the part worth checking. On the
commit this entry resolves to: **329 backend tests, 1145 UI tests across 47
files, and 104 Playwright end-to-end specs with zero skips**, plus source and
test typechecks. Public CI on that repo runs the backend suite on Linux and macOS
× py3.12 (3.13 non-gating), the UI suite and production build on Linux, macOS and
Windows, a gate that byte-compares the committed `ui/dist` against a fresh build,
and e2e on Linux. It is green.

Data safety in that app is written as testable claims rather than intentions: a
save is refused when the file changed on disk, every destructive path leaves a
recoverable backup, a backup that cannot be written aborts the operation instead
of proceeding, and a partial write can duplicate a line but never lose one.

## Manual verification

**§14 review checklist, item by item:**

| Item | Evidence |
|---|---|
| `app.json` validates | `name: todo-txt` (kebab), `version: 1.0.0` (semver), all required fields non-empty |
| No `..` or absolute paths in resource fields | `agents/ai-edit.json`, `ui.entry: dist/index.mjs`, `backend.entryPoint: backend/server.py` — pinned by a test that exists because the three path conventions in one manifest are not interchangeable |
| Permissions minimal, and each one used | `mcpTools: []`, `network: false`, `cron: false`. `storage` for app-scoped settings, `spawn` + `api: /api/spawn` for the hand-to-chat path, `memory: app-scoped`, `events: [notification]` for save/conflict toasts |
| Icon committed, square, ≥256 | `ui/brand/icon-512.png` — 512×512 RGBA with transparency, no metadata chunks, rasterized from the source SVG. Regenerated with `npm run icon:png`, which asserts the render before writing it; a test digests the SVG geometry so the raster cannot silently go stale |
| ≥1 screenshot and ≥1 hero | 3 screenshots at 1280×800, hero cards at 1280×720 (16:9) and detail banners at 1250×300 (25:6), each in light and dark |
| `description` plain text, reads truncated | Plain text; the first sentence stands alone at 29 words |
| `tags` lowercase, right category | `todo`, `todo.txt`, `plaintext`, `editor`, `vim`, `productivity` |
| UI bundle built and committed | `ui/dist/index.mjs` committed; CI byte-compares it against a fresh build, so a stale bundle fails the run rather than shipping |
| Agent JSON valid | `agents/ai-edit.json`, `tools: []` and `allowedTools: []` — a restricted text-transformation agent with no tool surface. No skills or SOPs |
| Install script non-interactive, idempotent, exits 0 <300s | No install script — `lifecycle: gateway`, nothing runs at install time |
| `onUninstall` cleans up outside `~/.kiro/crew/apps/{name}/` | Deliberately absent. What the app writes outside its own directory is the user's `todo.txt`, `done.txt`, `report.txt` and their backups, at a path the user chose. Deleting those on uninstall would destroy user data |
| `README.md` explains usage | Yes, including the file-path setting and the filter grammar |
| Installs and enables cleanly from a local clone | Verified, and verified again through the registry's own path: `git clone --depth 1 --branch main` of the public URL, then boot — every asset the manifest declares is present in that clone, `ui/dist/index.mjs` is committed, and `backend/server.py` starts and answers `/health` with no build step |

## Screenshots / video

No UI change in this repo — the diff is one JSON row. Included because the store
renders these from the app's own repo, so they are what a user would actually
see, and they are the three committed under `ui/brand/screenshots/` that feed the
detail-page gallery.

**Editor** — syntax-highlighted priorities, projects and contexts, due-date
urgency tint, and an active filter chip.

![todo.txt editor](https://raw.githubusercontent.com/LeTeutz/todo-txt/main/ui/brand/screenshots/editor.png)

**Command palette** — the todo.txt CLI verbs, here filtered to `filter`.

![command palette](https://raw.githubusercontent.com/LeTeutz/todo-txt/main/ui/brand/screenshots/palette.png)

**Selection popover** — the AI-edit entry point, with the destructive path staged
for approval rather than applied.

![selection popover](https://raw.githubusercontent.com/LeTeutz/todo-txt/main/ui/brand/screenshots/popover.png)

## Related Issues

no linked issue: this adds a registry row for an app developed outside this
repository, so there is no tracked issue here to close.

## Checklist

- [x] Single commit with a Conventional Commits title (`chore: list todo-txt in the app registry`)
- [x] Existing tests pass and new tests added for new functionality — no code added; the referenced app's own suite is green (329 / 1145 / 104)
- [x] Self-review completed; code follows project style guidelines — the diff is append-only and the two existing entries are byte-identical
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff

## On the standing-trust question

The advisory reviews are right that the ref is the whole content of this PR, so
it should not arrive as an open question. **I am asking for `main`**, and closing
the decision rather than leaving it to you.

- **There is no install script.** `lifecycle: gateway`, no setup hooks, nothing
  executes at install time, so the `setup.onInstall` privilege path does not
  exist for this app. `ui/dist` is committed precisely so an install needs no
  build step.
- **`network: false`, `cron: false`, `mcpTools: []`.** No outbound requests, no
  background jobs, no MCP surface. The backend binds loopback on a
  gateway-assigned port and refuses every request without a valid HMAC
  (`X-KiroCrew-Proxy`), failing closed when the secret is absent.
- **On pinning:** I had offered `v1.0.0` instead, and the first-principles review
  corrected that offer in a way worth repeating — a lightweight tag is itself a
  movable ref, and `install_from_registry` clones with `git clone --branch`,
  which cannot take a commit sha. Pinning would buy re-review-on-update, not
  immutability, while giving up §13's push-to-update. If you want the stronger
  property the lever is review-on-update policy, not this field. Say the word and
  I will still change it.
- **What to review, and where.** The release tree is the `v1.0.0` tag,
  `b3ed378be593708155e93847cbc9cea0eb7d71b2` — every claim above was checked
  against that commit. `main` additionally carries three follow-up commits
  touching only `.github/workflows/ci.yml`, `RELEASE-NOTES.md`,
  `ui/tsconfig.tests.json`, `ui/vitest.config.ts` and `README.md`: the first CI
  run on the public repo caught two genuine clean-checkout bugs in the test
  harness. No application code differs between the tag and `main`.

If you would prefer this vendored into the repo as a built-in instead of listed
as a registry pointer, say so and I will open that PR instead.
