### PR TITLE
feat(desktop): ship Linux deb and rpm packages with per-format update lanes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,6 +53,8 @@ body:
       label: How is it installed?
       options:
         - Desktop app
+        - Desktop app (deb)
+        - Desktop app (rpm)
         - pip / pipx
         - Docker
         - From source

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -9,8 +9,8 @@ name: Build Desktop (reusable)
 #
 # Platform matrix (expand as support lands):
 #   - macOS universal (arm64 + x86_64): shipped (one desktop DMG)
-#   - Linux x64:    shipped (AppImage)
-#   - Linux arm64:  shipped (AppImage — Graviton, Raspberry Pi, ARM laptops)
+#   - Linux x64:    shipped (AppImage + deb + rpm)
+#   - Linux arm64:  shipped (AppImage + deb + rpm — Graviton, Raspberry Pi, ARM laptops)
 #
 # Linux is built NATIVELY per arch, never cross-compiled: build-desktop.sh
 # provisions a python-build-standalone interpreter and then RUNS it (pip
@@ -148,5 +148,40 @@ jobs:
             website/electron/dist/*.dmg
             website/electron/dist/*.zip
             website/electron/dist/*.AppImage
+            website/electron/dist/*.deb
+            website/electron/dist/*.rpm
           if-no-files-found: error
           retention-days: 14
+
+  # Install the Linux packages for real, in the distros they target.
+  #
+  # Everything this job checks is invisible to a unit test, because it lives in
+  # metadata the package manager interprets rather than in code we run:
+  # dependency names that must exist in the target distro's repositories (they
+  # differ per distro, and Ubuntu 24.04's 64-bit time_t rename split several of
+  # them), the .desktop entry electron-builder generates, and the maintainer
+  # scripts that place the launcher symlink. A wrong name here produces a package
+  # that builds green and refuses to install, which no other gate would catch.
+  #
+  # x64 only: the checks are about metadata and dependency resolution, neither of
+  # which is arch-specific, and running arm64 containers under emulation would
+  # cost far more than it proves.
+  smoke-linux-packages:
+    name: Smoke-install Linux packages (deb + rpm)
+    needs: build-desktop
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download Linux x64 build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-linux-x64
+          path: dist
+
+      # x64 only: every assertion is about metadata and dependency resolution,
+      # neither of which is arch-specific, and running arm64 containers under
+      # emulation would cost far more than it proves.
+      - name: Install the packages in their target distros
+        run: ./scripts/smoke-linux-packages.sh dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
     outputs:
       only_backend: ${{ steps.decide.outputs.only_backend }}
       only_frontend: ${{ steps.decide.outputs.only_frontend }}
+      linux_packaging: ${{ steps.filter.outputs.linux_packaging }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -96,6 +97,16 @@ jobs:
               - '!website/**'
               - '!.github/**'
               - '!scripts/**'
+            # Independent of the three buckets above: it answers a different
+            # question ("could this diff change what a Linux package installs?")
+            # and so may overlap them freely.
+            linux_packaging:
+              - 'website/electron/package.json'
+              - 'website/electron/auto-update.js'
+              - 'website/electron/bundle-location.js'
+              - 'packaging/build-desktop.sh'
+              - 'scripts/stamp-distribution.sh'
+              - '.github/workflows/build-desktop.yml'
 
       - name: Decide surface
         id: decide
@@ -120,6 +131,47 @@ jobs:
           echo "only_backend=$only_backend"   >> "$GITHUB_OUTPUT"
           echo "only_frontend=$only_frontend" >> "$GITHUB_OUTPUT"
           echo "backend=$BACKEND frontend=$FRONTEND meta=$META full_run=$FULL_RUN -> only_backend=$only_backend only_frontend=$only_frontend"
+
+  # Build the Linux desktop packages and install them for real, but ONLY when the
+  # diff could change what a package installs. The check is expensive (a PBS
+  # interpreter, a full pip closure, then electron-builder three times), and it
+  # verifies things no cheaper gate can: dependency names that must exist in the
+  # target distro's repositories, the generated .desktop entry, and the maintainer
+  # scripts. Same trade the macOS-packaging path gate already makes.
+  #
+  # A packaging change that lands without this having run is the failure mode this
+  # exists to prevent: a package that builds green and refuses to install.
+  linux-packaging:
+    name: Linux Packaging (build + smoke-install)
+    needs: changes
+    if: ${{ needs.changes.outputs.linux_packaging == 'true' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      # Builds all three Linux formats from one backend tree, re-stamping the
+      # beacon distribution between electron-builder invocations.
+      - name: Build the Linux desktop packages
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: bash packaging/build-desktop.sh
+
+      - name: Install the packages in their target distros
+        run: ./scripts/smoke-linux-packages.sh website/electron/dist
 
   scrub-lint:
     name: De-Amazon Scrub Lint

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -195,8 +195,8 @@ jobs:
   # existed. True per-arch publish independence needs the publishers to run
   # past a partial build failure and let their own artifact download decide;
   # tracked in #2645 rather than reshaped here.
-  publish-linux-x64:
-    name: Publish Linux Desktop (nightly channel · x64)
+  publish-linux-appimage-x64:
+    name: Publish Linux appimage (nightly channel · x64)
     needs: [version, build-desktop]
     permissions:
       contents: read
@@ -207,12 +207,14 @@ jobs:
       channel: nightly
       version: ${{ needs.version.outputs.nightly_version }}
       arch: x64
+      format: appimage
       publish: true
-      appimage_artifact: build-linux-x64
-    secrets: inherit
+      build_artifact: build-linux-x64
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
 
-  publish-linux-arm64:
-    name: Publish Linux Desktop (nightly channel · arm64)
+  publish-linux-appimage-arm64:
+    name: Publish Linux appimage (nightly channel · arm64)
     needs: [version, build-desktop]
     permissions:
       contents: read
@@ -223,9 +225,83 @@ jobs:
       channel: nightly
       version: ${{ needs.version.outputs.nightly_version }}
       arch: arm64
+      format: appimage
       publish: true
-      appimage_artifact: build-linux-arm64
-    secrets: inherit
+      build_artifact: build-linux-arm64
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+
+  publish-linux-deb-x64:
+    name: Publish Linux deb (nightly channel · x64)
+    needs: [version, build-desktop]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-linux.yml
+    with:
+      channel: nightly
+      version: ${{ needs.version.outputs.nightly_version }}
+      arch: x64
+      format: deb
+      publish: true
+      build_artifact: build-linux-x64
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+
+  publish-linux-deb-arm64:
+    name: Publish Linux deb (nightly channel · arm64)
+    needs: [version, build-desktop]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-linux.yml
+    with:
+      channel: nightly
+      version: ${{ needs.version.outputs.nightly_version }}
+      arch: arm64
+      format: deb
+      publish: true
+      build_artifact: build-linux-arm64
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+
+  publish-linux-rpm-x64:
+    name: Publish Linux rpm (nightly channel · x64)
+    needs: [version, build-desktop]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-linux.yml
+    with:
+      channel: nightly
+      version: ${{ needs.version.outputs.nightly_version }}
+      arch: x64
+      format: rpm
+      publish: true
+      build_artifact: build-linux-x64
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+
+  publish-linux-rpm-arm64:
+    name: Publish Linux rpm (nightly channel · arm64)
+    needs: [version, build-desktop]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-linux.yml
+    with:
+      channel: nightly
+      version: ${{ needs.version.outputs.nightly_version }}
+      arch: arm64
+      format: rpm
+      publish: true
+      build_artifact: build-linux-arm64
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
 
   # ── Windows installer publish ─────────────────────────────────────────
   # Depends on build-windows rather than build-desktop: the installer is

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -1,6 +1,6 @@
 name: Publish Linux Desktop (reusable)
 
-# Reusable workflow: publish an already-built Linux AppImage to a release
+# Reusable workflow: publish one already-built Linux artifact (AppImage or deb) to a release
 # channel on the distribution CDN. Called by nightly.yml (channel: nightly)
 # and release.yml (channel: insider | stable) as its own lane BESIDE the
 # macOS sign-and-notarize workflow, mirroring publish-cli.yml: the Linux
@@ -18,17 +18,17 @@ name: Publish Linux Desktop (reusable)
 # on GitHub Releases.
 #
 # Key properties:
-#   - The versioned key desktop/<channel>/<version>/KiroCrew-<arch>.AppImage
+#   - The versioned key desktop/<channel>/<version>/KiroCrew-<arch>.<ext>
 #     is immutable-cached by CloudFront and is never republished with
 #     different bytes (--if-none-match conditional write; a 412 on a job
 #     re-run keeps the existing object and continues idempotently).
-#   - The mutable alias desktop/<channel>/latest/KiroCrew-<arch>.AppImage
+#   - The mutable alias desktop/<channel>/latest/KiroCrew-<arch>.<ext>
 #     (max-age=300) is written AFTER the versioned key so it never points
 #     at bytes that are not yet live.
 #   - Arch-qualified filename: Linux has no universal binary, so per-arch
 #     filenames are the contract (per-arch, never per-distro). One
-#     invocation of this workflow publishes exactly one arch, so x86_64 and
-#     aarch64 never share a key, a feed, or an alias.
+#     invocation of this workflow publishes exactly one (arch, format) pair,
+#     so no two of them ever share a key, a feed, or an alias.
 #   - Writes feed/<channel>/latest-linux[-arm64].yml (electron-updater
 #     channel metadata) AFTER the versioned AppImage is live and BEFORE the
 #     latest alias, mirroring the mac lane's go-live order: a feed must
@@ -51,13 +51,22 @@ on:
         description: "Desktop CPU architecture this invocation publishes: x64 | arm64"
         required: true
         type: string
+      format:
+        description: >-
+          Linux artifact format this invocation publishes: appimage | deb.
+          One invocation publishes exactly ONE (arch, format) pair, so no two
+          formats ever share a CDN key, a feed, or a latest alias — the same
+          discipline the arch dimension already enforces.
+        required: false
+        type: string
+        default: appimage
       publish:
         description: "Publish to the public CDN; false skips the job entirely"
         required: false
         type: boolean
         default: true
-      appimage_artifact:
-        description: "Name of the uploaded artifact containing the AppImage"
+      build_artifact:
+        description: "Name of the uploaded artifact containing the Linux artifact to publish"
         required: true
         type: string
       promote:
@@ -70,6 +79,13 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      # The only secret this workflow reads. Declared so a caller can pass just
+      # this one rather than `secrets: inherit`, which would hand a reusable
+      # workflow every secret in the repository. Not `required`, because the job
+      # skips itself when it is absent (a fork has no signing role).
+      AWS_SIGNING_ROLE_ARN:
+        required: false
 
 permissions:
   contents: read
@@ -78,7 +94,7 @@ permissions:
 
 jobs:
   publish-linux:
-    name: Publish Linux AppImage (${{ inputs.channel }} · ${{ inputs.arch }})
+    name: Publish Linux ${{ inputs.format }} (${{ inputs.channel }} · ${{ inputs.arch }})
     # Public-distribution gates: skipped when the caller runs publish-less
     # or the CDN is not configured (fork). BOTH variables are required --
     # the bucket receives the upload and the CDN base is baked into the
@@ -99,6 +115,7 @@ jobs:
       CHANNEL: ${{ inputs.channel }}
       VERSION: ${{ inputs.version }}
       ARCH: ${{ inputs.arch }}
+      FORMAT: ${{ inputs.format }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -123,14 +140,51 @@ jobs:
               echo "LINUX_BASENAME=KiroCrew-x86_64" >> "$GITHUB_ENV"
               echo "FEED_FILE=latest-linux.yml" >> "$GITHUB_ENV"
               echo "EXPECT_ELF_MACHINE=x86-64" >> "$GITHUB_ENV"
+              echo "EXPECT_DEB_ARCH=amd64" >> "$GITHUB_ENV"
+              echo "EXPECT_RPM_ARCH=x86_64" >> "$GITHUB_ENV"
               ;;
             arm64)
               echo "LINUX_BASENAME=KiroCrew-aarch64" >> "$GITHUB_ENV"
               echo "FEED_FILE=latest-linux-arm64.yml" >> "$GITHUB_ENV"
               echo "EXPECT_ELF_MACHINE=aarch64" >> "$GITHUB_ENV"
+              echo "EXPECT_DEB_ARCH=arm64" >> "$GITHUB_ENV"
+              echo "EXPECT_RPM_ARCH=aarch64" >> "$GITHUB_ENV"
               ;;
             *)
               echo "::error::unsupported arch '${ARCH}' (expected x64 or arm64)"
+              exit 1
+              ;;
+          esac
+
+      # Resolve every FORMAT-dependent name, fail-closed for the same reason as
+      # the arch block: a wrong extension or feed prefix writes bytes under a key
+      # that is immutable once published.
+      #
+      # FEED_PREFIX is what keeps the two formats' electron-updater metadata
+      # apart. The channel FILE name is derived by electron-updater from platform
+      # and arch with no hook to change it, so two formats cannot share a
+      # directory without one overwriting the other's feed. A per-format
+      # subdirectory leaves that derivation — including the -arm64 suffix —
+      # completely untouched; auto-update.js points a package install at the same
+      # subdirectory via buildFeedBase()'s `variant`.
+      - name: Resolve format-dependent names
+        run: |
+          set -euo pipefail
+          case "${FORMAT}" in
+            appimage)
+              echo "LINUX_EXT=AppImage" >> "$GITHUB_ENV"
+              echo "FEED_PREFIX=feed/${CHANNEL}" >> "$GITHUB_ENV"
+              ;;
+            deb)
+              echo "LINUX_EXT=deb" >> "$GITHUB_ENV"
+              echo "FEED_PREFIX=feed/${CHANNEL}/deb" >> "$GITHUB_ENV"
+              ;;
+            rpm)
+              echo "LINUX_EXT=rpm" >> "$GITHUB_ENV"
+              echo "FEED_PREFIX=feed/${CHANNEL}/rpm" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "::error::unsupported format '${FORMAT}' (expected appimage, deb or rpm)"
               exit 1
               ;;
           esac
@@ -146,7 +200,7 @@ jobs:
         if: env.HAS_SIGNING_SECRETS
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ inputs.appimage_artifact }}
+          name: ${{ inputs.build_artifact }}
           path: artifacts
 
       - name: Verify immutable promotion bundle
@@ -159,30 +213,32 @@ jobs:
             --expected-source-sha "${GITHUB_SHA}" \
             --expected-base-version "${PROMOTION_BASE_VERSION}"
 
-      - name: Locate AppImage
+      - name: Locate Linux artifact
         if: env.HAS_SIGNING_SECRETS
         env:
           PROMOTE: ${{ inputs.promote }}
         run: |
           set -euo pipefail
           # Promotion bundles carry BOTH arches under canonical names, so the
-          # match must be arch-pinned there. Fresh builds carry one AppImage
-          # with electron-builder's versioned filename, which never equals the
-          # canonical basename -- match any AppImage in that mode.
+          # match must be arch-pinned there. Fresh builds carry one artifact per
+          # format with electron-builder's versioned filename, which never equals
+          # the canonical basename -- match any file of this format in that mode.
+          # The extension alone separates the formats, so a build that produced
+          # both an AppImage and a deb still yields exactly one match here.
           if [ "${PROMOTE}" = "true" ]; then
-            PATTERN="${LINUX_BASENAME}.AppImage"
+            PATTERN="${LINUX_BASENAME}.${LINUX_EXT}"
           else
-            PATTERN="*.AppImage"
+            PATTERN="*.${LINUX_EXT}"
           fi
-          mapfile -t APPIMAGES < <(find artifacts -type f -name "$PATTERN")
-          if [ "${#APPIMAGES[@]}" -eq 0 ]; then
-            echo "No AppImage found matching ${PATTERN} in build artifacts"; exit 1
+          mapfile -t MATCHES < <(find artifacts -type f -name "$PATTERN")
+          if [ "${#MATCHES[@]}" -eq 0 ]; then
+            echo "No ${LINUX_EXT} found matching ${PATTERN} in build artifacts"; exit 1
           fi
-          if [ "${#APPIMAGES[@]}" -gt 1 ]; then
-            echo "Expected exactly one AppImage matching ${PATTERN}, found ${#APPIMAGES[@]}:"; printf '%s\n' "${APPIMAGES[@]}"; exit 1
+          if [ "${#MATCHES[@]}" -gt 1 ]; then
+            echo "Expected exactly one ${LINUX_EXT} matching ${PATTERN}, found ${#MATCHES[@]}:"; printf '%s\n' "${MATCHES[@]}"; exit 1
           fi
-          echo "APPIMAGE_PATH=${APPIMAGES[0]}" >> "$GITHUB_ENV"
-          ls -la "${APPIMAGES[0]}"
+          echo "ARTIFACT_PATH=${MATCHES[0]}" >> "$GITHUB_ENV"
+          ls -la "${MATCHES[0]}"
 
       # The artifact NAME is caller-supplied, so nothing upstream proves the
       # bytes are the arch this invocation publishes them as. Verify it against
@@ -190,17 +246,48 @@ jobs:
       # passes every checksum the updater applies (sha512 matches the bytes that
       # were uploaded) and only fails on the user's machine as "cannot execute
       # binary file", after the key is already burned.
-      - name: Verify AppImage architecture
+      - name: Verify artifact architecture
         if: env.HAS_SIGNING_SECRETS
+        env:
+          # Through env, not `${{ }}` inside run: a caller-supplied value
+          # interpolated into the script body is a shell-injection surface, and
+          # this one only ever appears in a diagnostic string.
+          BUILD_ARTIFACT: ${{ inputs.build_artifact }}
         run: |
           set -euo pipefail
-          FILE_OUT="$(file -b "${APPIMAGE_PATH}")"
-          echo "${FILE_OUT}"
-          if ! printf '%s' "${FILE_OUT}" | grep -qi -- "${EXPECT_ELF_MACHINE}"; then
-            echo "::error::artifact ${{ inputs.appimage_artifact }} is not ${ARCH} (expected ELF machine '${EXPECT_ELF_MACHINE}'): ${FILE_OUT}"
-            exit 1
+          # An AppImage is an ELF, so its own header carries the machine. A deb and
+          # an rpm are archives whose ELF payload is compressed inside, so the
+          # authoritative statement is the package metadata's own architecture
+          # field -- which is also the value dpkg/rpm enforce at install time,
+          # making it the right thing to gate on. Each format names that arch
+          # differently (amd64 vs x86_64), which is why the expectations are
+          # resolved per format rather than shared.
+          if [ "${FORMAT}" = "deb" ]; then
+            PKG_ARCH="$(dpkg-deb -f "${ARTIFACT_PATH}" Architecture)"
+            EXPECT="${EXPECT_DEB_ARCH}"
+          elif [ "${FORMAT}" = "rpm" ]; then
+            PKG_ARCH="$(rpm -qp --queryformat '%{ARCH}' "${ARTIFACT_PATH}" 2>/dev/null)"
+            EXPECT="${EXPECT_RPM_ARCH}"
+          else
+            PKG_ARCH=""
+            EXPECT=""
           fi
-          echo "Architecture verified: ${ARCH} (${EXPECT_ELF_MACHINE})"
+          if [ -n "${EXPECT}" ]; then
+            echo "${FORMAT} architecture: ${PKG_ARCH}"
+            if [ "${PKG_ARCH}" != "${EXPECT}" ]; then
+              echo "::error::artifact ${BUILD_ARTIFACT} declares architecture '${PKG_ARCH}', expected '${EXPECT}' for ${ARCH}"
+              exit 1
+            fi
+            echo "Architecture verified: ${ARCH} (${EXPECT})"
+          else
+            FILE_OUT="$(file -b "${ARTIFACT_PATH}")"
+            echo "${FILE_OUT}"
+            if ! printf '%s' "${FILE_OUT}" | grep -qi -- "${EXPECT_ELF_MACHINE}"; then
+              echo "::error::artifact ${BUILD_ARTIFACT} is not ${ARCH} (expected ELF machine '${EXPECT_ELF_MACHINE}'): ${FILE_OUT}"
+              exit 1
+            fi
+            echo "Architecture verified: ${ARCH} (${EXPECT_ELF_MACHINE})"
+          fi
 
       # Signed SLSA provenance for the EXACT bytes this lane uploads,
       # attested before anything reaches S3. This closes the decoupling
@@ -211,16 +298,16 @@ jobs:
       # with no verifiable provenance. Placed BEFORE the versioned-key
       # write so un-attested bytes never go live; if attestation fails,
       # the job fails and nothing is published.
-      - name: Attest AppImage provenance
+      - name: Attest artifact provenance
         if: env.HAS_SIGNING_SECRETS && !inputs.promote
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-path: ${{ env.APPIMAGE_PATH }}
+          subject-path: ${{ env.ARTIFACT_PATH }}
 
-      - name: Verify promoted AppImage provenance
+      - name: Verify promoted artifact provenance
         if: env.HAS_SIGNING_SECRETS && inputs.promote
         run: |
-          gh attestation verify "${APPIMAGE_PATH}" \
+          gh attestation verify "${ARTIFACT_PATH}" \
             --repo "${{ github.repository }}" \
             --signer-workflow "${{ github.repository }}/.github/workflows/publish-linux.yml"
 
@@ -229,16 +316,16 @@ jobs:
       # never carry different bytes. --if-none-match makes the write
       # conditional; a 412 on a job re-run keeps the existing object and
       # continues idempotently.
-      - name: Publish AppImage to distribution bucket
+      - name: Publish artifact to distribution bucket
         if: env.HAS_SIGNING_SECRETS
         run: |
           set -euo pipefail
-          APPIMAGE_KEY="desktop/${CHANNEL}/${VERSION}/${LINUX_BASENAME}.AppImage"
+          ARTIFACT_KEY="desktop/${CHANNEL}/${VERSION}/${LINUX_BASENAME}.${LINUX_EXT}"
           set +e
           PUT_OUT=$(aws s3api put-object \
             --bucket "${{ vars.CLI_DIST_BUCKET }}" \
-            --key "${APPIMAGE_KEY}" \
-            --body "${APPIMAGE_PATH}" \
+            --key "${ARTIFACT_KEY}" \
+            --body "${ARTIFACT_PATH}" \
             --if-none-match '*' \
             --content-type application/octet-stream \
             --cache-control "public, max-age=31536000, immutable" 2>&1)
@@ -254,13 +341,13 @@ jobs:
               # key. Same discipline as publish-cli.yml's 412 path; the
               # compare goes through the public CDN because the publish
               # role's S3 read-back grant covers cli/* only.
-              echo "Key already published (job re-run) -- verifying existing bytes match this build: ${APPIMAGE_KEY}"
-              curl -fsSL --retry 3 "${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}" -o /tmp/published.AppImage
-              PUBLISHED_SHA=$(sha256sum /tmp/published.AppImage | awk '{print $1}')
-              LOCAL_SHA=$(sha256sum "${APPIMAGE_PATH}" | awk '{print $1}')
-              rm -f /tmp/published.AppImage
+              echo "Key already published (job re-run) -- verifying existing bytes match this build: ${ARTIFACT_KEY}"
+              curl -fsSL --retry 3 "${{ vars.CLI_CDN_BASE }}/${ARTIFACT_KEY}" -o /tmp/published.artifact
+              PUBLISHED_SHA=$(sha256sum /tmp/published.artifact | awk '{print $1}')
+              LOCAL_SHA=$(sha256sum "${ARTIFACT_PATH}" | awk '{print $1}')
+              rm -f /tmp/published.artifact
               if [ "$PUBLISHED_SHA" != "$LOCAL_SHA" ]; then
-                echo "::error::Immutable key ${APPIMAGE_KEY} already holds DIFFERENT bytes (published ${PUBLISHED_SHA}, this build ${LOCAL_SHA}). The version string is burned -- cut a new version instead of re-running. Refusing to repoint the latest alias."
+                echo "::error::Immutable key ${ARTIFACT_KEY} already holds DIFFERENT bytes (published ${PUBLISHED_SHA}, this build ${LOCAL_SHA}). The version string is burned -- cut a new version instead of re-running. Refusing to repoint the latest alias."
                 exit 1
               fi
               echo "Published bytes identical -- keeping existing object and continuing."
@@ -269,8 +356,8 @@ jobs:
               exit $RC
             fi
           fi
-          echo "APPIMAGE_KEY=${APPIMAGE_KEY}" >> "$GITHUB_ENV"
-          echo "Public artifact: ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}"
+          echo "ARTIFACT_KEY=${ARTIFACT_KEY}" >> "$GITHUB_ENV"
+          echo "Public artifact: ${{ vars.CLI_CDN_BASE }}/${ARTIFACT_KEY}"
 
       # electron-updater channel metadata (latest-linux.yml) -- the feed
       # website/electron/auto-update.js reads on Linux. Written only after
@@ -302,8 +389,8 @@ jobs:
         if: env.HAS_SIGNING_SECRETS
         run: |
           set -euo pipefail
-          APPIMAGE_SHA512=$(openssl dgst -sha512 -binary "${APPIMAGE_PATH}" | base64 -w 0)
-          APPIMAGE_SIZE=$(stat -c%s "${APPIMAGE_PATH}")
+          ARTIFACT_SHA512=$(openssl dgst -sha512 -binary "${ARTIFACT_PATH}" | base64 -w 0)
+          ARTIFACT_SIZE=$(stat -c%s "${ARTIFACT_PATH}")
 
           # FAIL CLOSED if the feed would describe bytes other than the ones
           # served. The versioned AppImage key is conditionally written and a
@@ -314,49 +401,49 @@ jobs:
           # Aborting is correct: republishing an immutable key causes edge
           # divergence (#62) -- cut a new version instead.
           SERVED_SHA512=$(curl -fsS --retry 3 --retry-delay 2 \
-            "${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}" | openssl dgst -sha512 -binary | base64 -w 0)
-          if [ "$SERVED_SHA512" != "$APPIMAGE_SHA512" ]; then
-            echo "::error::published AppImage does not match the artifact this feed would advertise."
-            echo "::error::  expected sha512 (local build): $APPIMAGE_SHA512"
+            "${{ vars.CLI_CDN_BASE }}/${ARTIFACT_KEY}" | openssl dgst -sha512 -binary | base64 -w 0)
+          if [ "$SERVED_SHA512" != "$ARTIFACT_SHA512" ]; then
+            echo "::error::published artifact does not match the bytes this feed would advertise."
+            echo "::error::  expected sha512 (local build): $ARTIFACT_SHA512"
             echo "::error::  served   sha512 (published):   $SERVED_SHA512"
             exit 1
           fi
-          echo "Verified published AppImage matches the feed digest."
+          echo "Verified published artifact matches the feed digest."
           cat > /tmp/"${FEED_FILE}" <<EOF
           version: ${VERSION}
           files:
-            - url: ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}
-              sha512: '${APPIMAGE_SHA512}'
-              size: ${APPIMAGE_SIZE}
-          path: ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}
-          sha512: '${APPIMAGE_SHA512}'
+            - url: ${{ vars.CLI_CDN_BASE }}/${ARTIFACT_KEY}
+              sha512: '${ARTIFACT_SHA512}'
+              size: ${ARTIFACT_SIZE}
+          path: ${{ vars.CLI_CDN_BASE }}/${ARTIFACT_KEY}
+          sha512: '${ARTIFACT_SHA512}'
           releaseDate: '$(date -u +%Y-%m-%dT%H:%M:%SZ)'
           EOF
           aws s3 cp /tmp/"${FEED_FILE}" \
-            "s3://${{ vars.CLI_DIST_BUCKET }}/feed/${CHANNEL}/${FEED_FILE}" \
+            "s3://${{ vars.CLI_DIST_BUCKET }}/${FEED_PREFIX}/${FEED_FILE}" \
             --content-type text/yaml \
             --cache-control "public, max-age=300"
-          echo "Feed written: feed/${CHANNEL}/${FEED_FILE} -> ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}"
+          echo "Feed written: ${FEED_PREFIX}/${FEED_FILE} -> ${{ vars.CLI_CDN_BASE }}/${ARTIFACT_KEY}"
 
       # Human-clickable permalink to the current AppImage:
-      #   <CDN>/desktop/<channel>/latest/KiroCrew-x86_64.AppImage
+      #   <CDN>/desktop/<channel>/latest/KiroCrew-x86_64.<ext>
       # Same mutable-alias semantics as the latest-DMG alias: plain
       # overwrite, max-age=300, written AFTER the versioned key and the
       # feed so it never points at bytes that are not yet live nor ahead
       # of the go-live switch.
-      - name: Update latest AppImage alias
+      - name: Update latest artifact alias
         if: env.HAS_SIGNING_SECRETS
         run: |
           set -euo pipefail
-          LATEST_APPIMAGE_KEY="desktop/${CHANNEL}/latest/${LINUX_BASENAME}.AppImage"
+          LATEST_ARTIFACT_KEY="desktop/${CHANNEL}/latest/${LINUX_BASENAME}.${LINUX_EXT}"
           aws s3api put-object \
             --bucket "${{ vars.CLI_DIST_BUCKET }}" \
-            --key "${LATEST_APPIMAGE_KEY}" \
-            --body "${APPIMAGE_PATH}" \
+            --key "${LATEST_ARTIFACT_KEY}" \
+            --body "${ARTIFACT_PATH}" \
             --content-type application/octet-stream \
             --cache-control "public, max-age=300" > /dev/null
-          echo "LATEST_APPIMAGE_KEY=${LATEST_APPIMAGE_KEY}" >> "$GITHUB_ENV"
-          echo "Latest alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_APPIMAGE_KEY}"
+          echo "LATEST_ARTIFACT_KEY=${LATEST_ARTIFACT_KEY}" >> "$GITHUB_ENV"
+          echo "Latest alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_ARTIFACT_KEY}"
 
       - name: Summary
         if: env.HAS_SIGNING_SECRETS
@@ -364,7 +451,7 @@ jobs:
           {
             echo "## Publish Linux (${CHANNEL} · ${ARCH})"
             echo "- Version: ${VERSION}"
-            echo "- Public AppImage: ${{ vars.CLI_CDN_BASE }}/${APPIMAGE_KEY}"
-            echo "- Feed: \`feed/${CHANNEL}/${FEED_FILE}\`"
-            echo "- Latest AppImage alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_APPIMAGE_KEY}"
+            echo "- Public artifact: ${{ vars.CLI_CDN_BASE }}/${ARTIFACT_KEY}"
+            echo "- Feed: \`${FEED_PREFIX}/${FEED_FILE}\`"
+            echo "- Latest alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_ARTIFACT_KEY}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,8 +404,8 @@ jobs:
   # existed. True per-arch publish independence needs the publishers to run
   # past a partial build failure and let their own artifact download decide;
   # tracked in #2645 rather than reshaped here.
-  publish-linux-x64:
-    name: Publish Linux Desktop (${{ needs.version.outputs.channel }} channel · x64)
+  publish-linux-appimage-x64:
+    name: Publish Linux appimage (${{ needs.version.outputs.channel }} channel · x64)
     needs: [version, stable-gate, build-desktop, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
@@ -420,14 +420,16 @@ jobs:
       channel: ${{ needs.version.outputs.channel }}
       version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       arch: x64
+      format: appimage
       publish: true
-      appimage_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
+      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
       promote: ${{ needs.version.outputs.channel == 'stable' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
-    secrets: inherit
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
 
-  publish-linux-arm64:
-    name: Publish Linux Desktop (${{ needs.version.outputs.channel }} channel · arm64)
+  publish-linux-appimage-arm64:
+    name: Publish Linux appimage (${{ needs.version.outputs.channel }} channel · arm64)
     needs: [version, stable-gate, build-desktop, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
@@ -442,11 +444,109 @@ jobs:
       channel: ${{ needs.version.outputs.channel }}
       version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       arch: arm64
+      format: appimage
       publish: true
-      appimage_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
+      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
       promote: ${{ needs.version.outputs.channel == 'stable' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
-    secrets: inherit
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+
+  publish-linux-deb-x64:
+    name: Publish Linux deb (${{ needs.version.outputs.channel }} channel · x64)
+    needs: [version, stable-gate, build-desktop, resolve-promotion]
+    if: >-
+      ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
+          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-linux.yml
+    with:
+      channel: ${{ needs.version.outputs.channel }}
+      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      arch: x64
+      format: deb
+      publish: true
+      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
+      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      promotion_base_version: ${{ needs.version.outputs.base_version }}
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+
+  publish-linux-deb-arm64:
+    name: Publish Linux deb (${{ needs.version.outputs.channel }} channel · arm64)
+    needs: [version, stable-gate, build-desktop, resolve-promotion]
+    if: >-
+      ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
+          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-linux.yml
+    with:
+      channel: ${{ needs.version.outputs.channel }}
+      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      arch: arm64
+      format: deb
+      publish: true
+      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
+      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      promotion_base_version: ${{ needs.version.outputs.base_version }}
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+
+  publish-linux-rpm-x64:
+    name: Publish Linux rpm (${{ needs.version.outputs.channel }} channel · x64)
+    needs: [version, stable-gate, build-desktop, resolve-promotion]
+    if: >-
+      ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
+          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-linux.yml
+    with:
+      channel: ${{ needs.version.outputs.channel }}
+      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      arch: x64
+      format: rpm
+      publish: true
+      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
+      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      promotion_base_version: ${{ needs.version.outputs.base_version }}
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+
+  publish-linux-rpm-arm64:
+    name: Publish Linux rpm (${{ needs.version.outputs.channel }} channel · arm64)
+    needs: [version, stable-gate, build-desktop, resolve-promotion]
+    if: >-
+      ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
+          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/publish-linux.yml
+    with:
+      channel: ${{ needs.version.outputs.channel }}
+      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      arch: arm64
+      format: rpm
+      publish: true
+      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
+      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      promotion_base_version: ${{ needs.version.outputs.base_version }}
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
 
   # ── Windows installer publish ─────────────────────────────────────────
   # INSIDER ONLY, and that is a deliberate boundary rather than an omission.
@@ -593,7 +693,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release
-          find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.AppImage" \) -exec cp {} release/ \;
+          find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \) -exec cp {} release/ \;
 
           NOTARIZED_DIR="artifacts/KiroCrew-notarized-${{ needs.version.outputs.channel }}-${{ needs.version.outputs.version }}"
           NOTARIZED_ZIP="${NOTARIZED_DIR}/notarized.zip"
@@ -674,11 +774,15 @@ jobs:
       ${{ always() && needs.version.outputs.channel == 'insider' &&
           needs.release-candidate-tests.result == 'success' &&
           needs.publish-cli.result == 'success' &&
-          needs.publish-linux-x64.result == 'success' &&
-          needs.publish-linux-arm64.result == 'success' &&
+          needs.publish-linux-appimage-x64.result == 'success' &&
+          needs.publish-linux-appimage-arm64.result == 'success' &&
+          needs.publish-linux-deb-x64.result == 'success' &&
+          needs.publish-linux-deb-arm64.result == 'success' &&
+          needs.publish-linux-rpm-x64.result == 'success' &&
+          needs.publish-linux-rpm-arm64.result == 'success' &&
           needs.publish-docker.result == 'success' &&
           needs.sign-and-notarize.result == 'success' }}
-    needs: [version, release-candidate-tests, publish-cli, publish-linux-x64, publish-linux-arm64, publish-docker, sign-and-notarize]
+    needs: [version, release-candidate-tests, publish-cli, publish-linux-appimage-x64, publish-linux-appimage-arm64, publish-linux-deb-x64, publish-linux-deb-arm64, publish-linux-rpm-x64, publish-linux-rpm-arm64, publish-docker, sign-and-notarize]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -708,17 +812,28 @@ jobs:
           }
           WHEEL=$(one wheel -name '*.whl')
           SDIST=$(one sdist -name '*.tar.gz')
-          # The bundle records both x64 and arm64 AppImages; each artifact
-          # directory must be scoped to its specific arch or "exactly one"
-          # fails when both are present in the download tree.
+          # The bundle records every Linux artifact the promotion will republish:
+          # three formats x two arches. Each lookup is scoped to BOTH its arch
+          # directory and its extension, because "exactly one" is otherwise
+          # ambiguous the moment a second format lands in the same download tree.
+          # A format missing here would be silently absent from stable while its
+          # publish job still succeeds against a bundle that never carried it.
           APPIMAGE=$(one AppImage -path '*build-linux-x64*' -name '*.AppImage')
           APPIMAGE_ARM64=$(one AppImage-arm64 -path '*build-linux-arm64*' -name '*.AppImage')
+          DEB=$(one deb -path '*build-linux-x64*' -name '*.deb')
+          DEB_ARM64=$(one deb-arm64 -path '*build-linux-arm64*' -name '*.deb')
+          RPM=$(one rpm -path '*build-linux-x64*' -name '*.rpm')
+          RPM_ARM64=$(one rpm-arm64 -path '*build-linux-arm64*' -name '*.rpm')
           MAC_ZIP=$(one notarized.zip -path '*KiroCrew-notarized-*' -name 'notarized.zip')
           DMG=$(one notarized-DMG -path '*KiroCrew-notarized-*' -name 'KiroCrew.dmg')
           cp "$WHEEL" "promotion-bundle/$(basename "$WHEEL")"
           cp "$SDIST" "promotion-bundle/$(basename "$SDIST")"
           cp "$APPIMAGE" promotion-bundle/KiroCrew-x86_64.AppImage
           cp "$APPIMAGE_ARM64" promotion-bundle/KiroCrew-aarch64.AppImage
+          cp "$DEB" promotion-bundle/KiroCrew-x86_64.deb
+          cp "$DEB_ARM64" promotion-bundle/KiroCrew-aarch64.deb
+          cp "$RPM" promotion-bundle/KiroCrew-x86_64.rpm
+          cp "$RPM_ARM64" promotion-bundle/KiroCrew-aarch64.rpm
           cp "$MAC_ZIP" promotion-bundle/notarized.zip
           cp "$DMG" promotion-bundle/KiroCrew.dmg
           OWNER=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')

--- a/README.md
+++ b/README.md
@@ -60,18 +60,47 @@ remote Gateway over an SSH tunnel. See the
 [desktop app guide](docs/build/desktop-app.md).
 
 - **macOS** (one universal DMG, Apple Silicon + Intel): [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew.dmg) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew.dmg) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew.dmg)
-- **Linux x86_64**: [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-x86_64.AppImage) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.AppImage) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.AppImage)
-- **Linux aarch64** (Graviton, Raspberry Pi, ARM laptops): [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-aarch64.AppImage) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-aarch64.AppImage) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.AppImage)
 - **Windows**: no desktop build yet, so run the Gateway from a [source install](#build-from-source) and open the dashboard in your browser
 
-Not sure which Linux file you need? `uname -m` prints it — `x86_64` or `aarch64`.
+**On Linux, start with the one-line install** — it is the smoothest path, works
+on every distro and both architectures, and puts `kirocrew` on your `PATH`,
+which is what makes `kirocrew service install` (and the AppArmor profile the
+agent sandbox needs on Ubuntu 23.10+) reachable:
+
+```bash
+curl -fsSL https://download.crew.kiro.dev/cli.sh | sh
+```
+
+You then work in the dashboard at `http://localhost:5476`. Add a **desktop
+package** when you want what only the Electron shell gives you: an
+application-menu entry and icon, a native window, a taskbar badge, a system-wide
+hotkey, a Gateway that starts and stops with the app, and in-app updates. A
+`.deb` or `.rpm` installs to a fixed path under `/opt`, which is what lets it set
+the AppArmor profile up for you; the AppImage needs no root but needs FUSE and
+carries a manual sandbox step. `uname -m` prints which architecture you need.
+
+| Linux desktop package | x86_64 | aarch64 (Graviton, Raspberry Pi, ARM laptops) |
+|---|---|---|
+| **`.deb`** (Debian, Ubuntu) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-x86_64.deb) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.deb) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.deb) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-aarch64.deb) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-aarch64.deb) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.deb) |
+| **`.rpm`** (Fedora, RHEL, CentOS Stream, Amazon Linux 2023) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-x86_64.rpm) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.rpm) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.rpm) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-aarch64.rpm) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-aarch64.rpm) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.rpm) |
+| **AppImage** (no root, any distro) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-x86_64.AppImage) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.AppImage) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.AppImage) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-aarch64.AppImage) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-aarch64.AppImage) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.AppImage) |
+
+```bash
+sudo apt install ./KiroCrew-x86_64.deb     # Debian, Ubuntu
+sudo dnf install ./KiroCrew-x86_64.rpm     # Fedora, RHEL, CentOS Stream, AL2023
+```
+
+The Linux desktop app needs **glibc 2.34 or newer** (Ubuntu 22.04+, Debian 12+,
+Fedora, CentOS Stream 9, Amazon Linux 2023). On an older host — Ubuntu 20.04,
+Debian 11, Amazon Linux 2 — use the one-line install above.
+
 Every architecture below is a first-class lane: each gets its own build, its own
 auto-update feed, and its own SLSA provenance attestation.
 
 | Install path | x86_64 | aarch64 (ARM64) |
 |---|---|---|
-| **Desktop AppImage** | yes | yes |
 | **CLI one-liner / wheel** | yes | yes (the wheel is `py3-none-any`; native libraries are vendored per architecture) |
+| **Desktop `.deb` / `.rpm` / AppImage** | yes | yes |
 | **Docker image** | yes | yes (`linux/amd64` and `linux/arm64` under every tag, so `docker pull` picks yours) |
 
 Take Stable unless you have a reason not to — the table below says who each

--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -13,7 +13,7 @@ build is driven by [`packaging/build-desktop.sh`](../../packaging/build-desktop.
 ## What `make desktop` produces
 
 ```bash
-make desktop               # macOS: ONE universal DMG (arm64 + x86_64) · Linux: AppImage
+make desktop               # macOS: ONE universal DMG (arm64 + x86_64) · Linux: AppImage + deb + rpm
 UNIVERSAL=0 make desktop   # macOS: faster host-arch-only DMG (local iteration)
 ```
 
@@ -23,7 +23,7 @@ Output lands in **`website/electron/dist/`**:
 |---------|----------|----------|
 | `make desktop` | macOS | `KiroCrew-<version>-universal.dmg` |
 | `UNIVERSAL=0 make desktop` | macOS | `KiroCrew-<version>-arm64.dmg` (Apple Silicon host) or `KiroCrew-<version>.dmg` (Intel host) |
-| `make desktop` | Linux | `KiroCrew-*.AppImage` (host arch) |
+| `make desktop` | Linux | `KiroCrew-*.AppImage`, `*.deb`, `*.rpm` (host arch) |
 
 The electron-builder configuration lives in
 [`website/electron/package.json`](../../website/electron/package.json):
@@ -34,7 +34,20 @@ The electron-builder configuration lives in
   remains aligned with `productName` because Electron uses it to locate the
   `KiroCrew Helper` app bundles during startup
 - mac target: `dmg` (category `public.app-category.developer-tools`)
-- linux target: `AppImage` (category `Development`)
+- linux targets: `AppImage`, `deb`, `rpm` (category `Development`). One backend
+  tree is packaged three times, with `scripts/stamp-distribution.sh` re-run
+  between electron-builder invocations so each artifact's beacon `dist` names
+  its OWN format -- a single stamp would label one artifact as another.
+- `desktopName` + `linux.syncDesktopName` are what make window association
+  work: Electron derives its app_id from `desktopName`, and electron-builder
+  derives the `.desktop` file's name and `StartupWMClass` from the same value,
+  so the three agree by construction instead of by coincidence. Overriding
+  `StartupWMClass` by hand breaks that agreement.
+- `deb.depends` declares alternatives (`libgtk-3-0 | libgtk-3-0t64`) because
+  Ubuntu 24.04's 64-bit `time_t` transition renamed several libraries;
+  `rpm.depends` needs no such thing but uses entirely different names
+  (`gtk3`, `nss`, `alsa-lib`). Both lists are verified against a real
+  `apt-get install` / `dnf` resolution by `scripts/smoke-linux-packages.sh`.
 
 ### macOS default — one universal DMG for both arches
 
@@ -58,15 +71,19 @@ an Intel Mac where the universal build cannot run. Per-arch targets:
 |--------|-----------|----------|
 | macOS arm64 (Apple Silicon) | Apple Silicon Mac (`UNIVERSAL=0`) | arm64 `.dmg` |
 | macOS x86_64 (Intel) | Intel Mac | x86_64 `.dmg` |
-| Linux x86_64 | x86_64 Linux | x86_64 `.AppImage` |
-| Linux aarch64 (Graviton/ARM) | aarch64 Linux | aarch64 `.AppImage` |
+| Linux x86_64 | x86_64 Linux | x86_64 `.AppImage`, `.deb`, `.rpm` |
+| Linux aarch64 (Graviton/ARM) | aarch64 Linux | aarch64 `.AppImage`, `.deb`, `.rpm` |
 
 **Both Linux architectures ship.** `build-desktop.yml` builds them on
 `ubuntu-22.04` and `ubuntu-22.04-arm`, and `publish-linux.yml` runs once per
 arch — each writing its own immutable S3 key, its own electron-updater channel
 file (`latest-linux.yml` for x64, `latest-linux-arm64.yml` for arm64) and its own
-`latest` alias. Published basenames are `KiroCrew-x86_64.AppImage` and
-`KiroCrew-aarch64.AppImage`.
+`latest` alias. Published basenames are `KiroCrew-<arch>.<ext>` for each of the
+six (arch, format) pairs -- `KiroCrew-x86_64.deb`, `KiroCrew-aarch64.rpm`, and so
+on. A package format also gets its own feed DIRECTORY
+(`feed/<channel>/deb/latest-linux.yml`), because electron-updater derives the
+channel FILE name from platform and arch with no hook to change it, so two
+formats sharing a directory would overwrite each other's metadata.
 
 Two properties are load-bearing and worth knowing before you touch that lane:
 
@@ -75,7 +92,15 @@ Two properties are load-bearing and worth knowing before you touch that lane:
   install, plus the `python -m kiro_crew --version` self-containment gate), so a
   host that cannot execute the target architecture cannot build it. macOS gets
   away with one host only because Rosetta 2 executes the x86_64 slice.
-- **The runner's glibc is the floor for every user.** The AppImage links against
+- **The runner's glibc is the ceiling on what the artifacts may require.** The
+  binaries link against it, so the runner bounds compatibility. The MEASURED
+  requirement of the shipped binaries is lower than the runner's own version:
+  the highest `GLIBC_*` symbol version across the Electron binary and every
+  bundled `.so` is **2.34**, which covers Ubuntu 22.04+, Debian 12+, Fedora,
+  CentOS Stream 9 and Amazon Linux 2023, and excludes Ubuntu 20.04, Debian 11
+  and Amazon Linux 2. Read the requirement with
+  `objdump -T <binary> | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1` rather
+  than assuming it equals the runner's glibc. The AppImage links against
   it, which is why both Linux legs stay on 22.04 (glibc 2.35) rather than moving
   to 24.04 (2.39) — the newer floor would exclude AL2023, Debian 12 and RHEL 9.
 

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -78,10 +78,10 @@ concurrency group, and their version derivation.
 | `release.yml` | trigger (`push` on `v*` tags) | Derives version + channel + wheel version from the tag. A prerelease tag builds, publishes to insider, and records the immutable promotion bundle; a bare tag verifies that same-commit bundle and promotes the exact files/OCI digest to stable without building. Then creates the GitHub Release. `concurrency: release-publish` with `cancel-in-progress: false` (queued). |
 | `dependency-vulnerability.yml` | reusable gate | `scripts/check_npm_audit.py`. Runs first; every build job needs it. |
 | `build-wheel.yml` | reusable build | Stamps the PEP 440 version into `pyproject.toml` and `__init__.py`, stamps the distribution channel, builds the frontend and stages it into the package, then `python -m build`. Uploads artifact `cli-wheel` (wheel + sdist). Credential-free. |
-| `build-desktop.yml` | reusable build | Matrix `macos-15` (universal macOS app) and `ubuntu-22.04` (AppImage) via `packaging/build-desktop.sh`. Deliberately credential-free (`contents: read` only, pinned by `test_workflow_permissions.py`), so it builds **unsigned** and hands the `.app` downstream. |
+| `build-desktop.yml` | reusable build | Matrix `macos-15` (universal macOS app) and `ubuntu-22.04` / `ubuntu-22.04-arm` (AppImage + deb + rpm) via `packaging/build-desktop.sh`, then a `smoke-linux-packages` job that installs the deb and rpm in Ubuntu 24.04 and Amazon Linux 2023 containers. Deliberately credential-free (`contents: read` only, pinned by `test_workflow_permissions.py`), so it builds **unsigned** and hands the `.app` downstream. |
 | `build-windows.yml` | reusable build | `windows-latest`, an NSIS `Setup.exe`. Separate from `build-desktop.yml` because Authenticode signing has to happen *inside* the build (the installer compresses its own already-signed executable), so this job holds an AWS Signer identity and `build-desktop.yml` can stay credential-free. Callers pass `soft_fail: true`, so a Windows failure cannot skip the mac/Linux lanes. |
 | `publish-cli.yml` | reusable publish | Wheel + `SHA256SUMS` + KMS-signed `cli-manifest.json` to `cli/<channel>/<version>/`, the same signed manifest to `feed/<channel>/latest-cli.json`, and a PEP 503 index under `feed/<channel>/simple/`. |
-| `publish-linux.yml` | reusable publish | AppImage to `desktop/<channel>/<version>/`, `feed/<channel>/latest-linux[-arm64].yml`, then the `latest/` alias. Invoked ONCE PER ARCH (`arch: x64` / `arch: arm64`), each with its own keys and feed. |
+| `publish-linux.yml` | reusable publish | One Linux artifact to `desktop/<channel>/<version>/`, its channel file under `<feed prefix>/latest-linux[-arm64].yml`, then the `latest/` alias. Invoked ONCE PER (ARCH, FORMAT) PAIR — `arch: x64\|arm64` × `format: appimage\|deb\|rpm`, six callers — each with its own keys and feed, so no two ever share one. |
 | `sign-and-notarize.yml` | reusable publish | Three chained jobs (`sign`, `notarize`, `publish`) covering the whole macOS trust chain and the mac feed write. |
 | `publish-docker.yml` | reusable publish | Multi-arch (`linux/amd64,linux/arm64`) image built from the same wheel, pushed to `ghcr.io/<owner>/kirocrew`. |
 | `publish-installer.yml` | independent publish | Publishes `cli.sh` to the distribution bucket root. Triggered by a push to `main` touching `cli.sh` (path-filtered), plus manual dispatch. **Not** part of a channel release. |
@@ -122,9 +122,15 @@ desktop/<channel>/<version>/KiroCrew.zip                      immutable
 desktop/<channel>/<version>/KiroCrew.dmg                      immutable
 desktop/<channel>/<version>/KiroCrew-x86_64.AppImage          immutable
 desktop/<channel>/<version>/KiroCrew-aarch64.AppImage         immutable
+desktop/<channel>/<version>/KiroCrew-x86_64.deb               immutable
+desktop/<channel>/<version>/KiroCrew-aarch64.deb              immutable
+desktop/<channel>/<version>/KiroCrew-x86_64.rpm               immutable
+desktop/<channel>/<version>/KiroCrew-aarch64.rpm              immutable
 desktop/<channel>/latest/KiroCrew.dmg                         pointer, max-age=300
 desktop/<channel>/latest/KiroCrew-x86_64.AppImage             pointer, max-age=300
 desktop/<channel>/latest/KiroCrew-aarch64.AppImage            pointer, max-age=300
+desktop/<channel>/latest/KiroCrew-<arch>.deb                  pointer, max-age=300
+desktop/<channel>/latest/KiroCrew-<arch>.rpm                  pointer, max-age=300
 feed/<channel>/latest-mac.yml                                 pointer, max-age=300
 feed/<channel>/latest-mac.json                                pointer, max-age=300 (legacy bridge)
 feed/<channel>/latest-linux.yml                               pointer, max-age=300  (x64)
@@ -229,7 +235,7 @@ triggers. Nothing about it is caller-specific: the trigger files carry only
 version derivation and `uses:` calls.
 
 1. **sign** (ubuntu). Flattens the build artifacts, attests SLSA provenance for
-   the wheel, sdist, and AppImage (not the mac zip or DMG, whose bytes are not
+   the wheel, sdist, and every Linux artifact (not the mac zip or DMG, whose bytes are not
    final yet), uploads everything to `pre-signed/`, extracts the `.app` from the
    `*-mac.zip`, and submits it to CDSigner with a manifest generated at sign
    time from the actual bundle contents by
@@ -443,7 +449,14 @@ exactly `{darwin, linux, win32}`.
 On macOS electron-updater's `MacUpdater` downloads the archive itself and serves
 it to Electron's built-in `autoUpdater` (Squirrel.Mac) over a loopback proxy, so
 the atomic bundle swap is unchanged and `NSURLCache` is no longer in the feed
-path. On Linux it replaces the AppImage in place. On Windows `NsisUpdater` reads
+path. On Linux the install shape decides: an AppImage is replaced in place (so
+the directory holding it must be writable, which `bundle-location.js`'s
+`canUpdateLinuxInstall` gates on), while a deb or rpm is handed to
+`dpkg`/`rpm` behind an elevation prompt by electron-updater's `DebUpdater` /
+`RpmUpdater`. `resolveLinuxInstall()` picks the shape from three positive
+signals — `resources/package-type`, `$APPIMAGE`, and an `/opt` install path —
+and a package whose FORMAT cannot be named is refused rather than pointed at
+another format's feed. On Windows `NsisUpdater` reads
 `latest.yml` and runs the NSIS installer, verifying the download's Authenticode
 signature **fail-closed** against the `publisherName` pinned in
 `website/electron/package.json`. That verification is why `publish-windows.yml`

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -40,9 +40,9 @@ Builds use plain `pip` + `npm`/Vite + `pytest`, driven by the repo-root
 | **Node.js + npm** | Building the dashboard | `20 \|\| >= 22` (`website/package.json` `engines`); `ensure-node.sh` targets 20, and drops to 16 on Amazon Linux 2 where newer official builds need a glibc that host does not have |
 | **`kiro-cli`** | Driving the LLM | Required; see below |
 
-Node is only needed to *build* the dashboard. The prebuilt wheel, the DMG, and
-the AppImage all ship the dashboard already bundled, so end users of those
-artifacts need neither Node nor a compiler.
+Node is only needed to *build* the dashboard. The prebuilt wheel, the DMG, the
+AppImage, and the Linux `.deb` / `.rpm` packages all ship the dashboard already
+bundled, so end users of those artifacts need neither Node nor a compiler.
 
 ### Agent backend: `kiro-cli` (required)
 
@@ -84,6 +84,38 @@ hatches exist for mirrored or airgapped installs:
 config is coerced to it on load.
 
 ## Install paths
+
+### Which path on Linux
+
+**Start with the one-line install below.** It is the smoothest Linux path and
+the one that needs the fewest decisions: it puts `kirocrew` on your `PATH` at a
+stable location, which is what makes `kirocrew service install` — and therefore
+the [AppArmor profile](#linux-the-agent-sandbox-and-unprivileged-user-namespaces)
+the agent sandbox needs on Ubuntu 23.10+ — reachable in the first place. You
+work in the dashboard through your browser at `localhost:5476`.
+
+Install a **desktop package** (`.deb` / `.rpm`) *in addition* when you want the
+things only the Electron shell provides: an application-menu entry and icon, a
+native window with persisted geometry, a dock/taskbar badge, a system-wide hotkey
+to summon the dashboard, a gateway that starts and stops with the app, and
+in-app updates. The packages install to a fixed path under `/opt`, so the same
+PATH and AppArmor mechanics that make the one-line install work apply to them
+too.
+
+The **AppImage** stays available for hosts where you cannot install a system
+package (no root, an unsupported distro). It needs FUSE present, and because it
+runs from a randomized temporary mount there is no durable path to attach an
+AppArmor profile to or to point a `kirocrew` launcher at — so on a distro that
+restricts unprivileged user namespaces it needs the extra manual step described
+in the sandbox section. Prefer a package where you can.
+
+| You want | Use |
+|---|---|
+| The dashboard, a terminal, scheduled work, a server | **One-line install** (a) |
+| A desktop app on Debian/Ubuntu | **`.deb`** (d) |
+| A desktop app on Fedora / RHEL / CentOS Stream / Amazon Linux 2023 | **`.rpm`** (d) |
+| A desktop app with no root and no package manager | **AppImage** (d) |
+| A container host | **Docker** ([guide](docker.md)) |
 
 ### a. One-line install (fastest)
 
@@ -256,13 +288,47 @@ npm, or Node:
 make desktop
 ```
 
-Output is a DMG (plus a zip) on macOS and an AppImage on Linux, under
-`website/electron/dist/`. On macOS the default is ONE universal DMG: the
-Electron shell is lipo-merged, and the backend, which cannot be lipo-merged,
-ships as two complete PBS trees selected at launch by `process.arch`. The
-x86_64 backend is built under Rosetta 2, so a universal build needs an
-Apple-Silicon host; `UNIVERSAL=0` forces a faster host-arch-only build. Linux is
-always host-arch.
+Output is a DMG (plus a zip) on macOS, and an AppImage plus a `.deb` and an
+`.rpm` on Linux, under `website/electron/dist/`. On macOS the default is ONE
+universal DMG: the Electron shell is lipo-merged, and the backend, which cannot
+be lipo-merged, ships as two complete PBS trees selected at launch by
+`process.arch`. The x86_64 backend is built under Rosetta 2, so a universal
+build needs an Apple-Silicon host; `UNIVERSAL=0` forces a faster host-arch-only
+build. Linux is always host-arch, and the three Linux formats come from one
+backend tree packaged three times.
+
+#### Installing a Linux desktop package
+
+```bash
+sudo apt install ./KiroCrew-x86_64.deb     # Debian, Ubuntu
+sudo dnf install ./KiroCrew-x86_64.rpm     # Fedora, RHEL, CentOS Stream, AL2023
+```
+
+Either one installs to `/opt/KiroCrew`, registers the application-menu entry and
+MIME database, refreshes the icon cache, links `/usr/bin/kirocrew-desktop`, and —
+on a host whose AppArmor supports the bundled profile — installs and loads the
+`userns` profile the agent sandbox needs, so no manual `sandbox install-profile`
+step is required. The fixed install path is what makes all of that durable.
+
+Updates arrive through the app (**About → Check for updates**), which downloads
+the new package and hands it to `dpkg` / `rpm`. That needs root, so expect one
+elevation prompt (`pkexec` or `sudo`) at install time — it is the package
+manager doing the write, not the app. `sudo apt remove kirocrew` /
+`sudo dnf remove kirocrew` uninstalls; see
+[Uninstalling](#uninstalling) for what happens to your data.
+
+The AppImage needs no root and no package manager, which is the reason to pick
+it, but it also needs FUSE present (`sudo dnf install fuse` on Amazon Linux
+2023, which ships without it; `--appimage-extract-and-run` is the escape hatch)
+and it runs from a randomized temporary mount, so it carries the manual
+sandbox-profile step and the move-breaks-it caveat documented in the
+[sandbox section](#linux-the-agent-sandbox-and-unprivileged-user-namespaces).
+
+All three Linux formats are built from the same glibc floor as the build runner.
+Verified requirement at the time of writing is **glibc 2.34**, which covers
+Ubuntu 22.04+, Debian 12+, Fedora, CentOS Stream 9 and Amazon Linux 2023, and
+excludes Ubuntu 20.04, Debian 11 and Amazon Linux 2 — on those, use the
+[one-line install](#a-one-line-install-fastest) instead.
 
 Prebuilt downloads for the release channels are linked from the
 [README](../../README.md#app-downloads). Windows has no desktop build yet:
@@ -624,6 +690,12 @@ nothing. Run the gateway as the service instead.
 
 ### The AppImage (desktop app) needs its own profile
 
+A **`.deb` or `.rpm` install needs none of this section**: the package's
+post-install step writes and loads a `userns` profile attached to its own fixed
+path under `/opt`, so the sandbox works on a stock Ubuntu 23.10+ host with no
+manual step and nothing to re-point later. That fixed path is the whole
+difference — everything below exists because an AppImage does not have one.
+
 The profile above is applied **by systemd**, so it covers the installed service
 and nothing else. Launching the AppImage directly gives systemd no part to play:
 the app execs the bundled backend itself, so neither process gets a profile and
@@ -952,6 +1024,11 @@ For reference, the data home structure and what each uninstall path touches:
   cleanup hook.
 - The macOS DMG/zip and the Linux AppImage have no cleanup hook, so removing the
   application bundle or image leaves the data home intact.
+- A Linux `.deb` / `.rpm` removal DOES run the package's own post-remove step,
+  which drops `/usr/bin/kirocrew-desktop` and the installed AppArmor profile. It
+  deliberately leaves the data home alone: `~/.kiro/crew` holds your sessions,
+  memory and credentials, so it is yours to remove (see
+  [Removing user data](#removing-user-data)), not the package manager's.
 - App Kit uninstall preserves `apps/<name>/data/` by default. Deleting that app
   data is a separate, explicit action:
   `kirocrew app uninstall NAME --purge-data`, or unchecking **Keep app data** in

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -46,8 +46,8 @@ HOST_ARCH="$(uname -m)"
 
 # Beacon provenance for the artifact this run produces, derived from the
 # electron-builder target rather than the host: mac.target is dmg, linux.target
-# is AppImage (website/electron/package.json). Reading the host OS instead would
-# be wrong on Linux, where the same machine also builds wheels.
+# is AppImage + deb + rpm (website/electron/package.json). Reading the host OS instead
+# would be wrong on Linux, where the same machine also builds wheels.
 # Windows ships an NSIS installer, which has no KNOWN_DISTRIBUTIONS value yet;
 # "source" is the honest answer until "nsis" is added on both sides.
 case "$OS" in
@@ -55,6 +55,14 @@ case "$OS" in
   windows) KC_DISTRIBUTION="source" ;;
   *)       KC_DISTRIBUTION="appimage" ;;
 esac
+
+# Linux packages ONE backend tree into several artifact formats, and the beacon
+# `dist` value is baked INTO that tree — so each format needs its own stamp or
+# one artifact reports itself as the other, which is exactly the mislabel
+# scripts/stamp-distribution.sh exists to prevent. Pair each target with its
+# dist label here; the packaging step re-stamps between invocations. The
+# expensive work (PBS interpreter + pip closure) still happens once.
+LINUX_TARGET_DISTS=( "AppImage:appimage" "deb:deb" "rpm:rpm" )
 
 # Universal is the macOS default; Linux has no universal concept (AppImage is
 # per-arch). UNIVERSAL=0 opts a macOS build out.
@@ -112,6 +120,25 @@ case "$KC_VERSION" in
 esac
 
 log() { printf '\n\033[1;36m▶ %s\033[0m\n' "$*"; }
+
+# Re-stamp every staged backend tree with <dist>, for the Linux multi-format
+# path (see LINUX_TARGET_DISTS). Rewrites one generated module per tree, so it
+# is cheap enough to run between electron-builder invocations. Finding the trees
+# by their site-packages layout keeps this working for both the single-tree
+# Linux build and macOS's two-arch layout.
+restamp_backends() {
+  local dist="$1" sp found=0
+  while IFS= read -r sp; do
+    [ -n "$sp" ] || continue
+    bash "$ROOT/scripts/stamp-distribution.sh" "$dist" "$sp" >/dev/null
+    found=$((found + 1))
+  done < <(find "$ELECTRON_DIR/backend-dist" -type d -path "*/site-packages/kiro_crew" 2>/dev/null)
+  if [ "$found" -eq 0 ]; then
+    echo "ERROR: no staged backend tree found to stamp as '$dist'" >&2
+    exit 1
+  fi
+  echo "    stamped $found backend tree(s) as dist=$dist"
+}
 
 # Recursively remove a directory tree, defeating the macOS .DS_Store/ENOTEMPTY
 # race. macOS Desktop Services (Finder/Spotlight) can drop a fresh .DS_Store
