### PR TITLE
fix: resolve the provider CLI off the event loop

### DIFF
--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -718,7 +718,14 @@ async def _run_json(
             "OS-level provider sandboxing is unavailable."
         )
     try:
-        resolved_executable = _resolve_provider_executable(executable)
+        # Off the loop: resolution walks every candidate dir and stats the whole
+        # parent chain of each hit (github_runner.validate_provider_executable),
+        # and a miss re-walks all of PATH. The sidebar chip refresh reaches this
+        # on a timer with no user present, so on the loop thread one slow
+        # filesystem freezes every task -- including the liveness heartbeat --
+        # until the loop watchdog kills the gateway and the supervisor respawns
+        # into the same condition.
+        resolved_executable = await asyncio.to_thread(_resolve_provider_executable, executable)
     except SourceProviderError:
         _audit_provider_cli(executable, "denied", "executable_untrusted")
         raise

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -705,6 +705,39 @@ async def test_run_json_refuses_provider_cli_on_windows(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_json_resolves_the_provider_cli_off_the_event_loop(monkeypatch) -> None:
+    """Resolution stats every candidate and the whole parent chain of each hit,
+    and the sidebar chip refresh reaches it on a timer with no user present. On
+    the loop thread a slow filesystem freezes every task until the loop watchdog
+    kills the gateway, so the walk has to happen on a worker thread."""
+
+    class FakeProcess:
+        returncode = 0
+
+    resolver_threads: list[int] = []
+
+    def recording_resolver(_name: str) -> str:
+        resolver_threads.append(threading.get_ident())
+        return "/usr/bin/gh"
+
+    monkeypatch.setattr(source, "_resolve_provider_executable", recording_resolver)
+    monkeypatch.setattr(
+        source,
+        "sandboxed_spawn_argv",
+        lambda argv, **kwargs: (argv, kwargs["env"], None),
+    )
+    monkeypatch.setattr(
+        source.asyncio, "create_subprocess_exec", AsyncMock(return_value=FakeProcess())
+    )
+    monkeypatch.setattr(source, "_collect_process_output", AsyncMock(return_value=(b"{}", b"")))
+
+    assert await source._run_json("gh", "api", "repos/acme/repo") == {}
+
+    assert len(resolver_threads) == 1
+    assert resolver_threads[0] != threading.get_ident()
+
+
+@pytest.mark.asyncio
 async def test_run_json_sandboxes_with_minimal_provider_environment(monkeypatch) -> None:
     class FakeProcess:
         returncode = 0
@@ -832,11 +865,16 @@ async def test_run_json_awaits_critical_audit_off_loop_before_spawn(
     order: list[str] = []
 
     async def fake_to_thread(func, *args, **kwargs):
+        # Only the audit offload is under test; every other offload on this path
+        # (executable resolution) has to pass through with its real result.
+        if func is not source._audit_provider_cli:
+            return func(*args, **kwargs)
         order.append("audit-started")
         audit_started.set()
         await release_audit.wait()
-        func(*args, **kwargs)
+        result = func(*args, **kwargs)
         order.append("audit-completed")
+        return result
 
     class FakeProcess:
         returncode = 0


### PR DESCRIPTION
## What broke

On 2026-08-17 a single gateway was killed by `LoopStallWatchdog` three times in
fourteen hours (05:02, 05:19, 18:47 local). Every chat session died with it. The
crash dump's main-thread stack is unambiguous:

```
source_providers.py:4743  _refresh_check_status
source_providers.py:4831  _fetch_check_status
source_providers.py:721   _run_json
source_providers.py:262   _resolve_provider_executable   <- blocked here
asyncio/base_events.py:1936 _run_once                    <- on the event loop
```

`_run_json` resolved the `gh`/`glab` executable **synchronously on the event
loop thread**. Resolution is stat-heavy: it walks every well-known install dir,
and for each hit validates the file plus every parent directory
(`resolve(strict=True)`, `Path.stat()`, `os.access()` per component in
`github_runner.validate_provider_executable`). A miss additionally re-walks all
of `PATH`. When those syscalls got slow, the loop stopped serving every other
task — including the liveness heartbeat — the watchdog fired at its 25s
`exit_after`, and the supervisor respawned into the same condition.

## Why it took this long to bite

The defect is compositional; no single diff contains it.

| PR | What it added | Effect |
|---|---|---|
| #84 | the four functions, resolution called synchronously | only reachable on user interaction — a user waiting out a slow stat |
| #290 | periodic owner-WS refresh loop | the same call now fires on a timer **with nobody present** |
| #630 | override -> well-known dirs -> `PATH`, relaxed ownership checks | one resolution went from one candidate to a list, each with a full parent-chain walk |
| #443 | turn-boundary forced refresh | another unattended trigger |

#84's synchronous call was nearly harmless on its own. #290 is what turned it
into something that can kill an idle gateway, and #630 multiplied the cost per
call. Each PR was individually defensible.

Worth noting: `_run_json` already offloads its SEL audit write with
`asyncio.to_thread`, and the same module offloads config reads and Jira auth the
same way. The offload habit was present; this one call site was simply missed.

## The fix

One line — the resolution now runs on a worker thread:

```python
resolved_executable = await asyncio.to_thread(_resolve_provider_executable, executable)
```

A slow filesystem now costs latency on one sidebar chip refresh instead of
freezing the gateway.

## Deliberately not in this change

**No resolution cache.** `github_runner.resolve_gh` keeps a `_RESOLVE_CACHE`
keyed on the override env values, and mirroring it here would cut the repeat
cost — but that key does not cover `KIROCREW_PROVIDER_BIN_STRICT`, `PATH`, or
`PROVIDER_EXECUTABLE_CANDIDATES`, all three of which change what resolution
returns. A cache is a performance optimization with a real staleness surface; it
is not what keeps the loop alive, so it does not belong in a fix for a crash
loop.

**Sibling call sites are untouched.** The same shape exists elsewhere — at
minimum `apps/builtins/dev_fleet/server.py:1102` (`_trusted_bin`, structurally
identical), `apps/routes.py:1085` (an unbounded `shutil.rmtree` directly inside
an `async def` uninstall handler), and `knowledge/watcher.py:302` (an `os.stat`
in a periodic scan whose seven sibling I/O calls all go through `to_thread`).
Those deserve their own change rather than being folded into an incident fix.

## Tests

`test_run_json_resolves_the_provider_cli_off_the_event_loop` asserts the
resolver ran on a thread whose id differs from the loop thread's. It compares
thread identity rather than elapsed time, so it cannot flake on a loaded host.
Verified load-bearing: reverting the production line to the synchronous call
makes it fail, restoring the line makes it pass.

This is the first test in the repo that asserts a handler does not block the
event loop. `test/test_loop_watchdog.py`'s 13 tests all cover the watchdog's own
decision logic — whether it dumps, debounces, and re-arms — never whether any
handler is off-loop.

One existing test needed a correction. `fake_to_thread` in
`test_run_json_awaits_critical_audit_off_loop_before_spawn` replaced
`asyncio.to_thread` wholesale, assuming the audit write was the only offload on
this path, and discarded the wrapped function's return value. It now dispatches
on the function it received and returns the real result, so it tests the audit
ordering it names instead of pinning "the audit is the only thing offloaded
here".

## Review-gap note

`AUTOSDE.yaml` already carries a `blocking: true` rule named
`no-blocking-call-on-event-loop`, added by #82 five days before #84 introduced
this call. Its text covers both this defect's shapes — "large synchronous file
IO or filesystem walks" and "a sync helper called transitively from an async
handler" — and it predicts the watchdog-plus-supervisor crash loop.

The rule has no deterministic counterpart. The backend grep pre-gate in
`code-review.yml` checks four unrelated things and its comment routes this class
of rule to the semantic AI layer, and the repo pins bare `flake8` with no
`flake8-async` / `ASYNC` rule set. So the rule was enforceable only by LLM
judgment, and on #84 that judgment read it as "does this use blocking
`subprocess.run`?", answered no, and passed — in the same review that described
the parent-directory stat walk as a security property.

Making the rule mechanical (the `flake8-async` ASYNC22x family, or promoting
`history.py`'s `OnLoopPersistError` discipline into a general off-loop
assertion) is the durable follow-up. It is out of scope here.

## Verification

- `pytest test/test_source_providers.py` — 438 passed, 2 skipped
- full backend suite — 55,659 passed, 259 skipped, 6 xfailed. Seven failures
  remain, all in `test_artifact_source.py` / `test_artifacts_handlers.py`, and
  all pre-existing on this host: stashing this diff and re-running the same
  files reproduces the identical seven. They assert paths are outside `$HOME`,
  which misreads a host where the real home path and `$HOME` differ by a symlink.
- `isort --check-only src/kiro_crew test` — clean
- `flake8 src/kiro_crew test` — clean
- `mypy src/kiro_crew/` (1.14.1, no faiss, matching CI) — no issues in 982 files
- no frontend files in the diff, so `tsc`/`vitest` are unaffected
