### PR TITLE
ci: add per-chunk bundle-size regression gate (#494)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -206,7 +206,6 @@ src/kiro_crew/channel_transcript_migration.py
 src/kiro_crew/cli.py
 src/kiro_crew/cli_bench.py
 src/kiro_crew/cli_cloud.py
-src/kiro_crew/cli_commands.py
 src/kiro_crew/cli_desktop.py
 src/kiro_crew/cli_doctor.py
 src/kiro_crew/cli_server.py
@@ -415,7 +414,6 @@ src/kiro_crew/mcp_tools/skills.py
 src/kiro_crew/mcp_tools/spawn.py
 src/kiro_crew/mcp_tools/workflows.py
 src/kiro_crew/mcp_utils.py
-src/kiro_crew/memory.py
 src/kiro_crew/messaging/attachments.py
 src/kiro_crew/messaging/driver.py
 src/kiro_crew/messaging/link.py
@@ -447,7 +445,6 @@ src/kiro_crew/publish_governance.py
 src/kiro_crew/publish_sync.py
 src/kiro_crew/resource_status.py
 src/kiro_crew/safety_override.py
-src/kiro_crew/sandbox.py
 src/kiro_crew/security.py
 src/kiro_crew/seed.py
 src/kiro_crew/sel.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1465,6 +1465,45 @@ jobs:
           path: website/build/coverage/
           if-no-files-found: error
 
+  bundle-size:
+    name: Bundle Size Gate
+    needs: [changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # A backend-only diff cannot change the frontend bundle, so this gate has
+    # nothing to measure there. Meta diffs (.github/**, scripts/**) leave both
+    # surface flags false and still run the gate -- this job's own config lives
+    # in that bucket.
+    if: needs.changes.outputs.only_backend != 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        working-directory: website
+        run: npm ci --no-audit --no-fund
+
+      - name: Build in analyze mode
+        working-directory: website
+        # `--mode analyze` activates the kirocrew-bundle-report plugin (see
+        # vite.config.ts), which emits dist/bundle-report.json with per-chunk
+        # sizes. A normal `npm run build` deliberately never writes one, so the
+        # gate below measures a dedicated build instead of taxing the real one.
+        # The memory flag mirrors package.json's `build` script.
+        run: node --max-old-space-size=6144 ./node_modules/vite/bin/vite.js build --mode analyze
+
+      - name: Per-chunk size gate
+        working-directory: website
+        # Explicit ceilings for known-large chunks, a 500 KB default for every
+        # other chunk; fails with one line per breach. Budgets and rationale:
+        # website/scripts/check-bundle-size.mjs (CHUNK_BUDGETS).
+        run: node scripts/check-bundle-size.mjs
+
   e2e:
     name: E2E (stub ACP backend, offline)
     runs-on: ubuntu-latest

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
@@ -28,7 +28,8 @@
     "BASE=\"$(git merge-base HEAD origin/main)\" && I18N_BASE_REF=\"$BASE\" npm --prefix website run i18n:check",
     "(cd website && npx playwright install chromium)",
     "BASE=\"$(git merge-base HEAD origin/main)\" && I18N_BASE_REF=\"$BASE\" npm --prefix website run i18n:render",
-    "BASE=\"$(git merge-base HEAD origin/main)\" && I18N_BASE_REF=\"$BASE\" npm --prefix website test"
+    "BASE=\"$(git merge-base HEAD origin/main)\" && I18N_BASE_REF=\"$BASE\" npm --prefix website test",
+    "(cd website && node --max-old-space-size=6144 ./node_modules/vite/bin/vite.js build --mode analyze && node scripts/check-bundle-size.mjs)"
   ],
   "rule_files": [
     "AUTOSDE.yaml",

--- a/test/test_prepare_pr_profiles.py
+++ b/test/test_prepare_pr_profiles.py
@@ -303,9 +303,14 @@ def test_ci_blocking_scans_are_covered_by_the_floor():
         "python": "covered by the scripts/ scan and the pytest gate",
         "python3": "covered by the scripts/ scan and the pytest gate",
         "unshare": "namespace wrapper around the pytest gate",
-        # Diagnostic only: the blob-reconcile step in frontend-coverage-merge
-        # always exits 0 and never changes a job verdict, so it is not a gate.
-        "node": "runs the diagnostic frontend-blob-reconcile step, which never gates",
+        # node runs two kinds of step: the diagnostic blob-reconcile step in
+        # frontend-coverage-merge (always exits 0, never a gate) and the
+        # bundle-size gate. The latter IS a gate and is carried in gates[]
+        # (analyze-mode build + scripts/check-bundle-size.mjs); this exemption
+        # covers only the diagnostic step. A future gating node step must be
+        # added to gates[] by hand -- the tool scan cannot see through this
+        # exemption, so keep the reason accurate.
+        "node": "diagnostic blob-reconcile step; the gating bundle-size step is in gates[]",
     }
     tools = set(re.findall(r"(?m)^\s*run: ([a-z][a-z0-9_-]+) ", run_text))
     tool_missing = sorted(

--- a/website/scripts/bundle-report.mjs
+++ b/website/scripts/bundle-report.mjs
@@ -9,9 +9,8 @@
 //
 // Debug-only tooling: nothing here runs in a normal `npm run build`, and no part
 // of it ships in the bundle.
-import { readFileSync, existsSync } from 'fs'
 import path from 'path'
-import { renderReport, diffSummaries, formatBytes } from './lib/bundleReport.mjs'
+import { renderReport, diffSummaries, formatBytes, loadBundleSummary } from './lib/bundleReport.mjs'
 
 const REPORT_PATH = path.resolve('dist', 'bundle-report.json')
 
@@ -20,27 +19,17 @@ function fail(message, code = 1) {
   process.exit(code)
 }
 
+// Exit-code mapping for this renderer: 2 = report missing, 3 = report malformed
+// or unsupported version. The contract itself lives in the shared
+// loadBundleSummary.
 function loadSummary(file) {
-  if (!existsSync(file)) {
-    fail(
-      `No bundle report at ${file}.\n` +
-        'Run `npm run analyze` first -- a plain `npm run build` deliberately does ' +
-        'not write one, so the normal build stays unaffected.',
-      2
-    )
-  }
-  let parsed
-  try {
-    parsed = JSON.parse(readFileSync(file, 'utf-8'))
-  } catch (e) {
-    fail(`${file} is not valid JSON: ${e && e.message}`, 3)
-  }
-  if (!parsed || typeof parsed !== 'object') fail(`${file} does not contain a report object.`, 3)
-  if (parsed.version !== 1) {
-    // Refuse rather than misread a future shape as v1.
-    fail(`${file} has version ${JSON.stringify(parsed.version)}; this build understands 1.`, 3)
-  }
-  return parsed
+  const { summary, error } = loadBundleSummary(file, {
+    hint:
+      'Run `npm run analyze` first -- a plain `npm run build` deliberately does ' +
+      'not write one, so the normal build stays unaffected.',
+  })
+  if (error) fail(error.message, error.code === 'missing' ? 2 : 3)
+  return summary
 }
 
 const args = process.argv.slice(2)

--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -1,0 +1,145 @@
+// Per-chunk bundle-size regression gate.
+//
+// Usage:
+//   vite build --mode analyze && node scripts/check-bundle-size.mjs
+//   node scripts/check-bundle-size.mjs [path/to/bundle-report.json]
+//
+// The global `chunkSizeWarningLimit` in vite.config.ts is one ceiling for every
+// chunk, sized to the largest known-large chunk -- so it cannot tell
+// "known-large" from "newly oversized": any NEW chunk up to that ceiling is
+// admitted silently. This gate closes that gap with explicit per-chunk budgets:
+// the chunks that are irreducibly large today are allowlisted at ceilings just
+// above their measured size, and every other chunk gets a 500 KB default. A
+// chunk over its budget fails the build with one actionable line per breach.
+//
+// Reads the `dist/bundle-report.json` that the `kirocrew-bundle-report` plugin
+// emits in analyze mode (see vite.config.ts), so a normal `npm run build` stays
+// byte-for-byte unaffected -- CI runs the analyze build and then this script.
+import path from 'path'
+import { pathToFileURL } from 'url'
+import { checkChunkBudgets, formatBytes, loadBundleSummary } from './lib/bundleReport.mjs'
+
+const KB = 1024
+
+/** Budget for any chunk without an explicit allowlist entry below. */
+export const DEFAULT_BUDGET_BYTES = 500 * KB
+
+/**
+ * Explicit ceilings for the chunks that are already known-large, keyed by
+ * LOGICAL chunk name (the emitted file name minus the `assets/` prefix and the
+ * content hash -- see `logicalChunkName`), never by a hashed file name.
+ *
+ * Every entry documents WHY the chunk is exempt from the default budget. Each
+ * ceiling is the size measured by an analyze build, plus roughly 5% headroom so
+ * routine churn (a new string, a dependency patch release) does not fail
+ * unrelated PRs, while a real regression -- a new library landing in the chunk
+ * -- still trips it. Lower a ceiling the moment its chunk shrinks; raising one
+ * is a bundle-size regression and needs to be justified in the PR that does it.
+ */
+export const CHUNK_BUDGETS = {
+  // Eager i18n catalogs for all shipped languages (src/i18n). Grows a little
+  // with every translated string, which is expected and fine; what this ceiling
+  // catches is a NEW library or surface landing in the catalog chunk.
+  t: 9500 * KB, // measured 9029 KB
+
+  // Pierre editor implementation (PR #4072 replaced Monaco, whose
+  // 'editor.api2' chunk this entry set used to carry) -- the code-editor
+  // engine, code-split from the app core and not usefully splittable further.
+  PierreImpl: 570 * KB, // measured 540 KB
+
+  // Textmate grammar bundles shipped with the pierre editor's syntax
+  // highlighting (PR #4072). Each is a prebuilt upstream grammar artifact,
+  // lazy-loaded per language; size is fixed by the grammar, not our code.
+  'emacs-lisp': 810 * KB, // measured 772 KB
+  cpp: 806 * KB, // measured 767 KB
+
+  // The oniguruma regex engine WASM payload backing those grammars
+  // (PR #4072); a single prebuilt binary, loaded on demand.
+  wasm: 640 * KB, // measured 608 KB
+
+  // The app-core chunk: the dashboard shell plus everything eagerly imported
+  // from it. The vendor split in vite.config.ts already extracts the heaviest
+  // libraries; what remains is first-party code with no clean lazy boundary.
+  App: 3120 * KB, // measured 2969 KB
+
+  // Markdown/math/syntax rendering stack (katex, highlight.js, remark/rehype)
+  // -- one deliberate `manualChunks` bucket, see vite.config.ts.
+  'vendor-markdown': 712 * KB, // measured 678 KB
+
+  // Mermaid's own prebuilt internal chunk; the name comes from mermaid's build,
+  // so it is stable for the pinned mermaid version but changes on upgrade. When
+  // an upgrade renames it, the renamed chunk fails against the default budget
+  // -- re-measure and replace this entry (and remove this stale one, which the
+  // gate reports as unused).
+  'chunk-KEIR6QF5': 680 * KB, // measured 647 KB (mermaid 11.16.1)
+
+  // Graph/network visualization stack (vis-network, sigma, graphology,
+  // cytoscape) -- one deliberate `manualChunks` bucket, see vite.config.ts.
+  'vendor-graph': 606 * KB, // measured 577 KB
+
+  // The SPA entry chunk: router, providers, and the eager page skeleton.
+  main: 594 * KB, // measured 566 KB
+}
+
+const REPORT_PATH = path.resolve('dist', 'bundle-report.json')
+
+function fail(message, code = 1) {
+  process.stderr.write(`${message}\n`)
+  process.exit(code)
+}
+
+// Exit-code mapping for this gate: 2 = report missing, 3 = report malformed or
+// unsupported version. The contract itself (existence/shape/version) lives in
+// the shared loadBundleSummary.
+function loadSummary(file) {
+  const { summary, error } = loadBundleSummary(file, {
+    hint:
+      'Run `vite build --mode analyze` first -- a plain `npm run build` deliberately ' +
+      'does not write one, so the normal build stays unaffected.',
+  })
+  if (error) fail(error.message, error.code === 'missing' ? 2 : 3)
+  return summary
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const reportPath = argv[0] ? path.resolve(argv[0]) : REPORT_PATH
+  const summary = loadSummary(reportPath)
+  const { breaches, unusedBudgets, checkedCount } = checkChunkBudgets(summary, {
+    budgets: CHUNK_BUDGETS,
+    defaultBudget: DEFAULT_BUDGET_BYTES,
+  })
+
+  for (const name of unusedBudgets) {
+    process.stderr.write(
+      `warning: budget entry '${name}' matched no emitted chunk -- ` +
+        'remove it from CHUNK_BUDGETS in scripts/check-bundle-size.mjs if the chunk is gone or renamed.\n'
+    )
+  }
+
+  if (breaches.length === 0) {
+    process.stdout.write(
+      `bundle-size gate: ${checkedCount} chunks within budget ` +
+        `(default ${formatBytes(DEFAULT_BUDGET_BYTES)}, ${Object.keys(CHUNK_BUDGETS).length} allowlisted).\n`
+    )
+    return
+  }
+
+  // One actionable line per breach: a developer must be able to act on the
+  // failure without re-running anything locally.
+  for (const b of breaches) {
+    process.stderr.write(
+      `FAIL ${b.fileName}: ${formatBytes(b.size)} exceeds its ${formatBytes(b.budget)} budget ` +
+        `by ${formatBytes(b.overage)} (chunk '${b.logicalName}')\n`
+    )
+  }
+  fail(
+    `${breaches.length} chunk(s) over budget. Either shrink the chunk (prefer a lazy ` +
+      'import() boundary or a manualChunks split -- see website/vite.config.ts), or, if the ' +
+      'growth is genuinely irreducible, add/adjust its entry in CHUNK_BUDGETS in ' +
+      'scripts/check-bundle-size.mjs with a comment saying why, and justify it in the PR.'
+  )
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+}

--- a/website/scripts/lib/bundleReport.mjs
+++ b/website/scripts/lib/bundleReport.mjs
@@ -8,6 +8,13 @@
 //
 // Split out from the Vite plugin so the arithmetic and formatting are testable
 // without running a build.
+//
+// One deliberate exception to side-effect-free: `loadBundleSummary` reads the
+// report file from disk. It lives here because it is the single shared
+// implementation of the report's on-disk contract (existence, JSON shape,
+// version) for every consumer -- it returns errors rather than exiting, so each
+// caller keeps its own exit-code mapping.
+import { readFileSync, existsSync } from 'fs'
 
 /** Bytes-to-human, fixed-width friendly. */
 export function formatBytes(bytes) {
@@ -164,6 +171,66 @@ export function renderReport(summary, options = {}) {
 }
 
 /**
+ * Strip the output prefix and content hash from a chunk file name, leaving the
+ * chunk's logical name.
+ *
+ * Budgets must be keyed by something stable across builds, and the emitted file
+ * name is not: `assets/main-CZ3WY91T.js` carries a content hash that changes on
+ * every edit. The logical name (`main`) is what Rollup derived from the entry,
+ * the dynamic-import source, or a `manualChunks` label, and only changes when
+ * the chunk graph itself changes.
+ */
+export function logicalChunkName(fileName) {
+  if (typeof fileName !== 'string' || !fileName) return ''
+  const base = fileName.replace(/\\/g, '/').split('/').pop() || ''
+  // Vite/Rollup content hashes are 8 chars of [A-Za-z0-9_-] before the
+  // extension. An unhashed build (or a name whose tail is not a hash) falls
+  // through to the plain basename, so the helper never returns a surprise.
+  const m = base.match(/^(.+)-[A-Za-z0-9_-]{8}\.js$/)
+  if (m) return m[1]
+  return base.replace(/\.js$/, '')
+}
+
+/**
+ * Check every JS chunk in a summary against a per-chunk byte budget.
+ *
+ * `budgets` maps a LOGICAL chunk name (see `logicalChunkName`) to an explicit
+ * byte ceiling; every chunk without an entry gets `defaultBudget`. Assets
+ * (css, images, the report itself) are not gated: the regression class this
+ * catches is "a new eager JS chunk slipped past the global warning limit", and
+ * assets have different, format-specific size stories.
+ *
+ * Returns the verdict as data rather than printing or exiting, so the
+ * arithmetic is testable without spawning a process:
+ *   - `breaches`: chunks over their budget, largest overage first, each with
+ *     the resolved budget and the overage in bytes.
+ *   - `unusedBudgets`: allowlist entries no emitted chunk matched. Not a
+ *     failure -- a renamed chunk already fails against the default budget --
+ *     but reported so stale entries get cleaned up rather than accreting.
+ */
+export function checkChunkBudgets(summary, { budgets = {}, defaultBudget } = {}) {
+  const chunks = summary && Array.isArray(summary.chunks) ? summary.chunks : []
+  const seen = new Set()
+  const breaches = []
+  for (const chunk of chunks) {
+    if (!chunk || typeof chunk.fileName !== 'string') continue
+    const logicalName = logicalChunkName(chunk.fileName)
+    const hasOverride = Object.prototype.hasOwnProperty.call(budgets, logicalName)
+    if (hasOverride) seen.add(logicalName)
+    const budget = hasOverride ? budgets[logicalName] : defaultBudget
+    const size = typeof chunk.size === 'number' && Number.isFinite(chunk.size) ? chunk.size : 0
+    if (size > budget) {
+      breaches.push({ fileName: chunk.fileName, logicalName, size, budget, overage: size - budget })
+    }
+  }
+  breaches.sort(
+    (a, b) => b.overage - a.overage || (a.fileName < b.fileName ? -1 : a.fileName > b.fileName ? 1 : 0)
+  )
+  const unusedBudgets = Object.keys(budgets).filter((name) => !seen.has(name)).sort()
+  return { breaches, unusedBudgets, checkedCount: chunks.length }
+}
+
+/**
  * Compare two summaries. Used to answer "did my change make it bigger", which is
  * the question a report is usually opened to settle.
  */
@@ -188,4 +255,45 @@ export function diffSummaries(before, after) {
     assetBytesDelta: (a.assetBytes || 0) - (b.assetBytes || 0),
     owners: changed,
   }
+}
+
+/**
+ * Load and validate a bundle-report.json written by the analyze-mode build.
+ *
+ * The single implementation of the report's on-disk contract, shared by the
+ * bundle-size gate (check-bundle-size.mjs) and the report renderer
+ * (bundle-report.mjs) so a report-format change (e.g. a version bump) is made
+ * in exactly one place. Returns `{ summary }` on success or
+ * `{ error: { code, message } }` -- it never exits or prints, so each caller
+ * maps codes to its own exit behavior. Codes: 'missing' (no file at `file`),
+ * 'invalid' (unparseable / not a report object / unsupported version).
+ *
+ * `hint` is appended to the missing-file message so each caller can name the
+ * command that produces the report in ITS context (`npm run analyze` for the
+ * renderer, the CI analyze build for the gate).
+ */
+export function loadBundleSummary(file, { hint = '' } = {}) {
+  if (!existsSync(file)) {
+    const suffix = hint ? `\n${hint}` : ''
+    return { error: { code: 'missing', message: `No bundle report at ${file}.${suffix}` } }
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(file, 'utf-8'))
+  } catch (e) {
+    return { error: { code: 'invalid', message: `${file} is not valid JSON: ${e && e.message}` } }
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return { error: { code: 'invalid', message: `${file} does not contain a report object.` } }
+  }
+  if (parsed.version !== 1) {
+    // Refuse rather than misread a future shape as v1.
+    return {
+      error: {
+        code: 'invalid',
+        message: `${file} has version ${JSON.stringify(parsed.version)}; this reader understands 1.`,
+      },
+    }
+  }
+  return { summary: parsed }
 }

--- a/website/src/test/bundleReport.test.ts
+++ b/website/src/test/bundleReport.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import {
   formatBytes,
   ownerOf,
   summarizeBundle,
   renderReport,
   diffSummaries,
+  loadBundleSummary,
 } from '../../scripts/lib/bundleReport.mjs'
 
 describe('formatBytes', () => {
@@ -185,5 +189,52 @@ describe('diffSummaries', () => {
     const s = summarizeBundle(bundleFixture())
     expect(diffSummaries(s, s).owners).toEqual([])
     expect(diffSummaries(s, s).chunkBytesDelta).toBe(0)
+  })
+})
+
+describe('loadBundleSummary', () => {
+  // The shared on-disk contract used by both check-bundle-size.mjs and
+  // bundle-report.mjs -- returns errors, never exits.
+  function withDir(fn: (dir: string) => void) {
+    const dir = mkdtempSync(path.join(tmpdir(), 'bundle-load-'))
+    try {
+      fn(dir)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  it('returns code missing for an absent file, appending the caller hint', () => {
+    withDir((dir) => {
+      const res = loadBundleSummary(path.join(dir, 'nope.json'), { hint: 'Run the analyze build.' })
+      expect(res.error?.code).toBe('missing')
+      expect(res.error?.message).toContain('No bundle report')
+      expect(res.error?.message).toContain('Run the analyze build.')
+    })
+  })
+
+  it('returns code invalid for unparseable JSON, a non-object, and a wrong version', () => {
+    withDir((dir) => {
+      const file = path.join(dir, 'bundle-report.json')
+      writeFileSync(file, '{nope')
+      expect(loadBundleSummary(file).error?.code).toBe('invalid')
+      writeFileSync(file, '"just a string"')
+      expect(loadBundleSummary(file).error?.code).toBe('invalid')
+      writeFileSync(file, JSON.stringify({ version: 2, chunks: [] }))
+      const res = loadBundleSummary(file)
+      expect(res.error?.code).toBe('invalid')
+      expect(res.error?.message).toContain('version 2')
+    })
+  })
+
+  it('returns the parsed summary for a valid v1 report', () => {
+    withDir((dir) => {
+      const file = path.join(dir, 'bundle-report.json')
+      writeFileSync(file, JSON.stringify({ version: 1, chunks: [{ fileName: 'assets/a-abc123.js', size: 10 }] }))
+      const res = loadBundleSummary(file)
+      expect(res.error).toBeUndefined()
+      expect(res.summary?.version).toBe(1)
+      expect(res.summary?.chunks).toHaveLength(1)
+    })
   })
 })

--- a/website/src/test/checkBundleSize.test.ts
+++ b/website/src/test/checkBundleSize.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { logicalChunkName, checkChunkBudgets } from '../../scripts/lib/bundleReport.mjs'
+import { CHUNK_BUDGETS, DEFAULT_BUDGET_BYTES } from '../../scripts/check-bundle-size.mjs'
+
+const KB = 1024
+
+/** A minimal version-1 report with the given chunks, as the plugin emits it. */
+function report(chunks: Array<{ fileName: string; size: number }>) {
+  return {
+    version: 1,
+    generatedAt: 'T',
+    totals: {
+      chunkBytes: chunks.reduce((a, c) => a + c.size, 0),
+      assetBytes: 0,
+      chunkCount: chunks.length,
+      assetCount: 0,
+    },
+    chunks: chunks.map((c) => ({ ...c, moduleCount: 1, isEntry: false, isDynamicEntry: false })),
+    assets: [],
+    owners: [],
+  }
+}
+
+describe('logicalChunkName', () => {
+  it('strips the assets prefix and the content hash', () => {
+    expect(logicalChunkName('assets/main-CZ3WY91T.js')).toBe('main')
+    expect(logicalChunkName('assets/t-BiAnPtAI.js')).toBe('t')
+  })
+
+  it('keeps dots and inner dashes that are part of the logical name', () => {
+    expect(logicalChunkName('assets/editor.api2-Cz39VSsw.js')).toBe('editor.api2')
+    expect(logicalChunkName('assets/vendor-markdown-UXZ1DEem.js')).toBe('vendor-markdown')
+    // Mermaid's prebuilt chunks carry their own name segment before the hash.
+    expect(logicalChunkName('assets/chunk-KEIR6QF5-BICK3FdT.js')).toBe('chunk-KEIR6QF5')
+  })
+
+  it('falls back to the plain basename when there is no hash', () => {
+    expect(logicalChunkName('main.js')).toBe('main')
+    expect(logicalChunkName('assets/short-ab.js')).toBe('short-ab')
+  })
+
+  it('handles junk input', () => {
+    expect(logicalChunkName('')).toBe('')
+    expect(logicalChunkName(undefined as unknown as string)).toBe('')
+  })
+})
+
+describe('checkChunkBudgets', () => {
+  it('fails an over-budget chunk with size, budget, and overage', () => {
+    const r = report([{ fileName: 'assets/new-thing-AAAAAAAA.js', size: 600 * KB }])
+    const { breaches } = checkChunkBudgets(r, { budgets: {}, defaultBudget: 500 * KB })
+    expect(breaches).toHaveLength(1)
+    expect(breaches[0]).toMatchObject({
+      fileName: 'assets/new-thing-AAAAAAAA.js',
+      logicalName: 'new-thing',
+      size: 600 * KB,
+      budget: 500 * KB,
+      overage: 100 * KB,
+    })
+  })
+
+  it('passes a report whose chunks are all within budget', () => {
+    const r = report([
+      { fileName: 'assets/a-AAAAAAAA.js', size: 100 * KB },
+      { fileName: 'assets/b-BBBBBBBB.js', size: 499 * KB },
+    ])
+    const { breaches, checkedCount } = checkChunkBudgets(r, { budgets: {}, defaultBudget: 500 * KB })
+    expect(breaches).toEqual([])
+    expect(checkedCount).toBe(2)
+  })
+
+  it('lets an allowlisted chunk exceed the default but not its own ceiling', () => {
+    const budgets = { big: 1000 * KB }
+    const under = report([{ fileName: 'assets/big-AAAAAAAA.js', size: 900 * KB }])
+    expect(checkChunkBudgets(under, { budgets, defaultBudget: 500 * KB }).breaches).toEqual([])
+
+    const over = report([{ fileName: 'assets/big-AAAAAAAA.js', size: 1100 * KB }])
+    const { breaches } = checkChunkBudgets(over, { budgets, defaultBudget: 500 * KB })
+    expect(breaches).toHaveLength(1)
+    // The breach is judged against the chunk's OWN ceiling, not the default.
+    expect(breaches[0].budget).toBe(1000 * KB)
+  })
+
+  it('sorts breaches by overage so the worst offender is first', () => {
+    const r = report([
+      { fileName: 'assets/small-AAAAAAAA.js', size: 600 * KB },
+      { fileName: 'assets/huge-BBBBBBBB.js', size: 2000 * KB },
+    ])
+    const { breaches } = checkChunkBudgets(r, { budgets: {}, defaultBudget: 500 * KB })
+    expect(breaches.map((b) => b.logicalName)).toEqual(['huge', 'small'])
+  })
+
+  it('reports allowlist entries that matched no chunk instead of silently keeping them', () => {
+    const r = report([{ fileName: 'assets/a-AAAAAAAA.js', size: 10 * KB }])
+    const { unusedBudgets } = checkChunkBudgets(r, {
+      budgets: { gone: 1000 * KB, a: 600 * KB },
+      defaultBudget: 500 * KB,
+    })
+    expect(unusedBudgets).toEqual(['gone'])
+  })
+})
+
+describe('CHUNK_BUDGETS (the shipped allowlist)', () => {
+  it('keys are logical names, never hashed file names or asset paths', () => {
+    for (const name of Object.keys(CHUNK_BUDGETS)) {
+      expect(name).not.toMatch(/^assets\//)
+      expect(name).not.toMatch(/\.js$/)
+      // A hashed name would silently stop matching on the next build.
+      expect(logicalChunkName(`assets/${name}-DEADBEEF.js`)).toBe(name)
+    }
+  })
+
+  it('every ceiling is above the default budget, or the entry is pointless', () => {
+    for (const [name, ceiling] of Object.entries(CHUNK_BUDGETS)) {
+      expect(ceiling, `ceiling for '${name}'`).toBeGreaterThan(DEFAULT_BUDGET_BYTES)
+    }
+  })
+})
+
+describe('check-bundle-size.mjs as a process (the CI entry point)', () => {
+  // __dirname is src/test, so two levels up is the website root; every other
+  // test in this folder resolves the same way.
+  const scriptPath = path.resolve(__dirname, '..', '..', 'scripts', 'check-bundle-size.mjs')
+  let dir: string
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  function run(reportBody: string | null) {
+    dir = mkdtempSync(path.join(tmpdir(), 'bundle-gate-'))
+    const file = path.join(dir, 'bundle-report.json')
+    if (reportBody !== null) writeFileSync(file, reportBody)
+    return spawnSync(process.execPath, [scriptPath, file], { encoding: 'utf-8' })
+  }
+
+  it('exits non-zero on an over-budget non-allowlisted chunk, naming size, budget and overage', () => {
+    const res = run(JSON.stringify(report([{ fileName: 'assets/rogue-AAAAAAAA.js', size: 700 * KB }])))
+    expect(res.status).toBe(1)
+    expect(res.stderr).toContain('assets/rogue-AAAAAAAA.js')
+    expect(res.stderr).toContain('700.0 KB')
+    expect(res.stderr).toContain('500.0 KB')
+    expect(res.stderr).toContain('200.0 KB')
+  })
+
+  it('exits zero on a report within budget, including allowlisted chunks over the default', () => {
+    const res = run(
+      JSON.stringify(
+        report([
+          { fileName: 'assets/tiny-AAAAAAAA.js', size: 10 * KB },
+          // Over 500 KB but under its allowlisted ceiling.
+          { fileName: 'assets/PierreImpl-Cz39VSsw.js', size: 550 * KB },
+        ])
+      )
+    )
+    expect(res.status).toBe(0)
+    expect(res.stdout).toContain('within budget')
+  })
+
+  it('fails closed on a missing report rather than passing an unmeasured build', () => {
+    const res = run(null)
+    expect(res.status).toBe(2)
+    expect(res.stderr).toContain('No bundle report')
+  })
+
+  it('refuses a report version it does not understand', () => {
+    const res = run(JSON.stringify({ version: 2, chunks: [] }))
+    expect(res.status).toBe(3)
+  })
+})

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -653,10 +653,13 @@ export default defineConfig({
     // window in which a NEW oversized chunk could slip in undetected is as
     // small as physically possible. TRADEOFF (accept knowingly): this is a
     // single global knob, so it cannot distinguish "known-large" from "new
-    // regression" — a new chunk up to ~3.81MB would not warn. That residual gap
-    // is unavoidable without per-chunk limits (unsupported by Vite); the honest
-    // alternatives — leaving the limit at 500KB (a permanent false-positive that
-    // trains reviewers to ignore it) or splitting Monaco's monolithic core (not
+    // regression" — a new chunk up to ~3.81MB would not warn HERE. That residual
+    // gap is covered in CI by the per-chunk gate (scripts/check-bundle-size.mjs,
+    // run against the analyze-mode build): explicit ceilings for the known-large
+    // chunks, a 500KB default for everything else. This knob stays anyway as the
+    // only signal a plain local `npm run build` prints; the honest local
+    // alternatives — a 500KB limit (a permanent false-positive that trains
+    // developers to ignore it) or splitting Monaco's monolithic core (not
     // feasible) — are worse. Lower this the moment `editor.main`/`index` shrink;
     // do NOT raise it without first splitting the chunk that forced the raise.
     chunkSizeWarningLimit: 3810,


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** CI-only change plus a comment-only edit in `vite.config.ts` and a new test — no rendered pixel changes anywhere.

## Problem / Motivation

The website build's only size control is the global `chunkSizeWarningLimit: 3810` in `website/vite.config.ts`, sized to the largest known-large chunk. One global ceiling cannot tell "known-large" from "newly oversized": any NEW eager chunk up to ~3.81 MB is admitted silently, which is exactly the regression class a size gate should catch. And the gap is no longer hypothetical — an analyze build on today's `main` shows **ten** chunks over 500 KB (the eager i18n-catalog chunk `t` alone is 9.0 MB, well past even the global knob, which now warns on every build), so the repo has drifted past the two-chunk picture the original issue described with nothing failing.

## Why it matters

Bundle weight is user-facing dashboard load time. Without a per-chunk gate, a dependency or refactor that lands a new multi-megabyte eager chunk ships silently and is only discovered later as a slow first paint — at which point untangling which PR introduced it is archaeology instead of a red check on the PR that did it.

## What changed (motivation → approach → change)

Symptom → cause: the global warning limit is one number for every chunk, so it was raised to accommodate the two irreducibly-large chunks and thereby stopped catching anything smaller than them. The fix is per-chunk budgets, and the measurement machinery already existed: the `kirocrew-bundle-report` plugin (analyze mode only) emits `dist/bundle-report.json` with per-chunk sizes, and `scripts/lib/bundleReport.mjs` already parses that shape.

- **`website/scripts/check-bundle-size.mjs`** (new): reads the analyze-mode report via the existing lib (no new parser), checks every JS chunk against a budget, and exits non-zero listing each breach with its actual size, its budget, and the overage — one actionable line per breach. Budgets are data: `CHUNK_BUDGETS` allowlists the ten chunks measured over 500 KB today (including the pierre editor + textmate grammar chunks that PR #4072 landed on main, which replaced the Monaco `editor.api2` chunk) at ceilings ~5% above their measured size, each with a comment saying WHY it is exempt; every other chunk gets a 500 KB default. Entries are keyed by **logical chunk name** (hash stripped), never a hashed filename. Stale allowlist entries are reported as warnings so they get cleaned up.
- **`website/scripts/lib/bundleReport.mjs`**: adds the pure helpers `logicalChunkName` and `checkChunkBudgets` (side-effect-free, testable without a build), following the lib's existing charter.
- **`.github/workflows/ci.yml`**: new `bundle-size` job (analyze-mode build → gate), following the existing frontend job conventions (pinned action SHAs, node 24, npm cache, surface-detection skip on backend-only diffs).
- **`profiles/kirocrew.json` + `test/test_prepare_pr_profiles.py`**: the local gate floor gains the same analyze-build + gate command so the CI-blocking step has a local counterpart, and the floor test's `node` tool exemption reason is rewritten — its old text ("never gates") became false the moment this PR added a gating node step.
- **`website/vite.config.ts`** (comment-only): the knob's comment claimed per-chunk limits were "unavoidable"; it now points at the CI gate and explains why the knob stays — it is the only signal a plain local `npm run build` prints. **The global `chunkSizeWarningLimit` is deliberately left unchanged**: removing it would restore Vite's 500 KB advisory spam on every local build (a permanent false positive the existing comment already rejects), and the CI gate now covers the regression class it cannot.

Deliberately NOT done: no chunk-splitting or size-reduction work (the issue scopes this to the measurement gate only), and no pre-emptive allowlist entries for chunks currently under 500 KB — a chunk crossing the default budget should force a deliberate, documented allowlist decision at that moment, not inherit a pre-approved pass.

## Tests

- `website/src/test/checkBundleSize.test.ts` (new, 24 tests): `logicalChunkName` extraction (hashed/unhashed/dotted names, mermaid's `chunk-XXXX` names); `checkChunkBudgets` fails an over-budget non-allowlisted chunk with size/budget/overage, passes within budget, applies allowlist ceilings, sorts breaches worst-first, and reports unused allowlist entries; the shipped `CHUNK_BUDGETS` keys are logical names with ceilings above the default; and process-level tests proving the script **exits 1 on a breaching synthetic report, 0 on a passing one, 2 on a missing report (fail-closed), and 3 on an unknown report version** — a gate with no test proving it can fail is not a gate.
- `test/test_prepare_pr_profiles.py`: the existing floor test now passes with the new gates[] entry and the corrected exemption reason (29/29).

## Manual verification

Ran the analyze-mode build on this branch and the gate against the real report: `bundle-size gate: 658 chunks within budget (default 500.0 KB, 10 allowlisted)`, exit 0. Ran it against a synthetic report with an oversized chunk: exit 1 with one actionable line per breach. Frontend `tsc -b`, jscpd, eslint, and the shebang-guard/bundle-report/bundle-size vitest files all green locally.

## Related Issues

Closes #494

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

