### PR TITLE
fix(skills): keep a disabled app's skills out of trigger matching

### DIFF
--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import difflib
 import fnmatch
+import functools
 import hashlib
 import json
 import logging
@@ -595,6 +596,49 @@ def _walk_confined_skill_tree(base: Path) -> Iterator[tuple[str, list[str], list
         yield from _walk_confined_skill_fd(fd, base)
     finally:
         os.close(fd)
+
+
+def _disabled_app_names() -> frozenset[str]:
+    """Installed apps that are currently DISABLED.
+
+    Used to keep a disabled app's bundled skills out of trigger matching.
+    ``bridges`` registers each app skill under ``skills/<app>/<skill>`` (plus a
+    flat link), so the first path segment names the owning app.
+
+    Read once per matching pass rather than per skill: this runs on every
+    message, and ``is_app_enabled`` reads a JSON file per call. Failures return
+    an EMPTY set on purpose — the gate then hides nothing, which keeps a
+    transient read error from silently stripping an enabled app's skills.
+    Deferred import: ``apps.manager`` is a higher layer than this module.
+    """
+    try:
+        from kiro_crew.apps.manager import list_apps
+
+        return frozenset(
+            str(a.get("name")) for a in list_apps() if a.get("name") and not a.get("enabled")
+        )
+    except Exception:
+        logger.debug("skills: could not read app enablement", exc_info=True)
+        return frozenset()
+
+
+@functools.lru_cache(maxsize=None)
+def _builtin_dir_app_name(pkg_dir: str) -> str | None:
+    """The manifest name of the builtin app shipped in *pkg_dir*, or ``None``.
+
+    A shipped builtin's package directory is named for its Python package
+    (``auto_improvement``) while the app registry keys on the manifest name
+    (``auto-improvement``), so the mapping must come from the manifest itself —
+    the same source ``apps.discovery`` registers builtins from. Cached for the
+    process lifetime: the installed package tree is immutable while running,
+    and this is consulted from the per-message trigger-matching pass.
+    """
+    try:
+        with open(os.path.join(pkg_dir, "app.json"), encoding="utf-8") as fh:
+            name = json.load(fh).get("name")
+        return name if isinstance(name, str) and name else None
+    except Exception:
+        return None
 
 
 def _iter_skill_files(
@@ -1899,6 +1943,47 @@ class SkillsLoader:
                 }
             )
         return skills
+
+    def _owning_app(self, name: str, skill_file: Path) -> str | None:
+        """The app whose bundle this skill came from, or ``None``.
+
+        Two shapes have to resolve to the same owner, because ``bridges``
+        registers every app skill twice and either registration can be the one
+        this walk kept (see ``_iter_skill_files``'s ``seen_real`` note):
+
+        * the namespaced ``skills/<app>/<skill>`` directory — the first segment
+          of ``name`` IS the app;
+        * the flat ``skills/<skill>`` link, whose name says nothing — so the
+          real path is consulted. An externally installed app resolves under
+          the data home's apps root, where the directory name IS the app name.
+          A shipped BUILTIN resolves inside the package tree
+          (``…/apps/builtins/<pkg dir>/skills/…``), and its package directory
+          (``auto_improvement``) is not its app name (``auto-improvement``) —
+          the manifest in that directory is the authoritative mapping (see
+          ``apps.discovery``).
+
+        Path-shaped, not manifest-keyed, on purpose: it must answer for a
+        third-party app just as well as a builtin, and the registration layout
+        is the one thing every app shares.
+        """
+        head = name.split("/", 1)[0]
+        if head != name:
+            return head
+        try:
+            from kiro_crew.apps.manager import apps_dir
+
+            real = Path(os.path.realpath(skill_file))
+            root = apps_dir()
+            if real.is_relative_to(root):
+                # <apps root>/<app>/... — the segment directly under the root.
+                return real.relative_to(root).parts[0]
+            builtins_root = Path(os.path.realpath(Path(__file__).parent)) / "apps" / "builtins"
+            if real.is_relative_to(builtins_root):
+                pkg_dir = builtins_root / real.relative_to(builtins_root).parts[0]
+                return _builtin_dir_app_name(str(pkg_dir))
+        except Exception:
+            return None
+        return None
 
     def _owned_hint(self, skill_file: Path) -> bool:
         """Whether *skill_file* sits under the directory Kiro Crew owns.
@@ -3938,12 +4023,21 @@ class SkillsLoader:
         Returns up to ``max_triggered`` skills sorted by best overlap score.
         """
         text_words = set(re.findall(r"\w+", text.lower()))
+        # Disabling an app must actually stop its skills loading. The skill tree
+        # an app bundles was never gated on the app's enabled state, so a
+        # disabled app's skills stayed in this index and kept matching into
+        # every turn's context on generic trigger words — burning tokens and
+        # polluting the prompt for an app the user explicitly opted out of,
+        # with no visible reason (#4023).
+        disabled_apps = _disabled_app_names()
 
         scored: list[tuple[str, float]] = []
         # Skills a negative trigger actively excluded — a permission DENY that
         # must still be audited (see the audit event below).
         negated_skills: list[str] = []
         for name, skill_file, _within in self._iter(project_dir):
+            if disabled_apps and self._owning_app(name, skill_file) in disabled_apps:
+                continue
             meta = self._cached_frontmatter(skill_file, within=_within)
             if meta.get("always", "").lower() == "true":
                 continue

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -1890,3 +1890,150 @@ class TestSearchSkills:
         loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
         loader.search_skills("alpha")
         assert loader._usage.score("s1")[0] == 0.0  # searching is not using
+
+
+class TestDisabledAppSkillsAreNotTriggered:
+    """Disabling an app must actually stop its bundled skills loading (#4023).
+
+    The skill tree an app bundles under ``skills/<app>/`` was never gated on the
+    app's enabled state, so a disabled app's skills stayed in the matching index
+    and kept firing into every turn's context on generic trigger words -- burning
+    tokens and polluting the prompt for an app the user explicitly opted out of,
+    with no visible reason.
+    """
+
+    @staticmethod
+    def _write_app_skill(skills: Path, app: str, name: str, triggers: str) -> None:
+        d = skills / app / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: d\ntriggers: {triggers}\n---\n\nbody\n"
+        )
+
+    @staticmethod
+    def _apps(monkeypatch, **enabled: bool) -> None:
+        """Stub the app registry: name -> enabled."""
+        import kiro_crew.apps.manager as mgr
+
+        monkeypatch.setattr(
+            mgr, "list_apps",
+            lambda: [{"name": n, "enabled": e} for n, e in enabled.items()],
+        )
+
+    def test_a_disabled_apps_skill_does_not_trigger(self, tmp_path, monkeypatch):
+        skills = tmp_path / "skills"
+        self._write_app_skill(skills, "deploy_web", "artifact-deploy", "deploy")
+        self._apps(monkeypatch, deploy_web=False)
+        loader = SkillsLoader(
+            skills_path=skills, install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        assert loader.get_triggered_skills("please deploy this") == []
+
+    def test_an_enabled_apps_skill_still_triggers(self, tmp_path, monkeypatch):
+        skills = tmp_path / "skills"
+        self._write_app_skill(skills, "deploy_web", "artifact-deploy", "deploy")
+        self._apps(monkeypatch, deploy_web=True)
+        loader = SkillsLoader(
+            skills_path=skills, install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        assert loader.get_triggered_skills("please deploy this") == ["deploy_web/artifact-deploy"]
+
+    def test_only_the_disabled_apps_skill_is_withheld(self, tmp_path, monkeypatch):
+        """One disabled app must not silence a sibling app's skill."""
+        skills = tmp_path / "skills"
+        self._write_app_skill(skills, "deploy_web", "artifact-deploy", "deploy")
+        self._write_app_skill(skills, "ops_mc", "ops-mission-control", "deploy")
+        self._apps(monkeypatch, deploy_web=False, ops_mc=True)
+        loader = SkillsLoader(
+            skills_path=skills, install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        assert loader.get_triggered_skills("please deploy this") == ["ops_mc/ops-mission-control"]
+
+    def test_a_plain_user_skill_is_never_gated(self, tmp_path, monkeypatch):
+        """A skill owned by no app has no enablement to consult."""
+        skills = tmp_path / "skills"
+        d = skills / "my-notes"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("---\nname: my-notes\ndescription: d\ntriggers: deploy\n---\n\nb\n")
+        self._apps(monkeypatch, deploy_web=False)
+        loader = SkillsLoader(
+            skills_path=skills, install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        assert loader.get_triggered_skills("please deploy this") == ["my-notes"]
+
+    def test_an_unreadable_app_registry_hides_nothing(self, tmp_path, monkeypatch):
+        """Fail OPEN here, deliberately: a transient read error must not silently
+        strip an enabled app's skills out of context."""
+        import kiro_crew.apps.manager as mgr
+
+        skills = tmp_path / "skills"
+        self._write_app_skill(skills, "deploy_web", "artifact-deploy", "deploy")
+
+        def _boom():
+            raise OSError("installed.json unreadable")
+
+        monkeypatch.setattr(mgr, "list_apps", _boom)
+        loader = SkillsLoader(
+            skills_path=skills, install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        assert loader.get_triggered_skills("please deploy this") == ["deploy_web/artifact-deploy"]
+
+    @staticmethod
+    def _link_shipped_builtin_skill(skills: Path) -> str:
+        """Flat-link a REAL shipped builtin's skill into *skills*, as bridges does.
+
+        Uses ``auto-improvement``'s ``ai-discover``: the flat name sorts before
+        the app name, so the flat registration is the one ``_iter_skill_files``'s
+        ``seen_real`` dedup keeps -- and its realpath resolves into the PACKAGE
+        tree (``apps/builtins/auto_improvement/skills/ai-discover``), not the
+        data-home apps root. Returns the app's manifest name.
+        """
+        import kiro_crew.skills as skills_mod
+
+        target = (
+            Path(skills_mod.__file__).parent
+            / "apps" / "builtins" / "auto_improvement" / "skills" / "ai-discover"
+        )
+        skills.mkdir(parents=True, exist_ok=True)
+        try:
+            (skills / "ai-discover").symlink_to(target, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlinks unavailable on this platform")
+        return "auto-improvement"
+
+    def test_a_disabled_builtins_package_tree_skill_is_gated(self, tmp_path, monkeypatch):
+        """The headline case (#4023): a shipped builtin registers its skills
+        straight out of the package tree, and the flat link -- whose name says
+        nothing -- can be the registration the walk keeps. Ownership must resolve
+        through the builtin's manifest, not only the data-home apps root."""
+        skills = tmp_path / "skills"
+        app = self._link_shipped_builtin_skill(skills)
+        self._apps(monkeypatch, **{app: False})
+        loader = SkillsLoader(
+            skills_path=skills, install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        assert loader.get_triggered_skills("find hotspots for me") == []
+
+    def test_an_enabled_builtins_package_tree_skill_still_triggers(self, tmp_path, monkeypatch):
+        """The gate's other direction: enabling the builtin restores matching."""
+        skills = tmp_path / "skills"
+        app = self._link_shipped_builtin_skill(skills)
+        self._apps(monkeypatch, **{app: True})
+        loader = SkillsLoader(
+            skills_path=skills, install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        assert loader.get_triggered_skills("find hotspots for me") == ["ai-discover"]


### PR DESCRIPTION
## Problem / Motivation

Builtin apps can be turned off with `kirocrew app disable <name>`, but the skill links an app registers under the skills tree were never gated on that state in the matching index. Whenever the links outlive the disable (a self-managed `resources == "app"` app whose links teardown must not delete, a direct `manager.disable_app()` caller that skips the CLI/dashboard deregister ceremony, or leftovers from a crash between the metadata write and the deregister), the disabled app's skills keep matching into **every turn's** injected context on generic trigger words — e.g. `auto-improvement`'s `ai-discover` (triggers like `find hotspots`) keeps firing after the app is switched off. That is the currently-shipping app-owned case the tests pin. (#4023's original `artifact-deploy` example dates from when a deploy app bundled that skill; on current main it is core-owned — registered by `deploy/__init__.py:_register_core_skills` with no owning app — so it is deliberately outside this gate, per the "a skill owned by no app is never gated" rule below.)

## Why it matters

That burns tokens and credits on every affected turn for zero benefit, and pollutes the prompt with instructions the agent then has to actively recognize and ignore — with no visible reason why. The two systems *look* coupled ("installing the app activates this skill") but were only coupled on the enable path, so `app disable` silently did less than it says.

## What changed (motivation → approach → change)

Symptom → root cause: `disable_app()` is a pure metadata write — it never deregisters the skill symlinks `bridges` created, and `get_triggered_skills` never consulted app enablement. So the links persist and keep matching.

Approach: gate trigger matching on the owning app's enabled state, resolving ownership from the **registration layout** (path-shaped) rather than a manifest key, so it answers for a third-party app as well as a builtin.

Change: `get_triggered_skills` resolves each candidate's owning app (`_owning_app`) and skips it when that app is disabled (`_disabled_app_names`, read once per matching pass — the registry read touches a JSON file per app and this runs on every message). `bridges` registers every app skill twice — the namespaced `skills/<app>/<skill>` directory, whose first name segment *is* the app, and a flat `skills/<skill>` link whose name says nothing — and either registration can be the one the walk kept. The flat case consults the real path:

- an externally installed app resolves under the data-home apps root, where the directory name **is** the app name;
- a shipped **builtin** resolves inside the package tree (`apps/builtins/<pkg dir>/skills/…`), where the package directory name (`auto_improvement`) is not the app name (`auto-improvement`) — it is mapped through that directory's own `app.json` manifest, the same source `apps.discovery` registers builtins from (cached for the process lifetime).

Two deliberate non-behaviours:

- **A skill owned by no app is never gated** — there is no enablement to consult.
- **An unreadable app registry hides nothing.** That direction fails *open* on purpose: a transient read error silently stripping an enabled app's skills out of context would be a worse failure than the one being fixed, and unlike a security gate this is a relevance filter.

Scope: this PR gates **trigger matching** (`get_triggered_skills`), the path the issue's headline harm flows through. Other surfaces that can still reach a disabled app's skill — the skill-index summary lines in `get_context`, always-on injection via `get_always_skills`, explicit `$skill` mentions, and `skill_search` — are deliberately not touched here; gating them (or deregistering links on disable via the existing `bridges` reconcile machinery) is follow-up work.

Not addressed here (from the issue's secondary point): trigger lists like a bare `deploy` are too broad even for an *enabled* app. That is per-skill copy in each app's `SKILL.md` rather than a matching-engine defect, and tightening it is a judgement call per app that belongs with its owner.

## Tests

`test/test_skills.py::TestDisabledAppSkillsAreNotTriggered` (7 tests):

- a disabled app's skill does not trigger; an enabled one still does;
- one disabled app does not silence a sibling app's skill;
- a plain user skill (owned by no app) is never gated;
- an unreadable registry hides nothing (fail-open direction);
- a shipped builtin's **package-tree flat link** is gated when the app is disabled and still matches when enabled (pinned against the real `auto-improvement`/`ai-discover` layout; proven to fail without the fix).

Full `test/test_skills.py`: 134 passed. isort / flake8 / black ratchet clean on touched files.

## Manual verification

N/A — unit coverage exercises both registration shapes (namespaced dir and flat link, data-home and package tree) against a stubbed registry, which is the entire decision surface of the gate.

## Related Issues

Closes #4023.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
