### PR TITLE
ci: run the eleven test suites the shards deselected

### DIFF
--- a/.github/coverage-baselines/backend.txt
+++ b/.github/coverage-baselines/backend.txt
@@ -37,7 +37,6 @@ src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/cloudwatch.py 
 src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/github_issues.py 58.4   # 52/89
 src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/http.py 53.8   # 35/65
 src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/pagerduty.py 68.8   # 75/109
-src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/schedule_file.py 50.7   # 102/201
 src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py 71.5   # 186/260
 src/kiro_crew/apps/builtins/workflows/server.py 61.2   # 82/134
 src/kiro_crew/apps/hooks_integration.py 43.0   # 65/151
@@ -55,7 +54,6 @@ src/kiro_crew/context_management.py 74.2   # 178/240
 src/kiro_crew/dashboard/_types.py 0.0   # 0/3
 src/kiro_crew/dashboard/handlers/agents.py 77.4   # 579/748
 src/kiro_crew/dashboard/handlers/cron.py 70.9   # 400/564
-src/kiro_crew/dashboard/handlers/feedback.py 29.9   # 23/77
 src/kiro_crew/dashboard/handlers/portability.py 17.0   # 15/88
 src/kiro_crew/dashboard/handlers/prompts.py 64.5   # 260/403
 src/kiro_crew/dashboard/handlers/weixin_qr.py 47.0   # 119/253

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,29 +19,23 @@ concurrency:
   # ~1.4min median merge gap, main gets periodic verdicts instead of none.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Tests that need capabilities the GH Actions runners lack (Linux-namespace
-# sandbox, a real git/gh, or POSIX rmtree/path assumptions). Deselected on
-# EVERY backend pytest invocation -- full AND reduced, Linux AND Windows --
-# from this single source so the lists cannot drift apart. They drifted once:
-# the reduced (frontend-only) runs omitted these, and the surface selector
-# legitimately lists test_dogfood_learnings.py as cross-surface, so a reduced
-# run re-ran a file the full run excludes and failed the shards. A --deselect
-# of a path a given run did not collect is a harmless no-op, so the reduced
-# runs carry the full list safely. Expanded UNQUOTED on purpose so it
-# word-splits into separate args (no deselect path contains a space).
-env:
-  BACKEND_DESELECTS: >-
-    --deselect=test/test_script_hooks.py
-    --deselect=test/test_cron_script.py
-    --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py
-    --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py
-    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
-    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py
-    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_lint_findings.py
-    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py
-    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_profile_capture.py
-    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py
-    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_perf_track_propose.py
+# There is deliberately no BACKEND_DESELECTS here any more. Eleven files used to be
+# deselected from EVERY backend pytest invocation because they drive a real
+# `git`/`gh`/`pytest` through `sandboxed_spawn_argv`, and a GH runner denies
+# `unshare(CLONE_NEWNS)` (EPERM) so `wrap_argv` fails closed. That kept 608 tests --
+# including the suites guarding the ops autonomy gate -- off every pull request.
+#
+# They no longer need it: each one that requires a sandbox carries its own
+# `skipif(not userns_available())`, so on a runner it skips with a named reason and on
+# a capable host it runs for real. MEASURED against a faithful local simulation of the
+# runner (`unshare(CLONE_NEWUSER)` ok, `CLONE_NEWNS` EPERM, no user session bus for the
+# cgroup scope, no gh token): 608 passed, 85 skipped, 0 failed.
+#
+# A whole-file deselect is the wrong tool for a missing host capability, and this is
+# why: it is invisible in the run output, it takes the file's OTHER tests with it, and
+# nothing goes red when the reason expires. A capability guard says which capability,
+# on which test, in the report. If a suite here starts needing one again, add the guard
+# -- not a deselect.
 
 jobs:
   # ── Surface detection (issue #1556) ──────────────────────────────────
@@ -431,38 +425,17 @@ jobs:
             pytest -q -n auto --timeout=120 \
               --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
               --no-cov \
-              $BACKEND_DESELECTS \
               "${TARGETS[@]}"
             exit 0
           fi
           pytest -q -n auto --timeout=120 \
             --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
-            ${{ matrix.python-version == '3.12' && '--cov=kiro_crew --cov=sage_lib' || '--no-cov' }} \
-            $BACKEND_DESELECTS
-        # Deselected tests require capabilities unavailable on GH Actions:
-        #   test_script_hooks, test_cron_script: Linux namespace sandbox (unshare NEWNS)
-        #   ops_mission_control test_ledger_sync_git, test_schedule_file: the same
-        #     capability gap, for the same reason. They drive REAL `git`/`gh` through
-        #     `sandboxed_spawn_argv`, which raises SandboxUnavailableError on these runners
-        #     (`unshare(CLONE_NEWNS)` -> EPERM), so all 29 + 1 of them fail here.
-        #   auto_improvement: same capability gap. These seven spawn a real `git`/`pytest`
-        #     through the profile's strict-mode sandbox (or need a real OS sandbox), which the
-        #     runner cannot provide; they pass locally with a working sandbox and are the exact
-        #     set kept off the shards while `testpaths` was a per-file list, now that the dir
-        #     is globbed. Making them CI-portable is tracked as a follow-up in the PR body.
-        #
-        #     These only became visible when `testpaths` grew to cover the in-package app
-        #     suites (see setup.cfg) -- before that they never ran in CI at all, on any job.
-        #     Surfacing them is the point of that change: the ~1490 tests guarding the ops
-        #     autonomy gate now run, and these two files are the residue that cannot.
-        #
-        #     They are NOT added to the namespace-sandbox job below. That was tried and the
-        #     job failed at the test step while its sandbox-verify step passed, so something
-        #     other than the namespace probe is missing there; the two files take ~6 minutes
-        #     against a real `git`, which is also a poor fit for a 20-minute job scoped to
-        #     118 fast tests. Left deselected rather than shipped red -- they run locally
-        #     (220 passed, real sandbox available) and in the app suite. Wiring them into a
-        #     job of their own is a follow-up, tracked in the PR body.
+            ${{ matrix.python-version == '3.12' && '--cov=kiro_crew --cov=sage_lib' || '--no-cov' }}
+        # Nothing is deselected. The eleven files that used to be -- the two sandbox
+        # suites, the two ops git/gh suites, and the seven auto_improvement suites --
+        # each carry `skipif(not userns_available())` on the tests that need a namespace
+        # sandbox, so on this runner (`unshare(CLONE_NEWNS)` -> EPERM) those skip with a
+        # named reason and the other ~523 run. See the note above the `jobs:` key.
 
       - name: Stage shard coverage data
         if: matrix.python-version == '3.12' && steps.scope.outputs.reduced != 'true'
