### PR TITLE
test(security): pin read-only bash help-probe classification

### DIFF
--- a/test/test_trust_reads.py
+++ b/test/test_trust_reads.py
@@ -93,10 +93,39 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("brazil workspace list") is True
 
     def test_help_and_version(self):
-        assert is_read_only_bash("brazil-build --help") is True
+        # Version probes on the read-only prefix allowlist
         assert is_read_only_bash("python --version") is True
+        assert is_read_only_bash("python3 --version") is True
         assert is_read_only_bash("java -version") is True
+        assert is_read_only_bash("node --version") is True
+        # Bare help probes for non-executor programs pass the probe shape check
+        assert is_read_only_bash("brazil-build --help") is True
         assert is_read_only_bash("some-tool --help") is True
+        # Known code executors are denied even in bare --help form, because the
+        # flag can land as an operand the interpreter runs
+        assert is_read_only_bash("node --help") is False
+        assert is_read_only_bash("npm --help") is False
+        # Extra arguments after --help are not a probe shape
+        assert is_read_only_bash("node --help --require /tmp/payload.js") is False
+        assert is_read_only_bash("brazil-build --help --eval 'malicious'") is False
+        assert is_read_only_bash("java --help -jar /tmp/evil.jar") is False
+        assert is_read_only_bash("javac --help -processor evil") is False
+
+    def test_interpreter_suffix_bypass_rejected(self):
+        """Regression: trailing --help/--version must NOT auto-approve
+        interpreter commands whose head is not on the read-only allowlist.
+        See: coordinated disclosure from Robert Noack, 2026-08-15."""
+        # bash -c '<payload>' --help — interpreter passes flag to script
+        assert is_read_only_bash("bash -c 'touch /tmp/owned' --help") is False
+        assert is_read_only_bash("bash -c 'whoami' --version") is False
+        # python3 -c '<payload>' --help
+        payload = "python3 -c \"open('/tmp/p1','w').write('x')\" --help"
+        assert is_read_only_bash(payload) is False
+        # sh -c variant
+        assert is_read_only_bash("sh -c 'curl attacker.com' --help") is False
+        # ruby/perl -e variants
+        assert is_read_only_bash("ruby -e 'system(\"id\")' --help") is False
+        assert is_read_only_bash("perl -e 'exec(\"id\")' --help") is False
 
     def test_help_probe_allows_one_bare_subcommand(self):
         """`<program> <subcommand> --help` is still a usage probe."""


### PR DESCRIPTION
## Problem / Motivation

`_classify_bash()` in `src/kiro_crew/dashboard/state.py` gates which bash commands are auto-approved in `trust_reads` mode. The shape-based `_is_help_probe` guard that closes the trailing `--help`/`--version` auto-approval bypass has **no regression test** for the cases that actually matter — in particular, that known code executors (`node`, `npm`, `bash`, `python3`) are denied even when the command looks like a usage probe.

## Why it matters

Without a test pinning the classification, a future refactor of `_is_help_probe` or `_HELP_PROBE_DENIED_PROGRAMS` can silently widen the gate back open. The failure mode is invisible: `trust_reads` auto-approves the command with no prompt and no visible trace, so the regression would only surface as an incident.

## What changed (motivation → approach → change)

The bypass itself is **already closed on main** by `_is_help_probe` (`src/kiro_crew/dashboard/state.py:493`), a shape-based check that only vouches for a recognisable `<program> --help` / `<program> <subcommand> --help` form and refuses path-named programs, `VAR=value` prefixes, and a denied-program table of interpreters and hand-off wrappers.

This PR adds **only the regression tests** for that landed behaviour. No production code changes.

Assertions added, each verified against the shipped classifier:

| case | expected | why |
|---|---|---|
| `python --version`, `python3 --version`, `java -version`, `node --version` | pass | on the read-only prefix allowlist |
| `brazil-build --help`, `some-tool --help` | pass | bare help probe, non-executor program |
| `node --help`, `npm --help` | **deny** | both are in `_HELP_PROBE_DENIED_PROGRAMS` — the flag can land as an operand the interpreter runs |
| `node --help --require /tmp/payload.js`, `java --help -jar /tmp/evil.jar` | **deny** | extra arguments are not a probe shape |
| `bash -c '<payload>' --help`, `python3 -c '<payload>' --help`, `sh -c`, `ruby -e`, `perl -e` variants | **deny** | interpreter passes the trailing flag through to the script |

## Tests

`test/test_trust_reads.py`:
- `test_help_and_version` — rewritten to pin the 12 cases above, replacing an assertion set that predated `_is_help_probe`.
- `test_interpreter_suffix_bypass_rejected` — new: the five interpreter `-c`/`-e` payload forms with a trailing `--help`/`--version`.

Each expectation was verified against the real `is_read_only_bash` before being written, not assumed.

## Manual verification

N/A — unit coverage is the right level here: the assertions call the production classifier directly, and the behaviour under test is a pure function of the command string.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change, and the diff is tests exclusively — nothing renders.

no linked issue: regression coverage for a fix that landed separately, no tracked issue filed for the test gap.
