### PR TITLE
fix(update): reset the install mutation when an aborted dispatch ends without a restart

### DIFF
--- a/website/src/components/UpdateModal.cov80.test.tsx
+++ b/website/src/components/UpdateModal.cov80.test.tsx
@@ -205,3 +205,30 @@ describe('UpdateModal', () => {
     })
   })
 })
+
+describe('aborted install recovery', () => {
+  beforeEach(() => {
+    install.mockReset()
+    install.mockResolvedValue(undefined)
+    ;(window as unknown as { updateAPI?: { install: () => Promise<unknown> } }).updateAPI = { install }
+  })
+  afterEach(() => {
+    delete (window as unknown as { updateAPI?: unknown }).updateAPI
+  })
+
+  it('an aborted install does not brick the modal for the next downloaded version', async () => {
+    const { push } = await mount({ state: 'downloaded', version: '9.9.9' })
+    fireEvent.click(
+      await screen.findByRole('button', { name: i18nT('components.updateModal.restart_update') }),
+    )
+    await waitFor(() => expect(install).toHaveBeenCalledTimes(1))
+    // Main process aborts the handoff (stage invalidated) — error/install state.
+    await push({ state: 'error', phase: 'install', version: '9.9.9' })
+    // The superseding version is later downloaded: the modal must reopen LIVE.
+    await push({ state: 'downloaded', version: '9.9.10' })
+    const restart = await screen.findByRole('button', { name: i18nT('components.updateModal.restart_update') })
+    expect(restart).toBeEnabled()
+    fireEvent.click(restart)
+    await waitFor(() => expect(install).toHaveBeenCalledTimes(2))
+  })
+})

--- a/website/src/components/UpdateModal.tsx
+++ b/website/src/components/UpdateModal.tsx
@@ -57,6 +57,28 @@ export default function UpdateModal() {
   // unexplained quit — which reads as a crash.
   const installing = installMutation.isPending || installMutation.isSuccess
 
+  // A dispatched install normally ends in the app quitting, so isSuccess is a
+  // fine proxy for "about to restart" -- EXCEPT when the main process aborts
+  // the handoff (stage invalidated mid-dispatch) and the app keeps running.
+  // Without a reset, the stale isSuccess keeps `installing` true forever: the
+  // next downloaded version reopens this modal with every button disabled and
+  // no way out short of a reload. The dispatch is only "still live" while the
+  // state is 'installing' or 'downloaded' FOR THE VERSION the user clicked
+  // (tracked below) -- keying on the version matters because the IPC
+  // resolution can land after the abort/supersede states have already been
+  // pushed, at which point a bare state check reads the NEW version's
+  // 'downloaded' as the old dispatch still running.
+  const [installFor, setInstallFor] = useState<string | undefined>(undefined)
+  const state = update?.state
+  const stateVersion = update?.version
+  useEffect(() => {
+    if (!installMutation.isSuccess) return
+    const dispatchStillLive = state === 'installing'
+      || (state === 'downloaded' && stateVersion === installFor)
+    if (!dispatchStillLive) installMutation.reset()
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reset identity is stable; keying on state transition
+  }, [state, stateVersion, installFor, installMutation.isSuccess])
+
   const open = !!update && update.state === 'downloaded' && !update.replayed && !dismissed
 
   // Escape dismisses the modal (unless an install is in flight), matching the
@@ -184,7 +206,7 @@ export default function UpdateModal() {
           <button
             type="button"
             className="px-3 py-1.5 text-sm rounded-md bg-accent text-accent-fg hover:opacity-90 cursor-pointer disabled:opacity-50"
-            onClick={() => installMutation.mutate()}
+            onClick={() => { setInstallFor(update!.version); installMutation.mutate() }}
             disabled={installing}
           >
             {installing ? i18nT('components.updateModal.restarting') : i18nT('components.updateModal.restart_update')}


### PR DESCRIPTION
## Problem / Motivation

Follow-up to #3955: I wrote this deadlock fix during that PR's review, but the maintainer merged head 1774f897 before my final amend landed, so the merged branch shipped without it. The symptom: UpdateModal derives `installing` from `installMutation.isPending || isSuccess`, and when the main process aborts a dispatched install (stage invalidated — the abort path that merged via #3951's branch, emitting an error/install state) the app keeps running with a stale `isSuccess`. That pins `installing` true forever, so the next downloaded version reopens the modal with every button disabled — Restart, Later, the close button, and Escape are all dead — until a full reload.

## Why it matters

Anyone whose staged update gets invalidated mid-dispatch (a superseding version arrives while the handoff is in flight) is left with an update modal they cannot interact with and no visible way out. It also completes the renderer half of the UX round-6 concern raised on #3951 — the main-process abort path merged there, but the renderer never recovered from it.

## What changed (motivation → approach → change)

Observed symptom: a permanently disabled update modal after an aborted install. Root cause: `isSuccess` is a fine proxy for "about to restart" only while a dispatched install always ends in the app quitting; the abort path broke that invariant and nothing ever reset the mutation. The change: track which version the user dispatched (`installFor`, set in the Restart & Update onClick) and add an effect that calls `installMutation.reset()` when `isSuccess` is true but the update state no longer belongs to that dispatch — anything other than `'installing'`, or `'downloaded'` for that same version. Keying on the version matters because the IPC resolution can land after the abort/supersede states were already pushed, at which point a bare state check would read the NEW version's `'downloaded'` as the old dispatch still running.

## Tests

New `aborted install recovery` describe block in `UpdateModal.cov80.test.tsx`: click Restart & Update on 9.9.9, push `{state:'error', phase:'install'}` (the abort), push `{state:'downloaded', version:'9.9.10'}` — asserts the reopened modal's Restart button is enabled and a second install dispatch reaches `window.updateAPI.install`. Gates run locally: `npx tsc -b` (exit 0), `npx vitest run src/components/UpdateModal.cov80.test.tsx` (19 passed, exit 0), full vitest suite (20891 passed; one unrelated `CronFolderHeader` waitFor timeout under load that passes in isolation on both clean main and this branch), `npm run lint` (exit 0, no errors).

## Manual verification

N/A — the recovery flow is fully pinned by the regression test; the abort states are pushed through the same query-cache path the real IPC subscription uses.

## Related Issues

no linked issue: follow-up completing a review finding from #3955's UX review

<!-- no-visual-delta -->
**Why no screenshot:** behavioral mutation-reset fix; no pixel differs at rest, and the recovery flow is pinned by the new regression test.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavioral fix with no doc surface
- [x] No secrets, credentials, or internal references in the diff