@@ -567,21 +540,17 @@ jobs:
             while IFS= read -r line; do line=${line%$'\r'}; if [ -n "$line" ]; then TARGETS+=("$line"); fi; done < "$TARGETS_FILE"
             pytest -q -n auto --timeout=180 --no-cov \
               --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
-              $BACKEND_DESELECTS \
               "${TARGETS[@]}"
             exit 0
           fi
           pytest -q -n auto --timeout=180 --no-cov \
-            --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
-            $BACKEND_DESELECTS
-        # Same deselects as backend-test (the Linux-namespace sandbox tests are
-        # unavailable here too). The ops git/gh suites are deselected for a second reason as
-        # well: they drive a real POSIX `git`/`gh` and the namespace-sandbox job that DOES run
-        # them is Linux-only, so on Windows they are simply out of scope. The seven
-        # auto_improvement suites are deselected for the same sandbox reason; the two that also
-        # carry POSIX path/rmtree assumptions (test_dogfood_learnings, test_pr_watchers) would
-        # fail on Windows regardless, and their residual node ids stay tracked in
-        # test/windows-expected-failures.txt.
+            --splits "$SHARD_COUNT" --group ${{ matrix.group }}
+        # Nothing is deselected here either, and the same guards carry it: Windows has no
+        # namespace sandbox at all, so `userns_available()` is False and every
+        # sandbox-dependent test skips. Residual POSIX assumptions in
+        # test_dogfood_learnings / test_pr_watchers stay tracked as node ids in
+        # test/windows-expected-failures.txt, which is the mechanism a whole-file deselect
+        # was standing in for.
 
   # macOS gateway line. Until this job existed macOS had ZERO pytest coverage in
   # CI -- the macos-14 runners appear only in build.yml, build-desktop.yml and
@@ -652,11 +621,21 @@ jobs:
             test/test_service.py \
             test/test_dev_fleet_app.py
 
-  # Runs the tests the sharded matrix deselects. They need unprivileged user
-  # namespaces (unshare NEWNS), which ubuntu-24.04 restricts via AppArmor --
-  # the same restriction codex-review.yml clears for its bwrap sandbox. Without
-  # this job the ~/.kiro/crew sensitive-path keystone has no CI coverage at all,
+  # The one job where the sandbox-dependent tests EXECUTE rather than skip. They need
+  # unprivileged user namespaces (unshare NEWNS), which ubuntu-24.04 restricts via
+  # AppArmor -- the same restriction codex-review.yml clears for its bwrap sandbox.
+  # Without this job the ~/.kiro/crew sensitive-path keystone has no CI coverage at all,
   # even though branch protection treats breaking it as a blocking offence.
+  #
+  # The shards now COLLECT these two files as well (nothing is deselected any more), but
+  # there the `skipif(not userns_available())` tests skip -- so this job is still what
+  # actually asserts the sandbox behaviour.
+  #
+  # The nine ops/auto_improvement suites belong here too, for the same reason, and were
+  # rejected the first time as "~6 minutes against a real git". That cost was the
+  # launcher's pre-exec hardlink scan arming on every spawn; measured after the fix, all
+  # eleven run in 38s under this job's environment. Adding them waits on that fix
+  # landing, so it is not part of this change.
   #
   backend-test-sandbox:
     name: Backend Tests (namespace sandbox)
@@ -780,7 +759,8 @@ jobs:
     # How backend got here, so the next person can judge the headroom:
     #   78.69%  starting point
     #   80.15%  #2090 stopped measuring test files CI never executes (the
-    #           BACKEND_DESELECTS set) -- an accounting fix, not new tests
+    #           BACKEND_DESELECTS set) -- an accounting fix, not new tests.
+    #           Since retired: CI runs those files, so they are measured again.
     #   81.50%  #2103 added unit coverage for 7 pure-logic-ish modules
     #   81.94%  #2115 added 11 dashboard/Slack/app-platform modules
     # 80% therefore leaves ~1.9pp of headroom, wider than the ~1.4pp the 77%

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,24 +118,11 @@ jobs:
 
       - name: Run release candidate tests
         run: |
