### PR TITLE
test(crew): assert durability against queue.json, not the whole store

### DIFF
--- a/test/test_crew_chat.py
+++ b/test/test_crew_chat.py
@@ -11,6 +11,8 @@ and mode plumbing (_VALID_MODES, create validation).
 from __future__ import annotations
 
 import asyncio
+import errno
+import json
 import logging
 import os
 import subprocess
@@ -18,6 +20,7 @@ import sys
 import threading
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -75,6 +78,30 @@ def _slot_save(side_effect: BaseException | None = None):
     )
 
 
+def _durable_queue(slot_key: str = "s1") -> list[dict[str, Any]]:
+    """Read one slot's queue file, WITHOUT building a `CrewStore`.
+
+    Every caller of this asks the same question — "is this queue row on disk
+    yet?" — and `queue.json` is the only file the code under test awaits before
+    the moment being asserted. Building a store to answer it also reads
+    `topics.json` and `forwards.json`, which nothing awaits: `_reconcile` hands
+    them to the executor via `st.save()` and returns. So a store built here can
+    open a file that is mid-`replace()`, and on Windows that open fails with
+    `PermissionError` — issue #4142. Reading the one file the product promises
+    is durable keeps the assertion and drops the unpromised dependency.
+    """
+    path = crew_mod.data_home() / "crew" / crew_mod._store_name(slot_key) / "queue.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return []                      # nothing enqueued yet, as `_load` reads it
+
+
+def _durable_entry(slot_key: str, msg_id: str) -> dict[str, Any] | None:
+    """`CrewStore.entry` against the queue FILE — see :func:`_durable_queue`."""
+    return next((e for e in _durable_queue(slot_key) if e.get("msg_id") == msg_id), None)
+
+
 # ── store ──
 
 
@@ -129,6 +156,99 @@ class TestCrewStore:
             assert (st.dir / "queue.json").exists()
 
 
+class TestWindowsReplaceWindow:
+    """Issue #4142: a store read must not race a store write nothing awaited.
+
+    `CrewStore` publishes each file by writing a temp file and calling
+    `Path.replace`. That is atomic on both platforms, but only POSIX makes it
+    invisible to a concurrent opener — on Windows the destination is briefly
+    unopenable and `open()` fails with `PermissionError` (errno 13), which
+    `_load` re-raises as `RuntimeError`. Windows CI is the only place that
+    fails, so the platform difference is emulated here to give the bug a
+    deterministic reproduction that runs everywhere.
+    """
+
+    @staticmethod
+    def _emulate_windows_replace(monkeypatch, target: str) -> tuple[set[str], threading.Event]:
+        """Make `target` unopenable while its write is in flight, as Windows does.
+
+        The write parks on the returned gate instead of sleeping, so the window
+        is open for as long as the test needs rather than for a guessed number of
+        milliseconds — a timing-based window would make this test itself flaky.
+        The gate has a timeout so a regression cannot hang CI.
+        """
+        inflight: set[str] = set()
+        gate = threading.Event()
+        real_write_text, real_replace, real_read_text = (
+            Path.write_text, Path.replace, Path.read_text)
+
+        def write_text(self, data, *a, **k):          # type: ignore[no-untyped-def]
+            if self.name == f".{target}.tmp":
+                inflight.add(str(self.parent / target))
+                gate.wait(timeout=10.0)
+            return real_write_text(self, data, *a, **k)
+
+        def replace(self, dest):                      # type: ignore[no-untyped-def]
+            try:
+                return real_replace(self, dest)
+            finally:
+                inflight.discard(str(dest))
+
+        def read_text(self, *a, **k):                 # type: ignore[no-untyped-def]
+            if str(self) in inflight:
+                raise PermissionError(errno.EACCES, "Permission denied", str(self))
+            return real_read_text(self, *a, **k)
+
+        monkeypatch.setattr(Path, "write_text", write_text)
+        monkeypatch.setattr(Path, "replace", replace)
+        monkeypatch.setattr(Path, "read_text", read_text)
+        return inflight, gate
+
+    @pytest.mark.asyncio
+    async def test_the_durable_queue_read_does_not_touch_unawaited_files(
+            self, monkeypatch) -> None:            # type: ignore[no-untyped-def]
+        # `ingest` awaits `queue.json` by name and nothing else: `_reconcile`
+        # hands `topics.json` and `forwards.json` to the executor and never waits.
+        # So a durability assertion may read the queue and must not read the
+        # other two, which may still be mid-replace.
+        inflight, gate = self._emulate_windows_replace(monkeypatch, "topics.json")
+        orch, slot = _orch(), _slot(key="winrace")
+        shown: list[list[str]] = []
+        control: list[str] = []
+
+        def _on_append(*a: object, **k: object) -> None:
+            # The property: the queue row is on disk the moment the user can see
+            # their message. Answerable from the queue file alone.
+            shown.append([e["text"] for e in _durable_queue("winrace")])
+            # Positive control, in the same window: the three-file read this
+            # assertion used to do DOES fail here, so a pass above is the fix
+            # working and not an emulator that never armed.
+            assert inflight, "the topics.json write is not in flight — window missed"
+            try:
+                CrewStore("winrace")
+            except RuntimeError as exc:
+                control.append(str(exc))
+
+        slot.append = MagicMock(side_effect=_on_append)
+        try:
+            with patch.object(orch, "_post", return_value=True), \
+                    patch.object(orch, "_decide", new=AsyncMock()):
+                await orch.ingest(slot, "do the thing")
+        finally:
+            # Release the parked write AND join it. Left unjoined, the executor
+            # thread outlives the test: it straddles this monkeypatch teardown,
+            # and its write failure would surface in whatever runs next.
+            gate.set()
+            st = orch._stores.get("winrace")
+            if st is not None:
+                await st.wait_writes()
+
+        assert shown == [["do the thing"]], \
+            f"queue row was not readable while topics.json was mid-replace: {shown}"
+        assert control and "topics.json" in control[0], \
+            "building a whole store did NOT fail in the window — the emulator is inert"
+
+
 # ── ingest ──
 
 
