### PR TITLE
fix(apps): make the app-backend stale-reap work on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
+- **App backends are actually reaped on Windows now.** The app-backend
+  stale-reap identifies a recorded pid through `_proc_start_time`, which read
+  `/proc/<pid>/stat` on Linux and otherwise shelled out to `ps -o lstart=` — a
+  branch its docstring called "macOS", but `else` covers every non-Linux
+  platform and Windows has no standard `ps`. There the call raised, was
+  swallowed, and returned `None` for every pid, so a null identity was
+  persisted and the reap — which correctly refuses to kill a pid it cannot
+  confirm — could never confirm one. No app backend was ever reaped on that
+  platform, and because unconfirmed entries are deliberately KEPT rather than
+  dropped, the pidfile accumulated an entry per gateway generation. The probe
+  now routes through `platform_compat.get_process_start_id`, the same shared
+  primitive this module already uses for every other process operation, which
+  gains a Windows branch reading the `GetProcessTimes` creation FILETIME. macOS
+  improves as a side effect: `libproc` at microsecond resolution replaces the
+  1-second, locale-formatted `ps` output, so same-second PID reuse can no
+  longer alias — and the probe no longer spawns a subprocess on the gateway's
+  startup path. (#3930)
 
 - **Switching Kiro accounts mid-session no longer leaves the chat showing a raw
   `The bearer token included in the request is invalid.` with no way out.** A

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -76,7 +76,6 @@ _BOOT_SPAWN_MAX_WORKERS = 8
 # applied PER orphan, not shared across the batch.
 _REAP_SIGTERM_GRACE = 3.0  # seconds to wait for an orphan to exit after SIGTERM
 _REAP_POLL_INTERVAL = 0.1  # liveness re-poll cadence during the grace window
-_PS_TIMEOUT = 2  # seconds before a `ps` start-time probe is abandoned
 
 
 # ---------------------------------------------------------------------------
@@ -1385,25 +1384,33 @@ def _proc_start_time(pid: int) -> str | None:
     prior generation against one read now), so it cannot use ``hash()`` — that
     is salted per interpreter by ``PYTHONHASHSEED``.
 
