### PR TITLE
fix(apps): verify proxy HMAC over the raw request-target (#4192)

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -52,6 +52,7 @@ from aiohttp import web
 
 from kiro_crew import frontend, hooks, platform_compat
 from kiro_crew.apps.builtins.dev_fleet import gateway_service
+from kiro_crew.apps.proxy_auth import raw_request_target
 from kiro_crew.env import find_node_tool, node_bin_dirs
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.instances import run_marker
@@ -4540,7 +4541,7 @@ async def hmac_proxy_middleware(request: web.Request, handler) -> web.Response:
     """Verify X-KiroCrew-Proxy HMAC on every request except /health.
 
     Message format matches routes.py signing:
-      msg = "<timestamp>:<METHOD>:<path>[?query]:<sha256(body)>"
+      msg = "<timestamp>:<METHOD>:<raw request-target>:<sha256(body)>"
     Fail-closed: missing/invalid/expired signature -> 401.
     """
     if request.path == "/health":
@@ -4588,11 +4589,10 @@ async def hmac_proxy_middleware(request: web.Request, handler) -> web.Response:
     # Reconstruct the signed message exactly as routes.py builds it
     body = await request.read() if request.can_read_body else b""
     body_hash = hashlib.sha256(body).hexdigest()
-    # The gateway signs "/api/<path>[?query]" — the path as received by the backend
-    msg = f"{ts_str}:{request.method}:{request.path}"
-    if request.query_string:
-        msg += f"?{request.query_string}"
-    msg += f":{body_hash}"
+    # The gateway signs the RAW percent-encoded request-target; recompute over
+    # the same wire bytes, never the decoded path + query_string (which diverge
+    # on percent-encodable characters and would fail closed with 401).
+    msg = f"{ts_str}:{request.method}:{raw_request_target(request)}:{body_hash}"
 
     expected_sig = _hmac_mod.new(secret.encode(), msg.encode(), hashlib.sha256).hexdigest()
     if not _hmac_mod.compare_digest(sig_received, expected_sig):

--- a/src/kiro_crew/apps/builtins/md_notebook/server.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/server.py
@@ -38,7 +38,7 @@ from aiohttp import web
 from kiro_crew import hooks, platform_compat, security
 from kiro_crew.apps.builtins.md_notebook import git_ops
 from kiro_crew.apps.builtins.md_notebook import notes as notes_mod
-from kiro_crew.apps.proxy_auth import verify_proxy_request
+from kiro_crew.apps.proxy_auth import raw_request_target, verify_proxy_request
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.platform_compat import restrict_to_owner
@@ -826,7 +826,9 @@ async def proxy_auth_middleware(request: web.Request, handler: Callable) -> web.
     """
     if request.path == "/health":
         return await handler(request)
-    target = request.path + (f"?{request.query_string}" if request.query_string else "")
+    # Verify over the RAW request-target — the exact bytes the gateway signed;
+    # the decoded path + query_string diverge on percent-encodable characters.
+    target = raw_request_target(request)
     body = await request.read() if request.can_read_body else b""
     if not verify_proxy_request(
         request.headers.get("X-KiroCrew-Proxy", ""),

--- a/src/kiro_crew/apps/proxy_auth.py
+++ b/src/kiro_crew/apps/proxy_auth.py
@@ -26,9 +26,29 @@ import hashlib
 import hmac
 import os
 import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # typing only — ThreadingHTTPServer backends never need aiohttp
+    from aiohttp import web
 
 _ENV_KEY = "KIROCREW_PROXY_SECRET"
 _MAX_SKEW_SECONDS = 60
+
+
+def raw_request_target(request: web.Request) -> str:
+    """The raw, percent-encoded request-target an aiohttp backend received.
+
+    The gateway signs ``target_url.raw_path_qs`` — the request-target exactly
+    as it goes on the wire, query string included, with no ``?`` when there is
+    none. aiohttp *decodes* ``request.path`` and ``request.query_string``, so a
+    reconstruction from those diverges from the signed bytes (and fails closed
+    with 401) as soon as a query parameter carries a percent-encodable
+    character such as a space, ``+``, or non-ASCII. ``request.raw_path`` is the
+    request line's target verbatim, so verifying against it recomputes the HMAC
+    over the same bytes the gateway signed. aiohttp middlewares must use this;
+    ``ThreadingHTTPServer`` backends already get the raw form as ``self.path``.
+    """
+    return request.raw_path
 
 
 def proxy_secret() -> str:

--- a/test/test_app_proxy_auth.py
+++ b/test/test_app_proxy_auth.py
@@ -5,8 +5,9 @@ import hmac
 import time
 
 import pytest
+from aiohttp.test_utils import make_mocked_request
 
-from kiro_crew.apps.proxy_auth import verify_proxy_request
+from kiro_crew.apps.proxy_auth import raw_request_target, verify_proxy_request
 
 SECRET = "s3cret-app-key"
 
@@ -83,3 +84,25 @@ def test_stale_timestamp_fails():
 def test_wrong_secret_fails():
     hdr = _sign("GET", "/api/read", b"")
     assert not verify_proxy_request(hdr, method="GET", target="/api/read", body=b"", secret="different")
+
+
+@pytest.mark.parametrize(
+    "wire_target",
+    [
+        "/api/read?path=/tmp/my%20notes.md",
+        "/api/read?path=/tmp/caf%C3%A9.md",
+        "/api/read?path=/tmp/my+notes.md",
+        "/api/search?q=hello%20world&dir=/tmp/my%20folder",
+    ],
+)
+def test_raw_request_target_preserves_wire_encoding(wire_target: str):
+    """The aiohttp reconstruction helper must return the raw request-target
+    byte-for-byte — the exact string routes.py signs — never a decoded form."""
+    req = make_mocked_request("GET", wire_target)
+    assert raw_request_target(req) == wire_target
+
+
+def test_raw_request_target_no_query_appends_nothing():
+    """No query string means no '?' on either side of the HMAC."""
+    req = make_mocked_request("GET", "/api/vaults")
+    assert raw_request_target(req) == "/api/vaults"

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import yarl
 from aiohttp import web  # noqa: F401  (used by builtin re-shell tests)
 from aiohttp.test_utils import TestClient, TestServer  # noqa: F401
 
@@ -2672,6 +2673,43 @@ async def test_hmac_health_bypasses_verification():
             assert resp.status == 200
             body = await resp.json()
             assert body["status"] == "ok"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "wire_target",
+    [
+        "/api/fleet?name=my%20worktree",  # space
+        "/api/fleet?name=caf%C3%A9",  # non-ASCII
+        "/api/fleet?name=a+b",  # '+' (decodes to space in query)
+    ],
+)
+async def test_hmac_gateway_signed_escapable_query_passes(wire_target: str):
+    """The gateway signs the RAW percent-encoded request-target; the middleware
+    must recompute over the same wire bytes, not aiohttp's decoded
+    path + query_string reconstruction, or every escapable query value 401s."""
+    secret = "test-secret"
+    app = _make_hmac_app()
+    with patch.object(mod, "_load_app_secret", return_value=secret):
+        async with TestClient(TestServer(app)) as client:
+            headers = _sign_request(secret, "GET", wire_target)
+            # encoded=True keeps the exact signed bytes on the wire, mirroring
+            # the gateway's yarl.URL(..., encoded=True) forwarding.
+            resp = await client.get(yarl.URL(wire_target, encoded=True), headers=headers)
+            assert resp.status == 200, await resp.text()
+
+
+@pytest.mark.asyncio
+async def test_hmac_gateway_signed_no_query_target_passes():
+    """Without a query string neither side appends a '?' — raw and decoded
+    spellings coincide and the signature must still verify."""
+    secret = "test-secret"
+    app = _make_hmac_app()
+    with patch.object(mod, "_load_app_secret", return_value=secret):
+        async with TestClient(TestServer(app)) as client:
+            headers = _sign_request(secret, "GET", "/api/fleet")
+            resp = await client.get("/api/fleet", headers=headers)
+            assert resp.status == 200, await resp.text()
 
 
 # =============================================================================

--- a/test/test_md_notebook.py
+++ b/test/test_md_notebook.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, AsyncIterator, Optional
 
 import pytest
+import yarl
 from aiohttp.test_utils import TestClient, TestServer
 
 from conftest import requires_symlinks
@@ -127,10 +128,14 @@ class SignedClient:
         self, method: str, path: str, payload: Optional[dict[str, Any]] = None
     ) -> tuple[int, Any]:
         body = json.dumps(payload).encode() if payload is not None else b""
-        headers = self._headers(method, path, body)
+        # Sign the WIRE form of the target, as the gateway does: yarl requotes
+        # the human-readable path (e.g. a space becomes %20), and raw_path_qs
+        # is the exact request-target the client puts on the wire.
+        url = yarl.URL(path)
+        headers = self._headers(method, url.raw_path_qs, body)
         if payload is not None:
             headers["Content-Type"] = "application/json"
-        resp = await self._client.request(method, path, data=body or None, headers=headers)
+        resp = await self._client.request(method, url, data=body or None, headers=headers)
         try:
             return resp.status, await resp.json()
         except Exception:  # noqa: BLE001 — a non-JSON body is itself the failure
@@ -239,6 +244,52 @@ async def test_tampered_signature_is_rejected(fixtures) -> None:
             "/api/vaults", headers={"X-KiroCrew-Proxy": f"{int(time.time())}:deadbeef"}
         )
         assert resp.status == 401
+
+
+def _sign_wire_target(method: str, wire_target: str, body: bytes = b"") -> dict[str, str]:
+    """Sign exactly as the gateway does (apps/routes.py::handle_app_api_proxy):
+    over the RAW, percent-encoded request-target, never a decoded form."""
+    ts = str(int(time.time()))
+    digest = hashlib.sha256(body).hexdigest()
+    msg = f"{ts}:{method}:{wire_target}:{digest}"
+    sig = hmac.new(SECRET.encode(), msg.encode(), hashlib.sha256).hexdigest()
+    return {"X-KiroCrew-Proxy": f"{ts}:{sig}"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "wire_target",
+    [
+        "/api/health?path=/tmp/my%20notes.md",  # space
+        "/api/health?path=/tmp/caf%C3%A9.md",  # non-ASCII
+        "/api/health?path=/tmp/my+notes.md",  # '+' (decodes to space in query)
+    ],
+)
+async def test_gateway_signed_escapable_query_verifies(fixtures, wire_target: str) -> None:
+    """A query parameter needing percent-escaping (a note path with a space or
+    non-ASCII character) must verify: the middleware has to recompute the HMAC
+    over the same RAW request-target the gateway signed, not aiohttp's decoded
+    path + query_string reconstruction (issue: note reads 401ing while plain
+    listings pass)."""
+    server_mod, _remote, _seed = fixtures
+    app = server_mod.create_app()
+    async with TestClient(TestServer(app)) as raw:
+        # encoded=True keeps the exact signed bytes on the wire, mirroring the
+        # gateway's yarl.URL(..., encoded=True) forwarding.
+        url = yarl.URL(wire_target, encoded=True)
+        resp = await raw.get(url, headers=_sign_wire_target("GET", wire_target))
+        assert resp.status == 200, await resp.text()
+
+
+@pytest.mark.asyncio
+async def test_gateway_signed_no_query_target_verifies(fixtures) -> None:
+    """Without a query string neither side appends a '?' — the raw and decoded
+    spellings coincide and the signature must still verify."""
+    server_mod, _remote, _seed = fixtures
+    app = server_mod.create_app()
+    async with TestClient(TestServer(app)) as raw:
+        resp = await raw.get("/api/health", headers=_sign_wire_target("GET", "/api/health"))
+        assert resp.status == 200, await resp.text()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

The built-in Notes app lists vaults, folders and files fine, but opening a note whose path contains a space, a `+`, or a non-ASCII character fails with `invalid or missing proxy signature` (401). Reported on the stable channel after updating to 0.3.0 (Linux, installed from source).

## Why it matters

Any user whose note filenames contain a space or non-ASCII character — extremely common for real note titles — cannot read those notes at all. The same defect sits latent in the Dev Fleet backend, where any query parameter needing percent-escaping (e.g. a worktree name) would 401 identically.

## What changed (motivation → approach → change)

- **Symptom:** listings pass, note reads 401. Listings carry plain identifiers, so the raw and decoded spellings of the request-target are byte-identical; a note read sends the note path as a query parameter, where any percent-encodable character makes them diverge.
- **Root cause:** a canonicalization mismatch in the gateway→backend HMAC. The gateway (`apps/routes.py`) signs the **raw, percent-encoded** request-target (`target_url.raw_path_qs`) — its own comment explains that aiohttp decodes `request.query_string`, so signing the decoded form fails closed. But both aiohttp backends recompute the HMAC from exactly that decoded form: `md_notebook`'s `proxy_auth_middleware` built `request.path + "?" + request.query_string`, and `dev_fleet`'s `hmac_proxy_middleware` did the same. The recomputed bytes differ from the signed bytes, the comparison fails, and the middleware returns 401.
- **Change:** add a small shared helper, `proxy_auth.raw_request_target()`, returning `request.raw_path` — the request line's target verbatim, query string included, with no `?` when there is none (verified empirically to be the exact byte-for-byte counterpart of the signed `raw_path_qs`, including the no-query case). Both aiohttp middlewares now verify against it. The helper lives in `proxy_auth.py` next to `verify_proxy_request()` so a future aiohttp backend cannot reintroduce the decoded reconstruction; it needs no runtime aiohttp import (typing only), so the `ThreadingHTTPServer` backends' import surface is unchanged. Those backends (`file_explorer`, `design_tweak`, `workflows`) already verify against the raw `self.path` and are untouched. The `/health` exemptions, fail-closed behavior, `_deny` reasons and SEL audit calls are all preserved.

## Tests

- `test/test_md_notebook.py::test_gateway_signed_escapable_query_verifies` — drives `proxy_auth_middleware` with query parameters containing a space, non-ASCII, and `+`, signed exactly the way `routes.py` signs (raw wire bytes, `yarl.URL(..., encoded=True)`); asserts 200. **All three failed with the reported 401 before the fix.**
- `test/test_md_notebook.py::test_gateway_signed_no_query_target_verifies` — the no-query case, where neither side appends a `?`.
- `test/test_dev_fleet_app.py::test_hmac_gateway_signed_escapable_query_passes` / `test_hmac_gateway_signed_no_query_target_passes` — the same matrix against `hmac_proxy_middleware` (all escapable-query cases failed before the fix).
- `test/test_app_proxy_auth.py::test_raw_request_target_preserves_wire_encoding` / `test_raw_request_target_no_query_appends_nothing` — pin the helper's contract: byte-for-byte wire form, no `?` without a query.
- `test/test_md_notebook.py`'s `SignedClient` test emulator carried the same decoded-form bug as the backends (it signed the human-readable path while the wire carried the encoded form — passing only because both sides were wrong the same way); it now signs the wire form like the gateway does, which is what surfaced `test_duplicate_note_copies_content_beside_the_source` (a note path with a space) as a true positive.

## Manual verification

N/A — unit coverage sufficient: the regression tests drive the real middlewares over a real aiohttp test server with the exact signed wire bytes, reproducing the reported 401 before the fix and 200 after.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no frontend files touched and no rendered output differs.

## Related Issues

Closes #4192

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
