### PR TITLE
feat(apps): add recipes seams for an edition-supplied recipes app

### DIFF
--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -89,6 +89,7 @@ agent loads only the one it needs.
 | [mcp-gateway-daemon-lifecycle.md](mcp-gateway-daemon-lifecycle.md) | The MCP gateway daemon has one owning gateway and one code revision: owner-liveness self-exit, the fingerprint adoption gate, the CLI stop, and the stale-backend diagnosis. |
 | [mcp-probe-quarantine.md](mcp-probe-quarantine.md) | A durable consecutive-probe-failure count per MCP server, surfaced on its dashboard row with a reset control. The unmount half is deferred; the spec records why. |
 | [app-notifications.md](app-notifications.md) | How an app publishes a notification to the local bus, and the two shipped producers. |
+| [recipes.md](recipes.md) | Seams for an edition-supplied recipes app: the `recipes` manifest vocabulary plus brokered Slack channel provisioning and routing. Core ships no recipes implementation. |
 | [artifacts.md](artifacts.md) | Artifact identity, versioning, and the companion chat panel. |
 | [prompt-optimizer.md](prompt-optimizer.md) | Rewriting a draft prompt on demand, and the paste-forwarding surface. |
 | [steering-viewer.md](steering-viewer.md) | Reading, creating, editing and deleting the steering files a session loads, and the declared-`inclusion` reporting. |

--- a/docs/system-specs/modules/recipes.md
+++ b/docs/system-specs/modules/recipes.md
@@ -1,0 +1,140 @@
+# Recipes seams
+
+Kiro Crew does not ship a recipes implementation. This page documents the two
+seams core provides so an **edition-supplied app** can implement one, and states
+what deliberately does not exist here.
+
+A "recipe" is an app-declared, per-user installable: a Slack channel with agent
+routing, or a customizable cron job. Discovery, prompting, the install ledger,
+channel lifecycle, and cleanup all live in the app. Core owns only the shared
+vocabulary and the one operation an app cannot perform from its own process.
+
+## Seam 1: the `recipes` manifest vocabulary
+
+`AppManifest` parses and validates a `recipes` block so a recipe-declaring app
+validates identically in every edition, including this one:
+
+```json
+{
+  "name": "my-app",
+  "agents": ["agents/triage.json"],
+  "recipes": {
+    "slack": [
+      {
+        "name": "triage-room",
+        "description": "Triage inbox",
+        "channelNamePart": "triage",
+        "agent": "triage",
+        "activation": "mention"
+      }
+    ],
+    "crons": [
+      {
+        "name": "daily-digest",
+        "description": "Daily digest",
+        "schedule": "0 9 * * MON-FRI",
+        "agent": "triage"
+      }
+    ]
+  }
+}
+```
+
+Types are `SlackRecipe`, `CronRecipe`, and `RecipesConfig`
+in `kiro_crew.apps.manifest`; `AppManifest._validate_recipes` enforces
+kebab-case names, the `channelNamePart` length cap, the activation enum, and the
+`schedule` / `everySecs` exclusivity. Nothing in core reads this block; it is
+inert, validated data here.
+
+### Recipes that bring their own agent
+
+A recipe's `agent` is resolved per turn by
+`kiro_crew.config.loader.resolve_agent_bindings`, which accepts either a Kiro
+Crew alias (a `config.agents` key) or a **materialized kiro agent**. An app that
+ships `agents: ["agents/triage.json"]` gets that file registered into the kiro
+agents directory by `apps.bridges.register_app` on install and enable, under a
+namespaced filename while the config keeps its bare `name`. Both spellings
+resolve, so the recipe references either `triage` or `my-app--triage`. An
+implementing app should verify resolution (`ResolvedBindings.requested_resolved`)
+before it routes a channel, so it never points a channel at an agent that will
+silently fall back to the default.
+
+## Seam 2: `PUT /api/slack/channels/{channel_id}/routing`
+
+Writes (or removes) a channel's agent / activation routing, then refreshes the
+gateway's in-memory routing table.
+
+```json
+{ "agent": "triage", "activation": "mention" }
+```
+
+Teardown uses the same endpoint:
+
+```json
+{ "remove": true }
+```
+
+Response `{"ok": true, "changed": ["agent"], "routing_refreshed": bool}`.
+
+Why this is the only Slack seam: the app does its own Slack API calls (create,
+archive, invite, set purpose) with the bot token it reads from the credential
+store, so channel lifecycle needs no core endpoint. The one thing an app cannot
+do from its own process is reach into the running gateway to make a routing
+change take effect. Routing also lives in `config.json`, and a read-modify-write
+of that file has to hold *both* the sidecar advisory flock and the loop-side
+`asyncio.Lock` (see `chat_utils.run_config_write`); a writer holding only one can
+be reverted from a stale snapshot by the other family. Funneling the write
+through this endpoint keeps the gateway the single writer and removes the race.
+
+The endpoint does not implement the write. It delegates to
+`slack.handler._persist_channel_config` through `run_config_write`, the same
+locked path `!channel agent` and the Slack interaction handlers use, which also
+fails closed on an unreadable `config.json` rather than rewriting a `{}` baseline
+over the rest of your settings. A corrupt document yields
+`{"code": "config_write_failed"}` with status 500 and no change on disk.
+
+When the Slack orchestrator is not bound (gateway down, or Slack disabled) the
+durable write still lands and `routing_refreshed` is `false`; the change applies
+at next boot.
+
+Core stores no provenance for these entries. `ChannelConfig` carries only
+`activation`, `agent`, and `thread_follow`, so any extra key written into a
+channel entry is dropped the next time a typed `KiroCrewConfig.save()` runs. An
+installing app already knows which channels it created and is the durable record
+of that; core does not keep a second one that silently decays.
+
+## Reaching the seams from an app
+
+Apps authenticate with their per-app secret at `POST /api/apps/{name}/token`,
+receive an app-scoped token carrying a verified identity, and must declare the
+paths they call in manifest `permissions.api`, which `token_auth` enforces as a
+prefix allowlist. An implementing app declares:
+
+```json
+{ "permissions": { "api": ["/api/slack/channels/", "/api/apps/my-app/"],
+                   "cron": true } }
+```
+
+Cron jobs come from `permissions.cron` plus `apps.cron_sdk`; the app's own REST
+surface and UI come from manifest `backend.routes` and `ui.entry`; its MCP tools
+come from manifest `mcpServers`. None of those need a recipes-specific seam.
+
+## Security note: the token is not contained
+
+The app reads the bot token from the credential store and calls Slack directly.
+This is not a security boundary: an app backend is a same-UID subprocess with
+full filesystem access, so it could read the token regardless. The routing
+endpoint exists for correctness (single config writer, in-memory refresh), not
+containment. The real control against a hostile app is **admission** (app
+signing / review in `apps/admission.py`) plus, if it is ever needed, sandboxing
+the app backend, neither of which these endpoints attempt.
+
+## What core does not provide
+
+- **No recipe installer, ledger, discovery, or cleanup.** App territory.
+- **No channel create / archive / invite endpoint.** The app does these itself
+  with the bot token.
+- **No package-registry install.** `CapabilityManager`
+  (`platform/interfaces.py`) exposes `install_agent` / `install_skill`, but the
+  public default reports `available() == False`, so `/api/capability/*` answers
+  503. An app must ship agents in-tree via manifest `agents`.

--- a/src/kiro_crew/apps/discovery.py
+++ b/src/kiro_crew/apps/discovery.py
@@ -99,6 +99,9 @@ def _manifest_to_builtin_dict(manifest: AppManifest) -> dict[str, Any]:
     notif_d = manifest.notifications.to_dict()
     if notif_d:
         d["notifications"] = notif_d
+    recipes_d = manifest.recipes.to_dict()
+    if recipes_d:
+        d["recipes"] = recipes_d
     platform_d = manifest.platform.to_dict() if manifest.platform else {}
     if platform_d:
         d["platform"] = platform_d

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -1588,6 +1588,64 @@ def disable_app(name: str) -> AppResult:
 # ---------------------------------------------------------------------------
 
 
