### PR TITLE
perf(chat): render slot detail off the event loop

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -1114,31 +1114,58 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
         # and drops done, so their count is not the span consumed here.
         next_before = start
 
-    prepared = _prepare_messages(messages, slot.running)
+    # Snapshot every slot field the response needs BEFORE leaving the event
+    # loop: the render below runs in a worker thread, and it must not read
+    # attributes the loop keeps mutating mid-turn. `messages` is already a
+    # fresh top-level list in both branches above; the message dicts inside it
+    # are shared with live mutation, which _prepare_messages tolerates by the
+    # same snapshot discipline the flush-thread save path relies on.
+    key = slot.key
+    running = slot.running
+    stopping = slot._stopping
+    display_title = slot.display_title
+    queue_snapshot = [{"id": q["id"], "content": q["content"]} for q in slot._queue]
+    context_fields = await _context_snapshot_fields(state, slot)
 
-    return web.json_response(
-        {
-            "key": slot.key,
-            # Redacted at emit like every sibling path (_ChatSlot.to_dict does the
-            # same for the sidebar payload). Titles can be LLM-generated or set by
-            # a rename, so they are content, not configuration.
-            "title": _redact_for_display(slot.display_title),
-            "running": slot.running,
-            "stopping": slot._stopping,
-            "messages": prepared,
-            "queue": [
-                {"id": q["id"], "content": _redact_for_display(q["content"])} for q in slot._queue
-            ],
-            "total": total,
-            "has_more": has_more,
-            "next_before": next_before,
-            # Seeds the context meter on open. Turn-scoped WS frames alone leave
-            # it empty for a session reopened in a new tab; omitted entirely
-            # (not zeroed) when genuinely unknown, so the frontend can tell
-            # "no reading" from "0% used".
-            **(await _context_snapshot_fields(state, slot)),
-        }
-    )
+    def _render() -> str:
+        # Off-loop on purpose. _prepare_messages applies a regex-heavy
+        # redaction battery to the ENTIRE history; on a multi-MB session that
+        # blocked the event loop past the loop-stall watchdog's exit budget
+        # and hard-exited the gateway. json.dumps of the same payload is a
+        # second loop-blocking cost, so it lives in the thread too.
+        prepared = _prepare_messages(messages, running)
+        return json.dumps(
+            {
+                "key": key,
+                # Redacted at emit like every sibling path (_ChatSlot.to_dict
+                # does the same for the sidebar payload). Titles can be
+                # LLM-generated or set by a rename, so they are content, not
+                # configuration.
+                "title": _redact_for_display(display_title),
+                "running": running,
+                "stopping": stopping,
+                "messages": prepared,
+                "queue": [
+                    {"id": q["id"], "content": _redact_for_display(q["content"])}
+                    for q in queue_snapshot
+                ],
+                "total": total,
+                "has_more": has_more,
+                "next_before": next_before,
+                # Seeds the context meter on open. Turn-scoped WS frames alone
+                # leave it empty for a session reopened in a new tab; omitted
+                # entirely (not zeroed) when genuinely unknown, so the frontend
+                # can tell "no reading" from "0% used".
+                **context_fields,
+            }
+        )
+
+    # Per-slot single-flight: concurrent refetches of the same slot (WS
+    # reconnect + switchSlot + chat_done all refetch) queue here instead of
+    # each burning a worker thread on the same multi-MB redaction pass.
+    async with slot._detail_render_lock:
+        body = await asyncio.to_thread(_render)
+    return web.Response(text=body, content_type="application/json")
 
 
 async def api_chat_slot_create(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -1674,9 +1674,12 @@ def _prepare_messages(messages: list[dict], running: bool) -> list[dict]:
                 m = {**m, "content": text}
             msg_out = dict(m)
             if msg_out.get("variants"):
+                # Snapshot for the same reason as _redact_meta — this runs in a
+                # worker thread (slot-detail render offload) while the event
+                # loop may still be appending variants to the live list.
                 msg_out["variants"] = [
                     {**v, "content": redact_credentials(redact_exfiltration_urls(v.get("content", ""))[0])[0]}
-                    for v in msg_out["variants"] if isinstance(v, dict)
+                    for v in list(msg_out["variants"]) if isinstance(v, dict)
                 ]
             meta = parse_cls_meta(m.get("cls", ""))
             if meta is not None:

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1029,6 +1029,7 @@ class _ChatSlot:
         "_title_retry_pending",
         "_summary_in_flight",
         "_summary_turn_mark",
+        "_detail_render_lock",
         "_last_stop_reason",
         "_artifact",
         "_channel_folder_filed",
@@ -1196,6 +1197,13 @@ class _ChatSlot:
         # summary pass outlives the turn that triggered it, so a fast follow-up
         # turn would otherwise start a second pass over the same transcript.
         self._summary_in_flight: bool = False
+        # Serializes the slot-detail render offload (see api_chat_slot_detail):
+        # rendering redacts the ENTIRE history with a regex battery, so on a
+        # multi-MB session two concurrent refetches (WS reconnect + switchSlot)
+        # would burn that CPU twice in parallel worker threads for the same
+        # payload. The lock queues them instead; each holder re-renders from
+        # fresh state, so a queued waiter never serves a stale response.
+        self._detail_render_lock = asyncio.Lock()
         # User-turn count at the last successful summary, so the configured
         # regeneration cadence can be honored without re-reading the sidecar.
         self._summary_turn_mark: int = 0

--- a/test/test_slot_detail_offload.py
+++ b/test/test_slot_detail_offload.py
@@ -1,0 +1,132 @@
+"""The slot-detail render runs OFF the event loop, single-flight per slot.
+
+Rendering ``GET /api/chat/slots/{slot}`` redacts the entire history with a
+regex battery and serializes the result. On a multi-MB session, doing that on
+the event loop blocks it past the loop-stall watchdog's exit budget, which
+hard-exits the gateway. These tests pin the properties that prevent that:
+
+- ``_prepare_messages`` executes on a worker thread, never the loop thread.
+- Concurrent requests for the same slot serialize on the per-slot render lock
+  (single-flight) instead of redacting the same corpus in parallel threads.
+- The offloaded response keeps the shape and content type the frontend reads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+from kiro_crew.dashboard import chat_handlers
+from kiro_crew.dashboard.state import _ChatSlot
+
+
+@pytest.fixture()
+def state(tmp_path: Any) -> Any:
+    st = _make_state(tmp_path)
+    st.push_slots_update = lambda: None  # type: ignore[method-assign]
+    return st
+
+
+def _slot_with_messages(state: Any, name: str, count: int) -> Any:
+    slot = _ChatSlot(key=name)
+    slot.messages = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"} for i in range(count)
+    ]
+    state._slots[name] = slot
+    return slot
+
+
+class TestRenderRunsOffTheEventLoop:
+    @pytest.mark.asyncio
+    async def test_prepare_messages_runs_on_a_worker_thread(
+        self, state: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The redaction pass must not execute on the loop thread."""
+        _slot_with_messages(state, "chat-1", 6)
+        loop_thread = threading.get_ident()
+        seen: list[int] = []
+        real = chat_handlers._prepare_messages
+
+        def _spy(messages: list[dict], running: bool) -> list[dict]:
+            seen.append(threading.get_ident())
+            return real(messages, running)
+
+        monkeypatch.setattr(chat_handlers, "_prepare_messages", _spy)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/chat-1")
+            assert resp.status == 200
+            body = await resp.json()
+
+        assert body["total"] == 6
+        assert seen, "render never invoked _prepare_messages"
+        assert all(t != loop_thread for t in seen)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_for_one_slot_serialize(
+        self, state: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The per-slot lock keeps at most ONE render in flight at a time."""
+        _slot_with_messages(state, "chat-1", 4)
+        real = chat_handlers._prepare_messages
+        gauge_lock = threading.Lock()
+        active = 0
+        max_active = 0
+
+        def _slow(messages: list[dict], running: bool) -> list[dict]:
+            nonlocal active, max_active
+            with gauge_lock:
+                active += 1
+                max_active = max(max_active, active)
+            # Widens the overlap window so a removed lock is caught; the
+            # asserted property (max one render in flight) is deterministic.
+            time.sleep(0.05)
+            with gauge_lock:
+                active -= 1
+            return real(messages, running)
+
+        monkeypatch.setattr(chat_handlers, "_prepare_messages", _slow)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resps = await asyncio.gather(
+                *[client.get("/api/chat/slots/chat-1") for _ in range(3)]
+            )
+            assert [r.status for r in resps] == [200, 200, 200]
+            bodies = [await r.json() for r in resps]
+
+        assert all(b["total"] == 4 for b in bodies)
+        assert max_active == 1
+
+
+class TestResponseParity:
+    @pytest.mark.asyncio
+    async def test_shape_and_content_type_are_unchanged(self, state: Any) -> None:
+        """The hand-serialized response reads exactly like json_response did."""
+        slot = _slot_with_messages(state, "chat-1", 2)
+        slot._queue.append({"id": "q1", "content": "queued text"})
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/chat-1")
+            assert resp.status == 200
+            assert resp.content_type == "application/json"
+            body = await resp.json()
+
+        assert set(body) >= {
+            "key",
+            "title",
+            "running",
+            "stopping",
+            "messages",
+            "queue",
+            "total",
+            "has_more",
+            "next_before",
+        }
+        assert body["key"] == "chat-1"
+        assert body["total"] == 2
+        assert body["has_more"] is False
+        assert body["queue"] == [{"id": "q1", "content": "queued text"}]
+        assert [m["content"] for m in body["messages"]] == ["m0", "m1"]


### PR DESCRIPTION
## Problem / Motivation

Opening or refetching a large session in the dashboard can kill the whole gateway. `GET /api/chat/slots/{slot}` redacts the ENTIRE message history (regex battery: `redact_credentials` + `redact_exfiltration_urls` over every non-user message, variant, and meta dict) and then `json.dumps`-serializes the multi-MB payload — all synchronously on the event loop. On a ~28 MB session history that blocks the loop past the loop-stall watchdog's exit budget (default 25s), and the watchdog hard-exits the process (`_exit(1)`). Three production crash dumps on one morning (2026-08-17 06:31, 07:06, 08:06 UTC) show the identical main-thread stack: `api_chat_slot_detail` → `_prepare_messages` → `redact_credentials`.

## Why it matters

Each occurrence is a full gateway outage — every chat session, cron, and Slack integration goes down — triggered by an ordinary UI action (opening a big session, a WS reconnect, or the frontend's `chat_done` refetch). Under systemd with `Restart=always` and `StartLimitBurst=3`/300s, a dashboard tab that keeps refetching a large session can crash-loop the unit into a locked `failed` state. Session histories only grow, so the blast radius widens over time.

## What changed (motivation → approach → change)

Symptom: watchdog kills with the render stack on the main thread. Root cause: O(history) regex redaction plus multi-MB JSON serialization on the event loop. Change: keep the loop free by doing that work on a worker thread —

- `api_chat_slot_detail` now snapshots every loop-owned field the response needs (`key`, `running`, `stopping`, `display_title`, queue contents, context-snapshot fields) **before** leaving the loop, then runs `_prepare_messages` **and** `json.dumps` inside one `asyncio.to_thread` closure, returning `web.Response(text=..., content_type="application/json")`. Serialization moves off-loop too because dumping the same multi-MB payload is a second loop-blocking cost.
- A per-slot `asyncio.Lock` (`_detail_render_lock` on `_ChatSlot`) single-flights concurrent refetches of the same slot, so a reconnect burst queues instead of burning parallel worker threads redacting the same corpus. Each holder re-renders from fresh state, so queued waiters never serve stale bytes.
- Thread-safety rests on the discipline this module already has: the redact helpers snapshot every container they iterate (`list(meta.items())` / `list(v)`) because the flush-executor save path already runs them off-loop against live objects. The one gap — `_prepare_messages` iterating a live `variants` list directly — gets the same `list()` snapshot. Top-level message lists were already fresh per-request copies in both handler branches; `dict(m)` / `{**m}` copies are single C-level calls that hold the GIL for their duration.

Alternatives considered: response caching (rejected here — messages mutate in place until a turn ends, and a rules-hash-keyed cache is security-sensitive complexity) and capping the default response (a real follow-up, but it changes the endpoint contract and needs frontend pagination work). This change removes the crash without touching the API shape.

## Tests

`test/test_slot_detail_offload.py` (new):
- `test_prepare_messages_runs_on_a_worker_thread` — pins the off-loop property; fails if the render is ever moved back onto the loop thread.
- `test_concurrent_requests_for_one_slot_serialize` — pins single-flight: max one render in flight across 3 concurrent requests; fails if the per-slot lock is removed.
- `test_shape_and_content_type_are_unchanged` — pins response parity: same JSON shape and `application/json` content type as the previous `web.json_response` path.

Existing `test/test_slot_detail_full_history.py` (7 tests) passes unchanged, locking content parity for both handler branches. Full backend suite, isort, flake8, and mypy (979 files) are green.

## Manual verification

The crash itself requires a multi-MB session history; reproducing it live was not done in this change. Evidence stands on the three production loop-stall crash dumps carrying the exact fixed stack, plus the unit tests above pinning the off-loop and single-flight properties.

no linked issue: crash diagnosed directly from production loop-stall crash dumps on the operator's gateway; no tracker issue was filed.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, internal handler behavior, no doc surface
- [x] No secrets, credentials, or internal references in the diff
