### PR TITLE
refactor(dashboard): share one open-and-check envelope for the file endpoints

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1369,
+    "missing_code": 1363,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1097,
+  "_compliant": 1154,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -97,7 +97,7 @@
       "missing_code": 15
     },
     "dashboard/handlers/files.py": {
-      "missing_code": 114
+      "missing_code": 108
     },
     "dashboard/handlers/kiro_prerequisite.py": {
       "missing_code": 1

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -22,6 +22,7 @@ import urllib.parse
 import uuid
 import zipfile
 from pathlib import Path
+from typing import NamedTuple
 
 from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
@@ -1798,6 +1799,114 @@ async def api_file_read(request: web.Request) -> web.Response:
         return web.json_response({"error": "failed to read file"}, status=500)
 
 
+class _OpenRefusal(NamedTuple):
+    """A refusal from :func:`_open_checked`: the response to return, already audited."""
+
+    response: web.Response
+
+
+class _OpenedFile(NamedTuple):
+    """A successful :func:`_open_checked`: the validated path and full bytes."""
+
+    path: str
+    data: bytes
+
+
+def _open_checked(
+    raw_path: str,
+    *,
+    tool_name: str,
+    max_bytes: int,
+) -> _OpenedFile | _OpenRefusal:
+    """The dashboard file endpoints' shared open-and-check envelope.
+
+    validate -> sensitive-path check -> is-file -> ``_open_rb_nofollow`` ->
+    bounded read (cap enforced on the bytes actually read, so a concurrent
+    writer cannot outgrow it), with every refusal SEL-audited under
+    *tool_name*.
+
+    This is a SECURITY boundary, and it was spelled out independently by each
+    endpoint that needed it, with small divergences in cap values and error
+    vocabularies. Three (now two) hand-rolled copies of a boundary means a
+    future hardening fix — a new TOCTOU guard, a tightened sniff, a cap change —
+    lands in some and silently leaves the others on the old posture. The same
+    shape already bit the zip-vetting surfaces (#3908, #4031).
+
+    Per-endpoint POLICY stays with the endpoint and is passed in rather than
+    copied: which cap applies, and what the endpoint does with the bytes
+    afterwards (``data`` is the full file — a caller sniffing magic slices
+    its own header). Only the envelope is shared.
+
+    Returns the opened result, or a refusal carrying the response to return —
+    a typed either, so a caller cannot accidentally use the data on a refusal
+    path the way an ``(data, error)`` tuple invites.
+
+    Synchronous by design — callers offload it via ``asyncio.to_thread`` (the
+    same shape as ``api_file_stream``'s ``_open_media``): everything here is
+    blocking file I/O and must not run on the event loop. SEL audit writes are
+    thread-safe (locked appends).
+    """
+    import kiro_crew.dashboard.handlers as _h  # noqa: F811  # circular import
+
+    def _log(outcome: str, res: str, error: str = "") -> None:
+        kw = {"error": error} if error else {}
+        _sel().log_tool_invocation(
+            session_key="dashboard", tool_name=tool_name,
+            outcome=outcome, resources=res, **kw,
+        )
+
+    path = _h._validate_dashboard_path(raw_path)
+    if not path:
+        _log("denied", raw_path)
+        return _OpenRefusal(
+            web.json_response({"error": "invalid or forbidden path"}, status=400)
+        )
+    # One seam for the sensitive-path check. The two copies this replaces called
+    # DIFFERENT bindings of the same function -- api_file_raw re-imported it from
+    # ``kiro_crew.security`` per call, api_file_download used this module's
+    # import-time alias -- so an override applied to one was invisible to the
+    # other. Identical in production; the divergence only showed up as the two
+    # endpoints' tests patching different names, which is precisely the kind of
+    # drift a shared envelope exists to make impossible.
+    if is_sensitive_path(path):
+        _log("denied", path, "sensitive_path")
+        return _OpenRefusal(
+            web.json_response({"error": "sensitive path blocked"}, status=403)
+        )
+    if not os.path.isfile(path):
+        _log("not_found", path)
+        return _OpenRefusal(web.json_response({"error": "not found"}, status=404))
+
+    # Symlinks rejected atomically (O_NOFOLLOW on POSIX; lstat guard +
+    # O_BINARY on Windows -- see _open_rb_nofollow). Bounded read IS the size
+    # guard: an fstat pre-check races a concurrent writer (the file can grow
+    # between the stat and the read, e.g. an agent still generating it), while
+    # reading at most cap+1 bytes bounds memory unconditionally -- the same
+    # shape as _load_sheet_payload's guard.
+    try:
+        fd = _open_rb_nofollow(path)
+        with os.fdopen(fd, "rb") as f:
+            data = f.read(max_bytes + 1)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:  # symlink with O_NOFOLLOW
+            _log("denied", path, "symlink_rejected")
+            return _OpenRefusal(
+                web.json_response({"error": "symlinks not allowed"}, status=403)
+            )
+        # Keep the traceback main's per-endpoint copies wrote here: this 500 is
+        # the only signal for a failed read, and SEL records outcome, not cause.
+        logger.exception("%s read failed for %s", tool_name, path)
+        _log("failure", path)
+        return _OpenRefusal(web.json_response({"error": "cannot read file"}, status=500))
+    if len(data) > max_bytes:
+        _log("denied", path, "file_too_large")
+        return _OpenRefusal(
+            web.json_response({"error": "file too large"}, status=413)
+        )
+
+    return _OpenedFile(path=path, data=data)
+
+
 async def api_file_download(request: web.Request) -> web.Response:
     """GET /api/file-download?path=... — download a file as raw bytes.
 
@@ -1817,12 +1926,10 @@ async def api_file_download(request: web.Request) -> web.Response:
     disposition + nosniff prevents inline rendering on the dashboard
     origin.
     """
-    # ``_h`` is a late-binding alias for the parent ``handlers`` package so that
-    # tests can monkey-patch ``kiro_crew.dashboard.handlers._validate_dashboard_path``;
-    # this is the same pattern api_file_raw uses (legitimate circular-import
-    # workaround, listed as an exception in the top-level-imports rule).
-    import kiro_crew.dashboard.handlers as _h  # noqa: F811  # circular import
-
+    # Path validation now happens inside ``_open_checked``, which keeps the
+    # late-binding ``handlers`` alias so tests can still monkey-patch
+    # ``_validate_dashboard_path`` (legitimate circular-import workaround,
+    # listed as an exception in the top-level-imports rule).
     raw_path = request.query.get("path", "")
     # Resolve relative paths against project dir when resolve=1 (mirrors api_file_read)
     if request.query.get("resolve") == "1":
@@ -1845,52 +1952,16 @@ async def api_file_download(request: web.Request) -> web.Response:
         )
         return web.json_response({"error": "invalid input"}, status=400)
 
