### PR TITLE
perf(sidebar): cache relative-time day boundaries instead of rebuilding per row

### DIFF
--- a/website/src/pages/chat/sessionOrder.ts
+++ b/website/src/pages/chat/sessionOrder.ts
@@ -96,26 +96,56 @@ export function comparePinnedThenSort(
   return compareBySort(a, b, key)
 }
 
+/**
+ * The local-midnight instants `fmtRelativeTime` classifies against, in epoch ms.
+ *
+ * Every visible session row compares against the same boundaries, so they are
+ * built once per day rather than once per call. `dayEnd` is the next local
+ * midnight, which is when they stop being true.
+ *
+ * The lower bound matters as much as the upper one: a clock that moves BACKWARDS
+ * is also outside the cached day, and must not be served boundaries from a day
+ * that has not happened yet.
+ */
+let dayStart = 0
+let yesterdayStart = 0
+let sixDaysAgoStart = 0
+let dayEnd = 0
+let dayYear = 0
+
+function ensureDayBoundaries(nowMs: number): void {
+  if (nowMs >= dayStart && nowMs < dayEnd) return
+  const now = new Date(nowMs)
+  const y = now.getFullYear()
+  const m = now.getMonth()
+  const day = now.getDate()
+  // Day arithmetic goes through the Date constructor rather than ms subtraction
+  // because it has to survive DST: a local day is not always 86_400_000 ms long.
+  dayStart = new Date(y, m, day).getTime()
+  yesterdayStart = new Date(y, m, day - 1).getTime()
+  sixDaysAgoStart = new Date(y, m, day - 6).getTime()
+  dayEnd = new Date(y, m, day + 1).getTime()
+  dayYear = y
+}
+
 /** Relative timestamp for a session row.
  *  Accepts ISO string (active slots) or Unix epoch seconds (history `modified`). */
 export function fmtRelativeTime(ts: string | number | undefined): string {
   if (ts == null) return ''
   const d = typeof ts === 'number' ? new Date(ts * 1000) : new Date(ts)
-  if (isNaN(d.getTime())) return ''
-  const now = new Date()
-  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-  const startOfYesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
-  const startOf6DaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6)
+  const at = d.getTime()
+  if (isNaN(at)) return ''
+  ensureDayBoundaries(Date.now())
   // Every branch read the BROWSER's locale before this, so a zh dashboard on an
   // en-US browser showed "3:04 PM" and "Jul 30". This is the twin of
   // `commandPalette/providers/recentsProvider.ts`; the two are now consistent.
   const time = fmtDateFields(d, { hour: '2-digit', minute: '2-digit' })
-  if (d >= startOfToday) return time
+  if (at >= dayStart) return time
   // The existing catalog key, NOT `fmtRelative`: CLDR returns a lowercase
   // "yesterday", which clashed with the capitalized group header in ChatSidebar
   // that already uses this same key. One key, one casing.
-  if (d >= startOfYesterday) return `${i18nT('pages.chatSidebar.yesterday')} ${time}`
-  if (d >= startOf6DaysAgo) return `${fmtDateFields(d, { weekday: 'short' })} ${time}`
-  if (d.getFullYear() === now.getFullYear()) return fmtDateFields(d, { month: 'short', day: 'numeric' })
+  if (at >= yesterdayStart) return `${i18nT('pages.chatSidebar.yesterday')} ${time}`
+  if (at >= sixDaysAgoStart) return `${fmtDateFields(d, { weekday: 'short' })} ${time}`
+  if (d.getFullYear() === dayYear) return fmtDateFields(d, { month: 'short', day: 'numeric' })
   return fmtDateFields(d, { year: 'numeric', month: 'short', day: 'numeric' })
 }

--- a/website/src/test/sessionOrder.test.ts
+++ b/website/src/test/sessionOrder.test.ts
@@ -12,9 +12,11 @@
  *      not shift with the app language.
  *  (5) A running session ranks by `last_turn_ts` (its prompt), so mid-turn rows
  *      moving `last_ts` cannot reshuffle the list.
