### PR TITLE
fix(publish): deny when the publish config section is malformed

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -836,6 +836,87 @@ def read_config_for_update(path: Path | None = None) -> dict:
     return raw
 
 
+#: Marker used in :attr:`KiroCrewConfig.degraded_sections` for "a whole config
+#: FILE could not be read" (unparseable, or a top level that is not a JSON
+#: object), as opposed to one named section being malformed. A gate that reads
+#: any security value must treat it exactly like its own section being
+#: degraded: the operator's settings are unknown either way.
+DEGRADED_WHOLE_CONFIG = "*"
+
+#: Sections observed malformed by ANY read in this process, remembered for its
+#: lifetime.
+#:
+#: Stickiness is the point, not an optimization. ``load()`` runs a migration
+#: that REWRITES ``config.json`` in normalized form, so the very first load
+#: repairs the file: a second load — including the one a security gate makes
+#: moments later in the same request — sees a clean file with the malformed
+#: section silently gone, and an empty allowlist that reads as "operator
+#: configured nothing". Remembering keeps the answer truthful for as long as the
+#: process could still act on that value.
+#:
+#: The operator's fix is to correct the file and restart the gateway, which is
+#: the same ceremony every other boot-time config decision already requires.
+_OBSERVED_DEGRADED_SECTIONS: set[str] = set()
+
+
+def reset_degraded_observations() -> None:
+    """Forget every degradation this process has observed.
+
+    The observations are deliberately sticky for the life of a gateway (see
+    :data:`_OBSERVED_DEGRADED_SECTIONS`), so the ONLY legitimate callers are
+    tests, which share one interpreter and would otherwise let one case's
+    malformed config deny in the next. Production clears it by restarting,
+    which is the same ceremony every other boot-time config decision requires.
+    """
+    _OBSERVED_DEGRADED_SECTIONS.clear()
+
+
+def _mark_file_degraded(path: Path) -> None:
+    """Record that a whole config FILE could not be read as a JSON object.
+
+    Adds both the generic marker (so a gate can ask one question) and the file's
+    name (so the refusal can tell the operator which file to go and fix).
+    """
+    _OBSERVED_DEGRADED_SECTIONS.add(DEGRADED_WHOLE_CONFIG)
+    _OBSERVED_DEGRADED_SECTIONS.add(f"{DEGRADED_WHOLE_CONFIG}{path.name}")
+
+
+def degraded_config_files(sections: frozenset[str]) -> list[str]:
+    """The config file names inside a ``degraded_sections`` set."""
+    return sorted(
+        s[len(DEGRADED_WHOLE_CONFIG) :]
+        for s in sections
+        if s.startswith(DEGRADED_WHOLE_CONFIG) and s != DEGRADED_WHOLE_CONFIG
+    )
+
+
+def _coerced_section(data: dict, key: str, degraded: set[str]) -> dict:
+    """Return ``data[key]`` as a dict, RECORDING the coercion when it is not one.
+
+    The loader must keep degrading — a malformed section cannot be allowed to
+    take the whole process down — but it must stop doing so SILENTLY. Every
+    section read goes through here so the "was this value real, or invented by
+    the parser" question has one answer for every consumer, instead of each
+    security gate growing its own shadow parser beside the loader (#4057).
+
+    An ABSENT section is not degraded: that is the genuine unconfigured state.
+    """
+    if key not in data:
+        return {}
+    value = data[key]
+    if isinstance(value, dict):
+        return value
+    degraded.add(key)
+    _OBSERVED_DEGRADED_SECTIONS.add(key)
+    logger.warning(
+        "config: '%s' section is not a JSON object (got %s) — using defaults; "
+        "any setting it carried is NOT in effect",
+        key,
+        type(value).__name__,
+    )
+    return {}
+
+
 def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> None:
     """Write a config dict to *path* atomically, PRESERVING its permissions.
 
@@ -6566,6 +6647,38 @@ class KiroCrewConfig:
         default=True,
         metadata=_meta("Auto Update", "Enable automatic update checks."),
     )
+    #: Top-level sections that were PRESENT on disk but not a JSON object, and
+    #: were therefore coerced to defaults by :meth:`load`.
+    #:
+    #: The loader's whole contract is to degrade rather than raise, which is
+    #: right for an ordinary consumer and dangerous for one reading a SECURITY
+    #: value out of a section: a coerced-away section is indistinguishable from
+    #: "the operator configured nothing", so a narrowing silently becomes
+    #: allow-all (#4057, and the same shape as #3945).
+    #:
+    #: A consumer cannot recover this by re-reading the file, which is why the
+    #: signal has to live here: ``load()`` runs a migration that REWRITES
+    #: ``config.json`` in normalized form, so by the time any gate looks, the
+    #: malformed section is gone from disk. The evidence only exists during the
+    #: parse that discarded it.
+    #:
+    #: Excluded from serialization (``repr=False``, and the config writers work
+    #: from explicit field lists) — it describes THIS read, not the operator's
+    #: settings, and must never be written back into their config. The leading
+    #: underscore keeps it out of the config schema/baseline machinery, which
+    #: skips private fields (same convention as ``_extra_sections``); consumers
+    #: read the :attr:`degraded_sections` property.
+    _degraded_sections: frozenset[str] = field(
+        default_factory=frozenset,
+        repr=False,
+        compare=False,
+    )
+
+    @property
+    def degraded_sections(self) -> frozenset[str]:
+        """Sections this load discarded (see ``_degraded_sections``)."""
+        return self._degraded_sections
+
     timezone: str = field(
         default="",
         metadata=_meta(
@@ -6683,9 +6796,11 @@ class KiroCrewConfig:
                     else:
                         config_source_unreadable = True
                         logger.warning("Config is not a JSON object, using defaults")
+                        _mark_file_degraded(path)
                 except (json.JSONDecodeError, OSError) as e:
                     config_source_unreadable = True
                     logger.warning("Failed to load config from %s: %s", path, e)
+                    _mark_file_degraded(path)
 
             # Report -- never correct -- a stored BASE value that still holds a
             # superseded default (issue #5244), before the overlay merge below:
@@ -6716,9 +6831,11 @@ class KiroCrewConfig:
                     else:
                         config_source_unreadable = True
                         logger.warning("config.local.json is not a JSON object, ignoring")
+                        _mark_file_degraded(local_path)
                 except (json.JSONDecodeError, OSError) as e:
                     config_source_unreadable = True
                     logger.warning("Failed to load config.local.json: %s", e)
+                    _mark_file_degraded(local_path)
 
             if local_data:
                 data = _deep_merge(data, local_data)
@@ -6739,7 +6856,12 @@ class KiroCrewConfig:
             # file to invalidate against, and the path is already cheap
             # (existence checks only, no read/parse/validate).
             if not loaded_base and not local_data:
-                cfg = cls()
+                # An UNREADABLE file reaches this same "no config" branch as a
+                # genuinely absent one, and the two are opposite claims for a
+                # security gate: "the operator configured nothing" versus "we
+                # could not read what they configured". Carry the observation
+                # through so the caller can tell them apart (#4057).
+                cfg = cls(_degraded_sections=frozenset(_OBSERVED_DEGRADED_SECTIONS))
                 cfg.skills.project_skills_enabled = (
                     data.get("skills", {}).get("project_skills_enabled", True) is True
                 )
@@ -6765,110 +6887,89 @@ class KiroCrewConfig:
             # a mid-read write self-heals (next load misses and re-reads).
             _store_validated_data(data, pre_read_fp)
 
-        agent_data = data.get("agent", {})
-        if not isinstance(agent_data, dict):
-            agent_data = {}
-        session_data = data.get("session", {})
-        if not isinstance(session_data, dict):
-            session_data = {}
-        taskrunner_data = data.get("taskrunner", {})
-        if not isinstance(taskrunner_data, dict):
-            taskrunner_data = {}
-        cron_history_data = data.get("cron_history", {})
-        if not isinstance(cron_history_data, dict):
-            cron_history_data = {}
-        memory_data = data.get("memory", {})
-        if not isinstance(memory_data, dict):
-            memory_data = {}
-        knowledge_data = data.get("knowledge", {})
-        if not isinstance(knowledge_data, dict):
-            knowledge_data = {}
-        telegram_data = data.get("telegram", {})
-        if not isinstance(telegram_data, dict):
-            telegram_data = {}
-        weixin_data = data.get("weixin", {})
-        if not isinstance(weixin_data, dict):
-            weixin_data = {}
-        whatsapp_data = data.get("whatsapp", {})
-        if not isinstance(whatsapp_data, dict):
-            whatsapp_data = {}
-        feishu_data = data.get("feishu", {})
-        if not isinstance(feishu_data, dict):
-            feishu_data = {}
-        discord_data = data.get("discord", {})
-        if not isinstance(discord_data, dict):
-            discord_data = {}
-        webex_data = data.get("webex", {})
-        if not isinstance(webex_data, dict):
-            webex_data = {}
-        teams_data = data.get("teams", {})
-        if not isinstance(teams_data, dict):
-            teams_data = {}
-        imessage_data = data.get("imessage", {})
-        if not isinstance(imessage_data, dict):
-            imessage_data = {}
-        slack_data = data.get("slack", {})
-        if not isinstance(slack_data, dict):
-            slack_data = {}
-        publish_data = data.get("publish", {})
-        if not isinstance(publish_data, dict):
-            publish_data = {}
+        # Collected during the parse that discards them — the only moment the
+        # evidence exists, since the migration below rewrites config.json in
+        # normalized form (see KiroCrewConfig.degraded_sections).
+        _degraded: set[str] = set()
+        agent_data = _coerced_section(data, "agent", _degraded)
+        session_data = _coerced_section(data, "session", _degraded)
+        taskrunner_data = _coerced_section(data, "taskrunner", _degraded)
+        cron_history_data = _coerced_section(data, "cron_history", _degraded)
+        memory_data = _coerced_section(data, "memory", _degraded)
+        knowledge_data = _coerced_section(data, "knowledge", _degraded)
+        telegram_data = _coerced_section(data, "telegram", _degraded)
+        weixin_data = _coerced_section(data, "weixin", _degraded)
+        whatsapp_data = _coerced_section(data, "whatsapp", _degraded)
+        feishu_data = _coerced_section(data, "feishu", _degraded)
+        discord_data = _coerced_section(data, "discord", _degraded)
+        webex_data = _coerced_section(data, "webex", _degraded)
+        teams_data = _coerced_section(data, "teams", _degraded)
+        imessage_data = _coerced_section(data, "imessage", _degraded)
+        slack_data = _coerced_section(data, "slack", _degraded)
+        publish_data = _coerced_section(data, "publish", _degraded)
+        # A malformed allowed_destinations is the same class as a malformed
+        # section one level down (#4057), in two shapes. A non-LIST value:
+        # iterating it either crashes load() with a TypeError (a scalar — a
+        # config typo must not abort gateway startup) or yields garbage (a
+        # dict iterates as its keys, a string as its characters). A list with
+        # non-string/empty ENTRIES: the parse filter drops them, so an
+        # all-invalid narrowing like [1, 2] parses to [] — indistinguishable
+        # from "no restriction configured", the exact silent widening this fix
+        # exists to stop. Both shapes record the degradation so the publish
+        # gate denies, and parse from what safely remains. Validation cannot
+        # repair these values (publish.allowed_destinations is fail-closed
+        # there — repairing an OPEN default silently widens), so the loader
+        # must be the layer that survives them.
+        _dests_raw = publish_data.get("allowed_destinations", [])
+        if not isinstance(_dests_raw, list):
+            _degraded.add("publish")
+            _OBSERVED_DEGRADED_SECTIONS.add("publish")
+            logger.warning(
+                "config: 'publish.allowed_destinations' is not a list (got %s) "
+                "— treating the publish section as degraded; publishing is "
+                "denied until the file is fixed and the gateway restarted",
+                type(_dests_raw).__name__,
+            )
+            _dests_raw = []
+        elif any(not (isinstance(_d, str) and _d) for _d in _dests_raw):
+            _degraded.add("publish")
+            _OBSERVED_DEGRADED_SECTIONS.add("publish")
+            logger.warning(
+                "config: 'publish.allowed_destinations' carries entr(y/ies) "
+                "that are not non-empty strings — treating the publish section "
+                "as degraded; publishing is denied until the file is fixed and "
+                "the gateway restarted",
+            )
+            _dests_raw = []
         # Back-compat: this channel's config section was renamed
         # "wechat" -> "wecom". Fall back to the legacy key so existing
         # installs keep their WeCom settings on upgrade (read-only alias;
         # no broader migration machinery).
-        wecom_data = data.get("wecom", data.get("wechat", {}))
-        if not isinstance(wecom_data, dict):
-            wecom_data = {}
-        dashboard_data = data.get("dashboard", {})
-        if not isinstance(dashboard_data, dict):
-            dashboard_data = {}
-        stt_data = data.get("stt", {})
-        if not isinstance(stt_data, dict):
-            stt_data = {}
-        computer_use_data = data.get("computer_use", {})
-        if not isinstance(computer_use_data, dict):
-            computer_use_data = {}
-        instances_data = data.get("instances", {})
-        if not isinstance(instances_data, dict):
-            instances_data = {}
+        # Alias-aware: record under whichever key the operator actually used, so
+        # the warning names the section they can go and fix.
+        _wecom_key = "wecom" if "wecom" in data else "wechat"
+        wecom_data = _coerced_section(data, _wecom_key, _degraded)
+        dashboard_data = _coerced_section(data, "dashboard", _degraded)
+        stt_data = _coerced_section(data, "stt", _degraded)
+        computer_use_data = _coerced_section(data, "computer_use", _degraded)
+        instances_data = _coerced_section(data, "instances", _degraded)
         connect_timeout_raw = instances_data.get("connect_timeout_secs")
         mint_timeout_raw = instances_data.get("mint_timeout_secs")
-        mcp_gateway_data = data.get("mcp_gateway", {})
-        if not isinstance(mcp_gateway_data, dict):
-            mcp_gateway_data = {}
-        mcp_data = data.get("mcp", {})
-        if not isinstance(mcp_data, dict):
-            mcp_data = {}
-        heartbeat_data = data.get("heartbeat", {})
-        if not isinstance(heartbeat_data, dict):
-            heartbeat_data = {}
+        mcp_gateway_data = _coerced_section(data, "mcp_gateway", _degraded)
+        mcp_data = _coerced_section(data, "mcp", _degraded)
+        heartbeat_data = _coerced_section(data, "heartbeat", _degraded)
         heartbeat_default_deliver = (
             str(heartbeat_data.get("default_deliver", "slack")).strip().lower()
         )
         if heartbeat_default_deliver not in ("slack", "dashboard"):
             heartbeat_default_deliver = "slack"
-        tunnel_data = data.get("tunnel", {})
-        if not isinstance(tunnel_data, dict):
-            tunnel_data = {}
-        skills_data = data.get("skills", {})
-        if not isinstance(skills_data, dict):
-            skills_data = {}
-        session_summary_data = data.get("session_summary", {})
-        if not isinstance(session_summary_data, dict):
-            session_summary_data = {}
-        messaging_data = data.get("messaging", {})
-        if not isinstance(messaging_data, dict):
-            messaging_data = {}
-        telemetry_data = data.get("telemetry", {})
-        if not isinstance(telemetry_data, dict):
-            telemetry_data = {}
-        orchestrator_data = data.get("orchestrator", {})
-        if not isinstance(orchestrator_data, dict):
-            orchestrator_data = {}
-        watchdog_data = data.get("watchdog", {})
-        if not isinstance(watchdog_data, dict):
-            watchdog_data = {}
+        tunnel_data = _coerced_section(data, "tunnel", _degraded)
+        skills_data = _coerced_section(data, "skills", _degraded)
+        session_summary_data = _coerced_section(data, "session_summary", _degraded)
+        messaging_data = _coerced_section(data, "messaging", _degraded)
+        telemetry_data = _coerced_section(data, "telemetry", _degraded)
+        orchestrator_data = _coerced_section(data, "orchestrator", _degraded)
+        watchdog_data = _coerced_section(data, "watchdog", _degraded)
 
         # Parse agents section into dict[str, KiroCrewAgentConfig]
         raw_agents = data.get("agents", {})
@@ -7386,11 +7487,7 @@ class KiroCrewConfig:
                 ),
             ),
             publish=PublishConfig(
-                allowed_destinations=[
-                    d
-                    for d in publish_data.get("allowed_destinations", [])
-                    if isinstance(d, str) and d
-                ],
+                allowed_destinations=[d for d in _dests_raw if isinstance(d, str) and d],
                 relocate_roots=[
                     r
                     for r in publish_data.get("relocate_roots", [])
@@ -7609,6 +7706,7 @@ class KiroCrewConfig:
                 cursor_motion=_safe_bool(computer_use_data.get("cursor_motion", False), False),
             ),
             auto_update=data.get("auto_update", True),
+            _degraded_sections=frozenset(_degraded | _OBSERVED_DEGRADED_SECTIONS),
             timezone=data.get("timezone", ""),
             snapshot_dir=data.get("snapshot_dir", ""),
             registries=[
@@ -7839,9 +7937,25 @@ class KiroCrewConfig:
                     cfg.default_agent = "default"
                 needs_migration = True
 
-            if needs_migration:
+            if needs_migration and not cfg._degraded_sections:
                 _write_migration_backup(path)
                 cfg.save()
+            elif needs_migration:
+                # This load DISCARDED something (a malformed section, an
+                # unreadable file). cfg.save() serializes only the parsed
+                # fields, so writing back here would replace the operator's
+                # malformed narrowing with clean defaults — erasing the only
+                # on-disk evidence and turning the denial into silent
+                # allow-all at the next restart (#4057). Keep the malformed
+                # bytes; every future process re-observes and re-denies until
+                # the operator actually fixes the file. Migration re-runs on
+                # the first clean load.
+                logger.warning(
+                    "config: skipping write-back migration — this load "
+                    "degraded section(s) %s and writing back would erase the "
+                    "evidence; fix the file to clear",
+                    sorted(cfg._degraded_sections),
+                )
         except Exception as e:
             # Migration write-back is best-effort; never block startup.
             logger.warning("Config write-back failed: %s", e)

--- a/src/kiro_crew/config/validation.py
+++ b/src/kiro_crew/config/validation.py
@@ -135,6 +135,33 @@ def _actual_type_name(value: object) -> str:
     return type(value).__name__
 
 
+#: Exact dot-paths whose malformed values must SURVIVE advisory validation.
+#:
+#: ``_apply_field_default`` repairs a violating value by removing it so the
+#: loader falls back to defaults. Whether that repair is safe depends on the
+#: DIRECTION of the field's default:
+#:
+#: * ``publish`` (the section) and ``publish.allowed_destinations``: the
+#:   default is **open** (no restriction), so repairing a malformed narrowing
+#:   silently widens it to allow-all with no denial and no audit record
+#:   (#4057). The loader's recording coercion (``_coerced_section``) and the
+#:   gate's fail-closed checks are the honest handlers — but they can only run
+#:   if validation leaves the evidence in place. Keeping the value also keeps
+#:   security behaviour identical whether or not ``jsonschema`` is installed
+#:   (validation is a no-op without it), which is the split that let this gap
+#:   ship unnoticed.
+#:
+#: * Every OTHER publish field stays repairable, deliberately. For a field
+#:   whose default is **restrictive** the repair is the safe direction, and
+#:   preserving the malformed value can itself widen: a dict-shaped
+#:   ``publish.relocate_roots`` of ``{"/etc": false}`` iterates as its keys in
+#:   the loader's comprehension and would inject ``/etc`` as an allowed
+#:   relocate root, where the repaired default ``[]`` means home-only.
+#:
+#: Exact-match only: this is a per-path judgment, not a subtree rule.
+_FAIL_CLOSED_PATHS = frozenset({"publish", "publish.allowed_destinations"})
+
+
 def _apply_field_default(data: dict, dot_path: str) -> bool:
     """Remove the invalid value at *dot_path* so the loader falls back to defaults.
 
