### PR TITLE
fix(dashboard): seed chat folders from the slots WS frame so the sidebar groups on first paint

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -95,6 +95,22 @@ _CHANNEL_LABELS = {
 }
 
 
+def _safe_folder_tree(folders: object) -> list[dict[str, Any]]:
+    """Well-formed folder entries safe to ship on the slots broadcast frame.
+
+    ``load_folders`` does a bare ``json.loads`` with no shape validation, so a
+    corrupt ``folders.json`` can leave ``_folders`` as a non-list (``list()``
+    would then raise ``TypeError`` on the broadcast hot path) or a list holding
+    non-dicts / dicts without an ``id`` (which the client's grouping keys on).
+    Keep only dict entries carrying a string ``id`` so a corrupt store degrades
+    to a smaller/empty tree rather than crashing every slot push. A non-list
+    (including ``None`` from an unset/partially-constructed state) yields ``[]``.
+    """
+    if not isinstance(folders, list):
+        return []
+    return [f for f in folders if isinstance(f, dict) and isinstance(f.get("id"), str)]
+
+
 def _split_namespaced_channel_id(channel_id: str | None) -> tuple[str, str] | None:
     """Return ``(channel_type, target)`` for a ``<type>:<target>`` id."""
     if not channel_id:
@@ -5707,6 +5723,17 @@ class DashboardState:
         # ['dashboardConfig'] query only when the GitLab-hosts allowlist actually
         # changed -- an event-driven refresh that replaces a constant 30s poll
         # (which multiplied audit-log writes across every same-key observer).
+        #
+        # Piggyback the folder tree (the in-memory ``_folders`` list, WITHOUT the
+        # per-folder ``history_count`` that ``GET /api/chat/folders`` computes via
+        # a synchronous session scan) so the sidebar can group sessions correctly
+        # on the FIRST paint. Sessions arrive on this WS frame the instant the
+        # socket connects; folders otherwise arrive only via a separate HTTP GET,
+        # so the sidebar would render every session ungrouped (Unfiled bucket)
+        # until that GET resolved, then visibly re-shuffle them into folders. The
+        # HTTP query still runs to backfill ``history_count``; grouping no longer
+        # waits on it. Slicing to the fields the client's grouping needs keeps
+        # this hot-path frame small and never touches the filesystem.
         self._broadcast(
             {
                 "_type": "slots",
@@ -5715,6 +5742,23 @@ class DashboardState:
                 "slots": json.dumps(slots_data),
                 "channelTrusted": ch_trusted,
                 "gitlabHostsGeneration": gitlab_hosts_generation(),
+                # getattr, not self._folders: this read path runs on EVERY slots
+                # push, including on a __new__-built DashboardState that seeded only
+                # the push essentials and never ran __init__ (several endpoint
+                # suites build their fixture that way). _folders is an __init__-only
+                # assignment, so a bare attribute access would AttributeError there
+                # — the exact break test_push_slots_update_survives_a_partially_
+                # constructed_state pins against. An absent/None folder store is an
+                # empty tree.
+                #
+                # Coerce to well-formed dict entries rather than `list(_folders)`:
+                # load_folders() does a bare json.loads with no shape check, so a
+                # corrupt folders.json can leave _folders as a non-list (crashing
+                # list() with TypeError on this hot path) or a list of non-dicts /
+                # dicts without an "id" (which the client's grouping keys on). Filter
+                # to dict entries carrying a string "id" so a corrupt store degrades
+                # to a smaller/empty tree instead of crashing the broadcast.
+                "folders": _safe_folder_tree(getattr(self, "_folders", None)),
             }
         )
         owner_ws_clients = getattr(self, "_owner_ws_clients", None)
@@ -5840,6 +5884,13 @@ class DashboardState:
                         # so anything not named here is silently dropped. The client
                         # invalidates its cached dashboard config when this changes.
                         "gitlabHostsGeneration": note.get("gitlabHostsGeneration"),