-          # The sysctl above enables the namespace sandbox on this runner,
-          # so all sandbox-dependent tests can run here.  If for any reason
-          # the sysctl is reverted, uncomment the deselects below to match
-          # ci.yml's sharded matrix (which cannot sysctl and deselects them
-          # into a dedicated namespace-sandbox job instead).
-          #
-          # Fallback deselects (mirror of ci.yml BACKEND_DESELECTS):
-          #   --deselect=test/test_script_hooks.py
-          #   --deselect=test/test_cron_script.py
-          #   --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py
-          #   --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py
-          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
-          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py
-          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_lint_findings.py
-          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py
-          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_profile_capture.py
-          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py
-          #   --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_perf_track_propose.py
+          # The sysctl above enables the namespace sandbox on this runner, so the
+          # sandbox-dependent tests run for real here rather than skipping. No fallback
+          # deselect list any more: if the sysctl is reverted, those tests skip
+          # themselves on `skipif(not userns_available())` and the rest of the suite
+          # still runs -- which is what ci.yml's sharded matrix relies on too.
           pytest -q -n auto --timeout=120 --no-cov
 
   resolve-promotion:

--- a/.github/workflows/test-durations.yml
+++ b/.github/workflows/test-durations.yml
@@ -50,10 +50,14 @@ jobs:
         # --store-durations writes/updates .test_durations. `|| true` keeps a
         # flaky failure from aborting the refresh -- durations for tests that
         # ran are still recorded.
+        #
+        # Nothing is deselected. Two sandbox suites used to be, which meant the file
+        # this job produces carried no durations for them -- so pytest-split gave them
+        # the AVERAGE duration and balanced the shards on a guess. They record real
+        # durations now; the tests inside them that need a namespace sandbox skip here
+        # (this runner has none) and a skip is measured as the near-zero it is.
         run: |
-          pytest -q -n auto --timeout=120 --no-cov --store-durations \
-            --deselect=test/test_script_hooks.py \
-            --deselect=test/test_cron_script.py || true
+          pytest -q -n auto --timeout=120 --no-cov --store-durations || true
           test -f .test_durations || { echo "::error::no .test_durations produced"; exit 1; }
 
       - name: Open PR if durations changed

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -93,7 +93,7 @@ Every job here is blocking.
 | `backend-test` | 2 Python versions x 4 duration-balanced pytest-split shards (8 jobs), `-n auto` within each. Coverage only on 3.12 (3.10 passes `--no-cov` for a trace-free run) |
 | `backend-test-windows` | windows-latest, 4 shards, `--no-cov`, 180s per-test timeout. The backend supports Windows natively via `platform_compat`, and nothing else in CI holds that line |
 | `backend-test-macos` | macos-14, deliberately SCOPED (gateway, socketsec, platform-compat, pod and MCP-apps suites via a glob). A full macOS run needs its own exclusion burn-down first, and a job that is red on arrival trains people to ignore it |
