### PR TITLE
fix(security): vet untrusted zip inventory before ZipFile allocates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
+- **Untrusted zip containers are inventory-vetted before `ZipFile` allocates.**
+  `.docx`/`.pptx`/`.xlsx` uploads are zip archives, so every parse site reads
+  attacker-controlled container metadata. `ZipFile.__init__` materializes one
+  `ZipInfo` per DECLARED central-directory entry, so a member cap read off
+  `infolist()` runs *after* the allocation it is meant to bound — an archive
+  declaring hundreds of thousands of entries exhausted memory during
+  construction while the check sat on the next line, never reached. The
+  knowledge-ingest inspector had exactly that shape, and the two OOXML parse
+  sites in `doc_parser` had no inventory bound at all. A shared
+  `zip_vet.vet_zip_inventory` now does a raw-bytes EOCD/ZIP64 preflight before
+  the archive is opened, and all three route through it with their own caps as
+  parameters. (#3908)
 
 - **Switching Kiro accounts mid-session no longer leaves the chat showing a raw
   `The bearer token included in the request is invalid.` with no way out.** A

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -9,7 +9,6 @@ import re
 import subprocess
 import sys
 import tempfile
-import zipfile
 from datetime import datetime
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
@@ -56,6 +55,7 @@ from kiro_crew.knowledge.sync import SyncScheduler
 from kiro_crew.knowledge.watcher import KnowledgeWatcher
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
+from kiro_crew.zip_vet import ZipVetError, vet_zip_inventory
 
 logger = logging.getLogger(__name__)
 
@@ -1324,19 +1324,22 @@ def _inspect_zip_archive(path: str) -> str | None:
     synchronous zip I/O, so callers MUST run it off the event loop (via
     ``asyncio.to_thread``) — a large/hostile central directory would otherwise
     stall the gateway loop and heartbeat.
+
+    Delegates to the shared vet, which adds the guard this site was missing: the
+    member cap used to be read off ``infolist()``, i.e. AFTER ``ZipFile.__init__``
+    had already allocated one ``ZipInfo`` per declared entry, so an archive
+    declaring hundreds of thousands of entries exhausted memory before the check
+    ran. The shared vet bounds the declared count from raw EOCD bytes first
+    (#3908).
     """
     try:
-        with zipfile.ZipFile(path) as zf:
-            infos = zf.infolist()
-            if len(infos) > _MAX_INGEST_ARCHIVE_MEMBERS:
-                return "too_many_members"
-            uncompressed = 0
-            for zi in infos:
-                uncompressed += zi.file_size
-                if uncompressed > _MAX_INGEST_ARCHIVE_UNCOMPRESSED:
-                    return "uncompressed_too_large"
-    except zipfile.BadZipFile:
-        return "bad_archive"
+        vet_zip_inventory(
+            path,
+            max_members=_MAX_INGEST_ARCHIVE_MEMBERS,
+            max_uncompressed_bytes=_MAX_INGEST_ARCHIVE_UNCOMPRESSED,
+        )
+    except ZipVetError as exc:
+        return exc.reason
     return None
 
 

--- a/src/kiro_crew/doc_parser.py
+++ b/src/kiro_crew/doc_parser.py
@@ -17,6 +17,7 @@ They never raise — on failure they return an empty string and log a warning.
 from __future__ import annotations
 
 import logging
+import os
 import re
 import zipfile
 import zlib
@@ -33,6 +34,7 @@ except ModuleNotFoundError:  # pragma: no cover — exercised via monkeypatch
 
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
+from kiro_crew.zip_vet import ZipVetError, vet_zip_inventory
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +145,37 @@ def _read_zip_entry(
 _W_NS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
 
 
+# Inventory bounds for the OOXML containers this module opens. A .docx/.pptx is
+# a zip, so every parse here is parsing attacker-controlled container metadata:
+# without a vet, ``ZipFile.__init__`` allocates one ``ZipInfo`` per DECLARED
+# central-directory entry, and neither site had any bound at all (#3908).
+#
+# Looser than the ingest caps in the knowledge handler on purpose — this is a
+# text extractor for a document a user already has, not an upload gate — but
+# bounded, which is the property that was missing.
+_DOC_MAX_MEMBERS = 20000
+_DOC_MAX_UNCOMPRESSED = 500 * 1024 * 1024  # 500 MB declared expansion
+
+
+def _open_vetted_zip(path: str) -> zipfile.ZipFile | None:
+    """Vet an OOXML container's inventory, then open it. ``None`` if refused.
+
+    Returning ``None`` rather than raising matches this module's contract: every
+    extractor here degrades to "" on an unreadable document instead of failing
+    the caller, and a refused archive is exactly that case.
+    """
+    try:
+        vet_zip_inventory(
+            path,
+            max_members=_DOC_MAX_MEMBERS,
+            max_uncompressed_bytes=_DOC_MAX_UNCOMPRESSED,
+        )
+    except ZipVetError as exc:
+        logger.warning("doc_parser: refused %s archive (%s)", os.path.basename(path), exc.reason)
+        return None
+    return zipfile.ZipFile(path, "r")
+
+
 def _extract_docx(path: str) -> str:
     """Extract text from a .docx file (ZIP containing word/document.xml).
 
@@ -152,7 +185,10 @@ def _extract_docx(path: str) -> str:
     if is_sensitive_path(path):
         return ""
     paragraphs: list[str] = []
-    with zipfile.ZipFile(path, "r") as zf:
+    zf_or_none = _open_vetted_zip(path)
+    if zf_or_none is None:
+        return ""
+    with zf_or_none as zf:
         if "word/document.xml" not in zf.namelist():
             return ""
         data = _read_zip_entry(zf, "word/document.xml")
@@ -184,7 +220,10 @@ def _extract_pptx(path: str) -> str:
     if is_sensitive_path(path):
         return ""
     slides: list[tuple[int, str]] = []
-    with zipfile.ZipFile(path, "r") as zf:
+    zf_or_none = _open_vetted_zip(path)
+    if zf_or_none is None:
+        return ""
+    with zf_or_none as zf:
         slide_names = sorted(
             (n for n in zf.namelist() if _SLIDE_RE.match(n)),
             key=lambda n: int(_SLIDE_RE.match(n).group(1)),  # type: ignore[union-attr]

--- a/src/kiro_crew/zip_vet.py
+++ b/src/kiro_crew/zip_vet.py
@@ -1,0 +1,152 @@
+"""One inventory vet for every site that parses an UNTRUSTED zip container.
+
+``.docx``/``.xlsx``/``.pptx`` are zip archives, so any upload path that hands one
+to a parser is parsing attacker-controlled container metadata. Two bounds matter,
+and they are not interchangeable:
+
+* **How much the archive expands.** A small file whose members declare gigabytes
+  of uncompressed content is a decompression bomb (CWE-409/770). The declared
+  sizes in the central directory are enough to refuse it without extracting.
+* **How many entries the archive declares.** This is the one that is easy to get
+  wrong, and the reason this module exists rather than a shared constant:
+
+      ``ZipFile.__init__`` materializes one ``ZipInfo`` per declared
+      central-directory entry.
+
+  So a cap checked through ``infolist()`` runs AFTER the allocation it is meant
+  to bound. An archive declaring hundreds of thousands of entries exhausts memory
+  during construction, while the check that was supposed to stop it sits on the
+  next line, never reached. The only guard that actually binds is a raw-bytes
+  preflight over the End Of Central Directory record — reading the fields at the
+  exact fixed offsets ``zipfile`` itself parses — performed BEFORE the
+  ``ZipFile`` is constructed.
+
+Caps are parameters, not constants here: a preview endpoint legitimately runs
+tighter limits than an ingest path. The implementation is what is shared.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import struct
+import zipfile
+
+logger = logging.getLogger(__name__)
+
+# End Of Central Directory record: signature, then fixed-width fields. The
+# comment that may follow it is why the record has to be searched for rather
+# than read at a fixed offset from the end.
+_EOCD_SIG = b"PK\x05\x06"
+_EOCD_SIZE = 22
+_EOCD_MAX_COMMENT = 0xFFFF
+
+# ZIP64 End Of Central Directory locator/record. A ZIP64 archive stores 0xFFFF /
+# 0xFFFFFFFF sentinels in the classic EOCD and the real counts here, so trusting
+# the classic record alone lets a crafted archive declare a tiny entry count and
+# still carry a huge directory -- the "ZIP64 shadow record" case.
+_ZIP64_LOCATOR_SIG = b"PK\x06\x07"
+_ZIP64_LOCATOR_SIZE = 20
+_ZIP64_EOCD_SIG = b"PK\x06\x06"
+
+#: Bytes read from the tail when hunting the EOCD. The record is at most 22
+#: bytes plus a 64 KiB comment, so this always contains it when one exists.
+_TAIL_READ = _EOCD_SIZE + _EOCD_MAX_COMMENT + _ZIP64_LOCATOR_SIZE
+
+
+class ZipVetError(Exception):
+    """An untrusted archive was refused. ``reason`` is a short stable token."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _read_tail(path: str) -> bytes:
+    with open(path, "rb") as fh:
+        size = os.fstat(fh.fileno()).st_size
+        fh.seek(max(0, size - _TAIL_READ))
+        return fh.read()
+
+
+def _declared_entry_count(path: str) -> int:
+    """Entries the archive's directory DECLARES, from raw bytes only.
+
+    Raises :class:`ZipVetError` when no EOCD record is present — a file that
+    reached here passed a PK magic-byte gate, so a missing directory means
+    truncated or crafted, not "an empty archive".
+    """
+    tail = _read_tail(path)
+    idx = tail.rfind(_EOCD_SIG)
+    if idx < 0 or len(tail) - idx < _EOCD_SIZE:
+        raise ZipVetError("missing_eocd")
+    # EOCD: sig(4) disk(2) cd_disk(2) this_disk_entries(2) total_entries(2) ...
+    total_entries = struct.unpack_from("<H", tail, idx + 10)[0]
+
+    # ZIP64: the classic field saturates at 0xFFFF, and the true count lives in
+    # the ZIP64 EOCD that the locator points at. Consult it whenever a locator
+    # is present, not only when the classic count is saturated -- a crafted
+    # archive can declare a small classic count beside a large ZIP64 record, and
+    # `zipfile` reads the ZIP64 one.
+    loc = tail.rfind(_ZIP64_LOCATOR_SIG)
+    if loc >= 0 and len(tail) - loc >= _ZIP64_LOCATOR_SIZE:
+        z64_offset = struct.unpack_from("<Q", tail, loc + 8)[0]
+        try:
+            with open(path, "rb") as fh:
+                fh.seek(z64_offset)
+                rec = fh.read(56)
+        except OSError:
+            raise ZipVetError("bad_zip64_locator") from None
+        # A locator pointing at something that is not a ZIP64 EOCD -- including
+        # past EOF, where the read simply comes back short rather than raising --
+        # is itself a refusal: the archive claims a record it does not contain.
+        if rec[:4] != _ZIP64_EOCD_SIG or len(rec) < 40:
+            raise ZipVetError("bad_zip64_locator")
+        # ZIP64 EOCD: sig(4) size(8) vers(2) vers_needed(2) disk(4)
+        # cd_disk(4) this_disk_entries(8) total_entries(8)
+        total_entries = max(total_entries, struct.unpack_from("<Q", rec, 32)[0])
+    return total_entries
+
+
+def vet_zip_inventory(
+    path: str,
+    *,
+    max_members: int,
+    max_uncompressed_bytes: int,
+) -> None:
+    """Refuse an untrusted zip container that exceeds either bound.
+
+    Order is the whole point:
+
+    1. the raw-bytes EOCD preflight, BEFORE ``ZipFile`` is constructed, so the
+       declared entry count is bounded before it can drive an allocation;
+    2. only then the central-directory walk for declared expansion size.
+
+    Raises :class:`ZipVetError` with a short stable reason; returns ``None`` when
+    the archive is within both bounds. Does synchronous file I/O, so callers on
+    the event loop must run it via ``asyncio.to_thread``.
+    """
+    declared = _declared_entry_count(path)
+    if declared > max_members:
+        logger.warning(
+            "zip vet: refused archive declaring %d entries (cap %d)", declared, max_members
+        )
+        raise ZipVetError("too_many_members")
+
+    try:
+        with zipfile.ZipFile(path) as zf:
+            infos = zf.infolist()
+            # Belt to the preflight's braces: a directory whose real entry count
+            # disagrees with its declared one is malformed, and the parser about
+            # to run would be reading the real one.
+            if len(infos) > max_members:
+                raise ZipVetError("too_many_members")
+            uncompressed = 0
+            for zi in infos:
+                uncompressed += zi.file_size
+                if uncompressed > max_uncompressed_bytes:
+                    raise ZipVetError("uncompressed_too_large")
+    except zipfile.BadZipFile:
+        raise ZipVetError("bad_archive") from None
+    except OSError:
+        raise ZipVetError("bad_archive") from None

--- a/test/test_zip_vet.py
+++ b/test/test_zip_vet.py
@@ -1,0 +1,150 @@
+"""The shared untrusted-zip inventory vet (#3908).
+
+The load-bearing property, and the reason a shared constant would not have been
+enough: ``ZipFile.__init__`` materializes one ``ZipInfo`` per DECLARED
+central-directory entry, so a member cap read off ``infolist()`` runs after the
+allocation it is meant to bound. These pin that the declared count is refused
+from raw EOCD bytes BEFORE any ``ZipFile`` is constructed.
+"""
+
+from __future__ import annotations
+
+import struct
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.zip_vet import ZipVetError, vet_zip_inventory
+
+
+def _zip_with(path: Path, members: dict[str, bytes]) -> Path:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    return path
+
+
+def _forge_declared_entry_count(path: Path, count: int) -> None:
+    """Rewrite the EOCD's total-entries field without adding real members.
+
+    This is the crafted-archive shape the preflight exists for: a tiny file that
+    DECLARES a huge directory. `zipfile` believes the declaration during
+    construction, which is where the allocation happens.
+    """
+    raw = bytearray(path.read_bytes())
+    idx = raw.rfind(b"PK\x05\x06")
+    assert idx >= 0, "test fixture has no EOCD"
+    struct.pack_into("<H", raw, idx + 8, min(count, 0xFFFF))   # this-disk entries
+    struct.pack_into("<H", raw, idx + 10, min(count, 0xFFFF))  # total entries
+    path.write_bytes(bytes(raw))
+
+
+class TestDeclaredEntryCount:
+    def test_a_forged_entry_count_is_refused_before_zipfile_is_built(self, tmp_path, monkeypatch):
+        """The whole point: refusal happens without ``ZipFile`` being constructed.
+
+        Asserted by making construction fail loudly — if the vet reached it, the
+        test would surface that error instead of the refusal.
+        """
+        p = _zip_with(tmp_path / "a.docx", {"word/document.xml": b"<x/>"})
+        _forge_declared_entry_count(p, 60000)
+
+        def _must_not_construct(*a, **k):
+            raise AssertionError("ZipFile was constructed before the member cap bound")
+
+        monkeypatch.setattr(zipfile, "ZipFile", _must_not_construct)
+
+        with pytest.raises(ZipVetError) as exc:
+            vet_zip_inventory(p, max_members=100, max_uncompressed_bytes=1 << 30)
+        assert exc.value.reason == "too_many_members"
+
+    def test_an_ordinary_archive_within_bounds_passes(self, tmp_path):
+        p = _zip_with(tmp_path / "ok.docx", {"word/document.xml": b"<x/>"})
+        vet_zip_inventory(p, max_members=100, max_uncompressed_bytes=1 << 30)
+
+    def test_a_missing_eocd_is_refused(self, tmp_path):
+        """A file that got here passed a PK magic gate, so no directory means
+        truncated or crafted -- not 'an empty archive'."""
+        p = tmp_path / "trunc.docx"
+        p.write_bytes(b"PK\x03\x04" + b"\x00" * 64)
+        with pytest.raises(ZipVetError) as exc:
+            vet_zip_inventory(p, max_members=100, max_uncompressed_bytes=1 << 30)
+        assert exc.value.reason == "missing_eocd"
+
+    def test_a_zip64_locator_pointing_outside_the_file_is_refused(self, tmp_path):
+        """A ZIP64 shadow record: the archive claims a record it does not carry."""
+        p = _zip_with(tmp_path / "z.docx", {"a": b"x"})
+        raw = bytearray(p.read_bytes())
+        idx = raw.rfind(b"PK\x05\x06")
+        locator = bytearray(b"PK\x06\x07")
+        locator += struct.pack("<I", 0)              # disk with ZIP64 EOCD
+        locator += struct.pack("<Q", 1 << 40)        # offset far past EOF
+        locator += struct.pack("<I", 1)              # total disks
+        raw[idx:idx] = locator
+        p.write_bytes(bytes(raw))
+
+        with pytest.raises(ZipVetError) as exc:
+            vet_zip_inventory(p, max_members=100, max_uncompressed_bytes=1 << 30)
+        assert exc.value.reason == "bad_zip64_locator"
+
+
+class TestExpansionBound:
+    def test_declared_expansion_over_the_cap_is_refused(self, tmp_path):
+        # Highly compressible content: small on disk, large declared.
+        p = _zip_with(tmp_path / "bomb.docx", {"big": b"0" * 5_000_000})
+        with pytest.raises(ZipVetError) as exc:
+            vet_zip_inventory(p, max_members=100, max_uncompressed_bytes=1_000_000)
+        assert exc.value.reason == "uncompressed_too_large"
+
+    def test_a_bad_zipfile_becomes_a_refusal_not_an_escaping_exception(
+        self, tmp_path, monkeypatch
+    ):
+        """`zipfile` is tolerant of several malformed directories and recovers,
+        so the mapping is pinned at the boundary rather than by crafting bytes
+        that a future CPython might also decide to recover from."""
+        p = _zip_with(tmp_path / "x.docx", {"a": b"x"})
+
+        def _bad(*a, **k):
+            raise zipfile.BadZipFile("truncated central directory")
+
+        monkeypatch.setattr(zipfile, "ZipFile", _bad)
+        with pytest.raises(ZipVetError) as exc:
+            vet_zip_inventory(p, max_members=100, max_uncompressed_bytes=1 << 30)
+        assert exc.value.reason == "bad_archive"
+
+    def test_an_empty_archive_is_accepted(self, tmp_path):
+        """An EOCD with zero entries is a VALID empty zip, not a refusal."""
+        p = tmp_path / "empty.docx"
+        with zipfile.ZipFile(p, "w"):
+            pass
+        vet_zip_inventory(p, max_members=100, max_uncompressed_bytes=1 << 30)
+
+
+class TestCallSitesAreRouted:
+    """Both untrusted-archive parse sites on main go through the shared vet."""
+
+    def test_knowledge_ingest_reports_the_shared_reason(self, tmp_path):
+        from kiro_crew.dashboard.handlers.knowledge import _inspect_zip_archive
+
+        p = _zip_with(tmp_path / "k.docx", {"word/document.xml": b"<x/>"})
+        _forge_declared_entry_count(p, 60000)
+        assert _inspect_zip_archive(str(p)) == "too_many_members"
+
+    def test_knowledge_ingest_still_accepts_an_ordinary_archive(self, tmp_path):
+        from kiro_crew.dashboard.handlers.knowledge import _inspect_zip_archive
+
+        p = _zip_with(tmp_path / "k2.docx", {"word/document.xml": b"<x/>"})
+        assert _inspect_zip_archive(str(p)) is None
+
+    @pytest.mark.parametrize("suffix", ["docx", "pptx"])
+    def test_doc_parser_refuses_a_forged_archive_instead_of_opening_it(self, tmp_path, suffix):
+        """These two sites had NO inventory vet at all before this change."""
+        import kiro_crew.doc_parser as dp
+
+        member = "word/document.xml" if suffix == "docx" else "ppt/slides/slide1.xml"
+        p = _zip_with(tmp_path / f"d.{suffix}", {member: b"<x/>"})
+        _forge_declared_entry_count(p, 60000)
+
+        extract = dp._extract_docx if suffix == "docx" else dp._extract_pptx
+        assert extract(str(p)) == ""


### PR DESCRIPTION
Closes #3908.

## The insight this is built on

> `ZipFile.__init__` materializes one `ZipInfo` per **declared** central-directory entry.

So a member cap read off `infolist()` runs *after* the allocation it is meant to bound. An archive declaring hundreds of thousands of entries exhausts memory during construction while the check that was supposed to stop it sits on the next line, never reached. The only guard that binds is a **raw-bytes EOCD preflight before the `ZipFile` is constructed**.

## What this adds

`kiro_crew/zip_vet.py` does that preflight — EOCD plus the ZIP64 locator and record, read at the fixed offsets `zipfile` itself parses — then the declared-expansion walk. **Caps are parameters, not constants**: a preview endpoint legitimately runs tighter limits than an ingest path; the implementation is what is shared.

Two call sites on `main` route through it:

- **`knowledge.py::_inspect_zip_archive`** had exactly the after-the-fact shape — it constructed `ZipFile`, *then* checked `len(infolist()) > _MAX_INGEST_ARCHIVE_MEMBERS`.
- **`doc_parser.py`'s two OOXML sites** had **no inventory bound at all**. They now refuse a crafted archive by returning `""`, matching that module's existing contract that an unreadable document degrades to empty rather than failing the caller.

ZIP64 is consulted whenever a locator is present, not only when the classic count is saturated: a crafted archive can declare a small classic count beside a large ZIP64 record, and `zipfile` reads the ZIP64 one. A locator pointing at something that is not a ZIP64 EOCD — including past EOF, where the read comes back short rather than raising — is itself a refusal.

## Scope note

The issue lists a **third** site, `files.py`'s `/api/file-sheet` (`_vet_zip_eocd`, `_SHEET_MAX_MEMBERS`). **That endpoint does not exist on `main`** — it is added by PR #3875, still open — so there is nothing to route yet, and `test/test_file_sheet.py` (which the issue expected to become this module's suite) does not exist either. When #3875 lands, its inline vet can be deleted in favour of this module rather than becoming a fourth copy, which is the outcome the issue is after. I wrote a fresh suite here instead.

## Test plan

- **`test/test_zip_vet.py`** (new, 11 tests). The important one: a forged entry count is refused **with `ZipFile` monkeypatched to fail loudly** — that is what proves the refusal happens before construction rather than after, which a plain "it returned an error" assertion could not distinguish. Plus missing EOCD, a ZIP64 locator pointing past EOF, declared-expansion overflow, the `BadZipFile` → refusal mapping, an empty archive still accepted, and both call sites shown routing through the shared vet.
- `test_zip_vet` + `test_doc_parser` + `test_knowledge`: **176 passed**.
- `flake8` / `isort` clean on touched files.