### PR TITLE
fix: make the backend own the settled ordering key, and keep a running turn recent

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1014,6 +1014,7 @@ class _ChatSlot:
         "event",
         "_pending",
         "_queue",
+        "_last_enqueue_ts",
         "_approval_futures",
         "_trust",
         "_trust_scope",
@@ -1151,6 +1152,9 @@ class _ChatSlot:
         self.event = asyncio.Event()
         self._pending: list[dict[str, str]] = []
         self._queue: list[dict[str, str]] = []  # [{"id": uuid, "content": str}, ...]
+        # Newest enqueue instant, read only while ``_queue`` is non-empty — see
+        # ``_note_enqueue``.
+        self._last_enqueue_ts: str = ""
         self._approval_futures: dict[str, asyncio.Future[str]] = {}  # type: ignore[type-arg]
         self._trust: bool = False  # auto-approve tools for this slot
         # SafetyOverride scope key holding an EXPIRING, SEL-audited auto-approve
@@ -1923,7 +1927,23 @@ class _ChatSlot:
         if meta:
             item["meta"] = meta
         self._queue.append(item)
+        self._note_enqueue()
         return qid
+
+    def _note_enqueue(self) -> None:
+        """Record that work was just queued for this slot.
+
+        Held BESIDE the queue rather than on the entry: an entry dict is compared
+        wholesale in a great many places, and widening its shape would make every
+        one of those comparisons depend on a clock.
+
+        Read only while ``_queue`` is non-empty (see ``to_dict``), so the value
+        cannot outlive the queue it describes. Individual removals leave it
+        pointing at the most recent enqueue rather than at the oldest surviving
+        entry, which is the same statement for ranking purposes: work is waiting,
+        and it was asked for at this instant.
+        """
+        self._last_enqueue_ts = datetime.now(timezone.utc).isoformat()
 
     def queue_insert(self, index: int, content: str, kind: str = "", payload: str = "") -> str:
         """Insert a message at a specific queue position. Returns the queue ID.
@@ -1935,6 +1955,7 @@ class _ChatSlot:
         """
         qid = uuid.uuid4().hex[:12]
         self._queue.insert(index, {"id": qid, "content": content, "kind": kind, "payload": payload})
+        self._note_enqueue()
         return qid
 
     def queue_pop(self, index: int = 0) -> dict[str, str]:
@@ -2274,7 +2295,7 @@ class _ChatSlot:
                 break
         pending_approval = any(not f.done() for f in self._approval_futures.values())
         # Ordering instant for the session list: the last time this session
-        # SETTLED -- a prompt arrived, or a turn finished. Deliberately not
+        # SETTLED -- work was asked of it, or a turn finished. Deliberately not
         # ``last_ts``, which is the newest row of ANY role and therefore advances
         # on every streamed tool call: a list ranked by that reshuffles
         # continuously whenever several sessions are working, so rows swap under
@@ -2282,12 +2303,17 @@ class _ChatSlot:
         # started it, and the single re-rank lands when the turn ends -- at which
         # point the newest row IS the completion.
         #
-        # The prompt scan is running-only, so an idle slot (the common case in a
-        # long sidebar) costs nothing, and a running one is bounded by the rows
-        # its current turn has emitted.
+        # A send that arrived behind a running turn is QUEUED, not appended, so
+        # the message scan alone would not see it and this snapshot would rank the
+        # session by the older prompt -- overwriting the client's own bump and
+        # dropping the row the user just typed into. Ranking queued entries here
+        # makes this the single owner of the key instead of racing the client.
+        #
+        # Both scans are running-only, so an idle slot (the common case in a long
+        # sidebar) costs nothing, and a running one is bounded by its own turn.
         last_turn_ts = last_ts
         if self.running:
-            last_turn_ts = next(
+            prompt_ts = next(
                 (
                     m.get("ts") or ""
                     for m in reversed(self.messages)
@@ -2295,6 +2321,15 @@ class _ChatSlot:
                 ),
                 "",
             )
+            queued_ts = self._last_enqueue_ts if self._queue else ""
+            last_turn_ts = prompt_ts
+            if queued_ts:
+                # Parse-based, not string ``max``: rows carry both aware and naive
+                # isoformat, and comparing those as strings can pick the earlier
+                # one. Consulted only while something is queued, so a prompt row
+                # whose own ``ts`` is unparseable still ranks the session instead
+                # of being discarded by the combiner.
+                last_turn_ts = latest_transcript_ts(prompt_ts, queued_ts) or queued_ts
         # waiting_for_input: turn ended (not running), no options, no approval,
         # and the last conversational message is from the assistant (not user).
         waiting_for_input = (

--- a/test/test_to_dict_board_fields.py
+++ b/test/test_to_dict_board_fields.py
@@ -154,6 +154,43 @@ def test_last_turn_ts_empty_when_running_with_no_prompt_row():
     assert d["last_turn_ts"] == ""
 
 
+def test_last_turn_ts_counts_a_send_queued_behind_a_running_turn():
+    # A send that lands mid-turn is QUEUED, not appended, so a message-only scan
+    # would rank the session by the older prompt — and this snapshot is
+    # authoritative, so it would drop a row the user just typed into back down
+    # the list even after the client bumped it.
+    s = _slot(
+        {"role": "user", "content": "do it", "ts": "2026-08-17T01:00:00+00:00"},
+        {"role": "tool_call", "content": "grep ...", "ts": "2026-08-17T01:00:05+00:00"},
+    )
+    s.task = SimpleNamespace(done=lambda: False)
+    s.queue_append("and also this")
+    d = s.to_dict()
+    assert d["last_turn_ts"] > "2026-08-17T01:00:00+00:00"
+    assert d["last_turn_ts"] != d["last_ts"]
+
+
+def test_queue_entries_keep_their_exact_shape():
+    # The enqueue instant lives beside the queue, not on the entry: entry dicts
+    # are compared wholesale across the suite, so widening them would make those
+    # comparisons depend on a clock.
+    s = _slot()
+    qid = s.queue_append("later")
+    assert s._queue == [{"id": qid, "content": "later", "kind": ""}]
+
+
+def test_last_turn_ts_ignores_the_queue_once_idle():
+    # Queue drains only while a turn runs; an idle slot's newest row is the
+    # completion, and a leftover queued entry must not outrank it.
+    s = _slot(
+        {"role": "user", "content": "do it", "ts": "2026-08-17T01:00:00+00:00"},
+        {"role": "assistant", "content": "done", "ts": "2026-08-17T01:00:09+00:00"},
+    )
+    s.queue_append("held")
+    d = s.to_dict()
+    assert d["last_turn_ts"] == "2026-08-17T01:00:09+00:00"
+
+
 def test_last_turn_ts_empty_for_empty_slot():
     d = _slot().to_dict()
     assert d["last_turn_ts"] == ""

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -948,6 +948,17 @@ export function useWebSocket() {
               slot: (data as { slot?: string }).slot || store.getState().chat.activeSlot || '',
               message: { role: 'user', content: (data as { content?: string }).content || '', cls: 'msg msg-u', meta: { steer: true }, ts: (data as { ts?: string }).ts },
             }))