-    path = _h._validate_dashboard_path(raw_path)
-    if not path:
-        _sel().log_tool_invocation(
-            session_key="dashboard", tool_name="file_download",
-            outcome="denied", resources=raw_path,
-        )
-        return web.json_response({"error": "invalid or forbidden path"}, status=400)
-    if is_sensitive_path(path):
-        _sel().log_tool_invocation(
-            session_key="dashboard", tool_name="file_download",
-            outcome="denied", resources=path, error="sensitive_path",
-        )
-        return web.json_response({"error": "sensitive path blocked"}, status=403)
-    if not os.path.isfile(path):
-        _sel().log_tool_invocation(
-            session_key="dashboard", tool_name="file_download",
-            outcome="not_found", resources=path,
-        )
-        return web.json_response({"error": "not found"}, status=404)
-
-    # Read raw bytes rejecting symlinks (atomic O_NOFOLLOW on POSIX; lstat
-    # guard + O_BINARY on Windows -- see _open_rb_nofollow).
-    try:
-        fd = _open_rb_nofollow(path)
-        with os.fdopen(fd, "rb") as f:
-            st = os.fstat(f.fileno())
-            if st.st_size > _MAX_UPLOAD_BYTES:
-                _sel().log_tool_invocation(
-                    session_key="dashboard", tool_name="file_download",
-                    outcome="denied", resources=path, error="file_too_large",
-                )
-                return web.json_response({"error": "file too large"}, status=413)
-            data = f.read()
-    except OSError as exc:
-        if exc.errno == errno.ELOOP:  # symlink with O_NOFOLLOW
-            _sel().log_tool_invocation(
-                session_key="dashboard", tool_name="file_download",
-                outcome="denied", resources=path, error="symlink_rejected",
-            )
-            return web.json_response({"error": "symlinks not allowed"}, status=403)
-        logger.exception("file_download read failed for %s", path)
-        _sel().log_tool_invocation(
-            session_key="dashboard", tool_name="file_download",
-            outcome="failure", resources=path,
-        )
-        return web.json_response({"error": "cannot read file"}, status=500)
+    # Envelope shared with api_file_raw (#4031). No header sniff: this endpoint
+    # serves attachment + nosniff rather than choosing a content type. Offloaded
+    # to a worker thread: the envelope is synchronous file I/O (realpath, open,
+    # fstat, full read up to the cap) and must not block the event loop.
+    opened = await asyncio.to_thread(
+        _open_checked, raw_path, tool_name="file_download", max_bytes=_MAX_UPLOAD_BYTES,
+    )
+    if isinstance(opened, _OpenRefusal):
+        return opened.response
+    path, data = opened.path, opened.data
 
     # Defense in depth: scan content for credentials / exfil URLs via the
     # context-aware redact() shim, which runs BOTH the exfil-URL and credential