+                        # Folder tree (no history_count) so the sidebar groups
+                        # sessions on first paint without waiting for the separate
+                        # GET /api/chat/folders. Only the dashboard-user frame
+                        # (default_msg) carries it; app-token frames are rebuilt in
+                        # the scope chokepoint and deliberately omit it (apps do not
+                        # render the chat folder tree).
+                        "folders": note.get("folders"),
                     }
                 )
             elif msg_type == "slot_title":

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -14,7 +14,7 @@ from kiro_crew import __version__ as _local_version
 from kiro_crew import shutdown_event
 from kiro_crew.dashboard.chat_utils import effective_session_key, subagent_event_slot
 from kiro_crew.dashboard.origin import check_origin
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import DashboardState, _safe_folder_tree
 from kiro_crew.dashboard.ws_event_scope import (
     _audit_allow,
     _audit_deny,
@@ -367,6 +367,18 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
             if ws.get("_is_dashboard_user", False)
             else dict(slots_envelope_extras(allowed_events, yolo=state._yolo))
         )
+        # Seed the folder tree on the CONNECT-TIME push (dashboard users only) —
+        # this is the frame that populates the sidebar on a cold page load, so it
+        # is where the client must receive `folders` to group sessions on the
+        # first paint (issue #4127). The broadcast path (_do_slots_broadcast) also
+        # carries it for live folder create/rename/move, but on an idle-gateway
+        # load no broadcast fires before GET /api/chat/folders resolves, so
+        # without this the ungrouped→regrouped flicker survives. App tokens are
+        # excluded (they do not render the chat folder tree), matching the
+        # broadcast decision. `_safe_folder_tree` drops history_count and any
+        # malformed entry (see its docstring).
+        if ws.get("_is_dashboard_user", False):
+            envelope_extras["folders"] = _safe_folder_tree(getattr(state, "_folders", None))
         if not ws.get("_is_dashboard_user", False) and "yolo" in envelope_extras:
             # Handing an app token the live blanket-approval override is a
             # grant of operator security posture, not slot data, and this

--- a/test/test_dashboard_state_ws.py
+++ b/test/test_dashboard_state_ws.py
@@ -100,6 +100,90 @@ class TestSubagentSubscribers:
         assert ws_alive in state._ws_clients
 
 
+class TestSlotsBroadcastCarriesFolders:
+    """The slots broadcast frame piggybacks the folder tree so the sidebar can
+    group sessions on first paint without waiting for GET /api/chat/folders.
+
+    A dashboard-user client receives the ``default_msg`` verbatim (the scope
+    chokepoint only rebuilds the frame for app tokens), so ``folders`` on the
+    broadcast note reaches it in the sent JSON. The frame must carry the cheap
+    in-memory tree WITHOUT ``history_count`` (that field costs a synchronous
+    session scan the broadcast hot path must never run)."""
+
+    class _DashboardWS:
+        """Minimal fake WS that reads as a dashboard user and captures sends.
+
+        ``send_str`` is an ``AsyncMock`` so the fire-and-forget
+        ``asyncio.ensure_future(ws.send_str(msg))`` in ``_spawn_ws_send`` records
+        the call synchronously — the same pattern the other broadcast tests use
+        to inspect a frame without draining the loop."""
+
+        def __init__(self) -> None:
+            self.closed = False
+            self.send_str = AsyncMock()
+            self._flags = {"_is_dashboard_user": True}
+
+        def get(self, key, default=None):
+            return self._flags.get(key, default)
+
+    def test_frame_carries_folder_tree_without_counts(
+        self, state: DashboardState
+    ) -> None:
+        state.serialize_slots = MagicMock(return_value=[{"key": "chat-1", "folder_id": "f1"}])  # type: ignore[method-assign]
+        # In-memory folder tree as loaded from folders.json — no history_count.
+        state._folders = [
+            {"id": "f1", "name": "Work", "order": 0},
+            {"id": "f2", "name": "Personal", "order": 1, "parent_id": "f1"},
+        ]
+        ws = self._DashboardWS()
+        state.register_ws(ws)  # type: ignore[arg-type]
+
+        state._do_slots_broadcast()
+
+        ws.send_str.assert_called_once()
+        frame = json.loads(ws.send_str.call_args[0][0])
+        assert frame["type"] == "slots"
+        assert frame["folders"] == state._folders
+        # The expensive per-folder count must NOT ride this hot-path frame.
+        assert all("history_count" not in f for f in frame["folders"])
+
+    def test_malformed_folder_store_degrades_instead_of_crashing(
+        self, state: DashboardState
+    ) -> None:
+        # A corrupt folders.json can leave _folders as a non-list, or a list with
+        # non-dict / id-less entries. The broadcast must not crash; well-formed
+        # entries survive and the rest are dropped.
+        state.serialize_slots = MagicMock(return_value=[])  # type: ignore[method-assign]
+        state._folders = [
+            {"id": "ok", "name": "Keep", "order": 0},
+            {"name": "no id", "order": 1},   # missing id -> dropped
+            "not a dict",                     # non-dict -> dropped
+            {"id": 42, "name": "int id"},     # non-string id -> dropped
+        ]
+        ws = self._DashboardWS()
+        state.register_ws(ws)  # type: ignore[arg-type]
+
+        state._do_slots_broadcast()  # must not raise
+
+        frame = json.loads(ws.send_str.call_args[0][0])
+        assert frame["folders"] == [{"id": "ok", "name": "Keep", "order": 0}]
+
+    def test_non_list_folder_store_yields_empty_tree(
+        self, state: DashboardState
+    ) -> None:
+        # A scalar/dict where a list is expected would make list() raise; the
+        # coercion must yield [] instead of crashing the slot push.
+        state.serialize_slots = MagicMock(return_value=[])  # type: ignore[method-assign]
+        state._folders = {"corrupt": "mapping"}  # type: ignore[assignment]
+        ws = self._DashboardWS()
+        state.register_ws(ws)  # type: ignore[arg-type]
+
+        state._do_slots_broadcast()  # must not raise
+
+        frame = json.loads(ws.send_str.call_args[0][0])
+        assert frame["folders"] == []
+
+
 class TestOwnerScopedBroadcast:
     """Owner-only typed broadcast + its delivery count (PR #461)."""
 
