### PR TITLE
fix(dashboard): broadcast a slot close before the teardown awaits

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -2719,6 +2719,9 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
         )
     else:
         state._restricted_keys.discard(f"dashboard:{name}")
+        # Durable, so no rollback can retract this frame — a client pruning its
+        # per-slot cards on it can never be pruning a slot that comes back.
+        state.push_slots_update()
     # The app was already told, and compensated if the persist above failed — see
     # the notify block before the pop and the rollback in the except branch.
     # Kill the per-tab session to free resources

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -14693,3 +14693,199 @@ class TestSessionReload:
 
         assert resp.status == 409
         state.sessions.reset.assert_not_awaited()
+
+
+class TestCloseBroadcastDurability:
+    """A slot-list frame must never omit a slot that is coming back.
+
+    Clients treat a frame omitting a slot as licence to drop that slot's cached
+    per-slot state, including follow-up and folder-suggestion cards that only
+    ever exist in the browser and are never re-sent. So the close may only
+    broadcast once the history save is durable: past that point no rollback can
+    put the slot back, and the omission can never be retracted.
+
+    Every test records the ORDER of the close steps, because asserting only that
+    a broadcast happened passes against any placement and proves nothing.
+    """
+
+    @staticmethod
+    def _instrument(state, slot, monkeypatch, frames=None):
+        """Record close steps in call order; append each frame's slot keys."""
+        from kiro_crew.dashboard import chat_handlers
+
+        calls: list[str] = []
+
+        def _push():
+            calls.append("broadcast")
+            if frames is not None:
+                frames.append(set(state._slots))
+
+        state.push_slots_update = MagicMock(side_effect=_push)
+
+        real_sync = chat_handlers._sync_dashboard_slots
+
+        def _sync(st):
+            calls.append("sync")
+            return real_sync(st)
+
+        monkeypatch.setattr(chat_handlers, "_sync_dashboard_slots", _sync)
+
+        real_unblock = chat_handlers._unblock_pending_waits
+
+        def _unblock(st, sl):
+            calls.append("unblock_pending_waits")
+            return real_unblock(st, sl)
+
+        monkeypatch.setattr(chat_handlers, "_unblock_pending_waits", _unblock)
+
+        async def _save(*args, **kwargs):
+            calls.append("save")
+
+        monkeypatch.setattr(chat_handlers, "save_slot_off_loop", _save)
+
+        state.sessions.remove = AsyncMock(side_effect=lambda *a, **k: calls.append("remove"))
+
+        eager = MagicMock()
+        eager.done = MagicMock(return_value=False)
+        eager.cancel = MagicMock(side_effect=lambda: calls.append("cancel_eager"))
+        slot._eager_spawn_task = eager
+
+        async def _never() -> None:
+            await asyncio.sleep(30)
+
+        task = asyncio.get_running_loop().create_task(_never())
+        real_cancel = task.cancel
+
+        def _task_cancel(*args, **kwargs):
+            calls.append("cancel_task")
+            return real_cancel(*args, **kwargs)
+
+        task.cancel = _task_cancel  # type: ignore[method-assign]
+        # `running` is derived from `task`, so assigning the task is enough to
+        # reach the cancel-and-wait_for branch.
+        slot.task = task
+
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_failed_close_never_emits_a_frame_without_the_slot(
+        self, tmp_path, monkeypatch
+    ):
+        """The regression guard: a rollback must not be preceded by an omission.
+
+        A frame omitting the slot is what makes another client drop this slot's
+        follow-up and folder-suggestion cards. Those are browser-only and the
+        backend re-offers a folder suggestion at most once per slot, so a prune
+        on a close that then rolls back loses them permanently.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard import chat_handlers
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "hello")
+        slot.drain()
+        frames: list[set] = []
+        calls = self._instrument(state, slot, monkeypatch, frames=frames)
+
+        async def _boom(*args, **kwargs):
+            calls.append("save")
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(chat_handlers, "save_slot_off_loop", _boom)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete("/api/chat/slots/s1")
+            assert resp.status == 500
+
+        assert frames, "no frame was broadcast at all, so this proves nothing"
+        missing = [i for i, f in enumerate(frames) if "s1" not in f]
+        assert not missing, (
+            f"frame(s) {missing} omitted a slot that the rollback restores, so a "
+            f"client pruned its cards for it: frames={frames} calls={calls}"
+        )
+        assert state._slots.get("s1") is slot, "slot was not restored"
+
+    @pytest.mark.asyncio
+    async def test_broadcast_precedes_the_session_teardown(self, tmp_path, monkeypatch):
+        """On success, broadcast after the save but before the slow teardown."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "hello")
+        slot.drain()
+        calls = self._instrument(state, slot, monkeypatch)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete("/api/chat/slots/s1")
+            assert resp.status == 200
+
+        for step in ("save", "remove", "broadcast"):
+            assert step in calls, f"{step} never ran, so this proves nothing: {calls}"
+        assert calls.index("save") < calls.index("broadcast"), (
+            f"broadcast ran before the save was durable: {calls}"
+        )
+        assert calls.index("broadcast") < calls.index("remove"), (
+            f"broadcast waited out the session teardown: {calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_broadcast_beats_a_slow_session_teardown(self, tmp_path, monkeypatch):
+        """A session teardown that never returns must not hold the broadcast."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "hello")
+        slot.drain()
+        calls = self._instrument(state, slot, monkeypatch)
+        seen = asyncio.Event()
+        state.push_slots_update = MagicMock(
+            side_effect=lambda: (calls.append("broadcast"), seen.set())
+        )
+
+        async def _hang(*args, **kwargs):
+            calls.append("remove")
+            await asyncio.sleep(30)
+
+        state.sessions.remove = AsyncMock(side_effect=_hang)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            close = asyncio.get_running_loop().create_task(client.delete("/api/chat/slots/s1"))
+            await asyncio.wait_for(seen.wait(), timeout=5.0)
+            assert "save" in calls and calls.index("save") < calls.index("broadcast")
+            assert "s1" not in state._slots
+            close.cancel()
+            try:
+                await close
+            except asyncio.CancelledError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_active_slot_set_is_published_only_after_the_teardown(
+        self, tmp_path, monkeypatch
+    ):
+        """_sync_dashboard_slots must stay after the teardown.
+
+        Publishing the shrunken set earlier lets the idle sweep classify this
+        session as orphaned and reap it mid-teardown, and that reap releases a
+        shared subagent runtime which outlives the turn — the turn semaphore, the
+        sweep's only busy guard, is free while subagents run.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "hello")
+        slot.drain()
+        calls = self._instrument(state, slot, monkeypatch)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete("/api/chat/slots/s1")
+            assert resp.status == 200
+
+        assert "sync" in calls, f"the trailing sync never ran: {calls}"
+        assert calls.index("save") < calls.index("sync"), (
+            f"active-slot set published before the save was durable: {calls}"
+        )
+        assert calls.index("remove") < calls.index("sync"), (
+            f"active-slot set published before the session teardown: {calls}"
+        )


### PR DESCRIPTION
## Problem / Motivation

Closing a chat slot removes it from `state._slots` — the dictionary the dashboard's slot list is built from — and then does the whole teardown before telling anyone. In `src/kiro_crew/dashboard/chat_handlers.py`, `api_chat_slot_delete` ran this order (line numbers are from this PR's head):

