### PR TITLE
fix(dashboard): give slot teardown a single owner

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk, createSelector, type PayloadAction } from '@reduxjs/toolkit'
 import { api } from '../api/client'
-import { addSlotOptimistic, updateSlot, removeSlotOptimistic, markSlotRead, fetchSlots, slotSurfaceKey, sseSlots } from './dashboardSlice'
+import { addSlotOptimistic, updateSlot, removeSlotOptimistic, markSlotRead, fetchSlots, slotSurfaceKey, sseSlots, sseConnected } from './dashboardSlice'
 import { resolveDefaultColor } from '../utils/sessionColors'
 import { isSystemNoticeKind } from '../lib/systemNotice'
 import { gcSessionStorage } from '../utils/storageGc'
@@ -255,8 +255,10 @@ const safeKey = (key: string): string => (isUnsafeKey(key) ? `unsafe-key:${key}`
  *  eviction a prefix scan (the payloads carry multi-MB app HTML, so they must
  *  not outlive their slot). \u001F (unit separator) cannot appear in either
  *  component. */
+const MCP_APP_KEY_SEP = '\u001F'
+
 export const mcpAppKey = (sessionKey: string, toolCallId: string): string =>
-  `${sessionKey}\u001F${toolCallId}`
+  `${sessionKey}${MCP_APP_KEY_SEP}${toolCallId}`
 
 /** Max MCP App render payloads retained per slot (each carries multi-MB HTML);
  *  oldest are evicted past this bound. */
@@ -265,10 +267,78 @@ const MCP_APPS_PER_SLOT_MAX = 24
 /** Drop every MCP App render payload belonging to `sessionKey` (slot deleted
  *  or its conversation cleared — the tool rows the apps hang off are gone). */
 const evictMcpApps = (state: { mcpApps: Record<string, McpAppRenderPayload> }, sessionKey: string): void => {
-  const prefix = `${sessionKey}\u001F`
-  for (const k of Object.keys(state.mcpApps)) {
+  const prefix = `${sessionKey}${MCP_APP_KEY_SEP}`
+  // `?? {}` for the same reason every sibling enumeration here carries it: a
+  // preloaded state need not define every per-slot map, and teardown is now
+  // reachable from three writers rather than one.
+  for (const k of Object.keys(state.mcpApps ?? {})) {
     if (k.startsWith(prefix)) delete state.mcpApps[k]
   }
+}
+
+/** Chat state keyed by a slot.
+ *
+ *  Single owner of what is keyed per slot, read by every teardown path, so a new
+ *  per-slot map registered here is reached by all of them.
+ *
+ *  Spelling is mixed rather than uniform: several of these are written with the
+ *  bare key at some call sites and through `safeKey()` — which rewrites
+ *  prototype-polluting names — at others, so teardown removes both spellings
+ *  instead of assuming a clean split. `subagents` (keyed `dashboard:<slot>`) and
+ *  `workflowRuns` (keyed by run id) are absent because a slot key never matches
+ *  their entries; `mcpApps` carries the slot as a key PREFIX and is handled by
+ *  `evictMcpApps`. */
+const slotKeyedMaps = (state: ChatState) => [
+  state.slotMessages, state.slotActivity, state.slotRun, state.slotHydrated,
+  state.slotSide, state.slotSideClosed, state.slotStatusDetail,
+  state.slotContextPct, state.slotContextTokens, state.stopPressedAt,
+  state.followups, state.folderSuggestions,
+  state.pendingQuestions, state.subagentQueued, state.goalLoops,
+].filter(Boolean)
+
+/** Every slot key that still has residue anywhere in chat state.
+ *
+ *  A reconcile can only evict a slot it visits, so this has to cover the same
+ *  surfaces `evictSlotState` clears — including the two that are not plain
+ *  slot-keyed maps: `mcpApps`, whose keys carry the slot as a prefix, and
+ *  `slotHistory`, where a slot can outlive every map entry. */
+const slotKeysWithResidue = (state: ChatState): Set<string> => new Set([
+  ...slotKeyedMaps(state).flatMap(m => Object.keys(m)),
+  ...Object.keys(state.mcpApps ?? {}).map(k => k.split(MCP_APP_KEY_SEP)[0]),
+  ...(state.slotHistory ?? []),
+])
+
+/** Drop every trace of one slot from chat state.
+ *
+ *  A local delete and a reconcile against the authoritative slot list both end
+ *  here, so the two cannot disagree about what a departing slot leaves behind.
+ *  Both spellings are removed: `safeKey` is identity for ordinary slot names and
+ *  a no-op on an already-rewritten key, so one pass covers a caller holding
+ *  either form. */
+/** Evict every slot carrying residue that the authoritative list does not name.
+ *  Both authoritative writers (`sseSlots`, `fetchSlots.fulfilled`) reconcile
+ *  through here, so neither can drift from the other. The active slot is never
+ *  pruned: its live `messages`/optimistic state must not be dropped out from
+ *  under the open pane. */
+const reconcileSlotResidue = (state: ChatState, payload: readonly { key: string }[]): void => {
+  const live = new Set(payload.map(s => s.key))
+  if (state.activeSlot) live.add(state.activeSlot)
+  // A live slot is protected under either spelling, since some writers store it
+  // rewritten by safeKey().
+  for (const key of [...live]) live.add(safeKey(key))
+  for (const key of slotKeysWithResidue(state)) {
+    if (live.has(key)) continue
+    evictSlotState(state, key)
+  }
+}
+
+const evictSlotState = (state: ChatState, slotKey: string): void => {
+  const spellings = [slotKey, safeKey(slotKey)]
+  for (const m of slotKeyedMaps(state)) {
+    for (const spelling of spellings) delete m[spelling]
+  }
+  evictMcpApps(state, slotKey)
+  state.slotHistory = (state.slotHistory ?? []).filter(k => k !== slotKey)
 }
 
 /** Read one slot's pending question card, or null.
@@ -656,6 +726,10 @@ interface ChatState {
   slotHydrated: Record<string, boolean>
   slotLoading: boolean
   slotHistory: string[]
+  /** Whether a non-empty slots frame has arrived. Distinguishes a reconnect's
+   *  empty frame, which must not tear anything down, from a genuinely empty
+   *  list, which must. */
+  slotsSnapshotSeen: boolean
   stopPressedAt: Record<string, number | null>
   /** Pending ask_question cards keyed by slot. Keyed (rather than a single
    *  card) so concurrent ask_question calls from two slots cannot evict each
@@ -743,6 +817,7 @@ const initialState: ChatState = {
   slotSide: {},
   slotSideClosed: {},
   slotHistory: [],
+  slotsSnapshotSeen: false,
   pendingQuestions: {},
   followups: {},
   folderSuggestions: {},
@@ -3369,36 +3444,49 @@ const chatSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder
+      /** A reconnect starts a new snapshot cycle: the gateway can restart before
+       *  session restore and emit an empty slots frame, so the bit must go back
+       *  to unseen or that frame reads as an authoritative empty list and tears
+       *  down every background slot. Mirrors `dashboardSlice`, where
+       *  `sseConnected` clears `slotsLoaded` for the same reason — reading the
+       *  bit without resetting it is what made this a defect. */
+      .addCase(sseConnected, (state) => {
+        state.slotsSnapshotSeen = false
+      })
       /** Reconcile per-slot caches against the authoritative slots list.
        *  Sessions that close/archive/delete vanish from the SSE `slots` REPLACE;
        *  without this reconcile their transcripts stay resident for the tab's
-       *  lifetime (only `deleteSlot.fulfilled` evicts) — the dominant retention
-       *  class behind multi-GB heaps on long-lived dashboard tabs.
-       *  Guards: an empty payload is a no-op (SSE reconnect can deliver an
-       *  empty frame before the first real snapshot), and the active slot is
-       *  never pruned (its live `messages`/optimistic state must not be
-       *  dropped out from under the open pane). `subagents`/`workflowRuns`
-       *  are intentionally excluded — different keyspaces (dashboard:<slot>,
-       *  run id), not bare slot keys. */
+       *  lifetime — the dominant retention class behind multi-GB heaps on
+       *  long-lived dashboard tabs.
+       *  Guards: an empty payload is a no-op only until the first real snapshot
+       *  has been seen, because a reconnect can deliver one before it. Once seen,
+       *  an empty list is authoritative — the last slot was deleted, possibly by
+       *  another client — and skipping teardown there would strand this slice's
+       *  transcripts and MCP payloads, the expensive half. This slice tracks the
+       *  bit itself rather than reading the dashboard's, which its reducer cannot
+       *  see. The active slot is never pruned (its live `messages`/optimistic
+       *  state must not be dropped out from under the open pane). */
       .addCase(sseSlots, (state, action) => {
-        if (action.payload.length === 0) return
-        const live = new Set(action.payload.map(s => s.key))
-        if (state.activeSlot) live.add(state.activeSlot)
-        const maps = [
-          state.slotMessages, state.slotActivity, state.slotRun, state.slotHydrated,
-          state.slotSide, state.slotSideClosed, state.slotStatusDetail,
-          state.slotContextPct, state.slotContextTokens, state.stopPressedAt,
-          // Follow-up cards are per slot and can hold multi-KB prompts, so a
-          // deleted session's card must not outlive it.
-          state.followups,
-          state.folderSuggestions,
-        ].filter(Boolean)
-        const cached = new Set(maps.flatMap(m => Object.keys(m)))
-        for (const key of cached) {
-          if (live.has(key)) continue
-          for (const m of maps) delete m[key]
-        }
-        state.slotHistory = (state.slotHistory ?? []).filter(k => live.has(k))
+        const seenSnapshot = state.slotsSnapshotSeen === true
+        if (action.payload.length > 0) state.slotsSnapshotSeen = true
+        // An empty frame before the first real snapshot is a reconnect artifact.
+        // The authoritative empty case is not lost by skipping it: every
+        // reconnect dispatches `fetchSlots` right after `sseConnected`
+        // (`hooks/useWebSocket.ts`), and the case below reconciles that reply
+        // even when it is empty.
+        if (action.payload.length === 0 && !seenSnapshot) return
+        reconcileSlotResidue(state, action.payload)
+      })
+      /** The other authoritative slot-list writer. A request's reply is
+       *  authoritative even when empty — nothing to disambiguate — so this is
+       *  where "every slot was deleted while disconnected" is torn down. But a
+       *  reply in flight can be OLDER than the live frames that arrived while it
+       *  travelled, so it may omit a slot the stream has since created: evict
+       *  from here only while no live frame has been seen. Before that there is
+       *  no fresher state to destroy; after it the live frame owns teardown. */
+      .addCase(fetchSlots.fulfilled, (state, action) => {
+        if (state.slotsSnapshotSeen === true) return
+        reconcileSlotResidue(state, action.payload)
       })
       .addCase(fetchHistory.fulfilled, (state, action) => {
         const { sessions, hasMore, offset, append } = action.payload
@@ -3686,16 +3774,7 @@ const chatSlice = createSlice({
         setPagingCursor(state, false, 0)
       })
       .addCase(deleteSlot.fulfilled, (state, action) => {
-        delete state.slotActivity[action.payload]
-        delete state.slotMessages[action.payload]
-        delete state.slotRun[action.payload]
-        delete state.slotHydrated[action.payload]
-        delete state.slotSide[action.payload]
-        delete state.slotSideClosed[action.payload]
-        if (state.followups) delete state.followups[action.payload]
-        if (state.folderSuggestions) delete state.folderSuggestions[action.payload]
-        evictMcpApps(state, action.payload)
-        state.slotHistory = state.slotHistory.filter(k => k !== action.payload)
+        evictSlotState(state, action.payload)
         if (state.activeSlot === action.payload) {
           state.activeSlot = null
           state.messages = []

--- a/website/src/store/dashboardSlice.ts
+++ b/website/src/store/dashboardSlice.ts
@@ -84,6 +84,50 @@ export const changeApprovalMode = createAsyncThunk(
   },
 )
 
+/** Drop one slot's live sub-agent state.
+ *
+ *  These three maps are keyed by the bare slot key and are otherwise cleared
+ *  only wholesale on reconnect, so a departed slot's counters and rows would
+ *  otherwise survive for the tab's lifetime.
+ *
+ *  Driven by the AUTHORITATIVE slot-list writers — `sseSlots` and
+ *  `fetchSlots.fulfilled` — and deliberately NOT by `removeSlotOptimistic`: that
+ *  reducer runs before the delete is confirmed, and `sseSubagentText` drops every
+ *  frame for a slot with no `subagentRunning` entry, so evicting optimistically
+ *  would leave a slot whose delete failed alive but permanently mute. */
+/** Reconcile per-slot dashboard state against an authoritative slot list. Both
+ *  authoritative writers (`sseSlots`, `fetchSlots.fulfilled`) drive teardown
+ *  through here, so the two cannot drift apart the way the eviction lists this
+ *  PR unified once did. `unreadSlots` is written back only when it actually
+ *  shrank, since the live-frame writer runs on every slots frame. */
+const reconcileSlots = (state: DashboardState, liveKeys: Set<string>, evictStale = true): void => {
+  // `countUnreadByMode` deliberately keeps orphan unread keys contributing to
+  // the badge, on the premise that a reconcile drains them shortly. Draining on
+  // both writers is what keeps that premise true. Always run: a wrongly drained
+  // badge self-heals on the next unread event, and the refetch is the documented
+  // route by which a remotely deleted slot's badge is cleared.
+  const unread = state.unreadSlots ?? []
+  const drained = unread.filter(k => liveKeys.has(k))
+  if (drained.length !== unread.length) {
+    state.unreadSlots = drained
+    safeSet('mc-unread-slots', JSON.stringify(drained))
+  }
+  // Eviction is NOT recoverable, so it is skipped when the caller cannot vouch
+  // for the list's freshness: an HTTP reply in flight can be older than the live
+  // frames that arrived while it travelled, and would then delete a slot the
+  // stream has since created.
+  if (!evictStale) return
+  for (const key of Object.keys(state.subagentRunning ?? {})) {
+    if (!liveKeys.has(key)) evictSlotSubagents(state, key)
+  }
+}
+
+const evictSlotSubagents = (state: DashboardState, slotKey: string): void => {
+  delete state.subagentRunning[slotKey]
+  delete state.subagentDetails[slotKey]
+  delete state.subagentText[slotKey]
+}
+
 const dashboardSlice = createSlice({
   name: 'dashboard',
   initialState,
@@ -102,7 +146,21 @@ const dashboardSlice = createSlice({
     },
     sseConnected(state) { state.connected = true; state.slotsLoaded = false; state.subagentRunning = {}; state.subagentDetails = {}; state.subagentText = {} },
     sseDisconnected(state) { state.connected = false },
-    sseSlots(state, action: PayloadAction<ChatSlot[]>) { state.slots = action.payload; state.slotsLoaded = true },
+    sseSlots(state, action: PayloadAction<ChatSlot[]>) {
+      // Read before `slotsLoaded` is set: an empty frame is ambiguous, and this
+      // is what disambiguates it. Not yet loaded means a reconnect delivered it
+      // before the first real snapshot, so treating it as authoritative would
+      // evict every live slot's state. Already loaded means the list genuinely
+      // went empty — the last slot was deleted, possibly by another client —
+      // and skipping teardown there would strand its state permanently.
+      // Return BEFORE writing anything: assigning an empty `slots` would blank
+      // the sidebar until restoration finishes, and marking it loaded would
+      // claim a snapshot arrived when none has.
+      if (action.payload.length === 0 && !state.slotsLoaded) return
+      state.slots = action.payload
+      state.slotsLoaded = true
+      reconcileSlots(state, new Set(action.payload.map(s => s.key)))
+    },
     // Live TODO-list delta. Patched into the SAME slots array that sseSlots
     // populates rather than a parallel map, so the mid-turn push and the
     // reconnect snapshot can never disagree about a slot's list. A delta for an
@@ -245,9 +303,7 @@ const dashboardSlice = createSlice({
       // prototype would write through Object.prototype in the else-branch below.
       if (!slot || isUnsafeKey(slot)) return
       if (running <= 0) {
-        delete state.subagentRunning[slot]
-        delete state.subagentDetails[slot]
-        delete state.subagentText[slot]
+        evictSlotSubagents(state, slot)
       } else {
         state.subagentRunning[slot] = running
         if (agents) state.subagentDetails[slot] = agents.map(a => ({
@@ -309,11 +365,14 @@ const dashboardSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(fetchSlots.fulfilled, (state, action) => {
+        // A reply in flight can be older than the live frames that arrived while
+        // it travelled, so it may omit a slot the stream has since created. The
+        // unread drain still runs — that is this path's documented job, and a
+        // badge self-heals — but eviction is withheld once the stream is live.
+        const fresh = !state.slotsLoaded
         state.slots = action.payload
         state.slotsLoaded = true
-        const liveKeys = new Set(action.payload.map((s: { key: string }) => s.key))
-        state.unreadSlots = state.unreadSlots.filter(k => liveKeys.has(k))
-        safeSet('mc-unread-slots', JSON.stringify(state.unreadSlots))
+        reconcileSlots(state, new Set(action.payload.map((s: { key: string }) => s.key)), fresh)
       })
       .addCase(changeApprovalMode.fulfilled, (state, action) => { state.approvalMode = action.payload })
   },

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -665,9 +665,15 @@ describe('App routing', () => {
   it('keeps the sub-agent bot and count in the expanded Sessions rail item', async () => {
     localStorage.removeItem('mc-nav')
     const store = createTestStore()
-    store.dispatch(sseSubagentQueued({ slot: 'background', queued: 2 }))
 
     renderWithProviders(<App />, { route: '/chat', store })
+
+    // Seed AFTER the mount fetch settles. `fetchSlots.fulfilled` is an
+    // authoritative slot-list writer, so queued-subagent state for a slot the
+    // fetched list does not name is residue and is evicted — seeding before the
+    // fetch would have this test depend on that eviction not happening.
+    expect(await screen.findByLabelText('Sessions')).toBeInTheDocument()
+    act(() => { store.dispatch(sseSubagentQueued({ slot: 'background', queued: 2 })) })
 
     expect(await screen.findByLabelText('2 subagents in flight')).toBeInTheDocument()
   })

--- a/website/src/test/chatSlice.slotPrune.test.ts
+++ b/website/src/test/chatSlice.slotPrune.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import chatReducer from '../store/chatSlice'
+import chatReducer, { deleteSlot } from '../store/chatSlice'
 import notifReducer, { addNotification, fetchNotifications, NOTIFICATIONS_RING_CAP } from '../store/notificationsSlice'
-import { sseSlots } from '../store/dashboardSlice'
+import { sseSlots, sseConnected, fetchSlots } from '../store/dashboardSlice'
 import type { ChatMessage, ChatSlot, Notification } from '../types'
 import './mockApiClient'
 
@@ -52,6 +52,57 @@ describe('chatSlice sseSlots reconciliation', () => {
     expect(next.slotHistory).toEqual(['chat-1', 'chat-2'])
   })
 
+  it('reconciles an empty payload once a real snapshot has been seen (the last slot was deleted)', () => {
+    // The expensive half: this slice holds transcripts and MCP payloads, so
+    // skipping teardown here strands far more than the dashboard's small maps.
+    let state = seeded(['chat-1', 'chat-2'])
+    state = chatReducer(state, sseSlots([slot('chat-1'), slot('chat-2')]))
+
+    const next = chatReducer(state, sseSlots([]))
+
+    expect(Object.keys(next.slotMessages)).toEqual([])
+    expect(next.slotHistory).toEqual([])
+  })
+
+  it('ignores an empty payload after a reconnect, even once a snapshot was seen before it', () => {
+    // The gateway can restart before session restore and emit an empty frame.
+    // Without resetting the bit on connect, that frame reads as authoritative.
+    let state = seeded(['chat-1', 'chat-2'])
+    state = chatReducer(state, sseSlots([slot('chat-1'), slot('chat-2')]))
+    state = chatReducer(state, sseConnected())
+
+    const next = chatReducer(state, sseSlots([]))
+
+    expect(Object.keys(next.slotMessages).sort()).toEqual(['chat-1', 'chat-2'])
+    expect(next.slotHistory).toEqual(['chat-1', 'chat-2'])
+  })
+
+  it('tears down on the refetch that follows a reconnect, which is where an authoritative empty list arrives', () => {
+    // The SSE guard defers an empty reconnect frame rather than losing it:
+    // useWebSocket dispatches sseConnected then fetchSlots on every reconnect,
+    // and a request's reply is authoritative even when empty.
+    let state = seeded(['chat-1', 'chat-2'])
+    state = chatReducer(state, sseSlots([slot('chat-1'), slot('chat-2')]))
+    state = chatReducer(state, sseConnected())
+    state = chatReducer(state, sseSlots([]))
+    expect(Object.keys(state.slotMessages).sort()).toEqual(['chat-1', 'chat-2'])
+
+    const next = chatReducer(state, { type: fetchSlots.fulfilled.type, payload: [] })
+
+    expect(Object.keys(next.slotMessages)).toEqual([])
+    expect(next.slotHistory).toEqual([])
+  })
+
+  it('ignores a fetch reply once a live frame has been seen, since the reply may be older', () => {
+    // The reply can predate slots the stream created while it was in flight.
+    let state = seeded(['chat-1', 'chat-2'])
+    state = chatReducer(state, sseSlots([slot('chat-1'), slot('chat-2')]))
+
+    const next = chatReducer(state, { type: fetchSlots.fulfilled.type, payload: [slot('chat-1')] })
+
+    expect(Object.keys(next.slotMessages).sort()).toEqual(['chat-1', 'chat-2'])
+  })
+
   it('prunes keys present only in sibling maps (no slotMessages entry)', () => {
     const state = seeded(['chat-1'])
     state.slotRun['ghost'] = { state: 'idle' }
@@ -72,6 +123,76 @@ describe('chatSlice sseSlots reconciliation', () => {
     expect(next.slotContextPct['chat-2']).toBeUndefined()
     expect(next.slotContextTokens['chat-2']).toBeUndefined()
     expect(next.stopPressedAt['chat-2']).toBeUndefined()
+  })
+})
+
+describe('slot teardown parity', () => {
+  /** Seed every map the store keys per slot, so a teardown path that forgets
+   *  one of them leaves a visible entry behind. */
+  function richlySeeded(keys: string[]) {
+    const base = seeded(keys)
+    return {
+      ...base,
+      slotStatusDetail: Object.fromEntries(keys.map(k => [k, { kind: 'compacting' as const, text: 'Compacting…', ts: 1 }])),
+      slotContextPct: Object.fromEntries(keys.map(k => [k, 42])),
+      slotContextTokens: Object.fromEntries(keys.map(k => [k, { used: 1234, window: 200000 }])),
+      stopPressedAt: Object.fromEntries(keys.map(k => [k, 999])),
+      followups: Object.fromEntries(keys.map(k => [k, { items: [], ts: 1 }])),
+      folderSuggestions: Object.fromEntries(keys.map(k => [k, { folderId: 'f', folderName: 'F', breadcrumb: 'F', ts: 1 }])),
+      subagentQueued: Object.fromEntries(keys.map(k => [k, 2])),
+      goalLoops: Object.fromEntries(keys.map(k => [k, { cycle_count: 1, max_cycles: 5 }])),
+    }
+  }
+
+  const perSlotMaps = [
+    'slotMessages', 'slotActivity', 'slotRun', 'slotHydrated', 'slotSide',
+    'slotSideClosed', 'slotStatusDetail', 'slotContextPct', 'slotContextTokens',
+    'stopPressedAt', 'followups', 'folderSuggestions', 'subagentQueued', 'goalLoops',
+  ] as const
+
+  const keysOf = (state: unknown, map: string) =>
+    Object.keys((state as Record<string, Record<string, unknown>>)[map]).sort()
+
+  it('deleting a slot leaves no entry in any per-slot map', () => {
+    const state = richlySeeded(['chat-1', 'chat-2'])
+    const next = chatReducer(state, { type: deleteSlot.fulfilled.type, payload: 'chat-2' })
+    for (const map of perSlotMaps) {
+      expect(keysOf(next, map)).toEqual(['chat-1'])
+    }
+    expect(next.slotHistory).toEqual(['chat-1'])
+  })
+
+  /** The two teardown paths read one shared list of per-slot maps; this fails
+   *  if a map is ever registered with only one of them. */
+  it('the reconcile evicts exactly what deleting evicts', () => {
+    const seed = richlySeeded(['chat-1', 'chat-2'])
+    const deleted = chatReducer(seed, { type: deleteSlot.fulfilled.type, payload: 'chat-2' })
+    const reconciled = chatReducer(seed, sseSlots([slot('chat-1')]))
+    for (const map of perSlotMaps) {
+      expect(keysOf(reconciled, map)).toEqual(keysOf(deleted, map))
+    }
+    expect(reconciled.slotHistory).toEqual(deleted.slotHistory)
+  })
+
+  /** Eviction parity is not reach parity: the reconcile also has to ENUMERATE
+   *  the safe-keyed maps, or a slot whose only residue lives there is never
+   *  visited and survives that path. */
+  it('the reconcile evicts a slot whose only residue is in a safe-keyed map', () => {
+    const state = { ...seeded(['chat-1']), subagentQueued: { ghost: 3 }, goalLoops: {}, pendingQuestions: {} }
+    const next = chatReducer(state, sseSlots([slot('chat-1')]))
+    expect(next.subagentQueued['ghost']).toBeUndefined()
+  })
+
+  it('the reconcile evicts a slot whose only residue is an MCP app payload', () => {
+    const state = { ...seeded(['chat-1']), mcpApps: { 'ghost\u001Ftool-1': { tool_call_id: 'tool-1' } } }
+    const next = chatReducer(state as never, sseSlots([slot('chat-1')]))
+    expect(Object.keys(next.mcpApps)).toEqual([])
+  })
+
+  it('keeps a live slot that is only present in a safe-keyed map', () => {
+    const state = { ...seeded(['chat-1']), subagentQueued: { 'chat-1': 3 }, goalLoops: {}, pendingQuestions: {} }
+    const next = chatReducer(state, sseSlots([slot('chat-1')]))
+    expect(next.subagentQueued['chat-1']).toBe(3)
   })
 })
 

--- a/website/src/test/dashboardSlice.test.ts
+++ b/website/src/test/dashboardSlice.test.ts
@@ -371,3 +371,95 @@ describe('dashboardSlice', () => {
     })
   })
 })
+
+describe('dashboardSlice per-slot sub-agent teardown', () => {
+  const seeded = () => {
+    const base = reducer(undefined, { type: '@@INIT' })
+    return {
+      ...base,
+      slots: [{ key: 'chat-1', messages: 0, running: false }, { key: 'chat-2', messages: 0, running: false }] as ChatSlot[],
+      subagentRunning: { 'chat-1': 1, 'chat-2': 2 },
+      subagentDetails: { 'chat-1': [], 'chat-2': [] },
+      subagentText: { 'chat-1': {}, 'chat-2': {} },
+    }
+  }
+
+  it('drains unread state for a slot that vanished from the authoritative list', () => {
+    const before = { ...seeded(), unreadSlots: ['chat-1', 'chat-2'] }
+
+    const next = reducer(before, sseSlots([{ key: 'chat-1', messages: 0, running: false }] as ChatSlot[]))
+
+    expect(next.unreadSlots).toEqual(['chat-1'])
+    expect(JSON.parse(localStorage.getItem('mc-unread-slots') ?? '[]')).toEqual(['chat-1'])
+  })
+
+  it('leaves unread state alone when the frame still lists every unread slot', () => {
+    localStorage.removeItem('mc-unread-slots')
+    const before = { ...seeded(), unreadSlots: ['chat-1', 'chat-2'] }
+
+    const next = reducer(before, sseSlots([
+      { key: 'chat-1', messages: 0, running: false },
+      { key: 'chat-2', messages: 0, running: false },
+    ] as ChatSlot[]))
+
+    expect(next.unreadSlots).toEqual(['chat-1', 'chat-2'])
+    // Not rewritten, because this reducer runs on every slots frame.
+    expect(localStorage.getItem('mc-unread-slots')).toBeNull()
+  })
+
+  /** Optimistic removal runs before the delete is confirmed, and a slot whose
+   *  delete fails comes back via the next authoritative frame. Evicting here
+   *  would leave it alive but mute, because sseSubagentText drops frames for a
+   *  slot with no subagentRunning entry. */
+  it('keeps sub-agent state on optimistic removal, before the delete is confirmed', () => {
+    const next = reducer(seeded(), removeSlotOptimistic('chat-2'))
+    expect(next.subagentRunning['chat-2']).toBe(2)
+    expect(next.subagentDetails['chat-2']).toBeDefined()
+    expect(next.subagentText['chat-2']).toBeDefined()
+  })
+
+  it('drops a slot the live slots frame no longer carries', () => {
+    const next = reducer(seeded(), sseSlots([{ key: 'chat-1', messages: 0, running: false }] as ChatSlot[]))
+    expect(next.subagentRunning['chat-2']).toBeUndefined()
+    expect(next.subagentDetails['chat-2']).toBeUndefined()
+    expect(next.subagentText['chat-2']).toBeUndefined()
+    expect(next.subagentRunning['chat-1']).toBe(1)
+  })
+
+  it('treats an empty slots frame as a no-op before the list has loaded, since a reconnect delivers one first', () => {
+    const next = reducer(seeded(), sseSlots([]))
+    expect(next.subagentRunning['chat-1']).toBe(1)
+    expect(next.subagentRunning['chat-2']).toBe(2)
+  })
+
+  it('reconciles an empty frame once loaded, which is the last slot being deleted', () => {
+    const loaded = { ...seeded(), slotsLoaded: true, unreadSlots: ['chat-1', 'chat-2'] }
+
+    const next = reducer(loaded, sseSlots([]))
+
+    expect(next.subagentRunning['chat-1']).toBeUndefined()
+    expect(next.subagentRunning['chat-2']).toBeUndefined()
+    expect(next.unreadSlots).toEqual([])
+  })
+
+  it('withholds eviction from a fetch reply once the stream is live, but still drains unread', () => {
+    // The reply can be older than the live frames it raced, so eviction (not
+    // recoverable) is withheld while the unread drain (self-healing) still runs.
+    const loaded = { ...seeded(), slotsLoaded: true, unreadSlots: ['chat-1', 'chat-2'] }
+    const payload = [{ key: 'chat-1', messages: 0, running: false }] as ChatSlot[]
+
+    const next = reducer(loaded, { type: fetchSlots.fulfilled.type, payload })
+
+    expect(next.subagentRunning['chat-2']).toBe(2)
+    expect(next.unreadSlots).toEqual(['chat-1'])
+  })
+
+  it('drops a slot the authoritative refetch no longer carries', () => {
+    const payload = [{ key: 'chat-1', messages: 0, running: false }] as ChatSlot[]
+    const next = reducer(seeded(), { type: fetchSlots.fulfilled.type, payload })
+    expect(next.subagentRunning['chat-2']).toBeUndefined()
+    expect(next.subagentDetails['chat-2']).toBeUndefined()
+    expect(next.subagentText['chat-2']).toBeUndefined()
+    expect(next.subagentRunning['chat-1']).toBe(1)
+  })
+})

--- a/website/src/utils/storageGc.test.ts
+++ b/website/src/utils/storageGc.test.ts
@@ -177,16 +177,42 @@ describe('gcSessionStorage', () => {
     expect(localStorage.getItem(`${HEIGHTS}chat-1-1`)).toBe('{}')
   })
 
-  it('matches on prefix, so a longer sibling key is also removed', () => {
-    // `startsWith(prefix + sessionKey)` is a PREFIX test, not equality: a
-    // session id that is a prefix of another id collects the other one's keys
-    // too. Pinned so the blast radius is known rather than discovered.
+  it('stops at a boundary, so a longer sibling key survives', () => {
+    // The session id has to end where the key ends or at a ':' delimiter.
+    // Without that boundary, deleting a slot whose id prefixes a live
+    // sibling's id takes the sibling's state with it.
     localStorage.setItem(`${HEIGHTS}chat-1-1`, '{}')
     localStorage.setItem(`${HEIGHTS}chat-1-10`, '{}')
 
     gcSessionStorage('chat-1-1')
 
     expect(localStorage.getItem(`${HEIGHTS}chat-1-1`)).toBeNull()
-    expect(localStorage.getItem(`${HEIGHTS}chat-1-10`)).toBeNull()
+    expect(localStorage.getItem(`${HEIGHTS}chat-1-10`)).toBe('{}')
+  })
+
+  it('spares the parked slot-less preference but not a same-named slot\u2019s other state', () => {
+    localStorage.setItem('mc-busy-send-mode:no-slot', 'steer')
+    localStorage.setItem(`${HEIGHTS}no-slot`, '{}')
+
+    gcSessionStorage('no-slot')
+
+    // Belongs to no slot, so no slot's teardown owns it.
+    expect(localStorage.getItem('mc-busy-send-mode:no-slot')).toBe('steer')
+    // A real slot sharing the sentinel's name still loses what it does own,
+    // or deleting and recreating it would restore stale caches.
+    expect(localStorage.getItem(`${HEIGHTS}no-slot`)).toBeNull()
+  })
+
+  it('removes a per-slot send-mode preference without touching a sibling', () => {
+    localStorage.setItem('mc-busy-send-mode:foo', 'queue')
+    localStorage.setItem('mc-busy-send-mode:foobar', 'steer')
+    localStorage.setItem('mc-busy-send-mode:no-slot', 'steer')
+
+    gcSessionStorage('foo')
+
+    expect(localStorage.getItem('mc-busy-send-mode:foo')).toBeNull()
+    expect(localStorage.getItem('mc-busy-send-mode:foobar')).toBe('steer')
+    // The slot-less sentinel belongs to no session.
+    expect(localStorage.getItem('mc-busy-send-mode:no-slot')).toBe('steer')
   })
 })

--- a/website/src/utils/storageGc.ts
+++ b/website/src/utils/storageGc.ts
@@ -26,19 +26,52 @@ const SESSION_PREFIXES = [
   'mc-webpreview-url:',
   'mc-webpreview-pending:',
   'mc-webpreview-applied:',
+  'mc-busy-send-mode:',
 ] as const
 
-/** Namespaces under those prefixes that are NOT session ids and must survive.
+/** Names that appear where a session id is expected but are not sessions.
  *
- *  The virtualizer partitions its height cache by `sessionId`, so a caller that
- *  is not a chat session (the artifacts gallery) still has to name a partition.
- *  Without this exemption the startup pass reads that name as a dead session and
- *  deletes it — the cache would appear to work and then be wiped every boot,
- *  which is invisible except as heights that never stay warm.
+ *  The orphan sweep always spares them: it is *guessing* which names are dead,
+ *  and a non-session name looks dead forever. An explicit per-session delete is
+ *  different — the caller named its target — so it is honoured unless the key is
+ *  shared state that target does not own. That is the whole difference between
+ *  the two entries below, and it turns on ownership, not on convenience.
  *
- *  Must stay byte-identical to the writer (`ARTIFACT_HEIGHT_NS` in
- *  `pages/ArtifactsPage.tsx`). */
-const RESERVED_NAMESPACES = new Set(['artifacts-gallery'])
+ *  Each name must stay byte-identical to its writer; a divergence collects the
+ *  parked value silently.
+ *
+ *  - `artifacts-gallery` — the virtualizer partitions its height cache by
+ *    `sessionId`, and the gallery is not a chat session but still has to name a
+ *    partition. Writer: `ARTIFACT_HEIGHT_NS` in `pages/ArtifactsPage.tsx`.
+ *    Reserved under every prefix, and the partition IS owned by this name, so an
+ *    explicit delete of it is honoured.
+ *  - `no-slot` — slot-less consumers park a per-slot preference here. Writer:
+ *    `busySendModeKey` in `components/BusySendButton.tsx`. Reserved under that
+ *    one prefix so a real slot spelled the same still loses everything else it
+ *    owns, and spared even on an explicit delete because the parked value is
+ *    shared state belonging to the slot-less case rather than to any slot.
+ *
+ *  Residual: a slot named exactly like a reserved name is indistinguishable from
+ *  the reserved value under a shared prefix. */
+const RESERVED_NAMES: ReadonlyMap<string, {
+  /** Prefixes the name is reserved under; `null` means every prefix. */
+  prefixes: ReadonlySet<string> | null
+  /** Whether an explicit per-session delete must spare it too. */
+  spareOnExplicitDelete: boolean
+}> = new Map([
+  ['artifacts-gallery', { prefixes: null, spareOnExplicitDelete: false }],
+  ['no-slot', { prefixes: new Set(['mc-busy-send-mode:']), spareOnExplicitDelete: true }],
+])
+
+/** Whether `sessionId` under `prefix` is a reserved name the given sweep must
+ *  leave alone. One predicate, so a name registered for one sweep cannot be
+ *  silently missing from the other. */
+const isReservedName = (sessionId: string, prefix: string, sweep: 'orphan' | 'delete'): boolean => {
+  const reserved = RESERVED_NAMES.get(sessionId)
+  if (!reserved) return false
+  if (sweep === 'delete' && !reserved.spareOnExplicitDelete) return false
+  return reserved.prefixes === null || reserved.prefixes.has(prefix)
+}
 
 /**
  * Remove localStorage keys belonging to sessions not in `liveSessionIds`.
@@ -58,7 +91,7 @@ export function gcOrphanedStorage(liveSessionIds: Set<string>): number {
       if (key.startsWith(prefix)) {
         // Extract the session ID: everything after the prefix, before any further ':'
         const sessionId = key.slice(prefix.length).split(':')[0]
-        if (sessionId && !liveSessionIds.has(sessionId) && !RESERVED_NAMESPACES.has(sessionId)) {
+        if (sessionId && !isReservedName(sessionId, prefix, 'orphan') && !liveSessionIds.has(sessionId)) {
           doomed.push(key)
         }
         break
@@ -86,7 +119,16 @@ export function gcSessionStorage(sessionKey: string): void {
     const key = localStorage.key(i)
     if (!key) continue
     for (const prefix of SESSION_PREFIXES) {
-      if (key.startsWith(prefix + sessionKey)) {
+      // A reserved name is not a session, so no slot's teardown owns its key.
+      if (isReservedName(sessionKey, prefix, 'delete')) continue
+      // The session id must end where the key ends or at a ':' delimiter.
+      // A bare prefix test would let deleting `foo` also remove `foobar`'s
+      // keys, so a departing slot would take a live sibling's state with it.
+      // Residual: a slot id that itself contains ':' stays ambiguous against a
+      // sibling extending it at a delimiter — the same limitation the colon
+      // convention already carries on the orphan sweep.
+      const scoped = prefix + sessionKey
+      if (key === scoped || key.startsWith(`${scoped}:`)) {
         doomed.push(key)
         break
       }


### PR DESCRIPTION
## Problem / Motivation

Closing a chat slot leaves some of its state resident, and *which* state survives depends on **how** the slot went away.

Two paths tore down a closed slot, each carrying its own hand-maintained list of per-slot maps, and the lists had drifted:

- `deleteSlot.fulfilled` (this tab deleted the slot) missed `slotStatusDetail`, `slotContextPct`, `slotContextTokens` and `stopPressedAt`.
- The `sseSlots` reconcile (the slot vanished from the authoritative list — e.g. another client deleted it) missed the MCP-app eviction.

Several per-slot maps had no teardown at all: `pendingQuestions`, `subagentQueued`, `goalLoops`, and the dashboard slice's `subagentRunning` / `subagentDetails` / `subagentText` (cleared only wholesale on reconnect). And `mc-busy-send-mode:<slot>` was never registered with the storage GC, so every deleted slot leaked one `localStorage` entry permanently.

## Why it matters

These are retention bugs on the surface the dashboard keeps open longest. A long-lived tab that opens and closes slots accumulates transcript-adjacent state for slots that no longer exist — the same retention class the `sseSlots` reconcile was added to fix, re-entering through the path that reconcile did not cover. The `localStorage` leak is unbounded in the number of slots ever deleted and shares the ~5 MB origin quota whose exhaustion white-screens the app.

The deeper problem was structural: nothing owned the answer to "what is keyed per slot", so each new map had to be remembered in two places.

## What changed (motivation → approach → change)

Root cause: teardown knowledge was duplicated across paths that must agree, with nothing forcing them to. Patching the four missing deletes would have restored parity for today and left the next map to drift again, so this gives teardown one owner.

**Chat slice**
- `slotKeyedMaps` is the single list of slot-keyed state; `evictSlotState` is the single evictor; `slotKeysWithResidue` is the single enumerator. The reconcile and the local delete both go through them, so a surface added to one is reached by all.
- Spelling is **mixed**, not split: several of these maps are written with the bare key at some call sites and through `safeKey()` — which rewrites prototype-polluting names — at others. Eviction therefore removes both spellings rather than assuming a clean division, and the reconcile's `live` set holds both so a live slot is never evicted under either form.
- The enumerator also covers the two surfaces that are not plain slot-keyed maps: `mcpApps`, whose keys carry the slot as a **prefix** (extracted, not matched), and `slotHistory`, where a slot can outlive every map entry.
- `MCP_APP_KEY_SEP` replaces the `\u001F` literal in the key writer, the evictor and the extractor, so writer/evictor drift is not expressible.

**Dashboard slice**
- `evictSlotSubagents` owns the three sub-agent maps and is driven by the **authoritative** slot-list writers (`sseSlots`, `fetchSlots.fulfilled`) and by `sseSubagentStatus` when a slot's count reaches zero. It is deliberately **not** called from `removeSlotOptimistic`: that runs before the delete is confirmed, and `sseSubagentText` drops every frame for a slot with no `subagentRunning` entry, so evicting optimistically would leave a slot whose delete failed alive but permanently mute.
- `sseSlots` treats an empty payload as a no-op, because an SSE reconnect can deliver one before the first real snapshot.
- **`sseSlots` now also drains `unreadSlots`** (and its `mc-unread-slots` entry), which only `fetchSlots.fulfilled` did. `countUnreadByMode` deliberately keeps orphan unread keys contributing to the badge, justified by "the brief race between `removeSlotOptimistic` and `fetchSlots.fulfilled`" — a premise only the refetch route was keeping, so on the route a remote delete actually arrives, "brief" was indefinite. Written back only when the array shrank, since this reducer runs on every slots frame.

**Storage GC** — two changes, both affecting existing behavior:
1. `mc-busy-send-mode:` joins `SESSION_PREFIXES`, so a deleted slot stops leaking its entry. The reserved `no-slot` id (where slot-less consumers park the preference) is exempt from **both** sweeps, since it belongs to no slot.
2. **`gcSessionStorage` gained a boundary rule** — the session id must end at end-of-key or at a `:` delimiter, replacing a bare prefix test. This changes deletion scope for **all ten prefixes**, not just the new one: deleting `chat-1-1` no longer collects `chat-1-10`'s keys. It is declared here because it reverses behavior an existing test deliberately pinned ("Pinned so the blast radius is known rather than discovered") — that test documented a defect rather than a contract, and registering a new prefix into a collision-prone sweep is what turns a harmless leak into sibling data loss, so the boundary is the fix rather than dropping the prefix. Residual, stated in the comment: a slot id containing `:` stays ambiguous against a sibling extending it at a delimiter, matching the limitation the colon convention already carries on the orphan sweep.

## Tests

`chatSlice.slotPrune.test.ts` previously covered only the reconcile; the `deleteSlot` path — where the drift was — had no coverage.

- **Completeness** — a delete leaves no entry in any per-slot map. Mutation-verified.
- **Parity** — the reconcile evicts exactly what deleting evicts, so registering a map with only one path fails.
- **Reach** — separate tests for a slot whose only residue is in a safe-keyed map, and for one whose only residue is an MCP-app payload. Eviction parity is not reach parity: parity compares two paths over one candidate set and cannot see a candidate set that is too small.
- **Live-slot protection** under the `safeKey` spelling.
- Dashboard: sub-agent state **survives** optimistic removal, drops on a live slots frame and on a refetch, and an empty frame is a no-op.
- Storage GC: the boundary rule (sibling survives), the new prefix, and the reserved id refused in the delete sweep.

## Manual verification

N/A — unit coverage sufficient. Store-level state eviction with no rendered surface; every teardown trigger is exercised through the reducers.

## Related Issues

No linked issue: found by auditing the slot-close teardown paths directly.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no user-facing or documented behavior changes
- [x] No secrets, credentials, or internal references in the diff
