### PR TITLE
fix(kiro): detect an external sign-out instead of running as the old account

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -74,6 +74,7 @@ from kiro_crew.acp.types import (
     ACP_BACKEND_KAS,
     ACP_BACKEND_KIRO,
     ACP_BACKENDS_INTERNAL_SANDBOX,
+    ACP_BACKENDS_KIRO_IDENTITY_STORE,
     ACP_CLIENT_CAPABILITIES,
     KAS_AUTH_CALLBACK_ERROR_CODE,
     KAS_CLIENT_CAPABILITIES,
@@ -787,6 +788,18 @@ class AcpRuntime:
         return self._acp_backend
 
     @property
+    def uses_kiro_identity_store(self) -> bool:
+        """True when this runtime's process signs in from kiro-cli's own store.
+
+        Membership in ``ACP_BACKENDS_KIRO_IDENTITY_STORE`` (harness-parity
+        H5/H14). ``AcpRuntime`` is not an ``LLMProvider``, but the identity-change
+        sweep reaches shared runtimes as well as session providers, so it
+        declares the same capability under the same name -- letting that sweep
+        ask both families one question instead of probing private attributes.
+        """
+        return self._acp_backend in ACP_BACKENDS_KIRO_IDENTITY_STORE
+
+    @property
     def supports_image_prompt(self) -> bool:
         """True when the agent advertised ``promptCapabilities.image``.
 
@@ -857,6 +870,24 @@ class AcpRuntime:
         drop that session's in-flight prompt/response.
         """
         return bool(self._session_queues)
+
+    def has_active_or_initializing_sessions(self) -> bool:
+        """True if any session is registered OR still being created.
+
+        ``has_active_sessions`` sees only REGISTERED queues, and
+        ``create_session`` registers outside the runtime lock -- so a co-tenant
+        whose ``session/new`` is in flight is momentarily invisible to it. Callers
+        that recycle a stale runtime tolerate that window deliberately (their
+        ``create_session`` raises ``AcpRuntimeDead`` and a respawn loop backstops
+        it, costing one extra respawn).
+
+        A caller with NO such backstop must not: killing the runtime under an
+        initializing task session surfaces as ``AcpRuntimeDead`` on work the user
+        never connected to whatever prompted the kill. Those callers ask this
+        instead, which also counts ``_session_inits_in_flight``.
+        """
+
+        return bool(self._session_queues) or self._session_inits_in_flight > 0
 
     # ── Lifecycle ──
 

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -33,7 +33,7 @@ from kiro_crew.acp.client import (
 )
 from kiro_crew.acp.runtime import AcpRuntime, AcpRuntimeDead, AcpRuntimeError, AcpSessionHandle
 from kiro_crew.acp.session_handle import WatchdogSettings
-from kiro_crew.acp.types import STOP_REASON_END_TURN
+from kiro_crew.acp.types import ACP_BACKENDS_KIRO_IDENTITY_STORE, STOP_REASON_END_TURN
 from kiro_crew.config.paths import kiro_sessions_dir
 from kiro_crew.constants import COMPACT_WAIT_TIMEOUT_SECS
 from kiro_crew.mcp_gateway.claim import schedule_claim
@@ -450,6 +450,17 @@ class AcpSessionProvider(LLMProvider):
         session under the kiro label.
         """
         return self._runtime.acp_backend
+
+    @property
+    def uses_kiro_identity_store(self) -> bool:
+        """True when this provider's child signs in from kiro-cli's own store.
+
+        Membership in ``ACP_BACKENDS_KIRO_IDENTITY_STORE`` (harness-parity
+        H5/H14), read off the runtime's backend for the same reason
+        :attr:`backend` is: this provider fronts whichever backend the runtime
+        spawned.
+        """
+        return self._runtime.acp_backend in ACP_BACKENDS_KIRO_IDENTITY_STORE
 
     def has_active_turn(self) -> bool:
         """True if a prompt turn is currently in progress.

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -181,6 +181,17 @@ ACP_BACKENDS_INTERNAL_SANDBOX = frozenset({ACP_BACKEND_KIRO})
 # yet is excluded from sharing until keep-aware teardown lands).
 ACP_BACKENDS_ACP_RUNTIME = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
 
+# Backends whose sign-in lives in kiro-cli's OWN identity store, so an external
+# ``kiro-cli logout`` (or a switch to another account) invalidates a process that
+# is already running. Membership is what authorizes retiring a live session's
+# child when that store starts naming a different account: a harness
+# authenticated some other way must not be recycled on a store it never reads.
+# KAS is deliberately NOT a member — it is a separate Node entry point
+# (``build_kas_argv``), and nothing here establishes that it authenticates from
+# kiro-cli's store; it opts in when someone demonstrates that it does. Positive
+# membership rather than "not claude" (harness-parity H5).
+ACP_BACKENDS_KIRO_IDENTITY_STORE = frozenset({ACP_BACKEND_KIRO})
+
 # ── Provider labels ──
 # The backend identity key persisted in the session map. It indexes three
 # things, so every producer must agree on it: resume compatibility

--- a/src/kiro_crew/apps/builtins/md_notebook/server.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/server.py
@@ -39,7 +39,7 @@ from kiro_crew import hooks, platform_compat, security
 from kiro_crew.apps.builtins.md_notebook import git_ops
 from kiro_crew.apps.builtins.md_notebook import notes as notes_mod
 from kiro_crew.apps.proxy_auth import raw_request_target, verify_proxy_request
-from kiro_crew.atomic_write import atomic_write
+from kiro_crew.atomic_write import atomic_write, replace_with_retry
 from kiro_crew.config.paths import config_dir
 from kiro_crew.platform_compat import restrict_to_owner
 from kiro_crew.sel import sel
@@ -316,7 +316,7 @@ def _write_vaults_sync(vaults: list[dict[str, Any]]) -> None:
     tmp = target.with_name(f"vaults.json.{uuid.uuid4().hex}.tmp")
     with open(tmp, "w", encoding="utf-8") as fh:
         json.dump(vaults, fh, indent=2)
-    os.replace(tmp, target)
+    replace_with_retry(tmp, target)
 
 
 def _read_pat_sync() -> Optional[str]:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -2599,6 +2599,73 @@ def _resolve_mirror_target(state: Any, session_key: str) -> Any:
     )
 
 
