### PR TITLE
fix(dashboard): split ChatSidebar drag into mouse+touch sensors (#4208)

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -6,7 +6,7 @@ import GithubLogo from '../components/icons/GithubLogo'
 import GitlabLogo from '../components/icons/GitlabLogo'
 import JiraLogo from '../components/icons/JiraLogo'
 import FolderGlyph from '../components/FolderGlyph'
-import { DndContext, closestCenter, pointerWithin, KeyboardSensor, PointerSensor, useSensor, useSensors, useDroppable, DragOverlay, MeasuringStrategy, type DragEndEvent, type DragStartEvent, type DragOverEvent, type CollisionDetection } from '@dnd-kit/core'
+import { DndContext, closestCenter, pointerWithin, KeyboardSensor, MouseSensor, TouchSensor, useSensor, useSensors, useDroppable, DragOverlay, MeasuringStrategy, type DragEndEvent, type DragStartEvent, type DragOverEvent, type CollisionDetection } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy, useSortable, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -417,8 +417,9 @@ function SortableFolderBlock({ folder, subtree, renderFolderBlock }: { folder: C
   // The whole folder header is the drag handle (pointer + touch): dragging the
   // row reorders the folder — no grip, consistent with session-card drag. Only
   // pointer listeners are forwarded (not attributes) so the header keeps
-  // its inner collapse/action buttons valid. The PointerSensor activation
-  // distance lets clicks through. setNodeRef stays on the block for sortable
+  // its inner collapse/action buttons valid. The MouseSensor activation
+  // distance lets clicks through, and the TouchSensor's press-and-hold delay
+  // lets touch swipes pan the list. setNodeRef stays on the block for sortable
   // positioning. While dragging, the body is force-collapsed so the source
   // shrinks to a single row — the drop-target gap (and the DragOverlay ghost)
   // stay compact.
@@ -2142,8 +2143,19 @@ function ChatSidebar({
   }, [folders, updateFolderMutation])
 
   // ── Folder drag-to-reorder ──
+  // Mouse and touch are split on purpose — a single PointerSensor with a
+  // distance constraint swallows touch swipes on WebKit: past the activation
+  // distance dnd-kit preventDefault()s every move via its non-passive window
+  // touchmove listener ("required for iOS Safari", TouchSensor.setup), so a
+  // swipe that begins on a row cannot pan the list. Chromium ignores
+  // preventDefault() on pointermove for panning, which is why it only shows on
+  // WebKit. The TouchSensor's DELAY constraint inverts the contention: moving
+  // past the tolerance CANCELS the sensor and hands the gesture back to the
+  // browser; only a stationary 250ms hold arms a drag. Same split as the Apps
+  // nav rail (App.tsx) and the artifact library.
   const dndSensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
   // Tracks the item currently being dragged, for the DragOverlay preview.

--- a/website/src/test/ChatSidebar.dragSensors.test.tsx
+++ b/website/src/test/ChatSidebar.dragSensors.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * A finger swipe starting on a session or folder row pans the sidebar list;
+ * only a deliberate press-and-hold picks the row up.
+ *
+ * The sidebar's session/folder drag used a single `PointerSensor` with a 5px
+ * activation distance. Past that distance dnd-kit's `AbstractPointerSensor`
+ * calls `preventDefault()` on every subsequent move event, and dnd-kit installs
+ * a non-passive window `touchmove` listener specifically so those calls take
+ * effect — its own source says "This is required for iOS Safari"
+ * (`TouchSensor.setup`). So on WebKit a swipe that began on a row was swallowed
+ * by the sensor, while the same swipe beginning in a GAP between rows — no
+ * listener there, so no sensor — panned normally. Chromium ignores
+ * `preventDefault()` on `pointermove` for panning, which is why the asymmetry
+ * does not reproduce there and cannot be measured with a headless Chromium
+ * probe.
+ *
+ * The split sensors remove the contention instead of tuning it:
+ *  - MouseSensor keeps the 5px distance, so mouse drag is unchanged.
+ *  - TouchSensor's DELAY constraint means `handleMove` CANCELS the sensor as
+ *    soon as the finger travels past the tolerance, handing the gesture back to
+ *    the browser; only a stationary hold arms a drag.
+ *
+ * Same split as the Apps nav rail (App.tsx). These are wiring assertions read
+ * from source. jsdom has no compositor, so it cannot demonstrate a pan being
+ * swallowed — the mechanism above is what the assertions pin, at the one place
+ * where it is decided.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const SRC = join(__dirname, '..', 'pages', 'ChatSidebar.tsx')
+const src = readFileSync(SRC, 'utf8')
+
+describe('chat sidebar drag sensors', () => {
+  it('splits mouse and touch sensors instead of using one PointerSensor', () => {
+    expect(src).toMatch(/useSensor\(MouseSensor,\s*\{\s*activationConstraint:\s*\{\s*distance:\s*5\s*\}/)
+    expect(src).toMatch(/useSensor\(TouchSensor,\s*\{\s*activationConstraint:\s*\{\s*delay:\s*250,\s*tolerance:\s*5\s*\}/)
+  })
+
+  it('keeps the keyboard sensor for accessible reordering', () => {
+    expect(src).toMatch(/useSensor\(KeyboardSensor,\s*\{\s*coordinateGetter:\s*sortableKeyboardCoordinates\s*\}/)
+  })
+
+  it('does not construct a PointerSensor', () => {
+    // Both the import binding and the call site have to go: leaving the import
+    // behind is how a later edit quietly reinstates the swallowed-swipe sensor.
+    // Asserted on derived values, not on `src`, so a failure prints the
+    // offending line rather than the whole file. Prose may still NAME
+    // PointerSensor — the comment at the call site explains why it is not used.
+    const importLine = src.split('\n').find(l => l.includes("from '@dnd-kit/core'")) ?? ''
+    expect(importLine).not.toContain('PointerSensor')
+    expect(src.match(/useSensor\(\s*PointerSensor/g)).toBeNull()
+  })
+
+  it('gives the touch sensor a delay constraint, never a bare distance', () => {
+    // A distance-only touch constraint is the defect: `handleMove` ACTIVATES on
+    // distance (and then preventDefaults every move), where a delay constraint
+    // CANCELS on distance and lets the browser pan.
+    const touch = src.match(/useSensor\(TouchSensor,[^)]*\)/)?.[0] ?? ''
+    expect(touch).toContain('delay:')
+    expect(touch).not.toMatch(/\bdistance:/)
+  })
+
+  it('locks touch-action only on resize separators, never on drag rows', () => {
+    // dnd-kit documents `touch-action: none` as PointerSensor's requirement.
+    // The sidebar legitimately locks touch on its two RESIZE separators (the
+    // width handle and the history-pane splitter — custom usePointerDrag, not
+    // dnd-kit; a resize handle must own the touch). A lockout on a DRAG ROW
+    // would re-break panning by the other mechanism, so every occurrence must
+    // sit on a role="separator" element.
+    expect(src).not.toMatch(/\btouch-none\b/)
+    const occurrences = [...src.matchAll(/touchAction:\s*'none'/g)]
+    expect(occurrences.length).toBeGreaterThan(0)
+    for (const m of occurrences) {
+      const context = src.slice(Math.max(0, (m.index ?? 0) - 600), m.index ?? 0)
+      expect(context).toContain('role="separator"')
+    }
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

On WebKit (iOS Safari, macOS Safari, the iOS in-app dashboard), a touch swipe that begins on a session or folder row in the chat sidebar does not scroll the list. The same swipe starting in a gap between rows pans normally. The list is effectively unscrollable by touch wherever rows fill the viewport, since almost every point in the list is a row.

## Why it matters

Phone and tablet users scroll the session list constantly -- it is the primary navigation surface of the dashboard. On WebKit the sidebar becomes nearly unusable by touch: users must hunt for the thin gaps between rows to scroll. Chromium users never see it, so the defect ships silently past Chromium-only testing.

## What changed (motivation -> approach -> change)

- **Symptom:** touch swipes starting on a row are swallowed on WebKit; swipes starting on gaps pan.
- **Root cause:** the sidebar's drag used a single dnd-kit `PointerSensor` with a 5px activation distance (`website/src/pages/ChatSidebar.tsx`). Past that distance, dnd-kit's `AbstractPointerSensor.handleMove` calls `preventDefault()` on every subsequent move, and dnd-kit installs a non-passive window `touchmove` listener specifically so those calls take effect -- its own source says "This is required for iOS Safari" (`TouchSensor.setup`). Chromium ignores `preventDefault()` on `pointermove` for panning, so the contention is WebKit-only.
- **Change:** split the one sensor into `MouseSensor { distance: 5 }` + `TouchSensor { delay: 250, tolerance: 5 }`, keeping the `KeyboardSensor`. The constraint TYPE is the fix, not the numbers: a distance constraint *activates* on movement (then preventDefaults every move), while a delay constraint *cancels* on movement past the tolerance and hands the gesture back to the browser -- only a stationary 250ms hold arms a drag. Mouse drag is unchanged (same 5px distance). Drag call sites spread `{...listeners}`, which becomes `{onMouseDown, onTouchStart}` instead of `{onPointerDown}` with no call-site change; the file's only named listener access is `onKeyDown` (KeyboardSensor, kept). Both `DndContext`s in the file share this sensor set.
- **Precedent:** the exact split already shipped for the Apps nav rail (`App.tsx`, `appDndSensors`), and PR #4151 applies it to the artifact library. The two `touchAction: 'none'` sites in ChatSidebar are the resize separators (custom `usePointerDrag`, not dnd-kit) and deliberately keep owning their touch.

## Tests

`website/src/test/ChatSidebar.dragSensors.test.tsx` (new) pins the mechanism at the one place it is decided, mirroring the artifact-library test shape:

- splits mouse and touch sensors instead of using one `PointerSensor` (exact constraints)
- keeps the keyboard sensor for accessible reordering
- does not construct a `PointerSensor` (import binding and call site both gone -- leaving the import is how a later edit quietly reinstates the bug)
- touch sensor uses a delay constraint, never a bare distance (a distance-only touch constraint IS the defect)
- `touch-action` lockouts sit only on `role="separator"` resize handles, never on drag rows

Mutation-verified: reverting the `ChatSidebar.tsx` hunk fails 3 of the 5 assertions. Full ChatSidebar suite (48 files, 374 tests) passes; `npx tsc -b` clean; `jscpd` 0 clones.

## Manual verification

Playwright WebKit is not installed on the CI-adjacent dev host, and the defect cannot be measured in headless Chromium (Chromium ignores `preventDefault()` on `pointermove` for panning -- that asymmetry is the bug). As with #4151, the change rests on dnd-kit's own documented iOS divergence (`TouchSensor.setup`: "This is required for iOS Safari"), the in-repo App.tsx precedent that shipped the identical split, and the wiring test above. Mouse-path behavior was manually confirmed unchanged: activation constraint and distance are identical.

<!-- no-visual-delta -->
**Why no screenshot:** sensor wiring only -- no pixel renders differently; the delta is which input gesture arms a drag, which a still image cannot show and this host cannot record (no WebKit build).

## Related Issues

Closes #4208

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, no documented behavior/config change
- [x] No secrets, credentials, or internal references in the diff
