### PR TITLE
fix(subagent): emit result paths in the home spelling the reader can use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **A parent agent can read its own sub-agent's result file again on a host
+  whose home is a symlink.** The result path handed back in a completion event
+  was built through `Path.resolve()`, which is correct for the traversal check
+  it exists to serve and wrong for a path somebody is told to go read: on an
+  Amazon cloud desktop, where `/home/<user>` is a symlink to
+  `/local/home/<user>`, that resolved spelling carries a `/local/home/...`
+  prefix the reader's own path allowlist -- keyed on the `$HOME` it was given --
+  does not match. The file was always readable; only the spelling was
+  unrecognized. So the read was refused, and refused as an approval prompt that
+  times out rather than as an error, which made a whole wave of sub-agent
+  results look unreadable while the parent concluded it lacked permission.
+  Paths emitted as TEXT (the completion event, the batch digest, `spawn_status`,
+  the prior-result hint on an unresumable conversation, and `info.result_path`
+  wherever it surfaces) now carry the declared home spelling, while every path
+  used to open a file stays symlink-resolved so the traversal check is unchanged.
+  Validation is delegated to the resolving helper rather than duplicated, so the
+  two cannot drift apart.
+
 - **A long-running cron job's next tick is no longer dispatched up to 30s
   late.** A job is invisible to the scheduler's wake computation while it's
   executing (`_next_wake_secs` skips anything in `self._executing`), so for

--- a/src/kiro_crew/mcp_tools/spawn.py
+++ b/src/kiro_crew/mcp_tools/spawn.py
@@ -30,7 +30,7 @@ from kiro_crew.mcp_shared import ToolCancelled, is_tool_cancelled
 from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.subagent import resolve_max_subagents