@@ -1941,44 +2012,28 @@ async def api_file_download(request: web.Request) -> web.Response:
 
 async def api_file_raw(request: web.Request) -> web.Response:
     """GET /api/file-raw?path=... — serve a file with its native content type (images, etc.)."""
-    import kiro_crew.dashboard.handlers as _h  # noqa: F811
+    # Envelope (validate -> sensitive -> nofollow-open -> bounded read) is
+    # shared with api_file_download so a hardening change lands on both (#4031).
+    # Offloaded to a worker thread: the envelope is synchronous file I/O and
+    # must not block the event loop (same shape as api_file_stream's _open_media).
+    opened = await asyncio.to_thread(
+        _open_checked,
+        request.query.get("path", ""),
+        tool_name="file_raw",
+        max_bytes=_MAX_UPLOAD_BYTES,
+    )
+    if isinstance(opened, _OpenRefusal):
+        return opened.response
+    path, data = opened.path, opened.data
+    # SNIFF_BYTES: the shared raster sniffer's documented minimum, and enough
+    # for every magic matched below (WebP's form tag ends at byte 12).
+    header = data[:SNIFF_BYTES]
 
     def _log(outcome: str, res: str) -> None:
         _sel().log_tool_invocation(
             session_key="dashboard", tool_name="file_raw", outcome=outcome, resources=res,
         )
 
-    raw_path = request.query.get("path", "")
-    path = _h._validate_dashboard_path(raw_path)
-    if not path:
-        _log("denied", raw_path)
-        return web.json_response({"error": "invalid or forbidden path"}, status=400)
-    from kiro_crew.security import is_sensitive_path as _isp  # noqa: F811
-    if _isp(path):
-        _log("denied", path)
-        return web.json_response({"error": "sensitive path blocked"}, status=403)
-    if not os.path.isfile(path):
-        _log("not_found", path)
-        return web.json_response({"error": "not found"}, status=404)
-    # Open rejecting symlinks (atomic O_NOFOLLOW on POSIX; lstat guard +
-    # O_BINARY on Windows -- see _open_rb_nofollow).
-    # Read header + full content through the same fd to avoid re-opening.
-    try:
-        fd = _open_rb_nofollow(path)
-        with os.fdopen(fd, "rb") as f:
-            st = os.fstat(f.fileno())
-            if st.st_size > _MAX_UPLOAD_BYTES:
-                _log("denied", path)
-                return web.json_response({"error": "file too large"}, status=413)
-            header = f.read(SNIFF_BYTES)
-            f.seek(0)
-            data = f.read()
-    except OSError as exc:
-        if exc.errno == errno.ELOOP:  # symlink with O_NOFOLLOW
-            _log("denied", path)
-            return web.json_response({"error": "symlinks not allowed"}, status=403)
-        _log("failure", path)
-        return web.json_response({"error": "cannot read file"}, status=500)
     # Raster types are detected by the shared sniffer
     # (kiro_crew.messaging.raster), which requires the full PNG signature and
     # WebP's form tag at offset 8 — so a RIFF/WAVE audio file is not served as