+#: Manifest tag by which an app declares itself a recipes provider (the engine
+#: that discovers and installs other apps' ``recipes`` declarations). Core ships
+#: no provider: the vocabulary is validated here, the implementation is supplied
+#: by an edition. A tag rather than a schema field, so recognising a provider
+#: needs no manifest change. See docs/system-specs/features/recipes.md.
+RECIPES_PROVIDER_TAG = "recipes-provider"
+
+
+def recipes_provider_installed() -> bool:
+    """True when some installed, enabled app declares itself a recipes provider.
+
+    ``list_apps`` returns ``{**installed-metadata, "manifest": <manifest dict>}``,
+    so the tag is read from the nested manifest: it is a manifest field, not
+    installed-metadata, and a top-level lookup would silently always miss.
+    """
+    try:
+        for app in list_apps():
+            if not isinstance(app, dict) or not app.get("enabled", False):
+                continue
+            manifest = app.get("manifest")
+            if not isinstance(manifest, dict):
+                continue
+            tags = manifest.get("tags")
+            if isinstance(tags, list) and RECIPES_PROVIDER_TAG in tags:
+                return True
+    except Exception:  # pragma: no cover - defensive: a hint must never raise
+        logger.debug("recipes provider probe failed", exc_info=True)
+    return False
+
+
+def recipes_provider_hint(app_name: str) -> str:
+    """Hint text when *app_name* declares recipes but nothing can install them.
+
+    An app whose manifest carries a ``recipes`` block installs cleanly here and
+    then does nothing, because core validates the vocabulary but ships no
+    installer. Without this, the first symptom is silence. Returns "" when the
+    app declares no recipes or a provider is already present.
+    """
+    try:
+        manifest = get_app_manifest(app_name)
+        if manifest is None:
+            return ""
+        recipes = getattr(manifest, "recipes", None)
+        declared = len(getattr(recipes, "slack", []) or []) + len(
+            getattr(recipes, "crons", []) or []
+        )
+        if not declared or recipes_provider_installed():
+            return ""
+        return (
+            f"{app_name} declares {declared} recipe(s), but no recipes provider is "
+            f"installed, so nothing will install them. Install an app tagged "
+            f"{RECIPES_PROVIDER_TAG!r} (see docs/system-specs/features/recipes.md)."
+        )
+    except Exception:  # pragma: no cover - defensive: a hint must never raise
+        logger.debug("recipes hint failed for %s", app_name, exc_info=True)
+        return ""
+
+
 def list_apps() -> list[dict[str, Any]]:
     """Return metadata for all installed apps."""
     root = apps_dir()

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -1167,6 +1167,159 @@ class PublishProviderConfig:
 
 
 # ---------------------------------------------------------------------------
+# Recipes — interactive, user-personalized resource installs (Slack channels,
+# customizable crons). See docs/system-specs/features/recipes.md.
+# Recipes are *declared* in the manifest and validated here; core ships no
+# installer, so nothing in this repo acts on the block. An edition-supplied app
+# tagged ``recipes-provider`` owns the install/update/cleanup lifecycle.
+# ---------------------------------------------------------------------------
+
+# Maximum length for the channelNamePart segment used in Slack channel naming
+# ({alias}-{channelNamePart}-kc-{ts}). Slack channel names are capped at 80
+# chars; 15 here leaves room for prefix, suffix, and a unique timestamp.
+_RECIPE_CHANNEL_NAME_PART_MAX = 15
+
+# Allowed values for SlackRecipe.activation. Mirrors ChannelConfig.activation
+# in kiro_crew.config.loader. Update both together if either changes.
+_SLACK_ACTIVATION_VALUES = frozenset({"always", "mention", "observe"})
+
+
+@dataclass
+class SlackRecipe:
+    """A Slack channel recipe — creates a private channel and routes an agent.
+
+    Fields baked from manifest (not prompted at install): ``name``,
+    ``description``, ``channelNamePart``, ``purpose``.
+    Prompted at install: full channel name (default uses ``channelNamePart``),
+    ``agent``, ``activation``.
+    """
+
+    name: str = ""  # kebab-case, unique within app
+    description: str = ""  # one-line summary shown in `recipes list`
+    channelNamePart: str = ""  # ≤15 chars; used in {alias}-{part}-kc-{ts}  # noqa: N815
+    agent: str = ""  # default agent (prompt overridable)
+    activation: str = "always"  # always | mention | observe (prompt overridable)
+    purpose: str = ""  # optional Slack channel purpose override; default derived from description
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "channelNamePart": self.channelNamePart,
+            "agent": self.agent,
+            "activation": self.activation,
+        }
+        if self.purpose:
+            d["purpose"] = self.purpose
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SlackRecipe:
+        return cls(
+            name=str(data.get("name", "")),
+            description=str(data.get("description", "")),
+            channelNamePart=str(data.get("channelNamePart", "")),  # noqa: N815
+            agent=str(data.get("agent", "")),
+            activation=str(data.get("activation", "always")),
+            purpose=str(data.get("purpose", "")),
+        )
+
+
+@dataclass
+class CronRecipe:
+    """A cron job recipe — creates a scheduled job with a templated prompt.
+
+    Exactly one of ``schedule`` or ``everySecs`` must be specified.
+    Exactly one of ``promptFile`` or ``promptText`` must be specified — the
+    cron job needs work to do.  ``promptFile`` is resolved relative to the
+    app root and may not contain ``..``.
+
+    Fields baked from manifest: ``name``, ``description``, ``channelNamePart``,
+    ``promptFile`` / ``promptText``, ``everySecs``, ``persistentSession``,
+    ``silent``.  Prompted at install: ``agent``, ``schedule``
+    (when set, not for ``everySecs``-based recipes), output channel name
+    (when ``channelNamePart`` is set).
+    """
+
+    name: str = ""  # kebab-case, unique within app
+    description: str = ""
+    schedule: str = ""  # 5-field cron expression; XOR with everySecs
+    everySecs: int = 0  # interval in seconds; XOR with schedule  # noqa: N815
+    agent: str = ""  # default agent (prompt overridable)
+    channelNamePart: str = ""  # if set, creates an output channel  # noqa: N815
+    promptFile: str = ""  # path relative to app root; XOR with promptText  # noqa: N815
+    promptText: str = ""  # inline prompt; XOR with promptFile  # noqa: N815
+    persistentSession: bool = True  # carry context between runs (maps to CronEntry)  # noqa: N815
+    silent: bool = False  # suppress dashboard notifications (matches CronEntry)
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "agent": self.agent,
+        }
+        if self.schedule:
+            d["schedule"] = self.schedule
+        if self.everySecs:
+            d["everySecs"] = self.everySecs
+        if self.channelNamePart:
+            d["channelNamePart"] = self.channelNamePart
+        if self.promptFile:
+            d["promptFile"] = self.promptFile
+        if self.promptText:
+            d["promptText"] = self.promptText
+        if not self.persistentSession:
+            d["persistentSession"] = False
+        if self.silent:
+            d["silent"] = True
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CronRecipe:
+        return cls(
+            name=str(data.get("name", "")),
+            description=str(data.get("description", "")),
+            schedule=str(data.get("schedule", "")),
+            everySecs=int(data.get("everySecs", 0)),  # noqa: N815
+            agent=str(data.get("agent", "")),
+            channelNamePart=str(data.get("channelNamePart", "")),  # noqa: N815
+            promptFile=str(data.get("promptFile", "")),  # noqa: N815
+            promptText=str(data.get("promptText", "")),  # noqa: N815
+            persistentSession=bool(data.get("persistentSession", True)),  # noqa: N815
+            silent=bool(data.get("silent", False)),
+        )
+
+
+@dataclass
+class RecipesConfig:
+    """Recipes section of an app manifest.
+
+    Holds the two recipe types as parallel arrays (flat schema, no spec
+    wrapper, type implicit from array membership).
+    """
+
+    slack: list[SlackRecipe] = field(default_factory=list)
+    crons: list[CronRecipe] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        if self.slack:
+            d["slack"] = [r.to_dict() for r in self.slack]
+        if self.crons:
+            d["crons"] = [r.to_dict() for r in self.crons]
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RecipesConfig:
+        # ``or []`` rather than a ``.get`` default: a manifest carrying an
+        # explicit ``"slack": null`` returns None from ``.get``, and iterating
+        # that raises TypeError out of install_app rather than validating.
+        slack = [SlackRecipe.from_dict(r) for r in (data.get("slack") or []) if isinstance(r, dict)]
+        crons = [CronRecipe.from_dict(r) for r in (data.get("crons") or []) if isinstance(r, dict)]
+        return cls(slack=slack, crons=crons)
+
+
+# ---------------------------------------------------------------------------
 # Main AppManifest
 # ---------------------------------------------------------------------------
 
@@ -2337,6 +2490,7 @@ _KNOWN_FIELDS = frozenset(
         "publishProvider",
         "notifications",
         "contributes",
+        "recipes",
     }
 )
 
@@ -2406,6 +2560,9 @@ class AppManifest:
     # ``extra`` is by definition the un-checked bucket. Being a known field is what
     # makes ``validate()`` see it on every parse.
     contributes: Contributes = field(default_factory=Contributes)
+
+    # --- Recipes (interactive, user-personalized installs) ---
+    recipes: RecipesConfig = field(default_factory=RecipesConfig)
 
     # --- Discovery ---
     tags: list[str] = field(default_factory=list)
@@ -2616,6 +2773,84 @@ class AppManifest:
                     "(no traversal, no other app's namespace, no core route)"
                 )
 
