### PR TITLE
fix(sandbox): stop a busy /tmp and a stray thread disabling the sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,13 @@ Two traps are worth naming here because neither is visible when reading the test
   directory the first caller resolved and re-creates it after a test's own teardown
   deleted it, so the fix is a session-scoped directory owned by no test, never tidier
   cleanup.
+- **A stub is not a stop: SPY on a `shutdown`/`close`/`stop` and delegate.** A stub that
+  only records leaves the thing running for the whole worker. Replacing the metrics
+  provider's `shutdown` left an OpenTelemetry exporter thread alive, and because that SDK
+  reinstalls it in every fork child via `os.register_at_fork`, the sandbox probe's child
+  became multithreaded — `unshare(CLONE_NEWUSER)` implies `CLONE_THREAD` and fails EINVAL
+  there, which was cached as "this host has no sandbox backend" and failed every later
+  sandboxed spawn closed. 19 red tests, none of them a metrics test.
 
 ## Code style
 

--- a/conftest.py
+++ b/conftest.py
@@ -70,6 +70,7 @@ and tolerate an ImportError so a partial checkout cannot break collection.
 from __future__ import annotations
 
 import asyncio.base_events
+import contextlib
 import getpass
 import importlib
 import os
@@ -78,6 +79,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import warnings
 
 import pytest
@@ -500,6 +502,168 @@ def pytest_runtest_teardown(item, nextitem):
     try:
         os.chdir(_SESSION_CWD)
     except OSError:  # pragma: no cover - the starting directory would have to be gone
