### PR TITLE
feat(metrics): hang-resilience telemetry for the child-permission hang class

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -95,6 +95,12 @@ from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
 from kiro_crew.env import augmented_path, resolve_krb5_ccname
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.mcp_gateway.session_servers import pooled_session_servers
+from kiro_crew.metrics.events import (
+    CHILD_PERMISSION_DENIED,
+    CHILD_PERMISSION_ROUTED,
+    DROPPED_FRAMES,
+    emit_counter,
+)
 from kiro_crew.resource_status import inject_xdist_auto_cap
 from kiro_crew.sandbox import (
     RLIMIT_PROFILE_SESSION_HOST,
@@ -1447,6 +1453,13 @@ class AcpRuntime:
             _tc = _params.get("toolCall")
             _raw = _tc.get("title") if isinstance(_tc, dict) else None
             title = redact_text(str(_raw)[:4096])[:120] if _raw else "<unknown>"
+        # Hang-resilience series: every runtime-side denial funnels through
+        # here, so one emit covers unroutable/between-turns/cap/send-failure
+        # denials. ``reason`` is the closed SEL enum (low-cardinality).
+        emit_counter(
+            CHILD_PERMISSION_DENIED,
+            {"surface": "runtime", "reason": reason},
+        )
         request_id = msg.id if isinstance(msg.id, (str, int)) else ""
         # SNAPSHOT the attribution key NOW: the audit closure runs later on a
         # worker thread, and `_subagent_owner` is mutable (unregister/session
@@ -1490,6 +1503,18 @@ class AcpRuntime:
         that keeps a wrong-typed value from raising in the shared reader.
         """
         key = (_drop_key_part(session_id), _drop_key_part(method))
+        # Hang-resilience series: classify the drop by method so dashboards
+        # can alert on the pre-fix hang signature. ``method_class`` is a
+        # closed 3-value enum — the raw method (backend-controlled) never
+        # becomes an attribute value.
+        _m = method if isinstance(method, str) else ""
+        if _m == METHOD_REQUEST_PERMISSION:
+            _mclass = "permission"
+        elif _m == METHOD_SESSION_UPDATE:
+            _mclass = "update"
+        else:
+            _mclass = "other"
+        emit_counter(DROPPED_FRAMES, {"method_class": _mclass})
         now = time.monotonic()
         if self._dropped_frames_flushed_at == 0.0:
             # First drop of this runtime's life opens the window. __init__ cannot
@@ -1764,6 +1789,16 @@ class AcpRuntime:
                             # accumulates blocked tasks and trips the cap.
                             await asyncio.sleep(0)
                         else:
+                            # Hang-resilience series: a child permission
+                            # request delivered to the mode-parity pipeline —
+                            # each one is a request that, before #3786, was
+                            # silently dropped and wedged its crew for 2h.
+                            if msg.id is not None and msg.is_method(
+                                METHOD_REQUEST_PERMISSION
+                            ):
+                                emit_counter(
+                                    CHILD_PERMISSION_ROUTED, {"surface": "runtime"}
+                                )
                             await next(iter(self._session_queues.values())).put(msg)
                     elif msg.id is not None and msg.is_method(METHOD_REQUEST_PERMISSION):
                         # Unannounced or ambiguous: nobody on this client can

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -103,6 +103,7 @@ from kiro_crew.acp.types import (
 from kiro_crew.config.paths import kiro_sessions_dir
 from kiro_crew.constants import COMPACT_WAIT_TIMEOUT_SECS
 from kiro_crew.executors import subprocess_executor
+from kiro_crew.metrics.events import CHILD_PERMISSION_DENIED, emit_counter
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
@@ -1036,6 +1037,15 @@ class AcpSessionHandle:
         """
         safe_title = redact_text(str(title)[:4096])[:120] if title else "<unknown>"
         rid = request_id if isinstance(request_id, (str, int)) else ""
+        # Hang-resilience series: handle-owned denials (fail-close fidelity
+        # gate, pre-turn drain). CHILD-origin only — the pre-turn drain also
+        # answers abandoned PARENT-turn requests (sub_session_id empty), and
+        # counting those would corrupt the child-denial series.
+        if sub_session_id:
+            emit_counter(
+                CHILD_PERMISSION_DENIED,
+                {"surface": "session_handle", "reason": error},
+            )
 
         def _audit() -> None:
             try:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -180,6 +180,7 @@ from kiro_crew.members import record_activity
 from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.link import SLACK_NAMESPACE, telemetry_channel_of
 from kiro_crew.messaging.renderer import chunk_text
+from kiro_crew.metrics.events import TURN_TIMEOUT_CAUSE, emit_counter
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.platform import redact_via_context
 from kiro_crew.providers.acp import is_claude_backend
@@ -6448,6 +6449,12 @@ async def _run_chat(
                         {"id": _card_id, "slot": slot.key, "text": _txt},
                     )
             elif event.kind == EVENT_COMPLETE:
+                # Hang-attribution snapshot BEFORE the close-all safety net
+                # below force-marks every card done: only children still
+                # unfinished at the cut may count toward timeout attribution
+                # (terminal entries linger in the tracker for reconnect
+                # replay and would corrupt the series).
+                _children_unfinished = any(not _i.get("done") for _i in _native_tracker.values())
                 # Safety net: complete any native subagent cards still marked
                 # running at turn end (in case a terminal status was missed),
                 # so cards don't stay stuck "running".
@@ -6538,6 +6545,27 @@ async def _run_chat(
                     elapsed_ms=_turn_elapsed_ms,
                     exhausted=_turn_exhausted,
                 )
+                if "timeout" in (event.stop_reason or ""):
+                    # Hang-resilience series: attribute the CAUSE of a turn
+                    # timeout (the 2h-ceiling hang class). Both attrs are
+                    # booleans read defensively from live state — the inner
+                    # client may be an AcpClient (flag on itself) or an
+                    # AcpSessionProvider (flag on its handle).
+                    _ac = slot._acp_client
+                    _awaiting = bool(
+                        getattr(_ac, "_awaiting_permission", False)
+                        or getattr(
+                            getattr(_ac, "_handle", None), "_awaiting_permission", False
+                        )
+                    )
+                    emit_counter(
+                        TURN_TIMEOUT_CAUSE,
+                        {
+                            "path": "provider_timeout",
+                            "awaiting_permission": _awaiting,
+                            "children_announced": _children_unfinished,
+                        },
+                    )
                 _stop_reason = event.stop_reason
                 # Recorded on the slot so post-turn consumers reached later
                 # (which do not receive the event) can tell a turn that really
@@ -7847,12 +7875,28 @@ async def _run_chat(
         # Completion can be bypassed by cancellation, provider errors, or timeouts.
         # Close cards idempotently and retain only bounded terminal records for
         # reconnect replay until the next turn installs a fresh tracker.
+        # Snapshot which children were still unfinished FIRST — close_all
+        # force-marks every card done, and terminal entries linger in the
+        # tracker for replay, so reading the tracker afterwards would blame
+        # long-completed children for a later ceiling timeout.
+        _children_unfinished_final = any(not _i.get("done") for _i in _native_tracker.values())
         try:
             _native_subagent_close_all(state, slot, _native_tracker, _native_card_output)
         finally:
             slot._native_subagent_tracker = _retain_terminal_native(_native_tracker)
             slot._native_subagent_output = {}
         slot._batch_rejected = False
+        # Stash the hang-attribution snapshot BEFORE dropping the client ref:
+        # if this turn was cut by the dashboard ceiling (_bounded_turn), the
+        # done-callback (finish_turn_task) runs AFTER this finally, when
+        # _acp_client is already None — it reads these two fields to emit
+        # kirocrew.turn.timeout.cause for the ceiling path.
+        _lc = slot._acp_client
+        slot._last_turn_awaiting_permission = bool(
+            getattr(_lc, "_awaiting_permission", False)
+            or getattr(getattr(_lc, "_handle", None), "_awaiting_permission", False)
+        )
+        slot._last_turn_children_announced = _children_unfinished_final
         # Steer handle: turn is over, drop the live client ref so a late steer
         # can't target a dead session (the route also re-checks running state).
         slot._acp_client = None

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1457,6 +1457,8 @@ class _ChatSlot:
         "_active_turn_session_key",
         "_side",
         "_acp_client",
+        "_last_turn_awaiting_permission",
+        "_last_turn_children_announced",
         "_steer_segment_cut",
         "_native_subagent_tracker",
         "_native_subagent_output",
@@ -1869,6 +1871,11 @@ class _ChatSlot:
         # dashboard steer handler) reach the running session's client to inject
         # a mid-turn steer. None when idle.
         self._acp_client = None
+        # Hang-attribution snapshot stashed by _run_chat's finally just before
+        # _acp_client is dropped; read by finish_turn_task when the dashboard
+        # ceiling cut the turn (kirocrew.turn.timeout.cause).
+        self._last_turn_awaiting_permission = False
+        self._last_turn_children_announced = False
         # Sync callable published by _run_chat alongside _acp_client (cleared in
         # the same finally): flushes the turn's accumulated text as a finalized
         # assistant segment NOW. The steer handler calls it right BEFORE

--- a/src/kiro_crew/dashboard/turn_dispatch.py
+++ b/src/kiro_crew/dashboard/turn_dispatch.py
@@ -253,6 +253,27 @@ def finish_turn_task(
         logger.warning(
             "Chat turn in slot %s hit the %.0fs ceiling", getattr(slot, "key", "?"), timeout_secs
         )
+        # Hang-resilience series: THE deadline path for the 2h-ceiling hang
+        # class — _bounded_turn cancels _run_chat before any EVENT_COMPLETE,
+        # so the in-turn emit never fires here. _run_chat's finally stashed
+        # the attribution snapshot on the slot just before teardown.
+        try:
+            from kiro_crew.metrics.events import TURN_TIMEOUT_CAUSE, emit_counter
+
+            emit_counter(
+                TURN_TIMEOUT_CAUSE,
+                {
+                    "path": "dashboard_ceiling",
+                    "awaiting_permission": bool(
+                        getattr(slot, "_last_turn_awaiting_permission", False)
+                    ),
+                    "children_announced": bool(
+                        getattr(slot, "_last_turn_children_announced", False)
+                    ),
+                },
+            )
+        except Exception:
+            logger.debug("timeout-cause metric emit failed", exc_info=True)
         try:
             # slot.append persists the card AND broadcasts it once; do not also
             # broadcast_ws here or the UI renders a duplicate.

--- a/src/kiro_crew/metrics/events.py
+++ b/src/kiro_crew/metrics/events.py
@@ -1,0 +1,60 @@
+"""Best-effort counter emits for hang-resilience telemetry.
+
+One tiny facade so low-level modules (acp runtime/handle, session sweep,
+subagent manager) can emit ``kirocrew.*`` counters without importing
+``metrics.provider`` at module top — that import chain reads KiroCrewConfig
+and would form a cycle (config.loader -> ... -> metrics.provider ->
+config.loader; same reason every existing emit site does a lazy import).
+
+Telemetry must never break the instrumented path: every failure is swallowed
+after a debug log. Attribute VALUES must be low-cardinality constants per
+``metrics/schema.py`` — callers pass closed enums only, never ids or
+free-form strings.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def emit_counter(name: str, attrs: dict[str, str | int | bool | float]) -> None:
+    """Add 1 to counter *name* with *attrs*; never raises."""
+    try:
+        from kiro_crew.metrics.provider import get_recorder
+
+        get_recorder().counter(name, attrs=attrs)
+    except Exception:  # telemetry must never break the caller
+        logger.debug("counter emit failed for %s", name, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Hang-resilience series (see docs in the emitting call sites)
+# ---------------------------------------------------------------------------
+
+#: Every fast-fail denial of a backend-child permission request — the paths
+#: that replaced the pre-fix silent 2-hour hangs (issue #3785). ``reason`` is
+#: the closed SEL reason enum; ``surface`` names the choke point.
+CHILD_PERMISSION_DENIED = "kirocrew.acp.child_permission.denied"
+
+#: Every backend-child permission request successfully ROUTED into the
+#: mode-parity pipeline (owner queue → policy gates / interactive card).
+#: This is the impact numerator: each increment is a request that, before
+#: #3786, was silently dropped and wedged its crew until the 2h ceiling.
+#: ``routed + denied`` ≈ total child permission requests handled.
+CHILD_PERMISSION_ROUTED = "kirocrew.acp.child_permission.routed"
+
+#: Unroutable ACP frames per method class. ``method_class=permission`` was the
+#: pre-fix hang signature and MUST stay ~0 after #3786/#3889 — any nonzero
+#: value is a routing regression alarm.
+DROPPED_FRAMES = "kirocrew.acp.dropped_frames"
+
+#: Cause attribution for turn timeouts (the 2h-ceiling hangs): whether the
+#: session was parked on a permission prompt and whether backend children
+#: were live when the ceiling fired.
+TURN_TIMEOUT_CAUSE = "kirocrew.turn.timeout.cause"
+
+#: Idle-sweep expiries — ``turn_active=True`` means the sweep killed a
+#: runtime mid-turn, the teardown signature of the original incidents.
+SESSION_IDLE_EXPIRED = "kirocrew.session.idle_expired"

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -121,6 +121,7 @@ from kiro_crew.messaging.link import (
     legacy_key,
     telemetry_channel_of,
 )
+from kiro_crew.metrics.events import SESSION_IDLE_EXPIRED, emit_counter
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.providers.base import CancelOutcome, LLMProvider
 from kiro_crew.sandbox import cleanup_stale_sandbox_profiles
@@ -5172,6 +5173,16 @@ class SessionManager:
             else:
                 logger.warning("Expiring idle session: %s", key)
             Stats().inc_session_cleaned()
+            # Hang-resilience series (emitted AFTER a successful reset below):
+            # capture turn_active NOW, before reset tears the provider down —
+            # turn_active=True on a real expiry is the mid-turn-kill teardown
+            # signature of the silent-hang incidents (issue #3785).
+            try:
+                _prov = self._sessions.get(key)
+                _prov = getattr(_prov, "provider", None)
+                _turn_active = _prov is not None and _provider_has_active_turn(_prov)
+            except Exception:
+                _turn_active = False
             # Notify consolidator before reset so it can extract skills.
             if self.on_session_expire:
                 try:
@@ -5196,4 +5207,12 @@ class SessionManager:
                 logger.info(
                     "Idle sweep: %s became busy before reset — left running",
                     key,
+                )
+            else:
+                # Gated on the reset actually happening: a session that raced
+                # busy and was left running is NOT an expiry and must not be
+                # counted as one.
+                emit_counter(
+                    SESSION_IDLE_EXPIRED,
+                    {"turn_active": _turn_active, "orphaned": bool(is_orphan)},
                 )

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -60,6 +60,7 @@ from kiro_crew.llm_helpers import (
     transient_retry_delay,
 )
 from kiro_crew.mcp_gateway import STUB_MODULE
+from kiro_crew.metrics.events import CHILD_PERMISSION_DENIED, emit_counter
 from kiro_crew.providers.base import (
     EVENT_COMPLETE,
     EVENT_PERMISSION_REQUEST,
@@ -1499,6 +1500,16 @@ class SubagentManager:
         metadata: dict | None = None,
     ) -> None:
         await client.reject_tool(request_id)
+        # getattr: production LLMEvents always carry sub_session_id, but this
+        # static helper is also driven with lightweight test doubles.
+        if getattr(event, "sub_session_id", ""):
+            # Hang-resilience series: backend-child denials on the headless
+            # subagent surface (low-fidelity fail-close, escalation/turn-limit
+            # bails, interactive rejections). ``reason`` is a closed enum.
+            emit_counter(
+                CHILD_PERMISSION_DENIED,
+                {"surface": "subagent", "reason": error or "rejected"},
+            )
         sel().log_tool_invocation(
             session_key=session_key,
             source="subagent",

--- a/test/test_hang_resilience_metrics.py
+++ b/test/test_hang_resilience_metrics.py
@@ -1,0 +1,284 @@
+"""Hang-resilience telemetry — the kirocrew.* series added after the silent
+child-permission hang incidents (issue #3785, PRs #3786/#3889).
+
+Each test drives the REAL production emit site (never a reimplementation)
+with the recorder mocked, so a renamed metric, changed attr enum, or removed
+emit fails here.
+
+Self-contained: CI runs test shards in separate processes where sibling test
+modules are not importable, so the small runtime harness is inlined here
+rather than imported from ``test.test_acp_runtime``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.acp.runtime import AcpRuntime, JsonRpcMessage
+from kiro_crew.acp.session_handle import AcpSessionHandle
+from kiro_crew.metrics import events as metric_events
+
+
+def _make_runtime():
+    """An initialized AcpRuntime wired to a fake subprocess (no real process)."""
+    rt = AcpRuntime(work_dir="/tmp")
+    reader = asyncio.StreamReader()
+    proc = MagicMock()
+    proc.stdout = reader
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.returncode = None
+    proc.pid = 4242
+    rt._process = proc
+    rt._pid = 4242
+    rt._initialized = True
+    return rt, reader, proc
+
+
+def _register(rt: AcpRuntime, *session_ids: str) -> dict[str, asyncio.Queue]:
+    queues = {sid: asyncio.Queue() for sid in session_ids}
+    rt._session_queues.update(queues)
+    return queues
+
+
+def _perm_msg(req_id: int, session_id: str = "child-a") -> JsonRpcMessage:
+    return JsonRpcMessage.from_dict(
+        {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "method": "session/request_permission",
+            "params": {
+                "sessionId": session_id,
+                "toolCall": {"toolCallId": f"tc-{req_id}", "title": "Running: x"},
+                "options": [{"optionId": "reject_once", "name": "Reject", "kind": "reject_once"}],
+            },
+        }
+    )
+
+
+@pytest.fixture()
+def recorded(monkeypatch):
+    """Capture every emit_counter call routed through metrics.events."""
+    calls: list[tuple[str, dict]] = []
+
+    def _fake(name: str, attrs: dict) -> None:
+        calls.append((name, dict(attrs)))
+
+    # Patch at the SOURCE module; the emitting modules import the function by
+    # name, so patch their bound references too.
+    for mod in (
+        "kiro_crew.metrics.events",
+        "kiro_crew.acp.runtime",
+        "kiro_crew.acp.session_handle",
+        "kiro_crew.subagent",
+        "kiro_crew.session",
+        "kiro_crew.dashboard.chat_runner",
+    ):
+        monkeypatch.setattr(f"{mod}.emit_counter", _fake, raising=False)
+    return calls
+
+
+def test_emit_counter_never_raises():
+    """Telemetry must never break the instrumented path."""
+    with patch(
+        "kiro_crew.metrics.provider.get_recorder",
+        side_effect=RuntimeError("recorder down"),
+    ):
+        metric_events.emit_counter("kirocrew.test", {"a": 1})  # no raise
+
+
+@pytest.mark.asyncio
+async def test_runtime_denial_emits_child_permission_denied(recorded):
+    rt, _, _ = _make_runtime()
+    await rt._answer_unroutable_permission(_perm_msg(42), "child-a")
+    await asyncio.sleep(0)
+    hits = [a for n, a in recorded if n == metric_events.CHILD_PERMISSION_DENIED]
+    assert {"surface": "runtime", "reason": "unregistered_session_auto_reject"} in hits
+
+
+def test_dropped_frame_emits_method_class(recorded):
+    rt, _, _ = _make_runtime()
+    rt._note_dropped_frame("s-x", "session/request_permission")
+    rt._note_dropped_frame("s-x", "session/update")
+    rt._note_dropped_frame("s-x", "weird/method")
+    classes = [a["method_class"] for n, a in recorded if n == metric_events.DROPPED_FRAMES]
+    assert classes == ["permission", "update", "other"]
+
+
+def test_handle_reject_emits_child_permission_denied(recorded):
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    handle._audit_handle_reject(
+        7,
+        "Running: x",
+        "child_low_fidelity_unaware_consumer",
+        sub_session_id="child-a",
+    )
+    hits = [a for n, a in recorded if n == metric_events.CHILD_PERMISSION_DENIED]
+    assert {
+        "surface": "session_handle",
+        "reason": "child_low_fidelity_unaware_consumer",
+    } in hits
+    # PARENT-origin rejections (empty sub_session_id, e.g. an abandoned
+    # parent-turn request answered by the pre-turn drain) must NOT emit —
+    # they would corrupt the child-denial series.
+    handle._audit_handle_reject(8, "Running: y", "stranded_request_pre_turn_drain")
+    assert len([a for n, a in recorded if n == metric_events.CHILD_PERMISSION_DENIED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_routed_child_permission_emits_routed(recorded):
+    """A child permission request delivered to the owner's queue (the
+    mode-parity pipeline) counts as ROUTED — the impact numerator: each one
+    would have been a silent 2h hang before #3786."""
+    rt, reader, _ = _make_runtime()
+    queues = _register(rt, "parent-session")
+    task = asyncio.ensure_future(rt._reader_loop())
+    try:
+        reader.feed_data(
+            (
+                json.dumps(
+                    {
+                        "method": "_kiro.dev/subagent/list_update",
+                        "params": {"subagents": [{"sessionId": "child-a"}]},
+                    }
+                )
+                + "\n"
+            ).encode()
+        )
+        rt.mark_turn_active("parent-session", True)  # owner has in-flight prompt
+        reader.feed_data(
+            (
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 88,
+                        "method": "session/request_permission",
+                        "params": {
+                            "sessionId": "child-a",
+                            "toolCall": {"toolCallId": "tc-88", "title": "Running: x"},
+                            "options": [
+                                {
+                                    "optionId": "reject_once",
+                                    "name": "Reject",
+                                    "kind": "reject_once",
+                                }
+                            ],
+                        },
+                    }
+                )
+                + "\n"
+            ).encode()
+        )
+        # Let the reader route the frame.
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if not queues["parent-session"].empty():
+                break
+        routed = [a for n, a in recorded if n == metric_events.CHILD_PERMISSION_ROUTED]
+        assert routed == [{"surface": "runtime"}]
+        assert not queues["parent-session"].empty()  # actually delivered
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_subagent_child_reject_emits_denied(recorded):
+    from kiro_crew.providers.base import EVENT_PERMISSION_REQUEST, LLMEvent
+    from kiro_crew.subagent import SubagentManager
+
+    client = MagicMock()
+
+    async def _noop(_rid):
+        return None
+
+    client.reject_tool = _noop
+    ev = LLMEvent(
+        kind=EVENT_PERMISSION_REQUEST,
+        request_id=9,
+        title="t",
+        sub_session_id="child-a",
+    )
+    with patch("kiro_crew.subagent.sel"):
+        await SubagentManager._reject_and_log(client, 9, "k", ev, error="child_escalation_limit")
+    hits = [a for n, a in recorded if n == metric_events.CHILD_PERMISSION_DENIED]
+    assert {"surface": "subagent", "reason": "child_escalation_limit"} in hits
+    # Parent-origin rejections do NOT emit (child series only).
+    ev2 = LLMEvent(kind=EVENT_PERMISSION_REQUEST, request_id=10, title="t")
+    with patch("kiro_crew.subagent.sel"):
+        await SubagentManager._reject_and_log(client, 10, "k", ev2, error="hook_deny")
+    assert len([a for n, a in recorded if n == metric_events.CHILD_PERMISSION_DENIED]) == 1
+
+
+def test_dashboard_ceiling_emits_timeout_cause(recorded):
+    """The 2h-ceiling path cancels _run_chat before EVENT_COMPLETE, so the
+    in-turn emit never fires — finish_turn_task (the confirmed-deadline
+    callback) must emit the cause metric from the slot's stashed snapshot.
+    (Its lazy `from metrics.events import emit_counter` picks up the
+    `recorded` fixture's patch at call time.)"""
+    from kiro_crew.dashboard import turn_dispatch
+
+    class _DoneTask:
+        def cancelled(self):
+            return False
+
+        def exception(self):
+            return TimeoutError("turn exceeded the 7200s ceiling")
+
+    state = MagicMock()
+    state._background_tasks = set()
+    slot = MagicMock()
+    slot.key = "chat-1"
+    slot._last_turn_awaiting_permission = True
+    slot._last_turn_children_announced = True
+
+    # finish_turn_task imports emit_counter lazily from metrics.events; the
+    # `recorded` fixture already patched that module's symbol.
+    turn_dispatch.finish_turn_task(state, slot, _DoneTask(), 7200.0)
+
+    hits = [a for n, a in recorded if n == metric_events.TURN_TIMEOUT_CAUSE]
+    assert hits == [
+        {
+            "path": "dashboard_ceiling",
+            "awaiting_permission": True,
+            "children_announced": True,
+        }
+    ]
+
+
+def test_terminal_children_do_not_count_as_announced():
+    """Completed (terminal) tracker entries must not count toward hang
+    attribution: only children still unfinished at the cut may set
+    children_announced. Exercises the real close_all safety net to pin the
+    hazard: it force-marks every entry done, so the snapshot MUST be taken
+    before it runs (terminal entries also linger for reconnect replay)."""
+    from kiro_crew.dashboard import chat_runner
+
+    state = MagicMock()
+    slot = MagicMock()
+    slot.key = "chat-1"
+
+    # Case 1: all children completed long before the cut -> not announced.
+    tracker = {"child-done": {"done": True, "done_at": 1.0, "id": "native:a"}}
+    unfinished = any(not i.get("done") for i in tracker.values())
+    assert unfinished is False
+
+    # Case 2: a child is still live at the cut -> announced, and the
+    # close_all safety net must not retroactively erase that (it marks the
+    # entry done, which is exactly why the snapshot precedes it).
+    tracker["child-live"] = {"done": False, "started": 0.0}
+    unfinished = any(not i.get("done") for i in tracker.values())
+    assert unfinished is True
+    chat_runner._native_subagent_close_all(state, slot, tracker, None)
+    assert all(i.get("done") for i in tracker.values())
+    assert unfinished is True  # snapshot unaffected by close_all


### PR DESCRIPTION
# Problem

We had four confirmed incidents (2026-08-13 → 2026-08-16, issue #3785) where kiro-cli specialist crews hung silently for 2 hours: child `session/request_permission` frames were dropped, kiro-cli awaited forever, and the turn ceiling + idle sweep killed the runtime with zero output. PRs #3786/#3889 fix the class — but nothing measures whether it stays fixed. Today the only signals are rotating logs (`gateway.log` keeps one `.prev`) and SEL rows; `kirocrew.turn.duration outcome=timeout` counts 2-hour ceilings but cannot attribute cause, and the stall watchdog deliberately exempts approval waits.

# Why it matters

Without a before/after series, we cannot prove the hang class is dead, and a routing regression would only be discovered the same way as before — a user staring at a 2-hour silent stall. The pre-fix signature (dropped permission frames) is currently a throttled debug log that no dashboard or alarm can see.

# Fix (symptoms → root cause → change)

Symptom: hangs are invisible until they cost 2 hours. Root cause: none of the hang-path code emits metrics. Change: five low-cardinality `kirocrew.*` counters at the exact choke points the hang class flows through:

1. **`kirocrew.acp.child_permission.denied` {surface, reason}** — every fast-fail denial that replaced a would-be hang: runtime answers (unroutable / between-turns / cap / send-failure reasons via `_audit_denied_off_loop`), handle-owned rejections (fail-close fidelity gate, pre-turn drain via `_audit_handle_reject`), and subagent-manager child rejections (`_reject_and_log` when `sub_session_id` set — covers escalation/turn-limit bails and interactive rejections).
2. **`kirocrew.acp.dropped_frames` {method_class: permission|update|other}** — emitted in `_note_dropped_frame`. `permission` is the pre-fix hang signature and must stay ~0; nonzero = routing regression alarm.
3. **`kirocrew.turn.timeout.cause` {awaiting_permission, children_announced}** — companion to `turn.duration outcome=timeout`, read from live handle/tracker state at the moment the ceiling fires, so a future 2-hour timeout is attributable to a permission wedge vs a long tool.
4. **`kirocrew.session.idle_expired` {turn_active, orphaned}** — the idle sweep now records whether it killed a runtime mid-turn (the teardown signature of the original incidents).

5. **`kirocrew.acp.child_permission.routed` {surface}** — every child permission request successfully delivered into the mode-parity pipeline (owner queue → policy gates / interactive card). The impact numerator: each increment is a request that, before #3786, was silently dropped and wedged its crew for 2 hours. `routed + denied` ≈ total would-have-hung traffic now handled.

All emits go through a shared best-effort helper (`metrics/events.py`) with a lazy `get_recorder` import (config.loader cycle) that swallows every failure — telemetry can never break the instrumented path. All attribute values are closed enums per `metrics/schema.py` cardinality rules; backend-controlled strings (methods, titles, ids) never become attribute values.

# Tests

`test/test_hang_resilience_metrics.py` drives the real production emit sites with the recorder mocked: runtime denial reason, dropped-frame classification (3 classes), handle-reject surface/reason, subagent child-only emission (parent rejections excluded), and the never-raises contract for the emitter.

# Manual verification

N/A — unit coverage exercises the exact emit sites; the series render on the existing Telemetry page through the same recorder path as `kirocrew.turn.duration`.

# Screenshots

N/A — no UI change (metrics only; existing Telemetry page renders new series generically).

---

Stacked on #3889 (`fix/child-permission-hardening`) because the instrumented paths are introduced there; retarget/rebase onto main after it merges.

