### PR TITLE
test: make two host-sensitive assertions independent of the interpreter

### DIFF
--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -755,13 +755,20 @@ class TestDependencyInstall:
         _capture_popen(monkeypatch)
         with pytest.raises(_StopSpawn):
             bmod._start_app_backend_body("deps-argv", _manifest("server.py"))
-        venv_run = " ".join(next(argv for argv in runs if "venv" in argv))
-        assert sys.executable in venv_run, venv_run
-        assert "python3 -m venv" not in venv_run, venv_run
-        pip_run = " ".join(next(argv for argv in runs if "install" in argv))
-        assert str(venv_python_path(spawn_root)) in pip_run, pip_run
-        assert "-m pip" in pip_run, pip_run
-        assert "/bin/pip" not in pip_run.replace("\\", "/"), pip_run
+        venv_argv = next(argv for argv in runs if "venv" in argv)
+        # Assert on the argv TOKEN, never on a substring of the joined command.
+        # sys.executable's own basename is frequently `python3` (any mise- or
+        # pyenv-managed interpreter, and /usr/bin/python3 itself), so a
+        # substring check for "python3 -m venv" matches the correct absolute
+        # form and fails on exactly the hosts it is meant to pass on.
+        assert venv_argv[0] == sys.executable, venv_argv
+        assert venv_argv[0] != "python3", venv_argv
+        assert venv_argv[1:3] == ["-m", "venv"], venv_argv
+        pip_argv = next(argv for argv in runs if "install" in argv)
+        assert pip_argv[0] == str(venv_python_path(spawn_root)), pip_argv
+        assert pip_argv[1:3] == ["-m", "pip"], pip_argv
+        # `.venv/bin/pip` is POSIX-only; the interpreter must run pip as a module.
+        assert not pip_argv[0].replace("\\", "/").endswith("/bin/pip"), pip_argv
 
     def test_a_failed_dependency_install_does_not_block_the_spawn(
         self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture

--- a/test/test_wecom_client_cov80.py
+++ b/test/test_wecom_client_cov80.py
@@ -155,8 +155,19 @@ class TestRunLoop:
     async def test_long_lived_connection_resets_the_backoff(
         self, client, no_sleep, monkeypatch
     ) -> None:
-        clock = iter([0.0, 100.0, 200.0, 200.0])
-        monkeypatch.setattr(client_mod.time, "monotonic", lambda: next(clock))
+        # A fixed-length iterator standing in for a monotonic clock is a trap:
+        # the loop reads it an implementation-defined number of times, and once
+        # the values run out `next()` raises StopIteration inside a coroutine,
+        # which PEP 479 surfaces as `RuntimeError: generator raised
+        # StopIteration` -- an error that names neither the clock nor this test.
+        # Hold the final value instead, so the scripted timeline is unchanged
+        # but the clock can be read any number of times.
+        scripted = [0.0, 100.0, 200.0, 200.0]
+
+        def _monotonic() -> float:
+            return scripted.pop(0) if len(scripted) > 1 else scripted[0]
+
+        monkeypatch.setattr(client_mod.time, "monotonic", _monotonic)
         calls = {"n": 0}
 
         async def _serve() -> None:


### PR DESCRIPTION
## Problem / Motivation

Two tests fail on any host whose interpreter basename is `python3`. That covers
every mise- and pyenv-managed Python, and `/usr/bin/python3` itself. Neither
failure involves production code, and CI does not see either one, so they land
on contributors rather than on the pipeline:

```
FAILED test/test_apps_backend_coverage.py::TestDependencyInstall::test_the_installer_never_shells_out_to_a_bare_interpreter
ERROR  test/test_wecom_client_cov80.py::TestRunLoop::test_long_lived_connection_resets_the_backoff
```

## Why it matters

A local full-suite run is the gate before every push, so a permanent two-test
red on a common interpreter layout trains people to skip or ignore the floor.
The second one is worse than a plain failure: it surfaces as
`RuntimeError: generator raised StopIteration`, which names neither the clock it
comes from nor the test, so it reads like a real async defect.

## What changed (motivation → approach → change)

**`test_the_installer_never_shells_out_to_a_bare_interpreter`** asserted
`"python3 -m venv" not in " ".join(argv)` to prove the installer does not rely
on `PATH`. On such a host `sys.executable` is `/…/3.12.13/bin/python3`, so the
**correct** absolute form contains that substring and the assertion fires on
exactly the hosts it exists to pass on. The check was a substring test standing
in for a token test, so it now asserts on the argv list directly: `argv[0]`
equals `sys.executable`, is not the bare string, and is followed by
`["-m", "venv"]`. The pip half gets the same treatment.

**`test_long_lived_connection_resets_the_backoff`** stubbed `time.monotonic`
with `iter([0.0, 100.0, 200.0, 200.0])`. The run loop reads the clock an
implementation-defined number of times, so exhausting the iterator raises
`StopIteration` inside a coroutine, and PEP 479 converts it. The stub now holds
its final value: the scripted timeline is unchanged, but the clock can be read
any number of times.

## Tests

No new tests. Both changes tighten existing assertions, and the guard the first
one carries is verified to still fire:

- Mutation check: changing `src/kiro_crew/apps/backend.py:701` back to
  `["python3", "-m", "venv", ...]` makes the rewritten test fail. The call site
  was restored from a backup copy, and `git status` confirms it is untouched.
- `test/test_apps_backend_coverage.py` + `test/test_wecom_client_cov80.py`:
  138 passed, 0 failed (both modules in full, under `-n auto --dist loadgroup`).
- Both failures reproduce on a second worktree that does not contain this
  change, confirming they are pre-existing rather than introduced.
- `isort --check-only` and `flake8` clean on both files.

## Manual verification

N/A — the failures are deterministic on this interpreter layout, so the
before/after test runs above are the verification.

<!-- no-visual-delta -->
**Why no screenshot:** test-only change with no rendered output.

no linked issue: found while running the local floor for unrelated work, and
small enough that filing an issue first would have cost more than the fix.
