### PR TITLE
fix(crews): stop Capabilities roster flashing empty on background refetch

### DIFF
--- a/website/src/pages/KiroCrewAgentsPage.tsx
+++ b/website/src/pages/KiroCrewAgentsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Boxes, FolderOpen, Database, Sparkles, Plus, MessageSquare, Users, Star, LayoutGrid, Rows3 } from 'lucide-react'
 import Clickable from '../components/Clickable'
-import { useQuery, useMutation } from '@tanstack/react-query'
+import { useQuery, useMutation, keepPreviousData } from '@tanstack/react-query'
 import { useAppSelector, useAppDispatch } from '../store'
 import { createSlot } from '../store/chatSlice'
 import { api } from '../api/client'
@@ -493,6 +493,14 @@ export default function KiroCrewAgentsPage({ embedded }: { embedded?: boolean } 
   const { data: agentsData, refetch: refetchAgents } = useQuery({
     queryKey: ['kirocrew-agents', refreshTrigger],
     queryFn: () => api.kirocrewAgents(),
+    // `refreshTrigger` is part of the key, so every WS-driven bump (a `refresh`,
+    // `sessions_restarting`, or `refine` frame from ANY session, not this page)
+    // mints a fresh query whose `data` starts `undefined`. Without this the
+    // roster would collapse to `[]` for the refetch window and the
+    // `agents.length === 0` branch below would flash the "No crews yet" empty
+    // state on a populated install. Retaining the prior roster keeps the page
+    // stable across those unrelated refreshes.
+    placeholderData: keepPreviousData,
   })
   const agents: KiroCrewAgent[] = agentsData?.agents || []
   const defaultAgent = agentsData?.default_agent || ''

--- a/website/src/test/CrewRoster.test.tsx
+++ b/website/src/test/CrewRoster.test.tsx
@@ -14,7 +14,7 @@
  * reordering a column does not break them.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
@@ -305,6 +305,49 @@ describe('crew roster — filtering', () => {
     // Distinct copy from the filter case — a first run is not a failed search.
     expect(screen.getByTestId('empty-state-title')).not.toHaveTextContent('match your filter')
     expect(screen.queryAllByTestId('crew-card')).toHaveLength(0)
+  })
+
+  it('does not flash the empty state while a refreshTrigger-driven refetch is in flight', async () => {
+    // `refreshTrigger` is part of the roster query key, so any WS-driven bump
+    // (a `refresh` / `sessions_restarting` / `refine` frame from ANOTHER
+    // session, a cron, or a restart) mints a fresh query whose `data` starts
+    // `undefined`. Without `placeholderData: keepPreviousData` that collapses
+    // `agents` to `[]` for the refetch window and the roster flashes the
+    // "No crews yet" empty state on a populated install — the reported bug.
+    let resolveSecond: (v: unknown) => void = () => {}
+    mockApi.kirocrewAgents
+      .mockResolvedValueOnce(AGENTS_RESPONSE)
+      .mockImplementationOnce(() => new Promise(res => { resolveSecond = res }))
+
+    const store = createTestStore()
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <Provider store={store}>
+          <MemoryRouter>
+            <KiroCrewAgentsPage />
+          </MemoryRouter>
+        </Provider>
+      </QueryClientProvider>,
+    )
+    await waitFor(() => expect(screen.getAllByTestId('crew-card')).toHaveLength(2))
+
+    // Bump refreshTrigger → the roster query key changes and refetches. The
+    // second fetch is deliberately left pending so the "no data yet" window is
+    // observable rather than a sub-millisecond flicker.
+    act(() => { store.dispatch({ type: 'dashboard/triggerRefresh' }) })
+
+    // The prior roster must remain on screen throughout the pending refetch —
+    // no empty state, cards intact.
+    await waitFor(() => expect(mockApi.kirocrewAgents).toHaveBeenCalledTimes(2))
+    expect(screen.queryByTestId('empty-state-title')).not.toBeInTheDocument()
+    expect(screen.getAllByTestId('crew-card')).toHaveLength(2)
+
+    // And once the refetch resolves the roster is still there (now from fresh
+    // data), never having blanked in between.
+    resolveSecond(AGENTS_RESPONSE)
+    await waitFor(() => expect(screen.getAllByTestId('crew-card')).toHaveLength(2))
+    expect(screen.queryByTestId('empty-state-title')).not.toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Problem / Motivation

The **Agents → Capabilities** page (Crews tab) intermittently flashes an empty state — *"No crews yet"* with the placeholder copy *"A crew is an assistant with its own files and its own memory…"* — even while the page is sitting idle and untouched, then snaps back to the populated roster a frame or two later.

## Why it matters

The Crews tab is the primary crew-management surface. Watching it randomly claim you have no crews is alarming and reads like data loss (it is not). Because it fires on unrelated background activity, it recurs on any active install.

## What changed (motivation → approach → change)

**Symptom:** the roster blanks to the empty state at random, unrelated to user action.

**Root cause:** `website/src/pages/KiroCrewAgentsPage.tsx` keys the roster query on the global `refreshTrigger` counter:

```ts
const refreshTrigger = useAppSelector(s => s.dashboard.refreshTrigger)
const { data: agentsData } = useQuery({
  queryKey: ['kirocrew-agents', refreshTrigger],   // refreshTrigger is IN the key
  queryFn: () => api.kirocrewAgents(),
})
const agents = agentsData?.agents || []            // undefined → []
```

`refreshTrigger` is a global counter in `dashboardSlice` (`triggerRefresh` → `+= 1`) that the WebSocket handler bumps on `refresh`, `sessions_restarting`, and `refine` frames (`hooks/useWebSocket.ts`), plus on chat activity. Because it is part of the **query key**, each bump makes React Query treat it as a **brand-new query with no cached data** → `agentsData` is `undefined` → `agents` falls back to `[]` → the `agents.length === 0` empty-state branch renders for the refetch window → snaps back when data arrives. It looks "random / untouched" because it is driven by backend WebSocket activity from *another* session, a cron, or a restart heartbeat — not by anything the user does on the page.

**Change:** add `placeholderData: keepPreviousData` to the roster query so the prior roster is retained across the key change instead of collapsing to `[]`. This matches the pattern already established in this codebase (`ArtifactsPage`, `FilePickerMenu`, `pages/knowledge`, `chat/ActivityViewer`). One-line behavioral change plus an explanatory comment.

Scope note: the **Templates** tab (`AgentsPage.tsx`) shares the `refreshTrigger`-in-key pattern but already gates its roster on `installedLoading ? <spinner> : installed.length === 0 ? …`, so it shows a loading spinner rather than the empty state during a refetch and does **not** have this bug. Left untouched to keep the diff minimal.

## Tests

- `website/src/test/CrewRoster.test.tsx` — new test *"does not flash the empty state while a refreshTrigger-driven refetch is in flight"*: renders the populated roster, dispatches `dashboard/triggerRefresh` while the second `kirocrewAgents` fetch is left pending, and asserts the empty state never mounts and the cards stay on screen throughout and after the refetch. Verified as a true regression test by mutation — it fails without the `placeholderData` line and passes with it. Full `CrewRoster.test.tsx` suite: 40/40 green.

## Manual verification

N/A — unit coverage reproduces the exact flash window (a pending refetch after a `refreshTrigger` bump) deterministically, which is more reliable than trying to catch the intermittent live flash by hand.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** No rendered delta in steady state. The populated roster and the genuine zero-crew empty state both render exactly as before; the fix only prevents a *transient* incorrect empty state during a background refetch — a sub-frame flicker a still image cannot capture. The behavior is proven by the deterministic regression test above.

## Related Issues

Fixes #4132

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
