### PR TITLE
fix(chat): read the command for a shell pill whose title is a kind label

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -320,33 +320,50 @@ def make_unified_diff(old: str, new: str, path: str, max_len: int = 6000) -> str
     return "".join(udiff).rstrip()[:max_len]
 
 
-def select_tool_title(title: object, raw_input: object, kind: object = None) -> str | None:
+def select_tool_title(
+    title: object,
+    raw_input: object,
+    kind: object = None,
+    *,
+    is_shell: bool | None = None,
+) -> str | None:
     """Pick the pill label, preferring a human-readable ``description`` when present.
 
     Some backends' Bash tool emits a ``description`` field alongside ``command``
     (e.g. "List KiroCrew ACP module files" rather than ``ls /workplace/...``).
-    We surface it on the pill when supplied; otherwise we fall back to the
-    SDK-provided ``title`` (the literal tool invocation). Used for both the
+    We surface it on the pill when supplied, then the literal shell command for
+    a shell tool, and only then the SDK-provided ``title``. Used for both the
     initial ``tool_call`` and the second-phase ``tool_call_update`` refinement
     so the title rule stays consistent across both events.
+
+    The command outranks ``title`` because backends disagree on what ``title``
+    holds for a shell call: some send the invocation itself, others a generic
+    kind label ("Run Command") that names no command at all. Reading the
+    command yields the same pill for the first shape and an informative one for
+    the second, and it is never the weaker choice — a genuinely human-readable
+    label arrives as ``description``, which still wins.
+
+    ``is_shell`` overrides the kind-derived classification for a caller holding
+    a RESOLVED signal. A ``tool_call_update`` may omit ``kind`` entirely, and
+    reading that absence as non-shell would put the generic title back on a
+    pill the initial ``tool_call`` had already labelled with its command.
     """
     if isinstance(raw_input, dict):
         desc = raw_input.get("description")
         if isinstance(desc, str) and desc.strip():
             return desc
+    kind_str = kind if isinstance(kind, str) else None
+    shell = is_shell_kind(kind_str) if is_shell is None else is_shell
+    # Shell kinds only, so an fs tool's operation name ("strReplace") is never
+    # mistaken for a command.
+    if shell and isinstance(raw_input, dict):
+        cmd = raw_input.get("command")
+        if isinstance(cmd, str) and cmd.strip():
+            return cmd
     # The flat title field defaults to an "unknown" sentinel when a backend
     # omits it; treat that (and blanks) as absent rather than surfacing it.
     if isinstance(title, str) and title and title != "unknown":
         return title
-    # Some backends omit the SDK title for a shell/exec tool and carry only the
-    # command in rawInput. Surface it for shell kinds only (so an fs tool's
-    # operation name is never mistaken for a command) instead of a bare kind
-    # label like "Run Command".
-    kind_str = kind if isinstance(kind, str) else None
-    if is_shell_kind(kind_str) and isinstance(raw_input, dict):
-        cmd = raw_input.get("command")
-        if isinstance(cmd, str) and cmd.strip():
-            return cmd
     return None
 
 