+        # Recipes validation
+        errors.extend(self._validate_recipes())
+
+        return errors
+
+    def _validate_recipes(self) -> list[str]:
+        """Validate recipes section. Returns list of errors."""
+        errors: list[str] = []
+        seen_names: set[tuple[str, str]] = set()  # (type, name)
+
+        for sr in self.recipes.slack:
+            ctx = f"recipes.slack[{sr.name!r}]"
+            if not sr.name:
+                errors.append("recipes.slack entry missing required field: name")
+                continue
+            if not KEBAB_RE.match(sr.name):
+                errors.append(f"{ctx} name must be kebab-case, got: {sr.name!r}")
+            key = ("slack", sr.name)
+            if key in seen_names:
+                errors.append(f"{ctx} duplicate recipe name within recipes.slack")
+            seen_names.add(key)
+            if not sr.description:
+                errors.append(f"{ctx} missing required field: description")
+            if not sr.channelNamePart:
+                errors.append(f"{ctx} missing required field: channelNamePart")
+            elif len(sr.channelNamePart) > _RECIPE_CHANNEL_NAME_PART_MAX:
+                errors.append(
+                    f"{ctx} channelNamePart must be ≤{_RECIPE_CHANNEL_NAME_PART_MAX} chars, "
+                    f"got {len(sr.channelNamePart)}: {sr.channelNamePart!r}"
+                )
+            if not sr.agent:
+                errors.append(f"{ctx} missing required field: agent")
+            if sr.activation not in _SLACK_ACTIVATION_VALUES:
+                errors.append(
+                    f"{ctx} activation must be one of "
+                    f"{sorted(_SLACK_ACTIVATION_VALUES)}, got: {sr.activation!r}"
+                )
+
+        for cr in self.recipes.crons:
+            ctx = f"recipes.crons[{cr.name!r}]"
+            if not cr.name:
+                errors.append("recipes.crons entry missing required field: name")
+                continue
+            if not KEBAB_RE.match(cr.name):
+                errors.append(f"{ctx} name must be kebab-case, got: {cr.name!r}")
+            key = ("cron", cr.name)
+            if key in seen_names:
+                errors.append(f"{ctx} duplicate recipe name within recipes.crons")
+            seen_names.add(key)
+            if not cr.description:
+                errors.append(f"{ctx} missing required field: description")
+            if not cr.agent:
+                errors.append(f"{ctx} missing required field: agent")
+            # schedule XOR everySecs (exactly one required)
+            if bool(cr.schedule) == bool(cr.everySecs):
+                if cr.schedule and cr.everySecs:
+                    errors.append(
+                        f"{ctx} must specify exactly one of 'schedule' or 'everySecs', not both"
+                    )
+                else:
+                    errors.append(f"{ctx} must specify either 'schedule' or 'everySecs'")
+            # promptFile XOR promptText (exactly one required)
+            if bool(cr.promptFile) == bool(cr.promptText):
+                if cr.promptFile and cr.promptText:
+                    errors.append(
+                        f"{ctx} must specify exactly one of 'promptFile' or 'promptText', "
+                        f"not both"
+                    )
+                else:
+                    errors.append(f"{ctx} must specify either 'promptFile' or 'promptText'")
+            if cr.promptFile and ".." in cr.promptFile:
+                errors.append(f"{ctx} promptFile contains path traversal: {cr.promptFile!r}")
+            if cr.channelNamePart and len(cr.channelNamePart) > _RECIPE_CHANNEL_NAME_PART_MAX:
+                errors.append(
+                    f"{ctx} channelNamePart must be ≤{_RECIPE_CHANNEL_NAME_PART_MAX} chars, "
+                    f"got {len(cr.channelNamePart)}: {cr.channelNamePart!r}"
+                )
+
         return errors
 
     def signing_payload(self) -> bytes:
@@ -2748,6 +2983,9 @@ class AppManifest:
         contrib_d = self.contributes.to_dict()
         if contrib_d:
             d["contributes"] = contrib_d
+        recipes_d = self.recipes.to_dict()
+        if recipes_d:
+            d["recipes"] = recipes_d
         if self.tags:
             d["tags"] = self.tags
         if self.jobFamilies:
@@ -2825,6 +3063,13 @@ class AppManifest:
             else Contributes(bad_block=True)
         )
 
+        recipes_raw = data.get("recipes", {})
+        recipes_cfg = (
+            RecipesConfig.from_dict(recipes_raw)
+            if isinstance(recipes_raw, dict)
+            else RecipesConfig()
+        )
+
         return cls(
             name=str(data.get("name", "")),
             version=str(data.get("version", "")),
@@ -2853,6 +3098,7 @@ class AppManifest:
             publishProvider=publish_provider,
             notifications=notifications,
             contributes=contributes,
+            recipes=recipes_cfg,
             tags=[str(t) for t in data.get("tags", []) if t],
             jobFamilies=[str(j) for j in data.get("jobFamilies", []) if j],  # noqa: N815
             extra=extra,

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -2484,8 +2484,13 @@ Examples:
         formatter_class=_fmt,
     )
     app_sub = app_parser.add_subparsers(dest="app_action")
-    app_install = app_sub.add_parser("install", help="Install an app from a local directory")
-    app_install.add_argument("source", help="Path to app directory containing app.json")
+    app_install = app_sub.add_parser(
+        "install", help="Install an app from a local directory or a configured registry"
+    )
+    app_install.add_argument(
+        "source",
+        help="Path to an app directory containing app.json, or registry:<app-name>",
+    )
     app_sub.add_parser("list", help="List installed apps")
     app_enable = app_sub.add_parser("enable", help="Enable an installed app")
     app_enable.add_argument("name", help="App name to enable")

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -39,6 +39,7 @@ from kiro_crew.apps.manager import (
     get_app,
     install_app,
     list_apps,
+    recipes_provider_hint,
     trust_grant_removal_blocked,
     uninstall_app,
 )
@@ -849,7 +850,30 @@ def _handle_app(args: argparse.Namespace) -> None:
         return
 
     if action == "install":
-        result = install_app(args.source)
+        source = str(args.source)
+        if source.startswith("registry:"):
+            # Registry install: clone from the configured registry, then install.
+            # `install_app` only accepts a local directory, so the registry path
+            # (which clones first) is a different entrypoint.
+            from kiro_crew.apps.registry import install_from_registry
+
+            entry_name = source[len("registry:") :].strip()
+            if not entry_name:
+                print("❌ registry install needs a name: registry:<app>", file=sys.stderr)
+                sys.exit(1)
+            reg_result = asyncio.run(install_from_registry(entry_name))
+            if not reg_result.get("ok"):
+                print(f"❌ {reg_result.get('error', 'registry install failed')}", file=sys.stderr)
+                sys.exit(1)
+            installed_name = str(reg_result.get("name") or entry_name)
+            print(f"✅ installed {installed_name} from registry")
+            hint = recipes_provider_hint(installed_name)
+            if hint:
+                print(f"   ℹ️  {hint}")
+            print(f"\n   Run: kirocrew app enable {installed_name}")
+            return
+
+        result = install_app(source)
         if result.ok:
             print(f"✅ {result.message}")
             reg = register_app(result.name)
@@ -862,6 +886,11 @@ def _handle_app(args: argparse.Namespace) -> None:
             if reg.errors:
                 for e in reg.errors:
                     print(f"   ⚠️  {e}")