@@ -500,6 +584,11 @@ class TestOwnerSourceStatusTransport:
         state.owner_id = "U_OWNER"
         state.serialize_slots.side_effect = serialize_slots
         state._yolo = False
+        # Real folder list (a MagicMock attr would coerce to [] via
+        # _safe_folder_tree); lets the dashboard-user branch below assert the
+        # connect-time frame carries the folder tree — the frame that fixes the
+        # first-paint flicker (#4127).
+        state._folders = [{"id": "f1", "name": "Work", "order": 0}]
 
         class Request(dict):
             def __init__(self) -> None:
@@ -549,7 +638,8 @@ class TestOwnerSourceStatusTransport:
 
         assert result is fake_ws
         state.register_ws.assert_called_once_with(fake_ws, owner=owner_request)
-        initial_slots = fake_ws.sent[0]["data"]
+        initial_frame = fake_ws.sent[0]
+        initial_slots = initial_frame["data"]
         if owner_request:
             assert initial_slots[0]["source_links"][0]["ci"] == "passed"
             refresh.assert_called_once_with([source_url], state.push_slots_update)
@@ -559,10 +649,16 @@ class TestOwnerSourceStatusTransport:
             # stronger guarantee than merely withholding check status.
             assert initial_slots == []
             refresh.assert_not_called()
+            # Folders never ride an app-token frame (apps don't render the tree).
+            assert "folders" not in initial_frame
         else:
             assert "ci" not in str(initial_slots)
             assert "state" not in initial_slots[0]["source_links"][0]
             refresh.assert_not_called()
+            # The connect-time frame is what populates the sidebar on a cold
+            # load, so a dashboard user MUST receive the folder tree here — this
+            # is the frame that fixes the #4127 flicker.
+            assert initial_frame["folders"] == [{"id": "f1", "name": "Work", "order": 0}]
         state.unregister_ws.assert_called_once_with(fake_ws)
 
 

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -14,7 +14,7 @@ import { TAB_ID } from '../api/tabId'
 import { api } from '../api/client'
 import { sanitizeLlmOutput } from '../utils/sanitize'
 import { applyStatusDelta, parseStatusDelta } from '../utils/pullRequestStatusDelta'
