### PR TITLE
fix(security): respect quoted separators in _extract_base_command

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -1397,6 +1397,10 @@ _REDIRECT_PLACEHOLDER = "\x00REDIR\x00"
 _REDIRECT_RE = re.compile(r"[0-9]*>&[0-9]*|&>>?")
 # After redirects are masked, split on remaining separators.
 _CMD_SPLIT_RE = re.compile(r"\s*(?:\|\||&&|;|&|\n|\|)\s*")
+# Grant-safe variant: excludes bare & (background/arithmetic) and \n (display)
+# because this function serves the Trust dropdown (grant direction) where each
+# extra segment becomes one more binary offered for auto-approval.
+_CMD_GRANT_SPLIT_RE = re.compile(r"\s*(?:\|\||&&|;|\|)\s*")
 # Command substitution forms that split-then-fnmatch cannot safely reach:
 # $(...), backticks, and process substitution <(...)/>(...). Deny-by-default
 # when any are present — the pattern match would operate on the outer shell
@@ -1404,7 +1408,7 @@ _CMD_SPLIT_RE = re.compile(r"\s*(?:\|\||&&|;|&|\n|\|)\s*")
 _CMD_SUBSTITUTION_RE = re.compile(r"\$\(|`|<\(|>\(")
 
 
-def _mask_quoted_separators(text: str) -> tuple[str, dict[str, str]]:
+def _mask_quoted_separators(text: str, *, mask_escaped: bool = False) -> tuple[str, dict[str, str]]:
     """Replace command separators that appear INSIDE quotes with placeholders.
 
     The split regex (``_CMD_SPLIT_RE``) is quote-unaware, so a separator inside
@@ -1436,7 +1440,18 @@ def _mask_quoted_separators(text: str) -> tuple[str, dict[str, str]]:
     for ch in text:
         if escaped:
             escaped = False
-            out.append(ch)
+            # When mask_escaped is True (grant path), an escaped separator
+            # (e.g. \|) is treated as a literal — mask it so the split regex
+            # skips it.  When False (deny path), escaped separators still
+            # segment because treating \; as a literal would let an attacker
+            # hide a second command behind an escape.
+            if mask_escaped and ch in "|&;\n":
+                ph = f"\x00SEP{n}\x00"
+                n += 1
+                restore[ph] = ch
+                out.append(ph)
+            else:
+                out.append(ch)
             continue
         if ch == "\\" and quote != "'":
             escaped = True
@@ -1844,25 +1859,44 @@ def _safe_native_crew_debug_title(title: str) -> str:
     return safe
 
 
-def _split_command_segments(tool_title: str) -> tuple[str, list[str]] | None:
+def _split_command_segments(
+    tool_title: str,
+    split_re: "re.Pattern[str] | None" = None,
+    mask_escaped: bool = False,
+) -> tuple[str, list[str]] | None:
     """Split a shell tool title into its unquoted command segments.
 
     Returns ``(normalized_title, segments)``. Returns ``None`` — which every
     caller MUST treat as "deny" — when the command contains substitution
     (``$(...)``, backticks, process substitution), because no amount of
-    per-segment matching can reach inside a sub-command.
+    per-segment matching can reach inside a sub-command, or when it contains a
+    NUL byte, which would forge one of this function's own placeholders.
 
     Extracted so that every command-keyed approval path shares ONE splitter:
     a second, independently written shell splitter is exactly how a bypass
     gets introduced (quoted separators, masked redirects, backgrounding).
