### PR TITLE
fix(apps): give the remaining builtin apps a narrow-first page gutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **Every builtin app now starts its content 8px from a phone screen edge, not 24px.**
+  The narrow-first page gutter (`px-2 md:px-6`) reached the core pages and Issue
+  Radar, while the remaining builtin apps kept an unconditional `px-6`, so their
+  content was inset 24px before any card inset stacked on top. Meetings, Code
+  Review Sage, Auto Research, Workflows, Mochi, Papyrus, PPTX Maker and Ops
+  Mission Control now carry the same gutter, converted a whole file at a time so
+  a header and the rows beneath it cannot render on two different left edges.
+  Centered empty states keep their `px-6`, where it is the element's only inset
+  and flushing it would push centered copy toward the edge for no width gain; a
+  guard test states that exclusion so a later pass does not read it as a miss.
+
 - **Destructive buttons look destructive on a phone.** `Btn`'s `danger`
   variant coloured its label only on `:hover`, and a touch viewport never
   produces `hover` — so a destructive button rendered identically to the

--- a/website/src/apps/auto-research/ResearchLabPage.tsx
+++ b/website/src/apps/auto-research/ResearchLabPage.tsx
@@ -738,11 +738,11 @@ export default function ResearchLabPage() {
 
   const active = campaigns.find((c: Campaign) => ACTIVE_STATUSES.includes(c.status))
 
-  if (view === 'wizard') return <div className="px-6 py-4"><h1 className="text-lg font-semibold mb-4">{i18nT('apps.autoResearch.researchLabPage.new_campaign')}</h1><SetupWizard onCancel={() => setView('list')} onDone={() => { qc.invalidateQueries({ queryKey: ['research-campaigns'] }); setView('list') }} /></div>
-  if (view === 'fork' && forkParentId) return <div className="px-6 py-4"><h1 className="text-lg font-semibold mb-4">{i18nT('apps.autoResearch.researchLabPage.continue_research')}</h1><ForkFlow parentId={forkParentId} onCancel={() => setView('list')} onDone={() => { qc.invalidateQueries({ queryKey: ['research-campaigns'] }); setView('list') }} /></div>
-  if (view === 'detail' && selectedId) return <div className="px-6 py-4"><CampaignDetail id={selectedId} onBack={() => setView('list')} onFork={(id) => { setForkParentId(id); setView('fork') }} onOpen={(pid) => setSelectedId(pid)} /></div>
+  if (view === 'wizard') return <div className="px-2 md:px-6 py-4"><h1 className="text-lg font-semibold mb-4">{i18nT('apps.autoResearch.researchLabPage.new_campaign')}</h1><SetupWizard onCancel={() => setView('list')} onDone={() => { qc.invalidateQueries({ queryKey: ['research-campaigns'] }); setView('list') }} /></div>
+  if (view === 'fork' && forkParentId) return <div className="px-2 md:px-6 py-4"><h1 className="text-lg font-semibold mb-4">{i18nT('apps.autoResearch.researchLabPage.continue_research')}</h1><ForkFlow parentId={forkParentId} onCancel={() => setView('list')} onDone={() => { qc.invalidateQueries({ queryKey: ['research-campaigns'] }); setView('list') }} /></div>
+  if (view === 'detail' && selectedId) return <div className="px-2 md:px-6 py-4"><CampaignDetail id={selectedId} onBack={() => setView('list')} onFork={(id) => { setForkParentId(id); setView('fork') }} onOpen={(pid) => setSelectedId(pid)} /></div>
 
-  return <div className="px-6 py-4">
+  return <div className="px-2 md:px-6 py-4">
     <div className="flex items-center justify-between mb-4">
       <h1 className="text-lg font-semibold flex items-center gap-2"><FlaskConical size={20} /> {i18nT('apps.autoResearch.researchLabPage.research_lab')}</h1>
       <button className="text-sm px-3 py-1.5 rounded-md bg-accent text-accent-fg disabled:opacity-50" disabled={!!active} onClick={() => setView('wizard')} title={active ? i18nT('apps.autoResearch.researchLabPage.one_campaign_at_a_time') : ''}>{i18nT('apps.autoResearch.researchLabPage.new_campaign_2')}</button>

--- a/website/src/apps/code-review-sage/components/AddReposModal.tsx
+++ b/website/src/apps/code-review-sage/components/AddReposModal.tsx
@@ -184,7 +184,7 @@ export default function AddReposModal({ onClose }: { onClose: () => void }) {
           className="relative w-[680px] max-w-full h-[620px] max-h-full border border-border rounded-[14px] bg-card flex flex-col shadow-2xl outline-none overflow-hidden"
           onKeyDown={(e) => e.stopPropagation()}
         >
-          <header className="px-6 pt-5 pb-4 border-b border-border flex-shrink-0">
+          <header className="px-2 md:px-6 pt-5 pb-4 border-b border-border flex-shrink-0">
             <h1 className="text-[19px] font-bold leading-tight text-text-strong pr-8">
               {i18nT('apps.codeReviewSage.components.addReposModal.add_repos')}
             </h1>
@@ -202,7 +202,7 @@ export default function AddReposModal({ onClose }: { onClose: () => void }) {
 
           {/* Inputs stay pinned; only the lists scroll, so the manual field and
               the filter are always reachable however long the lists get. */}
-          <div className="px-6 pt-4 pb-3 flex flex-col gap-2.5 flex-shrink-0">
+          <div className="px-2 md:px-6 pt-4 pb-3 flex flex-col gap-2.5 flex-shrink-0">
             {/* Manual entry FIRST: it always works, even with no gh, and it is
                 the answer when a repo is missing from both capped lists. */}
             <div className="flex items-center gap-2">
@@ -254,7 +254,7 @@ export default function AddReposModal({ onClose }: { onClose: () => void }) {
             </div>
           </div>
 
-          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-6 pb-5 flex flex-col gap-2.5">
+          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-2 md:px-6 pb-5 flex flex-col gap-2.5">
             {setupRequired && <GhNotice message={recent?.error ?? mine?.error} />}
             {err && !setupRequired && (
               <div className="text-[12.5px] text-danger">{err.message}</div>

--- a/website/src/apps/code-review-sage/components/PrReviewDetail.tsx
+++ b/website/src/apps/code-review-sage/components/PrReviewDetail.tsx
@@ -326,7 +326,7 @@ export default function PrReviewDetail({ pr }: { pr: PrRef }) {
 
   return (
     <article className="h-full flex flex-col min-h-0">
-      <header className="px-6 pt-5 pb-3 border-b border-border flex-shrink-0">
+      <header className="px-2 md:px-6 pt-5 pb-3 border-b border-border flex-shrink-0">
         <div className="flex items-start gap-3">
           <div className="flex-1 min-w-0">
             <h1 className="text-[21px] font-bold leading-tight text-text-strong break-words">
@@ -429,7 +429,7 @@ export default function PrReviewDetail({ pr }: { pr: PrRef }) {
         </div>
       </header>
 
-      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-6 py-5 flex flex-col gap-5">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-2 md:px-6 py-5 flex flex-col gap-5">
         {tab === 'review' && reviewBody}
         {tab === 'source' && sourceBody()}
       </div>

--- a/website/src/apps/code-review-sage/components/RunDetail.tsx
+++ b/website/src/apps/code-review-sage/components/RunDetail.tsx
@@ -39,7 +39,7 @@ function DetailHeader({ run }: { run: Run }) {
   const { startReview } = useSage()
   const { label, more } = runIdentity(run.repo, run.changes)
   return (
-    <header className="px-6 pt-5 pb-4 border-b border-border flex-shrink-0">
+    <header className="px-2 md:px-6 pt-5 pb-4 border-b border-border flex-shrink-0">
       <div className="flex items-start gap-3">
         <div className="flex-1 min-w-0">
           <h1 className="text-[22px] font-bold leading-tight text-text-strong break-words">
@@ -116,7 +116,7 @@ export default function RunDetail({ run }: { run: Run }) {
   return (
     <article className="h-full flex flex-col min-h-0">
       <DetailHeader run={run} />
-      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-6 py-5 flex flex-col gap-5">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-2 md:px-6 py-5 flex flex-col gap-5">
         <RunProgress
           run={run}
           pool={pool}

--- a/website/src/apps/code-review-sage/views/LearningView.tsx
+++ b/website/src/apps/code-review-sage/views/LearningView.tsx
@@ -153,7 +153,7 @@ export default function LearningView() {
 
   if (!ns) {
     return (
-      <div className="h-full overflow-y-auto scrollbar-none px-6 py-6">
+      <div className="h-full overflow-y-auto scrollbar-none px-2 md:px-6 py-6">
         <h1 className="text-[22px] font-bold leading-tight text-text-strong flex items-center gap-2">
           <Brain size={18} className="text-accent" aria-hidden="true" /> {i18nT('apps.codeReviewSage.views.learningView.learning')}
         </h1>
@@ -165,7 +165,7 @@ export default function LearningView() {
   }
 
   return (
-    <div className="h-full overflow-y-auto scrollbar-none px-6 py-6">
+    <div className="h-full overflow-y-auto scrollbar-none px-2 md:px-6 py-6">
       <div className="max-w-[820px]">
         <h1 className="text-[22px] font-bold leading-tight text-text-strong flex items-center gap-2">
           <Brain size={18} className="text-accent" aria-hidden="true" />

--- a/website/src/apps/code-review-sage/views/SettingsView.tsx
+++ b/website/src/apps/code-review-sage/views/SettingsView.tsx
@@ -54,7 +54,7 @@ export default function SettingsView() {
   const s = data?.settings
 
   return (
-    <div className="h-full overflow-y-auto scrollbar-none px-6 py-6">
+    <div className="h-full overflow-y-auto scrollbar-none px-2 md:px-6 py-6">
       <div className="max-w-[720px]">
         <h1 className="text-[22px] font-bold leading-tight text-text-strong flex items-center gap-2">
           <SettingsIcon size={18} className="text-accent" aria-hidden="true" /> {i18nT('apps.codeReviewSage.views.settingsView.settings')}

--- a/website/src/apps/meetings/MeetingView.tsx
+++ b/website/src/apps/meetings/MeetingView.tsx
@@ -127,7 +127,7 @@ export default function MeetingView({
     // pushing the meeting off-screen rather than narrowing it.
     <div className="flex flex-col lg:flex-row h-full overflow-hidden">
       <div className="flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden">
-        <div className="flex-none px-6 py-4 border-b border-border flex items-center justify-between gap-3">
+        <div className="flex-none px-2 md:px-6 py-4 border-b border-border flex items-center justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
             <Btn onClick={onBack} aria-label={i18nT('apps.meetings.meeting.back')}>
               <ArrowLeft className="lucide-inline" />

--- a/website/src/apps/meetings/components/AgentPillBar.tsx
+++ b/website/src/apps/meetings/components/AgentPillBar.tsx
@@ -50,7 +50,7 @@ export default function AgentPillBar({
   const presetNames = Object.keys(presets)
 
   return (
-    <div className="px-6 py-2 border-b border-border flex flex-wrap items-center gap-2">
+    <div className="px-2 md:px-6 py-2 border-b border-border flex flex-wrap items-center gap-2">
       {presetNames.length > 0 ? (
         <SimpleSelect
           options={presetNames}

--- a/website/src/apps/meetings/components/BroadcastBar.tsx
+++ b/website/src/apps/meetings/components/BroadcastBar.tsx
@@ -27,7 +27,7 @@ export default function BroadcastBar({ onSend, caption, disabled }: Props) {
   }
 
   return (
-    <div className="flex-none px-6 py-3 border-t border-border bg-bg">
+    <div className="flex-none px-2 md:px-6 py-3 border-t border-border bg-bg">
       {caption && (
         <div
           // Wraps rather than clipping to one line: `truncate` set

--- a/website/src/test/narrowFirstBaseline.test.ts
+++ b/website/src/test/narrowFirstBaseline.test.ts
@@ -94,6 +94,38 @@ describe('narrow-first layout baseline', () => {
     ).toEqual([])
   })
 
+  it('leaves only centered placeholders holding a bare px-6 in the builtin apps', async () => {
+    // The app sweep converted page gutters and deliberately did NOT convert
+    // centered empty states, where `px-6` is the element's ONLY inset: flushing
+    // it to 8px pushes centered copy toward the screen edge for no width gain,
+    // because the copy is already narrower than the pane. Stating that here is
+    // the point -- without it, the next pass reads those four lines as misses
+    // and "finishes" a sweep that was already complete.
+    //
+    // The rule is per-LINE rather than per-file, unlike the half-conversion
+    // check above, because these placeholders legitimately sit in files that
+    // carry no gutter at all. A pill's own padding (`rounded-full px-6`) is not
+    // a gutter either.
+    const offenders: string[] = []
+    for await (const file of walkSource(join(SRC, 'apps'))) {
+      const src = await readFile(file, 'utf8')
+      const stripped = src.replace(/(?<![\w:-])(?:md|sm|lg|xl):px-6/g, '')
+      for (const [i, line] of stripped.split('\n').entries()) {
+        if (!/(?<![\w:-])px-6/.test(line)) continue
+        const centered = /items-center/.test(line)
+          && /justify-center/.test(line)
+          && /text-center/.test(line)
+        if (!centered && !/rounded-full/.test(line)) {
+          offenders.push(`${file.replace(SRC, 'src')}:${i + 1}`)
+        }
+      }
+    }
+    expect(
+      offenders,
+      'a bare px-6 in a builtin app is a 24px phone gutter: write `px-2 md:px-6`',
+    ).toEqual([])
+  })
+
   it('keeps the page title in the SAME column as the content it labels', async () => {
     // The title belongs to the content column, not to the chrome above it: it shares
     // its left edge with the cards and rows beneath it, so those all read as one


### PR DESCRIPTION
Closes #4068.

## Problem

The narrow-first page gutter (`px-2 md:px-6`) landed on the core pages (#4039) and Issue Radar (#4066). The remaining builtin apps kept an unconditional `px-6`, so on a phone their content started 24px from the screen edge before any card inset stacked on top.

## What is here

`#4039` merged while I was working and swept most of the apps named in the issue's table — workflows, mochi, papyrus, pptx-maker, ops-mission-control, and the meetings page/settings/task-review surfaces. What remained after rebasing onto it is what this PR converts:

| App | Sites |
|---|---|
| `meetings` | 3 — `MeetingView`, `AgentPillBar`, `BroadcastBar` |
| `code-review-sage` | 10 — `SettingsView`, `LearningView` ×2, `RunDetail` ×2, `PrReviewDetail` ×2, `AddReposModal` ×3 |
| `auto-research` | 4 — `ResearchLabPage` |

## The three things the issue said a sweep has to get right

**1. Convert every gutter site in a file together.** A file holding both `px-2 md:px-6` and a bare `px-6` renders two different left edges at the same width — that is the defect, not a smaller version of it. Every file here was converted whole. This is also already machine-checked: `narrowFirstBaseline.test.ts`'s third assertion is per-file and fails on exactly that mix, so each converted file is now covered by it.

**2. Scan by value, not by one spelling.** I scanned `website/src/apps` for `px-8` and `px-5` as well as `px-6`. No bare `px-8` remains in any app. The `px-5` hits that remain are not page gutters: a sheet overlay's `sm:`-prefixed inset (`issue-radar/RefSheet`), the `design-tweak` floating panel's toolbar rows, and a centered placeholder in `meetings/TranscriptPanel`.

**3. Leave centered placeholders alone — and say so.** Four lines keep a bare `px-6`, all centered empty states, where `px-6` is the element's *only* inset: the copy is already narrower than the pane, so flushing the inset moves centered text toward the screen edge for no width gain.

Rather than leave that as a comment, it is now an assertion. A new case in `narrowFirstBaseline.test.ts` requires every bare `px-6` under `src/apps` to be on a centered-placeholder line (`items-center` + `justify-center` + `text-center`) or a pill's own padding (`rounded-full`). That does two jobs: a later pass reads those four lines as deliberate rather than as misses, and a *new* 24px phone gutter cannot be added to an app without failing. It is per-line rather than per-file, unlike the half-conversion check, because these placeholders legitimately live in files that carry no gutter at all.

## Deliberately out of scope

`spec-builder`'s `px-5` (`DocView` plus its two `Shimmer` mirrors). That is a reading-column inset inside a split pane rather than a page gutter, and the three sites would have to move together to keep the skeleton holding the document's shape. It is a different judgement from the one this issue makes, so I left it rather than fold it in silently — happy to take it in a follow-up if a maintainer reads it as in-scope.

## Test plan

- `narrowFirstBaseline.test.ts`: **6 passed.** The new assertion **fails on main** (it reports the unconverted app gutters) and passes here.
- Full `npx vitest run`: **20940 passed, 1324 of 1325 files.** The single failing file is `CronFolderHeader.cov80.test.tsx`, the known parallel-load flake — it passes in isolation on `main` and on this branch alike.
- `tsc --noEmit` clean. `eslint` on the touched apps reports only the two pre-existing `label-has-for` warnings in `code-review-sage`, on lines this PR does not touch.

The diff is class-string-only — no structural or logic changes — so the risk surface is the gutter value itself, which the guard test now pins.