### PR TITLE
feat(update): add pluggable update provider seam for enterprise self-update

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -965,6 +965,24 @@ def _update() -> None:
 
     print("👻 Updating Kiro Crew…\n")
 
+    # A policy-defined provider OWNS the update on this host. Checked before any
+    # layout dispatch so a manual `kirocrew update` cannot run the built-in
+    # git/CDN mechanism the administrator excluded.
+    from kiro_crew.platform.update_provider import apply_policy_update
+
+    applied = asyncio.run(apply_policy_update())
+    if applied is not None:
+        if applied:
+            print("\n✅ Update applied by the policy-defined update command.")
+            print("\n  Restart the gateway to use the new version:")
+            print("    kirocrew restart")
+        else:
+            print("\n❌ The policy-defined update command failed — see the log above.")
+            print("  Not falling back to the built-in updater: this host's policy")
+            print("  selects its own update mechanism.")
+            sys.exit(1)
+        return
+
     proj = os.environ.get("KIROCREW_PROJECT_DIR", "")
     proj_path = Path(proj) if proj else None
     is_git = proj_path is not None and (proj_path / ".git").exists()
@@ -1132,11 +1150,15 @@ def _update_wheel(layout) -> None:
     the standard state for ``curl | sh`` installs where the venv at
     ``~/.kiro/crew-venv`` has no source tree.
     """
-    import re
 
     from kiro_crew import __version__ as local_version
     from kiro_crew.platform.update_governance import update_blocked_reason
-    from kiro_crew.platform.update_layout import cdn_bases, release_channel, wheel_update_command
+    from kiro_crew.platform.update_layout import (
+        cdn_bases,
+        cdn_bases_are_safe,
+        release_channel,
+        wheel_update_command,
+    )
 
     channel = release_channel()
     feed_base, artifact_base = cdn_bases()
@@ -1154,8 +1176,7 @@ def _update_wheel(layout) -> None:
     # Shell safety: cdn_bases() reads KIROCREW_CDN_BASE which is operator-set.
     # Reject metacharacters that could enable command injection when the URL
     # flows through wheel_update_command() into ``sh -c``.
-    _SAFE_URL_RE = re.compile(r"^https://[A-Za-z0-9._/:%@~+\-]+$")
-    if not _SAFE_URL_RE.match(feed_base) or not _SAFE_URL_RE.match(artifact_base):
+    if not cdn_bases_are_safe():
         print("  ❌ CDN base URL contains disallowed characters")
         sys.exit(1)
 

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -328,13 +328,21 @@ def _wheel_update_command(channel: str, artifact_base: str) -> str:
     as untrusted display metadata.
 
     ``--proto '=https'`` is not decoration: this string is copied into a shell and
-    pipes an installer into ``sh``, and ``artifact_base`` is overridable via
+    runs an installer, and ``artifact_base`` is overridable via
     ``KIROCREW_CDN_BASE``. Without the restriction, an ``http://`` override would
     hand the user a command that fetches a script in plaintext and executes it, so
     an on-path attacker could swap the installer. curl refuses any other scheme,
     which is also exactly what ``cli.sh`` does for every fetch it makes itself.
+
+    Delegates to :func:`update_layout.wheel_update_command` rather than composing
+    a second copy: this string used to pipe curl into ``sh``, which reports only
+    the shell's status, so a failed download read as a successful update. Keeping
+    one builder is what stops the displayed command and the one the gateway runs
+    from drifting apart on that.
     """
-    return f"curl -fsSL --proto '=https' {artifact_base}/cli.sh | sh -s -- --channel {channel}"
+    from kiro_crew.platform.update_layout import wheel_update_command
+
+    return wheel_update_command(channel)
 
 
 def _set_update_info(**fields: object) -> None:
@@ -1104,6 +1112,31 @@ async def api_gateway_restart(request: web.Request) -> web.Response:
 async def api_update_apply(request: web.Request) -> web.Response:
     """POST /api/update — git pull, rebuild, restart gateway."""
     state: DashboardState = request.app["state"]
+
+    # A policy-defined provider OWNS the update on this host. Checked before the
+    # git precondition below so an authenticated operator clicking Update cannot
+    # run the built-in mechanism their own policy excluded. A dashboard token
+    # proves who the caller is, not that this host may update by git.
+    from kiro_crew.platform.update_provider import apply_policy_update
+
+    applied = await apply_policy_update()
+    if applied is not None:
+        if not applied:
+            # A configured provider's failure is a failure. Falling through to
+            # the git path would be the bypass the policy exists to prevent.
+            state.push_update_progress(
+                "failed", "Policy-defined update command failed — see logs"
+            )
+            return web.json_response(
+                {
+                    "error": "policy-defined update command failed",
+                    "code": "policy_update_failed",
+                    "governance": True,
+                },
+                status=500,
+            )
+        await _restart_gateway(state)
+        return web.json_response({"ok": True, "status": "updating"})
 
     proj = os.environ.get("KIROCREW_PROJECT_DIR", "")
     if not proj:

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -1184,6 +1184,20 @@ class UpdatePins:
     source: str = ""
     # The minimum version this fleet may run. Empty = no floor.
     min_version: str = ""
+    # The operator-authored shell commands for the command update provider. Their
+    # PRESENCE is what enables the provider (there is no mechanism selector): when
+    # either is set, resolve_provider() returns a CommandProvider. They live HERE
+    # (in the keystone-protected security_policy.json the agent cannot write),
+    # never in config.json, because a command provider executes unsandboxed code
+    # as the gateway — placing its commands in an agent-writable file would let a
+    # prompt-injected agent run arbitrary code. config.json has no path into this
+    # seam at all.
+    check_command: str = ""
+    apply_command: str = ""
+    # Per-platform command overrides, keyed by "{sys.platform}-{machine}"
+    # (e.g. "linux-x86_64", "darwin-arm64"). Falls back to the top-level
+    # check_command/apply_command when the current platform has no override.
+    platform_commands: Mapping[str, Mapping[str, str]] = field(default_factory=dict)
 
     def permits_source(self, url: str) -> bool:
         """Does *url* satisfy the source pin? An empty pin permits anything.
@@ -1224,15 +1238,58 @@ class UpdatePins:
 
     @staticmethod
     def from_dict(d: Mapping[str, object]) -> "UpdatePins":
-        _reject_unknown_keys(d, {"source", "min_version"}, "updates")
-        for key in ("source", "min_version"):
+        _reject_unknown_keys(
+            d,
+            {
+                "source",
+                "min_version",
+                "check_command",
+                "apply_command",
+                "platform_commands",
+            },
+            "updates",
+        )
+        for key in ("source", "min_version", "check_command", "apply_command"):
             # `str(raw or "")` would coerce `"source": false` to "" — silently
             # UNPINNING a policy that plainly meant to pin. Fail closed instead.
             if d.get(key) is not None and not isinstance(d[key], str):
                 raise PlatformCompositionError(f"updates.{key} must be a string")
+        raw_platform = d.get("platform_commands")
+        platform_commands: dict[str, dict[str, str]] = {}
+        if raw_platform is not None:
+            if not isinstance(raw_platform, Mapping):
+                raise PlatformCompositionError("updates.platform_commands must be a mapping")
+            for plat_key, plat_val in raw_platform.items():
+                if not isinstance(plat_key, str) or not isinstance(plat_val, Mapping):
+                    raise PlatformCompositionError(
+                        "updates.platform_commands entries must map a platform string "
+                        "to a command mapping"
+                    )
+                entry: dict[str, str] = {}
+                for cmd_key, cmd_val in plat_val.items():
+                    if cmd_key not in ("check_command", "apply_command"):
+                        raise PlatformCompositionError(
+                            f"updates.platform_commands.{plat_key} has unknown key {cmd_key!r}"
+                        )
+                    if not isinstance(cmd_val, str):
+                        raise PlatformCompositionError(
+                            f"updates.platform_commands.{plat_key}.{cmd_key} must be a string"
+                        )
+                    # Stripped like source/min_version above: a whitespace-only
+                    # command is truthy, so it would pass the presence check that
+                    # SELECTS the provider, and `sh -c "   "` exits 0. That reads
+                    # as a successful update, so the gateway restarts, the version
+                    # has not changed, the check still reports an update, and the
+                    # unattended path loops. Normalising here means absent and
+                    # blank are the same thing everywhere downstream.
+                    entry[cmd_key] = cmd_val.strip()
+                platform_commands[plat_key] = entry
         return UpdatePins(
             source=str(d.get("source") or "").strip(),
             min_version=str(d.get("min_version") or "").strip(),
+            check_command=str(d.get("check_command") or "").strip(),
+            apply_command=str(d.get("apply_command") or "").strip(),
+            platform_commands=platform_commands,
         )
 
 

--- a/src/kiro_crew/platform/update_layout.py
+++ b/src/kiro_crew/platform/update_layout.py
@@ -8,6 +8,7 @@ duplicating layout heuristics.
 from __future__ import annotations
 
 import os
+import re
 from typing import NamedTuple
 
 from kiro_crew.beacon import distribution
@@ -145,15 +146,67 @@ def cdn_bases() -> tuple[str, str]:
     return "https://updates.crew.kiro.dev", "https://download.crew.kiro.dev"
 
 
+#: Characters a CDN base may contain. ``KIROCREW_CDN_BASE`` is operator-set and
+#: the resulting base is interpolated into an installer command that is handed to
+#: a shell, so anything outside this set (a quote, ``;``, ``$(``, whitespace)
+#: could close the URL and append a second command. Also pins the scheme: an
+#: ``http://`` override would make the piped installer interceptable on-path.
+_SAFE_CDN_BASE_RE = re.compile(r"^https://[A-Za-z0-9._/:%@~+\-]+$")
+
+
+def cdn_bases_are_safe() -> bool:
+    """Are both CDN bases free of shell metacharacters and HTTPS-pinned?
+
+    Every caller that builds a shell command from :func:`cdn_bases` must gate on
+    this. It lives here, beside ``cdn_bases``, so the CLI path and the gateway's
+    unattended path cannot drift apart on what they consider safe.
+    """
+    feed_base, artifact_base = cdn_bases()
+    return bool(
+        _SAFE_CDN_BASE_RE.match(feed_base) and _SAFE_CDN_BASE_RE.match(artifact_base)
+    )
+
+
 def wheel_update_command(channel: str | None = None) -> str:
     """The shell command that upgrades a wheel/cli.sh install.
 
     Composed locally from validated inputs — never from feed data.
