### PR TITLE
fix: pin windows signing to sha256 so each artifact signs once

### DIFF
--- a/test/test_windows_signing_contract.py
+++ b/test/test_windows_signing_contract.py
@@ -184,6 +184,24 @@ def test_electron_builder_is_wired_to_the_signing_hook() -> None:
     assert SIGN_HOOK.is_file(), f"{sign} is configured but {SIGN_HOOK} does not exist"
 
 
+def test_only_one_hash_algorithm_is_signed() -> None:
+    # electron-builder's legacy signtool default is ["sha1", "sha256"], and it
+    # invokes the sign hook ONCE PER ALGORITHM. The signing profile is
+    # SHA256-only, so an unpinned list makes every file take a second round
+    # trip through S3 and the signing service that can only ever reproduce the
+    # first signature, doubling both the signing-job count and the build's
+    # wall-clock cost.
+    config = json.loads(ELECTRON_PACKAGE_JSON.read_text(encoding="utf-8"))
+    algorithms = config["build"]["win"]["signtoolOptions"].get(
+        "signingHashAlgorithms"
+    )
+    assert algorithms == ["sha256"], (
+        "signingHashAlgorithms must be pinned to exactly ['sha256']; found "
+        f"{algorithms!r}. Leaving it unset restores electron-builder's "
+        "sha1+sha256 default and signs every artifact twice."
+    )
+
+
 def test_local_certificate_discovery_stays_disabled() -> None:
     # There is no certificate on the runner; signing goes through the hook.
     env = _step("Build desktop app")["env"]

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -149,7 +149,10 @@
         "nsis"
       ],
       "signtoolOptions": {
-        "sign": "./scripts/sign-windows.js"
+        "sign": "./scripts/sign-windows.js",
+        "signingHashAlgorithms": [
+          "sha256"
+        ]
       }
     },
     "nsis": {


### PR DESCRIPTION
## Problem

`electron-builder`'s legacy signtool default for `signingHashAlgorithms` is
`["sha1", "sha256"]`, and it invokes the custom sign hook **once per
algorithm**. Our signing profile is `AuthenticodeSigner-SHA256-RSA`, so the
second pass can only ever reproduce the first signature.

The first production signing build made the cost visible. Every file was
uploaded, signed and downloaded twice, and the second pass took the
**already signed** bytes as its input:

```
[sign-windows] signing pythonw.exe (sha256 6a8c46f955f4…)
[sign-windows] signed  pythonw.exe (job 82b5e2dc…, sha256 761f0a0b6e10…)
[sign-windows] signing pythonw.exe (sha256 761f0a0b6e10…)   <- already signed
[sign-windows] signed  pythonw.exe (job 12d0e319…, sha256 bcebcf63022d…)
```

That is the input hash of round 2 equalling the output hash of round 1, which
rules out the "two copies of the same basename" explanation the hook's own
comment offers. It is one file signed twice in place.

## Impact

Roughly 80 signing jobs where 40 would do, plus an S3 round trip and a
SigningLambda trigger wait per extra job.

The shipped installer was **not** affected: the second signature replaces
rather than appends, so the artifact carries a single `WIN_CERTIFICATE` entry
(`wRevision=0x0200`, `wCertificateType=0x0002`) whose chain verifies to
`CN=Amazon Web Services, Inc.` / `OU=AWS Kiro` under
`DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1`. This is waste, not
a correctness bug.

## Change

Pin `signingHashAlgorithms` to exactly `["sha256"]`, collapsing signing to one
pass per file, plus a contract test so the default cannot creep back.

## Verification

- Fail-before: removing the pin makes the new test fail; restoring it passes.
- `test/test_windows_signing_contract.py` 18 passed.
- `flake8` clean on the changed file, verified identical to `origin/main` for
  the same path (this host has extra lint plugins that report several hundred
  pre-existing repo-wide violations unrelated to the diff).
- `isort --check-only` clean.
- `mypy src/kiro_crew/` unaffected: the diff touches only `test/` and
  `website/electron/package.json`, nothing under `src/kiro_crew/`.
- Electron node suite: **980 passed / 0 failed** (`npm test --prefix website/electron`,
  covering `test/`, `mochi/test/` and `crew-companion/test/`). An earlier run
  reported 12 failures; that was an unprovisioned worktree, not a defect. The
  electron-updater library-contract tests read the real package source, so they
  cannot pass until `npm ci` has run in `website/electron`. Installing the
  dependencies takes the suite to fully green with no code change.

## Known limits

Signing removes the unknown-publisher class, but it does not remove the
SmartScreen first-download prompt: Microsoft dropped EV bypass, and reputation
now accrues per file hash and per certificate over download volume. Nightly
builds produce a new hash daily and will keep prompting.
