### PR TITLE
fix: pace sprite animation at its fps instead of display refresh rate

### DIFF
--- a/website/src/apps/crew-companion/SpriteRenderer.tsx
+++ b/website/src/apps/crew-companion/SpriteRenderer.tsx
@@ -18,6 +18,7 @@ const SpriteRendererInner: React.FC<SpriteRendererProps> = ({
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const rafRef = useRef(0)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const frameRef = useRef(0)
   const lastTimeRef = useRef(0)
 
@@ -55,14 +56,35 @@ const SpriteRendererInner: React.FC<SpriteRendererProps> = ({
       if (frames < 1) frames = 1
 
       const interval = 1000 / fps
+      const drawFrame = () => {
+        ctx.clearRect(0, 0, frameWidth, frameHeight)
+        ctx.drawImage(img, frameRef.current * frameWidth, 0, frameWidth, frameHeight, 0, 0, frameWidth, frameHeight)
+        frameRef.current = (frameRef.current + 1) % frames
+      }
+
+      // Static sprite: draw once, no animation loop at all.
+      if (frames === 1) {
+        drawFrame()
+        return
+      }
+
+      // Pace wakeups at the sprite's fps, not the display's refresh rate.
+      // A bare rAF loop wakes the renderer at 60-120Hz to draw at ~8fps, and
+      // (because an active rAF consumer keeps the compositor's BeginFrame
+      // stream running) holds the GPU process busy too — this window runs with
+      // backgroundThrottling disabled, so nothing ever throttles it. Instead,
+      // sleep out the inter-frame gap with a timer and use rAF only to align
+      // the actual draw with the next vsync.
       const animate = (time: number) => {
+        rafRef.current = 0
         if (time - lastTimeRef.current >= interval) {
           lastTimeRef.current = time
-          ctx.clearRect(0, 0, frameWidth, frameHeight)
-          ctx.drawImage(img, frameRef.current * frameWidth, 0, frameWidth, frameHeight, 0, 0, frameWidth, frameHeight)
-          frameRef.current = (frameRef.current + 1) % frames
+          drawFrame()
         }
-        rafRef.current = requestAnimationFrame(animate)
+        const wait = Math.max(0, interval - (performance.now() - lastTimeRef.current))
+        timerRef.current = setTimeout(() => {
+          rafRef.current = requestAnimationFrame(animate)
+        }, wait)
       }
       rafRef.current = requestAnimationFrame(animate)
     }
@@ -71,6 +93,7 @@ const SpriteRendererInner: React.FC<SpriteRendererProps> = ({
     return () => {
       img.removeEventListener('load', onLoad)
       cancelAnimationFrame(rafRef.current)
+      clearTimeout(timerRef.current)
     }
   }, [src, frameWidth, frameHeight, fps, totalFrames])
 

--- a/website/src/apps/mochi/src/renderer/SpriteRenderer.tsx
+++ b/website/src/apps/mochi/src/renderer/SpriteRenderer.tsx
@@ -18,6 +18,7 @@ const SpriteRendererInner: React.FC<SpriteRendererProps> = ({
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const rafRef = useRef(0)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const frameRef = useRef(0)
   const lastTimeRef = useRef(0)
 
@@ -59,14 +60,35 @@ const SpriteRendererInner: React.FC<SpriteRendererProps> = ({
       if (frames < 1) frames = 1
 
       const interval = 1000 / fps
+      const drawFrame = () => {
+        ctx.clearRect(0, 0, frameWidth, frameHeight)
+        ctx.drawImage(img, frameRef.current * frameWidth, 0, frameWidth, frameHeight, 0, 0, frameWidth, frameHeight)
+        frameRef.current = (frameRef.current + 1) % frames
+      }
+
+      // Static sprite: draw once, no animation loop at all.
+      if (frames === 1) {
+        drawFrame()
+        return
+      }
+
+      // Pace wakeups at the sprite's fps, not the display's refresh rate.
+      // A bare rAF loop wakes the renderer at 60-120Hz to draw at ~8fps, and
+      // (because an active rAF consumer keeps the compositor's BeginFrame
+      // stream running) holds the GPU process busy too — this window runs with
+      // backgroundThrottling disabled, so nothing ever throttles it. Instead,
+      // sleep out the inter-frame gap with a timer and use rAF only to align
+      // the actual draw with the next vsync.
       const animate = (time: number) => {
+        rafRef.current = 0
         if (time - lastTimeRef.current >= interval) {
           lastTimeRef.current = time
-          ctx.clearRect(0, 0, frameWidth, frameHeight)
-          ctx.drawImage(img, frameRef.current * frameWidth, 0, frameWidth, frameHeight, 0, 0, frameWidth, frameHeight)
-          frameRef.current = (frameRef.current + 1) % frames
+          drawFrame()
         }
-        rafRef.current = requestAnimationFrame(animate)
+        const wait = Math.max(0, interval - (performance.now() - lastTimeRef.current))
+        timerRef.current = setTimeout(() => {
+          rafRef.current = requestAnimationFrame(animate)
+        }, wait)
       }
       rafRef.current = requestAnimationFrame(animate)
     }
@@ -75,6 +97,7 @@ const SpriteRendererInner: React.FC<SpriteRendererProps> = ({
     return () => {
       img.removeEventListener('load', onLoad)
       cancelAnimationFrame(rafRef.current)
+      clearTimeout(timerRef.current)
     }
   }, [src, frameWidth, frameHeight, fps, totalFrames])
 

--- a/website/src/apps/mochi/test/spriteRendererPacing.test.tsx
+++ b/website/src/apps/mochi/test/spriteRendererPacing.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * SpriteRenderer scheduling — the animation loop must wake at the sprite's
+ * fps, not the display's refresh rate, and must not run at all for a
+ * single-frame (static) sprite.
+ *
+ * The pet overlay window disables backgroundThrottling, so nothing external
+ * ever throttles this loop: a wakeup scheduled here runs forever. These tests
+ * pin the wakeup *count*, because that is the resource being spent.
+ */
+import React from 'react'
+import { render, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SpriteRenderer } from '../src/renderer/SpriteRenderer'
+
+/** Deterministic clock shared by rAF, setTimeout, and performance.now. */
+let now = 0
+/** Pending rAF callbacks, keyed by handle. */
+let rafQueue = new Map<number, FrameRequestCallback>()
+let rafHandle = 0
+let rafCalls = 0
+
+/** Run one display frame: advance the clock and fire pending rAF callbacks. */
+function tickFrame(ms: number) {
+  now += ms
+  vi.advanceTimersByTime(ms)
+  const pending = rafQueue
+  rafQueue = new Map()
+  pending.forEach(cb => cb(now))
+}
+
+function make2dContext() {
+  return {
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(64 * 64 * 4).fill(255) })),
+  }
+}
+
+let drawCtx: ReturnType<typeof make2dContext>
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  now = 0
+  rafQueue = new Map()
+  rafHandle = 0
+  rafCalls = 0
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    rafCalls += 1
+    rafHandle += 1
+    rafQueue.set(rafHandle, cb)
+    return rafHandle
+  })
+  vi.stubGlobal('cancelAnimationFrame', (h: number) => { rafQueue.delete(h) })
+  vi.spyOn(performance, 'now').mockImplementation(() => now)
+
+  drawCtx = make2dContext()
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+    () => drawCtx as unknown as CanvasRenderingContext2D,
+  )
+  // Sprite strips load through an Image(); fire `load` synchronously so the
+  // effect body runs inside the test's fake-timer scope.
+  vi.spyOn(Image.prototype, 'addEventListener').mockImplementation(
+    function (this: HTMLImageElement, type: string, cb: EventListenerOrEventListenerObject) {
+      if (type === 'load') (cb as EventListener)(new Event('load'))
+    },
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('SpriteRenderer wakeup pacing', () => {
+  it('wakes at the sprite fps, not once per display frame', () => {
+    render(
+      <SpriteRenderer src="strip.png" frameWidth={64} frameHeight={64} fps={8} totalFrames={4} />,
+    )
+    const baseline = rafCalls
+    // Simulate 1 second of a 120Hz display: 120 frames of ~8.33ms.
+    for (let i = 0; i < 120; i++) tickFrame(1000 / 120)
+    const wakeups = rafCalls - baseline
+    // At 8fps over 1s the loop needs ~8 wakeups; the old vsync-chained loop
+    // took ~120. Allow slack for timer/vsync alignment, but pin the order of
+    // magnitude.
+    expect(wakeups).toBeGreaterThanOrEqual(6)
+    expect(wakeups).toBeLessThanOrEqual(20)
+  })
+
+  it('advances frames at the configured fps while paced', () => {
+    render(
+      <SpriteRenderer src="strip.png" frameWidth={64} frameHeight={64} fps={8} totalFrames={4} />,
+    )
+    drawCtx.drawImage.mockClear()
+    for (let i = 0; i < 120; i++) tickFrame(1000 / 120)
+    // ~8 draws expected in 1s at 8fps (first draw lands one interval in).
+    expect(drawCtx.drawImage.mock.calls.length).toBeGreaterThanOrEqual(6)
+    expect(drawCtx.drawImage.mock.calls.length).toBeLessThanOrEqual(10)
+  })
+
+  it('draws a single-frame sprite once and schedules no loop', () => {
+    render(
+      <SpriteRenderer src="static.png" frameWidth={64} frameHeight={64} fps={8} totalFrames={1} />,
+    )
+    expect(drawCtx.drawImage).toHaveBeenCalledTimes(1)
+    const baseline = rafCalls
+    for (let i = 0; i < 120; i++) tickFrame(1000 / 120)
+    expect(rafCalls).toBe(baseline)
+    expect(drawCtx.drawImage).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops scheduling after unmount (no timer or rAF leak)', () => {
+    const { unmount } = render(
+      <SpriteRenderer src="strip.png" frameWidth={64} frameHeight={64} fps={8} totalFrames={4} />,
+    )
+    for (let i = 0; i < 12; i++) tickFrame(1000 / 120)
+    unmount()
+    const baseline = rafCalls
+    drawCtx.drawImage.mockClear()
+    for (let i = 0; i < 120; i++) tickFrame(1000 / 120)
+    expect(rafCalls).toBe(baseline)
+    expect(drawCtx.drawImage).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/test/CrewCompanionSpritePacing.test.tsx
+++ b/website/src/test/CrewCompanionSpritePacing.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * SpriteRenderer scheduling — the animation loop must wake at the sprite's
+ * fps, not the display's refresh rate, and must not run at all for a
+ * single-frame (static) sprite.
+ *
+ * The pet overlay window disables backgroundThrottling, so nothing external
+ * ever throttles this loop: a wakeup scheduled here runs forever. These tests
+ * pin the wakeup *count*, because that is the resource being spent.
+ */
+import React from 'react'
+import { render, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SpriteRenderer } from '../apps/crew-companion/SpriteRenderer'
+
+/** Deterministic clock shared by rAF, setTimeout, and performance.now. */
+let now = 0
+/** Pending rAF callbacks, keyed by handle. */
+let rafQueue = new Map<number, FrameRequestCallback>()
+let rafHandle = 0
+let rafCalls = 0
+
+/** Run one display frame: advance the clock and fire pending rAF callbacks. */
+function tickFrame(ms: number) {
+  now += ms
+  vi.advanceTimersByTime(ms)
+  const pending = rafQueue
+  rafQueue = new Map()
+  pending.forEach(cb => cb(now))
+}
+
+function make2dContext() {
+  return {
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(64 * 64 * 4).fill(255) })),
+  }
+}
+
+let drawCtx: ReturnType<typeof make2dContext>
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  now = 0
+  rafQueue = new Map()
+  rafHandle = 0
+  rafCalls = 0
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    rafCalls += 1
+    rafHandle += 1
+    rafQueue.set(rafHandle, cb)
+    return rafHandle
+  })
+  vi.stubGlobal('cancelAnimationFrame', (h: number) => { rafQueue.delete(h) })
+  vi.spyOn(performance, 'now').mockImplementation(() => now)
+
+  drawCtx = make2dContext()
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+    () => drawCtx as unknown as CanvasRenderingContext2D,
+  )
+  // Sprite strips load through an Image(); fire `load` synchronously so the
+  // effect body runs inside the test's fake-timer scope.
+  vi.spyOn(Image.prototype, 'addEventListener').mockImplementation(
+    function (this: HTMLImageElement, type: string, cb: EventListenerOrEventListenerObject) {
+      if (type === 'load') (cb as EventListener)(new Event('load'))
+    },
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('crew-companion SpriteRenderer wakeup pacing', () => {
+  it('wakes at the sprite fps, not once per display frame', () => {
+    render(
+      <SpriteRenderer src="strip.png" frameWidth={64} frameHeight={64} fps={8} totalFrames={4} />,
+    )
+    const baseline = rafCalls
+    // Simulate 1 second of a 120Hz display: 120 frames of ~8.33ms.
+    for (let i = 0; i < 120; i++) tickFrame(1000 / 120)
+    const wakeups = rafCalls - baseline
+    // At 8fps over 1s the loop needs ~8 wakeups; the old vsync-chained loop
+    // took ~120. Allow slack for timer/vsync alignment, but pin the order of
+    // magnitude.
+    expect(wakeups).toBeGreaterThanOrEqual(6)
+    expect(wakeups).toBeLessThanOrEqual(20)
+  })
+
+  it('advances frames at the configured fps while paced', () => {
+    render(
+      <SpriteRenderer src="strip.png" frameWidth={64} frameHeight={64} fps={8} totalFrames={4} />,
+    )
+    drawCtx.drawImage.mockClear()
+    for (let i = 0; i < 120; i++) tickFrame(1000 / 120)
+    // ~8 draws expected in 1s at 8fps (first draw lands one interval in).
+    expect(drawCtx.drawImage.mock.calls.length).toBeGreaterThanOrEqual(6)
+    expect(drawCtx.drawImage.mock.calls.length).toBeLessThanOrEqual(10)
+  })
+
+  it('draws a single-frame sprite once and schedules no loop', () => {
+    render(
+      <SpriteRenderer src="static.png" frameWidth={64} frameHeight={64} fps={8} totalFrames={1} />,
+    )
+    expect(drawCtx.drawImage).toHaveBeenCalledTimes(1)
+    const baseline = rafCalls
+    for (let i = 0; i < 120; i++) tickFrame(1000 / 120)
+    expect(rafCalls).toBe(baseline)
+    expect(drawCtx.drawImage).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops scheduling after unmount (no timer or rAF leak)', () => {
+    const { unmount } = render(
+      <SpriteRenderer src="strip.png" frameWidth={64} frameHeight={64} fps={8} totalFrames={4} />,
+    )
+    for (let i = 0; i < 12; i++) tickFrame(1000 / 120)
+    unmount()
+    const baseline = rafCalls
+    drawCtx.drawImage.mockClear()
+    for (let i = 0; i < 120; i++) tickFrame(1000 / 120)
+    expect(rafCalls).toBe(baseline)
+    expect(drawCtx.drawImage).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

macOS flagged Kiro Crew under "Using Significant Energy" on my machine, and profiling showed the Mochi pet's overlay window renderer burning ~8% CPU (with the GPU helper at ~13%) around the clock — even while the pet stands completely still.

Call-stack sampling traced it to the pet `SpriteRenderer` (two near-identical copies: mochi and crew-companion): its animation loop chains `requestAnimationFrame` unconditionally on every display frame and merely *skips drawing* until the sprite's frame interval (default 8 fps) has elapsed. On a ProMotion display that is up to 120 wakeups/second to produce 8 draws/second — ~93% of wakeups do nothing but compare timestamps. An active rAF consumer also keeps the compositor's BeginFrame vsync stream running, so the GPU process stays busy too. The pet overlay window deliberately runs with `backgroundThrottling: false` (it must animate while unfocused), so nothing ever throttles this loop: it spins at display rate for the entire lifetime of the app. A single-frame (static) sprite spins the loop forever without ever changing a pixel.

## Why it matters

Every Kiro Crew desktop user with the pet enabled pays this cost 24/7: measurable battery drain on laptops, an "Using Significant Energy" attribution in the macOS battery menu, and a permanently-active vsync stream that keeps the GPU process from idling. On a 120Hz display the wakeup overhead is ~15x the useful work.

## What changed (motivation → approach → change)

Symptom: pet window renderer burns CPU while the pet is idle → root cause: the rAF loop wakes at display refresh rate but draws at the sprite's fps, in a window that is never throttled → change: pace the loop at the sprite's actual fps.

- The inter-frame gap is slept out with a `setTimeout` sized to the remaining time until the next frame is due; `requestAnimationFrame` is kept, but only to align the actual draw with the next vsync. Wakeups drop from ~display-Hz to ~fps (≈8/s instead of up to 120/s), and the compositor's BeginFrame stream can go idle between frames.
- Single-frame sprites (static art) draw once and schedule no loop at all.
- Cleanup cancels both the pending timeout and any pending rAF, so unmount cannot leak either primitive.

Applied identically to both sprite renderer copies (`mochi/src/renderer/SpriteRenderer.tsx` and `crew-companion/SpriteRenderer.tsx`) — both render inside pet overlay windows that disable backgroundThrottling. Visual behavior is unchanged: same fps, same frames, draws still vsync-aligned.

## Tests

New `website/src/apps/mochi/test/spriteRendererPacing.test.tsx` and `website/src/test/CrewCompanionSpritePacing.test.tsx` (4 tests each, same contract for both renderer copies), driving a simulated 120Hz display with fake timers and counting scheduling calls:

- `wakes at the sprite fps, not once per display frame` — pins wakeups over a simulated second to the order of the sprite's fps (≤20) instead of the display rate (~120). Fails against the previous implementation (~120 wakeups).
- `advances frames at the configured fps while paced` — proves pacing didn't change the draw cadence (6–10 draws/second at 8 fps).
- `draws a single-frame sprite once and schedules no loop` — fails against the previous implementation, which looped forever on static sprites.
- `stops scheduling after unmount (no timer or rAF leak)` — locks in cleanup of both scheduling primitives.

`npx tsc -b` and the full `vitest` suite pass locally.

## Manual verification

The motivating measurements were taken on the live app (27h uptime): the pet overlay renderer averaged ~8% CPU during a 30-second window with the pet idle and no other dashboard activity. The fix's mechanism (wakeup count) and the unchanged draw cadence are both pinned by the unit tests above.

## Related Issues

N/A — found by profiling; no existing issue.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, internal rendering behavior
- [x] No secrets, credentials, or internal references in the diff


<!-- no-visual-delta -->
**Why no screenshot:** scheduling-only change — the sprite draws the same frames at the same fps as before; only the wakeup cadence between draws changed, so there is no pixel difference to capture.

