### PR TITLE
fix(security): derive the ACP image mimeType from decoded content

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -535,14 +535,22 @@ The `audit_source` constructor param (default `None`) tags an `AcpClient` that r
 `_send_prompt()` auto-detects image file paths in messages (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`) via regex. When a valid image path is found:
 
 1. Reads the file (paths over `MAX_IMAGE_BYTES` = 10 MB stay as text, not inlined)
-2. Downscales so the longest edge is <= `MAX_IMAGE_EDGE_PX` (2000 px), preserving aspect ratio and re-encoding to the same format (an oversized GIF becomes a PNG still frame)
-3. Shrinks further while the base64 payload still exceeds `MAX_IMAGE_B64_BYTES` (5 MiB), stopping at `MIN_IMAGE_EDGE_PX` (256 px)
-4. Base64-encodes the (possibly downscaled) bytes
-5. Appends an image content block: `{"type": "image", "data": "<base64>", "mimeType": "image/png"}`
-6. Replaces the path in the text with `[image: filename.png]`
-7. Sends both text and image blocks in the `prompt` array
+2. Identifies the format from the file's CONTENT (`_sniff_media_type`); a file that is not one of the supported rasters stays as text
+3. Downscales so the longest edge is <= `MAX_IMAGE_EDGE_PX` (2000 px), preserving aspect ratio and re-encoding to the same format (an oversized GIF becomes a PNG still frame)
+4. Shrinks further while the base64 payload still exceeds `MAX_IMAGE_B64_BYTES` (5 MiB), stopping at `MIN_IMAGE_EDGE_PX` (256 px)
+5. Base64-encodes the (possibly downscaled) bytes
+6. Appends an image content block: `{"type": "image", "data": "<base64>", "mimeType": "image/png"}`
+7. Replaces the path in the text with `[image: filename.png]`
+8. Sends both text and image blocks in the `prompt` array
 
 This leverages kiro-cli's `promptCapabilities.image: true` capability. The LLM receives the image inline — no tool call needed.
+
+**Media type is derived from content, not from the filename** (`_sniff_media_type`, same module). The path suffix decides only which paths are *candidates* — it is what the regex matched on. What a file IS, and therefore the `mimeType` that reaches the wire, is read from its bytes. A suffix is a claim made by whoever named the file (an upload handler that kept a client-supplied name, a channel that renamed an attachment, a screenshot tool with its own convention), and the backend decodes by the declared type, so a wrong label is the same wedge-the-session failure as an oversized image: the rejected block sits at a fixed history index that kiro-cli replays every turn. Deciding it once at this shared sink is what lets every producer feeding it stop carrying its own suffix guard.
+
+- Pillow's reported `format` wins when Pillow is installed, because it comes from a real decode (header-only — `Image.open` populates `format` without decompressing).
+- A signature table (`_IMAGE_SIGNATURES`) is the fallback for a hand-stripped install with no Pillow. It reaches the same verdict from magic bytes rather than degrading to the suffix, which would leave the sink trusting a filename exactly where it has least help. `RIFF` is matched together with its form field so a WAV does not read as a WEBP.
+- A candidate that decodes to nothing supported — a text file named `.png`, an SVG behind a raster name, a truncated image — is left as a path and **not** inlined. Fail closed, the same direction as the size caps.
+- A mismatch between content and suffix is **not** a refusal: the image is real, so it still travels, labelled by its content. Producers rename attachments routinely, and dropping a good image to placate a filename would trade a real capability for nothing. The mismatch is logged.
 
 **Dimension backstop** (`build_prompt_blocks` in `acp/prompt_blocks.py`). This shared builder is the single funnel every channel's images cross before reaching kiro-cli, so the `MAX_IMAGE_EDGE_PX` (2000 px) downscale runs for all of them — dashboard upload/paste/screenshot, Slack, Discord. Anthropic rejects the ENTIRE request when a many-image conversation (>20 images) carries any image over 2000 px on a side; because kiro-cli replays the full message history every turn, one oversized image would otherwise sit at a fixed history index and wedge the session permanently (a follow-up resize cannot evict the original). The browser's client-side resize (1568 px, `website/src/utils/resizeImage.ts`) is a token-cost optimization on top; this server-side cap is the correctness guarantee that still holds when that resize is skipped or bypassed (e.g. the native `/api/screenshot` capture, or non-dashboard channels).
 

--- a/src/kiro_crew/acp/prompt_blocks.py
+++ b/src/kiro_crew/acp/prompt_blocks.py
@@ -27,6 +27,7 @@ Wire shape (per docs/reference/kiro-cli/acp.md):
 from __future__ import annotations
 
 import base64
+import io
 import logging
 import os
 import re
@@ -34,7 +35,7 @@ from pathlib import Path
 
 from kiro_crew.hooks import is_unc_shape, safe_read_file_bytes, unc_probe_allowed
 
-# The budget constants and Pillow machinery live in the LEAF module
+# The budget constants and downscale machinery live in the LEAF module
 # kiro_crew.imaging (shared with the gateway's tool-result rewrite, which must
 # not import the ACP package). The two constants are re-exported because this
 # module is where the prompt path's callers and tests historically found them.
@@ -43,6 +44,13 @@ from kiro_crew.imaging import (  # noqa: F401 -- constants re-exported, see comm
     MAX_IMAGE_EDGE_PX,
     downscale_image_block,
 )
+
+try:
+    from PIL import Image
+
+    _HAS_PIL = True
+except ImportError:  # pragma: no cover - Pillow ships via qrcode[pil]/pdfplumber
+    _HAS_PIL = False
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +71,33 @@ IMAGE_MEDIA_TYPES: dict[str, str] = {
 #: unbounded image becomes an unbounded write. Matches the Slack producer cap so
 #: a file that passed ingestion is not silently dropped here.
 MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+#: Pillow format name -> wire mime, for the formats this builder inlines. Pillow
+#: reports the format it actually DECODED, which is the authoritative answer to
+#: "what is this file"; the suffix is only ever a claim made by whoever named it.
+_PIL_FORMAT_MEDIA_TYPE: dict[str, str] = {
+    "PNG": "image/png",
+    "JPEG": "image/jpeg",
+    "GIF": "image/gif",
+    "WEBP": "image/webp",
+    "BMP": "image/bmp",
+}
+
+#: Magic-byte signatures for the same set, as ``(offset, prefix)`` pairs plus an
+#: optional second window that must also match. This is the no-Pillow answer:
+#: without it a hand-stripped install falls back to trusting the suffix, which is
+#: exactly the property this sink is supposed to stop having. Signature checks
+#: need no dependency and no decode, so they also give the Pillow path a cheap
+#: cross-check on formats Pillow reports under a different name.
+_IMAGE_SIGNATURES: tuple[tuple[str, int, bytes, int, bytes], ...] = (
+    ("image/png", 0, b"\x89PNG\r\n\x1a\n", 0, b""),
+    ("image/jpeg", 0, b"\xff\xd8\xff", 0, b""),
+    ("image/gif", 0, b"GIF87a", 0, b""),
+    ("image/gif", 0, b"GIF89a", 0, b""),
+    # RIFF container: bytes 0-3 are "RIFF", 8-11 name the form. Only WEBP is ours.
+    ("image/webp", 0, b"RIFF", 8, b"WEBP"),
+    ("image/bmp", 0, b"BM", 0, b""),
+)
 
 # Absolute paths ending in a supported raster suffix.
 #
@@ -127,6 +162,41 @@ _WINDOWS_PATH_RE = re.compile(
 _PATH_RE = _WINDOWS_PATH_RE if os.name == "nt" else _POSIX_PATH_RE
 
 
+def _sniff_media_type(raw_bytes: bytes) -> str | None:
+    """Return the media type *raw_bytes* actually is, or ``None`` if it is not
+    one of the raster formats this builder inlines.
+
+    The DECODED identity, never the filename. A path suffix is a claim made by
+    whoever wrote the name -- an upload handler that kept a client-supplied
+    filename, a channel that renamed an attachment, a screenshot tool with its
+    own convention -- and every producer feeding this sink would otherwise need
+    its own guard to keep that claim honest. Deciding it once, here, is what
+    makes the wire metadata authoritative for all of them.
+
+    Pillow's report wins when Pillow is installed, because it comes from a real
+    decode. The signature table is the fallback for a hand-stripped install, and
+    it matters: a suffix-only fallback is the exact behaviour this function
+    exists to remove, so degrading into it would leave the sink lying whenever
+    Pillow is absent.
+    """
+    if _HAS_PIL:
+        try:
+            with Image.open(io.BytesIO(raw_bytes)) as img:
+                # Header read only -- `format` is populated by ``open`` itself,
+                # so this costs no decompression.
+                return _PIL_FORMAT_MEDIA_TYPE.get((img.format or "").upper())
+        except Exception:
+            # Undecodable: not an image we can inline, whatever it is named.
+            return None
+    for mime, offset, prefix, second_at, second in _IMAGE_SIGNATURES:
+        if not raw_bytes.startswith(prefix, offset):
+            continue
+        if second and not raw_bytes.startswith(second, second_at):
+            continue
+        return mime
+    return None
+
+
 def build_prompt_blocks(
     message: str,
     *,
@@ -173,8 +243,10 @@ def build_prompt_blocks(
                 continue
             path = Path(raw)
             suffix = path.suffix.lower()
-            mime = IMAGE_MEDIA_TYPES.get(suffix)
-            if mime is None or not path.is_file():
+            # The suffix decides only which paths are CANDIDATES -- it is what
+            # `_PATH_RE` matched on, and re-checking it here keeps a `.txt` from
+            # costing a stat. What the file IS gets decided from its bytes below.
+            if suffix not in IMAGE_MEDIA_TYPES or not path.is_file():
                 continue
             try:
                 size = path.stat().st_size
@@ -201,6 +273,29 @@ def build_prompt_blocks(
                 # stays in the text; it is NOT inlined.
                 logger.warning("acp prompt: image read refused for %s", path.name)
                 continue
+            mime = _sniff_media_type(raw_bytes)
+            if mime is None:
+                # Named like an image, not one (or not a format we inline). Leave
+                # the path as text and fail CLOSED rather than shipping bytes under
+                # a mimeType taken from the filename: the backend decodes by the
+                # declared type, and a block it rejects sits at a fixed history
+                # index that kiro-cli replays on every later turn.
+                logger.warning(
+                    "acp prompt: %s is not a supported image by content - "
+                    "sending path, not inline",
+                    path.name,
+                )
+                continue
+            if mime != IMAGE_MEDIA_TYPES[suffix]:
+                # Not an error: the bytes are authoritative and the block is built
+                # from them. Logged because a mismatch usually means a producer
+                # renamed an attachment, which is worth seeing.
+                logger.info(
+                    "acp prompt: %s is %s by content, not %s by suffix - using content",
+                    path.name,
+                    mime,
+                    IMAGE_MEDIA_TYPES[suffix],
+                )
             downscaled = downscale_image_block(
                 raw_bytes, mime, max_edge=max_image_edge, max_b64_bytes=max_image_b64_bytes
             )

--- a/test/test_acp_prompt_blocks.py
+++ b/test/test_acp_prompt_blocks.py
@@ -38,6 +38,28 @@ def _png(tmp_path, name="shot.png"):
     return p
 
 
+#: mime -> Pillow save format, for building genuine bytes of each supported
+#: format in tests. Keeping real bytes behind each name is the whole point: a
+#: PNG written to ``img.webp`` proves nothing about a builder that reads the
+#: suffix, because both agree by construction.
+_SAVE_FORMAT = {
+    "image/png": "PNG",
+    "image/jpeg": "JPEG",
+    "image/gif": "GIF",
+    "image/webp": "WEBP",
+    "image/bmp": "BMP",
+}
+
+
+def _image_bytes(mime, size=(1, 1)):
+    """Return real encoded bytes of *mime*."""
+    from PIL import Image as _Image
+
+    buf = io.BytesIO()
+    _Image.new("RGB", size, (127, 127, 127)).save(buf, format=_SAVE_FORMAT[mime])
+    return buf.getvalue()
+
+
 class TestBuildPromptBlocks:
     def test_always_returns_at_least_a_text_block(self):
         blocks = build_prompt_blocks("just words")
@@ -103,15 +125,15 @@ class TestBuildPromptBlocks:
 
     @pytest.mark.parametrize("suffix,mime", sorted(IMAGE_MEDIA_TYPES.items()))
     def test_every_supported_suffix_maps_to_its_mime(self, tmp_path, suffix, mime):
-        # Fixtures are format-faithful (real bytes per format, not one PNG
-        # renamed): the emitted mimeType tracks the header-DETECTED format,
-        # because the backend validates the bytes, not the file extension.
-        pil = pytest.importorskip("PIL.Image")
-        fmt = {".png": "PNG", ".jpg": "JPEG", ".jpeg": "JPEG",
-               ".gif": "GIF", ".webp": "WEBP", ".bmp": "BMP"}[suffix]
+        """A correctly-named file of each supported format keeps its own mime.
+
+        The bytes are now real bytes OF that format, not a PNG wearing the
+        suffix: this assertion used to pass with PNG content behind every name,
+        which is precisely what made it blind to the mime being read off the
+        filename.
+        """
         p = tmp_path / f"img{suffix}"
-        mode = "P" if fmt == "GIF" else "RGB"
-        pil.new(mode, (2, 2)).save(p, format=fmt)
+        p.write_bytes(_image_bytes(mime))
         blocks = build_prompt_blocks(f"see {p}")
         assert blocks[1]["mimeType"] == mime
 
@@ -135,6 +157,110 @@ class TestBuildPromptBlocks:
 
     def test_default_cap_is_ten_mib(self):
         assert MAX_IMAGE_BYTES == 10 * 1024 * 1024
+
+
+class TestMediaTypeFromContent:
+    """The wire ``mimeType`` describes the BYTES, never the filename.
+
+    A suffix is a claim made by whoever named the file — an upload handler that
+    kept a client-supplied name, a channel that renamed an attachment — and the
+    backend decodes by the declared type. Getting it wrong is not a one-turn
+    error: a block the backend rejects sits at a fixed history index that
+    kiro-cli replays on every later turn.
+    """
+
+    def test_content_wins_over_a_misleading_suffix(self, tmp_path):
+        p = tmp_path / "actually-a-jpeg.png"
+        p.write_bytes(_image_bytes("image/jpeg"))
+        blocks = build_prompt_blocks(f"see {p}")
+
+        assert [b["type"] for b in blocks] == ["text", "image"]
+        assert blocks[1]["mimeType"] == "image/jpeg"
+
+    def test_renamed_attachment_is_still_inlined(self, tmp_path):
+        """A mismatch is not a refusal: the image is real, so it still travels.
+
+        Producers rename attachments routinely; refusing them would drop good
+        images to placate a filename.
+        """
+        p = tmp_path / "screenshot.jpg"
+        p.write_bytes(_PNG)
+        blocks = build_prompt_blocks(f"see {p}")
+
+        assert blocks[1]["mimeType"] == "image/png"
+        assert base64.b64decode(blocks[1]["data"]) == _PNG
+
+    def test_non_image_named_like_an_image_is_left_as_a_path(self, tmp_path):
+        """Fail CLOSED. Previously these shipped as `image/png` because the name
+        said so, handing the backend a block it cannot decode."""
+        p = tmp_path / "notes.png"
+        p.write_bytes(b"this is plain text, not a raster")
+        blocks = build_prompt_blocks(f"see {p}")
+
+        assert [b["type"] for b in blocks] == ["text"]
+        assert str(p) in blocks[0]["text"]
+
+    def test_svg_content_behind_a_png_name_is_refused(self, tmp_path):
+        """SVG is excluded by policy (scriptable XML, not a raster). Excluding it
+        by SUFFIX alone let the same bytes through under another name."""
+        p = tmp_path / "vector.png"
+        p.write_bytes(b"<svg xmlns='http://www.w3.org/2000/svg'/>")
+        blocks = build_prompt_blocks(f"see {p}")
+
+        assert [b["type"] for b in blocks] == ["text"]
+
+    def test_truncated_image_is_left_as_a_path(self, tmp_path):
+        p = tmp_path / "cut.png"
+        p.write_bytes(_PNG[:12])
+        blocks = build_prompt_blocks(f"see {p}")
+
+        assert [b["type"] for b in blocks] == ["text"]
+
+    @pytest.mark.parametrize("mime", sorted(_SAVE_FORMAT))
+    def test_sniffer_identifies_every_supported_format(self, mime):
+        assert prompt_blocks._sniff_media_type(_image_bytes(mime)) == mime
+
+    @pytest.mark.parametrize("mime", sorted(_SAVE_FORMAT))
+    def test_signature_table_matches_pillow_without_pillow(self, monkeypatch, mime):
+        """The no-Pillow fallback must reach the SAME verdict.
+
+        A hand-stripped install cannot decode, and falling back to the suffix
+        there would leave the sink lying exactly when it has least help. The
+        signature table is what keeps the answer content-derived either way.
+        """
+        monkeypatch.setattr(prompt_blocks, "_HAS_PIL", False)
+        assert prompt_blocks._sniff_media_type(_image_bytes(mime)) == mime
+
+    def test_signature_table_refuses_a_non_image_without_pillow(self, monkeypatch):
+        monkeypatch.setattr(prompt_blocks, "_HAS_PIL", False)
+        assert prompt_blocks._sniff_media_type(b"not an image at all") is None
+
+    def test_riff_container_that_is_not_webp_is_refused(self, monkeypatch):
+        """`RIFF` alone is a container, not a format: WAV opens the same way."""
+        monkeypatch.setattr(prompt_blocks, "_HAS_PIL", False)
+        wav = b"RIFF" + b"\x00\x00\x00\x00" + b"WAVE" + b"fmt "
+        assert prompt_blocks._sniff_media_type(wav) is None
+
+    def test_downscale_reencodes_by_content_not_by_name(self, tmp_path):
+        """The re-encode picks its Pillow save format from the mime, so a wrong
+        mime also produced a wrongly-encoded payload — not just a wrong label."""
+        p = tmp_path / "big.png"
+        p.write_bytes(_image_bytes("image/jpeg", size=(MAX_IMAGE_EDGE_PX + 40, 10)))
+        blocks = build_prompt_blocks(f"see {p}")
+
+        assert blocks[1]["mimeType"] == "image/jpeg"
+        out = base64.b64decode(blocks[1]["data"])
+        assert prompt_blocks._sniff_media_type(out) == "image/jpeg"
+
+    def test_gif_still_collapses_to_png_on_re_encode(self, tmp_path):
+        """Unchanged behaviour, now keyed off the decoded format: a downscaled
+        GIF is re-encoded as a still PNG and the wire says so."""
+        p = tmp_path / "anim.gif"
+        p.write_bytes(_image_bytes("image/gif", size=(MAX_IMAGE_EDGE_PX + 40, 10)))
+        blocks = build_prompt_blocks(f"see {p}")
+
+        assert blocks[1]["mimeType"] == "image/png"
+        assert prompt_blocks._sniff_media_type(base64.b64decode(blocks[1]["data"])) == "image/png"
 
 
 class TestSensitivePathGate:


### PR DESCRIPTION
Closes #3769

## Problem / Motivation

The shared ACP image sink still trusted filename suffixes in three escape paths: a hand-stripped install without Pillow, `max_image_edge <= 0`, and the re-encode format selection for over-cap images. A genuine JPEG named `.png` could therefore be labelled or re-encoded according to its name, while non-raster content could be inlined under a raster MIME type when Pillow was unavailable.

## Why it matters

The backend decodes the bytes according to the declared `mimeType`. A contradictory image block can be rejected after it enters replayed conversation history, causing later turns to fail at the same fixed history position. The shared sink must make the content authoritative for every producer.

## What changed

- Rebuilt the change on current `main`, retaining only the behavior not already delivered by #4025.
- Reused `messaging.raster.sniff_raster_mime` instead of introducing another signature table.
- Require a complete sniff window and leave unsupported, non-raster, RIFF/non-WEBP, and truncated content as a path.
- Pass the detected MIME into the image budget pipeline and log suffix mismatches.
- Verify and correct MIME metadata even when the edge cap is disabled.
- Select an oversized image's re-encode format from Pillow's decoded format rather than the filename-derived claim.
- Document the content-derived media-type contract.

## Tests

- `test/test_acp_prompt_blocks.py`: 99 passed, 1 skipped.
- `test/test_mcp_gateway_image_budget.py` and `test/test_session_image_repair.py`: 86 passed.
- `isort --check-only` on all changed Python files.
- `flake8` on all changed Python files.
- `git diff --check`.

## Screenshots

N/A — backend security and wire-metadata correction with no visual UI change.