+            # An app can declare recipes that nothing here can install; say so
+            # rather than letting the block sit inert and silent.
+            hint = recipes_provider_hint(result.name)
+            if hint:
+                print(f"   ℹ️  {hint}")
             print(f"\n   Run: kirocrew app enable {result.name}")
         else:
             print(f"❌ {result.error}", file=sys.stderr)

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -407,6 +407,11 @@ from kiro_crew.dashboard.handlers.side import (  # noqa: E402, F401
 from kiro_crew.dashboard.handlers.skill_budget import (  # noqa: E402, F401
     api_skills_budget,
 )
+
+# ── Brokered Slack channel routing write (app-callable) ──
+from kiro_crew.dashboard.handlers.slack_routing import (  # noqa: E402, F401
+    api_slack_channel_routing_put,
+)
 from kiro_crew.dashboard.handlers.sso_login import (  # noqa: E402, F401
     api_sso_login_ws,
 )

--- a/src/kiro_crew/dashboard/handlers/slack_routing.py
+++ b/src/kiro_crew/dashboard/handlers/slack_routing.py
@@ -1,0 +1,221 @@
+"""Brokered Slack channel routing writes for edition-supplied apps.
+
+An app (the internal recipes app) performs its own Slack calls with the bot
+token it reads from the credential store; it owns channel create, archive,
+invite, and purpose. The one thing it cannot do from its own process is reach
+into the running gateway to make a routing change take effect, so core exposes
+exactly one operation:
+
+  ``PUT /api/slack/channels/{channel_id}/routing``
+      Write (or remove) ``slack.channels[channel_id]`` agent / activation, then
+      refresh the in-memory routing table.
+
+Why this and nothing more: a ``config.json`` read-modify-write must hold BOTH
+the sidecar advisory flock and the loop-side asyncio lock (see
+``chat_utils.run_config_write``), so a second process writing the file itself
+would interleave with the gateway's own writers and revert them from a stale
+snapshot. Funneling the write through the gateway keeps a single writer and
+removes the race. Channel lifecycle (create / archive) is the app's job, not
+core's, so there is no provisioning or destruction endpoint here.
+
+The write itself is NOT implemented here. It delegates to
+``slack.handler._persist_channel_config`` through ``run_config_write``, which is
+the repo's required path for a new ``config.json`` mutation: it takes both locks
+and fails closed on an unreadable config rather than rewriting a ``{}`` baseline
+over your other settings.
+
+Provenance is deliberately not recorded in ``config.json``. An earlier revision
+stamped an ``_owner`` block into the channel entry, but ``ChannelConfig`` carries
+only ``activation`` / ``agent`` / ``thread_follow``, so the first typed
+``KiroCrewConfig.save()`` by any unrelated writer silently dropped it. An
+installing app already knows which channels it created and is the durable record
+of that; core does not pretend to keep a second one.
+
+This is an ordinary dashboard endpoint, so an app reaches it with its app-scoped
+token (``POST /api/apps/{name}/token``) and must declare the path in its manifest
+``permissions.api`` allowlist, which ``token_auth`` enforces.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from aiohttp import web
+
+from kiro_crew.config.loader import (
+    ACTIVATION_ALWAYS,
+    ACTIVATION_MENTION,
+    ACTIVATION_OBSERVE,
+    ACTIVATION_OFF,
+    ACTIVATION_REVIEW,
+)
+from kiro_crew.dashboard.chat_utils import run_config_write
+from kiro_crew.sel import sel as _sel_impl
+
+# Imported as a module, not ``from ... import _persist_channel_config``: the
+# writer is resolved as an attribute at call time, which keeps the delegation
+# patchable in tests. Binding the bare name here would silently make the
+# regression test that proves this endpoint delegates pass vacuously.
+from kiro_crew.slack import handler as slack_handler
+
+logger = logging.getLogger(__name__)
+
+#: Activation modes ``ChannelConfig`` accepts.
+_ACTIVATION_VALUES = frozenset(
+    {
+        ACTIVATION_ALWAYS,
+        ACTIVATION_MENTION,
+        ACTIVATION_OBSERVE,
+        ACTIVATION_REVIEW,
+        ACTIVATION_OFF,
+    }
+)
+
+#: Slack channel ids are ``C``/``G`` followed by uppercase alphanumerics. Bounded
+#: and anchored so a path parameter cannot smuggle a traversal or an absurd value
+#: into the config document we are about to write.
+_CHANNEL_ID_RE = re.compile(r"^[CG][A-Z0-9]{2,31}$")
+
+
+def _caller(request: web.Request) -> str:
+    """Best-effort caller identity for the audit log.
+
+    ``request["app"]`` is the verified app identity set by ``token_auth`` when
+    the call arrived on an app-scoped token; fall back to the generic dashboard
+    caller so a browser-driven call is still attributable.
+    """
+    app_name = request.get("app") or ""
+    return f"app:{app_name}" if app_name else "dashboard"
+
+
+def _sel() -> Any:
+    return _sel_impl()
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/slack/channels/{channel_id}/routing
+# ---------------------------------------------------------------------------
+
+
+async def api_slack_channel_routing_put(request: web.Request) -> web.Response:
+    """Write or remove a channel's routing, then refresh the gateway.
+
+    Body (set):    ``{"agent": str?, "activation": str?}``
+    Body (remove): ``{"remove": true}`` -- deletes ``slack.channels[channel_id]``
+    Returns ``{"ok": True, "changed": [str], "routing_refreshed": bool}``.
+    """
+    caller = _caller(request)
+    channel_id = str(request.match_info.get("channel_id", "")).strip()
+
+    def _audit_refusal(msg: str) -> None:
+        _sel().log_api_access(
+            caller=caller,
+            operation="slack.channels.routing",
+            outcome="denied",
+            source="dashboard",
+            resources=f"channel={channel_id} {msg}",
+        )
+
+    def _deny(msg: str, code: str) -> web.Response:
+        """A malformed request. Status is the literal 400, never a variable.
+
+        The dashboard renders ``error`` verbatim into a localized page, so
+        ``code`` is the part a client can switch on and translate for itself.
+        Both responders here spell their status literally so the error-code
+        contract gate can classify them statically.
+        """
+        _audit_refusal(msg)
+        return web.json_response({"code": code, "error": msg}, status=400)
+
+    def _write_failed(msg: str, code: str) -> web.Response:
+        """The write could not be performed. Status is the literal 500."""
+        _audit_refusal(msg)
+        return web.json_response({"code": code, "error": msg}, status=500)
+
+    if not _CHANNEL_ID_RE.match(channel_id):
+        return _deny("channel_id must be a Slack channel id (C… or G…)", "invalid_channel_id")
+
+    try:
+        body = await request.json()
+    except Exception:
+        return _deny("invalid JSON", "invalid_json")
+    if not isinstance(body, dict):
+        return _deny("body must be an object", "body_not_an_object")
+
+    remove = body.get("remove", False)
+    if not isinstance(remove, bool):
+        return _deny("remove must be a boolean", "invalid_remove")
+
+    agent = body.get("agent")
+    activation = body.get("activation")
+
+    if remove:
+        # Teardown: agent/activation are meaningless alongside a delete.
+        if any(x is not None for x in (agent, activation)):
+            return _deny(
+                "remove cannot be combined with agent/activation",
+                "remove_with_updates",
+            )
+    else:
+        if agent is not None and not isinstance(agent, str):
+            return _deny("agent must be a string", "invalid_agent")
+        if activation is not None:
+            if not isinstance(activation, str) or activation not in _ACTIVATION_VALUES:
+                return _deny(
+                    f"activation must be one of: {', '.join(sorted(_ACTIVATION_VALUES))}",
+                    "invalid_activation",
+                )
+        if agent is None and activation is None:
+            return _deny("nothing to update", "nothing_to_update")
+
+    # The shared channel-config writer, reached through the one helper that holds
+    # BOTH config locks. Deliberately not re-implemented here: a second spelling
+    # of this read-modify-write is what lets the two writer families revert each
+    # other, which is the race this endpoint exists to remove.
+    try:
+        changed = await run_config_write(
+            slack_handler._persist_channel_config,
+            channel_id,
+            activation=activation,
+            agent=agent,
+            remove=remove,
+        )
+    except ValueError as exc:
+        # The writer fails closed on an unreadable/unwritable config rather than
+        # resetting it, so surface that instead of half-applying the change.
+        logger.warning("routing write refused for %s: %s", channel_id, exc)
+        return _write_failed(
+            "config.json could not be read or written; routing was not changed",
+            "config_write_failed",
+        )
+
+    refreshed = _refresh_routing()
+
+    _sel().log_api_access(
+        caller=caller,
+        operation="slack.channels.routing",
+        outcome="success",
+        source="dashboard",
+        resources=f"channel={channel_id} changed={','.join(changed) or 'none'}",
+    )
+    return web.json_response({"ok": True, "changed": changed, "routing_refreshed": refreshed})
+
+
+def _refresh_routing() -> bool:
+    """Copy on-disk channel routing into the running gateway.
+
+    Returns False when the Slack orchestrator is not bound yet (gateway not
+    running, or Slack disabled). That is not an error: the on-disk write already
+    landed and is read at next boot, so the caller is told the durable part
+    succeeded and only the live refresh was skipped.
+    """
+    try:
+        if slack_handler.get_orch_cfg() is None:
+            return False
+        slack_handler._reload_orch_cfg()
+        return True
+    except Exception as exc:
+        logger.warning("in-memory routing refresh failed: %s", exc, exc_info=True)
+        return False

--- a/src/kiro_crew/dashboard/routes/messaging.py
+++ b/src/kiro_crew/dashboard/routes/messaging.py
@@ -23,6 +23,13 @@ def register(app: web.Application) -> None:
     app.router.add_get("/api/slack/config", handlers.api_slack_config_get)
     app.router.add_put("/api/slack/config", handlers.api_slack_config_save)
     app.router.add_get("/api/slack/manifest", handlers.api_slack_manifest)
+    # Brokered channel-routing write for an edition-supplied recipes app: only
+    # the gateway can write config.json under its lock and refresh in-memory
+    # routing. See docs/system-specs/features/recipes.md.
+    app.router.add_put(
+        "/api/slack/channels/{channel_id}/routing",
+        handlers.api_slack_channel_routing_put,
+    )
     app.router.add_get("/api/discord/config", handlers.api_discord_config_get)
     app.router.add_put("/api/discord/config", handlers.api_discord_config_save)
     app.router.add_get("/api/telegram/config", handlers.api_telegram_config_get)

--- a/src/kiro_crew/dashboard/routes/taskrunner.py
+++ b/src/kiro_crew/dashboard/routes/taskrunner.py
@@ -63,7 +63,6 @@ def register(app: web.Application) -> None:
     app.router.add_post("/api/chat/slots/{name}/mirror-link", chat.api_chat_slot_mirror_link)
     app.router.add_post("/api/chat/slots/{name}/mirror-unlink", chat.api_chat_slot_mirror_unlink)
     app.router.add_post("/api/chat/slots/{name}/mirror-pause", chat.api_chat_slot_mirror_pause)
-    app.router.add_get("/api/slack/channels", chat.api_slack_channels)
     app.router.add_post("/api/outbox/notify", handlers.api_outbox_notify)
     app.router.add_get("/api/outbox", handlers.api_outbox_list)
     app.router.add_get("/api/outbox/{filename}", handlers.api_outbox_download)

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -1093,20 +1093,40 @@ def _persist_channel_config(
     channel_id: str,
     activation: str | None = None,
     agent: str | None = None,
-) -> None:
-    """Update a single channel's config in config.json (merge, not overwrite)."""
+    remove: bool = False,
+) -> list[str]:
+    """Update a single channel's config in config.json (merge, not overwrite).
+
+    ``remove=True`` deletes ``slack.channels[channel_id]`` outright; it is the
+    teardown direction used by the brokered routing endpoint
+    (``dashboard/handlers/slack_routing.py``) and is mutually exclusive with
+    ``activation`` / ``agent``.
+
+    Returns the field names actually changed (``["agent"]``, ``["removed"]``,
+    ``[]`` when the value was already what was asked for). Existing callers
+    ignore the return; the routing endpoint reports it to its caller so an app
+    can tell a real change from a no-op.
+    """
     path = config_path()
     if is_sensitive_path(str(path)):
         raise ValueError(f"Refusing to write to sensitive path: {path}")
 
