### PR TITLE
fix: anchor papyrus URL/name validators with \Z to reject trailing newline (#4040)

### DIFF
--- a/src/kiro_crew/apps/builtins/papyrus/backend/gitops.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/gitops.py
@@ -46,7 +46,10 @@ logger = logging.getLogger("kirocrew.app.papyrus")
 
 #: A clone URL must match a known transport. Modern git already refuses an
 #: option-shaped URL, but the check is free and closes the door on every version.
-GIT_URL_RE = re.compile(r"^(?:https?|git|ssh)://[^\s]+$|^git@[\w.-]+:[^\s]+$")
+#: Anchored at ``\Z`` in both alternations: Python's ``$`` matches before a
+#: trailing newline, so a ``$`` anchor would accept ``"https://host/repo\n"``
+#: and hand the newline through to git's argv.
+GIT_URL_RE = re.compile(r"^(?:https?|git|ssh)://[^\s]+\Z|^git@[\w.-]+:[^\s]+\Z")
 
 #: Wall-clock ceilings, by operation cost.
 CLONE_TIMEOUT_SEC = 120.0

--- a/src/kiro_crew/apps/builtins/papyrus/backend/store.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/store.py
@@ -55,7 +55,10 @@ MAIN_FILE_CANDIDATES = ("main.tex", "paper.tex", "article.tex", "manuscript.tex"
 #: A project name must be one lowercase slug segment. Anything else (a slash, a
 #: dot, a leading dash) is refused rather than sanitized, because a "cleaned up"
 #: name silently addresses a different project than the one the user typed.
-PROJECT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+#: Anchored at ``\Z``: Python's ``$`` matches before a trailing newline, so a
+#: ``$`` anchor would accept ``"name\n"`` and mint a directory whose name
+#: carries the newline into every later ``git``/``pdflatex`` argv.
+PROJECT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}\Z")
 
 #: Ceiling on how many files ``list_files`` will walk/return. A cloned repo can
 #: contain a build tree; an unbounded walk would be both a slow response and an

--- a/test/test_papyrus_gitops.py
+++ b/test/test_papyrus_gitops.py
@@ -78,19 +78,28 @@ class _GitScript:
         return next(c for c in self.calls if c[0] == verb)
 
 
+#: Every transport the URL gate accepts. Shared by the accept test and the
+#: trailing-newline regression test so a new transport is automatically covered
+#: by both.
+_ACCEPTED_URLS = (
+    "https://example.com/group/paper.git",
+    "http://example.com/paper",
+    "ssh://git@example.com/paper.git",
+    "git://example.com/paper.git",
+    "git@example.com:group/paper.git",
+)
+
+
 class TestUrlValidation:
-    @pytest.mark.parametrize(
-        "url",
-        [
-            "https://example.com/group/paper.git",
-            "http://example.com/paper",
-            "ssh://git@example.com/paper.git",
-            "git://example.com/paper.git",
-            "git@example.com:group/paper.git",
-        ],
-    )
+    @pytest.mark.parametrize("url", _ACCEPTED_URLS)
     def test_accepts_known_transports(self, url: str) -> None:
         assert gitops.GIT_URL_RE.match(url)
+
+    @pytest.mark.parametrize("url", _ACCEPTED_URLS)
+    def test_rejects_trailing_newline_on_accepted_url(self, url: str) -> None:
+        """Python's ``$`` matches before a trailing newline; the ``\\Z`` anchor
+        must not, or ``.match`` on a client URL hands the newline to git argv."""
+        assert gitops.GIT_URL_RE.match(url + "\n") is None
 
     @pytest.mark.parametrize(
         "url",

--- a/test/test_regex_anchor_contract.py
+++ b/test/test_regex_anchor_contract.py
@@ -1,0 +1,108 @@
+r"""Contract: client-facing request-path validators reject trailing newlines.
+
+Python's ``$`` regex anchor matches immediately BEFORE a trailing newline, so a
+``$``-anchored pattern used with ``.match`` accepts its own valid input with a
+``"\n"`` suffix. For a validator on the request path -- a client-supplied value
+that reaches a subprocess argv or a filesystem path -- that admits a value the
+pattern's author never meant to accept. The fix for the class is anchoring at
+``\Z``, which matches only at the true end of the string.
+
+This module guards the class two ways:
+
+* **Behaviorally** -- every registered request-path validator accepts a known
+  valid input and rejects the same input with ``"\n"`` appended.
+* **Structurally** -- no module-level compiled pattern in any module of the
+  registered request-path packages carries an unescaped ``$``
+  (``re.MULTILINE`` patterns are exempt: per-line anchoring is the point of
+  that flag, and such patterns parse trusted tool output, not client input).
+  Modules are discovered by walking the package, so a validator added to a new
+  or existing module inside a registered package is covered without editing
+  this file.
+
+When a NEW package gains client-facing validators, add it to
+``_REQUEST_PATH_PACKAGES`` and its canonical patterns to ``_VALIDATORS``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+import re
+from types import ModuleType
+
+import pytest
+
+from kiro_crew.apps.builtins.papyrus import backend as papyrus_backend
+from kiro_crew.apps.builtins.papyrus.backend import gitops, store
+
+#: Packages whose modules validate client-supplied input on a request path.
+#: The structural walk imports every module in each and inspects its
+#: module-level compiled patterns.
+_REQUEST_PATH_PACKAGES = (papyrus_backend,)
+
+#: (pattern, canonical valid input) for every request-path validator. The
+#: behavioral half of the contract runs each through accept and reject cases.
+#: GIT_URL_RE gets one entry per regex ALTERNATION (the URL form and the
+#: scp-like form each carry their own anchor), not one per transport.
+_VALIDATORS = (
+    pytest.param(gitops.GIT_URL_RE, "https://example.com/group/paper.git", id="git-url-url-form"),
+    pytest.param(gitops.GIT_URL_RE, "git@example.com:group/paper.git", id="git-url-scp-form"),
+    pytest.param(store.PROJECT_NAME_RE, "paper", id="project-name"),
+)
+
+#: A ``$`` that is a real anchor: preceded by an EVEN number of backslashes
+#: (``\$`` is a literal dollar; ``\\$`` is an escaped backslash then an
+#: anchor). Deliberately a heuristic: a literal ``$`` inside a character class
+#: would be flagged too -- that fails loud with a clear message, and no pattern
+#: in the walked packages needs one.
+_UNESCAPED_DOLLAR = re.compile(r"(?<!\\)(?:\\\\)*\$")
+
+
+def _package_modules(package: ModuleType) -> list[ModuleType]:
+    """Every module directly inside *package*, imported."""
+    return [
+        importlib.import_module(f"{package.__name__}.{info.name}")
+        for info in pkgutil.iter_modules(package.__path__)
+    ]
+
+
+class TestTrailingNewlineContract:
+    @pytest.mark.parametrize("pattern,valid", _VALIDATORS)
+    def test_valid_input_is_accepted(self, pattern: re.Pattern[str], valid: str) -> None:
+        """Tightening the anchor must not break the accept case."""
+        assert pattern.match(valid) is not None
+
+    @pytest.mark.parametrize("pattern,valid", _VALIDATORS)
+    def test_valid_input_plus_newline_is_rejected(
+        self, pattern: re.Pattern[str], valid: str
+    ) -> None:
+        assert pattern.match(valid + "\n") is None, (
+            f"{pattern.pattern!r} accepts a trailing newline -- anchor with \\Z, not $"
+        )
+
+    def test_no_request_path_pattern_is_dollar_anchored(self) -> None:
+        """The structural half: a ``$``-anchored validator anywhere in a
+        request-path package fails here even before it has a behavioral entry."""
+        offenders = [
+            f"{module.__name__}.{name}"
+            for package in _REQUEST_PATH_PACKAGES
+            for module in _package_modules(package)
+            for name, value in sorted(vars(module).items())
+            if isinstance(value, re.Pattern)
+            and isinstance(value.pattern, str)
+            and not value.flags & re.MULTILINE
+            and _UNESCAPED_DOLLAR.search(value.pattern)
+        ]
+        assert not offenders, (
+            "request-path validators must anchor with \\Z, not $ (Python's $ "
+            f"matches before a trailing newline): {offenders}"
+        )
+
+    def test_walk_sees_the_known_validators(self) -> None:
+        """Guards the walk itself: if package discovery silently breaks (an
+        import error path, a renamed package), the structural test would pass
+        vacuously -- so assert the walk still reaches the known validator
+        modules."""
+        walked = {m.__name__ for p in _REQUEST_PATH_PACKAGES for m in _package_modules(p)}
+        assert gitops.__name__ in walked
+        assert store.__name__ in walked


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend regex + test change only; nothing renders differently.

## Problem / Motivation

Python's `$` regex anchor matches immediately before a trailing newline, so a `$`-anchored pattern used with `.match` accepts its own valid input with a `"\n"` suffix. PR #3659 closed this defect class inside its own diff, but the class is wider than that diff. Two client-facing papyrus validators remained `$`-anchored:

- `GIT_URL_RE` (`src/kiro_crew/apps/builtins/papyrus/backend/gitops.py`) validates a client-supplied clone URL that feeds git argv: `"https://host/repo\n"` passed and handed the newline through to git.
- `PROJECT_NAME_RE` (`src/kiro_crew/apps/builtins/papyrus/backend/store.py`) validates a client-supplied project name that becomes a filesystem path component: `"name\n"` passed and minted a directory whose name carries the newline into every later `git`/`pdflatex` argv.

And no class-level contract test guarded the client-side request-path patterns, so the next `$`-anchored validator would ship the same way.

## Why it matters

Both patterns are the security chokepoint for values crossing from an HTTP client into subprocess argv and filesystem paths. A validator that accepts an input shape its author never meant to accept is exactly how argument-smuggling classes come back. The direct blast radius today is contained (the character classes already exclude interior newlines, and git rejects most malformed URLs), but the class keeps reappearing one instance at a time -- the contract test is what makes the next instance fail in CI instead of in review.

## What changed (motivation -> approach -> change)

Symptom: `$`-anchored `.match` validators accept trailing-newline variants. Root cause: `$` is the wrong anchor for end-of-string validation in Python; `\Z` is the correct one. Change, smallest that closes the class:

1. `GIT_URL_RE`: both alternations re-anchored `$` -> `\Z`; comment states why.
2. `PROJECT_NAME_RE`: re-anchored `$` -> `\Z`; comment states why. (`normalize_project_name` strips/collapses whitespace before this check, so no legitimately produced name is affected -- the only behavior delta is rejecting trailing-newline variants.)
3. New `test/test_regex_anchor_contract.py`, guarding the class two ways: behaviorally (each registered validator accepts its canonical valid input and rejects the same input + `"\n"`) and structurally (a package walk over the papyrus backend asserts no module-level compiled non-`re.MULTILINE` pattern carries an unescaped `$` -- MULTILINE log parsers in `latex.py` are exempt by flag since per-line anchoring is their point). Module discovery walks the package, so a `$`-anchored validator added to any papyrus backend module fails the test without editing it. A self-guard asserts the walk still reaches the known validator modules, so discovery cannot break vacuously-green.

Issue #4040's item 2 (defining the commit-SHA regex once in `apps/manifest.py` and importing it from `official_catalog` and `registry`) is deliberately **not** in this PR: `official_catalog._COMMIT_RE` and the `\Z`-anchored `registry._COMMIT_SHA_RE` only exist inside open PR #3659's diff -- unifying them on today's main would rewrite the exact lines #3659 changes and force a conflict onto a converged, readiness-passed PR. That item should land as a small follow-up once #3659 merges; #4040 stays open for it (see Related Issues).

## Tests

- `test/test_papyrus_gitops.py::TestUrlValidation::test_rejects_trailing_newline_on_accepted_url` -- every accepted transport + `"\n"` is rejected (the accepted-URL list is extracted to a shared `_ACCEPTED_URLS` constant so a new transport is automatically covered by both the accept and the reject test).
- `test/test_regex_anchor_contract.py::TestTrailingNewlineContract` -- behavioral accept/reject-newline cases per validator alternation; the structural `$`-anchor walk; and the walk self-guard.
- Mutation-verified: with the two source edits reverted, 9 of the new assertions fail; with them applied, all pass.

## Manual verification

N/A -- unit coverage sufficient: the change is two regex anchors, and the tests assert both the accept and reject sides directly against the compiled patterns.

## Related Issues

Part of #4040 (items 1 and 3). Item 2 (commit-SHA regex unification) is blocked on PR #3659 and should follow once it merges -- deliberately NOT closing the issue here so that follow-up stays tracked.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A: docs describe the validators' purpose, not their anchor spelling
- [x] No secrets, credentials, or internal references in the diff
