### PR TITLE
refactor(chat): register the filters that can hide a reveal target (#4141)

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -969,6 +969,13 @@ const REVEAL_FLASH_HOLD_MS = 1600
  *  the classes are removed at HOLD + FADE + slack, so shortening this below
  *  the CSS duration snaps the outline off mid-fade. */
 const REVEAL_FLASH_FADE_MS = 500
+/** One filter dimension that can hide a reveal target: whether it hides THIS
+ *  row, and how to drop it. `clear` receives the row because the folder filter
+ *  un-hides that row's own ancestor chain rather than clearing globally. */
+interface RevealBlockingFilter {
+  hides: (slot: Slot) => boolean
+  clear: (slot: Slot) => void
+}
 
 function ChatSidebar({
   slots, activeSlot, unreadSlots, history, historyHasMore,
@@ -1935,6 +1942,58 @@ function ChatSidebar({
   // or the folder lane strands its folders as empty "New chat in <name>" shells.
   const listNarrowed = Boolean(slotFilter) || activeFilters.size > 0 || activeTagIds.size > 0
 
+  /** Every filter that can hide a reveal target, registered ONCE: the reveal
+   *  effect iterates this list instead of naming the dimensions by hand, so a
+   *  new filter opts in here and nowhere else. Deliberately NOT `listNarrowed`
+   *  above — that asks "is anything filtering?", this asks "does THIS row fail a
+   *  filter?", and the two lists differ (the folder filter is in this one only,
+   *  and tags enter raw here but resolved there). */
+  const revealBlockingFilters = useMemo<RevealBlockingFilter[]>(() => {
+    // Search and status defer to list membership: both rank against backend
+    // state (relevance, unread) that a single row cannot answer for alone.
+    const excluded = (slot: Slot) => !filteredSlots.some(s => s.key === slot.key)
+    return [
+      {
+        // Raw `filterTagIds`, not resolved `activeTagIds`, and not behind
+        // `excluded`: mid-flight nothing is filtered, so the row is re-hidden.
+        hides: slot => filterTagIds.size > 0 && !(slot.tags ?? []).some(id => filterTagIds.has(id)),
+        clear: () => clearTagFilter(),
+      },
+      { hides: slot => Boolean(slotFilter) && excluded(slot), clear: () => setSlotFilter('') },
+      {
+        hides: slot => activeFilters.size > 0 && excluded(slot),
+        clear: () => {
+          // Persisted like toggleFilter: remount re-reads the stored '1' and
+          // would silently restore the filter that hides this row.
+          for (const filterDef of SESSION_FILTERS) {
+            if (activeFilters.has(filterDef.key)) safeSetItem(filterDef.storageKey, '0')
+          }
+          setActiveFilters(new Set())
+        },
+      },
+      {
+        hides: slot => !!slot.folder_id && filterHiddenSubtree.has(slot.folder_id),
+        clear: slot => {
+          // Un-hide the target's ancestor chain (persisted, mirroring
+          // toggleFolderFilter). Cycle-guarded like filterHiddenSubtree.
+          setFilterHiddenFolders(prev => {
+            const next = new Set(prev)
+            const visited = new Set<string>()
+            let curId: string | undefined = slot.folder_id
+            while (curId && !visited.has(curId)) {
+              visited.add(curId)
+              next.delete(curId)
+              const cid = curId
+              curId = folders.find(f => f.id === cid)?.parent_id
+            }
+            safeSetItem(HIDDEN_FOLDERS_LS_KEY, JSON.stringify([...next]))
+            return next
+          })
+        },
+      },
+    ]
+  }, [filteredSlots, filterTagIds, clearTagFilter, slotFilter, activeFilters, filterHiddenSubtree, folders])
+
   // List view (the folder tree) drops an unchecked folder's whole block —
   // header and sessions together. Only the folder's OWN id is checked here:
   // removing a parent block already takes its descendants with it.
@@ -2165,43 +2224,10 @@ function ChatSidebar({
       console.debug('reveal-in-sidebar: no session for key', key)
       return
     }
-    // A live sidebar search or status filter can exclude the target row from
-    // the list entirely (#912 D5) — reveal is an explicit "show me this row",
-    // so drop the filters that hide it rather than scrolling to nothing.
-    // Outside the filteredSlots check: while the tag query is in flight nothing
-    // is filtered, so the row reads present and is re-hidden when it resolves.
-    if (filterTagIds.size > 0 && !(slot.tags ?? []).some(id => filterTagIds.has(id))) clearTagFilter()
-    if (!filteredSlots.some(s => s.key === key)) {
-      if (slotFilter) setSlotFilter('')
-      if (activeFilters.size > 0) {
-        // Persisted like toggleFilter: state alone is not enough — the sidebar
-        // unmounts whenever the drawer collapses, and remount re-reads the
-        // stored '1', silently restoring the filter that hides this row.
-        for (const filterDef of SESSION_FILTERS) {
-          if (activeFilters.has(filterDef.key)) safeSetItem(filterDef.storageKey, '0')
-        }
-        setActiveFilters(new Set())
-      }
-    }
+    // Reveal means "show me this row", so drop every filter hiding the target
+    // rather than scrolling to nothing (#912 D5). Registered in one list above.
+    for (const dim of revealBlockingFilters) if (dim.hides(slot)) dim.clear(slot)
     if (slot.folder_id) {
-      // The folder filter hides whole subtrees in the flat and tree lanes —
-      // un-hide the target's ancestor chain (persisted, mirroring
-      // toggleFolderFilter). Cycle-guarded like filterHiddenSubtree.
-      if (filterHiddenSubtree.has(slot.folder_id)) {
-        setFilterHiddenFolders(prev => {
-          const next = new Set(prev)
-          const visited = new Set<string>()
-          let curId: string | undefined = slot.folder_id
-          while (curId && !visited.has(curId)) {
-            visited.add(curId)
-            next.delete(curId)
-            const cid = curId
-            curId = folders.find(f => f.id === cid)?.parent_id
-          }
-          safeSetItem(HIDDEN_FOLDERS_LS_KEY, JSON.stringify([...next]))
-          return next
-        })
-      }
       // Expand all collapsed ancestor folders. Cycle-guarded: a hand-edited
       // folders.json can contain a parent_id loop and must not hang the tab.
       const visited = new Set<string>()
@@ -2254,7 +2280,7 @@ function ChatSidebar({
       revealFlashTimersRef.current = [t1, t2]
     }
     tryScroll()
-  }, [revealRequest, dispatch, slots, folders, filteredSlots, filterHiddenSubtree, slotFilter, activeFilters, filterTagIds, clearTagFilter, updateFolderMutation])
+  }, [revealRequest, dispatch, slots, folders, revealBlockingFilters, updateFolderMutation])
   const renameCommit = useCallback((id: string, name: string) => {
     if (name.trim()) updateFolderMutation.mutate({ id, body: { name: name.trim() } })
     setEditingId(null)

--- a/website/src/test/ChatSidebar.revealFilterDimensions.test.tsx
+++ b/website/src/test/ChatSidebar.revealFilterDimensions.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * "Reveal in sidebar" must drop any filter hiding the row the user asked for,
+ * or it silently does nothing and the button looks broken. Those filters are
+ * registered in ONE list, and the reveal effect walks it instead of naming each.
+ *
+ * The behavioural cases pin the outcome across MORE THAN ONE filter, so the
+ * registry cannot quietly drop a dimension; they pass both before and after
+ * the refactor, which deliberately changed no filter's behaviour.
+ *
+ * The structural cases are the before/after guard, and their reach is narrow:
+ * they fail while the effect names filter state directly, and they pin the set
+ * that IS registered. A filter added to filteredSlots' enumeration and never
+ * registered here still reveals nothing -- one opt-in remains, not zero.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { requestSlotReveal } from '../store/chatSlice'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ tagColumnsEnabled: false, confirmCloseSession: false }),
+  saveChatConfig: vi.fn(),
+}))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: (_t, prop: string) => {
+      if (prop === 'chatTags') return vi.fn().mockResolvedValue([
+        { id: 't1', name: 'Alpha', color: '#ff0000', order: 0 },
+        { id: 't2', name: 'Beta', color: '#00ff00', order: 1 },
+      ])
+      return vi.fn().mockResolvedValue([])
+    },
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+const RUNNING_ONLY_LS_KEY = 'mc-session-running-only'
+const TAG_FILTER_LS_KEY = 'mc-session-tag-filter'
+
+/** `k-alpha` is running and tagged Alpha; `k-beta` is neither, so it is the row
+ *  every filter below excludes and therefore the reveal target throughout. */
+const SLOTS = [
+  { key: 'k-alpha', title: 'alpha session', running: true, messages: 2, tags: ['t1'] },
+  { key: 'k-beta', title: 'beta session', running: false, messages: 2, tags: ['t2'] },
+]
+
+function renderSidebar(slots: any[] = SLOTS) {
+  // Spread the real slice defaults: RTK REPLACES a slice with preloadedState
+  // rather than merging, so a partial drops keys the reducers assume exist.
+  const defaults = createTestStore().getState()
+  const store = createTestStore({
+    dashboard: {
+      ...defaults.dashboard,
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: {
+      ...defaults.chat,
+      activeSlot: null, slotStatusDetail: {},
+      revealRequest: null, revealNonce: 0,
+    } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], [])
+  const view = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={null} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { ...view, store }
+}
+
+/** jsdom has no scrollIntoView; the reveal effect calls it on the found row. */
+function withScrollStub(fn: () => Promise<void>) {
+  const original = Element.prototype.scrollIntoView
+  Element.prototype.scrollIntoView = vi.fn()
+  return fn().finally(() => { Element.prototype.scrollIntoView = original })
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.clearAllMocks())
+
+describe('reveal-in-sidebar drops every registered filter dimension', () => {
+  it('clears a search that hides the reveal target', async () => {
+    await withScrollStub(async () => {
+      const utils = renderSidebar()
+      await waitFor(() => expect(utils.queryByText('beta session')).not.toBeNull())
+      const search = utils.getByPlaceholderText('Search sessions…')
+      fireEvent.change(search, { target: { value: 'alpha' } })
+      // Precondition: the target really is excluded before the reveal.
+      await waitFor(() => expect(utils.queryByText('beta session')).toBeNull())
+
+      utils.store.dispatch(requestSlotReveal('k-beta'))
+
+      await waitFor(() => expect(utils.queryByText('beta session')).not.toBeNull())
+      expect(search).toHaveValue('')
+    })
+  })
+
+  it('clears a status filter that hides the reveal target', async () => {
+    await withScrollStub(async () => {
+      localStorage.setItem(RUNNING_ONLY_LS_KEY, '1')
+      const utils = renderSidebar()
+      await waitFor(() => expect(utils.queryByText('beta session')).toBeNull())
+      expect(utils.queryByText('alpha session')).not.toBeNull()
+
+      utils.store.dispatch(requestSlotReveal('k-beta'))
+
+      await waitFor(() => expect(utils.queryByText('beta session')).not.toBeNull())
+      // Persisted, not just state: the sidebar unmounts when the drawer
+      // collapses and remount re-reads a stored '1'.
+      expect(localStorage.getItem(RUNNING_ONLY_LS_KEY)).toBe('0')
+    })
+  })
+
+  it('clears two dimensions at once when both hide the reveal target', async () => {
+    await withScrollStub(async () => {
+      localStorage.setItem(RUNNING_ONLY_LS_KEY, '1')
+      localStorage.setItem(TAG_FILTER_LS_KEY, JSON.stringify(['t1']))
+      const utils = renderSidebar()
+      await waitFor(() => expect(utils.queryByText('beta session')).toBeNull())
+
+      utils.store.dispatch(requestSlotReveal('k-beta'))
+
+      await waitFor(() => expect(utils.queryByText('beta session')).not.toBeNull())
+      expect(localStorage.getItem(RUNNING_ONLY_LS_KEY)).toBe('0')
+      expect(JSON.parse(localStorage.getItem(TAG_FILTER_LS_KEY) || '[]')).toEqual([])
+    })
+  })
+})
+
+const SRC = join(__dirname, '..', 'pages', 'ChatSidebar.tsx')
+// Flattened first: a line-by-line scan misses a construct the moment a
+// reformat splits it across lines.
+const flat = readFileSync(SRC, 'utf8').replace(/\s+/g, ' ')
+
+/** The reveal effect's body, from its guard clause to its dependency array. */
+function revealEffect(): string {
+  const body = flat.match(/if \(!revealRequest\) return.*?\}, \[revealRequest[^\]]*\]\)/)?.[0]
+  expect(body).toBeDefined()
+  return body!
+}
+
+describe('reveal filter dimensions are registered, not enumerated in the effect', () => {
+  it('the effect names no filter state of its own', () => {
+    const effect = revealEffect()
+    // Each WAS named here. This pins that the effect no longer reads filter
+    // state; it cannot see a filter that skipped the registry entirely.
+    for (const named of [
+      'slotFilter', 'setSlotFilter',
+      'activeFilters', 'setActiveFilters', 'SESSION_FILTERS',
+      'filterTagIds', 'activeTagIds', 'clearTagFilter',
+      'filterHiddenSubtree', 'setFilterHiddenFolders',
+      'filteredSlots',
+    ]) {
+      expect(effect, `reveal effect must not name ${named} directly`).not.toContain(named)
+    }
+    // It consults the registry instead.
+    expect(effect).toContain('revealBlockingFilters')
+  })
+
+  it('the registry is the single place a dimension is declared', () => {
+    const registry = flat.match(/const revealBlockingFilters = useMemo<RevealBlockingFilter\[\]>.*?\}, \[[^\]]*\]\)/)?.[0]
+    expect(registry).toBeDefined()
+    // Search, status, tags, folder. Pins the REGISTERED set only: bump this in
+    // the same commit as a fifth entry so the addition is a decision, not drift.
+    expect([...registry!.matchAll(/\bhides:/g)]).toHaveLength(4)
+    // Every registered dimension carries the means to drop itself, so the
+    // effect never needs to know which state backs it.
+    expect([...registry!.matchAll(/\bclear:/g)]).toHaveLength(4)
+  })
+})


