### PR TITLE
fix(dashboard): count procs and MCP stubs for subagent rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **Subagent rows in System > Sessions no longer claim to carry no processes
+  and no MCP stubs.** Every task row rendered an em dash in the Procs and MCP
+  stubs columns while its parent session row reported real numbers — the
+  natural reading being that subagents do not participate in the MCP pool at
+  all. That is wrong, and wrong about the thing the page exists to answer: a
+  subagent session spawns its own poolable stub set and reaches the shared
+  backends through the same gateway daemon a top-level session does (measured:
+  18 `--poolable` stubs under one shared subagent runtime, 3 sessions × 6
+  servers, every one pooled). Nothing counted them — `task_memory_rows()`
+  emitted no such fields, the reaper's cost sweep took no such reading, and the
+  frontend hard-coded both to null. The sweep now counts each run's subtree and
+  attributes it the way RSS and CPU already are, split across the co-tenants of
+  a shared runtime. "Not measured yet" stays null (still an em dash, honestly)
+  rather than becoming a 0 that would restate the same false claim. (#3953)
+
 - **A parent agent can read its own sub-agent's result file again on a host
   whose home is a symlink.** The result path handed back in a completion event
   was built through `Path.resolve()`, which is correct for the traversal check

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -379,6 +379,40 @@ def _iter_descendant_pids(pid: int) -> list[int]:
     return order
 
 
+# Marker identifying an MCP stub process inside a runtime's tree. Stubs are the
+# per-server shims a session spawns, so their count is the useful "how many MCP
+# servers is this runtime carrying" signal.
+STUB_MARKER = "mcp_gateway.stub"
+
+
+def read_cmdline(pid: int) -> str:
+    """Return ``/proc/<pid>/cmdline`` as a string, or "" when unreadable."""
+    try:
+        with open(f"/proc/{pid}/cmdline", encoding="utf-8", errors="replace") as fh:
+            return fh.read().replace("\0", " ")
+    except OSError:
+        return ""
+
+
+def count_subtree_procs_and_stubs(pid: int) -> tuple[int, int] | None:
+    """``(process_count, mcp_stub_count)`` for ``pid``'s subtree, or ``None``.
+
+    ``None`` means "not measurable here", which is NOT the same as zero: the
+    walk reads ``/proc``, so it answers only on Linux. Callers must keep that
+    distinction — rendering an unmeasured count as ``0`` states that a session
+    carries no MCP servers, which is a claim rather than a gap.
+
+    Lives here, beside :func:`_iter_descendant_pids`, so the session-memory
+    surface and the subagent sampler share ONE definition of what an MCP stub
+    is. Two copies of that marker would let the parent-session and subagent
+    rows of the same table disagree about what they are counting.
+    """
+    if sys.platform != "linux":
+        return None
+    tree = _iter_descendant_pids(pid)
+    return len(tree), sum(1 for p in tree if STUB_MARKER in read_cmdline(p))
+
+
 #: A whole-machine process table: ``(children_by_ppid, rss_kib_by_pid)``.
 _ProcessTable = tuple[dict[int, list[int]], dict[int, int]]
 

--- a/src/kiro_crew/dashboard/session_memory.py
+++ b/src/kiro_crew/dashboard/session_memory.py
@@ -32,7 +32,11 @@ import time
 from collections import deque
 from typing import TYPE_CHECKING, Callable, Optional
 
-from kiro_crew.acp.runtime import _get_rss_tree_mb, _iter_descendant_pids
+from kiro_crew.acp.runtime import (
+    _get_rss_tree_mb,
+    _iter_descendant_pids,
+    count_subtree_procs_and_stubs,
+)
 from kiro_crew.dashboard.handlers_system import _get_static_system_info
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE
 from kiro_crew.executors import subprocess_executor
@@ -52,20 +56,6 @@ logger = logging.getLogger(__name__)
 # a memory-usage graph is not worth a disk write per poll, and it re-fills within
 # one window after a restart.
 _HISTORY_LEN = 60
-
-# Marker identifying an MCP stub process inside a session's tree. Stubs are the
-# per-server shims a session spawns, so their count is the useful "how many MCP
-# servers is this session carrying" signal.
-_STUB_MARKER = "mcp_gateway.stub"
-
-
-def _read_cmdline(pid: int) -> str:
-    """Return ``/proc/<pid>/cmdline`` as a string, or "" when unreadable."""
-    try:
-        with open(f"/proc/{pid}/cmdline", encoding="utf-8", errors="replace") as fh:
-            return fh.read().replace("\0", " ")
-    except OSError:
-        return ""
 
 
 def _spend_for_session(
@@ -190,12 +180,12 @@ class SessionMemorySampler:
         """Blocking per-pid sample. MUST run off the event loop — a session tree
         can be dozens of processes, i.e. dozens of ``/proc`` reads."""
         rss_mb = _get_rss_tree_mb(pid)
-        procs: Optional[int] = None
-        stubs: Optional[int] = None
-        if sys.platform == "linux":
-            tree = _iter_descendant_pids(pid)
-            procs = len(tree)
-            stubs = sum(1 for p in tree if _STUB_MARKER in _read_cmdline(p))
+        # One shared definition of "process in this tree" / "MCP stub", also used
+        # by the subagent sampler, so the parent and task rows of this very table
+        # cannot disagree about what they are counting (#3953).
+        counts = count_subtree_procs_and_stubs(pid)
+        procs: Optional[int] = counts[0] if counts else None
+        stubs: Optional[int] = counts[1] if counts else None
         return {
             "rss_mb": round(rss_mb, 1) if rss_mb is not None else None,
             "procs": procs,

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -868,6 +868,40 @@ def _proc_cpu_jiffies(pid: int) -> int:
         return 0
 
 
+def _apply_subtree_counts(info: "SubagentInfo", pid: int, shared_n: int) -> None:
+    """Record ``pid``'s subtree process / MCP-stub counts onto ``info``.
+
+    Attributed exactly the way RSS and CPU are in the same sweep: a shared
+    runtime's measurement divided by the number of concurrently-live sharing
+    sessions on that pid, so co-tenants of one runtime each report their share
+    rather than all claiming the whole tree.
+
+    A measured-but-nonzero count never rounds down to 0. Reporting "0 MCP
+    stubs" for a session that demonstrably has some is the misreading this
+    whole change exists to remove, and it would be worse than the em dash it
+    replaced — an em dash at least reads as "unknown". Unmeasurable stays
+    ``None``, which the surface still renders as an em dash, honestly.
+    """
+    # Local import: this module keeps ``acp.runtime`` behind TYPE_CHECKING, and
+    # the same deferred-import pattern is used elsewhere here for exactly that
+    # reason. Called once per live agent per reaper sweep, so the lookup cost is
+    # irrelevant next to the /proc walk it guards.
+    from kiro_crew.acp.runtime import count_subtree_procs_and_stubs
+
+    counts = count_subtree_procs_and_stubs(pid)
+    if counts is None or shared_n <= 0:
+        return
+    procs, stubs = counts
+
+    def _share(total: int) -> int:
+        if total <= 0:
+            return 0
+        return max(1, round(total / shared_n))
+
+    info.last_procs = _share(procs)
+    info.last_mcp_stubs = _share(stubs)
+
+
 def _subtree_cpu_jiffies(pid: int) -> int:
     """Sum utime+stime across ``pid`` and its descendants (clock ticks).
 
@@ -1083,6 +1117,16 @@ class SubagentInfo:
     # sample costs no extra syscalls.
     last_rss_gb: float = 0.0
     last_cpu_cores: float = 0.0
+    # Subtree process / MCP-stub counts from the same sweep. ``None`` means NOT
+    # MEASURED (no sweep yet, or a platform with no ``/proc``) and must stay
+    # distinct from 0: the System > Sessions task rows rendered a hard-coded
+    # null as an em dash, which read as "this subagent carries no MCP stubs" —
+    # a claim, and a wrong one. A shared subagent runtime does spawn its own
+    # poolable stub set (measured: 18 under one runtime, 3 sessions x 6
+    # servers) and reaches the shared backends through the same gateway daemon
+    # a top-level session does (#3953).
+    last_procs: Optional[int] = None
+    last_mcp_stubs: Optional[int] = None
     _cpu_jiffies_prev: int = 0  # last subtree utime+stime sample (clock ticks)
     _cpu_sample_ts: float = 0.0  # monotonic time of the last CPU sample
     # Session sharing — when True, this subagent runs as a session on the
@@ -1703,6 +1747,7 @@ class SubagentManager:
                             info.peak_cpu_cores = cores
                 info._cpu_jiffies_prev = jiffies
                 info._cpu_sample_ts = now
+                _apply_subtree_counts(info, pid_owner, shared_n)
                 continue
             pid = info._pid
             rss_kb = _proc_rss_kb(pid)
@@ -1721,6 +1766,7 @@ class SubagentManager:
                         info.peak_cpu_cores = cores
             info._cpu_jiffies_prev = jiffies
             info._cpu_sample_ts = now
+            _apply_subtree_counts(info, pid, 1)
 
     def _record_cost(self, info: SubagentInfo) -> None:
         """Persist this run's high-water RSS/CPU to the learned-cost store."""
@@ -2579,7 +2625,14 @@ class SubagentManager:
 
         ``shared`` mirrors ``_session_sharing``: the value is that runtime's
         measurement divided by the number of concurrently-live sharing sessions
-        on the same pid, i.e. an average share, not an exclusive figure.
+        on the same pid, i.e. an average share, not an exclusive figure. The
+        same split applies to ``procs``/``mcp``.
+
+        ``procs`` and ``mcp`` are the subtree's process and MCP-stub counts.
+        They were previously not emitted at all, so the System > Sessions task
+        rows hard-coded both to null and rendered an em dash — which reads as
+        "a subagent carries no MCP stubs", a claim rather than a gap, and wrong
+        about the very thing that page exists to answer (#3953).
         """
         return [
             {
@@ -2593,6 +2646,12 @@ class SubagentManager:
                 "started_at": a.started,
                 "shared": a._session_sharing,
                 "pid": a._pid,
+                # None until the first sweep observes this agent (or on a
+                # platform with no /proc). Deliberately NOT coerced to 0: the
+                # surface renders null as an em dash, and "0 MCP stubs" would be
+                # a false claim where the em dash is an honest "not measured".
+                "procs": a.last_procs,
+                "mcp": a.last_mcp_stubs,
                 "sampled": a.last_rss_gb > 0.0 or a.peak_rss_gb > 0.0,
             }
             for a in self._agents.values()

--- a/test/test_dashboard_sessions_memory.py
+++ b/test/test_dashboard_sessions_memory.py
@@ -58,12 +58,17 @@ def _row(key: str, pid: int | None) -> dict[str, object]:
 @pytest.fixture(autouse=True)
 def stub_proc(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep the handler off real /proc — the sampler is unit-tested separately."""
+    from kiro_crew.acp import runtime as rt
     from kiro_crew.dashboard import session_memory as sm
 
     monkeypatch.setattr(sm.sys, "platform", "linux")
     monkeypatch.setattr(sm, "_get_rss_tree_mb", lambda pid: 1525.0)
     monkeypatch.setattr(sm, "_iter_descendant_pids", lambda pid: [pid, pid + 1])
-    monkeypatch.setattr(sm, "_read_cmdline", lambda pid: "")
+    # The subtree walk + stub marker moved to acp.runtime so the session rows
+    # and the subagent rows of this table share one definition (#3953); patch it
+    # at its new home. Same shape as before: 2 procs, no stubs.
+    monkeypatch.setattr(rt, "_iter_descendant_pids", lambda pid: [pid, pid + 1])
+    monkeypatch.setattr(rt, "read_cmdline", lambda pid: "")
     monkeypatch.setattr(sm, "_subtree_cpu_jiffies", lambda pid: 0)
     monkeypatch.setattr(sm, "_get_static_system_info", lambda: {"mem_total_gb": 48.0})
 

--- a/test/test_subagent_sizing.py
+++ b/test/test_subagent_sizing.py
@@ -984,6 +984,115 @@ class TestLastSampleAndMemoryRows:
         (row,) = m.task_memory_rows()
         assert row["sampled"] is False
 
+    # ── Subtree process / MCP-stub counts (#3953) ──────────────────────────
+    #
+    # task_memory_rows emitted no procs/mcp fields at all, so sessionRows.taskRow
+    # hard-coded both to null and every subagent row rendered an em dash in the
+    # Procs and MCP-stubs columns. That reads as "a subagent carries no MCP
+    # stubs" -- a claim, and wrong about the thing the page exists to answer.
+
+    def _counts(self, monkeypatch, procs: int, stubs: int) -> None:
+        import kiro_crew.acp.runtime as rt
+
+        monkeypatch.setattr(
+            rt, "count_subtree_procs_and_stubs", lambda _pid: (procs, stubs)
+        )
+
+    def test_rows_report_the_sampled_subtree_counts(self, monkeypatch) -> None:
+        import kiro_crew.subagent as sub
+
+        m = _mgr(running=1, max_concurrent=16, last_ts=0.0)
+        info = self._agent(id="a1")
+        m._agents = {"a1": info}
+        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: 1024 * 1024)
+        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: 0)
+        self._counts(monkeypatch, procs=9, stubs=6)
+        m._sample_live_costs()
+
+        (row,) = m.task_memory_rows()
+        assert row["procs"] == 9
+        assert row["mcp"] == 6
+
+    def test_shared_co_tenants_each_report_their_share(self, monkeypatch) -> None:
+        """Attributed exactly like RSS and CPU: the runtime's counts divided by
+        the live sharing sessions on that pid. Measured on a live host: 18
+        stubs under one shared runtime, 3 sessions x 6 servers."""
+        import kiro_crew.subagent as sub
+
+        m = _mgr(running=3, max_concurrent=16, last_ts=0.0)
+        agents = {
+            f"a{i}": self._agent(id=f"a{i}", _session_sharing=True) for i in range(1, 4)
+        }
+        m._agents = agents
+        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: 1024 * 1024)
+        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: 0)
+        self._counts(monkeypatch, procs=21, stubs=18)
+        m._sample_live_costs()
+
+        for row in m.task_memory_rows():
+            assert row["procs"] == 7
+            assert row["mcp"] == 6
+
+    def test_a_measured_nonzero_count_never_rounds_down_to_zero(
+        self, monkeypatch
+    ) -> None:
+        """Reporting "0 MCP stubs" for a session that demonstrably has some is
+        WORSE than the em dash it replaced -- an em dash reads as unknown."""
+        import kiro_crew.subagent as sub
+
+        m = _mgr(running=4, max_concurrent=16, last_ts=0.0)
+        agents = {
+            f"a{i}": self._agent(id=f"a{i}", _session_sharing=True) for i in range(1, 5)
+        }
+        m._agents = agents
+        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: 1024 * 1024)
+        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: 0)
+        self._counts(monkeypatch, procs=4, stubs=1)  # 1/4 would round to 0
+        m._sample_live_costs()
+
+        for row in m.task_memory_rows():
+            assert row["mcp"] == 1
+
+    def test_a_genuinely_zero_count_stays_zero(self, monkeypatch) -> None:
+        import kiro_crew.subagent as sub
+
+        m = _mgr(running=1, max_concurrent=16, last_ts=0.0)
+        m._agents = {"a1": self._agent(id="a1")}
+        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: 1024 * 1024)
+        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: 0)
+        self._counts(monkeypatch, procs=1, stubs=0)
+        m._sample_live_costs()
+
+        (row,) = m.task_memory_rows()
+        assert row["mcp"] == 0
+
+    def test_an_unmeasured_task_reports_null_not_zero(self) -> None:
+        """No sweep yet (or no /proc): null, which the surface renders as an em
+        dash -- honest, unlike a 0 that would assert "no MCP stubs"."""
+        m = _mgr(running=1, max_concurrent=16, last_ts=0.0)
+        m._agents = {"a1": self._agent(id="a1")}
+
+        (row,) = m.task_memory_rows()
+        assert row["procs"] is None
+        assert row["mcp"] is None
+
+    def test_an_unmeasurable_platform_leaves_the_counts_null(
+        self, monkeypatch
+    ) -> None:
+        import kiro_crew.acp.runtime as rt
+        import kiro_crew.subagent as sub
+
+        m = _mgr(running=1, max_concurrent=16, last_ts=0.0)
+        m._agents = {"a1": self._agent(id="a1")}
+        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: 1024 * 1024)
+        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: 0)
+        monkeypatch.setattr(rt, "count_subtree_procs_and_stubs", lambda _pid: None)
+        m._sample_live_costs()
+
+        (row,) = m.task_memory_rows()
+        assert row["procs"] is None
+        assert row["mcp"] is None
+
     def test_done_and_queued_agents_are_excluded(self) -> None:
         m = _mgr(running=1, max_concurrent=16, last_ts=0.0)
         m._agents = {

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1628,6 +1628,9 @@ export const api = {
     tasks: {
       id: string; task: string; agent: string; parent: string
       rss_mb: number; peak_rss_mb: number; cpu_cores: number
+      // null = not measured yet (no sweep, or no /proc). Distinct from 0, which
+      // would assert that a subagent carries no MCP stubs -- it does carry them.
+      procs: number | null; mcp: number | null
       started_at: number; shared: boolean; pid: number | null; sampled: boolean
     }[]
     totals: {

--- a/website/src/pages/system/sessionRows.ts
+++ b/website/src/pages/system/sessionRows.ts
@@ -164,8 +164,14 @@ function taskRow(t: TaskPayloadRow): SessionRow {
     rssMb: t.sampled ? t.rss_mb : null,
     peakMb: t.sampled ? t.peak_rss_mb : null,
     cpuCores: t.sampled ? t.cpu_cores : null,
-    procs: null,
-    mcp: null,
+    // Previously hard-coded null, which the cell renderer turns into an em
+    // dash -- reading as "this subagent carries no processes and no MCP
+    // stubs". It does carry them: a subagent session spawns its own poolable
+    // stub set and reaches the shared backends through the same gateway daemon
+    // a top-level session does (#3953). Still null when the backend has not
+    // measured yet, which is what an em dash should mean.
+    procs: t.procs ?? null,
+    mcp: t.mcp ?? null,
     credits: null,
     turns: null,
     uptimeS: t.started_at ? Date.now() / 1000 - t.started_at : null,

--- a/website/src/test/sessionRows.test.ts
+++ b/website/src/test/sessionRows.test.ts
@@ -45,6 +45,8 @@ const task = (over: Partial<TaskPayloadRow> = {}): TaskPayloadRow => ({
   rss_mb: 50,
   peak_rss_mb: 60,
   cpu_cores: 0.05,
+  procs: 4,
+  mcp: 6,
   started_at: Date.now() / 1000 - 30,
   shared: false,
   pid: 8,
@@ -421,5 +423,39 @@ describe('buildTree credits and turns', () => {
     const rows = buildTree([session()], [task()])
     expect(rows[0].subRows![0].credits).toBeNull()
     expect(rows[0].subRows![0].turns).toBeNull()
+  })
+})
+
+// ── Task rows carry their own procs / MCP-stub counts (#3953) ──
+
+describe('task row procs and MCP stubs', () => {
+  it('reports the counts the backend measured instead of a hard-coded null', () => {
+    // Both were hard-coded null here, and the cell renderer turns null into an
+    // em dash -- which reads as "this subagent carries no processes and no MCP
+    // stubs". A subagent session spawns its own poolable stub set and reaches
+    // the shared backends through the same gateway daemon a top-level session
+    // does, so the em dash was a claim rather than a gap.
+    const rows = buildTree([session()], [task()])
+    const t = rows[0].subRows![0]
+    expect(t.kind).toBe('task')
+    expect(t.procs).toBe(4)
+    expect(t.mcp).toBe(6)
+  })
+
+  it('keeps null when the backend has not measured yet', () => {
+    // "Not measured" is what an em dash should mean, and it must stay
+    // reachable -- a fresh task has had no reaper sweep, and a non-Linux host
+    // cannot walk /proc at all.
+    const rows = buildTree([session()], [task({ procs: null, mcp: null })])
+    const t = rows[0].subRows![0]
+    expect(t.procs).toBeNull()
+    expect(t.mcp).toBeNull()
+  })
+
+  it('does not turn a genuine zero into a null', () => {
+    const rows = buildTree([session()], [task({ procs: 1, mcp: 0 })])
+    const t = rows[0].subRows![0]
+    expect(t.procs).toBe(1)
+    expect(t.mcp).toBe(0)
   })
 })


### PR DESCRIPTION
Closes #3953.

## Problem

In **System > Sessions** every subagent (task) row rendered an em dash in the **Procs** and **MCP stubs** columns while its parent session row reported real numbers. The natural reading is that a subagent carries no MCP stubs — that subagents do not participate in the MCP pool at all.

That reading is wrong, and it is wrong about the thing this page exists to answer. A subagent session spawns its own poolable stub set and reaches the shared backends through the same gateway daemon a top-level session does. The parent row *does* account for them (its subtree includes the subagent runtime), which is what makes the child rows' em dashes look like a claim rather than a gap.

Nothing counted them: `task_memory_rows()` emitted no `procs`/`mcp` fields, `_sample_live_costs` took no such reading, and with the fields absent `sessionRows.taskRow()` hard-coded both to `null`.

## Fix

- **`_sample_live_costs`** counts each run's subtree in the same sweep that samples RSS and CPU, and attributes it the same way: a shared runtime's measurement divided by the number of concurrently-live sharing sessions on that pid.
- **A measured-but-nonzero count never rounds down to 0.** Reporting "0 MCP stubs" for a session that demonstrably has some would be *worse* than the em dash it replaced — an em dash at least reads as unknown.
- **Unmeasured stays `null`** (no sweep yet, or no `/proc`), which the surface still renders as an em dash. That is what an em dash should mean.

The subtree walk and the stub marker move to `acp.runtime` as `count_subtree_procs_and_stubs()`, beside the `_iter_descendant_pids` they already used. One definition, shared by the session sampler and the subagent sampler — two copies of that marker would let the parent-session and subagent rows of the *same table* disagree about what they are counting. `subagent.py` reaches it through a local import, matching how that module already keeps `acp.runtime` behind `TYPE_CHECKING`.

## Test plan

- **`test/test_subagent_sizing.py`**: 6 new tests — rows report the sampled counts; shared co-tenants each report their share (21 procs / 18 stubs across 3 sessions → 7 and 6, the measured shape from the issue); a 1-stub runtime split 4 ways still reports 1, not 0; a genuine 0 stays 0; and both the never-swept and no-`/proc` cases stay null.
- **`website/src/test/sessionRows.test.ts`**: 3 new tests — the task row reports the measured counts instead of a hard-coded null, keeps null when unmeasured, and does not turn a genuine 0 into a null.
- `test/test_dashboard_sessions_memory.py`'s autouse fixture patched `session_memory._read_cmdline`, which moved; retargeted to `acp.runtime` with the same 2-procs/no-stubs shape. **No assertions changed.**
- `test_subagent_sizing` + `test_subagent_coverage` + `test_dashboard_sessions_memory` + `test_acp_runtime`: **528 passed**. **6 fail on main.**
- `sessionRows` + `SessionsTab`: **87 passed**. **2 fail on main.**
- `npx tsc --noEmit` clean. `flake8` clean on touched files.

Note: the counting walk is Linux-only (it reads `/proc`), exactly as the parent-row counts already were — on other platforms both rows report the same honest em dash.