### PR TITLE
fix(apps): route app-backend adoption through the platform port→PID helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
+- **App-backend adoption works on Windows.** Taking over a healthy instance
+  already listening on an app's fixed port recorded the owning PIDs by shelling
+  out to a bare `lsof`, which does not exist there: `subprocess.run` raised
+  `FileNotFoundError`, the PID list stayed empty, and adoption was refused on
+  every call — logging "cannot record PIDs (lsof unavailable?)" as though it
+  were a diagnosable local gap. Only the exec / shell-launcher branch is
+  POSIX-gated, so Python and Node app backends run on Windows normally and hit
+  this. Both the adoption and adopted-stop paths now route through the module's
+  own `_listening_pids` wrapper, which `platform_compat` already backs with
+  `lsof` on POSIX and `netstat -ano` on Windows. The stop path's PID-recycling
+  guard keeps its three-way behaviour explicitly: the port→PID helper collapses
+  "tool absent" and "nothing is listening" into one empty list, and those call
+  for opposite actions — fall back to the adopted set for the first, kill
+  nothing for the second. (#3876)
 
 - **Switching Kiro accounts mid-session no longer leaves the chat showing a raw
   `The bearer token included in the request is invalid.` with no way out.** A

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -136,7 +136,8 @@ def _survived_spawn(proc: Any, port: int | None = None) -> bool:
     established at all (no port to observe, or no port->PID tool on the host), it
     degrades to polling the full budget exactly as before.
 
-    The ownership probe shells out to lsof (~150ms), so it is gated behind a cheap
+    The ownership probe shells out to the port->PID tool (lsof on POSIX, netstat
+    on Windows; ~150ms), so it is gated behind a cheap
     loopback connect and is not run on every poll: the deadline below stays honest
     about wall-clock rather than adding the probe's cost to each interval, which
     would otherwise make the failure path take LONGER than the original budget.
@@ -631,24 +632,18 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                     )
                 except Exception as exc:
                     logger.debug("SEL audit failed for app %s backend adopt: %s", app_name, exc)
-                # Record PIDs listening on this port at adoption time
-                adopted_pids: list[int] = []
-                try:
-                    lsof_result = subprocess.run(
-                        ["lsof", "-ti", f":{port}", "-sTCP:LISTEN"],
-                        capture_output=True, text=True, timeout=5,
-                    )
-                    if lsof_result.returncode == 0 and lsof_result.stdout.strip():
-                        for pid_str in lsof_result.stdout.strip().split("\n"):
-                            try:
-                                adopted_pids.append(int(pid_str.strip()))
-                            except ValueError:
-                                pass
-                except (OSError, subprocess.TimeoutExpired):
-                    pass
+                # Record PIDs listening on this port at adoption time. Routed
+                # through this module's own port->PID wrapper rather than a bare
+                # `lsof`, which does not exist on Windows: subprocess.run raised
+                # FileNotFoundError there, adopted_pids stayed empty, and
+                # adoption was refused on EVERY call, logging "lsof
+                # unavailable?" as though it were a diagnosable local gap
+                # (#3876). App backends do run on Windows — only the exec /
+                # shell-launcher branch is POSIX-gated.
+                adopted_pids = _listening_pids(port)
                 if not adopted_pids:
                     logger.warning(
-                        "App %s: cannot record PIDs on port %d (lsof unavailable?) — skipping adoption",
+                        "App %s: cannot record PIDs on port %d — skipping adoption",
                         app_name, port,
                     )
                     return None
@@ -665,7 +660,8 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                 # If the gateway dies, the external instance keeps running and is
                 # simply re-probed and re-adopted on the next start — so reaping it
                 # would kill a healthy service we would immediately re-adopt. stop's
-                # adopted path kills only the lsof-revalidated PIDs for this reason.
+                # adopted path kills only the PIDs still revalidated as holding
+                # this port, for this reason.
                 with _lock:
                     _processes[app_name] = ap
                     _allocated_ports[app_name] = port
@@ -1106,25 +1102,25 @@ def stop_app_backend(app_name: str) -> bool:
             target_pids: set[int] = set(ap.adopted_pids)
 
             # Verify adopted PIDs still belong to this port (guards against