+    changed: list[str] = []
+
     def _apply(data: dict) -> dict:
         slack_data = data.setdefault("slack", {})
         channels = slack_data.setdefault("channels", {})
+        if remove:
+            if channels.pop(channel_id, None) is not None:
+                changed.append("removed")
+            return data
         ch = channels.setdefault(channel_id, {})
-        if activation is not None:
+        if activation is not None and ch.get("activation") != activation:
             ch["activation"] = activation
-        if agent is not None:
+            changed.append("activation")
+        if agent is not None and ch.get("agent") != agent:
             ch["agent"] = agent
+            changed.append("agent")
         return data
 
     try:
@@ -1119,6 +1139,7 @@ def _persist_channel_config(
         raise ValueError(f"Failed to read config: {e}") from e
     except OSError as e:
         raise ValueError(f"Failed to write config: {e}") from e
+    return changed
 
 
 class _PendingApproval:

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -2984,6 +2984,26 @@ class TestBuiltinDeclaredResourcesActuallyRegister:
                         }
                     ]
                 },
+                "recipes": {
+                    "slack": [
+                        {
+                            "name": "r",
+                            "description": "d",
+                            "channelNamePart": "r",
+                            "agent": "a",
+                            "activation": "always",
+                        }
+                    ],
+                    "crons": [
+                        {
+                            "name": "c",
+                            "description": "d",
+                            "schedule": "* * * * *",
+                            "agent": "a",
+                            "promptText": "p",
+                        }
+                    ],
+                },
             }
         )
         # Every declared field must be populated above, otherwise a conditional