+ *  (6) `fmtRelativeTime` shares one set of day boundaries across a whole list,
+ *      and rebuilds them when the clock leaves that day in either direction.
  */
-import { describe, it, expect } from 'vitest'
-import { compareBySort, comparePinnedThenSort, lastActivityEpoch, slotActivityTs } from '../pages/chat/sessionOrder'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { compareBySort, comparePinnedThenSort, fmtRelativeTime, lastActivityEpoch, slotActivityTs } from '../pages/chat/sessionOrder'
 import type { Sortable } from '../pages/chat/sessionOrder'
 
 const order = (items: Sortable[], key: Parameters<typeof compareBySort>[2] = 'date-desc') =>
@@ -157,5 +159,91 @@ describe('compareBySort created-*', () => {
     ]
     expect(order(items, 'created-desc')).toEqual(['created-first-active-last', 'created-last-active-first'])
     expect(order(items, 'date-desc')).toEqual(['created-last-active-first', 'created-first-active-last'])
+  })
+})
+
+/**
+ * Count `new Date(...)` constructions performed inside `fn`.
+ *
+ * The day-boundary cache is not visible in the string `fmtRelativeTime` returns,
+ * so the allocation count is the only direct evidence it is doing anything. The
+ * subclass is restored in `finally` so a failed assertion cannot leak it into a
+ * later test. `Date.now()` is a static and is inherited, so reading the clock is
+ * deliberately not counted — only allocation is.
+ */
+function countDateConstructions(fn: () => void): number {
+  const Real = globalThis.Date
+  let made = 0
+  class Counting extends Real {
+    constructor(...args: ConstructorParameters<typeof Date>) {
+      // @ts-expect-error variadic forwarding into the Date constructor overloads
+      super(...args)
+      made++
+    }
+  }
+  globalThis.Date = Counting as unknown as DateConstructor
+  try {
+    fn()
+  } finally {
+    globalThis.Date = Real
+  }
+  return made
+}
+
+describe('fmtRelativeTime day boundaries', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('builds the day boundaries once for a whole list, not once per row', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-17T12:00:00Z'))
+    const rows = Array.from({ length: 20 }, (_, i) => `2026-08-17T0${i % 9}:30:00Z`)
+
+    const cold = countDateConstructions(() => {
+      for (const ts of rows) fmtRelativeTime(ts)
+    })
+    const warm = countDateConstructions(() => {
+      for (const ts of rows) fmtRelativeTime(ts)
+    })
+
+    // A rebuild costs 5 (the clock reading plus four boundaries), so a cold list
+    // pays it once and a warm one not at all. Per-row it would be 5 every row.
+    expect(cold).toBeLessThanOrEqual(rows.length + 5)
+    expect(warm).toEqual(rows.length)
+  })
+
+  it('reclassifies a timestamp once the local day rolls over', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-17T12:00:00Z'))
+    const ts = '2026-08-17T10:00:00Z'
+    const asToday = fmtRelativeTime(ts)
+
+    vi.setSystemTime(new Date('2026-08-18T00:30:00Z'))
+    const asYesterday = fmtRelativeTime(ts)
+
+    expect(asYesterday).not.toEqual(asToday)
+    // The yesterday branch appends the same clock time, so this holds whatever
+    // the catalog renders for the label and whatever locale is active.
+    expect(asYesterday).toContain(asToday)
+  })
+
+  it('rebuilds when the clock moves backwards, so a future day is not reused', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-17T12:00:00Z'))
+    const asToday = fmtRelativeTime('2026-08-17T10:00:00Z')
+
+    vi.setSystemTime(new Date('2026-08-20T12:00:00Z'))
+    fmtRelativeTime('2026-08-20T10:00:00Z')
+
+    vi.setSystemTime(new Date('2026-08-17T12:00:00Z'))
+    // Held at the Aug 20 boundaries, Aug 17 would fall in the within-6-days
+    // branch and gain a weekday prefix.
+    expect(fmtRelativeTime('2026-08-17T10:00:00Z')).toEqual(asToday)
+  })
+
+  it('still returns empty for a missing or unparseable timestamp', () => {
+    expect(fmtRelativeTime(undefined)).toEqual('')
+    expect(fmtRelativeTime('not-a-date')).toEqual('')
   })
 })