--- a/test/test_dashboard_files_coverage.py
+++ b/test/test_dashboard_files_coverage.py
@@ -449,7 +449,7 @@ class TestFileRaw:
     async def test_sensitive_path_is_403(self, tmp_path, mock_sel):
         f = tmp_path / "s.png"
         f.write_bytes(b"\x89PNG\r\n\x1a\n")
-        with patch("kiro_crew.security.is_sensitive_path", return_value=True):
+        with patch("kiro_crew.dashboard.handlers.files.is_sensitive_path", return_value=True):
             async with TestClient(TestServer(self._client_app())) as client:
                 resp = await client.get(f"/api/file-raw?path={f}")
                 assert resp.status == 403

--- a/test/test_file_download.py
+++ b/test/test_file_download.py
@@ -189,24 +189,17 @@ async def test_symlink_rejected(tmp_path, mock_sel):
 
 @pytest.mark.asyncio
 async def test_oversize_file_rejected(tmp_path, mock_sel):
-    """Files larger than _MAX_UPLOAD_BYTES (50 MB) must be rejected with 413
-    before the body is buffered. We simulate via stat patching to avoid
-    actually writing 50 MB to disk in a unit test."""
-    f = tmp_path / "huge.docx"
-    f.write_bytes(b"\x00" * 1024)  # tiny on disk; we lie about the size
-    real_fstat = os.fstat
+    """Files larger than _MAX_UPLOAD_BYTES must be rejected with 413.
 
-    def _fake_fstat(fd):
-        st = real_fstat(fd)
-        # Replace st_size with one byte over the cap
-        from kiro_crew.dashboard.handlers.files import _MAX_UPLOAD_BYTES
-        return os.stat_result((
-            st.st_mode, st.st_ino, st.st_dev, st.st_nlink, st.st_uid, st.st_gid,
-            _MAX_UPLOAD_BYTES + 1, st.st_atime, st.st_mtime, st.st_ctime,
-        ))
+    The guard is the BOUNDED READ (read cap+1, refuse when over) rather than an
+    fstat pre-check, so a file growing between check and read cannot outrun the
+    cap. We shrink the cap instead of writing 50 MB to disk in a unit test; the
+    file is genuinely over the (patched) cap, exercising the real guard."""
+    f = tmp_path / "huge.docx"
+    f.write_bytes(b"\x00" * 1024)  # 1 KiB on disk, over the patched 512-byte cap
 
     with patch("kiro_crew.dashboard.handlers._validate_dashboard_path", return_value=str(f)), \
-         patch("os.fstat", side_effect=_fake_fstat):
+         patch("kiro_crew.dashboard.handlers.files._MAX_UPLOAD_BYTES", 512):
         async with TestClient(TestServer(_make_app())) as client:
             resp = await client.get(f"/api/file-download?path={f}")
             assert resp.status == 413

--- a/test/test_file_raw.py
+++ b/test/test_file_raw.py
@@ -22,7 +22,7 @@ def _make_app() -> web.Application:
 @pytest.fixture
 def mock_sel():
     with patch("kiro_crew.sel.sel") as m, \
-         patch("kiro_crew.security.is_sensitive_path", return_value=False):
+         patch("kiro_crew.dashboard.handlers.files.is_sensitive_path", return_value=False):
         instance = MagicMock()
         m.return_value = instance
         yield instance
@@ -133,7 +133,7 @@ async def test_rejects_sensitive_path(tmp_path, mock_sel):
     f = tmp_path / "creds.png"
     f.write_bytes(_PNG_HEADER)
     with patch("kiro_crew.dashboard.handlers._validate_dashboard_path", return_value=str(f)), \
-         patch("kiro_crew.security.is_sensitive_path", return_value=True):
+         patch("kiro_crew.dashboard.handlers.files.is_sensitive_path", return_value=True):
         async with TestClient(TestServer(_make_app())) as client:
             resp = await client.get(f"/api/file-raw?path={f}")
             assert resp.status == 403
@@ -185,3 +185,72 @@ class TestOpenRbNofollow:
         with pytest.raises(OSError) as exc_info:
             _open_rb_nofollow(str(link))
         assert exc_info.value.errno == errno.ELOOP
