### PR TITLE
fix(dashboard): scope composer focus lookup to the active pane (#4124)

### DIFF
--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -349,6 +349,22 @@ export default function ChatPane({
     <SlotProvider slotId={slotKey}>
       <div
         onMouseDownCapture={onFocus}
+        /* Focus capture keeps the grid's focused-pane state true under
+           KEYBOARD navigation: tabbing into a pane (or into its portaled
+           pickers, whose React events propagate through this component tree
+           even though their DOM lives under document.body) claims grid focus
+           exactly like a click. Without it only mousedown moved the marker,
+           and a keyboard user could type into one pane while another stayed
+           marked focused. */
+        onFocusCapture={onFocus}
+        /* Stable pane boundary for focus scoping: `queryComposer()` resolves
+           the composer inside the pane that owns `document.activeElement` via
+           this attribute, and falls back to the value "focused" — the grid's
+           focused pane — when the active element has no pane ancestor (the
+           pane's pickers portal to document.body). A data hook, not a class
+           name: classes here are styling and can churn without anyone
+           auditing focus behaviour. */
+        data-chat-pane={focused ? 'focused' : ''}
         className={`flex flex-col h-full min-h-0 rounded-lg overflow-hidden bg-bg border transition-colors ${focused ? 'border-accent' : 'border-border'}`}
         style={{ '--mc-content-width': '100%' } as React.CSSProperties}
       >

--- a/website/src/pages/chat/composerFocus.ts
+++ b/website/src/pages/chat/composerFocus.ts
@@ -3,16 +3,35 @@ import { isTouchDevice } from '../../utils/isTouchDevice'
 /**
  * Putting the caret in the chat composer after creating a session.
  *
- * There is exactly ONE composer element on the page and it is bound to
- * whichever slot is currently active. That single fact is what makes the
- * ordering load-bearing: focusing the composer while a `createSlot` is still in
- * flight puts the caret on the OLD session, so anything the user types in that
- * window becomes the old slot's draft and is lost the moment the new slot
- * activates. Slow creation makes the window real rather than theoretical.
+ * The single-chat surface renders ONE composer bound to whichever slot is
+ * currently active. That is what makes the ordering load-bearing: focusing the
+ * composer while a `createSlot` is still in flight puts the caret on the OLD
+ * session, so anything the user types in that window becomes the old slot's
+ * draft and is lost the moment the new slot activates. Slow creation makes the
+ * window real rather than theoretical.
+ *
+ * The session-grid split view breaks the one-composer assumption: each
+ * `ChatPane` mounts its own composer, so N composers coexist and a
+ * document-global first-match lookup would always land on the first pane.
+ * `queryComposer` therefore scopes the lookup to the pane holding focus.
  */
 
 /**
  * The one place the composer is looked up.
+ *
+ * Resolution order:
+ *  1. The composer inside the pane that currently holds focus — the
+ *     `[data-chat-pane]` ancestor of `document.activeElement`. In the split
+ *     view every pane mounts its own composer, and a global shortcut must act
+ *     on the pane the user is working in, not the first pane in document
+ *     order.
+ *  2. The composer inside the grid-focused pane (`[data-chat-pane="focused"]`).
+ *     The pane's pickers render through portals under `document.body`, so
+ *     while one is open the active element has NO pane ancestor — the grid's
+ *     own focused-pane marker is what still names the pane the user is in.
+ *  3. Document-wide fallback, which preserves single-pane behaviour: with one
+ *     composer on the page (or focus outside any pane in a view with no
+ *     focused marker) the first match IS the right one.
  *
  * The probe is the stable `data-composer-input` hook, NOT the textarea's
  * aria-label: the label is `i18nT('components.chatInput.message_input')` and
@@ -22,7 +41,11 @@ import { isTouchDevice } from '../../utils/isTouchDevice'
  * the label free to localize.
  */
 export function queryComposer(): HTMLTextAreaElement | null {
-  return document.querySelector<HTMLTextAreaElement>('textarea[data-composer-input]')
+  const pane =
+    document.activeElement?.closest('[data-chat-pane]') ??
+    document.querySelector('[data-chat-pane="focused"]')
+  const scoped = pane?.querySelector<HTMLTextAreaElement>('textarea[data-composer-input]')
+  return scoped ?? document.querySelector<HTMLTextAreaElement>('textarea[data-composer-input]')
 }
 
 /**

--- a/website/src/test/ChatInput.composerProbe.test.tsx
+++ b/website/src/test/ChatInput.composerProbe.test.tsx
@@ -8,6 +8,12 @@
  * exactly what the helper returns. The aria-label is translated at runtime, so
  * losing the attribute would not fail any label-based query in an English test
  * run — it would only no-op focus for non-English users in production.
+ *
+ * The split-view case locks the consumer side against REAL rendered
+ * composers: with two ChatInputs mounted in two `[data-chat-pane]` wrappers
+ * (the shape ChatPane renders in the session grid), the lookup must resolve
+ * the composer of the pane holding focus, not the first one in document
+ * order.
  */
 import { describe, expect, it, vi } from 'vitest'
 import { screen } from '@testing-library/react'
@@ -21,5 +27,27 @@ describe('composer focus probe', () => {
     const textarea = screen.getByLabelText('Message input')
     expect(textarea).toHaveAttribute('data-composer-input')
     expect(queryComposer()).toBe(textarea)
+  })
+
+  it('with two panes mounted, resolves the composer of the pane holding focus', () => {
+    renderWithProviders(
+      <>
+        <div data-chat-pane="">
+          <ChatInput value="" onChange={vi.fn()} onSend={vi.fn()} />
+        </div>
+        <div data-chat-pane="">
+          <ChatInput value="" onChange={vi.fn()} onSend={vi.fn()} />
+        </div>
+      </>,
+    )
+    const composers = screen.getAllByLabelText('Message input')
+    expect(composers).toHaveLength(2)
+    // Focus in the SECOND pane: the document-global first match would be
+    // composers[0]; the pane-scoped lookup must return composers[1].
+    composers[1].focus()
+    expect(queryComposer()).toBe(composers[1])
+    // And in single-pane terms: focus in the first pane resolves the first.
+    composers[0].focus()
+    expect(queryComposer()).toBe(composers[0])
   })
 })

--- a/website/src/test/ChatPane.dirSend.test.tsx
+++ b/website/src/test/ChatPane.dirSend.test.tsx
@@ -166,3 +166,63 @@ describe('ChatPane agent switch — failures reach the shared notice', () => {
     expect(store.getState().chat.agentSwitchNotice).toBeNull()
   })
 })