-import type { StatusData, ChatMessage, ChatSlot, Notification, PullRequestStatusBatch, TodoList } from '../types'
+import type { StatusData, ChatMessage, ChatSlot, ChatFolder, Notification, PullRequestStatusBatch, TodoList } from '../types'
 import { i18nT } from '../i18n/t'
 
 type LogCallback = ((data: { level: string; msg: string }) => void) | null
@@ -662,6 +662,48 @@ export function useWebSocket() {
             }
             if (msg.channelTrusted !== undefined) {
               dispatch(setChannelTrusted(msg.channelTrusted))
+            }
+            // Seed the ['chat-folders'] query cache from the folder tree carried
+            // on this frame so the sidebar groups sessions correctly on the FIRST
+            // paint. Sessions arrive on this WS frame the instant the socket
+            // connects; the folders otherwise come only from a separate HTTP GET,
+            // so without this the sidebar renders every session ungrouped (Unfiled)
+            // until that GET resolves, then visibly re-shuffles them into folders.
+            //
+            // Seed ONLY when the cache has no folder data yet (first paint). Two
+            // reasons this must not run on later frames, both from the shipped
+            // staleTime: Infinity on this query:
+            //   1. A `slots` frame fires on routine session activity, so a frame
+            //      landing inside an in-flight folder mutation's optimistic window
+            //      (collapse / reorder / rename / move) would overwrite the
+            //      optimistic cache value with backend state via a direct
+            //      setQueryData — which the mutation's cancelQueries cannot cancel
+            //      — snapping the folder back to its pre-action state until
+            //      onSettled refetches.
+            //   2. The WS payload omits per-folder `history_count` (the backend
+            //      computes it via a synchronous session scan that must not run on
+            //      this hot path). Seeding count-less data marks the query fresh,
+            //      so a mount-time query would skip GET /api/chat/folders and the
+            //      counts (the "hide when empty" filter's input) would never load.
+            // So seed the tree once, then invalidate to let the HTTP GET backfill
+            // counts; after the cache is populated, live frames leave it alone and
+            // folder create/rename/move propagate through their own mutation +
+            // invalidate path as before.
+            //
+            // Guard on `existing === undefined` (cache NEVER populated), NOT on
+            // `!existing || length === 0`: a user with genuinely zero folders has
+            // the HTTP GET cache the empty array `[]`, and `[].length === 0` would
+            // then re-match on EVERY subsequent slots frame — re-seeding `[]` and
+            // re-invalidating in a loop, hammering the session-scanning
+            // GET /api/chat/folders. `undefined` fires exactly once, on first paint.
+            if (Array.isArray(msg.folders)) {
+              const existing = queryClient.getQueryData<ChatFolder[]>(['chat-folders'])
+              if (existing === undefined) {
+                queryClient.setQueryData<ChatFolder[]>(['chat-folders'], msg.folders as ChatFolder[])
+                // Backfill history_count (omitted from the WS payload) — the seed
+                // marked the query fresh, so nudge the real GET to run.
+                queryClient.invalidateQueries({ queryKey: ['chat-folders'] })
+              }
             }
             // Refresh the cached GitLab-hosts allowlist when it may have changed.
             // The generation is PROCESS-local, so a gateway restart can hand out a

