### PR TITLE
fix(edition): scan KIROCREW_EDITION_DIR sources for Tailwind content

### DIFF
--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -27,8 +27,24 @@ const withAlpha = (cssVar) => ({ opacityValue }) =>
     : `color-mix(in srgb, var(${cssVar}) calc(${opacityValue} * 100%), transparent)`
 
 /** @type {import('tailwindcss').Config} */
+
+/**
+ * Content sources. The core app is always scanned. When a downstream edition is
+ * composed through the `KIROCREW_EDITION_DIR` seam (see `editionExtensionPlugin`
+ * in vite.config.ts), the edition's OWN sources must be scanned too — otherwise
+ * any utility class used only by edition components (e.g. `z-[95]`) is silently
+ * absent from the generated stylesheet, and the edition UI renders unstyled with
+ * no build error. Gated on the same `KIROCREW_ALLOW_EDITION=1` opt-in as the
+ * vite plugin (which fails the build on a dir without the opt-in), so a stray
+ * env var can never widen the scan of a stock build.
+ */
+const content = ['./index.html', './src/**/*.{ts,tsx}']
+if (process.env.KIROCREW_EDITION_DIR && process.env.KIROCREW_ALLOW_EDITION === '1') {
+  content.push(`${process.env.KIROCREW_EDITION_DIR}/**/*.{ts,tsx}`)
+}
+
 export default {
-  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  content,
   darkMode: ['selector', '[data-theme="dark"]'],
   theme: {
     extend: {


### PR DESCRIPTION
## Problem / Motivation

An edition composed through the `KIROCREW_EDITION_DIR` seam has its components compiled into the SPA by `editionExtensionPlugin` (vite.config.ts), but `website/tailwind.config.js` only scans `./index.html` and `./src/**/*.{ts,tsx}`. Any utility class used *only* by edition components is silently absent from the generated stylesheet: the edition UI renders unstyled (in our case an invisible popover — no z-index, background, or text size) with no build error or warning.

## Why it matters

Every downstream edition hits this trap the moment it uses a utility class the core happens not to use (`z-[95]`, `text-[12px]`, any arbitrary value). The failure is silent and presents as a rendering bug rather than a build gap. Known editions currently work around it by constraining themselves to classes the core already uses, or by inline-styling everything — which defeats the point of the seam.

## What changed (motivation → approach → change)

Observed symptom: edition components render with missing styles. Root cause: Tailwind's `content` globs never include the edition dir, so classes unique to it are never generated. Change: build the `content` array in a small documented prelude and append `${KIROCREW_EDITION_DIR}/**/*.{ts,tsx}` — gated on the same `KIROCREW_ALLOW_EDITION === '1'` opt-in that `editionExtensionPlugin` enforces, so a stray env var can never widen a stock build's scan. Alternative considered: per-edition `safelist` entries — rejected as boilerplate every edition must remember, failing silently again when forgotten.

## Tests

No automated test added — the behavior lives in the env-gated Tailwind build pipeline, which the vitest harness does not exercise (the change is unreachable from unit tests). Verification is via the three build-level gates below; happy to add a config-shape test if maintainers prefer one.

## Manual verification

Three gates against Tailwind v3.4.19 (the actual build engine; `@tailwindcss/browser` in package.json is a separate browser-runtime package):

1. Edition build (`KIROCREW_EDITION_DIR` set + `KIROCREW_ALLOW_EDITION=1`) with a probe class `pt-[123px]` used only in edition source → class **present** in the generated CSS bundle.
2. Stock build (no env vars) → probe class **absent**; scan and output unchanged.
3. `KIROCREW_EDITION_DIR` set **without** `KIROCREW_ALLOW_EDITION=1` → build fails closed via the existing vite plugin gate (behavior unchanged).

## Related Issues

N/A — found while building a downstream edition against the `KIROCREW_EDITION_DIR` seam; no existing issue filed for it.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality — config-only change unreachable from the unit suite (see Tests); build-level gates above verify the behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — gating rationale documented inline above the `content` prelude
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — section is a placeholder in the template pending final wording.