+
+    Pass ``split_re=_CMD_GRANT_SPLIT_RE`` for the grant path (Trust dropdown)
+    where bare ``&`` and ``\\n`` must NOT widen the offered set.
     """
     normalized = _normalize_tool_name(tool_title)
     if _CMD_SUBSTITUTION_RE.search(normalized):
         return None
+    # Both masking passes below key on NUL-delimited placeholders
+    # (``\x00REDIR\x00``, ``\x00SEP{n}\x00``), so the scheme is only
+    # unambiguous while the input carries no NUL of its own. A title that
+    # already contains one forges a placeholder: the redirect-restore loop
+    # then draws more placeholders than it masked and raises StopIteration
+    # (aborting the turn), and a forged ``\x00SEP{n}\x00`` restores to a
+    # separator the command never had. NUL is never legitimate here -- execve
+    # cannot carry it in an argument -- so deny by default rather than strip,
+    # which would match patterns against text that is not what would run.
+    if "\x00" in normalized:
+        return None
     # First mask separators that live INSIDE quotes (a quoted "a|b" must not be
     # split on its `|`), so _CMD_SPLIT_RE only ever cuts on real, unquoted
     # command boundaries. The placeholders are restored in each segment below.
-    quote_masked, sep_restore = _mask_quoted_separators(normalized)
+    quote_masked, sep_restore = _mask_quoted_separators(normalized, mask_escaped=mask_escaped)
     # Two-pass split: mask known redirect forms (2>&1, &>, &>>) so their &
     # isn't mistaken for a background operator, then split on remaining &.
     # Track masked positions to reconstruct original text in each segment.
@@ -1873,7 +1907,7 @@ def _split_command_segments(tool_title: str) -> tuple[str, list[str]] | None:
         return _REDIRECT_PLACEHOLDER
 
     masked = _REDIRECT_RE.sub(_mask, quote_masked)
-    split_parts = _CMD_SPLIT_RE.split(masked)
+    split_parts = (split_re or _CMD_SPLIT_RE).split(masked)
     # Restore original redirect syntax in each segment for pattern matching.
     redir_iter = iter(redirects)
     segments = []
@@ -2404,10 +2438,28 @@ def _extract_base_command(tool_title: str) -> str:
     "Running: ls /tmp" -> "ls"
     "Running: cat /etc/hosts | wc -l" -> "cat,wc"
     "Running: grep -r foo . && echo done" -> "grep,echo"
+    "Running: grep -E 'foo|bar' file.txt" -> "grep"
     "SomeMcpTool" -> "SomeMcpTool"
+
+    Delegates to :func:`_split_command_segments` with
+    ``_CMD_GRANT_SPLIT_RE`` — the same shared splitter (quote masking,
+    redirect masking, substitution denial) but a narrower operator set that
+    excludes bare ``&`` and ``\\n``.  Those operators are correct for the
+    deny path (enforcement) where over-splitting fails closed, but wrong
+    for the grant path (Trust dropdown) where each extra segment becomes
+    one more binary offered for auto-approval.
+
+    When the command contains substitution, returns only the first token —
+    the enforcement path independently denies substitution commands.
     """
-    normalized = _normalize_tool_name(tool_title)
-    segments = re.split(r"\s*(?:\|\||&&|;|\|)\s*", normalized)
+    split = _split_command_segments(tool_title, split_re=_CMD_GRANT_SPLIT_RE, mask_escaped=True)
+    if split is None:
+        # Command substitution — can't safely extract bases.  Return only
+        # the first token so the Trust dropdown doesn't offer junk patterns.
+        normalized = _normalize_tool_name(tool_title)
+        parts = normalized.strip().split(None, 1)
+        return parts[0] if parts else normalized
+    normalized, segments = split
     bases = []
     for seg in segments:
         parts = seg.strip().split(None, 1)

--- a/test/test_trust_patterns.py
+++ b/test/test_trust_patterns.py
@@ -270,14 +270,63 @@ class TestPipedCommandTrust:
         base = _extract_base_command("Running: test -f foo || touch foo")
         assert base == "test,touch"
 
-    def test_pipe_does_not_split_inside_args(self):
-        # A grep with a pipe char in the regex — the split is on | operator.
-        # This is inherently a limitation: we split on |, so "grep 'a|b'" splits.
-        # In practice the shell command title uses the full command.
+    def test_pipe_does_not_split_inside_single_quotes(self):
         base = _extract_base_command("Running: grep -E 'foo|bar' file.txt")