1. `state._slots.pop(name, None)` (:2665) — the slot is gone from the authoritative list here
2. `_unblock_pending_waits` (:2669), eager-task cancel (:2676) — both synchronous
3. `slot.task.cancel()` then `await asyncio.wait_for(asyncio.shield(slot.task), timeout=2.0)` (:2685)
4. `await save_slot_off_loop(..., best_effort=False)` (:2689) — the durable history write
5. `await state.sessions.remove(_history_key_for(name))` (:2728) — provider shutdown plus subagent-runtime release
6. only now `_sync_dashboard_slots` + `state.push_slots_update()` (:2729-2730)

Step 5 is the unbounded one: `SessionManager.remove` awaits `provider.shutdown()` (`session.py:3601`) and then `release_subagent_runtime()` (`:3606`), which walk a process tree and can SIGKILL it. So a connected browser could keep rendering a card for a slot the server had already dropped and durably recorded as closed, for as long as a process teardown takes.

Note for anyone reading the file: `_sync_dashboard_slots` / `push_slots_update` also appear earlier, at :2659-2660, but that is inside the `if not await notify_slot_closed(...)` block — the app-close-hook **failure** path, which aborts the close and returns 500. Different site.

## Why it matters

**Who actually benefits, stated precisely.** An earlier draft of this description said "the card stays", which is wrong for the client that clicked. `website/src/store/chatSlice.ts` dispatches `removeSlotOptimistic(key)` at :1360 *before* `await api.deleteChatSlot(key)` at :1362, so the clicking tab hides its own card immediately and never sees the delay. The beneficiaries are the callers that do not do that:

- **Every other connected client.** A second browser tab, another window, or a phone on the same account learns about the close only from the slot-list broadcast, and keeps rendering a card for a slot that is already gone.
- **Non-optimistic callers in this repo.** One counted: `website/src/pages/ArtifactDetailPage.tsx:1211` awaits `api.deleteChatSlot(slot.key)` with no optimistic removal.

So this is a multi-client correctness fix, not a perceived-latency fix for the person clicking ✕.

## What changed

One added call: broadcast the slot list as soon as the history save is durable, instead of waiting out the session teardown as well.

```python
    else:
        state._restricted_keys.discard(f"dashboard:{name}")
        # Durable, so no rollback can retract this frame — a client pruning its
        # per-slot cards on it can never be pruning a slot that comes back.
        state.push_slots_update()
```

Nothing else moves. Same teardown steps, same order, same error handling, and the trailing `_sync_dashboard_slots` + broadcast stay where they were, so the success path now broadcasts twice and the second frame carries the final state.

The placement is the whole design, and it is bounded on both sides:

- **Not before the save.** A frame that omits the slot is a licence for clients to drop that slot's cached per-slot state (see the revision note below). Before the save commits, the close can still roll back, so such a frame can be retracted — and the dropped state cannot be put back.
- **Not after the session teardown.** That is step 5, the unbounded one, and covering it is the point of the change.

Placed between the two, the frame is only ever emitted once the outcome is settled: the `except` branch around `save_slot_off_loop` is the only path that restores the slot, so past it no broadcast is retractable.

**Why the save could not simply be moved earlier.** It would close more of the window, but the `await asyncio.wait_for(asyncio.shield(slot.task), timeout=2.0)` at :2685 exists so an in-flight turn can finish flushing before the transcript is persisted. Saving first would durably record a transcript missing that turn's final messages — a correctness regression traded for latency. So the ≤2s task-cancel wait and the save itself remain uncovered by this change, and clients still see up to that much staleness. That is a deliberate reduction from an earlier revision of this PR, explained below.

**Deliberately not fixed here: two siblings with the same late-broadcast shape.** Left alone to keep this PR to one mechanism, and neither is a regression from this change:

- **Bulk cleanup**, `chat_handlers.py` — pops at :2851, broadcasts at :2885.
- **History delete**, `dashboard/handlers/sessions.py` — `api_session_delete` calls `_remove_slot_for_history_key` at :1187 (which pops at :1214) and broadcasts afterwards at :1190. The pop and the broadcast are in two different functions, which is why the line numbers read out of order.

### Revision: two blocking findings, both correct

Two separate automated review findings landed against earlier revisions of this PR. Both were verified at source and both were right; the code now reflects each. Recording them because each rests on a reasoning error a reader could repeat.

**Finding 1 — the early broadcast must not publish the shrunken active-slot set.** An earlier revision paired the early `push_slots_update()` with `_sync_dashboard_slots(state)`. That publishes the reduced key set to `SessionManager`, and `_expire_idle` classifies a `dashboard:`-prefixed session as `orphaned` when it is absent from `_active_dashboard_slots` (`session.py:5155-5159`) — a branch that ignores the idle clock entirely. The reap calls `reset(key, skip_if_busy=True)` (`:5192`), which releases the parent's shared subagent runtime (`:3190-3192`): *"Subagents on it are already dead since their queues are poisoned when the runtime dies."* The sweep's only busy guard is the turn semaphore (`:5152`, re-checked atomically in `reset` at `:3109`), and `chat_runner.py:3414-3421` computes `hold_users` from `running_agents_for(...)` inside `_start_next_ready_turn` — code that only makes sense if subagents can run while no turn does. So the semaphore is free exactly when subagent work is live. The error in the rejected counter-argument was treating "no turn in flight" as equivalent to "no subagent work in flight". `_sync_dashboard_slots` now runs only at the end.

