### PR TITLE
test(apps): exclude reserved names from the builtin-discovery name strategy (#4099)

### DIFF
--- a/test/test_builtin_discovery.py
+++ b/test/test_builtin_discovery.py
@@ -12,6 +12,7 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from kiro_crew.apps.discovery import discover_builtin_apps
+from kiro_crew.apps.manifest import RESERVED_APP_NAMES, UNPORTABLE_APP_NAMES
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -40,8 +41,18 @@ def _valid_manifest(name: str) -> dict:
 # ---------------------------------------------------------------------------
 
 def _app_name() -> st.SearchStrategy[str]:
-    """Generate valid kebab-case app names (no trailing hyphens)."""
-    return st.from_regex(r"[a-z][a-z0-9]+(-[a-z0-9]+)*", fullmatch=True).filter(lambda s: len(s) <= 15)
+    """Generate valid kebab-case app names (no trailing hyphens).
+
+    Excludes ``RESERVED_APP_NAMES`` and ``UNPORTABLE_APP_NAMES`` (imported from
+    the validator itself, so the strategy tracks the source of truth): manifest
+    validation correctly rejects those names, so a draw like ``aux`` would yield
+    zero discovered apps and fail the "exactly K valid manifests" properties.
+    """
+    return (
+        st.from_regex(r"[a-z][a-z0-9]+(-[a-z0-9]+)*", fullmatch=True)
+        .filter(lambda s: len(s) <= 15)
+        .filter(lambda s: s not in UNPORTABLE_APP_NAMES and s not in RESERVED_APP_NAMES)
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

The Backend Tests CI shard intermittently fails on `test/test_builtin_discovery.py` property tests -- most recently `TestBuiltinClassification::test_discovered_app_has_required_fields` with the falsifying example `name='aux'` and `assert 0 == 1`. Any PR can hit it, regardless of what the PR touches.

## Why it matters

A probabilistic flake on the shared Backend Tests shard taxes every open PR: contributors burn review rounds re-running a red that their diff did not cause, and a real regression can hide behind "it's just the aux flake" fatigue.

## What changed (motivation -> approach -> change)

- **Symptom:** a Hypothesis draw of `aux` (or any Windows-reserved device stem, or `system`) makes discovery return zero apps while the test expects one per generated manifest.
- **Root cause:** the `_app_name()` strategy draws any short kebab-case string, but `kiro_crew.apps.manifest` validation correctly rejects `UNPORTABLE_APP_NAMES` (Windows device stems: `aux`, `con`, `nul`, `prn`, `com1-9`, `lpt1-9`) and `RESERVED_APP_NAMES` (`system`). The production validation is right; the strategy's notion of a valid name is stale.
- **Change (test-only, single file):** the strategy now filters out both sets, importing them from `kiro_crew.apps.manifest` itself so the strategy tracks the source of truth and cannot drift if the reserved sets change -- no hardcoded copy. This covers every `_app_name()` user (`test_discovers_exactly_valid_manifests` and `test_discovered_app_has_required_fields`). Names like `com1-x` remain drawable: both the filter and the validator test exact membership, so strategy and validator stay in agreement. No production code change.

## Tests

No new test: this PR repairs the generator of two existing property tests so they assert what they always intended (discovery finds exactly the valid manifests). Verification that the repaired strategy agrees with the validator was done with a throwaway 300-example Hypothesis run asserting `app_name_error(name) is None` for every draw (plus a deterministic check that each reserved stem was drawable before and is excluded now).

## Manual verification

- `python -m pytest test/test_builtin_discovery.py` run 4x: 14/14 pass each time.
- Relevant scope (`test_builtin_discovery.py`, `test_app_manifest.py`, `test_kebab_gates_reject_trailing_newline.py`, `test_builtin_projects_manifest.py`): 154 passed.
- `isort --check-only`, `flake8` (7.1.0, CI-pinned) clean; `mypy src/kiro_crew/` shows only the 4 pre-existing boto3 stub-drift errors in `transcribe.py`/`cloudwatch.py`, untouched by this test-only diff.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** test-only change; no user-visible surface.

## Related Issues

Closes #4099

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, test-internal
- [x] No secrets, credentials, or internal references in the diff
