### PR TITLE
fix: give the narrow tabbed pane one owner for its top inset

### DIFF
--- a/website/docs/page-layout.md
+++ b/website/docs/page-layout.md
@@ -179,6 +179,42 @@ phase-advance controls leaves the phone user unable to advance the phase at all.
 (a split, a resizable rail, an embedded panel), measure the PANE with a `ResizeObserver`
 rather than calling `useIsMobile()`. A 1280px window can hold a 200px pane.
 
+**A tabbed shell's pane needs its own top inset once the header goes away — and it
+must be the only one.** `SidePanelLayout` drops the desktop header block below `md` —
+the block whose `pb-3` put 12px between a tab's title and its content — and replaces it
+with a pill strip that ends in a drawn `border-b`. The pane kept no inset of its own, so
+a tab whose first element is a `Card` or a `StatCard` rendered that element's own border
+ON the divider: two lines touching, measured at a 0px gap on four of Agent Capabilities'
+seven tabs and on seven of Developer's eight renderable ones at 390px. The pane carries
+`pt-3` on the narrow branch only — desktop must stay at 0 or the two insets stack.
+
+That inset is shared by all three pages built on the shell (Agent Capabilities,
+Developer, Settings), which makes the second half of the rule as load-bearing as the
+first: **a tab must not add a top margin to its own first element.** Doing so stacks on
+the pane and lands that tab 28px down while its siblings sit at 12px — the inconsistency
+reads as sloppiness precisely because the tabs are one keystroke apart. Two shapes, and
+the difference is whether the heading can ever have a sibling above it:
+
+- **A heading at the tab's root** (`SkillsTab`, `SteeringTab`) drops the margin outright.
+  Do NOT reach for `first:mt-0` here: `SkillsTab` renders `PendingSkillsPanel` above the
+  heading, and that panel returns `null` when nothing is pending — so the heading moves in
+  and out of `:first-child` with the pending count, and a positional rule would make the
+  gap depend on it. (A conditionally rendered `Modal` does NOT have this effect: it
+  `createPortal`s to `document.body` and never occupies a sibling slot.)
+- **A heading that repeats within one tab** (`SettingsSection`, used many times per
+  Settings tab; `LocalStorageDebug`'s section headings) keeps `mt-4`, because the gap
+  between two sections is real, and pairs it with `first:mt-0`. The fragment adds no DOM
+  node, so every section header is a sibling in one parent and only the leading one
+  matches — and when a tab renders something of its own above the first section, the
+  header stops being first and correctly keeps the margin.
+
+Measured at 390px with `website/scripts/capture-side-panel-pane-inset.mjs`, which reports
+the divider→first-in-flow-box distance per tab: all 31 renderable tabs across the three
+pages now read 12px. Residual differences in where the first *pixel* lands (21px on
+Connections, on Developer > System, on Settings > Instances) are a control's own internal
+padding — a sub-tab's or a segmented button's tap target — not stacked page padding, and
+tightening those would shrink a touch target.
+
 **An unbounded action cluster leaves the text row; it does not shrink it.** A row of
 actions whose count depends on state (enabled, updatable, uninstallable) and that carries
 `shrink-0` takes its natural width, and the text column gets the remainder — measured at

--- a/website/scripts/capture-side-panel-pane-inset.mjs
+++ b/website/scripts/capture-side-panel-pane-inset.mjs
@@ -1,0 +1,273 @@
+/**
+ * Measures — and photographs — the gap between the narrow tab strip's border
+ * and the first thing each SidePanelLayout tab paints, across all three pages
+ * built on that shell: Agent Capabilities, Developer, and Settings.
+ *
+ * On a phone SidePanelLayout replaces the desktop header block (whose `pb-3`
+ * spaces a tab's title from its content) with a pill strip that ends in a drawn
+ * `border-b`. The pane below it had no top inset, so a tab whose first element
+ * is a Card or a stat row rendered that element's own border ON the divider —
+ * two lines touching, with no gap to read as separation. The pane now carries
+ * that inset, which makes it the ONE owner of the gap: a tab that also puts a
+ * top margin on its own first element lands further down than its siblings, and
+ * this harness is what shows which tabs do.
+ *
+ * jsdom computes no geometry, so the unit guard
+ * (src/test/SidePanelLayout.narrowPaneTopInset.test.tsx) can only assert the
+ * class. This is the harness that produces the number: it runs the REAL built
+ * SPA (website/dist) behind a tiny static server and answers every /api/** call
+ * from fixtures, so the client code under test is unmodified — only the network
+ * is stubbed. Per tab it reports both the divider→first-in-flow-box distance
+ * (the number a tab's own top margin moves, so the one to compare across tabs)
+ * and the divider→first-painted-pixel distance, and writes a 390px screenshot.
+ *
+ * Usage: node scripts/capture-side-panel-pane-inset.mjs [outDir]
+ * Run it once on the fix and once with the inset reverted to get before/after.
+ */
+import { chromium } from 'playwright'
+import { mkdirSync, writeFileSync } from 'node:fs'
+// The static server is shared with the other capture harnesses in this folder:
+// it carries the MIME table, the index.html fallback that makes /capabilities
+// deep-link, a path-traversal containment check, and the `/logo.png` route the
+// real dashboard serves from outside the SPA bundle (a local copy 404s it and
+// renders a broken brand mark in every frame).
+import { serveDist } from './lib/serve-dist.mjs'
+
+const OUT = process.argv[2] || '/tmp/capabilities-pane-inset'
+// Viewport width: 390 (a phone) by default; pass a second argument to measure
+// another width. Above the md breakpoint the shell swaps the pill strip for the
+// desktop header, so `gap()` reports the header's own inset there.
+const WIDTH = Number(process.argv[3] || 390)
+
+mkdirSync(OUT, { recursive: true })
+
+const SKILLS = [
+  { key: 'babysit', name: 'babysit', description: 'Same-session monitoring loop for PRs and CI runs', path: '/home/user/.kiro/crew/skills/babysit/SKILL.md', source: 'kirocrew' },
+  { key: 'prepare-pr', name: 'prepare-pr', description: 'Drive working-tree changes to a review-ready pull request', path: '/home/user/.kiro/crew/skills/prepare-pr/SKILL.md', source: 'kirocrew' },
+  { key: 'widgets', name: 'widgets', description: 'Render rich HTML inline via mcwidget tags', path: '/home/user/.kiro/crew/skills/widgets/SKILL.md', source: 'kirocrew' },
+]
+const STEERING = {
+  files: [
+    { key: 'user/api-standards.md', rel: 'api-standards.md', source: 'user', bytes: 1840 },
+    { key: 'user/tone.md', rel: 'tone.md', source: 'user', bytes: 620 },
+  ],
+}
+const HOOKS = [
+  { name: 'lint-on-save', event: 'PostToolUse', matcher: 'fs_write', command: 'npm run lint', enabled: true, source: 'user' },
+  { name: 'block-force-push', event: 'PreToolUse', matcher: 'execute_bash', command: 'scripts/guard.sh', enabled: true, source: 'user' },
+]
+const PROMPTS = [
+  { name: 'triage', fullName: 'triage', source: 'user', description: 'Sort an inbox of reports into buckets' },
+  { name: 'retro', fullName: 'retro', source: 'user', description: 'Write a retrospective from a deploy log' },
+]
+const MCP = {
+  servers: {
+    'kirocrew-core': { command: 'kirocrew', args: ['mcp'], disabled: false },
+    'kirocrew-cron': { command: 'kirocrew', args: ['mcp-cron'], disabled: false },
+  },
+}
+const WORKSPACES = [
+  { name: 'default', path: '/home/user/.kiro/crew/workspace', active: true, sessions: 3 },
+  { name: 'research', path: '/home/user/.kiro/crew/workspaces/research', active: false, sessions: 0 },
+]
+const AGENTS = [
+  { name: 'kirocrew', description: 'Autonomous personal AI agent', source: 'kirocrew', model: 'auto', mcp_servers: ['kirocrew-core'], filename: 'kirocrew.json', skills: [] },
+  { name: 'code-reviewer', description: 'Reviews changes against the repo conventions', source: 'builtin', model: 'auto', mcp_servers: [], filename: 'code-reviewer.json', skills: [] },
+]
+
+const json = (route, body) =>
+  route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) })
+
+const { srv, base } = await serveDist()
+const browser = await chromium.launch()
+const context = await browser.newContext({
+  // Width is a parameter because the inset is a NARROW-branch value and the
+  // margins it replaced were unprefixed: the same edit therefore moves desktop
+  // too, and a claim about desktop has to be measured at desktop, not inferred
+  // from the phone number.
+  viewport: { width: WIDTH, height: WIDTH >= 768 ? 900 : 844 },
+  // 11–13px type at 1x renders soft once GitHub scales the image.
+  deviceScaleFactor: 2,
+})
+const page = await context.newPage()
+
+await page.routeWebSocket(/\/api\/ws/, () => {})
+
+await page.route('**/api/**', async route => {
+  const path = new URL(route.request().url()).pathname
+
+  if (path === '/api/skills') return json(route, SKILLS)
+  if (path === '/api/steering') return json(route, STEERING)
+  if (path === '/api/hooks') return json(route, HOOKS)
+  if (path === '/api/prompts') return json(route, PROMPTS)
+  if (path === '/api/mcp') return json(route, MCP)
+  if (path === '/api/workspaces') return json(route, WORKSPACES)
+  if (path === '/api/agents/installed') return json(route, AGENTS)
+  if (path === '/api/config/default-agent') return json(route, { default_agent: 'kirocrew' })
+  if (path === '/api/models') return json(route, [{ model_name: 'auto', description: 'Let Kiro choose' }])
+  // The app shell mounts behind this gate and reads status.operation.status — a
+  // generic object stub crashes it, blanking the whole page.
+  if (path === '/api/kiro-prerequisite') {
+    return json(route, {
+      platform: 'linux', installed: true, authenticated: true, ready: true,
+      initial_setup_complete: true, can_auto_install: false, can_login: false,
+      repair_required: false, docs_url: '', setup_allowed: false,
+      operation: { kind: '', status: 'idle', message: '', detail: '', url: '', error: '' },
+    })
+  }
+  if (path === '/api/status') return json(route, { sessions: 1, crons: 0, lessons: 0, subagents: 0, uptime: 120, version: 'dev' })
+  if (path === '/api/notifications') return json(route, { notifications: [], unread: 0 })
+  if (path === '/api/auth/me') return json(route, { user: 'owner', app: '' })
+  if (path === '/api/theme/boot') return json(route, { mode: 'dark', theme: '' })
+  if (path === '/api/dashboard/branding') return json(route, { bot_name: 'Kiro', avatar: '' })
+  if (path.startsWith('/api/instances')) return json(route, { instances: [], active: '' })
+  const objectish = /(config|tips|voice|autonudge|branding|status|usage|probe|scopes|active)/.test(path)
+  return json(route, objectish ? {} : [])
+})
+
+page.on('pageerror', err => console.log('PAGEERROR:', String(err).slice(0, 300)))
+
+await page.addInitScript(() => {
+  localStorage.clear()
+  localStorage.setItem('mc-theme', 'dark')
+  localStorage.setItem('mc-onboarded', '1')
+})
+
+/**
+ * Distance from the tab strip's bottom border to the top of the pane's content.
+ *
+ * Two numbers, because they answer different questions and an earlier version of
+ * this harness reported only the first one and misread a tab because of it:
+ *
+ *  - `boxGapPx` — the top of the first element that occupies flow space. This is
+ *    what a tab's own top margin moves, so it is the number to compare when
+ *    asking "does every tab start at the same place".
+ *  - `inkGapPx` — the topmost pixel that actually PAINTS: a drawn border, a
+ *    non-transparent background, an icon, or rendered text measured through a
+ *    Range (an element's own box is larger than its glyphs, and a text-bearing
+ *    element usually has element children too, so an `childElementCount === 0`
+ *    test silently skips every label — which is how Connections' sub-tab strip
+ *    went unmeasured and the empty-state card 40px below it got reported as
+ *    that tab's first content).
+ */
+async function gap() {
+  return page.evaluate(() => {
+    // The reference edge differs by breakpoint, because the shell swaps the
+    // block above the pane: narrow gets the pill strip (ends in a drawn border),
+    // desktop gets the header block (spaces its content with `pb-3`). Whichever
+    // is present is the thing the pane's first element must clear.
+    const strip = document.querySelector('[data-testid="side-panel-header"]')
+      || document.querySelector('div.shrink-0.border-b')
+    // On the narrow branch the scrolling column has no header block, so its
+    // first child IS the pane; on desktop the pane is the header's next sibling.
+    const pane = document.querySelector('[data-testid="side-panel-pane"]')
+      || strip?.nextElementSibling
+      || strip?.parentElement?.nextElementSibling?.firstElementChild
+    if (!pane || !strip) {
+      return {
+        error: 'pane or strip not found',
+        sawStrip: Boolean(strip),
+        stripClass: strip ? String(strip.className).slice(0, 80) : null,
+      }
+    }
+    const dividerY = strip.getBoundingClientRect().bottom
+
+    const rendered = (el) => {
+      const cs = getComputedStyle(el)
+      return cs.visibility !== 'hidden' && cs.display !== 'none' && cs.position !== 'fixed'
+    }
+
+    let box = null, boxWhat = null, ink = null, inkWhat = null
+    const name = (el) =>
+      el.tagName.toLowerCase() + (el.className ? '.' + String(el.className).split(/\s+/)[0] : '')
+
+    for (const el of pane.querySelectorAll('*')) {
+      if (!rendered(el)) continue
+      const r = el.getBoundingClientRect()
+      if (r.height < 1 || r.width < 1) continue
+      const cs = getComputedStyle(el)
+
+      // In-flow box. `relative` and `sticky` still occupy flow space (Card is
+      // relative, for its glow) — only absolute/fixed are lifted out, and those
+      // a tab's own top margin does not move, so they cannot answer the question.
+      const inFlow = cs.position !== 'absolute' && cs.position !== 'fixed'
+      if (inFlow && (box === null || r.top < box)) {
+        box = r.top
+        boxWhat = name(el)
+      }
+
+      const paints = parseFloat(cs.borderTopWidth) > 0
+        || cs.backgroundColor !== 'rgba(0, 0, 0, 0)'
+        || el instanceof SVGElement || el.tagName === 'IMG'
+      if (paints && (ink === null || r.top < ink)) {
+        ink = r.top
+        inkWhat = name(el)
+      }
+
+      // Glyph ink, via the element's OWN text nodes only, so a wrapper is not
+      // credited with the position of a descendant's text.
+      for (const node of el.childNodes) {
+        if (node.nodeType !== Node.TEXT_NODE || !node.textContent.trim()) continue
+        const range = document.createRange()
+        range.selectNodeContents(node)
+        const tr = range.getBoundingClientRect()
+        range.detach?.()
+        if (tr.height < 1 || tr.width < 1) continue
+        if (ink === null || tr.top < ink) {
+          ink = tr.top
+          inkWhat = name(el) + ':text'
+        }
+      }
+    }
+
+    const round = (v) => (v === null ? null : Math.round((v - dividerY) * 10) / 10)
+    return {
+      paneInsetTop: getComputedStyle(pane).paddingTop,
+      boxGapPx: round(box),
+      firstBox: boxWhat,
+      inkGapPx: round(ink),
+      firstInk: inkWhat,
+    }
+  })
+}
+
+/**
+ * Every page built on SidePanelLayout, and every tab on it. The shell is shared,
+ * so the inset is shared — and so is the way a tab can stack its own margin on
+ * top of it. Measuring one page would leave the other two unproven.
+ */
+const PAGES = [
+  {
+    route: 'capabilities',
+    tabs: ['crews', 'templates', 'mcp', 'skills', 'steering', 'hooks', 'prompts'],
+  },
+  {
+    route: 'developer',
+    tabs: ['logs', 'system', 'telemetry', 'storage', 'mcp-pool', 'memory', 'config',
+      'feature-previews', 'archive'],
+  },
+  {
+    route: 'settings',
+    tabs: ['overview', 'imports', 'chat', 'display', 'voice', 'notifications', 'shortcuts',
+      'skills', 'channels', 'browser', 'computer-use', 'webhooks', 'instances', 'privacy',
+      'security', 'developer', 'releases', 'about'],
+  },
+]
+
+const rows = []
+for (const { route, tabs } of PAGES) {
+  for (const tab of tabs) {
+    await page.goto(`${base}/${route}?tab=${tab}`, { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(1800)
+    const m = await gap()
+    rows.push({ page: route, tab, ...m })
+    await page.screenshot({ path: `${OUT}/${route}-${tab}.png` })
+    console.log(`${route}/${tab}`.padEnd(26), JSON.stringify(m))
+  }
+}
+
+writeFileSync(`${OUT}/measurements.json`, JSON.stringify(rows, null, 2))
+console.log('wrote', OUT)
+
+await browser.close()
+srv.close()

--- a/website/src/components/SidePanelLayout.tsx
+++ b/website/src/components/SidePanelLayout.tsx
@@ -236,7 +236,14 @@ export default function SidePanelLayout({ title, tabs, defaultTab, rememberKey, 
           {headerRight}
         </div>
         )}
-        <div className={`${isMobile ? 'px-4' : 'px-6'} ${fixed ? 'flex-1 min-h-0 flex flex-col' : 'flex-1 pb-8'}`}>
+        {/* `pt-3` is the narrow branch only, and it is not decoration: the tab
+          * strip above ends in a drawn border, and with no inset every tab's
+          * first card or stat row rendered ON that line. Desktop already gets
+          * the same 12px from the header block's `pb-3`, so this makes the
+          * phone match the rhythm rather than inventing one — which is also why
+          * it is not `md:pt-0`: the desktop pane must keep 0 or the two insets
+          * would stack. */}
+        <div data-testid="side-panel-pane" className={`${isMobile ? 'px-4 pt-3' : 'px-6'} ${fixed ? 'flex-1 min-h-0 flex flex-col' : 'flex-1 pb-8'}`}>
           {children(tab)}
         </div>
       </div>

--- a/website/src/components/settings.tsx
+++ b/website/src/components/settings.tsx
@@ -207,7 +207,16 @@ interface SettingsSectionProps {
 export function SettingsSection({ title, badge, children }: SettingsSectionProps) {
   return (
     <>
-      <div className="flex items-center gap-2 mt-4 mb-2">
+      {/* `mt-4` separates one section from the previous section's controls, so it
+        * is load-bearing between sections — but the FIRST section on a tab has
+        * nothing above it except the pane, which already owns the gap under the
+        * narrow tab strip (SidePanelLayout's `pt-3`) and under the desktop header
+        * (`pb-3`). `first:mt-0` drops it in exactly that case: the fragment adds
+        * no DOM node, so every section's header is a sibling in one parent and
+        * only the leading one matches. When a tab renders something of its own
+        * above the first section, the header is no longer first and keeps the
+        * margin — which is what it should do, because now something IS above it. */}
+      <div className="flex items-center gap-2 mt-4 mb-2 first:mt-0">
         <h4 className="text-sm font-semibold text-text-strong">{title}</h4>
         {badge}
       </div>

--- a/website/src/pages/LocalStorageDebug.tsx
+++ b/website/src/pages/LocalStorageDebug.tsx
@@ -118,7 +118,10 @@ export default function LocalStorageDebug() {
   return (
     <div className="space-y-4">
       {/* ── Usage Overview ── */}
-      <h4 className="text-sm font-semibold text-text-strong mt-4 mb-2">{i18nT('pages.localStorageDebug.usage')}</h4>
+      {/* `first:mt-0`: these headings separate one section from the previous
+        * one, but the leading heading has only the pane above it, and the pane
+        * already owns the gap under the tab strip. */}
+      <h4 className="text-sm font-semibold text-text-strong mt-4 mb-2 first:mt-0">{i18nT('pages.localStorageDebug.usage')}</h4>
       <div className="card-glow border border-border bg-card rounded-lg p-5 mb-4 shadow-sm">
         <div className="flex items-center justify-between mb-3">
           <div>

--- a/website/src/pages/overview/SkillsTab.tsx
+++ b/website/src/pages/overview/SkillsTab.tsx
@@ -215,7 +215,7 @@ export default function SkillsTab() {
   }
 
   if (isLoading) return (<>
-    <h4 className="text-sm font-semibold text-text-strong mt-4 mb-2 flex items-center gap-2">{i18nT('pages.overview.skillsTab.skills')} <InfoTip text={i18nT('pages.overview.skillsTab.on_demand_skills_loaded_when_the_agent_determine')} /> <Btn primary disabled>{i18nT('pages.overview.skillsTab.create_new_skill')}</Btn></h4>
+    <h4 className="text-sm font-semibold text-text-strong mb-2 flex items-center gap-2">{i18nT('pages.overview.skillsTab.skills')} <InfoTip text={i18nT('pages.overview.skillsTab.on_demand_skills_loaded_when_the_agent_determine')} /> <Btn primary disabled>{i18nT('pages.overview.skillsTab.create_new_skill')}</Btn></h4>
     <Card>
       <div className="flex items-center gap-2 mb-3"><div className="h-8 max-w-[480px] flex-1 rounded-md animate-pulse" style={{ background: 'var(--border)', opacity: 0.5 }} /></div>
       <div className={PANE_SHELL_CLASS}>
@@ -240,7 +240,15 @@ export default function SkillsTab() {
       <SkillForm data={formData} onChange={setFormData} />
     </Modal>
 
-    <h4 className="text-sm font-semibold text-text-strong mt-4 mb-2 flex flex-wrap items-center gap-2">{i18nT('pages.overview.skillsTab.skills_count', { count: skills.length })} <InfoTip text={i18nT('pages.overview.skillsTab.skills_tip')} /> <span className="w-full md:w-auto md:ml-auto flex flex-col md:flex-row items-stretch md:items-center [&>button]:justify-center md:[&>button]:justify-start gap-2"><Btn onClick={showBudget} className="text-accent border-accent/30 bg-accent/5 hover:bg-accent/10">{i18nT('pages.overview.skillsTab.budget_doorway_static')}</Btn><Btn onClick={() => setSkillBrowserOpen(true)}><Download size={14} /> {i18nT('pages.overview.skillsTab.add_skill')}</Btn><Btn primary onClick={() => { setFormData(EMPTY_FORM); setCreating(true) }}>{i18nT('pages.overview.skillsTab.create_new_skill')}</Btn></span></h4>
+    {/* No top margin: the pane that hosts this tab owns the gap under the tab
+      * strip (SidePanelLayout's narrow `pt-3`, the desktop header's `pb-3`).
+      * A margin here would stack on top of it and put this tab further from the
+      * divider than the tabs whose first element is a Card. Dropped outright
+      * rather than with `first:mt-0`, because `PendingSkillsPanel` above returns
+      * null when nothing is pending — this heading moves in and out of
+      * `:first-child` with the pending count, so a positional rule would make
+      * the gap depend on it. */}
+    <h4 className="text-sm font-semibold text-text-strong mb-2 flex flex-wrap items-center gap-2">{i18nT('pages.overview.skillsTab.skills_count', { count: skills.length })} <InfoTip text={i18nT('pages.overview.skillsTab.skills_tip')} /> <span className="w-full md:w-auto md:ml-auto flex flex-col md:flex-row items-stretch md:items-center [&>button]:justify-center md:[&>button]:justify-start gap-2"><Btn onClick={showBudget} className="text-accent border-accent/30 bg-accent/5 hover:bg-accent/10">{i18nT('pages.overview.skillsTab.budget_doorway_static')}</Btn><Btn onClick={() => setSkillBrowserOpen(true)}><Download size={14} /> {i18nT('pages.overview.skillsTab.add_skill')}</Btn><Btn primary onClick={() => { setFormData(EMPTY_FORM); setCreating(true) }}>{i18nT('pages.overview.skillsTab.create_new_skill')}</Btn></span></h4>
     <p className="text-[12px] text-muted mb-2"><Trans i18nKey="pages.overview.skillsTab.auto_create_hint" components={{ settingRef: <SettingRef configKey="skills.auto_create_from_sessions" /> }} /></p>
     <Card>
       <div className="flex items-center gap-2 mb-3">
@@ -648,8 +656,14 @@ function PendingSkillsPanel() {
   // already resolved lands on a Skills tab that looks completely normal, and
   // the user is left hunting for a row that no longer exists.
   if (pending.length === 0 && !reviewMissing) return null
+  // No top margin on the root, for the same reason as the tab's heading below:
+  // this panel is the Skills tab's FIRST in-flow element whenever it renders,
+  // and the pane already owns the gap under the tab strip. It is also WHY that
+  // heading drops its margin outright instead of using `first:mt-0` — this panel
+  // returns null when there is nothing pending, so the heading moves in and out
+  // of `:first-child` with the pending count.
   return (
-    <div className="mt-4 mb-2">
+    <div className="mb-2">
       {/* Suppressed when the ONLY thing to show is the resolved-candidate
           notice: a "Pending review (0)" heading over a sentence explaining
           there is nothing to review reads like a broken count. */}

--- a/website/src/pages/overview/SteeringTab.tsx
+++ b/website/src/pages/overview/SteeringTab.tsx
@@ -258,7 +258,8 @@ export default function SteeringTab() {
       </div>
     </Modal>
 
-    <h4 className="text-sm font-semibold text-text-strong mt-4 mb-2 flex items-center gap-2">
+    {/* No top margin — see the same note in SkillsTab: the hosting pane owns the
+      * gap under the tab strip, and a margin here would stack on it. */}    <h4 className="text-sm font-semibold text-text-strong mb-2 flex items-center gap-2">
       {i18nT('pages.overview.steeringTab.steering_count', { count: files.length })}
       <InfoTip text={i18nT('pages.overview.steeringTab.always_on_markdown_conventions_injected_into_eve')} />
       <span className="ml-auto">

--- a/website/src/test/SidePanelLayout.narrowPaneTopInset.test.tsx
+++ b/website/src/test/SidePanelLayout.narrowPaneTopInset.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * The narrow pane keeps a top inset under the tab strip — and owns it alone.
+ *
+ * On a phone SidePanelLayout drops the desktop header block — the one whose
+ * `pb-3` puts 12px between a tab's title and its content — and replaces it with
+ * a scrolling pill strip that ends in a drawn `border-b`. With no inset on the
+ * pane, every tab's first element (a Card, a stat row, a banner) rendered
+ * directly ON that border: measured at 390px, four of Agent Capabilities' seven
+ * tabs and most of Developer's nine had a 0px gap.
+ *
+ * The shell is shared by Agent Capabilities, Developer and Settings, so the
+ * inset is one number for all three — which makes the second half of the rule
+ * matter as much as the first: a tab that ALSO puts a top margin on its own
+ * first element stacks on the inset and lands further down than its siblings
+ * (12 + 16 = 28px against 12px). Skills, Steering, Developer > Storage and nine
+ * Settings tabs did. A heading that is its tab's root drops the margin outright;
+ * a heading that repeats within a tab keeps it and neutralises it with
+ * `first:mt-0`, because there the between-sections gap is load-bearing.
+ *
+ * The root headings drop the margin rather than neutralise it positionally
+ * because `SkillsTab` renders `PendingSkillsPanel` above its heading and that
+ * panel returns null when nothing is pending — `:first-child` would then track
+ * the pending count. (A conditionally rendered `Modal` is NOT such a sibling: it
+ * portals to document.body.)
+ *
+ * The classes are the contract: jsdom computes no geometry, so what is asserted
+ * here is that the narrow branch carries the inset, the desktop branch does NOT
+ * (its 12px comes from the header, and a second inset would stack), that
+ * containment (`fixedContent`) does not drop it, and that no tab re-stacks on
+ * top of it. The rendered gap is measured against a real build in
+ * website/scripts/capture-side-panel-pane-inset.mjs.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import SidePanelLayout, { type SidePanelTab } from '../components/SidePanelLayout'
+import { SettingsSection } from '../components/settings'
+
+const mobile = vi.hoisted(() => ({ value: false }))
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => mobile.value }))
+
+const TABS: SidePanelTab[] = [
+  { key: 'form', label: 'Form', icon: null },
+  { key: 'archive', label: 'Archive', icon: null, fixedContent: true },
+]
+
+function renderPage(opts: { url?: string; fixedContent?: boolean } = {}) {
+  return render(
+    <MemoryRouter initialEntries={[opts.url ?? '/page']}>
+      <SidePanelLayout title="Test" tabs={TABS} fixedContent={opts.fixedContent}>
+        {tab => <div data-testid="pane">{tab}</div>}
+      </SidePanelLayout>
+    </MemoryRouter>,
+  )
+}
+
+/** Every `pt-*` / `py-*` the pane wrapper carries, at any breakpoint. */
+function topInsets(el: HTMLElement): string[] {
+  return el.className.split(/\s+/).filter(c => /^(?:[a-z-]+:)?p[ty]-/.test(c))
+}
+
+describe('SidePanelLayout — the narrow pane clears the tab strip border', () => {
+  beforeEach(() => { mobile.value = false })
+
+  it('insets the pane from the strip border on a phone', () => {
+    mobile.value = true
+    renderPage()
+    expect(topInsets(screen.getByTestId('side-panel-pane'))).toEqual(['pt-3'])
+  })
+
+  it('keeps the inset when the tab is contained rather than page-scrolled', () => {
+    mobile.value = true
+    renderPage({ fixedContent: true })
+    expect(topInsets(screen.getByTestId('side-panel-pane'))).toEqual(['pt-3'])
+  })
+
+  it('pairs the inset with the border it clears', () => {
+    mobile.value = true
+    renderPage()
+    // The strip block sits beside the SCROLLING COLUMN, not beside the pane —
+    // the pane is that column's only child on this branch. The inset only reads
+    // as deliberate because the block above draws a line.
+    const strip = screen.getByTestId('side-panel-pane').parentElement!.previousElementSibling
+    // Token equality, not substring: `toContain('border-b')` also matches inside
+    // the neighbouring `border-border`, which makes the assertion vacuous.
+    expect(String(strip?.className).split(/\s+/)).toContain('border-b')
+  })
+
+  it('leaves the desktop pane flush, since the header already spaces it', () => {
+    renderPage()
+    expect(topInsets(screen.getByTestId('side-panel-pane'))).toEqual([])
+    expect(screen.getByTestId('side-panel-header').className).toContain('pb-3')
+  })
+
+  it('is the only owner of that gap: no tab root adds a top margin of its own', async () => {
+    // The pane's inset is the ONE number between the strip border and a tab's
+    // first element. A tab that also carries `mt-*` on its own first element
+    // stacks on it and lands further down than its sibling tabs — which is
+    // exactly what Skills and Steering did (12px pane + 16px heading = 28px,
+    // against 12px on every tab whose first element is a Card).
+    //
+    // These headings sit at the ROOT of their tab, with nothing above them, so
+    // the margin is dropped outright rather than with `first:mt-0`: `SkillsTab`
+    // renders `PendingSkillsPanel` above its heading and that panel returns null
+    // when nothing is pending, so `:first-child` would track the pending count.
+    //
+    // Read from source rather than by rendering: these tabs need the whole
+    // query/router/i18n stack to mount, and the assertion is about a class on a
+    // specific element, which cardInsetYield.test.tsx already checks this same
+    // pair of files for in the same way.
+    const { readFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    for (const file of ['SkillsTab.tsx', 'SteeringTab.tsx', 'PromptsTab.tsx']) {
+      const src = await readFile(join(__dirname, '..', 'pages', 'overview', file), 'utf8')
+      // Only headings: a top margin deeper in the tab separates two sections and
+      // is none of this rule's business.
+      const heads = src.match(/<h4 className="[^"]*"/g) ?? []
+      const stacked = heads.filter(h => /\b(?:mt|my)-[\d.]/.test(h))
+      expect(stacked, `${file}: heading must not add a top margin over the pane inset`)
+        .toEqual([])
+    }
+  })
+
+  it('covers a leading element that is NOT a heading, which the h4 scan cannot see', async () => {
+    // `PendingSkillsPanel` renders ABOVE the Skills heading and is the tab's
+    // first in-flow element whenever anything is pending, so its own root
+    // carried the same 12+16=28px stack — invisible to the scan above (not an
+    // h4) and to the capture harness (its fixture returns no pending skills).
+    // Anchored to the component's own returned root, so a top margin deeper
+    // inside the panel, which separates its sections, stays allowed.
+    const { readFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const src = await readFile(
+      join(__dirname, '..', 'pages', 'overview', 'SkillsTab.tsx'), 'utf8')
+    const body = src.slice(src.indexOf('function PendingSkillsPanel()'))
+    const root = body.match(/return \(\s*\n\s*<div className="([^"]*)"/)
+    expect(root, 'PendingSkillsPanel should still open with a single root div').toBeTruthy()
+    expect(root![1].split(/\s+/).filter(c => /^(?:[a-z-]+:)?(?:mt|my)-[\d.]/.test(c)),
+      'the panel is the tab\'s first in-flow element; the pane owns that gap')
+      .toEqual([])
+  })
+
+  it('lets a REPEATED section heading keep its margin only when something is above it', () => {
+    // Settings and Developer put many `SettingsSection`s in one tab, where the
+    // margin between two sections is load-bearing — so here the margin stays and
+    // is neutralised positionally. Asserted on the RENDERED class list: a source
+    // regex would pass on `mt-4` alone, which is the bug.
+    const { container } = render(<SettingsSection title="Section">body</SettingsSection>)
+    const head = container.firstElementChild as HTMLElement
+    const classes = head.className.split(/\s+/)
+    expect(classes, 'the between-sections margin is still there').toContain('mt-4')
+    expect(classes, 'and it is dropped for the leading section, which the pane already spaces')
+      .toContain('first:mt-0')
+  })
+
+  it('applies the same pairing to Developer > Storage, the one developer tab that stacked', async () => {
+    const { readFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const src = await readFile(join(__dirname, '..', 'pages', 'LocalStorageDebug.tsx'), 'utf8')
+    const lead = src.match(/<h4 className="([^"]*)"/)
+    expect(lead, 'LocalStorageDebug should still open with a section heading').toBeTruthy()
+    const classes = lead![1].split(/\s+/)
+    if (classes.some(c => /^(?:mt|my)-[\d.]/.test(c))) {
+      expect(classes, 'a leading heading that keeps a top margin must neutralise it')
+        .toContain('first:mt-0')
+    }
+  })
+})

--- a/website/src/test/cardFlushNarrow.test.ts
+++ b/website/src/test/cardFlushNarrow.test.ts
@@ -34,7 +34,13 @@ describe('capability panes reach the card edge below the breakpoint', () => {
     // 358px row shared with the title and the info icon, so every label wrapped and
     // the row stood 50px tall. Stacked below md each button is one line (358x30).
     const s = await src('overview', 'SkillsTab.tsx')
-    expect(s).toMatch(/mt-4 mb-2 flex flex-wrap items-center gap-2/)
+    // The header's TOP margin is deliberately not pinned here: the pane that
+    // hosts this tab owns the gap under the tab strip, and
+    // SidePanelLayout.narrowPaneTopInset.test.tsx asserts this heading carries no
+    // margin of its own. Pinning `mt-4` in this row's literal would make the two
+    // tests contradict each other over a spacing token that is not this test's
+    // subject — which is whether the three buttons get their own line.
+    expect(s).toMatch(/mb-2 flex flex-wrap items-center gap-2/)
     expect(s).toMatch(
       /className="w-full md:w-auto md:ml-auto flex flex-col md:flex-row items-stretch md:items-center/)
     expect(s, 'ml-auto without a width switch keeps the buttons on the title line')


### PR DESCRIPTION
## The defect

`SidePanelLayout` drops the desktop header block below `md` — the block whose `pb-3` puts 12px between a tab's title and its content — and replaces it with a pill strip that ends in a drawn `border-b`. The pane below it carried **no top inset of its own**, so a tab whose first element is a `Card` or a `StatCard` rendered that element's own border ON the divider: two lines touching, with nothing to read as separation.

Three pages are built on this shell, so all three had it: **Agent Capabilities**, **Developer**, **Settings**.

## Why the fix is two halves, not one

Adding the inset is the easy half. The hard half is that the inset must be the **only** owner of that gap. A tab that also puts a top margin on its own first element stacks on it and lands 28px down while its siblings sit at 12px — and because the tabs are one tap apart, that inconsistency is exactly what reads as sloppiness. Skills, Steering, Developer › Storage and nine of Settings' tabs did this.

Two shapes, and the difference is whether the heading can ever have a sibling above it:

| Shape | Where | Fix |
|---|---|---|
| Heading at the tab's **root** | `SkillsTab`, `SteeringTab` | drop `mt-4` outright |
| Heading that **repeats** within one tab | `SettingsSection` (many per Settings tab), `LocalStorageDebug` | keep `mt-4`, pair it with `first:mt-0` |

`first:mt-0` is deliberately **not** used for the root headings, and the reason is
`PendingSkillsPanel`: it renders **above** the Skills heading and returns `null` when
nothing is pending, so the heading moves in and out of `:first-child` with the pending
count. A positional rule would make the gap depend on that. (A conditionally rendered
`Modal` does *not* have this effect — it `createPortal`s to `document.body` and never
occupies a sibling slot.)

That same panel was the one sibling of the fixed cause left unfixed: its own root
carried `mt-4 mb-2`, so with anything pending the Skills tab still stacked to 28px. It
was invisible to both instruments — the guard test scanned only `<h4>` tags, and the
harness fixture returns no pending skills. Its root now carries `mb-2` alone, and the
guard has a second case anchored to that component's returned root rather than to a
tag name. Conversely the repeated headings must keep `mt-4`, because the gap between two consecutive sections is real — the fragment adds no DOM node, so every section header is a sibling in one parent and only the leading one matches. When a tab renders something of its own above the first section, the header stops being first and correctly keeps its margin.

## Measured, at 390px

`website/scripts/capture-side-panel-pane-inset.mjs` runs the **real** `website/dist` behind a static server with `/api/**` answered from fixtures, and per tab reports the divider→first-**in-flow-box** distance (the number a tab's own top margin moves) plus the divider→first-**painted-pixel** distance. Before = `origin/main`, after = this branch, same instrument for both.

| Page | tab | before | after |
|---|---|---|---|
| Capabilities | Agents (crews) | **0px** | 12px |
| Capabilities | Agent Templates | **0px** | 12px |
| Capabilities | Connections | **0px** | 12px |
| Capabilities | Skills | 16px | 12px |
| Capabilities | Steering | 16px | 12px |
| Capabilities | Hooks | **0px** | 12px |
| Capabilities | Prompts | **0px** | 12px |
| Developer | Logs | **0px** | 12px |
| Developer | System | **0px** | 12px |
| Developer | Telemetry | **0px** | 12px |
| Developer | Storage | 16px | 12px |
| Developer | MCP Management | **0px** | 12px |
| Developer | Memory | **0px** | 12px |
| Developer | Feature Previews | **0px** | 12px |
| Developer | Archive | **0px** | 12px |
| Settings | Overview, Channels, Webhooks, Instances, Privacy, Releases, About | **0px** | 12px |
| Settings | Imports, Chat, Display, Voice\*, Notifications, Shortcuts, Skills, Browser, Computer Use, Developer | 16px | 12px |

All 31 renderable tabs read 12px after.

**Not measured, disclosed rather than glossed:** `developer/config`, `settings/voice` and `settings/security` do not mount under the fixture stubs (the shell never renders, so the harness reports `pane or strip not found`) — identically before and after. `settings/voice` is marked `*` above because it goes through the same `SettingsSection`, not because it was measured.

**Residual differences in where the first *pixel* lands are deliberate.** Connections (21px), Developer › System (21px), Settings › Instances (21px): that extra 8-9px is a sub-tab's or a segmented control's own `py-2` tap target, not stacked page padding. Tightening it would shrink a touch target. Headings land at 13px against a card border's 12px — one pixel of line-box leading.

**Desktop moves too, and the description should say so.** The margins removed here were
unprefixed, so the edit is not narrow-only. Measured at 1280px, the affected tabs' first
element now begins at the header block's bottom edge — `developer/storage` and
`settings/display` both read 0px, meaning the entire visible gap is the header's own
`pb-3` (12px). The 16px that used to sit on top of that is **derived** from the removed
token, not separately measured. Two tabs (`capabilities/skills`, `capabilities/steering`)
do not resolve at 1280px under the harness fixtures, so their desktop value is derived
rather than measured; the shell and the removed token are the same, so the outcome is the
same 28px → 12px.

## Screenshots (390px, left = before, right = after)

Captured from the real `website/dist` by the same harness that reports the numbers, so the
frames and the table come from one run. Each pair was sha256-compared and is confirmed
**not** byte-identical, and the images are pinned to a commit
(`530e8deeb7b1`) on `evidence/side-panel-pane-top-inset` rather than added to this
branch, so attaching them costs no CI re-run.

The two 0px cases are the visible defect — the first card border sitting on the divider:

![Agent Capabilities > Connections: the sub-tab strip started flush against the divider](https://raw.githubusercontent.com/kirodotdev/KiroCrew/530e8deeb7b1256c0fe97d1ecb91b3796127368f/capabilities-mcp.png)

![Developer > Logs: the log-level row started flush against the divider](https://raw.githubusercontent.com/kirodotdev/KiroCrew/530e8deeb7b1256c0fe97d1ecb91b3796127368f/developer-logs.png)

The 16px cases are the stacking the pane inset would otherwise have made worse — these tabs
now agree with their siblings instead of sitting 4px lower than the fix intends (and 16px
lower than it, had the margin been left in place):

![Agent Capabilities > Skills: 16px to 12px](https://raw.githubusercontent.com/kirodotdev/KiroCrew/530e8deeb7b1256c0fe97d1ecb91b3796127368f/capabilities-skills.png)

![Agent Capabilities > Steering: 16px to 12px](https://raw.githubusercontent.com/kirodotdev/KiroCrew/530e8deeb7b1256c0fe97d1ecb91b3796127368f/capabilities-steering.png)

![Developer > Storage: 16px to 12px, via first:mt-0](https://raw.githubusercontent.com/kirodotdev/KiroCrew/530e8deeb7b1256c0fe97d1ecb91b3796127368f/developer-storage.png)

![Settings > Display: 16px to 12px, via SettingsSection's first:mt-0](https://raw.githubusercontent.com/kirodotdev/KiroCrew/530e8deeb7b1256c0fe97d1ecb91b3796127368f/settings-display.png)

Six pairs, not thirty-one: one per distinct shape (0px card tab, 0px control-row tab, root
heading, repeated heading on each of the two remaining pages). The rest of the table is
numbers, and the numbers are what the harness measures.

## Guard

`website/src/test/SidePanelLayout.narrowPaneTopInset.test.tsx`, 7 cases: the narrow branch carries the inset, containment (`fixedContent`) does not drop it, the desktop branch stays at 0 (its 12px comes from the header — a second inset would stack), the inset is paired with the border it clears, and no tab re-stacks on top of it.

Falsified by mutation — each of these turns it red:

- remove `pt-3` from the pane
- add `pt-3` to the desktop branch as well
- remove `border-b` from the strip block *(this one first passed falsely: `toContain('border-b')` also matches inside the neighbouring `border-border`, so the assertion is class-token equality)*
- re-add `mt-4` to `SkillsTab`'s heading
- drop `first:mt-0` from `SettingsSection`
- drop `first:mt-0` from `LocalStorageDebug`

The `SettingsSection` case asserts the **rendered** class list rather than source text, because a source regex passes on `mt-4` alone — which is the bug.

## Checks run locally

`tsc --noEmit` clean, `eslint src --max-warnings=0` 0 errors, i18n check ok (no new strings), brand gate ok, and the guard file plus `cardInsetYield` / `SkillsTab` / `SteeringTab` / `listDetailNarrowViewport` (50 tests) pass. **The full frontend suite was not run locally** — left to CI.

