### PR TITLE
fix(dashboard): one stated rule for small-size spinners

### DIFF
--- a/website/docs/page-layout.md
+++ b/website/docs/page-layout.md
@@ -609,6 +609,30 @@ Inline within a `Card`, built from the shared primitives:
   from). It maps known sources to colors and falls back to a neutral pill for an
   unknown one, so pass the raw source string.
 
+## Spinners
+
+**Below 15px use lucide `Loader`. At 15px and above use `LoaderCircle`.**
+
+`LoaderCircle` (exported as both `Loader2` and `LoaderCircle`) draws a single
+2px-stroke arc spanning about 270° of a circle. At 10–14px that stroke is thick
+relative to the radius and the gap is roughly a sixth of the glyph, so it reads
+as a broken ring rather than as motion. `Loader`'s eight discrete spokes stay
+legible as rotation at that size. From 15px up the arc is unambiguous and
+`LoaderCircle` is the better glyph, so both survive — the size decides, not
+per-call-site taste.
+
+```tsx
+<Loader size={14} className="animate-spin" />        {/* small */}
+<LoaderCircle size={16} className="animate-spin" />  {/* 15px and up */}
+```
+
+The rule keys on a **declared** `size`. A spinner sized by CSS instead — the
+`lucide-inline` class is `width: 1em`, so it follows the surrounding font size —
+has no size to check statically and is out of the rule's scope; leave those on
+`LoaderCircle` rather than guessing at their rendered size.
+
+`src/test/spinnerGlyphRule.test.ts` enforces this.
+
 ## Errors
 
 A dismissible banner above the content:

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -43,7 +43,7 @@ import type { KiroCreditUsage, KiroUsagePayload } from './api/client'
 import { safeSetItem } from './utils/safeStorage'
 import { gcOrphanedStorage } from './utils/storageGc'
 import { isMetricNumber, metricNumber } from './utils/metrics'
-import { Rocket, Bell, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, AudioWaveform, ChevronUp, MoreHorizontal, Coins, ArrowLeftToLine, Compass, LayoutGrid, Fullscreen, SquareTerminal, Bot, Smartphone, Search as SearchIcon } from 'lucide-react'
+import { Rocket, Bell, Code, RefreshCw, Package, Loader, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, AudioWaveform, ChevronUp, MoreHorizontal, Coins, ArrowLeftToLine, Compass, LayoutGrid, Fullscreen, SquareTerminal, Bot, Smartphone, Search as SearchIcon } from 'lucide-react'
 import { GithubIcon, DiscordIcon } from './components/BrandIcon'
 import { Toggle } from './components/ui'
 import OnboardingFlow from './components/OnboardingFlow'
