### PR TITLE
fix(install): recover frontend build from npm optional-deps bug (npm/cli#4828)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -416,16 +416,59 @@ if has node && [ -d "$KIROCREW_APP_DIR/website" ]; then
     _fe_log="$(mktemp)"
     (
         cd "$KIROCREW_APP_DIR/website" &&
+        # Raise V8's heap ceiling for the bundle build. The default (~2 GB on
+        # 64-bit) is not enough for this app's 6k+ module graph, and the OOM
+        # surfaces as a build that dies without a clear cause -- leaving no
+        # dist/ and a "Dashboard HTML not found" page at first launch.
+        _fe_build() { NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=8192}" npm run build 2>>"$_fe_log"; }
+
+        # Install the exact platform-specific rolldown native binding the
+        # bundler needs, keyed off the resolved rolldown version. Last-resort
+        # repair for npm/cli#4828 when even a clean reinstall omits it.
+        _fe_install_binding() {
+            _rd_ver="$(node -p "require('./node_modules/rolldown/package.json').version" 2>/dev/null)" || return 1
+            [ -n "$_rd_ver" ] || return 1
+            case "$(uname -s)" in
+                Linux)  _rd_os="linux" ;;
+                Darwin) _rd_os="darwin" ;;
+                *) return 1 ;;
+            esac
+            case "$(uname -m)" in
+                x86_64|amd64)  _rd_arch="x64" ;;
+                aarch64|arm64) _rd_arch="arm64" ;;
+                *) return 1 ;;
+            esac
+            _rd_abi=""
+            if [ "$_rd_os" = "linux" ]; then
+                if ldd --version 2>&1 | grep -qi musl; then _rd_abi="-musl"; else _rd_abi="-gnu"; fi
+            fi
+            echo "installing @rolldown/binding-${_rd_os}-${_rd_arch}${_rd_abi}@${_rd_ver} explicitly (npm/cli#4828)" >>"$_fe_log"
+            npm install --no-audit --no-fund --no-save --loglevel=error \
+                "@rolldown/binding-${_rd_os}-${_rd_arch}${_rd_abi}@${_rd_ver}" 2>>"$_fe_log"
+        }
+
         if [ -f package-lock.json ]; then
             npm ci --no-audit --no-fund --loglevel=error 2>"$_fe_log"
         else
             npm install --no-audit --no-fund --loglevel=error 2>"$_fe_log"
         fi &&
-        # Raise V8's heap ceiling for the bundle build. The default (~2 GB on
-        # 64-bit) is not enough for this app's 6k+ module graph, and the OOM
-        # surfaces as a build that dies without a clear cause -- leaving no
-        # dist/ and a "Dashboard HTML not found" page at first launch.
-        NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=8192}" npm run build 2>>"$_fe_log"
+        # npm's optional-dependencies bug (npm/cli#4828) can leave `npm ci`
+        # without the platform-specific native binding the bundler needs
+        # (e.g. @rolldown/binding-<os>-<arch>), so the build aborts with
+        # "Cannot find native binding". `npm ci` replays a lockfile resolved
+        # on another OS/arch and drops the entry for THIS platform. Recover in
+        # two escalating steps: re-resolve from scratch (re-evaluates optional
+        # deps for the current platform), then, if that still omits it, install
+        # the exact binding explicitly. Each step rebuilds; the first that
+        # produces a bundle wins.
+        if ! _fe_build; then
+            echo "npm run build failed; re-resolving optional native deps (npm/cli#4828) and retrying" >>"$_fe_log"
+            rm -rf node_modules package-lock.json
+            npm install --no-audit --no-fund --loglevel=error 2>>"$_fe_log"
+            if ! _fe_build; then
+                _fe_install_binding && _fe_build
+            fi
+        fi
     ) &
     spinner $! "Installing npm packages & building React app…"
     _fe_ok=0


### PR DESCRIPTION
## Problem / Motivation

On a fresh cloud launch (and any first-run/dev build) the frontend build can abort with:

```
Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828).
... Cannot find module '@rolldown/binding-linux-arm64-gnu'
```

`install.sh` builds the website with `npm ci` when a `package-lock.json` is present. `npm ci` strictly replays the committed lockfile (resolved on a different OS/arch), so npm's long-standing optional-dependencies bug (npm/cli#4828) drops the platform-specific native binding the bundler (rolldown/vite) needs. The build fails, no `website/dist` is produced, and the gateway serves the **"Dashboard HTML not found"** page.

## Why it matters

For a cloud crew the dashboard *is* the product. The failure is silent from the user's side: the launch "succeeds" (the gateway answers on :5476) but every dashboard load shows "Dashboard HTML not found" with no obvious cause. It reproduces reliably on `linux-arm64` (Amazon Linux 2023 arm64 EC2), a common cloud target.

## What changed (motivation → approach → change)

- **Symptom:** `npm run build` aborts with "Cannot find native binding".
- **Root cause:** `npm ci` + npm/cli#4828 → the `@rolldown/binding-<os>-<arch>` optional dep for the current platform is missing from `node_modules`.
- **Change:** keep the fast `npm ci` path when it works, but recover on build failure in two escalating steps:
  1. Re-resolve dependencies from scratch (`rm -rf node_modules package-lock.json && npm install`) so npm re-evaluates optional deps for **this** platform, then rebuild.
  2. If the binding is *still* missing, install the exact `@rolldown/binding-<os>-<arch>[-abi]` matching the resolved `rolldown` version (os/arch from `uname`, `-gnu`/`-musl` detected via `ldd`), then rebuild.

  Each step rebuilds; the first that produces a bundle wins. The common (working) `npm ci` path is untouched — the recovery only runs when the build would otherwise fail.

## Tests

No automated test change. The existing installer tests (`test/test_cloud_install.py`, `test/test_installer_shim_and_cleanup.py`) do not assert on the frontend-build block, so they are unaffected. `bash -n install.sh` passes.

## Manual verification

This exact two-step recovery is what resolved the failure on a live `linux-arm64` AL2023 EC2 instance during a cloud launch: a clean `npm install` alone did **not** restore the arm64 binding, and installing `@rolldown/binding-linux-arm64-gnu@<rolldown version>` explicitly did — after which `npm run build` produced `website/dist` and the dashboard rendered. The script change mirrors those manual steps. I was not able to run the live arm64 cloud bootstrap from CI/locally (macOS host), so the fix is verified by shell-syntax check + reproduction of the manual remedy rather than an automated arm64 build.

## Related Issues

N/A

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality (no new functionality; installer tests unaffected)
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