### PR DESCRIPTION
Closes #4141

<!-- no-visual-delta -->

**Why no screenshot:** Nothing rendered changes — this rewires the internals of one effect and adds no JSX, class name, inline style, user-facing string or ARIA attribute, and each filter's condition is preserved verbatim, which is why every behavioural test in this PR passes unchanged against the parent commit.

## Problem / Motivation

"Reveal in sidebar" scrolls to a session row and flashes it. If a filter is hiding that row, the reveal has to drop the filter first, or it scrolls to nothing and the user sees no result at all.

The sidebar already has one flag for "is the list narrowed", `listNarrowed`, and three call sites read it. The reveal effect did not. It named each filter dimension by hand instead — a tag check written out longhand, then a `filteredSlots` membership test wrapping the search and status resets, then a separate folder check — and its dependency array repeated the same three pieces of state individually.

That means a fifth filter has to remember to opt into this effect as well as everything else. Nothing fails loudly if it does not: the new filter simply keeps hiding reveal targets, so the reveal button looks broken rather than the filter looking at fault.

## Why it matters

This is the same class of bug the folder lane hit in #3993, where a collapse guard tested only search and status, so a tag-only filter left non-matching folders expanded. `listNarrowed` was introduced there to make that a one-place decision. The reveal effect was the last site still hand-rolling the list, so it was the last place a future filter could silently forget to register.

