### PR TITLE
feat(skills): add five-whys guided dive-deep research mode

### DIFF
--- a/src/kiro_crew/builtin_skills/five-whys/SKILL.md
+++ b/src/kiro_crew/builtin_skills/five-whys/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: five-whys
+description: Enter a guided dive-deep research mode — 5 Whys is the default engine (one focused question at a time along a What-it-is -> Example -> Why-not-alternatives -> Benefits -> Costs chain, user-steered branching), every step appended to an event-sourced log the tree and report are folded from, and extensible with plug-in capabilities (web search, recap, ...) that share that log.
+triggers: 5 whys, five whys, five whys mode, dive deep on, root-cause dive
+---
+
+# 5 Whys — guided dive-deep MODE
+
+This is a **mode**, not a one-shot answer — once triggered you **enter it and
+stay in it across turns** until the user is satisfied or exits. Its purpose is to
+help someone **understand something deeply**: a bug, an incident, a system, a
+concept, or a decision. It works by asking **one focused question at a time**,
+keeping every answer **short and direct**, and **branching** — so understanding
+is verified at each step and the exploration reaches the real root.
+
+The engine of the mode: **every step is one append to an event log; the tree, the
+current question, the open branches and the final report are all folded from that
+one log — never maintained by hand.** 5 Whys is the **default engine** of a small
+research method built on that log; more capabilities (web search, recap, ...) plug
+into the same log — see **Capabilities** below.
+
+## The core loop (this is the whole mode)
+
+Each turn does exactly one of these, then **stops and waits**:
+
+1. **Answer** the current question — short and direct (see disciplines below).
+2. **Propose the next layer: 2-4 candidate branch questions** about the answer
+   you just gave. Each is a single, direct "why...?" / "how...?" / "what causes...?"
+   — the obvious next things to dig into.
+3. **Let the user steer.** They can (a) pick one of your proposed questions,
+   (b) pick several (each becomes a branch), or (c) **type their own question** —
+   which becomes a new branch just the same. Never force your menu; the user's
+   own question always wins.
+4. **Append the events** for what happened (an `ask`, an `answer`, a `focus`
+   move...) to the log **via `scripts/five_whys.py`** (see The mechanical core),
+   then repeat.
+
+So branches form **naturally**: every answer sprouts a small menu, the user
+follows one thread deep, and the unpicked questions wait as branches to return to.
+
+## The reasoning chain (the spine of every dive)
+
+Peeling a thing apart should follow one basic chain of thought. Let it order the
+answers you give and the branch questions you propose, so the exploration always
+moves from grasping the thing to judging it:
+
+1. **What it is** — a plain, concrete definition, ideally via an everyday analogy
+   (a ledger, a git commit, a phone switchboard). Grasp the thing first.
+2. **Example** — one concrete, walked-through instance. Abstract only lands once
+   it's touchable.
+3. **Why not the alternatives** — contrast with the other plausible designs
+   (**not necessarily the naive one** — the serious rival approaches too), and
+   what breaks with each. This is where real understanding lives.
+4. **Benefits** — what this choice buys you that the alternatives don't.
+5. **Costs** — what it costs: complexity, edge cases, failure modes, tax on the
+   reader. Nothing is free; naming the price is the honest finish.
+
+Use it as a **default spine, not a rigid script.** A node usually advances one
+stage along this chain (its answer sits at one stage; the proposed menu offers
+the next stage's questions), but the user can jump stages or open a side branch
+anytime — their question always wins (see the core loop). Every `ask` event
+carries its `stage` (`what` / `example` / `why-not` / `benefits` / `costs`), so
+the folded report reads as a complete chain per thread.
+
+## Two disciplines (keep the thinking honest)
+
+- **One focused question per step.** Atomic, answerable in isolation, no compound
+  or multi-part questions. If it needs "and also...", split it into two branches.
+- **Short answer, expandable on demand.** Default to **one or two sentences** —
+  one idea per step is what makes it learnable and keeps each link verifiable. If
+  the user wants more on a node, they say "expand / go deeper" and you elaborate,
+  but the *default* stays short so the tree doesn't turn into a lecture.
+
+## Who answers
+
+- **Understanding questions -> you answer** from your knowledge, and cite concrete
+  evidence (`file:line`, a doc, a log) when the answer is about *their* code or
+  system so it's grounded, not guessed.
+- **Facts only the user holds -> ask the user** (what they observed, what they
+  intended, a decision they made). Two sentences from them, same cap.
+- **Never fabricate.** If you can't answer and can't cite it, say so and ask.
+
+## Side discussions
+
+At any point the user can open a **side discussion** to explore something more
+freely than the one-question / short-answer rhythm allows — anchored to the
+current node but off to the side.
+
+- **Enter:** the user says "side discussion" / "let's discuss this" (optionally
+  naming a topic). Say you're in a side discussion anchored at node `[x]` and
+  **pause the main loop** — the two disciplines and the question-menu are
+  suspended; talk freely, longer answers and tangents are fine.
+- **Record it:** append `discuss` events (anchored to node `[x]`) so the exchange
+  is kept even though it lives off-tree.
+- **Non-destructive by default:** a side discussion **never silently changes the
+  tree** — no `ask`/`prune` events are emitted from it unless the user approves.
+- **Offer to fold findings in:** when the discussion yields something worth
+  keeping (and again when it ends), tell the user they can (a) **add** a new
+  branch — emit an `ask` (+`answer`) event, (b) **remove** a node — emit a `prune`
+  event, or (c) keep it as discussion-only. Emit those events **only on their
+  explicit say-so.**
+- **Exit:** the user says "end discussion" / "resume 5 whys". Append a `discuss`
+  summary line, apply any approved `ask`/`prune` events, then **resume the main
+  loop exactly where it paused** — the last `focus` event in the log is the cursor.
+
+## The event log (single source of truth)
+
+Model the whole session as an **append-only event log**, one JSON object per line,
+at `<project-dir>/five-whys/<slug>-<YYYY-MM-DD>.jsonl` (fall back to the workspace
+dir if there is no project). **The log IS the state.** You never rewrite it and
+never keep a separate hand-maintained tree — the tree, the current question, the
+open branches and the report are all **projections you fold from the log** when
+you need them, so they can never drift out of sync.
+
+Every line: `{"ts": <ISO-8601>, "type": <type>, ...}`. The types:
+
+| type | key fields | meaning |
+|------|-----------|---------|
+| `ask` | `id`, `parent`, `stage`, `q`, `origin`(proposed\|user) | a question node is created; **`parent` records the relationship** — this is how the tree exists without being stored (root's `parent` is `null`) |
+| `answer` | `id`, `a`, `source`(ai\|user\|`<cite>`) | the answer to node `id` |
+| `focus` | `id` | the cursor: node `id` is now the current question (**latest `focus` wins**) |
+| `done` | `id`, `kind`(root\|takeaway), `note` | this thread bottomed out |
+| `discuss` | `anchor`, `text` | a side-discussion entry, off-tree, anchored to a node |
+| `prune` | `id`, `reason` | remove a node/branch — a **new event**, never an edit to history |
+
+This table is the **built-in core**; capabilities extend it with their own types
+(see Capabilities). Because every projection ignores types it doesn't recognize,
+adding a type never breaks the fold.
+
+Example:
+
+```
+{"ts":"2026-08-16T20:00:00Z","type":"ask","id":"1","parent":null,"stage":"what","q":"What is X?","origin":"proposed"}
+{"ts":"2026-08-16T20:00:01Z","type":"focus","id":"1"}
+{"ts":"2026-08-16T20:00:30Z","type":"answer","id":"1","a":"X is ...","source":"ai"}
+{"ts":"2026-08-16T20:01:00Z","type":"ask","id":"1.1","parent":"1","stage":"example","q":"An example?","origin":"user"}
+{"ts":"2026-08-16T20:03:00Z","type":"discuss","anchor":"1.1","text":"tangent about ..."}
+{"ts":"2026-08-16T20:05:00Z","type":"done","id":"1.2.1","kind":"root","note":"real root cause: ..."}
+```
+
+**Projections (fold the log, don't store them):**
+- **Tree** = group every `ask` by `parent` (minus `prune`d ids).
+- **Current question** = the `id` of the last `focus` event.
+- **Open branches / frontier** = `ask`ed ids with no `answer` and no `done`,
+  excluding the current focus and any `prune`d ids.
+- **Roots / key takeaways** = the `done` events.
+- **Report** = one fold over the log (see close-out).
+
+## The mechanical core (`scripts/five_whys.py`)
+
+**All log reads and writes go through this script — never hand-write or
+hand-fold JSONL.** It owns the deterministic mechanics (append + schema
+validation, id allocation, referential integrity, and folding to projections),
+so the LLM only supplies judgment. Run it with `python3` from the skill dir:
+
+```
+python3 scripts/five_whys.py ask     <log> --parent ID|root --stage S --stdin-json < f.json   # f.json={"q":"..."}; prints new id
+python3 scripts/five_whys.py answer  <log> --id ID --stdin-json < f.json                      # {"a":"...","source":"..."}
+python3 scripts/five_whys.py focus    <log> --id ID
+python3 scripts/five_whys.py done     <log> --id ID [--kind root|takeaway] --stdin-json < f.json   # {"note":"..."}
+python3 scripts/five_whys.py discuss  <log> --anchor ID --stdin-json < f.json                 # {"text":"..."}
+python3 scripts/five_whys.py prune    <log> --id ID --stdin-json < f.json                     # {"reason":"..."}
+python3 scripts/five_whys.py event    <log> --stdin-json < f.json                             # f.json = the plugin event object
+python3 scripts/five_whys.py view     <log>      # current path root->focus + open-branch count (show this each turn)
+python3 scripts/five_whys.py tree     <log> | frontier <log> | report <log> --stdin-json < f.json   # {"title":"..."}
+python3 scripts/five_whys.py validate <log>      # schema + integrity gate, exit 0/1
+```
+
+The script allocates ids, so you never invent them; `prune` cascades to
+descendants; unknown (plugin) event types validate fine and are ignored by the
+core folds. `report` prints the finished markdown — close-out is one command.
+
+**Free text never rides the shell command line.** A question, answer, note,
+citation, title, or plugin-event JSON can contain `$(...)`, backticks or quotes,
+which the shell would execute or mangle. So for every command that carries free
+text, write the field(s) to a **unique** temp file with the write tool — a fresh
+path per write (e.g. via `mktemp`), never a fixed shared path two concurrent
+dives could clobber — as **one JSON object**, and pass `--stdin-json`, feeding it
+on stdin: `... ask <log> --parent 1 --stage what --stdin-json < <unique>.json`
+where the file is `{"q": "..."}`. All of a command's free text (an answer and its
+`source`, or the whole plugin event) travels in that single object — so no free
+text is ever a shell argument, and two untrusted fields share one read. Short,
+safe values (`--parent`, `--stage`, `--id`, `--kind`, `--origin`, `--anchor`)
+stay as ordinary flags.
+
+## Capabilities (plugins)
+
+5 Whys is the **default engine**, but the mode is really a small **research
+method** built on the shared event log — new capabilities plug in by *reading
+that log* and *appending their own typed events*. Nothing else couples them; the
+log is the only contract.
+
+A capability declares four things:
+1. **Invocation** — a word the user types (e.g. "search", "recap") or a menu
+   entry you offer.
+2. **Reads** — the shared log (never a private store), so it starts with full
+   context.
+3. **Emits** — its own append-only event `type`(s), marked **structural**
+   (`ask`/`prune` — changes the tree) or **annotation** (everything else — never
+   changes the tree, only enriches a node).
+4. **Discipline** — same as the core loop: do one thing, append, stop and wait.
+
+Example capabilities:
+- **web search:** when an answer needs external facts, search, then append
+  `{type:"search", id, query, sources:[...], summary}` and feed it into an
+  `answer` whose `source` cites those URLs — a searched answer is never
+  ungrounded. (Annotation.)
+- **recap:** fold the log so far into a running summary and append
+  `{type:"recap", scope:(node|subtree|all), text}` to re-orient mid-session
+  without losing the thread. The close-out report is just a recap over the whole
+  log. (Annotation.)
+- add your own (`hypothesis`, `evidence`, `define`, ...) the same way — pick a
+  `type`, say whether it's structural or annotation, done.
+
+## Procedure
+
+1. **Anchor the starting point**, append its `ask` (`id:"1"`, `parent:null`) and a
+   `focus` on it. **Resume, don't fork:** if a `five-whys/<slug>*.jsonl` for this
+   topic already exists, continue the newest one (fold it, `focus` where it left
+   off) instead of starting a second log.
+2. **Give the first answer / orientation, then propose the first menu** of 2-4
+   branch questions. Append the `answer`; then **append an `ask` for every
+   question in the menu** (each `origin:"proposed"`) so the whole menu parks in
+   the `frontier`, and `focus` the one the user picks — or append + `focus` a
+   question the user types (`origin:"user"`). Unpicked proposals wait in the
+   frontier until pursued later or `prune`d; that is what makes "nothing is lost"
+   true. Stop.
+3. **Loop the core loop.** Pursue the user's chosen thread **depth-first**; each
+   answer produces a fresh menu. When they switch, just `focus` the parked node —
+   the frontier is whatever the fold says is still open, so nothing is lost.
+4. **Bottom out a thread** with a `done` event when the answer is a real root /
+   fundamental takeaway (incident: actionable and within the system's control;
+   concept: a first principle the user is satisfied with).
+5. **Show only the current path each turn** — fold root -> current node, indented —
+   with the short answer, the proposed menu, and a one-line "other open
+   branches: N". Do **not** paste the whole tree; it lives in the log. Offer an
+   `<mcwidget>` tree view (folded from the log) if the user wants the big picture.
+6. **Close out -> report.** When the user exits or every branch is `done`, run
+   `python3 scripts/five_whys.py report <log>` — it folds the log into a clean
+   markdown report (Starting point; the tree with each node's stage -> question ->
+   answer, so every thread reads as a What -> ... -> Costs chain; roots / key
+   takeaways; side-discussion summaries). Add (for an incident) corrective +
+   preventive actions, write it beside the log, and offer to save it as an
+   artifact. Because the log is complete, this is pure projection — no
+   reconstruction from memory.
+
+## Guardrails
+
+- **Append-only — never rewrite the log.** Correcting or removing something is a
+  *new* event (`prune`, a fresh `answer`, a new `focus`), never an edit to a past
+  line. History stays intact; that is what makes the fold trustworthy.
+- **Never hand-write or hand-fold JSONL.** Every read and write goes through
+  `scripts/five_whys.py` — it validates, allocates ids, and folds deterministically,
+  so the tree and report can't drift from the log.
+- **Never interpolate free text or plugin JSON into the shell command.** Put all
+  of a command's free text in one `--stdin-json` JSON object, written to a
+  **unique** temp file with the write tool and fed on stdin (see The mechanical
+  core); a fixed path risks a concurrent-session clobber, and text with `$(...)`,
+  backticks or quotes would otherwise be executed or corrupt the command.
+- **Don't dump — drip.** Resist answering the whole topic in one turn; the value
+  is the one-step-at-a-time ladder. Short answer + a menu, then wait.
+- **The user's own question always branches** — never redirect it back to your menu.
+- **"Human error" is never a root cause** (incident mode): the next question is
+  why the system *allowed* it, until the answer is a fixable system property.
+- **Cause, not blame.** The tree explains mechanism, not who to fault.
+- **Don't leap to the root and back-fill** — each level is earned by the one above.
+
+## Interaction mechanics (this runtime)
+
+- One answer + one question-menu, then **stop and wait** — this is what makes it
+  a mode, not a monologue.
+- Render the proposed menu as a final `[OPTIONS: ...]` line (each option is one
+  branch question, phrased in the user's voice) so they click to go deeper — and
+  remind them they can just type their own question instead, or say "side
+  discussion" to open one (and "end discussion" to come back).
+- Keep every turn to: current path + the short answer + the menu + open-branch
+  count. The log holds everything; the chat holds the focus.

--- a/src/kiro_crew/builtin_skills/five-whys/scripts/five_whys.py
+++ b/src/kiro_crew/builtin_skills/five-whys/scripts/five_whys.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""five_whys.py — deterministic mechanical core for the five-whys research mode.
+
+The event log (append-only JSONL) is the single source of truth. This script owns
+the mechanics that must NOT drift: appending validated events, allocating node ids,
+referential integrity, and folding the log into projections (tree / frontier /
+current / report). All judgment (what to ask, whether an answer is a real cause,
+when a thread is done) stays with the skill/LLM.
+
+Stdlib only, Python 3.8+. No network, no credentials, never rewrites history.
+
+Free text (a question, answer, note, citation, title) is never passed as a shell
+argument -- a value containing ``$(...)``, backticks or quotes would be executed or
+mangled by the shell. Instead, pass ``--stdin-json`` and feed a single JSON object
+of the free-text fields on stdin; the script reads them verbatim.
+
+Usage:
+  five_whys.py ask     <log> --parent ID|root --stage S (--q "..." | --stdin-json) [--origin proposed|user]
+  five_whys.py answer  <log> --id ID (--a "..." | --stdin-json) [--source ...]
+  five_whys.py focus   <log> --id ID
+  five_whys.py done    <log> --id ID [--kind root|takeaway] [--note "..." | --stdin-json]
+  five_whys.py discuss <log> --anchor ID (--text "..." | --stdin-json)
+  five_whys.py prune   <log> --id ID [--reason "..." | --stdin-json]
+  five_whys.py event   <log> (--json '{...}' | --stdin-json)   # plugin custom types
+  five_whys.py view    <log>                                   # current path + open-branch count
+  five_whys.py tree    <log>
+  five_whys.py frontier<log>
+  five_whys.py report  <log> [--title "..." | --stdin-json]    # folds to markdown
+  five_whys.py validate<log>                                   # schema+integrity gate (exit 0/1)
+
+  Free-text via stdin, e.g.:  five_whys.py ask <log> --parent 1 --stage what --stdin-json < fields.json
+  where fields.json is {"q": "..."} written with a file tool (never interpolated).
+"""
+import argparse
+import contextlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+CORE_TYPES = {"ask", "answer", "focus", "done", "discuss", "prune"}
+STAGES = {"what", "example", "why-not", "benefits", "costs"}
+
+
+def _now():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _reject_symlink(path):
+    """Refuse to read or write through a symlink at the final path component.
+
+    The log path is caller-supplied; a symlink planted there could make an
+    append follow the link and corrupt an unintended target file.
+    """
+    if Path(path).is_symlink():
+        raise SystemExit("refusing to follow symlink: %s" % path)
+
+
+def _apply_stdin_json(a, *fields):
+    """Override the named free-text fields from ONE JSON object read from stdin.
+
+    All of a command's free text arrives in a single ``--stdin-json`` object
+    (``{"a": "...", "source": "..."}``), so no free text is ever a shell argument
+    and multiple untrusted fields share one read of the pipe (a per-field stdin
+    sentinel could not -- a second read would drain empty). Only the named fields
+    are consulted; each present value must be a string.
+    """
+    if not getattr(a, "stdin_json", False):
+        return
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        raise SystemExit("invalid --stdin-json payload: %s" % e)
+    if not isinstance(payload, dict):
+        raise SystemExit("--stdin-json payload must be a JSON object")
+    for f in fields:
+        if f in payload:
+            v = payload[f]
+            if not isinstance(v, str):
+                raise SystemExit("--stdin-json field %r must be a string" % f)
+            setattr(a, f, v)
+
+
+def _flock(fd, acquire):
+    """Acquire/release an OS advisory lock on ``fd`` (auto-released on exit)."""
+    if sys.platform == "win32":
+        # msvcrt.locking needs a real byte range to lock; a freshly created
+        # lock file is empty, so seed one byte before the first acquire or the
+        # lock (and thus the first mutation) would fail.
+        if acquire and os.fstat(fd).st_size == 0:
+            os.write(fd, b"\0")
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_LOCK if acquire else msvcrt.LK_UNLCK, 1)
+    else:
+        fcntl.flock(fd, fcntl.LOCK_EX if acquire else fcntl.LOCK_UN)
+
+
+@contextlib.contextmanager
+def _log_lock(path):
+    """Serialize a whole read -> allocate -> append transaction on one log.
+
+    Two `ask` commands racing on the same log would load identical state,
+    allocate the same node id, and append duplicates -- corrupting the tree and
+    breaking validation. An advisory lock on a sibling ``<log>.lock`` makes each
+    mutating command's load+append atomic across processes; the lock releases
+    automatically when the process exits, so there is no stale lock to reap.
+    """
+    lock_path = str(path) + ".lock"
+    Path(lock_path).parent.mkdir(parents=True, exist_ok=True)
+    _reject_symlink(lock_path)
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        _flock(fd, True)
+        yield
+    finally:
+        try:
+            _flock(fd, False)
+        finally:
+            os.close(fd)
+
+
+def _load(path):
+    """Return list of event dicts. Missing file => empty log.
+
+    Newline is the commit marker: a final line with no terminating newline is an
+    uncommitted partial record (a prior append cut short by disk-full or a kill),
+    so it is dropped rather than parsed -- a torn tail can never brick the log.
+    """
+    p = Path(path)
+    _reject_symlink(p)
+    if not p.exists():
+        return []
+    raw = p.read_text(encoding="utf-8")
+    # Split ONLY on the "\n" that _append joins records with -- NOT str.splitlines(),
+    # which also breaks on U+2028/U+2029/U+0085. json.dumps(ensure_ascii=False)
+    # leaves those separators raw inside a free-text field, so splitlines() would
+    # fragment such a record into invalid-JSON pieces and brick the log.
+    lines = raw.split("\n")
+    if lines and not raw.endswith("\n"):
+        lines = lines[:-1]
+    events = []
+    for i, line in enumerate(lines, 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError as e:
+            raise SystemExit("corrupt log at line %d: %s" % (i, e))
+        events.append(ev)
+    return events
+
+
+def _repair_partial_tail(p):
+    """Drop an unterminated final record (uncommitted, torn write) in place.
+
+    Committed records end in a newline; a trailing partial line has none. Cut
+    the file back to the last newline so the next append starts clean and does
+    not concatenate onto the partial line. Runs under the mutating lock. Only
+    ever removes an uncommitted tail -- never a committed (newline-terminated)
+    record -- so it does not rewrite history.
+    """
+    if not p.exists() or p.stat().st_size == 0:
+        return
+    with p.open("rb") as f:
+        f.seek(-1, os.SEEK_END)
+        if f.read(1) == b"\n":
+            return
+        f.seek(0)
+        data = f.read()
+    os.truncate(p, data.rfind(b"\n") + 1)
+
+
+def _append(path, ev):
+    """Append one event as a single JSON line. Append-only: never rewrites."""
+    ev.setdefault("ts", _now())
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    _reject_symlink(p)
+    _repair_partial_tail(p)
+    with p.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(ev, ensure_ascii=False) + "\n")
+
+
+# ---- fold helpers -----------------------------------------------------------
+
+def _asks(events):
+    """id -> ask event (first definition wins; duplicates are integrity errors)."""
+    out: dict = {}
+    for e in events:
+        if e.get("type") == "ask":
+            out.setdefault(e["id"], e)
+    return out
+
+
+def _pruned(events, asks):
+    """Set of pruned ids plus all their descendants."""
+    roots = {e["id"] for e in events if e.get("type") == "prune"}
+    pruned = set()
+    for nid in asks:
+        cur = nid
+        hit = False
+        while cur is not None:
+            if cur in roots:
+                hit = True
+                break
+            cur = asks.get(cur, {}).get("parent")
+        if hit:
+            pruned.add(nid)
+    return pruned
+
+
+def _last(events, etype, key="id"):
+    val = None
+    for e in events:
+        if e.get("type") == etype:
+            val = e.get(key)
+    return val
+
+
+def _sort_key(nid):
+    """Total order over node ids that never raises on a non-numeric part.
+
+    Tool-allocated ids are dotted integers; a hand-corrupted log could carry a
+    non-numeric part. Rank numeric parts before non-numeric ones so a fold over
+    an imperfect log sorts deterministically instead of aborting a projection
+    with an unhandled ValueError. `validate` still flags the bad id.
+    """
+    key = []
+    for part in str(nid).split("."):
+        try:
+            key.append((0, int(part), ""))
+        except ValueError:
+            key.append((1, 0, part))
+    return tuple(key)
+
+
+def _alloc_id(asks, parent):
+    """Next child id under parent (None => root). Counts pruned ids to avoid reuse."""
+    def _tail_num(nid):
+        try:
+            return int(str(nid).split(".")[-1])
+        except ValueError:
+            return 0
+
+    sibs = [i for i, a in asks.items() if a.get("parent") == parent]
+    nxt = 1 + max((_tail_num(i) for i in sibs), default=0)
+    return str(nxt) if parent is None else "%s.%s" % (parent, nxt)
+
+
+def _answers(events):
+    out: dict = {}
+    for e in events:
+        if e.get("type") == "answer":
+            out[e["id"]] = e.get("a", "")
+    return out
+
+
+def _dones(events):
+    out: dict = {}
+    for e in events:
+        if e.get("type") == "done":
+            out[e["id"]] = e
+    return out
+
+
+def _children(asks, pruned, parent):
+    kids = [i for i, a in asks.items() if a.get("parent") == parent and i not in pruned]
+    return sorted(kids, key=_sort_key)
+
+
+# ---- commands ---------------------------------------------------------------
+
+def cmd_ask(a):
+    _apply_stdin_json(a, "q", "stage")
+    if not a.q:
+        raise SystemExit("ask requires --q or a 'q' field in --stdin-json")
+    if a.stage not in STAGES:
+        raise SystemExit(
+            "ask requires --stage one of: %s (got %r)" % (
+                ", ".join(sorted(STAGES)), a.stage))
+    events = _load(a.log)
+    asks = _asks(events)
+    parent = None if a.parent in (None, "", "root", "null") else a.parent
+    if parent is not None and parent not in asks:
+        raise SystemExit("parent %r does not exist" % parent)
+    if parent is not None and parent in _pruned(events, asks):
+        raise SystemExit(
+            "parent %r is pruned; a child added under it would be dropped from "
+            "every projection" % parent)
+    nid = _alloc_id(asks, parent)
+    _append(a.log, {"type": "ask", "id": nid, "parent": parent,
+                    "stage": a.stage, "q": a.q, "origin": a.origin})
+    print(nid)
+
+
+def _require(a, asks):
+    if a.id not in asks:
+        raise SystemExit("node %r does not exist" % a.id)
+
+
+def _require_live(a, events, asks):
+    _require(a, asks)
+    if a.id in _pruned(events, asks):
+        raise SystemExit("node %r is pruned" % a.id)
+
+
+def cmd_answer(a):
+    _apply_stdin_json(a, "a", "source")
+    if not a.a:
+        raise SystemExit("answer requires --a or an 'a' field in --stdin-json")
+    events = _load(a.log)
+    asks = _asks(events)
+    _require_live(a, events, asks)
+    _append(a.log, {"type": "answer", "id": a.id, "a": a.a, "source": a.source})
+    print("ok")
+
+
+def cmd_focus(a):
+    events = _load(a.log)
+    asks = _asks(events)
+    _require_live(a, events, asks)
+    _append(a.log, {"type": "focus", "id": a.id})
+    print("ok")
+
+
+def cmd_done(a):
+    _apply_stdin_json(a, "note")
+    events = _load(a.log)
+    asks = _asks(events)
+    _require_live(a, events, asks)
+    _append(a.log, {"type": "done", "id": a.id, "kind": a.kind, "note": a.note})
+    print("ok")
+
+
+def cmd_discuss(a):
+    _apply_stdin_json(a, "text")
+    if not a.text:
+        raise SystemExit("discuss requires --text or a 'text' field in --stdin-json")
+    asks = _asks(_load(a.log))
+    if a.anchor not in asks:
+        raise SystemExit("anchor %r does not exist" % a.anchor)
+    _append(a.log, {"type": "discuss", "anchor": a.anchor, "text": a.text})
+    print("ok")
+
+
+def cmd_prune(a):
+    _apply_stdin_json(a, "reason")
+    events = _load(a.log)
+    asks = _asks(events)
+    _require(a, asks)
+    cur = _last(events, "focus")
+    if cur is not None and (cur == a.id or cur.startswith(a.id + ".")):
+        raise SystemExit(
+            "%r is the current focus or an ancestor of it; focus elsewhere "
+            "first so resume cannot land on a pruned node" % a.id)
+    _append(a.log, {"type": "prune", "id": a.id, "reason": a.reason})
+    print("ok")
+
+
+def cmd_event(a):
+    if getattr(a, "stdin_json", False):
+        try:
+            ev = json.load(sys.stdin)
+        except json.JSONDecodeError as e:
+            raise SystemExit("invalid --stdin-json payload: %s" % e)
+    elif a.json is not None:
+        try:
+            ev = json.loads(a.json)
+        except json.JSONDecodeError as e:
+            raise SystemExit("invalid --json: %s" % e)
+    else:
+        raise SystemExit("event requires --json or --stdin-json")
+    if not isinstance(ev, dict) or "type" not in ev:
+        raise SystemExit("event must be a JSON object with a 'type' field")
+    if not isinstance(ev["type"], str):
+        raise SystemExit("event 'type' must be a string")
+    if ev["type"] in CORE_TYPES:
+        raise SystemExit(
+            "event type %r is a core type; use its dedicated subcommand so the "
+            "required fields are validated" % ev["type"])
+    _append(a.log, ev)
+    print("ok")
+
+
+def cmd_tree(a):
+    events = _load(a.log)
+    asks = _asks(events)
+    pruned = _pruned(events, asks)
+    answers = _answers(events)
+    dones = _dones(events)
+    cur = _last(events, "focus")
+    lines = []
+
+    def walk(nid, depth):
+        node = asks[nid]
+        mark = " ✅" if nid in dones else (" ⏳" if nid == cur else "")
+        ans = answers.get(nid)
+        tail = " → %s" % ans if ans else ""
+        lines.append("%s- [%s] (%s) %s%s%s" % (
+            "  " * depth, nid, node.get("stage", ""), node.get("q", ""), tail, mark))
+        for kid in _children(asks, pruned, nid):
+            walk(kid, depth + 1)
+
+    for root in _children(asks, pruned, None):
+        walk(root, 0)
+    print("\n".join(lines) if lines else "(empty)")
+
+
+def _frontier(events):
+    asks = _asks(events)
+    pruned = _pruned(events, asks)
+    answers = _answers(events)
+    dones = _dones(events)
+    cur = _last(events, "focus")
+    return [i for i in sorted(asks, key=_sort_key)
+            if i not in pruned and i not in answers and i not in dones and i != cur]
+
+
+def cmd_frontier(a):
+    events = _load(a.log)
+    asks = _asks(events)
+    fr = _frontier(events)
+    if not fr:
+        print("(none)")
+        return
+    for i in fr:
+        print("- [%s] %s" % (i, asks[i].get("q", "")))
+
+
+def cmd_view(a):
+    events = _load(a.log)
+    asks = _asks(events)
+    answers = _answers(events)
+    cur = _last(events, "focus")
+    fr = _frontier(events)
+    if cur is None:
+        print("(no current focus)")
+        print("open branches: %d" % len(fr))
+        return
+    parts = cur.split(".")
+    chain = [".".join(parts[:k + 1]) for k in range(len(parts))]
+    print("current path:")
+    for depth, nid in enumerate(chain):
+        node = asks.get(nid, {})
+        ans = answers.get(nid)
+        tail = " → %s" % ans if ans else ""
+        star = "  ← current" if nid == cur else ""
+        print("%s- [%s] (%s) %s%s%s" % (
+            "  " * depth, nid, node.get("stage", ""), node.get("q", ""), tail, star))
+    print("open branches: %d" % len(fr))
+
+
+def cmd_report(a):
+    _apply_stdin_json(a, "title")
+    events = _load(a.log)
+    asks = _asks(events)
+    pruned = _pruned(events, asks)
+    answers = _answers(events)
+    dones = _dones(events)
+    roots = _children(asks, pruned, None)
+    title = a.title or (asks[roots[0]].get("q") if roots else "5 Whys")
+    out = ["# 5 Whys report — %s" % title,
+           "_Generated: %s · %d events_" % (_now(), len(events)), ""]
+    out.append("## Starting point")
+    for r in roots:
+        out.append("- %s" % asks[r].get("q", ""))
+    out += ["", "## Tree (What -> Example -> Why-not -> Benefits -> Costs)"]
+
+    def walk(nid, depth):
+        node = asks[nid]
+        ans = answers.get(nid)
+        tail = " → %s" % ans if ans else ""
+        flag = "  **[root]**" if dones.get(nid, {}).get("kind") == "root" else (
+            "  _[takeaway]_" if nid in dones else "")
+        out.append("%s- **[%s]** (%s) %s%s%s" % (
+            "  " * depth, nid, node.get("stage", ""), node.get("q", ""), tail, flag))
+        for kid in _children(asks, pruned, nid):
+            walk(kid, depth + 1)
+
+    for r in roots:
+        walk(r, 0)
+
+    out += ["", "## Roots / key takeaways"]
+    dn = [e for e in events if e.get("type") == "done" and e["id"] not in pruned]
+    if dn:
+        for e in dn:
+            out.append("- **[%s]** (%s) %s" % (e["id"], e.get("kind", ""), e.get("note", "")))
+    else:
+        out.append("- (none yet)")
+
+    disc = [e for e in events if e.get("type") == "discuss"]
+    if disc:
+        out += ["", "## Side discussions"]
+        for e in disc:
+            out.append("- @[%s] %s" % (e.get("anchor", ""), e.get("text", "")))
+    print("\n".join(out))
+
+
+def cmd_validate(a):
+    events = _load(a.log)
+    issues = []
+    asks: dict = {}
+    for n, e in enumerate(events, 1):
+        if not isinstance(e, dict):
+            issues.append("line %d: not a JSON object" % n)
+            continue
+        if "type" not in e or "ts" not in e:
+            issues.append("line %d: missing type/ts" % n)
+            continue
+        t = e["type"]
+        if t == "ask":
+            aid = e.get("id")
+            if not isinstance(aid, str) or not aid or not all(
+                    part.isdigit() for part in aid.split(".")):
+                issues.append("line %d: ask has invalid id %r" % (n, aid))
+                continue
+            if "q" not in e:
+                issues.append("line %d: ask missing q" % n)
+                continue
+            if e.get("stage") not in STAGES:
+                issues.append("line %d: ask has out-of-schema stage %r" % (n, e.get("stage")))
+            if aid in asks:
+                issues.append("line %d: duplicate ask id %r" % (n, aid))
+            p = e.get("parent")
+            if p is not None and (not isinstance(p, str) or p not in asks):
+                issues.append("line %d: ask parent %r invalid or not yet defined" % (n, p))
+            asks[aid] = e
+        elif t in ("answer", "focus", "done", "prune"):
+            if not isinstance(e.get("id"), str) or e.get("id") not in asks:
+                issues.append("line %d: %s references unknown id %r" % (n, t, e.get("id")))
+        elif t == "discuss":
+            if not isinstance(e.get("anchor"), str) or e.get("anchor") not in asks:
+                issues.append("line %d: discuss anchor %r unknown" % (n, e.get("anchor")))
+        # unknown (plugin) types are allowed and ignored
+    if issues:
+        print("\n".join(issues))
+        sys.exit(1)
+    print("OK — %d events, %d nodes" % (len(events), len(asks)))
+
+
+def main():
+    # Folded output (tree markers, arrows) is non-ASCII; a Windows cp1252 console
+    # would raise UnicodeEncodeError on print. Make stdout tolerant before any
+    # output is written so no command can crash on the console encoding.
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        reconfigure(encoding="utf-8", errors="backslashreplace")
+    ap = argparse.ArgumentParser(description="five-whys event-log mechanical core")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    def add(name, fn):
+        p = sub.add_parser(name)
+        p.add_argument("log")
+        p.set_defaults(fn=fn)
+        return p
+
+    p = add("ask", cmd_ask)
+    p.add_argument("--parent", default=None)
+    p.add_argument("--stage", default="")
+    p.add_argument("--q", default="")
+    p.add_argument("--origin", default="proposed", choices=["proposed", "user"])
+    p.add_argument("--stdin-json", action="store_true", dest="stdin_json")
+
+    p = add("answer", cmd_answer)
+    p.add_argument("--id", required=True)
+    p.add_argument("--a", default="")
+    p.add_argument("--source", default="ai")
+    p.add_argument("--stdin-json", action="store_true", dest="stdin_json")
+
+    p = add("focus", cmd_focus)
+    p.add_argument("--id", required=True)
+
+    p = add("done", cmd_done)
+    p.add_argument("--id", required=True)
+    p.add_argument("--kind", default="root", choices=["root", "takeaway"])
+    p.add_argument("--note", default="")
+    p.add_argument("--stdin-json", action="store_true", dest="stdin_json")
+
+    p = add("discuss", cmd_discuss)
+    p.add_argument("--anchor", required=True)
+    p.add_argument("--text", default="")
+    p.add_argument("--stdin-json", action="store_true", dest="stdin_json")
+
+    p = add("prune", cmd_prune)
+    p.add_argument("--id", required=True)
+    p.add_argument("--reason", default="")
+    p.add_argument("--stdin-json", action="store_true", dest="stdin_json")
+
+    p = add("event", cmd_event)
+    p.add_argument("--json", default=None)
+    p.add_argument("--stdin-json", action="store_true", dest="stdin_json")
+
+    add("view", cmd_view)
+    add("tree", cmd_tree)
+    add("frontier", cmd_frontier)
+
+    p = add("report", cmd_report)
+    p.add_argument("--title", default="")
+    p.add_argument("--stdin-json", action="store_true", dest="stdin_json")
+
+    add("validate", cmd_validate)
+
+    args = ap.parse_args()
+    # Mutating commands read the log, derive state (e.g. the next id) and append;
+    # hold an exclusive lock across that whole transaction so two of them racing
+    # on one log cannot allocate the same id and corrupt the tree.
+    mutating = {"ask", "answer", "focus", "done", "discuss", "prune", "event"}
+    if args.cmd in mutating:
+        with _log_lock(args.log):
+            args.fn(args)
+    else:
+        args.fn(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem / Motivation

KiroCrew has no built-in skill for **structured deep understanding** of a
problem. Users can ask a question and get an answer, but there's no guided way to
peel a bug / incident / system / concept down to its root — one careful step at a
time, with the reasoning preserved.

## Why it matters

"Understand this properly" is a first-class activity, not a side effect of
answering. A disciplined dive (one focused question per step, short verifiable
answers, explicit branches) reaches truer roots than a single long explanation,
and leaves a durable, foldable record instead of scrollback.

## What changed

Adds one built-in skill under `src/kiro_crew/builtin_skills/five-whys/`:

- **`SKILL.md`** — the mode contract. 5 Whys is the default engine: one focused
  question per turn, 1–2 sentence answers, a reasoning chain (What it is →
  Example → Why not the alternatives → Benefits → Costs), user-steered branching,
  and side discussions.
- **`scripts/five_whys.py`** — the deterministic mechanical core (stdlib only,
  Python 3.8+). The session is modeled as an **append-only event log = single
  source of truth**; the tree, current question, open branches and final report
  are all **projections folded from the log**, never hand-maintained. Subcommands:
  `ask / answer / focus / done / discuss / prune / event / view / tree /
  frontier / report / validate`.
- **`README.md`** — the architecture (event log, skill-judges/script-mechanizes
  split, pluggable capabilities and frontends).

Design highlights: the log is the only coupling point, so **capabilities**
(web search, recap, …) and **frontends** (chat bubble, web page, report) plug in
by reading the log and appending their own typed events — unknown types are
ignored by the core folds, so extensions never break it. Triggered by
`5 whys` / `five whys`; trigger set is deliberately kept distinct from the
`grill` skill.

## Tests

- **Lint/type (local, green):** `isort --check-only`, `flake8`, `mypy` on
  `scripts/five_whys.py`.
- **pytest (local, 255 passed):** `test_brand_name_gate`, `test_portability`,
  `test_builtin_skill_sync_safety`, `test_agent_template_skills`,
  `test_skill_discover` — run with the worktree on `PYTHONPATH` so they exercise
  the new skill.
- **Script smoke test:** exercised the full command surface — id allocation
  (`1`, `1.1`, `1.2`), `prune` cascade to descendants, a plugin `event`
  (`type:"search"`) accepted and ignored by the core folds, `validate` returns
  `rc=0` clean and `rc=1` on a dangling reference, `report` emits markdown.
- No `security_posture` registration needed: the script calls no redactor, so
  the redaction-sink drift guard does not apply.

## Manual verification

Ran the mode end-to-end in a live session (a real "capability seam in dsh vs
KiroCrew" architecture dive): 41 events appended through the script, branches +
a side discussion recorded, and the close-out `report` folded the log into a
clean markdown report — no reconstruction from memory.