**Finding 2 — the early broadcast itself, even without the sync, made clients prune unrestorable state.** `chatSlice.ts` has an `addCase(sseSlots, ...)` at :3294 which, for every cached slot key missing from the incoming frame, deletes from a map list that includes `state.followups` (:3304) and `state.folderSuggestions` (:3305), and filters `state.slotHistory` (:3312). Its two guards do not cover the case: :3295 exempts only an empty frame, and :3297 exempts only the receiving client's own *active* slot — so a client holding the closing slot as open-but-not-active prunes. That state is unrestorable by the code's own account: :670 and :684-686 call these frontend-only and state that "a dismissed or lost card is never re-offered", `sseSlots` only ever deletes, and the sole writers are the `followup_card` / `slot_folder_suggestion` push events. The backend confirms the one-shot: `chat_folder_suggest.py:347` returns early when `slot._folder_suggested` is set, `:370` sets it, and its comment says it is "Not released on failure either". The rollback at :2693 restores the same slot object, so the flag is still set and that suggestion is gone permanently. Both card events go to `deliver_ws_owners`, i.e. every owner tab, so a second tab genuinely holds the card. This was new to this PR: at the parent commit there is no broadcast between the pop and the save, so before this change every frame a client saw on a failed close still contained the slot and no prune ever ran.

**The alternative that was rejected for Finding 2.** The lane's suggested fix was to remove the early broadcast outright, which is a full revert. The narrower shape considered instead was to mark the early frame provisional so a receiving client defers the prune until the close is durable. That was rejected on cost, not on merit: the frame reaches the reducer as a bare `ChatSlot[]` (`useSSE.ts:32`, `useWebSocket.ts:658`), so carrying a provisional marker means changing the payload contract across the SSE handler, the WS handler, `dashboardSlice.sseSlots` and the `chatSlice` reducer — a four-file protocol change in a backend PR. Broadcasting after the save achieves the same guarantee with one line and no protocol change, at the cost of leaving the ≤2s task-cancel wait and the save uncovered. Scope of the harm avoided, stated honestly: it needed a durable-save failure (disk full / IO error) plus a second connected client holding the slot as non-active plus a live card. The follow-up items are ephemeral by design and a reload drops them anyway; the folder suggestion is the worse loss because it is never re-offered.

## Tests

`test/test_dashboard_chat.py`, class `TestCloseBroadcastDurability` (4 cases). These assert on the recorded ORDER of close steps, because asserting merely that a broadcast happened passes against any placement and proves nothing. Each test records `push_slots_update`, `_sync_dashboard_slots`, `_unblock_pending_waits`, `save_slot_off_loop`, `sessions.remove`, the eager task's `cancel` and the turn task's `cancel` into one shared list; the durability test additionally snapshots the slot keys present in each broadcast frame.

- `test_failed_close_never_emits_a_frame_without_the_slot` — the guard for Finding 2. Makes the save raise, then asserts **no** emitted frame omitted the slot, and that the slot is restored.
- `test_broadcast_precedes_the_session_teardown` — the feature: broadcast after `save`, before `remove`.
- `test_broadcast_beats_a_slow_session_teardown` — replaces `sessions.remove` with one that never returns, and asserts the broadcast has already fired and the save already ran while the request is still in flight.
- `test_active_slot_set_is_published_only_after_the_teardown` — the guard for Finding 1: `_sync_dashboard_slots` must follow both the save and the teardown.

**Negative controls.** Two, each isolating one property:

| Control | Tree change | Result |
|---|---|---|
| A | restore the pre-save broadcast (the shape Finding 2 flagged) | 3 of 4 fail. The guard reports `frame(s) [0] omitted a slot that the rollback restores`, with `frames=[set(), {'s1'}]` — frame 0 omitting the slot, frame 1 after the rollback restoring it |
| B | remove the post-save broadcast (upstream behaviour) | 2 of 4 fail: `broadcast waited out the session teardown: [... 'save', 'remove', 'sync', 'broadcast']`, and the slow-teardown test times out |

Control A shows the guard fails for the intended reason — it names the offending frame and its contents, not merely an order mismatch. Control B shows the two placement assertions are load-bearing rather than satisfied by any broadcast. In each control the tests that pass are the ones orthogonal to the property removed.

**Suite.** `test/test_dashboard_chat.py` 581 passed on a clean tree. `flake8`, `isort` and `mypy` clean on both changed files.
