### PR TITLE
fix(acp): name the MCP server a stalled session start waited for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **A session that times out on startup now names the MCP server it was waiting
+  for.** Every cause of a stalled session start reported the same sentence,
+  `Request session/new timed out`, which named none of them: a slow MCP fleet, a
+  single unreachable remote server, a pending authorization, and an expired
+  credential were indistinguishable. The runtime already held both halves of the
+  answer at that moment and threw them away. It sends the server roster in the
+  request's own `mcpServers` array, and the reader loop stages every
+  `server_initialized` / `server_init_failure` / `oauth_request` frame that
+  arrives before the response, each carrying its server's name. A session-start
+  timeout now reads both and reports the difference, so the error says how many
+  servers reported out of how many were expected, which ones never reported,
+  which failed and why, and which are waiting on authorization. `session/load`
+  shares the budget and the staging, so it gets the same report. A failed
+  server's error text takes the same redaction the dashboard banner applies,
+  because a server's startup error can carry its own connection string, and each
+  listed name is redacted, collapsed onto one line and length-capped as well --
+  a name is config-derived, so an installed app chooses it, and an embedded
+  newline would otherwise forge a line in the gateway log while an unbounded one
+  would defeat the cap on how many names are listed. The reported count is taken
+  against the roster rather than against every staged frame, since the agent
+  spec's own servers report too and counting them produced impossible readings
+  like "2/1 reported". Timeouts now raise a dedicated `AcpRequestTimeout`, a subclass of
+  `AcpRuntimeError`, so a stall is distinguishable from a protocol fault without
+  changing what existing handlers catch. Startup telemetry also stops losing the
+  starts that failed: the `session_new` phase duration is recorded in a `finally`
+  like `session_load` already was, instead of only on success.
+
 - **Subagent rows in System → Sessions now report their process and MCP-stub
   counts.** Both columns rendered an em dash on every task row, which read as
   "a subagent carries no MCP stubs" — the opposite of the truth: a subagent

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -58,6 +58,7 @@ from kiro_crew.acp.kas_auth import (
     resolve_kas_access_token,
 )
 from kiro_crew.acp.session_handle import (
+    AcpRequestTimeout,
     AcpRuntimeDead,
     AcpRuntimeError,
     AcpRuntimeProtocol,
@@ -100,6 +101,7 @@ from kiro_crew.sandbox import (
     scrub_agent_denied_env,
     wrap_argv,
 )
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.session_pid import (
     _track_pid,
     _track_session_pid,
@@ -116,6 +118,7 @@ __all__ = [
     "AcpRuntime",
     "AcpRuntimeError",
     "AcpRuntimeDead",
+    "AcpRequestTimeout",
     "AcpRuntimeProtocol",
     "AcpSessionHandle",
 ]
@@ -147,6 +150,60 @@ _REQUEST_TIMEOUT = 30.0
 # raises it for agents whose MCP fleet legitimately needs longer (see
 # _resolve_session_start_timeout below).
 _SESSION_NEW_TIMEOUT = 90.0
+
+# Caps for the MCP progress line attached to a session-start timeout: a
+# 70-server agent must not turn one error into a multi-kilobyte string, and
+# neither a server's own error text nor its NAME is trusted for length. Both are
+# config-derived, and an installed app supplies its own server names.
+_MCP_PROGRESS_NAME_CAP = 8
+_MCP_PROGRESS_ERROR_CAP = 120
+_MCP_PROGRESS_NAME_LEN_CAP = 64
+
+
+def _strip_unprintable(text: str) -> str:
+    """Drop the control characters a whitespace collapse cannot reach.
+
+    ``str.split`` removes whitespace controls (newline, tab, CR), but ESC and
+    the other non-whitespace controls survive it, and a terminal rendering the
+    gateway log interprets them -- an MCP server's failure text could forge or
+    recolor terminal output. Spaces are printable, so a collapsed string keeps
+    its word separation.
+    """
+    return "".join(ch for ch in text if ch.isprintable())
+
+
+def _sanitize_progress_name(name: str) -> str:
+    """Make one MCP server name safe to put in a log line and an exception.
+
+    A name is config-derived, so an installed app chooses it. Four hazards, all
+    closed here rather than at each use: an embedded newline would forge a line
+    in the gateway log, a non-whitespace control (ESC) would inject terminal
+    escapes into it, an unbounded name would defeat the count cap that keeps
+    one error from becoming a wall of text, and a name carrying
+    credential-shaped text would leak it into a sink the error message reaches.
+    Whitespace collapse and the control strip run AFTER redaction so a
+    redaction marker cannot reintroduce a break.
+    """
+    scrubbed, _ = redact_exfiltration_urls(name)
+    scrubbed, _ = redact_credentials(scrubbed)
+    return _strip_unprintable(" ".join(scrubbed.split()))[
+        :_MCP_PROGRESS_NAME_LEN_CAP
+    ]
+
+
+def _capped_names(names: list[str]) -> str:
+    """Join names for an error line, truncating the tail to a countable summary.
+
+    A pure formatter: names arrive already sanitized from the two points that
+    admit them, so a composite like ``name (error)`` keeps its own error cap
+    instead of being re-truncated to a name's length.
+    """
+    head = names[:_MCP_PROGRESS_NAME_CAP]
+    rest = len(names) - len(head)
+    joined = ", ".join(head)
+    return f"{joined} (+{rest} more)" if rest > 0 else joined
+
+
 _INIT_NOTIFICATION_BUFFER_LIMIT = 100
 # Teardown must be snappy: a session is usually terminated on a hot path
 # (background task done, subagent reaped). kiro-cli's terminate handler responds
@@ -2068,6 +2125,110 @@ class AcpRuntime:
 
     # ── Session Management ──
 
+    def _mcp_init_progress(self, expected: Any) -> str:
+        """Describe MCP registration progress for a session start that stalled.
+
+        Reads the frames the reader loop already staged in
+        ``_pending_init_notifications`` so a session-start timeout can name the
+        servers that never reported, instead of reporting only the elapsed
+        budget. Must run BEFORE ``_finish_session_init``, which drops that
+        buffer once the last in-flight init closes.
+
+        ``expected`` is the ``mcpServers`` array sent with the request. Its
+        entries carry the roster names, and that is what makes the ABSENT
+        servers nameable rather than only the present ones.
+
+        Reports are runtime-wide rather than per-session: a request that never
+        answered has no session id to match its frames against, so a concurrent
+        init is called out in the text instead of being silently folded in.
+        Likewise the staging deque is bounded, so on a very large fleet the
+        reported count is a floor, not an exact tally.
+        """
+        roster = [
+            _sanitize_progress_name(str(e.get("name") or ""))
+            for e in (expected if isinstance(expected, list) else [])
+            if isinstance(e, dict) and e.get("name")
+        ]
+        ready: list[str] = []
+        failed: list[str] = []
+        failure_text: dict[str, str] = {}
+        awaiting_auth: list[str] = []
+        for msg in self._pending_init_notifications:
+            params = msg.params if isinstance(msg.params, dict) else {}
+            name = _sanitize_progress_name(
+                str(params.get("serverName") or params.get("name") or "")
+            )
+            if not name:
+                continue
+            if msg.is_method(METHOD_MCP_SERVER_INITIALIZED):
+                if name not in ready:
+                    ready.append(name)
+            elif msg.is_method(METHOD_MCP_SERVER_INIT_FAILURE):
+                # A failed server's error text can carry connection strings or
+                # tokens from its startup, so it takes the same scrub the
+                # dashboard banner applies before it lands in an exception.
+                err, _ = redact_exfiltration_urls(str(params.get("error") or ""))
+                err, _ = redact_credentials(err)
+                err = _strip_unprintable(" ".join(err.split()))[
+                    :_MCP_PROGRESS_ERROR_CAP
+                ]
+                if name not in failed:
+                    failed.append(name)
+                if err:
+                    failure_text[name] = err
+            elif msg.is_method(METHOD_MCP_OAUTH_REQUEST):
+                if name not in awaiting_auth:
+                    awaiting_auth.append(name)
+
+        reported = set(ready) | set(failed)
+        parts: list[str] = []
+        if roster:
+            # Count only reports that belong to the roster. kiro-cli initializes
+            # the agent spec's own servers as well as the session-injected ones,
+            # so the staged frames are a SUPERSET of the roster and a raw
+            # len(reported) can exceed the denominator -- "2/1 reported". The
+            # out-of-roster servers still appear by name in the failed and
+            # awaiting-authorization buckets, where naming them is the point.
+            parts.append(
+                f"{len(reported & set(roster))}/{len(roster)} MCP server(s) reported"
+            )
+            silent = [n for n in roster if n not in reported]
+            if silent:
+                parts.append(f"no report from {_capped_names(silent)}")
+        else:
+            parts.append(f"{len(reported)} MCP server(s) reported, roster unknown")
+        if failed:
+            parts.append(
+                "failed: "
+                + _capped_names(
+                    [f"{n} ({failure_text[n]})" if n in failure_text else n for n in failed]
+                )
+            )
+        if awaiting_auth:
+            parts.append(f"awaiting authorization: {_capped_names(awaiting_auth)}")
+        if self._session_inits_in_flight > 1:
+            parts.append(
+                f"{self._session_inits_in_flight} session inits in flight, "
+                "so these reports are runtime-wide"
+            )
+        return "; ".join(parts)
+
+    def _session_start_stalled(
+        self, exc: AcpRequestTimeout, method: str, expected: Any
+    ) -> AcpRequestTimeout:
+        """Attach MCP progress to a session-start timeout before it reaches the user.
+
+        Session start is the one request whose cost is dominated by work the
+        runtime can observe, so the bare budget is the least useful half of the
+        answer. Returns a replacement to raise rather than raising here, so the
+        caller keeps the ``from exc`` chain.
+        """
+        progress = self._mcp_init_progress(expected)
+        logger.warning("%s stalled: %s", method, progress or "no MCP reports staged")
+        if not progress:
+            return exc
+        return AcpRequestTimeout(f"{exc} ({progress})")
+
     def _finish_session_init(self, session_id: str) -> list[JsonRpcMessage]:
         """Take staged init frames for one session and close its init scope."""
         matched: list[JsonRpcMessage] = []
@@ -2202,6 +2363,9 @@ class AcpRuntime:
             session_id = str(resp.get("sessionId") or "")
             if not session_id:
                 raise AcpRuntimeError(f"session/new did not return sessionId: {resp}")
+        except AcpRequestTimeout as exc:
+            # Read the staged MCP reports before the finally below clears them.
+            raise self._session_start_stalled(exc, METHOD_SESSION_NEW, mcp_servers) from exc
         finally:
             buffered_init = self._finish_session_init(session_id)
 
@@ -2363,6 +2527,9 @@ class AcpRuntime:
                     f"session/load did not resume session {resume_sid}: {resp}"
                 )
             loaded_session_id = resume_sid
+        except AcpRequestTimeout as exc:
+            # Read the staged MCP reports before the finally below clears them.
+            raise self._session_start_stalled(exc, METHOD_SESSION_LOAD, mcp_servers) from exc
         finally:
             buffered_init = self._finish_session_init(loaded_session_id)
 
@@ -2484,7 +2651,7 @@ class AcpRuntime:
             self._pending_requests.pop(req_id, None)
             # Name the budget: a session-start timeout (90s) must be
             # distinguishable from a generic control-plane one (30s).
-            raise AcpRuntimeError(f"Request {method} timed out after {timeout:g}s")
+            raise AcpRequestTimeout(f"Request {method} timed out after {timeout:g}s")
 
     async def _drain_stderr(self) -> None:
         """Drain stderr to prevent subprocess blocking."""

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -343,6 +343,16 @@ class AcpRuntimeDead(AcpRuntimeError):
     """Raised when the underlying process has died."""
 
 
+class AcpRequestTimeout(AcpRuntimeError):
+    """Raised when a request's response does not arrive within its budget.
+
+    Distinguished from a plain ``AcpRuntimeError`` so a caller that knows what
+    the request was waiting on can attach that context before it reaches the
+    user. Subclasses the base so existing ``except AcpRuntimeError`` handlers
+    keep catching it.
+    """
+
+
 class AcpRuntimeProtocol(Protocol):
     """Minimal interface that AcpSessionHandle needs from AcpRuntime."""
 

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -781,7 +781,6 @@ class AcpProvider(LLMProvider):
             meta["resumed"] = resumed
 
             _t_sess = time.monotonic()
-            _ran_session_new = handle is None
 
             if handle is None:
                 # ── Fix B: respawn if runtime died during resume attempt ──
@@ -824,12 +823,14 @@ class AcpProvider(LLMProvider):
                     if runtime.saw_not_logged_in():
                         raise AcpAuthRequired(_NOT_LOGGED_IN_MESSAGE) from exc
                     raise
-            # session/new + MCP-toolset/system-prompt load done. Only recorded
-            # when create_session actually ran: a successful resume skips that
-            # block entirely, and reporting a near-zero session_new for it would
-            # understate the phase's real distribution.
-            if _ran_session_new:
-                phases["session_new"] = (time.monotonic() - _t_sess) * 1000.0
+                finally:
+                    # In a finally, mirroring session_load: a start that BLEW its
+                    # budget is the one whose duration matters most, and recording
+                    # it only after the try left startup telemetry with no row for
+                    # any failed start. Guarded by the enclosing ``handle is None``,
+                    # so a successful resume never reports a near-zero session_new
+                    # that would understate the phase's real distribution.
+                    phases["session_new"] = (time.monotonic() - _t_sess) * 1000.0
 
             # Apply the configured model override (mirrors AcpClient handshake).
             # DEFAULT_MODEL ("auto") means "let kiro-cli pick per agent config".

--- a/test/test_session_start_timeout_diagnostics.py
+++ b/test/test_session_start_timeout_diagnostics.py
@@ -1,0 +1,353 @@
+"""Session-start timeout diagnostics: name the MCP server that never reported.
+
+A session/new or session/load that blows its budget used to report only the
+budget. The runtime already holds both halves of the answer at that moment --
+the roster it sent in ``mcpServers`` and the registration frames the reader loop
+staged -- so these tests pin that the timeout carries them.
+
+The ordering matters and is what most of these guard: ``_finish_session_init``
+runs in the call site's ``finally`` and CLEARS the staging buffer, so the read
+has to happen in the ``except`` ahead of it. Every test here therefore lets the
+REAL ``_finish_session_init`` run; mocking it would make a read-after-clear
+regression pass.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.acp.runtime import (
+    _MCP_PROGRESS_NAME_CAP,
+    _MCP_PROGRESS_NAME_LEN_CAP,
+    AcpRequestTimeout,
+    AcpRuntime,
+    AcpRuntimeError,
+    _capped_names,
+)
+from kiro_crew.acp.types import (
+    METHOD_MCP_OAUTH_REQUEST,
+    METHOD_MCP_SERVER_INIT_FAILURE,
+    METHOD_MCP_SERVER_INITIALIZED,
+    JsonRpcMessage,
+)
+
+
+def _runtime() -> AcpRuntime:
+    """An initialized runtime whose subprocess is faked (no kiro-cli spawned)."""
+    rt = AcpRuntime(work_dir="/tmp")
+    proc = MagicMock()
+    proc.stdout = asyncio.StreamReader()
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.returncode = None
+    proc.pid = 4242
+    rt._process = proc
+    rt._pid = 4242
+    rt._initialized = True
+    return rt
+
+
+def _roster(*names: str) -> list[dict]:
+    """An ``mcpServers`` array shaped the way session_servers builds it."""
+    return [{"name": n, "command": "/bin/true", "args": [], "env": []} for n in names]
+
+
+def _stage(rt: AcpRuntime, method: str, name: str, **extra) -> None:
+    """Stage one registration frame as the reader loop would during an init."""
+    params = {"serverName": name}
+    params.update(extra)
+    rt._pending_init_notifications.append(JsonRpcMessage(method=method, params=params))
+
+
+def _timeout(rt: AcpRuntime) -> None:
+    rt._send_and_await = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AcpRequestTimeout("Request session/new timed out after 90s")
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_new_timeout_names_the_servers_that_never_reported():
+    rt = _runtime()
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "alpha")
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "beta")
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("alpha", "beta", "gamma", "delta"))
+
+    text = str(caught.value)
+    assert "timed out after 90s" in text  # the budget survives
+    assert "2/4 MCP server(s) reported" in text
+    assert "no report from gamma, delta" in text
+    # The servers that DID report are not the ones to chase.
+    assert "no report from alpha" not in text
+
+
+@pytest.mark.asyncio
+async def test_session_new_timeout_survives_the_staging_buffer_being_cleared():
+    """The read must happen in the except, ahead of the finally that clears.
+
+    Moving it after ``_finish_session_init`` empties the buffer and loses every
+    name, so this is the mutation guard for the ordering.
+    """
+    rt = _runtime()
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "alpha")
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("alpha", "beta"))
+
+    assert "no report from beta" in str(caught.value)
+    # The real _finish_session_init ran and did its job: nothing staged, no
+    # in-flight init left behind for the next attempt to misread.
+    assert not rt._pending_init_notifications
+    assert rt._session_inits_in_flight == 0
+
+
+@pytest.mark.asyncio
+async def test_session_new_timeout_scrubs_a_failed_servers_error_text():
+    """A failed server's error can carry its own credentials -- scrub, don't leak."""
+    rt = _runtime()
+    _stage(
+        rt,
+        METHOD_MCP_SERVER_INIT_FAILURE,
+        "gamma",
+        error="connect failed: https://evil.example.com/?token=AKIAIOSFODNN7EXAMPLE",
+    )
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("gamma"))
+
+    text = str(caught.value)
+    assert "failed: gamma" in text
+    # The credential is gone. The host survives inside the redactor's own marker
+    # by design -- an operator chasing an exfil attempt needs to know where it
+    # pointed -- so assert on the marker rather than on the host's absence.
+    assert "AKIAIOSFODNN7EXAMPLE" not in text
+    assert "REDACTED" in text
+
+
+@pytest.mark.asyncio
+async def test_session_new_timeout_flags_a_server_awaiting_authorization():
+    rt = _runtime()
+    _stage(rt, METHOD_MCP_OAUTH_REQUEST, "drive", oauthUrl="https://example.com/auth")
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("drive"))
+
+    text = str(caught.value)
+    assert "awaiting authorization: drive" in text
+    # An OAuth request is not a report: the server is still missing.
+    assert "no report from drive" in text
+
+
+@pytest.mark.asyncio
+async def test_session_new_timeout_counts_reports_when_the_roster_is_unknown():
+    """An empty roster still yields a count -- never a bare budget."""
+    rt = _runtime()
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "alpha")
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=[])
+
+    assert "1 MCP server(s) reported, roster unknown" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_session_new_timeout_notes_a_concurrent_init_is_runtime_wide():
+    """Staged frames cannot be attributed to a session id that never returned."""
+    rt = _runtime()
+    rt._session_inits_in_flight = 1  # another init already open
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "alpha")
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("alpha", "beta"))
+
+    assert "session inits in flight" in str(caught.value)
+    assert "runtime-wide" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_session_load_timeout_names_the_servers_that_never_reported(monkeypatch):
+    """session/load shares the budget and the staging, so it gets the same report.
+
+    It resolves its own roster rather than taking one, so the resolver is what
+    gets stubbed here.
+    """
+    rt = _runtime()
+    rt._can_load_session = True
+    monkeypatch.setattr(
+        "kiro_crew.acp.runtime.pooled_session_servers",
+        lambda *_a, **_k: _roster("alpha", "beta"),
+    )
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "alpha")
+    rt._send_and_await = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AcpRequestTimeout("Request session/load timed out after 90s")
+    )
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.load_session(session_file="", resume_sid="s1")
+
+    text = str(caught.value)
+    assert "session/load timed out" in text
+    assert "no report from beta" in text
+
+
+@pytest.mark.asyncio
+async def test_a_non_timeout_session_new_failure_gets_no_mcp_progress():
+    """Only a stall is explained by MCP progress; a protocol fault is not."""
+    rt = _runtime()
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "alpha")
+    rt._send_and_await = AsyncMock(return_value={})  # no sessionId
+
+    with pytest.raises(AcpRuntimeError) as caught:
+        await rt.create_session(mcp_servers=_roster("alpha", "beta"))
+
+    text = str(caught.value)
+    assert "did not return sessionId" in text
+    assert "MCP server(s) reported" not in text
+
+
+def test_request_timeout_is_still_catchable_as_a_runtime_error():
+    """Callers keying on AcpRuntimeError must keep catching timeouts."""
+    assert issubclass(AcpRequestTimeout, AcpRuntimeError)
+
+
+def test_capped_names_summarizes_the_tail_instead_of_listing_a_whole_fleet():
+    names = [f"srv{i}" for i in range(_MCP_PROGRESS_NAME_CAP + 5)]
+    text = _capped_names(names)
+    assert text.count(",") == _MCP_PROGRESS_NAME_CAP - 1
+    assert text.endswith("(+5 more)")
+    assert _capped_names(["only"]) == "only"
+
+
+# -- Names are config-derived, so an installed app chooses them --
+
+
+@pytest.mark.asyncio
+async def test_a_newline_in_a_server_name_cannot_forge_a_log_line():
+    """The summary goes into a logger.warning; a name must not add a line to it."""
+    rt = _runtime()
+    forged = "beta\n2026-08-18 00:00:00 ERROR kiro_crew: injected"
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "alpha")
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("alpha", forged))
+
+    text = str(caught.value)
+    assert "\n" not in text
+    assert "beta 2026-08-18" in text  # collapsed onto one line, not split
+
+
+@pytest.mark.asyncio
+async def test_an_overlong_server_name_is_length_capped():
+    """The count cap alone does not bound the string; one huge name would."""
+    rt = _runtime()
+    _stage(rt, METHOD_MCP_SERVER_INIT_FAILURE, "x" * 5000, error="nope")
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("alpha"))
+
+    text = str(caught.value)
+    assert "x" * (_MCP_PROGRESS_NAME_LEN_CAP + 1) not in text
+    assert "x" * _MCP_PROGRESS_NAME_LEN_CAP in text
+
+
+@pytest.mark.asyncio
+async def test_a_credential_shaped_server_name_is_scrubbed():
+    """Uses the failed bucket: a name only in `ready` is never printed at all,
+    so asserting on it would pass whether or not the scrub runs."""
+    rt = _runtime()
+    _stage(
+        rt, METHOD_MCP_SERVER_INIT_FAILURE, "svc-AKIAIOSFODNN7EXAMPLE", error="nope"
+    )
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("alpha"))
+
+    text = str(caught.value)
+    assert "AKIAIOSFODNN7EXAMPLE" not in text
+    assert "svc-" in text  # scrubbed, not dropped -- the name stays identifiable
+
+
+@pytest.mark.asyncio
+async def test_reports_outside_the_roster_never_produce_an_impossible_ratio():
+    """kiro-cli also initializes the agent spec's servers, so frames are a superset.
+
+    Counting them against the injected roster yielded nonsense like "2/1 reported".
+    """
+    rt = _runtime()
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "in-roster")
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "from-agent-spec")
+    _stage(rt, METHOD_MCP_SERVER_INITIALIZED, "also-agent-spec")
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("in-roster"))
+
+    text = str(caught.value)
+    assert "1/1 MCP server(s) reported" in text
+    assert "2/1" not in text and "3/1" not in text
+
+
+@pytest.mark.asyncio
+async def test_an_out_of_roster_failure_is_still_named():
+    """Excluding them from the COUNT must not hide a server that actually failed."""
+    rt = _runtime()
+    _stage(rt, METHOD_MCP_SERVER_INIT_FAILURE, "from-agent-spec", error="boom")
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("in-roster"))
+
+    text = str(caught.value)
+    assert "0/1 MCP server(s) reported" in text
+    assert "failed: from-agent-spec (boom)" in text
+
+
+@pytest.mark.asyncio
+async def test_a_terminal_escape_in_error_text_is_stripped():
+    """`kirocrew logs` renders the gateway log in a terminal; an ESC in a failed
+    server's error text would let it recolor or forge terminal output. ESC is
+    not whitespace, so a whitespace collapse alone would keep it."""
+    rt = _runtime()
+    _stage(
+        rt,
+        METHOD_MCP_SERVER_INIT_FAILURE,
+        "gamma",
+        error="boom \x1b[31mFAKE ERROR\x1b[0m \x07\x08 done",
+    )
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("gamma"))
+
+    text = str(caught.value)
+    assert "\x1b" not in text and "\x07" not in text and "\x08" not in text
+    # The printable words survive the strip.
+    assert "boom" in text and "FAKE ERROR" in text and "done" in text
+
+
+@pytest.mark.asyncio
+async def test_a_terminal_escape_in_a_server_name_is_stripped():
+    """A name takes the same strip: it reaches the same logger.warning, and the
+    failed bucket prints it verbatim next to its error text."""
+    rt = _runtime()
+    _stage(rt, METHOD_MCP_SERVER_INIT_FAILURE, "delta\x1b[2Jwiped", error="nope")
+    _timeout(rt)
+
+    with pytest.raises(AcpRequestTimeout) as caught:
+        await rt.create_session(mcp_servers=_roster("alpha"))
+
+    text = str(caught.value)
+    assert "\x1b" not in text
+    assert "delta[2Jwiped" in text


### PR DESCRIPTION
## 1. What is the problem?

When a session fails to start, the only thing that reaches the user is a sentence
that names no cause:

```
AcpRuntimeError: Request session/new timed out after 90s
```

That one sentence is the public face of at least four unrelated root causes: an
MCP fleet whose initialization exceeds the budget, a single unreachable remote
server, a server waiting on authorization, and an expired credential. Nothing in
it distinguishes them, so every report of this failure starts from zero.

The information is not missing. At the moment the timeout fires, `AcpRuntime` is
holding both halves of the answer in local scope:

- **The expected roster** -- `create_session` resolves the `mcpServers` array and
  sends it in the request's own params, in the same frame that then awaits the
  response.
- **Who reported** -- the reader loop stages every
  `_kiro.dev/mcp/server_initialized`, `server_init_failure` and `oauth_request`
  frame that arrives before the response, and each one carries
  `params["serverName"]`.

The timeout handler used neither. Worse, `_finish_session_init` runs in the call
site's `finally` and clears the staging buffer once the last in-flight init
closes, so the evidence was actively destroyed rather than merely unused.

Two adjacent holes on the same path:

- `phases["session_load"]` is recorded in a `try/finally`, but
  `phases["session_new"]` was recorded *after* the `try/except`. A timeout
  skipped it, so startup telemetry had a row for every start that succeeded and
  none for any that failed -- the starts you most want to measure.
- The credential branch consults `saw_not_logged_in()`, which matches only
  `not logged in` against a buffer holding the **last 20** stderr lines. An auth
  line printed early in startup is evicted by MCP chatter during the 90s wait,
  after which the actionable login prompt is never shown and the generic timeout
  is all that is left.

## 2. Why this issue matters to the user

This failure does not present as one slow session. It presents as a total
outage, and the warm pool is why.

Filling the pool pays `session/new` itself. So when session start is the broken
thing, already-filled entries keep serving and nothing looks wrong -- until the
pool drains. Then every surface fails at once, and the pool cannot refill,
because refilling requires the very call that times out; the fill loop stops on
the first failure and does not retry until the next claim, leaving only
`Warm pool: failed to spawn process` behind. The pool is also bypassed for a
resumed session, a stateless key, a project `cwd` that differs from the pool's,
or any `extra_env`.

The result is a system that worked minutes ago, now fails on every surface, and
reports an error that points at nothing. A user with no source access -- a
desktop-app install has no other view -- has no next step. Making the budget
configurable did not help here, because nothing told anyone the budget was even
the relevant dial, let alone which server was spending it.

## 3. How our fix solves it

The chain from symptom to root cause is: undiagnosable error <- the timeout
discards the roster and the staged reports <- nothing ever read them, and the
`finally` cleared them. So the fix is to read them, at the one point where they
still exist.

- **`_mcp_init_progress()`** walks the staged frames, buckets them into reported,
  failed and awaiting-authorization, and diffs the reported set against the
  roster names. Output shape:
  `2/4 MCP server(s) reported; no report from gamma, delta; failed: eps (connect refused); awaiting authorization: drive`
- **`_session_start_stalled()`** attaches that line to the timeout and logs it.
  It returns a replacement rather than raising, so the caller keeps its
  `from exc` chain.
- **Both session-start call sites in `AcpRuntime`** (`create_session`, `session/load`) catch in an
  `except` that runs *ahead of* the existing `finally`. This ordering is the whole
  fix: reading after `_finish_session_init` yields an empty buffer and loses every
  name. A test pins the ordering specifically.
- **`AcpRequestTimeout`**, a subclass of `AcpRuntimeError`, lets the call sites
  catch only a stall. A protocol fault such as a missing `sessionId` is not
  explained by MCP progress and deliberately gets no summary. Being a subclass
  means every existing `except AcpRuntimeError` handler -- including the
  `saw_not_logged_in()` branch in the provider -- keeps working unchanged.
- **`phases["session_new"]`** moves into a `finally`, matching `session_load`, so a
  failed start keeps its duration. It stays guarded by the enclosing
  `handle is None`, so a successful resume still does not report a near-zero
  phase that would understate the distribution.

Two constraints the implementation respects:

- **Redaction.** A failed server's error text can carry its own connection string
  or token, so it takes the same `redact_exfiltration_urls` +
  `redact_credentials` scrub the dashboard banner applies before it can land in
  an exception message. Names are capped at 8 per bucket with a `(+N more)` tail
  and error text at 120 characters, so a 70-server agent cannot turn one error
  into a wall of text.
- **Honesty about scope.** A request that never answered has no session id to
  match its frames against, so the reports are runtime-wide, not per-session.
  When more than one init is in flight the text says so rather than implying
  precision it does not have. The staging deque is bounded, so on a very large
  fleet the reported count is a floor.

The warm-pool log gets the improvement for free: it already logs with
`exc_info=True`, so an empty pool is now attributable to a named server instead
of a bare warning.

## 4. What tests we did

New file `test/test_session_start_timeout_diagnostics.py`, 10 tests:

- names the servers that never reported, and does not name the ones that did
- **ordering guard**: the report survives the `finally` clearing the buffer, and
  the real `_finish_session_init` still leaves nothing staged and no in-flight
  init behind. Every test lets the REAL `_finish_session_init` run -- mocking it,
  as the neighbouring suite does, would let a read-after-clear regression pass
- a failed server's credential is scrubbed out of the message
- a server awaiting authorization is flagged, and still counted as missing
- an unknown roster still produces a count instead of a bare budget
- a concurrent init is disclosed as runtime-wide
- `session/load` parity
- a non-timeout failure (missing `sessionId`) gets no MCP summary
- `AcpRequestTimeout` remains catchable as `AcpRuntimeError`
- the name list truncates to a countable tail

**Mutation-verified, both directions.** Neutering the enrichment turns 6 of the
10 red; the read-after-clear mutation also turns 6 red, and its message degrades
to `0/1 MCP server(s) reported; no report from gamma` -- the names lost exactly
as predicted. The 4 that stay green under a `create_session`-only mutation are
the `session/load`, non-timeout, subclass and formatter tests, which is correct.

Local gates green: 303 tests across the new file plus `test_acp_runtime.py` and
`test_acp_provider.py`, `isort` clean, `flake8` clean, `mypy` clean on 982 source
files. No frontend surface changed. Full suite to CI.

## 5. Any other suggestions on the work

Four things found while tracing this, deliberately left out of scope:

- **`AcpClient` carries the identical defect and is NOT fixed here** -- filed as
  #4245. `AcpClient._wait_for_response` raises a bare `AcpTimeoutError()`
  (`client.py:3582`) with no method, no budget and no MCP progress, while holding
  the same staged evidence in `self._mcp_notifications` (`client.py:3561`). The
  path is live: `src/kiro_crew/knowledge/llm_pool.py:302` constructs an
  `AcpClient` directly. It is a separate implementation with a different staging
  shape (a per-request list drained by `_drain_notifications`, not the
  init-count-keyed deque this PR reads), so mirroring the summary there is its own
  change -- probably behind a shared helper rather than a second copy.
- **The auth signal is the remaining blind spot.** Widening it is a judgement
  call about vocabulary, and the 20-line stderr window is the deeper issue: a
  startup-phase snapshot that eviction cannot reach would fix the class rather
  than adding one more pattern. Worth its own change.
- **The warm pool cannot self-heal from this.** It now reports the cause, but a
  pool whose refill fails for the same reason it drained still needs a human. A
  retry with backoff, or surfacing pool health, is a separate design question.
- **Two concurrent `session/new` requests were observed on one slot**, closer
  together than the budget, which means the two attempts overlapped rather than
  retried serially. Which path issues the second one is not yet established and
  is not touched here.

Closes #4237

