### PR TITLE
test: take the review subtractions #4065 could not land in time

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/conftest.py
@@ -96,6 +96,13 @@ def _isolated_app_data_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     path it migrates a legacy home, writes a recovery breadcrumb outside ``~/.kiro/``,
     and sweeps archive leftovers. Pointing the variable at a temp directory redirects
     every reader of the home, including the ones no fixture knows about.
+
+    Kept even though the rootdir conftest now pins ``KIROCREW_HOME`` for every testpath,
+    because this fixture pins something STRICTER that the floor does not: the home lands
+    under THIS test's ``tmp_path``, beside the app's own data dir, so the two coincide and
+    a fixture path is coherent across both. ``test_data_home_isolation.py::
+    test_the_config_home_resolver_is_the_tests_temp_dir`` fails without it — the floor's
+    home is under its own isolation root, which is a tmp dir but not this one.
     """
     data = tmp_path / "app-data-home"
     data.mkdir(parents=True, exist_ok=True)

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/conftest.py
@@ -47,16 +47,5 @@ def _mute_shared_runner_audit(monkeypatch):
     yield
 
 
-@pytest.fixture(autouse=True)
-def _isolate_app_home(monkeypatch, tmp_path):
-    """Point ``$KIROCREW_HOME`` at a tmp dir so the suite never touches the real one.
-
-    ``store.app_root()`` derives from ``crew_home()``, so without this every test
-    that reaches ``load_config()`` reads the DEVELOPER'S live app config -- and
-    seeds one into their real data directory when it is absent, because
-    ``load_config`` calls ``ensure_layout`` on a miss. Both are wrong: a machine
-    with ``review.max_concurrent`` configured fails assertions that CI passes
-    (CI has no config, so it sees the seeded default), and a machine without one
-    gets files written outside the test's tmp dir.
-    """
-    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "crew-home"))
+#: The rootdir ``conftest.py`` pins ``$KIROCREW_HOME`` for every testpath, which is what
+#: keeps this suite off the real data home: ``store.app_root()`` derives from ``crew_home()``.

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-tests
-description: "How to write a Kiro Crew backend test that has NO side effects and does not flake. Use when adding, editing, reviewing, or debugging a pytest test in the Kiro Crew source repo: which conftest is under your file, what leaks (temp dirs, the real data home, ~/.kiro, cron, threads, child processes), the five flake classes and the one correct fix for each, and the cross-platform traps on macOS/Linux/Windows and arm64. Also covers diagnosing a residue failure and keeping the parallel suite fast."
+description: "How to write a Kiro Crew backend test that has NO side effects and does not flake. Use when adding, editing, reviewing, or debugging a pytest test in the Kiro Crew source repo: which conftest is under your file, what leaks (temp dirs, the real data home, ~/.kiro, cron, threads, child processes), how to tell which of the five flake classes you have and where each one's fix is written, and the cross-platform traps on macOS/Linux/Windows and arm64. Also covers diagnosing a residue failure and keeping the parallel suite fast."
 triggers: write a test, add a test, fix a flaky test, test is flaky, test side effect, temp dir residue, tmp residue, kirocrew test, pytest kirocrew, test isolation, conftest, xdist, test leaked
 repo_scope: src/kiro_crew
 ---
@@ -166,13 +166,21 @@ cutover path must stub **both** `_run_cmd` and `_dropin_path`.
 Never "fix" a flake with a rerun, a longer `sleep`, a weakened assertion, or a skip.
 Full detail and examples: testing-conventions § Determinism.
 
-| Class | Tell | The one fix |
-|---|---|---|
-| Nondeterministic input | `os.urandom`/`random`/`uuid4`/`now()` feeding an assertion the RNG does not guarantee | Seed it (`random.Random(SEED).randbytes(n)`), or freeze the clock. Verify the seed against the real predicate and say in a comment that you did |
-| Wall-clock race | asserting a rate, a sample count, or an elapsed duration the host controls | Poll for the condition with a generous deadline, keeping the assertion. Where a timeout should *expire*, set it to `0` |
-| Leaked async object | `RuntimeWarning: coroutine ... never awaited`, blamed on an innocent later test | `MagicMock` for a **sync** method (`StreamWriter.write`, `stdin.close`); `await` the task after `cancel()` |
-| Order dependence / shared state | passes alone, fails in the suite | Mutate globals through `monkeypatch` — raw assignment does not revert when the test fails. `@pytest.mark.xdist_group` only when a test genuinely cannot share a worker |
-| Absolute time budget | a timing test that splits by **Python version** rather than by load | Bound the doubling **RATIO**, not a duration. CI enables coverage on 3.12 only, so an absolute ceiling is version-dependent: the same code measured ~1.7s bare and >5s instrumented |
+Each class has ONE correct fix, and they are written out with examples in
+[testing-conventions.md](../../../../../docs/system-specs/common/testing-conventions.md)
+§ Determinism. What this skill adds is the routing — the symptom you actually have in front
+of you, and which class it belongs to:
+
+| The tell you are looking at | The class it is |
+|---|---|
+| `os.urandom` / `random` / `uuid4` / `now()` feeding an assertion the RNG or clock does not guarantee | nondeterministic input |
+| an assertion on a rate, a sample count, or an elapsed duration the host controls | wall-clock race |
+| `RuntimeWarning: coroutine ... never awaited`, blamed on an innocent later test | leaked async object |
+| passes alone, fails in the suite | order dependence / shared state |
+| a timing test that splits by **Python version** rather than by machine load | absolute time budget on an instrumented run |
+
+Read the matching section before you change anything: four of the five have a fix that looks
+like the obvious one and is not.
 
 A sixth, adjacent trap: **a patch target that misses.** Patch the namespace whose
 globals the code under test actually reads. It fails in both directions — patching a


### PR DESCRIPTION
## Problem / Motivation

The reviews on #4065 raised three `Subtractions` that arrived after its final green head, and a
maintainer merged that PR before they were applied. They are small but they are the kind of thing
that is lost silently: two of them remove a second copy of a rule, and the third is a fixture
that became pure duplication the moment #4065 moved the isolation floor to the rootdir conftest.

## Why it matters

Duplicated rule text is worse than a pointer, because the copies drift and a reader has no way to
tell which one is current — and the worst offender here is the file that *declares* the other one
canonical and then copies it anyway. A redundant fixture is milder but reads as a real
requirement, so the next person to touch that suite has to work out whether it still does
anything.

## What changed (motivation → approach → change)

Advisory follow-ups only. **No behaviour changes** — one fixture deletion whose effect is now
provided by the rootdir conftest, and prose.

- **`writing-tests/SKILL.md` stops keeping a second copy of the five-flake table.** First
  Principles Review pointed out that the skill copied it out of
  `docs/system-specs/common/testing-conventions.md` in the same file whose own header says a
  second copy "would drift". The skill now keeps the part that is genuinely its own — the routing
  from *the symptom you are looking at* to *the class it belongs to* — and points at the doc for
  each fix. `AGENTS.md` and `AUTOSDE.yaml` keep their statements on purpose: the first is a router
  carrying rules whose violation costs something before a pointer could be read, the second is
  read by review bots that will not follow a link.

- **`code_review_sage/tests/conftest.py::_isolate_app_home` is deleted.** Its only action was
  `monkeypatch.setenv("KIROCREW_HOME", ...)`, which the rootdir conftest now does for every
  testpath, so the fixture was duplication. The *reason* it existed is kept as a comment because
  it is worth knowing: `store.app_root()` derives from `crew_home()` and `load_config()` calls
  `ensure_layout()` on a miss, so an unpinned test both **read** the developer's live app config
  and **seeded one into their real data directory**.

- **`auto_improvement`'s equivalent is KEPT, with the reason recorded.** The same subtraction was
  proposed for it and it does not hold: that fixture pins something *stricter* than the floor
  does — the home lands under **this test's** `tmp_path`, beside the app's own data dir, so the
  two coincide and a fixture path is coherent across both. I removed it, watched
  `test_data_home_isolation.py::test_the_config_home_resolver_is_the_tests_temp_dir` fail
  (`/tmp/.../i0/4-kirocrew-home` is not relative to `/tmp/.../test_the_config_home_resolver_0` —
  a tmp dir, but not that one), and put it back. The docstring now says so, so the next reader
  does not remove it again.

## Tests

No new tests. The existing ones are what decided two of the three calls:

- `auto_improvement/tests/test_data_home_isolation.py::test_the_config_home_resolver_is_the_tests_temp_dir`
  is the failing test that proved the second deletion was not safe, and it is why that fixture
  stays.
- The `code_review_sage` suite (809 tests) passes with its fixture gone, which is what proved the
  first deletion *was* safe.
- `test/test_builtin_skill_packaging.py` and `test/test_builtin_skill_sync_safety.py` cover the
  edited skill still packaging and syncing correctly.

Run locally on this change: 918 passed across those suites plus
`test/test_host_isolation_floor.py`, with `flake8`, `isort`, `mypy` and `docs-lint` green.

## Manual verification

N/A — unit coverage sufficient. Two of the three changes are prose, and the third is a fixture
deletion whose safety is decided by an existing test in the affected suite rather than by
inspection.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** test fixtures and a dev skill only — no frontend path is touched and
nothing renders in the browser.

## Related Issues

no linked issue: follow-up to review comments on #4065, which is already merged.
