### PR TITLE
fix(sessions): reap an orphan whose parent is a subreaper, not just init

### DIFF
--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -859,29 +859,24 @@ def cleanup_orphaned_session_roots() -> int:
             entries_to_remove.add(stripped)
             continue
 
-        # Additional PID-reuse guard: verify PPid is 1 (reparented to init)
-        # or the dead gateway PID (race window). A recycled PID would have
-        # a completely different parent. platform_compat.get_ppid returns
-        # -1 on failure (Linux /proc, macOS libproc, Windows snapshot).
-        try:
-            actual_ppid = platform_compat.get_ppid(child_pid)
-        except Exception:
-            actual_ppid = -1
-
-        # Valid orphan: PPid should be 1 (reparented to init/systemd) since
-        # the original parent (gateway) is dead. Also accept the dead gateway
-        # PID itself (brief race window before reparenting completes).
-        if actual_ppid not in (1, gw_pid, -1):
-            # PPid is something else entirely — PID was reused, prune
-            entries_to_remove.add(stripped)
-            continue
-
-        # Strongest PID-reuse guard: the entry recorded the child's start
+        # Strongest PID-reuse guard FIRST: the entry recorded the child's start
         # token at spawn (see _pid_start_token). A MISMATCH means this PID now
         # names a DIFFERENT process — prune, never kill. An unreadable live
         # token is "identity unknown", not a mismatch: retain the entry so a
         # live genuine orphan is not untracked (and thus leaked forever) on one
         # transient probe failure; the next sweep retries.
+        #
+        # A token that MATCHES is positive proof this PID is still the process
+        # we spawned, so it settles identity on its own and the weaker PPid
+        # heuristic below MUST NOT be allowed to veto it. That ordering is
+        # load-bearing: an orphan does not always reparent to init. A child
+        # placed in its own cgroup scope by the service manager reparents to
+        # that *user manager*, which is a subreaper, so its PPid is neither 1
+        # nor the dead gateway's. Running the PPid check first classified every
+        # such orphan as "PID recycled" and pruned its tracking entry WITHOUT
+        # killing it — sparing the process and then forgetting it, so no later
+        # sweep could ever reap it.
+        identity_confirmed = False
         if recorded_token is not None:
             live_token = _pid_start_token(child_pid)
             if live_token is not None and live_token != recorded_token:
@@ -889,6 +884,24 @@ def cleanup_orphaned_session_roots() -> int:
                 continue
             if live_token is None:
                 continue  # identity unknown — retain entry, retry next sweep
+            identity_confirmed = True
+
+        # Fallback PID-reuse guard for entries with NO recorded token (Windows,
+        # or a failed token probe at spawn): verify PPid is 1 (reparented to
+        # init) or the dead gateway PID (race window). A recycled PID would have
+        # a completely different parent. platform_compat.get_ppid returns -1 on
+        # failure (Linux /proc, macOS libproc, Windows snapshot). This is only
+        # reached when the token could not establish identity.
+        if not identity_confirmed:
+            try:
+                actual_ppid = platform_compat.get_ppid(child_pid)
+            except Exception:
+                actual_ppid = -1
+
+            if actual_ppid not in (1, gw_pid, -1):
+                # PPid is something else entirely — PID was reused, prune
+                entries_to_remove.add(stripped)
+                continue
 
         # Confirmed orphan: kill the process tree
         total_killed, root_killed = _kill_pid_tree(child_pid)

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -1932,6 +1932,49 @@ class TestPidStartTokenIdentityGuard:
         assert entry in session_pid_file.read_text(encoding="utf-8")
 
     @_POSIX_ONLY
+    def test_session_roots_subreaper_reparent_still_killed(
+        self, session_pid_file: Path
+    ) -> None:
+        """A recorded start token that MATCHES proves identity on its own.
+
+        Orphans do not always reparent to init: a process placed in its own
+        cgroup scope by the service manager reparents to that *user manager*,
+        which is a subreaper. Treating any other PPid as "the PID was recycled"
+        both spares the real orphan AND drops its tracking entry, so nothing
+        ever reaps it again. The token is strictly stronger evidence of identity
+        than the parent, so it must not be vetoed by the PPid heuristic.
+        """
+        from kiro_crew.session_pid import cleanup_orphaned_session_roots
+
+        entry = "999999:99998:sametoken"
+        session_pid_file.write_text(entry + "\n")
+        kills: list[tuple[int, int]] = []
+
+        def fake_liveness(pid: int) -> str:
+            return platform_compat.PID_DEAD if pid == 999999 else platform_compat.PID_ALIVE
+
+        with (
+            patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+            patch("kiro_crew.session_pid._pid_start_token", return_value="sametoken"),
+            patch("kiro_crew.session_pid.platform_compat.pid_liveness", side_effect=fake_liveness),
+            # The subreaper that adopted the orphan -- neither init(1), nor the
+            # dead gateway PID, nor the -1 probe-failure sentinel.
+            patch("kiro_crew.session_pid.platform_compat.get_ppid", return_value=7447),
+            patch("kiro_crew.session_pid.platform_compat.pid_exists", return_value=True),
+            patch(
+                "kiro_crew.session_pid.platform_compat.kill_pid",
+                side_effect=lambda p, s: kills.append((p, s)),
+            ),
+        ):
+            cleanup_orphaned_session_roots()
+
+        assert (99998, platform_compat.SIGKILL) in kills, (
+            "a token-verified orphan adopted by a subreaper was not reaped"
+        )
+        # And it must not be silently untracked, which is what leaks it forever.
+        assert entry not in session_pid_file.read_text(encoding="utf-8")
+
+    @_POSIX_ONLY
     def test_matching_token_still_killed(self, session_pid_file: Path) -> None:
         """A genuine orphan (token matches) is still reaped — no regression."""
         from kiro_crew.session_pid import cleanup_orphaned_sessions