@@ -179,7 +299,7 @@ class TestIngest:
         # The real harm: a later successful save must not resurrect it.
         st.save()
         await st.wait_writes()
-        assert CrewStore("s1").queue == [], "a later save persisted the rejected request"
+        assert _durable_queue() == [], "a later save persisted the rejected request"
         # Nothing was promised to the user, and nothing was routed.
         post.assert_not_called()
         assert decide.await_count == 0 and decide.call_count == 0
@@ -225,7 +345,7 @@ class TestIngest:
         assert (st.dir / "queue.json").read_text(encoding="utf-8") == "{ this is not json"
         # A file that was never written is a legitimate empty store.
         (st.dir / "queue.json").unlink()
-        assert CrewStore("s1").queue == []
+        assert _durable_queue() == []
 
     def test_enqueue_writes_only_the_queue_file(self) -> None:
         """A rollback-able write must touch ONLY the file it changed.
@@ -261,7 +381,7 @@ class TestIngest:
              patch.object(orch, "_post", return_value=True):
             await orch.ingest(slot, "do thing A")
 
-        on_disk = CrewStore("s1").queue
+        on_disk = _durable_queue()
         assert [e["text"] for e in on_disk] == ["do thing A"], \
             "an acknowledged request was dropped when only its transcript failed"
         assert on_disk[0]["state"] == "pending"
@@ -828,7 +948,7 @@ class TestGptRoundEleven:
         slot.key = "vis1"                    # own store; no state from other tests
         on_disk_when_shown: list[list[str]] = []
         slot.append = MagicMock(side_effect=lambda *a, **k: on_disk_when_shown.append(
-            [e["text"] for e in CrewStore("vis1").queue]))
+            [e["text"] for e in _durable_queue("vis1")]))
 
         with patch.object(orch, "_post", return_value=True), \
                 patch.object(orch, "_decide", new=AsyncMock()):
@@ -1809,7 +1929,7 @@ class TestGptRoundFive:
                           side_effect=lambda *a, **k: order.append("post") or True):
             assert await orch._settle_stragglers(slot) is False
         assert order.index("write") < order.index("post"), order
-        assert CrewStore("s1").queue[0]["state"] == "failed"
+        assert _durable_queue()[0]["state"] == "failed"
 
     @pytest.mark.asyncio
     async def test_steer_is_durable_before_it_reaches_the_run(self) -> None:
@@ -1828,7 +1948,7 @@ class TestGptRoundFive:
 
         async def _steer(rid, text):  # type: ignore[no-untyped-def]
             # What a crash at this instant would leave behind on disk.
-            seen_state.append((CrewStore("s1").entry(e["msg_id"]) or {}).get("state"))
+            seen_state.append((_durable_entry("s1", e["msg_id"]) or {}).get("state"))
             return True, ""
 
         orch._subagents.steer_run = AsyncMock(side_effect=_steer)
@@ -1933,7 +2053,7 @@ class TestGptRoundFive:
         orch._subagents.continue_conversation = MagicMock(
             side_effect=lambda cid, task, **kw: _spawn_info(kw["_preassigned_id"]))
         await orch._dispatch_continue(slot, st, t, e)
-        assert CrewStore("s1").entry(e["msg_id"])["topic_id"] == "t1"
+        assert _durable_entry("s1", e["msg_id"])["topic_id"] == "t1"
 
     @pytest.mark.asyncio
     async def test_the_fallback_respawn_carries_a_durable_id(self) -> None:
@@ -1953,7 +2073,7 @@ class TestGptRoundFive:
 
         def _spawn(task, **kw):
             # The identity must be readable from a FRESH store at spawn time.
-            on_disk.append((CrewStore("s1").entry(e["msg_id"]) or {}).get("dispatch_id"))
+            on_disk.append((_durable_entry("s1", e["msg_id"]) or {}).get("dispatch_id"))
             assert kw.get("_preassigned_id"), "respawn must carry the id it persisted"
             return _spawn_info(kw["_preassigned_id"])
 
@@ -2099,8 +2219,7 @@ class TestContinuationIdentity:
         def _continue(conv_id, task, **kw):
             # At the moment of the side effect, the id must already be readable
             # from a FRESH store — i.e. it reached the file, not just the object.
-            fresh = CrewStore("s1")
-            on_disk.append((fresh.entry(e["msg_id"]) or {}).get("dispatch_id"))
+            on_disk.append((_durable_entry("s1", e["msg_id"]) or {}).get("dispatch_id"))
             assert kw.get("_preassigned_id"), "the caller must supply the id it persisted"
             return _spawn_info(kw["_preassigned_id"])
 
@@ -2476,13 +2595,13 @@ class TestGatewayCrewInit:
         st.queue[0]["text"] = "final"
         st.save()
         await st.wait_writes()
-        assert CrewStore("s1").queue[0]["text"] == "final"
+        assert _durable_queue()[0]["text"] == "final"
 
     def test_save_writes_inline_without_loop(self) -> None:
         # Sync callers (boot reconcile, tests) still get immediate durability.
         st = CrewStore("s1")
         st.add_msg("hello")
-        assert CrewStore("s1").entry(st.queue[0]["msg_id"]) is not None
+        assert _durable_entry("s1", st.queue[0]["msg_id"]) is not None
 
     def test_post_appends_without_implicit_broadcast(self) -> None:
         # GPT finding on 120fd95e: the explicit chat_message frame is the
@@ -2508,7 +2627,7 @@ class TestGatewayCrewInit:
         on_disk_at_ack: list[list[str]] = []
 
         def _ack(*a: object, **k: object) -> bool:
-            on_disk_at_ack.append([e["text"] for e in CrewStore("s1").queue])
+            on_disk_at_ack.append([e["text"] for e in _durable_queue()])
             return True
 
         with patch.object(orch, "_post", side_effect=_ack), \
@@ -2517,7 +2636,7 @@ class TestGatewayCrewInit:
             await orch.ingest(slot, "important request")
             await asyncio.sleep(0)
         assert on_disk_at_ack == [["important request"]]
-        assert CrewStore("s1").queue[0]["text"] == "important request"
+        assert _durable_queue()[0]["text"] == "important request"
 
     @pytest.mark.asyncio
     async def test_failed_steer_on_idle_topic_dispatches(self) -> None:
@@ -2552,7 +2671,7 @@ class TestGatewayCrewInit:
         assert st._written_seq.get("queue.json", 0) == 0  # still retryable
         st.save()  # retry with healthy disk
         await st.wait_writes()
-        assert CrewStore("s1").queue[0]["text"] == "doomed"
+        assert _durable_queue()[0]["text"] == "doomed"
 
 
 class TestGptRoundSixteen:


### PR DESCRIPTION
## Problem / Motivation

`test/test_crew_chat.py` fails intermittently on the `Backend Tests (Windows)` shard with `RuntimeError: crew store: ...\crew\s1-e8bc163c\topics.json is unreadable ([Errno 13] Permission denied)`. The `RuntimeError` is a wrapper, not an assertion failure: `CrewStore._load` catches `(json.JSONDecodeError, OSError)` and re-raises, and `PermissionError` is an `OSError` subclass. It has been seen twice on the same shard in two different test methods, each time with everything else green, and it does not reproduce on Linux.

## Why it matters

Each occurrence needs a fresh commit to re-trigger CI, and on a pull request from a fork every new head commit also consumes a maintainer CI approval. The cost lands on whatever change happened to be in flight — both observed occurrences were on diffs that touched no Python at all.

## What changed (motivation → approach → change)

**Root cause.** The durability assertions in this file build a fresh `CrewStore` as their way of asking "is this queue row on disk yet?". That constructor reads three files — `queue.json`, `topics.json`, `forwards.json`. But the code under test only ever awaits **one** of them. `ingest` awaits the `queue.json` write by name (`add_msg_awaitable` → `save_queue()`, a single file), while `_reconcile` — which runs inside the same `ingest` call, via `_store_async` on a cold store — ends with `st.save()`, which schedules writes for all three files onto the default executor and returns without awaiting any of them.

So at the instant these assertions run, `topics.json` and `forwards.json` may still be mid-publish. `CrewStore._save` publishes each file by writing `.<name>.tmp` and calling `Path.replace`. That is atomic on both platforms, but only POSIX makes it invisible to a concurrent opener: `rename(2)` never fails another process's `open()`. On Windows the destination is briefly unopenable during the replace and the `open()` fails with `PermissionError` (errno 13), which `_load` turns into the `RuntimeError` above. That is why the failure is Windows-only, why it is intermittent, why it moves between test methods, and why the victim is always `topics.json` — the one file that is both written unawaited and read second by a store construction, so a reader that starts alongside the writer is most likely to meet it there.

**Confirming this rather than assuming it.** The hypothesis in the issue was that a write is still in flight when the assertion reads. That is correct, so this change is not built on a guess — but the specific writer named there is not the one responsible. It is not a thread left over from an earlier test, and it is not `save_slot_off_loop` (which these tests mock). It is `_reconcile`'s own `st.save()`, inside the same `ingest` call the assertion is testing. To establish that, `Path.write_text` / `Path.replace` / `Path.read_text` were instrumented on the real code path to record which reads overlap an in-flight write of the same path. Result: **9 tests performed 19 reads that raced an in-flight write**, including both methods that failed in CI. Every racing read was of `topics.json` or `forwards.json`; none was of the awaited `queue.json`.

**The change.** Read the file the assertion is actually about. `_durable_queue()` / `_durable_entry()` read `queue.json` directly, so the assertions no longer depend on writes the code under test never promised had landed. Every assertion is unchanged — this narrows what they read, not what they check. Nothing is skipped, retried, or given a longer timeout.

After the change the same instrumentation reports **1 racing read in 1 test**, and that one is an artifact of the instrument rather than of the code: `test_wait_writes_propagates_failure` patches `Path.replace` itself, so the probe's own release never runs and its counter stays stuck. That test's read sits directly after `await st.wait_writes()`, so it is genuinely covered by a barrier.

**A separate, product-side instance of the same race — not fixed here.** `_store_async` builds a store *before* claiming the cache slot with `setdefault`, and its own comments note that two concurrent first messages for one slot both build. Only the winner is reconciled, so the loser's three-file read can overlap the winner's unawaited `st.save()`. On Windows that is the same `PermissionError`, but on a real user request rather than in a test. That is a defect in `src/kiro_crew/crew_chat.py` with its own design question (serialize in-process readers against the publish, or give `_reconcile` a barrier), it cannot be verified from a test-only change, and mixing it into this commit would put two unrelated theses in one PR. It is worth its own issue.

## Tests

- All 14 call sites that read the durable queue now go through `_durable_queue` / `_durable_entry`. The 11 sites that genuinely read `.topics` / `.forwards` are untouched; the instrumentation showed none of them racing.
- New `TestWindowsReplaceWindow` emulates the Windows replace window — a read of a file whose write is in flight raises `PermissionError(EACCES)` — so this Windows-only bug has a deterministic reproduction that runs on Linux. It holds the window open with a `threading.Event` rather than a sleep, so the test is not itself timing-dependent, with a 10s timeout so a regression cannot hang CI.
- That test carries a **positive control**: inside the same window it also builds a whole `CrewStore` and asserts that *does* fail. Without it the test could pass with an emulator that never armed.
- **Negative control run:** restoring the pre-change read shape (`CrewStore("winrace").queue`) inside that test makes it fail with `PermissionError: [Errno 13] Permission denied: .../topics.json` raised from `self._load("topics.json")` — the issue's exact signature. Restoring the fix makes it pass.
- `test/test_crew_chat.py`: 150 passed, single-process and under `-n 4`. `flake8` clean. `mypy` reports the same 28 pre-existing errors as `upstream/main` on this file — byte-identical message sets, so no new ones.

## Manual verification

N/A for behaviour — this is a test-only change and the failure mode is fully covered by the emulated-Windows regression test above.

What would actually confirm the fix is Windows CI, and it should be judged honestly: **a single green Windows run proves nothing about an intermittent failure.** The observed rate was 2 failures across 3 commits on one pull request, so the evidence worth waiting for is on the order of **10+ consecutive green `Backend Tests (Windows)` shards** with no `topics.json` permission error. The stronger signal is not the count but the mechanism: the reads that raced are gone by construction, and the negative control demonstrates the failure returns the moment the old read shape comes back — so a future occurrence would indicate a *different* unawaited-write site, not this one regressing.

## Review dispositions

**GPT 5.6 Review, BLOCKING, `test/test_crew_chat.py:238` "Released executor write is not joined" — ACCEPTED and fixed.**

The finding is correct. `TestWindowsReplaceWindow` parked the store's `topics.json` write on a `threading.Event` and then only released it (`gate.set()`), never joined it. The write runs on the default thread-pool executor, so after the test returned that thread was still live: it straddled this test's own `monkeypatch` teardown, which restores `Path.write_text` / `Path.replace` / `Path.read_text` underneath a thread that is mid-write, and any failure in that write would have surfaced in whichever test happened to run next rather than in this one.

That is a hazard this pull request should be the last place to introduce, because "a thread left over from a previous test in the same worker" is one of the candidate mechanisms issue #4142 names for the flake being fixed here.

The fix releases the gate and then joins, inside the same `finally` so the write completes while the emulated Windows behaviour is still installed and self-consistent:

```python
gate.set()
st = orch._stores.get("winrace")
if st is not None:
    await st.wait_writes()
```

`wait_writes()` is the store's own barrier (`crew_chat.py:350`); it awaits everything still in `_pending_writes` and re-raises the first write failure, so a failed write now fails *this* test. The write is reachable through the store the orchestrator cached under the slot key, and `.get()` avoids masking an earlier exception if `ingest` raised before the store was built. `ingest` awaits its queue write through `wait_for`, which does not remove futures from `_pending_writes`, so the `topics.json` future is still pending at this point and does get joined.

Verified rather than assumed, both directions. With the join, a temporary assertion that `_pending_writes` is empty at test end passes. With the join removed and the same assertion in place, it fails and names the leak directly — four futures, one of them still `<Future pending>`. The regression test also still discriminates for its original purpose: restoring the pre-change three-file read makes it fail with the `[Errno 13]` error from the issue.

One link in the finding's stated chain does not hold, and it does not change the disposition. The chain says `tmp_path` deletion races the write; pytest does not delete a test's `tmp_path` at teardown — it keeps the last few numbered base directories and prunes them at the start of a later session. The teardown that the unjoined thread actually races is the `monkeypatch` restore, plus the dropped write failure. The defect is real; that one mechanism in the explanation is not.

**Design Review — PASS. Opus — PASS.** No findings to disposition.

## Related Issues

Fixes #4142

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, test-only change
- [x] No secrets, credentials, or internal references in the diff
