### PR TITLE
fix(auth): name the sides on the non-loopback mixed-path denial too

### DIFF
--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -1806,6 +1806,17 @@ def token_auth_middleware(
                     if not internal_secret or not hmac.compare_digest(
                         internal_secret, request.headers["X-Internal-Secret"]
                     ):
+                        # Same fingerprint detail and code as the loopback arm
+                        # above. This arm was left on the bare string, so a
+                        # denial here still could not say which side was wrong --
+                        # in particular an ABSENT credential (a caller that could
+                        # read no credential file at all) read identically to a
+                        # caller holding the wrong one, which is the exact
+                        # confusion the fingerprint exists to remove.
+                        _detail = (
+                            "wrong secret (non-loopback mixed, "
+                            f"{_credential_mismatch_detail(internal_secret, request.headers['X-Internal-Secret'])})"
+                        )
                         _sel = _sel_fn()
                         _sel.log_api_access(
                             caller=_caller,
@@ -1813,12 +1824,10 @@ def token_auth_middleware(
                             outcome="denied",
                             source="token_auth",
                             resources=path,
-                            error="wrong secret (non-loopback mixed)",
+                            error=_detail,
                         )
-                        _log_auth(
-                            request, "internal", "denied", "wrong secret (non-loopback mixed)"
-                        )
-                        return _deny(request, "Forbidden")
+                        _log_auth(request, "internal", "denied", _detail)
+                        return _deny(request, "Forbidden", "internal_auth_mismatch")
                 _valid, _uid, _reason, _app, _tok = _extract_and_validate_token(request, port)
                 if not _valid:
                     _sel = _sel_fn()

--- a/test/test_dashboard_peer_auth.py
+++ b/test/test_dashboard_peer_auth.py
@@ -720,3 +720,44 @@ def test_mcp_core_post_falls_back_to_tcp_when_socket_absent(
     monkeypatch.setattr(mcp_core, "_resolve_session_key", lambda: "dashboard:chat-1")
     out = mcp_core._get("/api/anything")
     assert "error" in out
+
+
+@_posix_only
+@pytest.mark.asyncio
+async def test_non_loopback_mixed_denial_names_which_credential_was_wrong(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mixed-path arm must name the sides too, like the loopback arm does.
+
+    The loopback arm records both credential fingerprints, so an ABSENT
+    credential (a caller that could read no credential file at all) is visibly
+    different from a caller holding the wrong one. This arm was left on a bare
+    string, so a denial here still said only "wrong secret" -- the exact
+    ambiguity the fingerprint exists to remove, in the one place a remote
+    mixed-path caller lands.
+    """
+    calls = _wire_peer(monkeypatch)
+    mw = ta.token_auth_middleware(
+        internal_paths=INTERNAL,
+        internal_secret=SECRET,
+        mixed_internal_paths=INTERNAL,
+        local_only=True,
+    )
+
+    # Non-loopback remote on a mixed internal path, header present but EMPTY.
+    req, _ = _make_request(headers={"X-Internal-Secret": ""}, remote="10.1.2.3")
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 403
+
+    denials = [
+        c
+        for c in calls
+        if c.get("operation") == "internal_auth" and c.get("outcome") == "denied"
+    ]
+    assert len(denials) == 1
+    err = denials[0]["error"]
+    assert "non-loopback mixed" in err, err
+    assert "received=absent" in err, (
+        "the mixed arm still cannot say an absent credential from a wrong one"
+    )
+    assert f"expected={ta._credential_fingerprint(SECRET)}" in err, err


### PR DESCRIPTION
## What is the problem?

The internal-auth denial on the loopback arm now records both credential
fingerprints, so an ABSENT credential is visibly different from a wrong one.
The **non-loopback mixed-path arm** was left on the bare string: a denial there
still records only `wrong secret (non-loopback mixed)` and names no side.

That is the one ambiguity the fingerprint exists to remove, surviving in the arm
a remote mixed-path caller lands on.

## Why this issue matters to the user

The two causes point in opposite directions and have different fixes. A wrong
credential means the caller reached the wrong listener -- for example a second
gateway may be running on the same machine and the caller dialled a port it does
not own. An absent one means the caller could not find a credential at all,
which is a resolution or lifecycle problem in the caller itself. The credential
readers return an empty string when the file is missing or unreadable rather
than raising, and the request header is built unconditionally, so the absent
case is reachable and common -- and on this arm it is still indistinguishable.

## How our fix solves it

Use the same `_credential_mismatch_detail` helper and the same
`internal_auth_mismatch` code the loopback arm already uses, so both denials
explain themselves identically instead of one being a second-class citizen. An
absent credential renders as `received=absent`; a wrong one carries its digest
and length.

The response body is unchanged for both cases -- still
`403 {"error": "Forbidden", "code": "internal_auth_mismatch"}` -- so nothing new
is exposed to a caller probing for valid credentials. The distinction exists
only in the operator-facing audit record.

## What tests we did

`test_non_loopback_mixed_denial_names_which_credential_was_wrong` in
`test/test_dashboard_peer_auth.py` drives the real middleware from a
non-loopback remote on a mixed internal path with an empty credential header,
and asserts the audit line carries both `non-loopback mixed` and
`received=absent`. Mutation-verified: with this arm restored to the bare string
the test fails, and the file's other 28 tests stay green (98 including the
pairing and error-code-contract suites). isort, flake8 and mypy clean.

## Any other suggestions on the work

This PR was originally a wider change that split the reason string at both deny
sites. The loopback half then landed on main through the credential-pairing work
with a strictly better mechanism (two-sided fingerprints plus a machine-readable
code) -- so that half is dropped and only the uncovered arm remains, converted
to main's mechanism rather than to a second style.

`cookie auth failed: no token` (the header absent entirely) was already
distinguishable and is untouched.

Refs #4111