### PR DESCRIPTION
<!-- no-visual-delta -->

**Why no screenshot:** this is a pure caching change with no rendered-output delta — it memoizes the local-midnight instants `fmtRelativeTime` compares against, so for any given timestamp the returned string is byte-identical to before.

## Problem / Motivation

`fmtRelativeTime` in `website/src/pages/chat/sessionOrder.ts` is what renders the timestamp on every session row in the chat sidebar. It is called once per visible row, on every sidebar render, from three places in `ChatSidebar.tsx`.

Each call rebuilt the same three day boundaries from scratch:

```ts
const now = new Date()
const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
const startOfYesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
const startOf6DaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6)
```

Those four `Date` objects are identical for every row in the list — they depend only on what day it is, not on the row. So a 20-row sidebar allocated 80 `Date` objects per render to compute one shared answer four times over, then threw them away.

## Why it matters

This is allocation churn in a hot render path, and the cost scales with the number of visible sessions multiplied by how often the sidebar re-renders (which is often — slot updates arrive over a websocket).

Measured on a 20-row list, counting `Date` constructions directly (the test below does this): **100 before, 25 after**. Per row it goes from 5 `Date` objects to 1 — the one that parses the row's own timestamp, which is genuinely per-row and stays.

To be precise about what this does *not* claim: the profiling that motivated this work attributed 5.5% self time to `toLocaleTimeString`, which is formatter *construction*, not `Date` allocation. That half is already solved in this repo — `src/i18n/format.ts` memoizes every `Intl` formatter on `(kind, locale, options)`, so `fmtDateFields` does not build a formatter per call. This change is the other half, and its win is allocation, not formatter construction. I have not re-profiled, so there is no self-time figure for it. What I can bound cheaply: timing the removed work in isolation (per-call `now` plus three boundary `Date`s and three `Date` comparisons, versus a cached numeric read) gives roughly 470 ns before and 90 ns after, so about 380 ns per call. At 50 visible rows that is on the order of **0.02 ms per render — about 0.1% of a single 60fps frame**. That is an upper bound on this change's benefit, not a render measurement, and it is small. The change is still correct and removes real garbage, but anyone weighing whether it is worth carrying should weigh it against that number rather than against the 5.5% figure, which belonged to the formatter half.

## What changed

One file plus its test.

`fmtRelativeTime` now reads the boundaries from module-scope state that is rebuilt only when the clock leaves the cached day:

- `dayStart` / `yesterdayStart` / `sixDaysAgoStart` are epoch ms rather than `Date` objects, so the comparisons are numeric.
- `dayEnd` is the next local midnight and acts as the cache's expiry. The cache is valid exactly while `now` is inside `[dayStart, dayEnd)`, which is when the boundaries are true — not for some duration.
- The lower half of that check is load-bearing, not symmetry: a clock that moves **backwards** (fake timers in a test, an NTP correction) is also outside the cached day, and must not be handed boundaries for a day that has not happened yet. There is a test for this, and it fails if that half is removed.
- `dayYear` replaces the `now.getFullYear()` that the same-year branch used to read off the freshly allocated `now`.
- Day arithmetic still goes through the `Date` constructor rather than subtracting milliseconds, because a local day is not always 86,400,000 ms long. Subtracting a fixed number of ms would misclassify rows on DST transition days.

Behaviour is unchanged. `d >= startOfToday` on two `Date`s already compared their epoch values, so `at >= dayStart` is the same comparison written directly.

### Deliberately not included

Two things from the same body of work are left out on purpose.

**Hoisting the `Intl.DateTimeFormat` instances to module scope.** This repo has already solved it better. A module-scope formatter resolves its locale once at import and can never follow a language switch — which is the exact defect `src/i18n/format.ts` exists to fix, and `src/i18n/localeFormatting.test.ts` ratchets against. Its `[added-lines]` gate has no exemption and no ceiling to raise, so the hoisted form would both fail CI and regress i18n. The memo in `format.ts` gets the same performance result while still reading the active language per call.