@@ -447,6 +474,23 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
       # space-free makes the packaged app abort with "Unable to find helper
       # app". Nightly re-overrides the static display name to keep its suffix.
       "-c.mac.extendInfo.CFBundleDisplayName=Kiro Crew Nightly"
+      # Linux packages key their INSTALL identity off the package name, so
+      # nightly needs its own or dpkg/rpm treat a nightly install as an UPGRADE
+      # of stable and remove it -- the same hazard as the nsis.guid below, from
+      # the Linux side. Three names move together because all three are
+      # per-install-unique paths a second channel must not claim:
+      #
+      #   packageName    -> the dpkg/rpm package identity
+      #   executableName -> /usr/bin/<name> and /opt/<Product>/<name>
+      #   desktopName    -> /usr/share/applications/<name>, and (via
+      #                     linux.syncDesktopName) Electron's app_id and the
+      #                     entry's StartupWMClass, which must keep matching
+      #
+      # productName already differs, so the /opt directory does not collide.
+      "-c.deb.packageName=kirocrew-nightly"
+      "-c.rpm.packageName=kirocrew-nightly"
+      "-c.linux.executableName=kirocrew-desktop-nightly"
+      "-c.extraMetadata.desktopName=kirocrew-desktop-nightly.desktop"
       # Squirrel.Windows keyed the INSTALL identity off squirrelWindows.name;
       # NSIS keys it off two separate things, and nightly needs both:
       #
