### PR TITLE
refactor: simplify the metrics module's reader list, prune plan and flags

### DIFF
--- a/src/kiro_crew/metrics/http_metrics.py
+++ b/src/kiro_crew/metrics/http_metrics.py
@@ -223,11 +223,13 @@ def make_route_latency_middleware(
                 response is None
                 and request.writer.output_size > output_size_before
             )
-            stream_lifetime = response_committed or isinstance(
-                response, web.WebSocketResponse
-            ) or (
-                isinstance(response, web.StreamResponse)
-                and response.content_type == "text/event-stream"
+            stream_lifetime = (
+                response_committed
+                or isinstance(response, web.WebSocketResponse)
+                or (
+                    isinstance(response, web.StreamResponse)
+                    and response.content_type == "text/event-stream"
+                )
             )
             if not stream_lifetime:
                 try:

--- a/src/kiro_crew/metrics/local_exporter.py
+++ b/src/kiro_crew/metrics/local_exporter.py
@@ -43,7 +43,7 @@ import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, NamedTuple
 
 from opentelemetry.sdk.metrics import Counter, Histogram, UpDownCounter
 from opentelemetry.sdk.metrics.export import (
@@ -72,6 +72,20 @@ _SHARD_NAME_RE = re.compile(
     r"metrics-(?P<day>\d{4}-\d{2}-\d{2})-(?P<pid>[1-9]\d*)"
     r"(?:-(?P<rotation>[1-9]\d*))?\.jsonl"
 )
+
+
+class _Shard(NamedTuple):
+    """One exporter-owned shard as retention sees it.
+
+    ``protected`` is resolved once, while stat'ing, and reused by both caps:
+    ``_is_protected_writer`` reads the wall clock, so re-deriving it per cap could
+    answer differently on either side of the recency cutoff within one plan.
+    """
+
+    mtime_ns: int
+    size: int
+    path: Path
+    protected: bool
 
 
 class JsonlMetricExporter(MetricExporter):
@@ -206,7 +220,7 @@ class JsonlMetricExporter(MetricExporter):
             line = metrics_data.to_json(indent=None)
             encoded = (line + "\n").encode("utf-8")
             self._dir.mkdir(parents=True, exist_ok=True)
-            # ~/.kirocrew convention: telemetry stays private (dir 0o700, file
+            # ~/.kiro/crew convention: telemetry stays private (dir 0o700, file
             # 0o600). mkdir/open modes are masked by umask, so chmod explicitly.
             self._chmod(self._dir, 0o700)
             # Per-PID shards have one writer, so append + rotation need no
@@ -291,7 +305,7 @@ class JsonlMetricExporter(MetricExporter):
         """Return exact exporter-owned shards eligible for deletion."""
         if not self._dir.exists():
             return []
-        shards: list[tuple[int, int, Path, bool]] = []
+        shards: list[_Shard] = []
         for path in self._dir.glob("metrics-*.jsonl"):
             if not self._is_exporter_shard(path):
                 continue
@@ -301,37 +315,41 @@ class JsonlMetricExporter(MetricExporter):
                 continue
             if not stat.S_ISREG(shard_stat.st_mode):
                 continue
-            protected = self._is_protected_writer(path, shard_stat.st_mtime_ns)
             shards.append(
-                (shard_stat.st_mtime_ns, shard_stat.st_size, path, protected)
+                _Shard(
+                    mtime_ns=shard_stat.st_mtime_ns,
+                    size=shard_stat.st_size,
+                    path=path,
+                    protected=self._is_protected_writer(path, shard_stat.st_mtime_ns),
+                )
             )
 
         deletions: list[Path] = []
         # Age cap: plan deletion for anything older than the retention window.
         if self._retention_days > 0:
             cutoff = time.time_ns() - self._retention_days * 86400 * 1_000_000_000
-            survivors: list[tuple[int, int, Path, bool]] = []
-            for mtime, size, path, protected in shards:
-                if mtime < cutoff and not protected:
-                    deletions.append(path)
+            survivors: list[_Shard] = []
+            for shard in shards:
+                if shard.mtime_ns < cutoff and not shard.protected:
+                    deletions.append(shard.path)
                 else:
-                    survivors.append((mtime, size, path, protected))
+                    survivors.append(shard)
             shards = survivors
 
         # Size cap: plan closed-shard deletion oldest-first until the surviving
         # footprint is within budget. Protected active writers may temporarily
         # keep the directory over budget.
         if self._max_total_bytes > 0:
-            total = sum(size for _mtime, size, _path, _protected in shards)
+            total = sum(shard.size for shard in shards)
             if total > self._max_total_bytes:
-                shards.sort(key=lambda item: item[0])
-                for _mtime, size, path, protected in shards:
+                shards.sort(key=lambda shard: shard.mtime_ns)
+                for shard in shards:
                     if total <= self._max_total_bytes:
                         break
-                    if protected:
+                    if shard.protected:
                         continue
-                    deletions.append(path)
-                    total -= size
+                    deletions.append(shard.path)
+                    total -= shard.size
         return deletions
 
     @staticmethod

--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -360,10 +360,12 @@ def _build_recorder() -> _Build:
 
     # PeriodicExportingMetricReader starts its daemon ticker thread inside
     # __init__, so if any later step (MeterProvider construction, etc.) raises,
-    # the reader is already ticking. Hoist the list here so the except can reap
-    # every reader it started — otherwise an orphaned thread keeps running and
-    # spamming export WARNINGs for the life of the process even though metrics
-    # are "disabled".
+    # the reader is already ticking. This list is bound BEFORE the try — binding
+    # it inside would leave it unbound when the first reader's constructor
+    # raises, and the except would then fail on the reap instead of degrading —
+    # and each reader joins it once constructed, so the except reaps every one.
+    # Otherwise an orphaned thread keeps running and spamming export WARNINGs for
+    # the life of the process even though metrics are "disabled".
     started_readers: list = []
     try:
         directory = (
@@ -371,23 +373,24 @@ def _build_recorder() -> _Build:
             if cfg.local_dir
             else _default_metrics_dir()
         )
-        reader = PeriodicExportingMetricReader(
-            JsonlMetricExporter(
-                directory,
-                retention_days=cfg.retention_days,
-                max_total_mb=cfg.max_total_mb,
-            ),
-            export_interval_millis=float(cfg.export_interval_seconds) * 1000.0,
+        started_readers.append(
+            PeriodicExportingMetricReader(
+                JsonlMetricExporter(
+                    directory,
+                    retention_days=cfg.retention_days,
+                    max_total_mb=cfg.max_total_mb,
+                ),
+                export_interval_millis=float(cfg.export_interval_seconds) * 1000.0,
+            )
         )
-        readers = [reader]
-        started_readers = readers
         # Opt-in OTLP egress: only when telemetry.otlp_endpoint is set.
         # Empty endpoint => local-only, no network egress (the default).
         otlp_reader = _build_otlp_reader(cfg)
+        otlp_active = otlp_reader is not None
         if otlp_reader is not None:
-            readers.append(otlp_reader)
+            started_readers.append(otlp_reader)
         provider = MeterProvider(
-            metric_readers=readers,
+            metric_readers=started_readers,
             resource=Resource.create({"service.name": _SERVICE_NAME}),
             # One View per instrument, from _HISTOGRAM_BUCKETS_MS. Deliberately
             # NOT a catch-all `instrument_type=Histogram` View: the OTEL SDK
@@ -404,18 +407,17 @@ def _build_recorder() -> _Build:
                 for name, bounds in _HISTOGRAM_BUCKETS_MS.items()
             ],
         )
-        _provider_built = provider
         logger.info(
             "telemetry enabled; local JSONL sink at %s (otlp=%s)",
             directory,
-            "on" if len(readers) > 1 else "off",
+            "on" if otlp_active else "off",
         )
-        if len(readers) > 1:
+        if otlp_active:
             # Name the egress start on its own line: a file/CLI enable is trusted
             # and ungated, so this log is the only record that metrics began
             # leaving the machine.
             logger.info("telemetry OTLP export active; metrics leave this machine")
-        return _Build(MetricsRecorder(provider.get_meter(_SCOPE)), _provider_built, consent)
+        return _Build(MetricsRecorder(provider.get_meter(_SCOPE)), provider, consent)
     except Exception as exc:
         logger.warning("telemetry init failed; metrics disabled: %s", exc)
         # Reap EVERY reader already started, not just the first: with


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only change under `src/kiro_crew/metrics/`; no frontend path is touched and nothing renders differently.

## Problem / Motivation

`src/kiro_crew/metrics/` carries a handful of constructs that cost a reader more
than they need to, all of them local:

- `provider.py` `_build_recorder()` assigns `_provider_built = provider` and then
  returns `_provider_built` two lines later — an alias for a name that is never
  rebound.
- The same function asks "is OTLP egress on?" twice by testing `len(readers) > 1`.
  That is true only because exactly one reader is created unconditionally and the
  OTLP reader is the only thing appended, so the reader's intent has to be
  reconstructed from a list length.
- It also keeps two names, `readers` and `started_readers`, for **one** list
  object. The except path reaps `started_readers`, and it only sees the OTLP
  reader because `started_readers = readers` aliased them — a dependency that is
  invisible at the reap site and that a later "tidy-up" (copying the list, or
  rebinding one name) would silently break.
- `local_exporter.py` `_prune_plan()` builds a positional
  `tuple[int, int, Path, bool]` per shard, then unpacks it three different ways
  across the two retention caps — twice with throwaway `_mtime` / `_path` /
  `_protected` names — and sorts by `item[0]`. This function decides which files
  get **unlinked**, so index-positional reads are the wrong shape for it.
- `http_metrics.py` wraps the `stream_lifetime` disjunction so that
  `isinstance(response, web.WebSocketResponse)` is split across the `or` it is an
  operand of, which makes the grouping of `A or B or (C and D)` hard to read off
  the page.
- One comment in `local_exporter.py` still names the legacy `~/.kirocrew` data
  home, which the module's own docstring and `config/paths.py` both contradict.

## Why it matters

These are all in the read path of code that is hard to be casual about: the
retention planner deletes files, and the reader list is what prevents an orphaned
`PeriodicExportingMetricReader` ticker thread from spamming export warnings for
the life of the process. Two of them are also latent-defect shaped rather than
merely verbose — the aliased reader list makes a correct reap look accidental,
and a stale data-home comment sends the next reader to a directory that no longer
exists.

This is a module-at-a-time readability sweep, so the diff is deliberately narrow:
one module, one commit, no behavior change.

## What changed (motivation → approach → change)

The sweep's two mechanically decidable classes (in-function shadow imports,
chained ternaries) are already at **zero** for this module, so everything here is
the judgment half: provably dead locals, a duplicated condition, an over-indexed
tuple, and comment accuracy in files already being edited. Every rewrite was
required to be provably equivalent before it landed.

**`provider.py`**
- Removed the `_provider_built` alias; `_Build` now receives `provider` directly.
  `provider` is assigned once and never rebound in between, and the name is a
  plain function local with no reference anywhere else in `src/` or `test/`.
- Named the egress predicate once as `otlp_active = otlp_reader is not None`, and
  used it for both the `otlp=%s` log field and the "metrics leave this machine"
  disclosure line. Control flow guarantees the first append already succeeded at
  that point, so the list holds `1 + (1 if otlp_reader else 0)` elements and
  `len(readers) > 1` ⟺ `otlp_reader is not None` for every input.
- Collapsed `readers` / `started_readers` into the one list the except path reaps,
  appending each reader to it as it is constructed and passing it as
  `metric_readers=`. This is the same object identity the old code already had via
  the alias, so the provider's reader set and the reap set remain *the same list*,
  not merely equal ones. The rewritten comment keeps the constraint that makes
  this correct — the list is bound **before** the `try`, so a raising constructor
  still degrades to the no-op recorder instead of hitting `UnboundLocalError`
  inside the `except`.

**`local_exporter.py`**
- Introduced a private `_Shard` NamedTuple (`mtime_ns`, `size`, `path`,
  `protected`) for the retention plan's per-shard record. Field order is
  unchanged, so `key=lambda shard: shard.mtime_ns` is the old `key=item[0]` and
  both caps compare the same fields in the same order with the same
  `break`/`continue` placement. `protected` is still resolved exactly once, at
  stat time, and consulted by both caps — the docstring records why that matters
  (`_is_protected_writer` reads the wall clock, so re-deriving it per cap could
  answer differently on either side of the recency cutoff within one plan).
- Corrected the stale `~/.kirocrew` comment to `~/.kiro/crew`.

**`http_metrics.py`**
- Parenthesized the `stream_lifetime` disjunction explicitly, breaking before each
  operator. The added grouping is exactly what Python already inferred; the two
  expressions AST-compare identical, so short-circuit order is preserved and
  `response.content_type` (a property) is still only reached on the same branch.

**Deliberately NOT changed**, so the omissions are decisions rather than misses:
- **`schema.py` was left alone entirely.** Its `redact` / `validate_attrs` /
  `_is_high_entropy` are the privacy floor in front of the OTEL SDK. There is a
  real duplicated pattern loop inside `_is_high_entropy`, but that loop *is* the
  credential matcher, and this repo's rule is that a security matcher or redaction
  path is not restructured for style. Applying that criterion to the whole file
  rather than hunk by hunk is what keeps it consistent.
- **`recorder.py`'s three double-checked-lock instrument caches were left
  duplicated.** A shared `_get_or_create(cache, name, factory)` helper would
  dedupe them, but it needs a factory closure allocated on every metric emit plus
  a TypeVar and a re-narrowed `self._meter` local to satisfy mypy — a net cost on
  a hot path in exchange for removing three short, identical blocks.

## Tests

No new tests: this is a behavior-preserving refactor, so the existing suite is the
contract and its job is to stay green unchanged. Nothing was weakened, skipped, or
re-asserted.

Coverage that specifically pins the rewritten code:
- `test/metrics/test_local_exporter.py` — `_prune()` behavior through the
  refactored `_prune_plan`: the warn-and-defer-once notice, protection of a live
  canonical writer, and oldest-first size-cap eviction.
- `test/metrics/test_provider.py` — the reader-reap paths, including
  `test_reader_thread_reaped_when_meterprovider_init_fails` and
  `test_the_otlp_reader_is_reaped_too_when_init_fails`, which are the tests that
  hold the `started_readers` change honest, plus the endpoint-redaction log
  assertions.
- `test/metrics/test_gateway_http_metrics.py::test_middleware_excludes_sse_stream_lifetime`
  — the rewritten disjunction.
- `test/metrics/test_provider_bucket_views.py`, `test/test_perf_boot_path.py`.

## Manual verification

N/A — unit coverage is sufficient for a behavior-preserving refactor with no new
surface, and the equivalence of each rewrite was proven against the pre-image
rather than observed at runtime.

Gates run locally on a Python 3.12 CI-parity venv, all exit 0: `flake8`,
`isort --check-only`, `mypy`, `scripts/check_brand_name.py`,
`scripts/check_harness_parity.py`, `scripts/docs_lint.py --test`,
`scripts/docs-lint.sh`, `scripts/check_per_file_coverage.py --test`,
`scripts/verify_vendor_manifest.py`, `scripts/scrub-lint.sh --no-history`.
Targeted tests: `test/metrics/` (400 passed) and, widened to every test file
referencing the metrics facade or telemetry, 3074 passed / 2 skipped.

The diff touches nothing under `website/`, `.github/` or `scripts/`, so CI's
`changes` job reports `only_backend=true` and the frontend suites cannot newly
fail; they were not run locally for that reason.

### Pre-review fleet

Before opening, the finished diff was reviewed by five independent read-only
passes with distinct lenses — AUTOSDE blocking rules + the `code-review.yml`
deterministic greps; hunk-by-hunk behavior preservation; import semantics and
test-substitution coupling; security keystone / boot path / resource lifecycle;
comment accuracy. Four returned no findings. The one finding that survived
verification was against **this PR's own comment rewrite**: the first draft
restated the reader-list invariant as an append discipline and dropped the
original's *placement* constraint, so a later edit folding the initialization into
the `try` would still satisfy the comment while leaving `started_readers` unbound
on a raising constructor. The comment now carries that constraint explicitly.

Nothing was dropped as a false positive, because nothing else was raised.

## Related Issues

no linked issue: a module-scoped readability sweep with no tracked defect behind it.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — behavior-preserving refactor, no new behavior to cover)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no documented API, schema, or behavior changed; `docs/system-specs/modules/metrics.md`'s claims about `_build_recorder` remain true
- [x] No secrets, credentials, or internal references in the diff