+            // Steering is the other way to type into a busy session, so it
+            // settles the rank exactly like a queued send. The server appends a
+            // real `user` row for it, so the authoritative snapshot already
+            // agrees — this only avoids waiting for the next slots push.
+            if ((data as { slot?: string }).slot) {
+              bufferSlotActivity(
+                (data as { slot: string }).slot,
+                (data as { ts?: string }).ts || new Date().toISOString(),
+                true,
+              )
+            }
             break
           case 'queue_cancel':
             dispatch(cancelQueuedMessage(data))

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1293,7 +1293,13 @@ function ChatSidebar({
     // date-sort comparator (`slotActivityTs`).
     const now = Date.now()
     return slots.map(s => {
-      const recent = isWithinRecentWindow(slotActivityTs(s), now, recentWindowMs)
+      // A running turn is recent BY DEFINITION, whatever its settled instant
+      // says. The ordering key deliberately stops advancing mid-turn, so a turn
+      // outliving the window — routine for unattended multi-step work — would
+      // otherwise age out of the Recent list while it is the busiest session on
+      // screen. `workflowActive` / `looping` below extend "running" the same way,
+      // hence the OR against the computed flag rather than `s.running`.
+      const recentByTs = isWithinRecentWindow(slotActivityTs(s), now, recentWindowMs)
       // A slot with a live dynamic-workflow run counts as running so the
       // "In progress" filter (and its count) surfaces it, even though the
       // parent turn has ended while the run executes in the background.
@@ -1304,7 +1310,8 @@ function ChatSidebar({
       // writes through `safeKey`, so a bare index read could resolve a
       // `__proto__`-like key to a truthy `Object.prototype`.
       const looping = Object.prototype.hasOwnProperty.call(goalLoops ?? {}, s.key)
-      return { ...s, running: s.running || !!workflowActive[s.key] || looping, midTurn: s.running, unread: unreadSet.has(s.key), recent }
+      const running = s.running || !!workflowActive[s.key] || looping
+      return { ...s, running, midTurn: s.running, unread: unreadSet.has(s.key), recent: running || recentByTs }
     })
     // `recentTick` is an intentional dep: it forces recency to re-evaluate on
     // the heartbeat above so idle sessions age out of the Recent filter.

--- a/website/src/test/ChatSidebarW3Coverage.test.tsx
+++ b/website/src/test/ChatSidebarW3Coverage.test.tsx
@@ -148,6 +148,7 @@ interface TestSlot {
   messages?: number
   folder_id?: string
   last_ts?: string
+  last_turn_ts?: string
 }
 
 const ALPHA: ChatFolder = { id: 'f1', name: 'Alpha', order: 0 }
@@ -473,6 +474,22 @@ describe('ChatSidebar — sort and filter menu', () => {
     await waitFor(() => expect(localStorage.getItem('mc-flat-hidden-folders')).toBe('[]'))
     // With nothing hidden the reset row retires itself.
     expect(screen.queryByTestId('folder-filter-show-all')).toBeNull()
+  })
+
+  it('keeps a still-running session in the Recent filter however old its settled instant is', async () => {
+    // The ordering key stops advancing mid-turn by design, so a turn outliving
+    // the recency window would age out of "Recent" while it is the busiest
+    // session on screen. Running has to satisfy the filter on its own.
+    const ancient = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+    localStorage.setItem('mc-session-recent-only', '1')
+    renderSidebar({
+      slots: [
+        { key: 'k-run', title: 'still working', running: true, messages: 40, last_turn_ts: ancient },
+        { key: 'k-idle', title: 'long finished', running: false, messages: 40, last_turn_ts: ancient },
+      ],
+    })
+    expect(await screen.findByText('still working')).toBeTruthy()
+    expect(screen.queryByText('long finished')).toBeNull()
   })
 
   it('toggles the Recent filter from its submenu row, by pointer and by keyboard', async () => {

--- a/website/src/test/useWebSocket.slotActivityCoalesce.test.ts
+++ b/website/src/test/useWebSocket.slotActivityCoalesce.test.ts
@@ -374,6 +374,23 @@ describe('useWebSocket slot-activity coalescing', () => {
     expect(lastTurnTs('slot-1')).toBe('2026-08-10T18:00:00Z')
   })
 
+  it('settles the ordering key for a mid-turn steer, like a queued send', () => {
+    // Steering is the other way to type into a busy session; without this the
+    // re-rank waits for the next slots push while a queued send re-ranks at once.
+    seedStore()
+    const { ws } = mount()
+
+    act(() => {
+      ws.simulateMessage({
+        type: 'steer_push',
+        data: { slot: 'slot-1', content: 'actually do X', ts: '2026-08-10T20:00:00Z' },
+      })
+    })
+    runFrames()
+
+    expect(lastTurnTs('slot-1')).toBe('2026-08-10T20:00:00Z')
+  })
+
   it('keeps the newest ts when a settling event arrives before older output', () => {
     // The buffer holds one entry per slot, so an out-of-order pair must not walk
     // the timestamp backwards while still settling the rank.

--- a/website/src/utils/recencyTint.ts
+++ b/website/src/utils/recencyTint.ts
@@ -27,9 +27,12 @@ export function clampTintCount(n: unknown): number {
  * `last_turn_ts` — the same key the sidebar SORTS by — so the tinted rows are the
  * top rows; ranking by `last_ts` instead would repaint the stripe on every
  * streamed tool call and highlight a session sitting further down the list.
- * Falls back to `last_ts` for a payload without the settled field, and excludes
- * sessions with no parseable timestamp so an empty session never occupies a tint
- * slot.
+ * Falls back to `last_ts` for a payload without the settled field.
+ *
+ * The ladder stops one rung SHORT of `slotActivityTs`, which continues on to
+ * `created`: a session that has never run must not occupy a tint slot, so an
+ * unparseable or absent instant is excluded here rather than resolved to its
+ * creation time.
  */
 export function computeRecentRank(
   slots: { key: string; last_turn_ts?: string; last_ts?: string }[],


### PR DESCRIPTION
Follow-up to #4038 (merged as `88bdd709a`), which made `last_turn_ts` — the last
instant a session *settled* — the session list's ordering key. Three of that PR's
advisory lanes found real defects in it; this fixes all three.

## 1. The backend did not rank queued work, so its own snapshot fought the client

*(raised by the Design lane)*

A send that arrives behind a running turn is **queued**, not appended, so the
message scan behind `last_turn_ts` could not see it. The client bumped the key
optimistically on `queue_push` — but any authoritative slots snapshot mid-turn
(reconnect, refetch, any state-change broadcast) replaces the slots array
wholesale and carried the *older* prompt instant. The row the user had just typed
into dropped back down the list for the remainder of the turn: the same
under-the-pointer churn #4038 set out to remove, reached by a narrower path.

The backend now ranks queued entries too, so it is the single owner of the key
rather than racing the client.

The enqueue instant is held **beside** the queue, not on the entry. Entry dicts
are compared wholesale in a great many tests (~70 assertions across
`test_subagent*`, `test_queue_*`, `test_dashboard_chat`), and widening their shape
made all of those depend on a clock. It is read only while the queue is
non-empty, so it cannot outlive the queue it describes.

## 2. A running turn could age out of its own Recent filter

*(raised by the UX lane)*

The ordering key deliberately stops advancing mid-turn, and it also feeds the
Recent filter. A turn outliving the window — routine for unattended multi-step
work, against a 1h default — therefore **vanished from the Recent-filtered list
while it was the busiest session on screen**. Running now satisfies the filter on
its own, alongside the existing `workflowActive` / goal-loop extensions of
"running".

## 3. A mid-turn steer did not settle the rank

*(raised by the UX lane)*

`steer_push` is the other way to type into a busy session; unlike `queue_push` it
had no client-side bump, so the re-rank waited for the next slots push. The
server already appends a real `user` row for a steer, so the authoritative value
was correct — only the echo lagged. Both paths now behave alike.

## 4. Ladder divergence, documented

*(raised by the First Principles lane)*

`computeRecentRank` hand-rolls `last_turn_ts || last_ts` where `slotActivityTs`
continues on to `created`. That difference is deliberate — a session that has
never run must not occupy a tint slot — and is now stated where the ladder is
written, instead of being contradicted by prose claiming one shared helper.

## Deferred, on purpose

The First Principles lane also counted two more lists that still rank by
`last_activity_ts`, which the backend advances on every tool row: the
command-palette recents (`recentsProvider.ts`) and the split-view session picker
(`SessionGridView.tsx`). Both are transient overlays, and the picker
primary-sorts by approval / needs-input / running before recency ever applies, so
neither shows the sustained churn the sidebar did. Left alone rather than widened
into this fix.

## Verification

| Gate | Result |
|---|---|
| `pytest` (full, 55285 passed) | Only the 7 failures + 2 errors this host fails on `origin/main` too (AF_UNIX sockets under the sandbox, PATH-owner checks) |
| `mypy src/kiro_crew/` | 979 files, clean |
| `isort` / `flake8` | clean |
| `tsc -b` | clean |
| `vitest` (targeted, 105) | pass |

New tests: the queued-send instant outranking a stale prompt mid-turn; the queue
being ignored once idle; queue entries keeping their exact shape; a running
session staying in the Recent filter however old its settled instant is; and the
`steer_push` settling bump.

Note on the full backend suite: `-n auto` on a many-core box drives available
memory under 4 GB, which trips the product's *own* subagent admission gate and
manufactures ~60 phantom `test_subagent*` failures. Run at `-n 8`; those files
pass.

## Behaviour evidence

The ordering behaviour this builds on is unchanged, and its before/after
recordings are already on main from #4038:

![Before #4038: three streaming sessions keep swapping position](https://github.com/kirodotdev/KiroCrew/raw/88bdd709a/temp-screenshots/session-order-settled-ts/sidebar-before.gif)

![After #4038: the three streaming sessions hold their position](https://github.com/kirodotdev/KiroCrew/raw/88bdd709a/temp-screenshots/session-order-settled-ts/sidebar-after.gif)

The three defects fixed here are each covered by a test that fails without the
fix; they are state-transition bugs (a snapshot overwriting a key, a filter
predicate, a missing echo) rather than new visual surface.
