### PR TITLE
fix: hoist the empty-message 400 above every /api/chat dispatch branch (#4223)

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1391,
+    "missing_code": 1390,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 807,
+  "_compliant": 819,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -40,7 +40,7 @@
       "missing_code": 17
     },
     "dashboard/chat_handlers.py": {
-      "missing_code": 74
+      "missing_code": 73
     },
     "dashboard/chat_mirror.py": {
       "missing_code": 11

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -272,6 +272,22 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         slot.theme_consent = theme_consent
         slot.theme_consent_sha = theme_consent_sha
 
+    if not message:
+        # One guard, above every dispatch branch. An empty wire text reaches
+        # here only from programmatic callers (app tokens, curl, integrations)
+        # — the dashboard composer always inlines staged files into the
+        # message text. Such a send may still carry attachments in `meta`:
+        # nothing downstream queues or broadcasts it, so any success receipt
+        # would report work that was silently dropped. Refusing here keeps
+        # every branch below (steer/queue, crew, subagent-hold, new turn)
+        # unable to bypass the check — the guard used to sit below the busy
+        # branch, which is exactly how the false `queued: true` receipt
+        # happened. `message_required` is the backend-owned code already used
+        # for this refusal (handlers/messaging.py).
+        return web.json_response(
+            {"error": "message is required", "code": "message_required"}, status=400
+        )
+
     if slot.running or slot._in_stage_execution:
         # Mid-turn steer: inject into the RUNNING turn instead of queueing for
         # the next turn. Gated on an explicit `steer` flag + a live, steer-capable
@@ -362,25 +378,23 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
             # steer requested but unavailable → fall through to queue below.
         # Queue the message — return JSON immediately (no SSE needed).
         # The existing SSE reader will pick up queued messages as _run_chat
-        # processes the queue in its finally block.
-        if message:
-            qid = slot.queue_append(message)
-            _c, _ = redact_exfiltration_urls(message)
-            _c, _ = redact_credentials(_c)
-            _redacted = _redact_for_display(_c)
-            state.broadcast_ws(
-                "queue_push",
-                {
-                    "slot": slot.key,
-                    "content": _redacted,
-                    "ts": datetime.now(timezone.utc).isoformat(),
-                    "queue_id": qid,
-                },
-            )
+        # processes the queue in its finally block. The message is non-empty
+        # here (hoisted guard above the busy branch), so `queued: true`
+        # always reports a real enqueue.
+        qid = slot.queue_append(message)
+        _c, _ = redact_exfiltration_urls(message)
+        _c, _ = redact_credentials(_c)
+        _redacted = _redact_for_display(_c)
+        state.broadcast_ws(
+            "queue_push",
+            {
+                "slot": slot.key,
+                "content": _redacted,
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "queue_id": qid,
+            },
+        )
         return web.json_response({"ok": True, "queued": True})
-
-    if not message:
-        return web.json_response({"error": "message is required"}, status=400)
 
     # ── Crew Mode dispatch (RFC orchestrator-chat-sessions) ─────────
     # MUST precede the hold-users gate below: crew topics ARE background

--- a/test/test_queue_during_subagents.py
+++ b/test/test_queue_during_subagents.py
@@ -9,6 +9,7 @@ steering is the effective opt-out.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -141,6 +142,78 @@ class TestApiChatSubagentQueueGate:
 
         assert data.get("queued") is not True  # not held → normal dispatch
         assert slot.queue_depth == 0
+
+
+# ── API test: api_chat busy-slot queue branch (receipt honesty) ──
+
+
+@pytest.mark.asyncio
+class TestApiChatBusySlotEmptyMessage:
+    """The busy-slot queue branch never answers `queued: true` for a send it
+    did not queue: an empty-message send (e.g. attachments only in `meta`)
+    gets an honest 400 with a stable code, and nothing is queued or
+    broadcast."""
+
+    async def _busy_client(self, tmp_path, monkeypatch):
+        """Real state + slot; the slot is made busy via a live, never-done task."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        pushes: list[tuple[str, dict]] = []
+        state.broadcast_ws = lambda kind, payload, **kw: pushes.append((kind, payload))
+        return state, slot, pushes
+
+    async def test_attachment_only_send_gets_honest_400(self, tmp_path, monkeypatch):
+        """Busy slot + empty message + meta attachments → 4xx with stable code,
+        nothing appended to the queue, no queue_push broadcast."""
+        state, slot, pushes = await self._busy_client(tmp_path, monkeypatch)
+        gate = asyncio.Event()
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            slot.task = asyncio.get_running_loop().create_task(gate.wait())
+            try:
+                assert slot.running is True  # precondition: authentically busy
+                resp = await client.post(
+                    "/api/chat?ws=1",
+                    json={
+                        "message": "",
+                        "slot": "s1",
+                        "meta": {"files": [{"name": "diagram.png"}]},
+                    },
+                )
+                assert resp.status == 400
+                data = await resp.json()
+            finally:
+                gate.set()
+                await slot.task
+
+        assert data.get("error") == "message is required"
+        assert data.get("code") == "message_required"
+        assert data.get("queued") is not True
+        assert slot.queue_depth == 0
+        assert [p for p in pushes if p[0] == "queue_push"] == []
+
+    async def test_nonempty_message_still_queued(self, tmp_path, monkeypatch):
+        """Busy slot + non-empty message → `queued: true`, one queue entry,
+        one queue_push broadcast (the receipt implies a real enqueue)."""
+        state, slot, pushes = await self._busy_client(tmp_path, monkeypatch)
+        gate = asyncio.Event()
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            slot.task = asyncio.get_running_loop().create_task(gate.wait())
+            try:
+                resp = await client.post(
+                    "/api/chat?ws=1", json={"message": "still here", "slot": "s1"}
+                )
+                assert resp.status == 200
+                data = await resp.json()
+            finally:
+                gate.set()
+                await slot.task
+
+        assert data.get("queued") is True
+        assert slot.queue_depth == 1
+        assert len([p for p in pushes if p[0] == "queue_push"]) == 1
 
 
 # ── Board annotation: DashboardState.serialize_slots subagents_running ──


### PR DESCRIPTION
## Problem / Motivation

The busy-slot branch of `POST /api/chat` guards `slot.queue_append` and the `queue_push` WebSocket broadcast on a non-empty message, but its `{"ok": true, "queued": true}` response returns unconditionally. The idle path's `if not message:` 400 sits **below** the busy branch, so it is unreachable while a turn is running. A programmatic caller (app token, curl, integration) that POSTs an empty `message` to a busy slot — possibly with attachments in `meta` — therefore receives an acceptance receipt for work that was silently dropped: nothing queued, no broadcast, attachments lost. The dashboard composer cannot hit this (it always inlines staged files into the wire text), so the affected surface is the HTTP API contract.

## Why it matters

Every API caller that trusts `queued: true` is misinformed, and the response gives no way to distinguish this from a real enqueue — the failure is invisible until the user notices their attachment never arrived. Two review lanes on PR #4180 independently identified this server response as the root cause and asked for this separate filing.

## What changed (motivation → approach → change)

Symptom: a false `queued: true` receipt for empty busy-slot sends. Root cause: guard placement — the single `if not message:` 400 sat **below** the early-returning busy branch, so any branch above it bypassed the check. Change: **hoist that one guard above every dispatch branch** (steer/queue, crew, subagent-hold, new turn), so no current or future branch can bypass it, and delete the now-redundant refusal copies. The 400 carries `code: message_required` — the backend-owned string already established for this refusal in `handlers/messaging.py` (AGENTS.md backend-string convention) — giving the error one machine-readable shape regardless of slot state. `queued: true` now implies a real `queue_append` on every path.

The first pushed revision cloned the refusal into the busy branch; the First Principles reviewer correctly flagged that this left the bug-causing placement intact, and the hoist is its suggested subtraction (2 refusal sites → 1 guard). Behavior is input-identical: the steer path already required a non-empty message, the crew and subagent-hold branches sat below the old guard, and the agent/theme side-effect ordering before the guard is unchanged.

Deliberately **not** done: queuing attachment-only sends (the larger behavioral alternative) — the honest refusal is consistent with the side-chat path, which also 400s on empty text. The two sibling `{"ok": true, "queued": true}` returns were verified truthful: the requeue-after-kill return fires only after the turn's `finally` requeued the steer (non-empty by the steer gate), and the subagent-hold return now sits below the hoisted guard.

Pre-push review (two model-pinned read-only subagents mirroring the codex-review and claude-review contracts): 0 blocking findings; 3 advisories fixed in this diff (comment framing corrected to programmatic callers, test docstrings reworded to present-tense invariants, `code` unified), 1 noted out of scope (see below). Server-side First Principles concern addressed by the hoist.

## Tests

`test/test_queue_during_subagents.py::TestApiChatBusySlotEmptyMessage` (new, on a real slot made busy via a live never-done task, so `slot.running` is authentic):
- `test_attachment_only_send_gets_honest_400` — busy slot + empty message + `meta` attachments → 400 with `code: message_required`, `queue_depth == 0`, zero `queue_push` broadcasts. Fails on the pre-fix code with `assert 200 == 400` (verified red-first).
- `test_nonempty_message_still_queued` — busy slot + non-empty message → `queued: true`, one queue entry, exactly one `queue_push` broadcast.

Gates: isort / flake8 / mypy clean; full pytest run 55,239 passed on the initial head, affected suites (127 tests incl. the error-code contract) re-run green after the hoist. 459 failures in the run were reproduced byte-identically on pristine `main` in the same sandbox (missing editable-install entry-point metadata plus jq/docker/userns host drift) and are unrelated to this diff.

## Manual verification

N/A — unit coverage sufficient: the change is a single guarded JSON response in one handler branch, and both the refusal and the preserved enqueue path are locked by handler-level tests against a real `TestServer`.

## Related Issues

Closes #4223

Out-of-scope note for reviewers: `restoreComposerAfterFailedSend` in `website/src/pages/ChatPage.tsx` does not restore staged files after a failed send. Moot for this server-side fix (the composer cannot produce an empty-text send today), but worth a follow-up if the frontend ever allows one. The client guard added by PR #4180 is not in `main`, so no `website/` change rides here; removing that guard once both land belongs to a follow-up.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, internal API error-shape fix
- [x] No secrets, credentials, or internal references in the diff