### PR DESCRIPTION
## What is the problem?

`cleanup_orphaned_session_roots()` never reaps an agent process whose gateway
died, and worse, it silently stops tracking it -- so nothing can reap it later
either. Orphaned agent trees accumulate across gateway generations without
bound.

On one long-running host this reached **339 agent-related processes holding
about 42 GB RSS**, spread across trees whose spawning gateway generation had
been gone for days.

## Why this issue matters to the user

Each orphaned tree is a full agent session (an adapter plus its MCP stubs),
roughly 0.5-1 GB. They are invisible in the product -- no session lists them,
nothing re-attaches to them, and the periodic sweep that exists specifically to
reap them has already forgotten they exist. The only symptoms a user sees are
the machine slowly running out of memory and, on a smaller host, the OOM killer
taking down unrelated work.

Two secondary effects: an orphan from a prior generation keeps polling internal
endpoints, which shows up as a stream of denied internal-API requests that look
like an auth problem; and because the tracking entry is dropped, `pod prune`
and any future reaper have nothing left to act on.

## How our fix solves it

Symptom to root cause:

1. The sweep finds the entry, confirms the gateway is dead and the child alive,
   and confirms the child is still a managed agent process by its command line.
2. It then applies a PPid heuristic: an orphan is only accepted when its current
   parent is init (PID 1), the dead gateway's own PID, or the -1 probe-failure
   sentinel. Anything else is classified as "the PID was recycled".
3. That classification is wrong for the way agent processes are actually
   spawned. Each one is placed in its own cgroup scope by the service manager,
   which makes it a child of the *user manager* -- and that manager is a
   subreaper, so an orphan reparents to it rather than to init. Its PPid is
   therefore neither 1 nor the dead gateway's.
4. So the sweep takes the "recycled" branch: it does not kill the process, and
   it removes the tracking entry. The orphan is spared and then forgotten.
5. Immediately below that heuristic sits a strictly stronger guard the sweep
   never reached: the process start token recorded at spawn time. A token that
   matches is positive proof the PID still names the process we spawned,
   regardless of who its current parent is.

The fix is an ordering change plus one guard: run the token check first, and
when a recorded token MATCHES, treat identity as settled and do not let the
weaker PPid heuristic veto it. Entries with no recorded token (Windows, or a
failed probe at spawn) keep exactly today's behaviour, so no platform loses its
existing guard. The mismatch and unreadable-token arms are unchanged: a
mismatch still prunes without killing, and an unreadable token still retains
the entry for the next sweep.

This deliberately removes a platform assumption rather than replacing it with
another one -- no list of valid reparent targets is introduced.

## What tests we did

A fail-then-pass test in `test/test_pid_lifecycle.py`: a token-verified orphan
whose PPid is a subreaper (neither 1, nor the dead gateway PID, nor -1) must be
reaped, and its entry must not be silently dropped. Verified failing against
the current implementation before the fix and passing after. The existing suite
covering both files stays green (376 tests), including the tests that pin the
mismatch-prunes and unreadable-token-retains arms.

## Any other suggestions on the work

Two adjacent observations from the same investigation, deliberately not fixed
here:

- Agent trees escaping the service cgroup is by design (each gets its own
  scope), and the MCP broker even has an adoption path that re-attaches a
  survivor to a new gateway generation. Agent sessions have no such path -- the
  startup sweep kills them rather than adopting them. Whether cross-generation
  agent sessions should be adoptable instead of reaped is a separate design
  question.
- A stream of denied internal-API requests can be produced by an orphan from a
  prior generation, and it is currently hard to tell apart from a genuine
  credential mismatch in the audit log. That is filed separately.

Fixes #4109
