### PR TITLE
test: stop the suite leaking host state and cut its inode footprint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ in the **same commit** when you change what it documents.
 | themes | [themes](docs/system-specs/modules/themes.md) + [theming-contract](website/docs/theming-contract.md) |
 | anything under `website/` | [`website/AGENTS.md`](website/AGENTS.md) |
 | user-facing strings, dates, numbers, sort order | [i18n-catalog](website/docs/i18n-catalog.md) (authoring) + [i18n-gates](docs/ci/i18n-gates.md) (CI) |
-| tests: flakes, speed, fixtures, sharding | [testing-conventions](docs/system-specs/common/testing-conventions.md) |
+| tests: flakes, speed, fixtures, sharding, side effects, conftest isolation | [testing-conventions](docs/system-specs/common/testing-conventions.md) + the [writing-tests](src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md) skill |
 | browser E2E | [e2e-gate](docs/ci/e2e-gate.md) |
 | CI, PR flow, review gates | [ci-and-reviews](docs/ci/ci-and-reviews.md) + [CONTRIBUTING.md](CONTRIBUTING.md) |
 | constants, magic numbers, where a limit lives | [code-style](docs/system-specs/common/code-style.md) |
@@ -258,6 +258,27 @@ for the five flake classes and the one correct fix for each. In particular, a ti
 test that asserts algorithmic **complexity** must bound the doubling RATIO, not an
 absolute duration: CI enables coverage on 3.12 only, and that multiplier made one shard
 fail on 3.12 and pass on 3.10 at the same commit.
+
+**A test must not touch the operator's machine, and the floor you stand on is not the
+same in every testpath.** `testpaths` collects three trees, and only `test/` gets
+`test/conftest.py`; the ~108 test modules under `src/kiro_crew/apps/builtins/*/tests/`
+see the **rootdir** `conftest.py`, plus that app's own `tests/conftest.py` where one
+exists (three of the eight apps ship one). So the rootdir conftest carries the
+host floor: `KIROCREW_HOME` pinned per test, the import-time `~/.kiro` bindings pinned
+(that directory is kiro-cli's own home, shared with the real installed agent, and a
+separate isolation axis from the data home), the SEL default dir pinned session-wide,
+`tempfile`'s base redirected with residue reported, and the checkout failed on residue.
+Before adding isolation, decide which floor it belongs to; before writing a test, read
+the [writing-tests skill](src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md).
+Two traps are worth naming here because neither is visible when reading the test:
+
+- **A child process inherits pytest's CWD, the repo root**, so a spawn that may create a
+  file needs `cwd=` under `tmp_path` — and the assertion must be scoped to where that
+  child actually ran, not to where you hoped it wrote.
+- **A singleton with a daemon thread beats every filesystem cleanup.** It captures the
+  directory the first caller resolved and re-creates it after a test's own teardown
+  deleted it, so the fix is a session-scoped directory owned by no test, never tidier
+  cleanup.
 
 ## Code style
 

--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -195,16 +195,75 @@ custom-rules:
         and a security test whose payload escapes its own assertion is worse
         than no test, because it reports the guarantee it failed to check.
 
+      THE PROCESS WORKING DIRECTORY IS SHARED STATE. It is per-PROCESS, so under
+      xdist one test's `os.chdir` becomes every later test's starting directory on
+      that worker. FLAG a bare `os.chdir` in a test; `monkeypatch.chdir` reverts on
+      its own. This is not untidiness: a passing test's `tmp_path` is removed at that
+      test's teardown, so a test that chdirs into `tmp_path` and does not come back
+      leaves the worker in a DELETED directory, and `Path.cwd()` then raises
+      FileNotFoundError in every later test that reaches it — including from inside
+      production code (`taskrunner.TaskRunner.__init__` does `work_dir or Path.cwd()`).
+      Measured instance and its numbers: testing-conventions.md § Rules. The shape to
+      recognise in review is that it reads as "the suite is flaky" -- many files, each
+      passing in isolation -- rather than as one test missing one line.
+
+      A BACKGROUND WORKER BEATS EVERY FILESYSTEM CLEANUP, and this is the shape
+      neither paragraph above catches. A process singleton whose writer is a daemon
+      thread binds its directory ONCE, from whatever the first caller resolved. The
+      thread then outlives that test and re-creates the directory on its next flush —
+      AFTER the test's own tearDown removed it. `sel.py` is the worked case:
+      `SecurityEventLog._init_locked` captures `_default_dir()` and `_flush_batch`
+      opens with `mkdir(parents=True, exist_ok=True)`, which left one stray directory
+      behind on every run of a suite whose tests all cleaned up correctly. FLAG a test
+      that hands a PER-TEST directory to a subsystem with a background thread, task or
+      timer; the fix is a session-scoped directory that belongs to no individual test,
+      never tidier cleanup. Same family: a bare `MagicMock` config reads TRUTHY, so
+      patching `KiroCrewConfig.load` with one starts whatever subsystem is gated on
+      `cfg.<x>.enabled` and resolves `Path(cfg.local_dir)` to a RELATIVE path in the
+      repo; and a sleeper child (`python -c "import time; time.sleep(30)"`) whose
+      kill/wait sits on the happy path instead of in a `finally` or `addCleanup`.
+
+      A SECURITY ANCHOR IS NOT A DATA PATH. Some module-level values are built FROM
+      the real home precisely so they can refuse access to it — `security`'s
+      extract-into-trust-root pattern, `kiro_usage_api`'s credential-store paths.
+      Redirecting one to a tmp dir so a test can be isolated makes that test assert
+      against a pattern that no longer matches the thing it protects. FLAG it: stub
+      the READER, never move the anchor. The mirror-image defect is equally real —
+      handing a runtime-resolved path to a home-anchored matcher, which passes only
+      while the suite is reading the operator's REAL home and reports a guarantee it
+      never checked.
+
       Know which floor you are standing on — it is NOT the same everywhere:
-      - Tests under `test/` inherit the autouse fixtures in `test/conftest.py`
-        (`_isolate_kirocrew_home` pins KIROCREW_HOME per test,
-        `_isolate_subagents_dir`, `_isolate_sel_default_dir`, and friends).
-      - Tests under `src/kiro_crew/apps/builtins/*/tests/` and `tests/` see only
-        the ROOT `conftest.py`, which isolates $XDG_CONFIG_HOME and blocks host
-        service mutation but does NOT pin KIROCREW_HOME. A test there that
-        reaches `config_dir()` / `apps_dir()` writes the developer's real data
-        dir. Isolate it yourself: `monkeypatch.setenv("KIROCREW_HOME",
-        str(tmp_path))`.
+      - The ROOTDIR `conftest.py` is the HOST-MUTATION FLOOR and applies to all
+        three testpaths. It pins $XDG_CONFIG_HOME and the launchd paths, blocks
+        host service mutation, pins KIROCREW_HOME per test (with
+        `config.paths._resolved_home` reset, since resolving the home CREATES it
+        and can run the legacy migration), pins the import-time `~/.kiro`
+        bindings via `_isolate_shared_kiro_paths`, pins the SEL default dir
+        session-wide, redirects `tempfile`'s base with residue reported, and
+        fails the run on residue at the repository root.
+      - `test/conftest.py` adds ~20 MORE autouse fixtures, and it applies ONLY to
+        `test/`. Tests under `src/kiro_crew/apps/builtins/*/tests/` and
+        `transfer/` see the rootdir conftest plus that app's own
+        `tests/conftest.py` where one exists (`auto_improvement`,
+        `code_review_sage`, `spec_builder` have one; the other five apps do not).
+        So a test there gets the host floor -- which now includes the data home,
+        the import-time `~/.kiro` bindings, the SEL dir, the subagent registry,
+        the model-download block and the agent-state sidecar -- but NOT the
+        suite-specific isolation (the Slack thread-state reset, the model-window
+        cache, the platform-context reset, the reasoning-effort globals, the
+        OPTIONS registries, …). FLAG a test in those trees that relies on one of
+        THOSE without arranging it itself.
+      - `~/.kiro` is a SEPARATE isolation axis from the data home: it is
+        kiro-cli's own machine-wide home, shared with the real installed agent,
+        so `~/.kiro/settings/mcp.json` is the LIVE agent's MCP server list. A new
+        module-level `Path.home()` binding in `src/kiro_crew` must be added to
+        `_SHARED_KIRO_PATHS` or excluded with a reason —
+        `test/test_host_isolation_floor.py` fails otherwise. That ratchet covers the
+        IMPORT-TIME shape only: a lazy resolver such as `config.paths.kiro_home()`
+        still names the operator's real `~/.kiro`, because the floor pins neither
+        `Path.home()` nor `$HOME`, so a test reaching one of those must isolate it
+        itself.
 
       Assert against the tmp dir, not the real one, and clean up anything you
       create. If a test genuinely needs a host-level effect, it must be opt-in
@@ -212,12 +271,18 @@ custom-rules:
       why.
 
       NEVER use bare `tempfile.mkdtemp()` or `tempfile.TemporaryDirectory()`
-      without cleanup. These create directories in /tmp that survive the test
-      run and accumulate across runs, exhausting inodes. Use pytest's `tmp_path`
-      fixture (automatically cleaned) or, in unittest.TestCase setUp, pair
-      every `mkdtemp()` with `self.addCleanup(shutil.rmtree, path,
-      ignore_errors=True)`. The rule is: if you create it, you must register
-      its destruction in the same scope.
+      without cleanup. These create directories that survive the test run and
+      accumulate across runs, exhausting inodes — and inode exhaustion returns
+      ENOSPC to every other process on the machine while 90% of the BYTES are
+      still free, so it does not look like a disk problem. Use pytest's
+      `tmp_path` fixture, or pair every `mkdtemp()` with
+      `self.addCleanup(shutil.rmtree, path, ignore_errors=True)` ON THE LINE
+      AFTER IT. An `rmtree` in `tearDown` is NOT equivalent and is the shape that
+      actually leaks: `unittest` skips `tearDown` entirely when `setUp` raises,
+      so it leaks on every setUp failure — the failing run nobody is watching
+      closely. The rule is: if you create it, you must register its destruction
+      in the same scope. `ignore_errors=True` also SWALLOWS a cleanup that could
+      not finish, so it is not evidence the directory is gone.
 
       NEVER use relative `Path("src/...")` or bare string paths to read source
       files from a test. Under pytest-xdist, workers may change CWD, making

--- a/conftest.py
+++ b/conftest.py
@@ -2,15 +2,37 @@
 
 ``test/conftest.py`` holds the bulk of the suite's isolation, but it only applies
 to ``test/``. ``[tool:pytest] testpaths`` also collects ``transfer`` and
