### PR TITLE
test: make two nondeterministic backend tests hermetic (#4236)

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1365,3 +1365,50 @@ def _no_release_feed_network(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "kiro_crew.dashboard.handlers.updates._fetch_feed_bytes", _refuse, raising=True
     )
+
+
+@pytest.fixture(autouse=True)
+def _no_live_catalog_network(monkeypatch: pytest.MonkeyPatch):
+    """Make the official app catalog's network seam unreachable for the suite.
+
+    ``official_catalog._open_catalog`` is THE seam every catalog fetch goes
+    through (its own docstring says tests must intercept there). Two paths
+    reach it without a test asking to: the install path's
+    ``inventory_for_install`` performs a fresh, deliberately UNCACHED HTTPS
+    fetch of ``official-registry.json`` on every call (#4236), and store
+    listings can trigger ``load_official_catalog``. Without this fixture,
+    any test that walks either path makes a real HTTPS request to the live
+    CDN — slow, offline-hostile, and nondeterministic: the test's verdict
+    then depends on the CI runner's network, and one transient failure also
+    poisons the module's on-disk failure memory for the rest of the worker.
+
+    Tests that want a catalog answer stub a higher seam
+    (``fetch_document``, ``fetch_inventory_entries``, or
+    ``inventory_for_install``), which keeps this fixture from ever being
+    reached. A test that genuinely needs the real opener — e.g. against a
+    loopback server it started itself — must opt in explicitly: request
+    this fixture by name and monkeypatch ``_open_catalog`` back to the
+    original it yields.
+
+    The refusal is an ``AssertionError`` — deliberately OUTSIDE the
+    exception family ``fetch_document`` degrades on — but note the install
+    path's fail-closed ``except Exception`` in
+    ``registry._resolve_registry_row`` will convert it into a catalog
+    refusal rather than failing the test with this message. Like
+    ``_no_release_feed_network`` above, this is a NETWORK guard first and a
+    diagnostic second.
+    """
+    from kiro_crew.apps import official_catalog
+
+    original = official_catalog._open_catalog
+
+    def _refuse(req: object) -> None:
+        url = getattr(req, "full_url", repr(req))
+        raise AssertionError(
+            f"test reached the live app catalog ({url}) — stub "
+            "kiro_crew.apps.official_catalog.fetch_document (or a higher "
+            "seam such as inventory_for_install) instead"
+        )
+
+    monkeypatch.setattr(official_catalog, "_open_catalog", _refuse, raising=True)
+    yield original

--- a/test/test_app_denial_code.py
+++ b/test/test_app_denial_code.py
@@ -115,6 +115,14 @@ class TestRegistryInstallDenialCarriesCode:
         # `registry.config_dir` would not redirect the policy read.
         monkeypatch.setattr(admission, "config_dir", lambda: tmp_path)
 
+        # The resolution path consults the official catalog FIRST, with a fresh
+        # uncached HTTPS fetch (#4236); pin "catalog reachable, app absent" so
+        # the seeded row below is what resolves, deterministically.
+        monkeypatch.setattr(
+            "kiro_crew.apps.official_catalog.inventory_for_install",
+            lambda name: None,
+        )
+
         monkeypatch.setattr(
             registry,
             "_load_registry_file",

--- a/test/test_apps_registry_coverage.py
+++ b/test/test_apps_registry_coverage.py
@@ -1023,6 +1023,14 @@ class TestCandidateResolution:
     def test_candidates_span_bundled_and_every_configured_registry(
         self, monkeypatch, cache_dir
     ):
+        # `_registry_app_candidates` consults the official catalog with a fresh
+        # uncached HTTPS fetch, and DROPS every candidate when that lookup
+        # fails (#4236); pin "catalog reachable, app absent" so the assertion
+        # exercises the bundled + external span deterministically.
+        monkeypatch.setattr(
+            "kiro_crew.apps.official_catalog.inventory_for_install",
+            lambda name: None,
+        )
         monkeypatch.setattr(
             registry,
             "_load_registry_file",

--- a/test/test_external_registry.py
+++ b/test/test_external_registry.py
@@ -43,6 +43,23 @@ def _explicit_registry_execution_admission(monkeypatch):
     monkeypatch.setattr("kiro_crew.apps.execution.third_party_execution_allowed", lambda: True)
 
 
+@pytest.fixture(autouse=True)
+def _catalog_absent(monkeypatch):
+    """Pin "official catalog reachable, app absent" for the whole module.
+
+    This module is about SEED and EXTERNAL-registry resolution; the official
+    catalog is upstream of both in ``_resolve_registry_row``, and its real
+    lookup performs a fresh uncached HTTPS fetch on every call (#4236).
+    Before the suite-wide network guard these tests silently depended on the
+    runner's live network being up. A test that wants a different catalog
+    answer overrides this by monkeypatching the same seam itself.
+    """
+    monkeypatch.setattr(
+        "kiro_crew.apps.official_catalog.inventory_for_install",
+        lambda name: None,
+    )
+
+
 @pytest.fixture()
 def cache_dir(tmp_path, monkeypatch):
     """Redirect manifest cache to a temp directory."""

--- a/test/test_gateway_appkit_endpoints.py
+++ b/test/test_gateway_appkit_endpoints.py
@@ -1365,7 +1365,21 @@ class TestRegistryInstallStream:
     async def test_unknown_app_streams_error(
         self, app_env: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Installing a non-existent app should stream a done event with error."""
+        """Installing a non-existent app should stream a done event with error.
+
+        ``inventory_for_install`` is pinned to ``None`` — "catalog reachable,
+        app absent", the exact scenario the assertion below describes. The
+        real call performs a fresh, deliberately UNCACHED HTTPS fetch on
+        every install (a planted cache row must not supply install
+        coordinates), so without this pin the test's verdict depended on
+        live network from the runner (#4236): a transient fetch failure
+        takes the fail-closed ``CatalogUnavailable`` branch instead, which
+        the companion test below pins separately.
+        """
+        monkeypatch.setattr(
+            "kiro_crew.apps.official_catalog.inventory_for_install",
+            lambda name: None,
+        )
         async with self._make_client() as client:
             resp = await client.post(
                 "/api/apps/registry/install-stream",
@@ -1377,6 +1391,41 @@ class TestRegistryInstallStream:
             # Should contain a done event with error
             assert "event: done" in body
             assert "not found in registry" in body
+
+    @pytest.mark.asyncio
+    async def test_catalog_outage_streams_fail_closed_error(
+        self, app_env: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the catalog cannot be consulted, install refuses fail-closed.
+
+        The other branch of the fork the test above pins: ``None`` means
+        authoritative absence, ``CatalogUnavailable`` means "could not ask" —
+        and the install path must refuse rather than fall back to unpinned
+        coordinates. Both branches are now deterministic instead of being
+        selected by the CI runner's live network (#4236).
+        """
+        from kiro_crew.apps import official_catalog
+
+        def _outage(name: str) -> None:
+            raise official_catalog.CatalogUnavailable(
+                "simulated catalog outage (test)"
+            )
+
+        monkeypatch.setattr(
+            "kiro_crew.apps.official_catalog.inventory_for_install", _outage,
+        )
+        async with self._make_client() as client:
+            resp = await client.post(
+                "/api/apps/registry/install-stream",
+                json={"name": "nonexistent-app"},
+            )
+            assert resp.status == 200
+            assert resp.headers["Content-Type"] == "text/event-stream"
+            body = await resp.text()
+            assert "event: done" in body
+            # The fail-closed refusal, not the absence message.
+            assert "official catalog could not be reached" in body
+            assert "not found in registry" not in body
 
     @pytest.mark.asyncio
     async def test_streams_log_lines_then_done(
@@ -1509,6 +1558,19 @@ class TestRegistryInstallStream:
 
 class TestInstallFromRegistryLogLines:
     """Verify install_from_registry accepts custom log_lines."""
+
+    @pytest.fixture(autouse=True)
+    def _catalog_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pin "catalog reachable, app absent" for the unknown-app path.
+
+        These tests exercise the same live-fetching resolution path as
+        ``test_unknown_app_streams_error`` (#4236); without the pin their
+        verdict depends on the runner's network.
+        """
+        monkeypatch.setattr(
+            "kiro_crew.apps.official_catalog.inventory_for_install",
+            lambda name: None,
+        )
 
     @pytest.mark.asyncio
     async def test_custom_log_lines_receives_entries(self) -> None:

--- a/test/test_official_catalog.py
+++ b/test/test_official_catalog.py
@@ -561,7 +561,15 @@ class TestRedirectsAreRefused:
 
         return srv, close
 
-    def test_a_redirect_to_loopback_http_is_not_followed(self, monkeypatch):
+    def test_a_redirect_to_loopback_http_is_not_followed(
+        self, monkeypatch, _no_live_catalog_network
+    ):
+        # This test needs the REAL opener: the property under test is the
+        # redirect refusal inside `_open_catalog` itself, exercised against
+        # loopback servers this test starts — never the live CDN. Opt back
+        # out of the suite-wide catalog network guard, which yields the
+        # original seam for exactly this purpose.
+        monkeypatch.setattr(oc, "_open_catalog", _no_live_catalog_network)
         reached = []
 
         class Target(http.server.BaseHTTPRequestHandler):

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -4499,147 +4499,167 @@ class TestInitServicesLoopResponsiveness:
     Invariant (issue #3051): the loop runs callbacks one at a time, so a
     synchronous subprocess/scan inside ``_init_services`` starves every other
     coroutine — including the loop-stall watchdog heartbeat once armed — for
-    its whole duration. These tests run a fast ticker concurrently with a
-    deliberately slow dependency install / store scan and assert the ticker's
-    max inter-tick gap stays under a load-adaptive ceiling. A regression to
-    the old synchronous shape (subprocess.run / a bare on-loop call) blocks
-    the ticker for the whole slow window and blows the ceiling.
+    its whole duration.
+
+    These tests assert the PROPERTY, not a duration (#4235): a fast ticker
+    runs concurrently with the init work, and the stand-in for each slow
+    call blocks — in whatever execution context production invoked it —
+    until it OBSERVES the ticker advance. Fixed code runs the work off the
+    loop (``asyncio.to_thread`` / an async subprocess), so the loop stays
+    free, the ticker advances, and the probe returns almost immediately. A
+    mutant reverted to the old synchronous on-loop shape blocks the loop
+    itself, the ticker can never advance while the probe waits, and the
+    probe gives up at a deliberately generous deadline and flags
+    starvation.
+
+    The previous shape bounded the ticker's max inter-tick gap by an
+    absolute, load-adaptive ceiling; a scheduler stall on a saturated
+    runner blew the ceiling with the invariant intact (a 1.87s gap against
+    the 0.40s floor at a commit whose diff contained zero Python files).
+    Polling for the property makes host contention cost only wall-clock,
+    never the verdict, while an on-loop regression still fails
+    deterministically: ticks CANNOT happen while the loop is blocked, so no
+    amount of waiting turns a mutant green.
     """
 
-    _SLOW_SECS = 0.5
-    # Floor for the gap ceiling. The real ceiling adapts to host load (see
-    # _gap_ceiling): an absolute constant alone is the flake class AGENTS.md
-    # warns about — coverage + a saturated -n auto runner can produce
-    # hundred-ms scheduler hiccups on a perfectly healthy loop.
-    _MAX_GAP_SECS = 0.4
-    # Multiple of the measured control gap. The mutant signal is ~_SLOW_SECS
-    # (0.5s) vs a healthy ~0.01s, so 8x still kills every mutant on any host
-    # where the control gap stays under ~60ms.
-    _GAP_CEILING_FACTOR = 8
+    # Ticks a probe must observe while the slow work is in flight. Each tick
+    # proves the loop scheduled another coroutine DURING the work; requiring
+    # a handful rules out a single lucky wakeup counting as liveness.
+    _MIN_TICKS_DURING_WORK = 5
+    # How long a probe waits for those ticks before declaring the loop
+    # starved. Generous on purpose (testing-conventions § Determinism: poll
+    # with a generous deadline): a loaded host only DELAYS ticks, so
+    # contention costs wall-clock, never the verdict. Only a blocked loop —
+    # where ticks cannot happen at all — exhausts it, so this is paid only
+    # on a genuinely regressed run.
+    _PROBE_DEADLINE_SECS = 30.0
 
     @staticmethod
-    def _gap_ticker(state: dict):
-        state["last"] = time.monotonic()
+    def _make_ticker(state: dict):
+        """A coroutine that advances ``state['ticks']`` whenever the loop is free.
+
+        Stand-in for the loop-stall watchdog heartbeat: anything that blocks
+        the loop freezes this counter for the whole block.
+        """
 
         async def _ticker():
-            state["last"] = time.monotonic()
             while True:
                 await asyncio.sleep(0.01)
-                now = time.monotonic()
-                state["max_gap"] = max(state["max_gap"], now - state["last"])
                 state["ticks"] += 1
-                state["last"] = now
 
         return _ticker
 
-    @staticmethod
-    def _fold_final_gap(state: dict) -> None:
-        """Record the gap between the last tick and measurement end.
+    def _make_probe(self, state: dict, label: str, result=None):
+        """A stand-in for slow init work that polls the loop-liveness property.
 
-        Without this, a block at the TAIL of the measured call is invisible:
-        the parent coroutine resumes first and cancels the ticker before it
-        can run once more to observe the gap.
+        Runs in whatever execution context production invokes it in. Off the
+        loop (the fixed shape) the ticker keeps running, the tick delta
+        reaches ``_MIN_TICKS_DURING_WORK`` almost immediately, and *label* is
+        recorded in ``state['probed']``. On the loop (the regressed shape)
+        the ticker is starved for exactly as long as this function runs, the
+        delta can never advance, and *label* lands in ``state['starved']``
+        once the deadline expires.
         """
-        state["max_gap"] = max(state["max_gap"], time.monotonic() - state["last"])
 
-    async def _gap_ceiling(self) -> float:
-        """Measure the host's baseline tick gap and derive the failure ceiling.
+        def _probe(*args, **kwargs):
+            start = state["ticks"]
+            give_up = time.monotonic() + self._PROBE_DEADLINE_SECS
+            while state["ticks"] - start < self._MIN_TICKS_DURING_WORK:
+                if time.monotonic() >= give_up:
+                    state["starved"].append(label)
+                    return result
+                time.sleep(0.01)
+            state["probed"].append(label)
+            return result
 
-        Runs the same ticker over a plain ``asyncio.sleep`` window with
-        nothing offloaded — any gap observed here is pure scheduler noise —
-        then allows the measured phase a small multiple of it, floored at
-        _MAX_GAP_SECS for quiet hosts.
-        """
-        control = {"ticks": 0, "max_gap": 0.0}
-        task = asyncio.create_task(self._gap_ticker(control)())
-        await asyncio.sleep(0.02)  # ticker baseline
-        try:
-            await asyncio.sleep(self._SLOW_SECS)
-            self._fold_final_gap(control)
-        finally:
-            task.cancel()
-        return max(self._MAX_GAP_SECS, self._GAP_CEILING_FACTOR * control["max_gap"])
+        return _probe
 
     @pytest.mark.asyncio
     async def test_slow_pip_install_does_not_starve_heartbeat(self):
         orch = _make_orchestrator()
-        ceiling = await self._gap_ceiling()
-        state = {"ticks": 0, "max_gap": 0.0}
-        _ticker = self._gap_ticker(state)
+        state: dict = {"ticks": 0, "starved": [], "probed": []}
+        _ticker = self._make_ticker(state)
 
-        async def _slow_exec(*args, **kwargs):
+        async def _async_exec(*args, **kwargs):
+            # The FIXED shape: production awaits communicate() on the loop,
+            # so this waits for the ticker asynchronously — each await IS the
+            # loop servicing another callback, which is the property.
             proc = MagicMock()
             proc.returncode = 0
             proc.kill = MagicMock()
 
             async def _communicate():
-                await asyncio.sleep(self._SLOW_SECS)  # yields to the loop
+                start = state["ticks"]
+                give_up = time.monotonic() + self._PROBE_DEADLINE_SECS
+                while state["ticks"] - start < self._MIN_TICKS_DURING_WORK:
+                    if time.monotonic() >= give_up:
+                        state["starved"].append("pip-communicate")
+                        return (b"", b"")
+                    await asyncio.sleep(0.01)
+                state["probed"].append("pip-communicate")
                 return (b"", b"")
 
             proc.communicate = MagicMock(side_effect=_communicate)
             return proc
 
-        def _blocking_run(*args, **kwargs):  # the OLD, buggy shape
-            time.sleep(self._SLOW_SECS)  # blocks the loop thread
-            return MagicMock(returncode=0, stdout="", stderr=b"")
+        # The OLD, buggy shape: a mutant reverted to subprocess.run invokes
+        # this synchronously ON the loop, where the probe's ticks can never
+        # arrive — it flags starvation at the deadline. Patched on the
+        # subprocess MODULE (not the gateway namespace) because the fixed
+        # gateway no longer imports subprocess at all.
+        _blocking_run = self._make_probe(
+            state,
+            "pip-blocking-run",
+            result=MagicMock(returncode=0, stdout="", stderr=b""),
+        )
 
         with patch("importlib.util.find_spec", return_value=None):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/proj"}):
                 with patch.object(
                     GatewayOrchestrator, "_is_brazil_install", return_value=False
                 ):
-                    # Patch BOTH shapes: the fixed code awaits the async exec
-                    # (ticker keeps running); a mutant reverted to
-                    # subprocess.run blocks the loop and starves the ticker.
-                    # The sync shape is patched on the subprocess MODULE (not
-                    # the gateway namespace) because the fixed gateway no
-                    # longer imports subprocess at all.
                     with patch(
-                        "asyncio.create_subprocess_exec", side_effect=_slow_exec
+                        "asyncio.create_subprocess_exec", side_effect=_async_exec
                     ):
                         with patch(
                             "subprocess.run",
                             side_effect=_blocking_run,
                         ):
                             ticker_task = asyncio.create_task(_ticker())
-                            # Let the ticker establish its baseline BEFORE the
-                            # measured call: awaiting a coroutine runs it
-                            # inline, so without this yield an on-loop block
-                            # would happen before the first tick and never be
-                            # observed as a gap.
-                            await asyncio.sleep(0.02)
                             try:
+                                # Above every probe deadline so a regressed
+                                # run fails on the starvation assert below,
+                                # not on a torn-down timeout.
                                 await asyncio.wait_for(
-                                    orch._check_missing_deps(), timeout=10
+                                    orch._check_missing_deps(), timeout=60
                                 )
-                                self._fold_final_gap(state)
                             finally:
                                 ticker_task.cancel()
-        assert state["max_gap"] < ceiling, (
-            f"loop blocked for {state['max_gap']:.2f}s during dep install "
-            f"(ceiling {ceiling:.2f}s)"
+        assert state["starved"] == [], (
+            f"loop starved during dep install: {state['starved']} observed no "
+            f"ticker progress within {self._PROBE_DEADLINE_SECS:.0f}s"
+        )
+        assert "pip-communicate" in state["probed"], (
+            "dep install never awaited the async subprocess — the loop-free "
+            f"path was not taken (probed={state['probed']})"
         )
 
     @pytest.mark.asyncio
     async def test_slow_fts_rebuild_does_not_starve_heartbeat(self):
         """rebuild_index and vector init scale with usage; both must run off-loop."""
         orch = _make_orchestrator(slack_enabled=False)
-        ceiling = await self._gap_ceiling()
-        state = {"ticks": 0, "max_gap": 0.0}
-        _ticker = self._gap_ticker(state)
-
-        def _slow_rebuild():
-            time.sleep(self._SLOW_SECS)  # off-loop this is harmless
-            return 3
-
-        def _slow_vector_init():
-            time.sleep(self._SLOW_SECS)  # off-loop this is harmless
+        state: dict = {"ticks": 0, "starved": [], "probed": []}
+        _ticker = self._make_ticker(state)
 
         mock_mem_inst = MagicMock()
         mock_mem_inst.init = MagicMock()
-        mock_mem_inst.rebuild_index = MagicMock(side_effect=_slow_rebuild)
+        mock_mem_inst.rebuild_index = MagicMock(
+            side_effect=self._make_probe(state, "rebuild-index", result=3)
+        )
         mock_vm_inst = MagicMock()
-        mock_vm_inst.init = MagicMock(side_effect=_slow_vector_init)
+        mock_vm_inst.init = MagicMock(
+            side_effect=self._make_probe(state, "vector-init")
+        )
         with patch("kiro_crew.slack.gateway.MemoryStore", return_value=mock_mem_inst):
             with patch("kiro_crew.vector_memory.VectorMemoryStore") as mock_vm:
                 mock_vm.return_value = mock_vm_inst
@@ -4657,19 +4677,23 @@ class TestInitServicesLoopResponsiveness:
                                                         new=AsyncMock(return_value=_fake_async_proc(stdout=b"kiro-cli 1.30.0")),
                                                     ):
                                                         ticker_task = asyncio.create_task(_ticker())
-                                                        # Baseline tick first — see the
-                                                        # comment in the pip test above.
-                                                        await asyncio.sleep(0.02)
                                                         try:
+                                                            # Above the sum of both probe
+                                                            # deadlines so a regressed run
+                                                            # fails on the starvation
+                                                            # assert, not on teardown.
                                                             await asyncio.wait_for(
-                                                                orch._init_services(), timeout=10
+                                                                orch._init_services(), timeout=90
                                                             )
-                                                            self._fold_final_gap(state)
                                                         finally:
                                                             ticker_task.cancel()
-        assert state["max_gap"] < ceiling, (
-            f"loop blocked for {state['max_gap']:.2f}s during service init "
-            f"(ceiling {ceiling:.2f}s)"
+        assert state["starved"] == [], (
+            f"loop starved during service init: {state['starved']} observed no "
+            f"ticker progress within {self._PROBE_DEADLINE_SECS:.0f}s"
+        )
+        assert {"rebuild-index", "vector-init"} <= set(state["probed"]), (
+            "service init skipped a probed call — the invariant was not "
+            f"exercised (probed={state['probed']})"
         )
 
 

--- a/test/test_trusted_apps_api.py
+++ b/test/test_trusted_apps_api.py
@@ -1504,6 +1504,14 @@ def seeded_registry(monkeypatch: pytest.MonkeyPatch):
         "_load_registry_file",
         lambda: [{"name": _REG_ONLY, "repo": "acme/registry-only-app", "branch": "main"}],
     )
+    # "Never touches the network" needs the catalog pinned too: resolution
+    # consults the official catalog BEFORE the seed row, with a fresh uncached
+    # HTTPS fetch (#4236) — and with a seed row present a failed lookup refuses
+    # rather than falling back to the seed.
+    monkeypatch.setattr(
+        "kiro_crew.apps.official_catalog.inventory_for_install",
+        lambda name: None,
+    )
     return _REG_ONLY
 
 


### PR DESCRIPTION
## Problem / Motivation

Two backend tests are nondeterministic — their verdicts depend on something other than the code under test (`docs/system-specs/common/testing-conventions.md` § Determinism):

- **#4236** — `test_gateway_appkit_endpoints.py::TestRegistryInstallStream::test_unknown_app_streams_error` depends on a **live catalog CDN fetch**. Since #3659, the install path calls `official_catalog.inventory_for_install()`, which by design performs a fresh, UNCACHED HTTPS fetch of `official-registry.json`. The test never mocked it: fetch succeeds → "not found in registry" → pass; fetch fails transiently → `CatalogUnavailable` fail-closed message → fail. Second-order: one earlier failed fetch in the same shard poisons the module's on-disk failure memory (`_FAILED_KEY`), keeping the test red after the network recovers.
- **#4235** — `test_slack_gateway.py::TestInitServicesLoopResponsiveness::test_slow_fts_rebuild_does_not_starve_heartbeat` bounds an **absolute wall-clock duration** ("loop blocked for 1.87s during service init (ceiling 0.40s)"). Six consecutive runs on a branch with ZERO Python files in the diff, same shard, five passes and one failure — a 4.7× overshoot is a scheduler stall on a saturated runner, not a lost `await`.

## Why it matters

Every contributor pays these flakes: a red shard on an unrelated PR forces a rerun round (~15–30 min each), erodes trust in CI red as a signal, and trains people to click rerun instead of reading failures. The catalog flake additionally makes CI generate real HTTPS traffic to the live CDN on every run.

## What changed (motivation → approach → change)

**Part A (#4236) — mock the seam, keep the fail-closed design.** The uncached fetch is deliberate and correct (a planted cache row must not supply install coordinates); the bug is the test's missing mock.
- `test_unknown_app_streams_error` pins `official_catalog.inventory_for_install → None` — "catalog reachable, app absent", exactly the scenario its assertion describes.
- A new companion test `test_catalog_outage_streams_fail_closed_error` pins the OTHER branch: `inventory_for_install` raises `CatalogUnavailable` → asserts the fail-closed refusal message. Both branches of the fork are now deterministic.
- A suite-wide autouse conftest guard `_no_live_catalog_network` refuses any live catalog fetch at `official_catalog._open_catalog` (the seam its own docstring designates for test interception), mirroring the existing `_no_release_feed_network` guard. It yields the original opener so a test that genuinely needs it can opt back in.
- The guard immediately earned its keep: it surfaced **six more tests silently depending on live network** — `test_external_registry.py` (4 tests, now pinned via a module autouse fixture), `test_app_denial_code.py`, `test_apps_registry_coverage.py`, and `test_trusted_apps_api.py` (whose `seeded_registry` fixture docstring claimed "never touches the network" while the resolution path fetched the catalog). Each now pins the same seam. The loopback-redirect test in `test_official_catalog.py` opts back into the real opener the guard yields — its property under test IS the opener's redirect refusal, exercised only against servers the test starts.

**Part B (#4235) — poll for the property, not a duration.** Chosen: option (2) from the issue, **poll for the property**, over a measured ratio — the invariant is "the heartbeat still gets scheduled during init", and a polled observation asserts that directly with no second timing measurement to also go wrong. Testing-conventions § Determinism class 5 says to prefer asserting the shape deterministically over any timed bound, and class 2 gives the poll-with-generous-deadline pattern used here.
- Both responsiveness tests (the fts/vector one from the issue AND its `pip install` sibling, which bounded the identical ceiling) replace the gap-ceiling machinery: the slow-work stand-in (`_make_probe`) blocks — in whatever execution context production invoked it — until it observes a concurrent ticker advance ≥5 ticks, with a generous 30s deadline.
- Fixed shape (`asyncio.to_thread` / async subprocess): the loop stays free, ticks arrive immediately, the probe records completion. Regressed shape (on-loop sync call): ticks CANNOT happen while the probe waits, so it flags starvation at the deadline — deterministically, on any host. Contention only costs wall-clock, never the verdict; the 30s deadline is paid only on genuinely broken code.
- Each test also asserts its probes actually completed, so the test fails loudly (instead of passing vacuously) if init stops invoking the probed seam.
- `_SLOW_SECS` / `_MAX_GAP_SECS` / `_GAP_CEILING_FACTOR` / `_gap_ceiling` / `_fold_final_gap` are deleted.

**Deliberate-break verification** (each break temporary, reverted before commit; per the fix contract "the test must still FAIL if the invariant it guards actually breaks"):

| Production break (temporary) | Test that went red |
|---|---|
| unknown-app path returns `{"ok": True}` | `test_unknown_app_streams_error` |
| collapse `catalog_failed` into authoritative absence | `test_catalog_outage_streams_fail_closed_error` |
| `memory.rebuild_index()` called on-loop | fts test — `loop starved: ['rebuild-index']` |
| `vector_memory.init()` called on-loop | fts test — `loop starved: ['vector-init']` |
| dep repair via blocking `subprocess.run` | pip test — `loop starved: ['pip-blocking-run']` |

No production file is changed by this PR — the defect in both issues was in the tests.

## Tests

- `test_unknown_app_streams_error` — deterministic "catalog reachable, app absent" branch.
- `test_catalog_outage_streams_fail_closed_error` (new) — deterministic fail-closed outage branch.
- `_no_live_catalog_network` (conftest, autouse) — no backend test can reach the live catalog CDN; opt-in path yields the real opener.
- `TestInstallFromRegistryLogLines` — autouse catalog pin (same unknown-app path).
- `test_slow_pip_install_does_not_starve_heartbeat` / `test_slow_fts_rebuild_does_not_starve_heartbeat` — loop-liveness property polled instead of duration-bounded; vacuity-guarded via completed-probe assertions.
- Catalog pins in `test_external_registry.py` (module fixture), `test_app_denial_code.py`, `test_apps_registry_coverage.py`, `test_trusted_apps_api.py`; explicit real-opener opt-in in `test_official_catalog.py`.

All touched tests pass **20/20 consecutive runs**. Full backend suite: **0 regressions vs base** (failure lists diffed branch-vs-base with parent-sandbox env vars stripped). isort / flake8 / mypy green.

## Manual verification

N/A — unit coverage sufficient: the change is test-only, and the deliberate-break table above is the manual proof that each test still guards its production invariant.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** test-only change; no frontend paths touched, nothing renders differently.

## Related Issues

Closes #4236
Closes #4235

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changed
- [x] No secrets, credentials, or internal references in the diff
