### PR TITLE
feat(doctor): surface a stale or off-branch source checkout

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from kiro_crew import __version__ as _mc_version
 from kiro_crew import diagnostics, platform_compat, sandbox
+from kiro_crew._bootstrap import _source_checkout_root
 from kiro_crew.acp import kas_assets, kas_auth
 from kiro_crew.acp.client import KIRO_CLI_BIN
 from kiro_crew.acp.types import ACP_BACKEND_KAS
@@ -784,6 +785,145 @@ def _linger_enabled(user: str) -> bool | None:
     return None
 
 
+# Git for Windows never lives in the system directories the trusted resolver
+# pins Windows lookups to — it installs under Program Files. Fixed literal
+# roots, not ``%ProgramFiles%``: doctor runs with operator privileges, and
+# reading the environment would let a poisoned variable redirect the lookup to
+# an agent-writable directory — the exact hole the pin exists to close.
+_WINDOWS_GIT_DIRS = (
+    r"C:\Program Files\Git\cmd",
+    r"C:\Program Files (x86)\Git\cmd",
+)
+
+
+def _windows_git_bin() -> str | None:
+    """``git.exe`` from the fixed Git for Windows install roots, else ``None``.
+
+    Without this, every supported Windows source install reported "could not
+    check" — :func:`platform_compat.trusted_system_bin` only probes the system
+    directories, where git never is. A non-default-drive install still misses
+    and degrades to "could not check", which is honest: this fallback widens
+    the pin only to paths an unprivileged attacker cannot write.
+    """
+    for directory in _WINDOWS_GIT_DIRS:
+        candidate = os.path.join(directory, "git.exe")
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _git_line(repo: Path, *args: str) -> str | None:
+    """First stdout line of ``git -C repo *args``, ``None`` on any failure.
+
+    A module-level seam (not inlined) so tests can drive the checkout probe
+    without a real repository. Failures are expected states here — a tarball
+    install has no ``.git``, a fresh clone may lack ``origin/HEAD`` — so every
+    error collapses to ``None`` and the caller renders "could not check".
+
+    ``git`` is resolved through :func:`platform_compat.trusted_system_bin`
+    rather than a bare ``PATH`` lookup: doctor runs with operator privileges,
+    and an agent-writable directory leading ``PATH`` could plant a ``git``
+    shim. On Windows a resolver miss falls back to the fixed Git for Windows
+    install roots (:func:`_windows_git_bin`); any remaining miss collapses to
+    ``None`` like every other failure here — no spawn at all.
+    """
+    git = platform_compat.trusted_system_bin("git")
+    if git is None and platform_compat.IS_WINDOWS:
+        git = _windows_git_bin()
+    if git is None:
+        return None
+    try:
+        res = subprocess.run(
+            [git, "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            errors="replace",
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if res.returncode != 0:
+        return None
+    return res.stdout.strip().splitlines()[0].strip() if res.stdout.strip() else None
+
+
+def _doctor_source_checkout(repo: Path) -> None:
+    """Report whether an editable install's source tree is current.
+
+    An editable install (``pip install -e``) runs whatever the source checkout
+    happens to be at process start. A checkout parked on a stale feature branch
+    is invisible at runtime: the gateway starts fine, serves traffic, and every
+    fix merged upstream since the branch diverged — security gates included —
+    is silently absent. Nothing else surfaces this (a real incident ran a
+    9-day-stale branch through a restart while doctor reported healthy), so
+    doctor names the branch and how far behind the default branch it is.
+
+    Advisory only (never appended to ``issues``, matching the linger and
+    model-url probes): running a feature branch is a legitimate developer
+    state, so doctor's job is to make it visible, not to block on it.
+
+    Offline by design: no ``git fetch`` — doctor must not touch the network or
+    mutate the repo. "behind" therefore means behind the LAST-FETCHED default
+    branch; a checkout that never fetches reports current. That bound is
+    acceptable because the failure mode being caught is a checkout parked on
+    an old branch while fetches happen around it (e.g. by update checks), not
+    a host that never talks to the remote.
+    """
+    print("\nSource Checkout")
+    if not (repo / ".git").exists():
+        print(f"  source:      ⏹ not a git checkout ({repo})")
+        return
+
+    branch = _git_line(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    if branch is None:
+        print("  branch:      ⚠️  could not check (git failed)")
+        return
+
+    # Default branch as recorded at clone time (refs/remotes/origin/HEAD).
+    # `git remote show` would be authoritative but hits the network.
+    default_ref = _git_line(repo, "rev-parse", "--abbrev-ref", "origin/HEAD")
+    default_branch = default_ref.split("/", 1)[1] if default_ref and "/" in default_ref else None
+
+    if default_branch is None:
+        # Fresh clones always have origin/HEAD; only manual remote surgery
+        # loses it. Report the branch we ARE on and stop — guessing "main"
+        # could mislabel a repo whose default genuinely differs.
+        print(f"  branch:      ⚠️  {branch} (could not determine default branch)")
+        return
+
+    if branch == default_branch:
+        behind = _git_line(repo, "rev-list", "--count", f"HEAD..origin/{default_branch}")
+        if behind is None or not behind.isdigit():
+            # A failed count must not masquerade as a verified-fresh checkout:
+            # "up to date" is a claim this probe could not actually establish.
+            print(f"  branch:      ⚠️  {default_branch} (could not count commits behind origin)")
+            return
+        if int(behind) > 0:
+            print(f"  branch:      ⚠️  {default_branch}, {behind} commit(s) behind origin (as of last fetch)")
+            print("               The running gateway predates those commits until an")
+            print("               update + restart.")
+        else:
+            print(f"  branch:      ✅ {default_branch} (up to date as of last fetch)")
+        return
+
+    behind = _git_line(repo, "rev-list", "--count", f"HEAD..origin/{default_branch}")
+    detail = (
+        f", {behind} commit(s) behind origin/{default_branch}"
+        if behind and behind.isdigit() and int(behind) > 0
+        else ""
+    )
+    print(f"  branch:      ⚠️  on '{branch}' — not the default branch{detail}")
+    print("               The gateway runs this checkout as-is: fixes merged to")
+    print(f"               {default_branch} since divergence are NOT active, and update")
+    print(f"               pulls this branch, not {default_branch}.")
+    # Remediation stays prose, never a rendered command: branch and path come
+    # from the repository (agent-writable), and a ref named e.g.
+    # ``$(touch${IFS}/tmp/pwn)`` pasted from a suggested command line would
+    # execute in the operator's shell.
+    print("               Fix: check out the default branch in the source checkout,")
+    print("               then update + restart.")
+
+
 def _doctor_pod_session_bus(issues: list[str]) -> None:
     """Report whether pods have a reachable ``systemd --user`` session bus.
 
@@ -1415,6 +1555,17 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
             issues.append("sqlite fts5")
     except Exception as exc:  # pragma: no cover - defensive
         print(f"  sqlite fts5: ⚠️  could not check ({exc})")
+
+    # ── Source Checkout (source/editable installs only) ──
+    # Gated on the checkout markers themselves (setup.cfg + src/kiro_crew, via
+    # _bootstrap), not on ./.venv existing: an editable install driven by an
+    # external virtualenv or a documented ``PYTHONPATH=src`` invocation runs
+    # stale source exactly the same way and was silently skipped by the venv
+    # gate. A wheel install resolves inside site-packages, has no markers two
+    # levels up, and correctly gets no section.
+    source_root = _source_checkout_root()
+    if source_root is not None:
+        _doctor_source_checkout(source_root)
 
     # ── Vector Memory (in-process embeddings) ──
     print("\nVector Memory (in-process embeddings)")

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -653,3 +653,357 @@ class TestPathLauncherOwnership:
 
         out = capsys.readouterr().out
         assert "kirocrew CLI: ✅" in out
+
+
+class TestSourceCheckout:
+    """`kirocrew doctor` Source Checkout section — stale/off-branch source tree.
+
+    Guards _doctor_source_checkout: an editable install parked on a stale
+    feature branch runs old code (merged security fixes included) while every
+    other doctor section reports healthy. These tests drive the probe through
+    the _git_line seam — no real repository needed.
+    """
+
+    @staticmethod
+    def _fake_git(answers: dict[tuple[str, ...], str | None]):
+        def fake(repo, *args):
+            return answers.get(tuple(args))
+
+        return fake
+
+    def _repo(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        return tmp_path
+
+    def test_on_default_up_to_date_passes(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setattr(
+            cli_doctor,
+            "_git_line",
+            self._fake_git(
+                {
+                    ("rev-parse", "--abbrev-ref", "HEAD"): "main",
+                    ("rev-parse", "--abbrev-ref", "origin/HEAD"): "origin/main",
+                    ("rev-list", "--count", "HEAD..origin/main"): "0",
+                }
+            ),
+        )
+        cli_doctor._doctor_source_checkout(self._repo(tmp_path))
+        out = capsys.readouterr().out
+        assert "✅ main (up to date" in out
+        assert "⚠️" not in out
+
+    def test_on_default_behind_warns_with_count(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setattr(
+            cli_doctor,
+            "_git_line",
+            self._fake_git(
+                {
+                    ("rev-parse", "--abbrev-ref", "HEAD"): "main",
+                    ("rev-parse", "--abbrev-ref", "origin/HEAD"): "origin/main",
+                    ("rev-list", "--count", "HEAD..origin/main"): "42",
+                }
+            ),
+        )
+        cli_doctor._doctor_source_checkout(self._repo(tmp_path))
+        out = capsys.readouterr().out
+        assert "⚠️" in out
+        assert "42 commit(s) behind" in out
+        assert "update + restart" in out
+
+    def test_feature_branch_behind_warns_with_fix(self, monkeypatch, tmp_path, capsys) -> None:
+        # The incident shape: gateway source parked on a feature branch for
+        # days, hundreds of commits behind — doctor must name the branch, the
+        # distance, and the recovery path.
+        monkeypatch.setattr(
+            cli_doctor,
+            "_git_line",
+            self._fake_git(
+                {
+                    ("rev-parse", "--abbrev-ref", "HEAD"): "fix/some-feature",
+                    ("rev-parse", "--abbrev-ref", "origin/HEAD"): "origin/main",
+                    ("rev-list", "--count", "HEAD..origin/main"): "798",
+                }
+            ),
+        )
+        cli_doctor._doctor_source_checkout(self._repo(tmp_path))
+        out = capsys.readouterr().out
+        assert "⚠️" in out
+        assert "fix/some-feature" in out
+        assert "798 commit(s) behind origin/main" in out
+        assert "NOT active" in out
+        assert "check out the default branch" in out
+
+    def test_remediation_never_renders_ref_inside_a_command(
+        self, monkeypatch, tmp_path, capsys
+    ) -> None:
+        """A hostile ref name must not become a pasteable command payload.
+
+        Branch names come from the repository — agent-writable on this threat
+        model — so a ref like ``$(touch${IFS}/tmp/pwn)`` rendered into a
+        suggested ``git checkout ...`` line would execute when the operator
+        pastes it. Remediation must stay prose: no line may combine a command
+        word with the interpolated ref.
+        """
+        evil = "$(touch${IFS}/tmp/pwn)"
+        monkeypatch.setattr(
+            cli_doctor,
+            "_git_line",
+            self._fake_git(
+                {
+                    ("rev-parse", "--abbrev-ref", "HEAD"): evil,
+                    ("rev-parse", "--abbrev-ref", "origin/HEAD"): "origin/main",
+                    ("rev-list", "--count", "HEAD..origin/main"): "3",
+                }
+            ),
+        )
+        cli_doctor._doctor_source_checkout(self._repo(tmp_path))
+        out = capsys.readouterr().out
+        # The state is still reported (prose may name the ref) ...
+        assert evil in out
+        # ... but never on a line shaped like a runnable git command.
+        for line in out.splitlines():
+            if "git -C" in line or "git checkout" in line:
+                raise AssertionError(f"pasteable command rendered: {line!r}")
+
+    def test_on_default_failed_count_reports_could_not_check(
+        self, monkeypatch, tmp_path, capsys
+    ) -> None:
+        # rev-list failing on the default branch must NOT masquerade as a
+        # verified-fresh checkout — "up to date" is a claim the probe could
+        # not establish.
+        monkeypatch.setattr(
+            cli_doctor,
+            "_git_line",
+            self._fake_git(
+                {
+                    ("rev-parse", "--abbrev-ref", "HEAD"): "main",
+                    ("rev-parse", "--abbrev-ref", "origin/HEAD"): "origin/main",
+                    ("rev-list", "--count", "HEAD..origin/main"): None,
+                }
+            ),
+        )
+        cli_doctor._doctor_source_checkout(self._repo(tmp_path))
+        out = capsys.readouterr().out
+        assert "✅" not in out
+        assert "could not count commits behind" in out
+
+    def test_feature_branch_unknown_distance_still_warns(
+        self, monkeypatch, tmp_path, capsys
+    ) -> None:
+        # rev-list failing (e.g. origin/main ref pruned) must not hide the
+        # off-branch state itself.
+        monkeypatch.setattr(
+            cli_doctor,
+            "_git_line",
+            self._fake_git(
+                {
+                    ("rev-parse", "--abbrev-ref", "HEAD"): "fix/some-feature",
+                    ("rev-parse", "--abbrev-ref", "origin/HEAD"): "origin/main",
+                    ("rev-list", "--count", "HEAD..origin/main"): None,
+                }
+            ),
+        )
+        cli_doctor._doctor_source_checkout(self._repo(tmp_path))
+        out = capsys.readouterr().out
+        assert "⚠️" in out
+        assert "on 'fix/some-feature' — not the default branch" in out
+        assert "behind" not in out.split("not the default branch")[1].splitlines()[0]
+
+    def test_missing_origin_head_reports_branch_without_guessing(
+        self, monkeypatch, tmp_path, capsys
+    ) -> None:
+        # No origin/HEAD → report what we know, never assume the default is
+        # "main" (could mislabel a repo whose default genuinely differs).
+        monkeypatch.setattr(
+            cli_doctor,
+            "_git_line",
+            self._fake_git(
+                {
+                    ("rev-parse", "--abbrev-ref", "HEAD"): "develop",
+                    ("rev-parse", "--abbrev-ref", "origin/HEAD"): None,
+                }
+            ),
+        )
+        cli_doctor._doctor_source_checkout(self._repo(tmp_path))
+        out = capsys.readouterr().out
+        assert "develop" in out
+        assert "could not determine default branch" in out
+        assert "main" not in out
+
+    def test_not_a_git_checkout_is_not_applicable(self, monkeypatch, tmp_path, capsys) -> None:
+        # Tarball installs (cloud/EC2) have no .git — mirror the update
+        # handler's guard and stay quiet rather than warning.
+        cli_doctor._doctor_source_checkout(tmp_path)
+        out = capsys.readouterr().out
+        assert "⏹ not a git checkout" in out
+        assert "⚠️" not in out
+
+    def test_git_failure_reports_could_not_check(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setattr(cli_doctor, "_git_line", self._fake_git({}))
+        cli_doctor._doctor_source_checkout(self._repo(tmp_path))
+        out = capsys.readouterr().out
+        assert "could not check" in out
+
+    def test_git_line_returns_none_on_nonzero_exit(self, monkeypatch, tmp_path) -> None:
+        import subprocess as _sp
+
+        def fake_run(*a, **k):
+            return _sp.CompletedProcess(a, 128, stdout="", stderr="fatal: not a repo")
+
+        monkeypatch.setattr(
+            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: "/usr/bin/git"
+        )
+        monkeypatch.setattr(cli_doctor.subprocess, "run", fake_run)
+        assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") is None
+
+    def test_git_line_returns_first_line_stripped(self, monkeypatch, tmp_path) -> None:
+        import subprocess as _sp
+
+        def fake_run(*a, **k):
+            return _sp.CompletedProcess(a, 0, stdout="  main  \nextra\n", stderr="")
+
+        monkeypatch.setattr(
+            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: "/usr/bin/git"
+        )
+        monkeypatch.setattr(cli_doctor.subprocess, "run", fake_run)
+        assert cli_doctor._git_line(tmp_path, "rev-parse", "--abbrev-ref", "HEAD") == "main"
+
+    def test_git_line_returns_none_on_oserror(self, monkeypatch, tmp_path) -> None:
+        def fake_run(*a, **k):
+            raise OSError("git not found")
+
+        monkeypatch.setattr(
+            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: "/usr/bin/git"
+        )
+        monkeypatch.setattr(cli_doctor.subprocess, "run", fake_run)
+        assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") is None
+
+    def test_git_line_survives_non_utf8_output(self, monkeypatch, tmp_path) -> None:
+        """A non-UTF-8 ref name must not crash doctor.
+
+        ``text=True`` decodes strictly unless an ``errors=`` policy is given:
+        a branch named with latin-1 bytes would raise ``UnicodeDecodeError``
+        inside ``_git_line`` — which the OSError/SubprocessError handler does
+        not catch — terminating the whole doctor run. The call passes
+        ``errors="replace"`` so undecodable bytes degrade to U+FFFD instead.
+        The fake below decodes with whatever policy the call supplies, so
+        removing ``errors="replace"`` makes this test crash exactly as the
+        real doctor would.
+        """
+        import subprocess as _sp
+
+        raw = b"exp\xe9rimental\n"  # latin-1 e-acute: invalid as UTF-8
+
+        def fake_run(argv, *a, **k):
+            errors = k.get("errors")
+            stdout = (
+                raw.decode("utf-8", errors=errors)
+                if errors
+                else raw.decode("utf-8")
+            )
+            return _sp.CompletedProcess(argv, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(
+            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: "/usr/bin/git"
+        )
+        monkeypatch.setattr(cli_doctor.subprocess, "run", fake_run)
+        line = cli_doctor._git_line(tmp_path, "rev-parse", "--abbrev-ref", "HEAD")
+        assert line == "exp\ufffdrimental"
+
+    def test_git_line_pins_git_and_returns_none_when_untrusted(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """git resolves via trusted_system_bin; a miss means no subprocess at all.
+
+        Doctor runs with operator privileges, so a ``git`` shim planted in an
+        agent-writable PATH directory must never execute: when the trusted
+        resolver declines, _git_line collapses to None without spawning.
+        When it resolves, the pinned absolute path — not the bare name — is
+        what reaches argv[0].
+        """
+        import subprocess as _sp
+
+        calls: list[list[str]] = []
+
+        def fake_run(argv, *a, **k):
+            calls.append(list(argv))
+            return _sp.CompletedProcess(argv, 0, stdout="main\n", stderr="")
+
+        monkeypatch.setattr(cli_doctor.subprocess, "run", fake_run)
+
+        # Miss: no trusted git -> None, and no process spawned. Neutralize
+        # the Windows fallback too so the miss is a miss on every platform
+        # (on a real Windows runner _windows_git_bin finds the actual Git
+        # for Windows install; the fallback has its own dedicated test).
+        monkeypatch.setattr(
+            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: None
+        )
+        monkeypatch.setattr(cli_doctor, "_windows_git_bin", lambda: None)
+        assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") is None
+        assert calls == []
+
+        # Hit: the resolved absolute path is argv[0], never the bare "git".
+        monkeypatch.setattr(
+            cli_doctor.platform_compat,
+            "trusted_system_bin",
+            lambda _n: "/usr/bin/git",
+        )
+        assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") == "main"
+        assert calls and calls[0][0] == "/usr/bin/git"
+
+    def test_git_line_windows_falls_back_to_git_for_windows_roots(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """On Windows a system-dirs miss probes the fixed Git for Windows roots.
+
+        Git for Windows installs under Program Files, never System32, so
+        without the fallback every supported Windows source install reported
+        "could not check". The fallback stays pinned: fixed literal roots, and
+        a miss there still means no subprocess.
+        """
+        import subprocess as _sp
+
+        calls: list[list[str]] = []
+
+        def fake_run(argv, *a, **k):
+            calls.append(list(argv))
+            return _sp.CompletedProcess(argv, 0, stdout="main\n", stderr="")
+
+        monkeypatch.setattr(cli_doctor.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: None
+        )
+        monkeypatch.setattr(cli_doctor.platform_compat, "IS_WINDOWS", True)
+
+        gfw = r"C:\Program Files\Git\cmd\git.exe"
+        monkeypatch.setattr(cli_doctor, "_windows_git_bin", lambda: gfw)
+        assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") == "main"
+        assert calls and calls[0][0] == gfw
+
+        # Fallback miss: still no spawn at all.
+        calls.clear()
+        monkeypatch.setattr(cli_doctor, "_windows_git_bin", lambda: None)
+        assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") is None
+        assert calls == []
+
+    def test_git_line_non_windows_never_probes_git_for_windows(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        # POSIX resolver miss must not consult the Windows fallback: the
+        # trusted-dirs decision is final there.
+        monkeypatch.setattr(
+            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: None
+        )
+        monkeypatch.setattr(cli_doctor.platform_compat, "IS_WINDOWS", False)
+        monkeypatch.setattr(
+            cli_doctor,
+            "_windows_git_bin",
+            lambda: (_ for _ in ()).throw(AssertionError("probed on POSIX")),
+        )
+        assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") is None
+
+    def test_windows_git_bin_returns_none_when_roots_empty(self, monkeypatch) -> None:
+        # Fixed roots only — a miss returns None without consulting PATH or
+        # the environment.
+        monkeypatch.setattr(cli_doctor, "_WINDOWS_GIT_DIRS", ("Z:\\nonexistent\\Git\\cmd",))
+        assert cli_doctor._windows_git_bin() is None

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -620,6 +620,18 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli_commands.py::_register_app_crons_to_scheduler",
         "cli_doctor.py::_doctor",
         "cli_doctor.py::_doctor_mcp_tools",
+        # Read-only diagnostic for the Source Checkout section: ``git -C <repo>
+        # rev-parse/rev-list`` with a hardcoded argv whose only variable is the
+        # install's own source directory (derived from the package's module
+        # path, never agent-supplied). The binary itself is pinned via
+        # ``platform_compat.trusted_system_bin("git")`` with a Windows-only
+        # fallback to the fixed Git for Windows install roots under Program
+        # Files (literal paths, never ``%ProgramFiles%`` — the environment is
+        # exactly what the pin declines to trust); a miss on both means no
+        # spawn at all. Operator-invoked doctor, 10s-capped, queries only — no
+        # fetch, no mutation. Same classification as the other fixed-argv
+        # doctor probes (``_detect_userspace_oom_killer``, ``_detect_linger``).
+        "cli_doctor.py::_git_line",
         # NOT a subprocess spawn here: the AST heuristic matches ``asyncio.run``
         # (attr ``run`` on base ``asyncio``), used only to drive the async KAS
         # token probe from the synchronous doctor. The actual child process is


### PR DESCRIPTION
## Problem / Motivation

An editable install (`pip install -e`) runs whatever the source checkout happens to be at process start. When that checkout is parked on a stale feature branch, nothing surfaces it: the gateway starts fine, serves traffic, and every fix merged upstream since the branch diverged — security gates included — is silently absent.

Observed in the wild: a host's gateway source tree sat on a feature branch for 9 days (~800 commits behind main) after a debugging session left it checked out. A gateway restart mid-window silently picked the stale tree up, so merged fixes (including retry-classification and route-hardening changes) never took effect — while `kirocrew doctor` reported fully healthy. The symptom that finally exposed it was recurring cron failures whose fix had already been merged days earlier.

## Why it matters

Every fix a user pulls and merges is inert until the checkout is actually on the branch being updated — and the dashboard update path runs a bare `git pull`, which on a feature branch pulls that branch, not the default. A user can "update" repeatedly and keep running old code, including security fixes, with zero signal from any diagnostic surface.

## What changed (motivation → approach → change)

Goal: make a stale or off-branch source tree visible in the one place users already look when something is off — `kirocrew doctor`.

Approach: an advisory Source Checkout section (never appended to `issues`, matching the linger and embedding-model-URL probes) — running a feature branch is a legitimate developer state, so doctor's job is to name it, not to block on it. Offline by design: no `git fetch`, no mutation; "behind" is bounded by the last fetch, which is acceptable because the failure mode being caught is a checkout parked on an old branch while fetches happen around it, not a host that never talks to the remote. The default branch is read from `refs/remotes/origin/HEAD` rather than assumed to be `main`, and when that ref is missing doctor reports the branch it is on without guessing.

Built:
- `_git_line()` — a small subprocess seam (first stdout line or `None` on any failure) so tests drive the probe without a real repository. `git` is resolved through `platform_compat.trusted_system_bin` (never a bare `PATH` lookup — doctor runs with operator privileges, so a planted shim must never execute); on Windows a resolver miss falls back to the fixed Git for Windows install roots under Program Files (literal paths, never `%ProgramFiles%`, since the environment is exactly what the pin declines to trust). A miss on both means no subprocess at all.
- `_doctor_source_checkout()` — renders one of: pass (on default, current), warn with commit count (on default, behind last fetch), warn when the count itself cannot be established (a failed `rev-list` must not masquerade as "up to date"), warn with branch name + distance on any other branch, not-applicable (tarball installs with no `.git`, mirroring the update handler's guard), or could-not-check (git failure). Remediation is prose only — branch and path come from the repository, so a suggested command line interpolating them would hand the operator a pasteable injection payload.
- Wired into `_doctor` gated on the source-checkout markers themselves (`_bootstrap._source_checkout_root()`: `setup.cfg` + `src/kiro_crew` above the package's own `__file__`), not on `./.venv` existing — an editable install driven by an external virtualenv or a `PYTHONPATH=src` invocation runs stale source the same way. Wheel installs have no markers and get no section.

## Tests

15 new tests in `test/test_cli_doctor.py` (`TestSourceCheckout`):
- on default branch and current → ✅ with no warning
- on default branch but behind → ⚠️ with the commit count and update hint
- on default branch with a failed count → ⚠️ could-not-count, never a false ✅
- on a feature branch behind main → ⚠️ naming the branch, the distance, that merged fixes are NOT active, and the recovery guidance
- on a feature branch with unknown distance (rev-list fails) → still warns on the off-branch state itself
- a hostile ref name (`$(touch${IFS}/tmp/pwn)`) → never rendered on a line shaped like a runnable command
- missing `origin/HEAD` → reports the branch without guessing the default
- no `.git` (tarball install) → not-applicable, no warning
- git wholly failing → "could not check"
- `_git_line`: `None` on nonzero exit, `None` on `OSError`, first line stripped on success; trusted-resolver miss spawns nothing and a hit pins the absolute path as argv[0]; Windows falls back to the fixed Git for Windows roots (and a miss there still spawns nothing); the fallback is never consulted on POSIX; the fixed-root probe returns `None` without consulting `PATH` or the environment

`test/test_spawn_audit.py`: `_git_line` added to `BENIGN_SPAWNS` with justification (operator-invoked doctor probe, fixed `rev-parse`/`rev-list` argv, repo path derived from the package's own module location, binary pinned with the Windows fixed-root fallback documented, read-only, 10s-capped) — the audit correctly flagged the new spawn site on first CI run.

Local gates: 86 passed across `test_cli_doctor.py` + `test_spawn_audit.py` + `test_bootstrap.py`; isort / flake8 / mypy clean on all changed files.

## Manual verification

Ran the probe read-only against two real checkouts: the stale tree that motivated this change (reported `⚠️ on 'fix/…' — not the default branch, 1017 commit(s) behind origin/main` with prose-only remediation) and a fresh worktree on a feature branch (reported the off-branch warning without a distance, as expected before any divergence). Also verified the marker gate resolves the repo root from a source checkout with no local `.venv`.

## Related Issues

N/A — found via runtime-log patrol; no existing issue or PR covers source-checkout freshness (nearest is #3396, which covers the built SPA bundle, not the Python source tree).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, doctor output is self-documenting
- [x] No secrets, credentials, or internal references in the diff
