### PR TITLE
refactor(chat): centralize send receipt parsing

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -39,6 +39,7 @@ import { ZoomProvider } from './hooks/ZoomProvider'
 import { api, isAuthBannerShown } from './api/client'
 import type { KiroCreditUsage, KiroUsagePayload } from './api/client'
 import { safeSetItem } from './utils/safeStorage'
+import { sendChatReceipt } from './utils/sendDelivery'
 import { gcOrphanedStorage } from './utils/storageGc'
 import { isMetricNumber, metricNumber } from './utils/metrics'
 import { Rocket, Menu, Bell, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, AudioWaveform, ChevronUp, MoreHorizontal, Coins, ArrowLeftToLine, LayoutGrid, Fullscreen, SquareTerminal, Bot, Search as SearchIcon } from 'lucide-react'
@@ -2116,11 +2117,13 @@ export default function App() {
       await api.chatSlotContext(slot, FEATURE_REQUEST_PROMPT_FALLBACK, { source: 'feature-request', maxAge: 60 })
     } catch { /* Send the visible request even if hidden context is unavailable. */ }
     try {
-      const r = await api.sendChat(visibleMessage, slot, colorTheme)
-      const body = await r.json().catch(() => ({}))
+      const receipt = await sendChatReceipt(await api.sendChat(visibleMessage, slot, colorTheme))
       // Resolution is not success: the server accepted neither `ok` nor
-      // `queued`, so no turn started and no WS response is coming.
-      if (!body.ok && !body.queued) reportFailedSend(typeof body.error === 'string' ? body.error : undefined)
+      // `queued`, so no turn started and no WS response is coming. Checked on
+      // `!accepted` rather than `refused` — an unreadable body (`.json()`
+      // itself throwing) is neither `ok` nor `queued` either, and must report
+      // the same way a readable refusal does.
+      if (!receipt.accepted) reportFailedSend(receipt.error)
     } catch { reportFailedSend() }
   }, [dispatch, navigate, colorTheme, appStore])
 

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -24,7 +24,7 @@ import { useAvailableModels } from '../hooks/useAvailableModels'
 import { useListboxKeyboard } from '../hooks/useListboxKeyboard'
 import { useAppSelector, useAppDispatch, store } from '../store'
 import { PANE_HYDRATE_LIMIT, retireStatelessQuestion, captureStatelessCard, capturePendingAskId, confirmOptimisticSend, selectSlotMessages, selectSlotStreamState, selectComposerBusy, hydrateSlotMessages, appendSlotMessage, requestStop, cancelQueuedMessage, setAgentSwitchNotice } from '../store/chatSlice'
-import { confirmedDelivered } from '../utils/sendDelivery'
+import { confirmedDelivered, sendChatReceipt } from '../utils/sendDelivery'
 import { triggerRefresh, updateSlot } from '../store/dashboardSlice'
 import { performSlotSwitch } from '../lib/slotSwitch'
 import { performAgentSlotSwitch } from '../lib/agentSwitch'