## What changed

Every filter that can hide a reveal target is now registered once, in `revealBlockingFilters`, next to `listNarrowed` in `website/src/pages/ChatSidebar.tsx`. Each entry carries two things: `hides(slot)`, the per-row predicate, and `clear(slot)`, the means to drop that filter. The reveal effect iterates the list and no longer names any filter state of its own — its dependency array is now the registry rather than six separate values.

What this does **not** fix, stated plainly so the paragraph above is not read as closing #4141: registration in `revealBlockingFilters` is still voluntary. A future filter can be added to the sidebar and never registered here, and nothing fails loudly — the reveal just keeps silently hiding its target, which is the exact failure mode #4141 describes. I verified that rather than assuming it: adding a fifth filter to the enumeration inside `filteredSlots` and deliberately not registering it leaves all five tests in this PR green. What the change actually buys is narrower and worth naming precisely — the reveal path's opt-in drops from two edits (an inline condition plus a dependency-array entry) to one array entry, and the count pin in the structural test turns any fifth registration into a same-commit, visible decision instead of silent drift.

The general fix is a single filter-dimension declaration feeding all three consumers, and it is deliberately out of scope here. Two sites still hand-enumerate the dimensions: the enumeration inside `filteredSlots` (`website/src/pages/ChatSidebar.tsx:1880-1905` on this branch) and `listNarrowed` (`:1943`), whose own comment already says "A new filter dimension must be added here too". Collapsing those onto one declaration changes what the filters DO and needs its own tests, so it belongs in its own change rather than widening this one.