@@ -470,24 +514,17 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
       "-c.nsis.guid=0f417bf9-2759-51d6-acfb-f864805d1f41"
     )
   fi
-  if [ "$OS" = "darwin" ]; then
-    EB_ARGS+=( --mac )
-    [ "$UNIVERSAL" = "1" ] && EB_ARGS+=( --universal )
-  elif [ "$OS" = "windows" ]; then
-    EB_ARGS+=( --win )
-  else
-    EB_ARGS+=( --linux )
-  fi
-
   # Start from a pristine output dir. A prior interrupted universal build can
   # leave dist/mac-universal-<arch>-temp dirs behind (with a .DS_Store inside);
   # those linger and re-trip the ENOTEMPTY cleanup below on every later run.
   # This pre-clean is itself exposed to the .DS_Store race (Finder re-drops one
   # mid-removal), so it MUST go through the resilient helper — a plain rm here
   # aborts the build before the retry loop below is ever reached.
+  # Runs ONCE, before any invocation: the Linux path invokes electron-builder
+  # per target, and clearing between them would delete the previous artifact.
   rm_rf_resilient dist
 
-  # macOS universal .DS_Store/ENOTEMPTY race:
+  # One electron-builder invocation, with the macOS .DS_Store/ENOTEMPTY retry:
   # electron-builder's universal step stages each arch into
   # dist/mac-universal-<arch>-temp, lipo-merges them, then removes the temp
   # dirs with a recursive fs.rm. If macOS Desktop Services (Finder/Spotlight)
