### PR TITLE
fix(dev-fleet): process force-only worktree prunes so progress and toast are correct

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -3877,8 +3877,15 @@ async def _prune_run(names: list[str], force_names: set[str] | None = None) -> d
     # and a duplicate would spawn two workers racing to remove the SAME
     # worktree — the second one then reports a spurious failure over the
     # first one's success.
-    names = list(dict.fromkeys(names))
     _force = force_names or set()
+    # Forced items (kept worktrees the user overrode) arrive in ``force_names``
+    # disjoint from the regular candidate ``names``. Both must be processed, so
+    # the work list is the order-preserving union — regulars first, then any
+    # forced name not already present. Building ``total``/``items``/the dispatch
+    # from this union (rather than ``names`` alone) is what keeps a force-only
+    # prune counted: otherwise its ``done`` bump has no matching denominator or
+    # item row, producing an impossible ``1/0`` counter and a false failure.
+    names = list(dict.fromkeys([*names, *_force]))
     async with _PRUNE_LOCK:
         if _PRUNE_STATE["running"]:
             return {"ok": False, "error": "prune already running"}

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -6614,6 +6614,85 @@ async def test_prune_run_deduplicates_names(reset_prune_state):
 
 
 @pytest.mark.asyncio
+async def test_prune_run_processes_force_only_names(reset_prune_state):
+    """A force-override on a kept worktree arrives in ``force_names`` disjoint
+    from ``names``. It must still be processed and counted: absent from the
+    work list, its ``done`` bump would have no denominator or item row,
+    producing the impossible ``1/0`` counter (and a false failure toast). The
+    forced item also skips the prunable-verdict recheck — ``_prunable`` is
+    never consulted for it."""
+    prunable_calls: list[str] = []
+    removed: list[str] = []
+
+    async def fake_find(nm):
+        return {"path": f"/wt/{nm}", "branch": f"feat/{nm}"}, None
+
+    async def fake_prunable(path, branch):
+        prunable_calls.append(path)
+        return {"ok": True, "code": "merged"}
+
+    async def fake_remove(nm, force=False, progress=None, _caller="handler"):
+        removed.append(nm)
+        return {"ok": True, "removed": True}
+
+    with patch.object(mod, "_find_worktree", side_effect=fake_find), \
+         patch.object(mod, "_prunable", side_effect=fake_prunable), \
+         patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_staged_target", return_value=None), \
+         patch.object(mod, "_worktree_remove", side_effect=fake_remove):
+        # No regular candidates; a single kept worktree via force-override.
+        r = await mod._prune_run([], force_names={"wt-kept"})
+        assert r == {"ok": True, "total": 1}
+        await _await_prune_idle()
+
+    st = await mod._prune_status()
+    # The forced worktree is in the denominator, has an item row, and is done.
+    assert st["total"] == 1 and st["done"] == 1
+    assert set(st["items"]) == {"wt-kept"}
+    assert st["items"]["wt-kept"]["status"] == "done"
+    assert removed == ["wt-kept"]
+    # Forced items bypass the prunable verdict recheck entirely.
+    assert prunable_calls == []
+
+
+@pytest.mark.asyncio
+async def test_prune_run_unions_regular_and_forced_names(reset_prune_state):
+    """A mixed batch (regular candidates + a forced kept worktree) processes
+    the order-preserving union: every name is counted and removed exactly
+    once, and only the non-forced names go through the prunable recheck."""
+    prunable_paths: list[str] = []
+    removed: list[str] = []
+
+    async def fake_find(nm):
+        return {"path": f"/wt/{nm}", "branch": f"feat/{nm}"}, None
+
+    async def fake_prunable(path, branch):
+        prunable_paths.append(path)
+        return {"ok": True, "code": "merged"}
+
+    async def fake_remove(nm, force=False, progress=None, _caller="handler"):
+        removed.append(nm)
+        return {"ok": True, "removed": True}
+
+    with patch.object(mod, "_find_worktree", side_effect=fake_find), \
+         patch.object(mod, "_prunable", side_effect=fake_prunable), \
+         patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None), \
+         patch.object(mod, "_staged_target", return_value=None), \
+         patch.object(mod, "_worktree_remove", side_effect=fake_remove):
+        r = await mod._prune_run(["wt-a", "wt-b"], force_names={"wt-forced"})
+        assert r == {"ok": True, "total": 3}
+        await _await_prune_idle()
+
+    st = await mod._prune_status()
+    assert st["total"] == 3 and st["done"] == 3
+    assert set(st["items"]) == {"wt-a", "wt-b", "wt-forced"}
+    assert all(it["status"] == "done" for it in st["items"].values())
+    assert sorted(removed) == ["wt-a", "wt-b", "wt-forced"]
+    # Only the two regular candidates go through the verdict recheck.
+    assert sorted(prunable_paths) == ["/wt/wt-a", "/wt/wt-b"]
+
+
+@pytest.mark.asyncio
 async def test_worktree_remove_refuses_when_pod_reactivates_before_mutation(reset_prune_state):
     """TOCTOU guard: pod inactivity is verified before _GIT_MUTATION_LOCK is
     acquired; if the pod comes back while the worker queues on the lock, the

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -1132,12 +1132,17 @@ export default function DevFleetPage() {
         let st: { running?: boolean; done?: number; items?: Record<string, { status?: string; error?: string | null }> } | null = null
         try { st = await api.get('/prune-status') } catch { continue }
         if (!st) continue
-        // Rebuild the item map in the ORIGINAL selection order; fall back to
-        // the pending seed for any name the backend has not populated yet.
+        // Rebuild the item map in the ORIGINAL selection order over the FULL
+        // regular-plus-forced set: the checklist, denominator, and success
+        // tally must all cover every name the backend tracks, forced worktrees
+        // included. Counting over ``names`` alone drops the forced worktrees
+        // from the denominator and the tally, restoring the ``1/0`` counter and
+        // the false failure toast. Fall back to the pending seed for any name
+        // the backend has not populated yet.
         const raw = st.items || {}
-        const backendTotal = Object.keys(raw).length || names.length
+        const backendTotal = Object.keys(raw).length || allNames.length
         const items: Record<string, { status: string; error?: string | null }> =
-          Object.fromEntries(names.map((n) => [n, {
+          Object.fromEntries(allNames.map((n) => [n, {
             status: raw[n]?.status || 'pending',
             error: raw[n]?.error ?? null,
           }]))
@@ -1146,14 +1151,14 @@ export default function DevFleetPage() {
           // A name the backend never tracked (filtered server-side, e.g. the
           // worktree vanished between preview and execute) must terminate as
           // an explained failure, not sit "Pending" in a finished checklist.
-          for (const n of names) {
+          for (const n of allNames) {
             if (!raw[n]) items[n] = { status: 'failed', error: 'not processed (unknown or no longer a worktree)' }
           }
         }
-        setPruneProgress({ names, items, done: st.done || 0, total: names.length, running })
+        setPruneProgress({ names: allNames, items, done: st.done || 0, total: allNames.length, running })
         if (!running) {
-          const removed = names.filter((n) => items[n]?.status === 'done').length
-          const failed = names.filter((n) => items[n]?.status === 'failed').length
+          const removed = allNames.filter((n) => items[n]?.status === 'done').length
+          const failed = allNames.filter((n) => items[n]?.status === 'failed').length
           notify(removed > 0 ? `Pruned ${removed} worktree(s)` + (failed > 0 ? ` (${failed} failed)` : '') : `Prune: ${failed} failed`, { type: removed > 0 ? 'success' : 'error' })
           invalidateAll()
           setTimeout(() => setPruneProgress(null), 5000)

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -1272,6 +1272,54 @@ describe('DevFleetPage', () => {
     expect(screen.getByText('Prune complete')).toBeInTheDocument()
   }, 15000)
 
+  it('force-only prune counts the forced worktree and reports success (issue #4128)', async () => {
+    // Force-overriding a KEPT worktree sends it in force_names, disjoint from
+    // the regular candidate names. The counter and success tally must cover it
+    // — otherwise the denominator drops to 0 (the impossible "1/0") and the
+    // toast turns red ("Prune 0: failed") on a removal that actually succeeded.
+    let runBody: unknown = null
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url, init) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/prune-candidates')) return Promise.resolve(new Response(JSON.stringify({
+        // No regular candidates — only a kept worktree offered for force-override.
+        ok: true, candidates: [], kept: [{ name: 'wt-kept', code: 'merged_new_commits' }], scanned: 1,
+      }), { status: 200 }))
+      if (u.includes('/prune-run')) {
+        runBody = init?.body ? JSON.parse(String(init.body)) : null
+        return Promise.resolve(new Response(JSON.stringify({ ok: true, total: 1 }), { status: 200 }))
+      }
+      if (u.includes('/prune-status')) {
+        // Backend tracks the forced item: it is in total/items and done bumps.
+        return Promise.resolve(new Response(JSON.stringify({
+          running: false, total: 1, done: 1, current: null,
+          results: [{ name: 'wt-kept', ok: true }],
+          items: { 'wt-kept': { status: 'done', error: null } },
+        }), { status: 200 }))
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Prune merged'))
+    await waitFor(() => expect(screen.getByText('Prune worktrees')).toBeInTheDocument())
+    // Check the force-override box on the kept row, then remove + confirm.
+    fireEvent.click(screen.getByLabelText('Force remove wt-kept'))
+    fireEvent.click(screen.getByText('Remove selected'))
+    fireEvent.click(await screen.findByText('Delete anyway'))
+    // The forced worktree is tracked as its own checklist row and finishes done.
+    await waitFor(() => expect(screen.getByTestId('prune-item-wt-kept')).toHaveAttribute('data-status', 'done'), { timeout: 8000 })
+    // Counter reads 1/1 (not 1/0) and completion is the success state.
+    expect(screen.getByText((_, el) => el?.textContent === 'Finished 1/1')).toBeInTheDocument()
+    expect(screen.getByText('Prune complete')).toBeInTheDocument()
+    // Success toast (green), not the red "Prune: 0 failed".
+    expect(screen.getByText('Pruned 1 worktree(s)')).toBeInTheDocument()
+    expect(screen.queryByText(/Prune: \d+ failed/)).not.toBeInTheDocument()
+    // The forced name went out in force_names, not the regular names list.
+    expect(runBody).toEqual({ names: [], force_names: ['wt-kept'] })
+  }, 15000)
+
   it('refetches the fleet with fresh=1 once a prune finishes', async () => {
     // The backend serves /fleet from a stale-while-revalidate cache, so a plain
     // refetch after a prune returns the PRE-prune snapshot and the removed rows


### PR DESCRIPTION
## Problem / Motivation

Force-overriding a **kept** worktree in Dev Fleet (checking the override box on a kept row with no regular candidate selected) shows two wrong things:

1. The progress counter reads `Pruning 0/1` (correct), then flips to `0/0`, then `1/0` — an impossible fraction where the numerator exceeds the denominator.
2. On completion the toast is a red `Prune: 0 failed`, even though the forced worktree was actually removed successfully.

## Why it matters

Force-override is the path a user reaches for precisely when a worktree is stuck and won't prune normally. Reporting a successful removal as a red failure (and showing a nonsensical `1/0` counter) makes the user think the operation failed and re-try or investigate a non-problem — undermining trust in the one action they use when things are already going wrong.

## What changed (motivation → approach → change)

**Root cause.** Forced worktrees are sent to the backend in a separate `force_names` argument, disjoint from the regular candidate `names`. In `_prune_run` (`src/kiro_crew/apps/builtins/dev_fleet/server.py`) the backend built `total`, the `items` map, and the `_prune_one` dispatch **from `names` only** — `force_names` was consulted solely inside `_prune_one` to set `is_forced`. So a force-only worktree (present in `force_names`, absent from `names`) was never dispatched, counted in `total`, or given an `items` row, while `done` was still bumped as it ran — producing the `1/0` counter. The frontend (`DevFleetPage.tsx` `pruneExecute`) seeded progress from the union `names ∪ forceNames` (hence the correct initial `0/1`) but then recomputed `total` and the `removed`/`failed` tallies over `names` only, driving both the counter glitch and the red `Prune: 0 failed` toast.

**Change.** Build the backend work list as the order-preserving union `list(dict.fromkeys([*names, *_force]))`, so `total` / `items` / `done` / dispatch all cover forced worktrees; `is_forced = nm in _force` still selects the verdict-recheck bypass, so forced items keep skipping the prunable recheck. The frontend poll loop and success tally now count over that same full set (`allNames`) instead of `names` alone.

## Tests

- `test_prune_run_processes_force_only_names` — a force-only request (`names=[]`, `force_names={"wt-kept"}`) is counted (`total==1`, `done==1`, `items=={wt-kept}`), removed, and skips the prunable verdict recheck. Fails on the pre-fix code (the item was never in `total`/`items`).
- `test_prune_run_unions_regular_and_forced_names` — a mixed batch processes the union: every name counted and removed once; only the non-forced names go through the prunable recheck.
- `DevFleetPage.test.tsx` — "force-only prune counts the forced worktree and reports success": drives the force-override checkbox + confirm, asserts the checklist row finishes `done`, the counter reads `Finished 1/1` (not `1/0`), and the toast is the green `Pruned 1 worktree(s)` (never the red `Prune: N failed`). Also asserts the request still sends `{ names: [], force_names: ['wt-kept'] }`.

## Manual verification

N/A — the fix is pure counting/dispatch logic covered by the new backend and frontend unit tests above.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the change is counting/dispatch logic and a comment reword; no component, layout, string, or styling changes — the same dialog and toast render, only with correct numbers and the success (green) variant.

## Related Issues

Fixes #4128