**Two same-shape siblings, both left for their own change.** `src/components/commandPalette/providers/recentsProvider.ts:141` and `dateSegment` in `src/pages/ChatSidebar.tsx:843` each rebuild local-midnight boundaries on every call, the way this function used to. `dateSegment` is the heavier of the two: it allocates `now` plus four boundaries per call, the active-slot list calls it once per row, and the history list calls it twice per row (once for the row, once to look ahead at the next one to decide whether to draw a divider). It is a different function with a different boundary set (today / yesterday / 7 days / 30 days), so caching it is its own change rather than a wider edit to this one. Grepping the exact shape `startOfToday = new Date(now.getFullYear()` finds those two sites and no others, now that this one is fixed. Two further midnight-truncation sites live outside the sidebar, at `src/apps/issue-radar/lib/format.ts:248` and `src/components/notifications/notifMeta.tsx:60`; both are out of scope here.

## Tests

Extended `src/test/sessionOrder.test.ts` with four cases, and ran the negative control for each claim rather than assuming.

1. **The boundaries are built once per list, not once per row.** A helper temporarily subclasses `Date` to count constructions. A cold pass over 20 rows must cost at most `20 + 5`; a second pass over the same day must cost exactly `20` — no boundary rebuild at all.
2. **The cache expires at midnight.** The same timestamp read at 12:00 and again after the day rolls over must classify differently, and the later form must still contain the earlier clock time (so the assertion holds whatever the catalog and locale render).
3. **The cache rebuilds when the clock moves backwards.**
4. **Missing and unparseable timestamps still return empty.**

Negative controls, both run:

- Reverting the production change and leaving the tests alone fails test 1 with `expected 100 to be less than or equal to 25` — the predicted pre-change count, 20 rows times 5 allocations. Tests 2 and 3 still pass there, which is correct and worth stating plainly: code that recomputes on every call is trivially right about day rollover. Those two are correctness guards on the cache, not evidence of the performance change.
- Removing only the backwards-clock half of the guard fails test 3 with `expected 'Mon 10:00 AM' to deeply equal 'Yesterday 10:00 AM'`, so that test pins that specific clause rather than the cache in general.

Gates run locally: full website suite, `tsc --noEmit`, `eslint` on both changed files, and `src/i18n/localeFormatting.test.ts` with `I18N_BASE_REF` set so its two diff-scoped gates actually execute instead of skipping. The host-locale count is unchanged at 27, under the ceiling of 37.

## Review notes

**First Principles Watch 2 is refuted.** It claims `dateSegment` at `ChatSidebar.tsx:843` "goes unmentioned" and scores "2 unfixed siblings, 1 undeclared". The "Deliberately not included" section above names both siblings explicitly — `recentsProvider.ts:141` and `dateSegment` in `ChatSidebar.tsx:843`. The correct score is **2 unfixed siblings, 0 undeclared**. The lane's site count of 3 was taken against this PR's base, where `sessionOrder.ts` still matched the pattern; grepping `startOfToday = new Date(now.getFullYear()` against the merged head returns 2 sites, both declared.

**First Principles Watch 1 is not refuted and is conceded above.** The justification is an allocation count rather than a measured cost in time, and the profiled hotspot was the formatter construction `src/i18n/format.ts` already memoises.

**Known defect in this change, fixed separately.** The cache validity check tests only the clock (`nowMs >= dayStart && nowMs < dayEnd`), but the boundaries are built by the `Date` constructor and so belong to the timezone active at the last rebuild, while `Date.now()` is zone-independent. A timezone change therefore never moves the clock out of the cached window, so the cache is never rebuilt and rows keep being labelled against the old zone's midnight. Verified: at one instant, boundaries built under `UTC` put a 03:00Z row in *today* while boundaries built under `Pacific/Auckland` put it in *yesterday*, and the stale window still reads as valid. This is a regression introduced here — the previous code rebuilt on every call and so always used the current zone. Follow-up adds a timezone term to the validity check.