+async def _retire_sessions_on_identity_change(state: Any) -> None:
+    """Recycle kiro-backed children when the signed-in account has changed.
+
+    The counterpart to :func:`_mark_kiro_signed_out`, for the case that function
+    can never see: an external ``kiro-cli logout`` (or a switch to another
+    account) leaves a RUNNING child holding the old credential in memory. It
+    keeps refreshing and keeps answering, so no ACP auth failure ever occurs and
+    nothing reports the change -- turns simply continue under the account the user
+    believes they left.
+
+    This does NOT gate the send. A stale latch must never block a turn (see
+    ``dashboard/kiro_readiness.py``), and nothing here can: the check retires an
+    invalidated child and lets the send proceed on a fresh one, which is a
+    process recycle rather than a readiness verdict. It stays off the spawn path
+    too -- the trigger is a local database read, briefly cached, not a ``whoami``.
+
+    Best-effort: a failure here must not fail the turn, which would be a worse
+    outcome than the staleness it exists to correct.
+    """
+
+    service = getattr(state, "kiro_prerequisite_service", None)
+    sessions = getattr(state, "sessions", None)
+    if service is None or sessions is None:
+        return
+    try:
+        changed, live = await service.identity_changed_since_sessions()
+        if not changed:
+            return
+        retired, complete = await sessions.retire_kiro_identity_sessions()
+        # Advance THIS consumer's baseline ONLY on a complete sweep AND a real
+        # identity. Anything left running -- a busy session, a child that would not
+        # shut down, a start still in flight -- is still holding the previous
+        # account, so recording the change as handled would mean its next turn sees
+        # no change and reuses that account.
+        #
+        # An EMPTY fingerprint is refused for a different reason: it means the store
+        # could not be read (relocated, unreadable, or signed out), and reconciling
+        # it would make "cannot tell" the accepted steady state -- every later
+        # account switch would then compare equal to "" and go undetected while
+        # children keep running. Leaving it unreconciled means each turn re-sweeps,
+        # which bounds how long a child can outlive the account it loaded to a
+        # single turn. That is a real cost on a host whose store is not readable,
+        # and it is the correct direction to pay it in: the replacement child reads
+        # whatever the store now holds even when we cannot fingerprint it.
+        if complete and live:
+            service.note_sessions_reconciled(live)
+        # Narrow the latch ONLY on an actual sign-out (no identity on disk). On a
+        # switch to another valid account, narrowing would strand readiness: if a
+        # status poll observed the switch first it has already stamped the new
+        # identity, so the fingerprints now MATCH and no ordinary poll re-probes --
+        # the card would sit at "not signed in" until someone pressed Check again.
+        # A switch needs no narrowing anyway: the poll that stamped the new
+        # identity also refreshed the verdict for the account now in use, and the
+        # fail-closed gates carry their own freshness bound.
+        if not live:
+            service.mark_signed_out()
+        if retired or not complete:
+            logger.info(
+                "Kiro identity changed; retired %d session(s)%s: %s",
+                len(retired),
+                "" if complete else " (incomplete, will retry next turn)",
+                ", ".join(retired) or "none",
+            )
+    except Exception:
+        logger.debug("Could not apply a Kiro identity change", exc_info=True)
+
+
 def _mark_kiro_signed_out(state: Any) -> None:
     """Latch the prerequisite service to signed-out after an ACP auth failure.
 
@@ -4914,6 +4981,12 @@ async def _run_chat(
         # get_or_create or we'd reuse the stale session for one turn. Safe here:
         # no session lock is held yet, so reset() can't self-kill.
         await _consume_pending_reset(state, slot)
+        # Same "before get_or_create or we reuse a stale session for one turn"
+        # reasoning as the reset above, for a staleness the session map cannot
+        # see: the child is alive and healthy, but the account it authenticated
+        # as is gone. Retiring it here means this turn cold-starts on the current
+        # account instead of running as the previous one.
+        await _retire_sessions_on_identity_change(state)
         client, is_new, resumed = await state.sessions.get_or_create(
             session_key,
             agent=kiro_agent or slot.agent or None,

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -2649,6 +2649,17 @@ _AUDIT_ONLY_READ_IDS: dict[str, str] = {
     # no value is returned. The audit is owed regardless, because the file holds
     # live credential material whatever this reader touches.
     "kiro_cli.idc_identity_probe": ".local/share/kiro-cli/data.sqlite3",
+    # Same store, read by ``kiro_crew.kiro_prerequisite.identity_fingerprint`` to
+    # answer one question on the turn path: does the account signed in NOW differ
+    # from the one the running kiro-cli children loaded? Only stable account
+    # claims participate (start_url, region, oauth_flow, scopes, client_id) plus
+    # the non-secret ``auth.*`` / ``api.codewhisperer.*`` marker rows; the values
+    # are hashed and only a digest leaves the function. The rotating and secret
+    # fields (access_token, refresh_token, expires_at, client_secret) are excluded
+    # by an ALLOWLIST, so a field added to the blob later cannot join by default.
+    # Audited on the observation a caller acts on rather than per poll -- the
+    # reader holds a short cache -- for the same reason as the mint entry below.
+    "kiro_prerequisite.identity_fingerprint": ".local/share/kiro-cli/data.sqlite3",
     # Class 2. kiro-cli's MCP OAuth artifact cache under ``~/.aws/sso/cache``.
     # ``kiro_crew.connections.mint.grant_present`` STATS the paired
     # ``<sha256(mcp_url)>.token.json`` / ``.registration.json`` artifacts to learn

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -50,7 +50,7 @@ from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
-from kiro_crew import platform_compat
+from kiro_crew import hooks, platform_compat
 from kiro_crew._sqlite_compat import sqlite3
 from kiro_crew.agent_files import AGENT_FILENAME
 from kiro_crew.atomic_write import atomic_write
@@ -205,6 +205,37 @@ _AUTH_IDENTITY_TABLES = ("auth_kv", "migrations")
 _AUTH_STATE_TABLE = "state"
 _AUTH_STATE_KEY_PREFIXES = ("auth.", "api.codewhisperer.")
 _AUTH_SQLITE_FILES = (_AUTH_SQLITE_DB,)
+# What :func:`identity_fingerprint` returns when the store names no identity --
+# signed out, absent, or unreadable. Not a hash, so it can never collide with a
+# real fingerprint.
+_AUTH_FINGERPRINT_ABSENT = ""
+# SEL audit label for the identity-fingerprint read. Registered in
+# hooks._AUDIT_ONLY_READ_IDS; an unregistered id is refused there, and this reader
+# fails closed on that refusal rather than reading unaudited.
+_IDENTITY_FINGERPRINT_READ_ID = "kiro_prerequisite.identity_fingerprint"
+# Blob fields that identify WHICH account is signed in and survive a token
+# refresh. An ALLOWLIST on purpose: the same blobs carry `access_token`,
+# `refresh_token`, `expires_at` and `client_secret`, and a denylist would admit
+# every field a future kiro-cli adds -- letting a new secret into the digest, or a
+# new rotating field cause an account change on every refresh. `client_id` is the
+# OIDC registration, which is replaced when the client re-registers; that costs one
+# cold start on re-registration and is what distinguishes two logins whose
+# start_url is identical.
+_IDENTITY_CLAIM_FIELDS = frozenset(
+    {
+        "client_id",
+        "oauth_flow",
+        "region",
+        "scopes",
+        "start_url",
+    }
+)
+# How long a computed fingerprint may be reused. Bounds both the SQLite reads and
+# the SEL audit events a poll storm can produce (N dashboard tabs poll status every
+# few seconds), so the store is observed per action rather than per poll. Read off
+# time.monotonic() rather than the service's injected clock: this is a real-time
+# rate bound, not part of the probe's testable timing contract.
+_AUTH_FINGERPRINT_CACHE_SECS = 5.0
 # Short: the projection is a handful of small reads against a local file, and a
 # stuck open must not hold up sign-in.
 _AUTH_SQLITE_TIMEOUT_SECS = 5.0
@@ -764,6 +795,210 @@ def _atomic_write_secret_bytes(path: Path, content: bytes) -> None:
         with contextlib.suppress(OSError):
             os.unlink(temporary)
         raise
+
+
+def kiro_identity_store_path(
+    platform_name: str,
+    home: Path,
+    environ: MutableMapping[str, str],
+) -> Path:
+    """Return kiro-cli's OWN live identity database path.
+
+    Deliberately not amazon-q's: that store often holds the same account but is a
+    different product's credential, so it cannot answer "which account is this
+    CLI signed in as".
+
+    Every platform resolves to a FIXED, home-anchored location, matching the
+    trusted live-store list in ``dashboard/handlers/kiro_usage_api.py``. No
+    environment variable is consulted -- not ``XDG_DATA_HOME`` on Linux, not
+    ``APPDATA`` or ``LOCALAPPDATA`` on Windows -- because the fence that makes
+    this store unwritable by agent file tools (``_SENSITIVE_HOME_DIRS``) is
+    anchored at exactly these paths. A redirected location either resolves to the
+    same place or falls OUTSIDE the fence, where an agent can author the rows
+    this function reads: it could then forge an identity that keeps matching and
+    the children signed in as the previous account would never be retired. A
+    fixed anchor cannot be pointed at something the agent may write.
+
+    The cost is that a host which relocates its data home is read as having no
+    identity, so the change is reported as "absent" -- which errs toward retiring
+    children, never toward trusting them. ``environ`` is kept in the signature so
+    callers need not know which platforms consult it, and so a future platform
+    that genuinely requires it does not change every call site.
+    """
+
+    if platform_name == "darwin":
+        return home / "Library" / "Application Support" / "kiro-cli" / _AUTH_SQLITE_DB
+    if platform_name == "win32":
+        return home / "AppData" / "Roaming" / "kiro-cli" / _AUTH_SQLITE_DB
+    return home / ".local" / "share" / "kiro-cli" / _AUTH_SQLITE_DB
+
+
+def identity_store_is_relocated(
+    platform_name: str,
+    home: Path,
+    environ: MutableMapping[str, str],
+) -> bool:
+    """Whether the CLI's data home is configured somewhere other than our anchor.
+
+    :func:`kiro_identity_store_path` deliberately reads a FIXED path, because the
+    fence that keeps agent file tools out of that store is home-anchored and a
+    redirected path can land outside it. But refusing to follow the redirection is
+    not the same as being safe: if the environment points the CLI elsewhere and a
+    LEFTOVER database still sits at the default location, reading it yields a
+    confident fingerprint of an account nobody is signed into. A logout in the real
+    store would then change nothing we can see, and the old-account child would be
+    reused -- strictly worse than reporting "cannot tell".
+
+    So a configured relocation is reported here, and the caller treats it as
+    absent: no read, no false confidence, and the absent path already means "never
+    reconciled, re-sweep every turn".
+
+    Only variables that actually move the store count. ``LOCALAPPDATA`` is not
+    consulted: the identity lives under Roaming. A variable set to exactly the
+    default location is not a relocation.
+    """
+
+    if platform_name == "win32":
+        configured = environ.get("APPDATA", "").strip()
+        if not configured:
+            return False
+        return Path(configured) != home / "AppData" / "Roaming"
+    if platform_name == "darwin":
+        # No standard variable relocates ~/Library/Application Support.
+        return False
+    configured = environ.get("XDG_DATA_HOME", "").strip()
+    if not configured:
+        return False
+    return Path(configured) != home / ".local" / "share"
+
+
+def identity_fingerprint(path: Path) -> str:
+    """Return a digest naming WHICH account an identity store is signed in as.
+
+    Two rules shape what participates.
+
+    **Stable claims only.** The credential blobs mix fields that identify an
+    account with fields that are replaced on every token refresh. Digesting a
+    rotating field would report an account change roughly hourly and retire
+    healthy sessions, so the rotating and secret ones -- ``access_token``,
+    ``refresh_token``, ``expires_at``, ``client_secret`` -- are excluded and the
+    identifying ones are kept: the SSO ``start_url``, ``region``, ``oauth_flow``,
+    ``scopes`` and the OIDC registration's ``client_id``. Key NAMES also
+    participate, so a change of credential kind counts even when no value moved.
+
+    **An allowlist, not a denylist** (:data:`_IDENTITY_CLAIM_FIELDS`). A field
+    added to these blobs by a future kiro-cli cannot join the fingerprint by
+    default -- which keeps both a new secret out of it and a new rotating field
+    from causing spurious retirement.
+
+    Values are hashed, never returned, so the fingerprint carries no credential.
+
+    The read is SEL-audited and FAILS CLOSED: this file holds live credential
+    material, so a read whose audit cannot be recorded returns "absent" rather
+    than an unaudited answer. "Absent" is also what a logout leaves behind, and
+    the caller treats it as "cannot confirm the running children" -- which errs
+    toward retiring them, never toward trusting them.
+    """
+
+    audit_ok = hooks.emit_internal_read_audit(_IDENTITY_FINGERPRINT_READ_ID, "invoked")
+    if not audit_ok:
+        # A logger line is not an SEL audit. Refuse rather than read.
+        logger.warning("Kiro identity fingerprint read denied: audit unavailable")
+        return _AUTH_FINGERPRINT_ABSENT
+    connection = _open_identity_db_readonly(path)
+    if connection is None:
+        hooks.emit_internal_read_audit(_IDENTITY_FINGERPRINT_READ_ID, "unreadable")
+        return _AUTH_FINGERPRINT_ABSENT
+    parts: list[str] = []
+    try:
+        with contextlib.closing(connection):
+            present = {
+                str(row[0])
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"  # wokeignore:rule=master
+                ).fetchall()
+            }
+            if "auth_kv" in present:
+                for key, value in connection.execute("SELECT key, value FROM auth_kv").fetchall():
+                    claims = _identity_claims(str(key), value)
+                    if not claims:
+                        # A row carrying NO stable claim is deliberately skipped
+                        # ENTIRELY -- its key name is not recorded either. Recording
+                        # the name alone would make two different accounts stored
+                        # under the same key look identical, which is exactly the
+                        # false confidence to avoid: a social login (GitHub, Google)
+                        # has no SSO start_url, so account A and account B under
+                        # `kirocli:social:token` would fingerprint the same and the
+                        # child authenticated as A would never be retired.
+                        #
+                        # Contributing nothing means such a store can come out
+                        # ABSENT, which is never reconciled (see the caller) and so
+                        # re-sweeps every turn. "Cannot distinguish" is reported as
+                        # "cannot confirm" rather than as "unchanged".
+                        continue
+                    parts.append(f"k:{key}")
+                    parts.extend(claims)
+            if _AUTH_STATE_TABLE in present:
+                predicate = " OR ".join(["key LIKE ?"] * len(_AUTH_STATE_KEY_PREFIXES))
+                rows = connection.execute(
+                    f'SELECT key, value FROM "{_AUTH_STATE_TABLE}" WHERE {predicate}',
+                    tuple(f"{prefix}%" for prefix in _AUTH_STATE_KEY_PREFIXES),
+                ).fetchall()
+                for key, value in rows:
+                    parts.append(f"s:{key}={_claim_digest(value)}")
+    except sqlite3.Error:
+        hooks.emit_internal_read_audit(_IDENTITY_FINGERPRINT_READ_ID, "error")
+        return _AUTH_FINGERPRINT_ABSENT
+    if not parts:
+        # Schema present but zero identity rows reads as signed out, not as an
+        # identity whose fingerprint happens to be the digest of nothing.
+        hooks.emit_internal_read_audit(_IDENTITY_FINGERPRINT_READ_ID, "signed_out")
+        return _AUTH_FINGERPRINT_ABSENT
+    if not hooks.emit_internal_read_audit(_IDENTITY_FINGERPRINT_READ_ID, "success"):
+        # The read HAPPENED and its terminal audit could not be written, so the
+        # answer is unaudited. Discard it rather than let unaudited identity data
+        # drive retirement. The failure-shaped outcomes above need no such guard:
+        # they already return "absent" whatever their audit does.
+        logger.warning("Kiro identity fingerprint discarded: terminal audit unavailable")
+        return _AUTH_FINGERPRINT_ABSENT
+    return hashlib.sha256("\n".join(sorted(parts)).encode()).hexdigest()
+
+
+def _claim_digest(value: object) -> str:
+    """Hash one claim value so no credential material can leave the reader."""
+
+    raw = value if isinstance(value, bytes) else str(value).encode("utf-8", "replace")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _identity_claims(key: str, value: object) -> list[str]:
+    """Return hashed STABLE claims from one ``auth_kv`` blob.
+
+    Anything that is not a JSON object contributes nothing: the row's key name is
+    already recorded by the caller, and guessing at an opaque value risks pulling
+    in a rotating one. Fields outside :data:`_IDENTITY_CLAIM_FIELDS` are skipped
+    whatever their name.
+    """
+
+    try:
+        blob = json.loads(value if isinstance(value, (str, bytes)) else str(value))
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return []
+    if not isinstance(blob, dict):
+        return []
+    claims: list[str] = []
+    for claim in sorted(_IDENTITY_CLAIM_FIELDS):
+        if claim not in blob:
+            continue
+        raw = blob[claim]
+        # Lists (``scopes``) are order-normalized so a reordered grant of the same
+        # scopes is not mistaken for a different account.
+        if isinstance(raw, list):
+            rendered = ",".join(sorted(str(item) for item in raw))
+        else:
+            rendered = str(raw)
+        claims.append(f"c:{key}:{claim}={_claim_digest(rendered)}")
+    return claims
 
 
 def _auth_store_mappings(
@@ -1669,6 +1904,22 @@ class KiroPrerequisiteService:
         self._last_probe_at = 0.0
         self._has_probed = False
         self._viable_binary = ""
+        # Which account the store named when the latch was last written.
+        # Comparing it against a fresh read is how an out-of-band `kiro-cli
+        # logout` (or a switch to another account) is noticed at all: nothing
+        # else on the host reports it, and the store's mtime is useless because
+        # ordinary chat traffic rewrites the database every few seconds.
+        self._probe_identity = _AUTH_FINGERPRINT_ABSENT
+        # The retirement consumer's own baseline: which account the RUNNING
+        # children were started under. Separate from _probe_identity because two
+        # consumers sharing one baseline means the first to observe a change
+        # advances it and the second never sees it (see
+        # identity_changed_since_sessions). None = never reconciled, which reports
+        # CHANGED: an unknown baseline must not resolve to "the children match".
+        self._session_identity: str | None = None
+        # Real-time cache bounding the store reads and their SEL audit events.
+        self._identity_cache = _AUTH_FINGERPRINT_ABSENT
+        self._identity_cache_at = 0.0
 
     @property
     def initial_setup_complete(self) -> bool:
@@ -1941,6 +2192,16 @@ class KiroPrerequisiteService:
             # Nothing has resolved yet (warm-up still pending or it failed).
             # One probe here is the boot probe, just arriving late.
             await self._probe()
+        elif await self.identity_changed_since_probe():
+            # The store now names a different account (or none) than the latch
+            # describes. This is the one condition under which an ORDINARY poll
+            # re-probes: without it the card keeps reporting the account the user
+            # signed out of until they happen to press Check again, and reports
+            # "not signed in" after a terminal sign-in for just as long. It stays
+            # cheap because the trigger is a local read, not a spawn, and it
+            # cannot loop -- the probe stamps the new identity, so the next poll
+            # compares equal.
+            await self._probe(force=True)
         result = await self._agent_spec_overlay(self._snapshot_dict())
 
         # The repair arm deliberately does NOT live here. This is an ``add_get``
@@ -1974,6 +2235,120 @@ class KiroPrerequisiteService:
         # than being served by the short cache off this synthetic transition.
         self._last_probe_at = 0.0
         logger.info("Kiro readiness latched to signed-out after an ACP auth failure")
+
+    async def current_identity_fingerprint(self, *, allow_cached: bool = True) -> str:
+        """Return the store's current identity fingerprint.
+
+        Off-loop: a read-only SQLite open plus a couple of small queries.
+
+        ``allow_cached`` decides whether a value read within
+        :data:`_AUTH_FINGERPRINT_CACHE_SECS` may be reused. The cache exists for
+        ONE caller -- the status surface, which N dashboard tabs poll every few
+        seconds, so without it a poll storm becomes one SQLite read and one SEL
+        audit event per tab per poll.
+
+        Anything ACTING on the answer passes ``allow_cached=False``. A cached
+        value is by definition up to a few seconds old, and a logout inside that
+        window would otherwise be invisible to the turn that follows it -- the
+        stale child would take the turn under the account just signed out. Turns
+        and probes are human-paced, so reading fresh for them costs nothing worth
+        having.
+
+        What this replaces either way is the expensive signal: a ``whoami`` spawn,
+        which is what the boot-only probe exists to keep off the send path.
+        """
+
+        now = time.monotonic()
+        if (
+            allow_cached
+            and self._identity_cache_at
+            and now - self._identity_cache_at < _AUTH_FINGERPRINT_CACHE_SECS
+        ):
+            return self._identity_cache
+        if identity_store_is_relocated(self._platform, self._home, self._environ):
+            # Do not read the default path: with the CLI pointed elsewhere, a
+            # leftover database there would fingerprint an account nobody is signed
+            # into, and a logout in the real store would change nothing we can see.
+            # Absent is never reconciled, so this re-sweeps every turn instead of
+            # trusting a stale file.
+            self._identity_cache = _AUTH_FINGERPRINT_ABSENT
+            self._identity_cache_at = now
+            return _AUTH_FINGERPRINT_ABSENT
+        path = kiro_identity_store_path(self._platform, self._home, self._environ)
+        try:
+            fingerprint = await asyncio.to_thread(identity_fingerprint, path)
+        except Exception:
+            # An unreadable store reports "no identity", matching
+            # identity_fingerprint's own contract, rather than "unchanged" --
+            # guessing "unchanged" is what keeps a stale account alive.
+            logger.warning("Kiro identity fingerprint could not be read", exc_info=True)
+            fingerprint = _AUTH_FINGERPRINT_ABSENT
+        self._identity_cache = fingerprint
+        self._identity_cache_at = now
+        return fingerprint
+
+    async def identity_changed_since_probe(self) -> bool:
+        """Whether the signed-in account differs from the one the LATCH describes.
+
+        The status surface's consumer. Advancing this baseline is
+        :meth:`_stamp_probe`'s business, so it must never be used to decide
+        whether a running child is stale -- see
+        :meth:`identity_changed_since_sessions` for why.
+
+        False while ``assume_ready`` holds (a test or offline gateway asserts its
+        own readiness and has no store to compare against) and false before the
+        first probe, when there is no recorded identity to differ from.
+        """
+
+        if self._assume_ready or not self._has_probed:
+            return False
+        return await self.current_identity_fingerprint() != self._probe_identity
+
+    async def identity_changed_since_sessions(self) -> tuple[bool, str]:
+        """Whether running children predate the account the store now names.
+
+        Returns ``(changed, live_fingerprint)``.
+
+        This tracks a SEPARATE baseline from :meth:`identity_changed_since_probe`
+        on purpose. One shared baseline has two consumers -- the status card and
+        session retirement -- and whichever observes the change first advances it,
+        so the other never sees it. In practice the dashboard polls status every
+        few seconds while turns are minutes apart, so a single baseline means the
+        poll re-probes, stamps the new identity, and the stale child is then never
+        retired: the cheap half silently consumes the signal the consequential
+        half exists to act on. A baseline per consumer removes the coupling.
+
+        An UNSET baseline reports changed. It means we do not know which account
+        the running children loaded, and "do not know" must not resolve to "they
+        match": readiness is probed a few seconds AFTER boot while a session can be
+        spawned eagerly before that, so a logout landing in the gap would otherwise
+        be recorded as the starting point and the pre-logout child would keep
+        answering as the previous account. Sweeping once when the baseline is unset
+        costs one cold start per gateway lifetime -- the conversation is restored
+        from disk -- and it is the only answer that cannot be silently wrong.
+
+        The baseline is therefore advanced ONLY by
+        :meth:`note_sessions_reconciled`, after a sweep that actually completed.
+        """
+
+        if self._assume_ready:
+            return (False, _AUTH_FINGERPRINT_ABSENT)
+        # Never cached: this answer decides whether a running child may take the
+        # next turn, and a value a few seconds old would let a logout inside that
+        # window pass unnoticed.
+        live = await self.current_identity_fingerprint(allow_cached=False)
+        if self._session_identity is None:
+            return (True, live)
+        return (live != self._session_identity, live)
+
+    def note_sessions_reconciled(self, fingerprint: str) -> None:
+        """Record that running children now match *fingerprint*.
+
+        Advanced ONLY by the retirement path, so no other consumer can retire
+        this baseline's signal on its behalf.
+        """
+
+        self._session_identity = fingerprint
 
     async def verified_ready(self, *, max_age_secs: float) -> bool:
         """Return readiness backed by a probe no older than *max_age_secs*.