@@ -495,22 +532,45 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
   # which performs no retries -- fails the final rmdir with ENOTEMPTY and the
   # whole build aborts (electron-userland/electron-builder#6890). It is a
   # transient race, so retry from a swept, clean dir a bounded number of times.
-  attempt=1; max_attempts=3
-  while : ; do
-    eb_log="$(mktemp "${TMPDIR:-/tmp}/kc-eb.XXXXXX")"
-    if CSC_IDENTITY_AUTO_DISCOVERY=false ./node_modules/.bin/electron-builder "${EB_ARGS[@]}" 2>&1 | tee "$eb_log"; then
-      rm -f "$eb_log"; break
-    fi
-    if grep -q "ENOTEMPTY" "$eb_log" && [ "$attempt" -lt "$max_attempts" ]; then
-      echo "  ⚠ macOS .DS_Store/ENOTEMPTY temp-dir race (attempt $attempt/$max_attempts); sweeping .DS_Store and retrying…" >&2
-      find dist -name .DS_Store -delete 2>/dev/null || true
-      rm -rf dist/*-temp 2>/dev/null || true
-      rm -f "$eb_log"; attempt=$((attempt + 1)); sleep 2; continue
-    fi
-    rm -f "$eb_log"
-    echo "❌ electron-builder failed (not the .DS_Store race, or retries exhausted)." >&2
-    exit 1
-  done
+  eb_run() {
+    local attempt=1 max_attempts=3 eb_log
+    while : ; do
+      eb_log="$(mktemp "${TMPDIR:-/tmp}/kc-eb.XXXXXX")"
+      if CSC_IDENTITY_AUTO_DISCOVERY=false ./node_modules/.bin/electron-builder "$@" 2>&1 | tee "$eb_log"; then
+        rm -f "$eb_log"; return 0
+      fi
+      if grep -q "ENOTEMPTY" "$eb_log" && [ "$attempt" -lt "$max_attempts" ]; then
+        echo "  ⚠ macOS .DS_Store/ENOTEMPTY temp-dir race (attempt $attempt/$max_attempts); sweeping .DS_Store and retrying…" >&2
+        find dist -name .DS_Store -delete 2>/dev/null || true
+        rm -rf dist/*-temp 2>/dev/null || true
+        rm -f "$eb_log"; attempt=$((attempt + 1)); sleep 2; continue
+      fi
+      rm -f "$eb_log"
+      echo "❌ electron-builder failed (not the .DS_Store race, or retries exhausted)." >&2
+      exit 1
+    done
+  }
+
+  if [ "$OS" = "darwin" ]; then
+    EB_ARGS+=( --mac )
+    [ "$UNIVERSAL" = "1" ] && EB_ARGS+=( --universal )
+    eb_run "${EB_ARGS[@]}"
+  elif [ "$OS" = "windows" ]; then
+    EB_ARGS+=( --win )
+    eb_run "${EB_ARGS[@]}"
+  else
+    # One invocation PER FORMAT, each preceded by its own beacon stamp, so the
+    # AppImage and the deb do not both claim the label of whichever was built
+    # last. Targets are named explicitly rather than letting package.json's
+    # target array drive a single invocation, because a single invocation shares
+    # one stamped backend tree between both artifacts.
+    for pair in "${LINUX_TARGET_DISTS[@]}"; do
+      target="${pair%%:*}"; dist="${pair##*:}"
+      log "Packaging Linux ${target} (dist=${dist})…"
+      restamp_backends "$dist"
+      eb_run "${EB_ARGS[@]}" --linux "$target"
+    done
+  fi
 )
 
 # Universal post-gate: the staged shell binary must carry BOTH arch slices.
@@ -533,6 +593,6 @@ if [ "$UNIVERSAL" = "1" ]; then
 fi
 
 log "Done. Installer(s) are in $ELECTRON_DIR/dist/"
-ls -1 "$ELECTRON_DIR/dist/"*.{dmg,AppImage,zip,exe} 2>/dev/null | sed 's/^/   /' || true
+ls -1 "$ELECTRON_DIR/dist/"*.{dmg,AppImage,deb,rpm,zip,exe} 2>/dev/null | sed 's/^/   /' || true
 echo ""
 echo "    The .app embeds the backend, so it runs with no PATH kirocrew needed."

--- a/scripts/release_promotion.py
+++ b/scripts/release_promotion.py
@@ -30,6 +30,10 @@ ARTIFACT_NAMES = {
     "sdist": re.compile(r"^kirocrew-[A-Za-z0-9_.]+\.tar\.gz$"),
     "appimage": re.compile(r"^KiroCrew-x86_64\.AppImage$"),
     "appimage_arm64": re.compile(r"^KiroCrew-aarch64\.AppImage$"),
+    "deb": re.compile(r"^KiroCrew-x86_64\.deb$"),
+    "deb_arm64": re.compile(r"^KiroCrew-aarch64\.deb$"),
+    "rpm": re.compile(r"^KiroCrew-x86_64\.rpm$"),
+    "rpm_arm64": re.compile(r"^KiroCrew-aarch64\.rpm$"),
     "mac_zip": re.compile(r"^notarized\.zip$"),
     "dmg": re.compile(r"^KiroCrew\.dmg$"),
 }

--- a/scripts/smoke-linux-packages.sh
+++ b/scripts/smoke-linux-packages.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Install the Linux desktop packages for real, in the distros they target, and
+# assert what only a real install can show.
+#
+# WHY A SCRIPT AND NOT INLINE YAML: two callers need the identical assertions --
+# ci.yml runs it on a packaging-path PR, build-desktop.yml runs it on every
+# nightly and release. Inlining is how those two drift, and a drifted smoke test
+# is worse than none: the lane that matters would be the one missing a check.
+#
+# Everything here is invisible to a unit test, because it lives in metadata the
+# package manager interprets rather than in code we run:
+#
+#   * dependency names must EXIST in the target distro's repositories. They
+#     differ per distro (libgtk-3-0 vs gtk3), and Ubuntu 24.04's 64-bit time_t
+#     transition renamed several, which is why the deb declares alternatives
+#     (`libgtk-3-0 | libgtk-3-0t64`). Ubuntu 24.04 is used deliberately here:
+#     it is the release that proves the alternative resolves.
+#   * the .desktop entry electron-builder generates, including the
+#     StartupWMClass that must equal Electron's app_id for a desktop
+#     environment to associate the running window with the launcher.
+#   * the maintainer scripts, which place the /usr/bin launcher and remove it.
+#   * the beacon distribution stamp, which must name THIS format. One backend
+#     tree is packaged three times, so a single stamp would label one artifact
+#     as another -- the exact mislabel scripts/stamp-distribution.sh exists to
+#     prevent, and it is only observable from inside an installed package.
+#
+# A wrong dependency name produces a package that builds green and refuses to
+# install, which no other gate in this repository would catch.
+#
+# Usage: smoke-linux-packages.sh <dist-dir>
+set -euo pipefail
+
+DIST_DIR="${1:?usage: smoke-linux-packages.sh <dir containing the built .deb and .rpm>}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker is required to smoke-install the packages" >&2
+  exit 1
+fi
+
+# Exactly one artifact per format. Zero means the build silently dropped it (a
+# glob that no longer matches); more than one means an ambiguous input, and
+# picking arbitrarily would test bytes nobody ships.
+resolve_one() {
+  local ext="$1" found
+  mapfile -t found < <(find "$DIST_DIR" -maxdepth 1 -type f -name "*.${ext}")
+  if [ "${#found[@]}" -ne 1 ]; then
+    echo "ERROR: expected exactly one .${ext} in ${DIST_DIR}, found ${#found[@]}" >&2
+    printf '  %s\n' "${found[@]}" >&2
+    exit 1
+  fi
+  printf '%s' "$(basename "${found[0]}")"
+}
+
+DEB_NAME="$(resolve_one deb)"
+RPM_NAME="$(resolve_one rpm)"
+ABS_DIST="$(cd "$DIST_DIR" && pwd)"
+
+# Shared assertions, run inside the container after the package manager has
+# installed the package. `$1` is the command that lists the package's own files
+# (`dpkg -L <pkg>` / `rpm -ql <pkg>`).
+#
+# EVERY identity is DERIVED from that list rather than written here, because the
+# nightly channel deliberately ships different ones so it can sit beside stable:
+# build-desktop.sh overrides packageName, executableName and desktopName for a
+# `-nightly.` version. Hardcoding stable's spelling would fail this gate on every
+# nightly build -- and because a failed job inside build-desktop.yml fails the
+# CALLER's `build-desktop` job, which every `publish-linux-*` lane depends on,
+# that would silently skip nightly's entire Linux publication. What is asserted
+# is the INVARIANT, not one channel's names.
+common_asserts() {
+  cat <<ASSERTS
+    files=\$($1)
+    entry=\$(printf '%s\\n' "\$files" | grep -E '^/usr/share/applications/[^/]+[.]desktop\$' | head -1)
+    stamp=\$(printf '%s\\n' "\$files" | grep -E '/kiro_crew/_build_info[.]py\$' | head -1)
+    test -n "\$entry" && test -f "\$entry"
+    test -n "\$stamp"
+    # The identity comes from the desktop entry's FILENAME, not from parsing its
+    # Exec value. linux.syncDesktopName ties four things to one name -- the entry
+    # filename, executableName, Electron's app_id and StartupWMClass -- so the
+    # filename IS the identity, and reading it needs no string parsing at all.
+    #
+    # Exec is deliberately NOT the source: electron-builder quotes that path when
+    # it contains a character outside [/0-9A-Za-z._-], which the nightly channel's
+    # `/opt/KiroCrew Nightly/...` does. Parsing it would work on stable and return
+    # empty on nightly -- the third time this gate assumed stable's shape.
+    exe=\$(basename "\$entry" .desktop)
+    launcher=/usr/bin/\$exe
+    test -x "\$launcher"
+    # Window association: StartupWMClass must equal Electron's app_id, which
+    # electron-builder derives from desktopName -- the same value the launcher
+    # name follows. A mismatch leaves the running window unassociated with its
+    # launcher icon, silently, at runtime.
+    grep -q "^StartupWMClass=\${exe}\$" "\$entry"
+    # Installed under the fixed /opt prefix, which is what makes the AppArmor
+    # profile, the PATH launcher and in-place updates durable.
+    grep -qE "^Exec=\\"?/opt/.*/\${exe}" "\$entry"
+    # The bundled CLI that fixed prefix makes reachable -- what an AppImage
+    # cannot offer, and what makes \`kirocrew service install\` usable.
+    printf '%s\\n' "\$files" | grep -qE '/backend-dist/kirocrew-backend/bin/kirocrew\$'
+ASSERTS
+}
+
+echo "▶ Installing '${DEB_NAME}' on Ubuntu 24.04 (the t64 release)…"
+docker run --rm -v "${ABS_DIST}:/dist:ro" -w /dist ubuntu:24.04 bash -euxc "
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -qq
+  # The package's OWN declared name, so a nightly build (kirocrew-nightly) is
+  # queried and removed under the identity it actually installed as.
+  pkg=\$(dpkg-deb -f './${DEB_NAME}' Package)
+  apt-get install -y --no-install-recommends './${DEB_NAME}'
+$(common_asserts 'dpkg -L "$pkg"')
+  grep -q 'DISTRIBUTION = \"deb\"' \"\$stamp\"
+  # \`dpkg -r\` rather than \`apt-get remove\`: assert OUR package's removal and
+  # its maintainer script, not the package manager's dependency bookkeeping.
+  dpkg -r \"\$pkg\"
+  test ! -e \"\$launcher\"
+"
+
+echo "▶ Installing '${RPM_NAME}' on Amazon Linux 2023…"
+docker run --rm -v "${ABS_DIST}:/dist:ro" -w /dist amazonlinux:2023 bash -euxc "
+  pkg=\$(rpm -qp --queryformat '%{NAME}' './${RPM_NAME}')
+  dnf install -y './${RPM_NAME}'
+$(common_asserts 'rpm -ql "$pkg"')
+  grep -q 'DISTRIBUTION = \"rpm\"' \"\$stamp\"
+  # \`rpm -e\` rather than \`dnf remove\`: dnf also plans the removal of
+  # now-unneeded DEPENDENCIES, and in a bare container several of ours are
+  # reverse-depended on by protected packages (systemd-udev), so it refuses the
+  # whole transaction.
+  rpm -e \"\$pkg\"
+  test ! -e \"\$launcher\"
+"
+
+echo "✅ Both Linux packages install, register, and uninstall cleanly."

--- a/scripts/stamp-distribution.sh
+++ b/scripts/stamp-distribution.sh
@@ -8,23 +8,23 @@
 # the artifact and a running install cannot change it. `beacon.distribution()`
 # prefers this file and falls back to the env var.
 #
-# WHY A SHARED SCRIPT: four packaging paths need the identical file (wheel,
-# dmg, appimage, docker). Inlining the write in each one is how they drift,
+# WHY A SHARED SCRIPT: six packaging paths need the identical file (wheel,
+# dmg, appimage, deb, rpm, docker). Inlining the write in each one is how they drift,
 # and a `dist` value that disagrees with the artifact is worse than no value,
 # because it is indistinguishable from a real population shift on the dashboard.
 #
-# Usage: stamp-distribution.sh <dmg|appimage|wheel|source|docker> [package_dir]
+# Usage: stamp-distribution.sh <dmg|appimage|deb|rpm|wheel|source|docker> [package_dir]
 set -euo pipefail
 
-DIST="${1:?usage: stamp-distribution.sh <dmg|appimage|wheel|source|docker> [package_dir]}"
+DIST="${1:?usage: stamp-distribution.sh <dmg|appimage|deb|rpm|wheel|source|docker> [package_dir]}"
 PKG_DIR="${2:-}"
 
 # Keep in sync with beacon.KNOWN_DISTRIBUTIONS. A typo here would otherwise bake
 # a value the clamp rejects, silently falling back to "source": the exact
 # failure this script exists to remove.
 case "$DIST" in
-  dmg|appimage|wheel|source|docker) ;;
-  *) echo "ERROR: unknown distribution '$DIST' (want: dmg|appimage|wheel|source|docker)" >&2
+  dmg|appimage|deb|rpm|wheel|source|docker) ;;
+  *) echo "ERROR: unknown distribution '$DIST' (want: dmg|appimage|deb|rpm|wheel|source|docker)" >&2
      exit 1 ;;
 esac
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -52,6 +52,7 @@ from kiro_crew.agent_files import RESEARCH_AGENT_FILENAME as _RESEARCH_AGENT_FIL
 from kiro_crew.config import config_dir
 from kiro_crew.config import config_path as _mc_config_path
 from kiro_crew.config.paths import (
+    _in_ephemeral_tree,
     _in_linked_git_worktree,
     _valid_override_home,
     isolated_agents_dir,
@@ -284,18 +285,107 @@ def _user_overrides_path() -> Path:
 _KIROCREW_BIN: str | None = None
 
 
-def _bin_is_usable(path: Path) -> bool:
-    """Return True if *path* is a readable file.
+def _interpreter_runnable(candidate: Path) -> bool:
+    """Return True if *candidate* could actually be exec'd as an interpreter.
 
-    Symbol preserved for callers; the previous Amazon-specific Apollo/Brazil
-    wrapper-script rejection logic is a no-op on a public install (those
-    binaries are absent), so any readable executable is accepted.
+    Existence is not enough: a present-but-not-executable interpreter fails at
+    exec time (``EACCES`` — "bad interpreter: Permission denied"), so a launcher
+    naming one is exactly as dead as a launcher naming a reaped path. Keeping
+    this stricter than ``exists()`` is what lets :func:`_bin_is_usable` promise it
+    narrows only by provably-dead targets.
+
+    POSIX-only narrowing by construction: Windows has no execute bit and
+    ``os.access(f, X_OK)`` is True for any existing file, so this degrades to an
+    existence check there rather than validating anything extra.
+    """
+    return candidate.is_file() and os.access(candidate, os.X_OK)
+
+
+def _bin_is_usable(path: Path) -> bool:
+    """Return True if *path* is a readable launcher whose interpreter still exists.
+
+    Readability alone is not usability. A launcher is a thin wrapper around an
+    interpreter living elsewhere, so it OUTLIVES the thing it needs: a reaped work
+    directory, a removed ``.venv``, or a pruned bundle leaves an executable file
+    that fails at run time with "virtual environment not found". Accepting one
+    makes ``ensure_kirocrew_on_path`` publish a machine-wide ``kirocrew`` that is
+    broken from the moment it is written — and that function runs on EVERY gateway
+    start, so it would keep re-publishing it.
+
+    Two launcher shapes, judged differently because only one of them states the
+    answer: a pip console script names its interpreter in the shebang, which stays
+    correct for every install layout (a venv, ``python3.12 -m pip install`` into
+    ``~/.local/bin``, a distro package), so it is read directly. A shell wrapper's
+    shebang names the SHELL, so its interpreter is resolved relative to the
+    wrapper instead.
+
+    Nothing is executed, and a launcher naming no interpreter of ours is accepted,
+    so this only ever narrows the set by provably-dead targets.
     """
     try:
-        with open(path, "rb"):
-            return True
+        with open(path, "rb") as stream:
+            head = stream.read(4096)
     except OSError:
         return False
+    if not head.startswith(b"#!"):
+        return True  # compiled launcher (pip's Windows .exe, a frozen binary)
+    text = head.decode("utf-8", errors="replace")
+
+    shebang = text.splitlines()[0][2:].strip()
+    interpreter = shebang.split()[0] if shebang else ""
+    # `#!/usr/bin/env python3` names the FINDER, not the interpreter, so it says
+    # nothing about a specific path; only an absolute python path is decisive.
+    # `is_absolute()` rather than a leading "/" so a native Windows path
+    # (`C:\...\python.exe`) is recognised there too -- pip ships a compiled
+    # `.exe` launcher on Windows, which returns above, but a shebang script that
+    # does reach here must not be judged by a POSIX-only shape.
+    candidate = Path(interpreter)
+    if candidate.is_absolute() and candidate.name.startswith("python"):
+        return _interpreter_runnable(candidate)
+
+    bin_dir = path.parent
+    # `<venv>/bin/kirocrew` (already inside the venv) vs `<root>/bin/kirocrew`
+    # (the repo launcher and the packaged bundle's wrapper, beside the venv).
+    venv_root = bin_dir.parent
+    if venv_root.name != ".venv":
+        venv_root = venv_root / ".venv"
+    checks: list[tuple[str, tuple[Path, ...]]] = [
+        (".venv", (venv_root / "bin" / "python", venv_root / "Scripts" / "python.exe")),
+        # Packaged PBS bundle: `<root>/bin/python3.12`, beside the launcher. The
+        # marker identifies that LAYOUT, not merely a version, and it stays a
+        # literal on purpose: widening it to `python3\.\d+` also matches shebangs
+        # that name a version while keeping their interpreter somewhere else
+        # entirely -- Apollo's `#!/apollo/sbin/envroot $ENVROOT/python3.10/bin/
+        # python3.10` is one, and it then gets held to a sibling `python3.10`
+        # that was never supposed to exist, so a working launcher is judged dead.
+        # Broadening the marker broadens the OBLIGATION it imposes, which is the
+        # opposite of what a liveness check should do when it cannot identify the
+        # shape. The same literal appears in `packaging/build-desktop.sh`, which
+        # builds this layout; unifying the two is its own change.
+        ("python3.12", (bin_dir / "python3.12", venv_root / "bin" / "python3.12")),
+    ]
+    for marker, candidates in checks:
+        if marker not in text:
+            continue
+        if not any(_interpreter_runnable(c) for c in candidates):
+            return False
+    return True
+
+
+def _launcher_works(path: Path) -> bool:
+    """Return True if *path* is a launcher that would actually run today.
+
+    Combines the two halves of the question asked of any launcher we did not
+    write ourselves: the file is present and executable, AND the interpreter it
+    delegates to still exists (:func:`_bin_is_usable`). Used to decide whether an
+    ``~/.local/bin/kirocrew`` that points somewhere ELSE is a working install's
+    launcher — which must be left alone — or a dead one we should replace.
+
+    Deliberately not folded into ``ensure_kirocrew_on_path``'s gate on its OWN
+    resolved target: that gate additionally requires an absolute path, and its
+    interpreter check already happened inside :func:`_resolve_kirocrew_bin`.
+    """
+    return path.is_file() and os.access(path, os.X_OK) and _bin_is_usable(path)
 
 
 def _kirocrew_bin_subpath(root: Path) -> Path:
@@ -339,9 +429,10 @@ def _resolve_kirocrew_bin() -> str:
 
     def _usable(p: str | Path) -> bool:
         sp = str(p)
-        if not (sp and os.path.isfile(sp) and os.access(sp, os.X_OK)):
-            return False
-        return _bin_is_usable(Path(sp))
+        # The empty-string guard is this resolver's own concern: its candidates
+        # come from config and env, where "" means "unset". Everything after it is
+        # the shared predicate, so the two cannot drift apart.
+        return bool(sp) and _launcher_works(Path(sp))
 
     # Frozen/PyInstaller app (shipped desktop app): ``sys.executable`` is the
     # bundled ``kirocrew-backend`` binary, which *is* the kirocrew CLI and
@@ -664,7 +755,9 @@ def _extra_mcp_scope_globals() -> list[Path]:
     return [s.global_json for s in scopes]
 
 
-def ensure_kirocrew_on_path(bin_dir: Path | None = None) -> str | None:
+def ensure_kirocrew_on_path(
+    bin_dir: Path | None = None, *, claim_existing: bool = False
+) -> str | None:
     """Ensure a ``kirocrew`` launcher is reachable on the user's PATH.
 
     The source ``install.sh`` symlinks ``~/.local/bin/kirocrew`` → the venv
@@ -675,10 +768,16 @@ def ensure_kirocrew_on_path(bin_dir: Path | None = None) -> str | None:
 
     * No-op if ``kirocrew`` already resolves on PATH to the same binary.
     * No-op if no concrete binary can be resolved (nothing to point at).
+    * No-op if a launcher for a DIFFERENT install is there and still works,
+      unless ``claim_existing`` says the user asked for this one by name.
     * Otherwise (re)create ``<bin_dir>/kirocrew`` → the resolved binary.
 
     Args:
         bin_dir: Target directory for the shim. Defaults to ``~/.local/bin``.
+        claim_existing: Take the name over from another install's working
+            launcher. ``kirocrew setup`` passes True because the user named this
+            install; gateway startup must NOT, since it runs unattended on every
+            start and would make the last install to boot win.
 
     Returns:
         The shim path if one was created/updated, else ``None``.
@@ -721,17 +820,75 @@ def ensure_kirocrew_on_path(bin_dir: Path | None = None) -> str | None:
         )
         return None
 
