### PR TITLE
fix: correct file_send 403 denial message and stale session-path docstring (#4092)

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1393,
+    "missing_code": 1392,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 800,
+  "_compliant": 806,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -97,7 +97,7 @@
       "missing_code": 15
     },
     "dashboard/handlers/files.py": {
-      "missing_code": 116
+      "missing_code": 115
     },
     "dashboard/handlers/kiro_prerequisite.py": {
       "missing_code": 1

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -466,7 +466,13 @@ async def api_slack_upload_file(request: web.Request) -> web.Response:
             downstream_service="slack",
             error=f"path_not_allowed: {file_path}",
         )
-        return web.json_response({"error": "file_path must be under ~/.kirocrew/"}, status=403)
+        return web.json_response(
+            {
+                "error": "file_path must be under the outbox directory or the workspace root",
+                "code": "path_not_allowed",
+            },
+            status=403,
+        )
     try:
         raw = safe_read_file_bytes(str(resolved))
     except FileTooLargeError as e:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -1,6 +1,6 @@
 """Persistent conversation history — JSONL per session + LLM consolidation.
 
-Session files: ~/.kirocrew/sessions/{safe_key}.jsonl
+Session files: ~/.kiro/crew/sessions/{safe_key}.jsonl
 Each entry tracks provenance (source_thread, source_user) for citation.
 Files auto-rotate at 512KB, keeping last 200 lines.
 """

--- a/test/test_file_send_channel.py
+++ b/test/test_file_send_channel.py
@@ -177,6 +177,43 @@ class TestFileUploadChannel:
         assert "invalid channel value" in body.get("error", "")
         slack.upload_file.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_path_outside_allowed_roots_denied_with_code(self, tmp_path):
+        """A file_path outside both the outbox and the workspace root returns 403
+        with a machine-readable code and a message naming the allowed roots."""
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        app = _make_app(slack, tmp_path)
+
+        outside = tmp_path / "elsewhere" / "secret.txt"
+        outside.parent.mkdir()
+        outside.write_text("data", encoding="utf-8")
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir",
+            return_value=tmp_path / "outbox",
+        ), patch(
+            "kiro_crew.config.loader.workspace_root",
+            return_value=tmp_path / "workspace",
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/slack/upload-file",
+                    json={
+                        "file_path": str(outside),
+                        "filename": "secret.txt",
+                        "thread_ts": "",
+                    },
+                )
+                body = await resp.json()
+
+        assert resp.status == 403
+        assert body.get("code") == "path_not_allowed"
+        assert "outbox directory or the workspace root" in body.get("error", "")
+        # The caller-supplied path must not be reflected back in the body.
+        assert str(outside) not in body.get("error", "")
+        slack.upload_file.assert_not_called()
+
 
 class TestFileUploadBinary:
     """Behaviour: binary files in BINARY_MIME_ALLOWLIST upload to Slack without UTF-8 decode."""


### PR DESCRIPTION
<!-- no-visual-delta -->
Backend JSON body and a module docstring; no rendered surface changes.

Closes #4092

## What broke

Two string literals outside `src/kiro_crew/metrics/` still named the retired data home `~/.kirocrew` as if it were current (the home moved to `~/.kiro/crew`; `.kirocrew` survives only as `LEGACY_CONFIG_DIR_NAME` for first-launch migration):

1. **`dashboard/handlers/files.py:469`** — the `file_send` path-allowlist 403 told the caller the file "must be under ~/.kirocrew/", a directory that exists on no current install. The message was wrong in a second way the issue did not name: the check enforces "under the outbox directory or the workspace root", not "under the crew home" — the crew home contains plenty of paths this check rejects. The body also lacked the machine-readable `code` field AGENTS.md requires of non-2xx JSON bodies.
2. **`history.py:3`** — module docstring documented session files at `~/.kirocrew/sessions/`. Verified against the code: the module resolves `config_dir() / SESSIONS_DIR_NAME` = `~/.kiro/crew/sessions/`.

## What changed

- 403 message now names the two roots the code actually accepts (by role, no absolute paths, no reflection of the caller-supplied `file_path` — the sibling SEL call already records it server-side).
- Added `"code": "path_not_allowed"`, matching the SEL audit term for this exact denial, following the `{"error", "code"}` convention already used in this file. The `error` key is preserved for existing clients. **Note: this is a wire-visible message-text change** (status code unchanged, no test asserted the old text; the only in-repo caller, `mcp_tools/messaging.py`, forwards `error` generically).
- Docstring corrected to `~/.kiro/crew/sessions/{safe_key}.jsonl`.
- New HTTP-level test: 403 body carries `code == "path_not_allowed"`, names both roots, and does not reflect the caller path.
- `error-code-baseline.json` re-snapshotted via `python test/test_error_code_contract.py --update` (`missing_code` 1393→1392, `files.py` 116→115). The informational `_compliant` counter moved 800→806; +1 is this PR, the other +5 is drift from earlier merged PRs that never re-snapshotted, absorbed here by the generator. No gated bucket increased.

## Scope guard (per issue: ~80 other `.kirocrew` hits are legitimate migration code)

- `git diff --stat` on the code change: exactly `files.py` + `history.py` (+ test + baseline).
- No hit under `config/paths.py`, nothing referencing `LEGACY_CONFIG_DIR_NAME` or migration helpers.

## Verification

- Local gates green: `isort` / `flake8 7.1.0` / `mypy` clean; `pytest` 55438 passed (1 pre-existing `test_wecom_client_cov80` teardown error reproduces on clean `main`, environment-local, unrelated).
- Pre-push reviews: GPT 5.6 Sol NO-BLOCKING (zero findings); Opus 5 NO-BLOCKING (2 advisories: `_compliant` drift → explained above; optional allow-side test assertion → declined, `test_upload_to_tracked_channel` in the same module already proves the patched roots are honored).