@@ -388,10 +388,10 @@ export default function ChatPane({
     api.sendChat(llm, slotKey, undefined, controller.signal, meta)
       .then(async (r) => {
         clearTimeout(timeout)
-        const body = await r.json().catch(() => ({}))
+        const body = await sendChatReceipt(r)
         // The server accepted neither `ok` nor `queued`, so nothing was sent.
         // Reported before the card logic below, which only runs on acceptance.
-        if (!body.ok && !body.queued) { reportFailedSend(body.error as string | undefined); return }
+        if (body.refused) { reportFailedSend(body.error); return }
         // A `queued` acceptance with no wire text is not an acceptance at all.
         // `chat_handlers` queues `if message:` but returns `{ok, queued}`
         // unconditionally, so an attachment-only send that raced the slot into

--- a/website/src/hooks/useSceneInteraction.tsx
+++ b/website/src/hooks/useSceneInteraction.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAppDispatch } from '../store'
 import { switchSlot } from '../store/chatSlice'
 import { api } from '../api/client'
+import { sendChatReceipt } from '../utils/sendDelivery'
 import type { AgentSource } from './useAgentSync'
 import { useImeGuard } from './useImeGuard'
 import { KIRO_GHOST_PIXELS } from './sceneText'
@@ -346,15 +347,18 @@ export function useSceneInteraction(
         await api.steerChat(msg, slotKey)
       } else {
         // Idle or waiting for input: start/continue the turn. `?ws=1` answers
-        // with a JSON receipt ({ok, queued, error}) and the turn itself streams
-        // over WS. An HTTP 4xx/5xx RESOLVES rather than rejecting, so the
-        // receipt must be read: without this check every refused send fell
+        // with a JSON receipt (read via sendChatReceipt) and the turn itself
+        // streams over WS. An HTTP 4xx/5xx RESOLVES rather than rejecting, so
+        // the receipt must be read: without this check every refused send fell
         // through to 'sent' below — the state asserting the opposite of what
-        // happened, for precisely the errors that matter.
-        const r = await api.sendChat(msg, slotKey)
-        const body = await r.json().catch(() => ({}))
-        if (!body.ok && !body.queued) {
-          reportFailedSend(typeof body.error === 'string' ? body.error : undefined)
+        // happened, for precisely the errors that matter. Checked on
+        // `!accepted` rather than `refused`: an unreadable body (a proxy error
+        // page where `.json()` itself throws) is neither `ok` nor `queued`
+        // either, and must report the same way a readable refusal does.
+        const response = await api.sendChat(msg, slotKey)
+        const receipt = await sendChatReceipt(response)
+        if (!receipt.accepted) {
+          reportFailedSend(receipt.error)
           return
         }
       }

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -34,7 +34,7 @@ import {
   requestSlotReveal,
   mcpAppKey,
 } from '../store/chatSlice'
-import { confirmedDelivered } from '../utils/sendDelivery'
+import { confirmedDelivered, sendChatReceipt } from '../utils/sendDelivery'
 import { addNotification, removeNotificationByTs } from '../store/notificationsSlice'
 import { onTerminalReady, sendToTerminalSession } from '../utils/terminalRegistry'
 import { addTab as addDockTerminal } from '../hooks/useBottomTerminal'
@@ -4329,8 +4329,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     try {
       const r = await api.sendChat(llmTxt, slot ?? undefined, colorThemeRef.current, controller.signal, metaPayload, steerNow)
       clearTimeout(timeout)
-      const body = await r.json().catch(() => ({}))
-      if (!body.queued && !body.ok) {
+      const body = await sendChatReceipt(r)
+      if (body.refused) {
         dispatch(setSlotRunning(false))
         dispatch(appendMessage({ role: 'error', content: body.error || i18nT('pages.chatPage.send_failed'), cls: '' }))
         // The server explicitly accepted neither (`ok` nor `queued`), so nothing
@@ -7608,4 +7608,3 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     </RowDisclosureProvider>
   )
 }
-

--- a/website/src/test/sendDelivery.test.ts
+++ b/website/src/test/sendDelivery.test.ts
@@ -14,7 +14,7 @@
  * is precisely what the 30s indicator is there to question.
  */
 import { describe, it, expect } from 'vitest'
-import { confirmedDelivered } from '../utils/sendDelivery'
+import { confirmedDelivered, sendChatReceipt } from '../utils/sendDelivery'
 
 describe('confirmedDelivered', () => {
   it('accepts an immediate dispatch', () => {
@@ -31,5 +31,28 @@ describe('confirmedDelivered', () => {
   it('refuses a rejection', () => {
     expect(confirmedDelivered({ ok: false })).toBe(false)
     expect(confirmedDelivered({})).toBe(false)
+  })
+})
+
+describe('sendChatReceipt', () => {
+  it('normalizes immediate and queued acceptances', async () => {
+    await expect(sendChatReceipt(new Response(JSON.stringify({ ok: true })))).resolves.toMatchObject({
+      accepted: true, ok: true, queued: false, refused: false, readable: true,
+    })
+    await expect(sendChatReceipt(new Response(JSON.stringify({ ok: true, queued: true })))).resolves.toMatchObject({
+      accepted: true, ok: true, queued: true, refused: false, readable: true,
+    })
+  })
+
+  it('normalizes an explicit refusal and its error', async () => {
+    await expect(sendChatReceipt(new Response(JSON.stringify({ ok: false, error: 'expired' })))).resolves.toMatchObject({
+      accepted: false, refused: true, readable: true, error: 'expired',
+    })
+  })
+
+  it('does not turn an unreadable receipt into an explicit refusal', async () => {
+    await expect(sendChatReceipt(new Response('{'))).resolves.toMatchObject({
+      accepted: false, refused: false, readable: false,
+    })
   })
 })

--- a/website/src/utils/sendDelivery.ts
+++ b/website/src/utils/sendDelivery.ts
@@ -23,3 +23,40 @@
 export function confirmedDelivered(body: { ok?: boolean; queued?: boolean }): boolean {
   return !!body.ok && !body.queued
 }
+
+export interface SendChatReceipt {
+  ok: boolean
+  queued: boolean
+  steered: boolean
+  accepted: boolean
+  refused: boolean
+  readable: boolean
+  error?: string
+}
+
+/** Parse the wire receipt once and keep an unreadable response distinct from an
+ * explicit `{ok: false, queued: false}` refusal. */
+export async function sendChatReceipt(response: Response): Promise<SendChatReceipt> {
+  let value: unknown
+  try {
+    value = await response.json()
+  } catch {
+    value = undefined
+  }
+
+  const readable = typeof value === 'object' && value !== null && !Array.isArray(value)
+  const body = readable ? value as Record<string, unknown> : {}
+  const ok = body.ok === true
+  const queued = body.queued === true
+  const accepted = ok || queued
+
+  return {
+    ok,
+    queued,
+    steered: body.steered === true,
+    accepted,
+    refused: readable && !accepted,
+    readable,
+    ...(typeof body.error === 'string' ? { error: body.error } : {}),
+  }
+}


### PR DESCRIPTION
## Motivation

`api.sendChat` returns a raw `Response`, so HTTP error responses resolve normally and each caller had to remember the receipt protocol. That duplicated parsing and made silent regressions easy.

## What changed

- add one normalized `sendChatReceipt` parser beside `confirmedDelivered`
- distinguish explicit refusal from an unreadable/unknown receipt
- migrate ChatPage, ChatPane, the feature-request flow, and scene interaction sends
- add coverage for immediate acceptance, queued acceptance, refusal, and malformed JSON

## Tests

- `npm exec vitest run src/test/sendDelivery.test.ts` (6 passed)
- `npm run typecheck`

## Screenshots

Not applicable; client receipt handling has no visual layout change.

Fixes #4239