-| `backend-test-sandbox` | The two suites the sharded matrix deselects because they need unprivileged user namespaces: `test_script_hooks.py` and `test_cron_script.py` |
+| `backend-test-sandbox` | The one job that clears the AppArmor userns restriction, so the tests guarded by `skipif(not userns_available())` EXECUTE instead of skipping. Runs `test_script_hooks` and `test_cron_script`. The shards collect the same files — nothing is deselected any more — but there the sandbox-guarded tests skip, so only here do those assertions actually run |
 | `coverage-combine` then `coverage-gate` | Combines the 3.12 shard data, then enforces the project line-rate floors, plus a per-file floor with a shrink-only baseline (all floors live in the job's `env:` block) |
 | `frontend-lint` | `tsc -b`, `eslint --max-warnings 1116`, `jscpd`, and `npm run i18n:check` |
 | `electron-test` | The Electron shell's own node:test suite (`website/electron`) |

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -296,6 +296,24 @@ where it costs the in-package suites nothing.
   That mode is off by default because a directory per test is exactly the per-test cost
   the fixture audit below exists to avoid.
 
+- **A missing host capability is guarded on the TEST, never deselected on the file.**
+  `--deselect` is the wrong tool three ways: it is invisible in the run output, it takes
+  the file's other tests with it, and nothing goes red when its reason expires. A
+  `skipif` names the capability, on the test that needs it, in the report.
+
+  Measured: eleven files were deselected from every CI backend invocation because a GH
+  runner denies `unshare(CLONE_NEWNS)`, which kept **608 tests** — the ops autonomy gate
+  among them — off every pull request. The sandbox-dependent tests inside them already
+  carried `skipif(not userns_available())`, so 85 would have skipped and **523 would have
+  run**, on Linux, Windows and macOS alike. The reason had also expired: the "~6 minutes
+  against a real git" that justified keeping them out was the launcher's hardlink scan
+  arming on every spawn, and all eleven now run in 38s.
+
+  Two mechanisms replace it, both of which say what they exclude:
+  `test/windows-expected-failures.txt` for a per-node-id Windows gap, and
+  `skipif(not userns_available())` for the sandbox. `test_coverage_omit_contract.py`
+  ratchets the rest: a returning `--deselect` fails it unless the coverage omit comes
+  with it, because a file CI cannot run must not be charged to the denominator either.
 - Tests SHOULD be fast (< 1s each)
 - Async tests MUST use `@pytest.mark.asyncio`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -288,27 +288,27 @@ parallel = true
 omit =
     */pytest-of-*/*
     */kirocrew-wt-example/*
-# Test files that CI's BACKEND_DESELECTS deselects on EVERY backend pytest
-# invocation, because the GH Actions runners lack what they need (Linux-namespace
-# sandbox, a real git/gh, POSIX rmtree/path assumptions). They are never
-# executed, so measuring them as coverable code is a measurement bug: it charged
-# ~3.9k permanently-unreachable statements to the denominator and understated the
-# real line-rate by ~1.5pp. Coverage measures code the suite CAN run.
+# Test files whose bodies are UNREACHABLE on a GH runner, for a reason the runner cannot
+# fix: each carries `skipif(not userns_available())` on the tests that need a namespace
+# sandbox, and a runner denies `unshare(CLONE_NEWNS)`. A skipped test's lines are never
+# executed, so measuring them charges the denominator for code the measuring host cannot
+# reach -- `test_ledger_sync_git.py` measured 16% (65/405) on CI for exactly that reason.
 #
-# This list MUST stay in sync with BACKEND_DESELECTS in .github/workflows/ci.yml
-# (and with [coverage:report] omit below). That is enforced, not trusted --
-# test/test_coverage_omit_contract.py fails if the two lists drift.
-    */test/test_script_hooks.py
-    */test/test_cron_script.py
+# This is NOT the old "CI deselects these files" list, which covered eleven files and is
+# gone: ci.yml deselects nothing now, so all eleven RUN and report their skips, and the
+# five without a sandbox guard are measured normally. What remains is the narrower and
+# checkable rule that test/test_coverage_omit_contract.py enforces -- an omitted test file
+# must carry a capability guard CI cannot satisfy, and a pattern here may never match
+# product code.
+#
+# The proper fix is upstream of coverage: `backend-test-sandbox` clears the AppArmor
+# restriction, so measuring THAT job would reach these lines. It runs `--no-cov` today.
     */ops_mission_control/tests/test_ledger_sync_git.py
     */ops_mission_control/tests/test_schedule_file.py
-    */auto_improvement/tests/test_dogfood_learnings.py
-    */auto_improvement/tests/test_pr_watchers.py
     */auto_improvement/tests/test_lint_findings.py
     */auto_improvement/tests/test_github_profile.py
     */auto_improvement/tests/test_profile_capture.py
     */auto_improvement/tests/test_runner.py
-    */auto_improvement/tests/test_perf_track_propose.py
 
 [coverage:paths]
 source =
@@ -353,21 +353,15 @@ show_missing = true
 omit =
     */pytest-of-*/*
     */kirocrew-wt-example/*
-# Same never-executed test files as [coverage:run] omit above -- repeated here
-# because Coverage Combine reads shard data and reports it in a separate
-# process, where only report-time omit applies. Kept in sync by
-# test/test_coverage_omit_contract.py.
-    */test/test_script_hooks.py
-    */test/test_cron_script.py
+# Same capability-guarded test files as [coverage:run] omit above -- repeated here because
+# Coverage Combine reads shard data and reports it in a separate process, where only
+# report-time omit applies. Kept in sync by test/test_coverage_omit_contract.py.
     */ops_mission_control/tests/test_ledger_sync_git.py
     */ops_mission_control/tests/test_schedule_file.py
-    */auto_improvement/tests/test_dogfood_learnings.py
-    */auto_improvement/tests/test_pr_watchers.py
     */auto_improvement/tests/test_lint_findings.py
     */auto_improvement/tests/test_github_profile.py
     */auto_improvement/tests/test_profile_capture.py
     */auto_improvement/tests/test_runner.py
-    */auto_improvement/tests/test_perf_track_propose.py
 
 [coverage:html]
 directory = build/coverage

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
@@ -30,6 +30,19 @@ from kiro_crew.apps.builtins.auto_improvement.backend import runner as R
 from kiro_crew.apps.builtins.auto_improvement.backend import store
 from kiro_crew.apps.builtins.auto_improvement.spine.driver import BudgetCaps
 
+#: Windows' extended-length path prefix. ``os.readlink`` returns an absolute target with
+#: it attached, and ``pathlib`` reads the prefix as part of the drive, so it survives
+#: ``resolve()`` too -- it has to be stripped explicitly to compare paths across
+#: platforms.
+_EXTENDED_LENGTH_PREFIX = "\\\\?\\"
+
+
+def _without_extended_prefix(target: str) -> str:
+    """*target* with the Windows extended-length prefix removed; unchanged elsewhere."""
+    if target.startswith(_EXTENDED_LENGTH_PREFIX):
+        return target[len(_EXTENDED_LENGTH_PREFIX) :]
+    return target
+
 
 class TestMetricDirectionIsPlumbed:
     """The keeper accepts ``direction`` — but a parameter nobody passes is dead code."""
@@ -4846,7 +4859,17 @@ class TestRepoControlledGitHooksDoNotExecuteHostSide:
         )
         # Copied verbatim as a link (its stored target is the original path), NOT resolved
         # into a real file that materialized the secret bytes inside the RED tree.