+
+    The installer is held in a shell VARIABLE and never lands on disk, which has
+    to satisfy two constraints that pull against each other.
+
+    1. A download failure must fail the command. Plain ``curl … | sh`` reports
+       the exit status of ``sh``, and a shell handed empty input exits 0, so a
+       CDN failure would look like a successful update: the version would not
+       change, the gateway would restart, the check would still see an update
+       available, and the unattended path would loop. Assigning the body in a
+       command substitution first makes the fetch's own failure abort the
+       command, portably — ``pipefail`` is not POSIX and the resolved ``sh`` is
+       not guaranteed to be bash.
+
+    2. No writable file may sit between download and execute. Staging to
+       ``mktemp`` opened a TOCTOU window: the gateway and an agent share a uid,
+       so the file's 0600 mode does not keep the agent out, and it could swap
+       the contents after ``curl`` wrote them and before ``sh`` opened them —
+       arbitrary code in the gateway's own context. Keeping the body in memory
+       removes the window rather than trying to police it.
+
+    ``-s --`` is required here and only here: it tells ``sh`` to read the script
+    from stdin and to pass what follows to that script. The file form must NOT
+    carry it, since ``cli.sh`` parses argv strictly and answers
+    "unknown argument '-s'" with exit 2.
     """
     if channel is None:
         channel = release_channel()
     _, artifact_base = cdn_bases()
-    return f"curl -fsSL --proto '=https' {artifact_base}/cli.sh " f"| sh -s -- --channel {channel}"
+    return (
+        "set -e; "
+        f"_kc_body=\"$(curl -fsSL --proto '=https' {artifact_base}/cli.sh)\"; "
+        # An empty body would let sh exit 0 on nothing at all, which is the same
+        # false success as the piped form.
+        'test -n "$_kc_body"; '
+        f'printf \'%s\\n\' "$_kc_body" | sh -s -- --channel {channel}'
+    )
 
 
 __all__ = [
@@ -162,6 +215,7 @@ __all__ = [
     "release_channel",
     "set_release_channel",
     "cdn_bases",
+    "cdn_bases_are_safe",
     "wheel_update_command",
     "RELEASE_CHANNELS",
     "EXTERNALLY_MANAGED",

--- a/src/kiro_crew/platform/update_provider.py
+++ b/src/kiro_crew/platform/update_provider.py
@@ -1,0 +1,559 @@
+"""Policy-only update provider seam for enterprise self-update.
+
+Abstracts *how* Kiro Crew checks for and applies updates behind a single
+operator-supplied :class:`CommandProvider`.
+
+**Trust placement (security-critical).** A command provider runs unsandboxed
+shell code AS THE GATEWAY. Its commands therefore live in exactly ONE place: the
+keystone-protected ``security_policy.json`` (surfaced as ``UpdatePins`` via
+:func:`~kiro_crew.platform.governance.active_update_pins`), which a
+prompt-injected agent shell can neither read nor write. ``config.json`` and
+environment variables are agent-writable / process-inherited, so they cannot
+reach this seam at all — there is no config or env path into it.
+
+**Selection is by PRESENCE, not by a mechanism name.** There is no mechanism
+enum any more. :func:`resolve_provider` returns a :class:`CommandProvider` when
+the policy pins define a check or apply command, and ``None`` otherwise (the
+ungoverned default, where the gateway keeps its built-in update behaviour).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import platform
+import sys
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import Protocol, runtime_checkable
+
+from kiro_crew.platform_compat import (
+    IS_POSIX,
+    trusted_system_bin,
+    trusted_system_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+#: Ceiling on how much of an update command's output is kept. A version string
+#: is tens of bytes and an error summary is logged truncated anyway, while a
+#: chatty package manager can emit megabytes per package. ``communicate()``
+#: buffers everything in the gateway's own memory with no bound, so a verbose
+#: command could exhaust it before the timeout fires.
+_MAX_CAPTURED_OUTPUT = 64 * 1024
+
+
+async def _read_bounded_output(
+    proc: asyncio.subprocess.Process, *, timeout: float, want_stdout: bool
+) -> tuple[bytes, bytes]:
+    """Wait for *proc*, keeping at most :data:`_MAX_CAPTURED_OUTPUT` per stream.
+
+    Drains both pipes concurrently so a full pipe buffer cannot deadlock the
+    child, but stops accumulating past the cap and discards the rest. ``apply``
+    passes ``want_stdout=False``: its stdout is installer chatter nobody reads,
+    and only a bounded stderr is kept for the log.
+    """
+
+    async def _drain(stream: asyncio.StreamReader | None, keep: bool) -> bytes:
+        if stream is None:
+            return b""
+        buf = bytearray()
+        while True:
+            chunk = await stream.read(8192)
+            if not chunk:
+                return bytes(buf)
+            if keep and len(buf) < _MAX_CAPTURED_OUTPUT:
+                buf.extend(chunk[: _MAX_CAPTURED_OUTPUT - len(buf)])
+
+    out, err = await asyncio.wait_for(
+        asyncio.gather(_drain(proc.stdout, want_stdout), _drain(proc.stderr, True)),
+        timeout=timeout,
+    )
+    await proc.wait()
+    return out, err
+
+
+async def _kill_and_reap(proc: asyncio.subprocess.Process) -> None:
+    """Kill *proc* AND its descendants, then wait for it under a bound.
+
+    Used on BOTH the timeout and the cancellation path. Cancellation matters as
+    much as timeout: a gateway shutdown (SIGTERM) cancels the update task, and
+    without this the updater keeps replacing files after the process that
+    started it is gone, leaving a half-updated installation nobody supervises.
+
+    The whole TREE is signalled, not just the direct child. An update command is
+    a shell line (``curl … | sh``, ``pkg update | tee log``), so killing only
+    the shell leaves the pipeline members running and can leave ``communicate()``
+    waiting on pipes those survivors still hold. Every spawn that reaches here
+    is started with ``start_new_session`` on POSIX so the tree is its own process
+    group and cannot reach back into the gateway's.
+
+    The reap is bounded: a descendant that ignores the signal must not turn
+    cleanup into a hang on the shutdown path. Both the kill and the reap are
+    best-effort, since the caller is already handling a timeout or a
+    cancellation and must not have it masked by a cleanup error.
+    """
+    # Function-local deliberately: the tests patch
+    # ``kiro_crew.platform_compat.kill_process_tree_async`` on the SOURCE module,
+    # and a module-scope ``from`` import would freeze the reference so the patch
+    # could not reach it.
+    from kiro_crew import platform_compat
+
+    with contextlib.suppress(Exception):
+        await platform_compat.kill_process_tree_async(proc.pid, platform_compat.SIGKILL)
+    with contextlib.suppress(Exception):
+        proc.kill()
+    with contextlib.suppress(Exception, asyncio.TimeoutError):
+        await asyncio.wait_for(proc.communicate(), timeout=_REAP_TIMEOUT_SECS)
+
+
+#: Ceiling on waiting for a killed updater tree. A descendant that ignores the
+#: signal must not turn cleanup into a hang while the gateway is shutting down.
+_REAP_TIMEOUT_SECS = 10
+
+
+@dataclass(frozen=True)
+class UpdateCheckResult:
+    """Result of an update availability check."""
+
+    available: bool = False
+    remote_version: str = ""
+    error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class UpdateProvider(Protocol):
+    """Documents the contract an operator-supplied provider must satisfy.
+
+    This Protocol has exactly one implementation in-tree
+    (:class:`CommandProvider`); it is kept purely as living documentation of the
+    check/apply contract an enterprise's command provider is expected to honour.
+    Implementations must be safe for concurrent use (the gateway may call
+    ``check()`` from multiple coroutines on boot).
+    """
+
+    async def check(self) -> UpdateCheckResult:
+        """Check whether an update is available.
+
+        Returns :class:`UpdateCheckResult` with ``available=True`` when a newer
+        version exists. On transient errors, ``error`` is set and ``available``
+        is False — callers must not treat an errored check as "up to date".
+        """
+        ...
+
+    async def apply(self) -> bool:
+        """Apply the update. Returns True on success.
+
+        On failure returns False (the existing install is left intact).
+        The caller is responsible for restarting the process after a
+        successful apply.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Platform helpers
+# ---------------------------------------------------------------------------
+
+# Canonical machine name mapping — covers the values platform.machine() returns
+# on each OS+arch combination we support.
+_MACHINE_ALIASES: dict[str, str] = {
+    "x86_64": "x86_64",
+    "amd64": "x86_64",
+    "x64": "x86_64",
+    "aarch64": "arm64",
+    "arm64": "arm64",
+}
+
+
+def _current_platform_key() -> str:
+    """Return the normalized platform key for the running host.
+
+    Format: ``{sys.platform}-{machine}`` where machine is one of
+    ``x86_64`` or ``arm64``.  Examples: ``linux-x86_64``, ``darwin-arm64``,
+    ``win32-x86_64``.
+
+    Falls back to the raw ``platform.machine()`` value (lowercased) when the
+    architecture is unrecognized, so an operator can still target exotic
+    hardware by using the raw key in ``platform_commands``.
+    """
+    raw_machine = platform.machine().lower()
+    normalized = _MACHINE_ALIASES.get(raw_machine, raw_machine)
+    return f"{sys.platform}-{normalized}"
+
+
+def _shell_exec_args(command: str) -> list[str] | None:
+    """Return the argv for running *command* in the platform's shell, or None.
+
+    POSIX: ``[<trusted sh>, "-c", command]``. Windows: ``None`` — see below.
+
+    The shell binary is resolved through :func:`trusted_system_bin` (fixed
+    system directories) rather than as a bare ``"sh"`` argv name, because a
+    gateway's ``PATH`` can lead with an agent-writable directory (a worktree venv
+    ``bin``, ``~/.local/bin``): a bare name would let a planted ``~/.local/bin/sh``
+    shim run with the gateway's credentials.
+
+    Returns ``None`` (fail CLOSED) when no trusted shell is found — the caller
+    must treat that as "cannot run" rather than falling back to a bare name,
+    because the bare-name fallback is exactly the agent-writable-PATH hole this
+    resolution exists to close.
+
+    **Windows is refused outright**, and that is a deliberate restriction rather
+    than a gap: pinning the shell alone does not make the CHILD's lookup safe,
+    and the second hop cannot be closed on Windows today.
+    :func:`platform_compat.trusted_system_path` returns ``None`` there (Windows
+    helpers live beside their install rather than on a search path), so
+    :func:`_trusted_path_env` has no trusted ``PATH`` to substitute, and
+    ``cmd.exe`` additionally resolves a bare command word from the working
+    directory first. A command provider that runs unsandboxed code as the gateway
+    must not rely on a lookup an agent can influence, so the Windows lane stays
+    closed until it has a trusted lookup and a trusted working directory.
+    """
+    if sys.platform == "win32":
+        return None
+    shell = trusted_system_bin("sh")
+    return [shell, "-c", command] if shell else None
+
+
+def _trusted_path_env() -> dict[str, str] | None:
+    """The gateway environment with ``PATH`` narrowed to trusted system dirs.
+
+    Pinning the shell binary is not sufficient on its own: the shell then
+    resolves the operator's own command words (``my-updater check``) through
+    ``PATH``, and a gateway's ``PATH`` can lead with agent-writable directories
+    (a worktree venv ``bin``, ``~/.local/bin``). Narrowing ``PATH`` for the child
+    closes that second hop.
+
+    Consequence for operators, and why it is the right default: a command whose
+    binary does NOT live in a system directory must be written as an ABSOLUTE
+    path in the policy (``/opt/acme/bin/acme-pkg update kirocrew``). An
+    execution-authorizing command naming its binary absolutely is the posture we
+    want anyway, since it also removes any ambiguity about which binary runs.
+
+    Only ``PATH`` is replaced; the rest of the environment is left alone, so a
+    command can still read the proxy, locale and credential-helper variables its
+    package manager needs.
+
+    Returns ``None`` (fail CLOSED) when there is no trusted ``PATH`` to
+    substitute. Passing the inherited ``PATH`` through instead would leave the
+    child's lookup agent-influenceable, which is the whole hole this closes.
+    """
+    trusted = trusted_system_path()
+    if not trusted:
+        return None
+    env = dict(os.environ)
+    env["PATH"] = trusted
+    # Narrowing PATH is not enough on its own: the loader variables below make an
+    # interpreter execute agent-writable code no matter which binary was resolved.
+    # PYTHONPATH plus a planted ``sitecustomize.py`` runs on EVERY Python start,
+    # and the LD_*/DYLD_* family does the same for any dynamically linked binary,
+    # so an update command that happens to be a Python or shell wrapper would
+    # execute that code as the gateway. Dropped rather than sanitised: an update
+    # command has no business inheriting an interpreter search path.
+    for var in _INJECTABLE_LOADER_VARS:
+        env.pop(var, None)
+    return env
+
+
+#: Environment variables that make an interpreter or dynamic linker load code
+#: from a caller-controlled path. Removed from every update-command child.
+_INJECTABLE_LOADER_VARS: tuple[str, ...] = (
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PYTHONSTARTUP",
+    "PYTHONEXECUTABLE",
+    "PYTHONUSERBASE",
+    "PYTHONWARNINGS",
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    "BASH_ENV",
+    "ENV",
+    "IFS",
+)
+
+
+# ---------------------------------------------------------------------------
+# Command provider (the one operator-supplied implementation)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CommandProvider:
+    """Runs operator-configured shell commands for check and apply.
+
+    Security: commands come ONLY from the keystone-protected
+    ``security_policy.json`` (via ``UpdatePins``), never from environment
+    variables, config.json, or feed data. The operator who controls that file
+    already has full host access.
+
+    ``check_command`` must exit 0 and print the available version to stdout
+    when an update is available, or exit non-zero when up to date.
+
+    ``apply_command`` must exit 0 on success; a non-zero exit means the apply
+    failed and the existing install is intact.
+
+    **Platform-aware commands.** The top-level ``check_command``/``apply_command``
+    are the default for all platforms. ``platform_commands`` allows per-platform
+    overrides keyed by ``{sys.platform}-{machine}`` (e.g. ``linux-x86_64``,
+    ``darwin-arm64``, ``win32-x86_64``). When the current platform key matches
+    an entry, its ``check_command``/``apply_command`` values override the
+    top-level defaults for that field only.
+
+    On POSIX systems commands run via a trusted ``sh -c`` with a trusted-only
+    ``PATH``. Windows is not supported yet and both verbs refuse there: the
+    child's command lookup cannot be made trustworthy on Windows today (see
+    :func:`_shell_exec_args`), so ``win32-*`` keys in ``platform_commands`` are
+    accepted by the schema but never reached.
+    """
+
+    check_command: str = ""
+    apply_command: str = ""
+    platform_commands: dict[str, dict[str, str]] = dataclass_field(default_factory=dict)
+
+    def _resolve_command(self, field: str) -> str:
+        """Resolve the effective command for *field* on this platform.
+
+        Checks ``platform_commands[current_key][field]`` first, then falls back
+        to the top-level attribute.
+        """
+        key = _current_platform_key()
+        overrides = self.platform_commands.get(key, {})
+        if overrides and overrides.get(field):
+            return overrides[field]
+        return getattr(self, field, "")
+
+    async def check(self) -> UpdateCheckResult:
+        """Run check_command. Exit 0 + non-empty stdout version = available."""
+        cmd = self._resolve_command("check_command")
+        if not cmd:
+            return UpdateCheckResult(error="no check_command configured")
+
+        argv = _shell_exec_args(cmd)
+        if argv is None:
+            return UpdateCheckResult(error="no trusted shell found")
+        env = _trusted_path_env()
+        if env is None:
+            return UpdateCheckResult(error="no trusted PATH for the update command")
+
+        proc: asyncio.subprocess.Process | None = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                # Own session so the whole pipeline is one killable group and
+                # cannot signal back into the gateway's group.
+                start_new_session=IS_POSIX,
+                # Root, not the gateway's cwd: a relative command word
+                # (``./update.sh``) would otherwise resolve inside whatever
+                # directory the gateway was launched from, which can be an
+                # agent-writable checkout. Operator commands name absolute paths.
+                cwd="/",
+            )
+            stdout, _stderr = await _read_bounded_output(
+                proc, timeout=60, want_stdout=True
+            )
+        except asyncio.CancelledError:
+            if proc is not None:
+                await _kill_and_reap(proc)
+            raise
+        except asyncio.TimeoutError:
+            if proc is not None:
+                await _kill_and_reap(proc)
+            return UpdateCheckResult(error="check_command timed out")
+        except OSError:
+            # OSError, not just FileNotFoundError: fd or process exhaustion
+            # raises a different OSError, and a manual update must get an error
+            # verdict back rather than an exception escaping the provider.
+            return UpdateCheckResult(error="could not start check_command")
+
+        if proc.returncode != 0:
+            # Non-zero = no update available (not an error)
+            return UpdateCheckResult(available=False)
+
+        version = (stdout or b"").decode(errors="replace").strip()
+        # An exit-0 check that prints NO version is a broken command, not an
+        # available update. Returning available=True with remote_version=''
+        # would make apply() run and the gateway restart to the SAME version,
+        # forever — an infinite update-restart loop. Fail the check instead.
+        if not version:
+            return UpdateCheckResult(error="check_command produced no version")
+        # Sanitize: version should be a short string, no shell metacharacters
+        if len(version) > 128:
+            version = version[:128]
+        return UpdateCheckResult(available=True, remote_version=version)
+
+    async def apply(self) -> bool:
+        """Run apply_command. Exit 0 = success."""
+        cmd = self._resolve_command("apply_command")
+        if not cmd:
+            logger.warning("CommandProvider.apply: no apply_command configured")
+            return False
+
+        argv = _shell_exec_args(cmd)
+        if argv is None:
+            logger.error("CommandProvider.apply: no trusted shell found — refusing to run")
+            return False
+        env = _trusted_path_env()
+        if env is None:
+            logger.error("CommandProvider.apply: no trusted PATH — refusing to run")
+            return False
+
+        logger.info("CommandProvider.apply: running apply command")
+        proc: asyncio.subprocess.Process | None = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                # Own session so the whole pipeline is one killable group and
+                # cannot signal back into the gateway's group.
+                start_new_session=IS_POSIX,
+                # Root, not the gateway's cwd: a relative command word
+                # (``./update.sh``) would otherwise resolve inside whatever
+                # directory the gateway was launched from, which can be an
+                # agent-writable checkout. Operator commands name absolute paths.
+                cwd="/",
+            )
+            _stdout, stderr = await _read_bounded_output(
+                proc, timeout=600, want_stdout=False
+            )
+        except asyncio.CancelledError:
+            if proc is not None:
+                await _kill_and_reap(proc)
+            logger.warning("CommandProvider.apply: cancelled — update child killed")
+            raise
+        except asyncio.TimeoutError:
+            if proc is not None:
+                await _kill_and_reap(proc)
+            logger.error("CommandProvider.apply: timed out (10 min)")
+            return False
+        except OSError:
+            # OSError, not just FileNotFoundError (see check() above).
+            logger.exception("CommandProvider.apply: could not start the command")
+            return False
+
+        if proc.returncode != 0:
+            # Redact credentials AND token-bearing URLs before logging stderr,
+            # so neither an inline token nor a presigned/token URL enters the
+            # persistent ring buffer or the /api/logs dashboard stream.
+            from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+            # Redact BEFORE truncating. Slicing first can cut a credential in
+            # half, and half a token no longer matches the redactors' patterns
+            # (an AWS key needs its full 20 chars to match), so the surviving
+            # fragment would reach gateway.log and /api/logs verbatim. The
+            # 500-char cap is for log volume, so it belongs last.
+            err_text = (stderr or b"").decode(errors="replace")
+            err_text, _ = redact_exfiltration_urls(err_text)
+            err_text, _ = redact_credentials(err_text)
+            err_text = err_text[:500]
+            logger.error(
+                "CommandProvider.apply: failed (rc=%d): %s",
+                proc.returncode,
+                err_text,
+            )
+            return False
+
+        logger.info("CommandProvider.apply: succeeded")
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+async def apply_policy_update() -> bool | None:
+    """Run the policy-defined update, or ``None`` when no provider is configured.
+
+    The single seam every MANUAL update entry point shares with the unattended
+    boot check. Without it, `POST /api/update` and `kirocrew update` would run
+    the built-in git/CDN update on a host whose administrator selected a
+    different package manager, which is exactly the bypass this policy exists to
+    prevent -- and a bypass an authenticated operator could trigger by accident.
+
+    ``None`` means "no policy provider, carry on with the built-in path".
+    ``True``/``False`` is the provider's own apply verdict, and the caller must
+    NOT fall back to the built-in path on ``False``: a configured provider owns
+    the update, and its failure is a failure, not a reason to run the mechanism
+    the operator excluded.
+    """
+    provider = resolve_provider()
+    if provider is None:
+        return None
+    return await provider.apply()
+
+
+def resolve_provider() -> CommandProvider | None:
+    """Resolve the operator-supplied command provider, or ``None``.
+
+    **Trust placement (security-critical).** A command provider executes
+    unsandboxed shell code AS THE GATEWAY, so its commands are read ONLY from the
+    keystone-protected ``security_policy.json`` (via ``UpdatePins``), which a
+    prompt-injected agent shell cannot write. There is no ``config.json`` or
+    environment path into this seam.
+
+    **Presence is the selection.** When the active pins define a ``check_command``
+    or an ``apply_command`` (top-level or per-platform), a
+    :class:`CommandProvider` is returned; otherwise ``None`` — the ungoverned
+    default, where the gateway keeps its built-in update behaviour.
+    """
+    try:
+        from kiro_crew.platform.governance import active_update_pins
+
+        pins = active_update_pins()
+    except Exception:
+        logger.debug("Reading update pins from policy failed", exc_info=True)
+        return None
+
+    check_command = getattr(pins, "check_command", "") or ""
+    apply_command = getattr(pins, "apply_command", "") or ""
+    platform_commands = {
+        k: dict(v) for k, v in (getattr(pins, "platform_commands", {}) or {}).items()
+    }
+    # A policy may define commands ONLY per platform (an operator whose package
+    # manager exists on some hosts and not others, with no sensible default).
+    # Ignoring that shape here would silently fall through to the built-in
+    # updater and bypass the administrator-selected package manager, so any
+    # per-platform command counts as presence too. Whether the CURRENT platform
+    # has one is CommandProvider's decision, and it refuses when it does not.
+    has_platform_command = any(
+        entry.get("check_command") or entry.get("apply_command")
+        for entry in platform_commands.values()
+    )
+    if check_command or apply_command or has_platform_command:
+        return CommandProvider(
+            check_command=check_command,
+            apply_command=apply_command,
+            platform_commands=platform_commands,
+        )
+    return None
+
+
+__all__ = [
+    "UpdateCheckResult",
+    "UpdateProvider",
+    "CommandProvider",
+    "apply_policy_update",
+    "resolve_provider",
+    "_current_platform_key",
+    "_kill_and_reap",
+    "_read_bounded_output",
+    "_shell_exec_args",
+    "_trusted_path_env",
+]

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -786,6 +786,12 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # goes out to a human.
         "context.py",
         "agent.py",
+        # Gate-side log hygiene: the update provider redacts an update command's
+        # stderr before writing it to the gateway log. It is a boot-time
+        # operational log line, not an output boundary bound for a human or a
+        # third party — the redaction is defensive so a credential-bearing
+        # installer error cannot leak into the log ring / /api/logs stream.
+        "platform/update_provider.py",
         # The shared recursive redactor helper itself — a pure scrubber, not an
         # egress boundary; the modules that CALL it (mochi routes/hooks) are the
         # registered sinks.

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -1695,9 +1695,14 @@ class GatewayOrchestrator:
             print("✅ Dependencies installed")
         else:
             print("❌ pip install failed — run manually: kirocrew update")
-            logger.error(
-                "Dep repair failed: %s", (stderr or b"").decode(errors="replace")[:500]
-            )
+            # pip stderr can echo an index URL with embedded credentials
+            # (https://user:token@internal-index/...), so redact before the
+            # volume cap: truncating first can bisect a token, and half a token
+            # no longer matches the redactors' patterns.
+            dep_err = (stderr or b"").decode(errors="replace")
+            dep_err, _ = redact_exfiltration_urls(dep_err)
+            dep_err, _ = redact_credentials(dep_err)
+            logger.error("Dep repair failed: %s", dep_err[:500])
 
     # ------------------------------------------------------------------
     # Service initialisation
@@ -6487,7 +6492,183 @@ class GatewayOrchestrator:
     # ------------------------------------------------------------------
 
     async def _check_for_updates(self) -> None:
-        """Blocking update check — auto-applies if enabled, otherwise notifies."""
+        """Blocking update check — auto-applies if enabled, otherwise notifies.
+
+        Delegates to the resolved :class:`~kiro_crew.platform.update_provider.CommandProvider`
+        when security_policy.json's ``updates`` block defines the update commands
+        (the enterprise escape hatch). When no policy-defined provider is active,
+        ``resolve_provider`` returns ``None`` and we fall through to the existing
+        layout-aware logic (backward compatible: no policy = existing behavior).
+        """
+        provider = None
+        try:
+            from kiro_crew.platform.update_provider import resolve_provider
+
+            provider = await asyncio.get_running_loop().run_in_executor(
+                None, resolve_provider
+            )
+        except Exception:
+            # ONLY resolution is tolerated here. If reading the policy fails we
+            # cannot know an operator selected a provider, so the built-in
+            # behaviour is the honest default.
+            logger.debug("Provider resolution failed, using legacy path", exc_info=True)
+
+        # A policy-defined provider (enterprise escape hatch) OWNS the update from
+        # here on. Its failures must NOT fall through to the legacy updater: doing
+        # so would run the built-in git/CDN update on a host whose administrator
+        # selected a different package manager, which is the bypass this seam
+        # exists to prevent. `_check_for_updates_via_provider` reports its own
+        # failures and leaves the install alone.
+        if provider is not None:
+            try:
+                await self._check_for_updates_via_provider(provider)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Contained, not swallowed and not retried elsewhere: the update
+                # check runs on the gateway's boot path, so an exception must not
+                # escape into it, and it must not reach the legacy updater either
+                # (that would run the built-in update the operator excluded).
+                logger.exception("Policy-defined update provider failed")
+                if self.dashboard_state:
+                    self.dashboard_state.push_update_progress(
+                        "failed",
+                        "Update provider failed — see logs; run manually: kirocrew update",
+                    )
+            return
+
+        # Legacy path: existing behavior for builtin/git auto-detected installs.
+        await self._check_for_updates_legacy()
+
+    def _publish_provider_update_state(self, result: object) -> None:
+        """Mirror a provider's verdict into the dashboard's authoritative status.
+
+        The SSE snapshot renders the update badge from
+        ``dashboard/handlers/updates.py::_update_info["available"]``, which only
+        the LEGACY check writes. A provider carries its own
+        :class:`UpdateCheckResult`, so notifying without this leaves the badge
+        reading a stale (usually False) value and the operator never sees that a
+        policy-defined update is waiting.
+        """
+        from kiro_crew.dashboard.handlers.updates import _update_info
+
+        _update_info["available"] = bool(getattr(result, "available", False))
+        remote = str(getattr(result, "remote_version", "") or "")
+        if remote:
+            _update_info["remote_version"] = remote
+        _update_info["checked"] = True
+
+    async def _check_for_updates_via_provider(self, provider: object) -> None:
+        """Provider-delegated update check and apply."""
+        from kiro_crew import __version__ as _running_version
+        from kiro_crew.config import KiroCrewConfig
+        from kiro_crew.platform.update_governance import min_version, update_required
+        from kiro_crew.platform.update_provider import UpdateProvider
+
+        assert isinstance(provider, UpdateProvider)
+
+        result = await provider.check()
+
+        # The mandatory floor is an enterprise ceiling and is evaluated FIRST,
+        # before any check-error early return: a host below min_version must
+        # still be updated even when the provider's check could not complete
+        # (a timed-out or misconfigured command must not strand the host below
+        # the policy floor).
+        if update_required(_running_version):
+            # Guard against an infinite update→restart loop: only apply when the
+            # check found a NEWER build available. If the floor is pinned above
+            # the highest installable build (a policy typo, or a floor set ahead
+            # of the current release), applying would reinstall the same version,
+            # restart, and re-enter this branch forever. When no newer build is
+            # available we notify and stop — the git path's no-new-commits early
+            # return is the equivalent guard.
+            if not result.available:
+                logger.warning(
+                    "Version compliance: running %s is below the policy minimum %s, "
+                    "but no newer build is available to apply — notifying, not looping",
+                    _running_version,
+                    min_version(),
+                )
+                self._publish_provider_update_state(result)
+                if self.dashboard_state:
+                    self.dashboard_state.push_refresh("update_available")
+                return
+            logger.warning(
+                "Version compliance: running %s is below the policy minimum %s — "
+                "applying mandatory update via provider (overrides auto_update)",
+                _running_version,
+                min_version(),
+            )
+            if self.dashboard_state:
+                self.dashboard_state.push_update_progress(
+                    "pulling", "Applying mandatory update…"
+                )
+            success = await provider.apply()
+            if success:
+                await self._restart_after_update()
+            else:
+                if self.dashboard_state:
+                    self.dashboard_state.push_update_progress(
+                        "failed", "Update apply failed — run manually: kirocrew update"
+                    )
+            return
+
+        # Below the mandatory floor: a check error is a non-answer, not a
+        # verdict — report it and stop rather than treating it as "up to date".
+        if result.error:
+            logger.info("Update check did not complete (%s)", result.error)
+            return
+
+        if result.available:
+            cfg = await asyncio.to_thread(KiroCrewConfig.load)
+            if cfg.auto_update:
+                logger.info("Auto-update enabled — applying update via provider")
+                if self.dashboard_state:
+                    self.dashboard_state.push_update_progress(
+                        "pulling", "Downloading update…"
+                    )
+                success = await provider.apply()
+                if success:
+                    await self._restart_after_update()
+                else:
+                    if self.dashboard_state:
+                        self.dashboard_state.push_update_progress(
+                            "failed", "Update apply failed — run manually: kirocrew update"
+                        )
+            else:
+                self._publish_provider_update_state(result)
+                if self.dashboard_state:
+                    self.dashboard_state.push_refresh("update_available")
+        else:
+            print("👻 Already on latest version")
+
+    async def _restart_after_update(self) -> None:
+        """Save state and restart the process after a successful update apply."""
+        logger.info("Update applied, restarting gateway")
+        if self.dashboard_state:
+            self.dashboard_state.push_update_progress("restarting", "Restarting server…")
+            from kiro_crew.dashboard.chat import save_all_slots_to_history
+
+            try:
+                await asyncio.wait_for(
+                    asyncio.get_running_loop().run_in_executor(
+                        subprocess_executor(),
+                        save_all_slots_to_history,
+                        self.dashboard_state,
+                    ),
+                    timeout=5.0,
+                )
+            except Exception:
+                logger.debug(
+                    "Dashboard slot save before update restart failed",
+                    exc_info=True,
+                )
+        if self.sessions:
+            await self.sessions.close_all()
+        os.execv(sys.executable, [sys.executable, "-m", "kiro_crew"] + sys.argv[1:])
+
+    async def _check_for_updates_legacy(self) -> None:
+        """Legacy update check — the existing layout-aware logic."""
         try:
             from kiro_crew import __version__ as _running_version
             from kiro_crew.dashboard.handlers import _do_update_check, _update_info
@@ -6495,21 +6676,6 @@ class GatewayOrchestrator:
             await _do_update_check()
             from kiro_crew.platform.update_governance import min_version, update_required
 
-            # A policy-pinned minimum version makes the update MANDATORY: it
-            # overrides the user's auto_update=False, because user config sits
-            # under the enterprise ceiling and an operator opting out must not
-            # hold a fleet on a build the policy forbids.
-            #
-            # Checked BEFORE the `available` branch, and deliberately independent
-            # of it: the mandate is about whether THIS host satisfies the floor,
-            # not about whether a newer build was advertised. `_auto_apply_update`
-            # still applies the source pin and its own no-new-commits early
-            # return, so this cannot bypass the ceiling or loop.
-            #
-            # Not gated on `self_updatable`: a policy floor is an enterprise
-            # ceiling, and this branch has always attempted the git apply on every
-            # layout. Teaching it the wheel path (which needs the installer, not a
-            # git reset) is a separate change from making the CHECK honest.
             if update_required(_running_version):
                 # A mandatory floor is handled by layout, because "apply" means
                 # different things per install shape:
@@ -6532,22 +6698,32 @@ class GatewayOrchestrator:
                     )
                     await self._auto_apply_update()
                     return
-                if _update_info.get("update_command"):
+                if (
+                    _update_info.get("update_command")
+                    and _update_info.get("install_kind") == "wheel"
+                ):
+                    # Only apply when a NEWER build is available; otherwise the
+                    # installer reinstalls the same below-floor version and the
+                    # execv-restart re-enters this branch forever (the git path's
+                    # no-new-commits guard is the equivalent). A floor pinned
+                    # above the latest build must notify, not loop.
+                    if not _update_info.get("available"):
+                        logger.warning(
+                            "Version compliance: running %s is below the policy minimum %s, "
+                            "but no newer build is available — notifying, not looping",
+                            _running_version,
+                            min_version(),
+                        )
+                        if self.dashboard_state:
+                            self.dashboard_state.push_refresh("update_available")
+                        return
                     logger.warning(
-                        "Version compliance: running %s is below the policy minimum %s, "
-                        "but this install (%s) updates by re-running the installer — "
-                        "run `kirocrew update`",
+                        "Version compliance: running %s is below the policy minimum %s — "
+                        "applying mandatory update via installer (overrides auto_update)",
                         _running_version,
                         min_version(),
-                        _update_info.get("install_kind") or "unknown",
                     )
-                    # Light the badge: the SSE snapshot reads
-                    # `_update_info["available"]`, which the check may have left
-                    # False (a pre-release remote reads as not-newer) even though
-                    # the floor makes this update mandatory.
-                    _update_info["available"] = True
-                    if self.dashboard_state:
-                        self.dashboard_state.push_refresh("update_available")
+                    await self._auto_apply_wheel_update()
                     return
                 logger.warning(
                     "Version compliance: running %s is below the policy minimum %s, but this "
@@ -6563,28 +6739,29 @@ class GatewayOrchestrator:
                 from kiro_crew.config import KiroCrewConfig
 
                 cfg = KiroCrewConfig.load()
-                # `_auto_apply_update` replaces code with git fetch + reset, so it
-                # can only serve a GIT CHECKOUT. A wheel install replaces itself by
-                # re-running the installer, which this process must not do
-                # unattended — so notify instead. Without this guard, the wheel
-                # path in `_do_update_check` (which can now report `available`)
-                # would drive a git reset in a tree that has no `.git`.
                 if cfg.auto_update and _update_info.get("self_updatable"):
                     logger.info("Auto-update enabled — applying update")
                     await self._auto_apply_update()
+                elif (
+                    cfg.auto_update
+                    and _update_info.get("update_command")
+                    and _update_info.get("install_kind") == "wheel"
+                ):
+                    # Only a managed WHEEL install can be safely self-updated by
+                    # re-running the cli.sh installer: it replaces the same venv
+                    # the running interpreter lives in. A "source" install (cloud
+                    # tarball / EC2) also carries an update_command but the
+                    # installer would create a SEPARATE managed venv while this
+                    # source interpreter re-execs unchanged — an infinite
+                    # update→restart loop. Those notify instead.
+                    logger.info(
+                        "Auto-update enabled for wheel install — running installer"
+                    )
+                    await self._auto_apply_wheel_update()
                 else:
-                    if cfg.auto_update:
-                        logger.warning(
-                            "Auto-update is on, but this install (%s) updates by "
-                            "re-running the installer, not by git — notifying instead",
-                            _update_info.get("install_kind") or "unknown",
-                        )
                     if self.dashboard_state:
                         self.dashboard_state.push_refresh("update_available")
             elif _update_info.get("error"):
-                # A check that could not run is NOT "already on latest" — saying so
-                # is the exact false reassurance the honest-`checked` contract in
-                # `handlers/updates.py` exists to prevent.
                 logger.info("Update check did not complete (%s)", _update_info.get("error"))
             else:
                 print("👻 Already on latest version")
@@ -6763,7 +6940,11 @@ class GatewayOrchestrator:
             )
             pip_out, pip_err = await asyncio.wait_for(pip_install.communicate(), timeout=400)
             if pip_install.returncode != 0:
-                err_text = pip_err.decode(errors="replace")[:500]
+                # Same reasoning as the dep-repair path: redact first, cap last.
+                err_text = pip_err.decode(errors="replace")
+                err_text, _ = redact_exfiltration_urls(err_text)
+                err_text, _ = redact_credentials(err_text)
+                err_text = err_text[:500]
                 logger.error(
                     "Auto-update: pip install failed (rc=%d): %s",
                     pip_install.returncode,
@@ -6847,6 +7028,215 @@ class GatewayOrchestrator:
                 self.dashboard_state.push_update_progress(
                     "failed", f"Restart failed — run: {restart_command_hint()}"
                 )
+
+    async def _auto_apply_wheel_update(self) -> None:
+        """Auto-apply a wheel/cli.sh update by re-running the signed installer.
+
+        The installer (``cli.sh``) handles the full security chain: RSA-SHA256
+        signature verification of the manifest against a pinned public key,
+        SHA-256 checksum of the downloaded wheel, and channel assertion. This
+        method simply invokes it as a subprocess, then restarts the gateway via
+        ``os.execv`` so the new code takes effect.
+
+        Preconditions (checked by the caller):
+        * ``auto_update`` is True in config.
+        * ``_update_info["update_command"]`` is set (the feed check succeeded
+          and composed the installer command locally from validated inputs).
+        * The install is NOT self_updatable (not a git checkout) and NOT
+          externally managed (not a desktop app or container).
+
+        The command is composed by :func:`_wheel_update_command` from a validated
+        channel name and a scheme-pinned artifact base URL (``--proto '=https'``),
+        never from feed data. A successful run replaces the venv in-place; a
+        failure leaves the existing install intact (cli.sh writes to a temp dir
+        and atomically replaces via ``ln -sf``).
+        """
+        from kiro_crew.dashboard.handlers import _update_info
+
+        update_cmd = _update_info.get("update_command")
+        if not update_cmd or not isinstance(update_cmd, str):
+            logger.warning("Auto-update (wheel): no update_command available")
+            return
+
+        # Platform guard: cli.sh is POSIX shell. Windows wheel installs do not
+        # exist in practice (install.ps1 makes Windows a thin client to a Linux
+        # gateway), but guard anyway.
+        if sys.platform == "win32":
+            logger.warning("Auto-update (wheel): not supported on Windows")
+            if self.dashboard_state:
+                self.dashboard_state.push_refresh("update_available")
+            return
+
+        # Source pin: the CDN bases that compose the installer command must
+        # satisfy the policy source pin, same check the git path applies to
+        # its remote. A pinned fleet's wheel installs cannot bypass the ceiling.
+        from kiro_crew.platform.update_governance import update_blocked_reason
+        from kiro_crew.platform.update_layout import cdn_bases, cdn_bases_are_safe
+
+        # The installer command embeds the CDN bases and is handed to a shell, and
+        # KIROCREW_CDN_BASE is operator-set: a metacharacter could close the URL
+        # and append a second command, and an http:// override would make the
+        # piped installer interceptable. Same gate `kirocrew update` applies.
+        if not cdn_bases_are_safe():
+            logger.error(
+                "Auto-update (wheel): CDN base contains disallowed characters "
+                "or is not HTTPS — refusing to run"
+            )
+            if self.dashboard_state:
+                self.dashboard_state.push_refresh("update_available")
+            return
+
+        feed_base, artifact_base = cdn_bases()
+        blocked = update_blocked_reason(feed_base)
+        if not blocked:
+            blocked = update_blocked_reason(artifact_base)
+        if blocked:
+            logger.warning("Auto-update (wheel) refused: %s", blocked)
+            if self.dashboard_state:
+                self.dashboard_state.push_refresh("update_available")
+            return
+
+        if self.dashboard_state:
+            self.dashboard_state.push_update_progress(
+                "pulling", "Downloading update from CDN…"
+            )
+
+        logger.info("Auto-update (wheel): running installer")
+        # Resolve sh through the trusted system dirs, not the gateway's PATH
+        # (which can lead with an agent-writable venv/bin), so a planted shim
+        # cannot hijack the installer spawn. Fail CLOSED if no trusted shell:
+        # a bare-name fallback would reopen the very hole this closes.
+        from kiro_crew.platform.update_provider import (
+            _kill_and_reap,
+            _read_bounded_output,
+            _trusted_path_env,
+        )
+        from kiro_crew.platform_compat import trusted_system_bin
+
+        _sh = trusted_system_bin("sh")
+        if not _sh:
+            logger.error("Auto-update (wheel): no trusted shell found — refusing to run")
+            if self.dashboard_state:
+                self.dashboard_state.push_update_progress(
+                    "failed", "No trusted shell — run manually: kirocrew update"
+                )
+            return
+        # Pinning the shell is only half of it: the installer line is
+        # ``curl … | sh``, so the child resolves `curl` (and its own inner shell)
+        # through the inherited PATH. Narrow the child's PATH to trusted system
+        # dirs, and fail CLOSED when there is none rather than handing over an
+        # agent-influenceable lookup.
+        _env = _trusted_path_env()
+        if _env is None:
+            logger.error("Auto-update (wheel): no trusted PATH — refusing to run")
+            if self.dashboard_state:
+                self.dashboard_state.push_update_progress(
+                    "failed", "No trusted PATH — run manually: kirocrew update"
+                )
+            return
+        proc: asyncio.subprocess.Process | None = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                _sh,
+                "-c",
+                update_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=_env,
+                # Root, not the gateway's cwd, which can be an agent-writable
+                # checkout a relative command word would resolve inside.
+                cwd="/",
+                # Own session: the installer line is a pipeline, so the whole
+                # tree must be one killable group that cannot signal back into
+                # the gateway's own group.
+                start_new_session=platform_compat.IS_POSIX,
+            )
+            # Bounded: the installer's stdout is chatter and only a capped
+            # stderr is logged, so a verbose CDN script cannot exhaust the
+            # gateway's memory buffering it.
+            stdout, stderr = await _read_bounded_output(
+                proc, timeout=300, want_stdout=False
+            )
+        except asyncio.CancelledError:
+            # Shutdown (SIGTERM) cancels this task. Without this branch the
+            # installer keeps mutating the installation after the gateway exits,
+            # leaving a half-replaced venv nobody is supervising. Kill the whole
+            # TREE (the line is a pipeline) and reap under a bound, then re-raise
+            # so cancellation still propagates. ``proc`` is None when the
+            # cancellation landed during the spawn itself.
+            if proc is not None:
+                await _kill_and_reap(proc)
+            logger.warning("Auto-update (wheel): cancelled — installer child killed")
+            raise
+        except asyncio.TimeoutError:
+            # Terminate the whole tree and reap under a bound so nothing keeps
+            # modifying the installation after we return.
+            if proc is not None:
+                await _kill_and_reap(proc)
+            logger.error("Auto-update (wheel): installer timed out (5 min)")
+            if self.dashboard_state:
+                self.dashboard_state.push_update_progress(
+                    "failed", "Installer timed out — run manually: kirocrew update"
+                )
+            return
+        except OSError:
+            # OSError, not just FileNotFoundError: fd or process exhaustion
+            # raises a different OSError, and this runs on the boot path.
+            logger.exception("Auto-update (wheel): could not start the installer")
+            if self.dashboard_state:
+                self.dashboard_state.push_update_progress(
+                    "failed", "'sh' not available — run manually: kirocrew update"
+                )
+            return
+
+        if proc.returncode != 0:
+            from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+            # Redact BEFORE truncating. Slicing first can cut a credential in
+            # half, and half a token no longer matches the redactors' patterns
+            # (an AWS key needs its full 20 chars to match), so the surviving
+            # fragment would reach gateway.log and /api/logs verbatim. The
+            # 500-char cap is for log volume, so it belongs last.
+            err_text = (stderr or b"").decode(errors="replace")
+            err_text, _ = redact_exfiltration_urls(err_text)
+            err_text, _ = redact_credentials(err_text)
+            err_text = err_text[:500]
+            logger.error(
+                "Auto-update (wheel): installer failed (rc=%d): %s",
+                proc.returncode,
+                err_text,
+            )
+            if self.dashboard_state:
+                self.dashboard_state.push_update_progress(
+                    "failed",
+                    f"Installer failed (exit {proc.returncode}) — "
+                    "run manually: kirocrew update",
+                )
+            return
+
+        logger.info("Auto-update (wheel): installer succeeded, restarting gateway")
+        if self.dashboard_state:
+            self.dashboard_state.push_update_progress("restarting", "Restarting server…")
+            from kiro_crew.dashboard.chat import save_all_slots_to_history
+
+            try:
+                await asyncio.wait_for(
+                    asyncio.get_running_loop().run_in_executor(
+                        subprocess_executor(),
+                        save_all_slots_to_history,
+                        self.dashboard_state,
+                    ),
+                    timeout=5.0,
+                )
+            except Exception:
+                logger.debug(
+                    "Dashboard slot save before wheel auto-update restart failed",
+                    exc_info=True,
+                )
+        if self.sessions:
+            await self.sessions.close_all()
+        # Restart into the freshly-installed version.
+        os.execv(sys.executable, [sys.executable, "-m", "kiro_crew"] + sys.argv[1:])
 
     # ------------------------------------------------------------------
     # Main run loop

--- a/test/test_dashboard_updates_coverage.py
+++ b/test/test_dashboard_updates_coverage.py
@@ -1210,12 +1210,19 @@ class TestUpdateInfoAccessors:
             "https://cdn.example.invalid",
         )
 
-    def test_the_recommended_command_pins_https_and_names_the_channel(self):
+    def test_the_recommended_command_pins_https_and_names_the_channel(self, monkeypatch):
+        # Asserts the invariants, not an exact string: the builder is shared with
+        # the gateway's unattended path, so its shape may change (it stopped
+        # piping curl into sh, which hid download failures) while these must hold.
+        monkeypatch.setenv("KIROCREW_CDN_BASE", "https://download.example.invalid")
         command = updates._wheel_update_command("insider", "https://download.example.invalid")
-        assert command == (
-            "curl -fsSL --proto '=https' https://download.example.invalid/cli.sh"
-            " | sh -s -- --channel insider"
-        )
+        assert "--proto '=https'" in command, "must refuse a plaintext override"
+        assert "https://download.example.invalid/cli.sh" in command
+        assert "--channel insider" in command, "a bare re-run would default to stable"
+        # The invariant is that the DOWNLOAD's failure fails the command.
+        # A pipe fed from an already-checked variable preserves that; only a
+        # bare `curl … | sh` would report just sh's status.
+        assert '_kc_body="$(curl' in command, "curl must not feed sh directly"
 
 
 class TestExternallyManagedCheck:

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -853,6 +853,7 @@ class TestCheckForUpdates:
         orch.dashboard_state = ds
         orch._auto_apply_update = AsyncMock()
         import kiro_crew.dashboard.handlers as _h
+        from kiro_crew.platform.governance import UpdatePins
         orig = _h._update_info.copy()
         # Create a config with auto_update=False
         fake_cfg = MagicMock()
@@ -861,7 +862,11 @@ class TestCheckForUpdates:
             _h._update_info.update({"available": True, "version": "9.9.9"})
             with patch.object(_h, "_do_update_check", new_callable=AsyncMock):
                 with patch("kiro_crew.config.KiroCrewConfig.load", return_value=fake_cfg):
-                    await orch._check_for_updates()
+                    with patch(
+                        "kiro_crew.platform.governance.active_update_pins",
+                        return_value=UpdatePins(),
+                    ):
+                        await orch._check_for_updates()
         finally:
             _h._update_info.clear()
             _h._update_info.update(orig)
@@ -5893,14 +5898,128 @@ class TestChannelTransportStartGate:
         assert orch._socket_client is socket_client
 
 
-class TestMandatoryUpdateOnWheelInstall:
-    """A policy min-version makes an update mandatory. On a wheel/cli.sh install
-    the git-based auto-apply cannot run, so the mandatory branch must NOTIFY
-    (warn + light the dashboard badge) instead of silently returning — which is
-    what it did before, leaving the host below the floor with no signal."""
+class TestProviderFailureDoesNotFallBackToLegacy:
+    """A policy-selected provider OWNS the update. Falling through to the legacy
+    updater on its failure would run the built-in git/CDN update on a host whose
+    administrator selected a different package manager."""
 
     @pytest.mark.asyncio
-    async def test_mandatory_update_on_wheel_notifies_not_silent(self, monkeypatch):
+    async def test_provider_raising_does_not_run_legacy(self, monkeypatch):
+        from kiro_crew.platform.update_provider import CommandProvider
+
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+
+        provider = CommandProvider(check_command="c", apply_command="a")
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_provider.resolve_provider", lambda: provider
+        )
+        boom = AsyncMock(side_effect=RuntimeError("provider exploded"))
+        monkeypatch.setattr(orch, "_check_for_updates_via_provider", boom)
+        legacy = AsyncMock()
+        monkeypatch.setattr(orch, "_check_for_updates_legacy", legacy)
+
+        # Contained, not propagated: this runs on the gateway boot path.
+        await orch._check_for_updates()
+
+        legacy.assert_not_awaited()
+        boom.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_resolution_failure_still_uses_legacy(self, monkeypatch):
+        """Only RESOLUTION failures may fall back: if the policy cannot be read
+        we do not know a provider was selected, so built-in behaviour is right."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+
+        def _boom():
+            raise RuntimeError("policy unreadable")
+
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_provider.resolve_provider", _boom
+        )
+        legacy = AsyncMock()
+        monkeypatch.setattr(orch, "_check_for_updates_legacy", legacy)
+
+        await orch._check_for_updates()
+        legacy.assert_awaited_once()
+
+
+class TestWheelInstallerRejectsUnsafeCdnBase:
+    """The installer command embeds the CDN bases and is handed to a shell, and
+    KIROCREW_CDN_BASE is operator-set, so a metacharacter could append a second
+    command. `kirocrew update` already gates on this; the unattended path must too."""
+
+    @pytest.mark.asyncio
+    async def test_unsafe_base_refuses_before_spawning(self, monkeypatch):
+        import kiro_crew.dashboard.handlers as handlers
+
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+
+        handlers._update_info.clear()
+        handlers._update_info.update({"update_command": "curl x | sh"})
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_layout.cdn_bases_are_safe", lambda: False
+        )
+        spawn = AsyncMock()
+        monkeypatch.setattr("asyncio.create_subprocess_exec", spawn)
+
+        await orch._auto_apply_wheel_update()
+
+        spawn.assert_not_awaited()
+        ds.push_refresh.assert_called_with("update_available")
+
+
+class TestProviderNotificationIsVisible:
+    """The SSE snapshot renders the update badge from _update_info["available"],
+    which only the legacy check writes. A provider carries its own result, so
+    notifying without publishing it left the badge reading a stale False and the
+    operator never saw a waiting policy-defined update."""
+
+    @pytest.mark.asyncio
+    async def test_auto_update_off_publishes_state_before_notifying(self, monkeypatch):
+        import kiro_crew.dashboard.handlers as handlers
+        import kiro_crew.platform.update_governance as gov
+        from kiro_crew.platform.update_provider import UpdateCheckResult
+
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+
+        handlers._update_info.clear()
+        handlers._update_info.update({"available": False})
+        monkeypatch.setattr(gov, "update_required", lambda _v: False)
+
+        cfg = MagicMock()
+        cfg.auto_update = False
+        # A real provider: the method asserts isinstance(provider, UpdateProvider),
+        # which a bare MagicMock does not satisfy.
+        from kiro_crew.platform.update_provider import CommandProvider
+
+        provider = CommandProvider(check_command="c", apply_command="a")
+        provider.check = AsyncMock(  # type: ignore[method-assign]
+            return_value=UpdateCheckResult(available=True, remote_version="9.9.9")
+        )
+
+        with patch("kiro_crew.config.KiroCrewConfig.load", return_value=cfg):
+            await orch._check_for_updates_via_provider(provider)
+
+        # The badge must be able to see it, not just the log.
+        assert handlers._update_info["available"] is True
+        assert handlers._update_info["remote_version"] == "9.9.9"
+        ds.push_refresh.assert_called_with("update_available")
+
+
+class TestMandatoryUpdateOnWheelInstall:
+    """A policy min-version makes an update mandatory. On a wheel/cli.sh install
+    the gateway now auto-applies via the signed installer (cli.sh handles
+    RSA-SHA256 verification). The _auto_apply_wheel_update method is called
+    instead of merely lighting the dashboard badge."""
+
+    @pytest.mark.asyncio
+    async def test_mandatory_update_on_wheel_auto_applies(self, monkeypatch):
         import kiro_crew.dashboard.handlers as handlers
         import kiro_crew.platform.update_governance as gov
 
