### PR TITLE
fix(security): write-protect the app-sources checkouts apps execute from

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -345,6 +345,35 @@ sync keep working.
 
 `test_security.py::TestModelWeightsAreWriteProtected` pins all of it, including the false-positive cost of both widenings.
 
+**App-sources checkouts** (`app-sources/`) — the persistent tree every installed app *executes*
+from (`apps.registry.app_source_dir` → `<data-home>/app-sources/{name}`). The entry is a whole
+DIRECTORY rather than a leaf, which `_path_in_home_dirs` already supports: it matches the entry
+and its `entry + os.sep` prefix, so every file under every checkout is covered without
+enumerating them.
+
+This is the strongest instance of the write-only class, because the protected file *is* the
+executed code rather than an input to a decision about it — an agent with ordinary file-write
+tools could edit an installed app's source, which then runs with that app's privileges on the
+app's next launch. Nothing downstream neutralizes it: unlike `config.json`, whose inflated values
+the load-time clamp below rewrites, a modified checkout is simply run. Provenance does not catch
+it either — `install_from_registry` records `_resolved_clone_commit` (the tree's real `HEAD`), and
+an agent write dirties the worktree without moving `HEAD`, so a modified tree still reports the
+pinned SHA.
+
+- **File-edit tool gate only**, deliberately: `app-sources` is in `_WRITE_PROTECTED_HOME_PATHS`
+  but NOT in `_WRITE_PROTECTED_BASH_LEAVES`. That matcher blocks on a command *naming* the path,
+  which would deny bash reads too — and unlike the marker and the two Ops Mission Control files,
+  reading app source is a routine, high-volume operation (the dashboard file viewer lists
+  `app-sources` as a browsable root, knowledge indexing walks it, and reading an app's code is how
+  anyone debugs one). Reads stay allowed on both paths; `app-sources` is not in
+  `_SENSITIVE_HOME_DIRS`. This leaves shell writes on the same footing as `config.json`'s, where
+  the tool gate is likewise the enforcement point.
+- The gateway's own installer is unaffected: `_clone_build_app` clones, builds and prunes through
+  direct Python/subprocess calls, which are not agent tool calls and never reach
+  `hooks.on_tool_call`.
+- An installed app's *data* directory (`apps/{name}/data/`) is a different tree and stays
+  writable — apps persist state there through the agent's own tools.
+
 **Load-time resource-limit clamp** (`config/loader.py`) — defends against a config-loader bound bypass: the dashboard config API rejects out-of-range writes, but a direct edit of `config.json` (any process as the same OS user, or a prompt-injected agent with file-write access) bypassed that gate.
 - `KiroCrewConfig.load()` calls `_clamp_security_bounds(data)` on the disk-read path (before caching) so cache hits and the `GET /api/config/kirocrew` serialization both report clamped values.
 - Clamped knobs: `agent.subagent_auto_max` ≤ `SUBAGENT_AUTO_MAX_CEILING` (64), `agent.max_subagents` ≤ 64, `agent.subagent_max_turns` ≤ `SUBAGENT_MAX_TURNS_CEILING` (200), `session.pool_size` ≤ `POOL_SIZE_MAX` (10). Mins match existing runtime floors (0/1); `bool` and non-int values are left untouched for dataclass coercion.

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -5341,6 +5341,45 @@ _WRITE_PROTECTED_HOME_PATHS += [
     f"{prefix}/connections-tool-aliases.json"
     for prefix in _CREW_HOME_PREFIXES
 ]
+_WRITE_PROTECTED_HOME_PATHS += [
+    # The app-sources checkout root — the persistent tree every installed app
+    # EXECUTES from (``apps.registry.app_source_dir``). This is a whole DIRECTORY
+    # rather than a leaf, which the shared matcher already supports: it compares a
+    # resolved path against the entry and its ``entry + os.sep`` prefix, so every
+    # file under every checkout is covered without enumerating them.
+    #
+    # It is the strongest instance of the write-protection class, because the
+    # protected file IS the executed code rather than an input to a decision about
+    # it: an agent session with ordinary file-write tools could edit an installed
+    # app's source, and that source then runs with the app's privileges on the
+    # app's next launch. Nothing downstream neutralizes it — unlike ``config.json``,
+    # whose inflated values the loader clamps at load time, a modified checkout is
+    # simply run. Provenance does not catch it either: ``install_from_registry``
+    # records ``_resolved_clone_commit`` (the tree's real ``HEAD``), and an agent
+    # write dirties the worktree without moving ``HEAD``, so a modified tree still
+    # reports the pinned SHA.
+    #
+    # Write-only, NOT ``_SENSITIVE_HOME_DIRS``, and the asymmetry is load-bearing:
+    # app source carries no secret and is legitimately READ all the time — the
+    # dashboard file viewer lists ``app-sources`` as a browsable root
+    # (``apps.builtins.file_explorer.server``), knowledge indexing walks it, and
+    # reading an installed app's code is how anyone debugs one. Classifying it
+    # read+write sensitive would break those.
+    #
+    # Deliberately NOT added to ``_WRITE_PROTECTED_BASH_LEAVES`` below: that
+    # matcher blocks on a command NAMING the path, which denies bash reads too.
+    # That is harmless for the marker and the two Ops Mission Control files, whose
+    # only legitimate readers are Python; it is not harmless here, where reading
+    # app source with ``grep``/``cat`` is routine. Shell writes therefore sit on
+    # the same footing as ``config.json``'s, with the file-edit tool gate as the
+    # enforcement point.
+    #
+    # The gateway's own installer is unaffected: ``_clone_build_app`` clones,
+    # builds and prunes through direct Python/subprocess calls, which are not
+    # agent tool calls and never reach ``hooks.on_tool_call``.
+    f"{prefix}/app-sources"
+    for prefix in _CREW_HOME_PREFIXES
+]
 
 # ── kiro-cli agent-spec directory (~/.kiro/agents) ──
 # The user-level directory kiro-cli reads its ``--agent <name>`` specs from

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1678,7 +1678,7 @@ def _write_protected_items() -> list[PostureItem]:
     return [
         PostureItem(
             label=f"~/{entry}",
-            detail="Reads allowed; writes blocked so the agent cannot raise its own limits",
+            detail="Reads allowed; the agent's file-edit tools cannot modify it",
         )
         for entry in security.write_protected_home_paths()
     ]

--- a/test/test_app_sources_write_protection.py
+++ b/test/test_app_sources_write_protection.py
@@ -1,0 +1,80 @@
+"""App-sources checkouts are write-protected against agent tools.
+
+``~/.kiro/crew/app-sources/{name}`` is the persistent tree every installed app
+EXECUTES from. Writes must be refused at the agent file-edit gate; reads must
+keep working, because app source carries no secret and the dashboard file
+viewer, knowledge indexing and ordinary debugging all read it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.apps.registry import app_source_dir
+from kiro_crew.security import (
+    is_sensitive_bash_command,
+    is_sensitive_path,
+    is_sensitive_write_path,
+    write_protected_home_paths,
+)
+
+_PREFIXES = ("~/.kiro/crew", "~/.kirocrew")
+
+
+class TestAppSourcesWriteProtection:
+    """Writes are refused for the checkout root and everything under it."""
+
+    @pytest.mark.parametrize("prefix", _PREFIXES)
+    def test_checkout_root_is_write_protected(self, prefix: str) -> None:
+        assert is_sensitive_write_path(f"{prefix}/app-sources")
+        assert is_sensitive_write_path(str(Path.home() / prefix[2:] / "app-sources"))
+
+    @pytest.mark.parametrize("prefix", _PREFIXES)
+    def test_files_under_a_checkout_are_write_protected(self, prefix: str) -> None:
+        # The whole tree, not just the root: the executed file is what matters,
+        # and it is always several levels down.
+        for rel in (
+            "app-sources/notes/server.py",
+            "app-sources/notes/src/handlers/index.ts",
+            "app-sources/notes/package.json",
+            "app-sources/notes/.git/config",
+        ):
+            assert is_sensitive_write_path(f"{prefix}/{rel}"), rel
+            assert is_sensitive_write_path(str(Path.home() / prefix[2:] / rel)), rel
+
+    def test_registry_checkout_path_is_covered(self) -> None:
+        """The gate covers the path the installer actually clones into.
+
+        Pins the entry to ``app_source_dir`` rather than to the spelling
+        ``app-sources``, so renaming the directory in ``apps.registry`` without
+        updating the security entry fails here instead of silently unprotecting
+        every installed app.
+        """
+        assert is_sensitive_write_path(str(app_source_dir("notes") / "server.py"))
+
+    @pytest.mark.parametrize("prefix", _PREFIXES)
+    def test_reads_stay_allowed(self, prefix: str) -> None:
+        # Write-only, deliberately NOT read+write sensitive: the file viewer
+        # lists app-sources as a browsable root and knowledge indexing walks it.
+        path = f"{prefix}/app-sources/notes/server.py"
+        assert is_sensitive_path(path) is False
+        assert is_sensitive_bash_command(f"cat {path}") is None
+        assert is_sensitive_bash_command(f"grep -rn handler {prefix}/app-sources/") is None
+
+    def test_sibling_data_home_paths_unaffected(self) -> None:
+        """A prefix-neighbour of the entry must not be caught by it."""
+        # `app-sources-backup` shares the entry's string prefix but is a
+        # different directory; the matcher compares whole segments.
+        assert is_sensitive_write_path("~/.kiro/crew/app-sources-backup/x.py") is False
+        # An installed app's DATA dir is a different tree and stays writable —
+        # apps persist state there through the agent's own tools.
+        assert is_sensitive_write_path("~/.kiro/crew/apps/notes/data/notes.json") is False
+
+    def test_entry_is_published_on_the_posture_surface(self) -> None:
+        """The posture page derives its list from the enforcing object."""
+        entries = write_protected_home_paths()
+        assert any(e.endswith("app-sources") for e in entries), entries
+        # Both data-home spellings, so a legacy install is gated too.
+        assert sum(1 for e in entries if e.endswith("app-sources")) == 2


### PR DESCRIPTION
## Problem / Motivation

`~/.kiro/crew/app-sources/{name}` — the persistent checkout every installed app **executes from** (`apps.registry.app_source_dir`) — is agent-writable for its entire lifetime. It is not in `security._SENSITIVE_HOME_DIRS` and was not in the write-protected path list, so a session with ordinary file-write tools can modify an installed app's code, which then runs with that app's privileges on the app's next launch.

Nothing downstream neutralizes it:

- Unlike `config.json`, whose out-of-range values `_clamp_security_bounds` rewrites at load time, a modified checkout is **simply run**.
- Provenance does not catch it either. `install_from_registry` records `_resolved_clone_commit(clone_root)` — the tree's real `HEAD` — and an agent write dirties the worktree **without moving `HEAD`**, so a modified tree still reports the pinned SHA.

As issue #4032 argues, the install window is the smallest instance of this rather than the problem itself: `_clone_build_app` has cloned into the same persistent directory for branch installs on `main` all along, and the window never closes, because the checkout persists and the app executes from it on every later run. Narrowing or reverting the pinned install path leaves the post-install exposure untouched.

## Why it matters

This is a privilege-escalation seam in the gate that is supposed to stop an agent from rewriting the code it runs under. Every user with an installed app is exposed: a single agent file-write into `app-sources/{name}` is persistent, survives the session that made it, executes on the app's next launch with that app's privileges, and — because `HEAD` never moves — leaves the provenance record still reporting the pinned commit, so neither the operator nor the registry sees anything wrong.

The write-protected path list already covers the other inputs an agent must not be able to raise its own limits through. App source is the one that was missing, and it is the most direct of them: modifying executed code needs no further step, where every other entry in the tier is an *input to a decision* about what runs.

## What changed (motivation → approach → change)

`app-sources` joins `_WRITE_PROTECTED_HOME_PATHS` under both data-home prefixes.

The entry is a whole **directory**, not a leaf. That needed no matcher change: `_path_in_home_dirs` already compares a resolved candidate against the entry *and* its `entry + os.sep` prefix, so every file under every checkout is covered without enumerating them — and the symlink-resolution and casefold hardening that core carries applies unchanged.

**Reads stay allowed, on both paths, and that is load-bearing rather than incidental.** App source carries no secret, and reading it is routine and high-volume: the dashboard file viewer lists `app-sources` as a browsable root (`apps.builtins.file_explorer.server`), knowledge indexing walks it, and reading an installed app's code is how anyone debugs one. So it is write-only (`is_sensitive_write_path`), not read+write sensitive.

### One deliberate limit, stated up front

`app-sources` is **not** added to `_WRITE_PROTECTED_BASH_LEAVES`. That matcher is verb-independent — it blocks any command *naming* the path — which incidentally denies bash **reads** too. The module's own comment calls that harmless for `.data-home-ready` and the two Ops Mission Control files, and it is, because their only legitimate readers are Python. It is not harmless here: `grep -rn handler ~/.kiro/crew/app-sources/` is a normal thing to run, and blocking it would trade a real capability for a partial gain.

So shell writes sit on exactly the same footing as `config.json`'s, where the file-edit tool gate is likewise the enforcement point. A verb-anchored bash branch that preserved reads would be the alternative, and I left it out on purpose: the module already argues that an enumerated write-verb allowlist is inherently bypassable, and adding a knowingly-partial branch to a security gate is worse than a clearly-stated boundary. Happy to add one if a maintainer wants it — it is a separable change either way.

The gateway's own installer is unaffected: `_clone_build_app` clones, builds and prunes through direct Python/subprocess calls, which are not agent tool calls and never reach `hooks.on_tool_call`.

### Posture caption

`security_posture` derives this control's list from the enforcing object, so the new entry appears there with no change. Its shared per-entry caption read "writes blocked so the agent cannot raise its own limits" — already inaccurate for the two Ops Mission Control authorization inputs, and inaccurate for app source — so it now states the mechanism (`the agent's file-edit tools cannot modify it`) instead of one entry's motive.

### Rebase note: the neighbouring model-weights tier

While this sat open, `main` landed the **downloaded model weights** entry (`<data home>/models`) into the same write-only tier, in the same spot in `docs/system-specs/modules/security.md`. That produced the one rebase conflict, and it was purely additive — both sections are kept, `models` first, `app-sources` after it. The two are worth reading together: `models` protects an **input to a trust decision** (a sha256-verified file whose path is handed to a native loader that re-opens it by name), while `app-sources` protects the **executed code itself**. `models` takes both layers including the bash leaf; `app-sources` deliberately takes only the tool layer, for the read-traffic reason above. Neither entry changes the other's behaviour — both are independent members of a list the matcher walks.

## Tests

`test/test_app_sources_write_protection.py` (new, 9 tests) locks in:

- the checkout root and files under it are write-blocked on both data-home spellings;
- the entry is pinned to `app_source_dir` rather than to the `app-sources` string, so renaming the directory in `apps.registry` fails here instead of silently unprotecting every installed app;
- reads stay allowed on the tool and bash paths — the deliberate boundary above, asserted rather than assumed;
- a prefix-neighbour (`app-sources-backup`) and an app's own `data/` dir stay writable;
- the entry reaches the posture surface under both prefixes.

**6 of the 9 fail on `main`**, so the suite is mutation-checked against the unfixed tree rather than merely passing.

Regression scope re-run locally on the rebased head: `test_app_sources_write_protection` + `test_security` + `test_security_posture` + `test_config_loader` → **1537 passed, 1 skipped**. That count includes `main`'s own `TestModelWeightsAreWriteProtected`, so the two adjacent tiers are verified green together. Also clean on the rebased head: `isort`, `flake8`, `mypy`, the black-baseline gate, and `./scripts/docs-lint.sh` (242 files).

## Manual verification

N/A — the change is one entry in a path list whose matcher, gate paths and posture surface are all exercised directly by the new unit tests, including the read-still-allowed boundary and the negative prefix-neighbour case.

## Related Issues

Fixes #4032

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/system-specs/modules/security.md` documents the new entry alongside the existing write-only tier, including why the bash layer is not extended
- [x] No secrets, credentials, or internal references in the diff