+    # Same hazard from the other direction: an AppImage's runtime mount and a
+    # scratch tree under the temp dir are both reaped out from under a launcher
+    # that points into them — and this function runs on EVERY gateway start, so
+    # it would re-create that dangling link every time. Declining leaves
+    # whatever already worked in place; a package install (fixed path under
+    # /opt) or a venv install is the shape that can carry a durable launcher.
+    if _in_ephemeral_tree(Path(target).resolve()):
+        logger.info(
+            "Not installing a kirocrew launcher: %s is inside an ephemeral tree (an "
+            "AppImage runtime mount, or the system temp directory), which is reaped "
+            "out from under the link. Install the deb/rpm package for a durable "
+            "`kirocrew` on PATH, or link a persistent install yourself.",
+            target,
+        )
+        return None
+
     # Already reachable on PATH as the same binary? Then there's nothing to do.
     existing = shutil.which("kirocrew")
     if existing and os.path.realpath(existing) == os.path.realpath(target):
         return None
+
+    # Ownership, checked on PATH before the target path: a working `kirocrew`
+    # ANYWHERE on PATH already belongs to some install — a pipx bin dir, a distro
+    # package, /usr/local/bin — and writing <bin_dir>/kirocrew would shadow it or
+    # be shadowed by it depending on PATH order, which is not a decision an
+    # unattended start gets to make. The per-path check further down is still
+    # needed and is not redundant with this one: it catches a working launcher
+    # sitting AT <bin_dir>/kirocrew while <bin_dir> is not on PATH at all.
+    if existing and not claim_existing:
+        existing_on_path = Path(os.path.realpath(existing))
+        if _launcher_works(existing_on_path):
+            logger.info(
+                "Leaving `kirocrew` on PATH alone: %s -> %s still works and belongs "
+                "to another install. Run `kirocrew setup` from the install you want "
+                "on PATH to switch it deliberately.",
+                existing,
+                existing_on_path,
+            )
+            return None
 
     bin_dir = bin_dir or (Path.home() / ".local" / "bin")
     link = bin_dir / "kirocrew"
     try:
         bin_dir.mkdir(parents=True, exist_ok=True)
         if link.is_symlink() or link.exists():
+            existing_target = Path(os.path.realpath(link))
             if os.path.realpath(link) == os.path.realpath(target):
+                return None
+            # A launcher that still WORKS belongs to another install — typically
+            # the cli.sh wheel under ~/.kiro/crew-venv — and taking the name from
+            # it is not a repair. This runs on EVERY gateway start, so whichever
+            # install booted last would win, and the losing installer's upgrades
+            # would then land on a path nothing points at: `kirocrew` keeps
+            # working, silently at the wrong version, which is worse than a
+            # visible break. The documented Linux pairing (cli.sh for the CLI,
+            # deb/rpm for the desktop shell) puts both on one machine by design,
+            # so this is the ordinary configuration rather than a corner case.
+            #
+            # An explicit `kirocrew setup` DOES claim the name: the user named
+            # this install. A dangling or otherwise dead launcher is replaced on
+            # either path — that vacuum is what this function exists to fill.
+            if not claim_existing and _launcher_works(existing_target):
+                logger.info(
+                    "Leaving the existing kirocrew launcher alone: %s -> %s still "
+                    "works and belongs to another install. Run `kirocrew setup` "
+                    "from the install you want on PATH to switch it deliberately.",
+                    link,
+                    existing_target,
+                )
                 return None
             link.unlink()
         link.symlink_to(target)
@@ -764,7 +921,10 @@ def run_first_run_setup() -> None:
     rebuild. This is invoked from gateway startup to close that gap:
 
     * **PATH shim** — ``ensure_kirocrew_on_path()`` is idempotent and only
-      writes ``~/.local/bin/kirocrew``, so it runs on every start.
+      writes ``~/.local/bin/kirocrew``, so it runs on every start. It is called
+      WITHOUT ``claim_existing`` for exactly that reason: running unattended on
+      every start, it must fill an empty or broken slot only, never take the
+      command away from another install that still works.
     * **Stale predecessor MCP purge** — ``clean_stale_managed_mcp()`` mutates
       the user's *global* ``~/.kiro/settings/mcp.json``, so it runs ONCE,
       guarded by a marker file, to honor the "KiroCrew owns only the agent

--- a/src/kiro_crew/beacon.py
+++ b/src/kiro_crew/beacon.py
@@ -165,7 +165,9 @@ _CI_ENV_VARS = (
 # "source" is the git-clone path and the correct answer for an unstamped tree,
 # so it is the default rather than an "unknown" bucket.
 DIST_ENV = "KIROCREW_DISTRIBUTION"
-KNOWN_DISTRIBUTIONS = frozenset({"dmg", "appimage", "wheel", "source", "docker"})
+KNOWN_DISTRIBUTIONS = frozenset(
+    {"dmg", "appimage", "deb", "rpm", "wheel", "source", "docker"}
+)
 DEFAULT_DISTRIBUTION = "source"
 
 # Optional dependency: ``_build_info`` exists only in a packaged artifact, so

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -506,6 +506,44 @@ def _doctor_data_home() -> None:
             )
 
 
+def _doctor_path_launcher() -> None:
+    """Report which install the ``kirocrew`` command on PATH actually belongs to.
+
+    A gateway never takes the name from another install's working launcher (see
+    ``agent.ensure_kirocrew_on_path``), which is the right call — but it leaves a
+    gap the user cannot see from anywhere else. The documented Linux pairing puts
+    a cli.sh wheel and a deb/rpm desktop install on ONE machine, so typing
+    ``kirocrew`` can run a different install, at a different version or channel,
+    than the app that is running. The desktop app has no terminal, so the decline
+    is logged where nobody reads it; this is the surface someone checks when a
+    version looks wrong.
+
+    Read-only: it resolves and compares paths, and never writes or relinks.
+    """
+    from kiro_crew.agent import _resolve_kirocrew_bin
+
+    on_path = shutil.which("kirocrew")
+    if not on_path:
+        # Not an error on its own: the desktop app runs its bundled backend
+        # directly, and a user who never wanted a terminal command is fine.
+        print("  kirocrew CLI: ⏹ not on PATH (run `kirocrew setup` to link it)")
+        return
+    running = _resolve_kirocrew_bin()
+    if not os.path.isabs(running) or os.path.realpath(on_path) == os.path.realpath(running):
+        print(f"  kirocrew CLI: ✅ {on_path}")
+        return
+    print("  ⚠ kirocrew CLI on PATH belongs to a different install than this one.")
+    # Paths are printed UNWRAPPED, one per line: a wrapped path cannot be copied
+    # or pasted into a command, which is the first thing someone does with it.
+    print(f"{_INDENT}on PATH:      {os.path.realpath(on_path)}")
+    print(f"{_INDENT}this install: {os.path.realpath(running)}")
+    _print_wrapped(
+        "Both can coexist — the wheel keeps its own updates — but `kirocrew` in a "
+        "terminal runs the one on PATH, which may be a different version or "
+        "channel. Run `kirocrew setup` from the install you want to own the name."
+    )
+
+
 def _doctor_trust_root() -> None:
     """Report whether session identities can be signed, and from which file.
 
@@ -1298,6 +1336,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
 
     # ── Data Home (+ leftover migration archive) ──
     _doctor_data_home()
+    _doctor_path_launcher()
     _doctor_trust_root()
 
     # ── KAS backend (only when selected) ──

--- a/src/kiro_crew/cli_setup.py
+++ b/src/kiro_crew/cli_setup.py
@@ -300,7 +300,11 @@ def _setup_impl(
     from kiro_crew.agent import ensure_kirocrew_on_path
     from kiro_crew.mcp_cleanup import clean_stale_managed_mcp
 
-    shim = ensure_kirocrew_on_path()
+    # `claim_existing`: this is the explicit setup path, so the user has named
+    # THIS install as the one they want `kirocrew` to mean. Gateway startup
+    # deliberately does not, so a background start never takes the command away
+    # from a working install (see ensure_kirocrew_on_path).
+    shim = ensure_kirocrew_on_path(claim_existing=True)
     if shim:
         print(f"  ✅ Linked kirocrew on PATH: {shim}")
     removed_mcp = clean_stale_managed_mcp()

--- a/src/kiro_crew/config/paths.py
+++ b/src/kiro_crew/config/paths.py
@@ -29,6 +29,7 @@ import os
 import shlex
 import shutil
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -645,6 +646,44 @@ def config_package_dir() -> Path:
     the config package, so this is simply its parent directory.
     """
     return Path(__file__).resolve().parent
