### PR TITLE
fix(dashboard): offload eager spawn's agent-binding config load

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4314,7 +4314,51 @@ async def _eager_spawn(
             loaded_cfg: KiroCrewConfig | None = None
             resolved_ok = False
             try:
-                cfg = KiroCrewConfig.load()
+                # Off-loop: the load stats and reads config.json plus any
+                # config.local.json overlay, deep-merges them and runs the full
+                # schema validation. This task is speculative — it only makes the
+                # first real message faster — so it has no business holding the
+                # loop the live sessions share.
+                #
+                # The suspension lands INSIDE the envelope this function already
+                # maintains: `_bound` was snapshotted just above, and the guards
+                # after get_or_create below already discard a session whose
+                # creator lost the race, whose slot was deleted or replaced, or
+                # whose bindings moved. So a switch or delete landing during the
+                # load is revalidated there, and nothing new is needed here.
+                # Only the load crosses over: bindings are resolved and the slot
+                # read back on the loop, so no slot or session state is handed to
+                # a worker.
+                #
+                # An abandoned worker (cancelled eager task) is acceptable, but
+                # NOT because the load is read-only — it is not. Every load
+                # publishes three process-global snapshots (mcp.extra_path_dirs,
+                # the agent alias table, the autocompact threshold) and its
+                # write-back migration can rewrite config.json. The narrower
+                # reason it is safe: the autocompact publish is ordered on a
+                # ticket drawn BEFORE the read, so a load that began earlier
+                # cannot overwrite a newer one, and the other two are idempotent
+                # rebinds of what was just read. Residue: those two carry no
+                # ordering of their own, so a late worker can republish a value a
+                # newer load already superseded — a property of concurrent loads
+                # in general, not of this call site. The stop-hook nudge-cap load
+                # in this module already runs off-loop for the same reason.
+                #
+                # The write-back MIGRATION cannot fire here, which is worth
+                # stating because the offload would otherwise look like it moves
+                # a config WRITE onto a worker. It is one-shot per process: only
+                # the first load whose on-disk config still has a legacy shape
+                # calls save(), and every later load skips it. This task is
+                # created at exactly one site -- schedule_eager_spawn -- which
+                # runs its own KiroCrewConfig.load() ON THE LOOP before it
+                # creates the task, and only creates it if that load succeeded.
+                # So a pending migration is always performed by that on-loop
+                # load, on the loop, exactly as before this change; by the time
+                # this call runs the config is canonical and needs_migration is
+                # False. Deleting that on-loop load (see #7734) must keep this
+                # invariant in view: it would make THIS the process's first load
+                # and hand the migration write to a worker.
+                cfg = await asyncio.to_thread(KiroCrewConfig.load)
                 loaded_cfg = cfg
                 bindings = resolve_agent_bindings(cfg, slot.agent or None)
                 kiro_agent = bindings.kiro_agent

--- a/test/test_eager_spawn_config_load_off_loop.py
+++ b/test/test_eager_spawn_config_load_off_loop.py
@@ -1,0 +1,216 @@
+"""Eager spawn's agent-binding config load must not run on the gateway loop.
+
+``_eager_spawn`` is speculative: it exists only to make the slot's FIRST real
+message faster. Before the handshake it resolves the slot's agent bindings, and
+that read goes through ``KiroCrewConfig.load()``, which stats and reads
+``config.json`` plus any ``config.local.json`` overlay, deep-merges them and runs
+the full jsonschema validation — synchronously, on the single event loop the
+gateway shares with every other session. So an optional latency optimisation
+stalls unrelated foreground work; that is the inversion this fixes.
+
+Only the load crosses to a worker. The bindings are resolved, the session
+acquired and the slot read back on the loop, so no slot or session object is
+handed to another thread.
+
+The hop widens an existing race window rather than opening a new one. The load
+sits INSIDE the envelope ``_eager_spawn`` already maintains:
+
+    _bound = (slot.agent, slot.model, slot.project, slot.reasoning_effort)
+        ↓
+    await asyncio.to_thread(KiroCrewConfig.load)   <- the new suspension
+        ↓
+    resolve bindings
+        ↓
+    await sessions.get_or_create(...)
+        ↓
+    not is_new              -> leave the winning session alone
+    slot identity changed   -> remove the session this task created
+    bindings != _bound      -> remove the session this task created
+
+Every action newly able to land during the load — slot deletion or replacement,
+an agent/model/project/effort switch, another creator winning the same key — is
+therefore already revalidated after the handshake by guards that predate this
+change. The two tests below pin that: they hold the loader suspended and fire the
+lifecycle action while it is suspended. They are preservation coverage for the
+new await, not proof of an old defect, so they do not need to fail on a pristine
+tree — only ``test_config_load_runs_off_the_event_loop`` does that.
+
+A worker left running by a cancelled eager task is acceptable, but not because
+the load is read-only -- it is not. The reasoning lives in the call-site comment
+in ``_eager_spawn`` and is deliberately not restated here: it turns on which of
+the loader's process-global publishes are ticket-ordered, and two copies of that
+argument would drift. Nothing in this module tests it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig, _invalidate_config_cache, config_dir
+from kiro_crew.dashboard import chat_runner
+from kiro_crew.dashboard.chat_runner import _eager_spawn
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+#: Upper bound on the cross-thread handoffs below. Purely a hang guard — every
+#: wait in the happy path returns the moment the other side signals, so raising
+#: this can never mask a failure, and no assertion depends on elapsed time.
+_GUARD_SECS = 30.0
+
+
+@pytest.fixture(autouse=True)
+def _no_debounce(monkeypatch: Any) -> None:
+    """Zero the debounce so the body runs without waiting on wall-clock time."""
+    monkeypatch.setattr(chat_runner, "_EAGER_SPAWN_DEBOUNCE_SECS", 0)
+
+
+def _state(slot: _ChatSlot) -> DashboardState:
+    state = MagicMock(spec=DashboardState)
+    state.get_slot = MagicMock(return_value=slot)
+    state.sessions = MagicMock()
+    state.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
+    state.sessions.release = MagicMock()
+    state.sessions.remove = AsyncMock()
+    state.sessions.resumable_hint = MagicMock(return_value=True)
+    return state
+
+
+def _write_real_config() -> None:
+    """Put a real config.json in the per-test KIROCREW_HOME.
+
+    The root conftest pins that home to a tmp dir for every testpath, so the real
+    loader runs against a controlled file rather than the developer's own
+    configuration.
+    """
+    directory = config_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "config.json").write_text(
+        json.dumps({"session": {"eager_spawn": True}}), encoding="utf-8"
+    )
+
+
+@pytest.mark.asyncio
+async def test_config_load_runs_off_the_event_loop() -> None:
+    """The thread that stats, reads, merges and validates must not be the loop's.
+
+    The wrapper delegates to the real classmethod, so the recorded thread is the
+    one that genuinely does the filesystem and schema work — not merely a thread
+    that reached a call site. It reads the same whether the production call is
+    direct or routed through ``asyncio.to_thread``, so the thread comparison is
+    what fails on an unfixed tree.
+    """
+    _write_real_config()
+    # Force the disk path: a warm fingerprint cache would let the recorded thread
+    # skip the read, merge and validation this test is about.
+    _invalidate_config_cache()
+
+    load_threads: list[int] = []
+
+    def loader() -> KiroCrewConfig:
+        load_threads.append(threading.get_ident())
+        return KiroCrewConfig.load()
+
+    slot = _ChatSlot("cfg-load-slot")
+    state = _state(slot)
+    loop_thread = threading.get_ident()
+
+    with patch.object(chat_runner, "KiroCrewConfig", types.SimpleNamespace(load=loader)):
+        await _eager_spawn(state, slot)
+
+    assert len(load_threads) == 1, f"expected exactly one config load, got {len(load_threads)}"
+    assert load_threads[0] != loop_thread, (
+        "KiroCrewConfig.load() ran on the event loop thread "
+        f"({loop_thread}); the gateway is blocked for the whole read, "
+        "merge and jsonschema validation"
+    )
+    # The handshake must still happen — a load moved off-loop that also skipped
+    # the spawn would satisfy the thread assertion while breaking eager spawn.
+    state.sessions.get_or_create.assert_awaited_once()
+
+
+async def _suspend_load_and(state: DashboardState, slot: _ChatSlot, action: Any) -> str:
+    """Run ``_eager_spawn`` with the config load held, firing *action* meanwhile.
+
+    *action* runs on the event loop thread, standing in for the request handler
+    that would really mutate the slot, and it runs while the loader is parked —
+    so it lands strictly inside the window the new await opens. Returns the
+    session key the handshake used.
+    """
+    entered = threading.Event()
+    release = threading.Event()
+
+    def loader() -> MagicMock:
+        entered.set()
+        # Bounded only so an unfixed tree fails instead of wedging the suite: on
+        # a fixed tree the loop is free to run *action* and set this at once.
+        release.wait(_GUARD_SECS)
+        cfg = MagicMock()
+        cfg.session.eager_spawn = True
+        return cfg
+
+    bindings = MagicMock()
+    bindings.kiro_agent = "kirocrew"
+    bindings.resolved_alias = "kirocrew"
+    bindings.model = ""
+
+    with (
+        patch.object(chat_runner, "KiroCrewConfig", types.SimpleNamespace(load=loader)),
+        patch.object(chat_runner, "resolve_agent_bindings", return_value=bindings),
+    ):
+        task = asyncio.ensure_future(_eager_spawn(state, slot))
+        # Waiting off-loop keeps the loop free, which is exactly what makes the
+        # loader's thread observable here; no sleep is involved.
+        await asyncio.to_thread(entered.wait, _GUARD_SECS)
+        assert entered.is_set(), "the config load never started"
+        action()
+        release.set()
+        await task
+
+    assert state.sessions.get_or_create.await_args is not None
+    return str(state.sessions.get_or_create.await_args.args[0])
+
+
+@pytest.mark.asyncio
+async def test_slot_replaced_during_the_load_leaves_no_orphan_session() -> None:
+    """A delete+recreate while the load is suspended must not strand a session.
+
+    The recreated slot shares the key, so an orphan registered under THIS slot's
+    bindings would be silently reused by it. The post-handshake identity guard
+    already covers the wider ``get_or_create`` window; this pins that it also
+    covers the load.
+    """
+    slot = _ChatSlot("t1")
+    live: dict[str, _ChatSlot] = {"slot": slot}
+    state = _state(slot)
+    state.get_slot = MagicMock(side_effect=lambda _key: live["slot"])
+
+    key = await _suspend_load_and(state, slot, lambda: live.__setitem__("slot", _ChatSlot("t1")))
+
+    state.sessions.remove.assert_awaited_once_with(key)
+
+
+@pytest.mark.asyncio
+async def test_binding_switch_during_the_load_removes_the_stale_session() -> None:
+    """An agent switch while the load is suspended must discard the session.
+
+    The switch handler's own reset finds nothing to reset (nothing is registered
+    yet), so the session this task goes on to register would carry the bindings
+    the user just moved away from. ``_bound`` was snapshotted before the load, so
+    the existing equality guard sees the change and tears the session down.
+    """
+    slot = _ChatSlot("t1")
+    slot.agent = "wfe-oncall"
+    state = _state(slot)
+
+    def _switch_agent() -> None:
+        slot.agent = "sre-oncall"
+
+    key = await _suspend_load_and(state, slot, _switch_agent)
+
+    state.sessions.remove.assert_awaited_once_with(key)


### PR DESCRIPTION
## Problem / Motivation

`_eager_spawn` in `src/kiro_crew/dashboard/chat_runner.py` resolves the slot's
agent bindings before the speculative handshake, and that read is synchronous:

```python
_bound = (slot.agent, slot.model, slot.project, slot.reasoning_effort)
...
try:
    cfg = KiroCrewConfig.load()                      # on the gateway loop
    bindings = resolve_agent_bindings(cfg, slot.agent or None)
```

`KiroCrewConfig.load()` is not a cheap accessor. It resolves the config path,
`exists()`/`read_text()`/`json.loads()` on `config.json`, `is_file()`/`stat()` and
deep-merges any `config.local.json` overlay, then runs the full `jsonschema`
validation. None of that yields, so the loop is occupied for the whole read.

Being accurate about the cost: the loader keeps a fingerprint cache, so a warm
call short-circuits. The blocking read is the **cold** path.

Correcting this section against the First Principles review of `a415e3276`, which
is right: `_eager_spawn` is created only by `schedule_eager_spawn`, and that
function runs its own bare `KiroCrewConfig.load()` **on the loop** at
`chat_runner.py:3229` to test `session.eager_spawn` before creating the task. So on
a cold gateway the loop pays the cold read *there*, roughly a debounce ahead of the
load this PR offloads, and the offloaded call then usually hits the warm
fingerprint cache. The cold case that reaches this call site is narrower than the
section originally claimed: a config write landing inside the debounce window.

What this PR still buys, stated honestly: the offloaded call is off the loop
whether warm or cold, so the loop stops paying even the warm path's `stat` pass and
stops being exposed to the cold case above. What it does **not** do is remove the
cold read from the loop, because the `schedule_eager_spawn:3229` load is the one
that lands first. That load is a separate defect and is not fixed here -- see
Scope.

## Why it matters

`_eager_spawn` is *speculative*. It exists only to make a slot's first real
message faster; nothing depends on its result, and it is already debounced and
capped by `_eager_spawn_sem`. So an optional latency optimisation was doing cold
filesystem and schema work on the single loop that every live session, every
WebSocket broadcast and every HTTP handler shares — the one place where the work
has no claim on the loop at all.

It is user-triggered rather than rare: `schedule_eager_spawn` re-arms on slot
create, agent switch, project set and slot focus.

No latency figure is claimed; none was measured.

## What changed (motivation → approach → change)

**Motivation** — take the filesystem and schema work off the shared loop without
altering a single handshake semantic.

**Approach** — not a new idiom. `await asyncio.to_thread(KiroCrewConfig.load)` is
already the established form on more than a dozen async paths, several of them in
this package, and `chat_runner.py` itself already carries eight `asyncio.to_thread`
offloads — one of them justified in-comment as *"`_run_chat` shares the single
gateway event loop with every other session"*. This call site is the outlier.

**Change** — the load, and only the load, moves to a worker:

```
worker:     KiroCrewConfig.load()
loop:       resolve_agent_bindings(cfg, slot.agent or None)
            read slot bindings, acquire the session, revalidate
```

No slot, session, `DashboardState` or tracker crosses the boundary. No new config
executor, no caching layer, no change to reload semantics, no change to any
default. The existing broad `except Exception` is kept: an exception raised inside
`to_thread` still propagates through the `await` into the same handler.

## Why this is safe: the suspension lands inside an existing envelope

The new `await` widens a window that already exists rather than opening a new one.
`_eager_spawn` already maintains a snapshot → handshake → revalidation envelope,
and the load sits inside it:

```
_bound = (slot.agent, slot.model, slot.project, slot.reasoning_effort)
    ↓
await asyncio.to_thread(KiroCrewConfig.load)      <- the new suspension
    ↓
resolve bindings
    ↓
await sessions.get_or_create(...)
    ↓
not is_new              -> leave the winning session alone
slot identity changed   -> remove the session this task created
bindings != _bound      -> remove the session this task created
```

Every action newly able to land during the load — slot deletion or replacement,
an agent/model/project/effort switch, another creator winning the same key — is
therefore revalidated after the handshake by guards that predate this change.
That is why no generation counter, no new slot field and no lock is added here.

Cancellation needs plumbing, but not new plumbing. Correcting this against the GPT
review of `a415e3276`, which is right that "the load is read-only" is false:
`KiroCrewConfig.load` publishes three process-global snapshots on every call
(`mcp.extra_path_dirs`, the agent alias table, the autocompact threshold) and its
write-back migration can rewrite `config.json`.

An abandoned worker is still acceptable, for a narrower reason than the one
originally given. The autocompact publish is ordered on a ticket drawn *before* the
read, so a load that began earlier cannot overwrite a newer one -- the loader
designed for exactly this. The other two are idempotent in-memory rebinds of what
was just read, so republishing an unchanged config is a no-op.

The residue, stated rather than hidden: those two publishes carry no ordering of
their own, so a worker that finishes late can republish a value a newer load has
already superseded. That is a property of concurrent loads in general and not of
this call site -- `main` already loads off-loop at the stop-hook nudge-cap site --
so it is not introduced here and is not fixed here.

## Tests

`test/test_eager_spawn_config_load_off_loop.py`:

- **`test_config_load_runs_off_the_event_loop`** — the fail-before. Wraps the
  loader `_eager_spawn` actually calls with a delegating wrapper that records
  `threading.get_ident()`, invalidates the fingerprint cache so the recorded
  thread genuinely does the disk work, drives the real `_eager_spawn`, and
  compares against the loop thread. On an unfixed tree:

  ```
  AssertionError: KiroCrewConfig.load() ran on the event loop thread (23964);
  the gateway is blocked for the whole read, merge and jsonschema validation
  ```

  No timing assertion, no sleep.

- **`test_slot_replaced_during_the_load_leaves_no_orphan_session`** and
  **`test_binding_switch_during_the_load_removes_the_stale_session`** —
  preservation coverage for the new window. A `threading.Event`-gated loader is
  held suspended, the lifecycle action is fired on the loop *while it is
  suspended*, and the existing guards are shown to still tear the session down.
  These are coverage for the new await, so they are not expected to fail on a
  pristine tree — only the thread-identity test does that. The event waits are
  bounded purely as hang guards; nothing asserts on elapsed time.

Local: `test_eager_spawn.py`, `test_eager_spawn_config_load_off_loop.py`,
`test_chat_runner_coverage.py`, `test_active_turn_session_key.py`,
`test_chat_slot_project.py`, `test_chat_slot_reasoning_effort.py`,
`test_chat_slot_mode.py`, `test_dashboard_chat.py` — 899 collected, all green.
The wider set of 74 test files that reference `chat_runner` is 4487 passed /
76 skipped, with 22 failures that reproduce identically with this commit's
production change stashed: 8 × `WinError 1314` (symlink privilege) and 14 in
`test_dashboard_file_io.py`, both pre-existing on this Windows host.

`flake8`, `isort --check-only` and `mypy --platform linux` clean on both changed
files; `git diff --check` clean.

## Scope

One call site. `KiroCrewConfig.load` appears at seven sites in this module: one is
fixed here, one already runs off-loop (the stop-hook nudge cap), and **five** bare
on-loop loads remain. The First Principles review of `a415e3276` is right that this
section previously named only two of the five, so here they all are:

| site (line at `8161898af`) | in scope? |
| --- | --- |
| `schedule_eager_spawn` (3229) | no -- see below |
| `_empty_auto_continue_enabled` (295) | no |
| `_start_next_queued_turn` (4224) | no -- has no suspension point today |
| `_run_chat` -> nested `_queue_recovery` (5150) | no |
| `_run_chat` -> nested `_queue_recovery` (5391) | no |

`schedule_eager_spawn:3229` is the consequential one, because it is this feature's
own first load and it is the one that actually pays the cold read on the loop.
First Principles proposes deleting it and gating `session.eager_spawn` inside
`_eager_spawn` from the already-offloaded `cfg`, which is the right shape: the
feature would then load config once, off-loop.

It is deliberately not done in this PR. This is an adoption rebase of a
contributor's change onto current `main`, and restructuring a second function's
control flow -- moving the feature's enablement gate from before task creation to
after it, which changes when a disabled feature stops creating tasks -- is a
different change needing its own argument and its own tests. Folding it in here
would trade this PR's short, checkable argument for a much longer one, which is the
same reason the other four are excluded. It should be its own issue and PR, and the
Pattern harvest gate entry below would surface all five as a bounded list.

## Pattern harvest

Rule candidate: extend `scripts/check_sync_io_in_async.py` with a small allowlist of
known-blocking FIRST-PARTY helpers, `KiroCrewConfig.load` first among them.

The gate that exists for exactly this defect class did not catch it, and the reason
generalises. `check_sync_io_in_async.py` matches `<module-alias>.<attr>(...)` for the
stdlib and client IO modules (`os`, `pathlib`, `shutil`, `subprocess`, `requests`,
`httpx`, `sqlite3`), plus DB methods and HTTP verbs. Every blocking call here is real
-- path resolution, `exists()`, `read_text()`, `json.loads()`, `is_file()`, `stat()`,
a deep merge and full jsonschema validation -- but all of it sits one frame down,
behind a first-party synchronous facade, so the AST scan sees only
`KiroCrewConfig.load()` and reports nothing. The gate passes on this file both before
and after the fix.

So the miss is structural, not an oversight in the rule's implementation: any
synchronous project-local function that performs IO internally is invisible to it,
and `KiroCrewConfig.load` is the highest-traffic instance of that shape in this tree.
An allowlist keyed on the callee name would have flagged this call site at the moment
it was written.

Two adjacent facts worth recording for whoever picks that up. `main` already carries
`await asyncio.to_thread(KiroCrewConfig.load)` at another call site in this same
module, so the fixed form is the one the file had already settled on -- the defect was
a lone holdout, which is the signature of a rule that should be mechanical rather than
remembered. And five bare on-loop loads remain in `chat_runner.py`, inventoried
under Scope above and all deliberately out of scope here; a gate entry would surface
them as a bounded, reviewable list instead of leaving them to be rediscovered one
review at a time -- which is how `schedule_eager_spawn:3229` surfaced on this PR.

Fixes #4117






