### PR TITLE
chore: reuse the shared dashboard API stub in the pane-inset harness

### DIFF
--- a/website/scripts/capture-side-panel-pane-inset.mjs
+++ b/website/scripts/capture-side-panel-pane-inset.mjs
@@ -32,6 +32,9 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 // real dashboard serves from outside the SPA bundle (a local copy 404s it and
 // renders a broken brand mark in every frame).
 import { serveDist } from './lib/serve-dist.mjs'
+// Same reason as the server: the ~25 boot endpoints every gateway-free harness
+// needs live in one place, with `extra` for the per-harness ones.
+import { stubDashboardApi, json, logPageProblems } from './lib/stub-dashboard-api.mjs'
 
 const OUT = process.argv[2] || '/tmp/capabilities-pane-inset'
 // Viewport width: 390 (a phone) by default; pass a second argument to measure
@@ -75,9 +78,6 @@ const AGENTS = [
   { name: 'code-reviewer', description: 'Reviews changes against the repo conventions', source: 'builtin', model: 'auto', mcp_servers: [], filename: 'code-reviewer.json', skills: [] },
 ]
 
-const json = (route, body) =>
-  route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) })
-
 const { srv, base } = await serveDist()
 const browser = await chromium.launch()
 const context = await browser.newContext({
@@ -91,47 +91,35 @@ const context = await browser.newContext({
 })
 const page = await context.newPage()
 
-await page.routeWebSocket(/\/api\/ws/, () => {})
-
-await page.route('**/api/**', async route => {
-  const path = new URL(route.request().url()).pathname
-
-  if (path === '/api/skills') return json(route, SKILLS)
-  if (path === '/api/steering') return json(route, STEERING)
-  if (path === '/api/hooks') return json(route, HOOKS)
-  if (path === '/api/prompts') return json(route, PROMPTS)
-  if (path === '/api/mcp') return json(route, MCP)
-  if (path === '/api/workspaces') return json(route, WORKSPACES)
-  if (path === '/api/agents/installed') return json(route, AGENTS)
-  if (path === '/api/config/default-agent') return json(route, { default_agent: 'kirocrew' })
-  if (path === '/api/models') return json(route, [{ model_name: 'auto', description: 'Let Kiro choose' }])
-  // The app shell mounts behind this gate and reads status.operation.status — a
-  // generic object stub crashes it, blanking the whole page.
-  if (path === '/api/kiro-prerequisite') {
-    return json(route, {
-      platform: 'linux', installed: true, authenticated: true, ready: true,
-      initial_setup_complete: true, can_auto_install: false, can_login: false,
-      repair_required: false, docs_url: '', setup_allowed: false,
-      operation: { kind: '', status: 'idle', message: '', detail: '', url: '', error: '' },
-    })
-  }
-  if (path === '/api/status') return json(route, { sessions: 1, crons: 0, lessons: 0, subagents: 0, uptime: 120, version: 'dev' })
-  if (path === '/api/notifications') return json(route, { notifications: [], unread: 0 })
-  if (path === '/api/auth/me') return json(route, { user: 'owner', app: '' })
-  if (path === '/api/theme/boot') return json(route, { mode: 'dark', theme: '' })
-  if (path === '/api/dashboard/branding') return json(route, { bot_name: 'Kiro', avatar: '' })
-  if (path.startsWith('/api/instances')) return json(route, { instances: [], active: '' })
-  const objectish = /(config|tips|voice|autonudge|branding|status|usage|probe|scopes|active)/.test(path)
-  return json(route, objectish ? {} : [])
+// Boot fixtures (prerequisite gate, status, notifications, auth, branding,
+// instances, websocket swallow, localStorage) come from the shared lib rather
+// than a local copy: it is consulted after `extra`, so only the endpoints this
+// harness actually cares about live here. It also gets the two-word `bot_name`
+// right, which a hand-rolled copy does not.
+await stubDashboardApi(page, {
+  // `extra` must report that it HANDLED the route: the lib awaits the return
+  // value, and `json()`'s promise resolves to undefined, so returning it alone
+  // reads as unhandled and the lib fulfils a second time ("Route is already
+  // handled!"). Hence the sibling harnesses' `return json(...), true` shape.
+  extra: (path, route) => {
+    if (path === '/api/skills') return json(route, SKILLS), true
+    if (path === '/api/steering') return json(route, STEERING), true
+    if (path === '/api/hooks') return json(route, HOOKS), true
+    if (path === '/api/prompts') return json(route, PROMPTS), true
+    if (path === '/api/mcp') return json(route, MCP), true
+    if (path === '/api/workspaces') return json(route, WORKSPACES), true
+    if (path === '/api/agents/installed') return json(route, AGENTS), true
+    if (path === '/api/config/default-agent') {
+      return json(route, { default_agent: 'kirocrew' }), true
+    }
+    if (path === '/api/models') {
+      return json(route, [{ model_name: 'auto', description: 'Let Kiro choose' }]), true
+    }
+    return false
+  },
 })
 
-page.on('pageerror', err => console.log('PAGEERROR:', String(err).slice(0, 300)))
-
-await page.addInitScript(() => {
-  localStorage.clear()
-  localStorage.setItem('mc-theme', 'dark')
-  localStorage.setItem('mc-onboarded', '1')
-})
+logPageProblems(page)
 
 /**
  * Distance from the tab strip's bottom border to the top of the pane's content.


### PR DESCRIPTION
Follow-up to #4155, which merged while First Principles' last advisory finding was still open. That finding was correct and this is the subtraction it asked for.

## What #4155 got wrong

The measurement harness it added, `website/scripts/capture-side-panel-pane-inset.mjs`, inlined ~45 lines of boot fixtures: the prerequisite gate, `/api/status`, notifications, auth, branding, instances, the websocket swallow and the `localStorage` init. `website/scripts/lib/stub-dashboard-api.mjs` already owns every one of those for the **83** other capture scripts in that folder, and its own docstring names this exact per-script copy as the harm it exists to remove — an endpoint added to the boot path previously had to be patched into every harness by hand.

The copy also carried `bot_name: 'Kiro'`. The shared lib documents why that value has to stay **two words**: the nav brand row accents the last word only, and the composer interpolates the whole name, so a single-word value silently yields frames with no "CREW" and a "Message Kiro…" composer. That is a real (if invisible-in-this-PR's-crops) defect that would have been copied forward by the next author who used this harness as a template.

## The change

Net **12 lines removed** (+30 / −42). Only the nine page-specific fixtures remain, passed through the lib's `extra` hook, which it consults before its own table.

One non-obvious detail worth the comment it now carries: `extra` returns `json(route, x), true`, matching the sibling harnesses. The lib does `if (extra && (await extra(path, route))) return` — and `json()`'s fulfil promise resolves to `undefined`, so returning it alone reads as *unhandled* and the lib fulfils the same route a second time. That fails loudly (`Route is already handled!`), which is how the first attempt at this refactor was caught.

## Verification

- **Behaviour-identical, checked per row.** All 34 tabs across the three `SidePanelLayout` pages (Agent Capabilities, Developer, Settings) produce measurements byte-identical to the pre-change run — same 31 measured, same 3 unrenderable, same `boxGapPx: 12` on every measured tab, zero differing rows.
- `npx jscpd .` → `Found 0 clones` (the gate #4155 tripped once already).
- `node --check` clean.

## A defect this surfaced, deliberately not fixed here

Switching to the lib's `logPageProblems` (it listens on `console` as well as `pageerror`) revealed why `developer/config` never renders under the fixtures: an app-shell `ErrorBoundary` catching `TypeError: Cannot convert undefined or null to object`. The harness's local `pageerror`-only handler had been swallowing it, so the tab just silently reported "pane or strip not found".

That is a **fixture gap, not a product bug**, and fixing it means finding which config endpoint the page iterates over — out of scope for a dedupe. `#4155`'s body already discloses those three tabs as unmeasured; this PR simply explains one of them.

## Not touched

No product code. This is one dev script; there is no user-visible surface and no screenshot to attach.

<!-- no-visual-delta -->
**Why no screenshot:** the only changed file is a development-only measurement harness under `website/scripts/`; it renders nothing in the shipped app, and its own output is proven unchanged row-for-row above.