@@ -777,7 +794,7 @@ def _build_tool_call_event(
         tool_input_cache[_ck] = input_str
     if purpose:
         purpose = _redact(purpose)
-    title = select_tool_title(title, raw_input, kind) or ""
+    title = select_tool_title(title, raw_input, kind, is_shell=is_shell) or ""
     if title:
         title = _redact(title)
     if kind:
@@ -1056,7 +1073,25 @@ def _build_tool_refinement_event(
     # and every child permission request downgrades to low fidelity.
     if raw_params_cache is not None and isinstance(raw_input, dict) and raw_input:
         raw_params_cache[_rk] = raw_input
-    title_source = select_tool_title(title, raw_input, kind)
+    # Refresh the cached shell signal only when this refinement carries a kind
+    # (kind is optional on updates); a kind-less refinement must not clobber a
+    # True cached by the initial tool_call. Mirrors AcpClient exactly. Resolved
+    # BEFORE the title so the label rule sees the real classification rather
+    # than a missing kind.
+    if shell_cache is not None:
+        if isinstance(kind, str) and kind:
+            shell_cache[_rk] = is_shell_kind(kind)
+        is_shell = shell_cache.get(_rk, False)
+    else:
+        is_shell = is_shell_kind(kind) if isinstance(kind, str) and kind else False
+    # A refinement carrying a title but no rawInput still overwrites the pill,
+    # so the command has to be recoverable from the params the initial
+    # tool_call cached — otherwise a backend that sends a generic title on both
+    # events lands that label on a pill the first event got right.
+    _title_params: object = raw_input
+    if not (isinstance(raw_input, dict) and raw_input) and raw_params_cache is not None:
+        _title_params = raw_params_cache.get(_rk)
+    title_source = select_tool_title(title, _title_params, kind, is_shell=is_shell)
     title_str = _redact(title_source) if title_source else ""
     kind_str = _redact(kind) if isinstance(kind, str) and kind else ""
     # The refinement's rawInput is the COMPLETE params object, so it carries the
@@ -1067,15 +1102,6 @@ def _build_tool_refinement_event(
     purpose = extract_tool_purpose(raw_input)
     if purpose:
         purpose = _redact(purpose)
-    # Refresh the cached shell signal only when this refinement carries a kind
-    # (kind is optional on updates); a kind-less refinement must not clobber a
-    # True cached by the initial tool_call. Mirrors AcpClient exactly.
-    if shell_cache is not None:
-        if isinstance(kind, str) and kind:
-            shell_cache[_rk] = is_shell_kind(kind)
-        is_shell = shell_cache.get(_rk, False)
-    else:
-        is_shell = is_shell_kind(kind) if isinstance(kind, str) and kind else False
     return AcpEvent(
         kind=EVENT_TOOL_CALL_UPDATE,
         title=title_str,

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1863,34 +1863,49 @@ def _make_unified_diff(old: str, new: str, path: str, max_len: int = 6000) -> st
     return "".join(udiff).rstrip()[:max_len]
 
 
-def _select_tool_title(title: object, raw_input: object, kind: object = None) -> str | None:
+def _select_tool_title(
+    title: object,
+    raw_input: object,
+    kind: object = None,
+    *,
+    is_shell: bool | None = None,
+) -> str | None:
     """Pick the pill label, preferring a human-readable `description` when present.
 
     Some backends' Bash tool emits a `description` field alongside `command`
     (e.g. "List KiroCrew ACP module files" rather than `ls /workplace/...`).
-    We surface it on the pill when supplied; otherwise we fall back to the
-    SDK-provided `title` (the literal tool invocation). Used by both
+    We surface it on the pill when supplied, then the literal shell command for
+    a shell tool, and only then the SDK-provided `title`. Used by both
     `_extract_tool_event` (initial tool_call) and
     `_extract_tool_call_refinement` (the second-phase tool_call_update from
     claude-agent-acp) so the title rule stays consistent across both events.
+
+    The command outranks `title` because backends disagree on what `title`
+    holds for a shell call: some send the invocation itself, others a generic
+    kind label ("Run Command") that names no command at all. A genuinely
+    human-readable label arrives as `description`, which still wins.
+
+    `is_shell` overrides the kind-derived classification for a caller holding a
+    RESOLVED signal — a tool_call_update may omit `kind` entirely, and reading
+    that absence as non-shell would put the generic title back on a pill the
+    initial tool_call had already labelled with its command.
     """
     if isinstance(raw_input, dict):
         desc = raw_input.get("description")
         if isinstance(desc, str) and desc.strip():
             return desc
+    kind_str = kind if isinstance(kind, str) else None
+    shell = _is_shell_kind(kind_str) if is_shell is None else is_shell
+    # Shell kinds only, so an fs tool's operation name ("strReplace") is never
+    # mistaken for a command.
+    if shell and isinstance(raw_input, dict):
+        cmd = raw_input.get("command")
+        if isinstance(cmd, str) and cmd.strip():
+            return cmd
     # The flat title field defaults to an "unknown" sentinel when a backend
     # omits it; treat that (and blanks) as absent rather than surfacing it.
     if isinstance(title, str) and title and title != "unknown":
         return title
-    # Some backends omit the SDK title for a shell/exec tool and carry only the
-    # command in rawInput. Surface it for shell kinds only (so an fs tool's
-    # operation name is never mistaken for a command) instead of a bare kind
-    # label like "Run Command".
-    kind_str = kind if isinstance(kind, str) else None
-    if _is_shell_kind(kind_str) and isinstance(raw_input, dict):
-        cmd = raw_input.get("command")
-        if isinstance(cmd, str) and cmd.strip():
-            return cmd
     return None
 
 
@@ -5140,7 +5155,7 @@ class AcpClient:
                 # Cache the trusted tool name too, so the permission event can
                 # rebuild mcp__<server>__<tool> for per-tool governance.
                 self._tool_call_tool_name[tool_call_id] = _kiro_tool_name(update)
-            title = _select_tool_title(title, raw_input, kind) or ""
+            title = _select_tool_title(title, raw_input, kind, is_shell=is_shell) or ""
             if title:
                 title, _ = redact_exfiltration_urls(title)
                 title, _ = redact_credentials(title)
@@ -5294,10 +5309,26 @@ class AcpClient:
             input_str, _ = redact_exfiltration_urls(input_str)
             input_str, _ = redact_credentials(input_str)
             self._tool_call_inputs[tool_use_id] = input_str
+        # Refresh the cached shell signal only when this refinement carries a
+        # kind. A refinement that omits kind must NOT clobber a True cached by
+        # the initial tool_call notification (kind is optional on updates).
+        # Cache off the RAW kind, not the redacted kind_str. Resolved BEFORE the
+        # title so the label rule sees the real classification rather than a
+        # missing kind.
+        if isinstance(kind, str) and kind:
+            self._tool_call_is_shell[tool_use_id] = _is_shell_kind(kind)
+        is_shell = self._tool_call_is_shell.get(tool_use_id, False)
         # Prefer rawInput.description over the SDK-supplied title (e.g.
         # Bash's "List KiroCrew ACP module files" rather than `ls /workplace/...`).
         # Same helper as `_extract_tool_event` so the rule is consistent.
-        title_source = _select_tool_title(title, raw_input, kind)
+        # A refinement carrying a title but no rawInput still overwrites the
+        # pill, so the command has to be recoverable from the params the initial
+        # tool_call cached — otherwise a backend that sends a generic title on
+        # both events lands that label on a pill the first event got right.
+        _title_params: object = raw_input
+        if not (isinstance(raw_input, dict) and raw_input):
+            _title_params = self._tool_call_params.get(tool_use_id)
+        title_source = _select_tool_title(title, _title_params, kind, is_shell=is_shell)
         title_str = ""
         if title_source:
             title_str, _ = redact_exfiltration_urls(title_source)
@@ -5316,13 +5347,6 @@ class AcpClient:
         if purpose:
             purpose, _ = redact_exfiltration_urls(purpose)
             purpose, _ = redact_credentials(purpose)
-        # Refresh the cached shell signal only when this refinement carries a
-        # kind. A refinement that omits kind must NOT clobber a True cached by
-        # the initial tool_call notification (kind is optional on updates).
-        # Cache off the RAW kind, not the redacted kind_str.
-        if isinstance(kind, str) and kind:
-            self._tool_call_is_shell[tool_use_id] = _is_shell_kind(kind)
-        is_shell = self._tool_call_is_shell.get(tool_use_id, False)
         return AcpEvent(
             kind=EVENT_TOOL_CALL_UPDATE,
             title=title_str,

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -6637,6 +6637,72 @@ class TestExtractToolCallRefinement:
         assert event is not None
         assert event.title == "List KiroCrew dashboard module files"
 
+    def test_generic_shell_title_yields_the_command(self):
+        # A backend whose shell `title` is a kind label ("Run Command") names no
+        # command; every pill in the transcript would read the same. The command
+        # is the ground truth of the call, so it is what the pill shows.
+        client = self._client()
+        msg = self._make_msg(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc-2d",
+                "title": "Run Command",
+                "kind": "execute",
+                "rawInput": {"command": "git status"},
+            }
+        )
+        event = client._extract_tool_call_refinement(msg)
+        assert event is not None
+        assert event.title == "git status"
+
+    def test_kindless_refinement_inherits_the_shell_classification(self):
+        # `kind` is optional on an update. Reading its absence as "not shell"
+        # repainted the pill with the generic title the initial tool_call had
+        # already resolved to a command, so the cached classification decides.
+        client = self._client()
+        call = self._make_msg(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc-2e",
+                "title": "Run Command",
+                "kind": "execute",
+                "rawInput": {"command": "git status"},
+            }
+        )
+        assert client._extract_tool_event(call).title == "git status"
+        refinement = self._make_msg(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc-2e",
+                "title": "Run Command",
+                "rawInput": {"command": "git status"},
+            }
+        )
+        event = client._extract_tool_call_refinement(refinement)
+        assert event is not None
+        assert event.title == "git status"
+
+    def test_title_only_refinement_reads_the_cached_params(self):
+        # A refinement can repeat the title without resending rawInput; the
+        # command then has to come from the params the initial call cached.
+        client = self._client()
+        call = self._make_msg(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc-2f",
+                "title": "Run Command",
+                "kind": "execute",
+                "rawInput": {"command": "git status"},
+            }
+        )
+        client._extract_tool_event(call)
+        refinement = self._make_msg(
+            {"sessionUpdate": "tool_call_update", "toolCallId": "tc-2f", "title": "Run Command"}
+        )
+        event = client._extract_tool_call_refinement(refinement)
+        assert event is not None
+        assert event.title == "git status"
+
     def test_blank_description_falls_back_to_title(self):
         # Whitespace-only description shouldn't override a useful title.
         client = self._client()

--- a/test/test_tool_purpose_key.py
+++ b/test/test_tool_purpose_key.py
@@ -194,7 +194,20 @@ class TestSelectToolTitle:
         raw = {"description": "List temp", "command": "ls /tmp"}
         assert select_tool_title("ls /tmp", raw) == "List temp"
 
-    def test_title_preferred_over_command(self) -> None:
+    def test_description_outranks_the_command_for_a_shell_tool(self) -> None:
+        """The prose label is the one thing that beats the command."""
+        raw = {"description": "List temp", "command": "ls /tmp"}
+        assert select_tool_title("Run Command", raw, "execute") == "List temp"
+
+    def test_command_outranks_a_generic_shell_title(self) -> None:
+        """A backend whose shell ``title`` is a kind label ("Run Command") names
+        no command, and treating it as a usable title leaves every pill in a
+        transcript identical. The command is the ground truth of the call."""
+        assert select_tool_title("Run Command", {"command": "ls /tmp"}, "execute") == "ls /tmp"
+
+    def test_command_matches_a_title_that_already_held_it(self) -> None:
+        """Backends whose shell ``title`` IS the invocation are unaffected: both
+        fields carry the same bytes, so preferring the command is a no-op."""
         assert select_tool_title("ls /tmp", {"command": "ls /tmp"}, "execute") == "ls /tmp"
 
     def test_unknown_sentinel_falls_through_to_command_for_shell(self) -> None:
@@ -210,9 +223,94 @@ class TestSelectToolTitle:
         # ("strReplace"), not a shell command — it must not become the label.
         assert select_tool_title("unknown", {"command": "strReplace"}, "edit") is None
 
+    def test_non_shell_title_is_kept_over_its_operation_name(self) -> None:
+        """The command bypass is shell-only, so an fs tool keeps its own title."""
+        assert select_tool_title("Write File", {"command": "create"}, "edit") == "Write File"
+
     def test_command_ignored_without_kind(self) -> None:
         # Without a kind we cannot confirm a shell tool, so no command fallback.
         assert select_tool_title("unknown", {"command": "ls"}) is None
 
     def test_blank_title_no_command_returns_none(self) -> None:
         assert select_tool_title("", {}, "execute") is None
+
+    def test_resolved_shell_flag_recovers_the_command_without_a_kind(self) -> None:
+        """A caller holding a resolved classification (the refinement path, whose
+        frame may omit ``kind``) gets the command anyway."""
+        got = select_tool_title("Run Command", {"command": "ls /tmp"}, None, is_shell=True)
+        assert got == "ls /tmp"
+
+    def test_resolved_non_shell_flag_overrides_a_shell_kind(self) -> None:
+        """The explicit flag wins in both directions, so a caller that resolved
+        "not shell" cannot be talked into reading an operation name."""
+        got = select_tool_title("Write File", {"command": "create"}, "execute", is_shell=False)
+        assert got == "Write File"
+
+
+class TestGenericShellTitleAcrossBothEvents:
+    """A backend may label a shell call ``Run Command`` on BOTH events.
+
+    The refinement overwrites the pill, so the command rule has to hold there as
+    well — and a refinement frame commonly omits ``kind``, which is exactly the
+    input that used to fall through to the generic title.
+    """
+
+    @staticmethod
+    def _sequence(refinement: dict) -> tuple[str, str]:
+        """Dispatch a generic-titled shell ``tool_call`` then ``refinement``.
+
+        Returns both titles. The caches are the caller-owned maps the real
+        dispatch loop keeps for the life of a turn, which is what carries the
+        initial call's classification and params into the refinement.
+        """
+        shell_cache: dict[str, bool] = {}
+        raw_params_cache: dict[str, dict] = {}
+        caches = {"shell_cache": shell_cache, "raw_params_cache": raw_params_cache}
+        (call_event,) = parse_session_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc-generic",
+                "title": "Run Command",
+                "kind": "execute",
+                "rawInput": {"command": "git status"},
+            },
+            **caches,  # type: ignore[arg-type]
+        )
+        refine_events = [
+            e
+            for e in parse_session_update({**refinement}, **caches)  # type: ignore[arg-type]
+            if e.kind == EVENT_TOOL_CALL_UPDATE
+        ]
+        assert len(refine_events) == 1
+        return call_event.title, refine_events[0].title
+
+    def test_initial_call_shows_the_command(self) -> None:
+        call_title, _ = self._sequence(
+            {"sessionUpdate": "tool_call_update", "toolCallId": "tc-generic", "kind": "execute"}
+        )
+        assert call_title == "git status"
+
+    def test_kindless_refinement_keeps_the_command(self) -> None:
+        """The refinement repeats the generic title and omits ``kind``; without
+        the cached classification it would repaint the pill ``Run Command``."""
+        _, refine_title = self._sequence(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc-generic",
+                "title": "Run Command",
+                "rawInput": {"command": "git status"},
+            }
+        )
+        assert refine_title == "git status"
+
+    def test_refinement_without_raw_input_reads_the_cached_params(self) -> None:
+        """A title-only refinement carries no command of its own, so the label
+        comes from the params the initial call cached."""
+        _, refine_title = self._sequence(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc-generic",
+                "title": "Run Command",
+            }
+        )
+        assert refine_title == "git status"


