### PR TITLE
fix(dashboard): stop the un-flushed tail duplicating persisted rows

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -34,6 +34,8 @@ from kiro_crew.dashboard.chat_auto_tag import maybe_auto_tag
 from kiro_crew.dashboard.chat_folders import _unhide_folder
 from kiro_crew.dashboard.chat_orchestrator import _stage_loop
 from kiro_crew.dashboard.chat_persistence import (
+    _FLUSH_SNAPSHOT_RETRIES,
+    _TRANSIENT_ROLES,
     COLOR_HEX_RE,
     _attach_variants,
     _rehydrate_slot_title,
@@ -74,6 +76,7 @@ from kiro_crew.dashboard.state import (
     _normalize_slot_key,
     is_stop_event_row,
     is_turn_interrupted,
+    parse_cls_meta,
     request_slot_origin,
 )
 from kiro_crew.dashboard.system_notices import SESSION_RELOAD_KIND, is_system_notice
@@ -1106,6 +1109,383 @@ async def api_chat_slot_summary_generate(request: web.Request) -> web.Response:
     )
 
 
+def _load_redacted(body: str) -> str:
+    """Apply the transcript redaction pair, in the one order the repo uses."""
+    redacted, _ = redact_exfiltration_urls(body)
+    redacted, _ = redact_credentials(redacted)
+    return redacted
+
+
+def _same_persisted_body(
+    disk_body: str, window_body: str, role: str, disk_ts: str = "", window_ts: str = ""
+) -> bool:
+    """True when *disk_body* is the persisted form of *window_body*.
+
+    A persisted row can differ from its window copy by exactly the redaction
+    transform, and EITHER side can be the redacted one, which is why the compare
+    applies it symmetrically. A restore redacts on load while keeping ``ts``
+    verbatim (``chat_persistence.py:708-709``), so the window holds the redacted
+    text; a save redacts every non-user role on the way out
+    (``chat_persistence.py:1282-1284``) while the window keeps it verbatim
+    (``state.py:2107``), so in a session that was never restored the DISK holds the
+    redacted text instead. Redacting one side only cannot converge on that second
+    pair — redacting an already-redacted body just reproduces it — so the row reads
+    as un-flushed and the persisted suffix is appended twice.
+
+    Applying the transform is also what separates a persisted row from a foreign
+    row that merely shares a ``ts``: on a coarse clock two writers flooring off the
+    same previous row both emit ``previous + 1µs`` (``history.py:1179-1219``), so
+    matching on ``ts`` alone treats an unrelated row as the window's own and drops
+    an un-flushed message from a response the client uses as a replacement.
+
+    Two bodies can redact to the same text while being different messages, so the
+    redaction-equivalent branch ALSO requires the stamps to match. That costs the
+    legitimate case nothing: this branch only ever fires for a row and its own
+    persisted copy, which differ by the transform precisely because one side was
+    redacted, and both the save and the load copy ``ts`` verbatim
+    (``chat_persistence.py:1288`` and ``:714``). A foreign row whose credential
+    merely redacts to the same text carries its own writer's stamp, so it no longer
+    consumes the window row.
+
+    The requirement is on this branch ALONE, which is why it does not reintroduce
+    the duplication above. A durable injection is byte-identical to its window row,
+    so it returns at the plain-equality check and never reaches here — and that pair
+    genuinely does carry different stamps, because the two writers mint
+    independently.
+    """
+    if disk_body == window_body:
+        return True
+    if role == "user":
+        return False
+    if disk_ts != window_ts:
+        return False
+    return _load_redacted(disk_body) == _load_redacted(window_body)
+
+
+#: Window rows a bounded read must NOT hand back. ``_TRANSIENT_ROLES`` documents
+#: itself as being about a window-region DISK line
+#: (``chat_persistence.py:1320-1322``) and ``chat_persistence.py:1571`` uses it that
+#: way. A bounded read answers a different question — which WINDOW rows does the
+#: client still need — and three of those roles are still needed. ``permission``:
+#: a pending approval is actionable and the client reads it out of the transcript,
+#: so dropping it hides the approval bar while the server is still waiting.
+#: ``chunk``/``streaming``: ``_prepare_messages`` does not discard a chunk run, it
+#: collapses one into a single ``streaming`` row, and that is the only way in-flight
+#: assistant text reaches this endpoint — the client filters raw ``chunk`` itself.
+#: ``done`` is discarded by ``_prepare_messages`` regardless, and ``queued`` stays
+#: listed because the client rebuilds those bubbles from the payload's ``queue``.
+_UNOWED_WINDOW_ROLES = _TRANSIENT_ROLES - {"permission", "chunk", "streaming"}
+
+
+def _is_answered_permission(m: dict) -> bool:
+    """True for a ``permission`` row whose approval has already been answered.
+
+    A permission row is never persisted, so it is always owed and therefore always
+    lands in the tail — i.e. after every row that DID reach disk. For a pending
+    approval that is the right place: it is the newest row, and nothing can follow
+    it because the agent is blocked waiting on it. An answered one is history, and
+    the agent has since produced turns that ARE on disk, so putting it in the tail
+    moves it after them and the rendered order no longer matches what happened.
+
+    The decision is written into the row's ``cls`` JSON in place
+    (``state.py`` ``_mark_permission_resolved``), which is also the only place the
+    stale-sweep and the slot resolver read it, so ``cls`` is the single source of
+    truth here. Truthiness rather than key presence mirrors the client's own
+    ``!meta.resolved`` test (``chatSlice.ts`` ``selectSlotPendingApproval``), so an
+    empty decision still counts as pending and an actionable approval is never lost.
+    """
+    if m.get("role") != "permission":
+        return False
+    meta = parse_cls_meta(m.get("cls", "")) or {}
+    return bool(meta.get("resolved"))
+
+
+def _snapshot_slot_window(slot: "_ChatSlot") -> tuple[int, list[dict]]:
+    """Capture ``(_disk_older_count, window)`` as one internally consistent pair.
+
+    Call this on the EVENT LOOP where possible. The two reads have no ``await``
+    between them, so no loop-scheduled writer can land in the middle — and the
+    finalization that motivates this, ``chat_runner._flush_segment``, is a plain
+    ``def`` that is never handed to ``to_thread``, so it cannot interleave with a
+    loop capture. It assigns ``slot.messages = head`` and only then appends the
+    finalized assistant row, so a reader that lands between those two statements
+    sees a transient chunk-free window missing that row. A worker thread CAN land
+    there, which is why capturing inside the threaded scan is the weaker option.
+
+    From a thread the pair can still tear, so retry: a front trim bumps
+    ``_disk_older_count`` (state.py:2191-2200) between the reads, and a PRE-trim
+    window paired with a POST-trim count shortens ``window_disk``, hides the
+    trimmed rows' ids and re-appends rows the disk read already returned. A trim
+    is the only mutation that changes the window/count relationship, so read the
+    count, copy the window, then confirm the count is unchanged. ``slot._lock``
+    is an ``asyncio.Lock`` and cannot be acquired from a thread, so this mirrors
+    the bounded re-read ``_save_slot_to_history`` uses for the same race
+    (chat_persistence.py:1711-1722).
+    """
+    for _ in range(_FLUSH_SNAPSHOT_RETRIES):
+        disk_older_count = slot._disk_older_count
+        window = list(slot.messages)
+        if slot._disk_older_count == disk_older_count:
+            break
+    else:
+        disk_older_count = slot._disk_older_count
+        window = list(slot.messages)
+    return disk_older_count, window
+
+
+def _append_unflushed_tail(
+    slot: "_ChatSlot",
+    all_msgs: list[dict],
+    *,
+    snapshot: tuple[int, list[dict]] | None = None,
+) -> list[dict]:
+    """Append window messages that are not yet on disk to a chained disk read.
+
+    ``all_msgs`` is a disk read, so it omits transient roles while the window
+    retains them, and it spans any older sessions a chained read walks. Sizing the
+    tail by subtracting the two lengths therefore mixes units AND measures the
+    whole file: it both re-appends rows the disk read already returned and lets a
+    row from another writer consume a turn that is still owed.
+
+    Takes the window itself rather than a caller-supplied count, so a caller cannot
+    pass a length captured before an ``await``; the window can grow while a threaded
+    disk read is in flight. ``snapshot`` is the one safe way to supply it: a
+    ``(disk_older_count, window)`` PAIR from ``_snapshot_slot_window`` captured on
+    the event loop AFTER the disk read, which is consistent by construction and
+    cannot observe a mid-finalization window. Passing no snapshot falls back to
+    capturing inside this thread, which is weaker — see that helper.
+
+    Prefer message identity. A save copies each window row's ``meta.mid`` to disk,
+    so a window row whose id appears in the disk read is persisted. Rows written by
+    any other writer carry no id — ``ConversationLog.append`` persists no ``meta``
+    — so they cannot be mistaken for a flushed window row.
+
+    A disk read holding no ids at all needs a different boundary: a session
+    persisted before ids existed, or rows a durable injector appended without
+    going through a save. Walk the window and the disk read forward TOGETHER and
+    stop at the first row that is not accounted for. A row from another writer no
+    longer ENDS the run, which is what sizing the boundary as
+    ``len(all_msgs) - slot._disk_older_count`` did — that measures the whole file,
+    so a foreign append walked one row too far and dropped the owed turn. Both
+    estimators the slot already carries are wrong here for opposite reasons: that
+    subtraction over-counts, and ``_disk_window_len`` is not advanced by an
+    injector, so it under-counts and would re-append a persisted row.
+
+    The window is matched against the disk region as an ordered SUBSEQUENCE: a row
+    that does not match the window row under consideration is SKIPPED rather than
+    treated as the end of the window. The save is non-destructive against a
+    cross-process append and merges the preserved rows back in TIME order
+    (``_interleave_foreign_lines``), so the region can read
+    ``[window, foreign, window]`` and an unmatched row means "not mine", not "end of
+    window". Ending the run there leaves every persisted row after it in the tail,
+    which appends an already-persisted suffix a second time.
+
+    Skipping cannot pass over a row that should have matched: both sequences are
+    chronological — the save's merge preserves each side's internal order — so a
+    later window row's persisted copy cannot precede the current row's. It is also
+    bounded: the disk cursor only ever moves forward, so the scans total
+    O(window + region), and the first window row with no match anywhere in the
+    remaining region ends the walk, which is the genuine end of the flushed prefix.
+
+    A row matches on role plus content, compared through the redaction transform
+    on both sides (``_same_persisted_body``). A shared ``ts`` is never SUFFICIENT —
+    on a coarse clock two writers flooring off the same previous row both emit
+    ``previous + 1µs`` (``history.py:1179-1219``), so accepting it alone drops an
+    un-flushed message — but it is REQUIRED on the redaction-equivalent branch,
+    where the only legitimate pair is a row and its own copy and the stamp is
+    carried through verbatim.
+
+    Ids are counted over the on-disk WINDOW REGION only,
+    ``all_msgs[slot._disk_older_count:]``. The rows before that are the frozen prefix
+    — on-disk rows older than the window, so none of them is in ``slot.messages``.
+    Counting them would let an occurrence that exists only in the prefix fund a match
+    for a window row that was never flushed, and the boundary would then walk past it.
+    The fallback below already starts its disk cursor at the same offset.
+
+    Id matching is selected only when EVERY row in that region carries a valid id, not
+    merely when some row does. A durable injection is written by two writers — the
+    window copy through ``slot.append``, where an id is minted, and the durable copy
+    through ``append_if_absent``, which persists no ``meta`` at all — so the region can
+    legitimately hold a MIX. Choosing id matching on the strength of one id-carrying
+    row then applies it to a row that structurally cannot match, which reads as
+    un-flushed and appends the injection a second time. A mixed region belongs on the
+    ordered path, which compares the fields both writers do record.
+
+    Ids are matched as a MULTISET, one disk occurrence consumed per window row, not
+    as a set. ``meta`` on an inbound message is caller-supplied and an id is minted
+    only when one is *absent*, so a caller can post the same id twice. A set then
+    matches EVERY window row carrying that id, so the boundary walks past a row that
+    was never persisted and the response omits it — the silent-loss direction. One
+    disk row is enough for that; two disk rows sharing an id are not required.
+    Consuming an occurrence bounds the match to as many rows as really reached disk,
+    and the earliest window row is the persisted one because flushes follow window
+    order.
+
+    Only string ids are matched. A truthy non-string ``mid`` survives to disk for the
+    same caller-supplied reason and would raise ``TypeError`` if hashed.
+
+    The id path selects the owed rows by MEMBERSHIP rather than by a prefix
+    boundary. A boundary assumes every persisted row precedes every un-flushed one.
+    When it does not, a later match moves the boundary past an un-flushed row and
+    the response omits it — a drop, which is worse than the duplication this
+    function exists to prevent. Ending the walk at the first miss is not the
+    remedy either: a transient row is dropped by the save and so can never match,
+    and stopping there re-appends every persisted row after it. Rows the client does
+    not need are skipped outright (``_UNOWED_WINDOW_ROLES``), so selecting by
+    membership cannot surface one the boundary happened to exclude; a pending
+    ``permission`` row is deliberately not among them. Because an id in
+    the disk window region proves that row reached disk, the owed set is simply the
+    rows whose id did not, kept in window order. Where the persisted rows really
+    are a prefix this returns the same answer, so it is a strict generalisation.
+    """
+    if snapshot is None:
+        snapshot = _snapshot_slot_window(slot)
+    disk_older_count, window = snapshot
+    window_disk = all_msgs[disk_older_count:]
+    disk_mid_positions: dict[str, list[int]] = {}
+    every_row_has_an_id = bool(window_disk)
+    for i, m in enumerate(window_disk):
+        meta = m.get("meta")
+        mid = meta.get("mid") if isinstance(meta, dict) else None
+        if isinstance(mid, str) and mid:
+            disk_mid_positions.setdefault(mid, []).append(i)
+        else:
+            every_row_has_an_id = False
+    tail: list[dict]
+    if every_row_has_an_id:
+        # Membership, not a prefix boundary: see the docstring for why neither a
+        # boundary nor a break-on-miss is correct here.
+        #
+        # Owed rows are MERGED at their window position, not concatenated after the
+        # whole disk slice. Window order is authoritative and a persisted row can
+        # sit LATER in it than an owed one: _flush_segment pulls a stop_event out of
+        # the trailing chunk run and re-appends it AFTER the finalized assistant row
+        # (chat_runner.py:2686-2687), so a stop that reached disk during streaming
+        # follows a reply that is still owed. Appending owed rows last renders that
+        # pair inverted -- stop before the reply it belongs to.
+        #
+        # Every row here carries an id, so the position is derivable without the
+        # body matching the other arm needs. Persisted rows keep their disk order
+        # and none is dropped; each owed row is only INSERTED before the disk row of
+        # the next window row that reached disk, so this is additive.
+        owed_before: dict[int, list[dict]] = {}
+        pending: list[dict] = []
+        for m in window:
+            if m.get("role", "assistant") in _UNOWED_WINDOW_ROLES:
+                continue
+            if _is_answered_permission(m):
+                continue
+            meta = m.get("meta")
+            mid = meta.get("mid") if isinstance(meta, dict) else None
+            positions = disk_mid_positions.get(mid) if isinstance(mid, str) else None
+            if positions:
+                at = positions.pop(0)
+                if pending:
+                    owed_before.setdefault(at, []).extend(pending)
+                    pending = []
+                continue
+            pending.append(m)
+        if not owed_before and not pending:
+            return all_msgs
+        merged: list[dict] = list(all_msgs[:disk_older_count])
+        for i, m in enumerate(window_disk):
+            merged.extend(owed_before.get(i, ()))
+            merged.append(m)
+        merged.extend(pending)
+        return merged
+    else:
+        start = 0
+        d = min(disk_older_count, len(all_msgs))
+        # An owed row is one the disk slice does not already carry, and this arm walks
+        # the WHOLE window so that a single owed row cannot strand the rows behind it.
+        # There are two ways to be owed, and both route to ``owed_rows``:
+        #
+        #   1. A TRANSIENT role. A disk read omits transient roles entirely, so such a
+        #      row can NEVER be matched and is ALWAYS owed. Only ``_UNOWED_WINDOW_ROLES``
+        #      (``done``/``queued``) and an already-answered ``permission`` are genuinely
+        #      not owed.
+        #   2. A non-transient row the forward scan does not find on disk. This used to
+        #      ``break`` the loop outright, which left ``start`` pointing AT the unmatched
+        #      row, so ``window[start:]`` re-emitted every LATER window row -- including
+        #      rows already on disk. With a stop_event flushed before reply finalization
+        #      (``_flush_segment`` re-appends the stop AFTER the finalized assistant row,
+        #      see the note at the top of this function) the window reads
+        #      ``[... unflushed reply, flushed stop]``: the reply missed, the loop broke,
+        #      and the persisted stop came back a second time and out of order -- the
+        #      very duplication this function exists to remove.
+        #
+        # The sibling id-carrying arm above already has the right rule, so mirror it
+        # rather than inventing a second one: an unmatched row is held, a later match
+        # flushes what is held at ITS disk position, and leftovers stay in the tail.
+        # That keeps owed rows in window order instead of after the whole disk slice.
+        #
+        # Nothing is emitted twice: ``start`` only advances on a match, and a match flushes
+        # ``owed_rows`` first, so every flushed row had an index below ``start``. Whatever
+        # is left over sits at or after ``start`` and is carried by the trailing slice --
+        # but that slice needs the unowed/answered exclusions applied to it as well, for
+        # the reason recorded at the slice itself.
+        owed_at: dict[int, list[dict]] = {}
+        owed_rows: list[dict] = []
+        for i, m in enumerate(window):
+            role = m.get("role", "assistant")
+            if role in _TRANSIENT_ROLES:
+                if role not in _UNOWED_WINDOW_ROLES and not _is_answered_permission(m):
+                    owed_rows.append(m)
+                continue
+            body = m.get("content", "")
+            probe = d
+            while probe < len(all_msgs):
+                row = all_msgs[probe]
+                if row.get("role", "assistant") == role and _same_persisted_body(
+                    row.get("content", ""),
+                    body,
+                    role,
+                    row.get("ts", ""),
+                    m.get("ts", ""),
+                ):
+                    break
+                probe += 1
+            if probe >= len(all_msgs):
+                owed_rows.append(m)
+                continue
+            if owed_rows:
+                owed_at.setdefault(probe, []).extend(owed_rows)
+                owed_rows = []
+            d = probe + 1
+            start = i + 1
+        # ``start`` does NOT advance past an unowed row: such a row takes the
+        # ``_TRANSIENT_ROLES`` branch above, is correctly kept out of ``owed_rows`` by the
+        # guard there, and then ``continue``s -- skipping ``start = i + 1``. So a raw
+        # ``window[start:]`` re-admits any unowed row that TRAILS the last match, and the
+        # exclusion the guard performed is undone. The sibling arm does not have this hole
+        # because it applies both exclusions at the TOP of its loop, so its leftovers can
+        # never hold one. Apply the same two exclusions here, which is what actually
+        # mirrors it.
+        #
+        # Two symptoms, one cause. A trailing ``done`` reaches the bounded response and
+        # ``_prepare_messages`` then drops it while rendering (``chat_utils.py``), so a
+        # page whose only row is that ``done`` renders EMPTY and replaces the transcript.
+        # A trailing answered ``permission`` is instead re-ordered after every persisted
+        # row -- the misordering ``_is_answered_permission`` exists to prevent.
+        #
+        # ``chunk``/``streaming`` and a still-PENDING ``permission`` are genuinely owed and
+        # MUST survive this filter; narrowing it further would be the opposite defect.
+        tail = [
+            m
+            for m in window[start:]
+            if m.get("role", "assistant") not in _UNOWED_WINDOW_ROLES
+            and not _is_answered_permission(m)
+        ]
+        if not owed_at and not tail:
+            return all_msgs
+        merged_idless: list[dict] = []
+        for idx, row in enumerate(all_msgs):
+            merged_idless.extend(owed_at.get(idx, ()))
+            merged_idless.append(row)
+        merged_idless.extend(tail)
+        return merged_idless
+
+
 async def api_chat_slot_detail(request: web.Request) -> web.Response:
     """GET /api/chat/slots/{slot} — message history for a slot.
 
@@ -1285,14 +1665,13 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
             logger.warning("read_messages_chained failed for %s", history_key, exc_info=True)
             all_msgs = []
         # Append any un-flushed in-memory tail messages beyond what's on disk.
-        # Use _disk_older_count to isolate current-session disk count, since
-        # chained disk includes older sessions that inflate disk_len.
-        mem_len = len(slot.messages)
-        disk_len = len(all_msgs)
-        current_session_disk = max(0, disk_len - slot._disk_older_count)
-        unflushed = mem_len - current_session_disk
-        if unflushed > 0:
-            all_msgs = list(all_msgs) + list(slot.messages[-unflushed:])
+        # Snapshot on the LOOP, after the disk read: the two reads inside the helper
+        # have no await between them, so a synchronous finalization cannot be caught
+        # half-done the way a worker thread can catch it.
+        tail_snapshot = _snapshot_slot_window(slot)
+        all_msgs = await asyncio.to_thread(
+            _append_unflushed_tail, slot, all_msgs, snapshot=tail_snapshot
+        )
         total = len(all_msgs)
         if before is not None:
             end = max(0, min(before, total))

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -1149,6 +1149,1079 @@ class TestSlotDetailPagination:
         assert "arrived mid-read" in contents, "message that landed during the await was dropped"
         assert contents == [f"msg {i}" for i in range(10)] + ["arrived mid-read"]
 
+    @pytest.mark.asyncio
+    async def test_transient_window_row_does_not_duplicate_the_tail(self, tmp_path, monkeypatch):
+        """A transient row in the window must not re-append rows already on disk.
+
+        A save drops transient roles, so the disk read holds only persisted rows
+        while the window holds both. Sizing the un-flushed tail by subtracting the
+        two lengths therefore counts each transient row as one missing message and
+        reaches that many rows too far back — rows the disk read already returned.
+
+        Here everything persisted is on disk, so the correct tail is empty. The
+        window carries one ``done`` row, which ``_prepare_messages`` drops from the
+        response, so a duplicated row is directly visible in the content sequence.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("dup")
+        log = state.conversation_log
+        for i in range(4):
+            log.append("dashboard:dup", "user", f"msg {i}")
+        slot.append("user", "msg 0")
+        slot.append("user", "msg 1")
+        slot.append("done", "")
+        slot.append("user", "msg 2")
+        slot.append("user", "msg 3")
+        slot.drain()
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/dup?limit=10")
+            assert resp.status == 200
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert contents == [f"msg {i}" for i in range(4)], (
+            "un-flushed tail sized by a length subtraction re-appended a persisted row"
+        )
+        assert data["total"] == 4
+
+    @pytest.mark.asyncio
+    async def test_genuinely_unflushed_tail_is_still_appended_once(self, tmp_path, monkeypatch):
+        """Control for the test above: a real un-flushed tail must still arrive.
+
+        Only the first two window rows reached disk, so the last two are owed to the
+        client. A transient row sits between them, so a fix that merely stopped
+        appending would pass the duplication test and fail this one.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("owed")
+        log = state.conversation_log
+        for i in range(2):
+            log.append("dashboard:owed", "user", f"msg {i}")
+        slot.append("user", "msg 0")
+        slot.append("user", "msg 1")
+        slot.append("done", "")
+        slot.append("user", "msg 2")
+        slot.append("user", "msg 3")
+        slot.drain()
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/owed?limit=10")
+            assert resp.status == 200
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert contents == [f"msg {i}" for i in range(4)], "un-flushed tail was dropped"
+
+    @pytest.mark.asyncio
+    async def test_foreign_disk_row_does_not_consume_the_unflushed_tail(
+        self, tmp_path, monkeypatch
+    ):
+        """A disk row absent from the window must not consume an owed turn.
+
+        This is the OVER-count direction. A writer other than this slot's own save
+        appends to the same transcript, so the chained disk read grows without any
+        window row having been flushed. Sizing the boundary as
+        ``len(all_msgs) - _disk_older_count`` therefore counts that foreign row as
+        one more persisted window row, walks one row too far, and drops the
+        genuinely un-flushed turn from a response the client uses as a replacement.
+        Under-count fails safe with an empty tail; over-count loses a message.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("overcount")
+        for i in range(3):
+            slot.append("user", f"msg {i}")
+        slot.drain()
+        # Persist through the real save path, so the disk rows carry the window's
+        # own message ids rather than a shape only a test helper produces.
+        _save_slot_to_history(state, slot, force=True)
+        # A writer that does not mirror into the window appends to the transcript.
+        state.conversation_log.append("dashboard:overcount", "assistant", "foreign row")
+        # A new turn arrives in memory and has not reached disk.
+        slot.append("user", "new turn")
+        slot.drain()
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/overcount?limit=10")
+            assert resp.status == 200
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert "new turn" in contents, f"over-count dropped the owed turn; got {contents}"
+
+    @pytest.mark.asyncio
+    async def test_non_string_message_id_does_not_crash_the_bounded_read(
+        self, tmp_path, monkeypatch
+    ):
+        """A caller-supplied non-string ``meta.mid`` must not turn the read into a 500.
+
+        ``meta`` on an inbound message comes from the HTTP caller and is checked
+        only for being a dict, so its values keep whatever type arrived. A truthy
+        non-string id is preserved rather than replaced, reaches disk, and is then
+        hashed by the boundary match, where a list raises ``TypeError``.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", AsyncMock())
+        state = _make_state(tmp_path)
+        state.get_or_create_slot("listmid")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "message": "hi",
+                    "slot": "listmid",
+                    "meta": {"mid": ["not-a-string"]},
+                },
+            )
+            assert resp.status == 200
+            slot = state.get_or_create_slot("listmid")
+            slot.drain()
+            # The id must be on disk as well as in the window: the boundary match
+            # hashes both sides.
+            _save_slot_to_history(state, slot, force=True)
+            assert slot.messages[-1]["meta"]["mid"] == ["not-a-string"], (
+                "fixture no longer reproduces a non-string id"
+            )
+
+            resp = await client.get("/api/chat/slots/listmid?limit=10")
+            assert resp.status == 200, await resp.text()
+
+    @pytest.mark.asyncio
+    async def test_foreign_row_does_not_consume_the_tail_of_an_id_less_session(
+        self, tmp_path, monkeypatch
+    ):
+        """The same over-count, on a session whose disk rows carry no message ids.
+
+        The id match cannot help here: a session persisted before ids existed has
+        none on disk, so the boundary falls back to counting. Sizing it as
+        ``len(all_msgs) - _disk_older_count`` measures the whole file rather than
+        this slot's own persisted rows, so a row appended by any other writer is
+        counted as one more flushed window row and the owed turn is dropped.
+
+        ``_disk_window_len`` is how many window rows are on disk, which is the
+        quantity the subtraction was approximating, and a foreign append does not
+        move it.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("legacy")
+        log = state.conversation_log
+        # ConversationLog.append writes role/content/ts only, so these rows reach
+        # disk with no ids -- what a pre-id session looks like.
+        for i in range(3):
+            log.append("dashboard:legacy", "user", f"msg {i}")
+        for i in range(3):
+            slot.append("user", f"msg {i}")
+        slot.drain()
+        # Mirror what the restore path leaves behind for such a session.
+        slot._disk_older_count = 0
+        slot._disk_window_len = len(slot.messages)
+        slot._dirty = False
+        # A writer that does not mirror into the window appends to the transcript.
+        log.append("dashboard:legacy", "assistant", "foreign row")
+        slot.append("user", "new turn")
+        slot.drain()
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/legacy?limit=10")
+            assert resp.status == 200
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert "new turn" in contents, f"over-count dropped the owed turn; got {contents}"
+        assert contents.count("msg 2") == 1, f"boundary walked short and duplicated; got {contents}"
+
+    def test_id_less_boundary_matches_a_row_redacted_on_load(self):
+        """A restored row keeps its ``ts`` verbatim but not always its content.
+
+        Restore redacts non-user content before it enters the window while the disk
+        row stays raw, so matching on content alone ends the run at that row and
+        re-appends everything from there — rows the disk read already returned.
+
+        The pair is taken from the REAL redactor rather than written by hand: an
+        invented pair passes for the wrong reason, because a stamp match would carry
+        it even when the transform would not.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+        from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+        raw = "AKIAIOSFODNN7EXAMPLE"
+        loaded, _ = redact_exfiltration_urls(raw)
+        loaded, _ = redact_credentials(loaded)
+        assert loaded != raw, "fixture no longer exercises a real redaction"
+
+        all_msgs = [
+            {"role": "user", "content": "ask", "ts": "t1"},
+            {"role": "assistant", "content": raw, "ts": "t2"},
+        ]
+        slot = SimpleNamespace(
+            messages=[
+                {"role": "user", "content": "ask", "ts": "t1"},
+                {"role": "assistant", "content": loaded, "ts": "t2"},
+                {"role": "user", "content": "new turn", "ts": "t3"},
+            ],
+            _disk_older_count=0,
+        )
+
+        out = _append_unflushed_tail(slot, all_msgs)  # type: ignore[arg-type]
+
+        assert [m["content"] for m in out] == ["ask", raw, "new turn"], (
+            "a row whose content was redacted on load was treated as un-flushed"
+        )
+
+    def test_shared_stamp_foreign_row_does_not_swallow_an_unflushed_row(self):
+        """A foreign row sharing a ``ts`` must not be accepted as the window's own.
+
+        On a coarse clock two writers flooring off the same previous row both emit
+        ``previous + 1µs`` (``history.py:1179-1219``), so a foreign disk row and an
+        un-flushed window row of the SAME role can carry an identical stamp while
+        holding different messages. Accepting a stamp match on its own then treats
+        the foreign row as the window row, the boundary advances past the un-flushed
+        one, and the bounded response omits it — from a payload the client uses to
+        REPLACE its transcript, so the message is simply gone from view.
+
+        Content is the discriminator: these two rows differ by more than the load
+        redaction, so nothing may match them.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        collided = "2026-08-18T12:00:00.000001+00:00"
+        all_msgs = [
+            {"role": "user", "content": "q", "ts": "2026-08-18T12:00:00+00:00"},
+            {"role": "assistant", "content": "another writer's row", "ts": collided},
+        ]
+        slot = SimpleNamespace(
+            messages=[
+                {"role": "user", "content": "q", "ts": "2026-08-18T12:00:00+00:00"},
+                {"role": "assistant", "content": "owed reply", "ts": collided},
+            ],
+            _disk_older_count=0,
+        )
+        assert all_msgs[1]["ts"] == slot.messages[1]["ts"], "fixture lost the collision"
+        assert all_msgs[1]["role"] == slot.messages[1]["role"], "fixture lost same-role"
+
+        out = _append_unflushed_tail(slot, all_msgs)  # type: ignore[arg-type]
+
+        assert "owed reply" in [m["content"] for m in out], (
+            f"a shared stamp swallowed the un-flushed row; got {[m['content'] for m in out]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_repeated_caller_supplied_id_does_not_hide_an_unflushed_row(
+        self, tmp_path, monkeypatch
+    ):
+        """A caller may repeat ``meta.mid``, and a set membership test over-reaches.
+
+        ``meta`` on an inbound message is caller-supplied and an id is minted only
+        when one is *absent*, so a client can post the same id twice. The first row
+        reaches disk; the second is still only in the window. Testing membership
+        against a *set* of disk ids matches both window rows, so the boundary walks
+        past the row that was never persisted and the bounded read omits it — the
+        silent-loss direction. One disk row is enough to reproduce it; two disk rows
+        sharing an id are not required.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", AsyncMock())
+        state = _make_state(tmp_path)
+        state.get_or_create_slot("dupmid")
+        dup = "m-deadbeefdeadbeef"
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={"message": "first", "slot": "dupmid", "meta": {"mid": dup}},
+            )
+            assert resp.status == 200
+            slot = state.get_or_create_slot("dupmid")
+            slot.drain()
+            # Only the first row reaches disk, so the id is on disk exactly once.
+            _save_slot_to_history(state, slot, force=True)
+
+            resp = await client.post(
+                "/api/chat",
+                json={"message": "second", "slot": "dupmid", "meta": {"mid": dup}},
+            )
+            assert resp.status == 200
+            slot.drain()
+            mids = [
+                m["meta"].get("mid")
+                for m in slot.messages
+                if isinstance(m.get("meta"), dict)
+            ]
+            assert mids.count(dup) == 2, (
+                f"fixture no longer reproduces a repeated id; got {mids}"
+            )
+
+            resp = await client.get("/api/chat/slots/dupmid?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert "second" in contents, f"a repeated id hid the un-flushed row; got {contents}"
+        assert contents.count("first") == 1, f"a row was duplicated; got {contents}"
+
+    def test_frozen_prefix_id_does_not_fund_a_window_match(self):
+        """An id occurrence in the frozen prefix must not count as a flushed window row.
+
+        ``all_msgs[:_disk_older_count]`` is the frozen prefix — on-disk rows OLDER
+        than the window, so none of them is in ``slot.messages``. Counting ids over
+        the whole disk read lets such an occurrence fund a consumption for a window
+        row that was never flushed, and the boundary then walks past it. Only the
+        on-disk window region, ``all_msgs[_disk_older_count:]``, may fund a match.
+
+        Reachable because a caller-supplied ``mid`` is preserved rather than re-minted
+        (``state.py:1801-1803``), which is what lets a redelivered row carry an id
+        whose original has since been paged into the prefix.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        dup = "m-deadbeefdeadbeef"
+        all_msgs = [
+            {"role": "user", "content": "paged out", "ts": "t0", "meta": {"mid": dup}},
+            {"role": "user", "content": "on disk", "ts": "t1", "meta": {"mid": "m-window1"}},
+        ]
+        slot = SimpleNamespace(
+            messages=[
+                {"role": "user", "content": "on disk", "ts": "t1", "meta": {"mid": "m-window1"}},
+                {"role": "user", "content": "owed turn", "ts": "t2", "meta": {"mid": dup}},
+            ],
+            _disk_older_count=1,
+        )
+        # Guard the fixture: with no frozen prefix this case cannot arise at all and
+        # the test would pass against the defect.
+        assert slot._disk_older_count > 0, "fixture establishes no frozen prefix"
+
+        out = _append_unflushed_tail(slot, all_msgs)  # type: ignore[arg-type]
+
+        assert [m["content"] for m in out] == ["paged out", "on disk", "owed turn"], (
+            "a frozen-prefix id funded a match and hid the owed turn"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mixed_id_and_id_less_disk_window_does_not_duplicate_an_injection(
+        self, tmp_path, monkeypatch
+    ):
+        """A disk window holding BOTH id-carrying and id-less rows must not duplicate.
+
+        A durable injection is written twice by design: ``slot.append`` puts it in the
+        window, where an id is minted, and ``append_if_absent`` persists the durable
+        copy with no ``meta`` at all (``history.py:2204-2245`` delegates to ``append``,
+        which has no ``meta`` parameter). When that durable copy lands before the next
+        slot save, the disk window holds earlier saved rows WITH ids plus this row
+        WITHOUT one.
+
+        Selecting id matching because SOME row carries an id then applies it to a row
+        that structurally cannot match, so the injection is treated as un-flushed and
+        appended a second time. Id matching is only sound when EVERY row in the disk
+        window carries one; a mixed window belongs on the ordered path, which matches
+        the fields both writers do record.
+
+        Driven through the real writers rather than a hand-built mixed window, so it
+        cannot encode a row shape neither writer emits.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("mixed")
+        key = "dashboard:mixed"
+
+        slot.append("user", "q1")
+        slot.append("assistant", "a1")
+        slot.drain()
+        # Real save: these disk rows carry the window's own ids.
+        _save_slot_to_history(state, slot, force=True)
+
+        # The injector shape: window copy (id minted) plus durable copy (no meta).
+        slot.append("assistant", "injected result")
+        slot.drain()
+        state.conversation_log.append_if_absent(key, "assistant", "injected result")
+
+        disk = state.conversation_log.read_messages_chained(key)
+        with_id = [
+            m
+            for m in disk
+            if isinstance(m.get("meta"), dict) and isinstance(m["meta"].get("mid"), str)
+        ]
+        without_id = [
+            m
+            for m in disk
+            if not (
+                isinstance(m.get("meta"), dict) and isinstance(m["meta"].get("mid"), str)
+            )
+        ]
+        assert with_id and without_id, (
+            f"fixture did not produce a MIXED disk window; "
+            f"with_id={len(with_id)} without_id={len(without_id)}"
+        )
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/mixed?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert contents.count("injected result") == 1, (
+            f"the durable injection was appended twice; got {contents}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_interleaved_foreign_row_does_not_duplicate_the_persisted_suffix(
+        self, tmp_path, monkeypatch
+    ):
+        """A foreign row BETWEEN two window rows must not end the ordered scan.
+
+        The save is non-destructive against a cross-process append: it preserves
+        rows another writer added and merges them back in TIME order
+        (``_interleave_foreign_lines``, ``chat_persistence.py:1337-1357``, whose
+        docstring notes such rows "genuinely happened BETWEEN the window's turns").
+        So the on-disk window region can read ``[window, foreign, window]``.
+
+        An unmatched row there means "not mine", not "end of window". Stopping at it
+        leaves every persisted row after it in the tail, and those rows are appended
+        a second time — duplication of an already-persisted suffix.
+
+        Built through the real save path so the interleave is produced by the code
+        that really orders these rows, and guarded so it cannot pass vacuously if no
+        interleave occurs.
+
+        The window timestamps are set EXPLICITLY, far apart, rather than left to the
+        clock. The foreign row takes its real "now" and must sort strictly between
+        them. With three clock-minted timestamps the test is platform-fragile: on a
+        coarse-clock platform the foreign append and the second window row land in
+        the same tick, and a shared ``ts`` carried by exactly one unmatched window
+        entry and one unmatched disk line is the save's UNAMBIGUOUS in-place-edit
+        case (``chat_persistence.py:1573-1587``), so the foreign row is dropped and
+        the interleave never happens. Do not collapse these back to clock defaults.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("interleave")
+        key = "dashboard:interleave"
+
+        slot.append("user", "w1", ts="2020-01-01T00:00:00.000000+00:00")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        # Another writer appends between saves; its ts is "now", between the two
+        # window rows below, so the merge must place it in the middle.
+        state.conversation_log.append(key, "assistant", "foreign row")
+
+        slot.append("user", "w2", ts="2030-01-01T00:00:00.000000+00:00")
+        slot.drain()
+        # This save preserves the foreign row and merges it back in time order.
+        _save_slot_to_history(state, slot, force=True)
+
+        disk = [m.get("content") for m in state.conversation_log.read_messages_chained(key)]
+        assert disk == ["w1", "foreign row", "w2"], (
+            f"fixture did not interleave the foreign row mid-window; disk={disk}"
+        )
+
+        # A genuinely un-flushed turn after the interleave.
+        slot.append("user", "w3", ts="2030-01-02T00:00:00.000000+00:00")
+        slot.drain()
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/interleave?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert contents.count("w2") == 1, (
+            f"the persisted suffix after the foreign row was duplicated; got {contents}"
+        )
+        assert "w3" in contents, f"the un-flushed turn was dropped; got {contents}"
+
+    @pytest.mark.asyncio
+    async def test_save_redacted_row_does_not_duplicate_the_persisted_suffix(
+        self, tmp_path, monkeypatch
+    ):
+        """A row the SAVE redacted must still match its raw window copy.
+
+        The redaction is asymmetric in a session that was never restored. The save
+        redacts every non-user role (``chat_persistence.py:1282-1284``) while the
+        window keeps the text verbatim (``state.py:2107``), so the disk side is
+        redacted and the window side is raw. Redacting only the disk side cannot
+        converge on that pair, because redacting an already-redacted body just
+        reproduces it. The row then reads as un-flushed, the walk stops, and the
+        persisted suffix is appended a second time.
+
+        Driven through the real writers, and the fixture asserts both preconditions
+        first: the disk window region is MIXED, which is what selects the ordered
+        path, and the two sides genuinely differ by the redaction transform.
+        """
+        from kiro_crew.dashboard.chat_persistence import (
+            _save_slot_to_history,
+            redact_credentials,
+            redact_exfiltration_urls,
+        )
+
+        secret = "key AKIAIOSFODNN7EXAMPLE here"
+        redacted, _ = redact_exfiltration_urls(secret)
+        redacted, _ = redact_credentials(redacted)
+        assert redacted != secret, "fixture needs content the real redactor changes"
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("redactdup")
+        key = "dashboard:redactdup"
+
+        # Explicit stamps, far apart, so the foreign row's real "now" sorts
+        # strictly between them and can equal neither. On a coarse-clock platform
+        # (Windows ticks in ~15.6 ms steps) clock-minted stamps put the foreign
+        # append and the second window row in the same tick, and a ``ts`` carried
+        # by exactly one unmatched window entry and one unmatched disk line is the
+        # save's UNAMBIGUOUS in-place-edit case, so the second save DROPS the
+        # foreign line and the region is no longer mixed. Do not collapse these
+        # back to clock defaults; the sibling interleave test pins them for the
+        # same reason.
+        slot.append("user", "q1", ts="2020-01-01T00:00:00.000000+00:00")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        # An id-less foreign row is what puts this region on the ordered path.
+        state.conversation_log.append(key, "assistant", "foreign row")
+
+        slot.append("assistant", secret, ts="2030-01-01T00:00:00.000000+00:00")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        disk = state.conversation_log.read_messages_chained(key)
+        has_id = [
+            isinstance(m.get("meta"), dict) and isinstance(m["meta"].get("mid"), str)
+            for m in disk
+        ]
+        assert any(has_id) and not all(has_id), (
+            f"fixture did not produce a MIXED disk window, so the ordered path "
+            f"would not run; has_id={has_id}"
+        )
+        assert any(m["content"] == redacted for m in disk), (
+            f"fixture did not persist the redacted form; disk="
+            f"{[m['content'] for m in disk]}"
+        )
+        assert any(m.get("content") == secret for m in slot.messages), (
+            "fixture did not keep the window copy raw"
+        )
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/redactdup?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert sum(1 for c in contents if "REDACTED" in c) == 1, (
+            f"the save-redacted row was appended twice; got {contents}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_redaction_equal_foreign_row_does_not_consume_an_unflushed_row(
+        self, tmp_path, monkeypatch
+    ):
+        """Two DIFFERENT secrets redact alike; they must not be treated as one row.
+
+        The redaction-equivalent compare exists for one shape only: a row and its
+        own persisted copy, which differ by the transform because one side was
+        redacted on save or load. That pair always carries the SAME ``ts`` — the
+        save copies it verbatim (``chat_persistence.py:1288``) and so does the load
+        (``:714``). So requiring the stamps to match costs the legitimate case
+        nothing, and it stops a foreign row whose credential merely redacts to the
+        same text from being consumed as the window's own.
+
+        It cannot disturb a durable injection either: that pair is byte-identical,
+        so it returns at the plain-equality branch above and never reaches here.
+        """
+        from kiro_crew.dashboard.chat_persistence import (
+            _save_slot_to_history,
+            redact_credentials,
+            redact_exfiltration_urls,
+        )
+
+        def red(text: str) -> str:
+            out, _ = redact_exfiltration_urls(text)
+            out, _ = redact_credentials(out)
+            return out
+
+        # Two different credential KINDS rather than two near-identical keys: an
+        # access-key id and a labelled secret-key assignment redact to the same tag,
+        # so no second key-shaped literal is needed to make the bodies collide.
+        mine = "key AKIAIOSFODNN7EXAMPLE here"
+        theirs = "key aws_secret_access_key=x here"
+        assert mine != theirs, "fixture needs two DISTINCT bodies"
+        assert red(mine) == red(theirs) != mine, (
+            f"fixture needs two bodies that redact alike; got {red(mine)!r} vs {red(theirs)!r}"
+        )
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("redconflate")
+        key = "dashboard:redconflate"
+
+        slot.append("user", "q1", ts="2020-01-01T00:00:00.000000+00:00")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        # A foreign, id-less row carrying a DIFFERENT secret. Id-less is what puts
+        # this region on the ordered path.
+        state.conversation_log.append(key, "assistant", theirs)
+
+        # Our own un-flushed row, never saved, with a stamp that cannot collide.
+        slot.append("assistant", mine, ts="2030-01-01T00:00:00.000000+00:00")
+        slot.drain()
+
+        disk = state.conversation_log.read_messages_chained(key)
+        has_id = [
+            isinstance(m.get("meta"), dict) and isinstance(m["meta"].get("mid"), str)
+            for m in disk
+        ]
+        assert any(has_id) and not all(has_id), (
+            f"fixture did not produce a MIXED disk window, so the ordered path "
+            f"would not run; has_id={has_id}"
+        )
+        assert not any(m.get("content") == mine for m in disk), (
+            "fixture expects our row to be un-flushed"
+        )
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/redconflate?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert sum(1 for c in contents if "REDACTED" in c) == 2, (
+            f"a foreign row that merely redacts alike consumed the un-flushed row; "
+            f"got {contents}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bounded_read_runs_the_tail_match_off_the_event_loop(
+        self, tmp_path, monkeypatch
+    ):
+        """The tail match must not run on the event loop.
+
+        It walks the whole window against the whole disk window region and applies
+        the redaction transform to both sides of every candidate compare, so on a
+        large mixed or id-less history the cost is real. Running it inline blocks
+        every other request on the loop, and the loop-stall watchdog treats a long
+        enough block as a hung gateway. The disk read immediately above it already
+        goes through ``asyncio.to_thread``; this makes the pair consistent.
+        """
+        import threading
+
+        import kiro_crew.dashboard.chat_handlers as ch
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("offloop")
+        slot.append("user", "q1")
+        slot.append("assistant", "a1")
+        slot.drain()
+
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+        original = ch._append_unflushed_tail
+
+        def spy(*args, **kwargs):
+            seen["thread"] = threading.get_ident()
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(ch, "_append_unflushed_tail", spy)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/offloop?limit=10")
+            assert resp.status == 200, await resp.text()
+
+        assert "thread" in seen, (
+            "the tail match never ran, so this test asserts nothing -- the request "
+            "did not reach it"
+        )
+        assert seen["thread"] != loop_thread, (
+            "the tail match ran on the event loop thread; it must be dispatched to a "
+            "worker so a large history cannot stall the loop"
+        )
+
+    @pytest.mark.asyncio
+    async def test_interleaved_unmatched_row_is_not_dropped_by_the_id_walk(
+        self, tmp_path, monkeypatch
+    ):
+        """An un-flushed row BEFORE a persisted one must still reach the response.
+
+        The id walk used to record a prefix boundary: on a match it set
+        ``start = i + 1``, and a miss simply did not advance. So an un-flushed row
+        followed by a matching row had the boundary moved PAST it, and the bounded
+        response omitted it entirely — a drop, not a duplicate.
+
+        Identity does not need a prefix. An id present in the disk window region
+        proves that row reached disk, so the owed set is the rows whose id did NOT,
+        taken in window order. That is a strict generalisation: when the persisted
+        rows really are a prefix it gives the same answer.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("interleaveid")
+        key = "dashboard:interleaveid"
+
+        slot.append("user", "q1")
+        slot.append("assistant", "a1")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        disk = state.conversation_log.read_messages_chained(key)
+        disk_mids = {
+            m["meta"]["mid"]
+            for m in disk
+            if isinstance(m.get("meta"), dict) and isinstance(m["meta"].get("mid"), str)
+        }
+        assert len(disk_mids) == len(disk) and disk, (
+            f"fixture needs EVERY disk row to carry an id so the id walk runs; "
+            f"disk={len(disk)} mids={len(disk_mids)}"
+        )
+
+        # An un-flushed assistant row positioned BEFORE the already-persisted one.
+        owed = {
+            "role": "assistant",
+            "content": "owed-turn",
+            "cls": "msg msg-a",
+            "ts": "2026-08-18T21:00:00+00:00",
+            "meta": {"mid": "m-owedneverpersist"},
+        }
+        slot.messages.insert(1, owed)
+        assert owed["meta"]["mid"] not in disk_mids, "fixture row must be un-persisted"
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/interleaveid?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert "owed-turn" in contents, (
+            f"the un-flushed row before a persisted row was dropped; got {contents}"
+        )
+        assert contents.count("a1") == 1, (
+            f"the persisted row was duplicated; got {contents}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_transient_window_row_does_not_truncate_the_id_prefix(
+        self, tmp_path, monkeypatch
+    ):
+        """A transient row mid-window must not push persisted rows into the tail.
+
+        Negative control for the test above. Transient roles are dropped by the
+        save, and ``queued`` is outside ``_WIRE_ONLY_ROLES`` so it still gets an id
+        minted — an id that can never appear on disk. Ending the walk at the first
+        miss would therefore stop at this row and re-append every persisted row
+        after it, which is the duplication this change exists to prevent.
+
+        Driven through the real writers.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("transid")
+        key = "dashboard:transid"
+
+        slot.append("user", "q1")
+        slot.append("queued", "queued-notice")
+        slot.append("assistant", "a1")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        disk = state.conversation_log.read_messages_chained(key)
+        assert [m.get("content") for m in disk] == ["q1", "a1"], (
+            f"fixture expects the save to drop the transient row; disk="
+            f"{[m.get('content') for m in disk]}"
+        )
+        queued = [m for m in slot.messages if m.get("role") == "queued"]
+        assert queued and isinstance(queued[0].get("meta"), dict), (
+            "fixture expects the queued row to carry a minted id"
+        )
+        assert isinstance(queued[0]["meta"].get("mid"), str), (
+            "fixture expects a string mid on the queued row"
+        )
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/transid?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        contents = [m["content"] for m in data["messages"]]
+        assert contents == ["q1", "a1"], (
+            f"a transient row truncated the id prefix and duplicated a persisted "
+            f"row; got {contents}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pending_approval_survives_a_bounded_read(self, tmp_path, monkeypatch):
+        """A live ``permission`` row must reach the bounded response.
+
+        ``_TRANSIENT_ROLES`` documents itself as being about a *window-region disk
+        line* (``chat_persistence.py:1320-1322``), and that is how
+        ``chat_persistence.py:1571`` uses it. The owed-set loop applies it to
+        in-memory ``slot.messages`` instead, which answers a different question:
+        which rows does the client still need? A pending approval is actionable, and
+        the client reads it straight out of the transcript
+        (``chatSlice.ts`` ``selectSlotPendingApproval``), so dropping it makes the
+        approval bar vanish while the server is still waiting on an answer.
+
+        Skipping it also bought nothing: ``permission`` is never persisted
+        (``chat_persistence.py:1274`` returns ``None`` for it), so it can never have
+        a disk counterpart for the id dedup to match.
+
+        Single delivery is safe because the client REPLACES its transcript from this
+        payload (``chatSlice.ts`` ``state.messages = next``) rather than appending,
+        so returning the row once cannot double it.
+        """
+        import json as _json
+
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("perm")
+        key = "dashboard:perm"
+
+        slot.append("user", "q1")
+        slot.append("assistant", "a1")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        # Same call shape the runner uses: the approval metadata rides in ``cls``.
+        slot.append("permission", "Run a shell command?", _json.dumps({"request_id": "req-1"}))
+        slot.drain()
+
+        disk = state.conversation_log.read_messages_chained(key)
+        mids = [
+            m["meta"]["mid"]
+            for m in disk
+            if isinstance(m.get("meta"), dict) and isinstance(m["meta"].get("mid"), str)
+        ]
+        assert disk and len(mids) == len(disk), (
+            f"fixture needs EVERY disk row to carry an id so the owed-set loop runs; "
+            f"disk={len(disk)} mids={len(mids)}"
+        )
+        assert not any(m.get("role") == "permission" for m in disk), (
+            "fixture expects the permission row to be un-persisted"
+        )
+        assert any(m.get("role") == "permission" for m in slot.messages), (
+            "fixture expects the permission row in the window"
+        )
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/perm?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        roles = [m["role"] for m in data["messages"]]
+        assert roles.count("permission") == 1, (
+            f"the pending approval prompt was dropped or duplicated; roles={roles}"
+        )
+        contents = [m["content"] for m in data["messages"]]
+        assert contents.count("a1") == 1, (
+            f"a persisted row was duplicated; got {contents}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolved_permission_is_not_appended_after_later_turns(
+        self, tmp_path, monkeypatch
+    ):
+        """A RESOLVED approval must not be re-appended after later persisted rows.
+
+        ``permission`` is never persisted (``chat_persistence.py:1274`` returns
+        ``None``), so a permission row in the window is ALWAYS owed. For a pending
+        one that is right — it is the last row, and the client needs it. A resolved
+        one is historical: the agent has continued past it and those later turns
+        have reached disk, so putting it in the tail moves it AFTER them and the
+        rendered order is wrong.
+
+        Resolution is an in-place edit of the row's ``cls`` JSON
+        (``state.py`` ``_mark_permission_resolved``), so the row stays in the window
+        and its position cannot distinguish it.
+        """
+        import json as _json
+
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("permdone")
+        key = "dashboard:permdone"
+
+        slot.append("user", "q1")
+        slot.append("permission", "Run a shell command?", _json.dumps({"request_id": "req-1"}))
+        slot.mark_permission_resolved("req-1", "approved")
+        slot.append("assistant", "a1")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        disk = state.conversation_log.read_messages_chained(key)
+        mids = [
+            m["meta"]["mid"]
+            for m in disk
+            if isinstance(m.get("meta"), dict) and isinstance(m["meta"].get("mid"), str)
+        ]
+        assert disk and len(mids) == len(disk), (
+            f"fixture needs EVERY disk row to carry an id so the owed-set loop runs; "
+            f"disk={len(disk)} mids={len(mids)}"
+        )
+        assert not any(m.get("role") == "permission" for m in disk), (
+            "fixture expects the permission row to be un-persisted"
+        )
+        window_roles = [m.get("role") for m in slot.messages]
+        assert "permission" in window_roles, "fixture expects the permission row in the window"
+        assert window_roles.index("permission") < window_roles.index("assistant"), (
+            f"fixture expects the approval to sit BEFORE the later turn; {window_roles}"
+        )
+        perm = next(m for m in slot.messages if m.get("role") == "permission")
+        assert _json.loads(perm["cls"]).get("resolved") == "approved", (
+            "fixture expects the permission row to be marked resolved"
+        )
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/permdone?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        roles = [m["role"] for m in data["messages"]]
+        assert roles == ["user", "assistant"], (
+            f"a resolved approval was re-appended after later persisted rows, "
+            f"corrupting transcript order; roles={roles}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_live_chunk_row_survives_a_bounded_read(self, tmp_path, monkeypatch):
+        """A live ``chunk`` row must reach the bounded response.
+
+        ``_prepare_messages`` does not discard chunk rows, it ACCUMULATES them and
+        emits one ``streaming`` row (``chat_utils.py:1651-1660``). That is the only
+        way in-flight assistant text reaches the client through this endpoint,
+        because the client filters raw ``chunk`` itself (``chatSlice.ts``
+        ``SKIP_ROLES``). So skipping chunk rows in the owed set does not merely omit
+        noise — it destroys the partial answer.
+
+        Driven through the real producer's call shape (``chat_runner.py:3784``).
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("livechunk")
+        key = "dashboard:livechunk"
+
+        slot.append("user", "q1")
+        slot.append("assistant", "a1")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        partial = "partial answer so far"
+        slot.append("chunk", partial, "chunk")
+
+        disk = state.conversation_log.read_messages_chained(key)
+        has_id = [
+            isinstance(m.get("meta"), dict) and isinstance(m["meta"].get("mid"), str)
+            for m in disk
+        ]
+        assert has_id and all(has_id), (
+            f"fixture needs every disk row to carry an id so the owed-set path "
+            f"runs; has_id={has_id}"
+        )
+        assert not any(m.get("content") == partial for m in disk), (
+            "fixture expects the chunk row to be un-persisted"
+        )
+        assert any(m.get("role") == "chunk" for m in slot.messages), (
+            "fixture expects the chunk row to be in the window"
+        )
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/livechunk?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        streamed = [m["content"] for m in data["messages"] if m.get("role") == "streaming"]
+        assert streamed == [partial], (
+            f"the live partial answer was dropped by the bounded read; "
+            f"streaming rows={streamed}"
+        )
+
+    def test_window_snapshot_survives_a_trim_between_the_two_reads(self):
+        """A trim landing mid-snapshot must not duplicate a persisted row.
+
+        The scan runs in a worker thread, so an event-loop append can trim the
+        front of the window and bump ``_disk_older_count``
+        (``state.py:2191-2200``) while the snapshot is being taken. Pairing a
+        PRE-trim window with a POST-trim count shortens ``window_disk``, hides the
+        trimmed rows' ids, and re-appends rows the disk read already returned.
+
+        ``slot._lock`` is an ``asyncio.Lock`` and cannot be taken from this thread,
+        so the fix is the bounded re-read ``_save_slot_to_history`` already uses
+        (``chat_persistence.py:1711-1722``).
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        all_msgs = [
+            {"role": "user", "content": "q1", "ts": "t1", "meta": {"mid": "m1"}},
+            {"role": "assistant", "content": "a1", "ts": "t2", "meta": {"mid": "m2"}},
+            {"role": "user", "content": "q2", "ts": "t3", "meta": {"mid": "m3"}},
+        ]
+
+        class TrimOnCopy(list):
+            """Fires ONE trim after a copy has read every element."""
+
+            def __init__(self, items):
+                super().__init__(items)
+                self.owner = None
+                self.fired = False
+
+            def __iter__(self):
+                snapshot = list(super().__iter__())
+                yield from snapshot
+                if not self.fired:
+                    self.fired = True
+                    del self[:2]
+                    self.owner._disk_older_count += 2
+
+        window = TrimOnCopy(
+            [
+                {"role": "user", "content": "q1", "ts": "t1", "meta": {"mid": "m1"}},
+                {"role": "assistant", "content": "a1", "ts": "t2", "meta": {"mid": "m2"}},
+                {"role": "user", "content": "q2", "ts": "t3", "meta": {"mid": "m3"}},
+                {"role": "assistant", "content": "owed", "ts": "t4"},
+            ]
+        )
+        slot = SimpleNamespace(messages=window, _disk_older_count=0)
+        window.owner = slot
+
+        out = _append_unflushed_tail(slot, all_msgs)  # type: ignore[arg-type]
+
+        assert window.fired, "fixture never fired the trim, so nothing was raced"
+        contents = [m["content"] for m in out]
+        assert contents.count("q1") == 1 and contents.count("a1") == 1, (
+            f"a trim between the two snapshot reads duplicated a persisted row; "
+            f"got {contents}"
+        )
+
 
 # ── History persistence and disk fallback ──
 
@@ -15153,4 +16226,470 @@ class TestCloseBroadcastDurability:
         )
         assert calls.index("remove") < calls.index("sync"), (
             f"active-slot set published before the session teardown: {calls}"
+        )
+
+
+class TestUnflushedTailOrderingAndSnapshot:
+    """The owed tail must land in window order, from a snapshot taken on the loop."""
+
+    @staticmethod
+    def _row(role: str, body: str, mid: str, ts: str) -> dict:
+        return {"role": role, "content": body, "cls": f"msg msg-{role[0]}", "ts": ts,
+                "meta": {"mid": mid}}
+
+    def test_owed_row_merges_at_its_window_position_not_after_the_disk_slice(self):
+        """A persisted row LATER in window order must not be rendered before an owed one.
+
+        ``_flush_segment`` pulls a ``stop_event`` out of the trailing chunk run and
+        re-appends it AFTER the finalized assistant row (chat_runner.py:2686-2687).
+        So a stop that reached disk during streaming sits, in window order, behind a
+        reply that is still owed. Concatenating the owed rows after the whole disk
+        slice therefore renders the pair inverted -- the stop card above the prose it
+        terminated.
+
+        Window order is authoritative and every row in this arm carries an id, so the
+        position is derivable without the body matching the other arm needs.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        q = self._row("user", "run it", "u1", "2026-08-19T10:00:00+00:00")
+        reply = self._row("assistant", "done", "a1", "2026-08-19T10:00:03+00:00")
+        stop = self._row("assistant", "stopped", "s1", "2026-08-19T10:00:02+00:00")
+
+        window = [q, reply, stop]
+        all_msgs = [q, stop]  # the reply has not been flushed yet
+        slot = SimpleNamespace(messages=window, _disk_older_count=0)
+
+        disk_mids = {m["meta"]["mid"] for m in all_msgs}
+        assert reply["meta"]["mid"] not in disk_mids, "fixture needs the reply un-persisted"
+        assert stop["meta"]["mid"] in disk_mids, "fixture needs the stop already on disk"
+        assert window.index(reply) < window.index(stop), (
+            "fixture must place the owed reply BEFORE the persisted stop, else there "
+            "is no inversion to detect"
+        )
+
+        out = _append_unflushed_tail(slot, all_msgs)  # type: ignore[arg-type]
+        bodies = [m["content"] for m in out]
+        assert bodies.count("stopped") == 1 and bodies.count("done") == 1, (
+            f"a row was dropped or duplicated; got {bodies}"
+        )
+        assert bodies.index("done") < bodies.index("stopped"), (
+            f"the persisted stop was rendered before the owed reply it follows in the "
+            f"window; got {bodies}"
+        )
+
+    def test_tail_with_no_inversion_still_appends_after_the_disk_slice(self):
+        """Negative control: with no inversion the result must be the old concatenation.
+
+        Fails for the intended reason if the merge reorders rows it should leave alone
+        -- every owed row here already follows every persisted one in window order, so
+        the answer must be exactly ``all_msgs + owed``.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        q = self._row("user", "run it", "u1", "2026-08-19T10:00:00+00:00")
+        stop = self._row("assistant", "stopped", "s1", "2026-08-19T10:00:02+00:00")
+        reply = self._row("assistant", "done", "a1", "2026-08-19T10:00:03+00:00")
+
+        all_msgs = [q, stop]
+        slot = SimpleNamespace(messages=[q, stop, reply], _disk_older_count=0)
+        out = _append_unflushed_tail(slot, all_msgs)  # type: ignore[arg-type]
+        assert out == [q, stop, reply], (
+            f"the no-inversion case must be untouched concatenation; got "
+            f"{[m['content'] for m in out]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_tail_snapshot_is_captured_on_the_loop_not_inside_the_worker(
+        self, tmp_path, monkeypatch
+    ):
+        """The window snapshot must be taken before the offload, not inside the thread.
+
+        ``_flush_segment`` assigns ``slot.messages = head`` and only THEN appends the
+        finalized assistant row, so between those two statements the window is a
+        transient chunk-free head missing that row. It is a plain ``def`` that is never
+        handed to ``to_thread``, so the event loop cannot interleave with it -- but the
+        threaded tail scan can land exactly there and snapshot the hole, and
+        ``_disk_older_count`` is untouched by that mutation so the bounded re-read
+        cannot detect it.
+
+        Simulated deterministically: the mutation is applied at the moment the worker
+        is entered. A snapshot captured on the loop predates it and keeps the row; one
+        taken inside the worker sees the hole and drops the row from the response.
+        """
+        import kiro_crew.dashboard.chat_handlers as ch
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("loopsnap")
+        key = "dashboard:loopsnap"
+
+        slot.append("user", "q1")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+        disk = state.conversation_log.read_messages_chained(key)
+        disk_mids = {
+            m["meta"]["mid"]
+            for m in disk
+            if isinstance(m.get("meta"), dict) and isinstance(m["meta"].get("mid"), str)
+        }
+        assert disk and len(disk_mids) == len(disk), (
+            f"fixture needs every disk row to carry an id so the id arm runs; "
+            f"disk={len(disk)} mids={len(disk_mids)}"
+        )
+
+        owed = {
+            "role": "assistant",
+            "content": "finalized-reply",
+            "cls": "msg msg-a",
+            "ts": "2026-08-19T10:00:03+00:00",
+            "meta": {"mid": "m-finalizedneverpersisted"},
+        }
+        slot.messages.append(owed)
+        assert owed["meta"]["mid"] not in disk_mids, "fixture row must be un-persisted"
+
+        original = ch._append_unflushed_tail
+        seen: dict[str, object] = {}
+
+        def worker_entered(slot_arg, all_msgs_arg, **kwargs):
+            # The worker is now running. Reproduce the mid-finalization window: the
+            # finalized assistant row is not in slot.messages yet.
+            seen["snapshot_kwarg"] = "snapshot" in kwargs
+            slot_arg.messages = [
+                m for m in slot_arg.messages if m.get("content") != "finalized-reply"
+            ]
+            return original(slot_arg, all_msgs_arg, **kwargs)
+
+        monkeypatch.setattr(ch, "_append_unflushed_tail", worker_entered)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/loopsnap?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        assert seen.get("snapshot_kwarg") is not None, (
+            "the tail match never ran, so this test asserts nothing"
+        )
+        assert seen["snapshot_kwarg"] is True, (
+            "the caller did not pass a snapshot, so the window is still read inside "
+            "the worker thread where a mid-finalization window is observable"
+        )
+        contents = [m["content"] for m in data["messages"]]
+        assert "finalized-reply" in contents, (
+            f"the worker snapshotted the transient chunk-free window and dropped the "
+            f"finalized row; got {contents}"
+        )
+
+    @staticmethod
+    def _idless(role: str, body: str, ts: str, cls: str | None = None) -> dict:
+        """A row with NO ``meta.mid`` -- forces the id-less body-matching arm."""
+        r = {"role": role, "content": body, "ts": ts}
+        if cls is not None:
+            r["cls"] = cls
+        return r
+
+    def test_live_streamed_row_before_a_persisted_row_is_not_dropped(self):
+        """An owed transient row must survive the suffix boundary in the id-less arm.
+
+        The matcher skipped a transient row WITHOUT advancing ``start``; a later
+        persisted match then set ``start = i + 1``, moving the boundary PAST the skipped
+        row, and ``window[start:]`` excluded it. So a live streamed chunk sitting before
+        a persisted ``stop_event`` was dropped from the bounded response entirely.
+
+        A disk read omits transient roles, so such a row can never be matched and is
+        always owed -- which is precisely the rule the id-based arm already applies.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        q = self._idless("user", "run it", "2026-08-19T15:00:00+00:00")
+        chunk = self._idless("chunk", "partial an", "2026-08-19T15:00:01+00:00")
+        stop = self._idless("assistant", "stopped", "2026-08-19T15:00:02+00:00")
+
+        all_msgs = [q, stop]  # a disk read holds no transient rows
+        window = [q, chunk, stop]
+        assert not any("meta" in m for m in all_msgs), (
+            "fixture must be id-less, else the id arm runs and this asserts nothing"
+        )
+        assert window.index(chunk) < window.index(stop), (
+            "fixture must place the transient BEFORE the persisted row, else the "
+            "suffix boundary never moves past it"
+        )
+
+        slot = SimpleNamespace(messages=window, _disk_older_count=0)
+        out = _append_unflushed_tail(slot, all_msgs)  # type: ignore[arg-type]
+        bodies = [m["content"] for m in out]
+        assert "partial an" in bodies, (
+            f"the live streamed row was dropped by the suffix boundary; got {bodies}"
+        )
+        assert bodies.index("partial an") < bodies.index("stopped"), (
+            f"the owed transient must keep its window position ahead of the persisted "
+            f"row; got {bodies}"
+        )
+
+    def test_trailing_transient_row_is_emitted_exactly_once(self):
+        """Negative control for the merge: an owed transient must not be emitted twice.
+
+        Rows left in ``pending`` sit at or after ``start`` and are therefore already
+        carried by ``window[start:]``. Emitting them again as well would re-append a
+        live row -- the duplication class this change exists to avoid. Fails for the
+        intended reason if the merge and the suffix both claim the same row.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        q = self._idless("user", "run it", "2026-08-19T15:00:00+00:00")
+        stop = self._idless("assistant", "stopped", "2026-08-19T15:00:02+00:00")
+        chunk = self._idless("chunk", "partial an", "2026-08-19T15:00:03+00:00")
+
+        slot = SimpleNamespace(messages=[q, stop, chunk], _disk_older_count=0)
+        out = _append_unflushed_tail(slot, [q, stop])  # type: ignore[arg-type]
+        bodies = [m["content"] for m in out]
+        assert bodies.count("partial an") == 1, (
+            f"the trailing transient was emitted more than once; got {bodies}"
+        )
+        assert bodies == ["run it", "stopped", "partial an"], (
+            f"a transient already after the last match must stay where it was; got "
+            f"{bodies}"
+        )
+
+    def test_unowed_and_answered_rows_stay_excluded_from_the_idless_tail(self):
+        """Negative control: only genuinely owed transients may be merged.
+
+        ``done``/``queued`` are ``_UNOWED_WINDOW_ROLES`` and an answered ``permission``
+        has already been dispositioned, so neither is owed. Merging transients
+        unconditionally would re-append them, which is the same defect in the opposite
+        direction from the drop above. A still-pending permission IS owed, so it is
+        included -- that arm of the assertion is what stops the fix from over-narrowing
+        into a second drop.
+        """
+        import json
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        q = self._idless("user", "run it", "2026-08-19T15:00:00+00:00")
+        stop = self._idless("assistant", "stopped", "2026-08-19T15:00:02+00:00")
+        done = self._idless("done", "unowed-marker", "2026-08-19T15:00:01+00:00")
+        answered = self._idless(
+            "permission", "answered-approval", "2026-08-19T15:00:01+00:00",
+            cls=json.dumps({"resolved": "approve"}),
+        )
+        pending = self._idless(
+            "permission", "pending-approval", "2026-08-19T15:00:01+00:00",
+            cls=json.dumps({}),
+        )
+
+        for extra, body, owed in (
+            (done, "unowed-marker", False),
+            (answered, "answered-approval", False),
+            (pending, "pending-approval", True),
+        ):
+            slot = SimpleNamespace(messages=[q, extra, stop], _disk_older_count=0)
+            out = _append_unflushed_tail(slot, [q, stop])  # type: ignore[arg-type]
+            bodies = [m["content"] for m in out]
+            if owed:
+                assert body in bodies, (
+                    f"{extra['role']} row {body!r} is owed and must be merged; got "
+                    f"{bodies}"
+                )
+            else:
+                assert body not in bodies, (
+                    f"{extra['role']} row {body!r} is NOT owed and must not be "
+                    f"re-appended; got {bodies}"
+                )
+
+    def test_unmatched_row_does_not_strand_the_persisted_rows_behind_it(self):
+        """An owed row must not make the id-less arm re-emit later persisted rows.
+
+        The arm forward-scans the disk slice for each window row. When a row was NOT
+        found the loop used to ``break`` outright, which left ``start`` pointing AT that
+        row -- so ``window[start:]`` carried it AND every later window row, including
+        rows the disk slice already holds. Those came back a second time, and out of
+        order, which is the duplication this function exists to remove.
+
+        The reachable shape is a ``stop_event`` flushed before reply finalization:
+        ``_flush_segment`` re-appends the stop AFTER the finalized assistant row, so the
+        window reads ``[... unflushed reply, flushed stop]``. The reply misses, and on
+        the old code the persisted stop was emitted twice.
+
+        The sibling id-carrying arm already holds an unmatched row and keeps walking, so
+        this mirrors that rule rather than inventing a second one.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        q = self._idless("user", "run it", "2026-08-19T16:00:00+00:00")
+        reply = self._idless("assistant", "the reply", "2026-08-19T16:00:01+00:00")
+        stop = self._idless("assistant", "stopped", "2026-08-19T16:00:02+00:00")
+
+        # The reply is still owed; the stop already reached disk ahead of it.
+        all_msgs = [q, stop]
+        window = [q, reply, stop]
+        assert not any("meta" in m for m in all_msgs), (
+            "fixture must be id-less, else the id arm runs and this asserts nothing"
+        )
+        assert window.index(reply) < window.index(stop), (
+            "fixture must place the UNMATCHED row before the persisted one, else the "
+            "loop never abandons the rows behind it"
+        )
+        assert not any(m["content"] == "the reply" for m in all_msgs), (
+            "fixture must keep the reply off disk, else there is nothing unmatched"
+        )
+
+        slot = SimpleNamespace(messages=window, _disk_older_count=0)
+        out = _append_unflushed_tail(slot, all_msgs)  # type: ignore[arg-type]
+        bodies = [m["content"] for m in out]
+
+        assert bodies.count("stopped") == 1, (
+            f"the persisted stop was re-emitted because an earlier unmatched row "
+            f"abandoned the scan; got {bodies}"
+        )
+        assert bodies == ["run it", "the reply", "stopped"], (
+            f"output must follow window order with each row exactly once; got {bodies}"
+        )
+
+    def test_unmatched_row_is_still_emitted_and_not_dropped(self):
+        """Negative control: holding the unmatched row must not silently drop it.
+
+        The fix stops an unmatched row from stranding the rows behind it. The opposite
+        failure is just as silent -- discarding that row instead of retaining it would
+        also stop the duplicate, and would pass a test that only counted the persisted
+        row. So assert the owed row itself survives, in both the with-a-later-match and
+        no-later-match shapes.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        q = self._idless("user", "ask", "2026-08-19T16:10:00+00:00")
+        owed = self._idless("assistant", "owed body", "2026-08-19T16:10:01+00:00")
+        persisted = self._idless("assistant", "on disk", "2026-08-19T16:10:02+00:00")
+
+        # (a) a later row DOES match, so the owed row is flushed at that disk position
+        slot = SimpleNamespace(messages=[q, owed, persisted], _disk_older_count=0)
+        out = _append_unflushed_tail(slot, [q, persisted])  # type: ignore[arg-type]
+        bodies = [m["content"] for m in out]
+        assert bodies.count("owed body") == 1, (
+            f"the owed row must be retained exactly once, not dropped; got {bodies}"
+        )
+        assert bodies.index("owed body") < bodies.index("on disk"), (
+            f"the retained row must keep its window position; got {bodies}"
+        )
+
+        # (b) NO later row matches, so the owed row can only arrive via the tail
+        slot = SimpleNamespace(messages=[q, owed], _disk_older_count=0)
+        out = _append_unflushed_tail(slot, [q])  # type: ignore[arg-type]
+        bodies = [m["content"] for m in out]
+        assert bodies.count("owed body") == 1, (
+            f"with no later match the owed row must still be emitted once; got {bodies}"
+        )
+
+    def test_trailing_unowed_and_answered_rows_are_excluded_from_the_idless_tail(self):
+        """An unowed row in the LAST window position must not reach the tail.
+
+        ``start`` only advances on a match, and an unowed row takes the transient branch
+        and ``continue``s -- skipping ``start = i + 1``. So when such a row TRAILS the last
+        match, a raw ``window[start:]`` re-admits it and undoes the exclusion the loop's own
+        guard performed. The sibling id-carrying arm has no such hole because it applies
+        both exclusions at the top of its loop.
+
+        Two symptoms share that cause. A trailing ``done`` reaches the bounded response and
+        ``_prepare_messages`` drops it while rendering, so a page whose only row is that
+        ``done`` renders EMPTY and replaces the transcript. A trailing answered
+        ``permission`` is instead re-ordered after every persisted row.
+
+        The sibling test above puts the extra row in the MIDDLE, where the later match
+        advances ``start`` PAST it -- so the exclusion it observes comes from ``start``
+        overshooting, not from any filter, and it cannot see this defect. The whole body
+        list is asserted rather than mere membership, because membership alone cannot see a
+        mis-ordering.
+        """
+        import json
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        q = self._idless("user", "run it", "2026-08-20T04:00:00+00:00")
+        stop = self._idless("assistant", "stopped", "2026-08-20T04:00:01+00:00")
+        done = self._idless("done", "unowed-marker", "2026-08-20T04:00:02+00:00")
+        queued = self._idless("queued", "queued-marker", "2026-08-20T04:00:02+00:00")
+        answered = self._idless(
+            "permission",
+            "answered-approval",
+            "2026-08-20T04:00:02+00:00",
+            cls=json.dumps({"resolved": "approve"}),
+        )
+
+        for extra, body in (
+            (done, "unowed-marker"),
+            (queued, "queued-marker"),
+            (answered, "answered-approval"),
+        ):
+            window = [q, stop, extra]
+            assert window[-1] is extra, (
+                "fixture must place the unowed row LAST, else a later match advances "
+                "start past it and the assertion passes without a filter"
+            )
+            slot = SimpleNamespace(messages=window, _disk_older_count=0)
+            out = _append_unflushed_tail(slot, [q, stop])  # type: ignore[arg-type]
+            bodies = [m["content"] for m in out]
+            assert body not in bodies, (
+                f"trailing {extra['role']} row {body!r} was re-admitted by the unfiltered "
+                f"tail slice; got {bodies}"
+            )
+            assert bodies == ["run it", "stopped"], (
+                f"the bounded page must hold exactly the persisted rows in order; got "
+                f"{bodies}"
+            )
+
+    def test_trailing_owed_rows_survive_the_idless_tail_filter(self):
+        """Negative control: the tail filter must not over-narrow into a second drop.
+
+        ``_UNOWED_WINDOW_ROLES`` is ``{done, queued}`` -- ``chunk`` and ``streaming`` are
+        subtracted out, and a still-PENDING ``permission`` has not been dispositioned. All
+        three are genuinely owed: a disk read carries no transient row, so they can never be
+        matched, and dropping them loses a live streamed answer or an approval the user has
+        yet to answer. That is the opposite defect from the leak, and it is the one an
+        over-eager filter actually produces.
+        """
+        import json
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+
+        q = self._idless("user", "run it", "2026-08-20T04:10:00+00:00")
+        stop = self._idless("assistant", "stopped", "2026-08-20T04:10:01+00:00")
+        pending = self._idless(
+            "permission",
+            "pending-approval",
+            "2026-08-20T04:10:02+00:00",
+            cls=json.dumps({}),
+        )
+        chunk = self._idless("chunk", "partial an", "2026-08-20T04:10:02+00:00")
+
+        slot = SimpleNamespace(messages=[q, stop, pending], _disk_older_count=0)
+        out = _append_unflushed_tail(slot, [q, stop])  # type: ignore[arg-type]
+        bodies = [m["content"] for m in out]
+        assert bodies == ["run it", "stopped", "pending-approval"], (
+            f"a still-pending permission is owed and must survive the tail filter; got "
+            f"{bodies}"
+        )
+
+        slot = SimpleNamespace(messages=[q, stop, chunk], _disk_older_count=0)
+        out = _append_unflushed_tail(slot, [q, stop])  # type: ignore[arg-type]
+        bodies = [m["content"] for m in out]
+        assert bodies.count("partial an") == 1, (
+            f"a trailing live chunk is owed and must be emitted exactly once; got {bodies}"
+        )
+        assert bodies == ["run it", "stopped", "partial an"], (
+            f"the owed chunk must keep its trailing window position; got {bodies}"
         )


### PR DESCRIPTION
## Problem / Motivation

A bounded slot-detail request (`GET /api/chat/slots/{slot}?limit=N`) can return the same message twice. The client replaces its message list with this response, so the duplicate is what the user sees in the transcript.

The endpoint serves a bounded page by reading the slot's chained history from disk and then appending any window messages that have not been written yet. It sized that tail by subtracting the disk length from the in-memory window length. Those two numbers are not in the same unit. A save drops transient roles — `chunk`, `done`, `streaming`, `queued`, `permission` — so the disk read omits them while the window keeps them. Each transient row in the window therefore inflated the subtraction by one, the negative slice `slot.messages[-unflushed:]` reached that many rows too far back, and the rows it picked up were ones the disk read had already returned.

Every streamed assistant turn puts a `done` row in the window, so this fires on ordinary use rather than an edge case: any slot with streaming activity in its window can serve a duplicated page.

## Why it matters

The duplication is silent and it is on a read path, so nothing reports an error and nothing self-corrects. A user paginating back through a session sees repeated messages, and because the count of rows returned no longer matches the span the server consumed, the `next_before` cursor the client sends for the following page is computed against a page whose contents overlap the previous one.

The magnitude scales with how many transient rows sit in the window before the last persisted row, so a long streaming session degrades further rather than staying at one duplicate.

## What changed (motivation → approach → change)

Observed symptom: a bounded page returns a message the previous rows already contained. Root cause: the boundary between "already on disk" and "still only in memory" was derived by comparing two lengths counted in different units, so the boundary itself was wrong.

The fix stops deriving that boundary from a subtraction at all. `_append_unflushed_tail` now identifies persisted window rows by message id: a save copies each window row's `meta.mid` to disk, so a window row whose id appears in the disk read has been persisted, and the tail is everything after the last such row. Ids are matched as a multiset — one disk occurrence consumed per window row — because a caller can post a duplicate id and a plain set would then match a row that never reached disk; and they are counted over the on-disk window region only, `all_msgs[slot._disk_older_count:]`, so a row in the frozen prefix cannot fund a match. See the set-membership and frozen-prefix sections below. This closes the over-count direction and keeps the duplication fix, but it is not free of edges — see the known gap below. Transient rows carry no id and cannot inflate the boundary, which is the duplication above. Rows written to the same transcript by anything other than this slot's own save also carry no id, so they cannot be mistaken for a flushed window row and consume a turn that is still owed. Id matching is selected only when EVERY row in that region carries a valid id, because a durable injection puts an id-carrying copy in the window and an id-less copy on disk, so the region can legitimately be mixed. For the cases identity cannot serve — a region with no ids at all, which is what a session persisted before ids existed looks like, or a mixed region — the fallback matches the window against the disk region as an ordered subsequence, skipping rows only another writer put there rather than treating the first unmatched row as the end of the window. The subtraction is gone from both paths.

Two details worth calling out for a reviewer:

- It reuses the existing `_TRANSIENT_ROLES` constant in `chat_persistence.py` instead of introducing a second name for the same set. That constant is already documented as mirroring the save-time drop gate, and their membership is identical — verified by feeding every role through `_build_message_entry_uncached` and comparing the set it returns `None` for against the constant.
- It takes the slot and reads `slot.messages` itself rather than accepting a precomputed count. The disk read runs in a worker thread, so the window can grow across that `await`; a count captured beforehand would be stale by the time the tail is sliced.

Scope is deliberately one thing. Two adjacent improvements to the same handler are out of scope here: an in-memory fast path for bounded reads (follow-up #4134), and unblocking the slot-close broadcast, which is being raised as its own pull request rather than folded into a correctness fix.

## Tests

`test/test_dashboard_chat.py`, in `TestSlotDetailPagination`:

- **`test_transient_window_row_does_not_duplicate_the_tail`** — locks in the fix. A window of four persisted rows with one `done` row among them, all four already on disk, so the correct tail is empty. Asserts the exact returned content sequence. Against the previous expression this fails with `msg 3` returned twice:
  ```
  AssertionError: un-flushed tail sized by a length subtraction re-appended a persisted row
  assert ['msg 0', 'ms...g 3', 'msg 3'] == ['msg 0', 'ms...g 2', 'msg 3']
    Left contains one more item: 'msg 3'
  ```
  `done` is used because `_prepare_messages` drops it from the response, so the duplicate is visible directly in the content list rather than mixed in with a transient row.

- **`test_genuinely_unflushed_tail_is_still_appended_once`** — the negative control. Only the first two window rows reached disk, so the last two are genuinely owed to the client, and a transient row sits between them. This test passes both before and after, which is what makes the pair discriminating: a "fix" that simply stopped appending the tail would satisfy the first test and fail this one.

- **`test_foreign_disk_row_does_not_consume_the_unflushed_tail`** — the over-count direction. Three window rows are persisted through the real save path (so the disk rows carry the window's own ids), then a writer that does not mirror into the window appends one row to the same transcript, then a new turn arrives in memory. Against the previous expression that foreign row counts as a fourth persisted window row, the forward walk steps past the new turn, and the response comes back as `['msg 0', 'msg 1', 'msg 2', 'foreign row']` with the owed turn missing. It persists through `_save_slot_to_history` rather than writing disk rows by hand, because a hand-written disk row carries no id and so exercises a shape no real save produces.

- **`test_non_string_message_id_does_not_crash_the_bounded_read`** — a type guard. `meta` on an inbound message comes from the HTTP caller and is checked only for being a dict, so its values keep whatever type arrived, and an id is minted only when one is *absent* — a truthiness test, so a truthy non-string id is preserved deliberately (a row replayed from disk must keep its id). Posting `meta: {"mid": ["not-a-string"]}` therefore lands a list on disk, and hashing it returned `TypeError: unhashable type: 'list'` as an HTTP 500. Both sides of the match now require a string, following the same shape the pin loader already uses at `state.py:4973`.

- **`test_foreign_row_does_not_consume_the_tail_of_an_id_less_session`** — the same over-count on the id-less fallback, which the test above cannot reach because it persists through the real save path and so puts ids on disk. Here the disk rows are written by `ConversationLog.append`, which persists no `meta`, so the read carries no ids and the fallback runs. A foreign row is then appended and a new turn arrives in memory. Against the previous expression it fails with `AssertionError: over-count dropped the owed turn`, and it also asserts no row is duplicated, so a boundary that walks short fails it too.

- **`test_id_less_boundary_matches_a_row_redacted_on_load`** — a unit test on `_append_unflushed_tail` covering the half of the match that content equality cannot carry. Restore copies `ts` verbatim but redacts non-user content, so a persisted row can differ from its disk copy in content alone; matching on content only ends the run there and re-appends rows the disk read already returned.

- **`test_repeated_caller_supplied_id_does_not_hide_an_unflushed_row`** — drives the duplicate id directly rather than waiting for state to settle, which is what makes it discriminating: it posts an id, saves so that id is on disk exactly once, posts the SAME id again, and reads bounded. Against a set membership test it fails with `got ['first']` — the unflushed row is missing. It asserts the fixture still reproduces the duplicate (both window rows carry the id), so it fails loudly rather than passing vacuously if id preservation ever changes. A control that removes only the occurrence-consuming line restores set semantics and fails this test and nothing else.

- **`test_interleaved_foreign_row_does_not_duplicate_the_persisted_suffix`** — built through the real save path rather than a synthesised region: save a window row, let another writer append, save again so `_interleave_foreign_lines` merges that row in time order, then add an un-flushed turn. It asserts the disk really reads `['w1', 'foreign row', 'w2']` *before* asserting anything about the response, so a fixture that produced no interleave fails loudly instead of passing vacuously. Against the stop-at-first-divergence behaviour the response comes back `['w1', 'foreign row', 'w2', 'w2', 'w3']`.

  The window timestamps are set **explicitly** and far apart rather than left to the clock, and that is load-bearing rather than cosmetic. With all three stamps clock-minted the test was green on Linux and failed on `windows-latest` with `disk=['w1', 'w2']` — the foreign row gone. The cause is a coarse clock, not buffering or line endings: `monotonic_transcript_ts` (`history.py:1179-1219`) returns `previous + 1µs` when the clock has not advanced, and its own docstring cites Windows' ~15.6 ms steps. The slot floors against the same previous row (`state.py:1764-1771`), so on a coarse host BOTH writers independently derive `w1 + 1µs` and produce an identical `ts`. Pass 1 then resolves `w1` against itself, leaving exactly one unmatched window entry and exactly one unmatched disk line sharing that stamp — the save's UNAMBIGUOUS in-place-edit case (`chat_persistence.py:1573-1587`) — so the foreign row is dropped before any interleave can happen. Reproduced on Linux under a frozen clock: the clock-minted shape yields `['w1', 'w2']`, the explicit-stamp shape yields `['w1', 'foreign row', 'w2']`. The precondition self-check was kept, not relaxed, and the control that reverts the production skip still fails this test.

Full `test/test_dashboard_chat.py` passes at 601. The wider set of every test file touching `chat_handlers`, `/api/chat/slots/`, `_disk_older_count`, `_disk_window_len`, session transfer, persistence, channel slots, backfill, rewind, open-slot restore, resume, the cron/workflow injectors, foreign-append handling and history locking runs 4633 passed / 11 skipped / 0 failed. That set deliberately includes the restore and resume paths, which establish a non-zero frozen prefix (`test_rehydrate_slot_loads_full_500_message_window`, `test_resume_from_disk_sends_the_older_history_cursor`), the injector paths, which are the writers a mixed disk window comes from, and the history-locking suite that covers the cross-process append the interleave comes from. `isort`, `flake8` and `mypy` (the three blocking backend gates) are clean — mypy reports no issues across 982 source files.

One unrelated failure was seen and dismissed only after checking: `test_gateway_lock_diagnosis.py::test_flock_is_held_by_a_fork_orphan` (`assert 284433 == 1`) exercises `gateway_lock` / `platform_compat` flock and `/proc` identity, nothing this change touches. With both changed files stashed it fails identically on the unmodified commit, same pid and same assertion, and the stash restore was checksum-verified. It is a sandbox `/proc` reparenting artifact.

## Manual verification

N/A — the bug is observable purely through the endpoint's JSON response, which both tests assert on directly.

### Note on the failing Windows shard

`Backend Tests (Windows) (2)` was cancelled at its 40-minute cap (19:33:57Z -> 20:14:10Z) while every other job in the run succeeded. Progress reached `[ 99%]` at 19:52:17Z and then went silent for 22 minutes. It is a hang, not a failing assertion, and it is not caused by this change. The chain, measured rather than inferred:

- **A pre-existing test is borderline against the per-test timeout.** On PR #3998's *passing* Windows shard 2 the durations report reads `104.11s call test/test_design_tweak_backend.py::TestWhatIsWrittenStaysReadable::test_anything_the_writer_accepts_the_reader_returns`, against the shard's `--timeout=180`. That is 58% of the budget in one test, and 5x the next slowest at 20.59s. It grows a record 1000 bytes at a time and re-writes the *whole* record each iteration until the 2 MiB `MAX_RECORD_BYTES` ceiling refuses it, so it performs roughly 2091 cycles of `os.fsync` + `os.replace` + `os.path.exists` + `os.unlink` and writes about 2 GiB in total. It costs 8-9 s on Linux.
- **On this run it crossed the line and took a worker down with it.** `pytest-timeout` fired at 19:42:16Z, dumped every thread with that test on top of the MainThread stack, and the worker went `[gw1] node down: Not properly terminated`. xdist replaced it and finished the tests to 99%. The controller then wedged, and no per-test timeout applies to the controller, which is why nothing interrupted the remaining 22 minutes and no second stack dump appears. On PRs #3998, #4116 and #4000 that same test ran in the same Windows shard 2 with zero timeout banners and zero node-down lines, in about 11 minutes each.
- **This change's tests are not in the region that hung, and they shut down cleanly.** Within shard 2's ordering the two tests added here sit at positions 1275 and 1276 of 13037, about 9.8% in, immediately after the pre-existing `test_message_arriving_during_the_disk_read_is_not_dropped` which uses the same `TestClient`/`TestServer` pattern. The hang is at 99%, which in this ordering is `test_kiro_usage_api.py`. Run locally under `-n auto` with the 180 s timeout, the whole of `test/test_dashboard_chat.py` gives 579 passed in 5.25 s with no `node down` and no `crashed worker`; the two new tests alongside that neighbour give 3 passed in 3.92 s.
- **Nothing here is asynchronous, so nothing can be awaited.** This change adds zero and removes zero occurrences of `await`, `async def`, `asyncio.`, `Lock(`, `.acquire(`, `.join(`, `Event(` and `.wait(`; it replaces eight synchronous lines with a call to one synchronous helper. `_ChatSlot.drain()`, which the new tests call, is four synchronous lines that copy a list and *clear* an event, so it cannot be awaited and cannot block.
- **The shard split is not affected in a way that matters.** `pytest-split` reports `No test durations found` and splits evenly by collection index, so adding tests does shift later boundaries. Measured directly, the borderline test resolves to group 2 both with and without the two tests added here, and it is independently present in shard 2 on the three other pull requests above, so its shard membership is stable and not a consequence of this change.

Classification: an environment-level hang triggered by a pre-existing test that carries 58% of the per-test budget on Windows. The remedy is to re-run that single job, and separately to bring that test's Windows cost down; no commit here can clear it.

*Two earlier statements in this section were wrong and are corrected above. It previously said that test "exceeds the 180 s per-test timeout" on Windows as a general property — it does not, it takes 104.11 s and passes. And it presented that timeout as the hang itself — it is a recovered timeout at roughly 36% through the shard, whereas the 22-minute hang is in the controller after the worker died.*

### Note on the two failure directions

The `GPT 5.6 Review` lane raised the foreign-row case as blocking, and it was right. It is fixed here rather than argued with, and this note records the distinction so the next reader does not have to re-derive it, because two review lanes examined the opposite direction and passed.

The old boundary, `max(0, len(all_msgs) - slot._disk_older_count)`, can be wrong in either direction, and the two are not symmetric.

**Under-count** happens when the window holds rows a save drops. The tail is sized too large and the response repeats rows the disk read already returned. That is the duplication this pull request set out to fix, and it fails loudly: the user sees a doubled message.

**Over-count** happens when the disk read grows without any window row having been flushed — a row appended to the same transcript by anything other than this slot's own save. The boundary walks past rows that are genuinely still owed, and they are dropped from a response the client uses to *replace* its message list. That fails silently, and it loses a message rather than repeating one.

`slot._disk_older_count` is a snapshot: it is set when a session is restored or trimmed and is never recomputed while serving a request, whereas `len(all_msgs)` is read live from disk on every bounded page. Any growth in the second that the first does not account for becomes over-count.

Both directions are pre-existing rather than introduced here — the hunk this pull request removed derived the identical value from the identical two quantities, and reverting only the production change while keeping the new test reproduces the same dropped turn. Matching by message id removes the need for the subtraction on the primary path, and ordered row matching removes it on the id-less fallback, so both directions are closed on both paths.

**Second round: the same over-count on the id-less fallback.** The `GPT 5.6 Review` lane raised this against head `42e5c44a` and it was also right. The first round fixed the over-count only where the disk read carries ids; the fallback still sized the boundary as `len(all_msgs) - slot._disk_older_count`, so on a session whose disk rows have no ids a foreign append still walked one row too far and dropped the owed turn. Reproduced before fixing, in `test_foreign_row_does_not_consume_the_tail_of_an_id_less_session`: against the previous expression it fails with `AssertionError: over-count dropped the owed turn`, while the four tests from the first round still pass — so the new test isolates the fallback rather than re-testing the identity path.

The fallback matches the window against the disk region as an ordered subsequence, starting at `slot._disk_older_count`. A row matches on role plus content, where content is compared **after applying the load redaction** — `_same_persisted_body` takes the disk body, runs the transform a restore runs on non-user content (`chat_persistence.py:708-709`, mirrored byte-for-byte by `channel_slots._redact_assistant`, whose docstring notes one transcript cannot have two redaction policies), and compares that to the window body.

That replaced an earlier `content OR ts` predicate, and the reason is a real defect rather than tidying. `ts` was there to tolerate the restore case, where a persisted row's content legitimately differs from its window copy. But `ts` is not an identity: on a coarse clock two writers flooring off the same previous row both emit `previous + 1µs` (`history.py:1179-1219`, which names Windows' ~15.6 ms steps), so a foreign disk row and an un-flushed window row of the same role can carry an identical stamp while holding different messages. Accepting `ts` alone then treated the foreign row as the window's own, advanced the boundary past the un-flushed row, and omitted it from a payload the client uses to **replace** its transcript — the message simply disappears from view. Redaction-aware content comparison covers the restore case for the right reason and leaves genuinely different rows unmatched.

Pinned by `test_shared_stamp_foreign_row_does_not_swallow_an_unflushed_row`, which asserts the collision and the same-role precondition before asserting anything else; a control restoring the `ts` clause fails that test and nothing else.

Fixing this also exposed a fictional fixture, worth recording because it had been passing for the wrong reason. `test_id_less_boundary_matches_a_row_redacted_on_load` used a hand-written pair, `token=SECRET` on disk against `token=[redacted]` in the window. The real redactor leaves `token=SECRET` untouched, so that pair is not a redaction at all and the test only ever passed via the `ts` branch. It now derives both sides from the real redactor (`AKIAIOSFODNN7EXAMPLE` → `[REDACTED: credential]`) and asserts the transform actually changed the string, so it cannot drift back to fiction.

### Interleaved foreign rows — why the scan skips rather than stops

This walk originally stopped at the first unmatched row. That conflates two different conditions: "we have run off the end of the flushed window" and "this row is not one of mine". The disk region can genuinely contain rows of the second kind, sitting *between* rows of the window.

`chat_persistence.py:1411-1421` documents why: the save is non-destructive against a cross-process append. It captures its window snapshot *before* taking the session lock, so another process — the docstring names subagent, cron and CLI — can append and release in that gap; a bare `meta + frozen + window` replace would silently delete that acknowledged message, so those rows are preserved. They are then merged back in **time order** by `_interleave_foreign_lines` (`chat_persistence.py:1337-1357`), whose own docstring says such rows "genuinely happened BETWEEN the window's turns". So the on-disk window region really can read `[window, foreign, window]`.

Stopping there left every persisted row *after* the foreign row in the tail, and `_append_unflushed_tail` returns `list(all_msgs) + list(tail)` — so an already-persisted suffix was appended a second time. Measured end to end through the real save path in `test_interleaved_foreign_row_does_not_duplicate_the_persisted_suffix`: the response came back `['w1', 'foreign row', 'w2', 'w2', 'w3']`.

The scan now skips a row that does not match the window row under consideration. Two properties make that safe rather than merely lenient. It cannot pass over a row that should have matched, because both sequences are chronological — the save's merge preserves each side's internal order — so a later window row's persisted copy cannot precede the current row's. And it is bounded: the disk cursor only moves forward, so the scans total O(window + region), and the first window row with no match anywhere in the remaining region ends the walk, which is the genuine end of the flushed prefix rather than an arbitrary stop. The test asserts the fixture actually interleaved before asserting anything else, so it cannot pass vacuously if the timestamps tie; a control restoring the stop-at-first-divergence behaviour fails it and nothing else.

One correction to the finding as filed: the line it cites is a docstring line, not the expression. The expression it quotes was three lines below it.

### The set-membership finding: one half refuted, one half real

The `GPT 5.6 Review` lane raised `if isinstance(mid, str) and mid in disk_mids:` as "collapses valid repeated and non-string IDs", so a repeated id drops an unflushed row and a mixed-type id re-appends a persisted one. **An earlier revision of this description dismissed both halves. That was wrong about the repeated-id half, and the argument it used is corrected below.** The line numbers drift in every citation: the predicate was at `chat_handlers.py:1054` on head `42e5c44a` and `1068` on `1e71993b`, against cited 1051 and 1061.

**Message ids are server-minted but NOT server-enforced.** The only mint site is `state.py:1806-1807`, which produces `f"m-{uuid.uuid4().hex[:16]}"` — always a `str`, 64 bits of entropy. But minting is conditional: `state.py:1801-1803` mints only when an id is *absent*, and `state.py:1150-1153` gives the reason (a row replayed from disk must keep its id or a post-restart redelivery would not be recognisable). A posted id therefore survives verbatim — `chat_handlers.py:460` passes `meta=_redact_meta(user_meta)` into `slot.append`, and `_redact_meta` (`chat_utils.py:1276`) is `{k: _redact_value(v) for k, v in list(meta.items())}`, which has no allowlist and preserves the key set. Nothing uniquifies a caller-supplied `mid`.

**No product path supplies one.** The frontend builds the `POST /api/chat` `meta` explicitly at `ChatPage.tsx:3944-3952` from `files`, `dirs`, `pastes`, `knowledge`, `origin` and `sendId`; there is no `mid` key, and the comment above it states the echo carries "the server-minted `mid`". Every other non-test `mid:` in `website/src` is the pins API (`api/pins.ts`, `useChatPins.ts`), which reads a server id and posts to `/api/chat/pins`. Channel replay cannot supply one either: it forwards `meta` only when the disk row has a dict (`channel_slots.py:492`) and `ConversationLog.append` takes no `meta` parameter. `chat_fork.py:235` does copy source ids into a forked slot, but appends in source order, so it cannot place an on-disk id after an unflushed row.

**Repeated id — REAL, and fixed.** Reproduced through the endpoint, not argued: post `first` with `meta:{"mid":"m-deadbeefdeadbeef"}`, save, post `second` with the same id, then `GET ?limit=10` returns `['first']`. The unflushed row is gone from a response the client uses to *replace* its list. Only ONE disk row is needed — the lane's "two on-disk rows sharing one id" overstates the precondition.

The earlier argument for dismissing this was: the walk has no `break`, so it takes the last window row whose id is on disk, and since flushes follow window order the persisted rows are a prefix, so last-match equals the true boundary. **That silently assumed each id appears at most once in the window.** Drop the assumption and last-match-wins *is* the defect: the second row satisfies the same single set entry and drags the boundary past a row that was never persisted. The code's correctness rested on an unstated uniqueness invariant.

The fix counts disk occurrences and consumes one per matched window row, bounding the match to as many rows as really reached disk. Behaviour is unchanged in the unique case. A "break on the first miss" fix was rejected: `queued` and `permission` rows carry ids (they are in `_TRANSIENT_ROLES` but not `_WIRE_ONLY_ROLES`) and are never persisted, so an early break would stop at one and re-append everything after it.

**Non-string id — still refuted, still unfixed by design.** Reproducing it needs a literal `meta: {"mid": ["not-a-string"]}`, and the failure direction is the opposite of the lane's `crash-data-loss-corruption` anchor: an unmatched id means the persisted row is not recognised as flushed, so it is RE-APPENDED — a visible duplicate in one bounded read, not a silent loss. The `isinstance(mid, str)` guard on both sides is what makes that a duplicate instead of `TypeError: unhashable type: 'list'` as an HTTP 500, which is why it stays.

Reachability for both halves is still caller-controlled only, so neither is a live user-facing bug. The repeated-id fix is defence-in-depth that removes an unstated invariant, and it is cheap enough that arguing the reachability was the wrong trade.

### Frozen-prefix scoping — a regression this diff introduced, now fixed

The id counting was built over the WHOLE chained disk read, which includes `all_msgs[:slot._disk_older_count]` — the frozen prefix, meaning on-disk rows OLDER than the window, none of which is in `slot.messages`. An id occurrence existing only in that prefix therefore funded a consumption for a window row that was never flushed, the boundary walked past it, and the bounded response silently omitted a real message.

This one is worth naming as a regression rather than an inherited edge. At base the arithmetic was already scoped to the current session — `current_session_disk = max(0, disk_len - slot._disk_older_count)` — and no id matching existed at all. Introducing the identity path dropped that scoping. Two further pieces of evidence that this was an oversight and not a deliberate widening: the id-less fallback in the same function already starts its disk cursor at `min(slot._disk_older_count, len(all_msgs))`, so the two branches disagreed about where the window's on-disk region begins; and `chat_handlers.py:4158-4160` names `all_msgs[:_disk_older_count]` "the frozen prefix saves never rewrite".

The fix counts only `all_msgs[slot._disk_older_count:]`. It is a strict narrowing: `_disk_older_count` is `max(0, disk_total - len(window))` (`chat_handlers.py:4135`) and is "set at restore/resume, never drifts with new messages" (`chat_handlers.py:1152`), so the slice is exactly the on-disk window region, and a never-resumed slot has `_disk_older_count == 0`, which makes the slice the whole list and changes nothing in the common case. Narrowing can only reduce counts, so it can only move the boundary earlier — it can never turn a duplicate into a loss.

Why the existing tests missed it: all seven prior tests run with no frozen prefix (`_disk_older_count == 0`), so the duplicate-id case they exercised had both occurrences inside the current session, which the multiset already handled. `test_frozen_prefix_id_does_not_fund_a_window_match` covers the untested variant, and asserts the fixture establishes a non-zero prefix so it cannot pass vacuously against the defect. It fails before the narrowing with "a frozen-prefix id funded a match and hid the owed turn" and passes after; a control that reverts only the slice fails that test and nothing else.

**Known gap, measured rather than assumed.** Identity only helps where the disk row carries an id, and only this slot's own save writes one — `ConversationLog.append` has no id parameter at all. So a row that is mirrored into the window *and* written to the same transcript through that append path (a workflow or crew result) has an id in the window and none on disk. Where the disk read holds *no* ids at all this is now handled, because the ordered fallback matches on role plus content or `ts` rather than on an id. The gap that remains is the **mixed** case: a session with ids on disk from an earlier save *and* an injector-written row. There the identity walk runs, does not match that row, treats it as still owed, and re-appends it, so a bounded page duplicates it until the next flush rewrites the window with ids. The previous count-based boundary happened to get that case right. The trade is therefore a rare silent loss exchanged for a rarer, visible and self-healing duplicate; closing it properly means giving the append path a way to carry the window row's id.

### Mixed id and id-less disk window — the ALL vs ANY quantifier

A third blocking item, distinct from the two above and not a set-vs-multiset error: the gate that selected id matching was `if disk_mid_counts:`, which is truthy when ANY row in the disk window carries an id. That region can legitimately be MIXED, and the reachability is a fact about the two writers rather than about the matcher:

- `slot.append` mints an id for any role outside `_WIRE_ONLY_ROLES` (`state.py:1801-1807`).
- `ConversationLog.append_if_absent` (`history.py:2204-2245`) has no `meta` parameter and delegates to `append`, which has none either, so the durable copy reaches disk with no id at all.
- Both writers run for a single row by design. `cron_inject.py:142` and `workflow_inject.py:192` call `slot.append` and then `append_if_absent_off_loop`, and `workflow_inject.py`'s own comment states the periodic slot save "may serialize it to disk before this durable copy runs" — `append_if_absent` no-ops in that order. In the other order the durable copy lands first, id-less, alongside earlier saved rows that do carry ids.

Confirmed rather than reasoned: `test_mixed_id_and_id_less_disk_window_does_not_duplicate_an_injection` drives both real writers and asserts the disk window really is mixed before it asserts anything else, so it cannot pass on a fixture neither writer emits. That guard passes, and against the ANY gate the test then fails with "the durable injection was appended twice" — id matching is applied to a row that structurally cannot match, the row reads as un-flushed, and the injection is appended a second time.

The fix requires EVERY row in the disk window to carry a valid id before selecting id matching; a mixed region takes the ordered path, which compares role plus content or `ts` — fields both writers do record. A control reverting only the quantifier fails that test and nothing else, and all eight earlier boundary tests pass under both quantifiers, so this is not a behaviour change for any previously covered shape.

### Note on the advisory Design Review

Recorded rather than actioned. Its Watch items — the divergent flush-boundary estimators, the three copies of the load-redaction pipeline, and an `id` parameter on `ConversationLog.append` as the root fix — are all real and all deferred by design. The last of those is the write-side fix that would retire the content matching discussed above, which is why it is the one worth doing next. None is clearable inside this change, and the lane self-declares that it does not block merge.

### Why identity rather than the existing `_disk_window_len` boundary

A fair question, since the repo already has a flush boundary and already uses it for this same job — `slot.messages[slot._disk_window_len:]` at `session_transfer.py:771`. It would also be immune to the foreign row, because the save path maintains it rather than deriving it from `len(all_msgs)`. So this is a trade rather than a clear win, and it is worth naming the case it gets wrong.

That boundary can run **ahead** of the window it indexes. `session_transfer.py:688-694` documents the mechanism: the save sets `_disk_window_len = len(window)` over the *raw* window, streaming `chunk` rows included, and `_flush_segment` then reassigns `slot.messages` to drop that trailing chunk run and append the finalised assistant message without adjusting the boundary. When that happens the slice `slot.messages[_disk_window_len:]` silently yields nothing, so the un-flushed tail is dropped — the same loss this pull request is trying to prevent, arriving by a different route. `state.py:1453-1454` says as much where the field is declared: it is a trim watermark and "NOT a fragile 'what to append' counter".

The existing consumer handles that case by refusing: `session_transfer.py:695-699` raises `SnapshotUnstable("the persisted boundary is ahead of the resident window")`. A snapshot can abort and be retried. A `GET` on this read path cannot — it has to return a page — so refusing is not an option here, which is what makes the boundary usable there and not here. Identity has no equivalent staleness, because it is derived from the disk rows the request just read.

It also fails in the opposite direction, which was measured by actually substituting it for the id-less fallback rather than reasoned about. `_disk_window_len` is advanced only by the save path, so a row a durable injector wrote (`cron_inject.py:142`, `workflow_inject.py:192` — each calls `slot.append` *and* `append_if_absent_off_loop`) is on disk while the counter has not moved. Substituting it makes `test_transient_window_row_does_not_duplicate_the_tail` and `test_genuinely_unflushed_tail_is_still_appended_once` fail, because it under-counts and re-appends persisted rows — the duplication this pull request exists to fix. So both candidate counters are wrong for the id-less case for opposite reasons, which is why that path matches rows rather than counting them.

### Three sibling sites, checked and deliberately left alone

The same disk-count-plus-window-count shape appears elsewhere. Both were checked against whether they can reintroduce the duplication fixed here, and neither can, so both are follow-ups rather than scope for this change.

`chat_handlers.py:4132`, in `api_chat_slot_resume`, computes `next_before = _disk_older_count + (total - len(recent))`. The second term counts in-memory rows including transient ones while the first counts disk rows excluding them, so the cursor can read high and the following page can overlap rows already shown. That is a cursor defect on the same endpoint family, not a tail-append defect: it cannot duplicate or drop rows within a single response, and correcting it means changing what `api_chat_slot_resume` hands the client, which needs its own test.

`chat_rewind.py:131` computes `chained_len = disk_older + len(msgs)` and uses it only to validate an index (`raw_index >= chained_len`) and to word the 400 error. The same unit mix can make that ceiling read a shade high, so a just-out-of-range index could be accepted, but nothing here appends a tail, so no response can gain or lose a row.


`session_transfer.py:771` computes `new_msgs = slot.messages[slot._disk_window_len :]` and sizes the same un-flushed tail with `_disk_window_len` — the estimator this change rejects for exactly this job, for the reason given above. The mechanism reaches: `_disk_window_len` advances only on the save and load paths, so a durable injector writes its row to disk without moving it while the window copy grows `slot.messages`, and the slice then re-includes a row the disk read already returned. The `SnapshotUnstable` guard does not cover it. That guard reads `if slot._disk_window_len > len(slot.messages)` at `session_transfer.py:695`, which fires only when the boundary runs AHEAD of the window; the failure here is the boundary running BEHIND, which the guard cannot see. So this site is genuinely undeclared rather than defended, and it is a follow-up rather than scope here — correcting it changes what an exported bundle contains and needs its own test. Verified by reading the guard and the assignment sites; the duplicate is mechanism-verified, not observed, because the export path was not executed.

### Asymmetric redaction on the id-less path — fixed

`_same_persisted_body` redacted only the DISK side before comparing. That is right for one direction and wrong for the other, and the wrong one duplicates.

A restore redacts non-user content on load (`chat_persistence.py:708-709`), so after a restore the WINDOW holds the redacted text and the disk may hold raw — redacting the disk side converges. But a save also redacts every non-user role on the way out (`chat_persistence.py:1282-1284`) while the window keeps the text verbatim (`state.py:2107`), so in a session that was never restored the DISK holds the redacted text and the window holds raw. Redacting only the disk side cannot converge on that pair, because redacting an already-redacted body just reproduces it. The row then reads as un-flushed, the walk stops, and the persisted suffix is appended a second time.

Reproduced through the real writers rather than argued: with one id-less foreign row present to select the ordered path, a saved assistant row containing a credential came back **twice** — `['q1', 'foreign row', 'key [REDACTED: credential] here', 'key [REDACTED: credential] here']`. The reachability detail worth stating is that this only bites on the id-less fallback; an all-id window matches on `meta.mid` and never consults body text at all, which is why the first attempt at reproducing it showed nothing.

The fix compares both sides through the transform. The pair is idempotent on already-redacted text (measured), so the restore direction keeps working. The redaction sequence is now applied through one `_load_redacted` helper rather than inlined again, which is a small step toward the advisory Design lane's concern about that pipeline having several copies.

Honest residual: two bodies that redact to the same text now compare equal, so a distinct row differing only inside a redacted span can be consumed. Measured — two different 20-character AWS-style keys both redact to `[REDACTED: credential]` and do match. This is the same class as the content-equality residual below, it already applied in the restore direction under the old code, and it is far narrower than the duplication it removes, which fired for every redaction-sensitive row on this path.

New test `test_save_redacted_row_does_not_duplicate_the_persisted_suffix` drives the real writers and asserts three preconditions before asserting the outcome: the disk window region is genuinely mixed, the disk side really is the redacted form, and the window side really is raw. Reverting only the comparison fails that test and nothing else — 60 other boundary tests pass either way.

The same edit corrects a docstring that had drifted: `_append_unflushed_tail` claimed "A row matches on role plus EITHER content or `ts`", while the loop contains no `ts` comparison at all. The `ts` arm was removed earlier in this pull request and the prose was not updated with it.

### Content equality and a foreign duplicate — reachable, pre-existing, and the suggested remedy is worse

The `GPT 5.6 Review` lane blocks on `chat_handlers.py:1236`, the ordered-walk predicate `row.get("role", "assistant") == role and _same_persisted_body(row.get("content", ""), body, role)`. Its claim is that a row written by a different process which happens to share the same role and the same body is consumed by this matcher, the boundary advances past it, and a genuinely un-flushed window message is then left out of a response the client uses to replace its transcript. That claim is correct, and it reproduces.

The concrete input: save a slot so `q1` and `a1` are on disk, append one more assistant row `ok` to the window without saving, then have a different process append its own unrelated assistant row that also reads `ok` — `ConversationLog.append`, which is how a subagent, cron or CLI writes into a session (`chat_persistence.py:1411-1421`). Disk then holds `['q1', 'a1', 'ok']` and the window holds `['q1', 'a1', 'ok']`, but those two `ok` rows are two different messages, so a correct response contains `ok` twice. The measured response contains it once, so one copy is lost.

Two further measurements decide what to do about it, and they point the same way.

First, this is not a regression. Running the identical scenario against the base commit `c7e2564f4`, whose slot-detail handler sized the tail by subtracting lengths instead of matching rows, produces the same single `ok`. The behaviour predates this change; this pull request neither introduces it nor makes it worse.

Second, the lane's suggested remedy — treat a content match with a differing timestamp as ambiguous and keep the window tail — was applied and measured rather than argued about, and it reopens the duplication this pull request exists to fix. Under it, `test_mixed_id_and_id_less_disk_window_does_not_duplicate_an_injection` fails with "the durable injection was appended twice". The reason is that a durable injection's disk copy legitimately carries a different timestamp from its window row: the injector calls `slot.append` and then `append_if_absent`, and those two mint their stamps independently — measured 0.6 ms apart, `2026-08-18T14:29:40.694745+00:00` in the window against `...695337+00:00` on disk. Requiring the stamps to be equal therefore refuses to match the durable copy, that row reads as un-flushed, and it is appended a second time — on every cron and workflow injection, not rarely.

That leaves whether some other field could separate the two cases, and none can. A durable copy and an unrelated foreign row are written by the same function, since `append_if_absent` delegates to `ConversationLog.append` (`history.py:2204-2245`). Both therefore carry no `meta.mid`, both share the window row's role and body, and both differ from it in `ts`. On the fields that reach disk today the two are indistinguishable, so this matcher cannot do better than choose which error to make. It currently assumes the row is the durable copy, which loses one copy of a duplicate-looking line only when a foreign writer emits an exact body collision against an un-flushed row. The alternative duplicates every durable injection. The current choice is the smaller error, and switching sides without a new field would be a straight downgrade.

The real fix is on the write side, and the advisory `Design Review` lane already names it: give `ConversationLog.append` an `id` parameter so a durable copy carries its window row's id. The id path is exact, needs neither body nor timestamp comparison, and removes the ambiguity instead of trading between its two failure modes. That is a change to `history.py` and its callers, so it is a follow-up rather than scope here, and it is recorded rather than coded around.

Status note: the blocking `GPT 5.6 Review` verdict re-raises this same item at the head that already carried this section. The finding is conceded and reproduced here; what is refuted is its prescribed remedy. A further commit does not change that analysis, so clearing the lane is a human decision rather than something another revision buys.


### The id walk dropped an un-flushed row that sat before a persisted one — fixed

The id path recorded a prefix boundary: on a match it set `start = i + 1`, and a miss simply did not advance it. That is only correct if every persisted row comes before every un-flushed one. When it does not, a later match moves the boundary PAST an un-flushed row, and the bounded response leaves that row out altogether. The harm is a drop — a message the reader should see is missing — which is worse than the duplication this change was written to prevent.

Measured, not argued. With `q1` and `a1` saved so both disk rows carry ids, and an un-flushed assistant row placed between them in the window, the response came back `['q1', 'a1']` — the owed turn simply gone.

The obvious fix is wrong, and it is worth writing down why. Ending the walk at the first miss makes the boundary a true prefix, but a transient row is dropped by the save and so can never match an id: the walk would stop there and re-append every persisted row after it. That is the duplication bug again. Traced on the same fixture, break-on-miss leaves `start` at 1 and returns `a1` twice.

So the id path now selects the owed rows by MEMBERSHIP instead. An id present in the disk window region proves that row reached disk, so the owed set is the rows whose id did not, kept in window order. Transient roles are skipped outright, exactly as the ordered path already does at the equivalent point. Where the persisted rows really are a prefix this produces the same answer, which makes it a strict generalisation rather than a behaviour change.

Two tests, and the second one earned its place. `test_interleaved_unmatched_row_is_not_dropped_by_the_id_walk` asserts the owed row arrives AND that the persisted row is not duplicated, so it fails against both the old boundary and against break-on-miss. `test_transient_window_row_does_not_truncate_the_id_prefix` is the negative control, driven through the real writers: `queued` sits outside the mint exclusion list so it carries an id that can never reach disk. That control caught a genuine regression in my first attempt — selecting purely by membership surfaced the transient row in the response, where the boundary had excluded it — which is why the transient skip is there. Reverting only the production change fails the first test and nothing else; 603 other tests pass either way.

One honest limit on reachability. The interleaved ordering is constructed at the unit level. I did not identify a producer that emits it: the queue reorder at `chat_handlers.py:2650` moves transient rows to the END of the window, where a miss is harmless, and I did not audit every segment-finalisation path. The fix is a strict generalisation and costs nothing where the ordering never arises, so it is worth having regardless; but the drop is demonstrated against the function's contract rather than observed in a live flow.

### Escalated: the id-presence discriminator for the content path cannot be adopted

The blocking lane also asked that the content-matching path refuse to treat a window row that carries an id as persisted when the only evidence is a role-and-content match against a disk row that carries none. That is a different proposal from the timestamp variant answered further down, and it was tested on its own terms rather than dismissed by reference to that answer.

It cannot be adopted, and the reason is a measurement of the legitimate case. A durable injection puts the row in the window through `slot.append`, which mints an id, and persists the durable copy through `append_if_absent`, which records no `meta` at all. Measured on that path, the window row carries an id and the disk copy carries none — precisely the shape the proposed rule refuses. Implementing it makes `test_mixed_id_and_id_less_disk_window_does_not_duplicate_an_injection` fail with "the durable injection was appended twice", so adopting it reinstates the duplication this change exists to remove.

That is the same conclusion the write-side note below reaches from the other direction: while the durable copy carries no id, nothing on disk distinguishes it from an unrelated row with the same text, so no rule reading only the persisted fields can separate them. Giving `ConversationLog.append` an `id` parameter would; that is a change to `history.py` and its callers.

**This item is escalated to rnoack rather than dispositioned here.** It is not being argued away: it is a real ambiguity, it has no safe fix inside this change, and the write-side fix that would resolve it is out of scope for this pull request.

### A pending approval prompt was dropped by the bounded read — fixed

`_TRANSIENT_ROLES` documents itself as being about a *window-region disk line* — see its comment at `chat_persistence.py:1320-1322` — and `chat_persistence.py:1571` uses it exactly that way, against lines read off disk. The owed-set loop was applying the same set to `slot.messages`, which are in-memory window rows, so it was answering a different question: not "is this disk line a real message" but "does the client still need this row". A pending `permission` row is actionable, and the client reads it straight out of the transcript (`selectSlotPendingApproval` in `chatSlice.ts`), so dropping it makes the approval bar disappear while the server is still waiting for an answer.

Skipping it also bought nothing. `permission` is never persisted — `chat_persistence.py:1274` returns `None` for it — so a `permission` row can never have a disk counterpart for the id dedup to match. The skip could only ever remove it.

Reproduced before fixing. `test_pending_approval_survives_a_bounded_read` drives the real producer's call shape (the approval metadata rides in `cls` as JSON, as at `chat_runner.py:5966`) and asserts four preconditions first — every disk row carries an id so the owed-set loop runs, the permission row is absent from disk, and present in the window — then asserts the response carries exactly one `permission` row. It fails before the change and passes after. Reverting only the predicate fails that test and nothing else; 604 other tests pass either way.

Single delivery is safe rather than assumed: the client REPLACES its transcript from this payload rather than appending (`state.messages = next` in `chatSlice.ts`), so returning the row once cannot double it. The test asserts the count is exactly one, not merely non-zero, and also asserts the persisted row is not duplicated.

The fix is a call-site predicate, `_UNOWED_WINDOW_ROLES`, rather than an edit to the shared frozenset. Changing the frozenset would alter persistence and the cross-process append logic at `chat_persistence.py:1571`, which is far more than this needs. `queued` deliberately stays excluded: the client rebuilds those bubbles from the payload's own `queue` field.

### The mixed-window fixture was not platform-honest — fixed

`Backend Tests (Windows) (2)` failed on the previous head, in the redaction test's own precondition guard: `has_id=[True, True]`. The give-away is the LENGTH — two entries, not three — so the id-less foreign row was absent from the chained read entirely rather than mislabelled.

Located by execution under a frozen clock, which is the coarse-clock extreme. The foreign row is present immediately after the append and disappears in the SECOND save, so the loss is in `_save_slot_to_history`, not in the append and not in the chained read. The window row derived its stamp as previous-plus-one-microsecond off `q1`, and the foreign row derived the SAME stamp off the same previous row; a stamp carried by exactly one unmatched window entry and one unmatched disk line is the save's unambiguous in-place-edit case, so the window's version won and the disk line was dropped. On a coarse clock that collision is the default rather than a rarity, which is why POSIX was green and Windows was not.

Fixed in the fixture only, by pinning the two window rows to explicit stamps far apart so the foreign row's real "now" sorts strictly between them and can equal neither — deterministic at any clock resolution. The sibling interleave test already pins stamps for exactly this reason; this test was the only other one with the same foreign-append-then-save shape, confirmed by scanning the file. No skip, so Windows keeps its coverage of the ordered path. Nothing in the product's timestamping or dedup was touched, and the guard was neither weakened nor removed — the guard is the reason the problem surfaced instead of passing vacuously.

Verified with an instrument proven to detect the defect: under the frozen clock the old clock-minted fixture reproduces `has_id=[True, True]` and the pinned fixture gives `has_id=[True, False, True]`. An earlier pytest-level freeze attempt was discarded because it failed its own positive control — the pre-fix test passed under it, so it could not have detected anything.

Negative control, as required: reverting the redaction fix this test covers still fails it with "the save-redacted row was appended twice", so the fixture change did not make it vacuous.

A note for the record rather than a change here: the underlying product behaviour — a cross-process foreign append whose stamp coincides with exactly one unflushed window row being dropped by the save's in-place-edit arm — is real, and on a coarse-clock host the coincidence is the common case rather than a rare one. It lives in `chat_persistence.py`, which this change does not touch, and it is the same root pressure as the write-side identity item already recorded above.

### A foreign row that merely redacts alike no longer consumes an un-flushed row

The redaction-equivalent compare treated any two bodies that redact to the same text as the same row. Two DIFFERENT credentials redact to the same placeholder, so a foreign row could be consumed as the window's own and the un-flushed message dropped from a payload the client uses as a replacement. That residual used to be written down here as accepted; it is now closed.

The redaction branch additionally requires the stamps to match, and the measurement is what makes that safe rather than a guess. The branch only ever fires for a row and its own persisted copy — they differ precisely because one side was redacted — and both the save and the load copy `ts` verbatim, so the legitimate pair carries an IDENTICAL stamp (measured: same value on both sides to the microsecond). A foreign writer's row carries its own stamp and no longer matches.

It cannot reinstate the duplication fixed earlier in this change, and that is checked the same way. A durable injection is byte-identical to its window row, so it returns at the plain-equality branch and never reaches the stamp check — which matters because that pair genuinely does carry different stamps, the two writers minting independently. The requirement is on the redaction branch alone; plain content equality is untouched.

New test `test_redaction_equal_foreign_row_does_not_consume_an_unflushed_row` asserts the fixture's own preconditions first — two distinct bodies, redacting alike, on a mixed disk window with our row un-flushed — then asserts both rows arrive. Reverting only the stamp requirement fails that test and nothing else; 606 others pass either way. The two bodies are deliberately different credential KINDS — an access-key id, and a labelled secret-key assignment whose value is a single character — because both collapse to the same redaction tag. That keeps the collision real while leaving only one key-shaped literal in the fixture, the canonical documentation example; an invented near-miss variant of that key is what a secret scanner flags.

### The tail match runs off the event loop

The tail match walks the window against the whole disk window region and applies the redaction transform to both sides of every candidate compare, so on a large mixed or id-less history the cost is real, and running it inline blocks every other request on the loop. The disk read immediately above it already went through `asyncio.to_thread`, so one async function had the I/O off-thread and the CPU-heavy scan on it. That asymmetry is now gone.

Moving it to a worker introduces a hazard the inline version did not have: the loop can mutate the window while the scan reads it. So the scan works from a snapshot of the window list and the disk offset taken before any scanning. That snapshot's first form read the two values back to back, which is NOT atomic once the scan is off-loop — corrected below. This keeps the property the function already documented — it reads the window itself rather than trusting a count a caller captured before an await — while making the read consistent for the whole walk.

New test `test_bounded_read_runs_the_tail_match_off_the_event_loop` compares the thread the match runs on against the loop thread, and guards that the match ran at all so it cannot pass by never reaching the code. Reverting only the dispatch fails that test and nothing else.

### Residual: the ordered path can still drop a pending approval

Only the owed-set site was changed. The ordered path has the same skip, but the two are not the same defect and the same edit is wrong there — measured, not reasoned.

In the owed-set path the skip excludes the row from the result outright, so un-skipping delivers it exactly once. In the ordered path the skip only stops the row from advancing the prefix boundary; the row can still reach the tail through the slice, which is what happens in the ordinary case where nothing follows a pending approval. Applying the same predicate there makes the permission row find no disk match, so the walk ends at it, the prefix stops short, and every persisted row after it is re-appended: the measured response became `['user', 'assistant', 'permission', 'assistant']` — the approval delivered, but the persisted assistant row duplicated. The full unit file stayed green under that change, so the suite would not have caught it.

The ordered path does drop a pending approval when a persisted row follows it, measured on an id-less disk window. Fixing it correctly means replacing that path's prefix slice with the same membership selection the id path now uses, which is the un-flushed-tail predicate work already escalated rather than scope here. **Recorded for rnoack rather than fixed in this change.**

### A live streaming chunk was dropped by the bounded read — fixed

While the agent is answering, each piece of text it produces is appended to the window as a `chunk` row. Those rows were on the list of roles a bounded read hands back nothing for, on the reasoning that they are transient noise. That reasoning was wrong, and the mistake is in what happens downstream: `_prepare_messages` does not throw chunk rows away, it concatenates a run of them and emits a single `streaming` row. That row is the only way the answer-in-progress reaches the client through this endpoint, because the client discards raw `chunk` rows itself. So skipping them upstream meant the collapse step had nothing to work with and the partial answer was simply absent — the user watching a reply arrive would see it vanish on any bounded refresh.

`chunk` and `streaming` are now excluded from that skip list, leaving `done` (which `_prepare_messages` discards regardless) and `queued` (which the client rebuilds from the response's own `queue` field, and which an existing test requires to stay out of the transcript). Only the owed-set path needed the change: on the ordered path the skip does not remove a row from the result, it only stops it advancing the boundary, so chunk rows already reach the tail there.

New test `test_live_chunk_row_survives_a_bounded_read` drives the real producer's call shape and asserts the response carries a `streaming` row holding the partial text. It fails before this change with no streaming row at all.

### The window snapshot could pair a pre-trim window with a post-trim count — fixed

Two facts have to agree for the scan to be correct: the window rows, and the count of persisted rows that sit before them. Once the scan moved to a worker thread, an append on the event loop could land between the two reads, trim the front of the window and raise that count. The window copy would then be from before the trim while the count was from after it. The count is used to decide which part of the disk read corresponds to the window, so an inflated count made that region too short, the trimmed rows' identifiers were missing from it, and those already-persisted rows were treated as still owed and appended a second time.

The slot's lock is an asyncio lock and cannot be taken from a worker thread, so the fix is the same bounded re-read the save path already uses for this exact race: read the count, copy the window, then confirm the count has not moved, retrying a small fixed number of times and falling through to a final read. It reuses that path's retry limit rather than introducing a second one, so the two cannot drift apart. The loop is bounded, so there is no spin.

New test `test_window_snapshot_survives_a_trim_between_the_two_reads` fires a trim at the moment the window copy finishes and asserts no persisted row comes back twice. Before the change it returns `['q1', 'a1', 'q2', 'q1', 'a1', 'owed']`.

### A resolved approval was re-appended after later turns — fixed

A `permission` row is never persisted, so it is always "owed" by the owed-set walk and therefore always lands in the tail — after every row that did reach disk. For a *pending* approval that is the right place: it is the newest row, and nothing can follow it because the agent is blocked waiting on the answer. For an *answered* one it is wrong. The agent has since produced turns that are on disk, so tail-appending moves the approval after them and the rendered transcript no longer matches what happened. Measured before the fix, a slot holding `q1` → approval (approved) → `a1` returned `['user', 'assistant', 'permission']`.

The decision is written into the row's `cls` JSON in place, so the row stays in the window and its position cannot distinguish it. The owed-set walk now skips a permission row that carries a decision. It tests truthiness rather than key presence, matching the client's own `!meta.resolved` check, so an empty decision still counts as pending and an actionable approval is never dropped — that is the direction that would hide a live approval bar, and the pending case is covered by its own test which still passes.

## Related Issues

Kept out of this pull request so it stays a single correctness fix:

- #4134 — serve a bounded slot-detail page from the in-memory window when it already holds enough rows
- Unblocking the slot-close broadcast in `api_chat_slot_delete` is being raised as its own pull request. It touches this same file but a different function, so the two are independent; whichever merges second will need a mechanical rebase.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe this internal boundary
- [x] No secrets, credentials, or internal references in the diff



