+
+
+# ── both file endpoints share ONE security envelope (#4031) ──────────────────
+
+
+def test_both_endpoints_route_through_the_shared_envelope():
+    """api_file_raw and api_file_download must not re-grow private copies.
+
+    The envelope (validate -> sensitive-path -> O_NOFOLLOW open -> bounded-read size
+    cap -> read) is a security boundary. It used to be spelled out per endpoint,
+    and the copies had already drifted -- they called different bindings of
+    is_sensitive_path, so an override applied to one was invisible to the other.
+    Three divergent copies mean a future hardening fix lands in some and leaves
+    the rest on the old posture.
+
+    Asserted on the source because the property is structural: what matters is
+    that neither endpoint opens files itself, not what a given call returns.
+    """
+    import inspect
+
+    from kiro_crew.dashboard.handlers import files as mod
+
+    for fn in (mod.api_file_raw, mod.api_file_download):
+        src = inspect.getsource(fn)
+        body = "\n".join(
+            line for line in src.splitlines() if not line.lstrip().startswith("#")
+        )
+        assert "_open_checked" in body, f"{fn.__name__} must use the shared envelope"
+        assert "asyncio.to_thread" in body, (
+            f"{fn.__name__} must offload the envelope to a worker thread -- the "
+            "envelope is synchronous file I/O and must not run on the event loop"
+        )
+        assert "_open_rb_nofollow(" not in body, (
+            f"{fn.__name__} re-opened a file itself instead of going through "
+            "_open_checked -- that is how the copies drifted apart"
+        )
+        assert "is_sensitive_path" not in body, (
+            f"{fn.__name__} re-checks the sensitive path itself; the envelope owns it"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_envelope_still_rejects_a_symlink_for_both(tmp_path):
+    """The boundary's most load-bearing guard, exercised through both endpoints
+    now that only one implementation of it exists."""
+    from kiro_crew.dashboard.handlers import api_file_download
+
+    real = tmp_path / "real.png"
+    real.write_bytes(b"\x89PNG\r\n\x1a\n" + b"0" * 32)
+    link = tmp_path / "link.png"
+    try:
+        link.symlink_to(real)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable on this platform/user")
+
+    app = web.Application()
+    app.router.add_get("/api/file-raw", api_file_raw)
+    app.router.add_get("/api/file-download", api_file_download)
+
+    for route in ("file-raw", "file-download"):
+        with patch(
+            "kiro_crew.dashboard.handlers._validate_dashboard_path", return_value=str(link)
+        ), patch(
+            "kiro_crew.dashboard.handlers.files.is_sensitive_path", return_value=False
+        ), patch("kiro_crew.sel.sel") as m:
+            m.return_value = MagicMock()
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.get(f"/api/{route}?path={link}")
+                assert resp.status == 403, route


### PR DESCRIPTION
## Problem / Motivation

`api_file_raw` and `api_file_download` each hand-rolled the same security envelope — validate → sensitive-path check → `_open_rb_nofollow` → fstat size cap → read — with small divergences.

**The copies had already drifted**, which is the argument for doing this at all: they called *different bindings* of `is_sensitive_path`. `api_file_raw` re-imported it from `kiro_crew.security` per call; `api_file_download` used the module's import-time alias. Identical in production, but an override applied to one was invisible to the other — and it showed up as the two endpoints' test suites patching different names for the same guard.

## Why it matters

Divergent copies of a security boundary mean a future hardening fix (a new TOCTOU guard, a tightened sniff, a cap change) lands in one and silently leaves the other on the old posture — the shape that already bit the zip-vetting surfaces.

## What changed (motivation → approach → change)

Both endpoints route through one `_open_checked` helper.

- **Policy is passed in, not copied**: which size cap applies, and how many header bytes the caller needs for a content sniff — the endpoint's own use of the bytes. `data` is the full file, so `file_raw` slices its sniff header (`data[:SNIFF_BYTES]`) and the envelope carries no sniff policy at all; `file_download` serves attachment + nosniff instead of choosing a type.
- **The sensitive-path seam is unified** to the module alias (the conventional one here). The two tests that patched the other name are retargeted — **no assertion changed**.
- `_open_checked` returns a **typed either** — the opened result, or a refusal carrying the already-audited response — rather than a `(data, error)` tuple, so a caller cannot accidentally use the data on a refusal path.
- **The size cap is enforced by bounded read** (read `cap+1`, refuse when over), not an fstat pre-check: a file growing between the stat and the read (e.g. an agent still generating it) would buffer unboundedly past the cap. Same guard shape as `_load_sheet_payload`, whose comment documents exactly this race. The oversize test exercises the real guard (genuinely-over-cap file against a patched cap) instead of a faked fstat.
- **Both call sites offload the envelope via `await asyncio.to_thread(...)`** — the envelope is synchronous file I/O (realpath, open, fstat, full read up to the cap) reachable from the event loop, which trips the `blocking: true` `no-blocking-call-on-event-loop` AUTOSDE rule on the moved lines. Same shape as `api_file_stream` → `_open_media`; SEL audit writes inside the helper are thread-safe (locked appends).

- **Two audit/log-shape deltas, both deliberate and declared**: `file_raw`'s denial audits now carry error causes (`sensitive_path`, `file_too_large`, `symlink_rejected`) — the flip side of unifying on `file_download`'s richer audit shape; and the generic-OSError 500 path keeps main's `logger.exception` traceback (restored after First Principles round 1 caught the consolidation silently dropping `file_download`'s only read-failure diagnostic — SEL records outcome, not cause).

