### PR TITLE
perf(sidebar): resolve slot-derived state by lookup, not per-render spread

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -509,14 +509,6 @@ interface Slot {
   clean_mode?: boolean
   folder_id?: string
   pinned?: boolean
-  // Derived (not a payload field), like `unread`: true when the slot's last
-  // activity falls inside `RECENT_WINDOW_MS`. Computed in `enrichedSlots`.
-  recent?: boolean
-  // Derived: the RAW per-turn flag, preserved before `running` is widened to
-  // the "in progress" notion (live workflow run / active goal loop) for the
-  // session filter. Subtitle logic reads this to tell mid-turn from idle —
-  // an idle-between-cycles loop must show its last message, not "Thinking…".
-  midTurn?: boolean
   tags?: string[]
   forked_from?: string | null
   source_links?: Array<{
@@ -1333,7 +1325,7 @@ function ChatSidebar({
   const unreadSet = useMemo(() => new Set(unreadSlots), [unreadSlots])
   // Heartbeat that re-evaluates recency even when nothing else re-renders.
   // Sidebar interactions (new messages, status changes, opening the menu) all
-  // recompute `enrichedSlots` for free, so this only matters when the sidebar
+  // recompute the recency lookup for free, so this only matters when the sidebar
   // sits idle with the Recent filter on — without it a stale session would
   // never age out of the list. Gated on the filter being active so we don't
   // wake an idle tab needlessly, mirroring the `staleTick` pattern in App.tsx.
@@ -1378,40 +1370,45 @@ function ChatSidebar({
     const id = setInterval(() => setRecentTick(t => t + 1), recentTickIntervalMs(recentWindowMs))
     return () => clearInterval(id)
   }, [recentFilterActive, recentWindowMs])
-  const enrichedSlots = useMemo<Slot[]>(() => {
-    // Snapshot `now` once per recompute so every slot's recency is measured
-    // against the same instant. The last-activity timestamp mirrors the
-    // date-sort comparator (`slotActivityTs`).
-    const now = Date.now()
-    return slots.map(s => {
-      // A running turn is recent BY DEFINITION, whatever its settled instant
-      // says. The ordering key deliberately stops advancing mid-turn, so a turn
-      // outliving the window — routine for unattended multi-step work — would
-      // otherwise age out of the Recent list while it is the busiest session on
-      // screen. `workflowActive` / `looping` below extend "running" the same way,
-      // hence the OR against the computed flag rather than `s.running`.
-      const recentByTs = isWithinRecentWindow(slotActivityTs(s), now, recentWindowMs)
-      // A slot with a live dynamic-workflow run counts as running so the
-      // "In progress" filter (and its count) surfaces it, even though the
-      // parent turn has ended while the run executes in the background.
-      // An active goal loop (auto-nudge) counts too: a looping session idles
-      // between cycles with running=false, but it is still mid-mission — its
-      // row shows "Loop N/M", so dropping it from "In progress" undercounts.
-      // Own-property read, matching the row renderer: the store normalizes
-      // writes through `safeKey`, so a bare index read could resolve a
-      // `__proto__`-like key to a truthy `Object.prototype`.
+  // Wider than the payload's `s.running`: a live workflow run or an active goal
+  // loop counts as in progress, so neither drops out of the filter or its count.
+  const runningSet = useMemo<Set<string>>(() => {
+    const out = new Set<string>()
+    for (const s of slots) {
+      // Own-property read: the store normalizes writes through `safeKey`, so a
+      // bare index read could resolve a `__proto__`-like key to a truthy value.
       const looping = Object.prototype.hasOwnProperty.call(goalLoops ?? {}, s.key)
-      const running = s.running || !!workflowActive[s.key] || looping
-      return { ...s, running, midTurn: s.running, unread: unreadSet.has(s.key), recent: running || recentByTs }
-    })
+      if (s.running || !!workflowActive[s.key] || looping) out.add(s.key)
+    }
+    return out
+  }, [slots, workflowActive, goalLoops])
+  // A running turn is recent BY DEFINITION: the ordering key stops advancing
+  // mid-turn, so a long turn would age out while it is the busiest row on screen.
+  const recentSet = useMemo<Set<string>>(() => {
+    // One `now` per recompute, so every slot is measured against the same instant.
+    // The last-activity timestamp mirrors the date-sort comparator.
+    const now = Date.now()
+    const out = new Set<string>()
+    for (const s of slots) {
+      if (runningSet.has(s.key) || isWithinRecentWindow(slotActivityTs(s), now, recentWindowMs)) out.add(s.key)
+    }
+    return out
     // `recentTick` is an intentional dep: it forces recency to re-evaluate on
     // the heartbeat above so idle sessions age out of the Recent filter.
-  }, [slots, unreadSet, recentWindowMs, recentTick, workflowActive, goalLoops]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [slots, runningSet, recentWindowMs, recentTick]) // eslint-disable-line react-hooks/exhaustive-deps
+  // Exhaustive over `SessionFilterKey` on purpose: a new filter key becomes a
+  // type error here instead of a predicate that silently matches nothing.
+  const _derivedLookup = useMemo<Record<SessionFilterKey, (slot: Slot) => boolean>>(() => ({
+    unread: slot => unreadSet.has(slot.key),
+    running: slot => runningSet.has(slot.key),
+    pinned: slot => !!slot.pinned,
+    recent: slot => recentSet.has(slot.key),
+  }), [unreadSet, runningSet, recentSet])
   const filterCounts = useMemo(() => {
     const counts = {} as Record<SessionFilterKey, number>
-    for (const filterDef of SESSION_FILTERS) counts[filterDef.key] = enrichedSlots.filter(slot => slot[filterDef.key]).length
+    for (const filterDef of SESSION_FILTERS) counts[filterDef.key] = slots.filter(_derivedLookup[filterDef.key]).length
     return counts
-  }, [enrichedSlots])
+  }, [slots, _derivedLookup])
   // Ref mirror of `activeFilters` so the auto-drain effect can read the
   // current toggle state without depending on it. Keeps the effect from
   // re-firing on its own setState output.
@@ -1691,7 +1688,7 @@ function ChatSidebar({
     [filterTagIds, tagById],
   )
   /** Rows for the filter menu's Tags section, in the tag vocabulary's own order.
-   *  Counts come from `enrichedSlots`, NOT `filteredSlots`, so they describe the
+   *  Counts come from all `slots`, NOT `filteredSlots`, so they describe the
    *  vocabulary rather than the current selection — otherwise every unselected tag
    *  would read 0 the moment any tag was selected, which is the number a user
    *  consults precisely when deciding what to select next. */
@@ -1700,10 +1697,10 @@ function ChatSidebar({
       .sort((a, b) => a.order - b.order)
       .map(t => ({
         tag: t,
-        count: enrichedSlots.filter(s => (s.tags ?? []).includes(t.id)).length,
+        count: slots.filter(s => (s.tags ?? []).includes(t.id)).length,
         selected: filterTagIds.has(t.id),
       })),
-    [tags, enrichedSlots, filterTagIds],
+    [tags, slots, filterTagIds],
   )
   /** Names of the selected tags, in vocabulary order. Disjunction, not a comma
    *  join: selection is a union, so a screen reader should hear "Blocked or
@@ -1876,9 +1873,9 @@ function ChatSidebar({
     // palette). Pinning stays a reachability promise for browsing, not a
     // ranking hint inside explicit search results.
     const searchRanked = slotFilter.trim().length >= SEARCH_MIN_CHARS ? slotSearchRanks : null
-    const next = enrichedSlots
+    const next = slots
       .filter(slot => {
-        if (activeFilterDefs.length > 0 && !activeFilterDefs.some(filterDef => slot[filterDef.key])) return false
+        if (activeFilterDefs.length > 0 && !activeFilterDefs.some(filterDef => _derivedLookup[filterDef.key](slot))) return false
         // Unlike the folder filter this does NOT go inert while searching: it is a
         // session property, so it behaves like the Unread/Pinned filters above.
         if (activeTagIds.size > 0 && !(slot.tags ?? []).some(id => activeTagIds.has(id))) return false
@@ -1895,7 +1892,7 @@ function ChatSidebar({
     frozenSlotsRef.current = next
     return next
   },
-    [enrichedSlots, slotFilter, slotSearchRanks, pinned, sortKey, activeFilters, activeTagIds, dragFrozen]
+    [slots, _derivedLookup, slotFilter, slotSearchRanks, pinned, sortKey, activeFilters, activeTagIds, dragFrozen]
   )
 
   // Folder IDs whose sessions are excluded from the flat lane because the
@@ -2694,19 +2691,18 @@ function ChatSidebar({
     // warn dot with an explicit "interrupted" instead. Guarded on the raw turn
     // flag plus workflow/subagent activity: while any of those run, the loop IS
     // working and `s.interrupted` only describes a superseded turn.
-    const goalLoopStalled = !!goalLoop && !!s.interrupted && !s.midTurn && !wfActive && subagentCount === 0
+    const goalLoopStalled = !!goalLoop && !!s.interrupted && !s.running && !wfActive && subagentCount === 0
     // Whatever this row would have said if no loop were running, reused as the
     // loop line's trailing detail. This is why the loop branch can outrank the
     // working signals below without swallowing them: live workflow/subagent/tool
     // status still shows, and between cycles it falls back to the last message.
-    // Reads `midTurn` (the raw turn flag), NOT `running`: enrichment widens
-    // `running` to include this very loop, and an idle-between-cycles row must
-    // say "Loop 7/24 · <last message>", not "Loop 7/24 · Thinking…".
+    // Reads the RAW `s.running`, not `runningSet`: the widened flag includes this
+    // very loop, and an idle-between-cycles row must show its last message.
     const goalLoopDetail = wfActive
       ? wfActive.label
       : subagentCount > 0
         ? subagentLabel
-        : s.midTurn
+        : s.running
           ? slotStatusText(slotStatusDetail[s.key], simplifiedToolNames, uiLang)
           : (s.last_message || '')
     const ci = s.color_index != null && s.color_index >= 0 && s.color_index < paletteColors.length ? s.color_index : null
@@ -2855,7 +2851,7 @@ function ChatSidebar({
         // with a definite direction, and rotation reads as progress where a
         // fading dot reads as a mere marker.
         key: 'running',
-        when: !!s.running,
+        when: runningSet.has(s.key),
         build: () => {
           const text = slotStatusText(slotStatusDetail[s.key], simplifiedToolNames, uiLang)
           return {
@@ -2879,7 +2875,7 @@ function ChatSidebar({
     // svg attribute, which is not a tooltip. It goes on the gutter element.
     const status: { glyph: React.ReactNode; label: string } | null = rowState
       ? { glyph: rowState.glyph, label: rowState.label }
-      : s.unread
+      : unreadSet.has(s.key)
         // A DOT, so it keeps its own size: `ROW_ICON_PX` sizes the lucide
         // glyphs, whose ink covers a fraction of their box, while a filled
         // disc covers all of it. At 10px it reads as heavier than every

--- a/website/src/test/ChatSidebar.slotDerivation.test.tsx
+++ b/website/src/test/ChatSidebar.slotDerivation.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * Sidebar slot derivation — the values that are NOT payload fields. They used to
+ * be attached by copying every slot per render; they are now resolved from
+ * membership lookups at the point of use.
+ *
+ * Each is pinned SEPARATELY, because the failure mode of that swap is a silently
+ * dropped field: the list still renders and the row count is unchanged, so only
+ * a per-field assertion can tell one piece of state has gone `undefined`.
+ *
+ *  (1) `recent`  — a timestamp inside the window OR a running turn. Both halves.
+ *  (2) `running` — wider than `s.running`: a workflow run or goal loop counts.
+ *  (3) `midTurn` — the RAW turn flag, deliberately NOT the widened one.
+ *  (4) `unread`  — reaches the row's status gutter.
+ * Plus `pinned`, a payload field read through the same lookup.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+// Legacy single-lane list (no tag columns) keeps the rows flat + easy to query.
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ tagColumnsEnabled: false, confirmCloseSession: false }),
+  saveChatConfig: vi.fn(),
+}))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: () => vi.fn().mockResolvedValue([]),
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+const UNREAD_DOT_TITLE = 'Agent finished — your turn'
+// Default recency window is 1h, so these sit either side of it.
+const FRESH = new Date(Date.now() - 60 * 1000).toISOString()
+const STALE = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString()
+
+/** Minimal WorkflowRunProgress for the sidebar (reads name/phase/status/sessionKey). */
+const wf = (over: Record<string, unknown> = {}) => ({
+  run_id: 'wf_000001', name: 'nightly-sweep', phase: 'gather',
+  lastLog: '', status: 'running', sessionKey: 'dashboard:k-wf', ...over,
+})
+
+function renderSidebar(
+  slots: any[],
+  chat: Record<string, unknown> = {},
+  { activeSlotProp = null, unreadSlots = [] }: { activeSlotProp?: string | null; unreadSlots?: string[] } = {},
+) {
+  const store = createTestStore({
+    dashboard: {
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots, updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: { activeSlot: null, slotStatusDetail: {}, subagents: {}, slotActivity: {}, workflowRuns: {}, goalLoops: {}, ...chat } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], [])
+  return render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={activeSlotProp} unreadSlots={unreadSlots}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.clearAllMocks())
+
+describe('sidebar slot derivation — every derived value still reaches the row', () => {
+  it('POSITIVE CONTROL: with no filter active, every row renders', () => {
+    const slots = [
+      { key: 'a', title: 'alpha', running: false, messages: 1, last_turn_ts: STALE },
+      { key: 'b', title: 'bravo', running: true, messages: 2, last_turn_ts: FRESH },
+      { key: 'c', title: 'charlie', running: false, messages: 3, last_turn_ts: FRESH, pinned: true },
+    ]
+    const { getByText } = renderSidebar(slots)
+    expect(getByText('alpha')).toBeTruthy()
+    expect(getByText('bravo')).toBeTruthy()
+    expect(getByText('charlie')).toBeTruthy()
+  })
+
+  it('`recent` counts a RUNNING turn whose timestamp has already aged out', () => {
+    // The ordering key stops advancing mid-turn, so a turn outliving the window
+    // must not age out of Recent. A timestamp-only lookup drops this half.
+    localStorage.setItem('mc-session-recent-only', '1')
+    const slots = [
+      { key: 'run', title: 'long running turn', running: true, messages: 5, last_turn_ts: STALE },
+      { key: 'idle', title: 'stale and idle', running: false, messages: 2, last_turn_ts: STALE },
+    ]
+    const { getByText, queryByText } = renderSidebar(slots)
+    expect(getByText('long running turn')).toBeTruthy()
+    expect(queryByText('stale and idle')).toBeNull()
+  })
+
+  it('`recent` still counts a fresh timestamp on an idle slot', () => {
+    // The other half of the same union: recency must not collapse into "running".
+    localStorage.setItem('mc-session-recent-only', '1')
+    const slots = [
+      { key: 'fresh', title: 'recently active', running: false, messages: 2, last_turn_ts: FRESH },
+      { key: 'old', title: 'long forgotten', running: false, messages: 2, last_turn_ts: STALE },
+    ]
+    const { getByText, queryByText } = renderSidebar(slots)
+    expect(getByText('recently active')).toBeTruthy()
+    expect(queryByText('long forgotten')).toBeNull()
+  })
+
+  it('`running` is widened by an active GOAL LOOP, not just the payload flag', () => {
+    localStorage.setItem('mc-session-running-only', '1')
+    const slots = [
+      { key: 'k-loop', title: 'looping session', running: false, messages: 5, last_turn_ts: STALE },
+      { key: 'k-idle', title: 'idle session', running: false, messages: 2, last_turn_ts: STALE },
+    ]
+    const { getByText, queryByText } = renderSidebar(slots, {
+      goalLoops: { 'k-loop': { cycle_count: 7, max_cycles: 24 } },
+    })
+    expect(getByText('looping session')).toBeTruthy()
+    expect(queryByText('idle session')).toBeNull()
+  })
+
+  it('`running` is widened by a live WORKFLOW run, not just the payload flag', () => {
+    localStorage.setItem('mc-session-running-only', '1')
+    const slots = [
+      { key: 'k-wf', title: 'workflow session', running: false, messages: 5, last_turn_ts: STALE },
+      { key: 'k-idle', title: 'idle session', running: false, messages: 2, last_turn_ts: STALE },
+    ]
+    const { getByText, queryByText } = renderSidebar(slots, { workflowRuns: { wf_000001: wf() } })
+    expect(getByText('workflow session')).toBeTruthy()
+    expect(queryByText('idle session')).toBeNull()
+  })
+
+  it('`midTurn` is the RAW turn flag: an idle-between-cycles loop shows its last message', () => {
+    // The widened flag is TRUE here (the goal loop widens it), so resolving
+    // this from the widened value would print "Thinking…" for an idle row.
+    const slots = [{ key: 'k', title: 'loop', running: false, messages: 5, last_message: 'cycle 7 output' }]
+    const { getByText, queryByText } = renderSidebar(
+      slots,
+      { goalLoops: { k: { cycle_count: 7, max_cycles: 24 } }, slotStatusDetail: { k: { text: 'Reading gateway.log' } } },
+    )
+    expect(getByText('Loop 7/24')).toBeTruthy()
+    expect(getByText(/cycle 7 output/)).toBeTruthy()
+    expect(queryByText(/Reading gateway\.log/)).toBeNull()
+  })
+
+  it('`midTurn` true mid-turn: the same loop row carries the live tool status instead', () => {
+    const slots = [{ key: 'k', title: 'loop', running: true, messages: 5, last_message: 'cycle 7 output' }]
+    const { getByText, queryByText } = renderSidebar(
+      slots,
+      { activeSlot: 'k', goalLoops: { k: { cycle_count: 7, max_cycles: 24 } }, slotStatusDetail: { k: { text: 'Reading gateway.log' } } },
+      { activeSlotProp: 'k' },
+    )
+    expect(getByText('Loop 7/24')).toBeTruthy()
+    expect(getByText(/Reading gateway\.log/)).toBeTruthy()
+    expect(queryByText(/cycle 7 output/)).toBeNull()
+  })
+
+  it('`unread` reaches the row gutter as the "your turn" dot', () => {
+    const slots = [{ key: 'k', title: 'answered', running: false, messages: 5, last_message: 'final answer' }]
+    const { queryByTitle } = renderSidebar(slots, {}, { unreadSlots: ['k'] })
+    expect(queryByTitle(UNREAD_DOT_TITLE)).toBeTruthy()
+  })
+
+  it('`unread` drives its own filter, and a read row is excluded', () => {
+    localStorage.setItem('mc-session-unread-only', '1')
+    const slots = [
+      { key: 'u', title: 'unread session', running: false, messages: 2, last_turn_ts: FRESH },
+      { key: 'r', title: 'read session', running: false, messages: 2, last_turn_ts: FRESH },
+    ]
+    const { getByText, queryByText } = renderSidebar(slots, {}, { unreadSlots: ['u'] })
+    expect(getByText('unread session')).toBeTruthy()
+    expect(queryByText('read session')).toBeNull()
+  })
+
+  it('`pinned` still resolves through the same lookup as the derived keys', () => {
+    localStorage.setItem('mc-session-pinned-only', '1')
+    const slots = [
+      { key: 'p', title: 'pinned session', running: false, messages: 2, last_turn_ts: FRESH, pinned: true },
+      { key: 'q', title: 'loose session', running: false, messages: 2, last_turn_ts: FRESH },
+    ]
+    const { getByText, queryByText } = renderSidebar(slots)
+    expect(getByText('pinned session')).toBeTruthy()
+    expect(queryByText('loose session')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The chat sidebar attached four values to every session row by copying the whole slot object on every render. `enrichedSlots` was a `slots.map(s => ({ ...s, running, midTurn, unread, recent }))`, so a list of N sessions allocated N new objects each time the component rendered — and the sidebar re-renders on every streamed status change, which is continuously while any agent is working. None of those four values is a payload field; they are all derived from data already in scope.

## Why it matters

This is allocation churn in the component that re-renders most often, and it scales with the number of open sessions rather than with what actually changed. A profile of a large session list attributed 4.2% of self time to that object spread alone (`CopyDataPropertiesUnfiltered`). This PR removes the copy; it does not re-measure the profile, so treat that figure as the original attribution rather than a claim about the delta here.

## What changed (motivation → approach → change)

The four derived values only ever needed a yes/no answer per session key, so they do not need to live on a copy of the slot. They are now resolved from membership lookups at the point of use, and no slot object is copied.

Two of them are not simply reads of the payload, and preserving that exactly is the whole risk in this change:

- `running` is **wider** than the payload's own `s.running`. A live dynamic-workflow run counts as in progress even though the parent turn has ended, and so does an active goal loop, which idles between cycles with `running` false while its row still reads "Loop N/M". `runningSet` keeps both, so the "In progress" filter and its count match exactly what they matched before.
- `recent` is the **union** of that widened flag with the timestamp window, not the timestamp test alone. The ordering key deliberately stops advancing mid-turn, so a turn that outlives the recency window would otherwise age out of the Recent filter while it is the busiest row on screen. `recentSet` keeps the union.

`midTurn` was only ever an alias for the raw turn flag (`midTurn: s.running`), so the two row sites that read it now read `s.running` directly. `unread` becomes `unreadSet.has(s.key)`, using a set that already existed in the file.

The four session-filter keys are resolved through one `Record<SessionFilterKey, (slot: Slot) => boolean>`. It is exhaustive on purpose: adding a fifth filter key becomes a type error at that record instead of a predicate that silently matches nothing.

Finally, `recent` and `midTurn` are removed from the `Slot` interface. They were derived, never payload, and dropping them means a consumer left reading either one fails to compile rather than silently evaluating `undefined` — which is the failure mode this kind of change has.

## Tests

New suite `website/src/test/ChatSidebar.slotDerivation.test.tsx` (10 tests). Because this is a data-shape change, each derived value is asserted **separately** — a render-count or row-count assertion would pass with a field dropped, since the list still renders either way.

- `recent` keeps a running turn whose timestamp has already aged out, and separately keeps a fresh timestamp on an idle slot — the two halves of the union.
- `running` is widened by an active goal loop, and by a live workflow run, in both cases with the payload flag false.
- `midTurn` is the raw flag: an idle-between-cycles loop row shows its last message, and the same row mid-turn shows the live tool status instead.
- `unread` reaches the row's status gutter as the "your turn" dot, and drives its own filter.
- `pinned` still resolves through the same lookup.
- A positive control asserts every row renders with no filter active.

The suite passes against the pre-change file as well as the new one, which is the expected result for a behaviour-preserving refactor and is the evidence that nothing was dropped. To show the suite is not vacuous, six mutations were applied to the new code and each failed exactly the test that names the affected value: dropping the running union from `recentSet` (the most likely way to write this change wrongly), resolving `midTurn` from the widened flag, removing the widening from `runningSet`, and breaking the `unread` lookup, the `unread` row read, and the `pinned` lookup.

Full website suite: 1342 files, 21132 passed, 0 failures. All 46 existing `ChatSidebar.*` suites pass unchanged (364 tests). `tsc -b` clean, and verified to discriminate — reintroducing a single `s.midTurn` read fails with `TS2339: Property 'midTurn' does not exist on type 'Slot'`. `eslint` reports no new findings (8 pre-existing warnings before and after, 0 errors). `jscpd` reports 0 clones.

## Manual verification

N/A — unit coverage sufficient. There is no visual or behavioural delta to observe: the change replaces how four boolean values are looked up, and the rendered output is asserted identical by the new suite passing against both the old and new implementations plus the 46 existing sidebar suites.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** No user-visible surface changes in this diff. It swaps four derived slot values (`running`, `midTurn`, `unread`, `recent`) from fields on a per-render copy of each slot to membership-set lookups that compute the identical values — `runningSet` is built from the same `s.running || workflowActive[key] || looping` expression the spread used, `recentSet` from the same `running || recentByTs` union, and `unread` / `midTurn` were already just `unreadSet.has(s.key)` and the raw `s.running`. No JSX element, `className`, or inline `style` is touched anywhere in the diff, so there is no layout, theme, or component surface to photograph. Verified rather than asserted: the new test suite passes unchanged against BOTH the pre-change and post-change implementations, and all 46 existing `ChatSidebar.*` suites (364 tests) pass untouched.

## Related Issues

None.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

