### PR TITLE
feat: expose the markdown memory layer through a CLI read API (#3192)

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -131,7 +131,8 @@ This allows `kirocrew` to find project-level agent config and skills from any di
 | `kirocrew config set --file <path>` | Replace config from a JSON file |
 | `kirocrew config edit` | Open config in `$EDITOR` |
 | `kirocrew memory list/search/stats/audit` | Inspect vector memory (entries, semantic search, counts, suspicious-content scan) |
-| `kirocrew memory export/import/migrate` | Export memory to JSON, import it back, or migrate legacy markdown memory into the vector store |
+| `kirocrew memory show [preferences\|projects\|history]` | Read the markdown memory layer (all three when no target given); `--format md\|json`, `--since YYYY-MM-DD` for history |
+| `kirocrew memory export/import/migrate` | Export memory to JSON (`--include-markdown` adds the markdown layer), import it back, or migrate legacy markdown memory into the vector store |
 | `kirocrew policy show/validate/explain/profile` | Inspect the effective enterprise security policy, load-check it and all profiles, explain one tool/scope decision for a surface, or print a profile. `show` also summarizes the built-in denied-command catalog as grouped counts (`--ids` lists each category's rule ids), on every install regardless of whether an enterprise policy is active — the one place an agent can learn a class of work is hard-denied before planning around it. |
 | `kirocrew pod up/down/ls/status/token/url/logs/exec/install/provision` | Isolated worktree test gateways (**Linux `systemd --user` only** — every systemd-touching verb refuses with a one-line message on macOS/Windows). See `src/kiro_crew/pod/README.md`. |
 | `kirocrew knowledge dedup [--apply]` | Collapse cross-source duplicate knowledge documents (dry-run unless `--apply`) |

--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -359,7 +359,9 @@ Model: `Qwen/Qwen3-Embedding-0.6B` Q8_0 GGUF (610MB). Apache-2.0 licensed. Serve
 
 ### CLI
 
-`kirocrew memory {list,search,stats,audit,export,migrate,import}` — manage vector memory from command line:
+`kirocrew memory {list,search,show,stats,audit,export,migrate,import}` — manage memory from the command line:
+- `show [preferences|projects|history]` — read the markdown layer through `MemoryStore` (all three targets when none given); `--format md|json` (json entries carry `path`, `updated_at` mtime in UTC ISO-8601, `content`), `--since YYYY-MM-DD` filters history days. Missing/empty files print as empty rather than erroring
+- `export` — vector-store collections; `--include-markdown` opts in a `markdown` collection (`preferences`/`projects` entries + per-day `history` list from `MemoryStore.markdown_snapshot()`) without changing the default payload shape
 - `migrate` — one-time markdown → structured migration (preferences.md → semantic, history/*.md → episodic)
 - `import <file>` — restore from JSON export with full validation
 - `kirocrew security audit` also scans vector memory for injection patterns

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1947,15 +1947,39 @@ Examples:
     art_ver.add_argument("slug", help="Artifact slug")
 
     # Memory
-    mem_parser = sub.add_parser("memory", help="Manage vector memory system")
+    mem_parser = sub.add_parser("memory", help="Manage memory (vector store + markdown layer)")
     mem_sub = mem_parser.add_subparsers(dest="mem_action")
     mem_sub.add_parser("list", help="Show semantic memory entries")
     mem_search = mem_sub.add_parser("search", help="Search episodic memories")
     mem_search.add_argument("query", help="Search query text")
+    mem_show = mem_sub.add_parser(
+        "show", help="Show the markdown memory layer (preferences, projects, daily history)"
+    )
+    mem_show.add_argument(
+        "target",
+        nargs="?",
+        choices=["preferences", "projects", "history"],
+        help="Layer to show (default: all three)",
+    )
+    mem_show.add_argument(
+        "--format",
+        choices=["md", "json"],
+        default="md",
+        help="Output format: raw markdown or structured JSON (default: md)",
+    )
+    mem_show.add_argument(
+        "--since",
+        help="History only: include days on or after DATE (YYYY-MM-DD)",
+    )
     mem_sub.add_parser("stats", help="Show memory statistics")
     mem_sub.add_parser("audit", help="Scan memory for suspicious content")
     mem_export = mem_sub.add_parser("export", help="Export all memory to JSON")
     mem_export.add_argument("--output", "-o", help="Output file (default: stdout)")
+    mem_export.add_argument(
+        "--include-markdown",
+        action="store_true",
+        help="Also include the markdown layer (preferences, projects, daily history)",
+    )
     mem_sub.add_parser("migrate", help="Migrate legacy markdown memory to vector store")
     mem_import = mem_sub.add_parser("import", help="Import memory from JSON file")
     mem_import.add_argument("file", help="Path to JSON file (export format)")

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -64,6 +64,7 @@ from kiro_crew.eval.scenario import AssertionType, load_scenario, load_scenarios
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.learn import Lesson, LessonStore
 from kiro_crew.loopback_http import loopback_urlopen
+from kiro_crew.memory import MemoryStore
 from kiro_crew.port_resolution import resolve_client_port_ex
 from kiro_crew.security import (
     BUILTIN_DENIED_RULES,
@@ -1508,7 +1509,9 @@ def _learn(args: argparse.Namespace) -> None:
                     # the dashboard's JSONL path: a blank/legacy category gets
                     # the store's own "knowledge" default instead of printing [].
                     category = normalize_lesson_category(le.category, strict=False)
-                    print(f"  [{_TERMINAL_CTRL_RE.sub('', category)}] {_TERMINAL_CTRL_RE.sub('', str(le.rule))}{neg}")
+                    print(
+                        f"  [{_TERMINAL_CTRL_RE.sub('', category)}] {_TERMINAL_CTRL_RE.sub('', str(le.rule))}{neg}"
+                    )
 
         elif action == "remove":
             if vs.get_lessons() and vs.delete_lesson(args.query):
@@ -1524,14 +1527,71 @@ def _learn(args: argparse.Namespace) -> None:
         vs.close()
 
 
+def _markdown_memory_store() -> MemoryStore:
+    """MemoryStore anchored where the DEFAULT runtime writer writes.
+
+    The markdown layer this surface exposes is written by the gateway's
+    consolidator, which is constructed over a bare ``MemoryStore()`` (the
+    hard-coded ``workspace`` dir under the data home). The reader must resolve
+    identically or an install whose config maps the default workspace
+    elsewhere would export a tree the consolidator never writes to. In a stock
+    config this is the same directory ``workspace_dir_for()`` returns; when
+    they diverge, the writer wins.
+    """
+    return MemoryStore()
+
+
+def _memory_show(args: argparse.Namespace) -> None:
+    """Read-only view of the markdown memory layer (preferences/projects/history).
+
+    Routes through :class:`MemoryStore`'s own readers so consumers depend on an
+    interface rather than the on-disk layout. A missing or empty file is a
+    normal state and prints as empty rather than erroring. Validation failures
+    go to stderr with a non-zero exit so scheduled (non-TTY) consumers get a
+    real failure signal instead of non-JSON text on stdout.
+    """
+    target = getattr(args, "target", None)
+    since_raw = getattr(args, "since", None)
+    since = None
+    if since_raw:
+        if target not in (None, "history"):
+            print("--since applies only to history", file=sys.stderr)
+            sys.exit(1)
+        try:
+            since = datetime.strptime(since_raw, "%Y-%m-%d").date()
+        except ValueError:
+            print(f"Invalid --since date (expected YYYY-MM-DD): {since_raw}", file=sys.stderr)
+            sys.exit(1)
+    snapshot = _markdown_memory_store().markdown_snapshot(since=since)
+    if getattr(args, "format", "md") == "json":
+        payload = snapshot[target] if target else snapshot
+        print(json.dumps(payload, indent=2))
+        return
+    parts: list[str] = []
+    for key in [target] if target else ["preferences", "projects", "history"]:
+        if key == "history":
+            parts.extend(e["content"].strip() for e in snapshot[key] if e["content"].strip())
+        elif snapshot[key]["content"].strip():
+            parts.append(snapshot[key]["content"].strip())
+    text = "\n\n".join(parts)
+    if text:
+        # The markdown layer is consolidator (LLM) written — strip terminal
+        # control sequences before printing, same policy as `memory list`.
+        print(_TERMINAL_CTRL_RE.sub("", text))
+
+
 def _memory_cmd(args: argparse.Namespace) -> None:
-    """Manage vector memory system."""
+    """Manage the memory system (vector store + markdown layer)."""
+    action = getattr(args, "mem_action", None)
+    # "show" reads only the markdown layer — don't open (or create) the
+    # vector store for it.
+    if action == "show":
+        _memory_show(args)
+        return
     cfg = KiroCrewConfig.load()
     store = VectorMemoryStore(embedding_dim=cfg.memory.embedding_dim)
     store.init()
     try:
-        action = getattr(args, "mem_action", None)
-
         if action == "list":
             entries = store.get_all_semantic()
             if not entries:
@@ -1548,7 +1608,9 @@ def _memory_cmd(args: argparse.Namespace) -> None:
                 if str(e["key"]).startswith("lesson."):
                     val = _lesson_display_text(val) or val
                 safe_val = _TERMINAL_CTRL_RE.sub("", str(val))
-                print(f"  {e['key']}: {safe_val}  (confidence={e['confidence']}, source={e['source']})")
+                print(
+                    f"  {e['key']}: {safe_val}  (confidence={e['confidence']}, source={e['source']})"
+                )
 
         elif action == "search":
             results = store.search_episodic(query_text=args.query, limit=10)
@@ -1591,11 +1653,15 @@ def _memory_cmd(args: argparse.Namespace) -> None:
                 print("✅ No suspicious content in memory.")
 
         elif action == "export":
-            data = {
+            data: dict[str, object] = {
                 "semantic": store.get_all_semantic(),
                 "episodic": store.get_episodic_list(limit=10000),
                 "events": store.get_events(limit=1000),
             }
+            if getattr(args, "include_markdown", False):
+                # Opt-in so the default payload shape stays byte-identical
+                # for existing consumers.
+                data["markdown"] = _markdown_memory_store().markdown_snapshot()
             output = json.dumps(data, indent=2, default=str)
             out_file = getattr(args, "output", None)
             if out_file:
@@ -1626,9 +1692,17 @@ def _memory_cmd(args: argparse.Namespace) -> None:
             print(f"  Semantic: {counts['semantic']}")
             print(f"  Episodic: {counts['episodic']}")
             print(f"  Skipped:  {counts['skipped']}")
+            if "markdown" in data:
+                # The markdown collection is export-only: the markdown layer is
+                # consolidator-owned, so import never writes it. Say so rather
+                # than letting a backup/restore silently drop it.
+                print(
+                    "Note: the 'markdown' collection is export-only and was NOT imported "
+                    "(the markdown memory layer has no write path here)."
+                )
 
         else:
-            print("Usage: kirocrew memory {list|search|stats|audit|export|migrate|import}")
+            print("Usage: kirocrew memory {list|search|show|stats|audit|export|migrate|import}")
     finally:
         store.close()
 

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -54,6 +54,16 @@ from .cron import _recognize_session
 
 logger = logging.getLogger(__name__)
 
+# Per-endpoint write serialization for the offloaded markdown saves below.
+# asyncio.to_thread hands each PUT to an executor worker, and workers can
+# acquire the store's file lock OUT OF REQUEST ORDER — a rapid pair of saves
+# could commit the older content last. The event loop used to serialize these
+# accidentally (inline writes); these locks restore that ordering explicitly
+# while keeping the blocking I/O off the loop.
+_prefs_write_lock = asyncio.Lock()
+_projects_write_lock = asyncio.Lock()
+_history_write_lock = asyncio.Lock()
+
 # Bounded because a wedged native load has no cancellation: without a deadline
 # the progress tracker would sit at `applying` forever and every later apply
 # would 409. Safe to bound ONLY because the candidate is gated — an abandoned
@@ -77,7 +87,18 @@ async def api_memory_preferences(request: web.Request) -> web.Response:
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         content = body.get("content", "")
-        mem.write_preferences(content)
+        # Offloaded to a worker thread: write_preferences does synchronous
+        # atomic file I/O plus an FTS index update, and this handler runs on
+        # the gateway event loop — inline, a slow filesystem stalls every
+        # other gateway task. asyncio.to_thread (not the embed pool): this
+        # write does no embedding, and the embed bulkhead's workers can all
+        # be parked behind a hung embedding endpoint, which would make a
+        # Memory-tab Save wait on unrelated embed traffic. The endpoint lock
+        # keeps rapid successive saves committing in request order (workers
+        # can otherwise acquire the store's file lock out of order — see
+        # module top).
+        async with _prefs_write_lock:
+            await asyncio.to_thread(mem.write_preferences, content)
         return web.json_response({"ok": True})
     return web.json_response({"content": mem.read_preferences()})
 
@@ -92,7 +113,9 @@ async def api_memory_projects(request: web.Request) -> web.Response:
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         content = body.get("content", "")
-        mem.write_projects(content)
+        # Offloaded for the same reason as api_memory_preferences above.
+        async with _projects_write_lock:
+            await asyncio.to_thread(mem.write_projects, content)
         return web.json_response({"ok": True})
     return web.json_response({"content": mem.read_projects()})
 
@@ -107,10 +130,16 @@ async def api_memory_history(request: web.Request) -> web.Response:
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         content = body.get("content", "")
-        # Write to today's history file
+        # Write to today's history file. Offloaded like the two handlers
+        # above (synchronous file I/O on the event loop stalls every other
+        # gateway task), and routed through the store's atomic writer:
+        # write_text would follow a planted symlink at the dated name and
+        # tear under concurrent PUTs; the atomic replace commits whole
+        # versions and never traverses a link at the temp path.
         today_path = mem._today_history_file()
         today_path.parent.mkdir(parents=True, exist_ok=True)
-        today_path.write_text(content, encoding="utf-8")
+        async with _history_write_lock:
+            await asyncio.to_thread(mem._atomic_write_text, today_path, content)
         return web.json_response({"ok": True})
     return web.json_response({"content": mem.read_recent_history()})
 

--- a/src/kiro_crew/docs/memory-and-learning.md
+++ b/src/kiro_crew/docs/memory-and-learning.md
@@ -93,8 +93,22 @@ Kiro Crew automatically consolidates conversations into memory:
 
 No manual action needed — it happens in the background.
 
+## Reading Memory Programmatically
+
+The markdown layer is readable through the CLI, so consumers depend on an
+interface rather than the on-disk layout:
+
+- `kirocrew memory show [preferences|projects|history]` — print the markdown
+  layer (all three when no target is given). `--format json` returns structured
+  entries with `path`, `updated_at`, and `content`; `--since YYYY-MM-DD` limits
+  history to days on or after that date.
+- `kirocrew memory export --include-markdown` — add a `markdown` collection to
+  the JSON export. Without the flag the export shape is unchanged.
+
+Both run non-interactively (no TTY or editor needed), so they work from
+scheduled jobs.
+
 ## Editing Memory
 
 - **Dashboard**: Overview → Memory tab → edit preferences.md or projects.md
-- **CLI**: `kirocrew memory show` / `kirocrew memory edit`
 - **Chat**: ask Kiro Crew to update its memory files directly

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -5151,7 +5151,24 @@ class HistoryConsolidator:
                             len(prefs),
                         )
                     elif prefs.strip() != current_prefs.strip():
-                        memory.write_preferences(prefs)
+                        # Offloaded like append_history above (blocking file
+                        # I/O on the event loop thread). expected_baseline is
+                        # the compare-and-swap guard: this whole-file result
+                        # was merged from current_prefs, read BEFORE the
+                        # minutes-long LLM call — if a dashboard Save landed
+                        # in that window, writing would silently revert it,
+                        # so the store skips the stale write instead.
+                        wrote = await run_in_embed_pool(
+                            lambda: memory.write_preferences(
+                                prefs, expected_baseline=current_prefs
+                            )
+                        )
+                        if not wrote:
+                            logger.info(
+                                "Consolidated preferences for %s discarded: file "
+                                "changed during consolidation",
+                                key,
+                            )
 
                 if projects := result.get("projects_update"):
                     if not _is_plausible_memory_file(projects, "# Active Projects"):
@@ -5162,7 +5179,17 @@ class HistoryConsolidator:
                             len(projects),
                         )
                     elif projects.strip() != current_projects.strip():
-                        memory.write_projects(projects)
+                        wrote = await run_in_embed_pool(
+                            lambda: memory.write_projects(
+                                projects, expected_baseline=current_projects
+                            )
+                        )
+                        if not wrote:
+                            logger.info(
+                                "Consolidated projects for %s discarded: file "
+                                "changed during consolidation",
+                                key,
+                            )
 
             # Lesson extraction: _save_lessons calls write_lesson which embeds
             # each rule (+ up to 5 lazy backfills) via blocking urllib to Ollama.

--- a/src/kiro_crew/memory.py
+++ b/src/kiro_crew/memory.py
@@ -12,19 +12,31 @@ Structure:
 
 from __future__ import annotations
 
+import heapq
 import logging
+import os
+import stat as _stat
 import time
 from datetime import date as _date
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from kiro_crew._sqlite_compat import FTS5_UNAVAILABLE_HINT, fts5_available, sqlite3
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
+from kiro_crew.hooks import (
+    FileTooLargeError,
+    is_unc_shape,
+    safe_read_file_bytes_nolink,
+    unc_probe_allowed,
+)
 from kiro_crew.metrics.db_metrics import timed, timed_query
-from kiro_crew.platform_compat import file_lock
+from kiro_crew.platform_compat import file_lock, is_link_or_junction
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from kiro_crew.vector_memory import VectorMemoryStore
 
 logger = logging.getLogger(__name__)
@@ -147,14 +159,110 @@ class MemoryStore:
     def vector_store(self, store: "VectorMemoryStore | None") -> None:
         self._vector_store = store
 
+    # ── Atomic writes (committed-versions-only contract) ──
+
+    def _require_link_free_roots(self) -> None:
+        """WRITE-path admission gate — the same single invariant the read
+        surface enforces in :meth:`_read_root_guard`: no filesystem syscall
+        may touch a path whose workspace, memory-root, or history-dir
+        component is a link/junction (or an untrusted UNC workspace on
+        Windows).
+
+        The write surface previously accumulated point defenses (hardened
+        temp files, symlink-safe lock opens) while each writer still trusted
+        the directories themselves, so a linked ``memory/`` or ``history/``
+        directory routed staging and replacement outside the workspace. One
+        gate at every writer entry makes that whole class unreachable
+        instead of patching instances. Writers must fail LOUD, not silently
+        no-op, so this raises where the read gate returns ``False`` (a
+        refused read degrades to an empty entry; a refused write must not
+        look like success). The refusal is SEL-audited by the shared guard.
+        """
+        if not self._read_root_guard():
+            raise OSError(
+                f"memory write refused (linked root or untrusted workspace): {self._memory_dir}"
+            )
+
+    def _open_lock_nofollow(self, lock_path: Path) -> int:
+        """Open (creating if absent) a lock file without following links.
+
+        A bare ``open(path, "w")`` truncates before locking and follows a
+        symlink, so an agent-planted ``.write.lock`` link would get its
+        same-user TARGET truncated by the next memory write. This opens with
+        ``O_NOFOLLOW`` (a symlink leaf fails with ELOOP instead of being
+        traversed), never truncates (no ``O_TRUNC`` — a lock file carries no
+        content), and requires a lone regular inode via ``fstat`` (rejects
+        special files and hardlinked inodes). A planted link therefore makes
+        the write fail closed rather than damage the link's target. Caller
+        owns the returned fd and must ``os.close`` it.
+
+        Windows has no ``O_NOFOLLOW`` (and ``O_NOFOLLOW`` would not cover a
+        directory junction anyway), so the leaf is additionally rejected with
+        an lstat-based link/junction check before the open — not race-free
+        like the POSIX flag, but it matches the platform's best available
+        primitive and the rest of this surface's Windows posture.
+        """
+        if is_link_or_junction(lock_path):
+            raise OSError(f"refusing lock file (link or junction): {lock_path}")
+        flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(lock_path, flags, 0o600)
+        try:
+            st = os.fstat(fd)
+            if not _stat.S_ISREG(st.st_mode) or st.st_nlink != 1:
+                raise OSError(f"refusing lock file (not a lone regular inode): {lock_path}")
+        except BaseException:
+            os.close(fd)
+            raise
+        return fd
+
+    def _atomic_write_text(self, path: Path, content: str) -> None:
+        """Publish *content* to *path* via unique temp file + ``os.replace``.
+
+        ``write_text`` truncates then writes, so a concurrent reader can
+        observe an empty or partial file between those two steps. Delegates
+        to :func:`kiro_crew.atomic_write.atomic_write`, which stages the
+        bytes in a ``tempfile.mkstemp`` sibling (``O_CREAT | O_EXCL`` with an
+        unpredictable name, so an agent-planted symlink at a guessable temp
+        path is never followed) and atomically renames it over the target —
+        a reader only ever observes COMMITTED versions. The structured read
+        surface additionally double-stats around its read, so a replace
+        landing mid-read is retried rather than pairing one version's bytes
+        with another version's mtime. The temp carries a ``.tmp`` suffix so
+        history ``*.md`` globbing never picks it up.
+
+        An existing destination's permission bits are preserved: ``write_text``
+        truncated in place and never touched the mode, but a rename-based
+        replace installs the temp file's mode, so without carrying the old
+        mode over a user's ``0o600`` memory file would silently widen to the
+        umask default on the next write.
+        """
+        # Admission gate FIRST (see _require_link_free_roots): even the mode
+        # stat below traverses the directory chain, and on Windows a stat of
+        # a UNC path is itself the outbound SMB probe.
+        self._require_link_free_roots()
+        # The LEAF must not be a link either: replacing a link with a regular
+        # file is safe, but callers doing read-modify-write would have read
+        # the link's TARGET, and the mode stat would report the target's
+        # mode. Reject before any following syscall; metadata via lstat.
+        if is_link_or_junction(path):
+            self._audit_read_refusal("leaf_link", path, "memory write target is a link/junction")
+            raise OSError(f"memory write refused (target is a link): {path}")
+        mode: int | None = None
+        try:
+            mode = _stat.S_IMODE(os.lstat(path).st_mode)
+        except OSError:
+            pass  # new file: let atomic_write apply the umask default
+        atomic_write(path, content, mode=mode)
+
     def init(self) -> None:
         """Create directory structure and default files."""
+        self._require_link_free_roots()  # gate before the first syscall
         self._memory_dir.mkdir(parents=True, exist_ok=True)
         self._history_dir.mkdir(parents=True, exist_ok=True)
         if not self._preferences_file.exists():
-            self._preferences_file.write_text(_DEFAULT_PREFERENCES, encoding="utf-8")
+            self._atomic_write_text(self._preferences_file, _DEFAULT_PREFERENCES)
         if not self._projects_file.exists():
-            self._projects_file.write_text(_DEFAULT_PROJECTS, encoding="utf-8")
+            self._atomic_write_text(self._projects_file, _DEFAULT_PROJECTS)
 
     # ── Preferences ──
 
@@ -164,11 +272,46 @@ class MemoryStore:
             return self._preferences_file.read_text(encoding="utf-8")
         return ""
 
-    def write_preferences(self, content: str) -> None:
-        """Write user preferences and update FTS index."""
+    def write_preferences(self, content: str, *, expected_baseline: str | None = None) -> bool:
+        """Write user preferences and update FTS index.
+
+        Serialized behind the same advisory ``file_lock`` mechanism
+        :meth:`append_history` uses: now that async callers offload these
+        writes to worker threads, a dashboard Save and a consolidation pass
+        can run concurrently (the event loop no longer accidentally
+        serializes them), and without the lock two whole-file atomic writes
+        of independently-read snapshots would silently last-writer-win.
+
+        ``expected_baseline`` is the compare-and-swap guard for the
+        read-merge-write callers: the consolidator reads the file, spends
+        minutes in an LLM call, then writes back a whole-file result — a
+        user's dashboard Save landing in that window would be silently
+        reverted. Pass the content the merge was computed FROM; if the file
+        no longer matches it EXACTLY (checked inside the lock — any byte
+        difference, whitespace included, means the merge is stale), the
+        write is skipped and ``False`` is returned. ``None`` writes
+        unconditionally (direct user intent wins). Returns ``True`` when the
+        write happened.
+        """
+        self._require_link_free_roots()  # gate before the first syscall
         self._memory_dir.mkdir(parents=True, exist_ok=True)
-        self._preferences_file.write_text(content, encoding="utf-8")
-        self._index_file(self._preferences_file, content)
+        lock_fd = self._open_lock_nofollow(self._memory_dir / ".write.lock")
+        try:
+            with file_lock(lock_fd, exclusive=True):
+                if expected_baseline is not None and self.read_preferences() != expected_baseline:
+                    logger.info(
+                        "Skipping stale preferences write: file changed since the "
+                        "baseline this update was computed from"
+                    )
+                    return False
+                self._atomic_write_text(self._preferences_file, content)
+                # Indexed INSIDE the lock: with concurrent writers, indexing
+                # after release lets writer B's file land while writer A's
+                # index write runs last — file says B, search returns A.
+                self._index_file(self._preferences_file, content)
+        finally:
+            os.close(lock_fd)
+        return True
 
     def add_preference(self, preference: str) -> None:
         """Append a preference line, avoiding duplicates."""
@@ -185,8 +328,13 @@ class MemoryStore:
             return self._projects_file.read_text(encoding="utf-8")
         return ""
 
-    def write_projects(self, content: str) -> None:
-        """Write active projects, adding header if missing, and update FTS index."""
+    def write_projects(self, content: str, *, expected_baseline: str | None = None) -> bool:
+        """Write active projects, adding header if missing, and update FTS index.
+
+        Locking and ``expected_baseline`` (compare-and-swap) semantics: see
+        :meth:`write_preferences`.
+        """
+        self._require_link_free_roots()  # gate before the first syscall
         self._memory_dir.mkdir(parents=True, exist_ok=True)
         date = datetime.now().strftime("%Y-%m-%d")
         # Don't double-wrap if content already has the header
@@ -194,8 +342,21 @@ class MemoryStore:
             full = content.strip() + "\n"
         else:
             full = f"# Active Projects\n\n_Updated: {date}_\n\n{content}\n"
-        self._projects_file.write_text(full, encoding="utf-8")
-        self._index_file(self._projects_file, full)
+        lock_fd = self._open_lock_nofollow(self._memory_dir / ".write.lock")
+        try:
+            with file_lock(lock_fd, exclusive=True):
+                if expected_baseline is not None and self.read_projects() != expected_baseline:
+                    logger.info(
+                        "Skipping stale projects write: file changed since the "
+                        "baseline this update was computed from"
+                    )
+                    return False
+                self._atomic_write_text(self._projects_file, full)
+                # Indexed inside the lock — see write_preferences.
+                self._index_file(self._projects_file, full)
+        finally:
+            os.close(lock_fd)
+        return True
 
     # ── Legacy read/write (used by consolidator) ──
 
@@ -215,11 +376,19 @@ class MemoryStore:
         if "# Active Projects" in content:
             idx = content.index("# Active Projects")
             self.write_preferences(content[:idx].strip() + "\n")
-            # Use write_text + index (not write_projects which adds header)
+            # Atomic write + index (not write_projects which adds header);
+            # same lock as write_preferences/write_projects.
             projects_content = content[idx:].strip() + "\n"
+            self._require_link_free_roots()  # gate before the first syscall
             self._memory_dir.mkdir(parents=True, exist_ok=True)
-            self._projects_file.write_text(projects_content, encoding="utf-8")
-            self._index_file(self._projects_file, projects_content)
+            lock_fd = self._open_lock_nofollow(self._memory_dir / ".write.lock")
+            try:
+                with file_lock(lock_fd, exclusive=True):
+                    self._atomic_write_text(self._projects_file, projects_content)
+                    # Indexed inside the lock — see write_preferences.
+                    self._index_file(self._projects_file, projects_content)
+            finally:
+                os.close(lock_fd)
         else:
             self.write_preferences(content)
 
@@ -236,16 +405,47 @@ class MemoryStore:
         file lock so concurrent appends from other sessions/threads or processes
         cannot interleave and clobber each other's entries. The lock uses
         :func:`kiro_crew.platform_compat.file_lock` (real cross-platform locking
-        — ``flock`` on POSIX, ``msvcrt`` on Windows). The lock covers read +
-        rewrite; indexing and cache invalidation run after it is released.
+        — ``flock`` on POSIX, ``msvcrt`` on Windows). The lock covers read,
+        rewrite AND the FTS index update, so the file and its index always
+        publish under the same lock tenure; cache invalidation runs after
+        release.
         """
+        self._require_link_free_roots()  # gate before the first syscall
         self._history_dir.mkdir(parents=True, exist_ok=True)
         path = self._today_history_file()
         lock_path = self._history_dir / ".append.lock"
         timestamp = datetime.now().astimezone().strftime("%H:%M %Z")
 
-        with open(lock_path, "w") as fd:
-            with file_lock(fd.fileno(), exclusive=True):
+        lock_fd = self._open_lock_nofollow(lock_path)
+        try:
+            with file_lock(lock_fd, exclusive=True):
+                # Reject a planted link at today's dated name BEFORE the
+                # read: read_text would follow it and this read-modify-write
+                # would republish the link target's contents into memory
+                # (and thus into show/export).
+                if is_link_or_junction(path):
+                    self._audit_read_refusal(
+                        "leaf_link", path, "today's history file is a link/junction"
+                    )
+                    raise OSError(f"memory write refused (history leaf is a link): {path}")
+                # A HARDLINK passes the link/junction check (it is a regular
+                # inode), but reading it republishes the shared inode's
+                # contents all the same — an existing leaf must be a LONE
+                # regular inode, the same standard _open_lock_nofollow and the
+                # hardened reader already enforce. lstat: never follows.
+                try:
+                    st = os.lstat(path)
+                except OSError:
+                    st = None  # missing: a fresh day, normal state
+                if st is not None and (not _stat.S_ISREG(st.st_mode) or st.st_nlink != 1):
+                    self._audit_read_refusal(
+                        "leaf_not_lone_regular",
+                        path,
+                        "today's history file is not a lone regular inode (hardlink/special)",
+                    )
+                    raise OSError(
+                        f"memory write refused (history leaf is not a lone regular file): {path}"
+                    )
                 content = ""
                 if path.exists():
                     content = path.read_text(encoding="utf-8")
@@ -254,8 +454,11 @@ class MemoryStore:
                     content = f"# {date}\n"
 
                 content += f"\n#### {timestamp}\n{entry.strip()}\n"
-                path.write_text(content, encoding="utf-8")
-        self._index_file(path, content)
+                self._atomic_write_text(path, content)
+                # Indexed inside the lock — see write_preferences.
+                self._index_file(path, content)
+        finally:
+            os.close(lock_fd)
         self._invalidate_history_cache()  # today's window changed
 
     def prune_history(self, keep_days: int = 365) -> int:
@@ -339,6 +542,265 @@ class MemoryStore:
     def read_history(self) -> str:
         """Read all history from the last 30 days (legacy compat)."""
         return self.read_recent_history(days=30)
+
+    # ── Structured markdown reads (CLI read API) ──
+
+    def _audit_read_refusal(self, rule: str, path: Path | str, reason: str) -> None:
+        """Best-effort SEL denial record for a refused markdown read.
+
+        The refusal branches below are security controls (link/UNC/special-file
+        admission gates over an agent-writable tree), so each denial must leave
+        a tamper-evident record in the security event log, not only a process
+        log line a same-host actor could suppress. Mirrors
+        ``hooks._audit_governance``: lazy import, never lets an audit failure
+        break the read path (the refusal itself already fails closed).
+        """
+        try:
+            from kiro_crew.sel import sel
+
+            sel().log_governance_decision(
+                session_key="_host",
+                tool_name="memory_markdown_read",
+                item=str(path),
+                outcome="denied",
+                rule=rule,
+                layer="memory_read_guard",
+                reason=reason,
+            )
+        except Exception:
+            logger.debug("memory read refusal audit emit failed", exc_info=True)
+
+    def _read_root_guard(self) -> bool:
+        """Single admission gate for the structured read surface.
+
+        INVARIANT: no filesystem syscall in this surface may touch a path
+        that has not passed this gate, and no component of a touched path may
+        be a link. That one property makes the whole finding class
+        (symlink/junction escapes, UNC credential probes, special-file reads)
+        unreachable instead of patching instances:
+
+        1. Windows UNC gate — purely LEXICAL, evaluated before any syscall
+           (``stat``/``glob``/``exists`` on a UNC path is itself the outbound
+           SMB credential probe). Mirrors ``hooks.validate_file_path``.
+        2. Reparse-point gate — the memory root and history dir must not be
+           symlinks or Windows junctions (``lstat``-based check that never
+           traverses the link). Leaf files get the same check in
+           :meth:`_guarded_entry`, so every component of every touched path
+           is verified link-free.
+        """
+        root = str(self._memory_dir)
+        if os.name == "nt" and is_unc_shape(root) and not unc_probe_allowed(root):
+            logger.warning("memory read refused (untrusted UNC workspace): %s", root)
+            self._audit_read_refusal("unc_workspace", root, "untrusted UNC workspace")
+            return False
+        # The workspace leaf is checked FIRST: a workspace swapped for a
+        # link/junction would make the two descendant checks below traverse it
+        # and validate paths inside the link's target instead of the admitted
+        # tree. lstat-based, so the link itself is never followed. (Linked
+        # ANCESTORS of the workspace are deliberately not rejected — resolving
+        # the whole chain would refuse legitimate setups like a symlinked
+        # /home, and those components are not agent-writable.)
+        if (
+            is_link_or_junction(self._workspace)
+            or is_link_or_junction(self._memory_dir)
+            or is_link_or_junction(self._history_dir)
+        ):
+            logger.warning("memory read refused (memory root is a reparse point): %s", root)
+            self._audit_read_refusal(
+                "root_reparse_point", root, "workspace, memory root or history dir is a link"
+            )
+            return False
+        return True
+
+    def markdown_snapshot(self, since: _date | None = None) -> dict:
+        """Structured, read-only view of the markdown memory layer.
+
+        Returns the three markdown surfaces as data::
+
+            {"preferences": entry, "projects": entry, "history": [day, ...]}
+
+        where ``entry`` is ``{"path", "updated_at", "content"}`` and each
+        history ``day`` additionally carries its ``date`` (``YYYY-MM-DD``).
+        ``updated_at`` is the file's mtime in UTC ISO-8601 so consumers can
+        sync incrementally instead of re-reading everything.
+
+        A missing or empty file is a normal state, not an error: the entry is
+        returned with ``content: ""`` and ``updated_at: None``. ``since``
+        filters history to days on or after that date.
+        """
+        return {
+            "preferences": self._guarded_entry(self._preferences_file),
+            "projects": self._guarded_entry(self._projects_file),
+            "history": self.read_history_entries(since=since),
+        }
+
+    def read_history_entries(self, since: _date | None = None) -> list[dict]:
+        """Per-day history entries, oldest first, as structured data.
+
+        Each entry is ``{"date", "path", "updated_at", "content"}``. Files
+        whose stem is not a ``YYYY-MM-DD`` date are skipped (mirrors
+        :meth:`prune_history`). Unlike :meth:`read_recent_history` this
+        enumerates full per-day content with no decay, so consumers get
+        discrete entries rather than one concatenated blob.
+
+        The aggregate is bounded: each file's read is individually
+        size-capped, but the agent-writable history dir can hold arbitrarily
+        many valid dated files, so without an aggregate cap a snapshot (and
+        thus ``memory show`` / ``memory export``) could retain unbounded
+        content and exhaust memory. At most
+        :attr:`_HISTORY_SNAPSHOT_MAX_ENTRIES` entries and
+        :attr:`_HISTORY_SNAPSHOT_MAX_BYTES` cumulative content bytes are
+        returned; the newest days win when trimming, and the result stays
+        oldest-first.
+        """
+        if not self._read_root_guard():
+            return []
+        if not self._history_dir.exists():
+            return []
+
+        def _dated_files() -> "Iterator[tuple[_date, Path]]":
+            for f in self._history_dir.glob("*.md"):
+                try:
+                    day = datetime.strptime(f.stem, "%Y-%m-%d").date()
+                except ValueError:
+                    continue
+                if since is not None and day < since:
+                    continue
+                yield (day, f)
+
+        # Bounded selection DURING enumeration: the history dir is
+        # agent-writable, so the number of valid dated files is unbounded and
+        # materializing every (date, path) tuple before capping would let a
+        # planted directory exhaust memory. heapq.nlargest keeps at most
+        # _HISTORY_SNAPSHOT_MAX_ENTRIES candidates alive and returns them
+        # newest-first, which is also the order the caps below want.
+        candidates = heapq.nlargest(self._HISTORY_SNAPSHOT_MAX_ENTRIES, _dated_files())
+        entries: list[dict] = []
+        total_bytes = 0
+        # Newest-first so the caps keep the most recent days (the ones a
+        # consumer syncing memory actually needs), then restore oldest-first
+        # order for the caller.
+        for day, f in candidates:
+            entry = self._guarded_entry(f)
+            # A glob-enumerated file exists, so missing updated_at means the
+            # guarded read either REFUSED it (planted link, special file,
+            # size cap — skip) or read a genuinely EMPTY day (retain, with
+            # null metadata per the documented empty-state contract). A true
+            # empty is a lone regular non-link file of size 0.
+            if entry["updated_at"] is None:
+                try:
+                    st = os.lstat(f)
+                except OSError:
+                    continue
+                if not (_stat.S_ISREG(st.st_mode) and st.st_size == 0):
+                    continue  # refused, not empty
+            size = len(entry["content"].encode("utf-8"))
+            # Always admit the first (newest) entry so one large-but-valid day
+            # cannot zero out the whole snapshot; the per-file read cap bounds
+            # that single entry.
+            if entries and total_bytes + size > self._HISTORY_SNAPSHOT_MAX_BYTES:
+                break
+            total_bytes += size
+            entry["date"] = day.isoformat()
+            entries.append(entry)
+        entries.reverse()
+        return entries
+
+    # Aggregate bounds for the history snapshot. Per-file reads are size-capped
+    # in _guarded_entry, but the number of valid dated files is attacker/agent
+    # controlled, so the aggregate must be bounded too or `memory show` /
+    # `memory export --include-markdown` retain unbounded content.
+    _HISTORY_SNAPSHOT_MAX_ENTRIES = 366  # ~one year of daily files
+    _HISTORY_SNAPSHOT_MAX_BYTES = 8 * 1024 * 1024  # cumulative content bytes
+
+    # One retry when a concurrent writer changes the file mid-read: the second
+    # attempt almost always lands after the writer's atomic rewrite finishes.
+    _GUARDED_READ_ATTEMPTS = 2
+
+    def _guarded_entry(self, path: Path) -> dict:
+        """Shape one markdown file as ``{"path", "updated_at", "content"}``.
+
+        The memory directory is agent-writable, so a planted dated ``.md``
+        name could be a symlink, a hardlink, or a special file. Reads go
+        through :func:`kiro_crew.hooks.safe_read_file_bytes_nolink` confined
+        to the memory root: it opens with ``O_NOFOLLOW``, rejects non-regular
+        files (so a ``/dev/zero`` target cannot wedge the read), rejects
+        hardlinked inodes and sensitive resolved targets, and caps the size.
+        A refused, unreadable, oversized, or undecodable file surfaces as an
+        empty entry — same shape as a missing file — never as leaked content
+        or a traceback.
+
+        ``updated_at`` is snapshotted before the read and re-checked after,
+        so the reported metadata always describes the bytes returned: when a
+        concurrent consolidation rewrites or prunes the file mid-read, the
+        read is retried once and then degrades to an empty entry rather than
+        pairing one version's content with another version's mtime.
+        """
+        empty = {"path": str(path), "updated_at": None, "content": ""}
+        # Admission gate BEFORE the stat below — see _read_root_guard for the
+        # invariant. The leaf gets its own lstat-based reparse check so every
+        # component of the touched path (root, history dir, file) is verified
+        # link-free before any following syscall.
+        if not self._read_root_guard():
+            return dict(empty)
+        if is_link_or_junction(path):
+            logger.warning("memory read refused (file is a link): %s", path)
+            self._audit_read_refusal("leaf_link", path, "memory file is a link/junction")
+            return dict(empty)
+        for _ in range(self._GUARDED_READ_ATTEMPTS):
+            try:
+                st_before = path.stat()
+            except OSError:
+                return dict(empty)  # missing (or vanished) is a normal state
+            # Reject non-regular files BEFORE any open: opening a planted FIFO
+            # read-only blocks forever waiting for a writer, so the reader's
+            # own fstat check would never be reached. stat() follows symlinks,
+            # so a link to a device/FIFO is also rejected here. (A racing swap
+            # to a FIFO after this check is the reader's O_NOFOLLOW + fstat
+            # problem for symlinks; an active same-host attacker racing the
+            # window is outside this surface's threat model.)
+            if not _stat.S_ISREG(st_before.st_mode):
+                logger.warning("memory read refused (not a regular file): %s", path)
+                self._audit_read_refusal(
+                    "not_regular_file", path, "memory path is not a regular file"
+                )
+                return dict(empty)
+            try:
+                data = safe_read_file_bytes_nolink(str(path), within_root=str(self._memory_dir))
+            except FileTooLargeError:
+                logger.warning("memory read refused (size cap) for %s", path)
+                self._audit_read_refusal("size_cap", path, "memory file exceeds read size cap")
+                return dict(empty)
+            if data is None:
+                logger.warning("memory read refused or failed for %s", path)
+                self._audit_read_refusal(
+                    "read_refused", path, "hardened read refused the file (link/hardlink/target)"
+                )
+                return dict(empty)
+            try:
+                st_after = path.stat()
+            except OSError:
+                return dict(empty)  # deleted mid-read: no stable version
+            if (st_before.st_mtime_ns, st_before.st_size) != (
+                st_after.st_mtime_ns,
+                st_after.st_size,
+            ):
+                continue  # rewritten mid-read: retry for a stable version
+            try:
+                content = data.decode("utf-8")
+            except UnicodeDecodeError:
+                logger.warning("memory file is not valid UTF-8: %s", path)
+                return dict(empty)
+            if content == "":
+                # Documented empty-state contract: empty content carries null
+                # metadata, same shape as a missing file — consumers key
+                # incremental sync on updated_at, and an "updated" empty file
+                # has nothing to sync.
+                return dict(empty)
+            updated_at = datetime.fromtimestamp(st_after.st_mtime, tz=timezone.utc).isoformat()
+            return {"path": str(path), "updated_at": updated_at, "content": content}
+        logger.warning("memory file kept changing during read: %s", path)
+        return dict(empty)
 
     # ── Context Injection ──
 
@@ -516,8 +978,7 @@ class MemoryStore:
                     (query, limit),
                 )
                 results = [
-                    {"path": row[0], "snippet": row[1], "rank": row[2]}
-                    for row in cursor.fetchall()
+                    {"path": row[0], "snippet": row[1], "rank": row[2]} for row in cursor.fetchall()
                 ]
             return results
         except Exception:

--- a/test/test_consolidation_placeholder_guard.py
+++ b/test/test_consolidation_placeholder_guard.py
@@ -166,8 +166,12 @@ class TestConsolidatePlaceholderGuard:
             }
             await c._consolidate("k", include_history=False)
 
-        memory.write_preferences.assert_called_once_with(new_prefs)
-        memory.write_projects.assert_called_once_with(new_projects)
+        memory.write_preferences.assert_called_once_with(
+            new_prefs, expected_baseline="# User Preferences\n\n- old\n"
+        )
+        memory.write_projects.assert_called_once_with(
+            new_projects, expected_baseline="# Active Projects\n\n## Old\n"
+        )
 
     @pytest.mark.asyncio
     async def test_shrunk_but_valid_update_is_written(self):
@@ -182,7 +186,7 @@ class TestConsolidatePlaceholderGuard:
             llm.return_value = {"projects_update": trimmed}
             await c._consolidate("k", include_history=False)
 
-        memory.write_projects.assert_called_once_with(trimmed)
+        memory.write_projects.assert_called_once_with(trimmed, expected_baseline=bloated)
 
     @pytest.mark.asyncio
     async def test_omitted_update_keys_write_nothing(self):

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -167,6 +167,40 @@ class TestPreferencesProjectsHistory:
         mem.write_preferences.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_preferences_put_write_runs_off_the_event_loop_thread(self) -> None:
+        """The atomic write is synchronous file I/O; run inline it stalls every
+        other gateway task on a slow filesystem, so the handler must offload it."""
+        import threading
+
+        loop_thread = threading.get_ident()
+        write_threads: list[int] = []
+        mem = MagicMock()
+        mem.write_preferences.side_effect = lambda _c: write_threads.append(
+            threading.get_ident()
+        )
+        state = _make_state(memory=mem)
+        req = _make_request(state, method="PUT", json_body={"content": "- new"})
+        resp = await mem_mod.api_memory_preferences(req)
+        assert resp.status == 200
+        assert write_threads and write_threads[0] != loop_thread
+
+    @pytest.mark.asyncio
+    async def test_projects_put_write_runs_off_the_event_loop_thread(self) -> None:
+        import threading
+
+        loop_thread = threading.get_ident()
+        write_threads: list[int] = []
+        mem = MagicMock()
+        mem.write_projects.side_effect = lambda _c: write_threads.append(
+            threading.get_ident()
+        )
+        state = _make_state(memory=mem)
+        req = _make_request(state, method="PUT", json_body={"content": "## P"})
+        resp = await mem_mod.api_memory_projects(req)
+        assert resp.status == 200
+        assert write_threads and write_threads[0] != loop_thread
+
+    @pytest.mark.asyncio
     async def test_projects_get_returns_stored_content(self) -> None:
         mem = MagicMock()
         mem.read_projects.return_value = "## Proj"
@@ -204,9 +238,14 @@ class TestPreferencesProjectsHistory:
         target = tmp_path / "history" / "2026-01-01.md"
         mem = MagicMock()
         mem._today_history_file.return_value = target
+        # The handler must route through the store's atomic, symlink-safe
+        # writer — a raw write_text would follow a planted dated symlink and
+        # tear under concurrent PUTs.
+        mem._atomic_write_text.side_effect = lambda p, c: p.write_text(c, encoding="utf-8")
         state = _make_state(memory=mem)
         req = _make_request(state, method="PUT", json_body={"content": "entry"})
         assert (await mem_mod.api_memory_history(req)).status == 200
+        mem._atomic_write_text.assert_called_once_with(target, "entry")
         assert target.read_text(encoding="utf-8") == "entry"
 
     @pytest.mark.asyncio

--- a/test/test_memory_markdown_read.py
+++ b/test/test_memory_markdown_read.py
@@ -1,0 +1,1005 @@
+"""Tests for the markdown memory read surface.
+
+Covers ``kirocrew memory show`` (the documented-but-previously-missing
+command) and ``kirocrew memory export --include-markdown``, plus the
+``MemoryStore`` readers behind them. The most important guard is that
+``export`` WITHOUT the flag stays byte-identical to its previous shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew import cli_commands
+from kiro_crew.memory import MemoryStore
+
+# ── Helpers ──
+
+
+def _store(tmp_path: Path) -> MemoryStore:
+    return MemoryStore(workspace=tmp_path / "ws")
+
+
+def _populated_store(tmp_path: Path) -> MemoryStore:
+    ms = _store(tmp_path)
+    ms.init()
+    ms.write_preferences("# User Preferences\n\n- prefers pytest\n")
+    ms.write_projects("# Active Projects\n\n- shipping the read API\n")
+    history = tmp_path / "ws" / "memory" / "history"
+    (history / "2026-01-01.md").write_text(
+        "# 2026-01-01\n\n#### 09:00\nold day\n", encoding="utf-8"
+    )
+    (history / "2026-03-05.md").write_text(
+        "# 2026-03-05\n\n#### 10:00\nnew day\n", encoding="utf-8"
+    )
+    (history / "2026-02-02.md").write_text(
+        "# 2026-02-02\n\n#### 11:00\nmid day\n", encoding="utf-8"
+    )
+    (history / "notes.md").write_text("not a daily file\n", encoding="utf-8")
+    return ms
+
+
+def _show_args(**overrides: object) -> argparse.Namespace:
+    base: dict[str, object] = {
+        "mem_action": "show",
+        "target": None,
+        "format": "md",
+        "since": None,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class _EmptyVectorStore:
+    """Stub with exactly the surface ``_memory_cmd`` export uses."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def init(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def get_all_semantic(self) -> list:
+        return []
+
+    def get_episodic_list(self, limit: int = 0) -> list:
+        return []
+
+    def get_events(self, limit: int = 0) -> list:
+        return []
+
+    def import_memory(self, data: dict) -> dict:
+        return {"semantic": 0, "episodic": 0, "skipped": 0}
+
+
+# ── MemoryStore readers ──
+
+
+class TestMarkdownSnapshot:
+    def test_missing_files_are_normal_not_errors(self, tmp_path: Path) -> None:
+        snap = _store(tmp_path).markdown_snapshot()
+        for key in ("preferences", "projects"):
+            assert snap[key]["content"] == ""
+            assert snap[key]["updated_at"] is None
+            assert snap[key]["path"]
+        assert snap["history"] == []
+
+    def test_reads_content_and_utc_mtime(self, tmp_path: Path) -> None:
+        snap = _populated_store(tmp_path).markdown_snapshot()
+        assert "- prefers pytest" in snap["preferences"]["content"]
+        assert "- shipping the read API" in snap["projects"]["content"]
+        for key in ("preferences", "projects"):
+            parsed = datetime.fromisoformat(snap[key]["updated_at"])
+            assert parsed.utcoffset() is not None and not parsed.utcoffset()
+            assert str(tmp_path) in snap[key]["path"]
+
+    def test_history_entries_sorted_dated_and_non_daily_skipped(self, tmp_path: Path) -> None:
+        entries = _populated_store(tmp_path).markdown_snapshot()["history"]
+        assert [e["date"] for e in entries] == ["2026-01-01", "2026-02-02", "2026-03-05"]
+        assert all("updated_at" in e and "path" in e and "content" in e for e in entries)
+        assert not any("notes" in e["path"] for e in entries)
+
+    def test_since_filters_history_days(self, tmp_path: Path) -> None:
+        ms = _populated_store(tmp_path)
+        entries = ms.markdown_snapshot(since=date(2026, 2, 1))["history"]
+        assert [e["date"] for e in entries] == ["2026-02-02", "2026-03-05"]
+
+
+class TestHistorySnapshotAggregateBounds:
+    """Many valid dated files must not yield an unbounded snapshot."""
+
+    def test_entry_count_cap_keeps_newest_days_oldest_first(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        history = tmp_path / "ws" / "memory" / "history"
+        for day in range(1, 10):
+            (history / f"2026-01-{day:02d}.md").write_text(f"day {day}\n", encoding="utf-8")
+        monkeypatch.setattr(MemoryStore, "_HISTORY_SNAPSHOT_MAX_ENTRIES", 3)
+        entries = ms.read_history_entries()
+        assert [e["date"] for e in entries] == ["2026-01-07", "2026-01-08", "2026-01-09"]
+
+    def test_cumulative_byte_cap_trims_older_days(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        history = tmp_path / "ws" / "memory" / "history"
+        for day in range(1, 5):
+            (history / f"2026-01-{day:02d}.md").write_text("x" * 100, encoding="utf-8")
+        monkeypatch.setattr(MemoryStore, "_HISTORY_SNAPSHOT_MAX_BYTES", 250)
+        entries = ms.read_history_entries()
+        # Newest two fit (200 bytes); the third would exceed 250 and stops the walk.
+        assert [e["date"] for e in entries] == ["2026-01-03", "2026-01-04"]
+
+    def test_single_oversized_day_is_still_returned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        history = tmp_path / "ws" / "memory" / "history"
+        (history / "2026-01-01.md").write_text("x" * 100, encoding="utf-8")
+        (history / "2026-01-02.md").write_text("y" * 100, encoding="utf-8")
+        monkeypatch.setattr(MemoryStore, "_HISTORY_SNAPSHOT_MAX_BYTES", 50)
+        entries = ms.read_history_entries()
+        # The newest entry always lands even when it alone exceeds the cap
+        # (its size is bounded by the per-file read cap, not this one).
+        assert [e["date"] for e in entries] == ["2026-01-02"]
+
+
+class TestMarkdownSnapshotSymlinkGuard:
+    """A planted link in the agent-writable memory dir must never leak file
+    contents through the read API. No HOME/USERPROFILE overrides here: the
+    guard is the lstat-based no-link gate plus in-root containment, which
+    reject the escaping link regardless of what is_sensitive_path anchors to
+    — and leaving HOME real keeps the exercised gate protecting the real
+    credential roots."""
+
+    SECRET = "aws_secret_access_key = SUPERSECRET"
+
+    def _secret_outside_memory_root(self, tmp_path: Path) -> Path:
+        outside = tmp_path / "outside"
+        outside.mkdir(parents=True)
+        secret = outside / "credentials"
+        secret.write_text(self.SECRET, encoding="utf-8")
+        return secret
+
+    def _symlink_or_skip(self, link: Path, target: Path) -> None:
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):  # pragma: no cover - Windows CI
+            pytest.skip("symlinks not available on this platform")
+
+    def test_history_symlink_to_outside_file_is_skipped(self, tmp_path: Path) -> None:
+        secret = self._secret_outside_memory_root(tmp_path)
+        ms = _populated_store(tmp_path)
+        history = tmp_path / "ws" / "memory" / "history"
+        self._symlink_or_skip(history / "2026-05-05.md", secret)
+        snapshot = ms.markdown_snapshot()
+        assert self.SECRET not in json.dumps(snapshot)
+        assert [e["date"] for e in snapshot["history"]] == [
+            "2026-01-01",
+            "2026-02-02",
+            "2026-03-05",
+        ]
+
+    def test_preferences_symlink_to_outside_file_yields_empty_entry(self, tmp_path: Path) -> None:
+        secret = self._secret_outside_memory_root(tmp_path)
+        ms = _store(tmp_path)
+        (tmp_path / "ws" / "memory").mkdir(parents=True)
+        self._symlink_or_skip(tmp_path / "ws" / "memory" / "preferences.md", secret)
+        prefs = ms.markdown_snapshot()["preferences"]
+        assert prefs["content"] == ""
+        assert prefs["updated_at"] is None
+
+    def test_symlinked_history_dir_is_refused(self, tmp_path: Path) -> None:
+        real_history = tmp_path / "elsewhere" / "history"
+        real_history.mkdir(parents=True)
+        (real_history / "2026-04-04.md").write_text("# 2026-04-04\nleak\n", encoding="utf-8")
+        ms = _store(tmp_path)
+        (tmp_path / "ws" / "memory").mkdir(parents=True)
+        self._symlink_or_skip(tmp_path / "ws" / "memory" / "history", real_history)
+        assert ms.markdown_snapshot()["history"] == []
+
+
+class TestReadRefusalSelAudit:
+    """Every security refusal in the guarded read surface must leave a
+    tamper-evident SEL denial record — a process-log warning alone can be
+    suppressed by the same same-host actor the guard defends against."""
+
+    def _recording_sel(self, monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+        import kiro_crew.sel as sel_mod
+
+        calls: list[dict] = []
+
+        class _StubSel:
+            def log_governance_decision(self, **kwargs: object) -> None:
+                calls.append(dict(kwargs))
+
+        monkeypatch.setattr(sel_mod, "sel", lambda: _StubSel())
+        return calls
+
+    def _symlink_or_skip(self, link: Path, target: Path) -> None:
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):  # pragma: no cover - Windows CI
+            pytest.skip("symlinks not available on this platform")
+
+    def test_leaf_symlink_refusal_emits_sel_denial(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = self._recording_sel(monkeypatch)
+        outside = tmp_path / "outside.md"
+        outside.write_text("secret", encoding="utf-8")
+        ms = _store(tmp_path)
+        (tmp_path / "ws" / "memory").mkdir(parents=True)
+        link = tmp_path / "ws" / "memory" / "preferences.md"
+        self._symlink_or_skip(link, outside)
+        entry = ms.markdown_snapshot()["preferences"]
+        assert entry["content"] == ""
+        denials = [c for c in calls if c.get("outcome") == "denied"]
+        assert denials, "symlink refusal must emit an SEL denial"
+        assert denials[0]["rule"] == "leaf_link"
+        assert denials[0]["layer"] == "memory_read_guard"
+        assert str(link) in str(denials[0]["item"])
+
+    def test_root_reparse_refusal_emits_sel_denial(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = self._recording_sel(monkeypatch)
+        real_history = tmp_path / "elsewhere" / "history"
+        real_history.mkdir(parents=True)
+        ms = _store(tmp_path)
+        (tmp_path / "ws" / "memory").mkdir(parents=True)
+        self._symlink_or_skip(tmp_path / "ws" / "memory" / "history", real_history)
+        assert ms.markdown_snapshot()["history"] == []
+        assert any(c.get("rule") == "root_reparse_point" for c in calls)
+
+    def test_fifo_refusal_emits_sel_denial(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        if not hasattr(os, "mkfifo"):  # pragma: no cover - Windows CI
+            pytest.skip("mkfifo not available on this platform")
+        calls = self._recording_sel(monkeypatch)
+        ms = _store(tmp_path)
+        mem_dir = tmp_path / "ws" / "memory"
+        mem_dir.mkdir(parents=True)
+        os.mkfifo(mem_dir / "preferences.md")
+        entry = ms.markdown_snapshot()["preferences"]
+        assert entry["content"] == ""
+        assert any(c.get("rule") == "not_regular_file" for c in calls)
+
+    def test_audit_failure_never_breaks_the_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import kiro_crew.sel as sel_mod
+
+        def _boom() -> object:
+            raise RuntimeError("sel unavailable")
+
+        monkeypatch.setattr(sel_mod, "sel", _boom)
+        outside = tmp_path / "outside.md"
+        outside.write_text("secret", encoding="utf-8")
+        ms = _store(tmp_path)
+        (tmp_path / "ws" / "memory").mkdir(parents=True)
+        self._symlink_or_skip(tmp_path / "ws" / "memory" / "preferences.md", outside)
+        entry = ms.markdown_snapshot()["preferences"]
+        assert entry["content"] == ""  # refusal still fails closed, no raise
+
+
+class TestGuardedReadRobustness:
+    """Special, oversized, malformed, and concurrently-rewritten files must
+    degrade to empty entries or a consistent retry — never a crash, an OOM
+    read, or content paired with another version's metadata."""
+
+    def test_invalid_utf8_yields_empty_entry(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        (tmp_path / "ws" / "memory" / "preferences.md").write_bytes(b"\xff\xfe broken \x80")
+        prefs = ms.markdown_snapshot()["preferences"]
+        assert prefs["content"] == ""
+        assert prefs["updated_at"] is None
+
+    def test_oversized_file_yields_empty_entry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import hooks
+
+        ms = _store(tmp_path)
+        ms.init()
+        (tmp_path / "ws" / "memory" / "preferences.md").write_text("x" * 64, encoding="utf-8")
+        monkeypatch.setattr(hooks, "MAX_FILE_BYTES", 16)
+        prefs = ms.markdown_snapshot()["preferences"]
+        assert prefs["content"] == ""
+        assert prefs["updated_at"] is None
+
+    def test_fifo_special_file_is_rejected_not_read(self, tmp_path: Path) -> None:
+        import os
+
+        if not hasattr(os, "mkfifo"):  # pragma: no cover - Windows CI
+            pytest.skip("mkfifo not available on this platform")
+        ms = _store(tmp_path)
+        ms.init()
+        history = tmp_path / "ws" / "memory" / "history"
+        os.mkfifo(history / "2026-06-06.md")
+        assert ms.markdown_snapshot()["history"] == []
+
+    def test_concurrent_rewrite_retries_to_consistent_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import memory as memory_mod
+
+        ms = _store(tmp_path)
+        ms.init()
+        prefs_path = tmp_path / "ws" / "memory" / "preferences.md"
+        prefs_path.write_text("old version", encoding="utf-8")
+        real_reader = memory_mod.safe_read_file_bytes_nolink
+        state = {"raced": False}
+
+        def racing_reader(raw: str, **kwargs: object) -> bytes | None:
+            data = real_reader(raw, **kwargs)
+            if not state["raced"]:
+                state["raced"] = True
+                prefs_path.write_text("new version longer", encoding="utf-8")
+            return data
+
+        monkeypatch.setattr(memory_mod, "safe_read_file_bytes_nolink", racing_reader)
+        prefs = ms.markdown_snapshot()["preferences"]
+        assert prefs["content"] == "new version longer"
+        assert prefs["updated_at"] is not None
+
+    def test_file_changing_on_every_read_degrades_to_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import memory as memory_mod
+
+        ms = _store(tmp_path)
+        ms.init()
+        prefs_path = tmp_path / "ws" / "memory" / "preferences.md"
+        prefs_path.write_text("v0", encoding="utf-8")
+        real_reader = memory_mod.safe_read_file_bytes_nolink
+        counter = {"n": 0}
+
+        def always_racing(raw: str, **kwargs: object) -> bytes | None:
+            data = real_reader(raw, **kwargs)
+            counter["n"] += 1
+            # Vary the LENGTH each round: the size delta guarantees the
+            # before/after comparison sees the change even on filesystems
+            # whose mtime granularity is coarser than this loop.
+            prefs_path.write_text("v" * (counter["n"] + 2), encoding="utf-8")
+            return data
+
+        monkeypatch.setattr(memory_mod, "safe_read_file_bytes_nolink", always_racing)
+        prefs = ms.markdown_snapshot()["preferences"]
+        assert prefs["content"] == ""
+        assert prefs["updated_at"] is None
+
+
+class TestUncWorkspaceGate:
+    """On Windows, an agent-configured UNC workspace must be rejected
+    LEXICALLY before any stat/glob/exists — those calls are themselves the
+    outbound SMB credential probe."""
+
+    def _unc_store(self, monkeypatch: pytest.MonkeyPatch) -> "object":
+        import types
+
+        from kiro_crew import memory as memory_mod
+        from kiro_crew.memory import MemoryStore
+
+        store = MemoryStore(workspace=Path("//evil-host/share/ws"))
+        # Patch ONLY memory.py's view of os (its sole use is the gate's
+        # os.name check) — patching the global os.name would make pathlib
+        # dispatch WindowsPath everywhere on a POSIX test host.
+        monkeypatch.setattr(memory_mod, "os", types.SimpleNamespace(name="nt"))
+        return store
+
+    def test_snapshot_refuses_unc_workspace_without_filesystem_touch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import memory as memory_mod
+
+        ms = self._unc_store(monkeypatch)
+
+        def boom(*args: object, **kwargs: object) -> bytes | None:  # pragma: no cover
+            raise AssertionError("filesystem reader must not be reached for a UNC workspace")
+
+        monkeypatch.setattr(memory_mod, "safe_read_file_bytes_nolink", boom)
+        snapshot = ms.markdown_snapshot()
+        assert snapshot["preferences"]["content"] == ""
+        assert snapshot["preferences"]["updated_at"] is None
+        assert snapshot["history"] == []
+
+    def test_non_windows_is_unaffected(self, tmp_path: Path) -> None:
+        ms = _populated_store(tmp_path)
+        assert "- prefers pytest" in ms.markdown_snapshot()["preferences"]["content"]
+
+
+# ── kirocrew memory show ──
+
+
+class TestMemoryShowCli:
+    def test_show_each_target_markdown(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        ms = _populated_store(tmp_path)
+        expected = {
+            "preferences": "- prefers pytest",
+            "projects": "- shipping the read API",
+            "history": "mid day",
+        }
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            for target, marker in expected.items():
+                cli_commands._memory_cmd(_show_args(target=target))
+                assert marker in capsys.readouterr().out
+
+    def test_show_all_targets_when_omitted(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ms = _populated_store(tmp_path)
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            cli_commands._memory_cmd(_show_args())
+        out = capsys.readouterr().out
+        assert "- prefers pytest" in out and "- shipping the read API" in out and "old day" in out
+
+    def test_show_json_returns_structured_entries(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ms = _populated_store(tmp_path)
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            cli_commands._memory_cmd(_show_args(target="preferences", format="json"))
+            prefs = json.loads(capsys.readouterr().out)
+            assert set(prefs) == {"path", "updated_at", "content"}
+            cli_commands._memory_cmd(_show_args(target="history", format="json"))
+            history = json.loads(capsys.readouterr().out)
+            assert [e["date"] for e in history] == ["2026-01-01", "2026-02-02", "2026-03-05"]
+
+    def test_show_history_since_filter(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        ms = _populated_store(tmp_path)
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            cli_commands._memory_cmd(
+                _show_args(target="history", format="json", since="2026-03-01")
+            )
+        history = json.loads(capsys.readouterr().out)
+        assert [e["date"] for e in history] == ["2026-03-05"]
+
+    def test_show_empty_store_prints_nothing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ms = _store(tmp_path)
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            cli_commands._memory_cmd(_show_args(target="preferences"))
+        assert capsys.readouterr().out == ""
+
+    def test_since_rejected_for_non_history_target(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ms = _store(tmp_path)
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            with pytest.raises(SystemExit) as excinfo:
+                cli_commands._memory_cmd(_show_args(target="preferences", since="2026-01-01"))
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "--since applies only to history" in captured.err
+        assert captured.out == ""
+
+    def test_invalid_since_date_exits_nonzero_with_stderr(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A scheduled JSON consumer must get a failure signal, not non-JSON
+        text on stdout with exit 0."""
+        ms = _store(tmp_path)
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            with pytest.raises(SystemExit) as excinfo:
+                cli_commands._memory_cmd(_show_args(target="history", since="March 1st"))
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "Invalid --since date" in captured.err
+        assert captured.out == ""
+
+    def test_store_reads_where_the_consolidator_writes(self) -> None:
+        """The read surface must anchor where the gateway's consolidator
+        (the writer of this layer) writes: the bare MemoryStore default."""
+        from kiro_crew.memory import MemoryStore, workspace_dir
+
+        store = cli_commands._markdown_memory_store()
+        writer = MemoryStore()
+        assert store._memory_dir == writer._memory_dir
+        assert str(workspace_dir()) in str(store._memory_dir)
+
+    def test_markdown_output_strips_terminal_control_sequences(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_preferences("# User Preferences\n\n- evil \x1b]0;pwned\x07title\n")
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            cli_commands._memory_cmd(_show_args(target="preferences"))
+        out = capsys.readouterr().out
+        assert "\x1b" not in out and "pwned" not in out and "evil" in out
+
+
+# ── kirocrew memory export --include-markdown ──
+
+
+class TestAtomicMemoryWrites:
+    """Writers publish via temp-file + os.replace so a concurrent reader only
+    ever observes committed versions — never a truncated in-progress file."""
+
+    def test_writers_produce_content_with_no_temp_residue(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_preferences("# User Preferences\n\n- atomic\n")
+        ms.write_projects("- project state\n")
+        ms.append_history("an entry")
+        memory_dir = tmp_path / "ws" / "memory"
+        residue = [p.name for p in memory_dir.rglob("*.tmp")]
+        assert residue == []
+        snap = ms.markdown_snapshot()
+        assert "- atomic" in snap["preferences"]["content"]
+        assert "- project state" in snap["projects"]["content"]
+        assert len(snap["history"]) == 1
+
+    def test_failed_replace_cleans_up_temp_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import atomic_write as atomic_write_mod
+
+        ms = _store(tmp_path)
+        ms.init()
+
+        def boom(src: object, dst: object) -> None:
+            raise OSError("simulated replace failure")
+
+        # Patch the rename step inside the atomic_write helper the memory
+        # writers delegate to — patching the global os.replace would affect
+        # unrelated machinery.
+        monkeypatch.setattr(atomic_write_mod, "replace_with_retry", boom)
+        with pytest.raises(OSError):
+            ms.write_preferences("# User Preferences\n\n- lost\n")
+        residue = list((tmp_path / "ws" / "memory").rglob("*.tmp"))
+        assert residue == []
+
+    def test_history_glob_ignores_temp_names(self, tmp_path: Path) -> None:
+        ms = _populated_store(tmp_path)
+        history = tmp_path / "ws" / "memory" / "history"
+        (history / ".2026-03-05.md.tmp-999").write_text("partial", encoding="utf-8")
+        entries = ms.markdown_snapshot()["history"]
+        assert [e["date"] for e in entries] == ["2026-01-01", "2026-02-02", "2026-03-05"]
+        assert not any(Path(e["path"]).name.endswith("tmp-999") for e in entries)
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    def test_rewrite_preserves_existing_restrictive_mode(self, tmp_path: Path) -> None:
+        """A rename-based replace installs the temp file's mode, so without
+        carrying the destination's mode over, a user's 0600 memory file would
+        silently widen to the umask default on the next write."""
+        import stat
+
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_preferences("# User Preferences\n\n- v1\n")
+        prefs = tmp_path / "ws" / "memory" / "preferences.md"
+        prefs.chmod(0o600)
+        ms.write_preferences("# User Preferences\n\n- v2\n")
+        assert stat.S_IMODE(prefs.stat().st_mode) == 0o600
+        assert "- v2" in ms.read_preferences()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    def test_new_file_gets_umask_default_mode(self, tmp_path: Path) -> None:
+        import stat
+
+        ms = _store(tmp_path)
+        ms.init()  # creates fresh files: no pre-existing mode to preserve
+        prefs = tmp_path / "ws" / "memory" / "preferences.md"
+        umask = os.umask(0)
+        os.umask(umask)
+        assert stat.S_IMODE(prefs.stat().st_mode) == (0o666 & ~umask)
+
+
+class TestStaleBaselineWriteGuard:
+    """Compare-and-swap on the markdown writers: a read-merge-write caller
+    (the consolidator) passes the baseline its merge was computed from; a
+    write landing after that baseline changed is skipped, not applied — so a
+    dashboard Save during the minutes-long consolidation window is never
+    silently reverted."""
+
+    def test_write_skipped_when_baseline_is_stale(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_preferences("# User Preferences\n\n- v1\n")
+        baseline = ms.read_preferences()
+        # A concurrent save lands after the baseline was read.
+        ms.write_preferences("# User Preferences\n\n- user edit\n")
+        wrote = ms.write_preferences(
+            "# User Preferences\n\n- merged from v1\n", expected_baseline=baseline
+        )
+        assert wrote is False
+        assert "- user edit" in ms.read_preferences()
+
+    def test_write_applies_when_baseline_matches(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_preferences("# User Preferences\n\n- v1\n")
+        baseline = ms.read_preferences()
+        wrote = ms.write_preferences(
+            "# User Preferences\n\n- merged\n", expected_baseline=baseline
+        )
+        assert wrote is True
+        assert "- merged" in ms.read_preferences()
+
+    def test_projects_guard_matches_preferences_semantics(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_projects("# Active Projects\n\n- p1\n")
+        baseline = ms.read_projects()
+        ms.write_projects("# Active Projects\n\n- user edit\n")
+        assert ms.write_projects("# Active Projects\n\n- merged\n", expected_baseline=baseline) is False
+        assert "- user edit" in ms.read_projects()
+        fresh = ms.read_projects()
+        assert ms.write_projects("# Active Projects\n\n- merged\n", expected_baseline=fresh) is True
+
+    def test_whitespace_only_edit_is_still_a_stale_baseline(self, tmp_path: Path) -> None:
+        """Any byte difference means the merge is stale — a save that only
+        adds trailing blank lines must not be reverted by a stripped compare."""
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_preferences("# User Preferences\n\n- v1\n")
+        baseline = ms.read_preferences()
+        ms.write_preferences("# User Preferences\n\n- v1\n\n\n")  # whitespace-only edit
+        wrote = ms.write_preferences(
+            "# User Preferences\n\n- merged from v1\n", expected_baseline=baseline
+        )
+        assert wrote is False
+        assert ms.read_preferences() == "# User Preferences\n\n- v1\n\n\n"
+
+    def test_no_baseline_writes_unconditionally(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_preferences("- a\n")
+        assert ms.write_preferences("- b\n") is True
+        assert ms.read_preferences() == "- b\n"
+
+
+class TestLockFileSymlinkGuard:
+    """The advisory lock files live in the agent-writable memory tree, so a
+    planted ``.write.lock``/``.append.lock`` symlink must never get its
+    target truncated or written through — the lock open is O_NOFOLLOW +
+    fstat(regular, nlink==1), and a planted link fails the write closed."""
+
+    def _plant_link(self, link: Path, target: Path) -> None:
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):  # pragma: no cover - Windows CI
+            pytest.skip("symlinks not available on this platform")
+
+    def test_planted_write_lock_symlink_fails_closed_target_intact(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "victim.txt"
+        target.write_text("precious", encoding="utf-8")
+        ms = _store(tmp_path)
+        ms.init()
+        lock = tmp_path / "ws" / "memory" / ".write.lock"
+        self._plant_link(lock, target)
+        with pytest.raises(OSError):
+            ms.write_preferences("# User Preferences\n\n- attack\n")
+        assert target.read_text(encoding="utf-8") == "precious"
+
+    def test_planted_append_lock_symlink_fails_closed_target_intact(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "victim.txt"
+        target.write_text("precious", encoding="utf-8")
+        ms = _store(tmp_path)
+        ms.init()
+        lock = tmp_path / "ws" / "memory" / "history" / ".append.lock"
+        self._plant_link(lock, target)
+        with pytest.raises(OSError):
+            ms.append_history("an entry")
+        assert target.read_text(encoding="utf-8") == "precious"
+
+    def test_regular_lock_file_reused_across_writes(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_preferences("- a\n")
+        ms.write_preferences("- b\n")  # second write reuses the existing lock file
+        assert ms.read_preferences() == "- b\n"
+
+
+class TestWriteRootGuard:
+    """The write path enforces the same single admission gate as the read
+    path: a linked workspace/memory/history directory refuses EVERY writer
+    loudly (raise, never a silent no-op), with the target tree untouched."""
+
+    def _link_or_skip(self, link: Path, target: Path) -> None:
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):  # pragma: no cover - Windows CI
+            pytest.skip("symlinks not available on this platform")
+
+    def test_linked_memory_dir_refuses_all_writers(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside-tree"
+        outside.mkdir()
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        self._link_or_skip(ws / "memory", outside)
+        ms = MemoryStore(workspace=ws)
+        with pytest.raises(OSError):
+            ms.write_preferences("- attack\n")
+        with pytest.raises(OSError):
+            ms.write_projects("- attack\n")
+        with pytest.raises(OSError):
+            ms.append_history("attack entry")
+        with pytest.raises(OSError):
+            ms.init()
+        assert list(outside.iterdir()) == []  # target tree untouched
+
+    def test_linked_history_dir_refuses_history_writer(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside-history"
+        outside.mkdir()
+        ms = _store(tmp_path)
+        ms.init()
+        history = tmp_path / "ws" / "memory" / "history"
+        # Replace the real history dir with a link
+        history.rmdir()
+        self._link_or_skip(history, outside)
+        with pytest.raises(OSError):
+            ms.append_history("attack entry")
+        assert list(outside.iterdir()) == []
+
+    def test_regular_roots_write_normally(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_preferences("- fine\n")
+        ms.append_history("fine entry")
+        assert "- fine" in ms.read_preferences()
+
+    def test_linked_todays_history_leaf_refuses_append(self, tmp_path: Path) -> None:
+        """A link planted at TODAY'S dated name must refuse the append —
+        read_text would follow it and the read-modify-write would republish
+        the link target's contents into memory (and show/export)."""
+        target = tmp_path / "victim.md"
+        target.write_text("secret contents", encoding="utf-8")
+        ms = _store(tmp_path)
+        ms.init()
+        today = ms._today_history_file()
+        self._link_or_skip(today, target)
+        with pytest.raises(OSError):
+            ms.append_history("an entry")
+        assert target.read_text(encoding="utf-8") == "secret contents"
+        assert "secret contents" not in json.dumps(ms.markdown_snapshot())
+
+    def test_hardlinked_todays_history_leaf_refuses_append(self, tmp_path: Path) -> None:
+        """A HARDLINK passes the link/junction check (regular inode) but
+        reading it republishes the shared inode's contents all the same — an
+        existing leaf must be a lone regular inode (st_nlink == 1)."""
+        target = tmp_path / "victim-credential.md"
+        target.write_text("secret credential", encoding="utf-8")
+        ms = _store(tmp_path)
+        ms.init()
+        today = ms._today_history_file()
+        try:
+            os.link(target, today)
+        except (OSError, NotImplementedError):  # pragma: no cover - FS without hardlinks
+            pytest.skip("hardlinks not available on this platform/filesystem")
+        with pytest.raises(OSError):
+            ms.append_history("an entry")
+        assert target.read_text(encoding="utf-8") == "secret credential"
+        assert "secret credential" not in json.dumps(ms.markdown_snapshot())
+
+    def test_linked_preferences_leaf_refuses_write(self, tmp_path: Path) -> None:
+        target = tmp_path / "victim.txt"
+        target.write_text("precious", encoding="utf-8")
+        ms = _store(tmp_path)
+        ms.init()
+        prefs = tmp_path / "ws" / "memory" / "preferences.md"
+        prefs.unlink()
+        self._link_or_skip(prefs, target)
+        with pytest.raises(OSError):
+            ms.write_preferences("- attack\n")
+        assert target.read_text(encoding="utf-8") == "precious"
+
+
+class TestEmptyStateContract:
+    """Documented contract: a missing OR empty file carries null metadata
+    (consumers key incremental sync on updated_at); a dated empty history
+    day is retained in enumeration rather than skipped as a refusal."""
+
+    def test_empty_preferences_has_null_updated_at(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        (tmp_path / "ws" / "memory").mkdir(parents=True)
+        (tmp_path / "ws" / "memory" / "preferences.md").write_text("", encoding="utf-8")
+        entry = ms.markdown_snapshot()["preferences"]
+        assert entry["content"] == ""
+        assert entry["updated_at"] is None
+
+    def test_empty_dated_history_day_is_retained(self, tmp_path: Path) -> None:
+        ms = _populated_store(tmp_path)
+        history = tmp_path / "ws" / "memory" / "history"
+        (history / "2026-04-04.md").write_text("", encoding="utf-8")
+        entries = ms.read_history_entries()
+        dates = [e["date"] for e in entries]
+        assert "2026-04-04" in dates
+        empty_entry = next(e for e in entries if e["date"] == "2026-04-04")
+        assert empty_entry["content"] == ""
+        assert empty_entry["updated_at"] is None
+
+
+class TestWorkspaceLinkGuard:
+    def test_symlinked_workspace_dir_is_refused(self, tmp_path: Path) -> None:
+        """A workspace swapped for a symlink would make every descendant
+        check validate paths inside the link's target instead of the
+        admitted tree — the root guard must reject the workspace leaf."""
+        real_ws = tmp_path / "real-ws"
+        (real_ws / "memory" / "history").mkdir(parents=True)
+        (real_ws / "memory" / "preferences.md").write_text("# secret\n", encoding="utf-8")
+        link_ws = tmp_path / "link-ws"
+        try:
+            link_ws.symlink_to(real_ws)
+        except (OSError, NotImplementedError):  # pragma: no cover - Windows CI
+            pytest.skip("symlinks not available on this platform")
+        ms = MemoryStore(workspace=link_ws)
+        snap = ms.markdown_snapshot()
+        assert snap["preferences"]["content"] == ""
+        assert snap["history"] == []
+
+    def test_regular_workspace_dir_is_unaffected(self, tmp_path: Path) -> None:
+        ms = _populated_store(tmp_path)
+        assert "prefers pytest" in ms.markdown_snapshot()["preferences"]["content"]
+
+
+class TestBoundedHistoryEnumeration:
+    def test_cap_selects_newest_without_materializing_all(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cap applies during enumeration (bounded heap), and still keeps
+        the newest days in oldest-first output order."""
+        ms = _store(tmp_path)
+        history = tmp_path / "ws" / "memory" / "history"
+        history.mkdir(parents=True)
+        for month in (1, 2, 3, 4, 5):
+            (history / f"2026-0{month}-01.md").write_text(
+                f"# 2026-0{month}-01\nday\n", encoding="utf-8"
+            )
+        monkeypatch.setattr(MemoryStore, "_HISTORY_SNAPSHOT_MAX_ENTRIES", 2)
+        entries = ms.read_history_entries()
+        assert [e["date"] for e in entries] == ["2026-04-01", "2026-05-01"]
+
+
+class TestMemoryExportMarkdown:
+    def _export_args(self, include_markdown: bool) -> argparse.Namespace:
+        return argparse.Namespace(
+            mem_action="export", output=None, include_markdown=include_markdown
+        )
+
+    def test_export_without_flag_is_byte_identical_to_previous_shape(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """The regression guard that matters most: no flag, no shape change."""
+        with patch.object(cli_commands, "VectorMemoryStore", _EmptyVectorStore):
+            cli_commands._memory_cmd(self._export_args(include_markdown=False))
+        expected = json.dumps({"semantic": [], "episodic": [], "events": []}, indent=2, default=str)
+        assert capsys.readouterr().out == expected + "\n"
+
+    def test_export_with_flag_adds_markdown_collection(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ms = _populated_store(tmp_path)
+        with (
+            patch.object(cli_commands, "VectorMemoryStore", _EmptyVectorStore),
+            patch.object(cli_commands, "_markdown_memory_store", lambda: ms),
+        ):
+            cli_commands._memory_cmd(self._export_args(include_markdown=True))
+        data = json.loads(capsys.readouterr().out)
+        assert list(data) == ["semantic", "episodic", "events", "markdown"]
+        markdown = data["markdown"]
+        assert "- prefers pytest" in markdown["preferences"]["content"]
+        assert [e["date"] for e in markdown["history"]] == [
+            "2026-01-01",
+            "2026-02-02",
+            "2026-03-05",
+        ]
+
+    def test_export_with_flag_handles_empty_markdown_layer(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ms = _store(tmp_path)
+        with (
+            patch.object(cli_commands, "VectorMemoryStore", _EmptyVectorStore),
+            patch.object(cli_commands, "_markdown_memory_store", lambda: ms),
+        ):
+            cli_commands._memory_cmd(self._export_args(include_markdown=True))
+        markdown = json.loads(capsys.readouterr().out)["markdown"]
+        assert markdown["preferences"]["content"] == ""
+        assert markdown["history"] == []
+
+
+# ── argparse wiring ──
+
+
+class TestMemoryImportMarkdownNotice:
+    """`memory import` never writes the markdown layer — a payload carrying the
+    export-only collection must say so instead of silently dropping it."""
+
+    def _import_args(self, file: str) -> argparse.Namespace:
+        return argparse.Namespace(mem_action="import", file=file)
+
+    def test_import_with_markdown_collection_prints_notice(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        payload = tmp_path / "export.json"
+        payload.write_text(
+            json.dumps({"semantic": [], "episodic": [], "markdown": {"history": []}}),
+            encoding="utf-8",
+        )
+        with patch.object(cli_commands, "VectorMemoryStore", _EmptyVectorStore):
+            cli_commands._memory_cmd(self._import_args(str(payload)))
+        out = capsys.readouterr().out
+        assert "export-only" in out and "NOT imported" in out
+
+    def test_import_without_markdown_collection_prints_no_notice(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        payload = tmp_path / "export.json"
+        payload.write_text(json.dumps({"semantic": [], "episodic": []}), encoding="utf-8")
+        with patch.object(cli_commands, "VectorMemoryStore", _EmptyVectorStore):
+            cli_commands._memory_cmd(self._import_args(str(payload)))
+        assert "export-only" not in capsys.readouterr().out
+
+
+class TestMemoryCliWiring:
+    def test_memory_show_arguments_parse(self) -> None:
+        argv = [
+            "kirocrew",
+            "memory",
+            "show",
+            "history",
+            "--format",
+            "json",
+            "--since",
+            "2026-01-01",
+        ]
+        with (
+            patch.object(sys, "argv", argv),
+            patch("kiro_crew.cli_commands._memory_cmd") as mock_cmd,
+        ):
+            from kiro_crew.cli import main
+
+            main()
+        ns = mock_cmd.call_args[0][0]
+        assert (ns.mem_action, ns.target, ns.format, ns.since) == (
+            "show",
+            "history",
+            "json",
+            "2026-01-01",
+        )
+
+    def test_memory_show_target_optional_defaults(self) -> None:
+        with (
+            patch.object(sys, "argv", ["kirocrew", "memory", "show"]),
+            patch("kiro_crew.cli_commands._memory_cmd") as mock_cmd,
+        ):
+            from kiro_crew.cli import main
+
+            main()
+        ns = mock_cmd.call_args[0][0]
+        assert (ns.target, ns.format, ns.since) == (None, "md", None)
+
+    def test_memory_export_include_markdown_defaults_off(self) -> None:
+        with (
+            patch.object(sys, "argv", ["kirocrew", "memory", "export"]),
+            patch("kiro_crew.cli_commands._memory_cmd") as mock_cmd,
+        ):
+            from kiro_crew.cli import main
+
+            main()
+        assert mock_cmd.call_args[0][0].include_markdown is False


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

Kiro Crew keeps memory in two layers, and only one is reachable programmatically. The vector store (semantic + episodic) exports via `kirocrew memory export`, but the markdown layer — `preferences.md`, `projects.md`, `history/{date}.md` — has no read API at all: any consumer must open the files directly and depend on an internal storage layout that can change at any release, and that breaks silently when it does.

There is also a documentation defect: `src/kiro_crew/docs/memory-and-learning.md` documented `kirocrew memory show` and `kirocrew memory edit`, and neither command existed (`invalid choice: 'show'`).

## Why it matters

The markdown layer is the higher-value half of memory: it is what the consolidator curates and what gets injected into every turn. Consumers building cross-agent memory sync (the reporter's use case in #3192) currently must either reach into Kiro Crew's internal files — violating the "memory leaves an agent only through an interface" rule — or ship an incomplete export. And the docs promised a command that errors, which erodes trust in the rest of the page.

## What changed (motivation → approach → change)

Goal: expose the markdown layer through an interface without changing what any existing consumer sees. Approach: reuse the read surface `MemoryStore` already owns (per the issue triage by @CrysisDeu, this is plumbing, not new storage work), keep the export payload opt-in-only, and correct the docs to exactly what ships.

- `MemoryStore.markdown_snapshot()` / `read_history_entries()` (`src/kiro_crew/memory.py`): structured, read-only views. Each entry carries `path`, `updated_at` (file mtime, UTC ISO-8601, so consumers can sync incrementally), and `content`; history days are enumerated as discrete entries, never concatenated. A missing or empty file is a normal state (`content: ""`, `updated_at: null` — consumers key incremental sync on `updated_at`), not an error; a dated empty history day is retained in enumeration with null metadata.
- Every filesystem touch in the read surface sits behind ONE admission gate (`MemoryStore._read_root_guard`), whose invariant is: no syscall on a path that has not passed lexical UNC validation, and no component of a touched path may be a link. Concretely: a lexical Windows UNC check runs before any `stat`/`glob`/`exists` (those calls are themselves the outbound SMB probe); the workspace leaf, memory root, history dir, and each leaf file are rejected if they are symlinks or junctions (lstat-based, never traverses; linked *ancestors* of the workspace are deliberately exempt — resolving the chain would refuse legitimate setups like a symlinked `/home`, and those components are not agent-writable); content then reads via `hooks.safe_read_file_bytes_nolink()` confined to the memory root (`O_NOFOLLOW`, non-regular and hardlinked inodes rejected, size-capped) with an `S_ISREG` pre-check so a planted FIFO cannot block the open. Metadata is snapshotted before the read and re-checked after: a concurrent rewrite retries once, then — like a refused, oversized, undecodable, or vanished file — degrades to an empty entry, never leaked content, a mismatched snapshot, or a traceback. Every security refusal in this surface also emits a tamper-evident SEL denial record (`memory_read_guard` layer) — a process-log line alone could be suppressed by the same same-host actor the guard defends against. The history snapshot is bounded end-to-end: candidate selection uses a bounded heap (`heapq.nlargest`) so an agent-planted directory with unbounded valid dated files can never be fully materialized, on top of the per-file size cap and the aggregate entry/byte caps (newest days win, output stays oldest-first).
- The write path enforces the SAME single admission gate as the read path: `_require_link_free_roots()` (the `_read_root_guard` invariant) runs at every writer entry and again at the atomic-write chokepoint, so a workspace, memory, or history directory swapped for a link/junction refuses every write loudly (raised + SEL-audited) with the link's target untouched — staging and replacement can never run outside the admitted tree. The LEAF is checked too: a link planted at a writable file name (today's history file, `preferences.md`) refuses the write before any read or replace, and mode-preservation metadata is taken via non-following `lstat`. Complementing that, all `MemoryStore` writers publish atomically (sibling temp file + `os.replace`), so readers can only ever observe committed file versions — never a truncated in-progress write. The replacement preserves an existing destination's permission bits (a user's `0o600` memory file no longer silently widens to the umask default on the next write; new files still get the umask default). The preferences/projects writers serialize behind the same advisory `file_lock` mechanism `append_history` uses (the lock covers the file write AND the FTS index update, so file bytes and search index always publish together); every lock file in the agent-writable tree is opened symlink-safe (lstat link/junction rejection on all platforms plus `O_NOFOLLOW` where available, no truncation, `fstat` requiring a lone regular inode — a planted `.write.lock`/`.append.lock` link fails the write closed instead of damaging its target). The writers take an optional `expected_baseline` compare-and-swap guard: the consolidator passes the content its merge was computed from, compared exactly (any byte difference, whitespace included, marks the merge stale), so a dashboard Save landing during the minutes-long LLM window is never silently reverted — the stale consolidated write is skipped instead.
- The async callers of these writers no longer block the gateway event loop: the dashboard memory PUT handlers (`preferences`, `projects`, and the sibling `history` endpoint) offload their file writes via `asyncio.to_thread` (not the embed pool — these writes do no embedding, and the embed bulkhead's workers can all be parked behind a hung embedding endpoint), serialized behind a per-endpoint `asyncio.Lock` so rapid successive saves commit in request order, and the consolidator's markdown writes are offloaded to a worker thread like its `append_history` call already was. The history PUT also routes through the store's atomic writer instead of a raw `write_text`, so it neither follows a planted dated symlink nor tears under concurrent saves.
- `kirocrew memory show [preferences|projects|history]` (`cli.py`, `cli_commands.py`): the documented-but-missing command, now real. `--format md|json`, `--since YYYY-MM-DD` for history; shows all three layers when no target is given. Validation failures go to **stderr with exit 1** so scheduled JSON consumers get a real failure signal. Markdown output is stripped of terminal control sequences (same policy as `memory list` — the layer is consolidator/LLM-written).
- `kirocrew memory export --include-markdown`: adds a `markdown` collection. **Without the flag the payload is byte-identical to before** — that is the regression guard the tests pin hardest. `memory import` prints a notice when a payload carries the export-only `markdown` collection, instead of silently dropping it.
- The store anchors where the layer's actual writer writes: the gateway's consolidator is built over a bare `MemoryStore()`, so the reader resolves identically (in a stock config this equals the configured-workspace resolution; when a custom mapping diverges, the writer wins). On Windows, an agent-configured UNC workspace is rejected lexically before any `stat`/`glob`/`exists` — those calls are themselves the outbound SMB probe.
- Docs: `memory-and-learning.md` now documents `memory show` as shipped and no longer mentions `memory edit` (editing is a write surface, deliberately not added); spec modules `cli.md` and `memory-skills-hooks.md` updated in the same commit.

**Scope note:** this PR implements the CLI half only. The MCP tool proposed in the issue (option c) is deliberately deferred — exposing memory through MCP needs its own admission-path review, which is a governance surface rather than plumbing. This is not an oversight.

## Tests

`test/test_memory_markdown_read.py` (47 tests):
- `markdown_snapshot`: missing files are normal (empty entries), content + UTC mtime round-trip, history sorted/dated with non-daily files skipped, `since` filtering; aggregate entry/byte caps keep the newest days oldest-first, and the cap selects during enumeration (bounded heap) without materializing every candidate.
- Symlink guard: a dated `.md` symlink to a sensitive path is **skipped** from history; a `preferences.md` symlink yields an empty entry; the secret string is asserted absent from the entire snapshot; a symlinked history dir and a symlinked **workspace dir** are refused wholesale (a regular workspace is unaffected).
- SEL audit: leaf-symlink, root-reparse, and FIFO refusals each emit a `memory_read_guard` denial record; an SEL failure never breaks the read (the refusal still fails closed).
- Atomic writers: temp-file residue absent, failed replace cleans up, history glob ignores temp names, an existing `0o600` file keeps its mode across rewrites while new files get the umask default.
- Compare-and-swap: a write carrying a stale `expected_baseline` is skipped (the concurrent edit survives), a matching baseline writes, no baseline writes unconditionally — for both preferences and projects.
- Lock-file symlink guard: a planted `.write.lock` or `.append.lock` symlink fails the write closed with the link's target byte-identical afterwards; a regular lock file is reused across writes.
- Write root guard: a linked `memory/` directory refuses all four writers (target tree untouched), a linked `history/` directory refuses the history writer, regular roots write normally; a link planted at today's dated history name or at `preferences.md` refuses the write with the target byte-identical and its contents absent from the snapshot.
- `memory show`: each target in both formats, all-targets default, `--since` filter, empty-store silence, terminal-control-sequence stripping, stderr + exit 1 on both validation failures, reader/writer directory parity, UNC-workspace refusal.
- `memory export`: **no flag ⇒ byte-identical output to the previous shape** (the guard that matters most), flag adds the `markdown` collection with correct shape, empty markdown layer handled.
- `memory import`: notice printed iff the payload carries the export-only `markdown` collection.
- argparse wiring: `show` args parse, `target` optional, `--include-markdown` defaults off.

`test/test_handlers_memory_coverage.py`: the preferences and projects PUT writes are pinned to run **off the event loop thread**; existing contract tests unchanged. `test/test_consolidation_placeholder_guard.py`: consolidator write assertions updated for the `expected_baseline` compare-and-swap call shape.

Local gates: isort, flake8, mypy, full `python -m pytest` (55,706 passed; the only failures are pre-existing host-environmental ones outside this diff — `test_perf_sampler` assumes no py-spy on PATH, `test_wecom_client_cov80` mock-teardown error, both reproduce on unmodified main). Frontend gates skipped: no frontend file changes in this diff.

## Manual verification

Run against an isolated `KIROCREW_HOME` with seeded markdown memory (real transcript):

```
$ kirocrew memory show preferences
# User Preferences

- prefers concise answers
- uses pytest for all Python testing

$ kirocrew memory show history --format json --since 2026-08-17
[
  {
    "path": "/tmp/kc-3192-demo-home/workspace/memory/history/2026-08-17.md",
    "updated_at": "2026-08-17T13:56:00.076247+00:00",
    "content": "# 2026-08-17\n\n#### 08:00 UTC\nImplemented the read API.\n",
    "date": "2026-08-17"
  }
]

$ kirocrew memory export | jq keys
[
  "episodic",
  "events",
  "semantic"
]

$ kirocrew memory export --include-markdown | jq keys
[
  "episodic",
  "events",
  "markdown",
  "semantic"
]
```

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** CLI-only change with no dashboard or app surface; the CLI transcript above is the evidence.

## Related Issues

Closes #3192

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff





