### PR TITLE
test: await the slack backfill instead of racing it

### DIFF
--- a/test/test_slack_options_lifecycle.py
+++ b/test/test_slack_options_lifecycle.py
@@ -744,6 +744,25 @@ def _slack_app(state):
     return app
 
 
+async def _drain_backfill(state) -> None:
+    """Await the backfill the slack-link handler spawns.
+
+    The handler deliberately backgrounds the drain (`_spawn_slack_backfill`) and
+    returns before it posts, so the response arriving proves only that the task
+    was CREATED. Reading the Slack mock straight after the request races that
+    task: it usually wins on an idle machine and loses under load, which is a
+    flake that reads as a plain count mismatch (`assert 0 == 2`) and names
+    neither the task nor the race.
+
+    The task is tracked in `state._background_tasks`, so awaiting the
+    not-yet-done members is an exact wait on the real completion condition
+    rather than a sleep. An empty set means it already finished; a done-callback
+    discards each task, so snapshot before awaiting.
+    """
+    for task in [t for t in state._background_tasks if not t.done()]:
+        await task
+
+
 class TestLinkTimeBackfill:
     """Replaying context into a freshly-linked thread."""
 
@@ -779,6 +798,7 @@ class TestLinkTimeBackfill:
         async with TestClient(TestServer(_slack_app(state))) as client:
             resp = await client.post("/api/chat/slots/s1/slack-link", json={})
             assert resp.status == 200
+            await _drain_backfill(state)
 
         texts = [c.args[1] for c in state.slack_client.post_message.await_args_list]
         assert all("[OPTIONS:" not in t for t in texts)
@@ -796,6 +816,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _drain_backfill(state)
 
         assert _is_live_control(state.slack_client.post_blocks.await_args.args[1])
         assert _recs(state, slot)
@@ -814,6 +835,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _drain_backfill(state)
 
         blocks = state.slack_client.post_blocks.await_args.args[1]
         assert not _is_live_control(blocks)
@@ -838,6 +860,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _drain_backfill(state)
 
         blocks = state.slack_client.post_blocks.await_args.args[1]
         assert _is_live_control(blocks)
@@ -862,6 +885,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _drain_backfill(state)
 
         texts = [c.args[1] for c in state.slack_client.post_message.await_args_list]
         assert any("[OPTIONS: A | B]" in t for t in texts)
@@ -878,6 +902,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
+            await _drain_backfill(state)
 
         posts = state.slack_client.post_blocks.await_args_list
         assert len(posts) == 2


### PR DESCRIPTION
## Problem / Motivation

`TestLinkTimeBackfill` reads the Slack mock immediately after POSTing
`/api/chat/slots/{name}/slack-link`, but that handler deliberately backgrounds
the transcript replay:

```python
_spawn_slack_backfill(state, slot, target_channel, thread_ts)
...
return web.json_response({"ok": True, ...})
```

So the response arriving proves the task was *created*, not that it ran. Six
tests then assert on what that task posted, without ever awaiting it.

The race usually wins on an idle machine and loses on a loaded CI runner. When
it loses it surfaces as a bare count mismatch that names neither the task nor
the race:

```
FAILED test/test_slack_options_lifecycle.py::TestLinkTimeBackfill::
  test_only_the_newest_reply_is_answerable - assert 0 == 2
```

`0` is `post_blocks.await_args_list` being empty, i.e. the drain had not run.

## Why it matters

This is a shared flake, not a local nuisance. It failed shard 4 of the 3.12
backend lane on [PR #4169](https://github.com/kirodotdev/KiroCrew/pull/4169), a
pull request whose diff is one `package.json` key and one contract test, and the
Coverage Gate then failed closed on `backend-test=failure`. So an unrelated
change was blocked by a test that was never asserting deterministically. Every
PR pays for that on a bad roll, and the failure text sends the reader looking at
Slack option lifecycle logic that is working correctly.

The handler's own comment shows the race is understood on the production side:

> that hop cost the spawned task its scheduling window under load, so the
> control never reached Slack

The tests had simply never been aligned with it.

## What changed (motivation → approach → change)

`_spawn_slack_backfill` tracks the task in `state._background_tasks`, so there
is an exact completion condition available. The fix awaits the not-yet-done
members of that set after the request:

```python
async def _drain_backfill(state) -> None:
    for task in [t for t in state._background_tasks if not t.done()]:
        await task
```

This is a wait on the real condition, not a sleep that trades flakiness for wall
time (the module runs in ~1.6s, unchanged). `test_chat_backfill.py` already
drains the same set for the same reason, so this reuses an established idiom
rather than inventing one. A done-callback discards each task, so the list
comprehension snapshots before awaiting; an empty set means the drain already
finished, which is why this is also correct in the case that was already passing.

No production code changed. The handler's fire-and-forget behaviour is
deliberate (the response must not wait on transcript I/O), and
`test_chat_backfill.py` explicitly asserts that it stays that way.

**One of the six tests was vacuous rather than flaky.**
`test_a_users_own_options_syntax_survives_the_replay` asserts
`post_blocks.assert_not_awaited()`, which passes trivially whenever the drain has
not run yet. It only tests anything now that the drain is awaited.

## Tests

No new test: this makes six existing tests assert deterministically. The change
is proven by forcing the race to lose instead of waiting to observe it, by
delaying the spawned drain 200ms:

| Test file | Delayed drain |
|---|---|
| before this change | **5 failed**, 1 passed |
| after this change | **6 passed** |

The production mutation was reverted from a backup copy; the diff is 25 added
lines in one test file and nothing else.

Also run: the module three times (78 passed each), and
`test_chat_backfill.py` + `test_slack_options_lifecycle.py` +
`test_dashboard_chat.py` together (683 passed). flake8 and isort clean.

Note for reviewers: `black --check` reports this file as unformatted **on
unmodified `main`** as well, so running black here would have added ~190 lines of
unrelated reformatting and buried the fix. The diff is deliberately limited to
the change.

## Manual verification

N/A — the change is entirely within the test suite and the mutation experiment
above is stronger evidence than a manual run.

## Related Issues

None filed; found while driving
[PR #4169](https://github.com/kirodotdev/KiroCrew/pull/4169) to green.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — this
      makes existing tests deterministic)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

Closes #4183. Resolves Area A of #4177 as a side effect (Area B, TestContinuationIdentity on Windows, is tracked separately under needs-investigation).