-        # This will incorrectly parse — but that's acceptable as an edge case
-        # since the extracted bases still include "grep" which is correct.
-        assert "grep" in base
+        assert base == "grep"
+
+    def test_pipe_does_not_split_inside_double_quotes(self):
+        base = _extract_base_command('Running: grep -e "Error|Failure|Problem" /var/log/app.log')
+        assert base == "grep"
+
+    def test_multiple_quoted_pipes_single_base(self):
+        base = _extract_base_command("Running: grep -E 'cat|dog|bird|fish' animals.txt")
+        assert base == "grep"
+
+    def test_quoted_pipe_with_real_pipe(self):
+        base = _extract_base_command("Running: grep -E 'foo|bar' file.txt | wc -l")
+        assert base == "grep,wc"
+
+    def test_quoted_semicolon_not_split(self):
+        base = _extract_base_command("Running: echo 'hello; world'")
+        assert base == "echo"
+
+    def test_double_quoted_pipe_with_real_pipe(self):
+        base = _extract_base_command('Running: grep "it is here" file | wc -l')
+        assert base == "grep,wc"
+
+    def test_unquoted_pipe_still_splits(self):
+        base = _extract_base_command("Running: ls /tmp | grep foo | wc -l")
+        assert base == "ls,grep,wc"
+
+    def test_double_quote_inside_single_quotes(self):
+        # Odd number of " on the line — naive parity counting would fail.
+        base = _extract_base_command("""Running: echo "abcdefgh" | tr '"' ' ' | wc""")
+        assert base == "echo,tr,wc"
+
+    def test_single_quote_inside_double_quotes(self):
+        # Odd number of ' on the line — naive parity counting would fail.
+        base = _extract_base_command("""Running: echo "abcdefgh" | tr "'" " " | wc""")
+        assert base == "echo,tr,wc"
+
+    def test_substitution_fallback_returns_first_token_only(self):
+        base = _extract_base_command("Running: echo $(date),touch /tmp/pwned")
+        assert base == "echo"
+        assert "touch" not in base
+
+    def test_backtick_substitution_fallback(self):
+        base = _extract_base_command("Running: cat `which python` | head")
+        assert base == "cat"
+        assert "head" not in base
+
+    def test_background_ampersand_not_split(self):
+        # Bare & (background) must NOT split in the grant path.
+        base = _extract_base_command("Running: sleep 999 & curl evil.com")
+        assert "curl" not in base
+
+    def test_escaped_pipe_not_split(self):
+        # Escaped separator outside quotes must NOT split.
+        base = _extract_base_command(r"Running: echo ok \| Failure")
+        assert "Failure" not in base
 
 
 # ── Handler trust_command / trust_base integration ──
@@ -374,6 +423,20 @@ class TestHandlerTrustBase:
         # Handler would build "cat *,wc *"
         pattern = ",".join(f"{b} *" for b in base.split(",") if b)
         assert pattern == "cat *,wc *"
+
+    def test_trust_base_quoted_pipe_no_privilege_widening(self):
+        """Regression: pipes inside quotes must NOT leak into base_command."""
+        base = _extract_base_command('Running: grep -e "Error|Failure|Problem" /var/log/app.log')
+        assert base == "grep"
+        pattern = ",".join(f"{b} *" for b in base.split(",") if b)
+        assert pattern == "grep *"
+        assert "Failure" not in pattern
+
+    def test_trust_base_quoted_pipe_with_real_pipe_correct(self):
+        """Quoted pipe + real pipe: only real commands are extracted."""
+        base = _extract_base_command('Running: grep -E "Error|Failure" /var/log/app.log | tail -20')
+        assert base == "grep,tail"
+        assert "Failure" not in base
 
 
 # ── Slot serialization ──
@@ -1128,3 +1191,52 @@ class TestMatchesTrustedPatternQuoted:
         # for genuinely unquoted pipes — an unmatched segment still denies.
         patterns = {"cat /etc/*"}
         assert _matches_trusted_pattern("Running: cat /etc/hosts | rm -rf /", patterns) is None
