### PR TITLE
refactor(pod): drop dead code and flatten four pod-module branches

### DIFF
--- a/src/kiro_crew/pod/cli.py
+++ b/src/kiro_crew/pod/cli.py
@@ -179,9 +179,9 @@ def _up(cfg: PodConfig, args: argparse.Namespace) -> None:
             # This failure cleanup runs INSIDE the same mutex hold as our start:
             # released between the two, a down + replacement up could interleave
             # during the health wait, and this stop_pod would then unload and
-            # erase the REPLACEMENT pod (verifier-found High). Holding the lock
-            # across the whole boot transaction means the pod we stop here can
-            # only be the one we started.
+            # erase the REPLACEMENT pod. Holding the lock across the whole boot
+            # transaction means the pod we stop here can only be the one we
+            # started.
             tail = rt.recent_journal(cfg, name, 30)
             print(tail, file=sys.stderr)
             rt.stop_pod(cfg, name)
@@ -284,23 +284,24 @@ def _ls(cfg: PodConfig, args: argparse.Namespace) -> None:
     # `ls`/`down` make them visible — but keep the JSON array shape unchanged
     # (three callers parse it); orphans are human-output only.
     if args.json:
-        rows = [
-            {"name": n, "port": rt.derive_port(cfg, n), "health": rt.health(rt.derive_port(cfg, n))}
-            for n in names
-        ]
+        # An unpinned port shells `cksum`, so deriving it twice per row would
+        # double the subprocess count for the same answer.
+        rows: list[dict[str, object]] = []
+        for n in names:
+            p = rt.derive_port(cfg, n)
+            rows.append({"name": n, "port": p, "health": rt.health(p)})
         print(json.dumps(rows))
         return
     # Any fail-closed probe underneath surfaces as PodError, which the dispatch
     # layer renders as the documented one-line `pod: <msg>` refusal.
     orphans = rt.orphan_homes(cfg)
-    if not names:
+    if names:
+        print(f"{'POD':<28} {'PORT':<7} HEALTH")
+        for n in names:
+            p = rt.derive_port(cfg, n)
+            print(f"{n:<28} {p:<7} {rt.health(p)}")
+    else:
         print("no pods running")
-        _print_orphans(cfg, orphans)
-        return
-    print(f"{'POD':<28} {'PORT':<7} HEALTH")
-    for n in names:
-        p = rt.derive_port(cfg, n)
-        print(f"{n:<28} {p:<7} {rt.health(p)}")
     _print_orphans(cfg, orphans)
 
 
@@ -463,11 +464,11 @@ def _prune(cfg: PodConfig, args: argparse.Namespace) -> None:
             results.append(row)
         else:
             results.append(_prune_one(cfg, name))
-    failed = sum(1 for r in results if r["status"] == "failed")
     counts = {
         s: sum(1 for r in results if r["status"] == s)
         for s in ("reclaimed", "would-reclaim", "kept", "skipped", "failed")
     }
+    failed = counts["failed"]
     # Invocation-level audit: the per-name events say what each delete decided,
     # but a bulk destructive verb must be visible in the trail even when it
     # touched nothing (empty set, all kept, dry run).
@@ -676,7 +677,7 @@ def _provision(cfg: PodConfig, args: argparse.Namespace) -> None:
         _die(f"provisioning {name!r} failed (see output above)")
     # Pin so a subsequent `up` (and the systemd boot) resolves the same checkout.
     # Under the per-name mutex: unlocked, a concurrent `down` finishing its
-    # teardown could unlink this fresh pin (verifier finding).
+    # teardown could unlink this fresh pin.
     with rt.pod_name_mutex(cfg, name):
         rt.pin_checkout(cfg, name, checkout)
 