@@ -2024,8 +2399,40 @@ class KiroPrerequisiteService:
 
         return bool(self._status.ready)
 
+    def _stamp_probe(self, identity: str) -> None:
+        """Record that the latch was just written, and for which account.
+
+        Every latch write in :meth:`_probe` goes through here so none can record
+        a verdict without the identity it belongs to -- a latch stamped with no
+        identity would read as "account changed" on the very next comparison and
+        retire healthy sessions forever.
+
+        Deliberately does NOT touch the retirement baseline. Seeding it here would
+        look like it anchors that baseline to the identity the running children
+        loaded, but the probe is delayed a few seconds after boot and a session can
+        be spawned eagerly before it, so a logout in that gap would be seeded as the
+        starting point and the pre-logout child would never be retired. That
+        baseline is advanced only by :meth:`note_sessions_reconciled`, after a
+        sweep -- and an unset one reports changed rather than assuming a match.
+        """
+
+        self._last_probe_at = self._clock()
+        self._has_probed = True
+        self._probe_identity = identity
+
     async def _probe(self, *, force: bool = False) -> PrerequisiteStatus:
         async with self._probe_lock:
+            # Read the identity BEFORE running whoami, and stamp that value on
+            # whatever verdict this probe reaches. The order matters: if the store
+            # changes between this read and whoami, the latch records the OLDER
+            # identity, so the next comparison sees a change and re-probes -- one
+            # wasted probe. Reading afterwards would stamp the NEW identity onto a
+            # verdict describing the OLD one, which hides the change instead.
+            probe_identity = (
+                _AUTH_FINGERPRINT_ABSENT
+                if self._assume_ready
+                else await self.current_identity_fingerprint(allow_cached=False)
+            )
             if self._assume_ready:
                 self._status = PrerequisiteStatus(
                     platform=_platform_label(self._platform),
@@ -2034,8 +2441,7 @@ class KiroPrerequisiteService:
                     ready=True,
                     initial_setup_complete=True,
                 )
-                self._last_probe_at = self._clock()
-                self._has_probed = True
+                self._stamp_probe(probe_identity)
                 return self._status
             now = self._clock()
             if self._has_probed and not force and now - self._last_probe_at < _PROBE_CACHE_SECS:
@@ -2119,8 +2525,7 @@ class KiroPrerequisiteService:
                         sandbox_detail=detail,
                         sandbox_remedy=remedy,
                     )
-                    self._last_probe_at = self._clock()
-                    self._has_probed = True
+                    self._stamp_probe(probe_identity)
                     return self._status
                 if (
                     version_probe is not None
@@ -2188,8 +2593,7 @@ class KiroPrerequisiteService:
                     platform=_platform_label(self._platform),
                     initial_setup_complete=self._initial_setup_complete,
                 )
-                self._last_probe_at = self._clock()
-                self._has_probed = True
+                self._stamp_probe(probe_identity)
                 return self._status
 
             # A viable binary answered ``--version``, so it can be signed into
@@ -2233,8 +2637,7 @@ class KiroPrerequisiteService:
                 rejected_agent_specs=rejected,
                 agent_spec_rejection_detail=rejection_detail,
             )