+
+
+class TestSplitterPlaceholderForgery:
+    """A NUL byte in the title forges the splitter's own placeholders.
+
+    ``_split_command_segments`` masks redirects as ``\\x00REDIR\\x00`` and
+    quoted separators as ``\\x00SEP{n}\\x00``. Both schemes assume the input
+    carries no NUL of its own. A model-authored title (or a ``tool_input``
+    command) containing one breaks that assumption two ways: the
+    redirect-restore loop draws more placeholders than it masked and raises
+    ``StopIteration`` — an unhandled exception on the approval path, which
+    aborts the chat turn — and a forged ``\\x00SEP{n}\\x00`` restores to a
+    separator the command never contained. A NUL can reach here because JSON
+    encodes it as ``\\u0000`` and Python decodes that to a real ``\\x00``; it is
+    never legitimate in a command, since ``execve`` cannot carry it in an
+    argument. So every path must deny rather than crash.
+    """
+
+    def test_forged_redirect_placeholder_denies_instead_of_crashing(self):
+        cmd = "Running: echo hi \x00REDIR\x00 there"
+        # Must not raise StopIteration; must not be trusted.
+        assert _matches_trusted_pattern(cmd, {"echo *"}) is None
+        assert _matches_trusted_pattern(cmd, {"*"}) is None
+
+    def test_forged_separator_placeholder_denies(self):
+        cmd = "Running: echo hi \x00SEP0\x00 there"
+        assert _matches_trusted_pattern(cmd, {"echo *"}) is None
+
+    def test_bare_nul_anywhere_denies(self):
+        assert _matches_trusted_pattern("Running: cat /etc/hosts\x00", {"cat *"}) is None
+
+    def test_grant_path_falls_back_to_first_token(self):
+        # The Trust dropdown must still offer something sane rather than
+        # propagating the crash: the substitution fallback (first token only).
+        assert _extract_base_command("Running: echo hi \x00REDIR\x00 there") == "echo"
+        assert _extract_base_command("Running: echo hi \x00SEP0\x00 there") == "echo"
+
+    def test_grant_path_does_not_offer_forged_extra_segments(self):
+        # A forged SEP placeholder must not restore into a separator that
+        # widens the offered trust set beyond the first binary.
+        assert _extract_base_command("Running: echo ok\x00SEP0\x00 rm -rf /") == "echo"
+
+    def test_nul_free_commands_are_unaffected(self):
+        # Guard against the deny becoming over-broad: normal commands, quoted
+        # separators and real redirects all still behave as before.
+        assert _matches_trusted_pattern("Running: cat /etc/hosts", {"cat *"}) is not None
+        assert _matches_trusted_pattern('Running: grep "a|b" f', {'grep "a|b" *'}) is not None
+        assert _matches_trusted_pattern("Running: ls 2>&1", {"ls *"}) is not None
+        assert _extract_base_command("Running: cat f | wc -l") == "cat,wc"


### PR DESCRIPTION
## Problem / Motivation

`_extract_base_command` splits shell commands on operators to extract base
binary names for the Trust dropdown's "Trust base" option. It had a bare
`re.split()` that was unaware of shell quoting — commands like
`grep -e "Error|Failure|Problem" file.log` would produce bogus trust
patterns (`Failure *`, `Problem *`). Additionally, escaped separators
(`echo ok \| Failure`) were also split on.

Separately, the shared splitter this fix delegates to crashes on a forged
placeholder. `_split_command_segments` masks redirects as `\x00REDIR\x00` and
quoted separators as `\x00SEP{n}\x00`, so its scheme is unambiguous only while
the input carries no NUL of its own. A title containing one forges a
placeholder: the redirect-restore loop then draws more placeholders than it
masked and raises `StopIteration`, aborting the chat turn, and a forged
`\x00SEP{n}\x00` restores into a separator the command never had. This
predates the PR — `_matches_trusted_pattern` on `main` raises the same
`StopIteration` — but consolidating a third caller onto that splitter is
what made it worth fixing at the cause.

## Why it matters

The trust dropdown is a security surface. Incorrectly parsed commands widen
the set of binaries a session will auto-approve beyond what the user
intended. Clicking "Trust base" on a command with quoted pipes would
auto-approve any future command starting with those non-command words.

## What changed (motivation → approach → change)