-    Linux reads ``/proc/<pid>/stat`` field 22 (start time in clock ticks since
-    boot): monotonic, locale-independent, and far finer than 1s, so same-second
-    PID reuse cannot alias. macOS falls back to ``ps -o lstart=`` (1s resolution,
-    locale/TZ-formatted); a format/resolution drift there can only make the guard
-    FAIL SAFE (decline to reap → orphan leaks), never kill the wrong process.
+    Routed through ``platform_compat.get_process_start_id`` — the same shared
+    primitive this module already uses for every other process operation
+    (``pid_exists``, ``pid_liveness``, ``kill_pid``, ``kill_process_tree``,
+    ``get_ppid``). The local implementation this replaces was Linux ``/proc``
+    with a bare ``ps -o lstart=`` fallback, whose docstring described the second
+    branch as "macOS" — but ``else`` covers every non-Linux platform, and
+    Windows has no standard ``ps``. There the call raised, was swallowed, and
+    returned ``None`` for every pid, so ``_record_app_pid`` persisted a null
+    identity and ``_reap_stale_app_backends`` could never confirm one: no app
+    backend was EVER reaped on Windows, and because unconfirmed entries are
+    deliberately kept rather than dropped, the pidfile accumulated them across
+    every gateway generation (#3930).
+
+    The shared helper answers on all three platforms, in-process and without a
+    subprocess: ``/proc/<pid>/stat`` field 22 on Linux, ``libproc`` at
+    microsecond resolution on macOS (finer than the 1-second, locale/TZ-formatted
+    ``ps -o lstart=`` it replaces, so same-second PID reuse can no longer alias),
+    and the ``GetProcessTimes`` creation FILETIME on Windows.
+
+    A recorded value written by a PRIOR gateway generation in the old macOS
+    ``ps`` format will not match the new one. That is the guard's fail-safe
+    direction — identity unconfirmed means decline to reap, never kill the wrong
+    process — and it self-clears: the reap drops any entry whose pid is already
+    dead, and ``_record_app_pid`` rewrites the entry in the new format the next
+    time that backend spawns.
     """
-    try:
-        if sys.platform == "linux":
-            stat = Path(f"/proc/{pid}/stat").read_text()
-            # The comm field can contain spaces/parens; split after the last ')'.
-            fields = stat.rsplit(")", 1)[1].split()
-            return fields[19]  # field 22 (1-based) = starttime in clock ticks
-        out = subprocess.check_output(
-            ["ps", "-o", "lstart=", "-p", str(pid)],
-            stderr=subprocess.DEVNULL, timeout=_PS_TIMEOUT,
-        )
-        return out.decode().strip() or None
-    except (OSError, ValueError, IndexError, subprocess.SubprocessError):
-        return None
+    return platform_compat.get_process_start_id(pid)
 
 
 def _pid_alive(pid: int) -> bool:
@@ -1452,11 +1459,12 @@ def _record_app_pid(app_name: str, pid: int, port: int) -> None:
     if pid <= 0:
         return
     try:
-        # Compute start_time BEFORE taking the lock: on macOS _proc_start_time
-        # shells out to `ps` (up to _PS_TIMEOUT), and holding _pidfile_lock
-        # across that slow IO would serialize concurrent enable/stop/uninstall
-        # ops behind it. Mirrors the reap path's validate-lock-free /
-        # store-under-lock discipline.
+        # Compute start_time BEFORE taking the lock. _proc_start_time is now an
+        # in-process read on every platform (no `ps` subprocess), so this is far
+        # cheaper than it was — but the ordering is kept deliberately: it still
+        # mirrors the reap path's validate-lock-free / store-under-lock
+        # discipline, and holding _pidfile_lock across any probe would serialize
+        # concurrent enable/stop/uninstall ops behind it.
         start_time = _proc_start_time(pid)
         with _pidfile_lock:
             data = _read_pidfile()

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -936,8 +936,11 @@ def get_process_start_id(pid: int) -> str | None:
     - macOS: ``libproc.proc_pidinfo`` ``pbi_start_tvsec``/``pbi_start_tvusec``
       (microsecond resolution, so processes spawned in the same second do not
       alias — unlike ``ps -o lstart=``, which is 1-second granularity).
-    - Windows / any failure (including a process we may not introspect): ``None``,
-      meaning "identity unknown" — callers must not treat that as a mismatch.
+    - Windows: ``GetProcessTimes`` creation time, a 100-ns-resolution FILETIME
+      opened with PROCESS_QUERY_LIMITED_INFORMATION (the least privilege that
+      answers, and the only one that works against an elevated process).
+    - Any failure (including a process we may not introspect): ``None``, meaning
+      "identity unknown" — callers must not treat that as a mismatch.
     """
     if sys.platform == "linux":
         try:
@@ -972,6 +975,52 @@ def get_process_start_id(pid: int) -> str | None:
             if sec == 0:
                 return None  # implausible — treat as unknown rather than a value
             return f"{sec}.{usec:06d}"
+        except Exception:
+            return None
+    if sys.platform == "win32":
+        # Branches on ``sys.platform`` rather than the ``IS_WINDOWS`` constant to
+        # match the two above it — one seam for the whole function, and the one
+        # this module's tests already patch.
+        try:
+            process_query_limited_information = 0x1000
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+            kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+            kernel32.OpenProcess.restype = wintypes.HANDLE
+            kernel32.GetProcessTimes.argtypes = [
+                wintypes.HANDLE,
+                ctypes.POINTER(wintypes.FILETIME),
+                ctypes.POINTER(wintypes.FILETIME),
+                ctypes.POINTER(wintypes.FILETIME),
+                ctypes.POINTER(wintypes.FILETIME),
+            ]
+            kernel32.GetProcessTimes.restype = wintypes.BOOL
+            kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+            kernel32.CloseHandle.restype = wintypes.BOOL
+            handle = kernel32.OpenProcess(
+                process_query_limited_information, False, pid
+            )
+            if not handle:
+                return None
+            try:
+                created = wintypes.FILETIME()
+                exited = wintypes.FILETIME()
+                kernel = wintypes.FILETIME()
+                user = wintypes.FILETIME()
+                ok = kernel32.GetProcessTimes(
+                    handle,
+                    ctypes.byref(created),
+                    ctypes.byref(exited),
+                    ctypes.byref(kernel),
+                    ctypes.byref(user),
+                )
+                if not ok:
+                    return None
+                ticks = (created.dwHighDateTime << 32) | created.dwLowDateTime
+                if ticks == 0:
+                    return None  # implausible — treat as unknown, not as a value
+                return str(ticks)
+            finally:
+                kernel32.CloseHandle(handle)
         except Exception:
             return None
     return None

--- a/test/test_app_backend_stale_reap.py
+++ b/test/test_app_backend_stale_reap.py
@@ -298,3 +298,99 @@ def test_reap_skips_sigkill_when_pid_recycled_during_grace(pidfile):
         n = backend_mod._reap_stale_app_backends()
     assert n == 1  # the SIGTERM was sent, so it counts as reaped
     assert sigkilled == []  # but the recycled pid must NOT be SIGKILLed
+
+
+# ---------------------------------------------------------------------------
+# The reap is reachable on Windows (#3930)
+# ---------------------------------------------------------------------------
+#
+# _proc_start_time was Linux-/proc with a bare `ps -o lstart=` fallback whose
+# docstring called the second branch "macOS". `else` covers every non-Linux
+# platform, and Windows has no standard `ps`, so the call raised, was swallowed,
+# and returned None for every pid. _record_app_pid then persisted a null
+# identity and the reap refused to act on an unconfirmed one -- so no app
+# backend was EVER reaped there, and because unconfirmed entries are
+# deliberately KEPT, the pidfile accumulated an entry per gateway generation.
+#
+# These drive the whole record -> reap cycle through a simulated Windows probe.
+
+
+def _windows_start_id(monkeypatch, value):
+    """Make the shared probe answer the way Windows now does (a FILETIME tick
+    count as a decimal string), for every pid."""
+    monkeypatch.setattr(
+        backend_mod.platform_compat, "get_process_start_id", lambda _pid: value
+    )
+
+
+def test_windows_records_a_real_identity_instead_of_null(pidfile, monkeypatch):
+    _windows_start_id(monkeypatch, "133700000000000000")
+    backend_mod._record_app_pid("code_reviewer", 4321, 9100)
+    entry = backend_mod._read_pidfile()["code_reviewer"]
+    # A null here is what made every later reap a no-op.
+    assert entry["start_time"] == "133700000000000000"
+
+
+def test_windows_orphan_is_reaped_instead_of_accumulating(pidfile, monkeypatch):
+    _windows_start_id(monkeypatch, "133700000000000000")
+    backend_mod._record_app_pid("code_reviewer", 4321, 9100)
+
+    killed: list[int] = []
+    monkeypatch.setattr(
+        backend_mod.platform_compat, "pid_liveness",
+        lambda _pid: backend_mod.platform_compat.PID_ALIVE,
+    )
+    monkeypatch.setattr(
+        backend_mod.platform_compat, "kill_process_tree",
+        lambda pid, _sig: killed.append(pid),
+    )
+    monkeypatch.setattr(backend_mod.platform_compat, "pid_exists", lambda _pid: False)
+
+    assert backend_mod._reap_stale_app_backends() == 1
+    assert killed == [4321]
+    # Handled entries are dropped -- this is the accumulation the null identity
+    # made permanent.
+    assert backend_mod._read_pidfile() == {}
+
+
+def test_a_recycled_windows_pid_is_still_never_killed(pidfile, monkeypatch):
+    """The PID-reuse guard must survive the platform fix: a DIFFERENT creation
+    time for the same pid means the pid was recycled onto an unrelated process."""
+    _windows_start_id(monkeypatch, "133700000000000000")
+    backend_mod._record_app_pid("code_reviewer", 4321, 9100)
+    _windows_start_id(monkeypatch, "133799999999999999")  # recycled
+
+    killed: list[int] = []
+    monkeypatch.setattr(
+        backend_mod.platform_compat, "pid_liveness",
+        lambda _pid: backend_mod.platform_compat.PID_ALIVE,
+    )
+    monkeypatch.setattr(
+        backend_mod.platform_compat, "kill_process_tree",
+        lambda pid, _sig: killed.append(pid),
+    )
+
+    assert backend_mod._reap_stale_app_backends() == 0
+    assert killed == []
+    # Unconfirmed but alive -> KEPT for a later attempt, unchanged behaviour.
+    assert "code_reviewer" in backend_mod._read_pidfile()
+
+
+def test_an_unknown_identity_still_declines_to_reap(pidfile, monkeypatch):
+    """None means "identity unknown" on every platform (a process we may not
+    introspect). It must keep failing safe, not become a licence to kill."""
+    _windows_start_id(monkeypatch, None)
+    backend_mod._record_app_pid("code_reviewer", 4321, 9100)
+
+    killed: list[int] = []
+    monkeypatch.setattr(
+        backend_mod.platform_compat, "pid_liveness",
+        lambda _pid: backend_mod.platform_compat.PID_ALIVE,
+    )
+    monkeypatch.setattr(
+        backend_mod.platform_compat, "kill_process_tree",
+        lambda pid, _sig: killed.append(pid),
+    )
+
+    assert backend_mod._reap_stale_app_backends() == 0
+    assert killed == []

--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -20,6 +20,7 @@ and ``urllib.request.urlopen`` are stubbed, and the spawn body is frozen at the
 """
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import subprocess
@@ -1287,62 +1288,43 @@ class TestPidfileHelpers:
 
 
 class TestProcStartTime:
-    def test_linux_reads_the_starttime_field_past_a_parenthesised_comm(
+    def test_delegates_to_the_shared_platform_primitive(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Splitting on the FIRST ')' would mis-index any comm containing one."""
+        """The per-platform parsing moved to platform_compat.get_process_start_id,
+        which answers on Windows too. The local Linux-/proc-or-`ps` pair it
+        replaced returned None for every pid there, silently disabling the
+        stale-reap entirely (#3930). Its per-platform behaviour is covered at its
+        new home in test_platform_compat_coverage.py."""
+        seen: list[int] = []
 
-        tail = " ".join(str(i) for i in range(4, 24))
-        stat = f"4242 (my (odd) proc) S 1 {tail}"
+        def _fake(pid: int) -> str | None:
+            seen.append(pid)
+            return "1700000000.123456"
 
-        class _FakeStatPath:
-            def __init__(self, _p: str) -> None:
-                pass
+        monkeypatch.setattr(bmod.platform_compat, "get_process_start_id", _fake)
+        assert bmod._proc_start_time(4242) == "1700000000.123456"
+        assert seen == [4242]
 
-            def read_text(self) -> str:
-                return stat
-
-        monkeypatch.setattr(bmod.sys, "platform", "linux")
-        monkeypatch.setattr(bmod, "Path", _FakeStatPath)
-        assert bmod._proc_start_time(4242) == "21"
-
-    def test_a_malformed_stat_line_yields_no_identity(
+    def test_an_unknown_identity_is_passed_through_as_none(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        class _FakeStatPath:
-            def __init__(self, _p: str) -> None:
-                pass
-
-            def read_text(self) -> str:
-                return "no closing paren here"
-
-        monkeypatch.setattr(bmod.sys, "platform", "linux")
-        monkeypatch.setattr(bmod, "Path", _FakeStatPath)
-        assert bmod._proc_start_time(4242) is None
-
-    def test_non_linux_shells_out_to_ps(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(bmod.sys, "platform", "darwin")
+        """None means "identity unknown", which the reap treats as
+        do-not-kill-and-keep — it must not be coerced into a value."""
         monkeypatch.setattr(
-            bmod.subprocess, "check_output", lambda *_a, **_k: b" Mon Jan  1 00:00:00 2024\n"
+            bmod.platform_compat, "get_process_start_id", lambda _pid: None
         )
-        assert bmod._proc_start_time(4242) == "Mon Jan  1 00:00:00 2024"
-
-    def test_empty_ps_output_yields_no_identity(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(bmod.sys, "platform", "darwin")
-        monkeypatch.setattr(bmod.subprocess, "check_output", lambda *_a, **_k: b"\n")
         assert bmod._proc_start_time(4242) is None
 
-    def test_a_failed_ps_probe_yields_no_identity(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        def _boom(*_a: Any, **_k: Any) -> bytes:
-            raise OSError("no ps")
+    def test_the_probe_no_longer_shells_out(self) -> None:
+        """A subprocess here ran on the gateway's startup path and, on Windows,
+        raised on every call. The replacement is in-process on all platforms.
 
-        monkeypatch.setattr(bmod.sys, "platform", "darwin")
-        monkeypatch.setattr(bmod.subprocess, "check_output", _boom)
-        assert bmod._proc_start_time(4242) is None
+        Asserted on the executable body only — the docstring above it discusses
+        the subprocess it replaced."""
+        body = inspect.getsource(bmod._proc_start_time).split('"""')[-1]
+        assert "subprocess" not in body
+        assert "get_process_start_id" in body
 
     def test_pid_alive_delegates_to_the_platform_shim(
         self, monkeypatch: pytest.MonkeyPatch

--- a/test/test_platform_compat_coverage.py
+++ b/test/test_platform_compat_coverage.py
@@ -462,6 +462,60 @@ def _bsdinfo(ppid: int = 0, sec: int = 0, usec: int = 0) -> bytes:
     return bytes(buf)
 
 
+def _boom_windll(*_a: Any, **_k: Any) -> Any:
+    raise OSError("kernel32 unavailable")
+
+
+def _fake_kernel32(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    handle: int,
+    high: int,
+    low: int,
+    times_ok: bool = True,
+) -> list[int]:
+    """Pretend to be Windows and stub the three kernel32 calls the probe makes.
+
+    Returns the list CloseHandle is called with, so a test can assert the
+    handle was released. ``wintypes`` supplies type aliases only and imports
+    cleanly here, so the FILETIME out-params are the real structures.
+    """
+    closed: list[int] = []
+
+    class _FakeKernel32:
+        def __init__(self) -> None:
+            self.OpenProcess = self._open
+            self.GetProcessTimes = self._times
+            self.CloseHandle = self._close
+
+        # ctypes lets callers assign .argtypes/.restype on a bound proc; these
+        # are plain functions, so accept and ignore those assignments.
+        def __setattr__(self, name: str, value: Any) -> None:
+            object.__setattr__(self, name, value)
+
+        @staticmethod
+        def _open(_access: Any, _inherit: Any, _pid: Any) -> int:
+            return handle
+
+        @staticmethod
+        def _times(_h: Any, created: Any, _e: Any, _k: Any, _u: Any) -> int:
+            if not times_ok:
+                return 0
+            created._obj.dwHighDateTime = high
+            created._obj.dwLowDateTime = low
+            return 1
+
+        @staticmethod
+        def _close(h: Any) -> int:
+            closed.append(int(h))
+            return 1
+
+    fake = _FakeKernel32()
+    monkeypatch.setattr(pc.sys, "platform", "win32")
+    monkeypatch.setattr(pc.ctypes, "WinDLL", lambda *_a, **_k: fake, raising=False)
+    return closed
+
+
 def _fake_libproc(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -578,8 +632,45 @@ class TestGetProcessStartId:
         _fake_libproc(monkeypatch, payload=None, ret=-1)
         assert pc.get_process_start_id(5) is None
 
-    def test_windows_is_unknown_rather_than_a_mismatch(self, monkeypatch):
+    def test_windows_reports_the_creation_filetime(self, monkeypatch):
+        """Windows used to fall through to `return None`, so every caller saw
+        "identity unknown" for every pid. In apps/backend that permanently
+        disabled the app-backend stale-reap: an entry whose identity can never
+        be confirmed is never killed AND never dropped, so the pidfile grew
+        across every gateway generation (#3930)."""
+        _fake_kernel32(monkeypatch, handle=99, high=0x01DA, low=0x1234ABCD)
+        # 100-ns FILETIME ticks, as a decimal string: stable across restarts,
+        # locale-independent, and finer than any plausible spawn cadence.
+        assert pc.get_process_start_id(5) == str((0x01DA << 32) | 0x1234ABCD)
+
+    def test_windows_closes_the_handle_it_opened(self, monkeypatch):
+        """The probe runs once per recorded pid on the gateway's startup path;
+        leaking a handle per call would accumulate for the process lifetime."""
+        closed = _fake_kernel32(monkeypatch, handle=99, high=1, low=2)
+        pc.get_process_start_id(5)
+        assert closed == [99]
+
+    def test_windows_closes_the_handle_even_when_the_query_fails(self, monkeypatch):
+        closed = _fake_kernel32(monkeypatch, handle=99, high=1, low=2, times_ok=False)
+        assert pc.get_process_start_id(5) is None
+        assert closed == [99]
+
+    def test_windows_unopenable_process_is_unknown(self, monkeypatch):
+        """A pid we may not introspect must read as unknown, not as a mismatch —
+        the reap's fail-safe direction is decline-to-kill."""
+        _fake_kernel32(monkeypatch, handle=0, high=1, low=2)
+        assert pc.get_process_start_id(5) is None
+
+    def test_windows_zero_creation_time_is_unknown(self, monkeypatch):
+        _fake_kernel32(monkeypatch, handle=99, high=0, low=0)
+        assert pc.get_process_start_id(5) is None
+
+    def test_windows_probe_failure_is_unknown_not_a_raise(self, monkeypatch):
+        """It runs on the startup path; a raise here would abort the reap."""
         monkeypatch.setattr(pc.sys, "platform", "win32")
+        monkeypatch.setattr(
+            pc.ctypes, "WinDLL", _boom_windll, raising=False
+        )
         assert pc.get_process_start_id(5) is None
 
     def test_identity_never_contains_a_colon(self, monkeypatch):

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -247,7 +247,6 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # ``capabilities.tailnet_origin`` ceiling at the enforcement call, and
         # never reached from a tool dispatch path.
         "dashboard/tailnet_serve.py::_run",
-        "apps/backend.py::_proc_start_time",
         "apps/backend.py::_resolve_nvm_path",
         "apps/backend.py::stop_app_backend",
         # py-spy attach for `kirocrew perf sample --pid`: fixed list-argv (no


### PR DESCRIPTION
Closes #3930.

## Problem

`_proc_start_time` is the identity source for the stale-reap's PID-reuse guard. It read `/proc/<pid>/stat` on Linux and otherwise shelled out to `ps -o lstart=`. Its docstring described the second branch as the macOS fallback — but `else` covers **every** non-Linux platform, and Windows has no standard `ps`. There the call raised, was swallowed, and returned `None` for every pid.

That disabled the feature completely. `_record_app_pid` persisted the null, and `_reap_stale_app_backends` refuses to act on an unconfirmed identity, so `not recorded_st` was always true: **no app backend was ever reaped on Windows**, and because unconfirmed entries are deliberately KEPT rather than dropped, the pidfile accumulated one per gateway generation. The fail-safe design is right; it was just permanently in the safe state there.

## Fix

- **`platform_compat.get_process_start_id` gains a Windows branch**: the `GetProcessTimes` creation FILETIME (100 ns resolution), opened with `PROCESS_QUERY_LIMITED_INFORMATION` — the least privilege that answers, and the only one that works against an elevated process. The handle is closed on every path, including the query-failure path. An unopenable process, a failed query, or a zero creation time all read as "identity unknown" (`None`), which is the reap's fail-safe direction rather than a mismatch.
- **`apps/backend._proc_start_time` delegates to it**, matching how this module already routes `pid_exists` / `pid_liveness` / `kill_pid` / `kill_process_tree` / `get_ppid` — the consolidation the issue points at.

**macOS improves as a side effect**: `libproc` at microsecond resolution replaces the 1-second, locale/TZ-formatted `ps` output, so two processes started in the same second can no longer alias onto one identity. The probe also stops spawning a subprocess on the gateway startup path — which is why the now-stale `apps/backend.py::_proc_start_time` entry is dropped from `test_spawn_audit`'s `BENIGN_SPAWNS` allowlist. That gate caught it unprompted.

**Migration**: a value recorded by a prior generation in the old macOS `ps` format will not match the new one. That is the guard's fail-safe direction — decline to reap, never kill the wrong process — and it self-clears: the reap drops any entry whose pid is already dead, and `_record_app_pid` rewrites the entry the next time that backend spawns.

The branch keys on `sys.platform == "win32"` rather than the `IS_WINDOWS` constant, matching the two branches above it, so the function has one test seam throughout.

## Test plan

I do not have a Windows host, so the Windows branch is driven through a faked `kernel32` rather than executed natively — flagging that explicitly.

- **`test/test_platform_compat_coverage.py`**: the existing `test_windows_is_unknown_rather_than_a_mismatch` pinned the defect and is replaced by **6 tests** — the FILETIME is reported as a decimal tick string; the handle is closed on both the success and query-failure paths; and unopenable / zero-creation-time / loader-failure all read as unknown rather than raising on the startup path.
- **`test/test_app_backend_stale_reap.py`**: **4 new end-to-end tests** through a simulated Windows probe — a real identity is recorded instead of null, an orphan is reaped and its entry dropped instead of accumulating, a recycled pid is still never killed, and an unknown identity still declines to reap.
- **`test/test_apps_backend_coverage.py`**: `TestProcStartTime` rewritten against the delegation. It tested the moved implementation through module-local `sys`/`Path`/`subprocess` seams — two of its four cases failed after the move and two passed vacuously.
- Full sweep of `test_spawn_audit` + `test_app_backend_stale_reap` + `test_platform_compat_coverage` + `test_apps_backend_coverage` + `test_app_backend` + `test_pid_lifecycle`: **595 passed, 13 skipped**. **5 fail on main.**
- `flake8` / `isort` clean on touched files.