+        pass
+
+
+# ── no test may leave a telemetry exporter running ────────────────────
+
+#: Thread-name marker for OpenTelemetry's periodic metric exporter. Matched on the
+#: name because the SDK is an optional import: naming the class would make this
+#: guard depend on it being installed.
+_OTEL_THREAD_MARKER = "Otel"
+
+
+def _live_exporter_threads() -> set:
+    """The exporter threads alive right now, as OBJECTS.
+
+    Objects, not names: the SDK gives every ``PeriodicExportingMetricReader`` ticker
+    the same name, so a name-keyed set makes a second leak indistinguishable from the
+    first one still running.
+    """
+    return {
+        t for t in threading.enumerate() if _OTEL_THREAD_MARKER in t.name and t.is_alive()
+    }
+
+
+def _stop_leaked_exporter(thread) -> None:
+    """Best-effort: stop *thread* through the reader that owns it.
+
+    The reader is unreachable from ``metrics.provider`` by this point -- a stubbed
+    ``shutdown`` is exactly what orphans it -- but the thread's target is the
+    reader's own bound method, so the thread still knows its owner. Reaching through
+    ``__self__`` is the only handle left, and stopping the thread is what keeps one
+    leak from reddening everything that follows it on this worker.
+
+    A thread we cannot reach is WARNED about rather than passed over: it means the
+    guard reported the leak and then left it running, which is the state that
+    corrupts every later fork child on the worker, so it must not be silent.
+    """
+    owner = getattr(getattr(thread, "_target", None), "__self__", None)
+    if owner is None:
+        warnings.warn(
+            f"telemetry exporter thread {thread.name!r} cannot be stopped: its target "
+            "exposes no owning reader, so it will keep running for the rest of this "
+            "worker and every later fork child will be multithreaded",
+            stacklevel=2,
+        )
+        return
+    try:
+        owner.shutdown(timeout_millis=1)
+    except Exception as exc:  # pragma: no cover - SDK-shape dependent
+        warnings.warn(
+            f"could not stop telemetry exporter thread {thread.name!r}: {exc!r}",
+            stacklevel=2,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_telemetry_exporter():
+    """Fail the test that leaves an OTel exporter thread alive, then clean up.
+
+    A leaked ``PeriodicExportingMetricReader`` is not just an idle thread. The SDK
+    registers an ``os.register_at_fork(after_in_child=...)`` hook that RESTARTS that
+    thread in every fork child, so from then on the sandbox's userns probe forks a
+    child that is multithreaded -- and ``unshare(CLONE_NEWUSER)`` implies
+    ``CLONE_THREAD``, which the kernel refuses with EINVAL unless the caller is
+    single-threaded. EINVAL is classified permanent, so the worker caches "this host
+    has no sandbox backend" and every later sandboxed spawn fails closed. Measured:
+    one leak reddened 19 tests across two app suites, all of which pass alone, and
+    none of which is a metrics test.
+
+    The thread also keeps its own reader alive (its target is a bound method), so no
+    amount of dropping references clears it; only a real ``shutdown()`` does. That is
+    why a test that observes the shutdown call must SPY on it and delegate, never
+    replace it.
+
+    Attributed by DIFFERENCE, not by observation: a thread alive at setup was left by
+    an earlier test, so only threads that appeared during this one are reported. That
+    is what makes the message name the culprit. The first version reported whatever
+    test was running when a leak was first seen, which on a Windows shard blamed three
+    tests in ``test_perf_boot_path.py`` that run every line of their subject in a
+    SUBPROCESS and cannot leak a thread into the worker at all.
+
+    Cleaning up after failing is deliberate: the leak damages every LATER test, so
+    letting it stand would turn one defect into a red suite -- and with cleanup, the
+    difference cannot double-report either.
+    """
+    before = _live_exporter_threads()
+    yield
+    leaked = _live_exporter_threads() - before
+    if not leaked:
+        return
+    provider = sys.modules.get("kiro_crew.metrics.provider")
+    if provider is not None:
+        with contextlib.suppress(Exception):
+            provider.reset_for_testing()
+    for thread in leaked:
+        _stop_leaked_exporter(thread)
+    raise AssertionError(
+        "this test STARTED a telemetry exporter thread and left it running: "
+        f"{sorted(t.name for t in leaked)}. A metrics provider must be shut down for "
+        "real (reset_for_testing()), and a test that stubs `shutdown` must delegate "
+        "to it -- see "
+        "conftest._no_leaked_telemetry_exporter."
+    )
+
+
+# ── the sandbox probe cache is warm for every test, in every testpath ──
+
+
+#: The verdict this worker's ONE real probe produced, so a later test that finds the
+#: cache cold can be handed the same answer instead of paying another probe. ``None``
+#: means "not established" -- either the probe has not run yet, or it came back
+#: transient and left nothing to cache.
+_probe_verdict: str | None = None
+_probe_attempted = False
+
+
+def pytest_runtest_setup(item):
+    """Keep ``sandbox._backend`` warm for every test, at one probe per worker.
+
+    ``detect_backend()`` reached from a running event loop with a COLD cache
+    deliberately refuses to probe -- the probe forks and waits, which must never
+    happen on the loop -- and returns "none" with a self-described transient reason.
+    Production fills the cache at gateway boot so that path is not reachable; a
+    pytest worker has no boot, so the first async test to spawn through
+    ``wrap_argv`` gets a hard ``SandboxUnavailableError`` reading "this host has no
+    OS sandbox backend" on a host whose sandbox works perfectly.
+
+    This lived in ``test/conftest.py``, which the in-package app suites never load,
+    so the ~1490 tests under ``src/kiro_crew/apps/builtins/*/tests/`` had no warm
+    cache at all -- 19 of them failed that way in a full run while every one passed
+    when its own file was run alone. Whether an app test file happened to land on an
+    xdist worker that had already run something under ``test/`` decided the verdict.
+
+    Acting at SETUP rather than once per session is what makes it order-independent:
+    the six ``test_sandbox_*.py`` files reset the cache in their own teardown
+    (correctly -- they test the cache), and a session-scoped prewarm cannot undo that
+    for whatever runs next on the worker.
+
+    **RESTORING the first verdict, not re-probing.** A probe is not cheap on every
+    host and its cost is not portable: it forks and then closes every inherited
+    descriptor, which is O(``RLIMIT_NOFILE``) -- measured 1ms at a 1024 limit, 102ms
+    at 524288 -- and on macOS it spawns a real ``sandbox-exec``. Re-probing per reset
+    took ``test_sandbox_argv.py`` from 3.7s to 18.6s across its 145 tests. The answer
+    cannot change within a process, so the second and later tests get the recorded
+    one by assignment.
+
+    Probing at most ONCE also bounds the transient case, which is the one that would
+    otherwise be unbounded: a transient verdict is deliberately never cached, so
+    "probe whenever cold" on a fork-starved host means two forks and a 50ms sleep for
+    every test in the run. A probe failure is swallowed either way -- a host genuinely
+    without a sandbox must still run the tests that do not need one.
+    """
+    global _probe_verdict, _probe_attempted
+    try:
+        from kiro_crew import sandbox
+
+        if not _probe_attempted:
+            _probe_attempted = True
+            sandbox.detect_backend()
+            _probe_verdict = sandbox._backend
+        elif sandbox._backend is None and _probe_verdict is not None:
+            sandbox._backend = _probe_verdict
+    except Exception:  # pragma: no cover - never let the warm-up fail a test
         pass
 
 
@@ -974,6 +1138,15 @@ def _isolate_kirocrew_home(_isolation_dirs, monkeypatch):
     ``KIROCREW_DEV_MODE`` / ``KIROCREW_STRICT_ON_LOOP_PERSIST`` are cleared so a
     developer who exports them does not flip the off-loop-IO guards strict for the
     whole suite.
+
+    ``KIRO_HOME`` is deliberately NOT pinned here, even though the lazy
+    ``config.paths.kiro_home()`` does name the operator's real machine-wide kiro-cli
+    home. The env var takes precedence over ``Path.home()`` by design, and ~35 tests
+    isolate that resolver the other way round -- ``patch("pathlib.Path.home",
+    return_value=tmp_path)`` -- so pinning the variable overrides their own isolation
+    and they read an empty directory instead of the tree they just built. A test that
+    reaches ``kiro_home()`` therefore isolates it itself, with whichever of the two
+    levers it already uses.
     """
     monkeypatch.setenv("KIROCREW_HOME", str(_isolation_dirs("kirocrew-home")))
     monkeypatch.delenv("KIROCREW_PROJECT_DIR", raising=False)

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -126,13 +126,30 @@ It also pins the other real host paths a test must not reach: the subagent regis
 running gateway sweeps stray entries there as orphans), the 610MB embedding-model
 download, and the agent-state sidecar.
 
+Two members are there for a different reason — a **process-global** that any testpath
+can poison for every test after it, which is the same failure shape as host mutation
+one scope down:
+
+* `pytest_runtest_setup` warms `sandbox._backend` when it is cold. A cold cache reached
+  from a running event loop deliberately refuses to probe (the probe forks and waits)
+  and answers "none", so the first async test to spawn through `wrap_argv` gets a hard
+  refusal on a host whose sandbox works. Warming at setup rather than once per session
+  is what makes it order-independent: the six `test_sandbox_*.py` files legitimately
+  reset that cache in their own teardown.
+* `_no_leaked_telemetry_exporter` fails the test that leaves an OTel exporter thread
+  running. See the Rules entry — that thread makes the sandbox probe's fork child
+  multithreaded, which the kernel answers with an EINVAL the probe used to cache as
+  "this host has no sandbox backend".
+
 `test/conftest.py` holds the rest: suite-specific isolation (Slack thread state, the
 model-window cache, the platform context, …), the Windows collect-ignore list, and the
 xdist worker budget.
 
 When you add isolation, put it in the rootdir conftest **only** if a test in any
-testpath could damage the host without it. Otherwise it belongs in `test/conftest.py`,
-where it costs the in-package suites nothing.
+testpath could damage the host — or poison a process global for every later test —
+without it. Otherwise it belongs in `test/conftest.py`, where it costs the in-package
+suites nothing. Both of the entries above started life in `test/conftest.py` and were
+silently absent from the ~1490 in-package tests, which is how each was found.
 
 ## Rules
 
@@ -163,10 +180,28 @@ where it costs the in-package suites nothing.
      `test/test_host_isolation_floor.py::TestTheSharedKiroPathRatchet` fails when
      `src/kiro_crew` grows a module-level `Path.home()` binding that is neither in the
      table nor explicitly excluded with a reason. The guarantee is exactly that:
-     **import-time bindings**. A LAZY resolver (`config.paths.kiro_home()` and its
-     callers) still names the operator's real `~/.kiro` — the floor pins neither
-     `Path.home()` nor `$HOME` — so a test that reaches one of those must isolate it
-     itself.
+     **import-time bindings**.
+
+     The LAZY half is **yours to isolate**, and the floor deliberately does not do it
+     for you. `config.paths.kiro_home()` resolves on every call, so `kiro_agents_dir()`
+     and `kiro_sessions_dir()` name the operator's real, machine-wide kiro-cli home.
+     There are two levers and they are not interchangeable: `KIRO_HOME` (the documented
+     production override, which also moves kiro-cli's session storage) outranks
+     `Path.home()`, so pinning it at the floor would defeat the ~35 tests that isolate
+     this resolver with `patch("pathlib.Path.home", return_value=tmp_path)` — they would
+     read an empty directory instead of the tree they had just built. Use whichever the
+     code path under test actually needs, per test.
+
+     Getting this wrong is not loud. `test_kas_spawn.py` projected the developer's
+     *installed* agent specs, so its verdict depended on which agents were present and
+     whether their `file://` prompt files still resolved; it failed with an
+     `AcpRuntimeError` naming a prompt file in an unrelated worktree. It is a write path
+     too — `ensure_agent_materialized` targets that directory, and only its
+     ephemeral-instance refusal ("This instance will use the existing specs instead")
+     keeps tests out of the operator's live `~/.kiro/agents/`.
+
+     The floor pins neither `Path.home()` nor `$HOME` either, so a path built from
+     either without going through a resolver is also yours.
 
      Two exclusions are excluded for **opposite** reasons, and the distinction
      matters: the launchd paths are excluded because another fixture already
@@ -206,6 +241,43 @@ where it costs the in-package suites nothing.
   no individual test (`_isolate_sel_default_dir`, in the rootdir conftest). When you
   add a subsystem with a background worker, ask which directory its thread captured
   and whether anything deletes that directory underneath it.
+
+- **When you stub a lifecycle method, SPY and delegate — never replace.** A stub that
+  only records the call leaves whatever that method was supposed to stop still running.
+  The worked example cost 19 failures in files that contain no metrics code at all:
+  three tests in `test/metrics/test_provider.py` needed to observe *that* the provider's
+  `shutdown` was called and on which thread, so they replaced it with a recorder. The
+  real `shutdown` is what stops OpenTelemetry's `PeriodicExportingMetricReader`, so its
+  exporter thread stayed alive for the life of the xdist worker — and it cannot be
+  cleaned up by dropping references, because the thread's target is a bound method of
+  the reader it keeps alive.
+
+  What that one thread then broke is the part worth remembering, because nothing about
+  it is local: the OTel SDK registers an `os.register_at_fork(after_in_child=…)` hook
+  that **restarts** the exporter thread in every fork child. The sandbox's userns probe
+  forks, and `unshare(CLONE_NEWUSER)` implies `CLONE_THREAD`, which the kernel refuses
+  with **EINVAL unless the caller is single-threaded**. EINVAL is indistinguishable from
+  a kernel built without `CONFIG_USER_NS`, which is permanent, so the worker cached
+  "this host has no sandbox backend" and every later sandboxed spawn on it failed
+  closed. Diagnosis went: 19 `SandboxUnavailableError`s in two app suites → each file
+  passes alone → the probe child had 2 threads, every time.
+
+  Two guards came out of it. The rootdir conftest fails the test that leaves an
+  exporter thread running (`_no_leaked_telemetry_exporter`, reported once per worker so
+  one defect cannot red the shard), and the probe reports a multithreaded child as its
+  own transient condition instead of letting an ambiguous EINVAL be cached as a verdict
+  about the host. Neither replaces the rule: **anything you start, something must
+  stop — and a stub is not a stop.**
+
+- **A handler that answers before its work finishes must be awaited, not slept on.**
+  `api_chat_slot_slack_link` returns 200 as soon as the link is persisted and hands the
+  Slack backfill to `asyncio.create_task`, tracked in `state._background_tasks`. Six
+  tests asserted on what that task did without awaiting it, which passes or fails purely
+  on how the loop was scheduled: on a loaded CI shard it surfaced as
+  `'NoneType' object has no attribute 'args'` on a **different test each run** (#4130),
+  which reads as a flaky suite rather than as a missing `await`. Use
+  `chat_test_helpers.drain_background_tasks(state)`, which awaits to a fixed point and
+  re-raises; exiting the `TestClient` block is not a synchronisation point.
 - Tests MUST NOT reconfigure or restart a real host service. This is enforced,
   not just asked for: the **rootdir** `conftest.py` (distinct from
   `test/conftest.py`, which only applies to `test/` — `testpaths` also collects
@@ -403,6 +475,16 @@ Fix: seed it. `random.Random(_SEED).randbytes(n)` keeps the payload high-entropy
 which is usually the property under test, while fixing the outcome. Verify the chosen
 seed against the real predicate, and say in a comment that you did.
 
+**The host is an input too, and a PID is the one that catches people.** `999999` is
+not an impossible PID: Linux `pid_max` is 4194304, so on a long-running host it names
+an ordinary live process. Two tests asserted its absence — one as "a dead gateway
+whose entry must be pruned", one as "a value only a planted `ps` shim could have
+produced" — and both went red on a host whose counter had passed it, the second while
+accusing the shim of running when it had not. Fix by kind: for a PID the code *probes*,
+pin the probe (`patch(..., "pid_exists", side_effect=lambda p: p != 999999)`); for a
+PID that must never appear in real output, use a number no OS can allocate
+(`99999999999`) rather than one that merely looks unused.
+
 ```python
 # WRONG: ~1% of runs match a credential prefix and the exemption assert fails
 body = os.urandom(20_000)
@@ -431,6 +513,11 @@ while not observed():
 
 Where a test wants a timeout to *expire*, set it to `0` rather than a small value: the
 same branch is reached with no clock dependency at all.
+
+The commonest shape here is not a rate but **an unawaited task**: a handler that
+answers before its work finishes leaves the assertion racing the loop. There is a
+synchronisation point, so use it — `drain_background_tasks(state)` — and see the Rules
+entry for what it looks like when you do not (a different test failing each run).
 
 ### 3. Leaked async objects
 

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
@@ -80,8 +80,12 @@ Two shapes escape the env var:
   shared with the real installed agent — `~/.kiro/settings/mcp.json` is the live
   agent's MCP server list. `_isolate_shared_kiro_paths` redirects these from a table,
   and `test/test_host_isolation_floor.py` **fails when `src/` grows a new one**. That
-  ratchet covers IMPORT-TIME bindings only: a lazy resolver such as
-  `config.paths.kiro_home()` still names the real `~/.kiro`, so isolate that yourself.
+  ratchet covers IMPORT-TIME bindings only. The lazy resolver
+  `config.paths.kiro_home()` — and so `kiro_agents_dir()` / `kiro_sessions_dir()` — is
+  yours to isolate, with `KIRO_HOME` or by patching `Path.home()`; they are not
+  interchangeable, because the env var outranks the other. A test that skipped this
+  projected the developer's *installed* agent specs and failed with an
+  `AcpRuntimeError` naming a prompt file in an unrelated worktree.
 
   Two entries are excluded because they must *never* be redirected —
   `security._EXTRACT_INTO_TRUST_ROOT_RE` and `kiro_usage_api._CLI_SQLITE_DBS` are
@@ -125,6 +129,24 @@ The fix was not better cleanup. It was giving the singleton a **session-scoped**
 directory belonging to no individual test. When you touch a subsystem with a background
 worker, ask: *which directory did its thread capture, and does anything delete that
 directory underneath it?*
+
+**The same shape, one level up: a stub that replaces a `shutdown`/`close`/`stop` is
+not a stop.** Three tests needed to observe *that* the metrics provider's `shutdown`
+was called, so they replaced it with a recorder — and the real `shutdown` is what stops
+OpenTelemetry's exporter thread. That thread then survived for the life of the worker,
+and because the OTel SDK reinstalls it in every fork child via `os.register_at_fork`,
+the sandbox's userns probe forked a MULTITHREADED child. `unshare(CLONE_NEWUSER)`
+implies `CLONE_THREAD`, which the kernel refuses with EINVAL unless the caller is
+single-threaded, and EINVAL is indistinguishable from "no `CONFIG_USER_NS`" — so the
+worker cached "this host has no sandbox backend" and every later sandboxed spawn failed
+closed. 19 red tests in two app suites, each passing alone, none of them a metrics test.
+**Spy and delegate; never replace a lifecycle method.** The rootdir conftest now fails
+the test that leaves an exporter thread running.
+
+Two general lessons worth carrying out of that one: a thread whose target is a bound
+method keeps its own object alive, so dropping references never collects it; and
+anything registered with `os.register_at_fork` runs inside `os.fork()`, before it
+returns, so a fork child is not reliably single-threaded.
 
 Related traps in the same family:
 
@@ -189,6 +211,13 @@ package re-export when the caller reads its own defining module, or patching
 Either way the real function runs, the assertion passes for the wrong reason, and the
 test pays real time. **Treat an unexpectedly slow "mocked" test as evidence the mock
 missed.**
+
+A seventh: **the host is an input, and a "surely-unused" number is not a constant.**
+`999999` reads as an impossible PID and is not — `pid_max` is 4194304, so on a
+long-running host it names a live process. That broke two tests in opposite ways: one
+stopped pruning an entry whose owner "must be dead", and one accused a planted `ps` shim
+of executing when it had not. If the code *probes* the PID, pin the probe; if the number
+must never appear in real output, pick one no OS can allocate (`99999999999`).
 
 ## Rule 3 — Cross-platform: macOS, Linux (x86_64 + arm64), Windows
 

--- a/src/kiro_crew/dashboard/handlers/worktree.py
+++ b/src/kiro_crew/dashboard/handlers/worktree.py
@@ -144,6 +144,13 @@ _SANDBOX_REFUSAL = (
 # established" from a genuine git error.
 _SANDBOX_LAUNCHER_PREFIX = "sandbox: "
 
+# The launcher prints this prefix for an ADVISORY it emits while still going on to
+# exec the child, so it must never be read as a refusal. Only one exists today: the
+# pre-exec hardlink scan degrades OPEN when it exhausts its per-root file budget,
+# because /tmp on a busy host exceeds any fixed budget from ordinary churn and
+# failing closed there would break every sandboxed spawn on such a host.
+_SANDBOX_LAUNCHER_WARNING_PREFIX = "sandbox: WARNING"
+
 # STRICT, not the "standard" default. `_checkout_filter` runs `git config
 # --includes`, and `include.path` is repo-controlled: a hostile checkout can point
 # it at `~/.aws/credentials` (or `~/.netrc`, `~/.git-credentials`) and have git
@@ -236,9 +243,35 @@ def _run_git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
     # runs, so without this the non-zero exit is misread downstream as "not a git
     # repository" or "cannot list worktrees". Surface it as the same refusal a
     # missing backend gets, so the user is told the truth.
-    if proc.returncode != 0 and (proc.stderr or "").startswith(_SANDBOX_LAUNCHER_PREFIX):
-        raise SandboxUnavailable((proc.stderr or "").strip())
+    launcher_failure = _launcher_failure_line(proc.stderr or "")
+    if proc.returncode != 0 and launcher_failure:
+        raise SandboxUnavailable(launcher_failure)
     return proc
+
+
+def _launcher_failure_line(stderr: str) -> str:
+    """The sandbox launcher's FATAL line in *stderr*, or ``""`` when it did not fail.
+
+    Line-wise and WARNING-aware, and both properties are load-bearing.
+
+    The launcher degrades OPEN on a truncated pre-exec hardlink scan and prints
+    ``sandbox: WARNING — …`` before exec'ing the child anyway. Reading the whole
+    stderr with ``startswith`` classified that advisory as a refusal, so on any host
+    with more than the scan budget of files under /tmp — ordinary telemetry and cache
+    churn reaches it — every git command that legitimately exits non-zero was
+    reported as "this host has no OS sandbox backend". ``rev-parse --verify --quiet``
+    on a branch that does not exist is exactly that shape, which made a plain
+    "does this branch exist" probe answer "your host cannot sandbox git".
+
+    Scanning per line rather than only the head also catches the opposite order: a
+    real fatal line that an advisory happens to precede.
+    """
+    for line in stderr.splitlines():
+        if line.startswith(_SANDBOX_LAUNCHER_PREFIX) and not line.startswith(
+            _SANDBOX_LAUNCHER_WARNING_PREFIX
+        ):
+            return line.strip()
+    return ""
 
 
 def _dir_slug(branch: str) -> str:

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -238,6 +238,12 @@ _WARM_JOIN_TIMEOUT_SECS = 2.0
 # reported transient forever — still gets told which sysctl to raise.
 _PROBE_STEP_NEWUSER = "unshare(CLONE_NEWUSER)"
 _PROBE_STEP_NEWNS = "unshare(CLONE_NEWNS)"
+#: Wire step the probe child sends INSTEAD of "U" when its ``CLONE_NEWUSER`` EINVAL
+#: is explained by the child having been multithreaded, carrying the thread count.
+#: The parent classifies it exactly as it classifies a plain EINVAL -- the step
+#: exists to carry the explanation, not to change the verdict. See
+#: ``_probe_child_thread_count``.
+_PROBE_STEP_MULTITHREADED = "M"
 
 # A probe child that vanished mid-handshake is a harness failure, not a kernel
 # verdict, so it must not be cached as "this host has no sandbox". Kept separate
@@ -518,6 +524,40 @@ def _probe_child_unshare(libc: ctypes.CDLL, flags: int) -> int:
     return ctypes.get_errno() or errno.EPERM
 
 
+def _probe_child_thread_count() -> int:
+    """Live threads in the probe child, or 0 when it cannot be determined.
+
+    ``unshare(CLONE_NEWUSER)`` implies ``CLONE_THREAD``, which the kernel refuses
+    with **EINVAL** unless the caller's thread group holds exactly one task. A
+    ``fork()`` child is single-threaded by construction, so this normally reads 1 --
+    but ``os.register_at_fork`` handlers run INSIDE ``os.fork()``, before it
+    returns, and a library can start a thread there. OpenTelemetry's metric SDK does
+    exactly that: its ``PeriodicExportingMetricReader`` registers an
+    ``after_in_child`` hook that restarts its exporter thread in every child.
+
+    Used ONLY to explain an EINVAL, never to reclassify one. EINVAL is genuinely
+    ambiguous here -- a kernel built without ``CONFIG_USER_NS`` returns it too, and a
+    multithreaded child cannot tell the two apart, because it never gets far enough to
+    ask. Calling it transient would be just as wrong as calling it permanent, and it
+    would additionally withhold the ``no_backend`` opt-in (``sandbox_allow_unsandboxed_exec``)
+    from a host that really has no user namespaces. So the classification stays exactly
+    as it was and the REASON names the thread, which is the part a reader cannot infer:
+    a bare "errno 22 (EINVAL)" sends them to check their kernel config, which is the
+    wrong place. Making such a process probe successfully needs a single-threaded
+    child, i.e. a different spawn mechanism, and that is its own change.
+
+    ``st_nlink`` of ``/proc/self/task`` is ``2 + threads`` (each thread is a
+    subdirectory), so this is one ``stat`` and no list: the probe child of a threaded
+    process must not allocate, because another thread may have owned the allocator lock
+    at fork time and no longer exists to release it. Linux-only, like the rest of the
+    probe.
+    """
+    try:
+        return max(0, os.stat("/proc/self/task").st_nlink - 2)
+    except OSError:
+        return 0
+
+
 def _probe_write_identity_maps(pid: int, uid: int, gid: int) -> tuple[str, int] | None:
     """Write the probe child's identity maps, exactly as the launcher's parent does.
 
@@ -649,7 +689,14 @@ def _probe_child_sequence(
         # dashboard listen socket) open and pin the home. Only the handshake
         # ends and the standard streams survive. (#3150)
         _close_fd_ranges(sweep_ranges)
+        # Read BEFORE the unshare: it is the only moment the count is the one the
+        # kernel judged. Reported only alongside an EINVAL, and only to explain it --
+        # see _probe_child_thread_count for why it must not change the verdict.
+        threads = _probe_child_thread_count()
         err = _probe_child_unshare(libc, _CLONE_NEWUSER)
+        if err == errno.EINVAL and threads > 1:
+            os.write(c2p_w, b"M:%d\n" % threads)
+            os._exit(0)
         os.write(c2p_w, b"U:%d\n" % err)
         if err:
             os._exit(0)
@@ -672,6 +719,20 @@ def _probe_parent_sequence(
         death = _probe_child_death(pid)
         return (False, True, f"probe child {death}; no {_PROBE_STEP_NEWUSER} result", "")
     step, err = report
+    if step == _PROBE_STEP_MULTITHREADED:
+        # Same classification and same remedy as a plain EINVAL -- deliberately, see
+        # _probe_child_thread_count. Only the reason gains the thread count, because
+        # that is the one part a reader cannot infer from the errno.
+        ok, transient, reason, remedy = _probe_failure(_PROBE_STEP_NEWUSER, errno.EINVAL)
+        return (
+            ok,
+            transient,
+            f"{reason}; the probe child had {err} threads, which alone makes it "
+            "return EINVAL (CLONE_NEWUSER implies CLONE_THREAD) -- an "
+            "os.register_at_fork hook started one, so the kernel's own verdict is "
+            "unobtainable from this child",
+            remedy,
+        )
     if step != "U":
         return (False, True, f"probe child sent unexpected step {step!r}", "")
     if err:
@@ -1230,6 +1291,7 @@ sys.path[:] = [p for p in sys.path if p not in ("", sys.path[0])]
 import ctypes
 import ctypes.util
 import os
+import stat
 import tempfile
 
 _CLONE_NEWUSER = 0x10000000
@@ -1600,6 +1662,17 @@ def main():
         # a stderr warning rather than failing closed: /tmp on a busy host can
         # exceed any fixed budget from ordinary telemetry/cache churn, and
         # exiting here would break every sandbox spawn on such hosts.
+        #
+        # REGULAR FILES ONLY, and that guard is what keeps the walk rare. Linux
+        # does not allow a hardlink to a directory, so nlink > 1 says nothing
+        # about a directory — and every directory has nlink >= 2 for `.` and
+        # `..`. `SENSITIVE_FILES` deliberately carries every hidden path of BOTH
+        # kinds (the hiding loops classify per entry, see `_build_launcher_script`),
+        # so without this check two ordinary directories — `~/.kiro/crew-auth-staging`
+        # and `~/.gnupg` on the measuring host — seeded the match set on every
+        # spawn. The 100k-entry walk of $CWD and /tmp then ran every time, costing
+        # 1.5s per sandboxed spawn and emitting the truncation warning constantly,
+        # while no credential had an alias at all.
         _protected_inodes = set()
         for _pd in SENSITIVE_DIRS:
             if os.path.isdir(_pd):
@@ -1607,7 +1680,7 @@ def main():
                     for _fname in _files_scan:
                         try:
                             _st = os.stat(os.path.join(_root, _fname))
-                            if _st.st_nlink > 1:
+                            if stat.S_ISREG(_st.st_mode) and _st.st_nlink > 1:
                                 _protected_inodes.add((_st.st_dev, _st.st_ino))
                         except OSError:
                             pass
@@ -1615,7 +1688,7 @@ def main():
         for _pf in SENSITIVE_FILES:
             try:
                 _st = os.stat(_pf)
-                if _st.st_nlink > 1:
+                if stat.S_ISREG(_st.st_mode) and _st.st_nlink > 1:
                     _protected_inodes.add((_st.st_dev, _st.st_ino))
             except OSError:
                 pass

--- a/test/chat_test_helpers.py
+++ b/test/chat_test_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from unittest.mock import AsyncMock, MagicMock
 
@@ -10,6 +11,13 @@ from aiohttp import web
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.history import ConversationLog
 from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
+
+#: Draining is a LOOP because a drained task may register another -- not because any
+#: current one does (``chat_slack`` has a single ``create_task``, and the backfill
+#: posts sequentially). Bounded rather than `while` so a task that re-arms itself
+#: forever fails the test instead of hanging until the 120s pytest timeout, whose
+#: report names the timeout and not the task.
+_DRAIN_ROUNDS = 20
 
 
 def move_transcript_past(log: ConversationLog, key: str, sig: float) -> None:
@@ -25,6 +33,46 @@ def move_transcript_past(log: ConversationLog, key: str, sig: float) -> None:
     """
     path = log._path(key)
     os.utime(path, (sig + 1, sig + 1))
+
+
+async def drain_background_tasks(state) -> None:
+    """Await every task *state* spawned, so an assertion cannot race one.
+
+    Handlers that must answer the request before their work finishes hand it to
+    ``asyncio.create_task`` and register it in ``state._background_tasks`` — the
+    Slack link-time backfill (``_spawn_slack_backfill``) is the one this exists for.
+    The response arriving therefore proves only that the task was CREATED, so reading
+    the Slack mock straight afterwards races it: it usually wins on an idle machine and
+    loses under load. That flake surfaces as a plain count mismatch (``assert 0 == 2``)
+    or as ``'NoneType' object has no attribute 'args'``, on a DIFFERENT test in the
+    class each run, and names neither the task nor the race (#4130).
+
+    Awaiting the not-yet-done members is an exact wait on the real completion
+    condition rather than a sleep. An empty set means the task already finished; a
+    done-callback discards each task, so the set is snapshotted before awaiting.
+
+    Never a ``sleep``: a sleep long enough to be reliable on the slowest runner is
+    paid by every run, and it is still only a guess.
+
+    Exceptions are re-raised, so a task that died silently fails its own test
+    instead of surfacing later as an unretrieved-exception warning.
+
+    Scope: this awaits EVERY task in ``state._background_tasks``, which several other
+    handlers also register (``handlers/sessions.py``, ``taskrunner.py``,
+    ``handlers/mcp.py``). That is right for a state a test built and will discard, and
+    wrong for one carrying a long-lived task -- a subscription or a poller would never
+    complete and the wait would run to the pytest timeout. Drain a specific task
+    directly in that case.
+    """
+    for _ in range(_DRAIN_ROUNDS):
+        pending = [t for t in list(getattr(state, "_background_tasks", ())) if not t.done()]
+        if not pending:
+            return
+        await asyncio.gather(*pending)
+    raise AssertionError(
+        f"background tasks still pending after {_DRAIN_ROUNDS} drain rounds: "
+        f"{sorted(t.get_name() for t in state._background_tasks if not t.done())}"
+    )
 
 
 class _ReadyKiroPrerequisiteService(KiroPrerequisiteService):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -213,24 +213,11 @@ def pytest_configure(config: pytest.Config) -> None:
 
     assert hasattr(tracemalloc, "get_object_traceback")
 
-    # ── Sandbox probe prewarm ───────────────────────────────────────────────
-    # Production processes (gateway, gatewayd) call prewarm_backend() at boot so
-    # the sandbox probe cache is populated off-loop before any on-loop handler
-    # runs.  pytest-xdist workers have no equivalent boot path, so whichever
-    # aiohttp-route test first exercises wrap_argv() on a cold worker hits the
-    # "never probe on event loop" guard and gets a transient failure.  Mirror the
-    # production prewarm here: one synchronous detect_backend() per worker
-    # process, populating the cache before any test runs.
-    #
-    # Tests that intentionally reset_backend() in their own fixtures
-    # (test_sandbox_backend_cache.py) are unaffected — they manage their own
-    # cache state.
-    try:
-        from kiro_crew.sandbox import detect_backend
-
-        detect_backend()
-    except Exception:
-        pass  # Probe failure must not break unrelated tests.
+    # The sandbox probe prewarm moved to the ROOTDIR conftest's
+    # ``pytest_runtest_setup``. A once-per-worker prewarm here reached neither the
+    # in-package app suites (which never load this file) nor any test that followed
+    # one of the ``test_sandbox_*.py`` files, both of which then hit the
+    # never-probe-on-the-loop guard and read it as "this host has no sandbox".
 
 
 _MAX_WORKERS_ENV = "KIROCREW_MAX_TEST_WORKERS"

--- a/test/metrics/test_provider.py
+++ b/test/metrics/test_provider.py
@@ -622,7 +622,22 @@ class TestConsentRecheck:
             live_provider = provider_mod._provider
             assert live_provider is not None
             flushed = threading.Event()
-            monkeypatch.setattr(live_provider, "shutdown", lambda *a, **k: flushed.set())
+
+            # SPY, never a replacement. A stub that only records leaves the
+            # provider's PeriodicExportingMetricReader ticker thread running for the
+            # life of the process, and OTel restarts that thread in every fork child
+            # via `os.register_at_fork` -- which makes the sandbox userns probe's
+            # child multithreaded, and `unshare(CLONE_NEWUSER)` then returns EINVAL
+            # (it implies CLONE_THREAD). That verdict is cached as "this host has no
+            # sandbox backend", so every later sandboxed spawn on the worker fails
+            # closed: 19 failures across two app suites, none of them here.
+            _real_shutdown = live_provider.shutdown
+
+            def _observed_shutdown(*a, **k):
+                flushed.set()
+                return _real_shutdown(*a, **k)
+
+            monkeypatch.setattr(live_provider, "shutdown", _observed_shutdown)
 
             done = _worker_event(monkeypatch)
             _patch_config(monkeypatch, enabled=False)
@@ -662,11 +677,17 @@ class TestConsentRecheck:
             released = threading.Event()
             flush_entered = threading.Event()
 
-            def _slow_shutdown(*_a, **_k):
+            _real_shutdown = live_provider.shutdown
+
+            def _slow_shutdown(*a, **k):
                 seen["thread"] = threading.get_ident()
                 flush_entered.set()
                 released.wait(timeout=10)  # stands in for the 30s join + final POST
                 seen["done"] = True
+                # Then do the real thing: the stand-in models the DELAY, and
+                # skipping the shutdown leaks the reader's ticker thread (see the
+                # sibling test above for what that thread goes on to break).
+                return _real_shutdown(*a, **k)
 
             monkeypatch.setattr(live_provider, "shutdown", _slow_shutdown)
             done = _worker_event(monkeypatch)
@@ -934,9 +955,12 @@ class TestConsentRecheck:
             in_flush = threading.Event()
             release = threading.Event()
 
-            def _slow_shutdown(*_a, **_k):
+            _real_shutdown = live_provider.shutdown
+
+            def _slow_shutdown(*a, **k):
                 in_flush.set()
                 release.wait(timeout=5)  # stands in for the reader join + final POST
+                return _real_shutdown(*a, **k)
 
             monkeypatch.setattr(live_provider, "shutdown", _slow_shutdown)
             worker = threading.Thread(target=provider_shutdown, daemon=True)

--- a/test/test_chat_slack.py
+++ b/test/test_chat_slack.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
-from chat_test_helpers import _make_state
+from chat_test_helpers import _make_state, drain_background_tasks
 
 
 def _make_slack_app(state):
@@ -65,6 +65,7 @@ class TestSlackLink:
         async with TestClient(TestServer(_make_slack_app(state))) as client:
             resp = await client.post("/api/chat/slots/s1/slack-link", json={})
             assert resp.status == 200
+            await drain_background_tasks(state)
             data = await resp.json()
             assert data["ok"] is True
             assert data["thread_ts"] == "ts123"
@@ -240,6 +241,7 @@ class TestSlackLinkUnlinkRoundTrip:
         async with TestClient(TestServer(_make_slack_app(state))) as client:
             link = await client.post("/api/chat/slots/s1/slack-link", json={})
             assert link.status == 200
+            await drain_background_tasks(state)
             link_data = await link.json()
             ts = link_data["thread_ts"]
             assert state.sessions.get_session_for_thread(ts) == "dashboard:s1"
@@ -357,6 +359,7 @@ class TestSlackLinkAnchorTitleFallback:
         async with TestClient(TestServer(_make_slack_app(state))) as client:
             resp = await client.post("/api/chat/slots/s1/slack-link", json={})
             assert resp.status == 200
+            await drain_background_tasks(state)
 
     def _anchor_text(self, state) -> str:
         return state.slack_client.post_message.await_args_list[0].args[1]

--- a/test/test_ci_surface_tests.py
+++ b/test/test_ci_surface_tests.py
@@ -237,6 +237,7 @@ def test_ignore_list_matches_the_names_conftest_previously_inlined() -> None:
         "test_harness.py",
         "test_sandbox_argv.py",
         "test_sandbox_cc_mode.py",
+        "test_sandbox_hardlink_scan.py",
         "test_sandbox_nested_tier.py",
         "test_pid_lifecycle.py",
         "test_pid_sweep_helpers.py",

--- a/test/test_kas_spawn.py
+++ b/test/test_kas_spawn.py
@@ -40,6 +40,7 @@ token callback by shelling out to kiro-cli). ``agent.acp_backend`` accepts ``kas
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -63,6 +64,7 @@ from kiro_crew.acp.types import (
     ACP_CLIENT_CAPABILITIES,
     KAS_CLIENT_CAPABILITIES,
 )
+from kiro_crew.config.paths import kiro_agents_dir
 
 
 class TestAssetResolution:
@@ -262,9 +264,38 @@ for line in sys.stdin:
 '''
 
 
+#: The one agent spec ``session/new`` projects onto KAS. Minimal on purpose: this
+#: file tests the SPAWN contract; the projection itself is covered elsewhere.
+_STUB_AGENT_SPEC = {
+    "name": "kirocrew",
+    "description": "spawn-contract stub",
+    "prompt": "You are a test agent.",
+    "tools": [],
+    "allowedTools": [],
+}
+
+
 @pytest.fixture
 def kas_stub(tmp_path, monkeypatch):
-    """Point the KAS asset overrides at a stub agent run by this interpreter."""
+    """Point the KAS asset overrides at a stub agent run by this interpreter.
+
+    Redirects the kiro agent home and puts a spec in it, because the projection reads
+    one and nothing in a test can make production write it: ``ensure_agent_materialized``
+    REFUSES to write the shared agent home from an ephemeral instance -- a checkout plus
+    a temp data home, which describes every test -- and logs "This instance will use the
+    existing specs instead". Without the redirect, "the existing specs" are the
+    developer's own installed agents, so this test's verdict depended on which of them
+    were present and whether their ``file://`` prompt files still resolved: it failed
+    with an ``AcpRuntimeError`` naming a prompt file in an unrelated worktree.
+
+    ``KIRO_HOME`` rather than patching ``Path.home()``: it is the documented override
+    and it reaches the resolver this path uses. Note its scope caveat
+    (``config/paths.py``) -- today only the agents directory follows it, so it moves
+    where kiro-cli WRITES without moving where Kiro Crew reads. That is enough here,
+    because the agents directory is the whole dependency. The rootdir conftest does NOT
+    pin it: the variable outranks ``Path.home()``, and many tests isolate this resolver
+    by patching that instead.
+    """
     script = tmp_path / "kas_stub.py"
     script.write_text(_STUB_AGENT)
     launcher = tmp_path / "node-stub"
@@ -274,6 +305,12 @@ def kas_stub(tmp_path, monkeypatch):
     launcher.chmod(0o755)
     monkeypatch.setenv(ENV_KAS_NODE, str(launcher))
     monkeypatch.setenv(ENV_KAS_SCRIPT, str(script))
+    monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro-home"))
+    agents_dir = kiro_agents_dir()
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / f"{_STUB_AGENT_SPEC['name']}.json").write_text(
+        json.dumps(_STUB_AGENT_SPEC), encoding="utf-8"
+    )
     return launcher
 
 

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -2133,6 +2133,17 @@ class TestSweepSparesLiveProcess:
             with (
                 # Cmdline check passes (as it did in the real incident).
                 patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+                # The owning gateway (999999) must read as DEAD, or `_skip_tagged`
+                # keeps the entry and the prune assertion below fails. Pinned rather
+                # than assumed: 999999 is a perfectly ordinary live PID on a host
+                # whose counter has passed it (`pid_max` is 4194304 here), which made
+                # this a load-dependent flake rather than a constant failure. Only
+                # that one PID is faked -- every other, the live victim included,
+                # still goes to the real probe.
+                patch(
+                    "kiro_crew.session_pid.platform_compat.pid_exists",
+                    side_effect=lambda p: p != 999999 and platform_compat.pid_exists(p),
+                ),
                 # Grace disabled: isolate the identity check as the sole guard.
                 patch("kiro_crew.session_pid._pid_in_spawn_grace", return_value=False),
                 patch("kiro_crew.session_pid._cleanup_orphaned_mcp_servers", return_value=0),

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -2389,13 +2389,19 @@ def test_parent_map_ignores_a_planted_ps_earlier_on_path(tmp_path, monkeypatch):
     if platform_compat.IS_WINDOWS:  # pragma: no cover - POSIX lookup
         pytest.skip("POSIX binary resolution")
 
+    # The sentinel must be a number NO real process table can contain, because the
+    # assertion below reads its absence as proof the shim did not run. A plausible
+    # PID cannot do that job: `pid_max` is 4194304 on Linux, so a host whose counter
+    # has passed 999999 has a live process with that id and the test failed with
+    # "planted PATH shim was executed" while the shim had not run at all.
+    unreachable_pid = 99999999999
     shim = tmp_path / "ps"
-    shim.write_text("#!/bin/sh\necho '999999 999998'\n")
+    shim.write_text(f"#!/bin/sh\necho '{unreachable_pid} {unreachable_pid - 1}'\n")
     shim.chmod(0o755)
     monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ.get('PATH', '')}")
 
     parent_map = platform_compat._posix_process_parent_map()
-    assert 999999 not in parent_map, "planted PATH shim was executed"
+    assert unreachable_pid not in parent_map, "planted PATH shim was executed"
     # A real snapshot still came back, so this is not passing by returning {}.
     assert os.getpid() in parent_map
 

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -516,8 +516,14 @@ class TestHardlinkScanBudget:
         # common healthy-host spawn pays nothing (and emits no truncation
         # warning). Both collection loops (SENSITIVE_DIRS and
         # SENSITIVE_FILES) carry the gate.
+        #
+        # REGULAR FILES only, and that half is not cosmetic: every directory has
+        # nlink >= 2, and SENSITIVE_FILES carries directories on purpose, so a bare
+        # nlink test armed the walk on every spawn. Behaviour is covered in
+        # test_sandbox_hardlink_scan.py; this is the source-level pin that both
+        # collection loops still carry the gate.
         script = _build_launcher_script("strict")
-        assert script.count("if _st.st_nlink > 1:") == 2
+        assert script.count("if stat.S_ISREG(_st.st_mode) and _st.st_nlink > 1:") == 2
 
     def test_per_root_budget_covers_a_busy_tmp(self):
         # The budget only applies once a credential inode is actually

--- a/test/test_sandbox_hardlink_scan.py
+++ b/test/test_sandbox_hardlink_scan.py
@@ -1,0 +1,245 @@
+"""The launcher's pre-exec hardlink scan: when it runs, and when it must not.
+
+The scan refuses to exec when it finds a hardlink alias to a protected credential
+inode. It is gated on "does any credential have more than one link", because
+walking $CWD and /tmp costs real time and the healthy-host answer is no.
+
+These tests execute the scan block from the SHIPPED launcher source rather than a
+copy of it, so the assertions cannot drift away from what actually runs in the
+child. Everything the block touches is redirected: the two path lists, the working
+directory, and ``/tmp`` (which the block hardcodes, so it is hidden rather than
+moved). That makes the verdict independent of the host's real credentials AND of how
+full its /tmp happens to be -- which matters twice over here, since a full /tmp is
+the condition this whole change is about.
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+import stat
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.sandbox import _build_launcher_script
+
+_BLOCK_START = "_protected_inodes = set()"
+_BLOCK_END = "os.execvp(argv[0], argv)"
+#: Structural landmarks the slice must contain. Deliberately NOT the guard
+#: EXPRESSION: pinning that text here would make all five behavioural tests fail on a
+#: functionally identical rewrite, and it is already pinned once, on purpose, by
+#: ``test_sandbox_argv.py::test_only_aliased_credential_inodes_arm_the_walk``.
+_SLICE_LANDMARKS = (
+    "for _pd in SENSITIVE_DIRS:",   # the directory collection loop
+    "for _pf in SENSITIVE_FILES:",  # the file collection loop
+    "_MAX_SCAN_PER_ROOT",           # the walk itself
+    "sandbox: BLOCKED",             # the refusal
+)
+
+
+def _scan_source() -> str:
+    """The Step 7 scan, lifted verbatim out of the generated launcher.
+
+    Sliced from the START OF THE LINE, not from the marker: ``dedent`` measures the
+    common prefix across all lines, so a first line already stripped of its indent
+    leaves the rest indented and the block will not even parse.
+    """
+    script = _build_launcher_script("strict")
+    start = script.rindex("\n", 0, script.index(_BLOCK_START)) + 1
+    end = script.rindex("\n", 0, script.index(_BLOCK_END, start)) + 1
+    block = textwrap.dedent(script[start:end])
+    # Pin what the slice must contain, so an edit that moves either marker and
+    # shrinks the block fails HERE rather than leaving every assertion below
+    # vacuously green against a fragment that no longer holds the gate.
+    missing = [landmark for landmark in _SLICE_LANDMARKS if landmark not in block]
+    assert not missing, f"the extracted scan block is missing {missing}"
+    return block
+
+
+class _Exited(Exception):
+    """Stands in for the launcher's ``sys.exit`` so the message is inspectable."""
+
+
+class _HiddenTmpPath:
+    """``os.path``, with ``/tmp`` reported as not-a-directory.
+
+    The scan walks ``(os.getcwd(), "/tmp")`` and only the first is redirectable, so
+    without this the arming tests walk the OPERATOR's /tmp: measured 70,319 ``lstat``
+    calls and ~0.9s per test, and on the host class this whole change is about
+    (>100k files under /tmp) they walk to the 100,000 budget. The block skips a root
+    whose ``isdir`` is False, so hiding it costs nothing and every assertion still
+    holds -- the walk is all-or-nothing across both roots.
+    """
+
+    @staticmethod
+    def isdir(path) -> bool:
+        return False if str(path) == "/tmp" else os.path.isdir(path)
+
+    def __getattr__(self, name: str):
+        return getattr(os.path, name)
+
+
+class _CountingOs:
+    """The real ``os``, counting ``lstat`` -- the walk's per-file call.
+
+    Counting is how these tests tell "the walk was skipped" from "the walk ran and
+    happened to find nothing". Only the walk calls ``lstat``, so a count of zero is
+    proof the gate held. Asserting on the truncation warning instead would make the
+    verdict depend on how many files the host has under /tmp.
+    """
+
+    def __init__(self) -> None:
+        self.lstat_calls = 0
+        self.path = _HiddenTmpPath()
+
+    def lstat(self, path):
+        self.lstat_calls += 1
+        return os.lstat(path)
+
+    def __getattr__(self, name: str):
+        return getattr(os, name)
+
+
+def _run_scan(
+    *, dirs: list[str], files: list[str], tmp_path: Path
+) -> tuple[int, str | None]:
+    """Run the scan with *dirs*/*files* as the protected paths.
+
+    Returns ``(files_walked, refusal)``; *refusal* is None when the scan let the
+    exec proceed.
+
+    Via ``runpy.run_path`` on the extracted block rather than ``exec`` of its text:
+    the two are equivalent here -- both run the shipped source with an injected
+    namespace -- but ``exec`` trips the SAST gate's ``exec-detected`` rule, and a
+    suppression comment would be this repo's first, spent on a false positive.
+    """
+    written: list[str] = []
+
+    class _Stderr:
+        def write(self, text: str) -> int:
+            written.append(text)
+            return len(text)
+
+    def _exit(message: str) -> None:
+        raise _Exited(message)
+
+    fake_sys = type(
+        "_sys", (), {"stderr": _Stderr(), "exit": staticmethod(_exit), "argv": list(sys.argv)}
+    )()
+    counting_os = _CountingOs()
+    namespace = {
+        "os": counting_os,
+        "stat": stat,
+        "sys": fake_sys,
+        "SENSITIVE_DIRS": dirs,
+        "SENSITIVE_FILES": files,
+    }
+    block = tmp_path / "_scan_block.py"
+    block.write_text(_scan_source(), encoding="utf-8")
+    refusal: str | None = None
+    try:
+        runpy.run_path(str(block), init_globals=namespace)
+    except _Exited as exc:
+        refusal = str(exc)
+    return counting_os.lstat_calls, refusal
+
+
+@pytest.fixture(autouse=True)
+def _scan_from_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run the scan with ``tmp_path`` as its only walk root, holding one file.
+
+    The block scans ``os.getcwd()`` and a hardcoded ``/tmp``; the first is moved here
+    and the second is hidden by ``_HiddenTmpPath``, so this directory is the whole
+    walk. The sentinel file is what makes the ``lstat`` count MEAN something: the walk
+    only lstats files, and a root holding nothing but directories yields a count of
+    zero whether it ran or not -- which would leave every "did not arm" assertion
+    passing against a walk that ran in full.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "walkable.txt").write_text("something for the walk to stat\n", encoding="utf-8")
+    return tmp_path
+
+
+class TestTheGateOnWhetherToWalkAtAll:
+    def test_a_directory_named_as_a_credential_file_does_not_arm_the_scan(
+        self, tmp_path: Path
+    ) -> None:
+        """Every directory has nlink >= 2 for ``.`` and ``..``.
+
+        ``SENSITIVE_FILES`` deliberately carries hidden paths of BOTH kinds -- the
+        launcher's hiding loops classify each entry themselves -- so it routinely
+        contains directories. Counting one as "a credential with an alias" armed
+        the 100k-entry walk of $CWD and /tmp on EVERY spawn: measured at 1.5s per
+        sandboxed spawn, with a constant scan-truncation warning, on a host where
+        no credential had an alias at all. Linux has no hardlinks to directories,
+        so nlink says nothing here.
+        """
+        cred_dir = tmp_path / "creds-dir"
+        cred_dir.mkdir()
+        (cred_dir / "sub").mkdir()  # nlink now 3, and still not a hardlink alias
+
+        walked, refusal = _run_scan(dirs=[], files=[str(cred_dir), str(tmp_path / "absent")], tmp_path=tmp_path)
+        # The COUNT is the discriminating assertion -- with the guard removed this is
+        # 70,319. `refusal is None` alone would not catch it: nothing under the walk
+        # roots aliases the directory's inode, because Linux has no such alias to make.
+        assert walked == 0, "a directory must not arm the walk"
+        assert refusal is None
+
+    def test_a_single_linked_credential_does_not_arm_the_scan(self, tmp_path: Path) -> None:
+        cred = tmp_path / "credentials"
+        cred.write_text("[default]\n", encoding="utf-8")
+        assert cred.stat().st_nlink == 1
+
+        walked, refusal = _run_scan(dirs=[], files=[str(cred)], tmp_path=tmp_path)
+        assert walked == 0
+        assert refusal is None
+
+    def test_a_symlink_to_a_directory_does_not_arm_the_scan(self, tmp_path: Path) -> None:
+        """A protected path can be a symlink, and ``os.stat`` follows it to a dir.
+
+        ``~/.kube`` and ``~/.docker`` are symlinks on plenty of managed hosts, so
+        the entry's own kind is not enough — the guard has to be on what the stat
+        resolved to.
+        """
+        target = tmp_path / "target-dir"
+        target.mkdir()
+        link = tmp_path / "creds-link"
+        try:
+            link.symlink_to(target, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("this host cannot create a symlink without elevation")
+
+        walked, refusal = _run_scan(dirs=[], files=[str(link)], tmp_path=tmp_path)
+        assert walked == 0
+        assert refusal is None
+
+
+class TestTheRefusalStillFires:
+    def test_an_alias_to_a_hardlinked_credential_file_is_refused(self, tmp_path: Path) -> None:
+        """The control itself: two links to one credential inode, one of them ours."""
+        cred = tmp_path / "credentials"
+        cred.write_text("[default]\naws_secret_access_key = x\n", encoding="utf-8")
+        alias = tmp_path / "workspace-alias"
+        os.link(cred, alias)
+        assert cred.stat().st_nlink == 2
+
+        walked, refusal = _run_scan(dirs=[], files=[str(cred)], tmp_path=tmp_path)
+        assert walked > 0, "an aliased credential must arm the walk"
+        assert refusal is not None
+        assert "BLOCKED" in refusal
+        assert "credential" in refusal
+
+    def test_a_credential_inside_a_protected_DIR_also_arms_it(self, tmp_path: Path) -> None:
+        cred_dir = tmp_path / "dot-aws"
+        cred_dir.mkdir()
+        cred = cred_dir / "credentials"
+        cred.write_text("[default]\n", encoding="utf-8")
+        os.link(cred, tmp_path / "leaked")
+
+        walked, refusal = _run_scan(dirs=[str(cred_dir)], files=[], tmp_path=tmp_path)
+        assert walked > 0
+        assert refusal is not None
+        assert "BLOCKED" in refusal

--- a/test/test_sandbox_probe.py
+++ b/test/test_sandbox_probe.py
@@ -27,6 +27,24 @@ _linux_only = pytest.mark.skipif(
 )
 
 
+class _ChildExit(Exception):
+    """Stands in for the probe child's ``os._exit``, which a test cannot survive."""
+
+    def __init__(self, code: int) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _exit_recorder(codes: list):
+    """An ``os._exit`` stand-in that records each code and unwinds instead of exiting."""
+
+    def _fake_exit(code: int) -> None:
+        codes.append(code)
+        raise _ChildExit(code)
+
+    return _fake_exit
+
+
 @patch("kiro_crew.sandbox.sys")
 def test_non_darwin_returns_false(mock_sys):
     mock_sys.platform = "linux"
@@ -317,6 +335,150 @@ class TestProbeSplitSequence:
 
         assert (ok, transient) == (False, True)
 
+    def test_a_multithreaded_child_explains_its_einval_without_reclassifying_it(
+        self, monkeypatch, pipe_fds
+    ):
+        """The verdict is a plain EINVAL's; only the REASON gains the thread count.
+
+        ``unshare(CLONE_NEWUSER)`` implies ``CLONE_THREAD``, so the kernel refuses it
+        with EINVAL unless the caller is single-threaded. A ``fork()`` child is, until
+        an ``os.register_at_fork`` handler starts a thread inside the fork -- which
+        OpenTelemetry's metric exporter does on every child.
+
+        But a kernel built without CONFIG_USER_NS returns EINVAL too, and this child
+        never got far enough to tell the two apart, so calling it transient would be
+        exactly as wrong as calling it permanent -- and it would additionally withhold
+        the ``no_backend`` opt-in (``sandbox_allow_unsandboxed_exec``) from a host that
+        really has no user namespaces. Classification and remedy therefore stay
+        identical to a plain EINVAL. What the thread count buys is a reader who is not
+        sent to check their kernel config.
+        """
+        read_fd, write_fd = pipe_fds
+        monkeypatch.setattr(
+            sb, "_probe_read_step", _scripted_steps((sb._PROBE_STEP_MULTITHREADED, 2))
+        )
+        plain = sb._probe_failure(sb._PROBE_STEP_NEWUSER, errno.EINVAL)
+
+        ok, transient, reason, remedy = sb._probe_parent_sequence(
+            4242, read_fd, write_fd, 1000, 1000
+        )
+
+        assert (ok, transient, remedy) == (plain[0], plain[1], plain[3]), reason
+        assert plain[2] in reason, "the plain EINVAL reason must survive verbatim"
+        assert "2 threads" in reason, reason
+        assert "register_at_fork" in reason, reason
+
+    def test_a_multithreaded_child_reports_the_count_only_with_an_einval(
+        self, monkeypatch, pipe_fds
+    ):
+        """The unshare still RUNS -- the kernel stays the authority on the verdict."""
+        read_fd, write_fd = pipe_fds
+        calls: list[int] = []
+        codes: list[int] = []
+        # A real pipe for the report, and -1 for every other fd: this runs in the
+        # pytest worker, not a fork child, so no closer may touch a live descriptor
+        # -- and a path that unexpectedly READS one must fail into the child's own
+        # `except BaseException` rather than block on the worker's stdin (fd 0).
+        monkeypatch.setattr(sb, "_close_probe_fds", lambda *fds: None)
+        monkeypatch.setattr(sb, "_close_fd_ranges", lambda ranges: None)
+        monkeypatch.setattr(sb, "_probe_child_thread_count", lambda: 3)
+        monkeypatch.setattr(
+            sb,
+            "_probe_child_unshare",
+            lambda libc, flags: calls.append(flags) or errno.EINVAL,
+        )
+        monkeypatch.setattr(sb.os, "_exit", _exit_recorder(codes))
+
+        with pytest.raises(_ChildExit):
+            sb._probe_child_sequence(None, -1, write_fd, -1, -1, ())
+
+        # The FIRST exit is the child's verdict. A second follows only because a test
+        # cannot really leave the process here: the stand-in raises, and the child's
+        # own ``except BaseException: os._exit(1)`` then runs.
+        assert codes[0] == 0
+        assert calls == [sb._CLONE_NEWUSER]
+        assert sb._probe_read_step(read_fd) == (sb._PROBE_STEP_MULTITHREADED, 3)
+
+    def test_a_multithreaded_child_with_another_errno_reports_it_plainly(
+        self, monkeypatch, pipe_fds
+    ):
+        """Only EINVAL is the ambiguous one; EPERM means what it says.
+
+        Routing every failure from a multithreaded child through the M step would bury
+        the AppArmor userns denial (EPERM), whose remedy is a real and different fix.
+        """
+        read_fd, write_fd = pipe_fds
+        monkeypatch.setattr(sb, "_close_probe_fds", lambda *fds: None)
+        monkeypatch.setattr(sb, "_close_fd_ranges", lambda ranges: None)
+        monkeypatch.setattr(sb, "_probe_child_thread_count", lambda: 3)
+        monkeypatch.setattr(sb, "_probe_child_unshare", lambda libc, flags: errno.EPERM)
+        monkeypatch.setattr(sb.os, "_exit", _exit_recorder([]))
+
+        with pytest.raises(_ChildExit):
+            sb._probe_child_sequence(None, -1, write_fd, -1, -1, ())
+
+        assert sb._probe_read_step(read_fd) == ("U", errno.EPERM)
+
+    def test_a_single_threaded_child_reports_its_einval_as_a_plain_U(
+        self, monkeypatch, pipe_fds
+    ):
+        """One thread means the EINVAL really is the kernel's answer about the host."""
+        read_fd, write_fd = pipe_fds
+        calls: list[int] = []
+        monkeypatch.setattr(sb, "_close_probe_fds", lambda *fds: None)
+        monkeypatch.setattr(sb, "_close_fd_ranges", lambda ranges: None)
+        monkeypatch.setattr(sb, "_probe_child_thread_count", lambda: 1)
+        monkeypatch.setattr(
+            sb, "_probe_child_unshare", lambda libc, flags: calls.append(flags) or errno.EINVAL
+        )
+        monkeypatch.setattr(sb.os, "_exit", _exit_recorder([]))
+
+        with pytest.raises(_ChildExit):
+            sb._probe_child_sequence(None, -1, write_fd, -1, -1, ())
+
+        assert calls == [sb._CLONE_NEWUSER]
+        assert sb._probe_read_step(read_fd) == ("U", errno.EINVAL)
+
+    def test_an_undeterminable_thread_count_reports_the_errno_plainly(
+        self, monkeypatch, pipe_fds
+    ):
+        """``/proc`` unreadable reads as 0, which must not be mistaken for "many"."""
+        read_fd, write_fd = pipe_fds
+        calls: list[int] = []
+        monkeypatch.setattr(sb, "_close_probe_fds", lambda *fds: None)
+        monkeypatch.setattr(sb, "_close_fd_ranges", lambda ranges: None)
+        monkeypatch.setattr(sb, "_probe_child_thread_count", lambda: 0)
+        monkeypatch.setattr(
+            sb, "_probe_child_unshare", lambda libc, flags: calls.append(flags) or errno.EINVAL
+        )
+        monkeypatch.setattr(sb.os, "_exit", _exit_recorder([]))
+
+        with pytest.raises(_ChildExit):
+            sb._probe_child_sequence(None, -1, write_fd, -1, -1, ())
+
+        assert calls == [sb._CLONE_NEWUSER]
+        assert sb._probe_read_step(read_fd) == ("U", errno.EINVAL)
+
+    def test_the_thread_count_is_the_task_dir_link_count_minus_two(self):
+        """One stat, no allocation: the probe child must not touch the allocator.
+
+        ``/proc/<pid>/task`` holds one subdirectory per thread, so its ``st_nlink`` is
+        ``2 + threads`` (``.`` and ``..``). Reading it that way keeps the child off
+        ``os.listdir``, which allocates a list and a string per task -- and the fd
+        sweep is precomputed pre-fork for exactly that reason: another thread may have
+        held the allocator lock at fork time and no longer exists to release it.
+        """
+        expected = len(os.listdir("/proc/self/task"))
+
+        assert sb._probe_child_thread_count() == expected
+
+    def test_an_unreadable_task_dir_reads_as_zero(self, monkeypatch):
+        monkeypatch.setattr(
+            sb.os, "stat", lambda *a, **k: (_ for _ in ()).throw(OSError("no /proc"))
+        )
+
+        assert sb._probe_child_thread_count() == 0
+
 
 @_linux_only
 class TestProbeStepReports:
@@ -545,6 +707,10 @@ class TestProbeChildFdSweep:
             "_close_fd_ranges",
             lambda ranges: calls.append(("sweep", tuple(ranges))),
         )
+        # This harness runs the child sequence IN the pytest worker, which has many
+        # threads; a real fork child has one. Pin the count so the child takes the
+        # probing path instead of reporting itself multithreaded and exiting.
+        monkeypatch.setattr(sb, "_probe_child_thread_count", lambda: 1)
 
         def fake_unshare(_libc, flags):
             calls.append(("unshare", flags))

--- a/test/test_slack_dashboard_live_sync.py
+++ b/test/test_slack_dashboard_live_sync.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
-from chat_test_helpers import _make_state
+from chat_test_helpers import _make_state, drain_background_tasks
 
 from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK, STOP_REASON_END_TURN
 from kiro_crew.dashboard.channel_slots import refresh_channel_window, surface_channel_session
@@ -172,6 +172,7 @@ class TestCTheMirrorIsResolvableInbound:
         async with TestClient(TestServer(self._app(state))) as client:
             resp = await client.post("/api/chat/slots/s1/slack-link", json={})
             assert resp.status == 200
+            await drain_background_tasks(state)
 
         # The inbound Slack path resolves a thread through get_linked_slot. The
         # old hand-assignment left this index empty, so a reply in the mirrored

--- a/test/test_slack_options_lifecycle.py
+++ b/test/test_slack_options_lifecycle.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
-from chat_test_helpers import _make_state
+from chat_test_helpers import _make_state, drain_background_tasks
 
 from kiro_crew.slack.format import (
     OPTIONS_CHECKBOXES_ACTION,
@@ -379,6 +379,7 @@ class TestLifecycleOnTheSlot:
         async with TestClient(TestServer(_slack_app(state))) as client:
             resp = await client.post("/api/chat/slots/s1/slack-link", json={})
             assert resp.status == 200
+            await drain_background_tasks(state)
             thread_ts = (await resp.json())["thread_ts"]
 
         key = effective_session_key(slot)
@@ -744,27 +745,54 @@ def _slack_app(state):
     return app
 
 
-async def _drain_backfill(state) -> None:
-    """Await the backfill the slack-link handler spawns.
-
-    The handler deliberately backgrounds the drain (`_spawn_slack_backfill`) and
-    returns before it posts, so the response arriving proves only that the task
-    was CREATED. Reading the Slack mock straight after the request races that
-    task: it usually wins on an idle machine and loses under load, which is a
-    flake that reads as a plain count mismatch (`assert 0 == 2`) and names
-    neither the task nor the race.
-
-    The task is tracked in `state._background_tasks`, so awaiting the
-    not-yet-done members is an exact wait on the real completion condition
-    rather than a sleep. An empty set means it already finished; a done-callback
-    discards each task, so snapshot before awaiting.
-    """
-    for task in [t for t in state._background_tasks if not t.done()]:
-        await task
-
-
 class TestLinkTimeBackfill:
     """Replaying context into a freshly-linked thread."""
+
+    @pytest.mark.asyncio
+    async def test_the_replay_is_a_background_task_the_caller_must_await(
+        self, tmp_path, monkeypatch
+    ):
+        """Pins WHY every case below drains: the handler answers before it posts.
+
+        The endpoint returns 200 as soon as the link is persisted and hands the
+        replay to ``asyncio.create_task``, so whether the replay has run by the time
+        the response is read depends only on how the loop was scheduled. Asserting on
+        the replay without awaiting it is a load-dependent coin flip, and it failed
+        as ``'NoneType' object has no attribute 'args'`` on a DIFFERENT test each CI
+        run (#4130) — which reads as a flaky suite rather than a missing await.
+
+        If this ever fails because the handler became synchronous, delete the drains
+        rather than weakening this.
+        """
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.append("assistant", "Your call.\n\n[OPTIONS: A | B]")
+        slot.drain()
+
+        # GATE the replay's own call, so "still pending" is a fact rather than a bet on
+        # the scheduler. Asserting it bare would be the same race inverted: it happens
+        # to hold because the replay suspends on a thread-pool hop that usually
+        # outlasts the loopback response, and it would flake on a host where the warm
+        # executor wins -- in the one test that documents why the drains exist.
+        release = asyncio.Event()
+
+        async def _gated_post_blocks(*_args, **_kwargs):
+            await release.wait()
+            return "opt_ts"
+
+        state.slack_client.post_blocks = AsyncMock(side_effect=_gated_post_blocks)
+
+        async with TestClient(TestServer(_slack_app(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/slack-link", json={})
+            assert resp.status == 200
+            assert [t for t in state._background_tasks if not t.done()], (
+                "the replay must still be pending here, or these tests are not "
+                "exercising the background path the gateway takes"
+            )
+            release.set()
+            await drain_background_tasks(state)
+            assert not [t for t in state._background_tasks if not t.done()]
+        assert state.slack_client.post_blocks.await_args is not None
 
     def _state(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
@@ -798,7 +826,7 @@ class TestLinkTimeBackfill:
         async with TestClient(TestServer(_slack_app(state))) as client:
             resp = await client.post("/api/chat/slots/s1/slack-link", json={})
             assert resp.status == 200
-            await _drain_backfill(state)
+            await drain_background_tasks(state)
 
         texts = [c.args[1] for c in state.slack_client.post_message.await_args_list]
         assert all("[OPTIONS:" not in t for t in texts)
@@ -816,7 +844,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
-            await _drain_backfill(state)
+            await drain_background_tasks(state)
 
         assert _is_live_control(state.slack_client.post_blocks.await_args.args[1])
         assert _recs(state, slot)
@@ -835,7 +863,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
-            await _drain_backfill(state)
+            await drain_background_tasks(state)
 
         blocks = state.slack_client.post_blocks.await_args.args[1]
         assert not _is_live_control(blocks)
@@ -860,7 +888,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
-            await _drain_backfill(state)
+            await drain_background_tasks(state)
 
         blocks = state.slack_client.post_blocks.await_args.args[1]
         assert _is_live_control(blocks)
@@ -885,7 +913,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
-            await _drain_backfill(state)
+            await drain_background_tasks(state)
 
         texts = [c.args[1] for c in state.slack_client.post_message.await_args_list]
         assert any("[OPTIONS: A | B]" in t for t in texts)
@@ -902,7 +930,7 @@ class TestLinkTimeBackfill:
 
         async with TestClient(TestServer(_slack_app(state))) as client:
             await client.post("/api/chat/slots/s1/slack-link", json={})
-            await _drain_backfill(state)
+            await drain_background_tasks(state)
 
         posts = state.slack_client.post_blocks.await_args_list
         assert len(posts) == 2

--- a/test/test_worktree_create.py
+++ b/test/test_worktree_create.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import functools
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import tempfile
@@ -19,6 +20,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from kiro_crew.dashboard.handlers import worktree as wt_mod
 from kiro_crew.dashboard.handlers.worktree import (
     _FILTER_PROBE_FAILED,
     SandboxUnavailable,
@@ -1064,3 +1066,122 @@ class TestRepoAllowList:
             assert resp.status == 403
             assert "outside" in (await resp.json())["error"]
         assert not (repo.parent / "proj-wt-x").exists()
+
+
+class TestLauncherAdvisoryIsNotARefusal:
+    """A sandbox launcher WARNING must never be read as "no sandbox backend".
+
+    The launcher's pre-exec hardlink scan degrades OPEN when it exhausts its
+    per-root file budget: /tmp on a busy host passes that budget from ordinary
+    churn, and failing closed would break every sandboxed spawn on such a host. It
+    says so on the child's stderr and execs the child anyway.
+
+    Reading that advisory as a refusal broke the endpoint on exactly those hosts,
+    because git commands here exit non-zero as a matter of course -- ``rev-parse
+    --verify --quiet`` on a branch that does not exist is the probe behind "does
+    this branch already exist", so the answer became "your host cannot sandbox
+    git" for every create.
+
+    Deliberately does NOT take the ``repo`` fixture. That fixture skips wherever
+    isolation cannot be established, which is every CI platform -- Windows has no
+    backend at all and ubuntu-latest denies ``unshare(NEWNS)`` under AppArmor -- so
+    the guard for the bug above would never run where it matters. Nothing here needs
+    a repo or a sandbox: ``run_limited`` is stubbed, the spawn goes through
+    ``_passthrough_spawn`` (the file's existing device for exactly this), and the cwd
+    only has to be a real directory.
+    """
+
+    _WARNING = (
+        "sandbox: WARNING — pre-exec hardlink scan truncated at 100000 files in "
+        "/tmp; scan incomplete (control degrades open)"
+    )
+    _FATAL = "sandbox: unshare(NEWNS) failed: errno 1"
+
+    @pytest.fixture(autouse=True)
+    def _spawn_passthrough(self, monkeypatch):
+        from kiro_crew.dashboard.handlers import worktree as wt
+
+        monkeypatch.setattr(wt, "sandboxed_spawn_argv", _passthrough_spawn)
+
+    def _completed(self, returncode: int, stderr: str):
+        return subprocess.CompletedProcess(
+            args=["git"], returncode=returncode, stdout="", stderr=stderr
+        )
+
+    def test_a_warning_on_a_non_zero_exit_is_returned_as_data(self, tmp_path, monkeypatch):
+        """The non-zero exit is the ANSWER here, not an error to translate."""
+        from kiro_crew.dashboard.handlers import worktree as wt
+
+        stderr = self._WARNING + "\n"
+        monkeypatch.setattr(wt, "run_limited", lambda *a, **k: self._completed(1, stderr))
+        proc = _run_git(["rev-parse", "--verify", "--quiet", "refs/heads/nope"], str(tmp_path))
+
+        assert proc.returncode == 1
+
+    def test_a_fatal_launcher_line_still_refuses(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.handlers import worktree as wt
+
+        stderr = self._FATAL + "\n"
+        monkeypatch.setattr(wt, "run_limited", lambda *a, **k: self._completed(1, stderr))
+
+        with pytest.raises(SandboxUnavailable):
+            _run_git(["rev-parse", "HEAD"], str(tmp_path))
+
+    def test_a_fatal_line_a_warning_precedes_is_still_found(self, tmp_path, monkeypatch):
+        """Order must not decide it: ``startswith`` on the whole stderr missed this."""
+        from kiro_crew.dashboard.handlers import worktree as wt
+
+        stderr = f"{self._WARNING}\n{self._FATAL}\n"
+        monkeypatch.setattr(wt, "run_limited", lambda *a, **k: self._completed(1, stderr))
+
+        with pytest.raises(SandboxUnavailable) as excinfo:
+            _run_git(["rev-parse", "HEAD"], str(tmp_path))
+
+        # The FATAL line alone, not the whole stderr: the message reaches the user as
+        # the reason the create was refused, and leading it with an advisory about
+        # /tmp names the wrong cause.
+        assert str(excinfo.value) == self._FATAL
+
+    @pytest.mark.skipif(
+        not hasattr(os, "getuid"),
+        reason="the namespace launcher is POSIX-only: _build_launcher_script reads "
+        "os.getuid(), which Windows has not got",
+    )
+    def test_the_launcher_emits_no_severity_the_classifier_does_not_know(self):
+        """Ratchet the coupling: `_WARNING` above is a hand-typed copy of the real text.
+
+        The classifier decides fatal-vs-advisory from one prefix, so a launcher line
+        that is neither -- a reworded advisory (``sandbox: note - ...``), or a second
+        non-fatal kind -- is read as a refusal, and on a busy-/tmp host every git
+        command that legitimately exits non-zero again reports "this host has no OS
+        sandbox backend". Nothing else pins that, because the tests above feed the
+        classifier their own strings.
+
+        Pinned as the SET of severities the launcher can emit, so adding one is a
+        deliberate edit here plus a decision about which side of the prefix it falls
+        on -- rather than a silent reclassification.
+        """
+        from kiro_crew.sandbox import _build_launcher_script
+
+        severities = {
+            token.split()[0]
+            for token in re.findall(
+                r"sandbox: ([^'\"%\\\n]+)", _build_launcher_script("strict")
+            )
+        }
+
+        assert severities == {"unshare(NEWUSER)", "unshare(NEWNS)", "BLOCKED", "WARNING"}
+        # And the one advisory is spelled the way the classifier looks for it.
+        assert self._WARNING.startswith(wt_mod._SANDBOX_LAUNCHER_WARNING_PREFIX)
+        assert wt_mod._SANDBOX_LAUNCHER_WARNING_PREFIX.startswith(
+            wt_mod._SANDBOX_LAUNCHER_PREFIX
+        ), "the advisory prefix must be a refinement of the launcher prefix, not a rival"
+
+    def test_gits_own_error_is_never_mistaken_for_a_refusal(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.handlers import worktree as wt
+
+        stderr = "fatal: not a git repository (or any of the parent directories): .git\n"
+        monkeypatch.setattr(wt, "run_limited", lambda *a, **k: self._completed(128, stderr))
+        proc = _run_git(["rev-parse", "HEAD"], str(tmp_path))
+
+        assert proc.returncode == 128

--- a/test/windows-collect-ignore.txt
+++ b/test/windows-collect-ignore.txt
@@ -24,6 +24,7 @@
 test_harness.py                    # spawns real gateways; PGID + socketpair plumbing
 test_sandbox_argv.py               # OS sandbox is POSIX-only
 test_sandbox_cc_mode.py            # OS sandbox is POSIX-only
+test_sandbox_hardlink_scan.py      # OS sandbox is POSIX-only (launcher uses getuid)
 test_sandbox_nested_tier.py        # OS sandbox is POSIX-only (launcher uses getuid; env at /usr/bin)
 test_pid_lifecycle.py              # process-group semantics
 test_pid_sweep_helpers.py          # process-group semantics


### PR DESCRIPTION
The backend suite failed **50 tests on my host and 0 in CI**, and every one traced to
production — or a test — reading host state as a verdict. Two of the four causes are
product defects a user hits.

## The two product defects

**A directory is not a hardlinked credential.** The launcher's pre-exec hardlink scan
arms when any protected path has `st_nlink > 1`. Every directory does, for `.` and `..`
— and the hidden-path list deliberately carries directories, because the launcher's own
masking loops classify each entry themselves. So `~/.gnupg` and
`~/.kiro/crew-auth-staging` seeded the credential-alias match set on **every spawn**, and
the 100k-entry walk of `$CWD` and `/tmp` ran every time.

| | before | after |
|---|---|---|
| a trivial sandboxed spawn | **1.49 s** | **0.05 s** |
| the truncation warning | every spawn | never (nothing is aliased) |

Linux has no hardlinks to directories, so the scan now considers regular files only.
That is a tightening, not a loosening: the only inodes it stops considering are ones no
`link(2)` can alias.

**An advisory is not a refusal.** That walk printed `sandbox: WARNING — … scan
truncated`, and `worktree.py` matched the launcher prefix against the whole stderr. The
launcher degrades *open* there on purpose — a busy `/tmp` exceeds any fixed budget. So on
any host past the scan budget, every git command that legitimately exits non-zero
answered *"this host has no OS sandbox backend"*. `rev-parse --verify --quiet` on a
branch that does not exist is the probe behind "does this branch already exist", so
worktree creation was dead on such a host. Classification is now per line and
WARNING-aware, which also catches a fatal line that an advisory precedes.

## The one that took the longest to find

`unshare(CLONE_NEWUSER)` implies `CLONE_THREAD`, so the kernel returns **EINVAL unless
the caller is single-threaded**. A `fork()` child is — until an `os.register_at_fork`
handler starts a thread *inside* the fork, which OpenTelemetry's metric exporter does.

So one leaked exporter thread made every probe child multithreaded, EINVAL got cached as
permanent, and every later sandboxed spawn on that worker failed closed. 19 red tests in
two app suites, each passing alone, none of them a metrics test. Instrumenting the child
showed `child_threads == 2` on all 22 occurrences.

The leak was a test: three metrics tests **replaced** the provider's `shutdown` with a
recorder, and the real one is what stops the exporter. They spy and delegate now, and the
rootdir conftest fails the test that leaves such a thread running — keyed on the thread
name, so a second distinct leak is not hidden by the first.

The probe child now reports its thread count so the *reason* names the thread. **The
verdict is deliberately unchanged**: a multithreaded child cannot tell a `CONFIG_USER_NS`-less
kernel apart from itself, so calling it transient would be as wrong as calling it
permanent *and* would withhold the `no_backend` opt-in from a host that really has no
user namespaces. Making such a process probe successfully needs a single-threaded child,
i.e. a different spawn mechanism — its own change.

## Floor and test fixes

- The sandbox probe cache is kept warm at **test setup** instead of once per session in
  `test/conftest.py`, which the ~1490 in-package app tests never load. It probes **once
  per worker** and re-seats the recorded verdict afterwards: a probe closes every
  inherited fd, which is ~1 ms at `ulimit -n 1024` and **102 ms at 524288**, and
  re-probing on every cold cache took `test_sandbox_argv.py` from 3.7 s to 18.6 s.
- The Slack link-time backfill is a background task six tests asserted on without
  awaiting — a different test failing each CI run (#4130). `drain_background_tasks` awaits
  it; the test that documents why gates the replay on an `Event` so "still pending" is a
  fact, not a bet on the scheduler.
- `999999` is not an impossible PID (`pid_max` is 4194304). Two tests assumed it was —
  one stopped pruning an entry whose owner "must be dead", one accused a planted `ps` shim
  of executing when it had not.
- The KAS spawn test projected whichever agents the developer happened to have installed,
  and failed naming a prompt file in an unrelated worktree. It brings its own spec now.

## Verification

Zero failures, twice consecutively and in every slice — no deselects:

| run | result |
|---|---|
| full suite ×2 | **55,832 passed, 0 failed** (295 s, 276 s) |
| `--splits 4 --group 1..4` | **13,960 / 13,965 / 13,939 / 13,968 passed, 0 failed** |
| baseline `origin/main`, same host | 50 failed in 386 s |

`isort`, `flake8`, `mypy`, `scrub-lint --no-history`, `docs-lint`, the brand gate and the
harness-parity gate are clean. Every behavioural test here was mutation-checked: the
production guard was removed and the test confirmed to fail.

## Review dispositions

Three read-only reviewers ran over the diff (security/correctness, test quality,
portability) before it was pushed. **All findings are fixed**, including:

- *Critical:* `test_sandbox_hardlink_scan.py` would have reddened the Windows shard —
  `_build_launcher_script` calls `os.getuid()`. Added to `windows-collect-ignore.txt`
  (with its ratchet in `test_ci_surface_tests.py`), where its five siblings already live.
- *High:* the warm-up re-probed per cold cache, ~146 ms each — now one probe per worker.
- *High:* the leak guard's report-once flag was a bare bool, so a second differently-named
  leak passed silently — now keyed on the thread names.
- *Medium:* the four new worktree tests took the `repo` fixture, which skips wherever a
  sandbox cannot be established — i.e. every CI platform — so the guard for the bug above
  would never have run there. They use `tmp_path` and the file's existing
  `_passthrough_spawn` now.
- *Medium:* the scan tests walked the operator's real `/tmp` (70,319 `lstat`s, ~0.9 s
  each) on exactly the host class this change is about. `/tmp` is hidden from the block,
  and a sentinel file makes the count meaningful — 0.01 s per test.
- *Medium:* the advisory text was hand-typed and pinned to nothing; a new severity or a
  reword would silently become a refusal again. The launcher's severity **set** is now
  ratcheted.

Docs, `AGENTS.md` and the packaged `writing-tests` skill are updated in the same commit.