+
+
+def _in_ephemeral_tree(path: Path, env: Mapping[str, str] | None = None) -> bool:
+    """Whether *path* lives inside an AppImage's ephemeral runtime mount.
+
+    An AppImage runs from a squashfs the runtime mounts under a randomized
+    ``/tmp/.mount_<name>XXXXXX`` directory and unmounts on exit, so anything
+    resolved there is valid ONLY for the life of that process. A machine-wide
+    launcher aimed into it dangles the moment the app quits — the same hazard as
+    :func:`_in_linked_git_worktree`, from a different direction.
+
+``$APPDIR`` (the mount point) is exported by the AppImage runtime and is the
+    authoritative signal; ``$APPIMAGE`` names the outer image file rather than the
+    mount, so it cannot answer an ancestry test. The ``.mount_`` path component is
+    the fallback for a child process that inherited no environment, matched on the
+    RESOLVED path so a symlink into the mount cannot slip past.
+
+    Deliberately NOT "anything under the temp directory". A scratch tree in
+    ``/tmp`` is every bit as ephemeral, but a blanket temp-dir rule cannot tell a
+    reaped work directory from a legitimate install a developer or test placed
+    there, and the launcher those produce is caught precisely by
+    :func:`_bin_is_usable` instead — by the interpreter being gone, which is the
+    property that actually breaks the command.
+
+    Stdlib-only and subprocess-free for the same reason as the worktree guard:
+    this runs on the gateway start path.
+    """
+    env = os.environ if env is None else env
+    appdir = (env.get("APPDIR") or "").strip()
+    if appdir:
+        try:
+            if path == Path(appdir) or Path(appdir) in path.parents:
+                return True
+        except (OSError, ValueError):
+            pass
+    # `.mount_` is the AppImage runtime's own prefix, so this does not condemn
+    # unrelated temp paths.
+    return any(part.startswith(".mount_") for part in path.parts)
 
 
 def _in_linked_git_worktree(path: Path) -> bool:

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -27,6 +27,7 @@ from kiro_crew.config.loader import (
     update_config_locked,
 )
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.platform import update_layout
 from kiro_crew.platform.update_governance import (
     min_version,
     resolve_remote_url,
@@ -128,10 +129,20 @@ _ERR_UNKNOWN = "unknown"
 #: makes the Windows machine a thin client for a gateway running on EC2 Linux, so
 #: the backend answering this call is a Linux install that identifies itself
 #: correctly on its own.
+#: The one externally-managed distribution whose remedy is an image pull
+#: rather than the desktop app.
+_CONTAINER_DISTRIBUTION = "docker"
+
+#: DERIVED, not restated: ``update_layout.EXTERNALLY_MANAGED`` owns WHICH
+#: distributions are externally managed, and this module owns only the wording
+#: shown for them. The two lists were duplicated once, and the copy here fell
+#: behind when Linux gained deb and rpm -- a package install then reached
+#: ``_check_release_feed()`` and was compared against the CLI wheel channel,
+#: which is exactly the wrong-stream false positive described above. Deriving the
+#: key set makes that drift impossible: a format added there appears here.
 _EXTERNALLY_MANAGED = {
-    "dmg": _ERR_MANAGED_BY_APP,
-    "appimage": _ERR_MANAGED_BY_APP,
-    "docker": _ERR_MANAGED_BY_IMAGE,
+    dist: _ERR_MANAGED_BY_IMAGE if dist == _CONTAINER_DISTRIBUTION else _ERR_MANAGED_BY_APP
+    for dist in update_layout.EXTERNALLY_MANAGED
 }
 
 

--- a/src/kiro_crew/diagnostics.py
+++ b/src/kiro_crew/diagnostics.py
@@ -322,6 +322,8 @@ _CHANNEL_LABELS = release_channel.CHANNEL_LABELS
 _INSTALL_OPTIONS = {
     "dmg": "Desktop app",
     "appimage": "Desktop app",
+    "deb": "Desktop app (deb)",
+    "rpm": "Desktop app (rpm)",
     "wheel": "pip / pipx",
     "docker": "Docker",
     "source": "From source",

--- a/src/kiro_crew/platform/update_layout.py
+++ b/src/kiro_crew/platform/update_layout.py
@@ -20,6 +20,10 @@ RELEASE_CHANNELS = ("stable", "insider", "nightly")
 EXTERNALLY_MANAGED = {
     "dmg": "Update via the desktop app's built-in updater (About → Check for updates).",
     "appimage": "Update via the desktop app's built-in updater (About → Check for updates).",
+    "deb": "Update via the desktop app's built-in updater (About → Check for updates), "
+           "which hands the new package to dpkg, or reinstall the .deb.",
+    "rpm": "Update via the desktop app's built-in updater (About → Check for updates), "
+           "which hands the new package to rpm, or reinstall the .rpm.",
     "docker": "Update by pulling a newer image (docker pull).",
 }
 
@@ -27,7 +31,7 @@ EXTERNALLY_MANAGED = {
 class InstallLayout(NamedTuple):
     """Describes how this Kiro Crew instance was installed."""
 
-    kind: str  # "git", "wheel", "dmg", "appimage", "docker", or "source"
+    kind: str  # "git", "wheel", "dmg", "appimage", "deb", "rpm", "docker", or "source"
     proj: str  # KIROCREW_PROJECT_DIR value (may be empty for non-git)
     is_git: bool
     is_externally_managed: bool

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -6519,7 +6519,7 @@ class GatewayOrchestrator:
                 #     light the dashboard badge so the operator runs `kirocrew
                 #     update`. Before this branch existed the path `return`ed
                 #     silently, leaving the host below the floor with no signal.
-                #   * externally managed (dmg/appimage/docker: not self_updatable
+                #   * externally managed (dmg/appimage/deb/rpm/docker: not self_updatable
                 #     AND no `update_command`) -> its own updater owns this; the
                 #     backend must not drive a git reset on a non-git tree nor
                 #     show an inapplicable CLI-update badge. Log and return.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3826,7 +3826,12 @@ class TestSetupChannelGating:
         monkeypatch.setattr(
             "kiro_crew.agent.install_agent", lambda clean=False: tmp_path / "agent.json"
         )
-        monkeypatch.setattr("kiro_crew.agent.ensure_kirocrew_on_path", lambda: None)
+        # Mirror the real signature (bin_dir, *, claim_existing): the setup path
+        # passes claim_existing=True, and a stub that refused it would fail here
+        # for a reason that has nothing to do with channel gating.
+        monkeypatch.setattr(
+            "kiro_crew.agent.ensure_kirocrew_on_path", lambda *a, **k: None
+        )
         monkeypatch.setattr("kiro_crew.mcp_cleanup.clean_stale_managed_mcp", lambda: [])
         # Neutralize every unrelated wizard step so only the gating is under test.
         for name in (

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -7,6 +7,7 @@ command on Linux where there is no brew.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from kiro_crew import cli_doctor
@@ -584,3 +585,71 @@ class TestDoctorKas:
         assert "2099-01-01T00:00:00Z" in out
         assert "SECRET-DO-NOT-PRINT" not in out
         assert issues == []
+
+
+class TestPathLauncherOwnership:
+    """`kirocrew doctor` names which install owns the `kirocrew` command.
+
+    A gateway deliberately never takes the name from another install's working
+    launcher, so the two can diverge silently: the documented Linux pairing puts
+    a cli.sh wheel and a deb/rpm desktop install on one machine, and the desktop
+    app has no terminal to show the decline. This is where that is visible.
+    """
+
+    def test_matching_launcher_is_reported_clean(self, monkeypatch, tmp_path, capsys) -> None:
+        exe = tmp_path / "opt" / "bin" / "kirocrew"
+        exe.parent.mkdir(parents=True)
+        exe.write_text("")
+        monkeypatch.setattr(cli_doctor.shutil, "which", lambda c, **kw: str(exe))
+        monkeypatch.setattr("kiro_crew.agent._resolve_kirocrew_bin", lambda: str(exe))
+
+        cli_doctor._doctor_path_launcher()
+
+        out = capsys.readouterr().out
+        assert "kirocrew CLI: ✅" in out
+        assert "different install" not in out
+
+    def test_divergent_launcher_names_both_paths(self, monkeypatch, tmp_path, capsys) -> None:
+        wheel = tmp_path / "crew-venv" / "bin" / "kirocrew"
+        wheel.parent.mkdir(parents=True)
+        wheel.write_text("")
+        package = tmp_path / "opt" / "KiroCrew" / "kirocrew"  # brand-ok: real /opt path
+        package.parent.mkdir(parents=True)
+        package.write_text("")
+        monkeypatch.setattr(cli_doctor.shutil, "which", lambda c, **kw: str(wheel))
+        monkeypatch.setattr("kiro_crew.agent._resolve_kirocrew_bin", lambda: str(package))
+
+        cli_doctor._doctor_path_launcher()
+
+        out = capsys.readouterr().out
+        assert "⚠ kirocrew CLI on PATH belongs to a different install" in out
+        # Both sides must be named, or the user cannot tell which is which.
+        # Compare like with like: the check prints realpath, and on Windows a
+        # realpath can differ in form (short vs long name, case) from str(path).
+        assert os.path.realpath(wheel) in out and os.path.realpath(package) in out
+        assert "kirocrew setup" in out
+
+    def test_no_launcher_on_path_is_informational(self, monkeypatch, capsys) -> None:
+        """The desktop app runs its bundled backend directly, so an absent
+        terminal command is a state, not a fault."""
+        monkeypatch.setattr(cli_doctor.shutil, "which", lambda c, **kw: None)
+
+        cli_doctor._doctor_path_launcher()
+
+        out = capsys.readouterr().out
+        assert "⏹ not on PATH" in out
+        assert "⚠" not in out
+
+    def test_unresolvable_install_does_not_cry_wolf(self, monkeypatch, tmp_path, capsys) -> None:
+        """A bare "kirocrew" sentinel is not a path, so there is nothing to
+        compare and no divergence to claim."""
+        found = tmp_path / "bin" / "kirocrew"
+        found.parent.mkdir(parents=True)
+        found.write_text("")
+        monkeypatch.setattr(cli_doctor.shutil, "which", lambda c, **kw: str(found))
+        monkeypatch.setattr("kiro_crew.agent._resolve_kirocrew_bin", lambda: "kirocrew")
+
+        cli_doctor._doctor_path_launcher()
+
+        out = capsys.readouterr().out
+        assert "kirocrew CLI: ✅" in out

--- a/test/test_installer_shim_and_cleanup.py
+++ b/test/test_installer_shim_and_cleanup.py
@@ -753,3 +753,315 @@ def test_rebuild_purge_drops_reinjected_entry_on_second_rebuild():
     assert "playwright-mcp" in removed_2
     assert "playwright-mcp" not in base_config["mcpServers"]
     assert "@playwright-mcp" not in base_config["tools"]
+
+
+def test_in_ephemeral_tree_matches_the_runtime_mount(tmp_path):
+    """An AppImage's `/tmp/.mount_<name>XXXXXX` tree disappears on exit, so a
+    launcher aimed into it dangles. Matched on the `.mount_` path component."""
+    mount = tmp_path / ".mount_KiroCrewAbc123"
+    binary = mount / "resources" / "backend-dist" / "kirocrew-backend" / "bin" / "kirocrew"
+    assert agent._in_ephemeral_tree(binary) is True
+    # A durable install is not condemned by the same check.
+    assert agent._in_ephemeral_tree(Path("/opt/KiroCrew/resources/bin/kirocrew")) is False
+    assert agent._in_ephemeral_tree(tmp_path / "clone" / "bin" / "kirocrew") is False
+
+
+def test_in_ephemeral_tree_honors_appdir(tmp_path):
+    """$APPDIR is the runtime's own statement of where it mounted, so it decides
+    even when the path carries no `.mount_` component (a custom TMPDIR, or a
+    runtime that changes its prefix)."""
+    appdir = tmp_path / "some-extracted-dir"
+    binary = appdir / "bin" / "kirocrew"
+    env = {"APPDIR": str(appdir)}
+    assert agent._in_ephemeral_tree(binary, env) is True
+    # Outside $APPDIR, the same env must not condemn an unrelated path.
+    assert agent._in_ephemeral_tree(tmp_path / "elsewhere" / "kirocrew", env) is False
+
+
+def test_shim_declines_an_appimage_mount_target(tmp_path, monkeypatch):
+    """The guard's payoff: ensure_kirocrew_on_path() runs on EVERY gateway start,
+    so without it an AppImage re-creates a dangling ~/.local/bin/kirocrew every
+    time. Declining leaves whatever already worked in place."""
+    mount = tmp_path / ".mount_KiroCrewXyz789"
+    binary = mount / "bin" / "kirocrew"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\nexit 0\n")
+    binary.chmod(0o755)
+    _resolve_to(monkeypatch, binary)
+
+    bin_dir = tmp_path / "localbin"
+    assert agent.ensure_kirocrew_on_path(bin_dir) is None
+    assert not (bin_dir / "kirocrew").exists()
+
+
+def test_launcher_whose_venv_is_gone_is_not_usable(tmp_path):
+    """The reaped-work-directory case, observed live: a clone's `bin/kirocrew`
+    survives while its `.venv` is deleted, so the file is readable and executable
+    but fails at run time. Publishing it as the machine-wide `kirocrew` writes a
+    command that is broken the moment it is written."""
+    root = tmp_path / "kc-work-dir"
+    launcher = root / "bin" / "kirocrew"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text('#!/bin/sh\nexec "$(dirname "$0")/../.venv/bin/python" -m kiro_crew "$@"\n')
+    launcher.chmod(0o755)
+
+    assert agent._bin_is_usable(launcher) is False
+
+    # The INTERPRETER decides, not the directory: a `.venv` that exists but has
+    # had its python removed is still dead.
+    (root / ".venv" / "bin").mkdir(parents=True)
+    assert agent._bin_is_usable(launcher) is False
+
+    (root / ".venv" / "bin" / "python").write_text("")
+    (root / ".venv" / "bin" / "python").chmod(0o755)  # a real interpreter is executable
+    assert agent._bin_is_usable(launcher) is True
+
+
+def test_console_script_inside_a_venv_stays_usable(tmp_path):
+    """A pip console script lives INSIDE `.venv/bin`, so its interpreter is its own
+    sibling. Resolving `<parent>/../.venv` from there probes a nested `.venv/.venv`
+    that never exists and would reject the most common source install -- dropping
+    the built-in MCP servers, because resolution then falls through to the bare
+    "kirocrew" sentinel."""
+    venv = tmp_path / "checkout" / ".venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").write_text("")
+    (venv / "bin" / "python").chmod(0o755)  # a real interpreter is executable
+    script = venv / "bin" / "kirocrew"
+    script.write_text(f"#!{venv}/bin/python\nfrom kiro_crew.cli import main\n")
+    script.chmod(0o755)
+
+    assert agent._bin_is_usable(script) is True
+
+
+def test_console_script_is_judged_by_its_own_shebang(tmp_path):
+    """A pip console script names its interpreter in the shebang, which is the only
+    form that stays correct across install layouts -- a venv, a `python3.12 -m pip
+    install` into ~/.local/bin, a distro package. Inferring sibling candidates from
+    the launcher's directory instead would reject a wheel install whose interpreter
+    is the system python."""
+    python = tmp_path / "usr" / "bin" / "python3.12"
+    python.parent.mkdir(parents=True)
+    python.write_text("")
+    python.chmod(0o755)  # a real interpreter is executable
+    script = tmp_path / "localbin" / "kirocrew"
+    script.parent.mkdir(parents=True)
+    script.write_text(f"#!{python}\nfrom kiro_crew.cli import main\n")
+    script.chmod(0o755)
+
+    assert agent._bin_is_usable(script) is True
+
+    python.unlink()
+    assert agent._bin_is_usable(script) is False
+
+
+def test_env_shebang_is_not_treated_as_an_interpreter_path(tmp_path):
+    """`#!/usr/bin/env python3` names the FINDER, not the interpreter, so it says
+    nothing about a specific path and must not be tested as one."""
+    script = tmp_path / "bin" / "kirocrew"
+    script.parent.mkdir(parents=True)
+    script.write_text("#!/usr/bin/env python3\nfrom kiro_crew.cli import main\n")
+    script.chmod(0o755)
+
+    assert agent._bin_is_usable(script) is True
+
+
+def test_launcher_naming_no_interpreter_stays_usable(tmp_path):
+    """A launcher that names no interpreter of ours — a compiled entry point, or a
+    plain script — must not be condemned by the check above."""
+    plain = tmp_path / "bin" / "kirocrew"
+    plain.parent.mkdir(parents=True)
+    plain.write_text("#!/bin/sh\nexit 0\n")
+    plain.chmod(0o755)
+    assert agent._bin_is_usable(plain) is True
+
+    compiled = tmp_path / "bin" / "kirocrew.exe"
+    compiled.write_bytes(b"MZ\x90\x00compiled-launcher")
+    assert agent._bin_is_usable(compiled) is True
+
+
+# --------------------------------------------------------------------------
+# Shim ownership — a background start must not take the name from another
+# install. The documented Linux pairing (cli.sh for the CLI, deb/rpm for the
+# desktop shell) puts a wheel launcher and a package launcher on ONE machine,
+# and `ensure_kirocrew_on_path` runs on every gateway start.
+# --------------------------------------------------------------------------
+def _simulate_frozen_app_honest(monkeypatch, tmp_path, exe):
+    """``_simulate_frozen_app``, but launchers under *tmp_path* are judged for real.
+
+    The shared helper stubs ``_bin_is_usable`` to accept ONLY the frozen exe. That
+    is right for the resolver tests -- it makes them independent of whatever dev
+    tree they run in -- but wrong for these, which turn entirely on whether
+    ANOTHER install's launcher is judged alive or dead. A stub that calls every
+    foreign launcher dead would report ownership working while the product still
+    hijacked a live one, so the verdict for the paths built by this test comes
+    from the real predicate.
+    """
+    real_usable = agent._bin_is_usable
+    _simulate_frozen_app(monkeypatch, exe)
+    monkeypatch.setattr(
+        agent,
+        "_bin_is_usable",
+        lambda p: str(p) == str(exe) or (str(p).startswith(str(tmp_path)) and real_usable(Path(p))),
+    )
+
+
+def _foreign_working_launcher(tmp_path):
+    """A launcher for another install: a pip console script whose venv exists."""
+    venv_bin = tmp_path / "crew-venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    interpreter = venv_bin / "python3"
+    interpreter.write_text("")
+    interpreter.chmod(0o755)
+    launcher = venv_bin / "kirocrew"
+    launcher.write_text(f"#!{interpreter}\nprint('cli.sh install')\n")
+    launcher.chmod(0o755)
+    return launcher
+
+
+@_posix_shim_only
+def test_gateway_start_leaves_another_installs_working_launcher(tmp_path, monkeypatch):
+    """A package/app start must NOT repoint a wheel install's working launcher.
+
+    Both live on one machine by design, and this runs unattended on every start,
+    so claiming the name would make the last install to boot win -- and the other
+    installer's upgrades would then land on a path nothing points at.
+    """
+    exe = _fake_frozen_exe(tmp_path)
+    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    foreign = _foreign_working_launcher(tmp_path)
+    bin_dir = tmp_path / "localbin"
+    bin_dir.mkdir()
+    link = bin_dir / "kirocrew"
+    link.symlink_to(foreign)
+
+    assert agent.ensure_kirocrew_on_path(bin_dir=bin_dir) is None
+    assert os.path.realpath(link) == os.path.realpath(foreign)
+
+
+@_posix_shim_only
+def test_explicit_setup_claims_the_name(tmp_path, monkeypatch):
+    """`kirocrew setup` names an install deliberately, so it MAY take over."""
+    exe = _fake_frozen_exe(tmp_path)
+    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    foreign = _foreign_working_launcher(tmp_path)
+    bin_dir = tmp_path / "localbin"
+    bin_dir.mkdir()
+    link = bin_dir / "kirocrew"
+    link.symlink_to(foreign)
+
+    created = agent.ensure_kirocrew_on_path(bin_dir=bin_dir, claim_existing=True)
+
+    assert created == str(link)
+    assert os.path.realpath(link) == os.path.realpath(exe)
+
+
+@_posix_shim_only
+def test_gateway_start_repairs_a_dangling_launcher(tmp_path, monkeypatch):
+    """Filling a BROKEN slot is the whole point -- ownership must not block it."""
+    exe = _fake_frozen_exe(tmp_path)
+    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    bin_dir = tmp_path / "localbin"
+    bin_dir.mkdir()
+    link = bin_dir / "kirocrew"
+    link.symlink_to(tmp_path / "reaped" / "bin" / "kirocrew")
+
+    created = agent.ensure_kirocrew_on_path(bin_dir=bin_dir)
+
+    assert created == str(link)
+    assert os.path.realpath(link) == os.path.realpath(exe)
+
+
+@_posix_shim_only
+def test_gateway_start_replaces_launcher_whose_interpreter_vanished(tmp_path, monkeypatch):
+    """The launcher file exists but its venv was reaped: dead, so replaceable.
+
+    This is the shape that made the live host's `kirocrew` fail -- a readable,
+    executable console script whose interpreter no longer exists.
+    """
+    exe = _fake_frozen_exe(tmp_path)
+    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    stale_bin = tmp_path / "reaped-venv" / "bin"
+    stale_bin.mkdir(parents=True)
+    stale = stale_bin / "kirocrew"
+    stale.write_text(f"#!{stale_bin / 'python3'}\n")  # interpreter never created
+    stale.chmod(0o755)
+    bin_dir = tmp_path / "localbin"
+    bin_dir.mkdir()
+    link = bin_dir / "kirocrew"
+    link.symlink_to(stale)
+
+    created = agent.ensure_kirocrew_on_path(bin_dir=bin_dir)
+
+    assert created == str(link)
+    assert os.path.realpath(link) == os.path.realpath(exe)
+
+
+_posix_exec_bit_only = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "the execute BIT is a POSIX concept: on Windows os.access(f, X_OK) is True "
+        "for any existing file, so chmod(0o644) cannot model a non-executable "
+        "interpreter there"
+    ),
+)
+
+
+@_posix_exec_bit_only
+def test_interpreter_that_is_not_executable_is_not_usable(tmp_path):
+    """A present-but-non-executable interpreter fails at exec time (EACCES), so
+    the launcher naming it is as dead as one naming a reaped path -- existence
+    alone must not qualify, or gateway startup would decline to repair a
+    `kirocrew` that cannot run."""
+    python = tmp_path / "venvless" / "bin" / "python3"
+    python.parent.mkdir(parents=True)
+    python.write_text("")
+    python.chmod(0o644)  # readable, NOT executable
+    script = tmp_path / "localbin" / "kirocrew"
+    script.parent.mkdir(parents=True)
+    script.write_text(f"#!{python}\nfrom kiro_crew.cli import main\n")
+    script.chmod(0o755)
+
+    assert agent._bin_is_usable(script) is False
+
+    python.chmod(0o755)
+    assert agent._bin_is_usable(script) is True
+
+
+@_posix_shim_only
+def test_gateway_start_does_not_shadow_a_working_launcher_elsewhere_on_path(tmp_path, monkeypatch):
+    """Ownership is about the NAME on PATH, not one directory.
+
+    A pipx bin dir, /usr/local/bin, or a distro package can own a working
+    `kirocrew` while ~/.local/bin holds none. Creating one there would shadow it
+    or be shadowed by it depending on PATH order -- not a choice an unattended
+    gateway start gets to make.
+    """
+    exe = _fake_frozen_exe(tmp_path)
+    foreign = _foreign_working_launcher(tmp_path)
+    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    # `kirocrew` resolves on PATH to the other install, and nothing is in bin_dir.
+    monkeypatch.setattr(
+        agent.shutil, "which", lambda c, **kw: str(foreign) if c == "kirocrew" else None
+    )
+    bin_dir = tmp_path / "localbin"
+
+    assert agent.ensure_kirocrew_on_path(bin_dir=bin_dir) is None
+    assert not (bin_dir / "kirocrew").exists()
+
+
+@_posix_shim_only
+def test_explicit_setup_may_shadow_a_launcher_elsewhere_on_path(tmp_path, monkeypatch):
+    """`kirocrew setup` names this install, so it may publish into bin_dir."""
+    exe = _fake_frozen_exe(tmp_path)
+    foreign = _foreign_working_launcher(tmp_path)
+    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    monkeypatch.setattr(
+        agent.shutil, "which", lambda c, **kw: str(foreign) if c == "kirocrew" else None
+    )
+    bin_dir = tmp_path / "localbin"
+
+    created = agent.ensure_kirocrew_on_path(bin_dir=bin_dir, claim_existing=True)
+
+    assert created == str(bin_dir / "kirocrew")
+    assert os.path.realpath(bin_dir / "kirocrew") == os.path.realpath(exe)

--- a/test/test_prepare_pr_profiles.py
+++ b/test/test_prepare_pr_profiles.py
@@ -262,6 +262,14 @@ def test_ci_blocking_scans_are_covered_by_the_floor():
         # Resolves the diff base inside Actions (it lives under .github/scripts).
         # The floor resolves the same base with `git merge-base` inline.
         "scripts/resolve-i18n-base.sh",
+        # Installs the built Linux packages in Ubuntu and Amazon Linux containers.
+        # It needs docker AND a completed electron-builder run, so it cannot be a
+        # pre-push gate: the floor would then demand a ~10-minute desktop build
+        # from every contributor whose diff happens to touch packaging.
+        "scripts/smoke-linux-packages.sh",
+        # Invoked BY packaging/build-desktop.sh to write the beacon provenance
+        # module, never standalone. Gating on it would gate on the build script.
+        "scripts/stamp-distribution.sh",
     }
 
     invoked = set(re.findall(r"\bscripts/[A-Za-z0-9_.-]+\.(?:py|sh)", run_text))
@@ -288,6 +296,8 @@ def test_ci_blocking_scans_are_covered_by_the_floor():
         "uv": "resolves/installs dependencies",
         "sudo": "privileged provisioning -- belongs in setup, never in a gate",
         # Wrappers whose payload is already covered by another assertion.
+        "bash": "an interpreter prefix -- the payload is the .sh path, covered by "
+                "the script scan above",
         "npm": "covered by the npm-script scan above",
         "npx": "covered by the npm-script scan and the tsc/eslint assertions",
         "python": "covered by the scripts/ scan and the pytest gate",

--- a/test/test_publish_feed_contract.py
+++ b/test/test_publish_feed_contract.py
@@ -57,13 +57,14 @@ _SUBS = {
     "CHANNEL": "nightly",
     "DESKTOP_KEY": "desktop/nightly/1.2.3/KiroCrew.zip",
     "DMG_KEY": "desktop/nightly/1.2.3/KiroCrew.dmg",
-    "APPIMAGE_KEY": "desktop/nightly/1.2.3/KiroCrew-x86_64.AppImage",
+    "ARTIFACT_KEY": "desktop/nightly/1.2.3/KiroCrew-x86_64.AppImage",
     "ZIP_SHA512": "ZIPSHA512BASE64==",
     "DMG_SHA512": "DMGSHA512BASE64==",
-    "APPIMAGE_SHA512": "APPIMAGESHA512BASE64==",
+    "ARTIFACT_SHA512": "APPIMAGESHA512BASE64==",
     "ZIP_SIZE": "111",
     "DMG_SIZE": "222",
-    "APPIMAGE_SIZE": "333",
+    "ARTIFACT_SIZE": "333",
+    "FEED_PREFIX": "feed/nightly",
 }
 _CDN_BASE = "https://download.crew.kiro.dev"
 
@@ -151,7 +152,7 @@ def test_linux_feed_layout_is_electron_updater_metadata() -> None:
     # (findFile(files, "AppImage", ["rpm","deb","pacman"])).
     assert any(u.endswith(".AppImage") for u in urls), "latest-linux.yml must list the AppImage"
     assert feed["path"].endswith(".AppImage")
-    assert feed["sha512"] == _SUBS["APPIMAGE_SHA512"]
+    assert feed["sha512"] == _SUBS["ARTIFACT_SHA512"]
 
 
 # ---------------------------------------------------------------------------
@@ -204,13 +205,17 @@ def test_feed_destination_is_pointer_prefix_yaml() -> None:
     into ``FEED_FILE`` (see the arch-mapping test below), so the assertion is on
     the destination SHAPE rather than one filename.
     """
-    for path, job, channel_file in (
-        (MAC_WORKFLOW, "publish", "latest-mac.yml"),
-        (LINUX_WORKFLOW, "publish-linux", "${FEED_FILE}"),
+    # Linux resolves BOTH halves: the channel file per arch (``FEED_FILE``) and the
+    # directory per format (``FEED_PREFIX``), because two formats sharing one
+    # directory would overwrite each other's channel file. The mac lane has one
+    # format, so it names both halves literally.
+    for path, job, destination in (
+        (MAC_WORKFLOW, "publish", "feed/${CHANNEL}/latest-mac.yml"),
+        (LINUX_WORKFLOW, "publish-linux", "${FEED_PREFIX}/${FEED_FILE}"),
     ):
         run = _feed_step(path, job)["run"]
-        assert f"feed/${{CHANNEL}}/{channel_file}" in run, (
-            f"{path.name}: feed must upload to feed/<channel>/{channel_file} -- the exact "
+        assert destination in run, (
+            f"{path.name}: feed must upload to {destination} -- the exact "
             "path website/electron/auto-update.js's provider resolves from the feed base"
         )
         assert "--content-type text/yaml" in run
@@ -249,8 +254,8 @@ def test_linux_lane_verifies_artifact_architecture_before_publishing() -> None:
     every checksum the updater applies and only fails on the user's machine.
     """
     steps = _steps(LINUX_WORKFLOW, "publish-linux")
-    verify = _step_index(steps, "Verify AppImage architecture")
-    publish = _step_index(steps, "Publish AppImage to distribution bucket")
+    verify = _step_index(steps, "Verify artifact architecture")
+    publish = _step_index(steps, "Publish artifact to distribution bucket")
     assert verify < publish, (
         "publish-linux.yml must verify the AppImage architecture before writing the "
         f"immutable versioned key (verify={verify} publish={publish})"
@@ -382,11 +387,11 @@ def test_mac_publish_order_bytes_then_feed_then_alias() -> None:
 
 def test_linux_publish_order_bytes_then_feed_then_alias() -> None:
     steps = _steps(LINUX_WORKFLOW, "publish-linux")
-    locate = _step_index(steps, "Locate AppImage")
-    attest = _step_index(steps, "Attest AppImage provenance")
-    bytes_pub = _step_index(steps, "Publish AppImage to distribution bucket")
+    locate = _step_index(steps, "Locate Linux artifact")
+    attest = _step_index(steps, "Attest artifact provenance")
+    bytes_pub = _step_index(steps, "Publish artifact to distribution bucket")
     feed = _step_index(steps, "Write update feed")
-    alias = _step_index(steps, "Update latest AppImage alias")
+    alias = _step_index(steps, "Update latest artifact alias")
     print(
         f"publish-linux.yml step indices: locate={locate} attest={attest} "
         f"bytes={bytes_pub} feed={feed} alias={alias}"
@@ -397,7 +402,7 @@ def test_linux_publish_order_bytes_then_feed_then_alias() -> None:
         "never go live; the feed trails the versioned key it references; the alias trails "
         "the go-live switch"
     )
-    assert "${APPIMAGE_KEY}" in steps[feed]["run"]
+    assert "${ARTIFACT_KEY}" in steps[feed]["run"]
 
 
 def test_feed_chain_steps_share_one_skip_gate() -> None:
@@ -419,9 +424,9 @@ def test_feed_chain_steps_share_one_skip_gate() -> None:
             LINUX_WORKFLOW,
             "publish-linux",
             (
-                "Publish AppImage to distribution bucket",
+                "Publish artifact to distribution bucket",
                 "Write update feed",
-                "Update latest AppImage alias",
+                "Update latest artifact alias",
             ),
         ),
     ):