-        assert os.readlink(staged_link) == str(secret), "the staged link's target was rewritten"
+        #
+        # Compared as PATHS with the Windows extended-length prefix stripped, not as the
+        # raw string `os.readlink` returns. Windows stores an absolute symlink target as
+        # `\\?\C:\...`, and neither a string comparison nor `Path.resolve()` closes that
+        # gap -- `pathlib` reads `\\?\C:` as the drive and keeps it. Comparing `Path`
+        # objects also gets Windows' case-insensitivity for free. The assertion still says
+        # what it did: a target rewritten to point inside the RED tree is a different path,
+        # and the sibling `is_symlink()` check above is what catches a dereferenced copy.
+        assert Path(_without_extended_prefix(os.readlink(staged_link))) == secret, (
+            "the staged link's target was rewritten"
+        )
 
 
 class TestANestedProcessCannotAuthenticateToGitHub:

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
@@ -210,6 +210,12 @@ missed.**
 - Windows gaps are tracked as burn-down lists, not scattered skips:
   `test/windows-collect-ignore.txt` and `test/windows-expected-failures.txt`. Anything
   NOT listed still fails the job. Delete a line when you fix its test.
+- **Never `--deselect` a whole file for a missing host capability.** Guard the test that
+  needs it — `skipif(not userns_available())` for the OS sandbox — so the report names the
+  capability. A deselect is invisible in the output, takes the file's other tests with it,
+  and never goes red when its reason expires: eleven such files kept 608 tests off every
+  PR, of which 523 would have run on all three platforms, long after the cost that
+  justified the exclusion had been fixed.
 
 ## Rule 4 — Diagnosing a residue failure
 

--- a/test/test_coverage_omit_contract.py
+++ b/test/test_coverage_omit_contract.py
@@ -1,21 +1,35 @@
-"""Contract: every test file CI refuses to run is excluded from coverage.
+"""Contract: CI runs every test file, and coverage measures every test file.
 
-``BACKEND_DESELECTS`` in ``.github/workflows/ci.yml`` deselects a fixed set of
-test files on EVERY backend pytest invocation, because the GitHub Actions
-runners lack what those tests need (Linux-namespace sandbox, a real ``git``/
-``gh``, POSIX rmtree/path assumptions). Those files are therefore never
-executed in CI.
+This used to enforce the opposite direction. ``BACKEND_DESELECTS`` in
+``.github/workflows/ci.yml`` deselected eleven test files from EVERY backend pytest
+invocation, because the GitHub Actions runners deny ``unshare(CLONE_NEWNS)`` and the
+suites drive a real ``git``/``gh``/``pytest`` through ``sandboxed_spawn_argv``. Files CI
+never executes must not be charged to the coverage denominator -- an unreachable file is
+not an uncovered file -- so ``setup.cfg`` omitted the same eleven from both
+``[coverage:run]`` and ``[coverage:report]``, and this test kept the three lists in
+agreement.
 
-Coverage must not charge their statements to the denominator: an unreachable
-file is not an uncovered file, and counting it silently understates the real
-line-rate (it hid ~3.9k permanently-unreachable statements, ~1.5pp). So
-``setup.cfg`` omits them from BOTH ``[coverage:run]`` (collection time, in the
-test job) and ``[coverage:report]`` (report time, in the Coverage Combine job,
-a separate process that re-reads shard data).
+The deselects are gone: every sandbox-dependent test in those files carries its own
+``skipif(not userns_available())``, so it skips on a runner with a named reason and runs
+for real on a capable host. All eleven files are collected on every platform now.
 
-Three lists therefore have to agree, and they live in two different files. The
-CI deselect list has already drifted once against another copy of itself, so
-this test enforces the invariant instead of trusting a comment to be read.
+The exemption did not disappear, it narrowed -- and its reason changed. A test that SKIPS
+never executes its body either, so a file whose sandbox-dependent tests skip on a runner
+still charges the denominator for lines the measuring host cannot reach:
+``test_ledger_sync_git.py`` measured 16% (65/405) on CI for exactly that reason, and the
+per-file floor caught it. So the six files carrying such a guard stay omitted, and the
+five without one are measured normally.
+
+That gives a rule worth enforcing in both directions:
+
+* an omitted test file must carry a capability guard CI cannot satisfy -- so a stale entry
+  cannot outlive its reason, which is how the retired eleven-file list would have rotted;
+* a ``--deselect`` that comes back must arrive WITH its coverage omit, because a deselected
+  file is unreachable for a second reason. A deselect is otherwise easy to add and
+  invisible afterwards: absent from the run output, taking the file's other tests with it,
+  never going red when its reason expires.
+
+The two lists must still agree, and no pattern may swallow product code.
 """
 
 from __future__ import annotations
@@ -27,22 +41,44 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
 SETUP_CFG = REPO_ROOT / "setup.cfg"
 
+#: Patterns that are legitimately omitted and are not test files at all. Both are pytest
+#: temporary-directory escapes: nothing real is ever measured from one, and a shard that
+#: recorded such a phantom path would otherwise trip ``coverage xml`` with "No source for
+#: code".
+_FIXTURE_ESCAPES = {"*/pytest-of-*/*", "*/kirocrew-wt-example/*"}
 
-def _ci_deselected_paths() -> list[str]:
-    """Repo-relative test paths from ci.yml's BACKEND_DESELECTS block.
+#: The predicate a test file must carry to earn an omit: the guard that makes its tests
+#: skip where the capability is absent. Matched as source text so the check needs no
+#: import of the suite under test.
+_CAPABILITY_GUARD = "userns_available"
 
