### PR TITLE
refactor: invert two trailing conditionals into guard clauses

### DIFF
--- a/src/kiro_crew/channel.py
+++ b/src/kiro_crew/channel.py
@@ -770,19 +770,20 @@ async def _stream_task(
         return
 
     full_text = "".join(chunks).strip()
-    if full_text:
-        # Sanitize LLM output before posting
-        full_text, _ = redact_exfiltration_urls(full_text)
-        full_text, _ = redact_credentials(full_text)
-        # Extract @mentions from agent's response
-        mention_ids = [
-            m.id for m in channel.members.values() if m.id != agent.id and f"@{m.role}" in full_text
-        ]
-        await channel.post(
-            agent.id,
-            full_text,
-            from_role=agent.role,
-            msg_type="progress",
-            thread_id=thread_id,
-            mention=mention_ids or None,
-        )
+    if not full_text:
+        return
+    # Sanitize LLM output before posting
+    full_text, _ = redact_exfiltration_urls(full_text)
+    full_text, _ = redact_credentials(full_text)
+    # Extract @mentions from agent's response
+    mention_ids = [
+        m.id for m in channel.members.values() if m.id != agent.id and f"@{m.role}" in full_text
+    ]
+    await channel.post(
+        agent.id,
+        full_text,
+        from_role=agent.role,
+        msg_type="progress",
+        thread_id=thread_id,
+        mention=mention_ids or None,
+    )

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -873,14 +873,15 @@ class SessionMap:
         which a whole entry leaves the map.
         """
         entry = self._data.pop(key, None)
-        if entry:
-            inbound = self._inbound_binding(entry)
-            ts = entry.get("slack_thread_ts")
-            if ts and self._thread_to_session.get(ts) == key:
-                del self._thread_to_session[ts]
-            self._save()
-            if inbound is not None:
-                self._note_inbound_unbind(key, inbound, reason)
+        if not entry:
+            return
+        inbound = self._inbound_binding(entry)
+        ts = entry.get("slack_thread_ts")
+        if ts and self._thread_to_session.get(ts) == key:
+            del self._thread_to_session[ts]
+        self._save()
+        if inbound is not None:
+            self._note_inbound_unbind(key, inbound, reason)
 
     @_guarded
     def set(self, key: str, sid: str, *, provider: str = "", cwd: str = "") -> None:


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only; two functions lose one level of indentation and
nothing about what they emit or render changes.

no linked issue: routine readability sweep, one module per PR.

## Problem

Two functions each ended with a single `if` that wrapped their entire remaining body,
so every statement inside sat one level deeper than it needed to:

- `SessionMap._remove_entry` — 8 lines under `if entry:`
- `_stream_task` — 16 lines under `if full_text:`

In both cases the `if` was the last statement in the function, so the indentation was
carrying no information: there was nothing to fall through *to*.

## Why it matters

`_stream_task`'s block is where agent output gets redacted before it is posted to a
channel, and `_remove_entry`'s is where a dying session entry releases its inbound
binding. Both are worth reading carefully, and both were reading one indent level away
from the margin for no reason. Guard clauses put the precondition where a reader looks
for it and the work at the level it belongs.

## Fix (symptom → root cause → change)

**Symptom:** the body of each function is indented under a condition that has no
alternative branch.
**Root cause:** the precondition is expressed as a wrapping `if` rather than a guard.
**Change:** invert each condition into an early return and dedent the body.

```python
# before                      # after
if entry:                     if not entry:
    <8 lines>                     return
                              <8 lines>
```

Equivalent by construction, and each premise was checked rather than assumed:

- **The `if` is the function's last statement** in both cases, so the fall-through
  already returned `None` implicitly — which is exactly what the guard's bare `return`
  produces. Confirmed by AST, not by eye.
- **Both are annotated `-> None`**, and every `return` already present in them is bare,
  so the new one is consistent with the rest.
- **Neither is a generator** — no `yield`, so `return` cannot change iteration.
- **The inverted condition is the exact negation** — `if entry:` → `if not entry:`,
  truthiness on the same object, not an identity or `is None` test.
- **No statement moved into or out of a `try`/`except`/`finally`**, and in the async
  case nothing moved across an `await`.

### The two things a reviewer will want to check

**`channel.py` keeps its redaction intact.** `AUTOSDE.yaml`'s blocking
`backend-security-controls` rule requires LLM output be scanned with
`redact_exfiltration_urls()` **and** `redact_credentials()` before it reaches an
external surface. The dedent moves those two lines and changes nothing about them:
both calls are still present, still in that order, and still on the single path that
reaches `channel.post`. The guard cannot skip them for a value that still gets posted —
it returns on empty text, which was never posted before either. The in-function
`from kiro_crew.security import ...` at the top of that function is deliberately
untouched (it resolves at call time so a test can substitute the attribute).

**`_remove_entry` still pops before the guard.** `self._data.pop(key, None)` runs
*above* the `if`, exactly as before, so a falsy entry is still removed from the map. The
guard only skips the reverse-index update, the `_save()` and the unbind audit — all of
which the old fall-through skipped too. The `@_guarded` decorator is unaffected: it does
not consume a return value, and an early `return` unwinds through it identically.

## Tests

No test changes; the diff is behavior-preserving, so the existing tests are the
assertion. **723 passed, 1 skipped** across the 29 `test_session_map*` /
`test_channel*` / `test_chat_mirror` files — including `test_session_map_unlink.py`,
which covers the unbind-audit path `_remove_entry` guards, and `test_channel.py`.

## Manual verification

Gates on a CI-parity venv (Python 3.12.13, dependency-group pins, no `faiss`), run with
`PYTHONPATH=$PWD/src` so they exercise this worktree, and **re-run after rebasing across
69 commits of new base**:

| Gate | Result |
|---|---|
| `flake8 src/kiro_crew test` | pass |
| `isort --check-only src/kiro_crew test` | pass |
| `mypy src/kiro_crew/` | pass |
| `check_brand_name.py` (diff vs merge-base) | pass |
| `check_harness_parity.py` (diff vs merge-base) | pass |
| `docs-lint.sh` | pass |
| `check_per_file_coverage.py --test` | pass |
| `verify_vendor_manifest.py` | pass |
| `scrub-lint.sh --no-history` | pass |

Reviewed before opening by four parallel subagents grounded in `AUTOSDE.yaml` and the
`codex-review.yml` / `claude-review.yml` / `code-review.yml` contracts — one lens each
on equivalence, the redaction invariant above, blocking AUTOSDE rules, and what the
early return now skips — with three adversarial refuters standing by per finding.
**Zero findings raised.**

Frontend gates were not run: the diff touches nothing under `website/`, `.github/` or
`scripts/`, so CI's `changes` job reports `only_backend=true`.