@@ -445,7 +450,7 @@ def test_versioned_keys_are_immutable_and_conditionally_written() -> None:
     for path, job, name in (
         (MAC_WORKFLOW, "publish", "Publish notarized artifact to distribution bucket"),
         (MAC_WORKFLOW, "publish", "Publish DMG to distribution bucket"),
-        (LINUX_WORKFLOW, "publish-linux", "Publish AppImage to distribution bucket"),
+        (LINUX_WORKFLOW, "publish-linux", "Publish artifact to distribution bucket"),
     ):
         run = _step(_steps(path, job), name)["run"]
         assert "public, max-age=31536000, immutable" in run, (
@@ -460,7 +465,7 @@ def test_versioned_keys_are_immutable_and_conditionally_written() -> None:
 def test_latest_aliases_use_short_ttl_and_plain_overwrite() -> None:
     for path, job, name in (
         (MAC_WORKFLOW, "publish", "Update latest DMG alias"),
-        (LINUX_WORKFLOW, "publish-linux", "Update latest AppImage alias"),
+        (LINUX_WORKFLOW, "publish-linux", "Update latest artifact alias"),
     ):
         run = _step(_steps(path, job), name)["run"]
         assert "public, max-age=300" in run, (
@@ -572,13 +577,15 @@ def test_mac_gated_artifact_contents_fail_loudly_when_missing() -> None:
     assert "exit 1" in run, "a missing gated artifact must fail the job before any publish"
 
 
-def test_linux_missing_appimage_fails_loudly() -> None:
-    run = _step(_steps(LINUX_WORKFLOW, "publish-linux"), "Locate AppImage")["run"]
-    assert "No AppImage found" in run and "exit 1" in run, (
-        "a missing AppImage must fail the job -- a silent skip would leave a green "
+def test_linux_missing_artifact_fails_loudly() -> None:
+    run = _step(_steps(LINUX_WORKFLOW, "publish-linux"), "Locate Linux artifact")["run"]
+    # The message names the resolved format (${LINUX_EXT}) rather than one
+    # extension, so the same guard covers the AppImage, deb and rpm lanes.
+    assert "No ${LINUX_EXT} found" in run and "exit 1" in run, (
+        "a missing artifact must fail the job -- a silent skip would leave a green "
         "run serving a stale feed"
     )
-    assert "Expected exactly one AppImage" in run, (
+    assert "Expected exactly one ${LINUX_EXT}" in run, (
         "ambiguous artifacts must also fail loudly rather than feeding an arbitrary file"
     )
 

--- a/test/test_release_promotion.py
+++ b/test/test_release_promotion.py
@@ -33,6 +33,10 @@ def _bundle(path: Path) -> Path:
         "kirocrew-1.2.3rc4.tar.gz": b"sdist",
         "KiroCrew-x86_64.AppImage": b"appimage",
         "KiroCrew-aarch64.AppImage": b"appimage-arm64",
+        "KiroCrew-x86_64.deb": b"deb",
+        "KiroCrew-aarch64.deb": b"deb-arm64",
+        "KiroCrew-x86_64.rpm": b"rpm",
+        "KiroCrew-aarch64.rpm": b"rpm-arm64",
         "notarized.zip": b"mac-zip",
         "KiroCrew.dmg": b"dmg",
     }
@@ -71,6 +75,10 @@ def test_manifest_round_trip_binds_source_and_every_shipping_file(tmp_path: Path
         "sdist",
         "appimage",
         "appimage_arm64",
+        "deb",
+        "deb_arm64",
+        "rpm",
+        "rpm_arm64",
         "mac_zip",
         "dmg",
     }

--- a/test/test_release_promotion_contract.py
+++ b/test/test_release_promotion_contract.py
@@ -16,6 +16,14 @@ WORKFLOWS = ROOT / ".github" / "workflows"
 RELEASE = WORKFLOWS / "release.yml"
 CLI = WORKFLOWS / "publish-cli.yml"
 LINUX = WORKFLOWS / "publish-linux.yml"
+#: Every (format, arch) Linux publish lane release.yml calls. Each is a
+#: separate job because publish-linux.yml writes one immutable versioned key
+#: per invocation.
+LINUX_LANES = tuple(
+    f"publish-linux-{fmt}-{arch}"
+    for fmt in ("appimage", "deb", "rpm")
+    for arch in ("x64", "arm64")
+)
 MAC = WORKFLOWS / "sign-and-notarize.yml"
 DOCKER = WORKFLOWS / "publish-docker.yml"
 PROMOTION_ARTIFACT = "KiroCrew-notarized-stable-${{ needs.version.outputs.version }}"
@@ -69,7 +77,7 @@ def test_stable_tag_resolves_candidate_and_never_enters_build_jobs() -> None:
 
 def test_every_stable_lane_consumes_the_verified_handoff() -> None:
     jobs = _workflow(RELEASE)["jobs"]
-    for name in ("publish-cli", "publish-linux-x64", "publish-linux-arm64", "publish-docker", "sign-and-notarize"):
+    for name in ("publish-cli", *LINUX_LANES, "publish-docker", "sign-and-notarize"):
         job = jobs[name]
         assert "resolve-promotion" in job["needs"]
         assert "needs.resolve-promotion.result == 'success'" in job["if"]
@@ -77,15 +85,10 @@ def test_every_stable_lane_consumes_the_verified_handoff() -> None:
     assert PROMOTION_ARTIFACT_FORMAT in jobs["publish-cli"]["with"]["wheel_artifact"]
     assert jobs["publish-cli"]["with"]["promote"].endswith(" == 'stable' }}")
 
-    linux_inputs = jobs["publish-linux-x64"]["with"]
-    assert PROMOTION_ARTIFACT_FORMAT in linux_inputs["appimage_artifact"]
-    assert "resolve-promotion.outputs.source_version" in linux_inputs["version"]
-    assert linux_inputs["promote"].endswith(" == 'stable' }}")
-
-    linux_arm64_inputs = jobs["publish-linux-arm64"]["with"]
-    assert PROMOTION_ARTIFACT_FORMAT in linux_arm64_inputs["appimage_artifact"]
-    assert "resolve-promotion.outputs.source_version" in linux_arm64_inputs["version"]
-    assert linux_arm64_inputs["promote"].endswith(" == 'stable' }}")
+    for lane in LINUX_LANES:
+        assert PROMOTION_ARTIFACT_FORMAT in jobs[lane]["with"]["build_artifact"], lane
+        assert "resolve-promotion.outputs.source_version" in jobs[lane]["with"]["version"], lane
+        assert jobs[lane]["with"]["promote"].endswith(" == 'stable' }}"), lane
 
     docker_inputs = jobs["publish-docker"]["with"]
     assert docker_inputs["promote"].endswith(" == 'stable' }}")
@@ -138,16 +141,24 @@ def test_prerelease_record_waits_for_test_gate_and_all_publish_lanes() -> None:
         "version",
         "release-candidate-tests",
         "publish-cli",
-        "publish-linux-x64",
-        "publish-linux-arm64",
+        "publish-linux-appimage-x64",
+        "publish-linux-appimage-arm64",
+        "publish-linux-deb-x64",
+        "publish-linux-deb-arm64",
+        "publish-linux-rpm-x64",
+        "publish-linux-rpm-arm64",
         "publish-docker",
         "sign-and-notarize",
     }
     for dependency in (
         "release-candidate-tests",
         "publish-cli",
-        "publish-linux-x64",
-        "publish-linux-arm64",
+        "publish-linux-appimage-x64",
+        "publish-linux-appimage-arm64",
+        "publish-linux-deb-x64",
+        "publish-linux-deb-arm64",
+        "publish-linux-rpm-x64",
+        "publish-linux-rpm-arm64",
         "publish-docker",
         "sign-and-notarize",
     ):
@@ -188,8 +199,8 @@ def test_file_publishers_verify_manifest_and_prior_provenance() -> None:
     assert "gh attestation verify" in cli_verify["run"]
 
     linux_manifest = _step(LINUX, "publish-linux", "Verify immutable promotion bundle")
-    linux_attest = _step(LINUX, "publish-linux", "Attest AppImage provenance")
-    linux_verify = _step(LINUX, "publish-linux", "Verify promoted AppImage provenance")
+    linux_attest = _step(LINUX, "publish-linux", "Attest artifact provenance")
+    linux_verify = _step(LINUX, "publish-linux", "Verify promoted artifact provenance")
     linux_promote = "env.HAS_SIGNING_SECRETS && inputs.promote"
     linux_fresh = "env.HAS_SIGNING_SECRETS && !inputs.promote"
     assert linux_manifest["if"] == linux_promote

--- a/test/test_stable_release_gate.py
+++ b/test/test_stable_release_gate.py
@@ -40,8 +40,12 @@ STEP_NAME = "Verify stable publication preconditions"
 #: would put stable bytes on the CDN without the preconditions check.
 PUBLISH_JOBS = (
     "publish-cli",
-    "publish-linux-x64",
-    "publish-linux-arm64",
+    "publish-linux-appimage-x64",
+    "publish-linux-appimage-arm64",
+    "publish-linux-deb-x64",
+    "publish-linux-deb-arm64",
+    "publish-linux-rpm-x64",
+    "publish-linux-rpm-arm64",
     "publish-docker",
     "sign-and-notarize",
     "github-release",

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -66,6 +66,16 @@ def _workflow_permissions(name: str) -> dict[str, str]:
     return permissions
 
 
+#: Job headers for every Linux publish caller. Six lanes = three formats
+#: (appimage / deb / rpm) x two arches, each its own job because
+#: publish-linux.yml writes one immutable versioned key per invocation.
+_PUBLISH_LINUX_JOB_HEADERS = tuple(
+    f"  publish-linux-{fmt}-{arch}:"
+    for fmt in ("appimage", "deb", "rpm")
+    for arch in ("x64", "arm64")
+)
+
+
 class TestNightlyPermissions:
     def test_only_publish_callers_can_mint_oidc_tokens(self) -> None:
         lines = _lines("nightly.yml")
@@ -92,7 +102,7 @@ class TestNightlyPermissions:
         # their own SLSA provenance for the exact bytes they upload -- never
         # contents:write. One lane per arch, so BOTH are asserted: a new arch
         # that quietly widened its grant would otherwise slip through.
-        for arch_job in ("  publish-linux-x64:", "  publish-linux-arm64:"):
+        for arch_job in _PUBLISH_LINUX_JOB_HEADERS:
             assert _permission_block(lines, arch_job) == {
                 "contents": "read",
                 "id-token": "write",
@@ -167,7 +177,7 @@ class TestReleasePermissions:
             "attestations": "write",
         }
         # Linux desktop lanes: OIDC + in-lane provenance (see nightly note).
-        for arch_job in ("  publish-linux-x64:", "  publish-linux-arm64:"):
+        for arch_job in _PUBLISH_LINUX_JOB_HEADERS:
             assert _permission_block(lines, arch_job) == {
                 "contents": "read",
                 "id-token": "write",

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -37,7 +37,67 @@ const {
   classifyBundleLocation,
   containingDirForBundle,
   canInstallUpdates,
+  classifyLinuxInstall,
+  containingDirForAppImage,
+  canUpdateLinuxInstall,
+  describeLinuxInstall,
 } = require("./bundle-location");
+
+// The Linux package formats this app ships. A format is BOTH the feed
+// sub-directory a package install reads its channel file from AND the download
+// extension its manual-reinstall link must use, so one set serves both: the
+// format has to be known rather than assumed, because `package-type` is the only
+// signal that names it and the resourcesPath fallback in classifyLinuxInstall()
+// proves only that this IS a package. An unnamed format therefore stays empty,
+// canUpdateLinuxInstall() refuses, and the download link falls back to the
+// AppImage — instead of pointing an rpm install at deb bytes either way.
+const LINUX_PACKAGE_EXTENSIONS = new Set(["deb", "rpm"]);
+
+/**
+ * Which Linux install shape is running, resolved from the three signals that
+ * exist at runtime. I/O-bearing (it reads the package-type file), so it sits
+ * here rather than in the pure bundle-location module, and every input is
+ * injectable so tests never touch a real filesystem.
+ *
+ * @param {object} [o]
+ * @param {object} [o.env=process.env]
+ * @param {string} [o.resourcesPath=process.resourcesPath]
+ * @returns {{kind:string, format:string, appImagePath:string}}
+ */
+function resolveLinuxInstall({ env = process.env, resourcesPath = process.resourcesPath } = {}) {
+  const appImagePath = (env && env.APPIMAGE) || "";
+  let packageType = "";
+  try {
+    const fs = require("fs");
+    const path = require("path");
+    packageType = fs.readFileSync(path.join(resourcesPath || "", "package-type"), "utf8").trim();
+  } catch {
+    // Absent on an AppImage and on any build whose target had no publish config
+    // — the other two signals cover both, so this is a normal case, not a fault.
+    packageType = "";
+  }
+  const kind = classifyLinuxInstall({ appImagePath, packageType, resourcesPath });
+  const format = kind === "package" && LINUX_PACKAGE_EXTENSIONS.has(packageType) ? packageType : "";
+  return { kind, format, appImagePath };
+}
+
+// Can the AppImage replace itself, i.e. is the directory HOLDING the image
+// writable? AppImageUpdater stages the new image beside the old one and `mv`s it
+// over the original, so the containing directory — not the mounted, read-only
+// squashfs the app runs from — is what must be writable. Same fail-safe TRUE as
+// isBundleContainerWritable: a probe that cannot run must not read as
+// "un-updatable".
+function isAppImageContainerWritable(appImagePath) {
+  const dir = containingDirForAppImage(appImagePath);
+  if (!dir) return true;
+  try {
+    const fs = require("fs");
+    fs.accessSync(dir, fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 // Can the macOS installer write the directory holding our .app (i.e. replace
 // the bundle)? electron-updater does NOT install on macOS itself: MacUpdater
@@ -173,13 +233,21 @@ function resolveChannel(stamped, preference) {
  * update harness (KIROCREW_UPDATE_FEED=http://127.0.0.1:PORT/feed) works;
  * cleartext update metadata over a real network stays rejected.
  *
- * @param {{base:string, channel:string}} o
+ * `variant` adds one path segment below the channel, which is how a Linux
+ * package install reaches its OWN channel file: electron-updater derives the
+ * file NAME from platform and arch with no hook to change it, so two formats
+ * cannot share a directory without one overwriting the other's metadata.
+ * Separating them by directory leaves that derivation — including the
+ * `-arm64` suffix — completely untouched.
+ *
+ * @param {{base:string, channel:string, variant?:string}} o
  * @returns {string}
  * @throws {Error} on a non-HTTPS, non-loopback base
  */
-function buildFeedBase({ base, channel }) {
+function buildFeedBase({ base, channel, variant = "" }) {
   const b = (base || DEFAULT_FEED_BASE).replace(/\/+$/, "");
-  const url = `${b}/${encodeURIComponent(channel)}/`;
+  const tail = variant ? `${encodeURIComponent(variant)}/` : "";
+  const url = `${b}/${encodeURIComponent(channel)}/${tail}`;
   const parsed = new URL(url);
   const isLoopback = ["127.0.0.1", "localhost", "[::1]", "::1"].includes(parsed.hostname);
   if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopback)) {
@@ -208,17 +276,27 @@ function buildFeedBase({ base, channel }) {
  * @param {string} channel    resolved update channel
  * @param {string} osPlatform process.platform value
  * @param {string} [osArch]   process.arch value; defaults to the running arch
+ * @param {string} [linuxFormat] resolved package format ("deb"/"rpm"), or "" for
+ *        an AppImage / unknown shape
  * @returns {string|null}
  */
-function manualDownloadUrl(channel, osPlatform, osArch = process.arch) {
+function manualDownloadUrl(channel, osPlatform, osArch = process.arch, linuxFormat = "") {
   if (!channelHasLane(channel, osPlatform)) return null;
   // The mac DMG is universal, so darwin needs no arch. Linux has no universal
-  // binary: publish-linux.yml publishes one AppImage per arch under the
-  // basenames below, so handing a user the wrong one is an immediate
-  // "cannot execute binary file" — which is exactly the dead end this link
-  // exists to avoid. An arch with no published lane returns null rather than
-  // guessing x86_64.
-  const linuxFile = { x64: "KiroCrew-x86_64.AppImage", arm64: "KiroCrew-aarch64.AppImage" }[osArch];
+  // binary: publish-linux.yml publishes one artifact per arch per format under
+  // the basenames below, so handing a user the wrong one is an immediate
+  // "cannot execute binary file" — or, for a package, one dpkg/rpm refuses.
+  // An arch with no published lane returns null rather than guessing x86_64.
+  // The format must match how they installed: offering an AppImage to someone
+  // whose files are managed by a package manager invites two parallel installs,
+  // so every recognised package format keeps its own extension and only an
+  // AppImage (or a shape we could not name) falls back to the image.
+  const linuxArch = { x64: "x86_64", arm64: "aarch64" }[osArch];
+  const linuxExt = LINUX_PACKAGE_EXTENSIONS.has(linuxFormat) ? linuxFormat : "AppImage";
+  // A published artifact FILENAME, not prose: the joined form is what
+  // publish-linux.yml writes to the CDN, and the arch and extension are
+  // interpolated because there are now six (arch, format) pairs to name.
+  const linuxFile = linuxArch ? `KiroCrew-${linuxArch}.${linuxExt}` : null; // brand-ok
   // Windows ships x64 only. build-windows.yml has no arm64 leg, and Windows has
   // exactly one channel file whatever the arch (electron-updater appends an arch
   // suffix for linux alone), so a second arch means another entry in the same
@@ -408,6 +486,11 @@ function initAutoUpdate(deps) {
     osArch = process.arch,
     resourcesPath = process.resourcesPath,
     probeBundleWritable = isBundleContainerWritable,
+    // Linux install shape + its AppImage writability probe, injected for the
+    // same reason as probeBundleWritable: the verdict must be assertable in a
+    // test without a real AppImage mount or a real /opt install.
+    linuxInstall = null,
+    probeAppImageWritable = isAppImageContainerWritable,
     // Electron's NATIVE autoUpdater, used only to observe
     // `before-quit-for-update` -- the signal that the platform installer has
     // actually taken over (see forceExitFailsafe). electron-updater drives it
@@ -420,6 +503,16 @@ function initAutoUpdate(deps) {
     onUpdateState = null,
     log = console,
   } = deps;
+
+  // Linux install shape. Resolved once, and BEFORE getInfo() is defined: the
+  // early-return stubs below hand getInfo out, so a renderer could call it
+  // before a later declaration initialised — a temporal dead zone crash on the
+  // one path that exists to report a problem gracefully. The signals cannot
+  // change while the process lives, and re-reading package-type per check would
+  // add a synchronous file read to a path that runs every four hours.
+  const linux = osPlatform === "linux"
+    ? (linuxInstall || resolveLinuxInstall({ resourcesPath }))
+    : { kind: "", format: "", appImagePath: "" };
 
   // When the in-app UI is wired (onUpdateState provided), it owns the prompt;
   // the native dialog stays as the fallback for headless / no-renderer cases.
@@ -471,7 +564,7 @@ function initAutoUpdate(deps) {
       platform,
       packaged: !!app.isPackaged,
       // Escape hatch for a failed install (see manualDownloadUrl).
-      downloadUrl: manualDownloadUrl(currentChannel(), osPlatform, osArch),
+      downloadUrl: manualDownloadUrl(currentChannel(), osPlatform, osArch, linux.format),
       // Replay seed for a freshly mounted renderer (see lastEmittedState).
       lastState: lastEmittedState,
     };
@@ -515,12 +608,12 @@ function initAutoUpdate(deps) {
   // verdict rests on whether the bundle's containing directory is writable.
   //
   // macOS only, by construction: classifyBundleLocation() returns "other" for
-  // every non-darwin platform, so this is a no-op on Linux. That is deliberate
-  // rather than an oversight — a Linux AppImage self-replaces via `mv` into
-  // dirname($APPIMAGE) and so shares the writability requirement, but deb/rpm
-  // installs go through the package manager with privilege escalation and do
-  // not. Getting Linux right needs AppImage-vs-package detection, which is its
-  // own change; guessing here would disable updates for deb/rpm users.
+  // every non-darwin platform, so this is a no-op on Linux. Linux asks the same
+  // question through its own signals, immediately below, because the two
+  // platforms agree on nothing but the question: an AppImage self-replaces via
+  // `mv` into dirname($APPIMAGE) and so shares the writability requirement,
+  // while a deb install is handed to dpkg behind an elevation prompt and needs
+  // no writable directory at all.
   // ... and carry the reason out as `disabled`, exactly like the dev/platform
   // paths above: main.js merges it into the info payload it hands the renderer,
   // so About shows "unavailable" instead of a live Check button that no-ops.
@@ -536,6 +629,25 @@ function initAutoUpdate(deps) {
       getInfo,
       disabled: bundleLocation,
     };
+  }
+
+  if (osPlatform === "linux") {
+    const imageWritable = linux.kind === "appimage"
+      ? probeAppImageWritable(linux.appImagePath)
+      : true;
+    if (!canUpdateLinuxInstall(linux.kind, { imageWritable, packageFormat: linux.format })) {
+      const reason = linux.kind === "package" ? "linux-package-unknown-format" : "appimage-readonly";
+      log.info(`[update] auto-update disabled (${reason}): `
+        + describeLinuxInstall(linux.kind, { imageWritable, packageFormat: linux.format }));
+      return {
+        check: () => {},
+        download: async () => {},
+        install: async () => {},
+        getInfo,
+        disabled: reason,
+      };
+    }
+    log.info(`[update] linux install: ${linux.kind}${linux.format ? ` (${linux.format})` : ""}`);
   }
 
   configureUpdater(autoUpdater);
@@ -590,7 +702,9 @@ function initAutoUpdate(deps) {
 
   function configureFeed() {
     const channel = currentChannel();
-    const url = buildFeedBase({ base: feedBase, channel });
+    // A package install reads its channel file from a per-format subdirectory,
+    // so the two Linux formats never overwrite each other's metadata.
+    const url = buildFeedBase({ base: feedBase, channel, variant: linux.format });
     autoUpdater.setFeedURL({ provider: "generic", url });
     log.info(`[update] feed: ${url}`);
     return url;
@@ -948,6 +1062,7 @@ module.exports = {
   configureUpdater,
   classifyError,
   manualDownloadUrl,
+  resolveLinuxInstall,
   DEFAULT_FEED_BASE,
   DOWNLOAD_BASE,
   SUPPORTED_PLATFORMS,

--- a/website/electron/bundle-location.js
+++ b/website/electron/bundle-location.js
@@ -29,6 +29,14 @@
 // Translocation is the exception that needs no writability test: even if the
 // ephemeral copy were writable, replacing it updates a temporary directory and
 // leaves the user's real app untouched.
+//
+// LINUX is the same question with different answers: an AppImage replaces itself
+// in the directory holding the image, so writability decides it there too, while
+// a deb/rpm install is the package manager's to update and the app must not try.
+// Those live in the classifyLinuxInstall() family at the bottom of this file,
+// kept separate from the macOS bundle functions because the two platforms share
+// no path shape — collapsing them would mean one function whose parameters only
+// ever apply to half its callers.
 
 // The randomized read-only mount point Gatekeeper uses for a quarantined app.
 // Path shape: /private/var/folders/<x>/<y>/d/AppTranslocation/<UUID>/d/Foo.app
@@ -37,6 +45,10 @@ const TRANSLOCATION_MARKER = "/AppTranslocation/";
 const VOLUME_PREFIX = "/Volumes/";
 const APPLICATIONS_MARKER = "/Applications/";
 const RESOURCES_SUFFIX = "/Contents/Resources";
+// fpm installs a deb/rpm under this prefix, so a resourcesPath below it is a
+// package install even when no other signal survived (an app relaunched without
+// $APPIMAGE, or a build whose package-type file was not written).
+const PACKAGE_PREFIX = "/opt/";
 
 /**
  * Classify the filesystem location an app bundle is running from. Path-only —
@@ -145,12 +157,113 @@ function describeLocation(location, { bundleWritable = true } = {}) {
   return "Kiro Crew is running from a read-only disk image, so it cannot install its own updates.";
 }
 
+/**
+ * Which Linux install shape is this process running as?
+ *
+ * Linux ships two formats with opposite update stories, and the shell must tell
+ * them apart before it arms an updater: an AppImage self-replaces by `mv`-ing a
+ * new image over itself, so it needs its containing directory to be writable,
+ * while a deb/rpm install is owned by the package manager and is updated with
+ * privilege escalation the app does not have.
+ *
+ * Both signals are positive identifications rather than the absence of the
+ * other, so a third format added later reports "unknown" instead of silently
+ * inheriting AppImage semantics: `resources/package-type` is written by
+ * electron-builder for its package targets, `$APPIMAGE` is exported by the
+ * AppImage runtime and holds the image's own path, and a package install is the
+ * only shape of ours that lands under /opt (fpm's fixed prefix).
+ *
+ * @param {object} [signals]
+ * @param {string} [signals.appImagePath=""]  value of process.env.APPIMAGE
+ * @param {string} [signals.packageType=""]   contents of resources/package-type
+ * @param {string} [signals.resourcesPath=""] process.resourcesPath
+ * @returns {"appimage"|"package"|"unknown"}
+ */
+function classifyLinuxInstall({ appImagePath = "", packageType = "", resourcesPath = "" } = {}) {
+  if (typeof packageType === "string" && packageType.trim() !== "") return "package";
+  if (typeof appImagePath === "string" && appImagePath !== "") return "appimage";
+  if (typeof resourcesPath === "string" && resourcesPath.startsWith(PACKAGE_PREFIX)) {
+    return "package";
+  }
+  return "unknown";
+}
+
+/**
+ * The directory an AppImage must be able to write in order to replace itself:
+ * the one holding the image. Mirrors containingDirForBundle()'s defensiveness —
+ * "" for anything that is not an absolute path, so no caller probes an
+ * unrelated directory.
+ *
+ * @param {string} appImagePath
+ * @returns {string}
+ */
+function containingDirForAppImage(appImagePath) {
+  if (typeof appImagePath !== "string" || !appImagePath.startsWith("/")) return "";
+  const sep = appImagePath.lastIndexOf("/");
+  if (sep <= 0) return "";
+  return appImagePath.slice(0, sep);
+}
+
+/**
+ * Can this Linux install apply its own update?
+ *
+ * Three different reasons to say no or yes:
+ *
+ * - "appimage" depends on the filesystem: it `mv`s a new image over itself and
+ *   so needs the containing directory writable.
+ * - "package" needs its FORMAT to be known, because each format reads its own
+ *   feed directory. The resourcesPath fallback in classifyLinuxInstall() proves
+ *   only that this IS a package, not which kind — and guessing would hand an rpm
+ *   install the deb feed (or an AppImage), so an unnamed format is refused.
+ * - "unknown" fails open, in the same direction as canInstallUpdates(): a signal
+ *   we could not read must not disable updates fleet-wide.
+ *
+ * @param {string} kind  a classifyLinuxInstall() result
+ * @param {object} [opts]
+ * @param {boolean} [opts.imageWritable=true]  can the AppImage's containing dir
+ *        be written? Only consulted for "appimage".
+ * @param {string} [opts.packageFormat=""]  resolved package format ("deb"/"rpm").
+ *        Only consulted for "package".
+ * @returns {boolean}
+ */
+function canUpdateLinuxInstall(kind, { imageWritable = true, packageFormat = "" } = {}) {
+  if (kind === "appimage") return imageWritable !== false;
+  if (kind === "package") return typeof packageFormat === "string" && packageFormat !== "";
+  return true;
+}
+
+/**
+ * User-facing explanation for a Linux install that cannot self-update, or ""
+ * when it can — so callers can treat "" as "nothing to say", exactly like
+ * describeLocation().
+ *
+ * @param {string} kind
+ * @param {object} [opts]
+ * @param {boolean} [opts.imageWritable=true]
+ * @param {string} [opts.packageFormat=""]
+ * @returns {string}
+ */
+function describeLinuxInstall(kind, { imageWritable = true, packageFormat = "" } = {}) {
+  if (canUpdateLinuxInstall(kind, { imageWritable, packageFormat })) return "";
+  if (kind === "package") {
+    return "Kiro Crew cannot tell which package format this install came from, so it "
+      + "cannot fetch the right update. Update it through your package manager.";
+  }
+  return "Kiro Crew cannot write to the folder holding its AppImage, so it cannot replace "
+    + "itself with an update. Move the AppImage somewhere you own, such as ~/Applications.";
+}
+
 module.exports = {
   classifyBundleLocation,
   containingDirForBundle,
   canInstallUpdates,
   shouldOfferRelocation,
   describeLocation,
+  classifyLinuxInstall,
+  containingDirForAppImage,
+  canUpdateLinuxInstall,
+  describeLinuxInstall,
   TRANSLOCATION_MARKER,
   VOLUME_PREFIX,
+  PACKAGE_PREFIX,
 };

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -2,6 +2,8 @@
   "name": "kirocrew-electron-mac",
   "version": "0.3.0",
   "description": "Kiro Crew \u2014 AI agent desktop app",
+  "homepage": "https://github.com/kirodotdev/KiroCrew",
+  "desktopName": "kirocrew-desktop.desktop",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -48,10 +50,61 @@
     "linux": {
       "category": "Development",
       "icon": "build/icons",
+      "executableName": "kirocrew-desktop",
+      "maintainer": "Kiro Crew Maintainers <maintainers@crew.kiro.dev>",
+      "synopsis": "Persistent AI agent workspace with memory, schedules, and unattended work",
+      "syncDesktopName": true,
       "target": [
-        "AppImage"
+        "AppImage",
+        "deb",
+        "rpm"
       ],
       "artifactName": "${productName}-${version}-${arch}.${ext}"
+    },
+    "deb": {
+      "packageName": "kirocrew",
+      "packageCategory": "devel",
+      "priority": "optional",
+      "publish": [
+        {
+          "provider": "generic",
+          "url": "https://updates.crew.kiro.dev/feed/stable/deb"
+        }
+      ],
+      "depends": [
+        "libgtk-3-0 | libgtk-3-0t64",
+        "libnotify4 | libnotify4t64",
+        "libnss3",
+        "libxss1",
+        "libxtst6",
+        "xdg-utils",
+        "libatspi2.0-0 | libatspi2.0-0t64",
+        "libuuid1",
+        "libsecret-1-0",
+        "libasound2 | libasound2t64"
+      ]
+    },
+    "rpm": {
+      "packageName": "kirocrew",
+      "packageCategory": "Development/Tools",
+      "publish": [
+        {
+          "provider": "generic",
+          "url": "https://updates.crew.kiro.dev/feed/stable/rpm"
+        }
+      ],
+      "depends": [
+        "gtk3",
+        "libnotify",
+        "nss",
+        "libXScrnSaver",
+        "libXtst",
+        "xdg-utils",
+        "at-spi2-core",
+        "libuuid",
+        "libsecret",
+        "alsa-lib"
+      ]
     },
     "dmg": {
       "writeUpdateInfo": false

--- a/website/electron/test/auto-update-errors.test.js
+++ b/website/electron/test/auto-update-errors.test.js
@@ -238,6 +238,31 @@ test("manualDownloadUrl: Linux picks the AppImage for the running arch", () => {
   );
 });
 
+test("manualDownloadUrl: the link matches the format they installed", () => {
+  // A package install's escape hatch must hand back the SAME format. Offering an
+  // AppImage to someone whose files are managed by dpkg/rpm creates a second,
+  // unmanaged install beside the first instead of repairing it -- and the
+  // package manager then knows nothing about the copy they actually run.
+  assert.strictEqual(
+    manualDownloadUrl("stable", "linux", "x64", "deb"),
+    `${DOWNLOAD_BASE}/desktop/stable/latest/KiroCrew-x86_64.deb`,
+  );
+  assert.strictEqual(
+    manualDownloadUrl("stable", "linux", "arm64", "rpm"),
+    `${DOWNLOAD_BASE}/desktop/stable/latest/KiroCrew-aarch64.rpm`,
+  );
+  // No format, or one we do not publish, falls back to the AppImage rather than
+  // inventing an extension no lane serves.
+  assert.strictEqual(
+    manualDownloadUrl("stable", "linux", "x64", ""),
+    `${DOWNLOAD_BASE}/desktop/stable/latest/KiroCrew-x86_64.AppImage`,
+  );
+  assert.strictEqual(
+    manualDownloadUrl("stable", "linux", "x64", "pacman"),
+    `${DOWNLOAD_BASE}/desktop/stable/latest/KiroCrew-x86_64.AppImage`,
+  );
+});
+
 test("manualDownloadUrl: null wherever there is no publish lane", () => {
   // A dev build has no channel lane -- offering a 404 is worse than offering
   // nothing.

--- a/website/electron/test/bundle-location.test.js
+++ b/website/electron/test/bundle-location.test.js
@@ -15,6 +15,10 @@ const {
   canInstallUpdates,
   shouldOfferRelocation,
   describeLocation,
+  classifyLinuxInstall,
+  containingDirForAppImage,
+  canUpdateLinuxInstall,
+  describeLinuxInstall,
 } = require("../bundle-location");
 
 const DARWIN = { platform: "darwin" };
@@ -117,4 +121,97 @@ test("containingDirForBundle refuses to guess on an unusable shape", () => {
   for (const bad of [undefined, null, "", 42, "relative/path", "/"]) {
     assert.equal(containingDirForBundle(bad), "", String(bad));
   }
+});
+
+// --- Linux: two formats, opposite update stories -----------------------------
+// Same shape of question as the macOS block above (where am I, and can I be
+// replaced), but the AppImage's containing directory is what decides it while a
+// package install is dpkg's to update. Every signal is a POSITIVE
+// identification, so a format we have never seen reports "unknown" and stays
+// updatable rather than inheriting AppImage semantics by default.
+
+const IMAGE_READ_ONLY = { imageWritable: false };
+
+test("the package-type file identifies a package install", () => {
+  assert.equal(classifyLinuxInstall({ packageType: "deb" }), "package");
+  assert.equal(classifyLinuxInstall({ packageType: "rpm" }), "package");
+});
+
+test("$APPIMAGE identifies an AppImage", () => {
+  assert.equal(
+    classifyLinuxInstall({ appImagePath: "/home/u/Applications/KiroCrew-x86_64.AppImage" }),
+    "appimage",
+  );
+});
+
+test("package-type wins over $APPIMAGE — it is the more authoritative signal", () => {
+  assert.equal(
+    classifyLinuxInstall({ appImagePath: "/home/u/K.AppImage", packageType: "deb" }),
+    "package",
+  );
+});
+
+test("an /opt resourcesPath is a package install even with no other signal", () => {
+  // A deb-installed app relaunched from its desktop entry carries no $APPIMAGE,
+  // and a build whose target had no publish config writes no package-type file.
+  // Without this fallback such a launch would classify "unknown" and be handed
+  // the AppImage self-replace path, which has no image to replace.
+  assert.equal(classifyLinuxInstall({ resourcesPath: "/opt/KiroCrew/resources" }), "package");
+});
+
+test("no signal at all is 'unknown', never a guess", () => {
+  assert.equal(classifyLinuxInstall(), "unknown");
+  assert.equal(classifyLinuxInstall({}), "unknown");
+  assert.equal(classifyLinuxInstall({ appImagePath: "", packageType: "   " }), "unknown");
+});
+
+test("the AppImage's containing directory is what must be writable", () => {
+  assert.equal(containingDirForAppImage("/home/u/Applications/K.AppImage"), "/home/u/Applications");
+});
+
+test("a non-absolute AppImage path yields no directory to probe", () => {
+  // Mirrors containingDirForBundle: resolving a relative path against the
+  // process cwd would probe an unrelated directory and report on the wrong one.
+  assert.equal(containingDirForAppImage("Apps/K.AppImage"), "");
+  assert.equal(containingDirForAppImage(""), "");
+  assert.equal(containingDirForAppImage("/K.AppImage"), "");
+});
+
+test("an AppImage in a directory it cannot write cannot self-update", () => {
+  assert.equal(canUpdateLinuxInstall("appimage", IMAGE_READ_ONLY), false);
+  assert.equal(canUpdateLinuxInstall("appimage", { imageWritable: true }), true);
+});
+
+test("a package install is updatable ONLY when its format is known", () => {
+  // Each format reads its own feed directory, so the format is what makes an
+  // update fetchable. Knowing only "this is a package" (the resourcesPath
+  // fallback) is not enough: guessing would hand an rpm install the deb feed.
+  assert.equal(canUpdateLinuxInstall("package", { packageFormat: "deb" }), true);
+  assert.equal(canUpdateLinuxInstall("package", { packageFormat: "rpm" }), true);
+  assert.equal(canUpdateLinuxInstall("package"), false);
+  assert.equal(canUpdateLinuxInstall("package", { packageFormat: "" }), false);
+  // Writability of /opt is irrelevant to a package install either way.
+  assert.equal(canUpdateLinuxInstall("package", { packageFormat: "deb", imageWritable: false }), true);
+});
+
+test("an unrecognised install shape fails OPEN", () => {
+  assert.equal(canUpdateLinuxInstall("unknown"), true);
+  assert.equal(canUpdateLinuxInstall("unknown", IMAGE_READ_ONLY), true);
+});
+
+test("each un-updatable state explains itself in its own terms", () => {
+  assert.equal(describeLinuxInstall("package", { packageFormat: "deb" }), "");
+  assert.equal(describeLinuxInstall("appimage"), "");
+  assert.equal(describeLinuxInstall("unknown"), "");
+
+  const ro = describeLinuxInstall("appimage", IMAGE_READ_ONLY);
+  assert.match(ro, /AppImage/);
+  assert.match(ro, /cannot write/);
+
+  // A package whose format could not be named points at the package manager
+  // rather than blaming the filesystem.
+  const pkg = describeLinuxInstall("package");
+  assert.match(pkg, /package format/);
+  assert.match(pkg, /package manager/);
+  assert.doesNotMatch(pkg, /AppImage/);
 });

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -252,4 +252,36 @@ describe("uninstall data preservation contract", () => {
     assert.equal(electronPkg.build.nsis.oneClick, false);
     assert.equal(electronPkg.build.nsis.perMachine, false);
   });
+
+  it("gives nightly its own Linux package identity so it installs beside stable", () => {
+    const nightlyOverrides = fs.readFileSync(
+      path.resolve(ROOT, "..", "..", "packaging", "build-desktop.sh"),
+      "utf8"
+    );
+    // Linux packages key install identity off the PACKAGE NAME, so a shared name
+    // makes dpkg/rpm treat a nightly install as an upgrade of stable and remove
+    // it -- the same class as the nsis.guid hazard above. The launcher and
+    // desktop-entry names are per-install paths and must move with it.
+    for (const override of [
+      "-c.deb.packageName=kirocrew-nightly",
+      "-c.rpm.packageName=kirocrew-nightly",
+      "-c.linux.executableName=kirocrew-desktop-nightly",
+      "-c.extraMetadata.desktopName=kirocrew-desktop-nightly.desktop",
+    ]) {
+      assert.ok(
+        nightlyOverrides.includes(override),
+        `build-desktop.sh must pass ${override} for the nightly channel`
+      );
+    }
+    // And the stable defaults they override must be the ones actually shipped,
+    // so a rename on either side fails here instead of silently colliding.
+    assert.equal(electronPkg.build.deb.packageName, "kirocrew");
+    assert.equal(electronPkg.build.rpm.packageName, "kirocrew");
+    assert.equal(electronPkg.build.linux.executableName, "kirocrew-desktop");
+    assert.equal(electronPkg.desktopName, "kirocrew-desktop.desktop");
+    // syncDesktopName is what ties Electron's app_id and the entry's
+    // StartupWMClass to desktopName; without it the nightly override above
+    // would move the filename but not the window association.
+    assert.equal(electronPkg.build.linux.syncDesktopName, true);
+  });
 });


### PR DESCRIPTION
no linked issue: this implements Taskei epic P485613886 (Improve Linux Desktop
Install), which has no GitHub issue. The #4049 reference below is a related PR,
not something this closes.

## Problem

The Linux desktop app shipped only as an AppImage, which has no fixed install path — and four separate mechanisms silently depend on one:

- **The agent sandbox fails closed.** The AppArmor `userns` profile Ubuntu 23.10+ requires attaches to a *file path* (`apparmor.py:761`), so moving or renaming the image stops it matching. Agent spawns then fail with nothing pointing at the cause. `install.md` documented this as a limitation.
- **`kirocrew` on `PATH` was a dangling link.** `ensure_kirocrew_on_path()` runs on *every* gateway start and resolved into the AppImage's temporary mount, so it republished a `~/.local/bin/kirocrew` that broke the moment the app exited.
- **No desktop integration existed.** Nothing registered a `.desktop` entry, so the launcher icon and window association were left to the desktop environment to guess.
- **Auto-update was a no-op on Linux.** The writability gate could not tell an AppImage (which replaces itself) from a package (which does not), so its own comment deferred the work — and a non-writable image downloaded updates forever and applied none.

## Why it matters

Install is where Linux adoption stalls, and every item above is invisible until it bites: the sandbox failure surfaces as unrelated spawn errors, the dangling launcher as `command not found`, the update failure as silence.

## Fix

**Root cause → change.** All four depend on a fixed install path, so the fix is to ship formats that have one: `.deb` and `.rpm`. electron-builder's own maintainer scripts then install the `userns` profile, register the desktop and MIME databases, refresh the icon cache, and place the launcher symlink — no custom `postinst`.

**Per-format lanes, not three pipelines.** One backend tree is packaged three times with the beacon distribution re-stamped between electron-builder invocations (a single stamp would label one artifact as another). `publish-linux.yml` gains a `format` input so its immutability, attestation, 412 re-run byte-verify and feed discipline stay **one** implementation — 144 added lines there, only 33 of them format-specific. Each package format reads its own feed *directory*, because electron-updater derives the channel file name from platform and arch with no hook to change it, so two formats sharing a directory would overwrite each other's metadata.

**Window association is now deterministic.** `desktopName` + `linux.syncDesktopName` make Electron's `app_id`, the `.desktop` filename and `StartupWMClass` derive from one value. An earlier revision hand-wrote `StartupWMClass`; that *overrode* electron-builder's derivation with a string that need not equal what Electron reports, which is a different way to be wrong.

**Two defects the work uncovered, both fixed here:**

- `_bin_is_usable()` accepted a launcher whose interpreter was gone, so a reaped work directory could be republished as the machine-wide `kirocrew` on every gateway start. Observed live on an AL2023 host: `/tmp/kc-*/bin/kirocrew` existed and was executable while its `.venv` had been swept.
- `deb`/`rpm` had to join `beacon.KNOWN_DISTRIBUTIONS` **and** `update_layout.EXTERNALLY_MANAGED` **and** the twin table in `dashboard/handlers/updates.py` together. Adding only the first would have offered a dpkg-managed `/opt` install the *pip* upgrade command, and left a package install compared against the CLI wheel feed. That twin table is now **derived** from the one owner rather than restated, so the drift cannot recur.

## Tests

- `test/test_installer_shim_and_cleanup.py` — the AppImage-mount guard, and five launcher shapes for `_bin_is_usable`: a `.venv` whose python was removed, a console script *inside* `.venv/bin` (the common source install, which an earlier revision rejected), a wheel install judged by its own shebang, `#!/usr/bin/env python3` (a finder, not an interpreter path), and a compiled launcher.
- `website/electron/test/bundle-location.test.js` — the three-signal Linux classifier, the AppImage writability gate, and that a package whose *format* cannot be named is refused rather than pointed at another format's feed.
- `website/electron/test/auto-update-errors.test.js` — the manual-reinstall link must match the installed format; offering an AppImage to a dpkg-managed install creates a second unmanaged copy.
- `test/test_publish_feed_contract.py`, `test/test_release_promotion*.py` — updated to the new reality rather than relaxed. The feed-destination assertion now pins `${FEED_PREFIX}/${FEED_FILE}`, keeping "two formats never share a directory" enforced.

## Manual verification

Dependency names are the part no unit test can check, so they were verified against real package managers in containers:

- **deb on Ubuntu 24.04** (chosen because it is the 64-bit `time_t` release): a probe package carrying this PR's exact `Depends` installs, and apt resolves the alternative to the **t64** side (`Setting up libgtk-3-0t64`). This is what proves `libgtk-3-0 | libgtk-3-0t64` works rather than merely parses.
- **rpm on Amazon Linux 2023**: all ten dependency names resolve via `dnf`.
- The live AppImage from the stable CDN was extracted on an AL2023 host: it reaches `Missing X server or $DISPLAY`, i.e. it loads and initialises. The measured glibc requirement across the Electron binary and every bundled `.so` is **2.34**, not the runner's 2.35 — so AL2023, CentOS Stream 9 and Fedora *can* run the desktop app, and the real AL2023 obstacle is that it ships without FUSE. Both facts are now in the docs where users see them.

`scripts/smoke-linux-packages.sh` makes this repeatable: it installs both packages in those two distros and asserts the `.desktop` entry, `StartupWMClass`, the launcher symlink, the bundled CLI, the per-format beacon stamp, and clean removal. It runs on every nightly and release, and on any PR touching packaging paths.

## Screenshots

N/A — no dashboard UI change. The user-visible surfaces are `README.md` and the install docs (diffed here), plus the About panel's update text, which changes only by which string it selects from an existing table.

## Notes for the reviewer

- **Docs put the one-line install first on Linux** and position the desktop packages as the "I want an app icon, a tray badge and in-app updates" option. That is what the evidence supports: `cli.sh` is smooth *because* it already had the fixed path this PR gives the desktop app.
- **Package updates need one elevation prompt** (`pkexec`/`sudo`), because dpkg/rpm does the write. Documented as expected behaviour rather than hidden.
- **The ticket also mentions GIO.** I could not locate a specific failure mode for it, so I am not claiming it fixed; the deb/rpm `update-mime-database` step may cover it.
- **`_bin_is_usable` runs on the gateway boot path.** Reviewed against `no-blocking-call-on-event-loop`: the added work is one bounded 4 KB read plus at most four `exists()` calls, on a path that already did `open`/`isfile`/`access`/`which`/`resolve`/`mkdir`/`symlink_to`. The class of call is unchanged.
- **No overlap with [#4049](https://github.com/kirodotdev/KiroCrew/pull/4049)** (the update-provider seam): zero shared files. They compose — that PR gates wheel auto-apply on `install_kind == "wheel"`, and this PR is what makes a deb install report `kind="deb", is_externally_managed=True` instead of falling through to wheel-shaped guidance.
