### PR TITLE
test: extend truncate_summary edge-case coverage

### DIFF
--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -27,7 +27,7 @@ from kiro_crew.tips import (
     _select_tip,
     _validate_tip_fields,
 )
-from kiro_crew.tips_text import truncate_summary
+from kiro_crew.tips_text import SUMMARY_MAX_CHARS, truncate_summary
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -1426,6 +1426,29 @@ class TestTruncateSummary:
     def test_bang_and_question_boundaries(self) -> None:
         assert truncate_summary("Stop! Then more words follow here.", limit=10) == "Stop!"
         assert truncate_summary("Why? Then more words follow here.", limit=10) == "Why?"
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert truncate_summary("") == ""
+
+    def test_default_limit_matches_summary_max_chars(self) -> None:
+        text = "word " * 80  # 400 chars, over the 300-char default cap
+        assert truncate_summary(text) == truncate_summary(text, SUMMARY_MAX_CHARS)
+        assert len(truncate_summary(text)) <= SUMMARY_MAX_CHARS
+
+    def test_result_never_exceeds_limit(self) -> None:
+        # Tightest guarantee across every branch, including sub-word limits where
+        # only the ellipsis (or a hard-cut prefix) fits — the existing cases only
+        # bound a single limit each.
+        samples = [
+            "",
+            "short",
+            "a sentence. another sentence. and more words trailing off here",
+            "nospacessingleverylongtokenwithoutanybreaks" * 3,
+            "word " * 200,
+        ]
+        for text in samples:
+            for limit in (1, 2, 5, 20, 100, 300):
+                assert len(truncate_summary(text, limit)) <= limit
 
 
 class TestCuratedTips:


### PR DESCRIPTION
## Problem / Motivation

`test/test_tips.py::TestTruncateSummary` already pins the main branches of
`kiro_crew.tips_text.truncate_summary` (sentence cut, word-boundary ellipsis,
hard cut, `!`/`?` endings). It leaves three edges unpinned: empty input, the
`len(result) <= limit` invariant at sub-word limits (1–2, where only the
ellipsis or a hard-cut prefix fits), and default-limit (`SUMMARY_MAX_CHARS`)
equivalence on a *truncating* input (the existing default-limit case only
exercises the fits path).

## Why it matters

`truncate_summary` output is served verbatim to users on the fallback tips
path. The unpinned edges — especially tiny limits — are exactly where an
off-by-one in the ellipsis/hard-cut branch would regress unnoticed.

## What changed (motivation → approach → change)

Extend the existing suite rather than add a parallel one: three focused tests
added to `TestTruncateSummary`, and `SUMMARY_MAX_CHARS` added to the existing
import. No new test module, no production change.

## Tests

Added to `test/test_tips.py::TestTruncateSummary`:
- `test_empty_string_returns_empty`
- `test_default_limit_matches_summary_max_chars` — default arg == explicit
  `SUMMARY_MAX_CHARS`, on a 400-char (truncating) input.
- `test_result_never_exceeds_limit` — property sweep over representative inputs
  × limits `{1,2,5,20,100,300}`, asserting `len(result) <= limit` on every branch.

## Manual verification

N/A — pure function, unit coverage is sufficient.

## Related Issues

N/A

## Checklist

- [x] Single commit with a Conventional Commits title (`test: ...`)
