### PR TITLE
docs: fix a stale pointer and stop restating the flake tells

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/conftest.py
@@ -97,12 +97,12 @@ def _isolated_app_data_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     and sweeps archive leftovers. Pointing the variable at a temp directory redirects
     every reader of the home, including the ones no fixture knows about.
 
-    Kept even though the rootdir conftest now pins ``KIROCREW_HOME`` for every testpath,
-    because this fixture pins something STRICTER that the floor does not: the home lands
-    under THIS test's ``tmp_path``, beside the app's own data dir, so the two coincide and
-    a fixture path is coherent across both. ``test_data_home_isolation.py::
-    test_the_config_home_resolver_is_the_tests_temp_dir`` fails without it — the floor's
-    home is under its own isolation root, which is a tmp dir but not this one.
+    This is STRICTER than the rootdir conftest's own per-test pin, and the difference is what
+    it is here for: the home lands under THIS test's ``tmp_path``, beside the app's own data
+    dir, so the two coincide and a fixture path is coherent across both.
+    ``test_data_home_isolation.py::test_the_config_home_resolver_is_the_tests_temp_dir``
+    fails without it — the rootdir home is under its own isolation root, a tmp dir but not
+    this one.
     """
     data = tmp_path / "app-data-home"
     data.mkdir(parents=True, exist_ok=True)

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/conftest.py
@@ -31,8 +31,8 @@ def _mute_shared_runner_audit(monkeypatch):
 
     ``discovery.run_gh_json`` / ``current_login`` / ``pipeline.list_open_prs``
     now route through ``github_runner.run_gh``, which emits a real SEL event
-    per spawn. ``KIROCREW_HOME`` is isolated below, but ``config_dir()`` caches
-    the resolved home at its FIRST call in the process, so a suite that
+    per spawn. ``KIROCREW_HOME`` is pinned by the rootdir ``conftest.py``, but
+    ``config_dir()`` caches the resolved home at its FIRST call in the process, so a suite that
     imported something touching it before the isolation fixture ran would
     write through the cached REAL data dir. The audit is not under test here
     (``test/test_github_runner.py`` covers it against a mocked SEL), so mute

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
@@ -166,21 +166,14 @@ cutover path must stub **both** `_run_cmd` and `_dropin_path`.
 Never "fix" a flake with a rerun, a longer `sleep`, a weakened assertion, or a skip.
 Full detail and examples: testing-conventions § Determinism.
 
-Each class has ONE correct fix, and they are written out with examples in
+The five classes, the tell that identifies each, and the ONE correct fix for each are in
 [testing-conventions.md](../../../../../docs/system-specs/common/testing-conventions.md)
-§ Determinism. What this skill adds is the routing — the symptom you actually have in front
-of you, and which class it belongs to:
+§ Determinism. Read the section matching your symptom before changing anything: four of the five
+have a fix that looks like the obvious one and is not.
 
-| The tell you are looking at | The class it is |
-|---|---|
-| `os.urandom` / `random` / `uuid4` / `now()` feeding an assertion the RNG or clock does not guarantee | nondeterministic input |
-| an assertion on a rate, a sample count, or an elapsed duration the host controls | wall-clock race |
-| `RuntimeWarning: coroutine ... never awaited`, blamed on an innocent later test | leaked async object |
-| passes alone, fails in the suite | order dependence / shared state |
-| a timing test that splits by **Python version** rather than by machine load | absolute time budget on an instrumented run |
-
-Read the matching section before you change anything: four of the five have a fix that looks
-like the obvious one and is not.
+What this skill adds is when to go looking — a test that passes alone and fails in the suite, or
+one that splits by Python version rather than by machine load, is one of those five and not a
+mystery. Do not reach for a rerun, a longer `sleep`, a weakened assertion, or a skip.
 
 A sixth, adjacent trap: **a patch target that misses.** Patch the namespace whose
 globals the code under test actually reads. It fails in both directions — patching a


### PR DESCRIPTION
## Problem / Motivation

Three prose corrections from the review of #4113, which a maintainer merged before they were
applied. One of them is a pointer to something that no longer exists, which is the kind of thing
that costs the next reader real time.

## Why it matters

`code_review_sage/tests/conftest.py`'s `_mute_shared_runner_audit` docstring says `KIROCREW_HOME`
"is isolated **below**" — but #4113 deleted the fixture that sentence pointed at, because the
rootdir `conftest.py` pins the home for every testpath now. A pointer to something that is not
there is worse than no pointer: the reader goes looking, finds nothing, and has to reconstruct
whether the isolation still happens at all.

The other two are the same drift problem #4113 was itself about, one level smaller.

## What changed (motivation → approach → change)

Prose only. **No behaviour changes.**

- **The stale pointer.** `KIROCREW_HOME` "is isolated below" → "is pinned by the rootdir
  `conftest.py`". The rest of that docstring is unchanged and still carries the fact that
  matters — `config_dir()` caches the resolved home at its first call, so muting the SEL emitter
  is what makes this suite deterministic regardless of cache state.

- **The skill stops restating the flake tells.** #4113 removed the copied *fixes* but kept a
  table of *tells*, and review checked all five rows against `testing-conventions.md`
  § Determinism: each is a near-copy and row 5 is verbatim. Compressing a copy does not stop it
  drifting, and this is the file whose own header says a second copy "would drift". It now points
  at the doc for the classes, the tells and the fixes, and keeps only what it genuinely adds:
  *when to go looking at all* — that a test which passes alone and fails in the suite, or one
  that splits by Python version rather than by machine load, is one of those five and not a
  mystery.

- **The `auto_improvement` docstring states an invariant instead of narrating a change.** It said
  "Kept even though the rootdir conftest now pins…", which is the "previously / we now" shape
  `AGENTS.md` bans in comments — and which I added while quoting that same rule elsewhere. It now
  says what is true (this pin is stricter than the floor's, so the home coincides with the app's
  data dir) and names the test that fails without it.

## Tests

No new tests; nothing executable changed. The suites that cover the touched files pass: 836 tests
across `code_review_sage`, `auto_improvement/tests/test_data_home_isolation.py`,
`test_builtin_skill_packaging.py` and `test_builtin_skill_sync_safety.py`, with `flake8`, `isort`
and `docs-lint` green.

## Manual verification

N/A — unit coverage sufficient. Every change is a docstring or markdown edit; the packaging and
sync tests are what confirm the edited skill still ships and syncs correctly.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** docstrings and a dev skill only — no frontend path is touched and nothing
renders in the browser.

## Related Issues

no linked issue: follow-up to review comments on #4113 and #4065, both already merged.
