### PR TITLE
fix(security): fingerprint the non-loopback mixed-path secret mismatch too

### DIFF
--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -1803,9 +1803,14 @@ def token_auth_middleware(
                 # If X-Internal-Secret header is present, validate it first
                 # (defense-in-depth: wrong secret = deny, even with valid cookie)
                 if "X-Internal-Secret" in request.headers:
+                    _provided_secret = request.headers["X-Internal-Secret"]
                     if not internal_secret or not hmac.compare_digest(
-                        internal_secret, request.headers["X-Internal-Secret"]
+                        internal_secret, _provided_secret
                     ):
+                        _detail = (
+                            "wrong secret (non-loopback mixed) "
+                            f"({_credential_mismatch_detail(internal_secret, _provided_secret)})"
+                        )
                         _sel = _sel_fn()
                         _sel.log_api_access(
                             caller=_caller,
@@ -1813,11 +1818,9 @@ def token_auth_middleware(
                             outcome="denied",
                             source="token_auth",
                             resources=path,
-                            error="wrong secret (non-loopback mixed)",
+                            error=_detail,
                         )
-                        _log_auth(
-                            request, "internal", "denied", "wrong secret (non-loopback mixed)"
-                        )
+                        _log_auth(request, "internal", "denied", _detail)
                         return _deny(request, "Forbidden")
                 _valid, _uid, _reason, _app, _tok = _extract_and_validate_token(request, port)
                 if not _valid:

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -763,6 +763,52 @@ async def test_internal_path_non_loopback_wrong_secret_denied() -> None:
 
 
 @pytest.mark.asyncio
+async def test_internal_path_non_loopback_distinguishes_empty_from_wrong_secret(
+    monkeypatch,
+) -> None:
+    """The non-loopback mixed-path deny site must fingerprint-distinguish an
+    EMPTY X-Internal-Secret header from a WRONG one, same as the loopback arm
+    already does -- otherwise the two causes (caller found no credential file
+    vs. caller reached the wrong gateway) collapse into one audit label and
+    cannot be told apart after the fact."""
+    import kiro_crew.dashboard.token_auth as ta
+
+    calls: list[dict] = []
+
+    class _FakeSel:
+        def log_api_access(self, **kw):
+            calls.append(kw)
+
+    monkeypatch.setattr(ta, "_sel_fn", lambda: _FakeSel())
+    mw = ta.token_auth_middleware(
+        internal_paths=frozenset({"/api/spawn"}), internal_secret="real", local_only=False
+    )
+
+    token = generate_token("testuser", ttl_seconds=300)
+    empty_req = _make_request(
+        path="/api/spawn",
+        remote="10.0.0.1",
+        headers={"X-Internal-Secret": ""},
+        cookies={"mc_token_5476": token},
+    )
+    resp = await mw(empty_req, _ok_handler)
+    assert resp.status == 403
+    assert "received=absent" in calls[-1]["error"]
+
+    calls.clear()
+    wrong_req = _make_request(
+        path="/api/spawn",
+        remote="10.0.0.1",
+        headers={"X-Internal-Secret": "wrong"},
+        cookies={"mc_token_5476": token},
+    )
+    resp = await mw(wrong_req, _ok_handler)
+    assert resp.status == 403
+    assert "received=absent" not in calls[-1]["error"]
+    assert "len=5" in calls[-1]["error"]  # len("wrong") == 5
+
+
+@pytest.mark.asyncio
 async def test_internal_path_non_loopback_valid_secret_and_cookie_granted() -> None:
     """Both valid secret and valid cookie on non-loopback → granted."""
     token = generate_token("testuser", ttl_seconds=300)


### PR DESCRIPTION
## Problem / Motivation

A denied internal-API request records `error="wrong secret"` whether the
caller sent a WRONG credential or an EMPTY one — the two causes are
indistinguishable in the audit log, which is the only place they could be
told apart (the HTTP response is intentionally identical for both).

## Why it matters

The two causes point in opposite directions: a wrong credential means the
caller reached the wrong gateway (e.g. a second instance running on the
same machine); an empty credential means the caller couldn't find one at
all, a home-resolution or lifecycle problem in the caller itself. On a
long-running host this bucket accumulates real denials under one label,
with no way to attribute which cause dominates.

## What I found (this is narrower than the issue as filed)

The loopback internal-auth deny path was **already fixed** by #3879, which
added `_credential_fingerprint()`/`_credential_mismatch_detail()` — a safe
hash+length fingerprint that reports `absent` for an empty secret and a
short digest for a real one — but only wired it into the loopback arm
(`token_auth.py` ~line 1737). The **non-loopback mixed-path arm** (DCV/
SSH-forwarded browsers, ~line 1816) was left on the old flat
`"wrong secret (non-loopback mixed)"` string with no fingerprint detail.

## What changed

`src/kiro_crew/dashboard/token_auth.py`: the non-loopback mixed-path deny
site now calls the same `_credential_mismatch_detail()` helper the loopback
arm already uses, appended to its existing `"(non-loopback mixed)"`
qualifier so any existing log-grepping on that literal substring still
matches. The HTTP response body is unchanged (`403 {"error": "Forbidden"}`)
— the distinction exists only in the operator-facing audit record, nothing
new is exposed to a caller probing for valid credentials.

## Out of scope

The non-loopback mixed arm's `_deny()` call doesn't pass the
`internal_auth_mismatch` machine-readable code the loopback arm's does —
that's a separate, pre-existing inconsistency the original issue didn't
ask for and this PR doesn't touch.

## Tests

`test/test_token_auth.py::test_internal_path_non_loopback_distinguishes_empty_from_wrong_secret`,
modeled on the existing `test_invalid_token_shell_serve_emits_distinct_sel_outcome`
pattern (monkeypatch `_sel_fn`, inspect logged calls): an empty
`X-Internal-Secret` header audits with `received=absent`; a wrong non-empty
one audits with a length-bearing fingerprint and never `absent`.

Mutation-verified locally: reverting the fix makes the new test fail with
`assert 'received=absent' in 'wrong secret (non-loopback mixed)'`; with the
fix applied it passes. Full `test/test_token_auth.py`: 246 passed. `mypy`
and `flake8` clean on the changed file.

## Related Issues

Fixes #4111

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — checked `docs/system-specs/modules/sel.md`
      and `instances.md`; neither documents the free-form audit detail text
      as stable API, only the unchanged `internal_auth` operation name and
      `internal_auth_mismatch` code, so nothing to update
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to an audit-log detail string; no user-facing or rendered surface.
