### PR TITLE
test(slack): await the spawned backfill before asserting on it

### DIFF
--- a/test/test_slack_options_lifecycle.py
+++ b/test/test_slack_options_lifecycle.py
@@ -378,6 +378,7 @@ class TestLifecycleOnTheSlot:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             resp = await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _settle_slack_backfill(state)
             assert resp.status == 200
             thread_ts = (await resp.json())["thread_ts"]
 
@@ -735,6 +736,24 @@ class TestTurnEntryWiring:
         assert calls == ["dashboard:chat-7-1785370000"]
 
 
+async def _settle_slack_backfill(state):
+    """Await the backfill the slack-link endpoint spawns fire-and-forget.
+
+    The endpoint answers 200 without awaiting the drain, so the mock it posts
+    through has not been called yet when the request resolves. The task is
+    registered in ``state._background_tasks`` synchronously, before the handler
+    returns, so by then the set is already populated and waiting on it is a
+    handshake rather than a second race. Loops because a settled task may have
+    spawned another.
+    """
+    for _ in range(10):
+        pending = [t for t in tuple(state._background_tasks) if not t.done()]
+        if not pending:
+            return
+        await asyncio.gather(*pending, return_exceptions=True)
+    raise AssertionError("slack backfill did not settle")
+
+
 def _slack_app(state):
     from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_link
 
@@ -778,6 +797,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             resp = await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _settle_slack_backfill(state)
             assert resp.status == 200
 
         texts = [c.args[1] for c in state.slack_client.post_message.await_args_list]
@@ -796,6 +816,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _settle_slack_backfill(state)
 
         assert _is_live_control(state.slack_client.post_blocks.await_args.args[1])
         assert _recs(state, slot)
@@ -814,6 +835,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _settle_slack_backfill(state)
 
         blocks = state.slack_client.post_blocks.await_args.args[1]
         assert not _is_live_control(blocks)
@@ -838,6 +860,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _settle_slack_backfill(state)
 
         blocks = state.slack_client.post_blocks.await_args.args[1]
         assert _is_live_control(blocks)
@@ -862,6 +885,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _settle_slack_backfill(state)
 
         texts = [c.args[1] for c in state.slack_client.post_message.await_args_list]
         assert any("[OPTIONS: A | B]" in t for t in texts)
@@ -878,6 +902,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _settle_slack_backfill(state)
 
         posts = state.slack_client.post_blocks.await_args_list
         assert len(posts) == 2


### PR DESCRIPTION
## Problem / Motivation

`test/test_slack_options_lifecycle.py::TestLinkTimeBackfill` has been failing intermittently across at least six open pull requests, on four different members of the class, with `AttributeError: 'NoneType' object has no attribute 'args'` when reading `state.slack_client.post_blocks.await_args`, and sometimes instead as `assert 0 == 2` on the recorded options. Both messages describe the same thing: the posting mock had not been awaited yet. The cause is a race in the tests, not in production code. `POST /api/chat/slots/{slot}/slack-link` is handled by `api_chat_slot_slack_link` (`src/kiro_crew/dashboard/chat_slack.py:323`), which at line 436 calls `_spawn_slack_backfill` (lines 298-320). That helper runs the work as `asyncio.create_task(drain_slack_backfill(...))` and the handler returns 200 without awaiting it. `drain_slack_backfill` (line 92) is what awaits `client.post_blocks(...)` and then records the options. So both things these tests assert on are produced by a background task the request does not wait for, and the tests asserted immediately after the POST with nothing synchronising on it.

## Why it matters

The failure is spread across pull requests that cannot have caused it -- several of the affected diffs contain no Python files at all, and others touch only an unrelated test module -- so the class currently blocks unrelated work and invites re-rolling shas that cannot fix anything. It also reads as flakiness rather than as a defect: which member loses depends on how much await-work sits between its POST and its assertion, and whether the event loop reaches the task in time depends on runner load, so a different member fails each run and a whole shard sometimes passes. That is a determinate bug with a determinate fix, and leaving it in place erodes trust in a suite that is otherwise a useful signal.

## What changed

The affected tests now await the tasks the endpoint registers, via a small `_settle_slack_backfill` helper. This is a handshake rather than a delay: `_spawn_slack_backfill` adds the task to `state._background_tasks` synchronously before the handler returns, so the set is already populated once the POST resolves, and waiting on it cannot itself race. The helper loops a bounded number of times so a task that spawns another is also covered, and raises rather than returning silently if the work never settles. No `asyncio.sleep` is used anywhere in the fix -- a fixed sleep would be the same race with a wider window. Production behaviour is deliberately untouched: awaiting the drain inline inside the handler would hold the HTTP request open across Slack rate limiting, which is precisely what the fire-and-forget design documents itself as avoiding. Sibling classes in the same file already avoid the race by calling `drain_slack_backfill` directly, and those tests do not flake; the members changed here assert endpoint-path behaviour specifically, so waiting on the spawned task keeps each test's thesis intact where switching to a direct call would not.

## Tests

All 78 tests in `test/test_slack_options_lifecycle.py` pass at this branch's base, including under `-n 4 --timeout=120` to mirror the parallel execution CI uses. `TestLinkTimeBackfill` was run five times in a row and returned 6 passed every time. The synchronisation was also proved to be load-bearing with a two-arm control that forces the race window open by wrapping `drain_slack_backfill` so it yields before doing its work: without the wait the assertion fails with the mock never awaited, which is the exact production symptom, and with the wait added and the same delay in place it passes. That control was a scratch harness and is not part of this change. flake8 is clean.