@@ -146,7 +173,14 @@ def _apply_field_default(data: dict, dot_path: str) -> bool:
     is stricter — removing them here would make validation destroy
     loader-valid data. Callers use the return value to log honestly: a kept
     value must not be reported as "using default".
+
+    Values at a fail-closed path (see :data:`_FAIL_CLOSED_PATHS`) are never
+    removed: repairing them to their open defaults silently widens a security
+    narrowing, and the loader/gate pair downstream turns the preserved
+    malformed value into a recorded degradation and a denial instead (#4057).
     """
+    if dot_path in _FAIL_CLOSED_PATHS:
+        return False
     parts = dot_path.split(".")
     if len(parts) == 1:
         data.pop(parts[0], None)

--- a/src/kiro_crew/publish_governance.py
+++ b/src/kiro_crew/publish_governance.py
@@ -41,11 +41,9 @@ from aiohttp import web
 
 from kiro_crew import sel as _sel_mod
 from kiro_crew.config.loader import (
-    ConfigReadError,
+    DEGRADED_WHOLE_CONFIG,
     KiroCrewConfig,
-    config_local_path,
-    config_path,
-    read_config_for_update,
+    degraded_config_files,
 )
 
 logger = logging.getLogger(__name__)
@@ -85,43 +83,67 @@ def _audit_deny(
         logger.debug("publish governance deny audit failed", exc_info=True)
 
 
-def _unparseable_config_reason() -> str | None:
-    """Return a denial reason when the on-disk config cannot be trusted.
+def _read_allowed_destinations() -> tuple[list[str], str | None]:
+    """Return ``(allowlist, denial_reason)`` from ONE read of the config.
 
-    ``KiroCrewConfig.load()`` deliberately DEGRADES: it catches
-    ``json.JSONDecodeError``/``OSError``, logs a warning and returns DEFAULTS.
-    That is right for an ordinary consumer and wrong here — an unparseable
-    ``config.json`` would turn a narrowed ``publish.allowed_destinations`` back
-    into the empty (allow-every-destination) default and silently reopen the path
-    the operator closed. Because ``load()`` cannot fail, a ``try/except`` around
-    it never fires, so this chokepoint has to ask the question itself.
+    The two questions this gate needs — "is the config trustworthy" and "what
+    did the operator allow" — are answered from a single ``load()``, because
+    answering them from two independent reads is what let a malformed section
+    reopen the allowlist (#4057).
 
-    It asks through :func:`read_config_for_update`, which already IS the repo's
-    fail-closed config read (absent → ``{}``, unreadable or non-object →
-    ``ConfigReadError``, ``UnicodeDecodeError`` named explicitly because it is a
-    ``ValueError`` rather than an ``OSError``). Hand-rolling a second spelling of
-    "a config parse must not degrade" would give the invariant two homes and let
-    them drift; the name reads oddly here only because nothing is being updated.
+    The old shape: a probe called ``read_config_for_update`` (which rejects only
+    a non-object TOP level) and, separately, the value came from
+    ``KiroCrewConfig.load().publish.allowed_destinations``. A ``config.json`` of
+    ``{"publish": []}`` is a valid object at the top level, so the probe PASSED —
+    and the loader then coerced the non-dict ``publish`` section to ``{}``, so
+    the allowlist came back empty. Empty is indistinguishable from "no
+    restriction configured", i.e. default-open. A malformed section did not deny
+    publishing and did not surface an error; it removed the restriction.
 
-    Both files are checked: the overlay ``config.local.json`` is deep-merged over
-    the base and swallows its own parse errors the same way, so a corrupt overlay
-    hides an allowlist just as effectively as a corrupt base.
+    Re-reading the FILE here cannot fix that, which is worth stating because it
+    is the obvious approach: ``load()`` runs a migration that REWRITES
+    ``config.json`` in normalized form, so after the gateway's first load the
+    malformed section is gone from disk and any later re-read sees a clean file
+    with an empty allowlist. The loader is the only place that ever sees the
+    degradation, so it is the loader that reports it — via
+    ``degraded_sections``.
 
-    A file that is simply ABSENT is not an error — that is the standalone default,
-    and an unnamed publish is ungoverned and permitted.
+    Two shapes deny: a config FILE that could not be read as a JSON object, and
+    a ``publish`` section present but not an object. Both arrive through
+    ``degraded_sections``.
 
-    These names are module-scope imports, unlike the ``kiro_crew.platform`` ones
-    inside :func:`publish_denied_reason`: ``config.loader`` is already a
-    module-scope dependency of this file (``KiroCrewConfig``), so the CPP
-    import-direction invariant has nothing to say about importing more of it.
+    NOT handled here, deliberately: a malformed ``allowed_destinations`` INSIDE
+    a well-formed section. The loader normalizes that value before this function
+    can see it — its comprehension iterates whatever it is given, so the string
+    ``"deploy-web"`` becomes the character list ``["d", "e", ...]`` — and a
+    check here would be dead code that only looked like a guard. It is the same
+    class one level down and wants the same treatment (the loader reporting what
+    it discarded), which is a change to the loader's per-field parsing rather
+    than to this gate. Filed separately rather than half-done here.
+
+    An ABSENT config or section is not degraded: genuinely unconfigured, and an
+    unnamed publish is ungoverned and permitted, so a standalone host is
+    unaffected.
     """
-    for path in (config_path(), config_local_path()):
-        try:
-            read_config_for_update(path)
-        except ConfigReadError as e:
-            logger.warning("publish denied: %s", e)
-            return f"publishing denied: {path.name} could not be read as a JSON object"
-    return None
+    cfg = KiroCrewConfig.load()
+    if DEGRADED_WHOLE_CONFIG in cfg.degraded_sections:
+        named = ", ".join(degraded_config_files(cfg.degraded_sections)) or "config.json"
+        reason = (
+            f"publishing denied: {named} could not be read as a JSON object, "
+            "so the destination allowlist is unknown; fix the file and restart "
+            "the gateway to clear"
+        )
+        logger.warning("%s", reason)
+        return [], reason
+    if "publish" in cfg.degraded_sections:
+        reason = (
+            "publishing denied: the 'publish' config section is malformed "
+            "(not a JSON object), so the destination allowlist is unknown; "
+            "fix the file and restart the gateway to clear"
+        )
+        logger.warning("%s", reason)
+        return [], reason
+    return list(cfg.publish.allowed_destinations), None
 
 
 def publish_denied_reason(request: web.Request, provider_name: str) -> str | None:
@@ -205,39 +227,28 @@ def publish_denied_reason(request: web.Request, provider_name: str) -> str | Non
     # Config allowlist (default-open, narrow-only). Empty list allows any
     # registered destination; a non-empty list restricts to those provider ids.
     #
-    # The parseability check comes FIRST and is not redundant with the try/except
-    # below: ``load()`` swallows its own parse errors and returns defaults, so a
-    # corrupt config would present as an EMPTY allowlist — indistinguishable from
-    # an operator who never narrowed it — and silently reopen a closed path. The
-    # except is kept for anything else ``load()`` can raise.
-    unparseable = _unparseable_config_reason()
-    if unparseable:
-        _audit_deny(
-            session_key=session_key,
-            provider_name=provider_name,
-            rule="publish.allowed_destinations",
-            layer="config",
-            reason=unparseable,
-        )
-        return unparseable
+    # ONE validated read yields both the verdict and the value. Asking those two
+    # questions separately is the defect: `load()` swallows its own parse errors
+    # and returns defaults, so a corrupt config (or a malformed `publish`
+    # section) presented as an EMPTY allowlist — indistinguishable from an
+    # operator who never narrowed it — and silently reopened a closed path.
     try:
-        allowed = KiroCrewConfig.load().publish.allowed_destinations
+        allowed, refusal = _read_allowed_destinations()
     except Exception:
-        logger.debug("publish config load failed; failing closed", exc_info=True)
-        # Audited like every other refusal: this was the last denial path that
-        # returned silently, which made `_audit_deny`'s "every layer routes
-        # through here" claim false. A refusal an operator cannot find in the
-        # audit log is indistinguishable to them from the publish never having
-        # been attempted.
-        reason = "publishing denied: publish config could not be loaded"
+        logger.debug("publish config read failed; failing closed", exc_info=True)
+        # Audited like every other refusal: a refusal an operator cannot find in
+        # the audit log is indistinguishable to them from the publish never
+        # having been attempted.
+        allowed, refusal = [], "publishing denied: publish config could not be loaded"
+    if refusal:
         _audit_deny(
             session_key=session_key,
             provider_name=provider_name,
             rule="publish.allowed_destinations",
             layer="config",
-            reason=reason,
+            reason=refusal,
         )
-        return reason
+        return refusal
     if allowed and provider_name not in allowed:
         _audit_deny(
             session_key=session_key,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -398,6 +398,30 @@ def _reset_safety_override_between_tests():
 
 
 @pytest.fixture(autouse=True)
+def _reset_degraded_config_observations():
+    """Forget the loader's process-sticky malformed-config observations.
+
+    ``kiro_crew.config.loader`` remembers every malformed config section it has
+    ever seen for the LIFE OF THE PROCESS (deliberately: ``load()``'s migration
+    repairs the file on first read, so the observation is the only surviving
+    evidence, and the publish gate fails closed on it). Tests share one
+    interpreter, so without this reset any test that writes a malformed
+    ``config.json`` — loader error-path tests do — makes the publish/deploy
+    gate deny in every LATER test in the same worker, failing tests in files
+    that never touched the config (seen as ``TestPending`` 4xx refusals in
+    ``test_deploy_handlers_coverage.py`` under random orderings).
+
+    ``reset_degraded_observations`` documents tests as its only legitimate
+    caller; this fixture is that caller.
+    """
+    from kiro_crew.config.loader import reset_degraded_observations
+
+    reset_degraded_observations()
+    yield
+    reset_degraded_observations()
+
+
+@pytest.fixture(autouse=True)
 def _restore_autonudge_singleton():
     """Floor under ``autonudge._INSTANCE`` — the process-global service reference.
 

--- a/test/test_config_validation.py
+++ b/test/test_config_validation.py
@@ -104,6 +104,43 @@ class TestSchemaIntrospectionHelpers:
         validation._apply_field_default(data, "agent.provider")
         assert data == {"agent": {"keep": "ok"}}
 
+    def test_apply_field_default_never_repairs_a_fail_closed_path(self) -> None:
+        """Repairing `publish` to defaults IS the #4057 widening: a popped
+        section reads as "operator configured nothing" and the allowlist
+        silently reopens. The malformed value must survive validation so the
+        loader records the degradation and the gate denies — on jsonschema
+        hosts exactly as on hosts without it (where validation is a no-op)."""
+        section = {"publish": []}
+        assert validation._apply_field_default(section, "publish") is False
+        assert section == {"publish": []}
+
+        inner = {"publish": {"allowed_destinations": "deploy-web"}}
+        assert validation._apply_field_default(inner, "publish.allowed_destinations") is False
+        assert inner == {"publish": {"allowed_destinations": "deploy-web"}}
+
+    def test_restrictive_default_publish_fields_are_still_repaired(self) -> None:
+        """The exemption is per-path, NOT a publish subtree rule. For a field
+        whose default is restrictive the repair is the safe direction, and
+        preserving the malformed value can itself widen: a dict-shaped
+        relocate_roots iterates as its keys in the loader's comprehension and
+        would inject '/etc' as an allowed relocate root, where the repaired
+        default [] means home-only."""
+        data = {"publish": {"relocate_roots": {"/etc": False}}}
+        assert validation._apply_field_default(data, "publish.relocate_roots") is True
+        assert data == {"publish": {}}
+
+    def test_every_fail_closed_path_is_a_real_schema_path(self) -> None:
+        """The exemption list must not drift from the schema: a name that stops
+        matching a declared field would silently exempt nothing."""
+        from kiro_crew.config.schema import JSON_SCHEMA
+
+        for dot_path in validation._FAIL_CLOSED_PATHS:
+            node = JSON_SCHEMA
+            for part in dot_path.split("."):
+                props = node.get("properties", {})
+                assert part in props, f"_FAIL_CLOSED_PATHS entry {dot_path!r} not in schema"
+                node = props[part]
+
 
 class TestValidateConfigData:
     """``validate_config_data`` strips invalid values and warns on the loader logger."""

--- a/test/test_deploy_public_gate_3599.py
+++ b/test/test_deploy_public_gate_3599.py
@@ -321,14 +321,22 @@ def test_an_app_declaring_a_different_id_is_untouched(monkeypatch):
 # ── the real decision, not a stub ───────────────────────────────────────────
 
 @pytest.fixture()
-def narrowed_allowlist(monkeypatch):
-    """Operator config permits only the internal registry — deploy is excluded."""
-    from kiro_crew.config.loader import KiroCrewConfig, PublishConfig
+def narrowed_allowlist(tmp_path, monkeypatch):
+    """Operator config permits only the internal registry — deploy is excluded.
 
-    cfg = KiroCrewConfig.load()
-    cfg.publish = PublishConfig(allowed_destinations=["internal-registry"])
-    monkeypatch.setattr(KiroCrewConfig, "load", staticmethod(lambda: cfg))
-    return cfg
+    Written as real bytes to a real config.json rather than by mocking
+    ``KiroCrewConfig.load()``. The gate now reads the FILE, and a mock here would
+    make the test agree with the reader instead of with what an operator typed —
+    which is exactly how a malformed section that reopens the allowlist went
+    unnoticed (#4057).
+    """
+    import kiro_crew.config.loader as loader
+
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"publish": {"allowed_destinations": ["internal-registry"]}}))
+    monkeypatch.setattr(loader, "config_path", lambda: cfg_file)
+    monkeypatch.setattr(loader, "config_local_path", lambda: tmp_path / "config.local.json")
+    return cfg_file
 
 
 def test_config_allowlist_reaches_the_deploy_endpoint(narrowed_allowlist, monkeypatch):
@@ -454,6 +462,10 @@ def test_a_broken_audit_sink_still_denies(narrowed_allowlist, monkeypatch):
 
 
 # ── a config we cannot parse must DENY, not degrade to allow-all ─────────────
+# (the loader's process-sticky observations are reset between tests by the
+# repo-wide autouse fixture _reset_degraded_config_observations in
+# test/conftest.py)
+
 
 @pytest.fixture()
 def _quiet_sel(monkeypatch):
@@ -482,11 +494,12 @@ def test_a_malformed_config_denies_instead_of_reopening_the_path(
     moment the file was corrupted. This module documents fail-CLOSED, so it checks
     parseability itself.
     """
+    import kiro_crew.config.loader as loader
     import kiro_crew.publish_governance as pg
     bad = tmp_path / "config.json"
     bad.write_text('{"publish": {"allowed_destinations": ["internal-registry"]')  # truncated
-    monkeypatch.setattr(pg, "config_path", lambda: bad)
-    monkeypatch.setattr(pg, "config_local_path", lambda: tmp_path / "config.local.json")
+    monkeypatch.setattr(loader, "config_path", lambda: bad)
+    monkeypatch.setattr(loader, "config_local_path", lambda: tmp_path / "config.local.json")
 
     reason = pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID)
 
@@ -501,13 +514,14 @@ def test_a_malformed_overlay_denies_too(tmp_path, monkeypatch, _quiet_sel):
     A corrupt overlay hides an allowlist exactly as effectively as a corrupt base,
     so checking only the base would leave half the hole open.
     """
+    import kiro_crew.config.loader as loader
     import kiro_crew.publish_governance as pg
     good = tmp_path / "config.json"
     good.write_text("{}")
     bad_overlay = tmp_path / "config.local.json"
     bad_overlay.write_text("}not json{")
-    monkeypatch.setattr(pg, "config_path", lambda: good)
-    monkeypatch.setattr(pg, "config_local_path", lambda: bad_overlay)
+    monkeypatch.setattr(loader, "config_path", lambda: good)
+    monkeypatch.setattr(loader, "config_local_path", lambda: bad_overlay)
 
     reason = pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID)
 
@@ -517,31 +531,31 @@ def test_a_malformed_overlay_denies_too(tmp_path, monkeypatch, _quiet_sel):
 
 def test_a_non_object_config_denies(tmp_path, monkeypatch, _quiet_sel):
     """Valid JSON that is not an object also degrades to defaults in the loader."""
+    import kiro_crew.config.loader as loader
     import kiro_crew.publish_governance as pg
     weird = tmp_path / "config.json"
     weird.write_text('["not", "an", "object"]')
-    monkeypatch.setattr(pg, "config_path", lambda: weird)
-    monkeypatch.setattr(pg, "config_local_path", lambda: tmp_path / "nope.json")
+    monkeypatch.setattr(loader, "config_path", lambda: weird)
+    monkeypatch.setattr(loader, "config_local_path", lambda: tmp_path / "nope.json")
 
     assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is not None
 
 
-def test_a_config_load_failure_is_audited_too(tmp_path, monkeypatch, _quiet_sel):
+def test_a_config_read_failure_is_audited_too(tmp_path, monkeypatch, _quiet_sel):
     """The LAST denial path that returned silently now audits like the rest.
 
     `_audit_deny` claims every layer that can refuse routes through it, and that
-    claim was false for the ``except`` around ``KiroCrewConfig.load()``. A refusal
-    an operator cannot find in the audit log is indistinguishable, to them, from
-    the publish never having been attempted.
-
-    The parseability guard sits in front of this branch, so the config on disk has
-    to be VALID while ``load()`` itself fails — hence a raising ``load``.
+    claim was false for the config branch. A refusal an operator cannot find in
+    the audit log is indistinguishable, to them, from the publish never having
+    been attempted.
     """
+    import kiro_crew.config.loader as loader
     import kiro_crew.publish_governance as pg
+
     good = tmp_path / "config.json"
     good.write_text("{}")
-    monkeypatch.setattr(pg, "config_path", lambda: good)
-    monkeypatch.setattr(pg, "config_local_path", lambda: tmp_path / "absent.json")
+    monkeypatch.setattr(loader, "config_path", lambda: good)
+    monkeypatch.setattr(loader, "config_local_path", lambda: tmp_path / "absent.json")
 
     class _Raising:
         """Only publish_governance's binding is replaced, so the governance layer
@@ -556,10 +570,10 @@ def test_a_config_load_failure_is_audited_too(tmp_path, monkeypatch, _quiet_sel)
 
     reason = pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID)
 
-    assert reason is not None, "a config that cannot be loaded must DENY"
+    assert reason is not None, "a config that cannot be read must DENY"
     assert "could not be loaded" in reason
     assert [e["outcome"] for e in _quiet_sel] == ["denied"], (
-        f"the config-load refusal must be audited exactly once, got {_quiet_sel}"
+        f"the config-read refusal must be audited exactly once, got {_quiet_sel}"
     )
 
 
@@ -570,9 +584,192 @@ def test_an_absent_config_still_permits(tmp_path, monkeypatch, _quiet_sel):
     merely MISSING would break every ordinary install, where an unnamed publish is
     ungoverned and permitted.
     """
+    import kiro_crew.config.loader as loader
     import kiro_crew.publish_governance as pg
-    monkeypatch.setattr(pg, "config_path", lambda: tmp_path / "absent.json")
-    monkeypatch.setattr(pg, "config_local_path", lambda: tmp_path / "absent.local.json")
+    monkeypatch.setattr(loader, "config_path", lambda: tmp_path / "absent.json")
+    monkeypatch.setattr(loader, "config_local_path", lambda: tmp_path / "absent.local.json")
 
     assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is None
     assert _quiet_sel == [], "a permitted publish must not audit"
+
+
+# ── a MALFORMED publish section must deny, not reopen the allowlist (#4057) ──
+#
+# The gate used to answer "is the config usable" and "what did the operator
+# allow" from two independent reads. `read_config_for_update` only rejects a
+# non-object TOP level, so `{"publish": []}` passed the probe -- and then the
+# loader coerced the non-dict section to `{}`, so the allowlist came back empty,
+# which is indistinguishable from "no restriction configured". A malformed
+# section removed the restriction instead of denying.
+#
+# Written as real bytes to a real config.json. Mocking KiroCrewConfig.load()
+# makes the test agree with the reader instead of with the file, which is what
+# let this class of widening ship unnoticed.
+
+
+def _config_on_disk(tmp_path, monkeypatch, base: str, overlay: str | None = None):
+    import kiro_crew.config.loader as loader
+
+    base_file = tmp_path / "config.json"
+    base_file.write_text(base)
+    overlay_file = tmp_path / "config.local.json"
+    if overlay is not None:
+        overlay_file.write_text(overlay)
+    monkeypatch.setattr(loader, "config_path", lambda: base_file)
+    monkeypatch.setattr(loader, "config_local_path", lambda: overlay_file)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        '{"publish": []}',                       # the issue's exact repro
+        '{"publish": "internal-registry"}',
+        '{"publish": 0}',
+        '{"publish": null}',
+    ],
+)
+def test_a_non_object_publish_section_denies(tmp_path, monkeypatch, _quiet_sel, body):
+    import kiro_crew.publish_governance as pg
+
+    _config_on_disk(tmp_path, monkeypatch, body)
+
+    reason = pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID)
+
+    assert reason is not None, "a malformed publish section must DENY, not allow-all"
+    assert "publish" in reason
+    assert [e["outcome"] for e in _quiet_sel] == ["denied"]
+
+
+def test_a_malformed_publish_section_in_the_OVERLAY_denies(tmp_path, monkeypatch, _quiet_sel):
+    """config.local.json is deep-merged over the base and is the file the
+    torn-read window actually describes, so it must be checked too."""
+    import kiro_crew.publish_governance as pg
+
+    _config_on_disk(
+        tmp_path, monkeypatch,
+        '{"publish": {"allowed_destinations": ["internal-registry"]}}',
+        overlay='{"publish": []}',
+    )
+
+    assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is not None
+
+
+@pytest.mark.parametrize("dests", ['"deploy-web"', '5', '{"a": 1}'])
+def test_a_non_list_allowed_destinations_denies(tmp_path, monkeypatch, _quiet_sel, dests):
+    """One level down, the same shape: the loader's comprehension filters
+    non-strings out silently, so a scalar here yielded [] -- a narrowing turned
+    into allow-all.
+
+    Asserted on the DECISION rather than the wording: these malformed shapes are
+    refused by different layers (a string reaches this module's own check, a
+    scalar trips the governance evaluation first), and which layer speaks is not
+    the property worth pinning. That every one of them denies is."""
+    import kiro_crew.publish_governance as pg
+
+    _config_on_disk(tmp_path, monkeypatch, '{"publish": {"allowed_destinations": %s}}' % dests)
+
+    assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is not None
+
+
+def test_non_string_entries_do_not_reopen_the_allowlist(tmp_path, monkeypatch, _quiet_sel):
+    """An all-invalid narrowing like [1, 2] used to parse to [] — silently
+    indistinguishable from "unconfigured", the #4057 widening one level down.
+    The loader now records the drop as a degradation, so the gate denies.
+    (This test previously pinned the permit as the anchor for a follow-up;
+    the loader-side treatment the PR prescribed landed here instead.)"""
+    import kiro_crew.publish_governance as pg
+
+    _config_on_disk(tmp_path, monkeypatch, '{"publish": {"allowed_destinations": [1, 2]}}')
+
+    assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is not None
+
+
+def test_a_partially_invalid_allowlist_fails_closed(tmp_path, monkeypatch, _quiet_sel):
+    """A typo'd entry beside a valid one must not silently shrink the
+    narrowing: the operator's intent is unknowable, so the whole section
+    degrades and everything denies — including the destination they DID name
+    correctly, until the file is fixed."""
+    import kiro_crew.publish_governance as pg
+
+    _config_on_disk(
+        tmp_path, monkeypatch,
+        '{"publish": {"allowed_destinations": ["deploy-web", 5]}}',
+    )
+
+    assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is not None
+
+
+def test_a_scalar_allowed_destinations_never_crashes_load(tmp_path, monkeypatch, _quiet_sel):
+    """A config typo must not abort gateway startup: load() is called on the
+    boot path (and everywhere else) without a TypeError net. A non-list value
+    parses as a recorded degradation — denied, not detonated."""
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    _config_on_disk(tmp_path, monkeypatch, '{"publish": {"allowed_destinations": 5}}')
+
+    cfg = KiroCrewConfig.load()  # must not raise
+    assert cfg.publish.allowed_destinations == []
+    assert "publish" in cfg.degraded_sections
+
+
+def test_the_malformed_bytes_survive_the_writeback_migration(tmp_path, monkeypatch, _quiet_sel):
+    """The write-back migration must not repair a config it misread: cfg.save()
+    serializes only the parsed fields, so writing back would replace the
+    operator's malformed narrowing with clean defaults — erasing the only
+    on-disk evidence, so the next process (the restart the denial reason
+    prescribes) would see a clean default-open file and silently allow-all.
+
+    The issue's exact repro doubles as the migration trigger: {"publish": []}
+    has no agents key, so the default-agent migration fires on first load."""
+    import json
+
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    _config_on_disk(tmp_path, monkeypatch, '{"publish": []}')
+
+    cfg = KiroCrewConfig.load()
+    assert "publish" in cfg.degraded_sections
+
+    on_disk = json.loads((tmp_path / "config.json").read_text())
+    assert on_disk == {"publish": []}, (
+        "write-back migration repaired the malformed config, destroying the "
+        "evidence a future process needs to keep denying"
+    )
+
+
+def test_a_well_formed_narrowing_still_denies_the_excluded_destination(
+    tmp_path, monkeypatch, _quiet_sel
+):
+    """Control: the happy path this gate exists for still works from a file."""
+    import kiro_crew.publish_governance as pg
+
+    _config_on_disk(
+        tmp_path, monkeypatch,
+        '{"publish": {"allowed_destinations": ["internal-registry"]}}',
+    )
+
+    assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is not None
+
+
+def test_a_well_formed_allowlist_naming_the_destination_permits(
+    tmp_path, monkeypatch, _quiet_sel
+):
+    """Control the other way: a valid narrowing that INCLUDES the destination
+    must not be refused by the new validation."""
+    import kiro_crew.publish_governance as pg
+
+    _config_on_disk(
+        tmp_path, monkeypatch,
+        '{"publish": {"allowed_destinations": ["%s"]}}' % pg.DEPLOY_WEB_PROVIDER_ID,
+    )
+
+    assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is None
+
+
+def test_an_absent_publish_section_stays_default_open(tmp_path, monkeypatch, _quiet_sel):
+    """Genuinely unconfigured is not degraded: a standalone host is unaffected."""
+    import kiro_crew.publish_governance as pg
+
+    _config_on_disk(tmp_path, monkeypatch, '{"dashboard": {}}')
+
+    assert pg.publish_denied_reason(_Req(), pg.DEPLOY_WEB_PROVIDER_ID) is None


### PR DESCRIPTION
Closes #4057.

## Problem / Motivation

The gate answered *"is the config usable"* and *"what did the operator allow"* from two independent reads. The probe rejects only a non-object **top level**, so a `config.json` of `{"publish": []}` passed it — and the loader then coerced the non-dict section to `{}`, so `allowed_destinations` came back empty, which is indistinguishable from "no restriction configured". A malformed section did not deny publishing and surfaced no error; **it removed the restriction**.

Proven on `main`: with `{"publish": []}` on disk, `publish_denied_reason` returns `None` (permitted).

## Why it matters

A malformed `publish` section silently reopens the destination allowlist: a narrowing the operator wrote becomes allow-all, with no error and no audit record. Worse, the evidence self-destructs — `load()` runs a migration that rewrites `config.json` in normalized form, so after the first load the malformed bytes are gone from disk and the file *looks* clean with an empty allowlist. This is the same two-reader shape as #3945, on a security gate.

## What changed (motivation → approach → change)

**Why the issue's option 2 (module-scoped re-read) cannot work:** by the time any gate re-reads the file, the migration has already repaired it. I verified this directly — the malformed bytes are replaced during the first `load()` in the process. So the loader is the only code that ever *sees* the degradation, which makes the issue's preferred **option 1** the only workable one:

- **`KiroCrewConfig.degraded_sections`** names every top-level section that was present but not a JSON object, plus a marker (and the file name) when a whole file could not be read as one. An **absent** section is not degraded — that is the genuine unconfigured state, so a standalone host is unaffected. (After the rebase this lives as the private field `_degraded_sections` behind a read-only `degraded_sections` property, keeping it out of main's config schema/baseline machinery — `_extra_sections` precedent.)
- **All ~27 section reads go through one `_coerced_section` helper** instead of 27 copies of `if not isinstance(x, dict): x = {}`. That is what stops each security gate from growing its own shadow parser beside the loader — the concern the reviewer raised on the per-call-site approach.
- **The write-back migration no longer repairs a config it misread** (review-round adoption, Design + First Principles convergent finding): `needs_migration -> cfg.save()` is skipped whenever the load degraded anything, so the malformed bytes stay on disk, every future process re-observes and re-denies, and migration re-runs on the first clean load. Without this, the issue's exact repro (`{"publish": []}`, no `agents` key) was normalized to a clean default-open file on first load — and the prescribed restart delivered silent allow-all.
- **Observations are additionally sticky for the process** — belt and suspenders over `cfg.save()` callers outside the load path. `reset_degraded_observations()` exists for tests, which share one interpreter (the repo-wide autouse fixture in `test/conftest.py` is that caller).
- **On `jsonschema` hosts, advisory validation no longer repairs `publish` / `publish.allowed_destinations`** (`_FAIL_CLOSED_PATHS` in `validation.py`): the repair replaced a malformed narrowing with its OPEN default before the loader's recorder could see it — silent allow-all on exactly the hosts that have the optional dependency installed. This exemption is load-bearing for the fix; every restrictive-default field (e.g. `relocate_roots`) stays repairable, since there the repair is the safe direction.
- **Malformed allowlist ENTRIES also degrade** (review-round adoption, GPT round 3): a list like `[1, 2]` used to filter to `[]` — indistinguishable from unconfigured. Any entry that is not a non-empty string now records the section degraded and denies, including a partially-invalid list beside a correctly-named destination (fail-closed until the file is fixed).
- **A non-list `publish.allowed_destinations` parses as a recorded degradation** (review-round adoption, GPT round 2): previously a scalar there made `load()` raise `TypeError` on the boot path (pre-existing on hosts without `jsonschema`, where advisory validation is a no-op). It now records `"publish"` degraded, warns naming the field, and parses from the safe default — denied, not detonated. Malformed entries INSIDE a well-formed list remain the documented follow-up.
- `publish_governance` makes **one** `load()` and asks that single question.

**Deliberately not fixed here:** a malformed `allowed_destinations` *inside* a well-formed section. The loader normalizes it before this gate can see it — its comprehension iterates whatever it is given, so the string `"deploy-web"` becomes the character list `["d", "e", …]` — so a check here would be dead code that only looked like a guard. It is the same class one level down and wants the same loader-side treatment. Current behaviour is pinned by a test as the anchor for that follow-up; happy to file it.

## Tests

Tests write **real bytes to a real `config.json`** rather than mocking `KiroCrewConfig.load()`, per the issue — a mock makes the test agree with the reader instead of with what an operator typed, which is how this class of widening ships unnoticed. The `narrowed_allowlist` fixture is converted the same way.

- **`test/test_deploy_public_gate_3599.py`**: 9 new tests — a non-object `publish` section (four shapes, including the exact `{"publish": []}` repro) denies and is audited; a malformed **overlay** denies; malformed `allowed_destinations` shapes all deny; plus controls that a well-formed narrowing still denies the excluded destination, still permits a named one, and that an absent section stays default-open.
- Full backend suite vs a pristine-main control worktree on the same host: failure sets match (host-environment baseline only, zero regressions).
- `flake8` / `isort` / `mypy` clean on touched files; `scripts/check_black_formatting.py` passes.

## Manual verification

Reproduced the issue's exact scenario on `main` (`{"publish": []}` on disk → publish permitted), then on this branch: the same bytes deny with a reason naming the degraded section, and the denial is audited.

## Related Issues

Closes #4057. Same two-reader shape as #3945.

## Checklist

- [x] Tests added/updated
- [x] All CI checks pass locally (isort / flake8 / mypy / black gate / pytest)

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.