--- a/website/src/test/useWebSocket.folderSeed.test.ts
+++ b/website/src/test/useWebSocket.folderSeed.test.ts
@@ -1,0 +1,176 @@
+/**
+/**
+ * The sidebar groups sessions by folder, but sessions arrive on the `slots` WS
+ * frame (instant on connect) while the folder tree otherwise comes only from a
+ * separate `GET /api/chat/folders`. Until that GET resolved, every session fell
+ * into the Unfiled bucket and then visibly re-shuffled into its folder once the
+ * folders arrived. The fix piggybacks the folder tree onto the `slots` frame and
+ * seeds the ['chat-folders'] query cache from it, so grouping is correct on the
+ * first paint.
+ *
+ * These tests pin: (1) a frame carrying `folders` seeds the query cache when it
+ * is empty (first paint), (2) a frame does NOT overwrite an already-populated
+ * cache — so a live frame arriving mid-optimistic-mutation, or after the HTTP
+ * GET has loaded counts, leaves the cache alone — and (3) the first-paint seed
+ * invalidates the query so the real GET backfills the omitted `history_count`.
+ *
+ * Uses the SINGLETON store for the same reason as slotsFrameDedupe: the hook
+ * reads slots off the imported singleton.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { store as globalStore } from '../store'
+import { sseSlots } from '../store/dashboardSlice'
+import type { ChatFolder } from '../types'
+import { useWebSocket } from '../hooks/useWebSocket'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+describe('useWebSocket seeds chat-folders from the slots frame', () => {
+  let qc: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    globalStore.dispatch(sseSlots([]))
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(Provider, { store: globalStore },
+      createElement(QueryClientProvider, { client: qc }, children),
+    )
+  }
+
+  function mountOpened() {
+    renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    return ws
+  }
+
+  const folders = (): ChatFolder[] | undefined =>
+    qc.getQueryData<ChatFolder[]>(['chat-folders'])
+
+  it('seeds an empty cache with the folder tree carried on the frame', () => {
+    const ws = mountOpened()
+    act(() => {
+      ws.simulateMessage({
+        type: 'slots',
+        data: [{ key: 'slot-a', title: 's', agent: 'kirocrew', folder_id: 'f1' }],
+        folders: [{ id: 'f1', name: 'Work', order: 0 }],
+      })
+    })
+    expect(folders()).toEqual([{ id: 'f1', name: 'Work', order: 0 }])
+  })
+
+  it('invalidates the chat-folders query after a first-paint seed so counts backfill', () => {
+    const invalidate = vi.spyOn(qc, 'invalidateQueries')
+    const ws = mountOpened()
+    act(() => {
+      ws.simulateMessage({
+        type: 'slots',
+        data: [],
+        folders: [{ id: 'f1', name: 'Work', order: 0 }],
+      })
+    })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['chat-folders'] })
+  })
+
+  it('does NOT overwrite an already-populated cache (optimistic edits / loaded counts survive)', () => {
+    // The HTTP GET (or an in-flight folder mutation's optimistic update) has
+    // already put data in the cache; a later live `slots` frame must leave it be.
+    qc.setQueryData<ChatFolder[]>(['chat-folders'], [
+      { id: 'f1', name: 'Work (optimistic rename)', order: 0, history_count: 7, collapsed: true },
+    ])
+    const invalidate = vi.spyOn(qc, 'invalidateQueries')
+    const ws = mountOpened()
+    act(() => {
+      ws.simulateMessage({
+        type: 'slots',
+        data: [],
+        folders: [{ id: 'f1', name: 'Work', order: 0 }],
+      })
+    })
+    // Untouched: the optimistic name, count, and collapsed state all survive,
+    // and no invalidate fired to clobber the in-flight mutation.
+    expect(folders()).toEqual([
+      { id: 'f1', name: 'Work (optimistic rename)', order: 0, history_count: 7, collapsed: true },
+    ])
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ['chat-folders'] })
+  })
+
+  it('does NOT re-seed a populated-but-EMPTY cache (no refetch storm for zero-folder users)', () => {
+    // A user with genuinely zero folders has the GET cache `[]`. Guarding on
+    // `existing.length === 0` would re-match every slots frame and loop
+    // invalidate→refetch against the session-scanning endpoint. The guard is
+    // `existing === undefined`, so an empty (but present) cache is left alone.
+    qc.setQueryData<ChatFolder[]>(['chat-folders'], [])
+    const invalidate = vi.spyOn(qc, 'invalidateQueries')
+    const ws = mountOpened()
+    act(() => {
+      ws.simulateMessage({
+        type: 'slots',
+        data: [],
+        folders: [{ id: 'f1', name: 'Work', order: 0 }],
+      })
+    })
+    expect(folders()).toEqual([])
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ['chat-folders'] })
+  })
+
+  it('does not touch the cache when the frame carries no folders field', () => {
+    qc.setQueryData<ChatFolder[]>(['chat-folders'], [
+      { id: 'f1', name: 'Work', order: 0, history_count: 3 },
+    ])
+    const ws = mountOpened()
+    act(() => {
+      ws.simulateMessage({ type: 'slots', data: [{ key: 'slot-a', agent: 'kirocrew' }] })
+    })
+    expect(folders()).toEqual([{ id: 'f1', name: 'Work', order: 0, history_count: 3 }])
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

On dashboard load, chat sessions in the sidebar render **before** their folder groupings resolve. For the first few hundred ms (up to a couple of seconds on a slow connection), every session appears flat/ungrouped in the Unfiled bucket, then abruptly **jumps into its folder group** once the folders data arrives — a visible layout shift on every page load.

## Why it matters

It's a jarring flicker every single time the dashboard loads, for every user who files sessions into folders. The sidebar is the first thing you look at, and watching your sessions re-shuffle themselves into groups reads as jank / instability in the core surface.

## What changed (motivation → approach → change)

**Root cause.** The sidebar's two data sources arrive on different transports with different timing, and only one gates the render:

- **Sessions (`slots`)** are pushed over the **WebSocket** the instant the socket connects (`sseSlots` → `slotsLoaded = true`).
- **Folders** came only from a **separate `GET /api/chat/folders`** fired on `ChatSidebar` mount. The global QueryClient uses `staleTime: Infinity` but has no query persistence, so this cache is cold on every load and must round-trip.

While `folders` is still `[]`, `groupHistoryByFolder` can't resolve any session's `folder_id` and drops everything into the Unfiled bucket → flat render. When the GET resolves, sessions re-render into their groups → the visible jump.

**Approach.** Rather than a localStorage cache (which only helps *repeat* loads), make folders arrive on the **same instant transport as sessions**. The `slots` broadcast frame already carries envelope extras (`channelTrusted`, `gitlabHostsGeneration`); piggyback the in-memory folder tree onto it the same way — **without** the per-folder `history_count`, because that field costs a synchronous session-directory scan the broadcast hot path must never run.

**Change.**
- Backend (`state.py`): `_do_slots_broadcast` adds `folders: list(self._folders)` to the note, and the key-by-key frame rebuild in `_broadcast` forwards it. Only the dashboard-user frame carries it; app-token frames (rebuilt in the scope chokepoint) omit it — apps don't render the folder tree.
- Frontend (`useWebSocket.ts`): the `slots` handler seeds `['chat-folders']` from the frame **only when the cache is empty (first paint)**, then invalidates so the real `GET` backfills `history_count`. Seeding only-when-empty is deliberate: under `staleTime: Infinity`, seeding on every frame would (a) let a frame landing inside an in-flight folder mutation's optimistic window clobber the optimistic value, and (b) mark count-less data fresh so a mount-time query skips the GET and the "hide when empty" counts never load. After the cache is populated, live frames leave it alone and folder create/rename/move propagate through their existing mutation + invalidate path.

Net effect: grouping is correct on the very first paint, with zero added filesystem I/O on the broadcast hot path and no new HTTP round-trip on any load.

## Tests

- `test/test_dashboard_state_ws.py::TestSlotsBroadcastCarriesFolders` — the dashboard-user slots frame carries the folder tree and, critically, carries it **without** `history_count` (guards the hot-path-scan invariant).
- `website/src/test/useWebSocket.folderSeed.test.ts` — (1) an empty cache is seeded from the frame; (2) a first-paint seed invalidates `['chat-folders']` so counts backfill; (3) an **already-populated** cache is left untouched (optimistic edits / loaded counts survive, no invalidate fires); (4) a frame with no `folders` field is a no-op.

## Manual verification

N/A — unit coverage sufficient. The change is a data-transport reroute (WS frame → query cache seed) plus a first-paint guard, all covered by the backend frame-shape test and the four frontend cache-behavior tests above; there is no rendered-output change to inspect visually (see below).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** This removes a *temporal* flicker — the steady-state rendered output is identical before and after; only the intermediate ungrouped frame is eliminated. The frontend change is purely data-cache seeding inside `useWebSocket.ts` (no JSX, layout, or styling change), so a still before/after screenshot would look identical and cannot capture the timing difference.

## Related Issues

Fixes #4127

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