1. **Parameterized `_split_command_segments`** with an optional `split_re`
   argument (defaults to `_CMD_SPLIT_RE` for backward compat). Added
   `_CMD_GRANT_SPLIT_RE` which excludes bare `&` and `\n`. Those operators
   are correct for the deny path (over-splitting fails closed) but wrong for
   the grant path (over-splitting fails open). Note this **preserves** the
   deleted splitter's behaviour rather than fixing a live defect: its regex
   was `\|\||&&|;|\|`, which never split on `&` or `\n` either. This keeps the
   module's "ONE shared splitter" invariant: same quote masking, redirect
   masking, and substitution denial — just two operator profiles.

2. **Rewrote `_extract_base_command`** to call `_split_command_segments` with
   the grant-safe regex instead of its own bare `re.split()`. On command
   substitution (`$(...)`, backticks), returns only the first token.

3. **Fixed escaped separators** in `_mask_quoted_separators`: a
   backslash-escaped separator outside quotes (e.g. `\|`) is now masked so
   the split regex skips it. Previously only in-quote separators were masked.

4. **Denied NUL-bearing commands** in `_split_command_segments`, restoring the
   precondition both masking passes rely on and closing both forgery families
   at once. Deny rather than strip, because stripping would match trust
   patterns against text that is not what would run; NUL is never legitimate
   here, since `execve` cannot carry it in an argument. The shape suits all
   three callers: the two deny callers treat `None` as deny and fail closed,
   and `_extract_base_command` already falls back to first-token extraction on
   `None`. Every caller therefore degrades to the normal manual-approval path
   rather than dropping anything silently.

## Tests

- Replaced the 1 "known limitation" test with 15 precise tests covering:
  single/double quoted pipes, odd-quote-count scenarios, mixed quoted + real
  pipes, quoted semicolons, unquoted pipes still splitting, substitution
  fallback (first token only), background `&` not splitting (pinning the
  status quo, not a behaviour change), and escaped separators not splitting.
- Added 2 regression tests in `TestHandlerTrustBase` proving the
  privilege-widening hole is closed.
- Added 6 tests in `TestSplitterPlaceholderForgery` for the NUL guard,
  revert-verified: with the guard removed 4 of them fail — two as the
  `StopIteration` crash, two as commands wrongly reported trusted — and one is
  a negative control pinning that ordinary commands, quoted separators and
  real redirects are unaffected.

21 new tests in total; `test/test_trust_patterns.py` passes 132, and 481 pass
across the trust and chat-runner suites together.

## Manual verification

N/A — unit coverage sufficient. The fix is entirely in command-string
parsing logic with no UI rendering change. Chris performed extensive manual
testing on a dev build of a prior iteration of this branch.

The `StopIteration` crash was reproduced directly against this checkout, and
confirmed to reproduce identically against a clean `origin/main` checkout via
`_matches_trusted_pattern`, establishing it as pre-existing rather than
introduced here.

**Maintainer-assisted update:** a maintainer squashed this branch to a single
commit (PR Hygiene requires one) and added the NUL guard, pushing via
maintainer edit access. Chris remains the commit author and the contributor.
One caution for anyone re-basing: the previous head was a merge commit whose
conflict resolution was the *only* place the `mask_escaped` gate existed, so a
plain `git rebase` drops it and silently reintroduces a segmentation bypass
(`ls \; whoami` collapses to one segment and matches `ls*`). `main`'s own
`test_an_escaped_separator_outside_quotes_still_segments` catches it. This
commit was rebuilt from the merge's net diff for that reason.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** Backend-only change to command string parsing logic.
No UI rendering change.

## Related Issues

no linked issue: discovered during manual investigation of trust dropdown
behavior with piped grep commands.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff


<!-- readiness re-trigger: the Stage-2 fork reviewers all completed green at 4ccacbd1133237a9ebd80c64753aabc230ffa0a0, but the PR Readiness aggregation that should publish on their completion was lost to concurrency cancellation, freezing the label at `readiness: checking` with a status stamped 17:03:05 (before the reviews landed). This edit fires pull_request_target:edited to re-aggregate. It does not re-run CI and does not re-arm the reviewers. -->