-            # PID recycling between adoption and stop).
-            try:
-                lsof_result = subprocess.run(
-                    ["lsof", "-ti", f":{ap.port}", "-sTCP:LISTEN"],
-                    capture_output=True, text=True, timeout=5,
-                )
-                if lsof_result.returncode == 0 and lsof_result.stdout.strip():
-                    current_pids: set[int] = set()
-                    for pid_str in lsof_result.stdout.strip().split("\n"):
-                        try:
-                            current_pids.add(int(pid_str.strip()))
-                        except ValueError:
-                            pass
-                    # Only kill PIDs that are both adopted AND still on this port
-                    target_pids = target_pids & current_pids
-            except (OSError, subprocess.TimeoutExpired):
-                # lsof unavailable at stop time — proceed with adopted PIDs
-                # (they were validated at adoption time)
-                pass
+            # PID recycling between adoption and stop). Same wrapper as the
+            # adoption side, so this no longer depends on a bare `lsof` that
+            # Windows does not have (#3876).
+            #
+            # The three-way distinction the old code got from lsof's exit status
+            # has to be preserved explicitly, because find_listening_pids
+            # collapses "tool absent" and "nothing is listening" into the same
+            # empty list, and they call for OPPOSITE actions here:
+            #   * tool absent      -> proceed with the adopted PIDs, which were
+            #                         validated at adoption time (the old
+            #                         `except OSError: pass` branch);
+            #   * genuinely empty  -> intersect to the empty set and kill
+            #                         nothing, because a PID that no longer
+            #                         holds this port may have been recycled
+            #                         onto an unrelated process. Killing it is
+            #                         the exact hazard this guard exists for.
+            if platform_compat.listening_pid_tool_available():
+                # Only kill PIDs that are both adopted AND still on this port.
+                target_pids = target_pids & set(_listening_pids(ap.port))
 
             pids: list[int] = []
             for pid in target_pids:

--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -20,6 +20,7 @@ and ``urllib.request.urlopen`` are stubbed, and the spawn body is frozen at the
 """
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import subprocess
@@ -156,6 +157,29 @@ def _capture_popen(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
     monkeypatch.setattr(bmod, "popen_limited", _popen)
     return seen
+
+
+def _fake_port_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    pids: list[int] | None = None,
+    tool_available: bool = True,
+) -> None:
+    """Stand in for the port->PID lookup at its CURRENT seam.
+
+    Adoption and adopted-stop route through
+    ``platform_compat.find_listening_pids`` / ``listening_pid_tool_available``
+    rather than a bare ``lsof`` subprocess, which does not exist on Windows
+    (#3876). ``tool_available=False`` is the "no port->PID tool on this host"
+    case, which is deliberately NOT the same as an empty result.
+    """
+
+    monkeypatch.setattr(
+        bmod.platform_compat, "find_listening_pids", lambda _port: list(pids or [])
+    )
+    monkeypatch.setattr(
+        bmod.platform_compat, "listening_pid_tool_available", lambda: tool_available
+    )
 
 
 def _record_runs(
@@ -698,8 +722,36 @@ class TestAdoptExistingInstance:
         self, occupied: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _fake_port_probe(monkeypatch, tool_available=False)
         assert self._run(bmod._MIN_PORT + 9) is None
+
+    # ── Adoption does not depend on `lsof` existing (#3876) ────────────────
+    #
+    # It used to shell out to a bare `lsof`, which does not exist on Windows:
+    # subprocess.run raised FileNotFoundError, adopted_pids stayed empty, and
+    # adoption was refused on EVERY call. App backends do run on Windows -- only
+    # the exec / shell-launcher branch is POSIX-gated -- so this was a live path.
+
+    def test_adoption_uses_the_platform_probe_not_a_bare_lsof(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Driven entirely through the platform wrapper, with the subprocess
+        seam left unpatched: on a host with no `lsof` the old code could not
+        have reached this result at all."""
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        _fake_port_probe(monkeypatch, pids=[4242])
+        ap = self._run(bmod._MIN_PORT + 10)
+        assert ap is not None
+        assert ap.adopted_pids == [4242]
+
+    def test_the_adoption_probe_never_names_lsof_directly(self) -> None:
+        """`lsof` must not be re-hardcoded here: platform_compat picks lsof on
+        POSIX and netstat on Windows, and only it knows which."""
+        src = inspect.getsource(bmod._start_app_backend_body)
+        code = "\n".join(
+            line for line in src.splitlines() if not line.lstrip().startswith("#")
+        )
+        assert '"lsof"' not in code
 
     def test_an_unhealthy_occupant_blocks_the_spawn_instead_of_colliding(
         self, occupied: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -1124,7 +1176,7 @@ class TestStopAdoptedBackend:
         self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
     ) -> None:
         self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _fake_port_probe(monkeypatch, tool_available=False)
         assert bmod.stop_app_backend("ext") is True
         assert kills == [(111, bmod.platform_compat.SIGTERM)]
 
@@ -1132,9 +1184,34 @@ class TestStopAdoptedBackend:
         self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
     ) -> None:
         self._track(adopted_pids=[0, -1], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _fake_port_probe(monkeypatch, tool_available=False)
         assert bmod.stop_app_backend("ext") is True
         assert kills == []
+
+    # ── The stop path's three-way probe semantics (#3876) ─────────────────
+    #
+    # find_listening_pids collapses "tool absent" and "nothing is listening"
+    # into one empty list, but they call for OPPOSITE actions here, so the stop
+    # path asks listening_pid_tool_available() explicitly.
+
+    def test_an_empty_probe_result_kills_nothing_rather_than_everything(
+        self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Probe worked and found NO listener: an adopted PID that no longer
+        holds this port may have been recycled onto an unrelated process, so it
+        must not be signalled. This is the opposite of the tool-absent case."""
+        self._track(adopted_pids=[111], healthy=True)
+        _fake_port_probe(monkeypatch, pids=[], tool_available=True)
+        assert bmod.stop_app_backend("ext") is True
+        assert kills == []
+
+    def test_a_recycled_pid_is_dropped_but_a_still_listening_one_is_killed(
+        self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._track(adopted_pids=[111, 222], healthy=True)
+        _fake_port_probe(monkeypatch, pids=[111, 999], tool_available=True)
+        assert bmod.stop_app_backend("ext") is True
+        assert kills == [(111, bmod.platform_compat.SIGTERM)]
 
     def test_a_survivor_is_escalated_to_sigkill(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1145,7 +1222,7 @@ class TestStopAdoptedBackend:
         )
         monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
         self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _fake_port_probe(monkeypatch, tool_available=False)
         assert bmod.stop_app_backend("ext") is True
         assert recorded == [
             (111, bmod.platform_compat.SIGTERM),
@@ -1161,7 +1238,7 @@ class TestStopAdoptedBackend:
         monkeypatch.setattr(bmod.platform_compat, "kill_pid", _denied)
         monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: False)
         self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _fake_port_probe(monkeypatch, tool_available=False)
         assert bmod.stop_app_backend("ext") is True
 
     def test_an_unexpected_stop_failure_restores_tracking(
@@ -1174,7 +1251,7 @@ class TestStopAdoptedBackend:
 
         monkeypatch.setattr(bmod.platform_compat, "kill_pid", _bad)
         ap = self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _fake_port_probe(monkeypatch, tool_available=False)
         with caplog.at_level(logging.WARNING):
             assert bmod.stop_app_backend("ext") is False
         assert any("Failed to stop adopted backend" in r.message for r in caplog.records)

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -249,7 +249,6 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "dashboard/tailnet_serve.py::_run",
         "apps/backend.py::_proc_start_time",
         "apps/backend.py::_resolve_nvm_path",
-        "apps/backend.py::stop_app_backend",
         # py-spy attach for `kirocrew perf sample --pid`: fixed list-argv (no
         # shell=True), binary resolved via shutil.which rather than from input,
         # and every value is either a range-validated int (pid/seconds/rate) or a


### PR DESCRIPTION
Closes #3876.

## Problem

Adoption — taking over a healthy instance already listening on the app's fixed port instead of colliding with it — recorded the owning PIDs by shelling out to a bare `lsof`. That binary does not exist on Windows, so `subprocess.run` raised `FileNotFoundError`, `adopted_pids` stayed empty, and adoption was **refused on every call**, logging `cannot record PIDs on port N (lsof unavailable?)` as though it were a diagnosable local gap.

Not a dead path: only the exec / shell-launcher branch is POSIX-gated (`backend.py:854`), so Python and Node app backends run on Windows normally.

## Fix

As the issue points out, the module already routes every other process primitive through `platform_compat` and has its own port→PID wrapper, `_listening_pids`, ~460 lines above the first offender. Both raw call sites now use it; `platform_compat` backs it with `lsof` on POSIX and `netstat -ano` on Windows.

### The stop path needed care rather than a straight swap

The adopted-stop path previously distinguished three outcomes via `lsof`'s exit status:

| outcome | action |
|---|---|
| probe failed | proceed with the adopted PIDs (validated at adoption time) |
| probe found listeners | intersect — only PIDs still on this port die |
| probe found none | intersect to empty — kill nothing |

`find_listening_pids` collapses **"tool absent"** and **"nothing is listening"** into one empty list, and those two call for *opposite* actions. Collapsing them either leaks the backend or — worse — signals a PID that no longer holds the port and may have been recycled onto an unrelated process, which is the exact hazard the guard exists for. The path therefore asks `listening_pid_tool_available()` explicitly, which `platform_compat` documents as the seam for precisely this distinction.

Two POSIX-centric comments corrected while here (the ownership probe "shells out to lsof"; stop "kills only the lsof-revalidated PIDs") — both describe code that was already platform-routed.

`stop_app_backend` no longer spawns, so its now-stale entry is dropped from `test_spawn_audit`'s `BENIGN_SPAWNS` allowlist. That gate caught it unprompted.

## Test plan

No Windows host here, so the platform split is driven through `platform_compat`'s seam rather than executed natively — flagging that explicitly.

- **`test/test_apps_backend_coverage.py`**: 4 new tests — adoption driven purely through the platform wrapper with the subprocess seam left unpatched (a result the old code could not reach on a host without `lsof`); a guard that `"lsof"` is not re-hardcoded in the adoption body; and both halves of the stop path's three-way semantics (an empty-but-successful probe kills nothing; a recycled PID is dropped while a still-listening one is killed).
- The five existing stop tests that drove the removed `subprocess.run` seam are retargeted to the current one via a `_fake_port_probe` helper. **No assertions changed.** The adoption tests keep working unmodified — `subprocess.check_output` dispatches through `subprocess.run`, so their existing patch still reaches `find_listening_pids`, including its non-numeric-line skip.
- `test_apps_backend_coverage` + `test_app_backend` + `test_app_backend_stale_reap` + `test_spawn_audit` + `test_builtin_app_optional_enable`: **221 passed**. **4 fail on main.**
- `flake8` clean on touched files.

Stacks cleanly alongside #4041 (the Windows stale-reap fix in the same file); they touch different functions.