### PR TITLE
fix(chat): focus the composer via a stable data-attr (#4088)

### DIFF
--- a/website/scripts/capture-clipboard-image-paste.mjs
+++ b/website/scripts/capture-clipboard-image-paste.mjs
@@ -64,7 +64,7 @@ const detail = {
  *  pressing Cmd/Ctrl+V with a screenshot on the clipboard produces. */
 async function pasteImage(page, { name, bytes }) {
   await page.evaluate(async ({ name, bytes }) => {
-    const ta = document.querySelector('textarea[aria-label="Message input"]')
+    const ta = document.querySelector('textarea[data-composer-input]')
     if (!ta) throw new Error('composer textarea not found')
     ta.focus()
     const data = new Uint8Array(bytes)
@@ -111,7 +111,7 @@ async function main() {
   })
 
   await page.goto(`${base}/chat/${SLOT}`)
-  await page.waitForSelector('textarea[aria-label="Message input"]')
+  await page.waitForSelector('textarea[data-composer-input]')
   await page.waitForTimeout(500)
 
   // ── Scenario 1: normal screenshot paste → attachment chip ────────────────
@@ -126,12 +126,12 @@ async function main() {
 
   // ── Scenario 2: oversize pasted image → same error as the picker ─────────
   await page.reload()
-  await page.waitForSelector('textarea[aria-label="Message input"]')
+  await page.waitForSelector('textarea[data-composer-input]')
   await page.waitForTimeout(500)
   const before = uploadRequests
   // 51 MB of zeros — over the 50 MB client-side cap.
   await page.evaluate(async () => {
-    const ta = document.querySelector('textarea[aria-label="Message input"]')
+    const ta = document.querySelector('textarea[data-composer-input]')
     ta.focus()
     const blob = new Blob([new ArrayBuffer(51 * 1024 * 1024)], { type: 'image/png' })
     const file = new File([blob], 'huge-screenshot.png', { type: 'image/png' })

--- a/website/scripts/capture-findbar-escape-focus.mjs
+++ b/website/scripts/capture-findbar-escape-focus.mjs
@@ -62,7 +62,7 @@ async function main() {
   }
 
   // 1. Dark theme: open the bar, Escape, prove the composer holds focus.
-  await h.load('dark', { selector: 'textarea[aria-label="Message input"]', settle: 800 })
+  await h.load('dark', { selector: 'textarea[data-composer-input]', settle: 800 })
   await h.page.keyboard.press('Control+f')
   await h.page.waitForTimeout(300)
   await shot('01-findbar-open-dark')
@@ -75,13 +75,13 @@ async function main() {
   const escFocus = await activeLabel(h.page)
   assert(`Escape hands focus to the composer (active: ${escFocus})`, escFocus === 'Message input')
   await h.page.keyboard.type('typing lands here immediately')
-  const typed = await h.page.inputValue('textarea[aria-label="Message input"]')
+  const typed = await h.page.inputValue('textarea[data-composer-input]')
   assert('keystrokes after Escape land in the composer', typed.includes('typing lands here'))
 
   // 2. The pane's own close control routes through the same close path
   //    (the docked find bar renders inside a DetailPanel with
   //    onClose={search.close}).
-  await h.load('dark', { selector: 'textarea[aria-label="Message input"]', settle: 800 })
+  await h.load('dark', { selector: 'textarea[data-composer-input]', settle: 800 })
   await h.page.keyboard.press('Control+f')
   await h.page.waitForTimeout(300)
   await h.page.getByRole('button', { name: 'Close panel' }).click()
@@ -91,7 +91,7 @@ async function main() {
   await shot('03-close-button-composer-focused-dark')
 
   // 3. Light theme evidence.
-  await h.load('light', { selector: 'textarea[aria-label="Message input"]', settle: 800 })
+  await h.load('light', { selector: 'textarea[data-composer-input]', settle: 800 })
   await h.page.keyboard.press('Control+f')
   await h.page.waitForTimeout(300)
   await shot('04-findbar-open-light')

--- a/website/scripts/capture-session-flyout.mjs
+++ b/website/scripts/capture-session-flyout.mjs
@@ -133,7 +133,7 @@ async function main() {
   // Measure the chat pane BEFORE, so "the page does not make room for it" is
   // asserted rather than eyeballed.
   const paneBefore = await page.evaluate(() => {
-    const composer = document.querySelector('textarea[aria-label="Message input"]')
+    const composer = document.querySelector('textarea[data-composer-input]')
     const r = composer?.getBoundingClientRect()
     return r ? { x: Math.round(r.x), w: Math.round(r.width) } : null
   })
@@ -201,7 +201,7 @@ async function main() {
     + `bottom ${bottoms[0]} -> ${bottoms[bottoms.length - 1]} (monotonic, never rises)`)
 
   const paneAfter = await page.evaluate(() => {
-    const composer = document.querySelector('textarea[aria-label="Message input"]')
+    const composer = document.querySelector('textarea[data-composer-input]')
     const r = composer?.getBoundingClientRect()
     return r ? { x: Math.round(r.x), w: Math.round(r.width) } : null
   })
@@ -262,7 +262,7 @@ async function main() {
   // Park focus AND the pointer elsewhere first. Clicking the toggle leaves it
   // focused, and `.focus()` on an already-focused element fires no `focusin`,
   // so probing without this measures nothing (it reported a false pass once).
-  await page.locator('textarea[aria-label="Message input"]').focus()
+  await page.locator('textarea[data-composer-input]').focus()
   await page.mouse.move(900, 700)
   await page.waitForTimeout(500)
   const beforeFocus = await page.locator(FLYOUT).count()

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -9,6 +9,7 @@ import { fetchSlots, sseStatus, setUpdateProgress, setEnabledAppIds, changeAppro
 import './surfaces/builtins'
 import { getBuiltinSurfaces, getBuiltinSurface, selectSurfaceBadgeCount, selectSurfaceActivityCount, selectAllSurfacesAttention, surfaceLabel, surfacePreviewEnabled } from './surfaces/registry'
 import { createSlot, appendMessage, setAgentSwitchNotice, setSlotRunning, switchSlot, selectActiveSlotProject } from './store/chatSlice'
+import { queryComposer } from './pages/chat/composerFocus'
 import { setNavIntentHandler as setArtifactNavIntentHandler } from './utils/artifactPopout'
 import { applyNavIntentInMain } from './utils/navIntent'
 import { installSoftNavigate } from './utils/errorReport'
@@ -1315,7 +1316,12 @@ export default function App() {
     mutationFn: () => dispatch(createSlot(undefined)).unwrap(),
     onSuccess: () => {
       navigate('/chat')
-      requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus())
+      // Unguarded on purpose: this mutation only fires from the new-chat
+      // keyboard shortcut, and a pressed shortcut proves a keyboard exists —
+      // focusComposer()'s touch-device skip would wrongly suppress focus on a
+      // tablet with a physical keyboard. Next frame, so the new slot's
+      // composer has been committed to the DOM.
+      requestAnimationFrame(() => queryComposer()?.focus())
     },
   })
   const refreshTrigger = useAppSelector(s => s.dashboard.refreshTrigger)

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -2480,6 +2480,7 @@ function ChatInput({
         <textarea
           ref={inputRef}
           aria-label={i18nT('components.chatInput.message_input')}
+          data-composer-input=""
           data-composer-typo
           className={`relative w-full bg-transparent border-none ${INPUT_TYPO} text-text outline-none min-h-[44px] max-h-[50vh] placeholder:text-muted resize-none ${manualHeight !== null ? 'flex-1' : ''} ${disabled ? 'opacity-40 pointer-events-none' : ''} ${optimizing ? 'opacity-30' : ''}`}
           style={manualHeight !== null ? { height: '100%' } : undefined}

--- a/website/src/hooks/useKeyboardShortcuts.ts
+++ b/website/src/hooks/useKeyboardShortcuts.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAppDispatch, useAppStore } from '../store'
 import { switchSlot, deleteSlot, openActivityToTab } from '../store/chatSlice'
 import { loadChatConfig } from '../pages/chat/ChatSettings'
+import { queryComposer } from '../pages/chat/composerFocus'
 import { reportSeamCollision } from '../apps/seamCollision'
 import { i18nT } from '../i18n/t'
 
@@ -610,7 +611,11 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
     // Alt+Enter: Focus text input — works even from other inputs
     if (code === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus()
+      // Synchronous and unguarded on purpose: no state change precedes this, so
+      // there is no next-frame commit to wait for, and a pressed keyboard
+      // shortcut proves a keyboard exists — the helper's touch-device skip
+      // would wrongly no-op it.
+      queryComposer()?.focus()
       return
     }
 

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -163,7 +163,7 @@ import { deriveFollowUpOptions } from '../app-sdk/protocol'
 import OverlayDrawer from '../components/OverlayDrawer'
 import { loadChatConfig, CONTENT_WIDTH, type ChatConfig } from './chat/ChatSettings'
 import SessionFlyout, { TOGGLE_RECT } from './chat/SessionFlyout'
-import { focusComposerAfter } from './chat/composerFocus'
+import { focusComposerAfter, revealComposer } from './chat/composerFocus'
 import { useHoverIntent } from '../hooks/useHoverIntent'
 import { useKnowledgeFetch, extractKnowledgeQuery, expandKnowledgeBlock } from './chat/useKnowledgeFetch'
 import { KnowledgePicker } from './chat/KnowledgePicker'
@@ -4142,14 +4142,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       widgetPrefillRef.current = text
       setInput(prev => (prev.trim() ? `${prev.trimEnd()}\n${text}` : text))
       setPrefillHint(true)
-      // Touch: reveal the pre-filled composer without focusing (focus pops the
-      // soft keyboard); desktop: focus, which scrolls it into view anyway.
-      requestAnimationFrame(() => {
-        const ta = document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')
-        if (!ta) return
-        if (isTouchDevice()) { if (typeof ta.scrollIntoView === 'function') ta.scrollIntoView({ block: 'nearest' }) }
-        else ta.focus()
-      })
+      revealComposer()
     }
     window.addEventListener('mc-widget-send', handler)
     return () => window.removeEventListener('mc-widget-send', handler)
@@ -4879,14 +4872,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     })
     // Trigger flying animation
     setFlyingQuote({ text, from: rect })
-    // Touch: reveal the pre-filled composer without focusing (focus pops the
-    // soft keyboard); desktop: focus, which scrolls it into view anyway.
-    requestAnimationFrame(() => {
-      const ta = document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')
-      if (!ta) return
-      if (isTouchDevice()) { if (typeof ta.scrollIntoView === 'function') ta.scrollIntoView({ block: 'nearest' }) }
-      else ta.focus()
-    })
+    revealComposer()
   }, [])
 
   // "Ask" (Select-to-Ask): open the isolated /side conversation seeded with the

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -44,7 +44,6 @@ import { platformShortcut } from '../utils/platform'
 import { useImeGuard } from '../hooks/useImeGuard'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { usePointerDrag } from '../hooks/usePointerDrag'
-import { isTouchDevice } from '../utils/isTouchDevice'
 import { safeSetItem } from '../utils/safeStorage'
 import { resolveFolderAgent, resolveFolderProjectDir } from '../utils/folderAgent'
 import FolderMoveSubmenu from '../components/FolderMoveSubmenu'
@@ -2373,7 +2372,7 @@ function ChatSidebar({
     }
   }, [folders, updateFolderMutation])
   const createChatInFolderMutation = useMutation({
-    mutationFn: ({ folderId }: { folderId: string; columnId?: string }) => {
+    mutationFn: ({ folderId }: { folderId: string; columnId?: string; focus?: boolean }) => {
       const agent = resolveFolderAgent(folders, folderId, defaultAgent)
       const effectiveMode = loadChatConfig().defaultAutopilot ? 'orchestrator' : (mode || '')
       // Carry folder membership in the create payload so createSlot publishes
@@ -2387,7 +2386,11 @@ function ChatSidebar({
       const project = resolveFolderProjectDir(folders, folderId)
       return dispatch(createSlot({ agent, mode: effectiveMode, folder_id: folderId, project })).unwrap()
     },
-    onSuccess: (slot: Slot, { columnId }: { folderId: string; columnId?: string }) => {
+    onSuccess: (slot: Slot, { columnId, focus }: { folderId: string; columnId?: string; focus?: boolean }) => {
+      // Focus only after the create fulfils: the composer is bound to the
+      // active slot, so focusing while createSlot is still in flight puts the
+      // caret on the OLD session and anything typed lands in its draft.
+      if (focus) focusComposer()
       if (slot?.key && columnId) {
         // Board view: also drop the new session into the column it was created
         // from, so a status-lane column shows it immediately instead of the
@@ -2401,7 +2404,7 @@ function ChatSidebar({
       console.error('Failed to create chat in folder:', err)
     },
   })
-  const createChatInFolder = useCallback((folderId: string, columnId?: string) => {
+  const createChatInFolder = useCallback((folderId: string, opts?: { columnId?: string; focus?: boolean }) => {
     // A nested folder selected from the create menu may be hidden behind one
     // or more collapsed ancestors. Expand the complete path optimistically so
     // the destination and its new session are visible as creation begins.
@@ -2414,7 +2417,7 @@ function ChatSidebar({
       if (folder.collapsed) updateFolderMutation.mutate({ id: folder.id, body: { collapsed: false } })
       currentId = folder.parent_id || undefined
     }
-    createChatInFolderMutation.mutate({ folderId, columnId })
+    createChatInFolderMutation.mutate({ folderId, columnId: opts?.columnId, focus: opts?.focus })
   }, [createChatInFolderMutation, folders, updateFolderMutation])
 
   // Create autopilot session mutation (consistent with useMutation pattern)
@@ -2431,7 +2434,7 @@ function ChatSidebar({
     mutationFn: () => {
       return dispatch(createSlot({ agent: defaultAgent || undefined, mode: 'crew' })).unwrap()
     },
-    onSuccess: () => { requestAnimationFrame(() => { if (!isTouchDevice()) document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus() }) },
+    onSuccess: focusComposer,
   })
 
   // Create default chat session mutation
@@ -2440,7 +2443,7 @@ function ChatSidebar({
       const effectiveMode = loadChatConfig().defaultAutopilot ? 'orchestrator' : (mode || '')
       return dispatch(createSlot({ agent: defaultAgent || undefined, mode: effectiveMode })).unwrap()
     },
-    onSuccess: () => { requestAnimationFrame(() => { if (!isTouchDevice()) document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus() }) },
+    onSuccess: focusComposer,
   })
 
   // Create a PLAIN chat, ignoring the `defaultAutopilot` preference.
@@ -2452,7 +2455,7 @@ function ChatSidebar({
   // entry pins the mode.
   const createPlainChatMutation = useMutation({
     mutationFn: () => dispatch(createSlot({ agent: defaultAgent || undefined, mode: mode || '' })).unwrap(),
-    onSuccess: () => { requestAnimationFrame(() => { if (!isTouchDevice()) document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus() }) },
+    onSuccess: focusComposer,
   })
 
   // Session colors
@@ -2573,7 +2576,7 @@ function ChatSidebar({
                 <DropdownMenuItem className="text-danger focus:text-danger" onClick={() => { if (confirm(i18nT('pages.chatSidebar.delete_folder_confirm', { name: folder.name }))) deleteFolderMutation.mutate(folder.id) }}><X size={13} /> {i18nT('pages.chatSidebar.delete_folder')}</DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <button type="button" data-testid={`col-${columnId}-folder-${folder.id}-new-chat`} className="text-muted hover:text-accent bg-transparent border-none cursor-pointer p-[2px]" title={i18nT('pages.chatSidebar.new_chat_in_name', { name: folder.name })} aria-label={i18nT('pages.chatSidebar.new_chat_in_name', { name: folder.name })} onClick={e => { e.stopPropagation(); createChatInFolder(folder.id, columnId) }} onMouseDown={e => { e.stopPropagation() }} onKeyDown={e => { e.stopPropagation() }}>
+            <button type="button" data-testid={`col-${columnId}-folder-${folder.id}-new-chat`} className="text-muted hover:text-accent bg-transparent border-none cursor-pointer p-[2px]" title={i18nT('pages.chatSidebar.new_chat_in_name', { name: folder.name })} aria-label={i18nT('pages.chatSidebar.new_chat_in_name', { name: folder.name })} onClick={e => { e.stopPropagation(); createChatInFolder(folder.id, { columnId }) }} onMouseDown={e => { e.stopPropagation() }} onKeyDown={e => { e.stopPropagation() }}>
               <MessageSquarePlus size={11} />
             </button>
           </span>
@@ -2587,7 +2590,7 @@ function ChatSidebar({
             {/* Empty-folder affordance — list-view parity (see renderFolderBlock). */}
             {deepChildren.length === 0 && childSlots.length === 0 && (
               <button key={`col-${columnId}-newchat-${folder.id}`} type="button"
-                onClick={() => createChatInFolder(folder.id, columnId)}
+                onClick={() => createChatInFolder(folder.id, { columnId })}
                 title={i18nT('pages.chatSidebar.new_chat_in_name', { name: folder.name })} aria-label={i18nT('pages.chatSidebar.new_chat_in_name', { name: folder.name })}
                 className="w-full flex items-center gap-2.5 px-4 py-2 rounded-md text-[11px] text-muted hover:text-accent hover:bg-bg-hover transition-all bg-transparent border-none cursor-pointer text-left">
                 <span>{i18nT('pages.chatSidebar.new_chat_in_name', { name: folder.name })}</span><MessageSquarePlus size={11} className="shrink-0 ml-auto" />
@@ -3793,7 +3796,7 @@ function ChatSidebar({
                         const walk = (list: ChatFolder[], depth: number) => { for (const f of list) { items.push({ f, depth }); walk(childrenOf(f.id), depth + 1) } }
                         walk(roots, 0)
                         return items.map(({ f, depth }) => (
-                          <DropdownMenuItem key={f.id} style={{ paddingLeft: `${12 + depth * 16}px` }} onClick={() => { createChatInFolder(f.id); requestAnimationFrame(() => { if (!isTouchDevice()) document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus() }) }}>
+                          <DropdownMenuItem key={f.id} style={{ paddingLeft: `${12 + depth * 16}px` }} onClick={() => createChatInFolder(f.id, { focus: true })}>
                             <Folder size={14} className={depth === 0 ? 'text-muted' : 'text-muted/60'} /> {f.name}
                           </DropdownMenuItem>
                         ))

--- a/website/src/pages/chat/composerFocus.ts
+++ b/website/src/pages/chat/composerFocus.ts
@@ -9,11 +9,21 @@ import { isTouchDevice } from '../../utils/isTouchDevice'
  * flight puts the caret on the OLD session, so anything the user types in that
  * window becomes the old slot's draft and is lost the moment the new slot
  * activates. Slow creation makes the window real rather than theoretical.
- *
- * Both New-chat entry points (the sidebar header button and the collapsed
- * sidebar's hover flyout) need the same sequence, and the selector was
- * previously spelled out at each call site.
  */
+
+/**
+ * The one place the composer is looked up.
+ *
+ * The probe is the stable `data-composer-input` hook, NOT the textarea's
+ * aria-label: the label is `i18nT('components.chatInput.message_input')` and
+ * every catalog translates it, so a label-based selector matches in English
+ * only and focus silently no-ops in the other eleven languages. The `data-`
+ * attribute is invisible to assistive tech and never translated, which leaves
+ * the label free to localize.
+ */
+export function queryComposer(): HTMLTextAreaElement | null {
+  return document.querySelector<HTMLTextAreaElement>('textarea[data-composer-input]')
+}
 
 /**
  * Focus the composer on the next frame.
@@ -24,17 +34,31 @@ import { isTouchDevice } from '../../utils/isTouchDevice'
  *
  * Skipped on touch devices, where focusing a textarea raises the on-screen
  * keyboard and covers the thing the user just created.
- *
- * The selector is written inline rather than hoisted to a named constant on
- * purpose: the i18n lint exempts literals passed straight to `querySelector`
- * (a machine callee) but reports any named string constant, and
- * `aria-label="Message input"` reads as prose to it. Same spelling as the
- * keyboard-shortcut layer's lookup — keep them in step.
  */
 export function focusComposer(): void {
   requestAnimationFrame(() => {
     if (isTouchDevice()) return
-    document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message input"]')?.focus()
+    queryComposer()?.focus()
+  })
+}
+
+/**
+ * Reveal the composer after pre-filling it (widget send, quote-to-compose).
+ *
+ * Touch devices scroll it into view WITHOUT focusing — focus would pop the
+ * soft keyboard over the content the user was reading. Desktop focuses, which
+ * scrolls it into view anyway. The `scrollIntoView` feature check keeps this
+ * safe in DOM environments that do not implement it.
+ */
+export function revealComposer(): void {
+  requestAnimationFrame(() => {
+    const ta = queryComposer()
+    if (!ta) return
+    if (isTouchDevice()) {
+      if (typeof ta.scrollIntoView === 'function') ta.scrollIntoView({ block: 'nearest' })
+    } else {
+      ta.focus()
+    }
   })
 }
 

--- a/website/src/styles/cli-mode.css
+++ b/website/src/styles/cli-mode.css
@@ -23,7 +23,7 @@
      [data-role="assistant"]           — AssistantMessage root (added by us)
      .msg-content                      — message text container (already in tree)
      [data-testid="input-wrapper"]     — chat-input rounded card wrapper
-     textarea[aria-label="Message input"] — chat input
+     textarea[data-composer-input]      — chat input
      [style*="--mc-content-width"]     — chat pane root (scope anchor)
      [style*="var(--mc-content-width"] — per-message row wrappers
    ───────────────────────────────────────────────────────────────────────── */
@@ -173,7 +173,7 @@
   user-select: none;
 }
 
-[data-ui="cli"] [style*="--mc-content-width"] textarea[aria-label="Message input"] {
+[data-ui="cli"] [style*="--mc-content-width"] textarea[data-composer-input] {
   padding-left: 24px !important;
   caret-color: var(--accent);
   /* font-family + font-size inherit from body; useZoom auto-resolves

--- a/website/src/test/ChatInput.composerProbe.test.tsx
+++ b/website/src/test/ChatInput.composerProbe.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * The composer's stable focus probe.
+ *
+ * `queryComposer()` (and through it every focus-the-composer path: keyboard
+ * shortcuts, new-chat flows, widget prefill, quote-to-compose) resolves the
+ * textarea by `data-composer-input`. This locks the producer side of that
+ * contract: the rendered ChatInput textarea must carry the attribute and be
+ * exactly what the helper returns. The aria-label is translated at runtime, so
+ * losing the attribute would not fail any label-based query in an English test
+ * run — it would only no-op focus for non-English users in production.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import ChatInput from '../components/ChatInput'
+import { queryComposer } from '../pages/chat/composerFocus'
+import { renderWithProviders } from './helpers'
+
+describe('composer focus probe', () => {
+  it('the rendered composer textarea is the element queryComposer resolves', () => {
+    renderWithProviders(<ChatInput value="" onChange={vi.fn()} onSend={vi.fn()} />)
+    const textarea = screen.getByLabelText('Message input')
+    expect(textarea).toHaveAttribute('data-composer-input')
+    expect(queryComposer()).toBe(textarea)
+  })
+})

--- a/website/src/test/composerFocus.test.ts
+++ b/website/src/test/composerFocus.test.ts
@@ -14,11 +14,16 @@
  *  (3) A rejected create focuses nothing and produces no unhandled rejection.
  *  (4) Touch devices are skipped — focusing raises the on-screen keyboard over
  *      the thing the user just made.
- *  (5) It finds the composer by the same aria-label the keyboard-shortcut layer
- *      uses, so a rename breaks here rather than silently breaking focus.
+ *  (5) The composer is found by the stable `data-composer-input` attribute,
+ *      NEVER by its aria-label: the label is translated in all twelve catalogs,
+ *      so a label-based lookup matches in English only and silently no-ops for
+ *      every other locale.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { focusComposer, focusComposerAfter } from '../pages/chat/composerFocus'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, extname, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { focusComposer, focusComposerAfter, queryComposer, revealComposer } from '../pages/chat/composerFocus'
 
 let touch = false
 vi.mock('../utils/isTouchDevice', () => ({ isTouchDevice: () => touch }))
@@ -35,7 +40,11 @@ let composer: HTMLTextAreaElement
 beforeEach(() => {
   touch = false
   composer = document.createElement('textarea')
-  composer.setAttribute('aria-label', 'Message input')
+  composer.setAttribute('data-composer-input', '')
+  // A translated label, exactly as a non-English catalog renders it. Every
+  // assertion below passing against THIS label is what proves the lookup is
+  // language-agnostic.
+  composer.setAttribute('aria-label', '消息输入')
   document.body.appendChild(composer)
 })
 afterEach(() => { composer.remove() })
@@ -63,6 +72,30 @@ describe('focusComposer', () => {
   it('does not throw when the composer is absent', async () => {
     composer.remove()
     focusComposer()
+    await expect(flushFrame()).resolves.toBeUndefined()
+  })
+})
+
+describe('revealComposer', () => {
+  it('focuses on desktop, which scrolls the composer into view', async () => {
+    revealComposer()
+    await flushFrame()
+    expect(document.activeElement).toBe(composer)
+  })
+
+  it('scrolls into view WITHOUT focusing on touch — focus would pop the soft keyboard', async () => {
+    touch = true
+    const scrolled = vi.fn()
+    composer.scrollIntoView = scrolled
+    revealComposer()
+    await flushFrame()
+    expect(document.activeElement).not.toBe(composer)
+    expect(scrolled).toHaveBeenCalledWith({ block: 'nearest' })
+  })
+
+  it('does not throw when the composer is absent', async () => {
+    composer.remove()
+    revealComposer()
     await expect(flushFrame()).resolves.toBeUndefined()
   })
 })
@@ -100,17 +133,60 @@ describe('focusComposerAfter', () => {
 })
 
 describe('how the composer is found', () => {
-  it('locates it by the aria-label, not by tag order or a test id', async () => {
-    // Both this module and useKeyboardShortcuts look the composer up by this
-    // label, so a rename must break here rather than silently breaking focus.
-    // A decoy textarea earlier in the document would win any tag-order lookup.
+  it('resolves by the stable data attribute even under a translated aria-label', () => {
+    // The fixture's label is Chinese; a lookup that consulted the label would
+    // return null here exactly as it did in production for eleven locales.
+    expect(queryComposer()).toBe(composer)
+  })
+
+  it('ignores a decoy textarea that lacks the attribute', async () => {
     const decoy = document.createElement('textarea')
-    decoy.setAttribute('aria-label', 'Something else')
+    decoy.setAttribute('aria-label', 'Message input')
     document.body.insertBefore(decoy, composer)
+    // The decoy carries the ENGLISH label — the old selector's exact target —
+    // so this fails loudly if the lookup ever reverts to the label.
     focusComposer()
     await flushFrame()
     expect(document.activeElement).toBe(composer)
     expect(document.activeElement).not.toBe(decoy)
     decoy.remove()
+  })
+})
+
+describe('no site queries the translated label (class ratchet)', () => {
+  // The nine hand-rolled `textarea[aria-label="Message input"]` queries this
+  // module replaced all no-opped outside English, and the compiler cannot flag
+  // a selector string that names a translated label. This scan holds the whole
+  // class shut: production code (including CSS, which had the same bug in
+  // cli-mode.css) must never target the composer through its label again —
+  // `queryComposer()` / `data-composer-input` is the one sanctioned lookup.
+  const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  // Quote- and whitespace-tolerant: `[aria-label='Message input']` or
+  // `[aria-label = "Message input"]` is the same defect as the canonical form.
+  const SELECTOR_FORM = /\[\s*aria-label\s*=\s*(['"])Message input\1\s*\]/
+
+  const walk = (dir: string): string[] => {
+    const out: string[] = []
+    for (const name of readdirSync(dir)) {
+      const p = join(dir, name)
+      if (statSync(p).isDirectory()) {
+        // Tests may name the English label as a testing-library query or a
+        // decoy fixture; only production lookups are the defect. Exclusion is
+        // the exact src/test tree (plus node_modules), not any dir named
+        // "test" — a future production dir named test stays inside the guard.
+        // *.test.* files elsewhere (e.g. src/apps/mochi/test) are already
+        // excluded by the filename filter below.
+        if (p === join(SRC, 'test') || name === 'node_modules') continue
+        out.push(...walk(p))
+      } else if (['.ts', '.tsx', '.css'].includes(extname(name)) && !/\.test\.[jt]sx?$/.test(name)) {
+        out.push(p)
+      }
+    }
+    return out
+  }
+
+  it('no production source targets the composer via its aria-label', () => {
+    const offenders = walk(SRC).filter(f => SELECTOR_FORM.test(readFileSync(f, 'utf-8')))
+    expect(offenders).toEqual([])
   })
 })

--- a/website/src/test/useKeyboardShortcuts.test.tsx
+++ b/website/src/test/useKeyboardShortcuts.test.tsx
@@ -179,6 +179,32 @@ describe('useKeyboardShortcuts — toggle behavior', () => {
     fireEvent.keyDown(document, { code: 'KeyN', altKey: true, shiftKey: true })
     expect(onNewChat).toHaveBeenCalledTimes(1)
   })
+
+  it('Alt+Enter focuses the composer even on a touch device (#4088)', () => {
+    // The Alt+Enter site is deliberately UNGUARDED: a pressed keyboard
+    // shortcut proves a keyboard exists, so focusComposer()'s touch-device
+    // skip must not apply. This exercises the failure path directly — a
+    // future "consistency" swap to the guarded helper turns this red.
+    const composer = document.createElement('textarea')
+    composer.setAttribute('data-composer-input', '')
+    document.body.appendChild(composer)
+    const matchMedia = window.matchMedia
+    // Make isTouchDevice() genuinely return true: coarse pointer + no hover.
+    window.matchMedia = ((q: string) => ({
+      matches: q === '(pointer: coarse)' || q === '(hover: none)',
+      media: q, addEventListener: () => {}, removeEventListener: () => {},
+      addListener: () => {}, removeListener: () => {}, onchange: null,
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia
+    try {
+      setup()
+      fireEvent.keyDown(document, { code: 'Enter', altKey: true })
+      expect(document.activeElement).toBe(composer)
+    } finally {
+      window.matchMedia = matchMedia
+      composer.remove()
+    }
+  })
 })
 
 describe('ShortcutsModal', () => {

--- a/website/src/test/useMessageSearch.test.ts
+++ b/website/src/test/useMessageSearch.test.ts
@@ -335,7 +335,9 @@ describe('close() hands focus back to the composer', () => {
 
   beforeEach(() => {
     composer = document.createElement('textarea')
-    composer.setAttribute('aria-label', 'Message input')
+    // The stable probe focusComposer resolves through; the aria-label is
+    // translated at runtime and deliberately not part of the lookup.
+    composer.setAttribute('data-composer-input', '')
     document.body.appendChild(composer)
   })
   afterEach(() => { composer.remove() })


### PR DESCRIPTION
## Problem / Motivation

Nine call sites focus the main chat composer by querying its **translated** aria-label: `document.querySelector('textarea[aria-label="Message input"]')`. The label is `i18nT('components.chatInput.message_input')` and all twelve catalogs translate it, so the selector matches in English only. In the other eleven languages the query returns `null` and composer focus silently no-ops — nothing throws; keyboard shortcuts and post-create focus just appear not to work.

## Why it matters

Every non-English user loses composer focus across the app: Alt+Enter, new-chat flows, widget prefill, and quote-to-compose all leave the caret nowhere. Because the failure is a silent `null`, it never surfaces in logs or error reports — it just reads as "shortcuts don't work" for 11/12 locales. The class audit also found CLI-mode composer **styling** broken outside English (`cli-mode.css` targeted the same label).

## What changed (motivation → approach → change)

Symptom → root cause: a translated string used as a DOM selector. Fix shape follows the Quick Chat panel's own probe (PR #4080): a stable, never-translated `data-` attribute.

- `ChatInput`'s textarea gains `data-composer-input` alongside its translated `aria-label` — the label stays free to localize; the data attribute is invisible to assistive tech.
- `composerFocus.ts` is now the **single** lookup path: `queryComposer()` resolves the stable attribute; `focusComposer` (next-frame, touch-skip) serves the new-chat mutations; a new `revealComposer` serves widget-prefill/quote-to-compose (touch scrolls into view without popping the soft keyboard; desktop focuses); `focusComposerAfter` gates focus on the create promise.
- The two keyboard-shortcut paths (Alt+Enter in `useKeyboardShortcuts.ts`, Alt+Shift+N's mutation in `App.tsx`) use **unguarded** `queryComposer()?.focus()` on purpose: a pressed shortcut proves a keyboard exists; the touch skip would wrongly no-op a tablet with a physical keyboard.
- Class audit beyond the nine reported sites: `cli-mode.css` migrated to `textarea[data-composer-input]` (same 0,1,1 specificity — no cascade shift); three `website/scripts/capture-*.mjs` dev scripts migrated off the dead selector.
- ChatSidebar's folder-dropdown site also fixed a latent race the migration made legible: it focused one frame after `mutate()` while `createSlot` was still in flight, landing the caret on the OLD slot's composer. Focus now rides the mutation's `onSuccess` (via a `focus` variable), like its sibling create flows.
- Deliberately out of scope: ChatPage's Quick Chat probe (`aria-label="Ask a side question"`) — open PR #4080 owns that panel and its diff already removes that selector; fixing it here would collide. Playwright `getByLabel('Message input')` accessible-name queries in two capture scripts are left as-is: they run against English-launched harnesses and fail loudly (timeout), not silently.

## Tests

- `composerFocus.test.ts`: fixture textarea carries a **Chinese** aria-label, so every focus assertion proves the lookup is language-agnostic; an English-labelled decoy fails loudly on a revert to the old selector; `revealComposer` covered on all three branches (touch scroll, desktop focus, missing `scrollIntoView`).
- Class ratchet (same file): a quote/whitespace-tolerant regex scan over production `ts/tsx/css` forbids `[aria-label="Message input"]` — mutation-verified (a planted single-quote variant fails it). Test-tree exclusion pinned to the exact `src/test` path, not any dir named `test`.
- `ChatInput.composerProbe.test.tsx`: render-level probe locks the producer side — ChatInput's textarea is exactly what `queryComposer()` resolves.
- `useKeyboardShortcuts.test.tsx`: behavioural Alt+Enter test with a coarse-pointer `matchMedia` asserts focus still lands — a future "consistency" swap to the guarded helper turns red.

Full suite: `npx tsc -b` clean; `npx vitest run` 21072 passed / 1337 files (2 expected-fail, 3 skipped).

## Manual verification

Keyboard focus has no meaningful screenshot. Language-agnostic resolution is proven in the suite itself: the contract fixture is labelled in Chinese and the decoy in English, so the assertions pass **only** if resolution ignores the label entirely. The ratchet was mutation-verified against a planted variant selector.

## Related Issues

Closes #4088

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior-preserving selector fix
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** keyboard-focus behavior and a non-rendering `data-` attribute — no pixel changes on any surface; language-agnostic resolution is proven by the Chinese-labelled test fixture instead.