--- a/test/test_app_manifest_recipes.py
+++ b/test/test_app_manifest_recipes.py
@@ -1,0 +1,356 @@
+"""Tests for the recipes section of kiro_crew.apps.manifest.
+
+Covers SlackRecipe, CronRecipe, and RecipesConfig
+dataclasses plus AppManifest._validate_recipes integration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.apps.manifest import (
+    AppManifest,
+    CronRecipe,
+    RecipesConfig,
+    SlackRecipe,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_app(**overrides) -> dict:
+    base = {
+        "name": "test-app",
+        "version": "1.0.0",
+        "displayName": "Test App",
+        "description": "A test app",
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_slack_recipe(**overrides) -> dict:
+    base = {
+        "name": "task-intake",
+        "description": "Task intake channel",
+        "channelNamePart": "intake",
+        "agent": "task-intake",
+        "activation": "always",
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_cron_recipe(**overrides) -> dict:
+    base = {
+        "name": "daily-briefing",
+        "description": "Morning briefing",
+        "schedule": "0 12 * * 1-5",
+        "agent": "gpu-comms",
+        "promptText": "Run daily briefing",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# SlackRecipe
+# ---------------------------------------------------------------------------
+
+
+class TestSlackRecipeRoundTrip:
+    def test_minimal_round_trip(self):
+        original = SlackRecipe.from_dict(_valid_slack_recipe())
+        restored = SlackRecipe.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_with_purpose_round_trip(self):
+        d = _valid_slack_recipe(purpose="custom channel purpose")
+        original = SlackRecipe.from_dict(d)
+        assert original.purpose == "custom channel purpose"
+        restored = SlackRecipe.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_purpose_omitted_when_empty(self):
+        d = SlackRecipe.from_dict(_valid_slack_recipe()).to_dict()
+        assert "purpose" not in d
+
+
+# ---------------------------------------------------------------------------
+# CronRecipe
+# ---------------------------------------------------------------------------
+
+
+class TestCronRecipeRoundTrip:
+    def test_schedule_based_round_trip(self):
+        original = CronRecipe.from_dict(_valid_cron_recipe())
+        restored = CronRecipe.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_every_secs_round_trip(self):
+        d = _valid_cron_recipe(schedule="", everySecs=300)
+        original = CronRecipe.from_dict(d)
+        assert original.everySecs == 300
+        assert original.schedule == ""
+        restored = CronRecipe.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_prompt_file_round_trip(self):
+        d = _valid_cron_recipe(promptText="", promptFile="prompts/daily.md")
+        original = CronRecipe.from_dict(d)
+        assert original.promptFile == "prompts/daily.md"
+        assert original.promptText == ""
+        restored = CronRecipe.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_channel_name_part_round_trip(self):
+        d = _valid_cron_recipe(channelNamePart="briefing")
+        original = CronRecipe.from_dict(d)
+        assert original.channelNamePart == "briefing"
+        restored = CronRecipe.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_persistent_session_default_omitted(self):
+        # Default True should not appear in serialized form
+        d = CronRecipe.from_dict(_valid_cron_recipe()).to_dict()
+        assert "persistentSession" not in d
+
+    def test_persistent_session_false_serialized(self):
+        d = _valid_cron_recipe()
+        d["persistentSession"] = False
+        original = CronRecipe.from_dict(d)
+        assert original.persistentSession is False
+        out = original.to_dict()
+        assert out["persistentSession"] is False
+
+    def test_silent_default_omitted(self):
+        d = CronRecipe.from_dict(_valid_cron_recipe()).to_dict()
+        assert "silent" not in d
+
+    def test_silent_true_serialized(self):
+        d = _valid_cron_recipe()
+        d["silent"] = True
+        original = CronRecipe.from_dict(d)
+        assert original.silent is True
+        assert original.to_dict()["silent"] is True
+
+
+# ---------------------------------------------------------------------------
+# RecipesConfig
+# ---------------------------------------------------------------------------
+
+
+class TestRecipesConfigRoundTrip:
+    def test_empty_to_dict(self):
+        assert RecipesConfig().to_dict() == {}
+
+    def test_slack_only_round_trip(self):
+        original = RecipesConfig.from_dict({"slack": [_valid_slack_recipe()]})
+        assert len(original.slack) == 1
+        assert len(original.crons) == 0
+        restored = RecipesConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_crons_only_round_trip(self):
+        original = RecipesConfig.from_dict({"crons": [_valid_cron_recipe()]})
+        assert len(original.slack) == 0
+        assert len(original.crons) == 1
+        restored = RecipesConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_mixed_round_trip(self):
+        original = RecipesConfig.from_dict(
+            {
+                "slack": [_valid_slack_recipe()],
+                "crons": [_valid_cron_recipe()],
+            }
+        )
+        restored = RecipesConfig.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_non_dict_entries_skipped(self):
+        # Defensive: malformed array entries must not crash discovery
+        cfg = RecipesConfig.from_dict(
+            {
+                "slack": [_valid_slack_recipe(), "not a dict", 42],
+                "crons": [_valid_cron_recipe(), None],
+            }
+        )
+        assert len(cfg.slack) == 1
+        assert len(cfg.crons) == 1
+
+
+# ---------------------------------------------------------------------------
+# AppManifest integration — recipes section parses, validates, round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestAppManifestRecipesIntegration:
+    def test_manifest_with_recipes_round_trip(self):
+        data = _valid_app(
+            recipes={
+                "slack": [_valid_slack_recipe()],
+                "crons": [_valid_cron_recipe()],
+            }
+        )
+        m = AppManifest.from_dict(data)
+        assert len(m.recipes.slack) == 1
+        assert len(m.recipes.crons) == 1
+        assert m.recipes.slack[0].name == "task-intake"
+        assert m.recipes.crons[0].name == "daily-briefing"
+        # Round-trip preserves the section
+        m2 = AppManifest.from_dict(m.to_dict())
+        assert m2.recipes == m.recipes
+
+    def test_manifest_without_recipes_omits_section(self):
+        m = AppManifest.from_dict(_valid_app())
+        assert m.recipes.slack == []
+        assert m.recipes.crons == []
+        assert "recipes" not in m.to_dict()
+
+    def test_recipes_field_not_in_extra(self):
+        # Forward-compat: 'recipes' is now a known field, must not leak into extra
+        data = _valid_app(recipes={"slack": [_valid_slack_recipe()]})
+        m = AppManifest.from_dict(data)
+        assert "recipes" not in m.extra
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestRecipesValidation:
+    def _validate(self, **recipes_overrides) -> list[str]:
+        data = _valid_app(recipes=recipes_overrides)
+        return AppManifest.from_dict(data).validate()
+
+    # ---- Slack recipes ----
+
+    def test_valid_slack_recipe_passes(self):
+        errors = self._validate(slack=[_valid_slack_recipe()])
+        assert errors == []
+
+    def test_slack_missing_name(self):
+        errors = self._validate(slack=[_valid_slack_recipe(name="")])
+        assert any("recipes.slack entry missing required field: name" in e for e in errors)
+
+    def test_slack_non_kebab_name(self):
+        errors = self._validate(slack=[_valid_slack_recipe(name="Not_Kebab")])
+        assert any("kebab-case" in e for e in errors)
+
+    def test_slack_missing_description(self):
+        errors = self._validate(slack=[_valid_slack_recipe(description="")])
+        assert any("description" in e for e in errors)
+
+    def test_slack_missing_channel_name_part(self):
+        errors = self._validate(slack=[_valid_slack_recipe(channelNamePart="")])
+        assert any("channelNamePart" in e for e in errors)
+
+    def test_slack_channel_name_part_too_long(self):
+        errors = self._validate(slack=[_valid_slack_recipe(channelNamePart="this-is-way-too-long")])
+        assert any("≤15" in e for e in errors)
+
+    def test_slack_missing_agent(self):
+        errors = self._validate(slack=[_valid_slack_recipe(agent="")])
+        assert any("agent" in e for e in errors)
+
+    def test_slack_invalid_activation(self):
+        errors = self._validate(slack=[_valid_slack_recipe(activation="invalid")])
+        assert any("activation" in e for e in errors)
+
+    @pytest.mark.parametrize("activation", ["always", "mention", "observe"])
+    def test_slack_valid_activations(self, activation):
+        errors = self._validate(slack=[_valid_slack_recipe(activation=activation)])
+        assert errors == []
+
+    def test_slack_duplicate_name(self):
+        errors = self._validate(
+            slack=[
+                _valid_slack_recipe(name="dup"),
+                _valid_slack_recipe(name="dup", channelNamePart="other"),
+            ]
+        )
+        assert any("duplicate" in e for e in errors)
+
+    # ---- Cron recipes ----
+
+    def test_valid_cron_recipe_schedule_passes(self):
+        errors = self._validate(crons=[_valid_cron_recipe()])
+        assert errors == []
+
+    def test_valid_cron_recipe_every_secs_passes(self):
+        errors = self._validate(crons=[_valid_cron_recipe(schedule="", everySecs=300)])
+        assert errors == []
+
+    def test_cron_missing_name(self):
+        errors = self._validate(crons=[_valid_cron_recipe(name="")])
+        assert any("recipes.crons entry missing required field: name" in e for e in errors)
+
+    def test_cron_non_kebab_name(self):
+        errors = self._validate(crons=[_valid_cron_recipe(name="BadName")])
+        assert any("kebab-case" in e for e in errors)
+
+    def test_cron_missing_agent(self):
+        errors = self._validate(crons=[_valid_cron_recipe(agent="")])
+        assert any("agent" in e for e in errors)
+
+    def test_cron_missing_schedule_and_every_secs(self):
+        errors = self._validate(crons=[_valid_cron_recipe(schedule="", everySecs=0)])
+        assert any("schedule" in e or "everySecs" in e for e in errors)
+
+    def test_cron_both_schedule_and_every_secs(self):
+        errors = self._validate(crons=[_valid_cron_recipe(schedule="0 12 * * *", everySecs=300)])
+        assert any("not both" in e for e in errors)
+
+    def test_cron_missing_prompt(self):
+        errors = self._validate(crons=[_valid_cron_recipe(promptText="", promptFile="")])
+        assert any("promptFile" in e or "promptText" in e for e in errors)
+
+    def test_cron_both_prompt_file_and_text(self):
+        errors = self._validate(
+            crons=[_valid_cron_recipe(promptFile="prompts/x.md", promptText="inline")]
+        )
+        assert any("not both" in e for e in errors)
+
+    def test_cron_prompt_file_path_traversal(self):
+        errors = self._validate(
+            crons=[_valid_cron_recipe(promptText="", promptFile="../../etc/passwd")]
+        )
+        assert any("path traversal" in e for e in errors)
+
+    def test_cron_channel_name_part_too_long(self):
+        errors = self._validate(crons=[_valid_cron_recipe(channelNamePart="this-is-way-too-long")])
+        assert any("≤15" in e for e in errors)
+
+    def test_cron_channel_name_part_valid_when_omitted(self):
+        # channelNamePart is OPTIONAL on cron recipes (no output channel)
+        errors = self._validate(crons=[_valid_cron_recipe(channelNamePart="")])
+        assert errors == []
+
+    def test_cron_duplicate_name(self):
+        errors = self._validate(
+            crons=[
+                _valid_cron_recipe(name="dup"),
+                _valid_cron_recipe(name="dup"),
+            ]
+        )
+        assert any("duplicate" in e for e in errors)
+
+    # ---- Combined ----
+
+    def test_slack_and_cron_can_share_name(self):
+        # Cross-type duplication is fine (different namespaces)
+        errors = self._validate(
+            slack=[_valid_slack_recipe(name="thing")],
+            crons=[_valid_cron_recipe(name="thing")],
+        )
+        assert errors == []
+
+    def test_existing_app_manifest_validation_still_works(self):
+        # Assert: pre-existing manifest validation paths unaffected by recipes addition
+        m = AppManifest.from_dict(_valid_app(name="Bad_Name"))
+        errors = m.validate()
+        assert any("kebab-case" in e for e in errors)

--- a/test/test_slack_routing.py
+++ b/test/test_slack_routing.py
@@ -1,0 +1,349 @@
+"""Tests for the brokered Slack channel-routing write.
+
+``PUT /api/slack/channels/{channel_id}/routing`` is the one config write core
+performs on behalf of an edition-supplied recipes app, so the things worth
+pinning are the ones an app depends on: that every malformed request is refused
+with a stable machine-readable ``code`` rather than prose a client would have to
+parse, that a successful write lands in ``config.json``, that teardown removes
+the entry, that an unreadable config is refused rather than overwritten, and
+that a gateway not running Slack still reports the durable half as done.
+
+The endpoint does not implement the write. It delegates to
+``slack.handler._persist_channel_config`` via ``run_config_write`` (both config
+locks, fail-closed on a corrupt document), so these tests drive the real writer
+with ``config_path`` redirected at ``tmp_path`` and never touch a real crew home.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+from kiro_crew.dashboard.handlers import slack_routing
+from kiro_crew.dashboard.handlers.slack_routing import (
+    _ACTIVATION_VALUES,
+    _caller,
+    _refresh_routing,
+    api_slack_channel_routing_put,
+)
+
+_CHANNEL = "C0123ABC"
+
+
+def _req(body, channel_id: str = _CHANNEL, app: str | None = None, bad_json: bool = False):
+    """A mocked PUT carrying *body*, optionally as a verified app identity."""
+    req = make_mocked_request(
+        "PUT",
+        f"/api/slack/channels/{channel_id}/routing",
+        match_info={"channel_id": channel_id},
+    )
+    if app is not None:
+        req["app"] = app
+    if bad_json:
+        req.json = AsyncMock(side_effect=ValueError("not json"))
+    else:
+        req.json = AsyncMock(return_value=body)
+    return req
+
+
+async def _call(req, tmp_path, *, orch: object | None = None):
+    """Drive the handler against the real writer, rooted at *tmp_path*.
+
+    ``config_path`` is patched where ``_persist_channel_config`` reads it, so the
+    genuine locked read-modify-write runs, just against a throwaway file.
+
+    ``orch`` is what ``get_orch_cfg`` returns: ``None`` models a gateway with no
+    Slack orchestrator bound, which must still succeed on the durable write. The
+    Slack functions are patched on the real module rather than by swapping
+    ``sys.modules``, because ``_refresh_routing`` does ``from kiro_crew.slack
+    import handler`` — an ATTRIBUTE lookup on the parent package that a
+    ``sys.modules`` entry never satisfies. It would also pass vacuously: the real
+    ``get_orch_cfg`` already returns ``None`` in a test process.
+    """
+    cfg = tmp_path / "config.json"
+    with (
+        patch.object(slack_routing, "_sel", return_value=MagicMock()),
+        patch("kiro_crew.slack.handler.config_path", return_value=cfg),
+        patch("kiro_crew.slack.handler.get_orch_cfg", return_value=orch),
+        patch("kiro_crew.slack.handler._reload_orch_cfg") as reload_mock,
+    ):
+        resp = await api_slack_channel_routing_put(req)
+    return resp, reload_mock
+
+
+def _payload(resp) -> dict:
+    return json.loads(resp.body.decode("utf-8"))
+
+
+def _channels(tmp_path) -> dict:
+    doc = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    return doc.get("slack", {}).get("channels", {})
+
+
+class TestRejections:
+    """Every refusal carries a stable ``code``; prose is advisory only."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "channel_id",
+        ["", "nope", "c0123abc", "X0123ABC", "C1", "C" + "A" * 40, "../etc/passwd"],
+    )
+    async def test_invalid_channel_id(self, channel_id, tmp_path):
+        resp, _ = await _call(_req({"agent": "a"}, channel_id=channel_id), tmp_path)
+        assert resp.status == 400
+        assert _payload(resp)["code"] == "invalid_channel_id"
+
+    @pytest.mark.asyncio
+    async def test_unparseable_body(self, tmp_path):
+        resp, _ = await _call(_req(None, bad_json=True), tmp_path)
+        assert _payload(resp)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("body", [[], "str", 3, None])
+    async def test_body_must_be_an_object(self, body, tmp_path):
+        resp, _ = await _call(_req(body), tmp_path)
+        assert _payload(resp)["code"] == "body_not_an_object"
+
+    @pytest.mark.asyncio
+    async def test_remove_must_be_a_boolean(self, tmp_path):
+        resp, _ = await _call(_req({"remove": "yes"}), tmp_path)
+        assert _payload(resp)["code"] == "invalid_remove"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("extra", [{"agent": "a"}, {"activation": "always"}])
+    async def test_remove_cannot_carry_updates(self, extra, tmp_path):
+        resp, _ = await _call(_req({"remove": True, **extra}), tmp_path)
+        assert _payload(resp)["code"] == "remove_with_updates"
+
+    @pytest.mark.asyncio
+    async def test_agent_must_be_a_string(self, tmp_path):
+        resp, _ = await _call(_req({"agent": 7}), tmp_path)
+        assert _payload(resp)["code"] == "invalid_agent"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("activation", ["sometimes", "", 5, []])
+    async def test_activation_must_be_a_known_mode(self, activation, tmp_path):
+        resp, _ = await _call(_req({"activation": activation}), tmp_path)
+        body = _payload(resp)
+        assert body["code"] == "invalid_activation"
+        # The prose lists the accepted modes, so a human sees the options.
+        assert "must be one of" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_update_is_refused(self, tmp_path):
+        # Neither a removal nor an update: writing nothing would still rewrite
+        # config.json and refresh routing for no reason.
+        resp, _ = await _call(_req({}), tmp_path)
+        assert _payload(resp)["code"] == "nothing_to_update"
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_writes_no_config(self, tmp_path):
+        await _call(_req({"agent": 7}), tmp_path)
+        assert not (tmp_path / "config.json").exists()
+
+
+class TestSet:
+    @pytest.mark.asyncio
+    async def test_agent_and_activation_land_in_config(self, tmp_path):
+        resp, _ = await _call(_req({"agent": "task-intake", "activation": "always"}), tmp_path)
+        assert resp.status == 200
+        body = _payload(resp)
+        assert body["ok"] is True
+        assert sorted(body["changed"]) == ["activation", "agent"]
+        assert _channels(tmp_path)[_CHANNEL] == {"activation": "always", "agent": "task-intake"}
+
+    @pytest.mark.asyncio
+    async def test_rewriting_the_same_values_reports_no_change(self, tmp_path):
+        await _call(_req({"agent": "a"}), tmp_path)
+        resp, _ = await _call(_req({"agent": "a"}), tmp_path)
+        assert _payload(resp)["changed"] == []
+        assert _channels(tmp_path)[_CHANNEL]["agent"] == "a"
+
+    @pytest.mark.asyncio
+    async def test_existing_unrelated_config_is_preserved(self, tmp_path):
+        (tmp_path / "config.json").write_text(
+            json.dumps({"dashboard": {"url": "http://x:1"}, "slack": {"botToken": "keep"}}),
+            encoding="utf-8",
+        )
+        await _call(_req({"agent": "a"}), tmp_path)
+        doc = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+        assert doc["dashboard"] == {"url": "http://x:1"}
+        assert doc["slack"]["botToken"] == "keep"
+        assert doc["slack"]["channels"][_CHANNEL]["agent"] == "a"
+
+    @pytest.mark.asyncio
+    async def test_other_channels_are_untouched(self, tmp_path):
+        (tmp_path / "config.json").write_text(
+            json.dumps({"slack": {"channels": {"C9999OTHER": {"agent": "other"}}}}),
+            encoding="utf-8",
+        )
+        await _call(_req({"agent": "a"}), tmp_path)
+        channels = _channels(tmp_path)
+        assert channels["C9999OTHER"] == {"agent": "other"}
+        assert channels[_CHANNEL]["agent"] == "a"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("activation", sorted(_ACTIVATION_VALUES))
+    async def test_every_activation_mode_is_accepted(self, activation, tmp_path):
+        resp, _ = await _call(_req({"activation": activation}), tmp_path)
+        assert resp.status == 200
+        assert _channels(tmp_path)[_CHANNEL]["activation"] == activation
+
+
+class TestRemove:
+    @pytest.mark.asyncio
+    async def test_remove_deletes_the_entry(self, tmp_path):
+        await _call(_req({"agent": "a"}), tmp_path)
+        resp, _ = await _call(_req({"remove": True}), tmp_path)
+        assert resp.status == 200
+        assert _payload(resp)["changed"] == ["removed"]
+        assert _CHANNEL not in _channels(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_remove_leaves_other_channels_alone(self, tmp_path):
+        (tmp_path / "config.json").write_text(
+            json.dumps({"slack": {"channels": {"C9999OTHER": {"agent": "other"}}}}),
+            encoding="utf-8",
+        )
+        await _call(_req({"agent": "a"}), tmp_path)
+        await _call(_req({"remove": True}), tmp_path)
+        channels = _channels(tmp_path)
+        assert _CHANNEL not in channels
+        assert channels["C9999OTHER"] == {"agent": "other"}
+
+    @pytest.mark.asyncio
+    async def test_removing_an_absent_entry_is_a_no_op(self, tmp_path):
+        # Teardown must be idempotent: an app that retries a removal, or removes
+        # a recipe whose channel was already archived, must not get an error.
+        resp, _ = await _call(_req({"remove": True}), tmp_path)
+        assert resp.status == 200
+        assert _payload(resp)["changed"] == []
+
+
+class TestFailClosed:
+    """An unreadable config must be refused, never overwritten."""
+
+    @pytest.mark.asyncio
+    async def test_corrupt_config_is_refused_and_left_intact(self, tmp_path):
+        # The regression this replaces: the endpoint used to log a warning and
+        # rewrite from {}, destroying every unrelated setting including the bot
+        # token. The shared writer fails closed instead.
+        corrupt = "{ this is not json"
+        (tmp_path / "config.json").write_text(corrupt, encoding="utf-8")
+        resp, reload_mock = await _call(_req({"agent": "a"}), tmp_path)
+        assert resp.status == 500
+        assert _payload(resp)["code"] == "config_write_failed"
+        # Untouched on disk, and no live refresh was attempted.
+        assert (tmp_path / "config.json").read_text(encoding="utf-8") == corrupt
+        reload_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_writer_failure_surfaces_as_a_coded_error(self, tmp_path):
+        with (
+            patch.object(slack_routing, "_sel", return_value=MagicMock()),
+            patch(
+                "kiro_crew.slack.handler._persist_channel_config",
+                side_effect=ValueError("Refusing to write to sensitive path"),
+            ),
+        ):
+            resp = await api_slack_channel_routing_put(_req({"agent": "a"}))
+        assert resp.status == 500
+        assert _payload(resp)["code"] == "config_write_failed"
+
+
+class TestDelegation:
+    """The write must go through the dual-locked shared writer, not a local one."""
+
+    @pytest.mark.asyncio
+    async def test_the_shared_channel_writer_is_what_runs(self, tmp_path):
+        cfg = tmp_path / "config.json"
+        with (
+            patch.object(slack_routing, "_sel", return_value=MagicMock()),
+            patch("kiro_crew.slack.handler.config_path", return_value=cfg),
+            patch("kiro_crew.slack.handler.get_orch_cfg", return_value=None),
+            patch(
+                "kiro_crew.slack.handler._persist_channel_config", return_value=["agent"]
+            ) as writer,
+        ):
+            resp = await api_slack_channel_routing_put(_req({"agent": "a", "activation": "always"}))
+        assert resp.status == 200
+        writer.assert_called_once_with(_CHANNEL, activation="always", agent="a", remove=False)
+
+    @pytest.mark.asyncio
+    async def test_this_module_no_longer_owns_a_config_writer(self):
+        # Guard against the duplicate returning: a second read-modify-write of
+        # config.json is what lets the two writer families revert each other.
+        import inspect
+
+        src = inspect.getsource(slack_routing)
+        assert "atomic_write" not in src
+        assert "_write_routing_locked" not in src
+
+
+class TestRefresh:
+    @pytest.mark.asyncio
+    async def test_routing_refreshes_when_the_orchestrator_is_bound(self, tmp_path):
+        resp, reload_mock = await _call(_req({"agent": "a"}), tmp_path, orch=object())
+        assert _payload(resp)["routing_refreshed"] is True
+        reload_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_durable_write_still_succeeds_with_no_orchestrator(self, tmp_path):
+        # Slack disabled or gateway not up: the on-disk write is what matters and
+        # is read at next boot, so this is reported as success-without-refresh.
+        resp, reload_mock = await _call(_req({"agent": "a"}), tmp_path, orch=None)
+        assert resp.status == 200
+        assert _payload(resp)["routing_refreshed"] is False
+        reload_mock.assert_not_called()
+        assert _channels(tmp_path)[_CHANNEL]["agent"] == "a"
+
+    def test_refresh_reports_false_when_the_reload_raises(self):
+        # Defensive branch: a broken in-memory refresh must not surface as a 500,
+        # because the durable write has already landed by this point.
+        with (
+            patch("kiro_crew.slack.handler.get_orch_cfg", return_value=object()),
+            patch(
+                "kiro_crew.slack.handler._reload_orch_cfg",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            assert _refresh_routing() is False
+
+
+class TestCaller:
+    def test_app_identity_is_attributed(self):
+        req = make_mocked_request("PUT", "/x")
+        req["app"] = "kiro-crew-recipe-system"
+        assert _caller(req) == "app:kiro-crew-recipe-system"
+
+    def test_dashboard_is_the_fallback(self):
+        assert _caller(make_mocked_request("PUT", "/x")) == "dashboard"
+
+    def test_empty_app_falls_back_to_dashboard(self):
+        req = make_mocked_request("PUT", "/x")
+        req["app"] = ""
+        assert _caller(req) == "dashboard"
+
+
+def test_sel_returns_the_audit_logger():
+    """``_sel`` is the audit seam every branch logs through."""
+    sentinel = object()
+    with patch.object(slack_routing, "_sel_impl", return_value=sentinel):
+        assert slack_routing._sel() is sentinel
+
+
+def test_activation_values_are_the_loader_constants():
+    from kiro_crew.config import loader
+
+    assert _ACTIVATION_VALUES == frozenset(
+        {
+            loader.ACTIVATION_ALWAYS,
+            loader.ACTIVATION_MENTION,
+            loader.ACTIVATION_OBSERVE,
+            loader.ACTIVATION_REVIEW,
+            loader.ACTIVATION_OFF,
+        }
+    )

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -869,6 +869,15 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # ``_cleanup_app_crons_from_scheduler`` above. No child process is
         # created; the sole input is the operator-typed app name.
         "cli_commands.py::_register_app_crons_to_scheduler",
+        # NOT a subprocess spawn: the AST heuristic matches ``asyncio.run`` (attr
+        # ``run`` on base ``asyncio``), used to drive the async
+        # ``install_from_registry`` coroutine from the loop-less CLI
+        # ``kirocrew app install registry:<name>`` path. No child process is
+        # created by this call; the registry clone it awaits does its own
+        # spawning inside ``apps/registry.py``, which is separately audited.
+        # The sole input is the operator-typed registry entry name. Same
+        # classification as the two ``cli_commands.py`` sites above.
+        "cli_commands.py::_handle_app",
         "cli_doctor.py::_doctor",
         # NOT a subprocess spawn: the AST heuristic matches ``asyncio.run`` (attr
         # ``run`` on base ``asyncio``), used to drive the async Discord


### PR DESCRIPTION
## Problem / Motivation

An app can ship agents in-tree today, but it has no way to say "this agent
wants a Slack channel of its own" or "this agent should run on a schedule".
Getting an agent from *installed* to *reachable* is manual every time: create
the channel in Slack, route it to the agent, repeat. That is tolerable once and
tedious at three, and the tedium is what stops anyone shipping small
agent-plus-channel bundles as installable units.

Two of those steps are ones an app genuinely cannot perform for itself, however
much code it ships:

- **The routing write has to be the gateway's.** `slack.channels[id]` lives in
  `config.json`, whose write lock is an in-process `asyncio.Lock`. A second
  process writing that file races every other config writer with no shared OS
  lock, so a lost update is rare but real.
- **The running gateway has to be told.** `_reload_orch_cfg` is in-process, so
  routing written from outside does not take effect until the next restart.

An external app backend also runs in its own process with its own `.venv` and
cannot import `kiro_crew`, so it has no in-process route to either one.

## Why it matters

This is the seam work that lets the agent-plus-channel bundle be a *thing you
install* rather than a runbook someone follows. Without it, every such bundle
costs manual Slack setup per recipe, which is precisely the friction that keeps
them from being shared.

It is deliberately inert on `main`: core gains a validated vocabulary and one
brokered endpoint, and ships no recipes implementation. The cost of carrying it
is a schema plus 248 lines of handler; the benefit is that an installed app can
own the whole workflow without a second config writer racing the gateway.

## What changed (motivation → approach → change)

**Goal:** let an installed app act on recipe declarations without core owning
the feature, and without a second process writing `config.json`.

**Approach, and what it is not.** The obvious design is to broker everything,
so core creates and archives Slack channels on the app's behalf. Rejected: an
app backend runs same-UID and can read the credential store directly, so
brokering the Slack calls buys no containment (see
`src/kiro_crew/docs/app-platform-trust-model.md`) while handing core a much
larger and more dangerous surface, channel creation and archival, to serve a
workflow not every install wants. So the app does its own Slack calls, and core
brokers only the one write it must own, for the correctness reasons above. The
alternative of letting the app write `config.json` itself, with core offering
only a reload nudge, is smaller but puts a second writer on a file whose lock is
in-process; making that safe means giving every existing config writer an
OS-level lock, a bigger change than the endpoint it saves.

**What was built:**

1. **`recipes` manifest vocabulary** (`apps/manifest.py`) — `SlackRecipe`,
   `CronRecipe`, `RecipesConfig`, `RecipeDependencies`, with
   `AppManifest._validate_recipes` enforcing kebab-case names, uniqueness,
   required fields, valid activations, and the cron either/or rules
   (`schedule` xor `everySecs`, `promptFile` xor `promptText`). Parsed,
   validated, otherwise ignored.
2. **`PUT /api/slack/channels/{channel_id}/routing`**
   (`dashboard/handlers/slack_routing.py`) — writes or removes
   `slack.channels[id]` under the gateway's existing `_get_config_lock()`, then
   refreshes in-memory routing. Handles teardown via `{"remove": true}`, so the
   lifecycle is symmetric. Channel id is validated against an anchored bounded
   pattern before it reaches the config document, activation against the values
   `ChannelConfig` accepts, and every call is attributed in the audit log.
3. **`recipes-provider` tag + install-time hint** (`apps/manager.py`,
   `cli_commands.py`) — `recipes_provider_installed()` and
   `recipes_provider_hint()` tell the user at install time when an app declares
   recipes but nothing is installed that would act on them. A manifest tag
   rather than a schema field, so provider detection costs the schema nothing;
   both helpers swallow every exception, because a hint must never break an
   install.
4. **`kirocrew app install registry:<name>`** (`cli.py`, `cli_commands.py`) —
   `install_app` already accepted this form; only the CLI help and dispatch
   were missing.

Also removes a duplicate `GET /api/slack/channels` registration. It was
registered twice, and the refactor that split the route table into
`dashboard/routes/` carried both copies into different modules
(`sessions.py` and `taskrunner.py`). `register_all` runs `sessions` before
`taskrunner`, so the `taskrunner` copy never resolved; this drops the dead one
and leaves the live registration and its `website/src/api/client.ts` caller
untouched.

## Tests

`test/test_app_manifest_recipes.py` — 50 cases in 6 classes, covering the
schema this PR makes public:

- **Round-trip fidelity** (`TestSlackRecipeRoundTrip`,
  `TestCronRecipeRoundTrip`, `TestRecipesConfigRoundTrip`,
  `TestRecipeDependencies`) — every field survives `from_dict` → `to_dict`, and
  optional fields are *omitted* rather than emitted empty when unset
  (`purpose`, `dependencies`, `persistentSession`, `silent`). This is what
  keeps a manifest from growing keys nobody wrote.
- **Manifest integration** (`TestAppManifestRecipesIntegration`) — a manifest
  with no `recipes` omits the section entirely, and `recipes` does not leak into
  `extra`.
- **Validation** (`TestRecipesValidation`) — each rule is pinned by the case
  that violates it: missing name, non-kebab name, missing
  description/agent/channelNamePart, over-long channel name part, invalid
  activation, duplicate names, and the cron either/or pairs in both directions
  (neither supplied, both supplied).

Not covered by unit tests: the routing endpoint itself. It is an aiohttp
handler whose behaviour is the config write plus the in-memory refresh, so a
meaningful test needs a gateway fixture; called out under Manual verification
rather than papered over.

## Manual verification

**Verified locally:**

- `./scripts/docs-lint.sh` — passes (213 files).
- `python -m py_compile` — clean across every touched module.
- Route table inspected after the `dashboard/routes/` split: exactly one
  `GET /api/slack/channels` registration remains (`routes/sessions.py`), and the
  new PUT is registered once (`routes/messaging.py`). Confirmed no catch-all
  (`:.*`) route exists in the package and that the literal three-segment path
  cannot be shadowed by the five-segment pattern, so registration order is not
  load-bearing here.
- Validation exercised directly against the real `AppManifest`: a well-formed
  `recipes` block validates to `[]`, and malformed entries produce the expected
  messages.
- `recipes_provider_installed()` / `recipes_provider_hint()` exercised across
  five states (enabled provider, disabled provider, no provider, app declaring
  no recipes, app absent) — the hint fires only in the intended one.

**Still required, and I could not run it here:** `pytest` and
`cd website && npm run check`. This checkout has no pytest, aiohttp, or
croniter, so CI is the first real execution of the new test file. Flagging that
rather than implying a green suite.

**Worth a reviewer's eye:** the routing endpoint against a live gateway — set
routing for a channel, confirm messages route to the named agent without a
restart, then `{"remove": true}` and confirm the entry is gone from
`config.json` and routing stops.

## Related Issues

Closes #4196

That issue also asks whether this wants an RFC in `docs/request-for-change/`
first. CONTRIBUTING routes changes to a public interface, changes other parts of
the project build around, and changes that would be expensive to reverse through
an RFC, and the `recipes` block is a manifest contract third-party app authors
would write against. If maintainers want it written up, folding it into
`rfc-federated-app-platform.md` as a phase looks better than a new document.
**Please rule on that before spending review time on the code.**

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality — **new
      tests added (50 cases); "existing tests pass" is unverified locally, see
      Manual verification. CI is the first run.**
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/system-specs/features/recipes.md`
      plus its index entry; `docs-lint.sh` green
- [x] No secrets, credentials, or internal references in the diff — diff scanned
      for credential patterns and internal names