**Rebase notes** (2026-08-25, rebased onto main past the 0.4.0 release):
- `api_file_raw` keeps main's shared raster sniffer (`sniff_raster_mime` + `_READ_PATH_EXTRA_MAGIC`) instead of the original local `_image_magic` table; `header_bytes` rises 12 → `SNIFF_BYTES` (16) to match the sniffer's documented minimum and main's exact read size.
- `api_file_download` keeps main's `resolve=1` project-relative resolution and `validate_tool_args` gate ahead of the shared envelope.
- The CHANGELOG entry is dropped: main's changelog gate now forbids draft (`[Unreleased]`) sections; release notes are written at version-bump time.
- `error-code-baseline.json` is re-snapshotted via the sanctioned `python test/test_error_code_contract.py --update`: consolidating the two hand-rolled envelopes removes 6 `missing_code` responses from `files.py` (114 → 108), and the good-news ratchet requires the baseline to follow. The regeneration is a full live scan, so `_compliant` also rises 1097 → 1154, 6 of those are this PR's own fixed responses and the remaining ~51 are unrelated compliant-side drift absorbed from main — declared here: that metadata is not asserted by the ratchet, the tool always rewrites it whole, and this PR's own contribution is the 6.

**Scope note**: `api_file_stream` landed on main after this PR was authored; it is a Range-streaming endpoint that never materializes the file in memory, so the whole-read envelope does not fit its shape. This consolidates the two whole-read *endpoints*. Full inventory of the hand-rolled prefix (per review): 4 `_open_rb_nofollow` call sites — this PR fixes 2; `api_file_stream`/`_open_media` and `_load_sheet_payload` (bounded-read cap variant) are deferred to #5742, which proposes splitting the envelope at the open-and-check boundary so all four share one security prefix.

## Tests

- **`test/test_file_raw.py`**: 2 new tests — a *structural* one asserting neither endpoint opens files, re-checks the sensitive path, or calls `_open_rb_nofollow` itself, and that both offload the envelope off the event loop (so a private copy cannot regrow and the envelope cannot quietly move back onto the loop), and a *behavioural* one driving a real symlink through **both** endpoints now that one implementation of the guard exists.
- `test_file_raw` + `test_file_download` + `test_dashboard_files_coverage`: **122 passed** locally after the rebase.
- Contract/ratchet suites (`test_error_code_contract`, `test_changelog_history_gate`, `test_security_posture`, `test_messaging_pre_turn`): **104 passed**.
- Full backend suite: **67454 passed**; the 83 remaining failures reproduce identically on pristine main (host-environment class: AF_UNIX path length, sandbox userns), zero related to this diff.
- `isort` / `flake8` / `mypy` / black ratchet: clean, zero new findings vs main.

## Manual verification

N/A — unit coverage sufficient: both endpoints' full behavior matrices (valid image formats, symlink rejection, size cap, sensitive-path block, SVG/PDF fallbacks, redaction abort) are exercised by the existing suites.

## Related Issues

Closes #4031

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