@@ -5911,14 +6030,14 @@ class TestMandatoryUpdateOnWheelInstall:
         async def _noop_check():
             return None
 
-        # Wheel install below a policy floor: a feed-checkable layout reports
-        # self_updatable False, and the check can leave available False (a
-        # pre-release remote reads as not-newer) even though the floor mandates
-        # the update. Start from available False to prove the branch lights it.
+        # Wheel install below a policy floor with a NEWER build available: the
+        # mandatory update applies. (A mandatory floor with no newer build is
+        # covered by test_mandatory_wheel_no_newer_build_notifies below — that
+        # path must NOT apply, to avoid an infinite update→restart loop.)
         handlers._update_info.clear()
         handlers._update_info.update(
             {
-                "available": False,
+                "available": True,
                 "self_updatable": False,
                 "install_kind": "wheel",
                 # A feed-checkable wheel carries an installer command; that is
@@ -5932,15 +6051,53 @@ class TestMandatoryUpdateOnWheelInstall:
 
         apply_called = AsyncMock()
         monkeypatch.setattr(orch, "_auto_apply_update", apply_called)
+        wheel_apply_called = AsyncMock()
+        monkeypatch.setattr(orch, "_auto_apply_wheel_update", wheel_apply_called)
 
         await orch._check_for_updates()
 
-        # Must NOT attempt the git apply on a non-git tree, and must surface it.
+        # Must NOT attempt the git apply on a non-git tree.
         apply_called.assert_not_awaited()
-        ds.push_refresh.assert_called_once_with("update_available")
-        # The dashboard badge reads _update_info["available"]; a mandatory
-        # update must light it even though the check left it False.
-        assert handlers._update_info.get("available") is True
+        # Must call the wheel auto-apply for mandatory updates.
+        wheel_apply_called.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_mandatory_wheel_no_newer_build_notifies(self, monkeypatch):
+        """A wheel install below the floor but with NO newer build available
+        must NOT apply — applying would reinstall the same below-floor version
+        and execv-restart into the same state forever. It notifies instead."""
+        import kiro_crew.dashboard.handlers as handlers
+        import kiro_crew.platform.update_governance as gov
+
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+
+        async def _noop_check():
+            return None
+
+        handlers._update_info.clear()
+        handlers._update_info.update(
+            {
+                "available": False,  # floor pinned above the latest build
+                "self_updatable": False,
+                "install_kind": "wheel",
+                "update_command": "curl -fsSL … | sh",
+            }
+        )
+        monkeypatch.setattr(handlers, "_do_update_check", _noop_check)
+        monkeypatch.setattr(gov, "update_required", lambda _v: True)
+        monkeypatch.setattr(gov, "min_version", lambda: "9.9.9")
+
+        wheel_apply_called = AsyncMock()
+        monkeypatch.setattr(orch, "_auto_apply_update", AsyncMock())
+        monkeypatch.setattr(orch, "_auto_apply_wheel_update", wheel_apply_called)
+
+        await orch._check_for_updates()
+
+        # Must NOT apply (would loop); must notify via the dashboard badge.
+        wheel_apply_called.assert_not_awaited()
+        ds.push_refresh.assert_called_with("update_available")
 
     @pytest.mark.asyncio
     async def test_mandatory_update_on_externally_managed_does_not_badge(self, monkeypatch):

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -851,6 +851,21 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "session_pid.py::find_orphan_mcp_candidates",
         "session_pid.py::kill_orphan_mcps",
         "slack/gateway.py::_auto_apply_update",
+        # Wheel/cli.sh auto-update: runs the signed installer command
+        # (composed locally from a validated channel name and https-pinned
+        # artifact base, never from feed data). The child is the cli.sh
+        # installer, which performs its own RSA-SHA256 signature verification.
+        # NOT sandbox-routed because the installer must write to the managed
+        # venv and symlink ~/.local/bin/kirocrew.
+        "slack/gateway.py::_auto_apply_wheel_update",
+        # Pluggable update provider: CommandProvider runs operator-configured
+        # shell commands from security_policy.json or config.json (sensitive
+        # home dirs the agent cannot write). The check command probes for a
+        # newer version; the apply command performs the update. Both are
+        # operator-authored, not agent-influenced. NOT sandbox-routed because
+        # the command must reach the host's package manager / registry.
+        "platform/update_provider.py::check",
+        "platform/update_provider.py::apply",
         "slack/gateway.py::_check_missing_deps",
         # The kiro-cli version probe, extracted from _init_services (issue
         # #3051). Fixed argv ("kiro-cli --version"), no agent-influenced

--- a/test/test_update_check_install_aware.py
+++ b/test/test_update_check_install_aware.py
@@ -146,15 +146,25 @@ class TestChannelResolution:
     def test_update_command_always_names_the_channel(self):
         # cli.sh defaults to stable and never reads the channel file, so a bare
         # re-run would silently move an insider install onto the stable lane.
+        # Asserts invariants, not a prefix: the shared builder now fetches to a
+        # temp file before running it (a pipe reported only sh's status, hiding a
+        # failed download), so the command no longer begins with curl.
         cmd = updates._wheel_update_command("insider", "https://download.example")
         assert "--channel insider" in cmd
-        assert cmd.startswith("curl -fsSL --proto '=https' https://download.example/cli.sh")
+        assert "curl -fsSL --proto '=https'" in cmd
+        assert "/cli.sh" in cmd
+        # The invariant is that the DOWNLOAD's failure fails the command.
+        # A pipe fed from an already-checked variable preserves that; only a
+        # bare `curl … | sh` would report just sh's status.
+        assert '_kc_body="$(curl' in cmd, "curl must not feed sh directly"
 
-    def test_update_command_pins_https(self):
-        # The string is copied into a shell and pipes an installer into `sh`, and
-        # the base is overridable via KIROCREW_CDN_BASE. Without --proto '=https'
-        # an http:// override yields a command that fetches a script in plaintext
-        # and executes it — an on-path attacker could swap the installer.
+    def test_update_command_pins_https(self, monkeypatch):
+        # The string is copied into a shell and runs an installer, and the base is
+        # overridable via KIROCREW_CDN_BASE. Without --proto '=https' an http://
+        # override yields a command that fetches a script in plaintext and
+        # executes it — an on-path attacker could swap the installer. curl
+        # refuses the scheme even when the override is plaintext.
+        monkeypatch.setenv("KIROCREW_CDN_BASE", "http://evil.example")
         cmd = updates._wheel_update_command("stable", "http://evil.example")
         assert "--proto '=https'" in cmd
 
@@ -547,6 +557,7 @@ class TestAutoApplyGuard:
         orch = object.__new__(GatewayOrchestrator)
         orch.dashboard_state = MagicMock()
         orch._auto_apply_update = AsyncMock()
+        orch._auto_apply_wheel_update = AsyncMock()
         return orch
 
     def _run(self, info: dict[str, object], *, auto_update: bool):
@@ -555,6 +566,7 @@ class TestAutoApplyGuard:
         orch = self._orchestrator()
         cfg = MagicMock()
         cfg.auto_update = auto_update
+        from kiro_crew.platform.governance import UpdatePins
         original = dict(handlers._update_info)
         try:
             handlers._update_info.clear()
@@ -565,7 +577,14 @@ class TestAutoApplyGuard:
                         "kiro_crew.platform.update_governance.update_required",
                         return_value=False,
                     ):
-                        asyncio.run(orch._check_for_updates())
+                        # No commands in the policy pins, so resolve_provider
+                        # returns None and the code falls through to the legacy
+                        # path under test.
+                        with patch(
+                            "kiro_crew.platform.governance.active_update_pins",
+                            return_value=UpdatePins(),
+                        ):
+                            asyncio.run(orch._check_for_updates())
         finally:
             handlers._update_info.clear()
             handlers._update_info.update(original)
@@ -573,11 +592,18 @@ class TestAutoApplyGuard:
 
     def test_wheel_install_notifies_instead_of_applying(self):
         orch = self._run(
-            {"available": True, "self_updatable": False, "install_kind": "wheel"},
+            {
+                "available": True,
+                "self_updatable": False,
+                "install_kind": "wheel",
+                "update_command": "curl -fsSL … | sh",
+            },
             auto_update=True,
         )
+        # The git apply must NOT run on a non-git tree.
         orch._auto_apply_update.assert_not_awaited()
-        orch.dashboard_state.push_refresh.assert_called_with("update_available")
+        # The wheel auto-apply IS called (new behavior).
+        orch._auto_apply_wheel_update.assert_awaited_once()
 
     def test_git_checkout_still_auto_applies(self):
         orch = self._run(

--- a/test/test_update_provider.py
+++ b/test/test_update_provider.py
@@ -1,0 +1,1405 @@
+"""Tests for kiro_crew.platform.update_provider."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.platform.governance import UpdatePins
+from kiro_crew.platform.update_provider import (
+    CommandProvider,
+    UpdateCheckResult,
+    UpdateProvider,
+    _current_platform_key,
+    _kill_and_reap,
+    _shell_exec_args,
+    _trusted_path_env,
+    resolve_provider,
+)
+
+
+class TestUpdateCheckResult:
+    def test_defaults(self) -> None:
+        r = UpdateCheckResult()
+        assert r.available is False
+        assert r.remote_version == ""
+        assert r.error == ""
+
+    def test_available(self) -> None:
+        r = UpdateCheckResult(available=True, remote_version="1.2.3")
+        assert r.available is True
+        assert r.remote_version == "1.2.3"
+
+    def test_error(self) -> None:
+        r = UpdateCheckResult(error="network timeout")
+        assert r.available is False
+        assert r.error == "network timeout"
+
+    def test_frozen(self) -> None:
+        r = UpdateCheckResult()
+        with pytest.raises(Exception):
+            r.available = True  # type: ignore[misc]
+
+
+class TestProtocol:
+    def test_command_is_provider(self) -> None:
+        assert isinstance(CommandProvider(), UpdateProvider)
+
+
+#: Tests that EXECUTE a generated command need a real POSIX shell: on Windows
+#: ``_shell_exec_args`` returns None by design (the command lane is refused there
+#: because the child's lookup cannot be made trustworthy), so anything asserting
+#: on the argv it builds cannot run. String-shape and mock-based assertions in
+#: the same classes deliberately keep running on Windows.
+_needs_posix_shell = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="executes a generated command; _shell_exec_args refuses on Windows by design",
+)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the command provider lane is POSIX-only by design: _shell_exec_args "
+    "refuses on Windows because the child's command lookup cannot be made "
+    "trustworthy there (no trusted PATH to substitute, and cmd.exe searches CWD)",
+)
+class TestCommandProvider:
+    @pytest.mark.asyncio
+    async def test_check_no_command(self) -> None:
+        p = CommandProvider(check_command="", apply_command="echo ok")
+        result = await p.check()
+        assert result.error == "no check_command configured"
+
+    @pytest.mark.asyncio
+    async def test_check_returns_version(self) -> None:
+        p = CommandProvider(check_command="echo 2.0.0", apply_command="echo ok")
+        result = await p.check()
+        assert result.available is True
+        assert result.remote_version == "2.0.0"
+
+    @pytest.mark.asyncio
+    async def test_check_no_update(self) -> None:
+        p = CommandProvider(check_command="exit 1", apply_command="echo ok")
+        result = await p.check()
+        assert result.available is False
+        assert result.error == ""
+
+    @pytest.mark.asyncio
+    async def test_check_empty_version_is_error(self) -> None:
+        # An exit-0 check that prints NO version is a broken command, not an
+        # available update: returning available=True with an empty version would
+        # make apply() run and restart to the SAME version forever. The provider
+        # fails the check (error set, available False) instead.
+        p = CommandProvider(check_command="true", apply_command="echo ok")
+        result = await p.check()
+        assert result.available is False
+        assert result.error != ""
+
+    @pytest.mark.asyncio
+    async def test_apply_success(self) -> None:
+        p = CommandProvider(check_command="echo 2.0.0", apply_command="echo done")
+        success = await p.apply()
+        assert success is True
+
+    @pytest.mark.asyncio
+    async def test_apply_failure(self) -> None:
+        p = CommandProvider(check_command="echo 2.0.0", apply_command="exit 1")
+        success = await p.apply()
+        assert success is False
+
+    @pytest.mark.asyncio
+    async def test_apply_no_command(self) -> None:
+        p = CommandProvider(check_command="echo 2.0.0", apply_command="")
+        success = await p.apply()
+        assert success is False
+
+    @pytest.mark.asyncio
+    async def test_check_version_truncated(self) -> None:
+        # Long output is truncated to 128 chars
+        long_version = "x" * 200
+        p = CommandProvider(check_command=f"echo {long_version}", apply_command="echo ok")
+        result = await p.check()
+        assert result.available is True
+        assert len(result.remote_version) <= 128
+
+
+class TestResolveProvider:
+    """The seam is policy-only and selection is by PRESENCE of commands.
+
+    resolve_provider() returns a CommandProvider carrying the policy's commands
+    when the active pins define a check_command or apply_command, and None
+    otherwise (the ungoverned default — the gateway keeps its built-in update
+    behaviour). There is no mechanism enum and no config/env path into the seam.
+    """
+
+    def test_no_commands_returns_none(self) -> None:
+        """Empty pins (no commands) → None."""
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins",
+            return_value=UpdatePins(),
+        ):
+            assert resolve_provider() is None
+
+    def test_commands_present_creates_command_provider(self) -> None:
+        """Policy pins carrying commands → CommandProvider with them."""
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins",
+            return_value=UpdatePins(
+                check_command="/opt/check.sh",
+                apply_command="/opt/apply.sh",
+            ),
+        ):
+            provider = resolve_provider()
+            assert isinstance(provider, CommandProvider)
+            assert provider.check_command == "/opt/check.sh"
+            assert provider.apply_command == "/opt/apply.sh"
+
+    def test_check_command_only_creates_provider(self) -> None:
+        """Presence of just a check_command is enough to select the provider."""
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins",
+            return_value=UpdatePins(check_command="/opt/check.sh"),
+        ):
+            provider = resolve_provider()
+            assert isinstance(provider, CommandProvider)
+            assert provider.check_command == "/opt/check.sh"
+            assert provider.apply_command == ""
+
+    def test_apply_command_only_creates_provider(self) -> None:
+        """Presence of just an apply_command is enough to select the provider."""
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins",
+            return_value=UpdatePins(apply_command="/opt/apply.sh"),
+        ):
+            provider = resolve_provider()
+            assert isinstance(provider, CommandProvider)
+            assert provider.check_command == ""
+            assert provider.apply_command == "/opt/apply.sh"
+
+    def test_platform_only_policy_is_still_a_provider(self) -> None:
+        """A policy may define commands ONLY per platform. Returning None there
+        would silently fall through to the built-in updater and bypass the
+        administrator-selected package manager."""
+        key = _current_platform_key()
+        pins = UpdatePins(
+            platform_commands={key: {"check_command": "c", "apply_command": "a"}}
+        )
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins", return_value=pins
+        ):
+            provider = resolve_provider()
+        assert isinstance(provider, CommandProvider)
+        assert provider._resolve_command("check_command") == "c"
+
+    def test_platform_only_policy_for_another_platform_still_provider(self) -> None:
+        """Presence is policy-wide, not host-specific: a policy naming only other
+        platforms must NOT fall through to the built-in updater. The provider is
+        returned and refuses on this host instead."""
+        pins = UpdatePins(
+            platform_commands={"some-other-platform": {"apply_command": "a"}}
+        )
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins", return_value=pins
+        ):
+            provider = resolve_provider()
+        assert isinstance(provider, CommandProvider)
+        assert provider._resolve_command("check_command") == ""
+
+    def test_empty_platform_entry_is_not_presence(self) -> None:
+        """A platform key carrying no commands is not a configured provider."""
+        pins = UpdatePins(platform_commands={"linux-x86_64": {}})
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins", return_value=pins
+        ):
+            assert resolve_provider() is None
+
+    def test_platform_commands_passed_through(self) -> None:
+        """policy platform_commands are carried onto the CommandProvider, and the
+        resolved provider picks the right one for the current platform."""
+        current_key = _current_platform_key()
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins",
+            return_value=UpdatePins(
+                check_command="/opt/check.sh",
+                apply_command="/opt/apply.sh",
+                platform_commands={
+                    current_key: {"apply_command": "/opt/apply-native.sh"},
+                },
+            ),
+        ):
+            provider = resolve_provider()
+            assert isinstance(provider, CommandProvider)
+            assert provider.platform_commands == {
+                current_key: {"apply_command": "/opt/apply-native.sh"},
+            }
+            # _resolve_command uses the platform override for apply, default for check
+            assert provider._resolve_command("apply_command") == "/opt/apply-native.sh"
+            assert provider._resolve_command("check_command") == "/opt/check.sh"
+
+    def test_reading_pins_fails_returns_none(self) -> None:
+        """If reading the policy pins raises, resolve_provider fails closed to
+        None (the gateway keeps its built-in behaviour)."""
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins",
+            side_effect=RuntimeError("policy unreadable"),
+        ):
+            assert resolve_provider() is None
+
+
+class TestPlatformHelpers:
+    """Test _current_platform_key and _shell_exec_args."""
+
+    def test_platform_key_format(self) -> None:
+        key = _current_platform_key()
+        parts = key.split("-")
+        assert len(parts) == 2
+        assert parts[0] == sys.platform
+
+    def test_platform_key_normalized_machine(self) -> None:
+        with patch("platform.machine", return_value="x86_64"):
+            key = _current_platform_key()
+            assert key.endswith("-x86_64")
+
+    def test_platform_key_amd64_normalized(self) -> None:
+        with patch("platform.machine", return_value="AMD64"):
+            key = _current_platform_key()
+            assert key.endswith("-x86_64")
+
+    def test_platform_key_aarch64_normalized(self) -> None:
+        with patch("platform.machine", return_value="aarch64"):
+            key = _current_platform_key()
+            assert key.endswith("-arm64")
+
+    def test_platform_key_arm64(self) -> None:
+        with patch("platform.machine", return_value="arm64"):
+            key = _current_platform_key()
+            assert key.endswith("-arm64")
+
+    def test_platform_key_unknown_passthrough(self) -> None:
+        with patch("platform.machine", return_value="riscv64"):
+            key = _current_platform_key()
+            assert key.endswith("-riscv64")
+
+    def test_shell_exec_args_posix(self) -> None:
+        # Shell is resolved via trusted_system_bin; patch it to a known path so
+        # the test does not depend on the host's actual /bin/sh location.
+        with patch.object(sys, "platform", "linux"):
+            with patch(
+                "kiro_crew.platform.update_provider.trusted_system_bin",
+                return_value="/bin/sh",
+            ):
+                args = _shell_exec_args("my-updater check")
+                assert args == ["/bin/sh", "-c", "my-updater check"]
+
+    def test_shell_exec_args_posix_fallback(self) -> None:
+        # When the trusted lookup misses, fail CLOSED (return None) rather than
+        # falling back to a bare name — the bare name is the agent-writable-PATH
+        # hole this resolution exists to close.
+        with patch.object(sys, "platform", "linux"):
+            with patch(
+                "kiro_crew.platform.update_provider.trusted_system_bin",
+                return_value=None,
+            ):
+                assert _shell_exec_args("my-updater check") is None
+
+    def test_shell_exec_args_windows_refused(self) -> None:
+        # Windows is refused outright: there is no trusted PATH to substitute
+        # there and cmd.exe resolves a bare command word from the CWD first, so
+        # the child's lookup stays agent-influenceable. Fail closed.
+        with patch.object(sys, "platform", "win32"):
+            with patch(
+                "kiro_crew.platform.update_provider.trusted_system_bin",
+                return_value="C:\\Windows\\System32\\cmd.exe",
+            ):
+                assert _shell_exec_args("my-updater check") is None
+
+
+class TestCommandProviderPlatformOverrides:
+    """Test platform_commands resolution in CommandProvider."""
+
+    @pytest.mark.asyncio
+    async def test_platform_override_apply(self) -> None:
+        """Platform-specific apply_command overrides the default."""
+        current_key = _current_platform_key()
+        p = CommandProvider(
+            check_command="echo 2.0.0",
+            apply_command="echo default-apply",
+            platform_commands={
+                current_key: {"apply_command": "echo platform-apply"},
+            },
+        )
+        # The resolved command uses the platform override
+        assert p._resolve_command("apply_command") == "echo platform-apply"
+
+    @pytest.mark.asyncio
+    async def test_platform_override_check(self) -> None:
+        """Platform-specific check_command overrides the default."""
+        current_key = _current_platform_key()
+        p = CommandProvider(
+            check_command="echo default-check",
+            apply_command="echo apply",
+            platform_commands={
+                current_key: {"check_command": "echo platform-check"},
+            },
+        )
+        assert p._resolve_command("check_command") == "echo platform-check"
+
+    def test_no_override_falls_back_to_default(self) -> None:
+        """When platform key doesn't match, default command is used."""
+        p = CommandProvider(
+            check_command="echo default",
+            apply_command="echo apply-default",
+            platform_commands={
+                "fake-platform-key": {"apply_command": "echo other"},
+            },
+        )
+        assert p._resolve_command("apply_command") == "echo apply-default"
+        assert p._resolve_command("check_command") == "echo default"
+
+    def test_partial_override_only_overrides_specified_field(self) -> None:
+        """Only the field specified in the override is replaced."""
+        current_key = _current_platform_key()
+        p = CommandProvider(
+            check_command="echo default-check",
+            apply_command="echo default-apply",
+            platform_commands={
+                current_key: {"apply_command": "echo platform-apply"},
+            },
+        )
+        # check_command falls back to default since not overridden
+        assert p._resolve_command("check_command") == "echo default-check"
+        assert p._resolve_command("apply_command") == "echo platform-apply"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="runs a real command through the shell; the command lane is "
+        "POSIX-only by design (see _shell_exec_args)",
+    )
+    @pytest.mark.asyncio
+    async def test_platform_override_actually_runs(self) -> None:
+        """Integration: platform override is actually executed."""
+        current_key = _current_platform_key()
+        p = CommandProvider(
+            check_command="echo default-version",
+            apply_command="echo default-apply",
+            platform_commands={
+                current_key: {"check_command": "echo 3.0.0-platform"},
+            },
+        )
+        result = await p.check()
+        assert result.available is True
+        assert result.remote_version == "3.0.0-platform"
+
+
+class TestUpdatePinsCommandFields:
+    """UpdatePins.from_dict parsing of command fields (governance)."""
+
+    def test_from_dict_command_fields(self) -> None:
+        pins = UpdatePins.from_dict(
+            {
+                "check_command": "/opt/check.sh",
+                "apply_command": "/opt/apply.sh",
+            }
+        )
+        assert pins.check_command == "/opt/check.sh"
+        assert pins.apply_command == "/opt/apply.sh"
+        assert pins.platform_commands == {}
+
+    def test_from_dict_command_defaults_empty(self) -> None:
+        pins = UpdatePins.from_dict({})
+        assert pins.check_command == ""
+        assert pins.apply_command == ""
+        assert pins.platform_commands == {}
+
+    def test_from_dict_platform_commands(self) -> None:
+        pins = UpdatePins.from_dict(
+            {
+                "check_command": "/opt/check.sh",
+                "apply_command": "/opt/apply.sh",
+                "platform_commands": {
+                    "linux-x86_64": {
+                        "check_command": "/opt/check-x64.sh",
+                        "apply_command": "/opt/apply-x64.sh",
+                    },
+                    "darwin-arm64": {"apply_command": "/opt/apply-arm64.sh"},
+                },
+            }
+        )
+        assert pins.platform_commands == {
+            "linux-x86_64": {
+                "check_command": "/opt/check-x64.sh",
+                "apply_command": "/opt/apply-x64.sh",
+            },
+            "darwin-arm64": {"apply_command": "/opt/apply-arm64.sh"},
+        }
+
+    def test_from_dict_command_non_string_raises(self) -> None:
+        from kiro_crew.platform.governance import PlatformCompositionError
+
+        with pytest.raises(PlatformCompositionError, match="must be a string"):
+            UpdatePins.from_dict({"check_command": 123})
+
+    def test_from_dict_platform_commands_not_mapping_raises(self) -> None:
+        from kiro_crew.platform.governance import PlatformCompositionError
+
+        with pytest.raises(PlatformCompositionError, match="must be a mapping"):
+            UpdatePins.from_dict({"platform_commands": "nope"})
+
+    def test_from_dict_platform_commands_unknown_key_raises(self) -> None:
+        from kiro_crew.platform.governance import PlatformCompositionError
+
+        with pytest.raises(PlatformCompositionError, match="unknown key"):
+            UpdatePins.from_dict(
+                {
+                    "platform_commands": {
+                        "linux-x86_64": {"bogus_command": "/opt/x.sh"},
+                    },
+                }
+            )
+
+    def test_from_dict_platform_commands_non_string_value_raises(self) -> None:
+        from kiro_crew.platform.governance import PlatformCompositionError
+
+        with pytest.raises(PlatformCompositionError, match="must be a string"):
+            UpdatePins.from_dict(
+                {
+                    "platform_commands": {
+                        "linux-x86_64": {"apply_command": 42},
+                    },
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for mocking asyncio subprocesses
+# ---------------------------------------------------------------------------
+
+
+def _stream(data: bytes) -> asyncio.StreamReader:
+    """A real StreamReader at EOF, so bounded reads behave as in production."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(data)
+    reader.feed_eof()
+    return reader
+
+
+def _fake_proc(returncode: int = 0, stdout: bytes = b"", stderr: bytes = b"") -> "MagicMock":
+    """Build a mock subprocess the production code can actually read.
+
+    ``_read_bounded_output`` drains ``proc.stdout``/``proc.stderr`` itself rather
+    than calling ``communicate()``, so the streams must be real readers; a bare
+    MagicMock attribute is not awaitable. ``communicate`` is still stubbed for
+    the cleanup paths that call it.
+    """
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = _stream(stdout)
+    proc.stderr = _stream(stderr)
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.wait = AsyncMock(return_value=returncode)
+    proc.kill = MagicMock()
+    proc.pid = 4242
+    return proc
+
+
+class TestCommandProviderNoShellAndTimeout:
+    """CommandProvider fail-closed shell + timeout + stderr redaction."""
+
+    @pytest.mark.asyncio
+    async def test_check_no_trusted_shell(self) -> None:
+        p = CommandProvider(check_command="echo hi", apply_command="echo ok")
+        with patch(
+            "kiro_crew.platform.update_provider._shell_exec_args",
+            return_value=None,
+        ):
+            result = await p.check()
+        assert result.error == "no trusted shell found"
+
+    @pytest.mark.asyncio
+    async def test_apply_no_trusted_shell(self) -> None:
+        p = CommandProvider(check_command="echo hi", apply_command="echo ok")
+        with patch(
+            "kiro_crew.platform.update_provider._shell_exec_args",
+            return_value=None,
+        ):
+            assert await p.apply() is False
+
+    @pytest.mark.asyncio
+    async def test_check_timeout_kills_proc(self) -> None:
+        p = CommandProvider(check_command="sleep 100", apply_command="echo ok")
+        proc = _fake_proc(returncode=0)
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "sleep 100"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            patch("asyncio.wait_for", AsyncMock(side_effect=asyncio.TimeoutError())),
+        ):
+            result = await p.check()
+        assert result.error == "check_command timed out"
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_check_file_not_found(self) -> None:
+        p = CommandProvider(check_command="echo hi", apply_command="echo ok")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "echo hi"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                AsyncMock(side_effect=FileNotFoundError()),
+            ),
+            patch.object(sys, "platform", "linux"),
+        ):
+            result = await p.check()
+        # Any spawn failure becomes an error verdict; the message no longer
+        # names the shell because OSError covers more than "missing binary".
+        assert result.error and result.available is False
+
+    @pytest.mark.asyncio
+    async def test_apply_timeout_kills_proc(self) -> None:
+        p = CommandProvider(check_command="echo hi", apply_command="sleep 100")
+        proc = _fake_proc(returncode=0)
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "sleep 100"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            patch("asyncio.wait_for", AsyncMock(side_effect=asyncio.TimeoutError())),
+        ):
+            assert await p.apply() is False
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_apply_file_not_found(self) -> None:
+        p = CommandProvider(check_command="echo hi", apply_command="echo ok")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "echo ok"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                AsyncMock(side_effect=FileNotFoundError()),
+            ),
+            patch.object(sys, "platform", "linux"),
+        ):
+            assert await p.apply() is False
+
+    @pytest.mark.asyncio
+    async def test_apply_failure_redacts_stderr(self) -> None:
+        import types
+
+        p = CommandProvider(check_command="echo hi", apply_command="fail")
+        proc = _fake_proc(returncode=1, stderr=b"token=secret123 failed")
+        sec = types.ModuleType("kiro_crew.security")
+        sec.redact_credentials = MagicMock(side_effect=lambda t: (t, 0))  # type: ignore[attr-defined]
+        sec.redact_exfiltration_urls = MagicMock(side_effect=lambda t: (t, 0))  # type: ignore[attr-defined]
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "fail"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            patch.dict(sys.modules, {"kiro_crew.security": sec}),
+        ):
+            assert await p.apply() is False
+        sec.redact_credentials.assert_called_once()
+        sec.redact_exfiltration_urls.assert_called_once()
+
+
+class TestCancellationKillsUpdaterChild:
+    """A gateway shutdown cancels the update task. The updater child must be
+    killed and reaped, not left mutating the installation after we are gone.
+
+    Every test here stubs BOTH ``_shell_exec_args`` AND ``trusted_system_path``
+    so the command lane runs identically on every host (POSIX and Windows
+    runners): the seams are what make it platform-dependent, so neutralising
+    both keeps these tests about the cancellation/reap semantics only.
+    """
+
+    @staticmethod
+    def _proc():
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.stdout = _stream(b"")
+        proc.stderr = _stream(b"")
+        proc.wait = AsyncMock(return_value=proc.returncode)
+        proc.kill = MagicMock()
+        return proc
+
+    @pytest.mark.asyncio
+    async def test_command_apply_cancelled_kills_child(self) -> None:
+        proc = self._proc()
+        p = CommandProvider(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "a"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            patch("asyncio.wait_for", AsyncMock(side_effect=asyncio.CancelledError())),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await p.apply()
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_command_check_cancelled_kills_child(self) -> None:
+        proc = self._proc()
+        p = CommandProvider(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "c"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            patch("asyncio.wait_for", AsyncMock(side_effect=asyncio.CancelledError())),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await p.check()
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_apply_runs_outside_any_writable_checkout(self) -> None:
+        """A relative command word must not resolve in the gateway's cwd."""
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.stdout = _stream(b"")
+        proc.stderr = _stream(b"")
+        proc.wait = AsyncMock(return_value=proc.returncode)
+        spawn = AsyncMock(return_value=proc)
+        p = CommandProvider(check_command="c", apply_command="./update.sh")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "./update.sh"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch("asyncio.create_subprocess_exec", spawn),
+        ):
+            assert await p.apply() is True
+        assert spawn.await_args.kwargs["cwd"] == "/"
+
+    @pytest.mark.asyncio
+    async def test_kill_and_reap_kills_the_whole_tree(self) -> None:
+        """An update command is a shell pipeline, so killing only the direct
+        child leaves its members running and can leave communicate() waiting on
+        pipes those survivors hold."""
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.kill = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.stdout = _stream(b"")
+        proc.stderr = _stream(b"")
+        proc.wait = AsyncMock(return_value=proc.returncode)
+        with patch(
+            "kiro_crew.platform_compat.kill_process_tree_async", AsyncMock()
+        ) as tree:
+            await _kill_and_reap(proc)
+        tree.assert_awaited_once()
+        assert tree.await_args.args[0] == 4242
+
+    @pytest.mark.asyncio
+    async def test_kill_and_reap_bounds_the_reap(self) -> None:
+        """A descendant ignoring the signal must not turn cleanup into a hang."""
+        proc = MagicMock()
+        proc.pid = 1
+        proc.kill = MagicMock()
+
+        async def _never_returns():
+            await asyncio.sleep(3600)
+
+        proc.communicate = _never_returns
+        with patch("kiro_crew.platform_compat.kill_process_tree_async", AsyncMock()):
+            await asyncio.wait_for(_kill_and_reap(proc), timeout=30)
+
+    @pytest.mark.asyncio
+    async def test_kill_and_reap_tolerates_dead_child(self) -> None:
+        """Reaping is best-effort: a child that already exited must not raise."""
+        proc = MagicMock()
+        proc.kill = MagicMock(side_effect=ProcessLookupError())
+        proc.communicate = AsyncMock(side_effect=RuntimeError("already reaped"))
+        await _kill_and_reap(proc)
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_spawn_propagates_cancellation(self) -> None:
+        """Cancellation landing INSIDE create_subprocess_exec leaves no child and
+        no bound name: the handler must re-raise CancelledError, not trip over an
+        unbound local and replace it with UnboundLocalError."""
+        p = CommandProvider(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "a"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                AsyncMock(side_effect=asyncio.CancelledError()),
+            ),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await p.apply()
+
+    @pytest.mark.asyncio
+    async def test_check_cancel_during_spawn_propagates_cancellation(self) -> None:
+        p = CommandProvider(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "c"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                AsyncMock(side_effect=asyncio.CancelledError()),
+            ),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await p.check()
+
+
+class TestCommandProviderTrustedPath:
+    """The child must not resolve the operator's command words through a PATH
+    that can lead with an agent-writable directory."""
+
+    def test_trusted_path_env_replaces_path_only(self) -> None:
+        with (
+            patch.dict(os.environ, {"PATH": "/home/u/.local/bin:/usr/bin", "LANG": "C"}),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+        ):
+            env = _trusted_path_env()
+        assert env is not None
+        assert env["PATH"] == "/usr/bin:/bin"
+        # Everything else survives, so a package manager keeps its proxy/locale.
+        assert env["LANG"] == "C"
+
+    def test_trusted_path_env_fails_closed_when_unavailable(self) -> None:
+        # No trusted PATH to substitute: refuse rather than pass the inherited
+        # (agent-influenceable) PATH through to the child.
+        with (
+            patch.dict(os.environ, {"PATH": "/orig"}),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value=None,
+            ),
+        ):
+            assert _trusted_path_env() is None
+
+    @pytest.mark.asyncio
+    async def test_apply_refuses_without_trusted_path(self) -> None:
+        spawn = AsyncMock()
+        p = CommandProvider(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "a"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch(
+                "kiro_crew.platform.update_provider._trusted_path_env",
+                return_value=None,
+            ),
+            patch("asyncio.create_subprocess_exec", spawn),
+        ):
+            assert await p.apply() is False
+        spawn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_check_refuses_without_trusted_path(self) -> None:
+        spawn = AsyncMock()
+        p = CommandProvider(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "c"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch(
+                "kiro_crew.platform.update_provider._trusted_path_env",
+                return_value=None,
+            ),
+            patch("asyncio.create_subprocess_exec", spawn),
+        ):
+            assert (await p.check()).error
+        spawn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_apply_passes_trusted_env(self) -> None:
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.stdout = _stream(b"")
+        proc.stderr = _stream(b"")
+        proc.wait = AsyncMock(return_value=proc.returncode)
+        spawn = AsyncMock(return_value=proc)
+        p = CommandProvider(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "a"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch(
+                "kiro_crew.platform.update_provider._trusted_path_env",
+                return_value={"PATH": "/usr/bin:/bin"},
+            ),
+            patch("asyncio.create_subprocess_exec", spawn),
+        ):
+            assert await p.apply() is True
+        assert spawn.await_args.kwargs["env"] == {"PATH": "/usr/bin:/bin"}
+
+    @pytest.mark.asyncio
+    async def test_check_passes_trusted_env(self) -> None:
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"9.9.9", b""))
+        proc.stdout = _stream(b"9.9.9")
+        proc.stderr = _stream(b"")
+        proc.wait = AsyncMock(return_value=proc.returncode)
+        spawn = AsyncMock(return_value=proc)
+        p = CommandProvider(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "c"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch(
+                "kiro_crew.platform.update_provider._trusted_path_env",
+                return_value={"PATH": "/usr/bin:/bin"},
+            ),
+            patch("asyncio.create_subprocess_exec", spawn),
+        ):
+            assert (await p.check()).available is True
+        assert spawn.await_args.kwargs["env"] == {"PATH": "/usr/bin:/bin"}
+
+
+class TestManualEntryPointsHonourPolicy:
+    """`POST /api/update` and `kirocrew update` must not run the built-in
+    git/CDN mechanism on a host whose policy selects its own updater. An
+    authenticated operator clicking Update is who they say they are, not proof
+    that this host may update by git."""
+
+    @pytest.mark.asyncio
+    async def test_apply_policy_update_returns_none_without_provider(self) -> None:
+        from kiro_crew.platform.governance import UpdatePins
+        from kiro_crew.platform.update_provider import apply_policy_update
+
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins",
+            return_value=UpdatePins(),
+        ):
+            assert await apply_policy_update() is None
+
+    @pytest.mark.asyncio
+    async def test_apply_policy_update_delegates_when_configured(self) -> None:
+        from kiro_crew.platform.governance import UpdatePins
+        from kiro_crew.platform.update_provider import apply_policy_update
+
+        pins = UpdatePins(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.governance.active_update_pins", return_value=pins
+            ),
+            patch.object(CommandProvider, "apply", AsyncMock(return_value=True)) as ap,
+        ):
+            assert await apply_policy_update() is True
+        ap.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_provider_failure_is_reported_not_swallowed(self) -> None:
+        """False must reach the caller so it can refuse to fall back."""
+        from kiro_crew.platform.governance import UpdatePins
+        from kiro_crew.platform.update_provider import apply_policy_update
+
+        pins = UpdatePins(apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.governance.active_update_pins", return_value=pins
+            ),
+            patch.object(CommandProvider, "apply", AsyncMock(return_value=False)),
+        ):
+            assert await apply_policy_update() is False
+
+
+class TestWheelUpdateCommandPropagatesDownloadFailure:
+    """`curl … | sh` reports sh's status, and a shell handed empty input exits 0,
+    so a CDN failure looked like a successful update: version unchanged, gateway
+    restarted, check still saw an update, unattended path looped."""
+
+    def test_download_status_is_not_swallowed_by_the_pipe(self) -> None:
+        """The invariant is that the DOWNLOAD's failure fails the command, not
+        that no pipe appears. A bare `curl … | sh` reports only sh's status; a
+        pipe fed from an already-checked variable does not, because the fetch
+        ran (and could abort) in the command substitution first."""
+        from kiro_crew.platform.update_layout import wheel_update_command
+
+        with patch(
+            "kiro_crew.platform.update_layout.cdn_bases",
+            return_value=("https://f", "https://a"),
+        ):
+            cmd = wheel_update_command("stable")
+        assert "set -e" in cmd
+        # curl's status is consumed by an assignment that `set -e` can abort on,
+        # so its output is never piped straight into sh.
+        assert "_kc_body=\"$(curl" in cmd
+        assert "curl" not in cmd.split("|", 1)[1], "curl must not sit inside the pipeline"
+
+    @_needs_posix_shell
+    def test_download_failure_is_non_zero(self, tmp_path, monkeypatch) -> None:
+        """Executed for real, but contained: a stub `curl` on a test-local PATH
+        stands in for the network, and TMPDIR plus cwd keep `mktemp` and any
+        stray write inside the test directory."""
+        import subprocess
+
+        from kiro_crew.platform.update_layout import wheel_update_command
+
+        # Stub curl that fails like an unreachable host, so the assertion is
+        # about OUR command's exit-status plumbing, not about the network.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        fake_curl = bin_dir / "curl"
+        fake_curl.write_text("#!/bin/sh\nexit 6\n")
+        fake_curl.chmod(0o755)
+
+        with patch(
+            "kiro_crew.platform.update_layout.cdn_bases",
+            return_value=("https://f", "https://cdn.invalid"),
+        ):
+            cmd = wheel_update_command("stable")
+        shell = _shell_exec_args(cmd)
+        assert shell is not None
+
+        env = dict(os.environ)
+        env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+        env["TMPDIR"] = str(tmp_path)
+        result = subprocess.run(
+            shell, capture_output=True, cwd=tmp_path, env=env
+        )
+        assert result.returncode != 0, "a failed download must fail the command"
+
+
+class TestTrustedEnvDropsLoaderInjection:
+    """Narrowing PATH is not enough: PYTHONPATH plus a planted sitecustomize.py
+    runs on every Python start, and LD_PRELOAD/DYLD_* do the same for any
+    dynamically linked binary, so an update command that is a Python or shell
+    wrapper would execute agent-writable code as the gateway."""
+
+    def test_loader_variables_are_removed(self, monkeypatch) -> None:
+        for var in ("PYTHONPATH", "PYTHONHOME", "LD_PRELOAD", "DYLD_INSERT_LIBRARIES",
+                    "BASH_ENV", "IFS"):
+            monkeypatch.setenv(var, "/tmp/agent-writable")
+        monkeypatch.setenv("LANG", "C.UTF-8")
+        with patch(
+            "kiro_crew.platform.update_provider.trusted_system_path",
+            return_value="/usr/bin:/bin",
+        ):
+            env = _trusted_path_env()
+        assert env is not None
+        for var in ("PYTHONPATH", "PYTHONHOME", "LD_PRELOAD",
+                    "DYLD_INSERT_LIBRARIES", "BASH_ENV", "IFS"):
+            assert var not in env, f"{var} must not reach the update command"
+        # Benign variables a package manager needs still survive.
+        assert env["LANG"] == "C.UTF-8"
+
+
+class TestSpawnStartupErrorsAreVerdicts:
+    """fd or process exhaustion raises an OSError that is not
+    FileNotFoundError; a manual update must get an error verdict, not a crash."""
+
+    @pytest.mark.asyncio
+    async def test_check_returns_error_on_oserror(self) -> None:
+        p = CommandProvider(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "c"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                AsyncMock(side_effect=OSError(24, "Too many open files")),
+            ),
+        ):
+            result = await p.check()
+        assert result.error and result.available is False
+
+    @pytest.mark.asyncio
+    async def test_apply_returns_false_on_oserror(self) -> None:
+        p = CommandProvider(check_command="c", apply_command="a")
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "a"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                AsyncMock(side_effect=OSError(24, "Too many open files")),
+            ),
+        ):
+            assert await p.apply() is False
+
+
+class TestOutputIsBounded:
+    """`communicate()` buffers a child's whole output in the gateway's memory
+    with no bound, so a chatty package manager could exhaust it before the
+    timeout fires. We keep a version string and a capped error summary."""
+
+    @pytest.mark.asyncio
+    async def test_huge_stdout_is_capped(self) -> None:
+        from kiro_crew.platform.update_provider import (
+            _MAX_CAPTURED_OUTPUT,
+            _read_bounded_output,
+        )
+
+        proc = _fake_proc(stdout=b"x" * (_MAX_CAPTURED_OUTPUT * 4))
+        out, _err = await _read_bounded_output(proc, timeout=5, want_stdout=True)
+        assert len(out) == _MAX_CAPTURED_OUTPUT
+
+    @pytest.mark.asyncio
+    async def test_apply_discards_stdout_but_keeps_bounded_stderr(self) -> None:
+        from kiro_crew.platform.update_provider import (
+            _MAX_CAPTURED_OUTPUT,
+            _read_bounded_output,
+        )
+
+        proc = _fake_proc(
+            stdout=b"chatter" * 5000, stderr=b"e" * (_MAX_CAPTURED_OUTPUT * 2)
+        )
+        out, err = await _read_bounded_output(proc, timeout=5, want_stdout=False)
+        assert out == b"", "installer chatter nobody reads must not be buffered"
+        assert len(err) == _MAX_CAPTURED_OUTPUT
+
+    @pytest.mark.asyncio
+    @_needs_posix_shell
+    async def test_a_real_flood_does_not_deadlock_or_grow(self) -> None:
+        """Executed for real: draining both pipes concurrently is what stops a
+        full pipe buffer from wedging the child."""
+        from kiro_crew.platform.update_provider import (
+            _MAX_CAPTURED_OUTPUT,
+            _read_bounded_output,
+            _shell_exec_args,
+        )
+
+        argv = _shell_exec_args("yes FLOOD | head -c 4194304")
+        assert argv is not None
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        out, _err = await _read_bounded_output(proc, timeout=60, want_stdout=True)
+        assert len(out) == _MAX_CAPTURED_OUTPUT
+        assert proc.returncode == 0
+
+
+class TestInstallerNeverLandsOnDisk:
+    """The gateway and an agent share a uid, so a 0600 temp file does not keep
+    the agent out: staging the installer to `mktemp` let it swap the contents
+    between `curl` writing them and `sh` opening them. The body stays in memory
+    instead, which removes the window rather than policing it."""
+
+    def test_command_stages_no_file(self) -> None:
+        from kiro_crew.platform.update_layout import wheel_update_command
+
+        with patch(
+            "kiro_crew.platform.update_layout.cdn_bases",
+            return_value=("https://f", "https://cdn.invalid"),
+        ):
+            cmd = wheel_update_command("stable")
+        assert "mktemp" not in cmd, "no writable temp file may hold the installer"
+        assert " -o " not in cmd, "curl must not write the installer to a path"
+        # stdin form: -s tells sh to read the script from stdin, -- passes the
+        # rest to that script. The file form must NOT carry these.
+        assert "sh -s --" in cmd
+
+    def test_empty_body_is_rejected(self) -> None:
+        """A shell handed empty input exits 0, which is the false success the
+        piped form had; the command must test the body before running it."""
+        from kiro_crew.platform.update_layout import wheel_update_command
+
+        with patch(
+            "kiro_crew.platform.update_layout.cdn_bases",
+            return_value=("https://f", "https://cdn.invalid"),
+        ):
+            cmd = wheel_update_command("stable")
+        assert 'test -n "$_kc_body"' in cmd
+
+    @_needs_posix_shell
+    def test_download_failure_still_fails_the_command(self, tmp_path) -> None:
+        """Executed for real against a stub `curl` that fails: removing the temp
+        file must not re-introduce the exit-status swallowing it was added for."""
+        import subprocess
+
+        from kiro_crew.platform.update_layout import wheel_update_command
+        from kiro_crew.platform.update_provider import _shell_exec_args
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        fake_curl = bin_dir / "curl"
+        fake_curl.write_text("#!/bin/sh\nexit 6\n")
+        fake_curl.chmod(0o755)
+
+        with patch(
+            "kiro_crew.platform.update_layout.cdn_bases",
+            return_value=("https://f", "https://cdn.invalid"),
+        ):
+            cmd = wheel_update_command("stable")
+        argv = _shell_exec_args(cmd)
+        assert argv is not None
+
+        env = dict(os.environ)
+        env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+        env["TMPDIR"] = str(tmp_path)
+        result = subprocess.run(argv, capture_output=True, cwd=tmp_path, env=env)
+        assert result.returncode != 0, "a failed download must fail the command"
+        # And nothing was staged on the way.
+        assert not list((tmp_path).glob("tmp*"))
+
+
+class TestPosixOnlyMarkerIsNotForgotten:
+    """Three separate rounds of this PR each added a test that EXECUTES a
+    generated command, and each passed locally on Linux while failing the Windows
+    shard, because `_shell_exec_args` returns None there BY DESIGN. A Linux-only
+    local run cannot catch that, so assert the coupling directly.
+
+    The signal is deliberately "builds an argv AND spawns it", not "mentions
+    `_shell_exec_args`": tests that only assert on its RETURN VALUE (such as the
+    one pinning the Windows refusal) must keep running on Windows, since that is
+    where the behaviour they check lives.
+    """
+
+    #: This guard's own body names the tokens it searches for, so it would match
+    #: itself; its class is skipped by name rather than by weakening the search.
+    _SELF_CLASS = "TestPosixOnlyMarkerIsNotForgotten"
+
+    def test_every_command_executing_test_is_marked(self) -> None:
+        import pathlib as _pathlib
+        import re
+
+        lines = _pathlib.Path(__file__).read_text().splitlines()
+        # (line index, name) for every test function, plus the class it sits in.
+        current_class = ""
+        tests: list[tuple[int, str, str]] = []
+        for i, line in enumerate(lines):
+            cls = re.match(r"class (\w+)", line)
+            if cls:
+                current_class = cls.group(1)
+                continue
+            fn = re.match(r"    (?:async )?def (test_\w+)", line)
+            if fn:
+                tests.append((i, fn.group(1), current_class))
+
+        offenders = []
+        for idx, name, cls in tests:
+            if cls == self._SELF_CLASS:
+                continue
+            # Walk UP from the def to collect its contiguous decorator lines.
+            decorators = []
+            j = idx - 1
+            while j >= 0 and lines[j].strip().startswith(("@", ")", '"', "'")) or (
+                j >= 0 and lines[j].strip() and not lines[j].strip().startswith("#")
+                and lines[j].startswith("        ")
+            ):
+                decorators.append(lines[j])
+                j -= 1
+                if len(decorators) > 12:
+                    break
+            decorator_text = "\n".join(decorators)
+
+            # Walk DOWN to the end of this test's body.
+            end = len(lines)
+            for k in range(idx + 1, len(lines)):
+                stripped = lines[k]
+                if stripped.strip() and not stripped.startswith("        ") and not stripped.startswith("    )"):
+                    end = k
+                    break
+            body = "\n".join(lines[idx:end])
+
+            builds = "_shell_exec_args(" in body
+            spawns = "subprocess.run(" in body or "create_subprocess_exec(" in body
+            if not (builds and spawns):
+                continue
+            if "_needs_posix_shell" in decorator_text or "skipif" in decorator_text:
+                continue
+            offenders.append(name)
+
+        assert not offenders, (
+            "these tests build an argv with _shell_exec_args (None on Windows by "
+            f"design) and spawn it, but lack @_needs_posix_shell: {offenders}"
+        )
+
+
+class TestWhitespaceCommandsAreNotPresence:
+    """A whitespace-only command is truthy, so it would pass the presence check
+    that SELECTS the provider, and `sh -c "   "` exits 0. That reads as a
+    successful update: the gateway restarts, the version has not changed, the
+    check still reports an update available, and the unattended path loops.
+    Normalising at parse time makes absent and blank the same thing everywhere,
+    matching how `source` and `min_version` were already handled."""
+
+    def test_parse_strips_top_level_commands(self) -> None:
+        from kiro_crew.platform.governance import UpdatePins
+
+        pins = UpdatePins.from_dict({"apply_command": "   ", "check_command": "\t\n"})
+        assert pins.apply_command == ""
+        assert pins.check_command == ""
+
+    def test_parse_strips_platform_commands(self) -> None:
+        from kiro_crew.platform.governance import UpdatePins
+
+        pins = UpdatePins.from_dict(
+            {"platform_commands": {"linux-x86_64": {"apply_command": "  ", "check_command": " \t"}}}
+        )
+        assert pins.platform_commands["linux-x86_64"] == {
+            "apply_command": "",
+            "check_command": "",
+        }
+
+    def test_a_real_command_keeps_its_text(self) -> None:
+        """Stripping must not corrupt a legitimate command."""
+        from kiro_crew.platform.governance import UpdatePins
+
+        pins = UpdatePins.from_dict({"apply_command": "  /usr/bin/pkg update  "})
+        assert pins.apply_command == "/usr/bin/pkg update"
+
+    def test_whitespace_policy_falls_through_to_legacy(self) -> None:
+        """The end-to-end invariant: a blank policy must NOT select a provider,
+        because a selected provider owns the update and never falls back."""
+        from kiro_crew.platform.governance import UpdatePins
+
+        pins = UpdatePins.from_dict(
+            {
+                "apply_command": "  ",
+                "check_command": "\t",
+                "platform_commands": {_current_platform_key(): {"apply_command": "  "}},
+            }
+        )
+        with patch(
+            "kiro_crew.platform.governance.active_update_pins", return_value=pins
+        ):
+            assert resolve_provider() is None
+
+
+class TestRedactionHappensBeforeTruncation:
+    """Slicing stderr to 500 chars BEFORE redacting can cut a credential in half,
+    and half a token no longer matches the redactors' patterns, so the surviving
+    fragment reaches gateway.log and /api/logs verbatim. Order, not presence, is
+    what makes the redaction effective."""
+
+    @pytest.mark.asyncio
+    async def test_a_credential_straddling_the_cap_is_not_leaked(self, caplog) -> None:
+        # An AWS-key-shaped secret positioned so the 500-char cap would bisect it.
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        padding = "x" * (500 - len(secret) // 2)
+        stderr = (padding + secret + " trailing").encode()
+
+        provider = CommandProvider(check_command="c", apply_command="a")
+        proc = _fake_proc(returncode=1, stderr=stderr)
+        with (
+            patch(
+                "kiro_crew.platform.update_provider._shell_exec_args",
+                return_value=["/bin/sh", "-c", "a"],
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            caplog.at_level(logging.ERROR),
+        ):
+            assert await provider.apply() is False
+
+        logged = "\n".join(r.getMessage() for r in caplog.records)
+        assert secret not in logged, "the whole secret must never be logged"
+        # The real regression: the FRAGMENT left by a mid-token cut.
+        assert secret[: len(secret) // 2] not in logged, (
+            "a credential bisected by the 500-char cap leaked its prefix; "
+            "redact before truncating"
+        )
+
+    def test_both_sites_redact_before_slicing(self) -> None:
+        """Pins the ordering in source at both spawn sites, so a future edit that
+        reintroduces `decode(...)[:500]` is caught even without a stderr fixture."""
+        import inspect
+
+        from kiro_crew.platform import update_provider as provider_mod
+        from kiro_crew.slack import gateway as gateway_mod
+
+        for module in (provider_mod, gateway_mod):
+            src = inspect.getsource(module)
+            assert 'decode(errors="replace")[:500]' not in src, (
+                f"{module.__name__} truncates before redacting"
+            )


### PR DESCRIPTION
## What

Adds a policy-only seam so an enterprise can point Kiro Crew's self-update at its own package manager, and closes the wheel auto-update gap.

Two parts:

1. **`CommandProvider`** — the enterprise escape hatch. An operator defines `check_command` / `apply_command` in the `updates` block of the keystone-protected `security_policy.json`. `check_command` exits 0 and prints a version when an update is available; `apply_command` performs it. `platform_commands` overrides either per `{sys.platform}-{machine}` key, covering linux / darwin / win32 across x86_64 and arm64.

2. **Wheel auto-update** — a `cli.sh` wheel install with `auto_update = true` now applies the signed installer unattended instead of only lighting the dashboard badge, which is what a git checkout already did.

No vendor-specific paths: any enterprise configures its own commands.

## Trust placement

A command provider runs unsandboxed code as the gateway, so its commands are read **only** from `security_policy.json`, which the agent cannot write. `config.json` and environment variables cannot reach this seam at all. Presence of a command is the selection; there is no mechanism enum to spoof.

Guards on the command path: shell resolved through `trusted_system_bin` (never a bare argv name), child `PATH` narrowed to trusted system dirs, `cwd="/"` so a relative command word cannot resolve inside an agent-writable checkout, stderr passed through `redact_exfiltration_urls` + `redact_credentials` before logging, and the child killed and reaped on both timeout and cancellation. Each of these fails closed rather than degrading. The Windows lane is deliberately refused: there is no trusted `PATH` to substitute there and `cmd.exe` resolves a bare command word from the working directory first, so it stays closed until it has a trusted lookup.

Guards on the wheel path: the CDN bases are checked against the policy source pin before the installer runs, auto-apply is restricted to `install_kind == "wheel"` (a `source` install would install into a separate venv and re-exec unchanged, so it notifies), and a mandatory `min_version` floor applies only when a newer build is actually available, so a floor pinned above the latest build cannot drive an update-restart loop.

## Verified

`pytest` / `isort` / `flake8` / `mypy` green by exit code. `update_provider.py` at 99% per-file coverage. Coverage, spawn-audit and security-posture gates pass. Tests cover the trusted-shell and trusted-PATH refusals, `cwd`, cancel-during-spawn, the empty-version guard, per-platform override resolution, and the wheel no-newer-build loop guard.

## Scope note

An earlier revision also carried `GitProvider` / `BuiltinProvider` classes and a three-tier mechanism selector (`security_policy` → `config.json` → env). Both were removed: the two providers had no production consumer (the gateway routed every non-command install to the legacy path, which owns the full safeguard chain), and the config/env tier could only ever no-op or refuse an update, which `auto_update = false` already covers. Net effect of the reduction: about 1500 lines deleted, and the trust boundary reduced to one file the agent cannot write.