-    Parsed with a regex rather than a YAML loader so the test does not depend on
-    PyYAML being installed, and so it reads the literal text a maintainer edits.
+
+def _ci_deselected_paths() -> list[tuple[str, str]]:
+    """``(workflow name, test path)`` for every ``--deselect`` in EVERY workflow.
+
+    Every workflow, not just ``ci.yml``: two lived in ``test-durations.yml`` for the same
+    two sandbox suites, where the sharded matrix could not see them and neither could a
+    reader of the shard job. That one did quieter damage than a plain exclusion -- the
+    durations file it produces then carried no entry for those files, so ``pytest-split``
+    gave them the average and balanced the shards on a guess.
+
+    Also scanned per line rather than per env block, so a deselect inlined into a run
+    step or parked in a new matrix job cannot slip past.
+
+    Read as literal text rather than through a YAML loader so the test needs no PyYAML
+    and sees exactly what a maintainer edits.
     """
-    text = CI_WORKFLOW.read_text(encoding="utf-8")
-    match = re.search(r"^  BACKEND_DESELECTS: >-\n((?:    .*\n)+)", text, re.MULTILINE)
-    assert match, "BACKEND_DESELECTS block not found in ci.yml -- did its shape change?"
-    paths = re.findall(r"--deselect=(\S+)", match.group(1))
-    assert paths, "BACKEND_DESELECTS matched but contained no --deselect= entries"
-    return paths
+    found: list[tuple[str, str]] = []
+    for workflow in sorted(WORKFLOWS.glob("*.yml")):
+        text = workflow.read_text(encoding="utf-8")
+        # Skip comment lines: several workflows document the retired mechanism in prose,
+        # and a comment describing a deselect is not one.
+        code = "\n".join(ln for ln in text.splitlines() if not ln.lstrip().startswith("#"))
+        found += [(workflow.name, path) for path in re.findall(r"--deselect=(\S+)", code)]
+    return found
 
 
 def _cfg_omit(section: str) -> list[str]:
@@ -55,28 +91,47 @@ def _cfg_omit(section: str) -> list[str]:
 def _matches(pattern: str, path: str) -> bool:
     """True if a coverage omit glob would exclude ``path``.
 
-    coverage.py matches omit patterns against the measured filename, which is
-    absolute at runtime, so the committed patterns are written with a leading
-    ``*/``. Compare on suffix semantics: translate the glob and allow it to
-    match the tail of the repo-relative path.
+    coverage.py matches omit patterns against the measured filename, which is absolute
+    at runtime, so the committed patterns are written with a leading ``*/``. Compare on
+    suffix semantics: translate the glob and allow it to match the tail of the
+    repo-relative path.
     """
     body = pattern[2:] if pattern.startswith("*/") else pattern
     regex = "".join(".*" if part == "*" else re.escape(part) for part in re.split(r"(\*)", body))
     return re.search(rf"(^|/){regex}$", path) is not None
 
 
-def test_ci_deselect_block_is_parseable() -> None:
-    """Guard the regex itself: a reshaped ci.yml must fail loudly, not silently."""
-    paths = _ci_deselected_paths()
-    assert len(paths) >= 11, f"expected the full deselect list, parsed only {len(paths)}"
-    assert all(p.endswith(".py") for p in paths), paths
+def test_no_workflow_deselects_a_test_file() -> None:
+    """The eleven suites run again; keep it that way, in every workflow.
+
+    A capability a runner lacks belongs on the test that needs it, as a skip with a
+    named reason, not on the file as a deselect. `userns_available()` is the predicate
+    those suites already use.
+    """
+    deselected = [f"{workflow}: {path}" for workflow, path in _ci_deselected_paths()]
+    assert not deselected, (
+        f"a workflow deselects {deselected}. A whole-file deselect hides the file's other "
+        "tests and expires silently -- guard the specific test with "
+        "skipif(not userns_available()) instead. If a deselect is genuinely right, add "
+        "a matching */... pattern to BOTH omit lists in setup.cfg so coverage does not "
+        "charge an unreachable file to the denominator."
+    )
 
 
 @pytest.mark.parametrize("section", ["coverage:run", "coverage:report"])
-def test_every_deselected_test_is_omitted_from_coverage(section: str) -> None:
-    """A file CI never executes must not be measured as coverable code."""
+def test_any_deselected_test_stays_out_of_coverage(section: str) -> None:
+    """The other half of the ratchet, live the moment a deselect returns.
+
+    Vacuous while nothing is deselected, which is the intended steady state -- it exists
+    so that re-adding one cannot silently leave coverage measuring a file the suite
+    cannot run.
+    """
     omit = _cfg_omit(section)