--- a/src/kiro_crew/pod/launchd.py
+++ b/src/kiro_crew/pod/launchd.py
@@ -243,7 +243,7 @@ def start(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:
 def stop(cfg: PodConfig, name: str, *, timeout: float = 15.0) -> subprocess.CompletedProcess:
     """``bootout`` the agent, wait for it to actually go, and drop its plist.
 
-    Two things here are not obvious and were both found by a real bring-up:
+    Three things here are not obvious:
 
     **``bootout`` is asynchronous.** It returns before launchd has finished
     unloading, so immediately afterwards ``launchctl print`` still resolves the
@@ -273,9 +273,9 @@ def stop(cfg: PodConfig, name: str, *, timeout: float = 15.0) -> subprocess.Comp
     while time.monotonic() < deadline:
         probe = _print(cfg, name)
         # Only the EXPLICIT not-loaded result confirms the unload. Any other
-        # nonzero print (permissions, transient daemon error) proves nothing —
-        # treating it as gone was itself a review-blocking bug: teardown would
-        # delete a possibly-live pod's state on a flaky probe.
+        # nonzero print (permissions, transient daemon error) proves nothing;
+        # treating one as gone would let teardown delete a possibly-live pod's
+        # state on a flaky probe.
         if _service_absent(probe):
             unloaded = True
             break
@@ -293,10 +293,6 @@ def stop(cfg: PodConfig, name: str, *, timeout: float = 15.0) -> subprocess.Comp
         )
     plist_path(cfg, name).unlink(missing_ok=True)
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=cp.stdout or "", stderr="")
-
-
-def restart(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:
-    return launchctl("kickstart", "-k", service_target(cfg, name))
 
 
 def _print(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -83,24 +83,31 @@ CRONS_TRUE: frozenset[str] = frozenset({"1", "true", "yes", "on"})
 
 
 def read_env_file(cfg: PodConfig, name: str) -> dict[str, str]:
-    out: dict[str, str] = {}
-    f = cfg.env_file(name)
+    """Parsed ``KEY='value'`` pairs for pod *name*, ``{}`` on any ``OSError``.
+
+    Fail-OPEN by design, which bounds who may use it: a missing pod, an
+    unreadable pods dir and a comments-only file all yield the same empty
+    mapping, so a caller that must tell "absent" from "exists but cannot be
+    positively read" MUST NOT read the pin through here — see
+    ``dev_fleet._read_pin_strict``, which propagates the failure instead.
+    """
     try:
-        if f.exists():
-            for ln in f.read_text().splitlines():
-                ln = ln.strip()
-                if not ln or ln.startswith("#") or "=" not in ln:
-                    continue
-                key, val = ln.split("=", 1)
-                raw = val.strip()
-                # Strip a single matched surrounding quote pair only (the form
-                # write_env_file emits), so a value that legitimately contains a
-                # quote is not mangled.
-                if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "\"'":
-                    raw = raw[1:-1]
-                out[key.strip()] = raw
+        text = cfg.env_file(name).read_text()
     except OSError:
-        pass
+        return {}
+    out: dict[str, str] = {}
+    for ln in text.splitlines():
+        ln = ln.strip()
+        if not ln or ln.startswith("#") or "=" not in ln:
+            continue
+        key, val = ln.split("=", 1)
+        raw = val.strip()
+        # Strip a single matched surrounding quote pair only (the form
+        # write_env_file emits), so a value that legitimately contains a quote is
+        # not mangled.
+        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "\"'":
+            raw = raw[1:-1]
+        out[key.strip()] = raw
     return out
 
 
@@ -536,8 +543,10 @@ def _write_and_load_unit(cfg: PodConfig) -> subprocess.CompletedProcess | None:
     systemd executes is the definition it loaded — so a writer that renders the
     current hookless template and then fails to reload leaves a file that reads
     "current" in front of a cached definition still carrying the destructive
-    ``ExecStopPost``. Every later caller then skips the refresh and the pod's HOME
-    is deleted from a stop hook. Unlinking on failure keeps the on-disk state
+    ``ExecStopPost``. :func:`start_pod` then skips its refresh and boots the pod
+    under that cached definition, whose hook deletes the pod's HOME on any
+    systemd-initiated stop — including the stop half of a ``Restart=``, which no
+    ``down`` gate is in the path of. Unlinking on failure keeps the on-disk state
     honest, so the next call re-renders and retries.
 
     Returns ``None`` on success, or the failing ``daemon-reload`` result.
@@ -867,11 +876,11 @@ def install_backend(cfg: PodConfig) -> tuple[str, subprocess.CompletedProcess | 
     dispatch layer — two different documented behaviours.
 
     Routed through :func:`_write_and_load_unit` so this path upholds the same
-    invariant the lifecycle paths do: a unit file left on disk has been loaded. A
-    reload that fails here used to leave a hookless file behind, which made
-    ``unit_is_current`` report "current" while systemd still ran the old
-    ``ExecStopPost`` — so a later ``down`` skipped its refresh and deleted the
-    pod's HOME from that hook.
+    invariant the lifecycle paths do: a unit file left on disk has been loaded.
+    A hookless file left behind by a failed reload would make
+    ``unit_is_current`` report "current" while systemd still runs the old
+    ``ExecStopPost`` — so :func:`start_pod` would skip its refresh and boot the
+    pod under a definition that deletes its HOME from a stop hook.
     """
     require_backend()
     if IS_MACOS:
@@ -1313,7 +1322,6 @@ def require_pod_safe_verb(argv: list[str], name: str) -> None:
     verb = argv[0] if argv else ""
     if verb in _POD_SAFE_VERBS:
         return
-    hint = ""
     if verb in _POD_EQUIVALENT:
         hint = f" Use `{_POD_EQUIVALENT[verb].format(name=name)}` instead."
     elif verb.startswith("-"):

--- a/src/kiro_crew/pod/unit.py
+++ b/src/kiro_crew/pod/unit.py
@@ -135,10 +135,11 @@ def unit_exec_ok(cfg: PodConfig) -> bool:
 
 
 # Directives an older installed unit may still carry that this build has removed.
-# ``ExecStopPost`` ran teardown before systemd's final kill of the pod's cgroup,
-# so it raced the pod's own subprocesses and also wiped the HOME on the stop half
-# of a ``Restart=``; reclamation now belongs to the ``down`` path.
-_REMOVED_DIRECTIVES = ("ExecStopPost=",)
+# ``ExecStopPost`` runs teardown before systemd's final kill of the pod's cgroup,
+# so it races the pod's own subprocesses and also wipes the HOME on the stop half
+# of a ``Restart=``; reclamation belongs to the ``down`` path instead. Must stay a
+# tuple: ``unit_is_current`` hands it straight to ``str.startswith``.
+_REMOVED_DIRECTIVES: tuple[str, ...] = ("ExecStopPost=",)
 
 
 def unit_is_current(cfg: PodConfig) -> bool:
@@ -157,8 +158,6 @@ def unit_is_current(cfg: PodConfig) -> bool:
         text = unit_path(cfg).read_text()
     except OSError:
         return False
-    return not any(
-        line.startswith(directive)
-        for line in text.splitlines()
-        for directive in _REMOVED_DIRECTIVES
-    )
+    # str.startswith takes the whole tuple, so one pass answers for every removed
+    # directive.
+    return not any(line.startswith(_REMOVED_DIRECTIVES) for line in text.splitlines())


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff — four files under `src/kiro_crew/pod/`, no frontend path touched, no rendered surface exists for the pod CLI.

## Problem / Motivation

`src/kiro_crew/pod/` carries the residue that accumulates in a subsystem grown
over many PRs: a function nobody calls, two values computed twice, three
control-flow shapes that nest or branch further than the logic needs, and
comments that read as a task log rather than as rationale. None of it is a bug,
and all of it is what a reader has to hold in their head before they can reason
about the destructive teardown path this module owns.

Three of those comments also make claims that are **false of the current code**,
which is the part that actually costs something: a reader who trusts them
mis-models when the pod's isolated HOME can be deleted.

## Why it matters

This module deletes directories (`pod down` reclaims a pod's isolated HOME) and
gates `pod exec` behind a deny-by-default allowlist. Both are paths where a
reviewer has to be able to see the decision at a glance, and where a comment
that names the wrong code path sends the next author to the wrong guard. The
duplicated port derivation is also a live cost: each one shells `cksum`, so
`pod ls --json` spawned two subprocesses per pod for one answer.

## What changed (motivation → approach → change)

Behaviour-preserving throughout — this is a readability pass, not a fix. Every
rewrite was proved equivalent before it landed (see **Tests**).

**Dead code**
- `launchd.restart()` removed. Zero callers anywhere in `src/`, `test/`,
  `scripts/`, `docs/`, `website/`, `packaging/` or `conftest.py`, including
  dynamic access; there is no `pod restart` verb (`_VERBS` has no entry,
  `cli.md` documents none) and Dev Fleet's `/api/pod/restart` is `down` then
  `up`, not a `kickstart`. The systemd twin `unit.py` has no counterpart, so the
  two backends are now symmetric.
- `require_pod_safe_verb`'s `hint = ""` initializer removed — the following
  `if/elif/else` is exhaustive, so no path could observe it. The guard's
  decision is byte-for-byte unchanged.

**De-duplication**
- `_ls --json` derived each pod's port twice per row (once for the reported
  value, once as the health probe's argument). Now once. Beyond halving the
  `cksum` subprocesses, the reported port can no longer differ from the one
  actually probed if a `PORT=` pin changes between the two calls.
- `_prune` computed the failed count standalone *and* inside the `counts`
  comprehension; it now reads the one it already built.

**Flattening**
- `read_env_file`'s `try` / `if exists()` / `for` nest becomes a guarded read
  plus one flat loop. `read_text()` raises the same `OSError` family
  `Path.exists()` swallows, so the pre-check was redundant, and dropping it
  closes a check-to-use window rather than opening one. `read_text()` is
  all-or-nothing, so the old code's partial-result path was unreachable.
- `_ls`'s empty-list early return becomes an `if/else`, so `_print_orphans` —
  how an operator learns about un-reclaimed pod HOMEs — is called from one
  place instead of two.
- `unit_is_current`'s nested double comprehension becomes one pass:
  `str.startswith` takes the whole tuple. `_REMOVED_DIRECTIVES` is now
  annotated `tuple[str, ...]` so that requirement is stated where it is relied on.

**Comment hygiene** (only in the files above, per `AGENTS.md` § Code style)
Dropped review-round markers, converted historical narration to present tense,
and corrected three claims that were false of the current code:
- The stale-unit hazard is skipped by **`start_pod`**, not by `down`.
  `unit_is_current` has exactly one caller (`runtime.py:614`); `stop_pod` gates
  on `loaded_teardown_hook`, i.e. on what systemd has *loaded*, so it cannot
  skip its refresh because of a stale file. Corrected in both places that said
  otherwise (`_write_and_load_unit` and `install_backend`).
- `read_env_file` is **fail-open**, so the docstring now bounds who may use it
  and points at `dev_fleet._read_pin_strict`, which exists precisely to refuse
  the absent-vs-unreadable conflation.
- `launchd.stop`'s docstring said "two things" above three bolded items.

No security control changed shape: no sensitive-path matcher, denied-command
rule, deny-by-default guard, SEL audit emit, redaction call, credential scrub
(`build_pod_env`) or path-containment check (`cleanup_home`) is in the diff. No
import was added, removed, moved or hoisted, and no in-function
`from X import Y` was touched.

## Tests

No test changes — that is the point of a behaviour-preserving pass, and the
existing suites are what hold it. **1097 passed, 2 skipped** across every suite
that imports `kiro_crew.pod`: `test_pod.py`, `test_pod_launchd.py`,
`test_pod_self_contained.py`, `test_pod_e2e_harness_paths.py`,
`test_pod_e2e_video_guard.py`, `test_agent_home_isolation.py`,
`test_cli_commands_coverage.py`, `test_dev_fleet_server_coverage.py`,
`test_dev_fleet_node_toolchain.py`, `test_dev_fleet_app.py`.

Equivalence was also proved directly, not just observed green. `read_env_file`
was differentially executed old-vs-new over 12 inputs (missing file, empty,
comment-only, no-`=`, quoted values, path-is-a-directory, mode-0, unreadable
parent, dangling symlink, `ELOOP`, `ENAMETOOLONG`, invalid UTF-8) — identical results in every case, including which exception escapes. `_prune`'s count was
brute-forced over 2000 random result sets including unknown statuses.
`startswith(tuple)` was checked against the nested form including the
empty-tuple case.

One input class where old and new differ, deliberately accepted as unreachable:
a pod name containing a NUL byte. `Path.exists()` swallows `ValueError`, while
`read_text()` raises it. `_NAME_RE` (`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,60}$`) gates
every validated path, argv cannot carry NUL, and the Dev Fleet call sites only
reach it for a name already in `rt.active_names`.

## Manual verification

N/A — unit coverage sufficient. The changed code is pure control flow and
string handling with no new external interaction; the platform-specific paths
(`systemctl`, `launchctl`) are exercised by the suites above on every OS via
their existing seams, and this diff adds no call to either.

## Related Issues

no linked issue: campaign refactor with no filed issue behind it.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (none needed — no new behaviour)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no documented API, schema or behaviour changed
- [x] No secrets, credentials, or internal references in the diff

## Gates run locally (Python 3.12 CI-parity venv)

`flake8` · `isort --check-only` · `mypy src/kiro_crew` (982 files) ·
`check_brand_name.py` · `check_harness_parity.py` · `docs_lint.py --test` ·
`docs-lint.sh` · `check_per_file_coverage.py --test` ·
`verify_vendor_manifest.py` · `scrub-lint.sh --no-history` — all exit 0.
Frontend suites not run: the diff touches nothing under `website/`, `.github/`
or `scripts/`, so CI's `changes` job reports `only_backend=true`.

## Pre-PR review fleet

Five independent read-only reviewers ran against this diff before it was
opened, each with a distinct lens: AUTOSDE blocking rules + the `code-review.yml`
grep contract, behaviour preservation, import semantics and test-patching seams,
security-guard/destructive-path integrity, and comment accuracy.

**Found and fixed (3, all comment accuracy):** the `unit_is_current`-victim-path
error, converged on by two reviewers and confirmed by reading the call sites;
the `read_env_file` docstring's false "indistinguishable to every caller" claim,
converged on by three reviewers with `dev_fleet._read_pin_strict` as the
counter-example; and the over-promised "`{}` when unreadable" summary, which
`UnicodeDecodeError` escapes. Also folded in two adjacent instances of the same
banned comment classes so the fix is not applied inconsistently within a file.

**Dropped after checking (2):** the NUL-byte `ValueError` divergence, verified
unreachable and recorded above rather than guarded speculatively; and a
suggestion to catch `ValueError` in `read_env_file`, which would be a behaviour
change and therefore belongs in its own PR, not a preservation pass.