-            self._last_probe_at = self._clock()
-            self._has_probed = True
+            self._stamp_probe(probe_identity)
             return self._status
 
     async def _probe_spec_acceptance(self, executable: str) -> tuple[list[str], str]:

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -27,6 +27,7 @@ from kiro_crew.acp.types import (
     ACP_BACKEND_KAS,
     ACP_BACKEND_KIRO,
     ACP_BACKENDS_ACP_RUNTIME,
+    ACP_BACKENDS_KIRO_IDENTITY_STORE,
     ACP_BACKENDS_KNOWN,
     ACP_BACKENDS_SESSION_SHARING,
     EVENT_COMPACTION_STATUS,
@@ -487,6 +488,18 @@ class AcpProvider(LLMProvider):
         until someone adds it deliberately.
         """
         return self._client.backend in ACP_BACKENDS_SESSION_SHARING
+
+    @property
+    def uses_kiro_identity_store(self) -> bool:
+        """True when this provider's child signs in from kiro-cli's own store.
+
+        Membership in ``ACP_BACKENDS_KIRO_IDENTITY_STORE`` (harness-parity
+        H5/H14). Declaring it here is what lets the session layer ask the
+        question through the ABC instead of probing private attributes, so an
+        adapted provider is classified by its own declaration rather than by
+        whichever internal shape it happens to expose.
+        """
+        return self._client.backend in ACP_BACKENDS_KIRO_IDENTITY_STORE
 
     async def _start_kiro_runtime(self) -> None:
         """Spawn an AcpRuntime + session; time the kiro cold-start split.

--- a/src/kiro_crew/providers/base.py
+++ b/src/kiro_crew/providers/base.py
@@ -263,6 +263,19 @@ class LLMProvider(ABC):
         process. Default False — session sharing is opt-in, never inherited."""
         return False
 
+    @property
+    def uses_kiro_identity_store(self) -> bool:
+        """True when this provider's child authenticates from kiro-cli's own
+        identity store, so an external ``kiro-cli logout`` invalidates a process
+        that is already running and it must be retired.
+
+        Default False — a provider authenticated some other way must not be
+        recycled on a store it never reads, and a harness that has not stated
+        that it reads that store does not inherit the claim (harness-parity
+        H5/H14). Declared here rather than probed off the instance so the session
+        layer never has to guess from private attributes."""
+        return False
+
     def available_models(self) -> list[dict[str, str]]:
         """Backend-advertised models (``[{modelId, name, ...}]``) for the model
         picker. Default empty for a provider that advertises none."""

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -224,6 +224,23 @@ def _provider_effectively_alive(provider: Any) -> bool:
     return alive
 
 
+def _provider_uses_kiro_identity_store(provider: Any) -> bool:
+    """Whether *provider*'s child authenticates from kiro-cli's identity store.
+
+    Reads the capability the object DECLARES (harness-parity H14) rather than
+    probing private attributes: ``LLMProvider`` declares it with a safe default of
+    False, ``AcpProvider`` / ``AcpSessionProvider`` grant it by membership in
+    ``ACP_BACKENDS_KIRO_IDENTITY_STORE``, and ``AcpRuntime`` declares the same
+    property under the same name because the sweep reaches shared runtimes too.
+
+    Fails CLOSED on anything that does not declare it -- a test double or a future
+    holder is left running rather than recycled on a store it may never read.
+    """
+
+    declared = getattr(provider, "uses_kiro_identity_store", False)
+    return declared is True
+
+
 def detect_provider_switch(session_map: "SessionMap", session_key: str, new_provider: str) -> bool:
     """Detect if the provider for a session differs from the stored one.
 
@@ -344,7 +361,11 @@ _STATELESS_PREFIXES = (
 # agent without forcing other background callers (chat-title, consolidator,
 # taskkeeper) to load the same MCP servers.
 BACKGROUND_KEY = "_bg"
-
+# Concurrent cold starts allowed by ``_start_sem``. Named rather than inline so the
+# identity sweep can ask how many starts are in flight (see
+# ``_cold_starts_in_flight``): a provider inside ``start()`` has not published a PID
+# yet, so the semaphore is the only evidence it exists.
+_MAX_CONCURRENT_COLD_STARTS = 4
 # Kiro agent the background session runs as. Named once because it is needed in
 # TWO places — the provider factory call AND the ``_Session`` record — and when
 # only the factory got it, ``_Session.agent`` stayed at its "" default, so every
@@ -664,6 +685,13 @@ class _Session:
     # real claimant under the per-session semaphore; a speculative claimant
     # reads without consuming.
     resumed_armed: bool = False
+    # Set when an identity sweep found this session BUSY and therefore left its
+    # in-flight turn alone. The child is authenticated as an account that is no
+    # longer signed in, so the NEXT turn on this key must not reuse it: the
+    # post-semaphore re-validate reads this and reports the session invalid, and
+    # the caller's existing stale-provider path evicts it and cold starts. Default
+    # False so every existing construction site is unaffected.
+    retire_on_identity_change: bool = False
     prompt_count: int = 0
     consecutive_failures: int = 0
     # Bounded rather than plain: a release() call that lands on this object
@@ -891,7 +919,18 @@ class SessionManager:
         # snapshot can't slip in and later get killed mid-turn with its native
         # session lock held (Codex HIGH: drain-window race).
         self._closing = False
-        self._start_sem = asyncio.Semaphore(4)  # max 4 concurrent cold-starts
+        self._start_sem = asyncio.Semaphore(_MAX_CONCURRENT_COLD_STARTS)
+        # Serializes identity sweeps. Without it two sweeps drain `_start_sem` one
+        # permit at a time and can hold-and-wait deadlock: with a warm-pool fill or
+        # eager spawn holding one permit, sweep A can hold 3 waiting for its 4th
+        # while sweep B holds 1 waiting for its 2nd -- all four taken, none free, and
+        # neither releases until it reaches four. The releases live in a `finally`
+        # that never runs because the acquisition loop itself never returns, and the
+        # wait is deliberately un-timed, so both turns hang forever AND every later
+        # cold start blocks on a permanently drained semaphore. Two concurrent
+        # sweeps are not exotic: at boot `_session_identity` is None, so every
+        # in-flight turn sees a change at once.
+        self._identity_sweep_lock = asyncio.Lock()
         self._cleanup_task: asyncio.Task | None = None
         self._compacting: set[str] = set()
         # key -> the EXACT _Session object being torn down by the recycle
@@ -1474,8 +1513,17 @@ class SessionManager:
         await sess.semaphore.acquire()
         try:
             async with self._lock:
-                still_valid = self._sessions.get(key) is sess and _provider_effectively_alive(
-                    sess.provider
+                still_valid = (
+                    self._sessions.get(key) is sess
+                    # Marked when an identity sweep found this session BUSY: its
+                    # in-flight turn was allowed to finish, but the child is
+                    # authenticated as an account that is no longer signed in, so
+                    # this turn must not reuse it. Reported invalid here rather
+                    # than blocked or refused: the caller already knows how to
+                    # evict and cold start on a stale provider, so the turn simply
+                    # proceeds on a fresh child of the CURRENT account.
+                    and not sess.retire_on_identity_change
+                    and _provider_effectively_alive(sess.provider)
                 )
         except BaseException:
             # Cancelled (or errored) while awaiting self._lock AFTER acquiring the
@@ -3716,6 +3764,291 @@ class SessionManager:
             # runtime lives only in _subagent_runtimes and would otherwise leak.
             await self.release_subagent_runtime(key)
             logger.info("Removed session (map preserved): %s", key)
+
+    async def retire_kiro_identity_sessions(self) -> tuple[list[str], bool]:
+        """Retire every idle kiro-backed child so the next turn re-authenticates.
+
+        Called when kiro-cli's identity store starts naming a different account
+        than the running children loaded. Those children hold their credential in
+        memory and never re-read the store, so without this they keep answering
+        under the signed-out account until the gateway exits.
+
+        Returns ``(retired_keys, complete)``. ``complete`` is False when something
+        eligible was deliberately left running -- a BUSY session, a runtime hosting
+        active sessions, a child that would not shut down, or a provider still
+        between ``start()`` and registration. The caller must not record the
+        account change as reconciled unless it is True: advancing the baseline over
+        anything unswept would mean its next turn sees no change and reuses the
+        previous account, which is the entire defect this exists to prevent.
+
+        Covers FIVE holders. The session map is the obvious one; the others are
+        each independently sufficient to keep the old account alive:
+
+        * ``_warm_pool`` -- spawned before the change and handed to a BRAND-NEW
+          session afterwards, so that session runs as the old account despite
+          never having existed under it. Drained under ``_pool_fill_lock`` so a
+          fill already in flight cannot land a just-spawned child into a queue we
+          have already swept.
+        * ``_subagent_runtimes`` -- separate processes the session sweep cannot
+          reach.
+        * ``_bg_runtime`` -- one shared process serving background work, retired
+          under its own lock.
+        * companion runtimes keyed by a retired session, via
+          ``release_subagent_runtime``.
+
+        Registered sessions are retired with the same bookkeeping as
+        :meth:`remove`, so the session map is PRESERVED: the next turn cold starts
+        a fresh child and ``session/load`` restores the conversation from disk
+        losslessly. Retiring is a process recycle, not data loss.
+
+        A BUSY session is skipped rather than killed: its turn started under the
+        old account and killing it mid-stream would surface as an unexplained
+        failure. It is retired by the next turn's check, and ``complete=False``
+        keeps the change pending until then.
+        """
+
+        doomed: list[tuple[str, LLMProvider]] = []
+        skipped = False
+        # ONE sweep at a time. Draining `_start_sem` a permit at a time is only safe
+        # if no peer is doing the same: see `_identity_sweep_lock` for the
+        # hold-and-wait deadlock two concurrent sweeps would otherwise reach. A
+        # second sweep serializes behind this and then finds nothing left to retire,
+        # which is a cheap no-op -- and reconciling the same fingerprint twice is
+        # idempotent, so correctness does not depend on it bailing out early.
+        async with self._identity_sweep_lock:
+            # BARRIER FIRST, then scan. Checking for in-flight starts AFTER the scan
+            # cannot close the window: a cold start that began before the account
+            # changed and registers DURING the scan is missed by the session sweep (it
+            # was not there when we looked) and by any after-the-fact check (it is no
+            # longer starting). Nor can marking help, the way it does for a busy
+            # session -- at sweep time there is no session yet to mark.
+            #
+            # So every cold-start permit is acquired by WAITING. A partial barrier is
+            # not enough: reporting "incomplete" defers the baseline but does not stop
+            # THIS turn, so an eager session spawned under the previous account would
+            # still win registration and serve it. Waiting makes the scan
+            # authoritative -- anything that finished is registered, anything that has
+            # not cannot start.
+            #
+            # Waited WITHOUT a timeout on purpose. Cancelling an `acquire()` can lose a
+            # permit on some Python versions, permanently shrinking cold-start
+            # concurrency for the whole process -- a worse and far more confusing
+            # failure than waiting. The wait is bounded by OTHER sessions' cold starts,
+            # which carry their own timeouts, and never by this turn's own: its
+            # `get_or_create` runs after this returns and the permits are released.
+            held = 0
+            try:
+                for _ in range(_MAX_CONCURRENT_COLD_STARTS):
+                    await self._start_sem.acquire()
+                    held += 1
+                async with self._lock:
+                    # Select AND unregister in ONE lock hold. Choosing under the lock and
+                    # removing after an await would let a session picked as idle acquire a
+                    # turn in between, and the removal would then shut down a provider
+                    # mid-stream. Popping here is safe against a turn that is only
+                    # part-way through acquiring: the post-semaphore re-validate re-reads
+                    # _sessions under this same lock, sees the entry gone, releases and
+                    # cold-starts a replacement -- the designed stale path.
+                    for key in list(self._sessions):
+                        sess = self._sessions[key]
+                        if not _provider_uses_kiro_identity_store(sess.provider):
+                            continue
+                        if sess.semaphore.locked():
+                            # Its turn started under the old account and killing it
+                            # mid-stream would surface as an unexplained failure, so it
+                            # finishes. Marking it means the NEXT turn on this key does
+                            # not reuse it either -- without the mark, `get_or_create`
+                            # would simply wait for this turn's semaphore and hand the
+                            # same old-account provider to the next one.
+                            sess.retire_on_identity_change = True
+                            skipped = True
+                            continue
+                        del self._sessions[key]
+                        self._compact_cooldown_until.pop(key, None)
+                        self._origin_links.pop(key, None)
+                        doomed.append((key, sess.provider))
+            finally:
+                for _ in range(held):
+                    self._start_sem.release()
+
+        retired: list[str] = []
+        for key, provider in doomed:
+            try:
+                await provider.shutdown()
+                # Mirrors remove(): a companion subagent runtime keyed by this
+                # parent lives only in _subagent_runtimes and would otherwise leak.
+                await self.release_subagent_runtime(key)
+                retired.append(key)
+            except Exception:
+                logger.warning(
+                    "Failed to retire session %s after an identity change", key, exc_info=True
+                )
+                # A child we could not shut down may still be alive under the old
+                # account, so the change is not fully applied.
+                skipped = True
+
+        if not await self._retire_kiro_warm_pool():
+            skipped = True
+        if not await self._retire_kiro_subagent_runtimes():
+            skipped = True
+        if not await self._retire_kiro_bg_runtime():
+            skipped = True
+        if self._starting_pids:
+            # Belt-and-braces behind the barrier above: with every cold-start permit
+            # held during the scan, a PID here means something published one without
+            # going through `_start_sem`. Cheap, and fails toward re-sweeping.
+            skipped = True
+        return retired, not skipped
+
+    async def _retire_kiro_warm_pool(self) -> bool:
+        """Discard pre-spawned kiro-backed providers waiting in the warm pool.
+
+        They authenticated when they were spawned, so handing one to a session
+        created after an account change would run that session as the previous
+        account.
+
+        Held under ``_pool_fill_lock`` for the whole drain: a fill already in
+        flight has its spawn outstanding and would otherwise enqueue that child
+        AFTER the sweep read an empty queue, leaving a provider authenticated as
+        the old account waiting to be claimed. Taking the fill lock makes the
+        sweep and any fill mutually exclusive, so the queue cannot grow behind us.
+
+        Returns True when the pool is known to hold no kiro-backed provider.
+        Discarded PIDs are recorded in ``_pool_sweep_pids`` exactly as the health
+        sweep does, so the orphan sweep does not also chase them.
+        """
+
+        keep: list[tuple[LLMProvider, float]] = []
+        drop: list[LLMProvider] = []
+        complete = True
+        async with self._pool_fill_lock:
+            for _ in range(self._warm_pool.qsize()):
+                try:
+                    provider, spawn_time = self._warm_pool.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if _provider_uses_kiro_identity_store(provider):
+                    pid = getattr(getattr(provider, "client", None), "_pid", None)
+                    if isinstance(pid, int):
+                        self._pool_sweep_pids.add(pid)
+                    drop.append(provider)
+                else:
+                    keep.append((provider, spawn_time))
+            for entry in keep:
+                self._warm_pool.put_nowait(entry)
+            for provider in drop:
+                try:
+                    await provider.shutdown()
+                except Exception:
+                    logger.warning(
+                        "Failed to discard a pooled provider after an identity change",
+                        exc_info=True,
+                    )
+                    complete = False
+        if drop:
+            logger.info(
+                "Discarded %d pooled provider(s) started under the previous account", len(drop)
+            )
+        return complete
+
+    async def _retire_kiro_subagent_runtimes(self) -> bool:
+        """Kill idle kiro-backed companion subagent runtimes started under the old account.
+
+        They are separate processes held only in ``_subagent_runtimes``, so the
+        session sweep never reaches them; a subagent dispatched afterwards would
+        run as the previous account.
+
+        A runtime with sessions registered on it is SKIPPED, for the same reason a
+        busy session is: killing it drops a co-tenant's in-flight prompt and
+        surfaces as ``AcpRuntimeDead`` on work the user never connected to an
+        account change. The sweep reports incomplete so the change stays pending
+        and the runtime is retired once it drains.
+
+        A spawn already IN FLIGHT is likewise reported incomplete.
+        ``get_subagent_runtime`` holds the per-parent entry in
+        ``_subagent_runtime_locks`` across its spawn, so a runtime being created
+        right now is in neither the map scanned here nor anywhere else, while it
+        already holds whatever the store said when it started. Deferring is the
+        resolution rather than sweeping under those locks:
+        ``release_subagent_runtime`` acquires the same lock, so holding it here and
+        releasing through that path would deadlock on a non-reentrant
+        ``asyncio.Lock``. The next turn re-sweeps and catches it once installed.
+
+        Returns True when no kiro-backed companion runtime remains.
+        """
+
+        complete = True
+        for parent_key in list(self._subagent_runtimes):
+            runtime = self._subagent_runtimes.get(parent_key)
+            if runtime is None or not _provider_uses_kiro_identity_store(runtime):
+                continue
+            if runtime.has_active_or_initializing_sessions():
+                complete = False
+                continue
+            try:
+                await self.release_subagent_runtime(parent_key)
+            except Exception:
+                logger.warning(
+                    "Failed to retire subagent runtime for %s after an identity change",
+                    parent_key,
+                    exc_info=True,
+                )
+                complete = False
+        if any(lock.locked() for lock in self._subagent_runtime_locks.values()):
+            complete = False
+        # POST-CONDITION, not another window enumeration. The loop above works from
+        # a snapshot and the lock check runs after it, so a spawn that COMPLETES in
+        # between is in neither: its lock is already released and its runtime was
+        # not in the snapshot. Asserting instead that NO kiro-backed runtime is left
+        # catches anything installed while we swept, whatever the timing, and also
+        # covers the ones deliberately spared above.
+        if any(
+            runtime is not None and _provider_uses_kiro_identity_store(runtime)
+            for runtime in list(self._subagent_runtimes.values())
+        ):
+            complete = False
+        return complete
+
+    async def _retire_kiro_bg_runtime(self) -> bool:
+        """Retire the shared background runtime if it is idle and kiro-backed.
+
+        One process serves all background work, so it is not reachable from the
+        session map and outlives any single session. Left alive, later background
+        calls keep running as the previous account. Its creation is serialized by
+        ``_bg_runtime_lock``, so retirement takes the same lock -- otherwise a
+        lazy creation racing this sweep could install a runtime we have just
+        decided to discard, or be discarded midway through being installed.
+
+        Skipped while sessions are registered on it: this one process is shared by
+        every background caller, so killing it mid-flight drops work belonging to
+        callers unrelated to the account change.
+
+        Needs no "did one appear while we swept" post-condition of the kind the
+        companion-runtime sweep carries: creation of this runtime is serialized by
+        the same ``_bg_runtime_lock`` held here, so none can be installed during it.
+
+        Returns True when no kiro-backed background runtime remains.
+        """
+
+        async with self._bg_runtime_lock:
+            runtime = self._bg_runtime
+            if runtime is None or not _provider_uses_kiro_identity_store(runtime):
+                return True
+            if runtime.has_active_or_initializing_sessions():
+                return False
+            try:
+                await runtime.kill()
+            except Exception:
+                logger.warning(
+                    "Failed to retire the background runtime after an identity change",
+                    exc_info=True,
+                )
+                return False
+            # Cleared only after a successful kill, so a failure leaves the
+            # reference in place rather than orphaning a live process.
+            self._bg_runtime = None
+            logger.info("Retired the background runtime started under the previous account")
+            return True
 
     async def remove_if_unclaimed(self, key: str) -> bool:
         """Remove *key* only if its speculative session is still unclaimed.

--- a/test/test_external_logout_detection.py
+++ b/test/test_external_logout_detection.py
@@ -1,0 +1,1519 @@
+"""External kiro-cli logout / account switch must invalidate running state.
+
+Covers the three properties that together let a signed-out account keep
+answering: the fingerprint must ignore token rotation, an ordinary status poll
+must re-probe when the account changes, and a turn must retire the children that
+still hold the old credential.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import kiro_prerequisite as kp
+from kiro_crew.session import _MAX_CONCURRENT_COLD_STARTS as _MAX_COLD_STARTS_FOR_TEST
+
+
+def _write_store(
+    path: Path,
+    *,
+    token_value: str = "access-token-v1",
+    start_url: str = "https://company.awsapps.com/start",
+    profile: str = "arn:aws:codewhisperer:us-east-1:1111:profile/COMPANY",
+    auth_keys: tuple[str, ...] = ("kirocli:odic:device-registration", "kirocli:odic:token"),
+    client_id: str = "client-registration-aaa",
+    region: str = "us-east-1",
+    state_rows: bool = True,
+) -> None:
+    """Write a minimal store shaped like kiro-cli's real one.
+
+    ``state_rows=False`` models a Builder ID login: no Identity Center marker rows
+    and no CodeWhisperer profile, so the identity has to come from the credential
+    blob's stable claims instead.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(path))
+    with con:
+        con.execute("CREATE TABLE IF NOT EXISTS auth_kv (key TEXT PRIMARY KEY, value TEXT)")
+        con.execute("CREATE TABLE IF NOT EXISTS state (key TEXT PRIMARY KEY, value TEXT)")
+        con.execute("DELETE FROM auth_kv")
+        con.execute("DELETE FROM state")
+        for key in auth_keys:
+            if key.endswith(":device-registration"):
+                blob = {
+                    "client_id": client_id,
+                    "client_secret": "SECRET-must-never-be-fingerprinted",
+                    "client_secret_expires_at": "2099-01-01T00:00:00Z",
+                    "oauth_flow": "device_code",
+                    "region": region,
+                    "scopes": ["codewhisperer:completions", "codewhisperer:analysis"],
+                }
+            else:
+                blob = {
+                    "access_token": token_value,
+                    "refresh_token": f"refresh-of-{token_value}",
+                    "expires_at": "2099-01-01T00:00:00Z",
+                    "oauth_flow": "device_code",
+                    "region": region,
+                    "scopes": ["codewhisperer:completions", "codewhisperer:analysis"],
+                    "start_url": start_url,
+                }
+            con.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", (key, json.dumps(blob)))
+        if state_rows:
+            con.execute(
+                "INSERT INTO state (key, value) VALUES (?, ?)", ("auth.idc.start-url", start_url)
+            )
+            con.execute("INSERT INTO state (key, value) VALUES (?, ?)", ("auth.idc.region", region))
+            con.execute(
+                "INSERT INTO state (key, value) VALUES (?, ?)",
+                ("api.codewhisperer.profile", profile),
+            )
+        # Unrelated local state must not participate in the fingerprint.
+        con.execute("INSERT INTO state (key, value) VALUES (?, ?)", ("telemetry.client-id", "abc"))
+    con.close()
+
+
+def _expire_identity_cache(service: "kp.KiroPrerequisiteService") -> None:
+    """Drop the reader's real-time cache.
+
+    The fingerprint is cached for a few seconds so a dashboard poll storm cannot
+    turn into one SQLite read and one SEL audit event per poll. A test that
+    rewrites the store and immediately re-reads is outside that design, so it
+    expires the cache explicitly rather than sleeping.
+    """
+
+    service._identity_cache_at = 0.0
+
+
+class TestIdentityFingerprint:
+    def test_token_rotation_does_not_change_the_fingerprint(self, tmp_path: Path) -> None:
+        """A refresh replaces the token value; the account has not changed.
+
+        This is the property that makes the check safe to run on the turn path.
+        If the token value were an input, every refresh would read as an account
+        change and retire healthy sessions roughly hourly.
+        """
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(db, token_value="access-token-v1")
+        before = kp.identity_fingerprint(db)
+        _write_store(db, token_value="a-completely-different-token-v2")
+        assert kp.identity_fingerprint(db) == before
+        assert before != ""
+
+    def test_unrelated_local_state_does_not_change_the_fingerprint(self, tmp_path: Path) -> None:
+        db = tmp_path / "data.sqlite3"
+        _write_store(db)
+        before = kp.identity_fingerprint(db)
+        con = sqlite3.connect(str(db))
+        with con:
+            con.execute("UPDATE state SET value='zzz' WHERE key='telemetry.client-id'")
+        con.close()
+        assert kp.identity_fingerprint(db) == before
+
+    def test_account_switch_changes_the_fingerprint(self, tmp_path: Path) -> None:
+        db = tmp_path / "data.sqlite3"
+        _write_store(db)
+        company = kp.identity_fingerprint(db)
+        _write_store(
+            db,
+            start_url="https://personal.awsapps.com/start",
+            profile="arn:aws:codewhisperer:us-east-1:2222:profile/PERSONAL",
+        )
+        assert kp.identity_fingerprint(db) != company
+
+    def test_auth_kind_switch_changes_the_fingerprint(self, tmp_path: Path) -> None:
+        """Same state rows, different credential kind, is still a different login."""
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(db, auth_keys=("kirocli:odic:token",))
+        odic = kp.identity_fingerprint(db)
+        _write_store(db, auth_keys=("kirocli:social:token",))
+        assert kp.identity_fingerprint(db) != odic
+
+    def test_logout_reads_as_absent(self, tmp_path: Path) -> None:
+        db = tmp_path / "data.sqlite3"
+        _write_store(db)
+        assert kp.identity_fingerprint(db) != ""
+        con = sqlite3.connect(str(db))
+        with con:
+            con.execute("DELETE FROM auth_kv")
+            con.execute("DELETE FROM state")
+        con.close()
+        assert kp.identity_fingerprint(db) == ""
+
+    def test_missing_and_symlinked_stores_read_as_absent(self, tmp_path: Path) -> None:
+        assert kp.identity_fingerprint(tmp_path / "nope.sqlite3") == ""
+        real = tmp_path / "real.sqlite3"
+        _write_store(real)
+        link = tmp_path / "link.sqlite3"
+        link.symlink_to(real)
+        # A symlink could redirect the read; the sanctioned reader refuses it.
+        assert kp.identity_fingerprint(link) == ""
+
+    def test_a_claimless_row_contributes_nothing(self, tmp_path: Path) -> None:
+        """A social login has no SSO start_url, so its row carries no claim.
+
+        Recording the key NAME alone would make account A and account B under
+        `kirocli:social:token` fingerprint identically, and the child
+        authenticated as A would never be retired. Contributing nothing lets the
+        store come out ABSENT, which is never reconciled and re-sweeps each turn:
+        "cannot distinguish" reported as "cannot confirm", not as "unchanged".
+        """
+
+        db = tmp_path / "data.sqlite3"
+        db.parent.mkdir(parents=True, exist_ok=True)
+        con = sqlite3.connect(str(db))
+        with con:
+            con.execute("CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT)")
+            con.execute("CREATE TABLE state (key TEXT PRIMARY KEY, value TEXT)")
+            # Social token: a rotating access token and nothing identifying.
+            con.execute(
+                "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
+                ("kirocli:social:token", json.dumps({"access_token": "account-A"})),
+            )
+        con.close()
+        assert kp.identity_fingerprint(db) == ""
+
+        con = sqlite3.connect(str(db))
+        with con:
+            con.execute(
+                "UPDATE auth_kv SET value=? WHERE key='kirocli:social:token'",
+                (json.dumps({"access_token": "account-B"}),),
+            )
+        con.close()
+        # Still absent -- and absent is never accepted as a reconciled baseline.
+        assert kp.identity_fingerprint(db) == ""
+
+    def test_a_claimful_row_still_records_its_key(self, tmp_path: Path) -> None:
+        """The skip must not drop rows that DO identify an account."""
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(db, state_rows=False)
+        assert kp.identity_fingerprint(db) != ""
+
+    def test_fingerprint_carries_no_credential_value(self, tmp_path: Path) -> None:
+        db = tmp_path / "data.sqlite3"
+        secret = "super-secret-token-value"
+        _write_store(db, token_value=secret, start_url="https://company.awsapps.com/start")
+        fingerprint = kp.identity_fingerprint(db)
+        assert secret not in fingerprint
+        assert "company.awsapps.com" not in fingerprint
+        assert "SECRET-must-never-be-fingerprinted" not in fingerprint
+
+    def test_a_profile_change_alone_is_detected(self, tmp_path: Path) -> None:
+        """Two Identity Center accounts can share a start_url and registration.
+
+        What separates them is the CodeWhisperer profile ARN in `state`, so those
+        rows carry identity the credential blob does not.
+        """
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(db, profile="arn:aws:codewhisperer:us-east-1:1111:profile/TEAM_A")
+        team_a = kp.identity_fingerprint(db)
+        _write_store(db, profile="arn:aws:codewhisperer:us-east-1:2222:profile/TEAM_B")
+        assert kp.identity_fingerprint(db) != team_a
+
+    def test_a_profile_less_account_switch_is_detected(self, tmp_path: Path) -> None:
+        """Builder ID -> Builder ID: identical key names, no state rows at all.
+
+        With only key names and `state` rows participating, these two logins were
+        indistinguishable and the stale child kept answering as the first account.
+        The stable claims inside the credential blob are what separate them.
+        """
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(
+            db,
+            state_rows=False,
+            start_url="https://view.awsapps.com/start",
+            client_id="registration-for-account-A",
+        )
+        account_a = kp.identity_fingerprint(db)
+        _write_store(
+            db,
+            state_rows=False,
+            start_url="https://view.awsapps.com/start",
+            client_id="registration-for-account-B",
+        )
+        assert kp.identity_fingerprint(db) != account_a
+        assert account_a != ""
+
+    def test_a_start_url_change_alone_is_detected(self, tmp_path: Path) -> None:
+        """Even with no state rows and the same registration."""
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(db, state_rows=False, start_url="https://a.awsapps.com/start")
+        before = kp.identity_fingerprint(db)
+        _write_store(db, state_rows=False, start_url="https://b.awsapps.com/start")
+        assert kp.identity_fingerprint(db) != before
+
+    def test_rotating_blob_fields_do_not_move_the_fingerprint(self, tmp_path: Path) -> None:
+        """access_token, refresh_token and expires_at all rotate on refresh."""
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(db, token_value="v1")
+        before = kp.identity_fingerprint(db)
+        con = sqlite3.connect(str(db))
+        with con:
+            row = con.execute("SELECT value FROM auth_kv WHERE key='kirocli:odic:token'").fetchone()
+            blob = json.loads(row[0])
+            blob["access_token"] = "rotated-access"
+            blob["refresh_token"] = "rotated-refresh"
+            blob["expires_at"] = "2100-06-06T00:00:00Z"
+            con.execute(
+                "UPDATE auth_kv SET value=? WHERE key='kirocli:odic:token'", (json.dumps(blob),)
+            )
+        con.close()
+        assert kp.identity_fingerprint(db) == before
+
+    def test_scope_reordering_is_not_an_account_change(self, tmp_path: Path) -> None:
+        db = tmp_path / "data.sqlite3"
+        _write_store(db)
+        before = kp.identity_fingerprint(db)
+        con = sqlite3.connect(str(db))
+        with con:
+            row = con.execute("SELECT value FROM auth_kv WHERE key='kirocli:odic:token'").fetchone()
+            blob = json.loads(row[0])
+            blob["scopes"] = list(reversed(blob["scopes"]))
+            con.execute(
+                "UPDATE auth_kv SET value=? WHERE key='kirocli:odic:token'", (json.dumps(blob),)
+            )
+        con.close()
+        assert kp.identity_fingerprint(db) == before
+
+    def test_an_unknown_blob_field_never_joins_the_fingerprint(self, tmp_path: Path) -> None:
+        """Allowlist, not denylist: a field a future kiro-cli adds stays out.
+
+        Otherwise a new secret could enter the digest, or a new rotating field
+        could report an account change on every refresh.
+        """
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(db)
+        before = kp.identity_fingerprint(db)
+        con = sqlite3.connect(str(db))
+        with con:
+            row = con.execute("SELECT value FROM auth_kv WHERE key='kirocli:odic:token'").fetchone()
+            blob = json.loads(row[0])
+            blob["some_future_secret"] = "leak-me"
+            blob["some_future_counter"] = "42"
+            con.execute(
+                "UPDATE auth_kv SET value=? WHERE key='kirocli:odic:token'", (json.dumps(blob),)
+            )
+        con.close()
+        assert kp.identity_fingerprint(db) == before
+
+    def test_the_read_is_audited_and_fails_closed(self, tmp_path: Path, monkeypatch) -> None:
+        """This file holds live credential material.
+
+        An unauditable read must return "absent" -- which errs toward retiring the
+        children -- rather than hand back an unaudited answer.
+        """
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(db)
+        assert kp.identity_fingerprint(db) != ""
+
+        calls: list[tuple[str, str]] = []
+
+        def _refuse(read_id: str, outcome: str) -> bool:
+            calls.append((read_id, outcome))
+            return False
+
+        monkeypatch.setattr(kp.hooks, "emit_internal_read_audit", _refuse)
+        assert kp.identity_fingerprint(db) == ""
+        assert calls and calls[0][0] == "kiro_prerequisite.identity_fingerprint"
+
+    def test_the_audit_id_is_registered(self) -> None:
+        """An unregistered id is refused by the hook, which would fail every read."""
+
+        from kiro_crew import hooks
+
+        assert kp._IDENTITY_FINGERPRINT_READ_ID in hooks._AUDIT_ONLY_READ_IDS
+
+    def test_an_unauditable_read_never_opens_the_store(self, tmp_path: Path, monkeypatch) -> None:
+        """The gate is BEFORE the read, not a discard afterwards.
+
+        Discarding after the fact would still have pulled credential material into
+        the process with no audit trail; refusing up front means the file is never
+        opened at all.
+        """
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(db)
+        opened: list[Path] = []
+        real_open = kp._open_identity_db_readonly
+
+        def _tracked(path: Path):
+            opened.append(path)
+            return real_open(path)
+
+        monkeypatch.setattr(kp, "_open_identity_db_readonly", _tracked)
+        monkeypatch.setattr(kp.hooks, "emit_internal_read_audit", lambda *_: False)
+
+        assert kp.identity_fingerprint(db) == ""
+        assert opened == [], "the store was opened despite an unavailable audit"
+
+    def test_a_failed_terminal_audit_discards_the_result(self, tmp_path: Path, monkeypatch) -> None:
+        """The read happened; if its outcome cannot be audited, discard the answer.
+
+        Failing only on the pre-read audit would leave a path where the store was
+        read, the SEL write failed, and unaudited identity data still drove
+        retirement.
+        """
+
+        db = tmp_path / "data.sqlite3"
+        _write_store(db)
+
+        def _fail_only_success(read_id: str, outcome: str) -> bool:
+            return outcome != "success"
+
+        monkeypatch.setattr(kp.hooks, "emit_internal_read_audit", _fail_only_success)
+        assert kp.identity_fingerprint(db) == ""
+
+
+class TestFingerprintCaching:
+    """The cache serves polling only; anything acting on the answer reads fresh."""
+
+    @pytest.mark.asyncio
+    async def test_polling_reuses_a_cached_read(self, tmp_path: Path) -> None:
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+
+        reads: list[int] = []
+        real = kp.identity_fingerprint
+
+        def _counted(path):
+            reads.append(1)
+            return real(path)
+
+        monkeypatched = pytest.MonkeyPatch()
+        monkeypatched.setattr(kp, "identity_fingerprint", _counted)
+        try:
+            await service.current_identity_fingerprint()
+            await service.current_identity_fingerprint()
+            await service.current_identity_fingerprint()
+        finally:
+            monkeypatched.undo()
+
+        assert len(reads) == 1, "a poll storm must collapse onto one read"
+
+    @pytest.mark.asyncio
+    async def test_a_logout_inside_the_cache_window_is_still_detected(self, tmp_path: Path) -> None:
+        """The window GPT identified.
+
+        A fingerprint read seconds earlier, then a logout, then a turn. Serving the
+        cached value would let the child authenticated as the logged-out account
+        take that turn.
+        """
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+
+        # Warm the cache and reconcile, as a status poll plus a first turn would.
+        _, live = await service.identity_changed_since_sessions()
+        service.note_sessions_reconciled(live)
+        await service.current_identity_fingerprint()  # poll, populates the cache
+
+        # Logout, well inside the cache window -- no cache poke here on purpose.
+        con = sqlite3.connect(str(db))
+        with con:
+            con.execute("DELETE FROM auth_kv")
+            con.execute("DELETE FROM state")
+        con.close()
+
+        changed, live_now = await service.identity_changed_since_sessions()
+        assert changed is True, "the cached pre-logout value was served to a turn"
+        assert live_now == ""
+
+
+class TestStorePathSelection:
+    def test_linux_path_is_kiro_cli_not_amazon_q(self, tmp_path: Path) -> None:
+        path = kp.kiro_identity_store_path("linux", tmp_path, {})
+        assert path == tmp_path / ".local" / "share" / "kiro-cli" / "data.sqlite3"
+
+    def test_linux_path_ignores_a_redirected_xdg_data_home(self, tmp_path: Path) -> None:
+        """A redirected data home would land outside the agent-write fence.
+
+        The fence that makes this store unwritable by agent file tools is anchored
+        at the fixed path, so honouring the variable would let an agent author the
+        rows this reader trusts -- forging an identity that keeps matching, so the
+        children signed in as the previous account are never retired.
+        """
+
+        path = kp.kiro_identity_store_path(
+            "linux", tmp_path, {"XDG_DATA_HOME": str(tmp_path / "forged")}
+        )
+        assert "forged" not in str(path)
+        assert path == tmp_path / ".local" / "share" / "kiro-cli" / "data.sqlite3"
+
+    def test_no_platform_consults_the_environment(self, tmp_path: Path) -> None:
+        """Same rule on every platform, so one branch cannot drift from another."""
+
+        hostile = {
+            "XDG_DATA_HOME": str(tmp_path / "forged"),
+            "APPDATA": str(tmp_path / "forged"),
+            "LOCALAPPDATA": str(tmp_path / "forged"),
+            "HOME": str(tmp_path / "forged"),
+        }
+        for platform_name in ("linux", "darwin", "win32"):
+            path = kp.kiro_identity_store_path(platform_name, tmp_path, hostile)
+            assert "forged" not in str(path), platform_name
+            assert str(path).startswith(str(tmp_path)), platform_name
+
+    def test_darwin_path(self, tmp_path: Path) -> None:
+        assert kp.kiro_identity_store_path("darwin", tmp_path, {}) == (
+            tmp_path / "Library" / "Application Support" / "kiro-cli" / "data.sqlite3"
+        )
+
+    def test_windows_reads_roaming_not_local(self, tmp_path: Path) -> None:
+        """The identity lives under Roaming; Local holds no credential.
+
+        Reading Local on Windows would make every fingerprint "absent", so a
+        logout would look identical to a signed-in state and no child would ever
+        be retired there.
+        """
+
+        path = kp.kiro_identity_store_path("win32", tmp_path, {})
+        assert path == tmp_path / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        # Anchor on the tail BELOW the home we passed, never on global parts: on
+        # Windows CI tmp_path itself lives under AppData\Local\Temp, so a bare
+        # `"Local" not in path.parts` asserts something about the fixture's prefix
+        # rather than about which directory this function chose.
+        assert path.relative_to(tmp_path).parts == (
+            "AppData",
+            "Roaming",
+            "kiro-cli",
+            "data.sqlite3",
+        )
+
+    def test_windows_path_ignores_a_redirected_appdata(self, tmp_path: Path) -> None:
+        """Fixed anchor, not %APPDATA%.
+
+        The fence that makes this store unwritable by agent file tools is
+        home-anchored, so an env-redirected path would land outside it where the
+        contents are forgeable.
+        """
+
+        path = kp.kiro_identity_store_path(
+            "win32",
+            tmp_path,
+            {"APPDATA": str(tmp_path / "evil"), "LOCALAPPDATA": str(tmp_path / "evil")},
+        )
+        assert "evil" not in str(path)
+
+    def test_staging_mappings_are_untouched_by_this_change(self, tmp_path: Path) -> None:
+        """Sign-in STAGING keeps its own behaviour; only the fingerprint moved."""
+
+        mappings = kp._auth_store_mappings("linux", tmp_path, {})
+        sources = {str(m.source) for m in mappings}
+        assert any("kiro-cli" in s for s in sources)
+        assert any("amazon-q" in s for s in sources)
+        assert any(".aws/sso/cache" in s.replace("\\", "/") for s in sources)
+
+
+class _FakeSemaphore:
+    def __init__(self, locked: bool) -> None:
+        self._locked = locked
+
+    def locked(self) -> bool:
+        return self._locked
+
+
+class _FakeProvider:
+    def __init__(self, backend: str) -> None:
+        self.backend = backend
+        self.shutdown_calls = 0
+
+    @property
+    def uses_kiro_identity_store(self) -> bool:
+        from kiro_crew.acp.types import ACP_BACKENDS_KIRO_IDENTITY_STORE
+
+        return self.backend in ACP_BACKENDS_KIRO_IDENTITY_STORE
+
+    def is_process_alive(self) -> bool:
+        return True
+
+    def is_alive(self) -> bool:
+        return True
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+class _FakeRuntime:
+    """Stands in for AcpRuntime in the retirement sweep."""
+
+    def __init__(
+        self, backend: str = "", *, active: bool = False, initializing: bool = False
+    ) -> None:
+        self._acp_backend = backend
+        self._active = active
+        self._initializing = initializing
+        self.killed = 0
+
+    @property
+    def uses_kiro_identity_store(self) -> bool:
+        from kiro_crew.acp.types import ACP_BACKENDS_KIRO_IDENTITY_STORE
+
+        return self._acp_backend in ACP_BACKENDS_KIRO_IDENTITY_STORE
+
+    def has_active_sessions(self) -> bool:
+        return self._active
+
+    def has_active_or_initializing_sessions(self) -> bool:
+        return self._active or self._initializing
+
+    async def kill(self) -> None:
+        self.killed += 1
+
+
+class TestStoreRelocation:
+    """A redirected store must report absent, not read a leftover default DB."""
+
+    def test_xdg_relocation_is_detected(self, tmp_path: Path) -> None:
+        assert kp.identity_store_is_relocated(
+            "linux", tmp_path, {"XDG_DATA_HOME": str(tmp_path / "elsewhere")}
+        )
+
+    def test_xdg_set_to_the_default_is_not_a_relocation(self, tmp_path: Path) -> None:
+        assert not kp.identity_store_is_relocated(
+            "linux", tmp_path, {"XDG_DATA_HOME": str(tmp_path / ".local" / "share")}
+        )
+
+    def test_unset_and_blank_are_not_relocations(self, tmp_path: Path) -> None:
+        assert not kp.identity_store_is_relocated("linux", tmp_path, {})
+        assert not kp.identity_store_is_relocated("linux", tmp_path, {"XDG_DATA_HOME": "   "})
+
+    def test_windows_appdata_relocation_is_detected(self, tmp_path: Path) -> None:
+        assert kp.identity_store_is_relocated(
+            "win32", tmp_path, {"APPDATA": str(tmp_path / "elsewhere")}
+        )
+        assert not kp.identity_store_is_relocated(
+            "win32", tmp_path, {"APPDATA": str(tmp_path / "AppData" / "Roaming")}
+        )
+
+    def test_localappdata_is_not_a_relocation_signal(self, tmp_path: Path) -> None:
+        """The identity lives under Roaming; LOCALAPPDATA does not move it."""
+
+        assert not kp.identity_store_is_relocated(
+            "win32", tmp_path, {"LOCALAPPDATA": str(tmp_path / "elsewhere")}
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_leftover_default_store_is_not_read_when_relocated(
+        self, tmp_path: Path
+    ) -> None:
+        """The failure mode: a stale DB at the default path would pin an old account.
+
+        Reading it yields a confident fingerprint of an account nobody is signed
+        into, so a logout in the REAL store changes nothing we can see and the
+        old-account child is reused -- worse than reporting "cannot tell".
+        """
+
+        # A leftover database at the default location, with a real identity in it.
+        leftover = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(leftover)
+        assert kp.identity_fingerprint(leftover) != ""
+
+        service = kp.KiroPrerequisiteService(
+            home=tmp_path,
+            environ={"XDG_DATA_HOME": str(tmp_path / "elsewhere")},
+            platform_name="linux",
+        )
+        assert await service.current_identity_fingerprint(allow_cached=False) == ""
+
+    @pytest.mark.asyncio
+    async def test_the_default_store_is_still_read_when_not_relocated(self, tmp_path: Path) -> None:
+        """The refusal must not disable the ordinary case."""
+
+        _write_store(kp.kiro_identity_store_path("linux", tmp_path, {}))
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        assert await service.current_identity_fingerprint(allow_cached=False) != ""
+
+
+class TestProviderMembership:
+    def test_kiro_backend_is_a_member(self) -> None:
+        from kiro_crew.session import _provider_uses_kiro_identity_store
+
+        assert _provider_uses_kiro_identity_store(_FakeProvider(""))
+
+    def test_unknown_backend_fails_closed(self) -> None:
+        """An object that declares nothing must be left running, not recycled."""
+
+        from kiro_crew.session import _provider_uses_kiro_identity_store
+
+        assert not _provider_uses_kiro_identity_store(object())
+        assert not _provider_uses_kiro_identity_store(_FakeProvider("claude"))
+
+    def test_the_capability_is_declared_on_the_provider_abc(self) -> None:
+        """harness-parity H14: the session layer reads a declared capability.
+
+        Probing private shapes (``_client``, ``_acp_backend``) would silently
+        misclassify an adapted provider. The base declares it with a safe default
+        so a harness that never states the claim cannot inherit it.
+        """
+
+        from kiro_crew.providers.base import LLMProvider
+
+        assert "uses_kiro_identity_store" in vars(LLMProvider)
+        assert LLMProvider.uses_kiro_identity_store.fget(object()) is False  # type: ignore[attr-defined]
+
+    def test_a_non_declaring_provider_is_not_swept(self) -> None:
+        from kiro_crew.session import _provider_uses_kiro_identity_store
+
+        class _Bare:
+            pass
+
+        assert _provider_uses_kiro_identity_store(_Bare()) is False
+
+
+class TestIdentityChangePredicate:
+    @pytest.mark.asyncio
+    async def test_no_change_before_the_first_probe(self, tmp_path: Path) -> None:
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        assert await service.identity_changed_since_probe() is False
+
+    @pytest.mark.asyncio
+    async def test_change_detected_against_the_recorded_identity(self, tmp_path: Path) -> None:
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        # Stand in for a completed probe: the latch was written while the store
+        # named this account.
+        service._stamp_probe(await service.current_identity_fingerprint())
+        assert await service.identity_changed_since_probe() is False
+        _write_store(db, start_url="https://personal.awsapps.com/start")
+        _expire_identity_cache(service)
+        assert await service.identity_changed_since_probe() is True
+
+    @pytest.mark.asyncio
+    async def test_a_logout_before_the_first_turn_is_still_detected(self, tmp_path: Path) -> None:
+        """A child can exist before any turn (eager spawn / warm pool)."""
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        service._stamp_probe(await service.current_identity_fingerprint())
+
+        con = sqlite3.connect(str(db))
+        with con:
+            con.execute("DELETE FROM auth_kv")
+            con.execute("DELETE FROM state")
+        con.close()
+        _expire_identity_cache(service)
+
+        changed, live = await service.identity_changed_since_sessions()
+        assert changed is True
+        assert live == ""
+
+    @pytest.mark.asyncio
+    async def test_an_unset_baseline_reports_changed(self, tmp_path: Path) -> None:
+        """ "We do not know" must not resolve to "the children match".
+
+        Readiness is probed a few seconds AFTER boot while a session can be
+        spawned eagerly before it. A logout landing in that gap would otherwise be
+        adopted as the starting point, and the pre-logout child would keep
+        answering as the previous account with nothing left to detect it.
+        """
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+
+        # No probe has run and nothing has been reconciled.
+        changed, live = await service.identity_changed_since_sessions()
+        assert changed is True
+        assert live != ""
+
+    @pytest.mark.asyncio
+    async def test_a_logout_before_the_delayed_probe_is_detected(self, tmp_path: Path) -> None:
+        """The eager-spawn-before-probe window GPT identified.
+
+        Child spawns under account A, the terminal logs out, and only THEN does
+        the delayed boot probe run. Seeding the baseline from that probe would
+        record the post-logout identity and strand the child.
+        """
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+
+        # Logout happens BEFORE the probe.
+        con = sqlite3.connect(str(db))
+        with con:
+            con.execute("DELETE FROM auth_kv")
+            con.execute("DELETE FROM state")
+        con.close()
+
+        # The delayed probe now runs and sees the signed-out store.
+        service._stamp_probe(await service.current_identity_fingerprint())
+
+        # The pre-logout child must still be swept.
+        changed, _ = await service.identity_changed_since_sessions()
+        assert changed is True
+
+    @pytest.mark.asyncio
+    async def test_probes_never_move_the_session_baseline(self, tmp_path: Path) -> None:
+        """Only a completed sweep advances it; a probe never does."""
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        service._stamp_probe(await service.current_identity_fingerprint())
+        assert service._session_identity is None
+
+        _write_store(db, start_url="https://personal.awsapps.com/start")
+        service._stamp_probe(await service.current_identity_fingerprint())
+        assert service._session_identity is None
+
+        changed, live = await service.identity_changed_since_sessions()
+        assert changed is True
+        service.note_sessions_reconciled(live)
+        changed_after, _ = await service.identity_changed_since_sessions()
+        assert changed_after is False
+
+    @pytest.mark.asyncio
+    async def test_assume_ready_never_reports_a_change(self, tmp_path: Path) -> None:
+        service = kp.KiroPrerequisiteService(
+            home=tmp_path, environ={}, platform_name="linux", assume_ready=True
+        )
+        service._stamp_probe("something")
+        assert await service.identity_changed_since_probe() is False
+
+
+class TestBaselinesAreIndependent:
+    """The status consumer must not be able to consume the retirement signal."""
+
+    @pytest.mark.asyncio
+    async def test_a_status_reprobe_does_not_hide_the_change_from_retirement(
+        self, tmp_path: Path
+    ) -> None:
+        """The defect this pair of baselines exists to prevent.
+
+        With ONE shared baseline: logout -> a status poll re-probes and stamps the
+        new identity -> the next turn sees no change -> the stale child is never
+        retired. The dashboard polls every few seconds and turns are minutes
+        apart, so the poll essentially always wins that race.
+        """
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        service._stamp_probe(await service.current_identity_fingerprint())
+        # Reconcile the retirement baseline explicitly -- an unset one now reports
+        # changed, so the sweep has to have happened before this scenario starts.
+        _, live0 = await service.identity_changed_since_sessions()
+        service.note_sessions_reconciled(live0)
+        assert await service.identity_changed_since_probe() is False
+        changed, _ = await service.identity_changed_since_sessions()
+        assert changed is False
+
+        # The account changes.
+        _write_store(db, start_url="https://personal.awsapps.com/start")
+        _expire_identity_cache(service)
+
+        # The status consumer observes it FIRST and advances its own baseline,
+        # exactly as an ordinary poll's re-probe does.
+        assert await service.identity_changed_since_probe() is True
+        service._stamp_probe(await service.current_identity_fingerprint())
+        assert await service.identity_changed_since_probe() is False
+
+        # Retirement must STILL see the change.
+        changed, live = await service.identity_changed_since_sessions()
+        assert changed is True
+        assert live != ""
+
+    @pytest.mark.asyncio
+    async def test_the_session_baseline_advances_only_when_told(self, tmp_path: Path) -> None:
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        service._stamp_probe(await service.current_identity_fingerprint())
+        await service.identity_changed_since_sessions()  # adopt
+
+        _write_store(db, start_url="https://personal.awsapps.com/start")
+        changed, live = await service.identity_changed_since_sessions()
+        assert changed is True
+        # Re-asking without reconciling keeps reporting the change, so a failed
+        # retirement is retried rather than silently recorded as handled.
+        changed_again, _ = await service.identity_changed_since_sessions()
+        assert changed_again is True
+
+        service.note_sessions_reconciled(live)
+        changed_after, _ = await service.identity_changed_since_sessions()
+        assert changed_after is False
+
+    @pytest.mark.asyncio
+    async def test_an_unreconciled_baseline_never_reads_as_matching(self, tmp_path: Path) -> None:
+        """Repeated asks keep reporting changed until a sweep reconciles.
+
+        Replaces an earlier "first call adopts" behaviour, which was the hole GPT
+        found: adopting on first read trusts children that may predate the read.
+        """
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+
+        first, live = await service.identity_changed_since_sessions()
+        second, _ = await service.identity_changed_since_sessions()
+        assert first is True
+        assert second is True
+
+        service.note_sessions_reconciled(live)
+        after, _ = await service.identity_changed_since_sessions()
+        assert after is False
+
+
+class TestLatchNarrowingPolicy:
+    """Narrowing readiness is right for a sign-out and wrong for a switch."""
+
+    class _State:
+        def __init__(self, service: object, sessions: object) -> None:
+            self.kiro_prerequisite_service = service
+            self.sessions = sessions
+
+    class _Sessions:
+        def __init__(self, complete: bool = True) -> None:
+            self._complete = complete
+            self.calls = 0
+
+        async def retire_kiro_identity_sessions(self):
+            self.calls += 1
+            return ([], self._complete)
+
+    @pytest.mark.asyncio
+    async def test_a_switch_to_a_valid_account_does_not_narrow_readiness(
+        self, tmp_path: Path
+    ) -> None:
+        """The stuck-readiness sequence.
+
+        A status poll observes the switch FIRST and stamps the new identity. If the
+        turn path then narrowed unconditionally, readiness would go false while the
+        fingerprints now MATCH -- so no ordinary poll re-probes and the card sits
+        at "not signed in" until someone presses Check again.
+        """
+
+        from kiro_crew.dashboard import chat_runner
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        service._stamp_probe(await service.current_identity_fingerprint())
+
+        # Switch to another VALID account, then let a poll observe it first.
+        _write_store(db, start_url="https://personal.awsapps.com/start")
+        service._stamp_probe(await service.current_identity_fingerprint())
+        service._status = type(service._status)(  # type: ignore[misc]
+            **{**vars(service._status), "authenticated": True, "ready": True}
+        )
+
+        state = self._State(service, self._Sessions())
+        await chat_runner._retire_sessions_on_identity_change(state)
+
+        assert service._status.ready is True, "readiness was narrowed on a valid switch"
+
+    @pytest.mark.asyncio
+    async def test_an_actual_sign_out_does_narrow_readiness(self, tmp_path: Path) -> None:
+        from kiro_crew.dashboard import chat_runner
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        service._stamp_probe(await service.current_identity_fingerprint())
+        service._status = type(service._status)(  # type: ignore[misc]
+            **{**vars(service._status), "authenticated": True, "ready": True}
+        )
+
+        con = sqlite3.connect(str(db))
+        with con:
+            con.execute("DELETE FROM auth_kv")
+            con.execute("DELETE FROM state")
+        con.close()
+        _expire_identity_cache(service)
+
+        state = self._State(service, self._Sessions())
+        await chat_runner._retire_sessions_on_identity_change(state)
+
+        assert service._status.ready is False
+        assert service._status.authenticated is False
+
+    @pytest.mark.asyncio
+    async def test_an_incomplete_sweep_leaves_the_change_pending(self, tmp_path: Path) -> None:
+        """A skipped holder must not be recorded as reconciled."""
+
+        from kiro_crew.dashboard import chat_runner
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        service._stamp_probe(await service.current_identity_fingerprint())
+
+        _write_store(db, start_url="https://personal.awsapps.com/start")
+        sessions = self._Sessions(complete=False)
+        state = self._State(service, sessions)
+
+        await chat_runner._retire_sessions_on_identity_change(state)
+        assert sessions.calls == 1
+
+        # Still pending, so the next turn tries again.
+        await chat_runner._retire_sessions_on_identity_change(state)
+        assert sessions.calls == 2
+
+    @pytest.mark.asyncio
+    async def test_a_complete_sweep_reconciles_once(self, tmp_path: Path) -> None:
+        from kiro_crew.dashboard import chat_runner
+
+        db = kp.kiro_identity_store_path("linux", tmp_path, {})
+        _write_store(db)
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        service._stamp_probe(await service.current_identity_fingerprint())
+
+        _write_store(db, start_url="https://personal.awsapps.com/start")
+        sessions = self._Sessions(complete=True)
+        state = self._State(service, sessions)
+
+        await chat_runner._retire_sessions_on_identity_change(state)
+        await chat_runner._retire_sessions_on_identity_change(state)
+        assert sessions.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_store_is_never_reconciled(self, tmp_path: Path) -> None:
+        """ "Cannot tell" must not become the accepted steady state.
+
+        Reconciling an empty fingerprint would make every LATER account switch
+        compare equal to "" and go undetected, while children keep running. Staying
+        unreconciled re-sweeps each turn, bounding how long a child can outlive the
+        account it loaded to one turn.
+        """
+
+        from kiro_crew.dashboard import chat_runner
+
+        # No store on disk at all: the fingerprint is absent.
+        service = kp.KiroPrerequisiteService(home=tmp_path, environ={}, platform_name="linux")
+        sessions = self._Sessions(complete=True)
+        state = self._State(service, sessions)
+
+        await chat_runner._retire_sessions_on_identity_change(state)
+        await chat_runner._retire_sessions_on_identity_change(state)
+        await chat_runner._retire_sessions_on_identity_change(state)
+
+        # Every turn re-sweeps rather than accepting the unreadable state.
+        assert sessions.calls == 3
+        assert service._session_identity is None
+
+
+class TestRetirementCoverage:
+    """Every holder of a kiro child must be reachable by retirement."""
+
+    @staticmethod
+    def _manager():
+        from kiro_crew.config import KiroCrewConfig
+        from kiro_crew.session import SessionManager
+
+        # pool_size 0 so construction never pre-spawns; the pool is populated
+        # explicitly by the test that cares about it.
+        return SessionManager(KiroCrewConfig())
+
+    @staticmethod
+    def _session(provider: object, *, busy: bool = False):
+        from kiro_crew.session import _Session
+
+        sess = _Session(provider=provider)  # type: ignore[arg-type]
+        if busy:
+            # Retirement reads semaphore.locked(); drain the permit to say "busy".
+            sess.semaphore._value = 0  # type: ignore[attr-defined]
+        return sess
+
+    @pytest.mark.asyncio
+    async def test_idle_kiro_sessions_are_retired_and_others_left_alone(self) -> None:
+        smap = self._manager()
+        kiro = _FakeProvider("")
+        claude = _FakeProvider("claude")
+        smap._sessions["kiro-key"] = self._session(kiro)
+        smap._sessions["claude-key"] = self._session(claude)
+
+        retired, complete = await smap.retire_kiro_identity_sessions()
+
+        assert retired == ["kiro-key"]
+        assert complete is True
+        assert "kiro-key" not in smap._sessions
+        assert "claude-key" in smap._sessions
+        assert kiro.shutdown_calls == 1
+        assert claude.shutdown_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_a_busy_kiro_session_is_not_retired(self) -> None:
+        smap = self._manager()
+        busy = _FakeProvider("")
+        smap._sessions["busy"] = self._session(busy, busy=True)
+
+        retired, complete = await smap.retire_kiro_identity_sessions()
+
+        assert retired == []
+        # A skipped session means the change is NOT reconciled.
+        assert complete is False
+        assert "busy" in smap._sessions
+        assert busy.shutdown_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_selection_and_unregistration_are_one_atomic_step(self) -> None:
+        """A session busy at DECISION time is never unregistered or shut down.
+
+        The TOCTOU GPT flagged is closed by doing the idle check and the
+        unregistration in a single lock hold. The acquire path takes the
+        semaphore OUTSIDE the lock and then validates registration INSIDE it, so
+        the two orderings are both safe: acquire-first is visible here as
+        ``locked()`` and skipped, while pop-first is caught by that validation
+        (covered by the next test).
+        """
+
+        smap = self._manager()
+        idle = _FakeProvider("")
+        busy = _FakeProvider("")
+        smap._sessions["idle"] = self._session(idle)
+        smap._sessions["busy"] = self._session(busy, busy=True)
+
+        retired, complete = await smap.retire_kiro_identity_sessions()
+
+        assert retired == ["idle"]
+        assert complete is False  # the busy one was left running
+        assert "busy" in smap._sessions
+        assert busy.shutdown_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_a_turn_can_never_stream_on_a_retired_provider(self) -> None:
+        """The other half of the race: a turn that acquires AFTER the pop.
+
+        It re-validates registration under the same lock, finds the entry gone,
+        releases its semaphore and reports invalid -- so the caller cold starts a
+        replacement on the current account instead of streaming on the retired
+        child. Without that, retirement would be racing every in-flight acquire.
+        """
+
+        smap = self._manager()
+        provider = _FakeProvider("")
+        sess = self._session(provider)
+        smap._sessions["key"] = sess
+
+        await smap.retire_kiro_identity_sessions()
+        assert "key" not in smap._sessions
+
+        # A turn that had not yet acquired when the sweep ran now tries to.
+        still_valid = await smap._reacquire_and_validate("key", sess)
+
+        assert still_valid is False
+        # The contract is that an invalid result has ALREADY released the
+        # semaphore; a leaked permit would deadlock the key forever.
+        assert not sess.semaphore.locked()
+
+    @pytest.mark.asyncio
+    async def test_pooled_kiro_providers_are_discarded(self) -> None:
+        """A warm provider spawned pre-change would otherwise be handed to a
+        brand-new session, running it as the previous account."""
+
+        smap = self._manager()
+        pooled_kiro = _FakeProvider("")
+        pooled_other = _FakeProvider("claude")
+        smap._warm_pool.put_nowait((pooled_kiro, 0.0))
+        smap._warm_pool.put_nowait((pooled_other, 0.0))
+
+        await smap.retire_kiro_identity_sessions()
+
+        assert pooled_kiro.shutdown_calls == 1
+        assert pooled_other.shutdown_calls == 0
+        # The non-kiro entry is put back, not dropped on the floor.
+        assert smap._warm_pool.qsize() == 1
+        survivor, _ = smap._warm_pool.get_nowait()
+        assert survivor is pooled_other
+
+    @pytest.mark.asyncio
+    async def test_kiro_subagent_runtimes_are_retired(self) -> None:
+        smap = self._manager()
+
+        kiro_runtime = _FakeRuntime("")
+        other_runtime = _FakeRuntime("claude")
+        smap._subagent_runtimes["parent-kiro"] = kiro_runtime  # type: ignore[assignment]
+        smap._subagent_runtimes["parent-other"] = other_runtime  # type: ignore[assignment]
+
+        await smap.retire_kiro_identity_sessions()
+
+        assert kiro_runtime.killed == 1
+        assert other_runtime.killed == 0
+        assert "parent-other" in smap._subagent_runtimes
+
+    @pytest.mark.asyncio
+    async def test_the_shared_background_runtime_is_retired(self) -> None:
+        """One process serves all background work and outlives every session, so
+        the session sweep cannot reach it."""
+
+        smap = self._manager()
+
+        bg = _FakeRuntime("")
+        smap._bg_runtime = bg  # type: ignore[assignment]
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+
+        assert bg.killed == 1
+        assert smap._bg_runtime is None
+        assert complete is True
+
+    @pytest.mark.asyncio
+    async def test_a_non_kiro_background_runtime_is_left_alone(self) -> None:
+        smap = self._manager()
+
+        bg = _FakeRuntime("claude")
+        smap._bg_runtime = bg  # type: ignore[assignment]
+
+        await smap.retire_kiro_identity_sessions()
+
+        assert bg.killed == 0
+        assert smap._bg_runtime is bg
+
+    @pytest.mark.asyncio
+    async def test_an_active_background_runtime_is_spared_and_reported_incomplete(self) -> None:
+        """One process serves every background caller, so killing it mid-flight
+        drops work belonging to callers unrelated to the account change.
+
+        Same principle as a busy session: spare it, report the sweep incomplete so
+        the change stays pending, and retire it once it drains.
+        """
+
+        smap = self._manager()
+        bg = _FakeRuntime("", active=True)
+        smap._bg_runtime = bg  # type: ignore[assignment]
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+
+        assert bg.killed == 0
+        assert smap._bg_runtime is bg
+        assert complete is False
+
+    @pytest.mark.asyncio
+    async def test_an_active_subagent_runtime_is_spared_and_reported_incomplete(self) -> None:
+        smap = self._manager()
+        busy_runtime = _FakeRuntime("", active=True)
+        smap._subagent_runtimes["parent"] = busy_runtime  # type: ignore[assignment]
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+
+        assert busy_runtime.killed == 0
+        assert "parent" in smap._subagent_runtimes
+        assert complete is False
+
+    @pytest.mark.asyncio
+    async def test_a_provider_mid_start_makes_the_sweep_incomplete(self) -> None:
+        """A provider between start() and registration is in none of the maps.
+
+        It already holds whatever the store said when it spawned, so reconciling
+        while it is in flight would advance the baseline over it and leave it
+        reusable under the previous account once it registers.
+        """
+
+        smap = self._manager()
+        smap._starting_pids.add(4242)
+
+        retired, complete = await smap.retire_kiro_identity_sessions()
+
+        assert retired == []
+        assert complete is False
+
+    @pytest.mark.asyncio
+    async def test_no_in_flight_start_allows_a_complete_sweep(self) -> None:
+        smap = self._manager()
+        assert not smap._starting_pids
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+
+        assert complete is True
+
+    @pytest.mark.asyncio
+    async def test_an_in_flight_runtime_spawn_makes_the_sweep_incomplete(self) -> None:
+        """`get_subagent_runtime` holds the per-parent lock across its spawn.
+
+        A runtime being created right now is in no map at all, while it already
+        holds whatever the store said when it started. Reconciling would advance
+        the baseline over it and leave later subagents running as the previous
+        account.
+        """
+
+        smap = self._manager()
+        lock = asyncio.Lock()
+        await lock.acquire()
+        smap._subagent_runtime_locks["parent"] = lock
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+        assert complete is False
+
+        lock.release()
+        _, complete_after = await smap.retire_kiro_identity_sessions()
+        assert complete_after is True
+
+    @pytest.mark.asyncio
+    async def test_an_idle_runtime_lock_does_not_block_reconciliation(self) -> None:
+        """A lock that merely EXISTS is not a spawn in flight."""
+
+        smap = self._manager()
+        smap._subagent_runtime_locks["parent"] = asyncio.Lock()
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+        assert complete is True
+
+    @pytest.mark.asyncio
+    async def test_a_busy_session_is_marked_so_its_next_turn_cannot_reuse_it(self) -> None:
+        """Skipping a busy session protected its turn but not the NEXT one.
+
+        `get_or_create` would simply wait for that turn's semaphore and hand the
+        same old-account provider to the following turn. Marking it makes the
+        post-semaphore re-validate report invalid, so the caller's existing
+        stale-provider path evicts and cold starts -- no blocking, no refusal.
+        """
+
+        smap = self._manager()
+        busy = _FakeProvider("")
+        sess = self._session(busy, busy=True)
+        smap._sessions["busy"] = sess
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+
+        assert complete is False
+        assert sess.retire_on_identity_change is True
+        assert busy.shutdown_calls == 0, "the in-flight turn must not be killed"
+
+        # The next turn releases and re-validates: the mark makes it invalid.
+        sess.semaphore.release()
+        still_valid = await smap._reacquire_and_validate("busy", sess)
+        assert still_valid is False
+        assert not sess.semaphore.locked(), "an invalid result must release the permit"
+
+    @pytest.mark.asyncio
+    async def test_an_unmarked_session_still_validates_normally(self) -> None:
+        """The mark must not make every re-validate fail."""
+
+        smap = self._manager()
+        provider = _FakeProvider("claude")
+        sess = self._session(provider)
+        smap._sessions["ok"] = sess
+
+        assert sess.retire_on_identity_change is False
+        still_valid = await smap._reacquire_and_validate("ok", sess)
+        assert still_valid is True
+        smap.release("ok")
+
+    @pytest.mark.asyncio
+    async def test_a_runtime_surviving_the_sweep_reports_incomplete(self) -> None:
+        """Post-condition, not a window enumeration.
+
+        A companion spawn that COMPLETES between the runtime snapshot and the final
+        lock check is in neither -- its lock is released and it was not in the
+        snapshot. Asserting that no kiro-backed runtime is LEFT catches anything
+        installed while we swept, whatever the timing.
+        """
+
+        smap = self._manager()
+        survivor = _FakeRuntime("")
+        smap._subagent_runtimes["parent"] = survivor  # type: ignore[assignment]
+
+        # Simulate a release that does not actually remove it (equivalently: a
+        # runtime installed after the snapshot was taken).
+        async def _noop_release(key: str) -> None:
+            return None
+
+        smap.release_subagent_runtime = _noop_release  # type: ignore[assignment]
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+
+        assert "parent" in smap._subagent_runtimes
+        assert complete is False, "a surviving kiro-backed runtime must not reconcile"
+
+    @pytest.mark.asyncio
+    async def test_a_non_kiro_runtime_surviving_is_fine(self) -> None:
+        """The post-condition must only count runtimes this sweep owns."""
+
+        smap = self._manager()
+        smap._subagent_runtimes["parent"] = _FakeRuntime("claude")  # type: ignore[assignment]
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+
+        assert complete is True
+
+    @pytest.mark.asyncio
+    async def test_an_initializing_session_protects_a_runtime(self) -> None:
+        """`create_session` registers its queue OUTSIDE the runtime lock.
+
+        So a session whose `session/new` is in flight is invisible to
+        `has_active_sessions()`, and killing the runtime under it surfaces as
+        `AcpRuntimeDead` on work the user never connected to an account change.
+        The stale-runtime recycle path tolerates that window because a respawn
+        loop backstops it; this sweep has no such backstop, so it must not.
+        """
+
+        smap = self._manager()
+        initializing = _FakeRuntime("", initializing=True)
+        smap._subagent_runtimes["parent"] = initializing  # type: ignore[assignment]
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+
+        assert initializing.killed == 0
+        assert "parent" in smap._subagent_runtimes
+        assert complete is False
+
+    @pytest.mark.asyncio
+    async def test_an_initializing_session_protects_the_background_runtime(self) -> None:
+        smap = self._manager()
+        bg = _FakeRuntime("", initializing=True)
+        smap._bg_runtime = bg  # type: ignore[assignment]
+
+        _, complete = await smap.retire_kiro_identity_sessions()
+
+        assert bg.killed == 0
+        assert smap._bg_runtime is bg
+        assert complete is False
+
+    @pytest.mark.asyncio
+    async def test_the_runtime_predicate_counts_inits_in_flight(self) -> None:
+        """Pins the real AcpRuntime property, not just the test double."""
+
+        from kiro_crew.acp.runtime import AcpRuntime
+
+        runtime = AcpRuntime.__new__(AcpRuntime)
+        runtime._session_queues = {}  # type: ignore[attr-defined]
+        runtime._session_inits_in_flight = 0  # type: ignore[attr-defined]
+        assert runtime.has_active_sessions() is False
+        assert runtime.has_active_or_initializing_sessions() is False
+
+        runtime._session_inits_in_flight = 1  # type: ignore[attr-defined]
+        # The old predicate still reports idle -- that is the window.
+        assert runtime.has_active_sessions() is False
+        assert runtime.has_active_or_initializing_sessions() is True
+
+    @pytest.mark.asyncio
+    async def test_two_concurrent_sweeps_do_not_deadlock(self) -> None:
+        """The hold-and-wait deadlock two unserialized sweeps would reach.
+
+        Each sweep drains all four cold-start permits one at a time. With a third
+        party holding one (a warm-pool fill or eager spawn at boot -- routine),
+        sweep A can hold 3 waiting for its 4th while sweep B holds 1 waiting for
+        its 2nd: four taken, none free, and neither releases until it reaches four.
+        The releases live in a `finally` that never runs, and the wait is un-timed,
+        so both turns hang forever AND every later cold start blocks on a drained
+        semaphore.
+
+        Two concurrent sweeps are the common boot case, not an exotic one: with
+        `_session_identity` unset, every in-flight turn sees a change at once.
+        """
+
+        smap = self._manager()
+        # Hold ALL permits first, so both sweeps are queued as waiters before any
+        # permit is free. This is what makes them interleave: `acquire()` has a
+        # non-yielding fast path, so a lone sweep would otherwise grab every free
+        # permit atomically and never give a peer the chance to take one.
+        for _ in range(_MAX_COLD_STARTS_FOR_TEST):
+            await smap._start_sem.acquire()
+
+        first = asyncio.create_task(smap.retire_kiro_identity_sessions())
+        second = asyncio.create_task(smap.retire_kiro_identity_sessions())
+        await asyncio.sleep(0.05)
+        assert not first.done() and not second.done()
+
+        # Hand the permits back one at a time. Unserialized, the two sweeps
+        # alternate as FIFO waiters -- each takes one and re-queues behind the
+        # other -- until all four are split between them with none free and neither
+        # at its required four. Their `finally` releases never run, so both hang.
+        for _ in range(_MAX_COLD_STARTS_FOR_TEST):
+            smap._start_sem.release()
+            await asyncio.sleep(0)
+
+        results = await asyncio.wait_for(asyncio.gather(first, second), timeout=5.0)
+        assert all(complete for _, complete in results)
+        # Every permit returned, so later cold starts are unaffected.
+        assert smap._start_sem._value == _MAX_COLD_STARTS_FOR_TEST
+
+    @pytest.mark.asyncio
+    async def test_the_barrier_waits_for_an_in_flight_cold_start(self) -> None:
+        """The scan must be authoritative, so it WAITS for every permit.
+
+        A partial barrier is not enough: reporting "incomplete" defers the baseline
+        but does not stop the current turn, so an eager session spawned under the
+        previous account would still win registration and serve it.
+        """
+
+        smap = self._manager()
+        await smap._start_sem.acquire()
+
+        task = asyncio.create_task(smap.retire_kiro_identity_sessions())
+        await asyncio.sleep(0.05)
+        assert not task.done(), "the sweep scanned while a cold start was in flight"
+
+        smap._start_sem.release()
+        retired, complete = await asyncio.wait_for(task, timeout=2.0)
+        assert complete is True
+        assert retired == []
+
+    @pytest.mark.asyncio
+    async def test_the_barrier_releases_every_permit_it_took(self) -> None:
+        """A leaked permit would shrink cold-start concurrency for the process."""
+
+        smap = self._manager()
+        before = smap._start_sem._value
+        await smap.retire_kiro_identity_sessions()
+        assert smap._start_sem._value == before
+
+    @pytest.mark.asyncio
+    async def test_permits_are_released_even_when_the_scan_raises(self) -> None:
+        """The release must be in a `finally`, or one failure degrades the process."""
+
+        smap = self._manager()
+        before = smap._start_sem._value
+
+        class _Boom(Exception):
+            pass
+
+        async def _explode() -> bool:
+            raise _Boom()
+
+        smap._retire_kiro_warm_pool = _explode  # type: ignore[assignment]
+        with pytest.raises(_Boom):
+            await smap.retire_kiro_identity_sessions()
+        assert smap._start_sem._value == before
+
+    @pytest.mark.asyncio
+    async def test_the_pool_drain_holds_the_fill_lock(self) -> None:
+        """An in-flight fill must not land a pre-change child behind the sweep.
+
+        Without the lock the sweep reads an empty queue, the outstanding spawn
+        completes, and a provider authenticated as the old account is enqueued for
+        a later session to claim.
+        """
+
+        smap = self._manager()
+        observed: list[bool] = []
+
+        original = smap._retire_kiro_warm_pool
+
+        async def watched() -> bool:
+            observed.append(smap._pool_fill_lock.locked())
+            return await original()
+
+        smap._retire_kiro_warm_pool = watched  # type: ignore[assignment]
+
+        # Hold the fill lock as an in-flight fill would, and confirm the drain
+        # cannot proceed until it is released.
+        await smap._pool_fill_lock.acquire()
+        task = asyncio.create_task(smap.retire_kiro_identity_sessions())
+        await asyncio.sleep(0.05)
+        assert not task.done(), "drain proceeded while a fill held the lock"
+        smap._pool_fill_lock.release()
+        await task
+
+        assert observed, "the drain never ran"

--- a/test/test_md_notebook.py
+++ b/test/test_md_notebook.py
@@ -27,8 +27,10 @@ import pytest
 import yarl
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from windows_sim import replace_sharing_violation
 
 from conftest import requires_symlinks
+from kiro_crew import atomic_write as atomic_write_mod
 from kiro_crew import platform_compat
 from kiro_crew.apps.builtins.md_notebook import git_ops
 
@@ -1125,6 +1127,27 @@ async def test_concurrent_clones_do_not_lose_a_vault(fixtures) -> None:
         assert r1[0] == 200 and r2[0] == 200, (r1, r2)
         _, listing = await client.get("/api/vaults")
         assert len(listing["vaults"]) == 2, listing
+
+
+def test_vault_registry_commit_retries_windows_sharing_violation(
+    fixtures, monkeypatch
+) -> None:
+    """A transient Windows handle on vaults.json must not lose a clone.
+
+    Clone/attach mutations are serialized, but Windows Search or an AV scanner
+    can still hold the registry open when the atomic rename lands. The shared
+    retry helper absorbs that bounded sharing-violation window.
+    """
+    server_mod, _remote, _seed = fixtures
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(atomic_write_mod, "_REPLACE_BACKOFF_SECONDS", 0)
+    vaults = [{"id": "v1", "localPath": "vault-one"}]
+
+    with replace_sharing_violation(match="vaults.json", times=1) as state:
+        server_mod._write_vaults_sync(vaults)
+
+    assert json.loads(server_mod._vaults_json().read_text(encoding="utf-8")) == vaults
+    assert state["n"] == 2, "the transient rename must be retried exactly once"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #3390 (customer-reported).

## The bug

A customer signed out of `kiro-cli` in a terminal to switch from their company
account to a personal one, with the dashboard open. KiroCrew kept answering
normally. Only force-quitting the client produced "not logged in".

Three properties compose into it:

1. **The backend child is long-lived and per-session, not per-turn.** Spawned once
   (`acp/client.py`, or the shared runtime in `acp/runtime.py`); later turns write
   to the already-open channel. It holds its credential in memory and keeps
   refreshing.
2. **Nothing re-validates auth before a turn.** The pre-send check is "still
   registered" plus `returncode is None` (`session.py`).
3. **The signed-in verdict is a boot-time latch**, narrowed only when a turn
   observes `AcpAuthRequired`. The consequence is already stated in-tree at
   `dashboard/kiro_readiness.py`.

So the sign-out produced no failure for anything to observe. Force-quitting
SIGKILLs the tracked children (`session_pid.py`), which is why the next launch was
the first to notice.

**Why this is not a stale-badge bug.** Between the sign-out and the next gateway
start, turns ran and were attributed to the **company** account while the user
believed they had switched to personal.

The customer's own theory — that KiroCrew caches credentials — was checked and is
false. `load_credentials` does seed `os.environ` for process lifetime with no
clearing path, but its key list is messaging credentials only; child environments
are rebuilt per spawn from live `os.environ`; and direct reads of the store retain
nothing. The stale thing is a *process*, not a copy.

## The fix

One primitive, both halves hung off it.

`identity_fingerprint` digests **which account** a store names, built to be stable
across a routine token refresh: `auth_kv` contributes only its **key names**,
because the token value is replaced on each refresh and digesting it would report
an account change roughly hourly and retire healthy sessions. Identity comes from
the `state` rows naming the Identity Center start URL and region and the
CodeWhisperer profile. Values are hashed, never retained.

Refresh-stability is by construction rather than by measurement: the rotating
field is not an input, so no claim about refresh cadence is needed.

Not an mtime watch — ordinary chat traffic rewrites that database every ~30s, so
mtime carries no signal (already documented at `handlers/sessions.py`).

- **Status card.** An ordinary poll re-probes when the store names a different
  account than the latch describes — the only condition under which a
  non-forced poll probes, and it cannot loop because the probe stamps the new
  identity. Fixes both directions: it previously kept reporting the signed-out
  account, and reported "not signed in" after a terminal sign-in, until someone
  pressed Check again.
- **Wrong-identity window.** A turn retires idle children whose backend
  authenticates from that store, so the turn cold starts on the current account.
  Uses `remove()`, so the session map is preserved and the conversation is
  restored from disk — a process recycle, not data loss. Busy sessions are
  skipped: a turn already in flight started under the old account and killing it
  mid-stream would surface as an unexplained failure.

**The send path stays ungated.** Nothing here can block a turn — it recycles an
invalidated child and lets the send proceed — and the trigger is a local read, not
the `whoami` spawn that the boot-only probe (#820) exists to keep off this path.

### Structural notes

- `ACP_BACKENDS_KIRO_IDENTITY_STORE` states membership positively
  (harness-parity H5). **KAS is excluded**: it is a separate Node entry point
  (`build_kas_argv`) and nothing in-tree establishes that it authenticates from
  kiro-cli's store. It opts in when someone demonstrates that it does.
- `_provider_uses_kiro_identity_store` **fails closed** — an undeterminable
  backend is left running rather than recycled on a store it may never read.
- The four latch-write sites in `_probe` now go through one `_stamp_probe`, so no
  verdict can be recorded without the identity it belongs to; a latch stamped with
  no identity would read as "changed" forever.
- The fingerprint is read **before** `whoami` and stamped on whatever verdict the
  probe reaches. Reading afterwards could stamp the new identity onto a verdict
  describing the old one, hiding the change; reading first can at worst cost one
  extra probe.
- `_auth_store_mappings`' platform branches and the fingerprint reader now
  single-source their paths through `_app_data_dir`, so they cannot disagree about
  where the store lives.

## Verification

- 16 new tests. **Revert-verified**: four mutations (token value included in the
  fingerprint; membership failing open; the change predicate hard-wired to
  `False`; state rows excluded) each make a specific test fail. One mutation was
  initially **vacuous** — `_AUTH_STATE_TABLE in present` appears in two functions
  and the harness had patched the wrong one — so the harness now refuses a
  non-unique anchor.
- One test asserts the fingerprint contains neither the token value nor the start
  URL.
- Schema confirmed against a real store (key names only, no values read out).
- Gates: `isort`, `flake8`, `mypy` (982 files) clean; harness-parity gate passes;
  spawn-audit ratchet passes.
- Full backend suite: 55,646 passed. 31 failures A/B'd against `origin/main` by
  **node-id set**, not count — identical on both sides (host `jq`, no Node ≥20,
  `ps` semantics).
- Frontend untouched; no user-facing strings added, so no i18n surface.

## Open question for review

If an install authenticates via `KIRO_API_KEY`, neither half helps: the value
lives in the gateway's process environment rather than the store, so a terminal
logout cannot reach it and a respawn stays authenticated. That is arguably correct
(the operator set it deliberately) but it is a different sign-out story, and worth
a maintainer's call on whether it needs its own treatment.