-    missing = [p for p in _ci_deselected_paths() if not any(_matches(pat, p) for pat in omit)]
+    missing = [
+        path
+        for _workflow, path in _ci_deselected_paths()
+        if not any(_matches(pat, path) for pat in omit)
+    ]
     assert not missing, (
         f"[{section}] omit does not cover these CI-deselected test files: {missing}. "
         "They are never executed, so measuring them understates the real line-rate. "
@@ -87,23 +142,63 @@ def test_every_deselected_test_is_omitted_from_coverage(section: str) -> None:
 def test_run_and_report_omit_lists_agree() -> None:
     """Collection-time and report-time omit must stay identical.
 
-    They govern different processes (the test job vs Coverage Combine); if only
-    one carries an entry, the gate silently measures a different denominator
-    than the shards were collected under.
+    They govern different processes (the test job vs Coverage Combine); if only one
+    carries an entry, the gate silently measures a different denominator than the shards
+    were collected under.
     """
     assert sorted(_cfg_omit("coverage:run")) == sorted(_cfg_omit("coverage:report"))
+
+
+def _repo_files_matching(pattern: str) -> list[Path]:
+    """Every tracked test file the omit *pattern* would exclude."""
+    tail = pattern[2:] if pattern.startswith("*/") else pattern
+    return [
+        path
+        for path in REPO_ROOT.rglob(tail.rsplit("/", 1)[-1])
+        if _matches(pattern, path.relative_to(REPO_ROOT).as_posix())
+    ]
+
+
+def test_every_omitted_test_file_carries_a_capability_guard() -> None:
+    """An omitted test file must be unreachable for a REASON that is in the file.
+
+    Without this, an entry outlives its reason silently -- which is exactly how the
+    retired eleven-file list rotted: it was justified by a `--deselect` and a "~6 minutes
+    against a real git" cost, both of which had been gone for some time while the omit
+    stayed. A deselected file is exempt for a second, separate reason and is allowed here
+    too, but the deselect itself has to survive `test_ci_deselects_no_test_file`.
+    """
+    deselected = [path for _workflow, path in _ci_deselected_paths()]
+    unjustified: list[str] = []
+    for pattern in _cfg_omit("coverage:run"):
+        if pattern in _FIXTURE_ESCAPES:
+            continue
+        if any(_matches(pattern, p) for p in deselected):
+            continue
+        matched = _repo_files_matching(pattern)
+        if not matched:
+            unjustified.append(f"{pattern} (matches no file in the repo)")
+        elif not any(
+            _CAPABILITY_GUARD in path.read_text(encoding="utf-8") for path in matched
+        ):
+            unjustified.append(f"{pattern} (no {_CAPABILITY_GUARD} guard)")
+    assert not unjustified, (
+        f"these omit patterns exempt a test file with nothing to justify it: {unjustified}. "
+        "Coverage measures what the measuring host can run: a file whose tests execute "
+        "there must be measured. Drop the pattern, or make the reason visible in the file "
+        f"as a {_CAPABILITY_GUARD} guard."
+    )
 
 
 def test_omit_patterns_do_not_swallow_product_code() -> None:
     """Fail-safe: no pattern may match a non-test source file.
 
-    A pattern like ``*/kiro_crew/*`` would omit all real source and turn the
-    coverage gate green by measuring almost nothing. Assert every committed
-    pattern is either a pytest-tmp fixture escape or targets a test file.
+    A pattern like ``*/kiro_crew/*`` would omit all real source and turn the coverage
+    gate green by measuring almost nothing. Assert every committed pattern is either a
+    pytest-tmp fixture escape or targets a test file.
     """
-    fixture_escapes = {"*/pytest-of-*/*", "*/kirocrew-wt-example/*"}
     for pattern in _cfg_omit("coverage:run"):
-        if pattern in fixture_escapes:
+        if pattern in _FIXTURE_ESCAPES:
             continue
         tail = pattern.rsplit("/", 1)[-1]
         assert tail.startswith("test_") and tail.endswith(".py"), (

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -1137,6 +1137,13 @@ class TestSshTunnelArgvCompression:
 
 requires_ssh = pytest.mark.skipif(shutil.which("ssh") is None, reason="ssh not available")
 
+#: Hang guard for a ``ssh -G`` config resolution, NOT a performance budget. The call does
+#: no network work, so any real duration is process-spawn overhead -- and on a loaded
+#: 4-core Windows runner that starves: at 30s this timed out and failed the shard on a
+#: config that was correct. Widening the guard cannot weaken an assertion (a genuine hang
+#: still fails, a few seconds later); pinning it low turns runner load into a red build.
+_SSH_CONFIG_PROBE_TIMEOUT_SECS = 120
+
 
 def _ssh_effective_config(tmp_path, config_text: str, ssh_args: list[str], host: str) -> dict:
     """Return ssh's OWN resolved settings (``ssh -G``) for *ssh_args* under a config.
@@ -1155,7 +1162,7 @@ def _ssh_effective_config(tmp_path, config_text: str, ssh_args: list[str], host:
         ["ssh", "-G", "-F", str(cfg), *ssh_args, host],
         capture_output=True,
         text=True,
-        timeout=30,
+        timeout=_SSH_CONFIG_PROBE_TIMEOUT_SECS,
     )
     assert out.returncode == 0, f"ssh -G failed: {out.stderr}"
     # Repeated keys are accumulated, not overwritten: ssh prints one
@@ -1260,7 +1267,7 @@ Host {host}
             ["ssh", "-G", "-F", str(cfg), *args, self._HOST],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=_SSH_CONFIG_PROBE_TIMEOUT_SECS,
         )
         assert out.returncode == 0, f"production argv broke a working config: {out.stderr}"
         assert "bad configuration option" not in out.stderr.lower()

--- a/test/windows-expected-failures.txt
+++ b/test/windows-expected-failures.txt
@@ -263,3 +263,9 @@ src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py::TestClon
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_lint_findings.py::TestLintFindingsOnDisk::test_findings_from_a_real_tree_carry_codes
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_suite_scope.py::TestSuiteScopeDerivation::test_a_test_dir_named_test_is_accepted
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_suite_scope.py::TestSuiteScopeDerivation::test_narrowed_globs_scope_to_the_nearest_tests_dir
+# Added when the CI deselect of this file was removed, so Windows collects it for the
+# first time. `PermissionError [Errno 13]` from `pathlib` writing the linked worktree's
+# `.git` pointer file: Windows refuses the write where POSIX allows it. The security
+# property it guards (a repointed gitdir must be refused) is POSIX-shaped; the other
+# 12,782 tests on that shard pass.
+src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py::TestRepoControlledGitHooksDoNotExecuteHostSide::test_a_repointed_worktree_gitdir_is_refused


### PR DESCRIPTION
`BACKEND_DESELECTS` dropped **eleven test files from every backend pytest invocation** —
full and reduced, Linux and Windows — because a GH runner denies `unshare(CLONE_NEWNS)`
and those suites drive a real `git`/`gh`/`pytest` through `sandboxed_spawn_argv`. That
kept **608 tests** off every pull request, including the set that guards the ops autonomy
gate.

They do not need it, and have not for a while.

## Every one of them already self-guards

Each test in those files that requires a namespace sandbox carries
`skipif(not userns_available())`. On a runner it skips with a named reason; on a capable
host it runs for real. Measured against a local simulation of the runner —
`unshare(CLONE_NEWUSER)` ok, `CLONE_NEWNS` EPERM, no user session bus for the cgroup
scope, no `gh` token — and verified *inside an xdist worker* rather than only the
controller, so the simulation could not have been silently absent:

| | result |
|---|---|
| the eleven files, runner-shaped | **608 passed, 85 skipped, 0 failed** (38 s) |
| the whole suite, runner-shaped | **55,735 passed, 271 skipped** |
| the eleven files, real sandbox + no gh token + no session bus | **694 passed, 1 skipped** (38 s) |

CI gains **523 executing tests on all three platforms**, plus 85 that now say which
capability they wanted instead of vanishing from the report.

## The reason had also expired

Keeping the nine ops/`auto_improvement` suites out of `backend-test-sandbox` was justified
in-tree as *"~6 minutes against a real git"*. That cost was the launcher's pre-exec
hardlink scan arming on every spawn; all eleven now run in **38 s** against a real
sandbox. Adding them to that job is the natural next step and waits on the scan fix
(#4197), so it is deliberately **not** here — this change is verified independent of it,
on plain `main`.

`test-durations.yml` deselected two of the same files, which did quieter damage than a
plain exclusion: that job writes `.test_durations`, so with no entry for those files
`pytest-split` gave them the **average** duration and balanced every shard on a guess.
Both lines are deleted.

## What the first real CI run said, per platform

- **Linux** (8 shards) and **macOS**: green first time.
- **Windows**: 12,782 passed, 2 failed, both in one class of `test_dogfood_learnings.py`.
  - *Fixed:* `test_red_base_staging_does_not_dereference_a_credential_symlink` compared
    `os.readlink()`'s raw string to the target, and Windows stores an absolute symlink
    target as `\\?\C:\...`. Neither a string compare nor `Path.resolve()` closes that gap —
    `pathlib` reads the prefix as part of the drive — so the prefix is stripped explicitly.
  - *Tracked:* `test_a_repointed_worktree_gitdir_is_refused` hits
    `PermissionError [Errno 13]` writing the linked worktree's `.git` pointer file, where
    POSIX allows the write. **This diff adds the 239th line** to
    `test/windows-expected-failures.txt` (7 from this file existed before), with that
    reason, per that file's rule that additions need one.

## Coverage

Both omit lists exempted all eleven files, because measuring a file CI cannot run
understates the line-rate. Emptying them measured 89% overall — and the **per-file** floor
then correctly failed on four of them, because a *skipped* test's lines are not executed
either: `test_ledger_sync_git.py` measured **16% (65/405)** on CI.

So the exemption narrows rather than disappears, with a different reason: the **six** files
carrying a `userns_available` guard stay omitted (their bodies are unreachable on a
runner); the **five** without one are measured again. `setup.cfg` notes the real fix —
`backend-test-sandbox` clears the AppArmor restriction, so measuring *that* job would reach
those lines; it runs `--no-cov` today.

The baseline refresh (run from this run's own artifact, as the gate instructs) deletes two
entries: `providers/schedule_file.py`, which went from a baselined **50.7% to 85.6%** purely
because its test file runs again — the deselects were suppressing **product** coverage, not
just test-file accounting — and `dashboard/handlers/feedback.py`, a mechanical prune of a
file that no longer exists.

## The contract test inverts rather than retires

`test_coverage_omit_contract.py` kept three lists in agreement. Its premise is gone, but
the failure mode it guarded is not — a `--deselect` is easy to add and invisible
afterwards: absent from the run output, taking the file's other tests with it, never going
red when its reason expires. It now enforces:

- **no workflow** may deselect a test file — scanned across every
  `.github/workflows/*.yml`, per line, and it names the offending workflow (the
  `test-durations.yml` pair is why: a single-file scan would not have seen them);
- an omitted test file must carry a `userns_available` guard, so an entry cannot outlive
  its reason the way the retired eleven-file list did;
- if a deselect is ever reinstated, it must arrive **with** its coverage omit;
- the run/report lists must still agree, and no pattern may swallow product code.

Each new direction was verified by planting the violation and watching it fire.

## One rider, declared

`test_instances.py`'s `ssh -G` probe had a **30 s** budget and timed out on Windows shard 2
in this PR's second run. That file was never among the eleven — but that call does no
network work, so its only cost is process spawn, and adding 523 tests to the shards is what
starved it. Raised to 120 s as a **hang guard, not a performance budget**: a genuine hang
still fails, a few seconds later, whereas a tight bound turns runner load into a red build.
It ships here because this change caused it.

## Verification

`isort`, `flake8`, `mypy`, `docs-lint`, `scrub-lint --no-history` clean; the rewritten
contract test and `test_ci_surface_tests.py` pass; 58/58 CI checks green.