### PR DESCRIPTION
## Problem

An ACP backend may label a shell `tool_call` with a generic kind label — `"Run Command"` — instead of the invocation. `select_tool_title` took any non-empty, non-sentinel `title` before it considered `rawInput.command`, so on such a backend **every** shell pill in a transcript reads the same three words:

```
🔧 Run Command
🔧 Run Command
🔧 Run Command
```

The command was never lost — it sits in the row's expanded input — but the collapsed transcript stopped being scannable, which is the whole job of the pill.

The earlier fallback only fired when the title was absent or the `"unknown"` sentinel, so it never engaged against a backend that supplies a useless title rather than none.

## Change

Move the shell command **ahead of** `title` in the label rule:

| | order |
|---|---|
| before | `description` → `title` → command (shell kinds) |
| after | `description` → command (shell kinds) → `title` |

- `description` still wins, so a backend supplying a human-readable label is untouched.
- A backend whose shell `title` already IS the command sees **no change** — both fields carry the same bytes.
- The bypass stays shell-only, so an fs tool's operation name (`strReplace`, `create`) can never be mistaken for a command.

Two further things were needed for the refinement path, where the pill is repainted:

- **`kind` is optional on a `tool_call_update`.** A kind-less refinement resolved to "not shell" and repainted the pill with the generic title the initial `tool_call` had already turned into a command. The cached classification is now resolved *before* the label rule and passed in explicitly via a new keyword `is_shell`, which overrides the kind-derived value in both directions.
- **A refinement can repeat the title without resending `rawInput`.** The command is now recovered from the params the initial `tool_call` cached, so a title-only refinement cannot blank out a good label either.

Both copies of the helper are updated — `acp/_dispatch.py` (`AcpRuntime`) and `acp/client.py` (`AcpClient`) — so the two transports keep the same rule.

No frontend change: `chat_runner` already paints whatever title the event carries and patches the persisted message in place, so fixing the event fixes the live pill and the reloaded transcript together.

## Tests

12 new tests across both transports, covering: a generic title yielding the command, `description` still outranking the command, a title that already held the command being a no-op, the shell-only guard for an fs tool, the resolved-flag override in both directions, a kind-less refinement inheriting the classification, and a title-only refinement reading the cached params.

Reverting only the two `src/` files makes **9 of them fail**, so they pin the behavior rather than describing it.

## Verification

- `pytest` — 55803 passed, 262 skipped, 6 xfailed, 0 failed
- `scripts/local-gate.py --base origin/main` — `all selected gates passed` (full backend + 136 cross-surface frontend guard specs, 3859 tests)
- `isort` / `flake8` — clean
- `mypy src/kiro_crew/` — clean, 982 source files (CI-parity venv: mypy matches the `pyproject.toml` pin, no faiss installed)