+
+/* Producer side of the split-view focus contract: `queryComposer()` scopes its
+ * lookup to the `[data-chat-pane]` ancestor of the focused element, falling
+ * back to the pane marked `data-chat-pane="focused"` when focus sits in a
+ * portal (the pane's own pickers render under document.body). The REAL pane
+ * wrapper must carry the attribute — with value "focused" exactly when the
+ * grid marks the pane focused — and contain the pane's composer. Losing
+ * either would not fail any focus test that mounts fake panes; it would only
+ * silently degrade split-view shortcuts back to first-pane-wins in
+ * production. */
+describe('ChatPane pane boundary — data-chat-pane contract', () => {
+  it('the pane wrapper carries data-chat-pane and contains the pane composer', async () => {
+    const { container } = renderPane('pane-focus')
+    const pane = container.querySelector('[data-chat-pane]')
+    expect(pane).not.toBeNull()
+    const composer = await screen.findAllByRole('textbox')
+    expect(pane!.contains(composer[0])).toBe(true)
+    expect(pane!.querySelector('textarea[data-composer-input]')).not.toBeNull()
+  })
+
+  it('the wrapper marks the grid-focused pane with the "focused" value', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const store = makeStore('pane-marked')
+    const { container } = render(
+      <Provider store={store}>
+        <QueryClientProvider client={qc}>
+          <ThemeProvider>
+            <MemoryRouter>
+              <ChatPane slotKey="pane-marked" focused />
+            </MemoryRouter>
+          </ThemeProvider>
+        </QueryClientProvider>
+      </Provider>,
+    )
+    expect(container.querySelector('[data-chat-pane="focused"]')).not.toBeNull()
+  })
+
+  it('keyboard focus into the pane claims grid focus, not just mousedown', async () => {
+    // Tab into a pane (no mousedown) must move the grid's focused marker,
+    // or the "focused" fallback would name a pane the user already left and
+    // route Alt+Enter from a portaled picker to the wrong session.
+    const onFocus = vi.fn()
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const store = makeStore('pane-kbd')
+    render(
+      <Provider store={store}>
+        <QueryClientProvider client={qc}>
+          <ThemeProvider>
+            <MemoryRouter>
+              <ChatPane slotKey="pane-kbd" onFocus={onFocus} />
+            </MemoryRouter>
+          </ThemeProvider>
+        </QueryClientProvider>
+      </Provider>,
+    )
+    const box = (await screen.findAllByRole('textbox'))[0]
+    box.focus()
+    expect(onFocus).toHaveBeenCalled()
+  })
+})