-``src/kiro_crew/apps/builtins`` (42 test modules that ship inside the package,
+``src/kiro_crew/apps/builtins`` (~108 test modules that ship inside the package,
 next to the code they cover), and those get no ``test/conftest.py`` fixtures at
-all. Anything that must hold for EVERY test therefore has to live here, at the
+all -- only this file, plus that app's own ``tests/conftest.py`` where one exists.
+Anything that must hold for EVERY test therefore has to live here, at the
 rootdir, which is the one conftest pytest applies to all three testpaths.
 
-Only the host-mutation floor belongs in this file. It is deliberately narrow: a
-guard that makes it impossible for a test to reconfigure or restart the
-developer's real Kiro Crew service, and one that fails the run when a test leaves
-residue in the repository checkout. Everything else stays in ``test/conftest.py``.
+Only the HOST-MUTATION FLOOR belongs in this file: the guards that must hold for a
+test collected from any of the three testpaths, because what they protect is the
+developer's machine rather than the correctness of one suite. Everything that is
+merely suite-specific isolation stays in ``test/conftest.py``.
+
+The floor has four parts, and each one exists because the "remember to isolate
+this" contract failed at least once:
+
+* **Services.** ``$XDG_CONFIG_HOME`` is redirected and the stdlib spawn funnels
+  refuse a ``systemctl``/``launchctl`` invocation carrying a mutating verb, so no
+  test can reconfigure or restart the operator's real gateway (issue #1722).
+* **The data home.** ``KIROCREW_HOME`` is pinned per test, and the ``~/.kiro``
+  paths that production binds at IMPORT time (which the env var cannot reach) are
+  pinned with it. Without this, the ~108 test modules that ship inside the package
+  under ``src/kiro_crew/apps/builtins/*/tests/`` -- which see this conftest and no
+  other -- write the operator's live ``~/.kiro/crew`` the moment they touch
+  ``config_dir()``.
+* **The system temp directory.** ``tempfile``'s base is redirected to a per-run
+  directory for the whole process, so a bare ``mkdtemp()`` whose cleanup is missing
+  or skipped leaves its directory somewhere this run owns and removes, instead of
+  accumulating in the shared temp root forever. What was left behind is REPORTED
+  first, so the leak is a red rather than silent inode consumption.
+* **The repository checkout.** The run fails when it ends with residue anywhere in
+  the checkout, which is how a subprocess spawned without ``cwd=`` announces
+  itself.
 
 One consequence of living at the rootdir: the module name ``conftest`` is now
 resolvable from the repository root as well as from ``test/``, and 11 test modules
@@ -32,22 +54,31 @@ real ``_make_live()`` because that function was the subject under test, and two
 of that function's seams (the drop-in path and the subprocess layer) were left
 for each test to remember to stub.
 
-The two fixtures below remove that "remember to" from the contract. Neither
-changes the behaviour of a test that already isolates itself correctly.
+The fixtures below remove that "remember to" from the contract. None of them
+changes the behaviour of a test that already isolates itself correctly: every one
+sets a value a test can still override, and a test that sets its own
+``KIROCREW_HOME`` or its own temp dir keeps winning.
 
-Imports are stdlib + pytest only, on purpose: a rootdir conftest is imported
-before every collection, so pulling ``kiro_crew`` in here would make the whole
-suite depend on import-time side effects of the package under test.
+Imports at MODULE level are stdlib + pytest only, on purpose: a rootdir conftest is
+imported before every collection, so pulling ``kiro_crew`` in here would make the
+whole suite depend on import-time side effects of the package under test. The
+fixtures that do need ``kiro_crew`` import it in their own body, which runs at test
+setup -- by which point the test module has already imported the package anyway --
+and tolerate an ImportError so a partial checkout cannot break collection.
 """
 
 from __future__ import annotations
 
 import asyncio.base_events
+import getpass
 import importlib
 import os
 import pathlib
+import shutil
 import subprocess
 import sys
+import tempfile
+import warnings
 
 import pytest
 
@@ -404,6 +435,748 @@ def _block_host_service_mutation(request, monkeypatch):
     )
     monkeypatch.setattr(os, "execve", guarded_exec)
 
+
+# ── the process working directory is shared state too ─────────────────
+
+
+#: The working directory pytest started in, captured once. Restoring to THIS rather than
+#: to a per-test snapshot is both simpler and more correct: it is the only value that is
+#: certain to still exist, and it is where every test expects to begin.
+_SESSION_CWD: str | None = None
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Record the working directory pytest started in, before any test can move it."""
+    global _SESSION_CWD
+    try:
+        _SESSION_CWD = os.getcwd()
+    except OSError:  # pragma: no cover - pytest could not have started here
+        _SESSION_CWD = str(_REPO_ROOT)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_teardown(item, nextitem):
+    """Put the process working directory back, BEFORE any fixture teardown runs.
+
+    The CWD is per-PROCESS, so under xdist one test's ``os.chdir`` silently becomes every
+    later test's starting directory on that worker. That was survivable while the
+    directory it pointed at outlived the run. It is not survivable now: with
+    ``tmp_path_retention_policy = failed`` pytest removes a passing test's ``tmp_path`` at
+    that test's own teardown, so a test that chdirs into ``tmp_path`` and does not come
+    back leaves the worker sitting in a DELETED directory -- and then ``Path.cwd()`` raises
+    ``FileNotFoundError`` in every later test that reaches it, including deep inside
+    production code (``taskrunner.TaskRunner.__init__`` does ``work_dir or Path.cwd()``).
+
+    Measured instance and its numbers:
+    ``docs/system-specs/common/testing-conventions.md`` § Rules. It reads as "the suite is
+    flaky" -- many files, each passing in isolation -- rather than as one missing line.
+
+    **A ``tryfirst`` teardown hook rather than an autouse fixture, and the difference is
+    load-bearing on Windows.** A fixture here would be an OUTER one (the rootdir conftest
+    is set up before the test's own fixtures), so it would tear down LAST -- after
+    ``tmp_path`` cleanup had already tried to remove a directory the process was still
+    sitting in. Windows refuses to delete a process's current working directory, so the
+    cleanup fails there. Making the fixture depend on ``tmp_path`` would invert the order,
+    but at the price of allocating a directory for every test in the suite, which is
+    exactly the per-test cost this change removed elsewhere. A ``tryfirst`` hookimpl runs
+    before the default ``pytest_runtest_teardown``, which is what performs fixture
+    finalization -- so the CWD is restored before ANY teardown, at no per-test cost.
+
+    Restoring rather than failing is deliberate. The damage a leaked CWD does is to OTHER
+    tests, so the floor's job is to stop it propagating; naming every offender is a
+    separate cleanup, and one a red suite would not help with. A test that wants to change
+    directory for its own duration keeps working, and ``monkeypatch.chdir`` (which reverts
+    itself, and whose undo lands on the same value) remains the right tool inside a test.
+    """
+    if _SESSION_CWD is None:  # pragma: no cover - configure always runs first
+        return
+    try:
+        if os.getcwd() == _SESSION_CWD:
+            return
+    except OSError:
+        # The CWD was deleted under us, so the comparison itself raises. Getting back to a
+        # real directory is the whole point, so fall through and do it unconditionally.
+        pass
+    try:
+        os.chdir(_SESSION_CWD)
+    except OSError:  # pragma: no cover - the starting directory would have to be gone
+        pass
+
+
+# ── tracked Windows gaps apply to every testpath ──────────────────────
+
+
+def pytest_collection_modifyitems(config, items):
+    """On Windows, skip the tracked known-gap tests (all parametrizations).
+
+    The list lives in ``test/windows-expected-failures.txt`` -- one unparametrized node
+    id per line, captured from the first Windows CI runs. It is a burn-down backlog:
+    fixed tests get their line deleted, and anything NOT on the list still fails the
+    job, so the Windows line holds for the tests that pass today.
+
+    Lives HERE rather than in ``test/conftest.py`` because the list already names node
+    ids under ``src/kiro_crew/apps/builtins/auto_improvement/tests/``, and a hook rooted
+    at ``test/`` is never registered when only in-package tests are collected -- which is
+    exactly what CI's reduced-scope Windows job does when a diff touches no path under
+    ``test/``. Those entries are also absent from ``BACKEND_DESELECTS``, so they were
+    collected unskipped and the shard went red for a gap that was already tracked.
+
+    The list file itself stays under ``test/``, read by path from here. Node ids are
+    always spelled with ``/`` even on Windows, so the in-package entries need no
+    translation.
+    """
+    if not platform_compat_or_none() or not platform_compat_or_none().IS_WINDOWS:
+        return
+    listfile = _REPO_ROOT / "test" / "windows-expected-failures.txt"
+    try:
+        text = listfile.read_text(encoding="utf-8")
+    except OSError:  # pragma: no cover - list file absent in a partial checkout
+        return
+    expected = {ln.strip() for ln in text.splitlines() if ln.strip() and not ln.startswith("#")}
+    marker = pytest.mark.skip(
+        reason="known Windows gap -- tracked in test/windows-expected-failures.txt"
+    )
+    for item in items:
+        if item.nodeid.split("[")[0] in expected:
+            item.add_marker(marker)
+
+
+def platform_compat_or_none():
+    """``kiro_crew.platform_compat``, or ``None`` when it cannot be imported.
+
+    Imported lazily so this rootdir conftest keeps its module-level imports to the
+    stdlib: it is loaded before every collection, and a module-scope import of the
+    package under test would make the whole suite depend on that package's import-time
+    side effects.
+    """
+    try:
+        from kiro_crew import platform_compat
+    except ImportError:  # pragma: no cover - partial checkout
+        return None
+    return platform_compat
+
+
+# ── the system temp directory is host state too ───────────────────────
+
+
+#: Prefix for the run's own temp base, a sibling of the platform temp root.
+#:
+#: The name is ``kc-pytest-<user>-<pid>``. The pid is what lets a later run tell an
+#: ABANDONED root (its process is gone) from one a concurrent run is still using. The
+#: user segment is not decoration: on POSIX the platform temp root is SHARED between
+#: accounts, so a bare pid collides across users -- two accounts can hold the same pid
+#: at the same time, and the second would try to reuse a directory it cannot write.
+#: Windows gives each account its own temp root, so there the segment is redundant and
+#: harmless.
+_TMP_ROOT_PREFIX = "kc-pytest-"
+
+
+def _tmp_root_prefix_for_run() -> str:
+    """``kc-pytest-<user>-<pid>-`` -- the stem this run's temp root is created under.
+
+    The user segment is not decoration: on POSIX the platform temp root is SHARED between
+    accounts, so a bare pid collides across users -- two accounts can hold the same pid at
+    the same time. The pid is what lets a later run tell an ABANDONED root from one a
+    concurrent run is still using. The trailing hyphen is where ``mkdtemp`` appends its
+    random component; see :func:`_create_tmp_root` for why that randomness is required and
+    not cosmetic.
+    """
+    try:
+        raw = getpass.getuser()
+    except Exception:  # noqa: BLE001 - no passwd entry and no env fallback
+        raw = "u"
+    user = "".join(ch if ch.isalnum() else "_" for ch in raw)[:24] or "u"
+    return f"{_TMP_ROOT_PREFIX}{user}-{os.getpid()}-"
+
+
+def _create_tmp_root(parent: pathlib.Path) -> pathlib.Path:
+    """Create this run's temp root under *parent*, atomically and unguessably.
+
+    ``mkdtemp`` rather than ``mkdir(exist_ok=True)`` on a name derived from the pid, and
+    the difference is a local privilege boundary rather than a style choice. The platform
+    temp root is world-writable with a sticky bit on POSIX, and a pid-derived name is
+    PREDICTABLE -- so another local account can pre-create that exact name as a SYMLINK to
+    a directory it controls. ``mkdir(..., exist_ok=True)`` succeeds against a
+    symlink-to-directory, the session redirect then follows it, and every temp write in
+    the run -- including whatever secrets a test fixture fabricates -- lands somewhere the
+    other account chose and can read.
+
+    ``mkdtemp`` closes that in three ways at once: it appends a random component, so the
+    name cannot be guessed ahead of time; it creates with ``O_EXCL``, so it fails rather
+    than adopting anything that already exists; and it sets mode ``0o700``, so the
+    directory is unreadable to other accounts once made. It also makes the name
+    UNPREDICTABLE to this suite, which is what lets the invariant below hold: a run can
+    only ever name the root it created itself.
+
+    The pid stays in the name for a human reading a stray directory, not for machinery:
+    nothing parses it. See :func:`_isolate_tempfile_base` for why this run never touches a
+    root it did not create.
+    """
+    return pathlib.Path(tempfile.mkdtemp(prefix=_tmp_root_prefix_for_run(), dir=parent))
+
+
+#: Env vars ``tempfile`` consults, so a CHILD process inherits the redirect too.
+#: A test that spawns a helper which writes to its temp dir would otherwise put
+#: that file in the real ``/tmp``, where nothing prunes it.
+_TMP_ENV_VARS = ("TMPDIR", "TEMP", "TMP")
+
+#: Opt-in diagnostic: give every test its OWN temp base, named after the test.
+#:
+#: Off by default because a directory per test is precisely the per-test cost the
+#: suite's fixture audit exists to avoid (paid ~26.5k times). It is the escape hatch
+#: for the one question the session-scoped guard below cannot answer: a single stray
+#: directory in a 26k-test run names no culprit. Re-run the suspect subset with
+#: ``KIROCREW_TMP_PER_TEST=1`` and the residue's parent directory IS the test id.
+_TMP_PER_TEST_ENV = "KIROCREW_TMP_PER_TEST"
+
+#: Names under the run's temp base that are NOT this suite's residue.
+#:
+#: Each entry is something OTHER than a test creating a directory it forgot to remove,
+#: which is the only thing this guard is about. Measured from CI, where the surfaces this
+#: developer host cannot reach are exercised:
+#:
+#: * ``pytest-of-`` -- a NESTED pytest's own ``basetemp`` tree. Several tests spawn one,
+#:   and it resolves ``gettempdir()`` after the redirect has taken effect, so it computes
+#:   its basetemp inside ours. A child runner's bookkeeping, with its own retention.
+#: * ``kirocrew-computer-shots`` -- the computer-use screenshot spool, which production
+#:   deliberately keeps under ``tempfile.gettempdir()`` as a persistent ring buffer
+#:   (pinned by ``test_computer_use_capture.py``). Long-lived BY DESIGN, so its presence
+#:   is the feature working, not a test leaking.
+#: * ``playwright-`` / ``.org.chromium.`` -- created by the browser and its driver, which
+#:   inherit the redirected ``TMPDIR`` like any other child. Third-party scratch this
+#:   suite does not own and cannot register cleanup for.
+_TMP_RESIDUE_ALLOWED_PREFIXES: tuple[str, ...] = (
+    "pytest-of-",
+    "kirocrew-computer-shots",
+    "playwright-",
+    ".org.chromium.",
+)
+
+#: Make temp residue FAIL the run rather than warn.
+#:
+#: Off by default, and that is a staged rollout rather than a soft opinion. The guard
+#: found real residue on CI surfaces this host cannot reach, and the entries that remain
+#: after the exclusions above are single ``mkstemp`` FILES rather than the ``mkdtemp``
+#: directories the rule is written about -- one inode each, several of them created by
+#: production code a test merely reached. Failing the suite on that set today would block
+#: every unrelated change while the set is attributed, and a guard that blocks unrelated
+#: work is a guard somebody deletes.
+#:
+#: So: the residue is removed either way (which is the whole inode win), and it is
+#: REPORTED either way. Set this to make it fatal -- in a burn-down branch, or in CI once
+#: the remaining set is empty. Same shape as ``windows-expected-failures.txt``: a known
+#: set, visible, with a way to hold the line once it is closed.
+_TMP_RESIDUE_STRICT_ENV = "KIROCREW_TMP_RESIDUE_STRICT"
+
+
+def _redirect_tempfile_base(base: pathlib.Path) -> None:
+    """Point ``tempfile`` AND every child process at *base*.
+
+    ``tempfile.tempdir`` is the module global ``gettempdir()`` memoises into, so
+    assigning it directly is what covers code already holding a reference to the
+    module; the env vars are what cover a child process, which re-derives its own.
+    Both are needed: patching only the global leaves subprocess writes in the real
+    temp dir, and setting only the env vars is a no-op for a process that already
+    resolved ``gettempdir()`` once.
+
+    All three names are set because the platforms disagree on which one is real:
+    ``TMPDIR`` is the POSIX spelling and ``TEMP``/``TMP`` are what Windows and the
+    tools spawned there read. Setting a name the running platform ignores is inert,
+    so there is no need to branch.
+    """
+    base.mkdir(parents=True, exist_ok=True)
+    tempfile.tempdir = str(base)
+    for name in _TMP_ENV_VARS:
+        os.environ[name] = str(base)
+
+
+def _remove_tree(path: pathlib.Path) -> bool:
+    """Delete *path*, defeating Windows read-only files. True when it is gone.
+
+    ``shutil.rmtree(..., ignore_errors=True)`` is the reflexive spelling and it is the
+    WRONG one here: on Windows a mode-444 file cannot be unlinked, a git checkout is
+    full of them (loose objects are written read-only), and ``ignore_errors`` swallows
+    every such failure so the caller reports success over a tree still on disk. Five
+    test modules combine a bare ``mkdtemp()`` with a real ``git`` spawn, so that is not
+    hypothetical. ``platform_compat.rmtree_force`` clears the attribute and retries, and
+    returns a filesystem-derived boolean rather than the hook's opinion.
+    """
+    try:
+        from kiro_crew import platform_compat as _pc
+    except ImportError:  # pragma: no cover - partial checkout
+        shutil.rmtree(path, ignore_errors=True)
+        return not path.exists()
+    return _pc.rmtree_force(path)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_tempfile_base(tmp_path_factory):
+    """Give the run its own ``tempfile`` base, then report and remove what leaked.
+
+    AUTOSDE forbids a bare ``tempfile.mkdtemp()`` / ``TemporaryDirectory()`` whose
+    destruction is not registered in the same scope, because those directories
+    survive the run and accumulate across runs until they exhaust inodes -- MEASURED
+    on this host, a ``/tmp`` tmpfs with a fixed 1,048,576-inode budget starts
+    returning ENOSPC to unrelated processes with 90% of its BYTES still free.
+    Enforcing that per call site is a contract every new test has to remember, and
+    the shape that breaks it is invisible when reading the test:
+    ``unittest.TestCase`` tearDown does NOT run when setUp raises, so a ``setUp:
+    mkdtemp()`` paired with a ``tearDown: rmtree()`` leaks on every setUp failure --
+    and it is the FAILING run, the one nobody is watching closely, that leaves the
+    residue.
+
+    Redirecting the base fixes the class instead of the call sites: whatever the suite
+    creates without cleaning up lands in one directory this fixture owns, so the teardown
+    can both NAME it (residue is still a defect) and REMOVE it (so the accumulation stops
+    regardless of whether anyone acts on the report).
+
+    The report WARNS by default and fails only under ``KIROCREW_TMP_RESIDUE_STRICT`` --
+    see ``_TMP_RESIDUE_STRICT_ENV`` for why that is a staged rollout and not a shrug.
+
+    Under ``-n auto`` each xdist worker is its own process, so each gets its own
+    root and reports only its own leaks; the controller runs no tests and creates
+    none.
+
+    **A run only ever deletes the root it created itself.** There is deliberately no sweep
+    of other roots, and that is a design decision rather than an omission. Reclaiming a
+    root left by a killed run means deciding that some OTHER directory is abandoned, and
+    every available signal for that is unsound: the name can be pre-created by another
+    local account, and a pid is meaningless across PID namespaces -- two containers sharing
+    a bind-mounted temp directory can each hold the same pid, so "that process is gone" is
+    a statement about the wrong namespace and the reward for getting it wrong is deleting
+    a live run's data. The platform already owns this job (``systemd-tmpfiles`` on a timer,
+    macOS's periodic cleanup, and a tmpfs cleared on reboot), and it owns it with
+    information this process does not have. So a run killed before its teardown leaves one
+    directory behind for the platform to reclaim -- bounded, and far smaller than the
+    375,780-inode-per-run accumulation this redirect removes.
+
+    **Why the platform's own temp dir rather than pytest's ``basetemp``.** Nesting
+    under ``basetemp`` would have been tidier -- pytest already prunes it -- but it
+    adds ``pytest-of-<user>/pytest-<n>/popen-gw<k>/`` to the front of every
+    ``mkdtemp()`` path in the suite, roughly 60 characters. Windows still caps a
+    path at 260 unless long paths are enabled, and a macOS ``AF_UNIX`` ``sun_path``
+    is capped at ~104 bytes, so that nesting would trade an inode leak for a
+    platform-specific path-length failure. A sibling of the platform temp root named
+    ``kc-pytest-<pid>`` is SHORTER than what pytest's own ``tmp_path`` already
+    hands out, so no existing path gets longer on any platform.
+
+    Two things deliberately stay outside the redirect:
+
+    * ``test/tmpdir_helpers.short_tmp_base()`` forces ``/tmp`` on POSIX, because
+      macOS's per-user temp root alone already exceeds the ``AF_UNIX`` cap. Those
+      sites clean up after themselves.
+    * A test that patches ``tempfile.gettempdir`` or passes its own ``dir=`` still
+      wins, as it should.
+    """
+    # Resolve pytest's basetemp FIRST, and discard the value: the call is what matters.
+    # pytest computes basetemp lazily from `tempfile.gettempdir()` on first use, so
+    # forcing it now pins it OUTSIDE the redirect below. Skip this and pytest's whole
+    # basetemp lands INSIDE the run's temp root, where the teardown here would delete
+    # it -- taking with it every failed test's retained `tmp_path`, which
+    # `tmp_path_retention_policy = failed` exists to keep -- and adding ~25 characters
+    # to every temp path in the suite, straight into the Windows 260-character cap and
+    # the macOS AF_UNIX 104-byte cap. That ordering was previously accidental: an
+    # unrelated fixture 300 lines above happened to call `mktemp` first.
+    tmp_path_factory.getbasetemp()
+    previous_tempdir = tempfile.tempdir
+    previous_env = {name: os.environ.get(name) for name in _TMP_ENV_VARS}
+    parent = pathlib.Path(tempfile.gettempdir())
+    base = _create_tmp_root(parent)
+    _redirect_tempfile_base(base)
+    try:
+        yield base
+    finally:
+        tempfile.tempdir = previous_tempdir
+        for name, value in previous_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        per_test = bool(os.environ.get(_TMP_PER_TEST_ENV))
+        leaked = _tmp_residue(base, per_test=per_test)
+        # Removed even when it is empty, and even when the report below raises:
+        # leaving the root behind would itself be the accumulation this guards.
+        _remove_tree(base)
+        if not leaked:
+            return
+        report = _tmp_residue_report(base, leaked, per_test=per_test)
+        if os.environ.get(_TMP_RESIDUE_STRICT_ENV):
+            raise AssertionError(report)
+        warnings.warn(report, stacklevel=1)
+
+
+def _tmp_residue(base: pathlib.Path, *, per_test: bool) -> list[str]:
+    """Names left under *base*, excluding what is not a leak.
+
+    In per-test mode the immediate children are the per-test bases the fixture itself
+    created, so the scan descends one level and reports ``<test id>/<name>``. Without
+    that, every test in the run would be reported as its own leak and the mode would
+    answer nothing.
+    """
+    try:
+        children = sorted(base.iterdir())
+    except OSError:
+        return []
+    residue: list[str] = []
+    for child in children:
+        if child.name.startswith(_TMP_RESIDUE_ALLOWED_PREFIXES):
+            continue
+        if not per_test:
+            residue.append(child.name)
+            continue
+        try:
+            residue.extend(f"{child.name}/{leaf.name}" for leaf in sorted(child.iterdir()))
+        except OSError:
+            continue
+    return residue
+
+
+def _tmp_residue_report(base: pathlib.Path, leaked: list[str], *, per_test: bool) -> str:
+    """The message naming what the run left behind, and how to find its owner."""
+    shown = leaked[:20]
+    more = f"    ... and {len(leaked) - len(shown)} more\n" if len(leaked) > len(shown) else ""
+    hint = (
+        "Each name above is a test id, so the leak is in that test."
+        if per_test
+        else f"Re-run the suspect subset with {_TMP_PER_TEST_ENV}=1 and each residue "
+        f"name becomes the id of the test that leaked it."
+    )
+    return (
+        f"{len(leaked)} temporary entr{'y' if len(leaked) == 1 else 'ies'} outlived "
+        f"this run under {base}:\n"
+        + "".join(f"    {name}\n" for name in shown)
+        + more
+        + "\nThis is reported at session teardown, so it is attributed to the last "
+        "test this worker ran -- that test is almost certainly NOT the culprit.\n"
+        "A test must register the destruction of anything it creates in the SAME "
+        "scope. Use pytest's tmp_path, or pair every tempfile.mkdtemp() with "
+        "self.addCleanup(shutil.rmtree, path, ignore_errors=True) on the line "
+        "after it -- NOT an rmtree in tearDown, which unittest skips entirely when "
+        "setUp raises.\n" + hint
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tempfile_base_per_test(_isolate_tempfile_base, request):
+    """Opt-in: give this test its own temp base so a leak names its own test.
+
+    Inert unless ``KIROCREW_TMP_PER_TEST`` is set, so the steady-state cost is one
+    environment read per test. See ``_TMP_PER_TEST_ENV``.
+
+    Named from the NODEID, not ``node.name``. The bare function name carries no module
+    or class, and 807 function names are duplicated across this suite (``test_defaults``
+    appears 17 times, ``test_invalid_json_is_400`` 29), so a name-keyed directory would
+    report a leak against a name shared by dozens of tests -- answering the wrong
+    question in the one mode that exists to answer it precisely. The nodeid is kept
+    TAIL-first under the length cap, because the distinguishing part is at the end.
+    """
+    if not os.environ.get(_TMP_PER_TEST_ENV):
+        return
+    safe = "".join(
+        ch if (ch.isalnum() or ch in "-._") else "_" for ch in request.node.nodeid
+    )
+    _redirect_tempfile_base(_isolate_tempfile_base / safe[-100:])
+
+
+# ── the operator's data home is host state too ────────────────────────
+
+
+@pytest.fixture(scope="session")
+def _isolation_root(tmp_path_factory):
+    """One session-scoped parent for the per-test isolation dirs below.
+
+    ``tmp_path_factory.mktemp`` picks its numbered suffix by scanning the whole
+    basetemp, so its cost grows with the number of entries already there. The
+    autouse fixtures that need a directory ``mkdir`` under this root instead, which
+    is a single syscall and does not scan.
+
+    Named ``i`` rather than something descriptive to keep the paths short: Windows
+    still caps a path at 260 characters unless long paths are enabled, and
+    everything a test writes under ``KIROCREW_HOME`` nests inside here.
+    """
+    return tmp_path_factory.mktemp("i")
+
+
+@pytest.fixture
+def _isolation_dirs(_isolation_root):
+    """Return an allocator for this test's isolation PATHS.
+
+    Each call returns ``<root>/<counter>-<name>``, so one test's paths cannot collide
+    with another's (the counter is per-process, and pytest-xdist gives every worker
+    its own ``basetemp``). Flat rather than nested, to keep Windows paths short.
+
+    **A path, not a directory: nothing is created.** Every consumer only needs somewhere
+    to POINT, and creates the directory itself if it ever writes -- ``config_dir()``
+    creates the data home, ``create_agent_folder`` creates the subagent registry,
+    ``OLLAMA_MODELS`` is only ever read. Creating them eagerly cost a ``mkdir`` per name
+    on every test and left the directories behind for the whole session, because they are
+    not ``tmp_path`` dirs and no retention policy reaches them.
+
+    MEASURED on one full ``test/`` run at ``-n 8``: 366,716 of the run's 372,126
+    basetemp inodes -- 98.5% -- were these directories, ~317k of them empty. On a
+    ``/tmp`` tmpfs with a fixed 1,048,576-inode budget that is a third of the machine's
+    entire allowance spent on directories nothing ever opened, and it is what made a
+    second concurrent run fail with ENOSPC while 90% of the bytes were free.
+
+    A future consumer that genuinely needs the directory to exist should ``mkdir`` at its
+    own call site, where the reason is visible, rather than through a flag here.
+    """
+    made: dict[str, pathlib.Path] = {}
+    _isolation_dirs.seq += 1  # type: ignore[attr-defined]
+    stem = _isolation_dirs.seq  # type: ignore[attr-defined]
+
+    def _get(name: str) -> pathlib.Path:
+        path = made.get(name)
+        if path is None:
+            path = _isolation_root / f"{stem}-{name}"
+            made[name] = path
+        return path
+
+    return _get
+
+
+_isolation_dirs.seq = 0  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kirocrew_home(_isolation_dirs, monkeypatch):
+    """Pin ``KIROCREW_HOME`` to a per-test tmp dir, for EVERY testpath.
+
+    This lives at the rootdir rather than in ``test/conftest.py`` because the leak it
+    closes is worst in the testpaths that conftest does not reach. The ~108 test
+    modules under ``src/kiro_crew/apps/builtins/*/tests/`` ship inside the package and
+    see only this file, so before this fixture existed here any of them that touched
+    ``config_dir()`` resolved the operator's live data home -- and that resolution is
+    not read-only: ``config_dir()`` CREATES the home and its marker on first use, and
+    can run the one-time ``~/.kirocrew`` -> ``~/.kiro/crew`` migration as a side
+    effect. Two of the eight app suites had grown their own redirect fixture; the
+    other six had not, which is exactly the "remember to" contract this file exists to
+    delete.
+
+    A test that sets its own ``KIROCREW_HOME`` still wins: ``monkeypatch.setenv``
+    applied later in setup overrides this, and reverts independently.
+
+    ``config.paths._resolved_home`` is reset with it. ``config_dir()`` memoises the
+    resolved home in that module global for the process lifetime, and under xdist one
+    worker runs thousands of tests in one process, so a value cached by an earlier
+    test would otherwise leak into a later one. Resetting it also invalidates
+    ``_config_dir_memo``, which is keyed on that global by identity.
+
+    ``KIROCREW_PROJECT_DIR`` is cleared for a different reason -- to match CI on a dev
+    box. It is auto-set to the repo root when running from a checkout, so
+    ``skills._project_skills_dir()`` resolves the repo's real ``skills/`` and a test
+    driving ``_ensure_builtin_skills`` against a tmp dir sees live skills as a
+    "source", flipping relocation behaviour: green in CI, red locally.
+
+    ``KIROCREW_BOUND_PORT`` is cleared because ``_export_bound_port`` writes it into
+    the real process environment when a test boots a server, so a port exported by one
+    test would leak into every later test's port resolution on that worker.
+    ``KIROCREW_DEV_MODE`` / ``KIROCREW_STRICT_ON_LOOP_PERSIST`` are cleared so a
+    developer who exports them does not flip the off-loop-IO guards strict for the
+    whole suite.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(_isolation_dirs("kirocrew-home")))
+    monkeypatch.delenv("KIROCREW_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+    monkeypatch.delenv("KIROCREW_DEV_MODE", raising=False)
+    monkeypatch.delenv("KIROCREW_STRICT_ON_LOOP_PERSIST", raising=False)
+    paths = sys.modules.get("kiro_crew.config.paths")
+    if paths is not None:
+        monkeypatch.setattr(paths, "_resolved_home", None, raising=False)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _isolate_sel_default_dir(tmp_path_factory):
+    """Redirect the Security Event Log's default dir to a session-local tmp dir.
+
+    SEL is a process SINGLETON whose writer is a DAEMON THREAD, and
+    ``_init_locked`` binds ``self._dir`` once, from whatever ``_default_dir()``
+    resolved at that moment. Two consequences, and the second is why this belongs at
+    the rootdir rather than in ``test/conftest.py``:
+
+    * Every event any test emits through the default ``sel()`` appends to ONE file.
+      Unredirected that is the operator's real ``security_events.jsonl`` -- a
+      non-atomic append, shared across xdist workers.
+    * Whichever test calls ``sel()`` FIRST fixes the directory for the whole
+      process, and the writer thread keeps using it after that test ends. When the
+      first caller is a test whose home is a per-test tmp dir, the thread outlives
+      the tmp dir and RE-CREATES it on the next flush -- ``_flush_batch`` opens with
+      ``self._dir.mkdir(parents=True, exist_ok=True)``. So the directory reappears
+      *after* the test's own cleanup removed it, and no amount of tidying in the
+      test can win against a thread that rebuilds the path. MEASURED: this is
+      exactly what left one stray ``mkdtemp`` directory behind per run of the
+      ops-mission-control suite. Full telling:
+      ``docs/system-specs/common/testing-conventions.md`` § Rules.
+
+    Session scope is what fixes both: the thread's directory is stable for the whole
+    run and belongs to no individual test, so nothing deletes it underneath the
+    writer, and the thread is not churned per test.
+
+    Patches the ``_default_dir()`` accessor rather than a captured constant, because
+    the module resolves its default lazily so that importing ``kiro_crew.sel`` never
+    triggers the one-time data-home migration as an import side effect. Tests that
+    manage their own ``SecurityEventLog`` (passing ``base_dir`` and resetting
+    ``_instance``) are unaffected.
+    """
+    try:
+        from kiro_crew import sel as _sel
+    except ImportError:  # pragma: no cover - partial checkout
+        yield
+        return
+    original_default = _sel._default_dir
+    original_instance = _sel.SecurityEventLog._instance
+    sel_dir = tmp_path_factory.mktemp("sel")
+    _sel._default_dir = lambda: sel_dir
+    _sel.SecurityEventLog._instance = None
+    try:
+        yield
+    finally:
+        _sel._default_dir = original_default
+        _sel.SecurityEventLog._instance = original_instance
+
+
+#: ``~/.kiro`` paths production binds at IMPORT time, which ``KIROCREW_HOME`` cannot
+#: reach: the module captured an absolute path from ``Path.home()`` before any test
+#: set an environment variable, so the env override is read too late to matter.
+#:
+#: This directory is a SEPARATE isolation axis from the data home. ``~/.kiro`` is
+#: kiro-cli's own home -- machine-wide, shared with the real installed agent -- so a
+#: test that writes ``~/.kiro/settings/mcp.json`` edits the MCP servers of the
+#: operator's live agent, not a copy of them.
+#:
+#: Each entry is ``(module, attribute, path relative to the per-test kiro home)``.
+#: The relative paths keep production's real SHAPE (``.kiro/settings/mcp.json``, not a
+#: flattened name) because several tests assert on the path's suffix, and a
+#: same-shaped tmp path keeps those assertions meaningful.
+#:
+#: ``test/test_host_isolation_floor.py`` ratchets this table against the
+#: ``Path.home()`` bindings ``src/kiro_crew`` actually has, so a new one cannot land
+#: unpinned.
+_SHARED_KIRO_PATHS: tuple[tuple[str, str, str], ...] = (
+    ("kiro_crew.agent", "_KIRO_MCP_JSON", ".kiro/settings/mcp.json"),
+    ("kiro_crew.agent", "_CC_MCP_JSON", ".claude.json"),
+    ("kiro_crew.agent", "_DEFAULT_KIRO_HOOKS_DIR", ".kiro/hooks"),
+    ("kiro_crew.learn", "_DEFAULT_DIR", ".kiro/crew"),
+    ("kiro_crew.apps.bridges", "_LEGACY_SHARED_MCP_PATH", ".kiro/settings/mcp.json"),
+    ("kiro_crew.dashboard.handlers.mcp", "_GLOBAL_MCP_JSON", ".kiro/settings/mcp.json"),
+    # A DERIVED sibling (`_GLOBAL_MCP_JSON.with_suffix(".lock")`), and it has to move
+    # WITH its json or the pair is worse than either alone: `_McpFileLockSync.__enter__`
+    # creates `_GLOBAL_MCP_JSON.parent` and then touches `_MCP_LOCK_PATH`, so redirecting
+    # only the json makes the code create a tmp directory and then touch a lock in the
+    # REAL one -- whose parent nothing created, giving `FileNotFoundError` on any host
+    # where `~/.kiro/settings` does not already exist. It passed on a developer box only
+    # because that directory was there, and on CI only because an earlier test had
+    # leaked into it. This is the sibling-binding case the ratchet's own docstring says
+    # it cannot see, which is why the set is enumerated here by hand.
+    ("kiro_crew.dashboard.handlers.mcp", "_MCP_LOCK_PATH", ".kiro/settings/mcp.lock"),
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_shared_kiro_paths(_isolation_dirs, monkeypatch):
+    """Redirect the import-time ``~/.kiro`` bindings to a per-test tmp tree.
+
+    Patches only a module ALREADY in ``sys.modules``, the same tolerance
+    ``_isolate_launchd_paths`` uses: several of these modules are heavy, and importing
+    them for all ~26.5k tests would cost far more than the leak they close.
+
+    That filter is not a coverage gap, but the reason is narrower than "collection
+    imports everything": a module that is not loaded has no binding for a test to
+    REACH, so there is nothing to leak. The residual hole is a module first imported
+    inside a test's own body, after this fixture has already run for that test.
+
+    Creates nothing. Every path here names a file whose absence is the normal
+    fresh-install state, so a READER handles it already, and every test in the suite
+    that WRITES one of them patches the same attribute itself (which wins over this
+    fixture). Pre-creating the ``.kiro/settings`` parents instead cost a ``mkdir`` per
+    entry on every test in the suite -- see ``_isolation_dirs`` for what that added up
+    to. So a test that touches none of these modules pays one ``sys.modules`` lookup
+    per entry and no syscall at all.
+    """
+    targets = [
+        (module, attr, relative)
+        for module, attr, relative in _SHARED_KIRO_PATHS
+        if sys.modules.get(module) is not None
+    ]
+    if not targets:
+        return
+    root = _isolation_dirs("kiro-home")
+    for module, attr, relative in targets:
+        monkeypatch.setattr(
+            sys.modules[module], attr, root.joinpath(*relative.split("/")), raising=False
+        )
+
+
+# ── other real host paths a test must not reach ───────────────────────
+#
+# Same test as the data home above: each of these protects something on the
+# operator's machine rather than the correctness of one suite, so it holds for every
+# testpath. They were in ``test/conftest.py``, which the ~108 in-package test modules
+# never load -- so an in-package test that spawned a subagent wrote the real registry,
+# and one that reached the embeddings boot path could start a 610MB download.
+
+
+@pytest.fixture(autouse=True)
+def _isolate_subagents_dir(_isolation_dirs, monkeypatch):
+    """Pin the subagent registry dir to a tmp dir for the whole suite.
+
+    ``kiro_crew.subagent_persistence._SUBAGENTS_DIR`` is bound at import time to
+    ``config_dir() / "subagents"``, so the ``KIROCREW_HOME`` safety net above
+    cannot retroactively redirect it. Any test that calls ``SubagentManager.spawn``
+    or ``create_agent_folder`` without isolating this global itself would write
+    stub agent folders into the operator's real ``~/.kirocrew/subagents/``. On the
+    next gateway start, orphan reconciliation sweeps those stubs and floods the
+    logs with "lost to gateway restart" warnings (e.g. tasks ``t`` / ``ls /tmp``).
+    Redirecting the module global gives every test an isolated, empty registry.
+    """
+    monkeypatch.setattr(
+        "kiro_crew.subagent_persistence._SUBAGENTS_DIR",
+        _isolation_dirs("subagents"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_model_download(monkeypatch, _isolation_dirs):
+    """Never let a test trigger the 610MB embedding-model download.
+
+    Embeddings are always-on, so any test that boots the gateway/server
+    startup path would otherwise kick ``start_background_model_download()``.
+    The env escape hatch is honored by ``ModelDownloadManager.ensure_model``
+    and ``start_background_model_download`` — a test that wants to exercise
+    the download path monkeypatches the manager's HTTP calls directly
+    (see test_embeddings.py) rather than unsetting this.
+
+    ``OLLAMA_MODELS`` is additionally pinned to an empty tmp dir so the
+    legacy-blob salvage fast-path (``_salvage_legacy_ollama_blob``) can never
+    read the developer's real ``~/.ollama`` store — without this, download
+    tests would pass/fail machine-dependently on hosts that ran the
+    Ollama-era embeddings.
+    """
+    monkeypatch.setenv("KIROCREW_SKIP_MODEL_DOWNLOAD", "1")
+    monkeypatch.setenv("OLLAMA_MODELS", str(_isolation_dirs("ollama-models")))
+    # Force telemetry OFF for every test. `_consent_enabled` reads this env var BEFORE
+    # the config flag, which is what makes it a reliable gate: ~15 tests patch
+    # `KiroCrewConfig.load` with a bare MagicMock, whose `telemetry.enabled` is TRUTHY,
+    # so a real recorder starts and `Path(cfg.local_dir)` resolves the mock to the
+    # RELATIVE path `MagicMock/load().telemetry.local_dir/...` -- writing metrics and a
+    # lock file into the repo root, plus a background reader thread that outlives the
+    # test. Tests that exercise telemetry delete this var themselves (test/metrics/).
+    monkeypatch.setenv("KIROCREW_TELEMETRY", "0")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_agent_state_sidecar(_isolation_dirs, monkeypatch):
+    """Pin the agent_state sidecar to a tmp dir for the whole suite.
+
+    ``kiro_crew.agent_state`` stores per-agent bookkeeping (model_managed,
+    cc_model) in ``~/.kirocrew/agent_model_state.json`` via ``config_dir()``.
+    Tests that exercise the install / refresh / migration / PATCH paths would
+    otherwise read and write the operator's real sidecar. Redirect
+    ``config_dir`` — referenced as a module attribute at call time — to a fresh
+    tmp dir so every test starts from empty state.
+    """
+    sidecar_root = _isolation_dirs("agent-state")
+    monkeypatch.setattr("kiro_crew.agent_state.config_dir", lambda: sidecar_root)
 
 # ── the repository checkout is host state too ─────────────────────────
 

--- a/docs/system-specs/common/README.md
+++ b/docs/system-specs/common/README.md
@@ -7,5 +7,5 @@ rather than restating them.
 |---|---|
 | [code-style.md](code-style.md) | Where each constant and limit lives, comment style, and the lint rules you will trip. |
 | [error-handling.md](error-handling.md) | Exception boundaries, retries, and user-facing failure text. |
-| [testing-conventions.md](testing-conventions.md) | Test patterns, the four flake classes and the one correct fix for each, and how to keep the suite fast. |
+| [testing-conventions.md](testing-conventions.md) | Test patterns, which conftest owns which isolation, the side-effect floor, the five flake classes and the one correct fix for each, and how to keep the suite fast. |
 | [injected-messages.md](injected-messages.md) | The envelopes automation injects into a session (cron, subagent, auto-nudge) and how to treat them. |

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -104,21 +104,108 @@ violates the isolation rules below and costs seconds per test (an unstubbed
 `find_orphan_mcp_candidates` alone added ~9s to every `TestCleanupLoop`
 test). The sweep's own behavior belongs in its own module's tests.
 
+## Which conftest you are standing on
+
+There are **three** testpaths (`setup.cfg`'s `testpaths = test transfer
+src/kiro_crew/apps/builtins`) and they do **not** get the same fixtures. Know which
+floor is under your file before you decide what to isolate yourself:
+
+| Your test lives in | It inherits |
+|---|---|
+| `test/` | the rootdir `conftest.py` **and** `test/conftest.py` |
+| `transfer/` | the rootdir `conftest.py` only |
+| `src/kiro_crew/apps/builtins/*/tests/` | the rootdir `conftest.py`, plus that app's own `tests/conftest.py` where one exists (`auto_improvement`, `code_review_sage`, `spec_builder` have one; the other five apps do not) |
+
+The **rootdir `conftest.py` is the host-mutation floor**: everything in it protects the
+developer's machine rather than the correctness of one suite, so it holds for all
+three testpaths. It pins `$XDG_CONFIG_HOME` and the launchd paths, traps the spawn
+funnels against service mutation, pins `KIROCREW_HOME` and the import-time `~/.kiro`
+bindings, redirects `tempfile`'s base, and fails the run on residue in the checkout.
+
+It also pins the other real host paths a test must not reach: the subagent registry (a
+running gateway sweeps stray entries there as orphans), the 610MB embedding-model
+download, and the agent-state sidecar.
+
+`test/conftest.py` holds the rest: suite-specific isolation (Slack thread state, the
+model-window cache, the platform context, …), the Windows collect-ignore list, and the
+xdist worker budget.
+
+When you add isolation, put it in the rootdir conftest **only** if a test in any
+testpath could damage the host without it. Otherwise it belongs in `test/conftest.py`,
+where it costs the in-package suites nothing.
+
 ## Rules
 
 - Tests MUST NOT spawn real kiro-cli processes
 - Tests MUST NOT depend on `~/.kiro/crew/` existing
-- Tests MUST NOT write into the operator's real data dir. A data-dir path that is
-  bound **at import time** (e.g. `subagent_persistence._SUBAGENTS_DIR`, set to
-  `config_dir() / "subagents"` on first import; or `sel._DEFAULT_DIR`) is NOT
-  covered by the `KIROCREW_HOME` env safety net, because that env var is read
-  after the module already captured the path. `conftest.py` pins each such global
-  with a dedicated autouse fixture (`_isolate_subagents_dir`,
-  `_isolate_sel_default_dir`, …). Paths that instead call `config_dir()` lazily on
-  each use (e.g. `agent_state`) already honor `KIROCREW_HOME`. A test that spawns
-  subagents or persists agent folders without isolating the import-time global
-  leaks stub folders into `~/.kiro/crew/subagents/`, which a running gateway then
-  sweeps as orphans on its next restart.
+- Tests MUST NOT write into the operator's real data dir. `KIROCREW_HOME` is pinned
+  per test by the rootdir conftest, which is what makes `config_dir()` safe — and it
+  needs to be, because resolving it is **not a read**: it creates the home and its
+  marker on first use, and can run the one-time `~/.kirocrew` → `~/.kiro/crew`
+  migration as a side effect.
+
+  Two kinds of path escape that env var, and both need their own pin:
+
+  1. **Bound at import time from `config_dir()`** — e.g.
+     `subagent_persistence._SUBAGENTS_DIR`, set to `config_dir() / "subagents"` on
+     first import. The env var is read *after* the module captured the path, so
+     `conftest.py` pins each such global with a dedicated autouse fixture
+     (`_isolate_subagents_dir`, …). Paths that instead call `config_dir()` lazily on
+     each use (e.g. `agent_state`) already honor `KIROCREW_HOME`. A test that spawns
+     subagents without isolating the import-time global leaks stub folders into
+     `~/.kiro/crew/subagents/`, which a running gateway then sweeps as orphans on its
+     next restart.
+  2. **Bound at import time from `Path.home()`** — `~/.kiro` is *kiro-cli's* home,
+     machine-wide and shared with the real installed agent, so it is a separate
+     isolation axis from the data home entirely. `~/.kiro/settings/mcp.json` is the
+     live agent's MCP server list. The rootdir conftest's `_isolate_shared_kiro_paths`
+     redirects these from a table, and
+     `test/test_host_isolation_floor.py::TestTheSharedKiroPathRatchet` fails when
+     `src/kiro_crew` grows a module-level `Path.home()` binding that is neither in the
+     table nor explicitly excluded with a reason. The guarantee is exactly that:
+     **import-time bindings**. A LAZY resolver (`config.paths.kiro_home()` and its
+     callers) still names the operator's real `~/.kiro` — the floor pins neither
+     `Path.home()` nor `$HOME` — so a test that reaches one of those must isolate it
+     itself.
+
+     Two exclusions are excluded for **opposite** reasons, and the distinction
+     matters: the launchd paths are excluded because another fixture already
+     redirects them, while `security._EXTRACT_INTO_TRUST_ROOT_RE` and
+     `kiro_usage_api._CLI_SQLITE_DBS` must **never** be redirected — they are
+     security anchors whose whole point is naming the real home. **Stub the reader,
+     never move the anchor.** Redirecting a matcher so a test can pass makes it assert
+     against a pattern that no longer matches the thing it protects.
+
+- **Never leave the process working directory somewhere else.** The CWD is
+  per-PROCESS, so under xdist one test's `os.chdir` becomes every later test's starting
+  directory on that worker. Use `monkeypatch.chdir`, which reverts on its own; the
+  rootdir conftest's `_restore_cwd` puts it back either way.
+
+  This was survivable only while the directory outlived the run. With
+  `tmp_path_retention_policy = failed` pytest removes a passing test's `tmp_path` at
+  that test's teardown, so a test that chdirs into `tmp_path` and does not come back
+  leaves the worker sitting in a **deleted** directory — and then `Path.cwd()` raises
+  `FileNotFoundError` in every later test that reaches it, including from inside
+  production code (`taskrunner.TaskRunner.__init__` does `work_dir or Path.cwd()`).
+  MEASURED: that one leak produced the large majority of a 124-failure run, spread
+  across ~10 files that every one of which passes in isolation — which is exactly why
+  it reads as "the suite is flaky" instead of as one test missing one line.
+
+- **A singleton with a background thread beats every filesystem cleanup.** `sel.py` is
+  the worked example: `SecurityEventLog` is a process singleton whose writer is a
+  *daemon thread*, and `_init_locked` binds its directory **once**, from whatever
+  `_default_dir()` resolved at that moment. So whichever test calls `sel()` first fixes
+  the directory for the whole worker, the thread keeps writing there after that test
+  ends, and `_flush_batch` opens with `mkdir(parents=True, exist_ok=True)` — which
+  **re-creates the directory after the test's own tearDown removed it**. MEASURED: that
+  is what left one stray `mkdtemp` directory behind on every run of the
+  ops-mission-control suite, and the stack came from `sel-writer`, not from any test.
+
+  The fix is not tidier cleanup — no cleanup can win against a thread that rebuilds
+  the path. It is to give the singleton a **session-scoped** directory that belongs to
+  no individual test (`_isolate_sel_default_dir`, in the rootdir conftest). When you
+  add a subsystem with a background worker, ask which directory its thread captured
+  and whether anything deletes that directory underneath it.
 - Tests MUST NOT reconfigure or restart a real host service. This is enforced,
   not just asked for: the **rootdir** `conftest.py` (distinct from
   `test/conftest.py`, which only applies to `test/` — `testpaths` also collects
@@ -140,6 +227,75 @@ test). The sweep's own behavior belongs in its own module's tests.
   after that dir was deleted. `test/test_host_service_guard.py` ratchets the
   guarded set against the service tools `src/` actually names, so a new
   host-mutating call site cannot land outside the floor.
+- **Register the destruction of anything you create, in the same scope.** Prefer
+  pytest's `tmp_path`. If you must call `tempfile.mkdtemp()`, pair it with
+  `self.addCleanup(shutil.rmtree, path, ignore_errors=True)` **on the next line** —
+  not with an `rmtree` in `tearDown`, which is the shape that leaks:
+
+  ```python
+  # WRONG — unittest does NOT run tearDown when setUp raises, so this leaks on
+  # every setUp failure, and it is the failing run nobody watches that leaves it
+  def setUp(self):
+      self.tmp = Path(tempfile.mkdtemp())
+      self.client = build_client()          # raises -> tearDown never runs
+  def tearDown(self):
+      shutil.rmtree(self.tmp, ignore_errors=True)
+
+  # RIGHT — registered immediately, runs even if the rest of setUp blows up
+  def setUp(self):
+      self.tmp = Path(tempfile.mkdtemp())
+      self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+      self.client = build_client()
+  ```
+
+  The rootdir conftest contains the *class* as well: `tempfile`'s base is redirected
+  per run to `<platform temp>/kc-pytest-<user>-<pid>`, which the run removes at the end,
+  so an unregistered directory no longer accumulates in the shared temp root forever.
+  Residue there is still **reported** — relocation is not absolution.
+
+  A run only ever deletes the root it created itself — there is deliberately no sweep of
+  other runs' roots, because every signal for "that directory is abandoned" is unsound from
+  inside a test process: the name can be pre-created by another local account, and a pid
+  means nothing across PID namespaces (two containers sharing a bind-mounted temp directory
+  can each hold the same one). So **a run killed before its teardown leaves one directory
+  for the platform to reclaim** — `systemd-tmpfiles` on a timer, macOS's periodic cleanup, a
+  tmpfs cleared on reboot. That reliance is deliberate and is worth knowing if you own a
+  long-lived CI host: it is bounded at one directory per killed run.
+
+  Reported, not yet fatal, and that split is a staged rollout rather than a soft opinion.
+  Two classes under that root are deliberately **not** residue and are excluded by name:
+  the computer-use screenshot spool, which production keeps as a persistent ring buffer,
+  and the scratch that Chromium and the Playwright driver create because a child inherits
+  the redirected `TMPDIR`. What remains is a handful of single `mkstemp` **files**, some
+  of them written by production code a test merely reached — one inode each, not the
+  `mkdtemp` directories the rule is about. Failing the suite on that set today would
+  block every unrelated change while it is attributed, and a guard that blocks unrelated
+  work is a guard somebody deletes. Set `KIROCREW_TMP_RESIDUE_STRICT=1` to make it fatal,
+  which is how the remaining set gets burned down and how the line gets held afterwards —
+  the same shape as `windows-expected-failures.txt`.
+
+  Why it is worth a guard rather than a convention: `/tmp` is commonly a tmpfs with a
+  fixed **inode** budget (1,048,576 on the hosts this was measured on), and it returns
+  `ENOSPC` to every other process on the machine while **90% of the bytes are still
+  free**. MEASURED on one such host: retained pytest basetemps alone held 249,550
+  inodes, a quarter of the whole budget — which is why `setup.cfg` now sets
+  `tmp_path_retention_policy = failed`, keeping a `tmp_path` only for the tests whose
+  directory anyone actually opens.
+
+  **Finding the culprit.** The residue report runs in a session-fixture teardown, so it
+  is attributed to the last test the worker ran, which is almost never the guilty one.
+  Re-run the suspect subset with `KIROCREW_TMP_PER_TEST=1` and each residue name
+  becomes the id of the test that leaked it:
+
+  ```bash
+  KIROCREW_TMP_PER_TEST=1 pytest src/kiro_crew/apps/builtins/<app>/tests -n0 -q
+  # AssertionError: 1 temporary entry outlived this run under /tmp/kc-pytest-you-951504:
+  #     test_provider_listing_never_contains_a_token/tmpw2kvty2z
+  ```
+
+  That mode is off by default because a directory per test is exactly the per-test cost
+  the fixture audit below exists to avoid.
+
 - Tests SHOULD be fast (< 1s each)
 - Async tests MUST use `@pytest.mark.asyncio`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -210,6 +210,15 @@ xfail_strict = true
 markers =
     integration: live browser tests requiring Chrome CDP
 pythonpath = src
+# Keep a test's tmp_path only when that test FAILED, which is the only case anyone
+# ever reads it. The default ("all") keeps every passing test's directory too, and
+# with tmp_path_retention_count also defaulting to 3 that retains the whole suite's
+# temp footprint three times over -- at ~26.5k tests, on a /tmp that is a tmpfs with
+# a fixed inode budget (1,048,576 on the hosts this was measured on), that is what
+# eventually returns ENOSPC to unrelated processes while 90% of the BYTES are still
+# free. Debuggability is unaffected: a failing test's directory is still kept, for
+# the configured number of runs, which is the only one anybody opens.
+tmp_path_retention_policy = failed
 addopts =
     --verbose
     --ignore=build/private

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
@@ -474,25 +474,41 @@ class TestTheScheduleIsWriteProtectedButReadable(unittest.TestCase):
         verb-independent, because a narrow allowlist is bypassable by a quoted redirect, `cp`,
         or any novel write verb.
 
-        Spelled with POSIX separators (`as_posix`), which is what the gate matches and what a
-        bash command carries. A native `WindowsPath` renders all-backslash and matches nothing —
-        a whole-gate limitation on `security`'s home-anchored patterns, not specific to this
+        Spelled with POSIX separators, which is what the gate matches and what a bash command
+        carries. A native `WindowsPath` renders all-backslash and matches nothing — a
+        whole-gate limitation on `security`'s home-anchored patterns, not specific to this
         leaf, so pinning it here would assert a fix this file does not own.
+
+        Iterates the HOME FORMS rather than `self._path()`, the same way the incidents-index
+        equivalent below does, and the difference is load-bearing rather than stylistic. The
+        bash gate is a STRING matcher over `_CREW_HOME_PREFIXES` (`.kiro/crew`, `.kirocrew`),
+        so it recognises a command only by the home spelling the command carries. The tool
+        gate on the two tests above is not: `is_sensitive_write_path` resolves through
+        `config_dir()`, so it DOES follow a non-default `KIROCREW_HOME`.
+
+        That asymmetry means a custom-`KIROCREW_HOME` install (a pod, `dev-backend.sh`) has
+        this file protected against the agent's file tools but not against a bash redirect
+        naming the resolved path. It is a `security` gate limitation, not this app's, so it is
+        recorded here rather than half-fixed at this leaf. Handing `self._path()` to the bash
+        gate does not test it either way: under test isolation that path is a tmp dir, so the
+        assertion passed only while the suite was reading the operator's REAL home, and it
+        reported a guarantee it had not checked.
         """
-        path = Path(self._path()).as_posix()
-        for cmd in (
-            f"echo 'who: attacker' > {path}",
-            f"cp /tmp/evil.yaml {path}",
-            f"tee {path}",
-            f"""python -c "open('{path}','w').write('x')" """,
-            f"sed -i s/alice/attacker/ {path}",
-            f"mv /tmp/evil.yaml {path}",
-        ):
-            with self.subTest(cmd=cmd[:40]):
-                self.assertTrue(
-                    security.is_sensitive_bash_command(cmd),
-                    f"shell write not blocked: {cmd!r}",
-                )
+        for home in ("~", "$HOME", "/home/alice", "/Users/alice"):
+            path = f"{home}/.kiro/crew/apps/ops-mission-control/data/rotation.yaml"
+            for cmd in (
+                f"echo 'who: attacker' > {path}",
+                f"cp /tmp/evil.yaml {path}",
+                f"tee {path}",
+                f"""python -c "open('{path}','w').write('x')" """,
+                f"sed -i s/alice/attacker/ {path}",
+                f"mv /tmp/evil.yaml {path}",
+            ):
+                with self.subTest(cmd=cmd[:40]):
+                    self.assertTrue(
+                        security.is_sensitive_bash_command(cmd),
+                        f"shell write not blocked: {cmd!r}",
+                    )
 
     def test_the_registered_path_is_not_a_bare_filename(self):
         """A bare `rotation.yaml` entry matches NOTHING, which is the trap here.

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
@@ -107,9 +107,10 @@ than fixed; if it only fails on your branch, it's yours. Never label a failure
 
 **A confirmed flake is a bug with a root cause, not noise to retry.** Do NOT add a
 rerun, lengthen a `sleep`, or relax an assertion. Read
-`docs/system-specs/common/testing-conventions.md` § Determinism for the four classes
+`docs/system-specs/common/testing-conventions.md` § Determinism for the five classes
 and the one correct fix for each: seed nondeterministic input, poll instead of
-sleeping, `MagicMock` for sync methods, `await` after `cancel()`. To find what is
+sleeping, `MagicMock` for sync methods, `await` after `cancel()`, and bound a
+complexity test's doubling RATIO rather than an absolute duration. To find what is
 actually flaky rather than guessing, mine CI instead of the local suite (a real flake
 often will not reproduce on macOS at all):
 

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: writing-tests
+description: "How to write a Kiro Crew backend test that has NO side effects and does not flake. Use when adding, editing, reviewing, or debugging a pytest test in the Kiro Crew source repo: which conftest is under your file, what leaks (temp dirs, the real data home, ~/.kiro, cron, threads, child processes), the five flake classes and the one correct fix for each, and the cross-platform traps on macOS/Linux/Windows and arm64. Also covers diagnosing a residue failure and keeping the parallel suite fast."
+triggers: write a test, add a test, fix a flaky test, test is flaky, test side effect, temp dir residue, tmp residue, kirocrew test, pytest kirocrew, test isolation, conftest, xdist, test leaked
+repo_scope: src/kiro_crew
+---
+
+# Writing a Kiro Crew test that does not leak and does not flake
+
+> **Scope guard: this skill applies ONLY to the Kiro Crew source repository** (or a
+> worktree of it). Its rules are conventions of this repo's suite. In any other
+> project, ignore it.
+>
+> The canonical, longer reference is
+> [`docs/system-specs/common/testing-conventions.md`](../../../../../docs/system-specs/common/testing-conventions.md).
+> If this skill and that document disagree, the document wins. What this skill adds is
+> the decision order — what to check first, and what the failure looks like when you
+> get it wrong.
+
+## The two properties, and why they are one problem
+
+A test must be **hermetic** (no effect that outlives it, anywhere but its own tmp dir)
+and **deterministic** (same verdict every run, on every platform, in any order). They
+are the same problem because the suite runs `-n auto --dist loadgroup`: a side effect
+is not just untidy, it is *the input to another test on the same worker*, and it
+surfaces as a flake in a file you never touched.
+
+## Rule 0 — Know which conftest is under your file BEFORE you isolate anything
+
+`setup.cfg` declares three testpaths and they do **not** get the same fixtures. The
+table is in [testing-conventions.md](../../../../../docs/system-specs/common/testing-conventions.md)
+§ Which conftest you are standing on — read it rather than a second copy here, which
+would drift. The short version: only `test/` gets `test/conftest.py`; `transfer/` and
+`src/kiro_crew/apps/builtins/*/tests/` get the rootdir `conftest.py` plus that app's
+own `tests/conftest.py` where one exists.
+
+The rootdir `conftest.py` is the **host-mutation floor** — the guards that protect the
+developer's machine, so they hold everywhere. Everything else is in `test/conftest.py`.
+
+Getting this wrong is the most expensive mistake in this suite, because it fails
+**silently and asymmetrically**: an in-package test that assumes `test/conftest.py`'s
+fixtures passes on CI (where the operator's home is empty) and damages a real install
+locally. When you add isolation, ask: *could a test in ANY testpath damage the host
+without this?* If yes it belongs at the rootdir; if no, put it in `test/conftest.py`,
+where the in-package suites pay nothing for it.
+
+## Rule 1 — The side-effect floor: what actually leaks
+
+Work down this list. Each item is a real leak that has happened here.
+
+### 1a. Temp directories — register the destruction in the SAME scope
+
+Prefer `tmp_path`. If you need `mkdtemp()`, register cleanup with `addCleanup` on the
+**next line** — never an `rmtree` in `tearDown`, because `unittest` skips `tearDown`
+entirely when `setUp` raises, so that shape leaks on exactly the failing runs nobody
+watches. The before/after example is in testing-conventions.md § Rules.
+
+`ignore_errors=True` also **hides** a cleanup that could not finish, so it is not proof
+of anything. The floor helps, but it is not your discipline: the rootdir conftest redirects
+`tempfile`'s base per run, removes it, and **reports** residue — as a warning today, fatal
+under `KIROCREW_TMP_RESIDUE_STRICT=1`. So a leak of yours will not necessarily turn CI red;
+clean up anyway. (Staged rollout and its owner: testing-conventions.md § Rules.)
+
+Why it earns a guard: `/tmp` is often a tmpfs with a fixed **inode** budget
+(1,048,576 on the hosts this was measured on) and it returns `ENOSPC` to every other
+process on the machine while **90% of the bytes are free**. It is not a tidiness issue,
+it is a "your shell stops working" issue.
+
+### 1b. The operator's data home, and `~/.kiro`, which is a DIFFERENT axis
+
+`KIROCREW_HOME` is pinned per test at the rootdir, which is what makes `config_dir()`
+safe — and it needs to be, because resolving it is **not a read**: it creates the home
+and its marker, and can run the `~/.kirocrew` → `~/.kiro/crew` migration.
+
+Two shapes escape the env var:
+
+- **Import-time from `config_dir()`** (`subagent_persistence._SUBAGENTS_DIR`): the var
+  is read after the module captured the path. Each has its own autouse pin.
+- **Import-time from `Path.home()`**: `~/.kiro` is *kiro-cli's* home, machine-wide and
+  shared with the real installed agent — `~/.kiro/settings/mcp.json` is the live
+  agent's MCP server list. `_isolate_shared_kiro_paths` redirects these from a table,
+  and `test/test_host_isolation_floor.py` **fails when `src/` grows a new one**. That
+  ratchet covers IMPORT-TIME bindings only: a lazy resolver such as
+  `config.paths.kiro_home()` still names the real `~/.kiro`, so isolate that yourself.
+
+  Two entries are excluded because they must *never* be redirected —
+  `security._EXTRACT_INTO_TRUST_ROOT_RE` and `kiro_usage_api._CLI_SQLITE_DBS` are
+  security anchors whose whole point is naming the real home. **Stub the reader, never
+  move the anchor.** Redirecting a matcher so a test can pass makes it assert against a
+  pattern that no longer matches the thing it protects.
+
+### 1c. A child process inherits pytest's CWD, which is the repo root
+
+This is the leak a reviewer cannot see: no line says `open(..., "w")`, the write
+happens in a grandchild, and the test can assert against `tmp_path` and pass while the
+artifact sits in the checkout. An empty file produced this way has been committed and
+shipped from this repo.
+
+- Pass `cwd=<a directory under tmp_path>` to any child that MAY create a file, and to
+  every helper that spawns one.
+- Scope the assertion to where that child's CWD actually **is**. An assertion over
+  `tmp_path` proves nothing about a child that ran somewhere else — and a security test
+  whose payload escapes its own assertion is worse than no test, because it reports a
+  guarantee it never checked.
+- A read-only query is exempt, and sometimes must be: `git check-ignore` against the
+  checkout is asking a question *about the checkout*.
+
+The rootdir conftest fails the run on new non-ignored entries at the repository root,
+which is how this announces itself.
+
+### 1d. Background lifecycle — the one that beats every filesystem cleanup
+
+**A singleton with a daemon thread cannot be cleaned up by tidying files.** The worked
+example is `sel.py`: `SecurityEventLog` is a process singleton, its writer is a daemon
+thread, and `_init_locked` binds the directory **once** from whatever `_default_dir()`
+resolved then. So the first test to call `sel()` fixes it for the whole worker, the
+thread keeps writing after that test ends, and `_flush_batch` opens with
+`mkdir(parents=True, exist_ok=True)` — **re-creating the directory after tearDown
+deleted it**. MEASURED: exactly one stray directory per run of the ops-mission-control
+suite. Full telling, with the stack it came from:
+[testing-conventions.md](../../../../../docs/system-specs/common/testing-conventions.md)
+§ Rules.
+
+The fix was not better cleanup. It was giving the singleton a **session-scoped**
+directory belonging to no individual test. When you touch a subsystem with a background
+worker, ask: *which directory did its thread capture, and does anything delete that
+directory underneath it?*
+
+Related traps in the same family:
+
+- **A `MagicMock` config reads TRUTHY.** Patching `KiroCrewConfig.load` with a bare
+  `MagicMock` makes `cfg.telemetry.enabled` truthy, which starts a real recorder and a
+  reader thread, and resolves `Path(cfg.local_dir)` to a *relative* path that writes
+  into the repo. That is why `KIROCREW_TELEMETRY=0` is forced for the whole suite. Any
+  subsystem gated on a truthy attribute read off a config object has this shape.
+- **A sleeper child that outlives the test.** The suite spawns
+  `python -c "import time; time.sleep(30)"` to simulate a hung process. Put the
+  kill/wait in a `finally` or an `addCleanup`, never only on the happy path.
+- **A fixed port.** Bind port `0`. A fixed number collides across xdist workers *and*
+  with the operator's running gateway.
+
+### 1e. Never leave the process working directory somewhere else
+
+The CWD is per-PROCESS, so under xdist one test's `os.chdir` becomes every later test's
+starting directory on that worker. Use `monkeypatch.chdir`, which reverts itself.
+
+This is the leak with the widest blast radius measured here. Because a passing test's
+`tmp_path` is removed at its own teardown, a test that chdirs into `tmp_path` and does
+not come back leaves the worker in a **deleted** directory, and `Path.cwd()` then raises
+`FileNotFoundError` for every later test that reaches it — including from inside
+production code. The measured instance is in
+[testing-conventions.md](../../../../../docs/system-specs/common/testing-conventions.md)
+§ Rules; the shape to recognise is that it reads as "the suite is flaky" — many files,
+each passing in isolation. The rootdir conftest restores the CWD before any fixture
+teardown, but write the test so it would not need to.
+
+### 1f. Never register a real cron job, and never touch a real service
+
+The rootdir conftest traps the stdlib spawn funnels and refuses a
+`systemctl`/`launchctl` invocation carrying a **mutating verb**. Read-only queries
+(`show`, `cat`, `is-active`) are allowed and need no stub. A test reaching the make-live
+cutover path must stub **both** `_run_cmd` and `_dropin_path`.
+
+## Rule 2 — Determinism: five classes, one correct fix each
+
+Never "fix" a flake with a rerun, a longer `sleep`, a weakened assertion, or a skip.
+Full detail and examples: testing-conventions § Determinism.
+
+| Class | Tell | The one fix |
+|---|---|---|
+| Nondeterministic input | `os.urandom`/`random`/`uuid4`/`now()` feeding an assertion the RNG does not guarantee | Seed it (`random.Random(SEED).randbytes(n)`), or freeze the clock. Verify the seed against the real predicate and say in a comment that you did |
+| Wall-clock race | asserting a rate, a sample count, or an elapsed duration the host controls | Poll for the condition with a generous deadline, keeping the assertion. Where a timeout should *expire*, set it to `0` |
+| Leaked async object | `RuntimeWarning: coroutine ... never awaited`, blamed on an innocent later test | `MagicMock` for a **sync** method (`StreamWriter.write`, `stdin.close`); `await` the task after `cancel()` |
+| Order dependence / shared state | passes alone, fails in the suite | Mutate globals through `monkeypatch` — raw assignment does not revert when the test fails. `@pytest.mark.xdist_group` only when a test genuinely cannot share a worker |
+| Absolute time budget | a timing test that splits by **Python version** rather than by load | Bound the doubling **RATIO**, not a duration. CI enables coverage on 3.12 only, so an absolute ceiling is version-dependent: the same code measured ~1.7s bare and >5s instrumented |
+
+A sixth, adjacent trap: **a patch target that misses.** Patch the namespace whose
+globals the code under test actually reads. It fails in both directions — patching a
+package re-export when the caller reads its own defining module, or patching
+`pkg.mod.fn` when the caller did `from pkg.mod import fn` and holds its own binding.
+Either way the real function runs, the assertion passes for the wrong reason, and the
+test pays real time. **Treat an unexpectedly slow "mocked" test as evidence the mock
+missed.**
+
+## Rule 3 — Cross-platform: macOS, Linux (x86_64 + arm64), Windows
+
+- **Route POSIX calls through `platform_compat`.** See AGENTS.md's shim table. Most
+  important: `os.kill(pid, 0)` **TERMINATES** the target on Windows — it is not a
+  liveness probe. Use `platform_compat.pid_exists`.
+- **Path length is a real constraint.** Windows caps a path at 260 characters unless
+  long paths are enabled, and a macOS `AF_UNIX` `sun_path` is capped at ~104 bytes —
+  which a macOS `basetemp` alone already exceeds. That is why
+  `test/tmpdir_helpers.short_tmp_base()` exists, and why anything that prefixes every
+  temp path in the suite has to be measured, not assumed.
+- **Case-insensitive filesystems.** macOS and Windows are case-insensitive by default,
+  so a test asserting that two paths differing only in case are distinct is broken
+  there.
+- **Windows timer granularity** rounds `sleep`/`Event.wait` up to ~15.6ms and has
+  coarser file mtime resolution — so "two writes have different timestamps" is a flake
+  there.
+- **Probe, do not guess the platform.** `test/conftest.py::_can_create_symlink` is the
+  model: creating a symlink needs `SeCreateSymbolicLinkPrivilege`, which CI runners
+  hold and an ordinary shell does not, so a blanket `skipif(IS_WINDOWS)` would drop the
+  assertion exactly where it needs to run. Use the `make_escaping_link` /
+  `make_dir_link` helpers, which fall back to a junction.
+- **arm64 vs x86_64** rarely matters for test logic, but check it when you touch memory
+  or page arithmetic (`SC_PAGE_SIZE` is 16K on some arm64 configurations) or a
+  dependency with per-architecture wheels.
+- Windows gaps are tracked as burn-down lists, not scattered skips:
+  `test/windows-collect-ignore.txt` and `test/windows-expected-failures.txt`. Anything
+  NOT listed still fails the job. Delete a line when you fix its test.
+
+## Rule 4 — Diagnosing a residue failure
+
+The residue report runs in a session-fixture teardown, so it is attributed to the **last
+test the worker ran**, which is almost never the culprit. The guard carries its own
+bisector — use it instead of guessing:
+
+```bash
+KIROCREW_TMP_PER_TEST=1 pytest src/kiro_crew/apps/builtins/<app>/tests -n0 -q
+# AssertionError: 1 temporary entry outlived this run under /tmp/kc-pytest-you-951504:
+#     test_provider_listing_never_contains_a_token/tmpw2kvty2z
+```
+
+Each residue name becomes `<test id>/<leaked name>`. If the leak survives a `tearDown`
+that visibly removes it, suspect Rule 1d: something **re-created** the path after
+cleanup. Confirm by wrapping `os.mkdir` in a throwaway `-p` plugin and printing a stack
+for paths under the run's temp root — that is how the `sel-writer` thread was found.
+
+For a repository-root residue failure, the cause is almost always Rule 1c: a subprocess
+spawned without `cwd=`.
+
+## Rule 5 — Keep the parallel suite fast
+
+At ~26.5k tests, **per-test setup cost dominates any single slow test** — an autouse
+fixture is paid ~26,500 times. Profile, never guess; compare candidates back to back on
+the same host (`git stash`, run, pop, run), because a loaded host makes an absolute
+number meaningless.
+
+The recurring wins, in order of leverage:
+
+1. **An autouse fixture that costs more than it protects** — one requesting a
+   `tmp_path` it never uses; a repeated `tmp_path_factory.mktemp` (it scans the whole
+   basetemp to pick its suffix, so it slows as siblings accumulate); an unconditional
+   `mkdir` where the consumer only needs a *path*. Measure the whole chain against a
+   file of trivial `assert True` tests.
+2. **A production timeout or poll the test never asserts on** — `monkeypatch` the
+   interval to `0`; the branch still executes, only the waiting goes.
+3. **An expensive immutable thing built per test** — a real `git` repo costs ~1–1.6s in
+   subprocesses. Build it once `scope="session"` and `copytree` it per test; copy *from*
+   the template rather than yielding it, so nothing one test does can reach another's.
+
+**After any speedup, mutate the production code the test covers and confirm the test
+still FAILS.** A test made faster by checking less is a regression. Restore from a copy
+of the file you mutated, not from git — `git checkout --` discards unrelated uncommitted
+work — and sequence with `;`, not `&&`, or the restore only runs when the mutation
+did *not* work.
+
+## Checklist before you push a test
+
+- [ ] Nothing outlives the run: no temp residue, no write to `~/.kiro` or the real data
+      home, no cron job, no service change, no file in the checkout
+- [ ] Every `mkdtemp` has `addCleanup` on the next line (or uses `tmp_path`)
+- [ ] Every child that may create a file gets `cwd=` under `tmp_path`, and every
+      assertion is scoped to where that child actually ran
+- [ ] Every thread, task, child process, socket and connection it starts is stopped in a
+      `finally` or an `addCleanup`
+- [ ] Globals mutated through `monkeypatch`, never raw assignment
+- [ ] No `AsyncMock` standing in for a synchronous method; every `cancel()` awaited
+- [ ] No assertion on a rate, a sample count, or an absolute duration
+- [ ] Source files read via `_REPO_ROOT = Path(__file__).resolve().parents[N]`, never a
+      relative `Path("src/...")` — xdist workers may change CWD
+- [ ] Passes at `-n0` **and** under `-n auto`, and passes when run alone
+- [ ] Cross-platform: `platform_compat` for process/signal/lock calls, no assumption
+      about path separators, case sensitivity, `/tmp`, or timer granularity

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,6 @@ import warnings
 import pytest
 from hypothesis import HealthCheck, settings
 
-from kiro_crew import sel as _sel
 from kiro_crew.safety_override import reset_singleton as _reset_safety_override
 from kiro_crew.slack.client import SlackClientOps
 from kiro_crew.slack.handler import _PHASE_EMOJIS, _build_phase_emojis
@@ -132,26 +131,17 @@ def make_dir_link(link: pathlib.Path, target: pathlib.Path) -> None:
     link.symlink_to(target, target_is_directory=True)
 
 
-def pytest_collection_modifyitems(config, items):
-    """On Windows, skip the tracked known-gap tests (all parametrizations).
-
-    The list lives in test/windows-expected-failures.txt -- one
-    unparametrized node id per line, captured from the first Windows CI
-    runs. It is a burn-down backlog: fixed tests get their line deleted,
-    and anything NOT on the list still fails the job, so the Windows line
-    holds for the ~16k tests that pass today.
-    """
-    if not platform_compat.IS_WINDOWS:
-        return
-    listfile = os.path.join(os.path.dirname(__file__), "windows-expected-failures.txt")
-    with open(listfile, encoding="utf-8") as fh:
-        expected = {ln.strip() for ln in fh if ln.strip() and not ln.startswith("#")}
-    marker = pytest.mark.skip(
-        reason="known Windows gap -- tracked in test/windows-expected-failures.txt"
-    )
-    for item in items:
-        if item.nodeid.split("[")[0] in expected:
-            item.add_marker(marker)
+#: ``pytest_collection_modifyitems`` -- which applies the
+#: ``windows-expected-failures.txt`` skips -- lives in the ROOTDIR ``conftest.py``.
+#: That list already names node ids under
+#: ``src/kiro_crew/apps/builtins/auto_improvement/tests/``, and a hook rooted here never
+#: runs when only those in-package tests are collected (which is exactly what CI's
+#: reduced-scope Windows job does on a frontend-only diff), so the skips silently did
+#: not apply where they were needed.
+#:
+#: ``collect_ignore`` above deliberately stays here: it names paths relative to its own
+#: conftest's directory and every entry is a file under ``test/``, so it is correct
+#: where it is.
 
 
 @pytest.fixture(autouse=True)
@@ -247,6 +237,10 @@ _MAX_WORKERS_ENV = "KIROCREW_MAX_TEST_WORKERS"
 _SLOT_DIR_ENV = "KIROCREW_TEST_SLOT_DIR"
 _DEFAULT_WORKER_CAP = 32
 _GIB = 1024**3
+# The LIVE memory readings are taken in MiB, because in GiB anything under 1 GiB
+# truncates to 0 -- which is the same value they use for "could not determine", and an
+# unknown reading is deliberately skipped. See _host_available_mib.
+_MIB = 1024**2
 # Headroom to reserve per worker. Measured peak RSS for a worker on a heavy
 # 1,231-test subset is ~0.37 GiB (~0.50 GiB under --cov), so 2 GiB reserves
 # roughly 4x typical and keeps the term from binding on ordinary hosts while
@@ -254,6 +248,15 @@ _GIB = 1024**3
 # for EXPECTED footprint: it cannot save a host from a genuinely leaking worker
 # (one orphaned run was observed at 4.3 GiB RSS), which is a separate bug.
 _GIB_PER_WORKER = 2
+# Headroom to reserve per worker against the LIVE availability reading, which needs a
+# different margin from the static ceilings above and not by preference -- by kind.
+# Total RAM and the cgroup limit are worst-case bounds that never move, so paying ~4x
+# measured RSS there is free. `MemAvailable` is ALREADY the current headroom, so
+# reserving 4x on top of it double-counts: on a host with 28 GiB free it would refuse
+# to spawn more than 14 workers on 32 idle cores, halving parallelism to protect memory
+# that was never at risk. 1 GiB is ~2x the measured peak under coverage (~0.50 GiB),
+# which still refuses to start 32 workers on a host with 8 GiB genuinely free.
+_GIB_PER_WORKER_AVAILABLE = 1
 
 # Lock files this process holds for its whole lifetime -- the fds MUST stay open,
 # because the lock lives exactly as long as the fd does.
@@ -311,14 +314,192 @@ def _host_total_gib() -> int:
     return int(pages * page_size // _GIB)
 
 
+def _cgroup_limit_files() -> list[str]:
+    """Every memory-ceiling file that bounds THIS process, tightest-first-ish.
+
+    The ceiling lives at the process's OWN cgroup, not at the root of the hierarchy.
+    Under cgroup v2 the root has no ``memory.max`` file at all, so reading
+    ``/sys/fs/cgroup/memory.max`` finds something only where a cgroup NAMESPACE has
+    remapped the container's own cgroup onto the mount root -- the docker/podman
+    default, but not what a systemd slice with ``MemoryMax=``, a ``cgroupns=host``
+    Kubernetes pod, or LXC gives you. There the limit is at
+    ``/sys/fs/cgroup/<relative path>/memory.max``, and a root-only read returns nothing,
+    which is indistinguishable from "no limit".
+
+    A cgroup is bounded by the tightest limit anywhere on its ancestor chain, so the own
+    cgroup and every ancestor are candidates. The bare root paths stay LAST so a
+    namespaced container -- and a host where ``/proc/self/cgroup`` cannot be read at
+    all -- keeps the reading it would otherwise have had.
+    """
+    files: list[str] = []
+    try:
+        with open("/proc/self/cgroup", encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+    except OSError:
+        lines = []
+    for line in lines:
+        fields = line.split(":", 2)
+        if len(fields) != 3:
+            continue
+        controllers, relative = fields[1], fields[2]
+        if not controllers:  # v2 spells its single entry "0::<path>"
+            base, leaf = "/sys/fs/cgroup", "memory.max"
+        elif "memory" in controllers.split(","):  # v1: "<id>:<controllers>:<path>"
+            base, leaf = "/sys/fs/cgroup/memory", "memory.limit_in_bytes"
+        else:
+            continue
+        parts = [part for part in relative.split("/") if part]
+        while parts:
+            files.append("/".join([base, *parts, leaf]))
+            parts.pop()
+    files.append("/sys/fs/cgroup/memory.max")
+    files.append("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+    return files
+
+
+def _cgroup_limit_mib() -> int:
+    """The cgroup's memory ceiling in MiB, or 0 when there is none.
+
+    ``SC_PHYS_PAGES`` reports the MACHINE's RAM, which is the wrong number inside a
+    container: a 2-CPU/8 GiB CI container on a 256 GiB host reads 256 GiB and sizes its
+    worker budget against memory it will be OOM-killed for touching.
+
+    Takes the TIGHTEST limit found on the process's cgroup chain (see
+    :func:`_cgroup_limit_files`), not the first one: an inner cgroup can be looser than
+    an ancestor, and the ancestor still binds.
+
+    MiB, not GiB, for the reason spelled out on :func:`_host_available_mib`: in GiB a
+    512 MiB container ceiling truncates to ``0``, which is this function's own "there is
+    no limit" answer -- so the tightest ceiling of all would be read as no ceiling.
+
+    ``max`` is cgroup v2's spelling for "no limit". v1 uses a very large sentinel
+    instead, which no ``min()`` will ever pick, so it needs no special case.
+    """
+    tightest = 0
+    for path in _cgroup_limit_files():
+        try:
+            with open(path, encoding="utf-8") as handle:
+                raw = handle.read().strip()
+        except OSError:
+            continue
+        if not raw or raw == "max":
+            continue
+        try:
+            mib = int(raw) // _MIB
+        except ValueError:
+            continue
+        if mib > 0 and (tightest == 0 or mib < tightest):
+            tightest = mib
+    return tightest
+
+
+def _host_available_mib() -> int:
+    """RAM in MiB that is actually free for a new worker, or 0 when unknown.
+
+    ``MemAvailable`` is the kernel's own estimate of what a new allocation can use
+    without swapping; it counts reclaimable page cache, which ``MemFree`` and
+    ``SC_AVPHYS_PAGES`` both omit and would therefore understate badly on any host
+    that has read files.
+
+    Bounding on this in ADDITION to total RAM is what makes the budget protective
+    rather than decorative. The flock slots below already stop two pytest runs from
+    oversubscribing each other, but they are blind to memory the host is using for
+    anything else -- a build, a browser, a running gateway. Sizing 32 workers against
+    total RAM on a machine with 2 GiB genuinely free is how a run starts swapping and
+    then makes no progress at all, which is the incident the whole budget exists to
+    prevent.
+
+    **MiB, not GiB, and the unit is load-bearing.** Truncating to whole GiB makes every
+    reading under 1 GiB come back as ``0`` -- which is also this function's "could not
+    determine" answer, and :func:`_memory_bounded_capacity` SKIPS an unknown reading. So
+    in GiB the bound would drop out precisely on the starved host it exists to protect:
+    860 MiB free would read as "unknown", the live term would be discarded, and the
+    static total-RAM bound would happily allow 16 workers. In MiB the same host reads
+    860, which floors the budget at one worker.
+
+    Linux-only by construction. macOS has no equivalent single number (its compressor
+    makes "available" a policy question rather than a reading), so this returns 0 there
+    and the static bounds stand alone.
+    """
+    try:
+        with open("/proc/meminfo", encoding="utf-8") as handle:
+            for line in handle:
+                if not line.startswith("MemAvailable:"):
+                    continue
+                # "MemAvailable:   107374182 kB" -- the unit is always kB.
+                return int(line.split()[1]) * 1024 // _MIB
+    except (OSError, IndexError, ValueError):
+        return 0
+    return 0
+
+
+def _bounded_by(limit: int, readings: tuple[tuple[int, int], ...]) -> int:
+    """*limit*, reduced by each ``(MiB, GiB-per-worker)`` reading that is available.
+
+    A reading of 0 means "could not determine" and is SKIPPED rather than treated as
+    zero memory. That direction matters more than it looks: reading it as zero would
+    collapse the run to a single worker on any platform without that reading -- macOS
+    and Windows have no ``/proc/meminfo`` and no ``/sys/fs/cgroup`` -- and a run that
+    silently drops to one worker looks like a hang, not like a bug.
+
+    Which is exactly why the readings that can be genuinely SMALL are in MiB: in GiB a
+    sub-1-GiB reading truncates to 0 and would be discarded as unknown, so the bound
+    would vanish on the starved host it exists to protect.
+    """
+    for mib, per_worker_gib in readings:
+        if mib > 0:
+            limit = min(limit, max(1, mib // (per_worker_gib * 1024)))
+    return max(1, limit)
+
+
+def _static_memory_bounded_capacity(cores: int) -> int:
+    """*cores*, reduced by the memory readings that are CONSTANT for the machine.
+
+    Total RAM and the cgroup ceiling only. Both are properties of the host, so a number
+    derived from them is stable across runs -- which is what makes it safe to use as the
+    shared slot RANGE below. Sharing a range only works if every run computes the same
+    one; a range that moves between runs is not a namespace, it is a race.
+
+    This is also what keeps the memory budget genuinely SHARED rather than per-run. On a
+    64-core / 32 GiB host the static bound is 16 workers, so there are 16 slots in
+    total: a first run takes them all, and a second gets its floor of one. Put the same
+    bound only on the per-run cap and both runs would take 16 each -- 32 workers against
+    a 16-worker memory budget, which is the swapping incident the budget exists to
+    prevent, reached from the opposite direction.
+
+    Total RAM stays in GiB because a machine with under 1 GiB of RAM in total is not a
+    configuration this suite runs on, and its unit is pinned by existing tests.
+    """
+    return _bounded_by(
+        cores,
+        (
+            (_host_total_gib() * 1024, _GIB_PER_WORKER),
+            (_cgroup_limit_mib(), _GIB_PER_WORKER),
+        ),
+    )
+
+
+def _live_memory_bounded_cap(cap: int) -> int:
+    """*cap*, reduced by what is free on the host RIGHT NOW.
+
+    Deliberately applied to the per-run cap and NOT to the shared slot range. The
+    reading is transient, and slots fill from index 0 upward, so a range shortened by a
+    momentary dip excludes precisely the slots an earlier run left free -- collapsing a
+    later run to one worker while most of the machine sits idle. A cap is the right
+    place for a transient reading: it throttles THIS run without reshaping the namespace
+    every other run has to agree on.
+    """
+    return _bounded_by(cap, ((_host_available_mib(), _GIB_PER_WORKER_AVAILABLE),))
+
+
 def _claim_worker_slots(capacity: int, cap: int) -> int:
     """Take up to ``cap`` of the host's ``capacity`` worker slots and HOLD them.
 
-    ``capacity`` is how many slots the HOST has (cores, bounded by RAM) and is
-    the range probed; ``cap`` is the most any single run may take. Keeping these
-    separate matters on a large host: with 64 cores and a cap of 32, a first run
-    takes slots 0-31 and a second still finds 32-63 free and gets its full 32.
-    Probing only ``cap`` slots would have collapsed that second run to one
+    ``capacity`` is how many slots the HOST has -- its core count, a constant, never a
+    transient memory reading -- and is the range probed; ``cap`` is the most any single
+    run may take. Keeping these separate matters on a large host: with 64 cores and a
+    cap of 32, a first run takes slots 0-31 and a second still finds 32-63 free and gets
+    its full 32. Probing only ``cap`` slots would have collapsed that second run to one
     worker while half the machine sat idle.
 
     Each slot is an advisory lock on its own file, acquired non-blocking and
@@ -365,6 +546,30 @@ def _claim_worker_slots(capacity: int, cap: int) -> int:
         try:
             fd = os.open(str(_slot_path(slot_dir, index)), os.O_CREAT | os.O_RDWR, 0o600)
         except OSError:
+            # The directory exists but this run cannot create a slot file in it: a
+            # read-only bind mount, an exhausted quota, a leftover dir owned by another
+            # account. `mkdir(exist_ok=True)` above does NOT catch that -- Linux reports
+            # EEXIST before it checks write permission -- so this is where it surfaces.
+            #
+            # Fall through to the one-worker floor rather than failing open to the
+            # unbudgeted ceiling. Fail-open is the wrong direction HERE specifically
+            # because the failure is not local: if this run cannot take a lock then
+            # neither can a concurrent one, so both would receive the full cap with no
+            # coordination at all -- which is precisely the oversubscription this budget
+            # exists to prevent (two runs, ten workers each, load average ~590, zero tests
+            # completing in 21 minutes). One worker is slow; two unbudgeted runs make no
+            # progress.
+            #
+            # Say so, though. Silently dropping to one worker is a suite that takes an
+            # hour for a reason nobody can see, and the fix -- point
+            # KIROCREW_TEST_SLOT_DIR somewhere writable -- is only obvious once the cause
+            # is named.
+            warnings.warn(
+                "xdist worker budget: cannot create a slot file under "
+                f"{slot_dir}, so this run falls back to a single worker. Point "
+                f"{_SLOT_DIR_ENV} at a writable directory to restore parallelism.",
+                stacklevel=2,
+            )
             break
         if platform_compat.try_acquire_lock(fd, exclusive=True):
             _held_slots.append(fd)  # keep the fd -- closing it drops the lock
@@ -379,19 +584,26 @@ def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
 
     Two separate quantities.
 
-    **Host capacity** -- how many slots exist to compete for:
+    **Host capacity** -- how many slots exist to compete for: cores, bounded by the
+    memory readings that are CONSTANT for the machine (total RAM and the cgroup ceiling;
+    see :func:`_static_memory_bounded_capacity`). It has to be constant, because it is
+    the range of slot indices probed and every run must compute the same range for
+    sharing to mean anything. Cores alone are the wrong unit: a 10-core / 32 GiB laptop
+    cannot back 32 multi-GiB workers, and once it starts swapping the run stops making
+    progress at all. Putting the static bound HERE rather than on the cap is also what
+    keeps the memory budget shared: 16 slots on a 32 GiB host means two runs share 16
+    workers, not 16 each.
 
-    1. **Cores.** ``os.cpu_count()``.
-    2. **RAM.** ~2 GiB per worker. Cores alone are the wrong unit: a 10-core /
-       32 GiB laptop cannot back 32 multi-GiB workers, and once it starts
-       swapping the run stops making progress altogether.
+    **Per-run cap** -- the most this single run may take, the tightest of:
 
-    **Per-run cap** (``KIROCREW_MAX_TEST_WORKERS``, default 32) -- the most any
-    single run may take. The optimal worker count for this suite plateaus around
-    24-32 and then *regresses*: every extra worker re-imports the full app
-    (aiohttp/boto3/numpy/pdfplumber/transcribe) and writes its own
-    ``.coverage.*`` file to combine at the end. Measured on a 64-core host:
-    156s @ 64 workers vs 92s @ 32 workers (-41%).
+    1. ``KIROCREW_MAX_TEST_WORKERS``, default 32. The optimal worker count for this
+       suite plateaus around 24-32 and then *regresses*: every extra worker re-imports
+       the full app (aiohttp/boto3/numpy/pdfplumber/transcribe) and writes its own
+       ``.coverage.*`` file to combine at the end. Measured on a 64-core host:
+       156s @ 64 workers vs 92s @ 32 workers (-41%).
+    2. What is free on the host right now (see :func:`_live_memory_bounded_cap`). This
+       reading is transient, so it throttles this run only and never reshapes the shared
+       range -- it says nothing about the machine, only about what else is running on it.
 
     Keeping them separate is what makes a big host behave: with 64 cores and a
     cap of 32, two runs get 32 workers each rather than the second collapsing
@@ -416,11 +628,16 @@ def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
     An explicit ``-n <N>`` on the command line always wins; this hook only fires
     for ``auto`` / ``logical``.
     """
-    capacity = os.cpu_count() or 1
-    total_gib = _host_total_gib()
-    if total_gib:
-        capacity = min(capacity, max(1, total_gib // _GIB_PER_WORKER))
-    cap = max(1, _int_env(_MAX_WORKERS_ENV, _DEFAULT_WORKER_CAP))
+    # The two memory bounds go to different places, and which one goes where is the
+    # whole correctness argument. The STATIC bound shapes the shared slot range, so the
+    # budget is shared between concurrent runs rather than granted to each of them. The
+    # LIVE bound only throttles this run, because a transient reading must not reshape a
+    # namespace every other run has to agree on -- slots fill from index 0, so a shrunken
+    # range excludes exactly the slots an earlier run left free.
+    capacity = _static_memory_bounded_capacity(os.cpu_count() or 1)
+    cap = _live_memory_bounded_cap(
+        min(capacity, max(1, _int_env(_MAX_WORKERS_ENV, _DEFAULT_WORKER_CAP)))
+    )
     return _claim_worker_slots(capacity, cap)
 
 
@@ -573,101 +790,11 @@ def _reset_reasoning_effort_globals():
         _cp._reasoning_effort_ordered = saved_ordered
 
 
-@pytest.fixture(scope="session")
-def _isolation_root(tmp_path_factory):
-    """One session-scoped parent for the per-test isolation dirs below.
-
-    ``tmp_path_factory.mktemp`` picks its numbered suffix by scanning the whole
-    basetemp, so its cost grows with the number of entries already there. Four autouse
-    fixtures called it per test, adding thousands of siblings to one directory. Those
-    fixtures now ``mkdir`` under this root instead, which is a single syscall and does
-    not scan.
-
-    Named ``i`` rather than something descriptive to keep the paths short: Windows
-    still caps a path at 260 characters unless long paths are enabled, and everything
-    a test writes under ``KIROCREW_HOME`` nests inside here.
-    """
-    return tmp_path_factory.mktemp("i")
-
-
-@pytest.fixture
-def _isolation_dirs(_isolation_root):
-    """Return an allocator for this test's isolation dirs, created on demand.
-
-    Each call returns ``<root>/<counter>-<name>``, so one test's dirs cannot collide
-    with another's (the counter is per-process, and pytest-xdist gives every worker its
-    own ``basetemp`` -- verified: workers report ``popen-gw0``/``popen-gw1`` roots).
-    Flat rather than nested, again to keep Windows paths short.
-    """
-    made: dict[str, pathlib.Path] = {}
-    _isolation_dirs.seq += 1  # type: ignore[attr-defined]
-    stem = _isolation_dirs.seq  # type: ignore[attr-defined]
-
-    def _get(name: str) -> pathlib.Path:
-        if name not in made:
-            path = _isolation_root / f"{stem}-{name}"
-            path.mkdir(parents=True, exist_ok=True)
-            made[name] = path
-        return made[name]
-
-    return _get
-
-
-_isolation_dirs.seq = 0  # type: ignore[attr-defined]
-
-
-@pytest.fixture(autouse=True)
-def _isolate_kirocrew_home(_isolation_dirs, monkeypatch):
-    """Pin ``KIROCREW_HOME`` to a per-test tmp dir as a safety net.
-
-    ``config_dir()`` reads ``KIROCREW_HOME`` on every call and falls back to the
-    operator's real ``~/.kirocrew`` when it is unset. Any test that reaches a
-    code path resolving ``apps_dir()`` / ``config_dir()`` (e.g. a lifecycle
-    dispatch that calls ``app_dir(name)/"data".mkdir()``) without setting
-    ``KIROCREW_HOME`` itself would otherwise create real dirs/files under the
-    developer's home — and under Hypothesis that means one orphan per generated
-    example, accumulating into thousands of stray ``~/.kirocrew/apps/<name>/``
-    dirs over a dev's test history.
-
-    This runs before the test body, so a test that sets its own
-    ``KIROCREW_HOME`` via ``monkeypatch.setenv`` still wins (its value is applied
-    later and reverted independently). The guard only changes behavior for tests
-    that did NOT isolate the home themselves — exactly the leak we want to close.
-
-    Also reset ``config.paths._resolved_home`` to ``None``: ``config_dir()`` now
-    caches the resolved data home in that module global for the process lifetime
-    (so the one-time ~/.kirocrew -> ~/.kiro/crew migration runs at most once).
-    Under xdist a worker runs many tests in one process, so a value cached by an
-    earlier test (which may have patched ``Path.home`` / cleared ``KIROCREW_HOME``)
-    would otherwise leak into a later test that resolves the default home. Reset
-    per test so each resolves fresh against its own patched environment.
-
-    Also clear ``KIROCREW_PROJECT_DIR`` for the same "match CI on a dev box"
-    reason: it is auto-set to the repo root when running from a checkout, so
-    ``skills._project_skills_dir()`` resolves to the repo's real ``skills/``.
-    A test that drives ``_ensure_builtin_skills`` against a tmp dir then sees the
-    live ``skills/kirocrew-dev/*`` as a "source", which flips relocation/cleanup
-    behavior — green in CI (env unset there), red locally. Tests that need a
-    project dir set it themselves via ``monkeypatch`` (which still wins).
-    """
-    home = _isolation_dirs("kirocrew-home")
-    monkeypatch.setenv("KIROCREW_HOME", str(home))
-    monkeypatch.delenv("KIROCREW_PROJECT_DIR", raising=False)
-    # ``_export_bound_port`` writes KIROCREW_BOUND_PORT into the real process
-    # environment when a test boots a dashboard/API server. Under xdist a
-    # worker runs many tests in one process, so a port exported by one test
-    # would leak into every later test's port resolution. Clear it per test;
-    # a test that wants it sets it via monkeypatch (which still wins).
-    monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
-    # Match CI on a dev box for the off-loop-IO strictness knob too: a developer
-    # with KIROCREW_DEV_MODE=1 (or KIROCREW_STRICT_ON_LOOP_PERSIST=1) exported
-    # would otherwise flip history's _locked guard AND the auto_research
-    # campaigns-DB guard strict for the whole suite, failing tests that call
-    # sync helpers directly on the loop as harness convenience. Tests that
-    # exercise strict mode set the env themselves via monkeypatch (which wins).
-    monkeypatch.delenv("KIROCREW_DEV_MODE", raising=False)
-    monkeypatch.delenv("KIROCREW_STRICT_ON_LOOP_PERSIST", raising=False)
-    monkeypatch.setattr("kiro_crew.config.paths._resolved_home", None)
+#: ``_isolation_root`` / ``_isolation_dirs`` / ``_isolate_kirocrew_home`` live in the
+#: ROOTDIR ``conftest.py``, not here. The data home has to be pinned for every
+#: testpath, including the ~108 test modules that ship inside the package under
+#: ``src/kiro_crew/apps/builtins/*/tests/`` and never see this file. The fixtures
+#: below still request ``_isolation_dirs`` and resolve it up the hierarchy.
 
 
 @pytest.fixture(autouse=True)
@@ -794,67 +921,12 @@ def _reset_options_control_state():
     outbound._LOCK_USERS.clear()
 
 
-@pytest.fixture(autouse=True)
-def _isolate_subagents_dir(_isolation_dirs, monkeypatch):
-    """Pin the subagent registry dir to a tmp dir for the whole suite.
-
-    ``kiro_crew.subagent_persistence._SUBAGENTS_DIR`` is bound at import time to
-    ``config_dir() / "subagents"``, so the ``KIROCREW_HOME`` safety net above
-    cannot retroactively redirect it. Any test that calls ``SubagentManager.spawn``
-    or ``create_agent_folder`` without isolating this global itself would write
-    stub agent folders into the operator's real ``~/.kirocrew/subagents/``. On the
-    next gateway start, orphan reconciliation sweeps those stubs and floods the
-    logs with "lost to gateway restart" warnings (e.g. tasks ``t`` / ``ls /tmp``).
-    Redirecting the module global gives every test an isolated, empty registry.
-    """
-    monkeypatch.setattr(
-        "kiro_crew.subagent_persistence._SUBAGENTS_DIR",
-        _isolation_dirs("subagents"),
-    )
-
-
-@pytest.fixture(autouse=True)
-def _no_model_download(monkeypatch, _isolation_dirs):
-    """Never let a test trigger the 610MB embedding-model download.
-
-    Embeddings are always-on, so any test that boots the gateway/server
-    startup path would otherwise kick ``start_background_model_download()``.
-    The env escape hatch is honored by ``ModelDownloadManager.ensure_model``
-    and ``start_background_model_download`` — a test that wants to exercise
-    the download path monkeypatches the manager's HTTP calls directly
-    (see test_embeddings.py) rather than unsetting this.
-
-    ``OLLAMA_MODELS`` is additionally pinned to an empty tmp dir so the
-    legacy-blob salvage fast-path (``_salvage_legacy_ollama_blob``) can never
-    read the developer's real ``~/.ollama`` store — without this, download
-    tests would pass/fail machine-dependently on hosts that ran the
-    Ollama-era embeddings.
-    """
-    monkeypatch.setenv("KIROCREW_SKIP_MODEL_DOWNLOAD", "1")
-    monkeypatch.setenv("OLLAMA_MODELS", str(_isolation_dirs("ollama-models")))
-    # Force telemetry OFF for every test. `_consent_enabled` reads this env var BEFORE
-    # the config flag, which is what makes it a reliable gate: ~15 tests patch
-    # `KiroCrewConfig.load` with a bare MagicMock, whose `telemetry.enabled` is TRUTHY,
-    # so a real recorder starts and `Path(cfg.local_dir)` resolves the mock to the
-    # RELATIVE path `MagicMock/load().telemetry.local_dir/...` -- writing metrics and a
-    # lock file into the repo root, plus a background reader thread that outlives the
-    # test. Tests that exercise telemetry delete this var themselves (test/metrics/).
-    monkeypatch.setenv("KIROCREW_TELEMETRY", "0")
-
-
-@pytest.fixture(autouse=True)
-def _isolate_agent_state_sidecar(_isolation_dirs, monkeypatch):
-    """Pin the agent_state sidecar to a tmp dir for the whole suite.
-
-    ``kiro_crew.agent_state`` stores per-agent bookkeeping (model_managed,
-    cc_model) in ``~/.kirocrew/agent_model_state.json`` via ``config_dir()``.
-    Tests that exercise the install / refresh / migration / PATCH paths would
-    otherwise read and write the operator's real sidecar. Redirect
-    ``config_dir`` — referenced as a module attribute at call time — to a fresh
-    tmp dir so every test starts from empty state.
-    """
-    sidecar_root = _isolation_dirs("agent-state")
-    monkeypatch.setattr("kiro_crew.agent_state.config_dir", lambda: sidecar_root)
+#: ``_isolate_subagents_dir``, ``_no_model_download`` and
+#: ``_isolate_agent_state_sidecar`` live in the ROOTDIR ``conftest.py``. Each one
+#: protects a real HOST path (the subagent registry a running gateway sweeps as
+#: orphans, a 610MB model download, the operator's agent-state sidecar), so by the
+#: same test the data home meets they belong to the floor that every testpath sees --
+#: not to this file, which the in-package suites never load.
 
 
 @pytest.fixture(autouse=True)
@@ -1020,31 +1092,10 @@ def _clean_slack_thread_state():
         _m.clear()
 
 
-@pytest.fixture(autouse=True, scope="session")
-def _isolate_sel_default_dir(tmp_path_factory):
-    """Redirect the Security Event Log default dir to a session-local tmp dir.
-
-    SEL's default singleton writes to the real security_events.jsonl under the
-    data home (``_default_dir()`` → ``config_dir()``, non-atomic append). Tests
-    that emit events via the default ``sel()`` would otherwise pollute that real
-    file and, under ``pytest -n auto``, share it across worker processes. Redirect
-    the module-level default accessor to a per-session tmp dir. Session-scoped so
-    we don't churn SEL's background writer thread per test; tests that manage
-    their own ``SecurityEventLog`` (test_sel.py resets ``_instance`` + passes
-    ``base_dir``) are unaffected.
-
-    Patches the ``_default_dir()`` accessor (not a captured constant): the module
-    now resolves its default lazily so importing ``kiro_crew.sel`` never triggers
-    the one-time data-home migration as an import side effect.
-    """
-    orig_fn = _sel._default_dir
-    orig_inst = _sel.SecurityEventLog._instance
-    _sel_dir = tmp_path_factory.mktemp("sel")
-    _sel._default_dir = lambda: _sel_dir
-    _sel.SecurityEventLog._instance = None
-    yield
-    _sel._default_dir = orig_fn
-    _sel.SecurityEventLog._instance = orig_inst
+#: ``_isolate_sel_default_dir`` lives in the ROOTDIR ``conftest.py`` too, and for a
+#: sharper reason than the data home: SEL's writer is a DAEMON THREAD on a process
+#: singleton, so it outlives the test that first called ``sel()`` and keeps writing to
+#: the directory that test resolved.
 
 
 class MockSlackClient(SlackClientOps):

--- a/test/test_builtin_skill_sync_safety.py
+++ b/test/test_builtin_skill_sync_safety.py
@@ -429,10 +429,14 @@ class TestFingerprint:
         (a / "hidden.txt").write_text("secret", encoding="utf-8")
         real_open = os.open
 
-        def _deny(path: object, flags: int, *args: object) -> int:
+        # ``**kwargs`` because this replaces the os module attribute, so it is live for
+        # the whole test INCLUDING teardown, where pytest's own tmp_path cleanup calls
+        # os.open with dir_fd=. A stub narrower than the API it stands in for turns that
+        # cleanup into a TypeError reported as an error at teardown.
+        def _deny(path: object, flags: int, *args: object, **kwargs: object) -> int:
             if "hidden.txt" in str(path):
                 raise PermissionError("denied")
-            return real_open(path, flags, *args)  # type: ignore[arg-type]
+            return real_open(path, flags, *args, **kwargs)  # type: ignore[arg-type]
 
         monkeypatch.setattr(skills_mod.os, "open", _deny)
         assert _skill_tree_fingerprint(a) is None

--- a/test/test_computer_use_capture.py
+++ b/test/test_computer_use_capture.py
@@ -400,8 +400,11 @@ def test_ring_trim_skips_a_file_removed_concurrently(spool: Path, monkeypatch: p
 
     real_unlink = capture_macos.os.unlink
 
-    def _racy(path):
-        real_unlink(path)
+    # Accepts the keyword arguments os.unlink really takes (dir_fd): this replaces
+    # the os module attribute, so it is live for the whole test INCLUDING teardown,
+    # where pytest's own tmp_path cleanup calls unlink with dir_fd=.
+    def _racy(path, **kwargs):
+        real_unlink(path, **kwargs)
         raise FileNotFoundError(path)
 
     monkeypatch.setattr(capture_macos.os, "unlink", _racy)

--- a/test/test_dashboard_themes_coverage.py
+++ b/test/test_dashboard_themes_coverage.py
@@ -499,7 +499,10 @@ class TestAtomicWriteFailureCleanup:
     def test_a_failed_temp_unlink_still_reraises_the_original_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def _no_unlink(_path: object) -> None:
+        # Accepts what os.unlink really takes (dir_fd): this replaces the os module
+        # attribute, so it is live through teardown, where pytest's tmp_path cleanup
+        # calls unlink with dir_fd=.
+        def _no_unlink(_path: object, **_kwargs: object) -> None:
             raise OSError("temp already gone")
 
         monkeypatch.setattr(th.os, "unlink", _no_unlink)

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -8,7 +8,6 @@ import hmac as _hmac_mod
 import json
 import os
 import sys
-import tempfile
 import textwrap
 import threading
 import time
@@ -3359,7 +3358,7 @@ def _mk_make_live_wt(tmp_path, *, venv: bool = False, dist: bool = False,
     return wt
 
 
-def _assert_sandboxed(path, what: str) -> None:
+def _assert_sandboxed(path, what: str, sandbox_root) -> None:
     """Fail loudly when a host-mutating make-live seam resolves outside the sandbox.
 
     The seams below decide WHERE the cutover writes and WHAT it executes. If one is
@@ -3368,10 +3367,17 @@ def _assert_sandboxed(path, what: str) -> None:
     drop-in to point at a pytest tmpdir and restarts the unit, which then fails
     203/EXEC on every boot once the tmpdir is reaped. Asserting containment here
     makes the next missed seam fail inside the test instead of taking down the host.
+
+    *sandbox_root* is THIS test's own directory, not a generic temp root. The
+    distinction is the whole strength of the check: "somewhere under the system temp
+    dir" is satisfied by any tmp path at all, whereas "inside the tree this test
+    built" is satisfied only by the redirect actually taking effect. It also stops the
+    assertion depending on where ``tempfile`` happens to be rooted, which the suite's
+    isolation floor now controls.
     """
     resolved = Path(path).resolve()
-    tmp_root = Path(tempfile.gettempdir()).resolve()
-    assert tmp_root in resolved.parents, (
+    root = Path(sandbox_root).resolve()
+    assert root == resolved or root in resolved.parents, (
         f"{what} resolved OUTSIDE the temp sandbox: {resolved}. A test that reaches "
         f"the cutover path must never touch a real host path."
     )
@@ -3416,15 +3422,14 @@ def _stub_make_live(monkeypatch, wt, *, live=None, in_pod=False, unit_status="ok
     monkeypatch.setattr(mod, "_live_worktree_path", AsyncMock(return_value=live))
     monkeypatch.setattr(mod, "_in_pod", lambda: in_pod)
     monkeypatch.setattr(mod, "_live_user_unit_status", AsyncMock(return_value=unit_status))
-    sandbox_dropin = (
-        Path(wt).parent / "_systemd" / f"{mod._LIVE_GATEWAY_UNIT}.d" / "make-live.conf"
-    )
-    _assert_sandboxed(sandbox_dropin, "_dropin_path")
+    sandbox_root = Path(wt).parent
+    sandbox_dropin = sandbox_root / "_systemd" / f"{mod._LIVE_GATEWAY_UNIT}.d" / "make-live.conf"
+    _assert_sandboxed(sandbox_dropin, "_dropin_path", sandbox_root)
     monkeypatch.setattr(mod, "_dropin_path", lambda: sandbox_dropin)
     monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "", "")))
     # Prove the redirect actually took: a rename of the production symbol would
     # otherwise leave the real path live while every test still looked green.
-    _assert_sandboxed(mod._dropin_path(), "patched _dropin_path()")
+    _assert_sandboxed(mod._dropin_path(), "patched _dropin_path()", sandbox_root)
     if pointer_dir is not None:
         pointer_dir.mkdir(parents=True, exist_ok=True)
         ptr_file = pointer_dir / "live_target.json"

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -1,0 +1,805 @@
+"""The rootdir conftest's isolation floor guards itself.
+
+``test_host_service_guard.py`` covers the SERVICE half of that floor. This file covers
+the three halves added around it, each of which protects a different piece of the
+operator's machine from a test that forgot to isolate itself:
+
+* the **data home** -- ``KIROCREW_HOME`` pinned per test, plus the ``~/.kiro`` paths
+  production binds at IMPORT time, which the env var cannot reach;
+* the **system temp directory** -- ``tempfile``'s base redirected per run, with residue
+  reported rather than silently accumulated;
+* the **worker budget** -- how many xdist workers the host can actually back.
+
+Two jobs, the same split ``test_host_service_guard.py`` uses:
+
+* **Behaviour** -- prove each guard is armed, catches what it claims, and stays silent
+  on what it must not touch. A guard nobody exercises is a guard that stops working at
+  the next refactor without anybody noticing.
+* **Ratchet** -- pin the guarded set against what ``src/kiro_crew`` actually contains,
+  so a NEW import-time ``Path.home()`` binding cannot land unpinned. Same shape as
+  ``test_host_service_guard.py``'s ratchet and ``test_spawn_preexec_guard.py``'s
+  ``_ALLOWED``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import os
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_ROOT_CONFTEST = _REPO_ROOT / "conftest.py"
+_SRC = _REPO_ROOT / "src" / "kiro_crew"
+
+
+def _load_root_conftest():
+    """Import the rootdir conftest under its own module name.
+
+    pytest already loads it as a plugin, but reaching it through the plugin manager
+    depends on the name pytest happened to register. Loading it by path is
+    deterministic, and the fixtures it defines are inert in this namespace (a
+    ``@pytest.fixture`` decorator only marks a function; nothing collects them here).
+    """
+    spec = importlib.util.spec_from_file_location("_kirocrew_isolation_conftest", _ROOT_CONFTEST)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_root = _load_root_conftest()
+
+
+#: The real directories the isolation floor exists to keep tests out of.
+#:
+#: Deliberately these specific roots and NOT ``Path.home()``. On POSIX "not under
+#: $HOME" reads as the stronger assertion, but on Windows ``tempfile.gettempdir()`` is
+#: ``%LOCALAPPDATA%\\Temp`` -- i.e. ``C:\\Users\\<user>\\AppData\\Local\\Temp`` -- which is
+#: itself under the home directory. So "not under $HOME" is unconditionally FALSE there
+#: for every correctly-isolated tmp path, and the assertion could never pass on the
+#: Windows shards. These roots are what the fixtures actually protect, and the narrower
+#: form is true on all four targets.
+_GUARDED_ROOTS: tuple[pathlib.Path, ...] = (
+    pathlib.Path.home() / ".kiro",
+    pathlib.Path.home() / ".kirocrew",
+    pathlib.Path.home() / ".claude.json",
+)
+
+
+def _inside_a_guarded_root(path: pathlib.Path) -> bool:
+    """Whether *path* is, or is under, one of the operator's real guarded paths."""
+    resolved = path.resolve()
+    for root in _GUARDED_ROOTS:
+        candidate = root.resolve()
+        if resolved == candidate or resolved.is_relative_to(candidate):
+            return True
+    return False
+
+
+# ── the data home ─────────────────────────────────────────────────────────
+
+
+class TestTheDataHomeIsPinnedForEveryTestpath:
+    """``KIROCREW_HOME`` must be a tmp dir here, and it must be the SAME one the
+    package resolves.
+
+    These assertions run against the LIVE fixtures rather than a reconstruction,
+    because the thing worth pinning is that the autouse chain actually fired. The
+    stakes are specific: ``config_dir()`` is not a read -- it CREATES the home and its
+    marker on first use and can run the one-time ``~/.kirocrew`` -> ``~/.kiro/crew``
+    migration as a side effect. A test that resolves it unpinned mutates the
+    operator's live install.
+    """
+
+    def test_kirocrew_home_is_not_the_operators_real_home(self) -> None:
+        home = pathlib.Path(os.environ["KIROCREW_HOME"]).resolve()
+
+        assert not _inside_a_guarded_root(home), f"KIROCREW_HOME is a real home path: {home}"
+
+    def test_config_dir_resolves_to_that_same_pinned_home(self) -> None:
+        """The env var is only worth pinning if the package actually follows it.
+
+        ``config_dir()`` memoises its answer in a module global for the process
+        lifetime, so this also proves the per-test reset of ``_resolved_home`` works --
+        without it a home cached by an earlier test on this xdist worker would win.
+        """
+        from kiro_crew.config.paths import config_dir
+
+        assert config_dir().resolve() == pathlib.Path(os.environ["KIROCREW_HOME"]).resolve()
+
+    def test_a_test_can_still_override_the_home_itself(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The floor is a safety net, not a cage: a test that isolates itself wins."""
+        from kiro_crew.config.paths import config_dir
+
+        mine = tmp_path / "my-own-home"
+        mine.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(mine))
+        monkeypatch.setattr("kiro_crew.config.paths._resolved_home", None)
+
+        assert config_dir().resolve() == mine.resolve()
+
+
+class TestTheSharedKiroPathsArePinned:
+    """``~/.kiro`` is kiro-cli's own home -- machine-wide, shared with the real agent.
+
+    A test that writes ``~/.kiro/settings/mcp.json`` edits the MCP servers of the
+    operator's LIVE agent, and ``KIROCREW_HOME`` does not help: these paths are bound
+    at import time from ``Path.home()``, before any test could set an env var.
+    """
+
+    @pytest.mark.parametrize(
+        ("module", "attr"),
+        [(module, attr) for module, attr, _ in _root._SHARED_KIRO_PATHS],
+    )
+    def test_each_pinned_path_is_outside_the_real_home(self, module: str, attr: str) -> None:
+        importlib.import_module(module)
+        value = pathlib.Path(getattr(sys.modules[module], attr))
+
+        assert not _inside_a_guarded_root(value), (
+            f"{module}.{attr} still resolves inside the operator's real "
+            f"kiro-cli/data home: {value.resolve()}"
+        )
+
+    def test_the_mcp_lock_stays_a_sibling_of_the_mcp_json(self) -> None:
+        """A derived pair must be redirected together, or it is worse than neither.
+
+        ``_McpFileLockSync.__enter__`` creates ``_GLOBAL_MCP_JSON.parent`` and then
+        touches ``_MCP_LOCK_PATH``. Redirect only the json and the code creates a tmp
+        directory, then touches a lock in the REAL one whose parent nothing created --
+        ``FileNotFoundError`` on any host where ``~/.kiro/settings`` does not already
+        exist. Pinning both is not enough on its own: they must land in the SAME
+        directory, which is what this asserts.
+        """
+        from kiro_crew.dashboard.handlers import mcp as mcp_mod
+
+        assert mcp_mod._MCP_LOCK_PATH.parent == mcp_mod._GLOBAL_MCP_JSON.parent
+
+    def test_the_table_names_a_real_attribute_on_a_real_module(self) -> None:
+        """A renamed constant would make its entry a silent no-op.
+
+        The fixture patches with ``raising=False`` so a partial checkout cannot break
+        collection, which is right for the fixture and exactly why the assertion has to
+        live here instead.
+        """
+        for module, attr, _relative in _root._SHARED_KIRO_PATHS:
+            imported = importlib.import_module(module)
+            assert hasattr(imported, attr), f"{module} has no attribute {attr!r}"
+
+
+class TestTheSharedKiroPathRatchet:
+    """A NEW import-time ``Path.home()`` binding must not land unpinned.
+
+    The fixture can only redirect what its table names, so the table is the guarded
+    set and this is what stops it from silently falling behind ``src/``. Deliberately
+    WIDER than the fixture acts on: an entry has to be either pinned or explicitly
+    excluded with a reason, so adding one forces a decision rather than an omission.
+    """
+
+    #: Import-time ``Path.home()`` bindings that deliberately need no redirect.
+    #: Each entry states why, in the same spirit as
+    #: ``test_spawn_preexec_guard.py``'s ``_ALLOWED``.
+    #:
+    #: Note the two shapes here are excluded for OPPOSITE reasons: the launchd paths
+    #: are already redirected somewhere else, while the security anchors must NOT be
+    #: redirected at all.
+    _EXCLUDED: dict[tuple[str, str], str] = {
+        # Already redirected, by the rootdir conftest's own ``_isolate_launchd_paths``
+        # fixture. It has to move the whole macOS launchd set together (PLIST_DIR,
+        # PLIST_PATH, LOG_DIR, STDOUT_LOG, STDERR_LOG, LIVE_PROGRAM) because both
+        # consumers import them by value.
+        ("kiro_crew/service/macos.py", "PLIST_DIR"): "covered by _isolate_launchd_paths",
+        ("kiro_crew/service/macos.py", "LOG_DIR"): "covered by _isolate_launchd_paths",
+        # NOT a data path -- a security MATCHER compiled from the real home. It exists
+        # to refuse `tar -C ~/.kiro/crew`, which can drop a `security_policy.json` or a
+        # `profiles/` entry into the governance trust root. Pointing it at a tmp dir
+        # would make every test that exercises it assert against a pattern that no
+        # longer matches the thing it protects -- weakening the guard to satisfy an
+        # isolation ratchet, which is backwards.
+        ("kiro_crew/security.py", "_EXTRACT_INTO_TRUST_ROOT_RE"): "security anchor: must name the REAL home",
+        # Also not redirectable: the home-anchoring IS the security property. These name
+        # OTHER products' credential stores (kiro-cli, amazon-q), and the module's own
+        # comment records that an entry either equals the home-anchored path inside
+        # `_SENSITIVE_HOME_DIRS`' fence or falls outside it and must not be trusted --
+        # so a redirected value would manufacture a forgeable "trusted" path. They are
+        # only ever READ, and `test_kiro_usage_api.py` stubs the tuples per test, which
+        # is the right seam: stub the READER, never move the anchor.
+        ("kiro_crew/dashboard/handlers/kiro_usage_api.py", "_CLI_SQLITE_DBS"): "security anchor: must name the REAL home",
+        ("kiro_crew/dashboard/handlers/kiro_usage_api.py", "_OTHER_SQLITE_DBS"): "security anchor: must name the REAL home",
+        # An ALLOW-LIST root, so the same rule applies from the other direction: the
+        # file browser's first permitted root is the operator's real home BY DESIGN,
+        # since that is the directory the user is entitled to browse. Redirecting it
+        # would make every containment test assert against a root that does not ship.
+        # Nothing here writes: the module reads the value to bound path resolution.
+        ("kiro_crew/apps/builtins/file_explorer/server.py", "_HOME"): "security anchor: the browsing allow-list root",
+    }
+
+    @staticmethod
+    def _home_bindings() -> dict[tuple[str, str], int]:
+        """Every module-level assignment whose value calls ``Path.home()``.
+
+        Parsed rather than grepped so a multi-line or parenthesised expression is
+        found too, and so a ``Path.home()`` inside a FUNCTION -- which is re-evaluated
+        per call and therefore already follows a patched home -- is correctly ignored.
+
+        Deliberately catches only a DIRECT call. A binding derived from another
+        (``PLIST_PATH = PLIST_DIR / "x.plist"``) is invisible here, so this is a
+        tripwire for the common shape rather than a completeness proof: pinning the
+        root of such a chain does not pin the leaves, which is why
+        ``_isolate_launchd_paths`` enumerates its whole set by hand.
+        """
+        found: dict[tuple[str, str], int] = {}
+        for path in sorted(_SRC.rglob("*.py")):
+            if "_vendor" in path.parts:
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (OSError, SyntaxError):  # pragma: no cover - unreadable source
+                continue
+            # Module SCOPE, not just ``tree.body``. The real cut is a FUNCTION or CLASS
+            # body, which is re-evaluated per call and so is not a value frozen at
+            # import. Note that is NOT the same as "already isolated": the floor pins
+            # neither ``Path.home()`` nor ``$HOME``, so a LAZY resolver
+            # (``config.paths.kiro_home()`` and its callers) still names the operator's
+            # real ``~/.kiro`` and this ratchet does not cover it. What this guards is
+            # precisely the import-time shape. Every other nested statement -- a
+            # module-level ``try:`` or a platform ``if:``, which is the normal shape for
+            # cross-platform code here -- still runs exactly once at import, so the
+            # "re-evaluated per call" reason for skipping it does not apply. Excluding
+            # the two scope-opening node kinds rather than enumerating control-flow
+            # kinds means ``match``, ``with`` and anything a later Python adds are
+            # covered without another edit.
+            pending: list[ast.stmt] = list(tree.body)
+            while pending:
+                node = pending.pop(0)
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    continue
+                pending.extend(
+                    child for child in ast.iter_child_nodes(node) if isinstance(child, ast.stmt)
+                )
+                if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                    continue
+                # A bare ``x: Path`` annotation binds nothing, and walking None raises.
+                if node.value is None:
+                    continue
+                calls_home = any(
+                    isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Attribute)
+                    and inner.func.attr == "home"
+                    for inner in ast.walk(node.value)
+                )
+                if not calls_home:
+                    continue
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                for target in targets:
+                    if isinstance(target, ast.Name):
+                        rel = path.relative_to(_REPO_ROOT / "src").as_posix()
+                        found[(rel, target.id)] = node.lineno
+        return found
+
+    def test_every_import_time_home_binding_is_pinned_or_excluded(self) -> None:
+        pinned = {
+            (module.replace(".", "/") + ".py", attr)
+            for module, attr, _relative in _root._SHARED_KIRO_PATHS
+        }
+        unhandled = {
+            key: line
+            for key, line in self._home_bindings().items()
+            if key not in pinned and key not in self._EXCLUDED
+        }
+
+        assert not unhandled, (
+            "these module-level Path.home() bindings are neither pinned by the rootdir "
+            "conftest's _SHARED_KIRO_PATHS nor excluded with a reason in _EXCLUDED:\n"
+            + "\n".join(f"    {mod}:{line} {attr}" for (mod, attr), line in sorted(unhandled.items()))
+            + "\nA test that reaches one of these writes the operator's real home. Pin it, "
+            "or exclude it and say why."
+        )
+
+    def test_the_exclusion_list_has_not_gone_stale(self) -> None:
+        """An exclusion for a binding that no longer exists hides the next one."""
+        bindings = self._home_bindings()
+        stale = [key for key in self._EXCLUDED if key not in bindings]
+
+        assert not stale, f"_EXCLUDED names bindings that no longer exist: {stale}"
+
+
+# ── the system temp directory ─────────────────────────────────────────────
+
+
+class TestTheTempBaseIsRedirected:
+    """``tempfile``'s base must be a per-run directory, not the shared temp root.
+
+    The point is not tidiness. A bare ``mkdtemp()`` whose cleanup is missing or skipped
+    used to leave its directory in the platform temp root forever, and MEASURED on the
+    hosts this was written against, ``/tmp`` is a tmpfs with a hard 1,048,576-INODE cap
+    that returns ENOSPC to unrelated processes while 90% of the BYTES are still free.
+    """
+
+    @pytest.mark.skipif(
+        bool(os.environ.get("KIROCREW_TMP_PER_TEST")),
+        reason="per-test diagnostic mode nests the base one level deeper on purpose",
+    )
+    def test_gettempdir_is_this_runs_own_root(self) -> None:
+        base = pathlib.Path(tempfile.gettempdir())
+
+        assert base.name.startswith(_root._TMP_ROOT_PREFIX), (
+            f"tempfile base is {base}, not a {_root._TMP_ROOT_PREFIX}* root -- the "
+            "redirect did not take effect"
+        )
+        assert base.is_dir()
+
+    def test_pytests_own_basetemp_is_not_inside_the_redirect(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """pytest resolves basetemp lazily from ``gettempdir()``, so ORDER decides this.
+
+        If the redirect wins the race, pytest's whole basetemp lands inside the run's
+        temp root -- which the session teardown deletes, taking every failed test's
+        retained ``tmp_path`` with it, and adding ~25 characters to every temp path in
+        the suite. ``_isolate_tempfile_base`` forces ``getbasetemp()`` before
+        redirecting to make that impossible; this is what keeps it that way.
+        """
+        assert not tmp_path.resolve().is_relative_to(
+            pathlib.Path(tempfile.gettempdir()).resolve()
+        ), f"pytest basetemp {tmp_path} is inside the redirected temp root"
+
+    def test_a_mkdtemp_with_no_dir_argument_lands_inside_it(self) -> None:
+        made = pathlib.Path(tempfile.mkdtemp())
+        try:
+            assert made.parent == pathlib.Path(tempfile.gettempdir())
+        finally:
+            made.rmdir()
+
+    def test_the_env_vars_carry_the_redirect_to_child_processes(self) -> None:
+        """A child re-derives its own temp dir, so the global alone is not enough.
+
+        All three names are set because the platforms disagree on which is real:
+        ``TMPDIR`` on POSIX, ``TEMP``/``TMP`` on Windows.
+        """
+        base = tempfile.gettempdir()
+
+        for name in _root._TMP_ENV_VARS:
+            assert os.environ.get(name) == base, f"{name} does not carry the redirect"
+
+    def test_the_root_name_carries_the_account_and_the_pid(self) -> None:
+        """A bare pid collides across accounts: POSIX shares one temp root.
+
+        Two accounts can hold the same pid simultaneously, so the account segment is what
+        keeps one run's root distinct from another's. The pid is carried for a HUMAN
+        reading a stray directory -- nothing parses it, and no code reclaims a root it did
+        not create.
+        """
+        prefix = _root._tmp_root_prefix_for_run()
+
+        assert prefix.startswith(_root._TMP_ROOT_PREFIX)
+        assert prefix.endswith(f"-{os.getpid()}-")
+        # the account segment sits between the two, and is non-empty
+        assert len(prefix) > len(_root._TMP_ROOT_PREFIX) + len(str(os.getpid())) + 2
+
+    def test_the_root_is_created_atomically_and_owner_only(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """A predictable name in a world-writable temp root is a hijack.
+
+        Another local account can pre-create the exact pid-derived name as a SYMLINK to a
+        directory it controls; ``mkdir(exist_ok=True)`` adopts it, the redirect follows it,
+        and every temp write in the run lands somewhere that account chose and can read.
+        ``mkdtemp`` closes it three ways: a random component nobody can guess ahead of
+        time, ``O_EXCL`` so nothing existing is adopted, and mode 0o700.
+        """
+        made = _root._create_tmp_root(tmp_path)
+
+        assert made.is_dir() and not made.is_symlink()
+        assert made.parent == tmp_path
+        assert made.name.startswith(_root._tmp_root_prefix_for_run())
+        # A random component after the pid is what makes the name unguessable.
+        assert made.name != _root._tmp_root_prefix_for_run().rstrip("-")
+        if os.name != "nt":  # POSIX mode bits; Windows uses ACLs
+            assert (made.stat().st_mode & 0o777) == 0o700
+
+    def test_two_roots_in_the_same_process_never_collide(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Which also proves nothing pre-existing is ever adopted."""
+        first = _root._create_tmp_root(tmp_path)
+        second = _root._create_tmp_root(tmp_path)
+
+        assert first != second
+
+
+class TestTheTempResidueReport:
+    """Residue must be REPORTED, not just relocated somewhere pytest prunes."""
+
+    def test_it_names_what_was_left_behind(self, tmp_path: pathlib.Path) -> None:
+        message = _root._tmp_residue_report(tmp_path, ["tmpleaked"], per_test=False)
+
+        assert "tmpleaked" in message
+        # The fix belongs in the message: an rmtree in tearDown is the shape that
+        # leaks, because unittest skips tearDown entirely when setUp raises.
+        assert "addCleanup" in message
+        assert _root._TMP_PER_TEST_ENV in message
+
+    def test_a_third_party_or_by_design_entry_is_not_residue(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """A guard that cries wolf gets deleted, and then it protects nothing.
+
+        Redirecting `tempfile`'s base also redirects every CHILD's, so the browser and
+        its driver put their scratch here too, and production's deliberately-persistent
+        screenshot spool lands here rather than in the real temp root. None of that is a
+        test forgetting to clean up.
+        """
+        for name in ("kirocrew-computer-shots", "playwright-transform-cache-1001",
+                     ".org.chromium.Chromium.AHpK6x"):
+            (tmp_path / name).mkdir()
+
+        assert _root._tmp_residue(tmp_path, per_test=False) == []
+
+    def test_it_stays_silent_when_nothing_was_left(self, tmp_path: pathlib.Path) -> None:
+        assert _root._tmp_residue(tmp_path, per_test=False) == []
+
+    def test_a_nested_pytests_basetemp_is_not_residue(self, tmp_path: pathlib.Path) -> None:
+        """Several tests spawn a nested pytest, which computes its own basetemp inside
+        ours because it resolves ``gettempdir()`` after the redirect. That is a child
+        runner's bookkeeping, with its own retention, not residue this suite dropped."""
+        (tmp_path / "pytest-of-someone").mkdir()
+
+        assert _root._tmp_residue(tmp_path, per_test=False) == []
+
+    def test_per_test_mode_reports_the_leaf_not_the_test_directory(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """In per-test mode the immediate children are bases the fixture itself made.
+
+        Reporting those would name every test in the run as its own leak and answer
+        nothing -- the whole point of the mode is that the leaf's PARENT is the test id.
+        """
+        (tmp_path / "test_guilty").mkdir()
+        (tmp_path / "test_guilty" / "tmpleaked").mkdir()
+        (tmp_path / "test_innocent").mkdir()
+
+        assert _root._tmp_residue(tmp_path, per_test=True) == ["test_guilty/tmpleaked"]
+
+    def test_an_unreadable_base_is_not_reported_as_residue(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """A guard that reds the suite on an unanswerable question gets deleted, and
+        then it protects nothing."""
+        assert _root._tmp_residue(tmp_path / "does-not-exist", per_test=False) == []
+
+
+# ── the process working directory ──────────────────────────────────────────
+
+
+#: Written by one test and asserted by the next: a failure raised inside a finalizer
+#: is reported as a teardown error against an innocent test id.
+_CWD_ORDER: dict[str, str] = {}
+
+
+class TestTheWorkingDirectoryIsRestored:
+    """The CWD is per-PROCESS, so one test's ``os.chdir`` is every later test's start.
+
+    Survivable only while the directory outlived the run. With
+    ``tmp_path_retention_policy = failed`` a passing test's ``tmp_path`` is removed at that
+    test's own teardown, so a leaked CWD leaves the worker in a DELETED directory and
+    ``Path.cwd()`` then raises ``FileNotFoundError`` in every later test that reaches it --
+    including inside production code (``TaskRunner.__init__`` does ``work_dir or Path.cwd()``).
+    """
+
+    def test_this_test_starts_somewhere_real(self) -> None:
+        """Which is only true if no earlier test on this worker leaked its directory."""
+        assert pathlib.Path.cwd().is_dir()
+
+    def test_a_chdir_is_undone_before_fixture_finalizers_run(
+        self, tmp_path: pathlib.Path, request: pytest.FixtureRequest
+    ) -> None:
+        """ORDER, not just eventual restoration -- and it is load-bearing on Windows.
+
+        An outer autouse FIXTURE would tear down LAST, after ``tmp_path`` cleanup had
+        already tried to remove a directory the process was still sitting in; Windows
+        refuses to delete its own working directory, so that cleanup fails there. A
+        ``tryfirst`` ``pytest_runtest_teardown`` hookimpl runs before the default one,
+        which is what performs fixture finalization -- so a finalizer registered here
+        observes the CWD already restored.
+
+        The observation is asserted by the NEXT test rather than in a finalizer, because a
+        failure raised inside a finalizer is reported as a teardown error against an
+        innocent-looking test id.
+        """
+        _CWD_ORDER["expected"] = os.getcwd()
+        request.addfinalizer(lambda: _CWD_ORDER.__setitem__("at_finalizer", os.getcwd()))
+
+        os.chdir(tmp_path)
+        assert pathlib.Path.cwd().samefile(tmp_path)
+
+    def test_the_finalizer_saw_the_cwd_already_restored(self) -> None:
+        """Reads what the previous test recorded. Ordered by definition order in the file."""
+        assert _CWD_ORDER.get("at_finalizer") == _CWD_ORDER.get("expected"), (
+            f"CWD at fixture-finalizer time was {_CWD_ORDER.get('at_finalizer')!r}, "
+            f"expected {_CWD_ORDER.get('expected')!r} -- the restore ran too late, so "
+            "tmp_path cleanup would be asked to delete the process's own directory"
+        )
+
+
+# ── the worker budget ─────────────────────────────────────────────────────
+
+
+class TestTheWorkerBudgetIsMemoryBounded:
+    """How many xdist workers the host can actually back, not just how many cores.
+
+    Cores alone oversubscribe: two worktrees each taking 10 workers on a 10-core box
+    once produced a load average of ~590 with zero tests completing in 21 minutes. But
+    TOTAL RAM alone is also the wrong number -- it is the MACHINE's, so it over-reports
+    inside a memory-capped container and says nothing about a host already using most
+    of its memory for something else.
+
+    The failure mode that matters most here is the inverted one: a reading that comes
+    back wrongly SMALL collapses the whole run to one worker, which looks like a hang
+    rather than a bug. So each reading must degrade to "skip this bound", never to zero.
+    """
+
+    @pytest.fixture
+    def slot_dir_env(self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+        """Point the host-global slot directory at a tmp dir, and release what is taken.
+
+        Mirrors ``test_xdist_host_budget.py``'s ``slot_dir``, and both halves matter. The
+        real slot directory is under ``~/.cache``, shared with every other run on the
+        machine, so a test that claims slots must not compete there. And a claim HOLDS an
+        open file descriptor for the process lifetime by design -- that is how the kernel
+        owns the lease -- so the descriptors have to be closed here or the test keeps real
+        capacity for the rest of the session, and on Windows the open handle also blocks
+        ``tmp_path`` cleanup and fails teardown.
+
+        ``_held_slots`` is REPLACED rather than cleared, so the suite's own list is never
+        touched and ``monkeypatch`` restores it even if the test fails.
+        """
+        import conftest as suite_conftest
+
+        monkeypatch.setenv(suite_conftest._SLOT_DIR_ENV, str(tmp_path / "slots"))
+        held: list[int] = []
+        monkeypatch.setattr(suite_conftest, "_held_slots", held)
+        yield tmp_path
+        for fd in held:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    def test_every_reading_is_optional_and_the_tightest_wins(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import conftest as suite_conftest
+
+        monkeypatch.setattr(suite_conftest, "_host_total_gib", lambda: 64)
+        monkeypatch.setattr(suite_conftest, "_cgroup_limit_mib", lambda: 8 * 1024)
+        monkeypatch.setattr(suite_conftest, "_host_available_mib", lambda: 0)
+
+        # 8 GiB ceiling at 2 GiB/worker is the tightest real reading, and the
+        # unavailable one (0) is skipped rather than read as "no memory".
+        assert suite_conftest._static_memory_bounded_capacity(32) == 4
+
+    def test_a_starved_host_is_bounded_rather_than_read_as_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The inversion this unit choice exists to prevent.
+
+        In whole GiB, 860 MiB free truncates to 0 -- indistinguishable from "could not
+        determine", which is SKIPPED. The live bound would therefore drop out on exactly
+        the starved host it protects, leaving the static total-RAM term to allow 16
+        workers on under a gigabyte of free memory.
+        """
+        import conftest as suite_conftest
+
+        monkeypatch.setattr(suite_conftest, "_host_available_mib", lambda: 860)
+
+        assert suite_conftest._live_memory_bounded_cap(32) == 1
+
+    def test_a_small_container_ceiling_is_not_read_as_no_ceiling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same inversion, reached through the cgroup reading instead."""
+        import conftest as suite_conftest
+
+        monkeypatch.setattr(suite_conftest, "_host_total_gib", lambda: 256)
+        monkeypatch.setattr(suite_conftest, "_cgroup_limit_mib", lambda: 512)
+        monkeypatch.setattr(suite_conftest, "_host_available_mib", lambda: 0)
+
+        assert suite_conftest._static_memory_bounded_capacity(32) == 1
+
+    def test_the_static_bound_shapes_the_shared_range_not_just_this_run(
+        self, monkeypatch: pytest.MonkeyPatch, slot_dir_env: pathlib.Path
+    ) -> None:
+        """The memory budget is SHARED between concurrent runs, not granted to each.
+
+        This is the property that decides where each bound goes. A 64-core / 32 GiB host
+        can back 16 workers, so there must be 16 SLOTS in total -- a first run takes them
+        all and a second gets its floor. Put the static bound only on the per-run cap and
+        both runs take 16 each: 32 workers against a 16-worker budget, which is the
+        swapping incident the budget exists to prevent, reached from the other end.
+        """
+        import conftest as suite_conftest
+
+        monkeypatch.setattr(os, "cpu_count", lambda: 64)
+        monkeypatch.setattr(suite_conftest, "_host_total_gib", lambda: 32)
+        monkeypatch.setattr(suite_conftest, "_cgroup_limit_mib", lambda: 0)
+        monkeypatch.setattr(suite_conftest, "_host_available_mib", lambda: 0)
+        monkeypatch.delenv(suite_conftest._MAX_WORKERS_ENV, raising=False)
+
+        first = suite_conftest.pytest_xdist_auto_num_workers(None)
+        # A second run in this same process cannot re-lock what it already holds, so the
+        # slot RANGE is what the assertion has to pin: 16, never 64.
+        assert first == 16
+        assert suite_conftest._static_memory_bounded_capacity(64) == 16
+
+    def test_the_live_bound_does_not_shrink_the_shared_range(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The other half: a transient reading must not reshape the namespace.
+
+        Slots fill from index 0, so a range shortened by a momentary dip excludes exactly
+        the slots an earlier run left free -- collapsing the later run while the machine
+        idles.
+        """
+        import conftest as suite_conftest
+
+        monkeypatch.setattr(suite_conftest, "_host_total_gib", lambda: 128)
+        monkeypatch.setattr(suite_conftest, "_cgroup_limit_mib", lambda: 0)
+        monkeypatch.setattr(suite_conftest, "_host_available_mib", lambda: 2048)
+
+        assert suite_conftest._static_memory_bounded_capacity(32) == 32
+
+    def test_an_unavailable_reading_never_collapses_the_run(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """macOS has no /proc/meminfo and no /sys/fs/cgroup; Windows raises on
+        ``os.sysconf``. All three readings returning 0 must leave the core count
+        standing."""
+        import conftest as suite_conftest
+
+        monkeypatch.setattr(suite_conftest, "_host_total_gib", lambda: 0)
+        monkeypatch.setattr(suite_conftest, "_cgroup_limit_mib", lambda: 0)
+        monkeypatch.setattr(suite_conftest, "_host_available_mib", lambda: 0)
+
+        assert suite_conftest._static_memory_bounded_capacity(12) == 12
+
+    def test_a_tiny_host_still_gets_one_worker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Slow beats stalled: the floor is one worker, never zero."""
+        import conftest as suite_conftest
+
+        monkeypatch.setattr(suite_conftest, "_host_total_gib", lambda: 1)
+        monkeypatch.setattr(suite_conftest, "_cgroup_limit_mib", lambda: 0)
+        monkeypatch.setattr(suite_conftest, "_host_available_mib", lambda: 1024)
+
+        assert suite_conftest._static_memory_bounded_capacity(8) == 1
+
+    @pytest.mark.parametrize(
+        ("kb", "expected"),
+        [
+            (99_328_704, 97_000),  # a large host, in whole MiB
+            (8_388_608, 8192),
+            (1_048_576, 1024),  # exactly 1 GiB
+            (900_000, 878),  # under 1 GiB: a REAL reading, not the unknown sentinel
+            (500, 0),  # half a MiB: genuinely below the resolution, reads as unknown
+        ],
+    )
+    def test_meminfo_is_parsed_into_whole_mib(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, kb: int, expected: int
+    ) -> None:
+        """Parsing is asserted against a FIXTURE, never against the live host.
+
+        ``assert available > 0`` on the real reading looks like a smoke test and is
+        actually the wall-clock-race flake class applied to memory: the value truncates
+        to whole GiB, so any host with under 1 GiB free returns 0 -- which is the
+        function's own "could not determine" sentinel, i.e. a CORRECT return that the
+        assertion would call a failure. Small CI containers are the most exposed.
+        """
+        import conftest as suite_conftest
+
+        meminfo = tmp_path / "meminfo"
+        meminfo.write_text(
+            f"MemTotal:       131549320 kB\nMemAvailable:   {kb} kB\nBuffers: 1 kB\n",
+            encoding="utf-8",
+        )
+        real_open = open
+
+        def _fake(path, *args, **kwargs):
+            if str(path) == "/proc/meminfo":
+                return real_open(meminfo, *args, **kwargs)
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", _fake)
+
+        assert suite_conftest._host_available_mib() == expected
+
+    @pytest.mark.skipif(
+        not pathlib.Path("/proc/meminfo").exists(), reason="Linux-only reading"
+    )
+    def test_available_never_exceeds_total_on_a_real_host(self) -> None:
+        """The one invariant that holds at ANY memory level, so it cannot flake."""
+        import conftest as suite_conftest
+
+        assert suite_conftest._host_available_mib() <= suite_conftest._host_total_gib() * 1024
+
+    def test_a_missing_meminfo_is_reported_as_unknown_not_as_zero_memory(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+    ) -> None:
+        """Stands in for macOS and Windows, where the file does not exist at all."""
+        import conftest as suite_conftest
+
+        real_open = open
+
+        def _no_meminfo(path, *args, **kwargs):
+            if str(path) == "/proc/meminfo":
+                raise FileNotFoundError(path)
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", _no_meminfo)
+
+        assert suite_conftest._host_available_mib() == 0
+
+    def test_an_unlimited_cgroup_is_not_read_as_a_ceiling(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+    ) -> None:
+        """cgroup v2 spells "no limit" as the literal ``max``.
+
+        v1 instead uses a huge sentinel (0x7FFFFFFFFFFFF000), which needs no special
+        case: divided into GiB it is a number no ``min()`` will ever pick. Both are
+        exercised here because the two files are read in the same loop.
+        """
+        import conftest as suite_conftest
+
+        limit_file = tmp_path / "memory.max"
+        limit_file.write_text("max\n", encoding="utf-8")
+        v1_file = tmp_path / "memory.limit_in_bytes"
+        v1_file.write_text(f"{0x7FFFFFFFFFFFF000}\n", encoding="utf-8")
+
+        real_open = open
+
+        def _fake_cgroup(path, *args, **kwargs):
+            if str(path) == "/sys/fs/cgroup/memory.max":
+                return real_open(limit_file, *args, **kwargs)
+            if str(path) == "/sys/fs/cgroup/memory/memory.limit_in_bytes":
+                return real_open(v1_file, *args, **kwargs)
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", _fake_cgroup)
+
+        # "max" is skipped outright; the v1 sentinel converts to a ceiling far above
+        # any real core count, so neither can bind.
+        assert suite_conftest._static_memory_bounded_capacity(8) <= 8
+        assert suite_conftest._cgroup_limit_mib() >= 8 * 1024
+
+    def test_a_real_cgroup_ceiling_binds(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+    ) -> None:
+        """The container case: 8 GiB inside a cgroup on a 256 GiB machine."""
+        import conftest as suite_conftest
+
+        limit_file = tmp_path / "memory.max"
+        limit_file.write_text(str(8 * 1024**3), encoding="utf-8")
+        real_open = open
+
+        # Falls THROUGH for every other path rather than raising. `builtins.open` is
+        # shared by every thread in this worker, and the SEL writer is a session-lived
+        # daemon thread that opens a file on each flush -- a blanket raise would hand it
+        # FileNotFoundError for a path that exists, and could kill the writer so that a
+        # later, unrelated SEL test on this worker fails for a reason it cannot see.
+        def _fake_cgroup(path, *args, **kwargs):
+            if str(path) == "/sys/fs/cgroup/memory.max":
+                return real_open(limit_file, *args, **kwargs)
+            if str(path) == "/sys/fs/cgroup/memory/memory.limit_in_bytes":
+                raise FileNotFoundError(path)
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", _fake_cgroup)
+
+        assert suite_conftest._cgroup_limit_mib() == 8 * 1024

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -216,9 +216,13 @@ class TestKiroPrerequisiteHelpers:
         real_open = os.open
         real_read = os.read
 
-        def windows_open(path: str, flags: int, mode: int = 0o777) -> int:
+        # ``**kwargs`` because this replaces the os module attribute, so it is live for
+        # the whole test INCLUDING teardown, where pytest's own tmp_path cleanup calls
+        # os.open with dir_fd=. A stub narrower than the API it stands in for turns that
+        # cleanup into a TypeError reported as an error at teardown.
+        def windows_open(path: str, flags: int, mode: int = 0o777, **kwargs: object) -> int:
             real_flags = flags if native_binary_flag else flags & ~binary_flag
-            fd = real_open(path, real_flags, mode)
+            fd = real_open(path, real_flags, mode, **kwargs)  # type: ignore[arg-type]
             if flags & binary_flag:
                 binary_fds.add(fd)
             return fd

--- a/test/test_learn.py
+++ b/test/test_learn.py
@@ -10,8 +10,20 @@ from unittest.mock import patch
 
 import pytest
 
+import kiro_crew.learn as learn_mod
 from kiro_crew.atomic_write import replace_with_retry
-from kiro_crew.learn import _DEFAULT_DIR, Lesson, LessonStore
+from kiro_crew.learn import Lesson, LessonStore
+
+# Read through the MODULE, never `from kiro_crew.learn import _DEFAULT_DIR`.
+# ``_DEFAULT_DIR`` is a ``Path.home()``-derived literal, so the isolation floor in the
+# rootdir conftest redirects it per test to keep the fallback from writing the
+# operator's real data home. A by-value capture at import time would freeze the
+# pre-redirect path and compare against a directory the code under test no longer
+# names — the assertion would fail while the behaviour was correct.
+
+
+def _default_dir() -> Path:
+    return learn_mod._DEFAULT_DIR
 
 
 def _make_lesson(rule: str, category: str = "knowledge", negative: str | None = None) -> Lesson:
@@ -78,7 +90,7 @@ class TestLessonStoreSecurity:
         sensitive.mkdir()
         with patch("kiro_crew.security.is_sensitive_path", return_value=True):
             store = LessonStore(base_dir=sensitive)
-        assert store._dir == _DEFAULT_DIR
+        assert store._dir == _default_dir()
 
     def test_sensitive_base_dir_emits_sel_audit(self, tmp_path: Path) -> None:
         sensitive = tmp_path / ".aws"
@@ -104,7 +116,7 @@ class TestLessonStoreSecurity:
             ),
         ):
             store = LessonStore(base_dir=sensitive)
-        assert store._dir == _DEFAULT_DIR
+        assert store._dir == _default_dir()
 
     def test_sensitive_config_dir_falls_back_to_default(self, tmp_path: Path) -> None:
         sensitive = tmp_path / ".kirocrew-sensitive"
@@ -114,17 +126,17 @@ class TestLessonStoreSecurity:
             patch("kiro_crew.security.is_sensitive_path", return_value=True),
         ):
             store = LessonStore()
-        assert store._dir == _DEFAULT_DIR
+        assert store._dir == _default_dir()
 
     def test_config_dir_exception_falls_back_to_default(self) -> None:
         with patch("kiro_crew.learn._config_dir", side_effect=OSError("broken loader")):
             store = LessonStore()
-        assert store._dir == _DEFAULT_DIR
+        assert store._dir == _default_dir()
 
     def test_config_dir_none_falls_back_to_default(self) -> None:
         with patch("kiro_crew.learn._config_dir", None):
             store = LessonStore()
-        assert store._dir == _DEFAULT_DIR
+        assert store._dir == _default_dir()
 
     def test_non_sensitive_base_dir_used_directly(self, tmp_path: Path) -> None:
         with patch("kiro_crew.security.is_sensitive_path", return_value=False):

--- a/test/test_platform_compat_coverage.py
+++ b/test/test_platform_compat_coverage.py
@@ -1391,7 +1391,9 @@ class TestLinkHelpers:
         victim.mkdir()
         calls: list[str] = []
         monkeypatch.setattr(pc, "_ISJUNCTION", lambda _p: True)
-        monkeypatch.setattr(pc.os, "rmdir", lambda p: calls.append(str(p)))
+        # ``**_`` because this replaces the os module attribute for the whole test,
+        # teardown included, and os.rmdir really takes dir_fd=.
+        monkeypatch.setattr(pc.os, "rmdir", lambda p, **_: calls.append(str(p)))
         pc.unlink_link_or_junction(victim)
         assert calls == [str(victim)]
 

--- a/test/test_xdist_host_budget.py
+++ b/test/test_xdist_host_budget.py
@@ -48,6 +48,24 @@ def slot_dir(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib
             pass
 
 
+@pytest.fixture(autouse=True)
+def _deterministic_live_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the LIVE memory readings to "unknown" for every test in this file.
+
+    The budget takes the tightest of three readings, and two of them describe the host
+    AT THIS MOMENT: the cgroup ceiling and ``MemAvailable``. Left live, a test asserting
+    that a big host reaches the worker cap measures whatever else is running on the
+    machine -- it passed on an idle host and returned 14 instead of 32 on the same
+    32-core box while another suite held memory. That is the wall-clock-race flake class
+    applied to memory instead of time.
+
+    "Unknown" (0) rather than a large number, because that is the reading these tests
+    want out of the way; each test then declares the ceiling it is actually about.
+    """
+    monkeypatch.setattr(ct, "_cgroup_limit_mib", lambda: 0)
+    monkeypatch.setattr(ct, "_host_available_mib", lambda: 0)
+
+
 @pytest.fixture
 def budget_host(slot_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
     """A deterministic 10-core / 32 GiB host, so only contention varies."""
@@ -345,6 +363,33 @@ def test_claim_fails_open_when_the_dir_cannot_be_made(
     monkeypatch.setattr(ct, "_held_slots", [])
 
     assert ct._claim_worker_slots(8, 64) == 8
+    assert ct._held_slots == []
+
+
+def test_an_unwritable_slot_dir_drops_to_one_worker_and_says_why(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A directory that EXISTS but cannot be written is the case ``mkdir`` misses.
+
+    ``mkdir(exist_ok=True)`` succeeds on it -- Linux reports EEXIST before it checks
+    write permission -- so the failure only appears at the first ``os.open``. It must NOT
+    fail open to the unbudgeted ceiling: if this run cannot take a lock then neither can a
+    concurrent one, so both would get the full cap with no coordination, which is the
+    oversubscription the budget exists to prevent. One worker, and a warning naming the
+    fix, because a silent hour-long suite is a bug nobody can see.
+    """
+    monkeypatch.setattr(ct, "_held_slots", [])
+    real_open = os.open
+
+    def _deny(path, *args, **kwargs):
+        if "worker-" in str(path):
+            raise PermissionError(13, "read-only", str(path))
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(ct.os, "open", _deny)
+
+    with pytest.warns(UserWarning, match=ct._SLOT_DIR_ENV):
+        assert ct._claim_worker_slots(16, 16) == 1
     assert ct._held_slots == []
 
 


### PR DESCRIPTION
## Problem / Motivation

Two symptoms, one root cause.

**The suite could damage the machine it ran on.** `setup.cfg`'s `testpaths` collects three
trees, but `test/conftest.py` — which holds almost all of the isolation — applies only to
`test/`. The ~108 test modules that ship *inside the package* under
`src/kiro_crew/apps/builtins/*/tests/` see the rootdir `conftest.py` and nothing else, and
that file did not pin `KIROCREW_HOME`. So any of them that touched `config_dir()` resolved the
operator's live data home — and resolving it is not a read: it *creates* the home and its
marker, and can run the one-time `~/.kirocrew` → `~/.kiro/crew` migration as a side effect.
Two of the eight app suites had grown their own redirect fixture; the other six had not.

**The suite consumed enough of `/tmp` to break unrelated processes.** `/tmp` is commonly a
tmpfs with a fixed **inode** budget — 1,048,576 on the host this was measured on — and it
returns `ENOSPC` to every other process on the machine while 90% of the bytes are still free,
so it does not look like a disk problem. Measured on `origin/main`: one full `test/ transfer`
run at `-n 8` leaves **375,780 inodes** behind and consumes **411,751** while running. Two
consecutive runs exhaust the host. A third, run on the exhausted host, reported **22,098
errors** that were nothing but `ENOSPC` — and it took down the shell of every other process on
the box, including the tooling that was trying to diagnose it.

## Why it matters

The first is a correctness-of-the-development-environment problem with a nasty shape: it fails
**silently and asymmetrically**. An in-package test that assumes `test/conftest.py`'s fixtures
is green in CI — where the operator's home is empty — and quietly writes a developer's real
install locally. `~/.kiro/settings/mcp.json` is the *live agent's* MCP server list.

The second is why "the suite is flaky" reads as unfixable. A leaked side effect is not merely
untidy: under `-n auto --dist loadgroup` it is *the input to another test on the same worker*,
so it surfaces as a failure in a file nobody touched. The worked example found here is the
one that motivated the whole change (below): a single leaked working directory produced the
large majority of a 124-failure run across ~10 files, **every one of which passes in
isolation**.

## What changed (motivation → approach → change)

The fix is structural, not a list of per-test corrections: put the guards where they apply to
every testpath, and make the leak *visible and self-limiting* instead of silently accumulating.

**The rootdir `conftest.py` becomes the explicit host-mutation floor** — everything in it
protects the developer's machine rather than the correctness of one suite. It gains:

- `KIROCREW_HOME` pinned per test, with `config.paths._resolved_home` reset alongside it
  (`config_dir()` memoises for the process lifetime, and one xdist worker runs thousands of
  tests).
- **`_isolate_shared_kiro_paths`** — the `~/.kiro` paths production binds at *import* time from
  `Path.home()`. That directory is kiro-cli's own machine-wide home, shared with the real
  installed agent, so it is a **separate isolation axis** from the data home, and the env var
  cannot reach it because the module captured an absolute path first.
- **`_isolate_sel_default_dir`, moved here from `test/conftest.py`.** This was the root cause of
  a stray directory left on every run of the ops-mission-control suite, and it is worth stating
  because no amount of tidier cleanup fixes it: `SecurityEventLog` is a process singleton whose
  writer is a **daemon thread**, and `_init_locked` binds its directory *once*, from whatever
  `_default_dir()` resolved at that moment. So the first test to call `sel()` fixed it for the
  whole worker, the thread kept writing there after that test ended, and `_flush_batch` opens
  with `mkdir(parents=True, exist_ok=True)` — **re-creating the directory after the test's own
  `tearDown` had removed it**. The stack came from `sel-writer`, not from any test. The fix is a
  session-scoped directory that belongs to no individual test.
- **`_isolate_tempfile_base`** — `tempfile`'s base is redirected per run to
  `<platform temp>/kc-pytest-<user>-<pid>`; residue there is **reported** and the root is then
  removed, so the accumulation stops regardless of whether anyone acts on the report.
  Relocation is not absolution — but the report **warns** rather than failing, gated behind
  `KIROCREW_TMP_RESIDUE_STRICT=1`, and that is a staged rollout with a filed owner
  (**#4081**), not a shrug. When the guard first ran on CI it found residue on surfaces this
  developer host cannot reach; two classes were not test residue at all and are now excluded
  by name with reasons (the computer-use screenshot spool, a deliberately persistent ring
  buffer; and the scratch Chromium and the Playwright driver create, because a child inherits
  the redirected `TMPDIR`). What remains is a handful of single `mkstemp` **files**, several
  written by production code a test merely reached — one inode each, not the `mkdtemp`
  directories the rule is about. Failing the suite on that set today would block every
  unrelated change while it is attributed, and a guard that blocks unrelated work is a guard
  somebody deletes. It resolves pytest's `basetemp`
  *before* redirecting, so pytest's own tree can never land inside the root this fixture
  deletes. It sits beside the platform temp root rather than under `basetemp` deliberately:
  nesting there would add ~60 characters to every temp path in the suite and trade an inode
  leak for the Windows 260-character cap and the macOS `AF_UNIX` 104-byte cap. The root is
  created with `mkdtemp` at mode `0o700`, so a predictable name in a world-writable temp root
  cannot be pre-created as a symlink and adopted.

  **A run only ever deletes the root it created itself.** An earlier revision swept roots left
  by killed runs, gated on a pid-liveness probe; review produced two separate blocking findings
  against it (a pre-created symlink being adopted, then a pid being meaningless across PID
  namespaces) and the second is right about the general case — every signal for "that directory
  is abandoned" is unsound from inside a test process. So the sweep is gone rather than patched
  a third time, which makes the class unreachable instead of the next instance of it. The cost
  is stated rather than hidden: a run killed before its teardown leaves **one** directory for
  the platform to reclaim (`systemd-tmpfiles`, macOS's periodic cleanup, a tmpfs cleared on
  reboot) — a job the platform already owns, with information this process does not have.
- **`_restore_cwd`** — the working directory is per-*process*, so one `os.chdir` became every
  later test's starting directory on that worker. Survivable only while that directory outlived
  the run; with the retention change below, a test that chdirs into `tmp_path` and does not come
  back leaves the worker in a **deleted** directory, and `Path.cwd()` then raises
  `FileNotFoundError` inside production code (`TaskRunner.__init__` does `work_dir or Path.cwd()`).
- `pytest_collection_modifyitems` moved here too: `windows-expected-failures.txt` already names
  node ids under `auto_improvement/tests/`, and a hook rooted at `test/` never runs when only
  in-package tests are collected — which is exactly what CI's reduced-scope Windows job does.
- **The other real host paths, moved for the same reason** — the subagent registry (a running
  gateway sweeps stray entries there as orphans and floods its log), the 610MB embedding-model
  download, and the agent-state sidecar. All three were `test/`-only, so an in-package test
  that spawned a subagent wrote the operator's real registry and one that reached the
  embeddings boot path could start that download. Raised in review as an acknowledged sibling
  of the root cause; now that the isolation dirs are lazy, moving them costs nothing.

**Then reduce what the suite consumes.** `_isolation_dirs` now returns a **path** and creates
nothing at all: every consumer only needs somewhere to point, and creates the directory itself if
it ever writes (`config_dir()` creates the data home, `create_agent_folder` creates the subagent
registry, `OLLAMA_MODELS` is only read). Creating them eagerly cost a `mkdir` per name on *every*
test and left the directories for the whole session, because they are not `tmp_path` dirs and no
retention policy reaches them — **366,716 of one run's 372,126 basetemp inodes, 98.5%**, most of
them empty. (An earlier revision carried a `create=True` escape hatch; review pointed out it had
zero callers, so it is gone — a future consumer can `mkdir` at its own site, where the reason is
visible.) `setup.cfg` also keeps a `tmp_path` only for tests that **failed**, the only ones
anyone ever opens.

**The xdist worker budget** now bounds by the cgroup ceiling and currently-available memory, not
total RAM alone: total is the *machine's* number, so it over-reports inside a memory-capped
container and says nothing about a host already using its RAM for something else. Three
corrections came out of review of that change and each is worth naming:

- The two bounds go to **different places**, and which one goes where is the whole correctness
  argument. The **static** readings (total RAM, cgroup ceiling) shape the shared slot **range**,
  because they are host constants and every run must compute the same range for sharing to mean
  anything — 32 GiB is 16 slots *in total*, so two runs share 16 workers rather than taking 16
  each. The **live** reading bounds only this run's **cap**, because slots fill from index 0 and
  a range shortened by a transient dip excludes precisely the slots a concurrent run left free.
  My first attempt put the whole term on the cap, which review correctly caught as turning a
  shared budget into a per-run grant.
- The cgroup ceiling is read from the process's **own** cgroup and its ancestors. Under cgroup
  v2 the root has no `memory.max` file at all, so the original root-only read was dead code
  except under a cgroup namespace.
- The live reading gets a smaller per-worker reservation than the static ceilings, by kind
  rather than by preference: `MemAvailable` is *already* the current headroom, so reserving 4×
  on top of it double-counts and refuses 32 workers on 32 idle cores.
- An unwritable slot directory drops to the one-worker floor **with a warning naming the fix**,
  rather than failing open. `mkdir(exist_ok=True)` succeeds on a directory that exists but cannot
  be written — Linux reports EEXIST before it checks permission — so the failure only surfaces at
  the first `os.open`. Fail-open is wrong specifically *here* because the failure is not local:
  if this run cannot take a lock then a concurrent one cannot either, so both would get the full
  cap with no coordination. My first attempt failed open and review caught it.

**Tests corrected rather than worked around.** Each of these was passing for the wrong reason:

- `ops_mission_control/tests/test_security.py` handed a *runtime-resolved* path to a
  **home-anchored** matcher. `is_sensitive_bash_command` matches on `_CREW_HOME_PREFIXES`
  literals, so under proper isolation it cannot match a tmp path — meaning the assertion passed
  only while the suite was reading the operator's real home, and it reported a guarantee it had
  never checked. It now iterates the home forms, exactly as its own sibling test for the
  incidents index already did. This surfaced a real asymmetry that is **left for a follow-up**
  because it is a change to the security keystone and deserves its own review: the tool gate
  (`is_sensitive_write_path`) resolves through `config_dir()` and *does* follow a custom
  `KIROCREW_HOME`, while the bash gate does not — so a custom-home install has that file
  protected against the agent's file tools but not against a bash redirect naming the resolved
  path. Recorded in a comment at the site, and filed as **#4082** so it has an owner rather
  than living only in a docstring.
- Five tests stubbed an `os.*` function with a **narrower signature than the API it replaces**.
  They patch the `os` module attribute, so the stub is live through teardown, where pytest's own
  cleanup now calls `os.unlink`/`os.open`/`os.rmdir` with `dir_fd=` — a `TypeError` reported as
  an error at teardown.
- `test_dev_fleet_app.py`'s sandbox containment check used `gettempdir()` as a proxy for "is this
  in a sandbox". It now asserts containment in the tree the test actually built, which is exact:
  "somewhere under the system temp dir" is satisfied by any tmp path, whereas "inside the tree
  this test built" is satisfied only by the redirect having taken effect.
- The worker-budget tests read the host's live free memory, so they measured whatever else was
  running on the box — the wall-clock-race flake class applied to memory instead of time. One
  returned 14 instead of 32 on an otherwise-green tree.

**Documentation, in the same commit as the behaviour.** `docs/system-specs/common/testing-conventions.md`
gains a "which conftest you are standing on" table, the `addCleanup`-versus-`tearDown` rule with
the reason (`unittest` skips `tearDown` entirely when `setUp` raises, so an `rmtree` there leaks
on exactly the failing runs nobody watches), the CWD rule, and the background-worker rule.
`AGENTS.md` and `AUTOSDE.yaml`'s `no-test-side-effects` rule are updated to match — the previous
text said the rootdir conftest "does NOT pin KIROCREW_HOME", which is now false. A new
`kirocrew-dev/writing-tests` skill carries the decision order for authoring a test, so it loads
on "writing a test" rather than only on worktree work.

## Tests

`test/test_host_isolation_floor.py` (new, 40 tests) ratchets the whole floor, in the two-part
shape `test_host_service_guard.py` already uses — prove the guard is armed, *and* pin the guarded
set against what `src/` actually contains:

- The data home is a tmp dir, `config_dir()` resolves to that same dir (which also proves the
  per-test `_resolved_home` reset works), and a test that sets its own home still wins.
- Every entry in `_SHARED_KIRO_PATHS` resolves outside the real guarded roots, and each names a
  real attribute on a real module — the fixture patches with `raising=False`, so a renamed
  constant would otherwise be a silent no-op.
- **The ratchet:** an AST scan fails when `src/kiro_crew` grows a module-level `Path.home()`
  binding that is neither pinned nor excluded with a stated reason, plus a staleness check so an
  exclusion for a binding that no longer exists cannot hide the next one. It found three
  bindings the table had missed. Three exclusions are **security anchors** — values built from
  the real home precisely so they can refuse access to it (`security`'s extract-into-trust-root
  pattern, `kiro_usage_api`'s credential-store paths, `file_explorer`'s browsing allow-list
  root). Redirecting one so a test can be isolated would make it assert against a pattern that
  no longer matches the thing it protects. **Stub the reader, never move the anchor.**
- The temp redirect: `gettempdir()` is the run's own root, a bare `mkdtemp()` lands inside it,
  all three env vars carry it to child processes, the name is unique per account *and* per run
  (POSIX shares one temp root between accounts, so a bare pid collides), and **pytest's basetemp
  is not inside the redirect** — that one was accidental before and is now enforced.
- The residue report names what leaked, stays silent on an empty base and on a nested pytest's
  own basetemp, and in per-test mode reports the *leaf* rather than the per-test directory the
  fixture itself created.
- The root is created atomically at mode `0o700` with a random component, so a predictable
  name in a world-writable temp root cannot be pre-created as a symlink and adopted, two roots
  in one process never collide, and pytest's own basetemp is never inside the redirect.
- The worker budget: every reading is optional and the tightest wins; an unavailable reading
  degrades to "skip this bound" and **never** to "zero memory" (that inversion would collapse
  every run to one worker on macOS and Windows, which have neither `/proc/meminfo` nor
  `/sys/fs/cgroup`); `MemAvailable` parsing is asserted against a **fixture file** at four
  values including a sub-1-GiB one, because the truncating integer division makes `0` the
  function's own "unknown" sentinel and `assert available > 0` on the live host would red on any
  small container.

`test_xdist_host_budget.py` gains an autouse fixture pinning the live memory readings, so the
whole file measures policy rather than the host.

## Manual verification

Measured on this host (32 cores / 123 GiB, Linux x86_64, py3.12), `test/ transfer` at `-n 8`,
`--no-cov`, each tree run back to back:

| | `origin/main` | this branch |
|---|---|---|
| basetemp inodes left behind | 375,780 | **20,811** (−94%) |
| `/tmp` inodes consumed by the run | 411,751 | **~28,000** (−93%) |
| retained per-test `tmp_path` dirs | 13,637 | **150** |
| wall clock | 336s | **304s** (−9.5%) |

The residue guard was verified to actually fire, and its `KIROCREW_TMP_PER_TEST=1` diagnostic
mode named the culprit test directly — which is how the `sel-writer` thread was found.

Failure counts are equal to baseline within this host's noise band. This host reds a set of
tests for environmental reasons (no user-namespace sandbox, no real `git`/`gh`, and a
concurrent unattended campaign competing for I/O); the remaining branch-vs-main delta is
confined to files CI **deselects on every invocation** via `BACKEND_DESELECTS`, plus
load-sensitive files that pass in isolation on both trees. Two were checked individually and
the branch is *better*: `test_worktree_create.py` fails 14 alone on this branch versus **25**
alone on `origin/main`.

Cross-platform review was explicit, since the guards touch process, path and temp semantics on
all four targets. Three defects it caught before push, all in this branch's own new code:
`shutil.rmtree(ignore_errors=True)` where the repo already owns `platform_compat.rmtree_force`
(on Windows a mode-444 file cannot be unlinked, a git checkout is full of them, and
`ignore_errors` swallows every failure so the caller reports success over a tree still on
disk); a new assertion that `Path.home()` is not an ancestor of the tmp dir, which is
**unconditionally false on Windows** because `gettempdir()` is `%LOCALAPPDATA%\Temp` — i.e.
under the home directory — and would have reddened 7 test ids on the Windows shards; and the
cgroup read described above. A fourth arrived later and is the reason there is no sweep at
all: a pid is meaningless across PID namespaces, so "that run is gone" was a statement about
the wrong namespace. And a fifth was a Windows teardown-ORDER bug — an autouse fixture in the
rootdir conftest tears down *after* `tmp_path` cleanup, which on Windows is then asked to
delete the process's own working directory; the CWD restore is now a `tryfirst`
`pytest_runtest_teardown` hookimpl, which runs before any fixture finalization and costs
nothing per test. arm64 was checked explicitly and is not implicated: the page-size arithmetic
is self-consistent at 4K/16K/64K.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** test infrastructure, documentation and a dev skill only — no frontend
path is touched and nothing renders in the browser.

## Related Issues

no linked issue: found while hardening the suite rather than from a filed report. Two
follow-ups this PR deliberately defers were filed from it — #4081 (flip the temp-residue
guard from warning to fatal) and #4082 (the bash gate does not follow a custom
`KIROCREW_HOME` while the tool gate does).

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