Coordinate note for anyone cross-referencing the First Principles lane: it cites `filteredSlots` at 1873-1898 and `listNarrowed` at 1936. Those are correct — the lane states it measured the base commit, and I confirmed both against it (base 1873 is `const activeFilterDefs = SESSION_FILTERS…`, base 1898 is the memo's dependency array). The numbers above are the same code on this branch, shifted down seven lines because this change adds the `RevealBlockingFilter` type above them. Neither set is miscounted; they are measured against different trees.

Deliberately not a reuse of `listNarrowed`, and not a plain boolean predicate either. `listNarrowed` answers "is anything filtering right now?", while reveal needs "does THIS row fail an active filter?" — and the two lists genuinely differ: the folder filter belongs only to the reveal list, and tags enter the reveal list raw rather than resolved. A bare `slotHiddenByFilters(slot)` boolean would have told the effect *that* a row was hidden but not *which* state to drop, so the effect would still have enumerated the clears; carrying `clear` in the entry is what actually reduces this to one place.

One clarification, because the sentence above has already been misread once. "The folder filter belongs only to the reveal list" contrasts the registry with `listNarrowed`, which genuinely omits the folder dimension. It does **not** mean the folder filter is newly part of the reveal path. It was already there before this change: on the parent commit the reveal effect body already un-hid a reveal target's hidden ancestor chain, and `filterHiddenSubtree`, `setFilterHiddenFolders` and the hidden-folders storage key all appear inside that effect at the parent commit. Moving that block into the registry turned a nested `if (slot.folder_id) { if (filterHiddenSubtree.has(...)) { ... } }` into the equivalent single conjunction and left the body identical. Revealing a row hidden by a folder filter un-hid its ancestor chain before this PR and still does.

Two behaviours are preserved on purpose and are easy to break by tidying, so they are worth pointing out to a reviewer. The tag entry keys on the raw `filterTagIds` rather than the resolved `activeTagIds`, and is evaluated independently of the `filteredSlots` membership test — while the tag vocabulary is still loading nothing is filtered yet, so a clear gated on exclusion would never run and the row would be re-hidden when the query settles (that is #3993's in-flight fix). And the folder-expansion step stays outside the registry, because it runs whether or not the folder filter was hiding anything.

No filter changes behaviour. Each registry entry is the existing condition rewritten as a single expression: `if (!inFilteredList) { if (slotFilter) … }` becomes `slotFilter && !inFilteredList`, and so on.

## Tests

New file `website/src/test/ChatSidebar.revealFilterDimensions.test.tsx`, five tests in two groups, because they guard different things and only one group can be a before/after test.

Three behavioural tests reveal a row hidden by a search filter, by a status filter, and by two dimensions at once, asserting in each case that the filter is dropped and the row becomes visible — and that the status and tag clears are persisted to storage, not merely held in state, since the sidebar unmounts when the drawer collapses and remount re-reads a stored value. These cover more than one dimension so the registry cannot quietly lose one. They pass both before and after this change, which is the honest result: the refactor deliberately changes no filter's behaviour, so no behavioural test can fail beforehand.

Two structural tests are the actual before/after guard. One asserts the reveal effect names no filter state of its own; the other pins the registry as the single declaration site. Negative control: with the original `ChatSidebar.tsx` restored, the three behavioural tests still pass while both structural tests fail, and they fail for the intended reason — `expected 'if (!revealRequest) return…' not to contain 'slotFilter'`. That is the regression this issue is about: a dimension hand-rolled into the effect instead of registered.

The folder dimension was checked directly rather than argued from the diff. A throwaway test that reveals a row hidden by the folder filter and asserts its ancestor chain is un-hidden passes against both this revision and its parent, and fails when the folder entry is removed from the registry — so it discriminates rather than passing vacuously. It is not committed: the committed structural pair already guards the registry, and this probe existed only to answer whether folder behaviour moved.

Also run green: `tsc --noEmit`, eslint with 0 errors (`react-hooks/exhaustive-deps` is enabled and raised no warning on the rewritten dependency array), the full ChatSidebar and chatSlice suites at 49 files / 414 tests, the i18n suites at 38 files / 597 tests, and jscpd with 0 clones. The two pre-existing reveal tests in the tag-filter suite, including the one covering a reveal that arrives while tags are still loading, were confirmed passing by name.


## Review dispositions

Design Review raised two Watch items and one Suggestion on this revision. Dispositions in order.

**Item 1 — accepted, and fixed in code.** The reviewer is right that registration stays voluntary, and I confirmed it by experiment rather than by reading: adding a fifth filter to the enumeration inside `filteredSlots` and deliberately NOT registering it leaves all five tests in this file green. So the structural pair genuinely cannot catch a forgotten registration. What this change actually buys is narrower than the comments claimed — it cuts the reveal path's opt-in from two edits (an inline condition plus a dependency-array entry) down to one, rather than eliminating the opt-in. The defect was therefore the CLAIM, not the design, so the fix is a reword: the test header and two comments now say the structural cases pin the *registered* set and fail when the effect reads filter state directly, and state plainly that a filter added to `filteredSlots` and never registered still reveals nothing. No behaviour and no architecture changed.

**Item 2 — accepted as a deliberate tradeoff, no change.** The structural tests do assert on regex-matched source text, and extracting the reveal effect into a hook would break them with behaviour intact. That coupling is the point. The property under test is "this effect does not read filter state directly", which is a property of the source rather than of runtime behaviour: nothing rendered can distinguish a hand-named condition from a registry lookup when both compute the same result, which is precisely why the behavioural tests pass against the parent commit too. Source assertions are the only check that can fail for the right reason here, and they are an established pattern in this suite — 77 test files read source, including one that pins a different invariant on this same component. If the effect is ever extracted, the remedy is to re-anchor the two regexes on the extracted hook's source; the assertions stay valid because the property is unchanged.

**Item 3 — declined as out of scope.** Registering a last-resort dimension (`hides: excluded`) so an unregistered future filter degrades loudly is a reasonable idea, but it is a behaviour change: a catch-all clear would drop filters that this registry deliberately leaves alone, and it would fire on rows excluded for reasons that are not a filter at all. The issue this PR closes asked for the registration refactor with an explicit instruction not to change what any filter does, so this belongs in its own change with its own tests rather than being folded in here.



**First Principles Review — one actionable item, fixed in prose; no code owed.** The lane's verdict is that the registry halves the reveal opt-in without removing it, and that the root cause is each filter dimension being hand-enumerated per site. That is correct, and the deferral is accepted on the lane's own terms: it called the general fix genuinely larger and did not ask for it here. Stated plainly for the record — this PR takes the reveal path's opt-in from two edits down to one array entry, and it does NOT close #4141's failure mode, because registration in `revealBlockingFilters` remains voluntary and an unregistered future filter will still silently hide its reveal target. The two sites still hand-enumerating the dimensions are the enumeration inside `filteredSlots` and the `listNarrowed` flag; both are named with branch-verified coordinates under "What changed", together with the residual opt-in, so the earlier sections no longer read as a cure. The lane's second Watch item is a confirmation rather than a defect — it independently verified that `listNarrowed` is not a duplicate of the registry, since it omits the folder dimension and uses the resolved `activeTagIds` — so nothing is owed for it. One further check, since "incomplete" and "wrong" are different charges: the registry is incomplete by design but it is not wrong. The complete set of things that actually exclude a row is four — status (`activeFilterDefs` from `SESSION_FILTERS`), tags (`activeTagIds`), search (`slotFilter`, which excludes through the trailing return chain rather than a `return false`, so a naive grep undercounts it), and folder (`filterHiddenSubtree`, applied in `flatSlots`) — and all four are registered. No fifth filter state exists in the component. Two non-filter paths can still leave a reveal target unrendered — the board lane when no column matches, which the reveal effect already logs and comments on, and the drag-time frozen snapshot — but neither is a filter, neither is claimed by the registry, and both predate this change untouched.