--- a/website/src/test/composerFocus.test.ts
+++ b/website/src/test/composerFocus.test.ts
@@ -153,6 +153,101 @@ describe('how the composer is found', () => {
   })
 })
 
+describe('split view: the lookup is scoped to the pane holding focus', () => {
+  // The session grid mounts one composer PER pane, so a document-global
+  // first-match lookup would always land on the first pane regardless of
+  // where the user is working. These lock the active-pane scoping and the
+  // document-wide fallback that keeps single-pane behaviour unchanged.
+  const buildPane = () => {
+    const pane = document.createElement('div')
+    pane.setAttribute('data-chat-pane', '')
+    const ta = document.createElement('textarea')
+    ta.setAttribute('data-composer-input', '')
+    pane.appendChild(ta)
+    document.body.appendChild(pane)
+    return { pane, ta }
+  }
+
+  let first: ReturnType<typeof buildPane>
+  let second: ReturnType<typeof buildPane>
+
+  beforeEach(() => {
+    // The suite-level fixture composer sits OUTSIDE any pane; remove it so
+    // these tests exercise the grid shape alone.
+    composer.remove()
+    first = buildPane()
+    second = buildPane()
+  })
+  afterEach(() => {
+    first.pane.remove()
+    second.pane.remove()
+  })
+
+  it('resolves the SECOND pane composer when focus is inside the second pane', () => {
+    second.ta.focus()
+    expect(queryComposer()).toBe(second.ta)
+    expect(queryComposer()).not.toBe(first.ta)
+  })
+
+  it('resolves via any focused element inside the pane, not only the composer itself', () => {
+    // A shortcut can fire while a header button or picker inside the pane
+    // holds focus — the pane boundary, not the focused element type, decides.
+    const btn = document.createElement('button')
+    second.pane.appendChild(btn)
+    btn.focus()
+    expect(queryComposer()).toBe(second.ta)
+  })
+
+  it('falls back to first-in-document-order when focus is outside every pane', () => {
+    // Focus on <body>: no pane context, so the document-wide fallback applies
+    // — identical to the pre-split behaviour.
+    ;(document.activeElement as HTMLElement | null)?.blur?.()
+    expect(queryComposer()).toBe(first.ta)
+  })
+
+  it('falls back document-wide when the active pane has no composer', () => {
+    second.ta.remove()
+    const btn = document.createElement('button')
+    second.pane.appendChild(btn)
+    btn.focus()
+    expect(queryComposer()).toBe(first.ta)
+  })
+
+  it('resolves the grid-focused pane when focus sits in a portal outside every pane', () => {
+    // The pane's pickers render through createPortal under document.body, so
+    // their focused input has NO pane ancestor. The grid marks its focused
+    // pane with data-chat-pane="focused"; that marker must win over the
+    // document-order fallback, or Alt+Enter from pane 2's picker would send
+    // the caret to pane 1.
+    second.pane.setAttribute('data-chat-pane', 'focused')
+    const portalInput = document.createElement('input')
+    document.body.appendChild(portalInput)
+    portalInput.focus()
+    expect(queryComposer()).toBe(second.ta)
+    portalInput.remove()
+  })
+
+  it('activeElement pane ancestry outranks the grid-focused marker', () => {
+    // Clicking INTO pane 1 while the grid still marks pane 2 as focused: the
+    // element the user is actually in wins.
+    first.pane.setAttribute('data-chat-pane', '')
+    second.pane.setAttribute('data-chat-pane', 'focused')
+    first.ta.focus()
+    expect(queryComposer()).toBe(first.ta)
+  })
+
+  it('focusComposer moves the caret to the active pane composer, not the first pane', async () => {
+    // The end-to-end behavioural claim from the issue: Alt+Enter (and every
+    // focus-the-composer path) acts on the pane the user is working in.
+    const btn = document.createElement('button')
+    second.pane.appendChild(btn)
+    btn.focus()
+    focusComposer()
+    await flushFrame()
+    expect(document.activeElement).toBe(second.ta)
+  })
+})
+
 describe('no site queries the translated label (class ratchet)', () => {
   // The nine hand-rolled `textarea[aria-label="Message input"]` queries this
   // module replaced all no-opped outside English, and the compiler cannot flag


### PR DESCRIPTION
## Problem / Motivation

In the session-grid split view, focusing the composer via any global path lands on the WRONG pane. `queryComposer()` resolves the composer with `document.querySelector('textarea[data-composer-input]')` -- a document-global first-match lookup. The split view mounts one composer per `ChatPane`, so N composers coexist and the first pane in document order always wins: Alt+Enter (focus composer), search-close focus handback, and every other `queryComposer()`-driven path put the caret in pane 1 no matter which pane the user is actually working in.

This is not a regression of #4119: the prior aria-label selector had byte-identical matched sets and first-match semantics. The defect is the document-global lookup itself, which predates both.

## Why it matters

Split view exists to work multiple sessions at once, and keyboard-first users are exactly the audience for Alt+Enter. For them the shortcut is actively hostile: it silently teleports the caret to a different pane, and the next thing typed lands in the wrong session's draft -- the same wrong-session-input failure class the module already guards against for slot creation.

## What changed (motivation -> approach -> change)

Symptom: shortcut focus routes to the first pane. Root cause: the one sanctioned composer lookup is document-global first-match, while the split view broke the module's founding "exactly one composer" assumption. Fix: scope the lookup to the pane the user is in, keeping the global lookup as the fallback.

- `website/src/pages/chat/composerFocus.ts` -- `queryComposer()` first resolves `document.activeElement?.closest('[data-chat-pane]')`; when the active element has no pane ancestor (the pane's pickers portal to `document.body`) it uses the grid-focused pane (`[data-chat-pane="focused"]`); only then does it fall back to the existing document-wide query, so non-split behaviour is byte-identical. Module docs updated to state the N-composer reality (ChatPage's own composer is unmounted in split mode, so the two surfaces never coexist).
- `website/src/components/ChatPane.tsx` -- two additions:
  - the pane wrapper gains a stable `data-chat-pane` attribute carrying `"focused"` for the grid-focused pane (a data hook, not a class name: classes are styling and churn without anyone auditing focus behaviour);
  - the wrapper gains `onFocusCapture={onFocus}`, so keyboard focus (Tab, portal autofocus, programmatic `.focus()`) claims grid focus exactly like a click. This is load-bearing for the `"focused"` fallback: grid focus previously moved only on mousedown, so pure keyboard navigation left the marker on a stale pane and portal-origin shortcuts routed to the wrong composer. It is also a deliberate interaction-semantics change beyond composer focus: the focused-pane accent border now follows keyboard entry into a pane, and the other grid-focus consumers (split target, fork source, `emitSlotFocused` prefetch) track keyboard focus too -- keyboard and mouse now have identical pane-focus semantics, which is the accessibility-consistent behaviour.

Alternatives considered: threading a pane/slot parameter through every `queryComposer()` caller (App.tsx, useKeyboardShortcuts, useMessageSearch, ChatSidebar, ChatPage) was rejected -- most callers have no pane context to thread, and `document.activeElement` is already the ground truth for "where the user is working".

## Tests

- `composerFocus.test.ts` (new `split view` block): with two pane fixtures, the lookup resolves the SECOND pane's composer when focus is in the second pane; resolves via any focused element inside the pane (header button), not only the composer itself; falls back to first-in-document-order when focus is outside every pane; falls back document-wide when the active pane has no composer; and `focusComposer()` end-to-end moves the caret to the active pane's composer.
- `ChatInput.composerProbe.test.tsx` -- consumer contract against two REAL mounted `ChatInput`s in two `[data-chat-pane]` wrappers: focus in pane 2 resolves pane 2's composer, focus in pane 1 resolves pane 1's.
- `ChatPane.dirSend.test.tsx` -- producer contract: the real `ChatPane` wrapper carries `data-chat-pane` and contains that pane's `data-composer-input` textarea; the `focused` prop maps to the `"focused"` attribute value; and keyboard `.focus()` inside the pane fires the grid's `onFocus` (mutation-verified: removing `onFocusCapture` fails this test), locking the convergence invariant between DOM focus and the grid's focused marker. Losing the attribute or the capture handler would silently degrade split-view scoping back to first-pane-wins without failing any fixture-based test; these lock it.

## Manual verification

N/A -- unit coverage sufficient: the two-real-composer mount reproduces the exact DOM shape of the split view, and the single-pane fallback is locked by the pre-existing suite (all previous `composerFocus` tests pass unchanged).

## Related Issues

Closes #4124

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** no new or changed pixels -- the `data-chat-pane` attribute is invisible, and the focused-pane accent border is a pre-existing visual whose trigger set widens (it now also follows keyboard focus, matching mouse); a static before/after renders identically. The behavioural delta is locked by the mutation-verified keyboard-focus test instead.