@@ -2985,7 +2985,7 @@ export default function App() {
                 // the modal's fuller explanation.
                 segments.push(<button key="usage" className={`${seg} text-muted opacity-60`} onClick={() => setKiroUsageOpen(true)} title={i18nT('app.kiro_credit_usage_api_key')} aria-label={i18nT('app.kiro_credit_usage_api_key')}><Coins size={12} /> <span className="font-mono text-[11px] tabular-nums">—</span></button>)
               } else if (!kiroUsageState) {
-                segments.push(<button key="usage" className={`${seg} text-muted`} onClick={() => setKiroUsageOpen(true)} title={i18nT('app.kiro_credit_usage_checking')} aria-label={i18nT('app.kiro_credit_usage_checking_2')}><Coins size={12} /> {!isMobile && <Loader2 size={11} className="animate-spin" />}</button>)
+                segments.push(<button key="usage" className={`${seg} text-muted`} onClick={() => setKiroUsageOpen(true)} title={i18nT('app.kiro_credit_usage_checking')} aria-label={i18nT('app.kiro_credit_usage_checking_2')}><Coins size={12} /> {!isMobile && <Loader size={11} className="animate-spin" />}</button>)
               } else {
                 // Pool every bonus grant into the compact readout. Bonus is
                 // drawn down before the plan, so excluding it looks like a

--- a/website/src/apps/auto-research/GrillTree.tsx
+++ b/website/src/apps/auto-research/GrillTree.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { ChevronDown, ChevronRight, Check, Circle, Search, Plus, Trash2, HelpCircle, Loader2, ThumbsUp } from 'lucide-react'
+import { ChevronDown, ChevronRight, Check, Circle, Search, Plus, Trash2, HelpCircle, ThumbsUp, Loader } from 'lucide-react'
 import { GrillNode, GrillAction, nodeDepth } from './grillTreeModel'
 
 import { i18nT } from '../../i18n/t'
@@ -127,7 +127,7 @@ export default function GrillTree({ tree, dispatch, onExpand }: Props) {
                 <span className="text-text">{i18nT('apps.autoResearch.grillTree.answered')} {node.answer}</span>
                 <button onClick={() => expand(node.id)} disabled={atMaxDepth || spinning}
                         className="flex items-center gap-1 text-accent disabled:opacity-40">
-                  {spinning ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />} {i18nT('apps.autoResearch.grillTree.expand')}
+                  {spinning ? <Loader size={12} className="animate-spin" /> : <Plus size={12} />} {i18nT('apps.autoResearch.grillTree.expand')}
                 </button>
                 {atMaxDepth && <span className="text-warn">{i18nT('apps.autoResearch.grillTree.max_depth_add_research_manually_or_prune')}</span>}
               </>

--- a/website/src/apps/auto-research/ResearchLabPage.tsx
+++ b/website/src/apps/auto-research/ResearchLabPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useReducer, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { FlaskConical, Play, Pause, Square, MessageCircle, ChevronDown, ChevronRight, Sparkles, ThumbsUp, ArrowRight, HelpCircle, XCircle, CheckCircle, AlertTriangle, Lock, X, Trash2, GitFork, Flame, BookOpen, FileText, RefreshCw, ExternalLink, Loader2 } from 'lucide-react'
+import { FlaskConical, Play, Pause, Square, MessageCircle, ChevronDown, ChevronRight, Sparkles, ThumbsUp, ArrowRight, HelpCircle, XCircle, CheckCircle, AlertTriangle, Lock, X, Trash2, GitFork, Flame, BookOpen, FileText, RefreshCw, ExternalLink, Loader } from 'lucide-react'
 import { api } from '../../api/client'
 import Clickable from '../../components/Clickable'
 import Modal from '../../components/Modal'
@@ -87,7 +87,7 @@ export const STATE_LABEL_KEY: Record<string, string> = {
 }
 
 const STATE_META: Record<string, { color: string; Icon: typeof CheckCircle; spin?: boolean }> = {
-  running: { color: 'text-accent', Icon: Loader2, spin: true },
+  running: { color: 'text-accent', Icon: Loader, spin: true },
   needs_input: { color: 'text-warn', Icon: HelpCircle },
   paused: { color: 'text-muted', Icon: Pause },
   stagnant: { color: 'text-warn', Icon: AlertTriangle },

--- a/website/src/apps/code-review-sage/components/AddReposModal.tsx
+++ b/website/src/apps/code-review-sage/components/AddReposModal.tsx
@@ -16,9 +16,7 @@
 // identically. The keyboard behaviour — capture-phase Escape, the Tab trap and
 // focus restore — comes from the shared `useDialogFocusTrap` hook.
 import { AnimatePresence, motion } from 'framer-motion'
-import {
-  AlertCircle, Check, FolderGit2, GitBranch, Loader2, Lock, Plus, RefreshCw, Search, Star, Trash2, X,
-} from 'lucide-react'
+import { AlertCircle, Check, FolderGit2, GitBranch, Lock, Plus, RefreshCw, Search, Star, Trash2, X, Loader } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState, type ReactNode } from 'react'
 
 import Clickable from '../../../components/Clickable'
@@ -265,7 +263,7 @@ export default function AddReposModal({ onClose }: { onClose: () => void }) {
             {loading && !setupRequired && (
               <>
                 <div className="inline-flex items-center gap-1.5 text-[12.5px] text-muted">
-                  <Loader2 size={13} className="animate-spin motion-reduce:animate-none" />
+                  <Loader size={13} className="animate-spin motion-reduce:animate-none" />
                   {i18nT('apps.codeReviewSage.components.addReposModal.reading_your_repos_from_github')}
                 </div>
                 <ListSkeleton count={5} />

--- a/website/src/apps/code-review-sage/components/FailureNotice.tsx
+++ b/website/src/apps/code-review-sage/components/FailureNotice.tsx
@@ -4,7 +4,7 @@
 // report's body text, so a failed review looked like a review that found nothing.
 // This states the reason where the status is, and puts the retry next to it: a
 // failed run's most likely next action is running it again.
-import { AlertTriangle, Loader2, RotateCcw } from 'lucide-react'
+import { AlertTriangle, RotateCcw, Loader } from 'lucide-react'
 
 import type { Run } from '../lib/types'
 import { failureReason } from '../lib/format'
@@ -55,7 +55,7 @@ export default function FailureNotice({
             className="flex-shrink-0 inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[12px] text-text hover:text-accent hover:border-accent disabled:opacity-50 cursor-pointer disabled:cursor-default"
           >
             {retrying
-              ? <Loader2 size={12} className="animate-spin motion-reduce:animate-none" aria-hidden="true" />
+              ? <Loader size={12} className="animate-spin motion-reduce:animate-none" aria-hidden="true" />
               : <RotateCcw size={12} aria-hidden="true" />}
             {retrying
           ? i18nT('apps.codeReviewSage.components.failureNotice.starting')

--- a/website/src/apps/code-review-sage/components/FindingCard.tsx
+++ b/website/src/apps/code-review-sage/components/FindingCard.tsx
@@ -29,7 +29,7 @@
 // renders through MarkdownRenderer; the `snippet` is code from a private diff and
 // renders verbatim in a monospace block — NEVER through the markdown renderer, so
 // it cannot be reinterpreted as markup.
-import { Check, Loader2, MessageSquarePlus } from 'lucide-react'
+import { Check, MessageSquarePlus, Loader } from 'lucide-react'
 import type { ReactNode } from 'react'
 import MarkdownRenderer from '../../../components/MarkdownRenderer'
 import type { Finding } from '../lib/types'
@@ -210,7 +210,7 @@ export default function FindingCard({
             </span>
           ) : posting ? (
             <span className="inline-flex items-center gap-1.5 text-[11.5px] text-muted">
-              <Loader2
+              <Loader
                 size={11}
                 className="animate-spin motion-reduce:animate-none"
                 aria-hidden="true"

--- a/website/src/apps/code-review-sage/components/LearningRail.tsx
+++ b/website/src/apps/code-review-sage/components/LearningRail.tsx
@@ -4,7 +4,7 @@
 // because neither has anything to do with learned patterns — leaving them up kept
 // a repo picker and a PR list on screen while you read the reviewer's ruleset.
 // Selection works like the review list: pick one on the left, read it on the right.
-import { ChevronRight, Loader2, Plus, Trash2, X } from 'lucide-react'
+import { ChevronRight, Plus, Trash2, X, Loader } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
@@ -175,7 +175,7 @@ export default function LearningRail() {
                       className="inline-flex items-center gap-1 bg-transparent px-1 font-medium text-danger hover:underline disabled:opacity-40 cursor-pointer"
                     >
                       {deleteMut.isPending && (
-                        <Loader2 size={11} className="animate-spin motion-reduce:animate-none" />
+                        <Loader size={11} className="animate-spin motion-reduce:animate-none" />
                       )}
                       {i18nT('apps.codeReviewSage.components.learningRail.delete_2')}
                     </button>

--- a/website/src/apps/code-review-sage/components/PostCommentsButton.tsx
+++ b/website/src/apps/code-review-sage/components/PostCommentsButton.tsx
@@ -9,7 +9,7 @@
 // that this app cannot undo — the comments land as a GitHub review from your
 // account. So the first click states the count and asks; only the second sends.
 import { useEffect, useState } from 'react'
-import { AlertTriangle, Check, Loader2, MessageSquarePlus } from 'lucide-react'
+import { AlertTriangle, Check, MessageSquarePlus, Loader } from 'lucide-react'
 
 import { relativeAge } from '../lib/format'
 import type { Run, RunReport } from '../lib/types'
@@ -90,7 +90,7 @@ export default function PostCommentsButton({
   if (posting) {
     return (
       <span className="inline-flex items-center gap-1.5 text-[12.5px] text-muted">
-        <Loader2 size={13} className="animate-spin motion-reduce:animate-none" aria-hidden="true" />
+        <Loader size={13} className="animate-spin motion-reduce:animate-none" aria-hidden="true" />
         {i18nT('apps.codeReviewSage.components.postCommentsButton.posting')}
       </span>
     )

--- a/website/src/apps/code-review-sage/components/PrPickList.tsx
+++ b/website/src/apps/code-review-sage/components/PrPickList.tsx
@@ -8,9 +8,7 @@
 // Lifted out of the old NewReviewPanel, which is gone: the repo chooser it also
 // carried is now the rail, so keeping it would have meant two ways to pick a
 // repo and two PR lists.
-import {
-  ClipboardPaste, GitPullRequest, Link2, Loader2, RefreshCw, ScanSearch, Search,
-} from 'lucide-react'
+import { ClipboardPaste, GitPullRequest, Link2, RefreshCw, ScanSearch, Search, Loader } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
 import { repoSlug, repoUrl, useSage, type ActiveRepo } from '../context'
@@ -29,7 +27,7 @@ function PrStateChip({ pr, reviewing }: { pr: RepoPr; reviewing?: boolean }) {
         title={i18nT('apps.codeReviewSage.components.prPickList.a_review_of_this_pull_request_is_running')}
         className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-accent-subtle text-accent whitespace-nowrap"
       >
-        <Loader2
+        <Loader
           size={9}
           className="animate-spin motion-reduce:animate-none"
           aria-hidden="true"
@@ -106,7 +104,7 @@ function PasteLinks() {
           className="inline-flex items-center gap-1.5 rounded-md bg-accent text-accent-fg px-2.5 py-1 text-[12px] font-medium border-none cursor-pointer hover:bg-accent-hover disabled:opacity-40 disabled:cursor-default transition-colors"
         >
           {busy
-            ? <Loader2 size={12} className="animate-spin motion-reduce:animate-none" />
+            ? <Loader size={12} className="animate-spin motion-reduce:animate-none" />
             : <Link2 size={12} />}
           {i18nT('apps.codeReviewSage.components.prPickList.review_these')}
         </button>
@@ -223,7 +221,7 @@ export default function PrPickList() {
             className="flex-1 inline-flex items-center justify-center gap-1.5 rounded-md bg-accent text-accent-fg px-2 py-1.5 text-[12px] font-medium border-none cursor-pointer hover:bg-accent-hover disabled:opacity-40 disabled:cursor-default transition-colors"
           >
             {busy
-              ? <Loader2 size={12} className="animate-spin motion-reduce:animate-none" />
+              ? <Loader size={12} className="animate-spin motion-reduce:animate-none" />
               : <ScanSearch size={12} />}
             {/* One plural key, not three fragments: `picked.size || ''` renders
                 "Review  selected" with no count and a double space when nothing is

--- a/website/src/apps/code-review-sage/components/PrReviewDetail.tsx
+++ b/website/src/apps/code-review-sage/components/PrReviewDetail.tsx
@@ -8,9 +8,7 @@
 //
 // Every tab reads ONE query (see usePrSource), so switching is free and no tab
 // triggers its own provider call.
-import {
-  ExternalLink, FileText, GitPullRequest, Loader2, ScanSearch,
-} from 'lucide-react'
+import { ExternalLink, FileText, GitPullRequest, ScanSearch, Loader } from 'lucide-react'
 import { useMemo, useState, type ReactNode } from 'react'
 
 import { useSage } from '../context'
@@ -377,7 +375,7 @@ export default function PrReviewDetail({ pr }: { pr: PrRef }) {
             className="flex-shrink-0 inline-flex items-center gap-1.5 rounded-md bg-accent text-accent-fg px-3 py-1.5 text-[12.5px] font-medium border-none cursor-pointer hover:bg-accent-hover disabled:opacity-40 disabled:cursor-default transition-colors"
           >
             {busy
-              ? <Loader2 size={13} className="animate-spin motion-reduce:animate-none" />
+              ? <Loader size={13} className="animate-spin motion-reduce:animate-none" />
               : <ScanSearch size={13} />}
             {running
               ? i18nT('apps.codeReviewSage.components.prReviewDetail.reviewing')

--- a/website/src/apps/code-review-sage/components/ReportView.tsx
+++ b/website/src/apps/code-review-sage/components/ReportView.tsx
@@ -12,9 +12,7 @@
 // MarkdownRenderer (which sanitizes), the outbound PR link is validated with
 // safeHttpUrl, and code `snippet`s render verbatim in a <pre> (never markdown).
 import { useCallback, useMemo, useState, type ReactNode } from 'react'
-import {
-  ChevronRight, ClipboardCheck, ExternalLink, Loader2, MessageSquarePlus, Share2, ShieldCheck,
-} from 'lucide-react'
+import { ChevronRight, ClipboardCheck, ExternalLink, MessageSquarePlus, Share2, ShieldCheck, Loader } from 'lucide-react'
 import MarkdownRenderer from '../../../components/MarkdownRenderer'
 import { safeHttpUrl } from '../../../lib/safeUrl'
 import FindingCard from './FindingCard'
@@ -421,7 +419,7 @@ export default function ReportView({
             className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[12.5px] text-text hover:text-accent hover:border-accent disabled:opacity-50 cursor-pointer disabled:cursor-default"
           >
             {archiving
-              ? <Loader2 size={13} className="animate-spin" aria-hidden="true" />
+              ? <Loader size={13} className="animate-spin" aria-hidden="true" />
               : <Share2 size={13} aria-hidden="true" />}
             {archiving
               ? i18nT('apps.codeReviewSage.components.reportView.sharing')

--- a/website/src/apps/code-review-sage/components/RunProgress.tsx
+++ b/website/src/apps/code-review-sage/components/RunProgress.tsx
@@ -10,9 +10,7 @@
 // a review already in flight runs to completion. The button copy says so; it
 // must never promise an instant stop.
 import { useEffect, useState } from 'react'
-import {
-  CheckCircle2, CircleSlash, Clock, Loader2, XCircle, XOctagon, type LucideIcon,
-} from 'lucide-react'
+import { CheckCircle2, CircleSlash, Clock, XCircle, XOctagon, type LucideIcon, Loader } from 'lucide-react'
 import type { ChangeActivity, PoolStats, Run, RunProgressEntry } from '../lib/types'
 import { TERMINAL_PHASES, formatElapsed, phaseLabel, prLabelFromChange, runElapsedMs } from '../lib/format'
 
@@ -21,7 +19,7 @@ import { i18nT } from '../../../i18n/t'
  * them; the reviewing spinner respects motion-reduce. */
 function phaseVisual(phase: string): { Icon: LucideIcon; color: string; spin?: boolean } {
   switch (phase) {
-    case 'reviewing': return { Icon: Loader2, color: 'text-accent', spin: true }
+    case 'reviewing': return { Icon: Loader, color: 'text-accent', spin: true }
     case 'done': return { Icon: CheckCircle2, color: 'text-ok' }
     case 'failed': return { Icon: XCircle, color: 'text-danger' }
     case 'cancelled': return { Icon: CircleSlash, color: 'text-muted' }
@@ -144,7 +142,7 @@ export default function RunProgress({
           <span className="inline-flex items-center gap-1.5 min-w-0">
             {activity && (
               <>
-                <Loader2
+                <Loader
                   size={11}
                   className="flex-shrink-0 animate-spin motion-reduce:animate-none"
                   aria-hidden="true"

--- a/website/src/apps/code-review-sage/components/ShipSummaryCard.tsx
+++ b/website/src/apps/code-review-sage/components/ShipSummaryCard.tsx
@@ -9,7 +9,7 @@
 // The body is the EXACT text that will be posted (`row.ship_comment`, built by
 // the same `pipeline.build_ship_comment` the poster uses), so what you read here
 // is what the author receives.
-import { Check, Loader2, MessageSquarePlus, ShipWheel } from 'lucide-react'
+import { Check, MessageSquarePlus, ShipWheel, Loader } from 'lucide-react'
 
 import MarkdownRenderer from '../../../components/MarkdownRenderer'
 
@@ -67,7 +67,7 @@ export default function ShipSummaryCard({
               </span>
             ) : posting ? (
               <span className="inline-flex items-center gap-1.5 text-[11.5px] text-muted">
-                <Loader2
+                <Loader
                   size={11}
                   className="animate-spin motion-reduce:animate-none"
                   aria-hidden="true"

--- a/website/src/apps/code-review-sage/views/LearningView.tsx
+++ b/website/src/apps/code-review-sage/views/LearningView.tsx
@@ -6,7 +6,7 @@
 // came to read were two clicks deep and the repo picker stayed on screen above
 // them.
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Brain, Loader2, Wand2 } from 'lucide-react'
+import { Brain, Wand2, Loader } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 import { sageApi } from '../api'
@@ -85,7 +85,7 @@ export function ConsolidateControl({
       )}
       {busy ? (
         <span className="inline-flex items-center gap-1.5 text-[11.5px] text-muted">
-          <Loader2 size={11} className="animate-spin motion-reduce:animate-none" />
+          <Loader size={11} className="animate-spin motion-reduce:animate-none" />
           {i18nT('apps.codeReviewSage.views.learningView.consolidating')}
         </span>
       ) : confirming ? (
@@ -188,7 +188,7 @@ export default function LearningView() {
 
         {learningsQuery.isLoading && (
           <div className="mt-6 inline-flex items-center gap-2 text-[13px] text-muted">
-            <Loader2 size={14} className="animate-spin motion-reduce:animate-none" />
+            <Loader size={14} className="animate-spin motion-reduce:animate-none" />
             {i18nT('apps.codeReviewSage.views.learningView.loading_learnings')}
           </div>
         )}

--- a/website/src/apps/code-review-sage/views/SettingsView.tsx
+++ b/website/src/apps/code-review-sage/views/SettingsView.tsx
@@ -5,7 +5,7 @@
 // it actually affects — "Concurrency: 5" means nothing without the sentence under
 // it.
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Loader2, Settings as SettingsIcon } from 'lucide-react'
+import { Settings as SettingsIcon, Loader } from 'lucide-react'
 
 import { sageApi } from '../api'
 import type { Settings } from '../lib/types'
@@ -65,7 +65,7 @@ export default function SettingsView() {
 
         {settingsQuery.isLoading && (
           <div className="mt-6 inline-flex items-center gap-2 text-[13px] text-muted">
-            <Loader2 size={14} className="animate-spin motion-reduce:animate-none" />
+            <Loader size={14} className="animate-spin motion-reduce:animate-none" />
             {i18nT('apps.codeReviewSage.views.settingsView.loading_settings')}
           </div>
         )}

--- a/website/src/apps/command-bar/CommandBarOverlay.tsx
+++ b/website/src/apps/command-bar/CommandBarOverlay.tsx
@@ -7,7 +7,7 @@ import {
   Clock,
   Command,
   Cog,
-  Loader2,
+  Loader,
   MessageSquare,
   MessageSquarePlus,
   Package,
@@ -926,7 +926,7 @@ export default function CommandBarOverlay({
             named here: an `invoke` launcher row, and the ask row. */}
         {((slot.tag === 'root' && pendingRow === slot.row.id) ||
           (slot.tag === 'ask' && pendingRow === ASK_SLOT_KEY)) && (
-          <Loader2
+          <Loader
             size={13}
             aria-label={i18nT('apps.commandBar.working')}
             className="lucide-inline text-muted shrink-0 animate-spin"

--- a/website/src/apps/issue-radar/components/AgentSessionButton.tsx
+++ b/website/src/apps/issue-radar/components/AgentSessionButton.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Check, RotateCcw, type LucideIcon } from 'lucide-react'
+import { Loader, Check, RotateCcw, type LucideIcon } from 'lucide-react'
 import type { InvestigationRecord } from '../api'
 
 import { i18nT } from '../../../i18n/t'
@@ -92,7 +92,7 @@ export default function AgentSessionButton({
         }
       >
         {busy
-          ? <Loader2 size={13} className="animate-spin" />
+          ? <Loader size={13} className="animate-spin" />
           : <ActionIcon size={13} />}
         {actionLabel}
       </button>

--- a/website/src/apps/issue-radar/components/DetailOverflowMenu.tsx
+++ b/website/src/apps/issue-radar/components/DetailOverflowMenu.tsx
@@ -26,7 +26,7 @@
 // shape, including the labelled icon trigger that `icon-buttons-need-labels`
 // requires.
 import type { ReactNode } from 'react'
-import { MoreHorizontal, Loader2 } from 'lucide-react'
+import { MoreHorizontal, Loader } from 'lucide-react'
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
 } from '../../../components/ui/dropdown-menu'
@@ -52,7 +52,7 @@ export default function DetailOverflowMenu(
               invites a second one. The glyph is the only thing that changes, so
               the trigger's width — and the row's fit — is unaffected. */}
           {pending
-            ? <Loader2 size={14} className="animate-spin" />
+            ? <Loader size={14} className="animate-spin" />
             : <MoreHorizontal size={14} />}
         </Btn>
       </DropdownMenuTrigger>

--- a/website/src/apps/issue-radar/components/IssueDetail.tsx
+++ b/website/src/apps/issue-radar/components/IssueDetail.tsx
@@ -25,7 +25,7 @@ import {
   Copy, Check, AlertCircle, RefreshCw, CircleDot, CircleCheck, CircleSlash, MessageSquare,
   Tag, UserPlus, UserMinus, Pencil, Milestone as MilestoneIcon, GitPullRequest,
   GitCommitHorizontal, Link2, Users, CalendarDays, Lock, Sparkles,
-  Plus, Loader2,
+  Plus, Loader,
   ThumbsUp, ThumbsDown, Laugh, PartyPopper, Frown, Heart, Rocket, Eye,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -154,7 +154,7 @@ function AiSuggestions({
     return (
       <div className="mt-3 text-[11px] text-muted flex items-center gap-1.5">
         <Sparkles size={11} className="text-accent flex-shrink-0" />
-        <Loader2 size={11} className="animate-spin flex-shrink-0" /> {i18nT('apps.issueRadar.components.issueDetail.finding_suggestions')}
+        <Loader size={11} className="animate-spin flex-shrink-0" /> {i18nT('apps.issueRadar.components.issueDetail.finding_suggestions')}
       </div>
     )
   }

--- a/website/src/apps/issue-radar/components/PrDetail.tsx
+++ b/website/src/apps/issue-radar/components/PrDetail.tsx
@@ -19,7 +19,7 @@ import {
   Copy, Check, AlertCircle, RefreshCw, GitPullRequest, GitMerge, GitPullRequestClosed, GitPullRequestDraft,
   MessageSquare, Tag, Users, CalendarDays, GitCommitHorizontal, FileDiff, Milestone as MilestoneIcon,
   Link2, CircleDot, CircleSlash, Pencil, UserPlus, UserMinus,
-  CheckCircle2, XCircle, Eye, GitBranch, ChevronDown, ChevronUp, Loader2, ShieldCheck,
+  CheckCircle2, XCircle, Eye, GitBranch, ChevronDown, ChevronUp, Loader, ShieldCheck,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import RefMarkdown from './RefMarkdown'
@@ -378,7 +378,7 @@ function eventVisual(
  * accent (with a spinner), successes/other stay quiet. */
 const CHECK_VISUAL: Record<PrCheck['bucket'], { Icon: LucideIcon; color: string }> = {
   failure: { Icon: XCircle, color: 'text-danger' },
-  running: { Icon: Loader2, color: 'text-accent' },
+  running: { Icon: Loader, color: 'text-accent' },
   success: { Icon: CheckCircle2, color: 'text-ok' },
   other: { Icon: CircleSlash, color: 'text-muted' },
 }
@@ -459,7 +459,7 @@ function AutoReviewChecks(
     <Section title={i18nT('apps.issueRadar.components.prDetail.auto_review')} icon={<ShieldCheck size={12} />}>
       {loading && checks.length === 0 && (
         <span className="inline-flex items-center gap-1.5 text-muted">
-          <Loader2 size={12} className="animate-spin flex-shrink-0 text-accent" />
+          <Loader size={12} className="animate-spin flex-shrink-0 text-accent" />
           {i18nT('apps.issueRadar.components.prDetail.loading_checks')}
         </span>
       )}

--- a/website/src/apps/issue-radar/components/PrList.tsx
+++ b/website/src/apps/issue-radar/components/PrList.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react'
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion'
 import { Virtuoso } from 'react-virtuoso'
-import {
-  RefreshCw, Search, X, GitPullRequest, GitMerge, GitPullRequestClosed, GitPullRequestDraft,
-  CheckCircle2, XCircle, CircleSlash, Loader2, FileDiff,
-} from 'lucide-react'
+import { RefreshCw, Search, X, GitPullRequest, GitMerge, GitPullRequestClosed, GitPullRequestDraft, CheckCircle2, XCircle, CircleSlash, FileDiff, Loader } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useIssueRadar } from '../context'
 import { relativeTimeOrDate, relativeTime } from '../lib/format'
@@ -35,7 +32,7 @@ function prStateVisual(pr: { state: string; draft?: boolean; merged_at?: string 
  * reshuffle between renders and the actionable states read first. */
 const CHECK_BADGES = [
   { key: 'failure', Icon: XCircle, color: 'text-danger', label: 'failing' },
-  { key: 'running', Icon: Loader2, color: 'text-accent', label: 'running' },
+  { key: 'running', Icon: Loader, color: 'text-accent', label: 'running' },
   { key: 'success', Icon: CheckCircle2, color: 'text-ok', label: 'passing' },
   { key: 'other', Icon: CircleSlash, color: 'text-muted', label: 'skipped / neutral' },
 ] as const
@@ -101,7 +98,7 @@ function ChecksDot({ state }: { state: PullRequest['checks_state'] }) {
   if (!state) return null
   const visual = {
     failure: { Icon: XCircle, color: 'text-danger', label: 'checks failing' },
-    running: { Icon: Loader2, color: 'text-accent', label: 'checks running' },
+    running: { Icon: Loader, color: 'text-accent', label: 'checks running' },
     success: { Icon: CheckCircle2, color: 'text-ok', label: 'checks passing' },
     other: { Icon: CircleSlash, color: 'text-muted', label: 'checks skipped / neutral' },
   }[state]

--- a/website/src/apps/mochi/src/renderer/ChatPanel.tsx
+++ b/website/src/apps/mochi/src/renderer/ChatPanel.tsx
@@ -3,34 +3,7 @@
  * Uses three-channel model: chunks via chat:chunk, done via chat:done, messages via chat:message
  */
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
-import {
-  Ban,
-  Check,
-  ChevronDown,
-  ChevronRight,
-  Copy,
-  Eraser,
-  Eye,
-  File,
-  Folder,
-  Handshake,
-  LayoutDashboard,
-  LoaderCircle,
-  Palette,
-  PawPrint,
-  Pin,
-  RotateCcw,
-  Settings,
-  Shield,
-  ShieldCheck,
-  ShieldPlus,
-  Square,
-  SquarePen,
-  Trash2,
-  Unplug,
-  Wrench,
-  X,
-} from 'lucide-react'
+import { Ban, Check, ChevronDown, ChevronRight, Copy, Eraser, Eye, File, Folder, Handshake, LayoutDashboard, Palette, PawPrint, Pin, RotateCcw, Settings, Shield, ShieldCheck, ShieldPlus, Square, SquarePen, Trash2, Unplug, Wrench, X, Loader } from 'lucide-react'
 import Clickable from '../../../../components/Clickable'
 import { familyGrantIsDistinct, trustBasePattern, truncateCommandLabel } from '../shared/trustPatterns'
 import Markdown from 'react-markdown'
@@ -1089,7 +1062,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ onToggleWatch, watchPanelV
         }}>
           <span>
             {cloudAutoConnecting
-              ? <><LoaderCircle size={11} style={{ display: 'inline', verticalAlign: '-1px', marginRight: 4 }} />{i18nT('apps.mochi.gateway.starting')}</>
+              ? <><Loader size={11} style={{ display: 'inline', verticalAlign: '-1px', marginRight: 4 }} />{i18nT('apps.mochi.gateway.starting')}</>
               : <><Unplug size={11} style={{ display: 'inline', verticalAlign: '-1px', marginRight: 4 }} />{i18nT('apps.mochi.gateway.disconnected')}</>}
           </span>
           {!cloudAutoConnecting && !gatewayStarting && (

--- a/website/src/apps/workflows/WorkflowRunTree.tsx
+++ b/website/src/apps/workflows/WorkflowRunTree.tsx
@@ -18,7 +18,7 @@
  * logic lives in ./runModel and is unit-tested.
  */
 import { memo, useMemo, useState } from 'react'
-import { CheckCircle2, XCircle, Loader2, ChevronRight, Workflow as WorkflowIcon } from 'lucide-react'
+import { CheckCircle2, XCircle, ChevronRight, Workflow as WorkflowIcon, Loader } from 'lucide-react'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
 import { groupByPhase, latestBudget, type WfEvent } from './runModel'
 
@@ -124,7 +124,7 @@ const WorkflowRunTree = memo(function WorkflowRunTree({
                 className={`text-muted shrink-0 transition-transform ${isCollapsed ? '' : 'rotate-90'}`}
               />
               {ps === 'running' ? (
-                <Loader2 size={12} className="text-accent animate-spin shrink-0" />
+                <Loader size={12} className="text-accent animate-spin shrink-0" />
               ) : ps === 'ok' ? (
                 <CheckCircle2 size={12} className="text-green-500 shrink-0" />
               ) : (
@@ -146,7 +146,7 @@ const WorkflowRunTree = memo(function WorkflowRunTree({
                       className="flex items-center gap-2 px-3 py-1.5 text-[12px]"
                     >
                       {a.ok === undefined ? (
-                        <Loader2 size={12} className="text-accent animate-spin shrink-0" />
+                        <Loader size={12} className="text-accent animate-spin shrink-0" />
                       ) : a.ok ? (
                         <CheckCircle2 size={12} className="text-green-500 shrink-0" />
                       ) : (

--- a/website/src/apps/workflows/WorkflowsRuns.tsx
+++ b/website/src/apps/workflows/WorkflowsRuns.tsx
@@ -21,6 +21,7 @@ import {
   Workflow as WorkflowIcon,
   CheckCircle2,
   XCircle,
+  Loader,
   Loader2,
   Ban,
   ListTree,
@@ -335,7 +336,7 @@ export default function WorkflowsRuns({ embedded = false }: { embedded?: boolean
                 }}
               >
                 {row.badge.active ? (
-                  <Loader2 size={14} className="text-accent animate-spin shrink-0" />
+                  <Loader size={14} className="text-accent animate-spin shrink-0" />
                 ) : row.status === 'finished' ? (
                   <CheckCircle2 size={14} className="text-green-500 shrink-0" />
                 ) : row.status === 'paused' ? (

--- a/website/src/components/ArtifactFolderDeleteDialog.tsx
+++ b/website/src/components/ArtifactFolderDeleteDialog.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Loader2, Trash2, FolderOutput } from 'lucide-react'
+import { Trash2, FolderOutput, Loader } from 'lucide-react'
 import Modal from './Modal'
 import { Btn } from './ui'
 import { folderSubtreeStats } from '../utils/artifactFolderTree'
@@ -51,7 +51,7 @@ export default function ArtifactFolderDeleteDialog({
           onClick={() => run(true)}
           className="justify-start text-left flex items-center gap-2"
         >
-          {busy === 'cascade' ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+          {busy === 'cascade' ? <Loader size={14} className="animate-spin" /> : <Trash2 size={14} />}
           <span>
             <span className="block font-medium">{i18nT('components.artifactFolderDeleteDialog.delete_folder_and_all_contents')}</span>
             <span className="block text-[12px] opacity-80">
@@ -64,7 +64,7 @@ export default function ArtifactFolderDeleteDialog({
           onClick={() => run(false)}
           className="justify-start text-left flex items-center gap-2"
         >
-          {busy === 'keep' ? <Loader2 size={14} className="animate-spin" /> : <FolderOutput size={14} />}
+          {busy === 'keep' ? <Loader size={14} className="animate-spin" /> : <FolderOutput size={14} />}
           <span>
             <span className="block font-medium">{i18nT('components.artifactFolderDeleteDialog.delete_folder_only_keep_artifacts')}</span>
             <span className="block text-[12px] opacity-80">

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo, useId, memo } from 'react'
-import { ArrowUpFromLine, ArrowUp, Loader2, RotateCw, Plus, Crop, Bot, Mic, Keyboard, Square, BookOpen, X, ClipboardList, CheckCircle, Ban, Sparkles, Target, Lock, Folder, FolderOpen, FileText } from 'lucide-react'
+import { ArrowUpFromLine, ArrowUp, Loader2, RotateCw, Plus, Crop, Bot, Mic, Keyboard, Square, BookOpen, X, ClipboardList, CheckCircle, Ban, Sparkles, Target, Lock, Folder, FolderOpen, FileText, Loader } from 'lucide-react'
 import CopyBranchButton from './CopyBranchButton'
 import RejectDropdown from './RejectDropdown'
 import { usePointerDrag } from '../hooks/usePointerDrag'
@@ -2790,7 +2790,7 @@ function ChatInput({
                 </span>
                 {spawnApprovalsResolving ? (
                   <span className="inline-flex items-center gap-1 text-[12px] text-muted/60 shrink-0">
-                    <Loader2 size={12} className="animate-spin shrink-0" />{i18nT('components.chatInput.resolving')}
+                    <Loader size={12} className="animate-spin shrink-0" />{i18nT('components.chatInput.resolving')}
                   </span>
                 ) : (
                   <div className="flex items-center gap-1.5 shrink-0">
@@ -2832,7 +2832,7 @@ function ChatInput({
                       </code>
                       {a.approving ? (
                         <span className="inline-flex items-center gap-1 text-[11px] text-muted/60 shrink-0">
-                          <Loader2 size={11} className="animate-spin shrink-0" />{i18nT('components.chatInput.resolving')}
+                          <Loader size={11} className="animate-spin shrink-0" />{i18nT('components.chatInput.resolving')}
                         </span>
                       ) : (
                         <div className="flex items-center gap-1 shrink-0">
@@ -3570,7 +3570,7 @@ function ChatInput({
                   data-testid="composer-continue"
                   {...offlineProps(connected, 'continue', continueLabel)}
                 >
-                  {continuing ? <Loader2 size={14} className="animate-spin" /> : <RotateCw size={14} />}
+                  {continuing ? <Loader size={14} className="animate-spin" /> : <RotateCw size={14} />}
                   {i18nT('components.chatInput.resume')}
                 </button>
               ) : (

--- a/website/src/components/CommentThreads.tsx
+++ b/website/src/components/CommentThreads.tsx
@@ -11,7 +11,7 @@
 import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
-  Check, ChevronDown, ChevronRight, CornerDownRight, Loader2, MessageSquare,
+  Check, ChevronDown, ChevronRight, CornerDownRight, Loader, MessageSquare,
   MessageSquarePlus, MessagesSquare, RotateCcw,
 } from 'lucide-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
@@ -215,7 +215,7 @@ function ReplyBox({
           className="inline-flex items-center gap-1.5 rounded-md border border-accent bg-accent-subtle px-2.5 py-1 text-[12.5px] font-medium text-accent disabled:opacity-50 cursor-pointer disabled:cursor-default"
         >
           {pending && (
-            <Loader2 size={12} className="animate-spin motion-reduce:animate-none" aria-hidden="true" />
+            <Loader size={12} className="animate-spin motion-reduce:animate-none" aria-hidden="true" />
           )}
           {label}
         </button>

--- a/website/src/components/LinkedSurfacesSection.tsx
+++ b/website/src/components/LinkedSurfacesSection.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { Loader2 } from 'lucide-react'
+import { Loader } from 'lucide-react'
 import { ApiError, api } from '../api/client'
 import { i18nT } from '../i18n/t'
 import { useAppDispatch, useAppSelector } from '../store'
@@ -294,7 +294,7 @@ export default function LinkedSurfacesSection({ slotKey, variant }: {
             * delivery — was indistinguishable from a channel that cannot be
             * connected at all. */}
           {row.pending
-            ? <Loader2 size={13} className="shrink-0 animate-spin" />
+            ? <Loader size={13} className="shrink-0 animate-spin" />
             : <ChannelBrandIcon channel={row.channel} size={13} />}
           <span className="flex min-w-0 flex-col">
             <span className="truncate">

--- a/website/src/components/McpBrowserModal.tsx
+++ b/website/src/components/McpBrowserModal.tsx
@@ -11,7 +11,7 @@
  */
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Download, Check, ExternalLink, Loader2, RefreshCw, AlertTriangle, ArrowLeft, KeyRound, Terminal } from 'lucide-react'
+import { Download, Check, ExternalLink, Loader2, RefreshCw, AlertTriangle, ArrowLeft, KeyRound, Terminal, Loader } from 'lucide-react'
 import { api, ApiError } from '../api/client'
 import Modal from './Modal'
 import { Btn } from './ui'
@@ -496,7 +496,7 @@ function ServerDetailPanel({
 
       {detailLoading ? (
         <div className="flex items-center gap-2 text-xs text-muted" role="status">
-          <Loader2 size={12} className="animate-spin" aria-hidden="true" /> {i18nT('components.mcpBrowserModal.loading_details')}
+          <Loader size={12} className="animate-spin" aria-hidden="true" /> {i18nT('components.mcpBrowserModal.loading_details')}
         </div>
       ) : (
         <>

--- a/website/src/components/McpCustomServerModal.tsx
+++ b/website/src/components/McpCustomServerModal.tsx
@@ -15,7 +15,7 @@
  */
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { AlertTriangle, Check, Loader2 } from 'lucide-react'
+import { AlertTriangle, Check, Loader } from 'lucide-react'
 import { api, ApiError } from '../api/client'
 import Modal from './Modal'
 import { Btn } from './ui'
@@ -216,7 +216,7 @@ export default function McpCustomServerModal({ open, onClose, editName }: Props)
         )}
         {editing && specQuery.isLoading && (
           <span className="flex items-center gap-1.5 text-xs text-muted" role="status">
-            <Loader2 size={13} className="animate-spin" aria-hidden="true" /> {i18nT('components.mcpCustomServerModal.loading_current_spec')}
+            <Loader size={13} className="animate-spin" aria-hidden="true" /> {i18nT('components.mcpCustomServerModal.loading_current_spec')}
           </span>
         )}
         {editing && specQuery.isError && (
@@ -298,7 +298,7 @@ export default function McpCustomServerModal({ open, onClose, editName }: Props)
             <Btn onClick={onClose}>{i18nT('components.mcpCustomServerModal.cancel')}</Btn>
             <Btn primary onClick={submit} disabled={!canSubmit || busy}>
               {busy ? (
-                <Loader2 size={14} className="animate-spin" aria-hidden="true" />
+                <Loader size={14} className="animate-spin" aria-hidden="true" />
               ) : (
                 <Check size={14} aria-hidden="true" />
               )}

--- a/website/src/components/ProjectSkillsTrustDialog.tsx
+++ b/website/src/components/ProjectSkillsTrustDialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { Loader2, ShieldAlert } from 'lucide-react'
+import { Loader, ShieldAlert } from 'lucide-react'
 
 import { api } from '../api/client'
 import { i18nT } from '../i18n/t'
@@ -110,7 +110,7 @@ export default function ProjectSkillsTrustDialog({
           </Btn>
           <Btn primary onClick={confirm} disabled={pending || !reviewedPath || !reviewedKey}>
             {pending
-              ? <><Loader2 size={14} className="animate-spin" /> {i18nT('components.projectSkillsTrust.working')}</>
+              ? <><Loader size={14} className="animate-spin" /> {i18nT('components.projectSkillsTrust.working')}</>
               : <><ShieldAlert size={14} /> {i18nT('components.projectSkillsTrust.confirm')}</>}
           </Btn>
         </>

--- a/website/src/components/QueueStack.tsx
+++ b/website/src/components/QueueStack.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, memo } from 'react'
 import { AnimatePresence, motion, useMotionValue, useSpring } from 'framer-motion'
-import { Hourglass, ChevronUp, X, Zap, Pencil, Check, Bot, Loader2, ArrowUp, ArrowDown } from 'lucide-react'
+import { Hourglass, ChevronUp, X, Zap, Pencil, Check, Bot, ArrowUp, ArrowDown, Loader } from 'lucide-react'
 import type { ChatMessage } from '../types'
 import { useImeGuard } from '../hooks/useImeGuard'
 
@@ -79,7 +79,7 @@ export function SubagentDeliveryProgress({ count }: { count: number }) {
     >
       <div className="mb-1 flex items-center gap-2 rounded-md bg-accent/5 border border-accent/15 px-3 py-1.5 text-[12px] font-mono text-muted">
         <Bot size={13} className="text-accent/70 shrink-0" />
-        <Loader2 size={12} className="animate-spin text-accent/70 shrink-0" />
+        <Loader size={12} className="animate-spin text-accent/70 shrink-0" />
         <span>
           {i18nT('components.queueStack.sub_agent_result', { count: count })} {i18nT('components.queueStack.ready_processing_after_the_current_turn')}
         </span>

--- a/website/src/components/ReportProblemModal.tsx
+++ b/website/src/components/ReportProblemModal.tsx
@@ -1,14 +1,6 @@
 import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
-import {
-  CheckCircle2,
-  AlertCircle,
-  FolderOpen,
-  Download,
-  ExternalLink,
-  Loader2,
-  Lock,
-} from 'lucide-react'
+import { CheckCircle2, AlertCircle, FolderOpen, Download, ExternalLink, Lock, Loader } from 'lucide-react'
 import { Btn, Toggle } from './ui'
 import { useGatewayPlatform } from '../hooks/useGatewayPlatform'
 import Modal from './Modal'
@@ -98,7 +90,7 @@ export default function ReportProblemModal({ open, onClose }: ReportProblemModal
             <Btn primary disabled={mut.isPending} onClick={() => mut.mutate()}>
               {mut.isPending ? (
                 <>
-                  <Loader2 size={13} className="lucide-inline animate-spin" />{' '}
+                  <Loader size={13} className="lucide-inline animate-spin" />{' '}
                   {i18nT('components.reportProblemModal.collecting')}
                 </>
               ) : (

--- a/website/src/components/SendToInstanceSubmenu.tsx
+++ b/website/src/components/SendToInstanceSubmenu.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useState } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { AlertCircle, Check, ChevronRight, Loader2, Send, Server } from 'lucide-react'
+import { AlertCircle, Check, ChevronRight, Send, Server, Loader } from 'lucide-react'
 import { api, type InstanceView } from '../api/client'
 import {
   DropdownMenuSub, DropdownMenuSubTrigger, DropdownMenuSubContent, DropdownMenuItem,
@@ -103,7 +103,7 @@ export function InstanceSendItems({ instances, states, onSend, Item }: {
               <span className="ml-auto text-[10px] text-muted shrink-0">{notConnected}</span>
             )}
             {st.kind === 'sending' && (
-              <Loader2 size={13} className="ml-auto shrink-0 animate-spin text-muted" />
+              <Loader size={13} className="ml-auto shrink-0 animate-spin text-muted" />
             )}
             {st.kind === 'sent' && st.transcriptOnly && (
               <span

--- a/website/src/components/SessionGridView.tsx
+++ b/website/src/components/SessionGridView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { X, Plus, GitFork, Loader2, Circle } from 'lucide-react'
+import { X, Plus, GitFork, Circle, Loader } from 'lucide-react'
 import { SplitGlyph } from './SplitGlyph'
 import { api } from '../api/client'
 import SessionGridLayout from './SessionGridLayout'
@@ -272,7 +272,7 @@ function PlaceholderPane({
           onClick={() => createSession.mutate()}
           className="flex-1 inline-flex items-center justify-center gap-1 text-[12px] font-semibold text-accent bg-accent/10 rounded px-2 py-1.5 cursor-pointer border-none hover:bg-accent/20 disabled:opacity-50 transition-colors"
         >
-          {createSession.isPending ? <Loader2 size={13} className="animate-spin" /> : <Plus size={13} />} {i18nT('components.sessionGridView.new_session')}
+          {createSession.isPending ? <Loader size={13} className="animate-spin" /> : <Plus size={13} />} {i18nT('components.sessionGridView.new_session')}
         </button>
         <button
           disabled={!forkSourceSlot || forkSession.isPending}
@@ -280,7 +280,7 @@ function PlaceholderPane({
           title={forkSourceSlot ? i18nT('components.sessionGridView.fork_child_session', { name: forkSourceTitle || forkSourceSlot }) : i18nT('components.sessionGridView.no_session_to_fork_yet')}
           className="flex-1 inline-flex items-center justify-center gap-1 text-[12px] font-semibold text-text border border-border rounded px-2 py-1.5 cursor-pointer bg-transparent hover:bg-bg-hover disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
         >
-          {forkSession.isPending ? <Loader2 size={13} className="animate-spin" /> : <GitFork size={13} />} {i18nT('components.sessionGridView.fork')}
+          {forkSession.isPending ? <Loader size={13} className="animate-spin" /> : <GitFork size={13} />} {i18nT('components.sessionGridView.fork')}
         </button>
       </div>
 

--- a/website/src/components/SkillBrowserModal.tsx
+++ b/website/src/components/SkillBrowserModal.tsx
@@ -8,7 +8,7 @@
  */
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Download, Check, ExternalLink, Loader2, RefreshCw, FileText, AlertTriangle, ArrowLeft } from 'lucide-react'
+import { Download, Check, ExternalLink, Loader2, RefreshCw, FileText, AlertTriangle, ArrowLeft, Loader } from 'lucide-react'
 import { api, ApiError } from '../api/client'
 import Modal from './Modal'
 import { Btn } from './ui'
@@ -442,7 +442,7 @@ function SkillDetailPanel({
 
       {previewLoading ? (
         <div className="flex items-center gap-2 text-xs text-muted" role="status">
-          <Loader2 size={12} className="animate-spin" aria-hidden="true" /> {i18nT('components.skillBrowserModal.loading_preview')}
+          <Loader size={12} className="animate-spin" aria-hidden="true" /> {i18nT('components.skillBrowserModal.loading_preview')}
         </div>
       ) : preview?.content ? (
         <>

--- a/website/src/components/appstore/TrustAppModal.tsx
+++ b/website/src/components/appstore/TrustAppModal.tsx
@@ -20,7 +20,7 @@
  */
 import { useCallback, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { Code2, GitBranch, Loader2, Server, ShieldAlert, Terminal } from 'lucide-react'
+import { Code2, GitBranch, Server, ShieldAlert, Terminal, Loader } from 'lucide-react'
 
 import { api } from '../../api/client'
 import Modal from '../Modal'
@@ -328,7 +328,7 @@ export default function TrustAppModal({ app, pending, failed, granted, onCancel,
           </Btn>
           <Btn primary onClick={onConfirm} disabled={pending}>
             {pending
-              ? <><Loader2 size={14} className="animate-spin" /> {i18nT('components.appstore.trustAppModal.working')}</>
+              ? <><Loader size={14} className="animate-spin" /> {i18nT('components.appstore.trustAppModal.working')}</>
               : failed
                 ? <><ShieldAlert size={14} /> {i18nT('components.appstore.trustAppModal.confirm_after_failure')}</>
                 : <><ShieldAlert size={14} /> {i18nT('components.appstore.trustAppModal.confirm')}</>}

--- a/website/src/components/library/LibraryTable.tsx
+++ b/website/src/components/library/LibraryTable.tsx
@@ -1,6 +1,6 @@
 import type * as React from 'react'
 import { useState, useRef } from 'react'
-import { ChevronRight, ChevronDown, ChevronUp, MoreVertical, Pencil, Trash2, Star, ExternalLink, Loader2, X, Share2, FileText, FolderOpen, Folder as FolderIcon } from 'lucide-react'
+import { ChevronRight, ChevronDown, ChevronUp, MoreVertical, Pencil, Trash2, Star, ExternalLink, Loader, X, Share2, FileText, FolderOpen, Folder as FolderIcon } from 'lucide-react'
 import { openPopout } from '../../utils/artifactPopout'
 import { Badge, Btn, Input, IconButton } from '../ui'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '../ui/dropdown-menu'
@@ -428,7 +428,7 @@ export function ArtifactRow({ a, onOpen, onDelete, deletingSlug, onTogglePin, pi
                 title={i18nT('pages.artifactsPage.remove_from_library')}
                 aria-label={i18nT('pages.artifactsPage.remove_from_artifacts_library')}
               >
-                {deletingSlug === a.slug ? <Loader2 size={13} className="animate-spin" /> : <X size={13} />}
+                {deletingSlug === a.slug ? <Loader size={13} className="animate-spin" /> : <X size={13} />}
               </button>
             </div>
           </td>
@@ -458,7 +458,7 @@ export function SessionDocStar({ d, busy, onMaterialize }: { d: SessionDoc; busy
       aria-label={i18nT('pages.artifactsPage.star_document')}
       className="shrink-0"
     >
-      {busy ? <Loader2 size={14} className="animate-spin" /> : <Star size={14} />}
+      {busy ? <Loader size={14} className="animate-spin" /> : <Star size={14} />}
     </IconButton>
   )
 }

--- a/website/src/pages/AppDetailPage.tsx
+++ b/website/src/pages/AppDetailPage.tsx
@@ -12,7 +12,7 @@ import {
   ArrowLeft, Download, Check, Loader2, Power, PowerOff,
   Trash2, RefreshCw, Bot, Zap, ArrowUp,
   Clock, ChevronLeft, ChevronRight, X, Monitor, Copy, Terminal,
-  Sparkles, Target, Settings2,
+  Sparkles, Target, Settings2, Loader,
 } from 'lucide-react'
 import { needsDesktopApp } from '../lib/electron'
 import { api } from '../api/client'
@@ -1156,7 +1156,7 @@ export default function AppDetailPage() {
             <div className="flex items-center gap-2 flex-wrap">
               {!app.installed && !clientInstall && (
                 <Btn primary onClick={handleInstall} disabled={actionLoading === 'install'}>
-                  {actionLoading === 'install' ? <><Loader2 size={14} className="animate-spin" /> {i18nT('pages.appDetailPage.installing')}</> : <><Download size={14} /> {i18nT('pages.appDetailPage.install')}</>}
+                  {actionLoading === 'install' ? <><Loader size={14} className="animate-spin" /> {i18nT('pages.appDetailPage.installing')}</> : <><Download size={14} /> {i18nT('pages.appDetailPage.install')}</>}
                 </Btn>
               )}
               {!app.installed && clientInstall && (
@@ -1191,7 +1191,7 @@ export default function AppDetailPage() {
               {app.installed && isSelfManaged && !isBuiltin && (
                 <>
                   <div className="text-[13px] text-ok flex items-center gap-1.5"><Check size={14} /> {i18nT('pages.appDetailPage.installed_version', { version: app.installedVersion })}</div>
-                  {app.updateAvailable && <Btn onClick={handleInstall} disabled={actionLoading === 'install'} className="!bg-[var(--info)] !text-white hover:!opacity-80">{actionLoading === 'install' ? <><Loader2 size={14} className="animate-spin" /> {i18nT('pages.appDetailPage.updating')}</> : <><ArrowUp size={14} /> {i18nT('pages.appDetailPage.update')}</>}</Btn>}
+                  {app.updateAvailable && <Btn onClick={handleInstall} disabled={actionLoading === 'install'} className="!bg-[var(--info)] !text-white hover:!opacity-80">{actionLoading === 'install' ? <><Loader size={14} className="animate-spin" /> {i18nT('pages.appDetailPage.updating')}</> : <><ArrowUp size={14} /> {i18nT('pages.appDetailPage.update')}</>}</Btn>}
                   {canUninstall && <Btn danger onClick={() => handleAction('uninstall')} disabled={actionLoading === 'uninstall'} title={i18nT('pages.appDetailPage.removes_kirocrew_metadata_only_the_app_itself_is')}><Trash2 size={14} /> {i18nT('pages.appDetailPage.uninstall')}</Btn>}
                 </>
               )}
@@ -1225,7 +1225,7 @@ export default function AppDetailPage() {
                   )}
                     </>
                   )}
-                  {canUpdate && app.updateAvailable && <Btn onClick={handleInstall} disabled={actionLoading === 'install'} className="!bg-[var(--info)] !text-white hover:!opacity-80">{actionLoading === 'install' ? <><Loader2 size={14} className="animate-spin" /> {i18nT('pages.appDetailPage.updating')}</> : <><ArrowUp size={14} /> {i18nT('pages.appDetailPage.update')}</>}</Btn>}
+                  {canUpdate && app.updateAvailable && <Btn onClick={handleInstall} disabled={actionLoading === 'install'} className="!bg-[var(--info)] !text-white hover:!opacity-80">{actionLoading === 'install' ? <><Loader size={14} className="animate-spin" /> {i18nT('pages.appDetailPage.updating')}</> : <><ArrowUp size={14} /> {i18nT('pages.appDetailPage.update')}</>}</Btn>}
                   {canUpdate && !app.updateAvailable && <Btn onClick={() => handleAction('update')} disabled={actionLoading === 'update'} title={i18nT('pages.appDetailPage.sync_app_from_its_source_directory')}><RefreshCw size={14} /> {i18nT('pages.appDetailPage.sync')}</Btn>}
                   {canUninstall && <Btn danger onClick={() => handleAction('uninstall')} disabled={actionLoading === 'uninstall'}><Trash2 size={14} /> {i18nT('pages.appDetailPage.uninstall')}</Btn>}
                 </>
@@ -1239,7 +1239,7 @@ export default function AppDetailPage() {
           <Card>
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
-                {!installDone && <Loader2 size={14} className="animate-spin text-accent" />}
+                {!installDone && <Loader size={14} className="animate-spin text-accent" />}
                 {installDone && !error && <Check size={14} className="text-ok" />}
                 {installDone && error && <X size={14} className="text-danger" />}
                 <CardTitle>

--- a/website/src/pages/ArtifactsPage.tsx
+++ b/website/src/pages/ArtifactsPage.tsx
@@ -2,7 +2,7 @@ import { safeGetItem, safeSetItem } from '../utils/safeStorage'
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useInfiniteQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
-import { AlertTriangle, Bookmark, Cloud, ExternalLink, Globe, ImageOff, Rocket, X, Share2, Loader2, LayoutDashboard, Table as TableIcon, Folder as FolderIcon, FolderPlus, FolderOpen, ChevronRight, ChevronDown, ChevronUp, Star, FileText, FilePlus } from 'lucide-react'
+import { AlertTriangle, Bookmark, Cloud, ExternalLink, Globe, ImageOff, Rocket, X, Share2, Loader2, LayoutDashboard, Table as TableIcon, Folder as FolderIcon, FolderPlus, FolderOpen, ChevronRight, ChevronDown, ChevronUp, Star, FileText, FilePlus, Loader } from 'lucide-react'
 import { openPopout } from '../utils/artifactPopout'
 import { VirtuosoMasonry } from '@virtuoso.dev/masonry'
 import type { ItemContent } from '@virtuoso.dev/masonry'
@@ -807,7 +807,7 @@ function LocalCardBody({ a, context }: { a: Artifact; context: LibCtx }) {
               aria-pressed={!!a.pinned}
             >
               {pinningSlug === a.slug
-                ? <Loader2 size={13} className="animate-spin" />
+                ? <Loader size={13} className="animate-spin" />
                 : <Star size={13} className={a.pinned ? 'fill-current' : ''} />}
             </button>
             <button
@@ -827,7 +827,7 @@ function LocalCardBody({ a, context }: { a: Artifact; context: LibCtx }) {
               title={i18nT('pages.artifactsPage.remove_from_library')}
               aria-label={i18nT('pages.artifactsPage.remove_from_artifacts_library')}
             >
-              {deleting ? <Loader2 size={13} className="animate-spin" /> : <X size={13} />}
+              {deleting ? <Loader size={13} className="animate-spin" /> : <X size={13} />}
             </button>
           </div>
         </div>
@@ -1909,7 +1909,7 @@ export default function ArtifactsPage() {  const navigate = useNavigate()
                 className="flex items-center gap-1.5 rounded-r-none"
                 title={i18nT('pages.artifactsPage.start_a_new_blank_document_in_the_library')}
               >
-                {newArtifactMut.isPending ? <Loader2 size={13} className="animate-spin" /> : <FilePlus size={13} />} {i18nT('pages.artifactsPage.new_artifact')}
+                {newArtifactMut.isPending ? <Loader size={13} className="animate-spin" /> : <FilePlus size={13} />} {i18nT('pages.artifactsPage.new_artifact')}
               </Btn>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -1931,7 +1931,7 @@ export default function ArtifactsPage() {  const navigate = useNavigate()
                     // outgrow.
                     className="rounded-l-none border-l-0 px-1 self-stretch"
                   >
-                    {addArtifactMut.isPending ? <Loader2 size={13} className="animate-spin" /> : <ChevronDown size={13} />}
+                    {addArtifactMut.isPending ? <Loader size={13} className="animate-spin" /> : <ChevronDown size={13} />}
                   </Btn>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -241,7 +241,7 @@ import { focusComposer, focusComposerAfter, revealComposer } from './chat/compos
 import { useHoverIntent } from '../hooks/useHoverIntent'
 import { useKnowledgeFetch, extractKnowledgeQuery, expandKnowledgeBlock } from './chat/useKnowledgeFetch'
 import { KnowledgePicker } from './chat/KnowledgePicker'
-import { BookOpen, EyeOff, Loader, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, MessageSquare, Sparkles, VenetianMask, Clock, Undo2, Columns2, ExternalLink, Paperclip, Folder, X } from 'lucide-react'
+import { BookOpen, EyeOff, LoaderCircle, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, MessageSquare, Sparkles, VenetianMask, Clock, Undo2, Columns2, ExternalLink, Paperclip, Folder, X } from 'lucide-react'
 import { PanelLeftSolid, PanelLeftLight, PanelRightSolid } from '../components/icons/panels'
 
 import InfoTip from '../components/InfoTip'
@@ -7331,7 +7331,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                     <TypewriterText text={title} className="session-header-title text-sm font-semibold text-muted font-body truncate min-w-0 md:max-w-[50vw]" />
                     <Pen size={13} className="shrink-0 text-muted opacity-0 group-hover/header:opacity-60 transition-opacity" />
                   </Clickable>
-                  {activeSlot && (generatingTitleSlots.has(activeSlot) ? <Loader size={16} className="shrink-0 text-accent animate-spin" /> : <Btn aria-label={i18nT('pages.chatPage.regenerate_title_with_llm')} className="shrink-0 text-muted opacity-0 group-hover/header:opacity-40 hover:!opacity-100 hover:text-accent transition-all cursor-pointer bg-transparent border-none p-0" title={i18nT('pages.chatPage.regenerate_title_with_llm')} onClick={e => { e.stopPropagation(); if (!activeSlot || generatingTitleSlots.has(activeSlot)) return; const slot = activeSlot; setGeneratingTitleSlots(prev => new Set(prev).add(slot)); api.generateTitle(slot).then(r => { /* title is redacted server-side via redact_exfiltration_urls + redact_credentials */ if (r.title) dispatch(sseSlotTitle({ key: slot, title: r.title })) }).catch(e => {
+                  {activeSlot && (generatingTitleSlots.has(activeSlot) ? <LoaderCircle size={16} className="shrink-0 text-accent animate-spin" /> : <Btn aria-label={i18nT('pages.chatPage.regenerate_title_with_llm')} className="shrink-0 text-muted opacity-0 group-hover/header:opacity-40 hover:!opacity-100 hover:text-accent transition-all cursor-pointer bg-transparent border-none p-0" title={i18nT('pages.chatPage.regenerate_title_with_llm')} onClick={e => { e.stopPropagation(); if (!activeSlot || generatingTitleSlots.has(activeSlot)) return; const slot = activeSlot; setGeneratingTitleSlots(prev => new Set(prev).add(slot)); api.generateTitle(slot).then(r => { /* title is redacted server-side via redact_exfiltration_urls + redact_credentials */ if (r.title) dispatch(sseSlotTitle({ key: slot, title: r.title })) }).catch(e => {
                     // eslint-disable-next-line no-console -- surface title-generation failures for debugging
                     console.warn('Failed to generate title:', e)
                   }).finally(() => setGeneratingTitleSlots(prev => { const next = new Set(prev); next.delete(slot); return next })) }}><Sparkles size={16} /></Btn>)}
@@ -7418,7 +7418,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
             <ChatDropOverlay active={dragOver} />
             {slotLoading && (
               <div className="absolute inset-0 flex items-center justify-center z-20 pointer-events-none">
-                <Loader size={20} className="animate-spin text-muted" />
+                <LoaderCircle size={20} className="animate-spin text-muted" />
               </div>
             )}
             {isWelcomeState ? (
@@ -7535,7 +7535,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                   browser's scroll anchor and jump the list mid-fetch. */}
               {loadingOlder && (
                 <div className="sticky top-16 z-[1] flex justify-center py-2" data-testid="older-messages-loading" role="status" aria-label={i18nT('pages.chatPage.loading_earlier_messages')} style={{ overflowAnchor: 'none', background: 'var(--bg)' }}>
-                  <Loader size={16} className="animate-spin text-muted" />
+                  <LoaderCircle size={16} className="animate-spin text-muted" />
                 </div>
               )}
               {/* Top spacer — reserves the height of all items above the mounted

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -16,11 +16,7 @@ import { handleMenuKeydown } from '../hooks/useMenuKeyboard'
 import { useAppDispatch } from '../store'
 import { addNotification } from '../store/notificationsSlice'
 import { setPendingInput } from '../store/chatSlice'
-import {
-  Server, RefreshCw, Play, Square, ExternalLink, ChevronRight, Trash2,
-  LoaderCircle, Check, Video, X,
-  Ellipsis, RotateCw, FileText, GitCommit, Rocket, Info, AlertTriangle, ShieldAlert,
-} from 'lucide-react'
+import { Server, RefreshCw, Play, Square, ExternalLink, ChevronRight, Trash2, LoaderCircle, Check, Video, X, Ellipsis, RotateCw, FileText, GitCommit, Rocket, Info, AlertTriangle, ShieldAlert, Loader } from 'lucide-react'
 import * as api from './devFleetApi'
 import { ApiError } from '../api/client'
 
@@ -1794,7 +1790,7 @@ export default function DevFleetPage() {
       out.push(<Btn key="open" onClick={() => act(w.name, 'open')}>{iconLabel(<ExternalLink size={13} className="lucide-inline" />, i18nT('pages.devFleetPage.open'))}</Btn>)
     }
     const podBusy = busy[w.name + ':up'] || busy[w.name + ':down'] || busy[w.name + ':restart']
-    if (podBusy) out.push(<span key="podbusy" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 11, color: 'var(--muted)' } as CSSProperties}><LoaderCircle size={12} className="lucide-inline animate-spin" /> {i18nT('pages.devFleetPage.pod')}{"\u2026"}</span>)
+    if (podBusy) out.push(<span key="podbusy" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 11, color: 'var(--muted)' } as CSSProperties}><Loader size={12} className="lucide-inline animate-spin" /> {i18nT('pages.devFleetPage.pod')}{"\u2026"}</span>)
     out.push(<MenuBtn key="menu" items={[
       podsAvailable && w.has_dist && !w.running ? { label: i18nT('pages.devFleetPage.spin_up_pod'), icon: <Play size={13} className="lucide-inline" />, onClick: () => act(w.name, 'up') } : null,
       podsAvailable && w.running ? { label: i18nT('pages.devFleetPage.restart_pod'), icon: <RefreshCw size={13} className="lucide-inline" />, onClick: () => act(w.name, 'restart') } : null,
@@ -1927,7 +1923,7 @@ export default function DevFleetPage() {
     const last = lastLine(pr.lines)
     return (
       <div style={{ gridColumn: '4 / -1', display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 } as CSSProperties}>
-        <LoaderCircle size={12} className="lucide-inline animate-spin" style={{ color: 'var(--accent)', flexShrink: 0 } as CSSProperties} />
+        <Loader size={12} className="lucide-inline animate-spin" style={{ color: 'var(--accent)', flexShrink: 0 } as CSSProperties} />
         <span style={{ fontSize: 11, fontWeight: 600, flexShrink: 0 }}>{i18nT('pages.devFleetPage.provisioning')}</span>
         {phase ? <span style={{ fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--accent)', background: 'var(--accent-subtle, rgba(99,102,241,0.14))', borderRadius: 5, padding: '1px 6px', flexShrink: 0 } as CSSProperties}>{phase}</span> : null}
         <span style={{ ...mono, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 } as CSSProperties} title={last}>{last || i18nT('pages.devFleetPage.starting')}</span>
@@ -2200,7 +2196,7 @@ export default function DevFleetPage() {
               <div key={nm} role="listitem" data-testid={`prune-item-${nm}`} data-status={it.status} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '3px 0', borderBottom: '1px solid var(--border)' }}>
                 <span style={{ width: 14, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
                   {meta.kind === 'spin'
-                    ? <LoaderCircle size={12} className="lucide-inline animate-spin" style={{ color: 'var(--muted)' }} />
+                    ? <Loader size={12} className="lucide-inline animate-spin" style={{ color: 'var(--muted)' }} />
                     : meta.kind === 'done'
                       ? <Check size={13} style={{ color: 'var(--ok)' }} />
                       : meta.kind === 'failed'

--- a/website/src/pages/RemoteArtifactDetailPage.tsx
+++ b/website/src/pages/RemoteArtifactDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
-import { ArrowLeft, AlertTriangle, ExternalLink, GitFork, Loader2, User, MessageSquare, RotateCw } from 'lucide-react'
+import { ArrowLeft, AlertTriangle, ExternalLink, GitFork, Loader, User, MessageSquare, RotateCw } from 'lucide-react'
 import { useTheme } from '../hooks/useTheme'
 import { safeHttpUrl } from '../lib/safeUrl'
 import { sanitizeCssValue } from '../lib/cssSanitize'
@@ -336,7 +336,7 @@ export default function RemoteArtifactDetailPage() {
               disabled={forking}
               title={i18nT('pages.remoteArtifactDetailPage.fork_into_your_local_artifacts_editable_copy')}
             >
-              {forking ? <Loader2 size={13} className="animate-spin" /> : <GitFork size={13} />} {i18nT('pages.remoteArtifactDetailPage.fork')}
+              {forking ? <Loader size={13} className="animate-spin" /> : <GitFork size={13} />} {i18nT('pages.remoteArtifactDetailPage.fork')}
             </Btn>
           </span>
         </div>

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect, memo, useRef, useId } from 'react'
 import { motion } from 'framer-motion'
-import { Copy, Check, Volume2, Code, ClipboardList, CheckCircle, RefreshCw, ChevronLeft, ChevronRight, GitFork, Loader2, Link2, Compass, Clock, Pin, PinOff, MoreHorizontal } from 'lucide-react'
+import { Copy, Check, Volume2, Code, ClipboardList, CheckCircle, RefreshCw, ChevronLeft, ChevronRight, GitFork, Loader, Link2, Compass, Clock, Pin, PinOff, MoreHorizontal } from 'lucide-react'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '../../components/ui/dropdown-menu'
 import { copyToClipboard } from '../../utils/clipboard'
 import { copySessionLink } from '../../utils/shareUrl'
@@ -324,8 +324,8 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
         {/* A loaded window keeps fork/plan as row buttons, as on base: the menu below exists
             only to give the UNAVAILABLE state a visible reason, and relocating the everyday
             controls taxed chats the bound never touched. */}
-        {onFork && forkIndex !== undefined && <button className={ROW_ACTION_CLS} disabled={busyAction !== null} data-testid="fork-from-here" title={forkLabel} aria-label={forkLabel} onClick={async () => { setBusyAction('fork'); try { await onFork(forkIndex) } finally { setBusyAction(null) } }}>{busyAction === 'fork' ? <Loader2 size={14} className="animate-spin" /> : <GitFork size={14} />}</button>}
-        {onPlanFromHere && forkIndex !== undefined && <button className={ROW_ACTION_CLS} disabled={busyAction !== null} data-testid="plan-from-here" title={planLabel} aria-label={planLabel} onClick={async () => { setBusyAction('plan'); try { await onPlanFromHere(forkIndex) } finally { setBusyAction(null) } }}>{busyAction === 'plan' ? <Loader2 size={14} className="animate-spin" /> : <ClipboardList size={14} />}</button>}
+        {onFork && forkIndex !== undefined && <button className={ROW_ACTION_CLS} disabled={busyAction !== null} data-testid="fork-from-here" title={forkLabel} aria-label={forkLabel} onClick={async () => { setBusyAction('fork'); try { await onFork(forkIndex) } finally { setBusyAction(null) } }}>{busyAction === 'fork' ? <Loader size={14} className="animate-spin" /> : <GitFork size={14} />}</button>}
+        {onPlanFromHere && forkIndex !== undefined && <button className={ROW_ACTION_CLS} disabled={busyAction !== null} data-testid="plan-from-here" title={planLabel} aria-label={planLabel} onClick={async () => { setBusyAction('plan'); try { await onPlanFromHere(forkIndex) } finally { setBusyAction(null) } }}>{busyAction === 'plan' ? <Loader size={14} className="animate-spin" /> : <ClipboardList size={14} />}</button>}
         {/* Row buttons, not menu items: neither depends on `slotHasMore`, and the raw-mode
             state has to be VISIBLE without opening anything. */}
         {text.length >= 50 && onSpeak && <button className="text-muted hover:text-text p-0.5 rounded transition-colors" title={i18nT('pages.chat.assistantMessage.speak')} aria-label={i18nT('pages.chat.assistantMessage.speak_message')} onClick={() => onSpeak(content)}><Volume2 size={14} /></button>}
@@ -376,7 +376,7 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
                 onSelect={(e) => { e.preventDefault(); if (busyAction !== null) return; setPagingToTarget(true) }}
               >
                 <span className="flex items-center gap-2 opacity-50">
-                  {busyAction === 'fork' || loadingOlder ? <Loader2 size={13} className="shrink-0 animate-spin" /> : <GitFork size={13} className="shrink-0" />}
+                  {busyAction === 'fork' || loadingOlder ? <Loader size={13} className="shrink-0 animate-spin" /> : <GitFork size={13} className="shrink-0" />}
                   <span>{forkLabel}</span>
                 </span>
                 <span id={`${reasonId}-fork`} data-testid="fork-unavailable-reason" className="text-[11px] leading-4 text-muted pl-[21px]">
@@ -393,7 +393,7 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
                 onSelect={(e) => { e.preventDefault(); if (busyAction !== null) return; setPagingToTarget(true) }}
               >
                 <span className="flex items-center gap-2 opacity-50">
-                  {busyAction === 'plan' || loadingOlder ? <Loader2 size={13} className="shrink-0 animate-spin" /> : <ClipboardList size={13} className="shrink-0" />}
+                  {busyAction === 'plan' || loadingOlder ? <Loader size={13} className="shrink-0 animate-spin" /> : <ClipboardList size={13} className="shrink-0" />}
                   <span>{planLabel}</span>
                 </span>
                 <span id={`${reasonId}-plan`} className="text-[11px] leading-4 text-muted pl-[21px]">

--- a/website/src/pages/chat/ErrorCard.tsx
+++ b/website/src/pages/chat/ErrorCard.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import { Loader2, Play } from 'lucide-react'
+import { Play, Loader } from 'lucide-react'
 
 import { i18nT } from '../../i18n/t'
 import { useLanguageGeneration } from '../../i18n/useLanguageGeneration'
@@ -60,7 +60,7 @@ export const ErrorCard = memo(function ErrorCard({ content, onContinue, continui
         data-testid="error-card-continue"
       >
         {continuing
-          ? <Loader2 size={12} className="lucide-inline shrink-0 animate-spin" aria-hidden="true" />
+          ? <Loader size={12} className="lucide-inline shrink-0 animate-spin" aria-hidden="true" />
           : <Play size={12} className="lucide-inline shrink-0" aria-hidden="true" />}
         {i18nT('pages.chat.errorCard.continue')}
       </button>

--- a/website/src/pages/chat/KnowledgePicker.tsx
+++ b/website/src/pages/chat/KnowledgePicker.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Brain, X, Loader2, Type, Network } from 'lucide-react'
+import { Brain, X, Type, Network, Loader } from 'lucide-react'
 import type { KnowledgeResult } from './useKnowledgeFetch'
 
 import { i18nT } from '../../i18n/t'
@@ -37,7 +37,7 @@ export function KnowledgePicker({ results, query, loading, onInject, onSkip }: P
     return (
       <div className="border border-border rounded-lg p-4 mb-3 animate-pulse">
         <div className="flex items-center gap-2 text-muted text-sm">
-          <Loader2 size={14} className="animate-spin" /> {i18nT('pages.chat.knowledgePicker.searching_knowledge_for_query', { query })}
+          <Loader size={14} className="animate-spin" /> {i18nT('pages.chat.knowledgePicker.searching_knowledge_for_query', { query })}
         </div>
       </div>
     )

--- a/website/src/pages/chat/SubagentProgressBar.tsx
+++ b/website/src/pages/chat/SubagentProgressBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react'
-import { Bot, X, AlertTriangle, Loader2, CheckCircle, AlertCircle, Square, RotateCcw, Clock, ChevronRight } from 'lucide-react'
+import { Bot, X, AlertTriangle, CheckCircle, AlertCircle, Square, RotateCcw, Clock, ChevronRight, Loader } from 'lucide-react'
 import { useAppSelector, useAppDispatch } from '../../store'
 import { openActivityToTab, selectSubagent, sseSubagentDone } from '../../store/chatSlice'
 import { api } from '../../api/client'
@@ -230,7 +230,7 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
           <Bot size={14} className="text-accent shrink-0" />
           {/* Histogram header: whole-wave counts so mid-wave failures stay visible */}
           <span className="text-text-strong font-medium flex items-center gap-2 min-w-0" data-testid="subagent-histogram">
-            <span className="inline-flex items-center gap-1" data-testid="subagent-running-count"><Loader2 size={12} className="animate-spin text-accent" /> {running}</span>
+            <span className="inline-flex items-center gap-1" data-testid="subagent-running-count"><Loader size={12} className="animate-spin text-accent" /> {running}</span>
             {queued > 0 && <span className="inline-flex items-center gap-1 text-muted" data-testid="subagent-queued-count" title={i18nT('pages.chat.subagentProgressBar.waiting_to_start_queued_behind_the_concurrency_l')}><Clock size={12} /> {queued}</span>}
             {counts.done > 0 && <span className="inline-flex items-center gap-1 text-ok"><CheckCircle size={12} /> {counts.done}</span>}
             {counts.failed > 0 && <span className="inline-flex items-center gap-1 text-danger"><AlertCircle size={12} /> {counts.failed}</span>}
@@ -294,7 +294,7 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
                     </span>
                     {a.retrying ? (
                       <span className="text-info flex items-center gap-1">
-                        <Loader2 size={11} className="shrink-0 animate-spin" />
+                        <Loader size={11} className="shrink-0 animate-spin" />
                         <span className="truncate">{i18nT('pages.chat.subagentProgressBar.backend_hiccup_retrying')}</span>
                       </span>
                     ) : a.stalled ? (

--- a/website/src/pages/chat/WorkflowProgressBar.tsx
+++ b/website/src/pages/chat/WorkflowProgressBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, memo, useState } from 'react'
-import { Workflow, Loader2, CheckCircle2, AlertCircle, ChevronDown } from 'lucide-react'
+import { Workflow, CheckCircle2, AlertCircle, ChevronDown, Loader } from 'lucide-react'
 import { useAppSelector, useAppDispatch } from '../../store'
 import { clearWorkflowRun, isTerminalWorkflowStatus, reconcileWorkflowRuns } from '../../store/chatSlice'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
@@ -159,7 +159,7 @@ function ExpandableRunRow({
         className="w-full px-3 py-1.5 text-[13px] font-mono flex items-start gap-2 hover:bg-accent/5 transition-colors text-left"
       >
         <span className="shrink-0 mt-0.5">
-          {run.status === 'running' && <Loader2 size={14} className="text-accent animate-spin" />}
+          {run.status === 'running' && <Loader size={14} className="text-accent animate-spin" />}
           {run.status === 'finished' && <CheckCircle2 size={14} className="text-green-500" />}
           {(run.status === 'failed' || run.status === 'cancelled') && <AlertCircle size={14} className="text-danger" />}
         </span>

--- a/website/src/pages/overview/SkillContextBudget.tsx
+++ b/website/src/pages/overview/SkillContextBudget.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Trans } from 'react-i18next'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Gauge, Loader2 } from 'lucide-react'
+import { ArrowLeft, Gauge, Loader2, Loader } from 'lucide-react'
 import { api } from '../../api/client'
 import { Card, Btn, Toggle, EmptyState } from '../../components/ui'
 import {
@@ -329,7 +329,7 @@ function BudgetRow({
       {/* Column 4: toggle */}
       <div className="w-[42px] shrink-0 flex items-center justify-end">
         {pending ? (
-          <Loader2 size={14} className="animate-spin text-muted" />
+          <Loader size={14} className="animate-spin text-muted" />
         ) : toggleable ? (
           <Toggle
             checked={inject}

--- a/website/src/pages/overview/SkillsTab.tsx
+++ b/website/src/pages/overview/SkillsTab.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Download, Loader2, RefreshCw, Sparkles } from 'lucide-react'
+import { Download, RefreshCw, Sparkles, Loader } from 'lucide-react'
 import { api } from '../../api/client'
 import ProjectSkillsTrustList from '../../components/ProjectSkillsTrustList'
 import { Card, Btn, SearchInput, EmptyState, Toggle } from '../../components/ui'
@@ -403,7 +403,7 @@ function InjectionRow({ skill }: { skill: Skill }) {
           </div>
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          {pending && <Loader2 size={14} className="animate-spin text-accent" />}
+          {pending && <Loader size={14} className="animate-spin text-accent" />}
           <Toggle
             checked={inject}
             onChange={flip}

--- a/website/src/pages/settings/BrowserPanel.tsx
+++ b/website/src/pages/settings/BrowserPanel.tsx
@@ -1,17 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import {
-  AlertTriangle,
-  CheckCircle2,
-  Copy,
-  Puzzle,
-  Download,
-  ExternalLink,
-  Globe,
-  HardDriveDownload,
-  KeyRound,
-  Loader2,
-} from 'lucide-react'
+import { AlertTriangle, CheckCircle2, Copy, Puzzle, Download, ExternalLink, Globe, HardDriveDownload, KeyRound, Loader } from 'lucide-react'
 
 import { api, type BrowserInstallData } from '../../api/client'
 import { SettingsSection, SettingsCard, SettingsToggle } from '../../components/settings'
@@ -282,7 +271,7 @@ export function BrowserPanel() {
                           >
                             {installing && engineMut.variables === engine ? (
                               <>
-                                <Loader2 size={13} className="lucide-inline animate-spin" />
+                                <Loader size={13} className="lucide-inline animate-spin" />
                                 {i18nT('pages.settings.browserPanel.installing')}
                               </>
                             ) : (
@@ -476,7 +465,7 @@ export function BrowserPanel() {
                 >
                   {installing ? (
                     <>
-                      <Loader2 size={14} className="lucide-inline animate-spin" />
+                      <Loader size={14} className="lucide-inline animate-spin" />
                       {i18nT('pages.settings.browserPanel.installing')}
                     </>
                   ) : (

--- a/website/src/pages/settings/WeixinPanel.tsx
+++ b/website/src/pages/settings/WeixinPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { QrCode, Loader2, Check, TriangleAlert, RefreshCw } from 'lucide-react'
+import { QrCode, Check, TriangleAlert, RefreshCw, Loader } from 'lucide-react'
 import { api, type WeixinConfigSave } from '../../api/client'
 import { WeixinLogo } from '../../components/WeixinLogo'
 import { SettingsInput, SettingsSelect, SettingsToggle } from '../../components/settings'
@@ -224,7 +224,7 @@ export function WeixinPanel() {
               className="flex items-center gap-1.5 text-xs py-1.5 px-3.5 rounded-md border border-border bg-bg text-text cursor-pointer hover:bg-bg-hover disabled:opacity-60 disabled:cursor-default shrink-0"
             >
               {phase === 'starting' ? (
-                <Loader2 size={13} className="animate-spin" />
+                <Loader size={13} className="animate-spin" />
               ) : credentialSet ? (
                 <RefreshCw size={13} />
               ) : (
@@ -249,7 +249,7 @@ export function WeixinPanel() {
               <div className="text-[12px] text-muted">{i18nT('pages.settings.weixinPanel.waiting_for_a_code')}</div>
             )}
             <div className="flex items-center gap-1.5 text-[12px] text-muted">
-              <Loader2 size={12} className="animate-spin" />
+              <Loader size={12} className="animate-spin" />
               {phase === 'scanned' ? i18nT('pages.settings.weixinPanel.scanned_confirm_in_wechat') : i18nT('pages.settings.weixinPanel.waiting_for_scan')}
             </div>
           </div>

--- a/website/src/pages/settings/WhatsAppPanel.tsx
+++ b/website/src/pages/settings/WhatsAppPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { QrCode, Loader2, Check, TriangleAlert, Trash2, Unlink } from 'lucide-react'
+import { QrCode, Loader2, Loader, Check, TriangleAlert, Trash2, Unlink } from 'lucide-react'
 import {
   ApiError,
   api,
@@ -688,7 +688,7 @@ export function WhatsAppPanel() {
               <div className="text-[12px] text-muted">{i18nT('pages.settings.whatsAppPanel.waiting_for_a_code')}</div>
             )}
             <div className="flex items-center gap-1.5 text-[12px] text-muted">
-              <Loader2 size={12} className="animate-spin" />
+              <Loader size={12} className="animate-spin" />
               {phase === 'scanned' ? i18nT('pages.settings.whatsAppPanel.scanned_confirm_on_your_phone') : i18nT('pages.settings.whatsAppPanel.waiting_for_scan')}
             </div>
           </div>

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -431,13 +431,13 @@ describe('AssistantMessage', () => {
     const idle = render(<AssistantMessage content={'x'.repeat(80)} isStreaming={false} slotRunning={false} onFork={vi.fn()} onPlanFromHere={vi.fn()} onLoadEarlier={vi.fn()} />)
     openOverflow()
     expect(screen.getByTestId('fork-from-here').querySelector('svg.lucide-git-fork')).toBeInTheDocument()
-    expect(screen.getByTestId('fork-from-here').querySelector('svg.lucide-loader-circle')).not.toBeInTheDocument()
+    expect(screen.getByTestId('fork-from-here').querySelector('svg.lucide-loader')).not.toBeInTheDocument()
     idle.unmount()
     render(<AssistantMessage content={'x'.repeat(80)} isStreaming={false} slotRunning={false} onFork={vi.fn()} onPlanFromHere={vi.fn()} onLoadEarlier={vi.fn()} loadingOlder />)
     openOverflow()
     // Both items carry it, so the cue is on whichever one the reader is looking at.
-    expect(screen.getByTestId('fork-from-here').querySelector('svg.lucide-loader-circle')).toBeInTheDocument()
-    expect(screen.getByTestId('plan-from-here').querySelector('svg.lucide-loader-circle')).toBeInTheDocument()
+    expect(screen.getByTestId('fork-from-here').querySelector('svg.lucide-loader')).toBeInTheDocument()
+    expect(screen.getByTestId('plan-from-here').querySelector('svg.lucide-loader')).toBeInTheDocument()
   })
 
   it('does not render fork button while streaming', () => {
@@ -467,17 +467,25 @@ describe('AssistantMessage', () => {
     const onPlanFromHere = vi.fn(() => new Promise<void>(res => { resolvePlan = res }))
     const onFork = vi.fn()
     render(<AssistantMessage content="Hello world" isStreaming={false} slotRunning={false} onFork={onFork} onPlanFromHere={onPlanFromHere} forkIndex={0} />)
-    fireEvent.click(screen.getByTitle('Plan from here'))
-    const planItem = screen.getByTitle('Plan from here')
-    const forkItem = screen.getByTitle('Fork conversation from here')
-    expect(planItem).toBeDisabled()
-    expect(forkItem).toBeDisabled()
-    // Fork keeps its GitFork icon -- it must NOT have been swapped for a spinner.
-    expect(forkItem.querySelector('svg.lucide-git-fork')).toBeInTheDocument()
-    expect(forkItem.querySelector('svg.lucide-loader-circle')).not.toBeInTheDocument()
-    // Plan's icon IS the spinner while its own action is in flight.
-    expect(planItem.querySelector('svg.lucide-loader-circle')).toBeInTheDocument()
-    expect(planItem.querySelector('svg.lucide-clipboard-list')).not.toBeInTheDocument()
+
+    const planBtn = screen.getByTitle('Plan from here')
+    const forkBtn = screen.getByTitle('Fork conversation from here')
+
+    fireEvent.click(planBtn)
+
+    // Plan button shows its Loader spinner (aria-hidden svg has no title, so
+    // assert via the disabled state + absence of the ClipboardList icon class
+    // is fragile; instead assert both buttons are disabled (busyAction !== null)
+    // while only the fork button still renders its GitFork icon svg).
+    expect(planBtn).toBeDisabled()
+    expect(forkBtn).toBeDisabled()
+    // Fork icon (GitFork, lucide class "lucide-git-fork") must remain the fork
+    // button's icon -- it must NOT have been swapped for a spinner.
+    expect(forkBtn.querySelector('svg.lucide-git-fork')).toBeInTheDocument()
+    expect(forkBtn.querySelector('svg.lucide-loader')).not.toBeInTheDocument()
+    // Plan button's icon IS the spinner while its action is in flight.
+    expect(planBtn.querySelector('svg.lucide-loader')).toBeInTheDocument()
+    expect(planBtn.querySelector('svg.lucide-clipboard-list')).not.toBeInTheDocument()
 
     await act(async () => { resolvePlan(); await Promise.resolve() })
     expect(screen.getByTitle('Plan from here')).not.toBeDisabled()
@@ -488,15 +496,18 @@ describe('AssistantMessage', () => {
     const onFork = vi.fn(() => new Promise<void>(res => { resolveFork = res }))
     const onPlanFromHere = vi.fn()
     render(<AssistantMessage content="Hello world" isStreaming={false} slotRunning={false} onFork={onFork} onPlanFromHere={onPlanFromHere} forkIndex={0} />)
-    fireEvent.click(screen.getByTitle('Fork conversation from here'))
-    const planItem = screen.getByTitle('Plan from here')
-    const forkItem = screen.getByTitle('Fork conversation from here')
-    expect(forkItem).toBeDisabled()
-    expect(planItem).toBeDisabled()
-    expect(planItem.querySelector('svg.lucide-clipboard-list')).toBeInTheDocument()
-    expect(planItem.querySelector('svg.lucide-loader-circle')).not.toBeInTheDocument()
-    expect(forkItem.querySelector('svg.lucide-loader-circle')).toBeInTheDocument()
-    expect(forkItem.querySelector('svg.lucide-git-fork')).not.toBeInTheDocument()
+
+    const planBtn = screen.getByTitle('Plan from here')
+    const forkBtn = screen.getByTitle('Fork conversation from here')
+
+    fireEvent.click(forkBtn)
+
+    expect(forkBtn).toBeDisabled()
+    expect(planBtn).toBeDisabled()
+    expect(planBtn.querySelector('svg.lucide-clipboard-list')).toBeInTheDocument()
+    expect(planBtn.querySelector('svg.lucide-loader')).not.toBeInTheDocument()
+    expect(forkBtn.querySelector('svg.lucide-loader')).toBeInTheDocument()
+    expect(forkBtn.querySelector('svg.lucide-git-fork')).not.toBeInTheDocument()
 
     await act(async () => { resolveFork(); await Promise.resolve() })
     expect(screen.getByTitle('Fork conversation from here')).not.toBeDisabled()

--- a/website/src/test/issueRadarStickyHeader.test.tsx
+++ b/website/src/test/issueRadarStickyHeader.test.tsx
@@ -100,7 +100,7 @@ describe('the toolbar row obeys max-two-buttons-per-row', () => {
     // mutation ran. The menu closes on select, so without this the write has no
     // acknowledgment anywhere until the pill flips — a dead-tap read on latency.
     expect(menu, 'the trigger must render a spinner while pending')
-      .toMatch(/pending\s*\n?\s*\?\s*<Loader2/)
+      .toMatch(/pending\s*\n?\s*\?\s*<Loader/)
     const issue = bare(await src('components/IssueDetail.tsx'))
     expect(issue, 'the issue pane must feed the mutation state to the trigger')
       .toMatch(/<DetailOverflowMenu pending=\{[^}]*stateMutation\.isPending[^}]*\}>/)

--- a/website/src/test/spinnerGlyphRule.test.ts
+++ b/website/src/test/spinnerGlyphRule.test.ts
@@ -1,0 +1,95 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+// One stated rule, enforced: below 15px use lucide `Loader`, at 15px and above
+// use `LoaderCircle`. Without a guard this is per-call-site taste again by the
+// third PR, which is the state the rule was written to end -- the glyph choice
+// is a property of the SIZE, so it can be checked rather than reviewed.
+//
+// See website/docs/page-layout.md -> Spinners for the reasoning.
+
+const SRC = join(__dirname, '..')
+const SKIP = new Set(['test', 'node_modules', '__snapshots__'])
+const SMALL_ARC = /<(?:Loader2|LoaderCircle)\s+size=\{(\d+)\}/g
+const LARGE_SPOKES = /<Loader\s+size=\{(\d+)\}/g
+
+async function* walkSource(dir: string): AsyncGenerator<string> {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP.has(entry.name)) continue
+      yield* walkSource(join(dir, entry.name))
+    } else if (/\.tsx?$/.test(entry.name)) {
+      yield join(dir, entry.name)
+    }
+  }
+}
+
+describe('small-size spinner glyph rule', () => {
+  it('uses Loader, not the arc, below 15px', async () => {
+    const offenders: string[] = []
+    for await (const file of walkSource(SRC)) {
+      const src = await readFile(file, 'utf8')
+      for (const m of src.matchAll(SMALL_ARC)) {
+        if (Number(m[1]) < 15) {
+          offenders.push(`${file.replace(SRC, 'src')}: size={${m[1]}}`)
+        }
+      }
+    }
+    expect(
+      offenders,
+      'the arc reads as a broken ring below 15px -- use `Loader` (see docs/page-layout.md)',
+    ).toEqual([])
+  })
+
+  it('uses the arc, not Loader, at 15px and above', async () => {
+    // The rule runs both ways on purpose. A one-directional check would let the
+    // spoke glyph spread upward into sizes where the arc is the better mark,
+    // and the app would end up with two spinners at one size again -- the exact
+    // inconsistency this rule replaced, just pointing the other way.
+    const offenders: string[] = []
+    for await (const file of walkSource(SRC)) {
+      const src = await readFile(file, 'utf8')
+      for (const m of src.matchAll(LARGE_SPOKES)) {
+        if (Number(m[1]) >= 15) {
+          offenders.push(`${file.replace(SRC, 'src')}: size={${m[1]}}`)
+        }
+      }
+    }
+    expect(
+      offenders,
+      'at 15px+ the arc is unambiguous -- use `LoaderCircle` (see docs/page-layout.md)',
+    ).toEqual([])
+  })
+
+  it('applies the rule to a spinner passed as a VALUE, not only as JSX', async () => {
+    // The size-keyed assertions above see `<Loader2 size={13} />` and miss
+    // `{ Icon: Loader2 }` in a phase/status map, because the size lives at the
+    // `<Icon size={13} />` render site instead. Two such maps were the only
+    // sites the first sweep of this rule missed, and they broke at RUNTIME
+    // rather than in review, so the case is worth checking rather than
+    // remembering.
+    //
+    // The check is per-file and deliberately narrow: an icon map naming the arc
+    // is an offender only when the file also renders `<Icon>` below 15px.
+    const offenders: string[] = []
+    for await (const file of walkSource(SRC)) {
+      const src = await readFile(file, 'utf8')
+      if (!/\bIcon:\s*(?:Loader2|LoaderCircle)\b/.test(src)) continue
+      const small = [...src.matchAll(/<Icon\s[^>]*?size=\{(\d+)\}/gs)]
+        .some(m => Number(m[1]) < 15)
+      if (small) offenders.push(file.replace(SRC, 'src'))
+    }
+    expect(
+      offenders,
+      'this icon map renders below 15px -- name `Loader` in the map',
+    ).toEqual([])
+  })
+
+  it('states the threshold in the doc the next page is copied from', async () => {
+    // Pinning the doc to the same number the assertions use: a rule that lives
+    // only in a test is a rule nobody reads before writing the call site.
+    const doc = await readFile(join(SRC, '..', 'docs', 'page-layout.md'), 'utf8')
+    expect(doc, 'page-layout.md should carry the spinner rule')
+      .toMatch(/Below 15px use lucide `Loader`\. At 15px and above use `LoaderCircle`\./)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Small loading indicators use `Loader2`/`LoaderCircle` inconsistently, and the arc glyph becomes difficult to read at 10–14px. The repository had no stated rule or regression guard.

## Why it matters

These indicators appear throughout dense dashboard controls. Inconsistent glyph selection makes equivalent states look different, while undersized arc spinners read as broken rings instead of motion.

## What changed (motivation → approach → change)

Adopt one size-based rule: below 15px use lucide `Loader`; at 15px and above use `LoaderCircle`. The change documents that rule, applies it across explicit-size call sites, covers spinner components stored in icon maps, and adds a source-level guard. CSS/`1em`-sized spinners remain outside the static rule because their rendered size is contextual.

## Tests

- `spinnerGlyphRule.test.ts`: four assertions cover sub-15px sites, 15px-and-up sites, icon maps, and the documentation pin.
- Updated glyph-class assertions in affected component tests.
- Full frontend run previously completed with 20,959 tests passing; one known unrelated parallel-load flake passed in isolation.
- TypeScript typecheck passed; ESLint reported zero errors.

## Manual verification

Reviewed the affected spinner sizes and confirmed the rule preserves `LoaderCircle` at normal sizes while using the spoke glyph only where the arc loses legibility.

## Screenshots / video

N/A — this is a repository-wide consistency sweep of existing loading states; no layout or interaction changed.

## Related Issues

Closes #3925

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository placeholder; no CLA text has been supplied.