-from kiro_crew.subagent_persistence import _agent_dir
+from kiro_crew.subagent_persistence import agent_dir_for_display
 from kiro_crew.validation import (
     MAX_MEDIUM_STRING,
     MAX_SHORT_STRING,
@@ -865,7 +865,7 @@ def spawn_sub_agents(name: str, args: dict[str, Any]) -> str:
             # context window and causing attention degradation.
             if len(result_text) > COMPLETION_KEEP_DEFAULT_CHARS:
                 try:
-                    result_path = str(_agent_dir(aid) / "result.txt")
+                    result_path = str(agent_dir_for_display(aid) / "result.txt")
                 except (ValueError, OSError):
                     result_path = ""
                 if result_path:

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -89,6 +89,7 @@ from kiro_crew.subagent_persistence import (
     _agent_dir,
     _cleanup_session_files_sync,
     _subagents_dir,
+    agent_dir_for_display,
     clear_tombstone,
     create_agent_folder,
     list_orphans,
@@ -1540,7 +1541,7 @@ class SubagentManager:
         """
         task_preview = (state.get("task", "") or "")[:100]
         parent_session = state.get("parent_session", "")
-        result_path = str(_agent_dir(agent_id) / "result.txt")
+        result_path = str(agent_dir_for_display(agent_id) / "result.txt")
 
         if has_result:
             msg = (
@@ -3372,7 +3373,7 @@ class SubagentManager:
             # (result.txt outlives the session under the tombstone TTL).
             result_hint = ""
             try:
-                _rp = _agent_dir(conv_id) / "result.txt"
+                _rp = agent_dir_for_display(conv_id) / "result.txt"
                 if _rp.exists():
                     result_hint = f" Prior result still readable at: {_rp}"
             except Exception:
@@ -5025,7 +5026,7 @@ class SubagentManager:
         except Exception:
             logger.debug("Failed to record session_id for %s", info.id, exc_info=True)
 
-        _rp = _agent_dir(info.id) / "result.txt"
+        _rp = agent_dir_for_display(info.id) / "result.txt"
         info.result_path = str(_rp)
         # Cache tool names by tool_call_id so PostToolUse can recover the tool name
         # when EVENT_TOOL_RESULT arrives (which only carries tool_call_id and output).

--- a/src/kiro_crew/subagent_persistence.py
+++ b/src/kiro_crew/subagent_persistence.py
@@ -53,6 +53,35 @@ def _agent_dir(agent_id: str) -> Path:
     return resolved
 
 
+def agent_dir_for_display(agent_id: str) -> Path:
+    """The run directory in the home spelling the reader's own tooling uses.
+
+    :func:`_agent_dir` returns a symlink-RESOLVED path, and must: a traversal
+    check is only sound against the canonical target. That resolved spelling is
+    the right one to open a file with, and the wrong one to hand to somebody as
+    a path to go read.
+
+    On a host whose home is itself a symlink the two spellings differ. An Amazon
+    cloud desktop's ``/home/<user> -> /local/home/<user>`` is the ordinary case,
+    and there ``data_home()`` under ``$HOME`` resolves to a ``/local/home/...``
+    prefix that the reader's path allowlist -- keyed on the ``$HOME`` it was
+    given -- does not match. The file is readable; the spelling is not
+    recognized. So a result path emitted in resolved form is refused, while the
+    identical file in declared form is allowed, and the refusal arrives as an
+    approval prompt that times out rather than as an error anyone can act on.
+
+    Hence: validate on the resolved form, hand out the declared one. Callers
+    doing file I/O keep using :func:`_agent_dir`; this is for a path that a
+    human or an agent will read and then act on.
+
+    Raises the same ``ValueError`` as :func:`_agent_dir` for a rejected
+    ``agent_id`` -- the validation is not duplicated here, it is delegated, so
+    the two cannot drift apart.
+    """
+    _agent_dir(agent_id)  # validation only; the return value is deliberately unused
+    return _subagents_dir() / agent_id
+
+
 # ── create ───────────────────────────────────────────────────────────
 
 

--- a/test/test_subagent_result_path_spelling.py
+++ b/test/test_subagent_result_path_spelling.py
@@ -1,0 +1,198 @@
+"""A subagent result path is emitted in the home spelling its reader can use.
+
+Regression guard for the case where the data home sits under a SYMLINKED home
+directory. ``/home/<user> -> /local/home/<user>`` is the ordinary layout on an
+Amazon cloud desktop, and there a path built through ``Path.resolve()`` comes
+back with a ``/local/home/...`` prefix that does not match the ``$HOME`` a
+reader's path allowlist was keyed on. The file is perfectly readable; only the
+spelling is unrecognized, so the read is refused rather than failing, and the
+refusal surfaces as an approval prompt that times out instead of an error
+anybody can act on.
+
+The invariant these tests pin: every subagent path handed to a reader as TEXT
+carries the declared home spelling, while the paths used to actually open files
+stay symlink-resolved so the traversal check remains sound.
+
+Each test asserts an observable emission, not an internal call, so reverting
+``agent_dir_for_display`` back to ``_agent_dir`` at any of the emission sites
+fails it.
+"""
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from kiro_crew import subagent_persistence
+from kiro_crew.subagent_persistence import (
+    _agent_dir,
+    agent_dir_for_display,
+    create_agent_folder,
+    write_result_chunk,
+)
+
+_AGENT_ID = "a1b2c3d4"
+
+
+@pytest.fixture
+def symlinked_home(tmp_path, monkeypatch):
+    """A data home reached through a symlink, mirroring /home -> /local/home.
+
+    Yields ``(declared, real)`` data-home paths. ``declared`` is what a caller
+    is configured with and what its allowlist knows; ``real`` is what
+    ``Path.resolve()`` returns. On a platform without usable symlinks the test
+    is skipped rather than silently asserting nothing.
+    """
+    real = tmp_path / "local" / "home" / "u" / ".kiro" / "crew"
+    real.mkdir(parents=True)
+    link_root = tmp_path / "home"
+    link_root.mkdir()
+    try:
+        (link_root / "u").symlink_to(tmp_path / "local" / "home" / "u")
+    except (OSError, NotImplementedError):  # pragma: no cover - platform guard
+        pytest.skip("symlinks unavailable on this platform")
+
+    declared = link_root / "u" / ".kiro" / "crew"
+    if declared.resolve() == declared:  # pragma: no cover - platform guard
+        pytest.skip("symlink not resolved distinctly on this platform")
+
+    monkeypatch.setattr(
+        subagent_persistence, "_SUBAGENTS_DIR", declared / "subagents", raising=False
+    )
+    (declared / "subagents").mkdir(parents=True, exist_ok=True)
+    yield declared, real
+
+
+class TestTheTwoSpellingsAreActuallyDifferent:
+    """Guards the fixture itself: without a real divergence nothing is proven."""
+
+    def test_the_fixture_produces_a_distinct_resolved_prefix(self, symlinked_home):
+        declared, real = symlinked_home
+        assert str(declared) != str(real)
+        assert declared.resolve() == real.resolve()
+
+
+class TestDisplayPathsUseTheDeclaredHome:
+    def test_display_helper_returns_the_declared_spelling(self, symlinked_home):
+        declared, real = symlinked_home
+        shown = agent_dir_for_display(_AGENT_ID)
+        assert str(shown).startswith(str(declared))
+        assert str(real) not in str(shown)
+
+    def test_io_helper_still_returns_the_resolved_spelling(self, symlinked_home):
+        _declared, real = symlinked_home
+        opened = _agent_dir(_AGENT_ID)
+        assert str(opened).startswith(str(real))
+
+    def test_both_spellings_name_the_same_file(self, symlinked_home):
+        create_agent_folder(_AGENT_ID, task="t", agent="")
+        write_result_chunk(_AGENT_ID, "payload")
+        shown = agent_dir_for_display(_AGENT_ID) / "result.txt"
+        opened = _agent_dir(_AGENT_ID) / "result.txt"
+        assert shown.read_text(encoding="utf-8") == "payload"
+        assert os.path.samefile(shown, opened)
+
+    def test_display_helper_delegates_traversal_validation(self, symlinked_home):
+        for bad in ("", ".", "..", "a/b", "a\\b", "a\0b"):
+            with pytest.raises(ValueError):
+                agent_dir_for_display(bad)
+
+
+class TestEmittedResultPointersAreReadable:
+    """Drives the real emission, not a copy of it.
+
+    ``_notify_orphan`` builds the completion notice a parent agent is told to
+    go read. With no parent session there is no injection surface, so it takes
+    the undelivered branch and hands the message straight back without touching
+    ``self`` -- which is what makes it callable here against a bare stub.
+    """
+
+    def _notice(self, agent_id: str) -> str:
+        import asyncio
+
+        from kiro_crew.subagent import SubagentManager
+
+        stub = object.__new__(SubagentManager)  # never touched on this branch
+        msg = asyncio.run(
+            SubagentManager._notify_orphan(
+                stub,
+                agent_id,
+                {"task": "summarize the diff", "parent_session": ""},
+                recovery="undeliverable",
+                has_result=True,
+            )
+        )
+        assert msg is not None, "the undelivered branch must hand the message back"
+        return msg
+
+    def test_orphan_notice_names_a_path_the_reader_can_use(self, symlinked_home):
+        declared, real = symlinked_home
+        msg = self._notice(_AGENT_ID)
+        assert str(declared) in msg, f"declared home missing from notice: {msg}"
+        assert str(real) not in msg, (
+            "the notice hands out the symlink-resolved spelling, which the "
+            f"reader's allowlist does not recognize: {msg}"
+        )
+
+    def test_the_named_path_is_actually_openable(self, symlinked_home):
+        create_agent_folder(_AGENT_ID, task="t", agent="")
+        write_result_chunk(_AGENT_ID, "payload")
+        msg = self._notice(_AGENT_ID)
+        # Pull the backticked path back out of the notice and open it, so the
+        # test proves the emitted text is usable rather than merely well-spelled.
+        quoted = [p for p in msg.split("`") if p.endswith("result.txt")]
+        assert quoted, f"no result path found in notice: {msg}"
+        assert Path(quoted[0]).read_text(encoding="utf-8") == "payload"
+
+
+class TestNoEmissionSiteStillUsesTheResolvedHelper:
+    """A grep-level guard so a NEW emission site cannot quietly regress this.
+
+    Reads the source rather than exercising every call path: the point is that
+    ``_agent_dir`` may only reach file operations, and a future edit that
+    stringifies it into a message would otherwise pass unnoticed.
+    """
+
+    _SRC = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+
+    def test_agent_dir_is_never_stringified_into_text(self):
+        offenders = []
+        for rel in ("subagent.py", "mcp_tools/spawn.py"):
+            # Explicit utf-8: these sources carry non-ASCII in comments, and a
+            # Windows runner's default cp1252 cannot decode them.
+            source = (self._SRC / rel).read_text(encoding="utf-8")
+            for lineno, line in enumerate(source.splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("#") or "_agent_dir(" not in stripped:
+                    continue
+                if "agent_dir_for_display(" in stripped:
+                    continue
+                # str(...) or an f-string interpolation means the path is
+                # becoming text somebody will read, not a file being opened.
+                if "str(_agent_dir(" in stripped or "{_agent_dir(" in stripped:
+                    offenders.append(f"{rel}:{lineno}: {stripped}")
+        assert not offenders, (
+            "these sites stringify the symlink-resolved path into text; use "
+            "agent_dir_for_display() so the reader's allowlist recognizes it:\n"
+            + "\n".join(offenders)
+        )
+
+
+class TestUnsymlinkedHomeIsUnchanged:
+    """On an ordinary home the two helpers agree, so nothing else shifts."""
+
+    def test_helpers_agree_when_home_is_not_a_symlink(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            subagent_persistence, "_SUBAGENTS_DIR", tmp_path / "subagents", raising=False
+        )
+        (tmp_path / "subagents").mkdir()
+        assert agent_dir_for_display(_AGENT_ID).resolve() == _agent_dir(_AGENT_ID)
+
+    def test_display_helper_does_not_touch_the_filesystem(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            subagent_persistence, "_SUBAGENTS_DIR", tmp_path / "subagents", raising=False
+        )
+        (tmp_path / "subagents").mkdir()
+        with mock.patch.object(Path, "mkdir", side_effect=AssertionError("must not create")):
+            agent_dir_for_display(_AGENT_ID)


### PR DESCRIPTION
## What broke

A parent agent handed its sub-agent's result path could not read the file, on any host whose home directory is a symlink. `/home/<user> -> /local/home/<user>` is the ordinary layout on an Amazon cloud desktop.

`_agent_dir()` returns `Path.resolve()` output. That is correct for the traversal check it exists to serve, since such a check is only sound against the canonical target. But the same value was being stringified into the completion event a parent is told to go read, and there the resolved spelling carries a `/local/home/...` prefix that the reader's own path allowlist, keyed on the `$HOME` it was given, does not match.

The file was always readable. Only the spelling was unrecognized.

## Why it was expensive

The refusal did not arrive as an error. It arrived as an approval prompt that times out. Observed: three consecutive ten-minute timeouts while an eight-agent review wave's results sat on disk, with the parent concluding it lacked permission to read its own output and reporting that to the user. A deterministic path bug presented as a permissions problem.

The decisive experiment is one file under two spellings: `/local/home/<user>/.kiro/crew/subagents/<id>/result.txt` refused three times, `/home/<user>/.kiro/crew/subagents/<id>/result.txt` allowed immediately.

## The change

Validate on the resolved form, hand out the declared one.

`agent_dir_for_display()` delegates to `_agent_dir()` for validation rather than repeating it, so the two cannot drift apart, and returns the unresolved path. Applied at the four sites that turn a run directory into text:

| Site | Surfaces as |
|---|---|
| `subagent.py` orphan completion notice | the `Result saved at:` line a parent is told to read |
| `subagent.py` prior-result hint | the error on an unresumable `spawn_continue` |
| `subagent.py` `info.result_path` | the batch digest's per-agent line, `spawn_list`, the messaging API |
| `mcp_tools/spawn.py` `summarize_result` pointer | `spawn_status` output when a result exceeds the keep threshold |

Everything that opens a file keeps using `_agent_dir()`. The one remaining call in `subagent.py` is an `exists()`/`stat()` pair, and every call in `subagent_persistence.py` is I/O. Both stay resolved.

### Checked before touching a shared field

`info.result_path` is not display-only: the messaging handler passes it to `is_sensitive_path()`. That predicate matches against multiple candidate forms including the fully symlink-resolved one, so the declared spelling cannot weaken its verdict. `cap_result_file()` and `os.path.getsize()` also consume the field and are unaffected, since the declared path names the same file.

## Tests

`test/test_subagent_result_path_spelling.py` builds a genuinely symlinked data home, and skips rather than silently asserting nothing where the platform cannot produce one. It also guards its own fixture: one test asserts the two spellings actually diverge, because without that the rest would prove nothing.

- Drives `_notify_orphan` for real instead of restating the assignment, then pulls the path back out of the emitted notice and opens it, so the test proves the text is usable rather than merely well-spelled
- Asserts the resolving helper still returns the resolved form, so the traversal guarantee is pinned too
- A source-level guard fails if any future edit stringifies `_agent_dir` into text, which is what protects the sites the unit tests do not reach
- Reverting the emission sites while keeping the helper fails two of these, verified rather than assumed

Local gates: 262 existing subagent, persistence and mcp-core tests pass; isort, flake8 and mypy clean on the changed modules.

## Scope note

This fixes the paths KiroCrew emits. The deeper fix, making the allowlist comparison symlink-aware on both sides so any path an agent constructs is recognized, appears to live in the client rather than here: `fs_read` is not in the agent spec's `allowedTools` and the spec carries no per-path read allowlist, yet reads under `$HOME` are auto-approved. I could not pin down which layer owns that rule, so I have not touched it. Emitting a recognized spelling is sufficient for this defect and is the half that clearly belongs to KiroCrew.