### PR TITLE
docs(remote): explain local gateway toggle prerequisite

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -675,6 +675,14 @@ A terminal-held tunnel dies with the terminal. A LaunchAgent survives reboots
 and reconnects after sleep. A ready-made plist is at
 [`assets/com.kirocrew.tunnel.plist`](assets/com.kirocrew.tunnel.plist):
 
+If the desktop app should act only as a client for this remote gateway, first
+bring up the tunnel and verify that it answers on the app's local port. Then turn
+off **Settings → Developer → Gateway → Run a local gateway**. Turning that switch
+off does not create or supervise a tunnel; on the next launch the app expects a
+gateway to already answer on port 5476. A connected entry on the Instances page
+does not satisfy this requirement because those tunnels are supervised by the
+local gateway itself and use separate loopback ports.
+
 ```bash
 cp docs/guides/assets/com.kirocrew.tunnel.plist ~/Library/LaunchAgents/
 sed -i '' 's|ALIAS@DEV_DESKTOP_HOSTNAME|user@your-host.example.com|g' \

--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -672,16 +672,19 @@ the browser holds, on the same clocks as [Session duration](#session-duration).
 ### Persistent SSH tunnel on macOS (LaunchAgent)
 
 A terminal-held tunnel dies with the terminal. A LaunchAgent survives reboots
-and reconnects after sleep. A ready-made plist is at
-[`assets/com.kirocrew.tunnel.plist`](assets/com.kirocrew.tunnel.plist):
+and reconnects after sleep.
 
-If the desktop app should act only as a client for this remote gateway, first
-bring up the tunnel and verify that it answers on the app's local port. Then turn
-off **Settings → Developer → Gateway → Run a local gateway**. Turning that switch
-off does not create or supervise a tunnel; on the next launch the app expects a
-gateway to already answer on port 5476. A connected entry on the Instances page
-does not satisfy this requirement because those tunnels are supervised by the
-local gateway itself and use separate loopback ports.
+If the desktop app should act only as a client for this remote gateway, turn off
+**Settings → Developer → Gateway → Run a local gateway**, then quit the app so
+its supervised gateway releases port 5476. Start the tunnel, verify the health
+probe below, and only then reopen the app. Turning the switch off does not create
+or supervise a tunnel; on the next launch the app expects a gateway to already
+answer on port 5476. A connected entry on the Instances page does not satisfy
+this requirement because those tunnels are supervised by the local gateway
+itself and use separate loopback ports.
+
+A ready-made plist is at
+[`assets/com.kirocrew.tunnel.plist`](assets/com.kirocrew.tunnel.plist):
 
 ```bash
 cp docs/guides/assets/com.kirocrew.tunnel.plist ~/Library/LaunchAgents/


### PR DESCRIPTION
## Problem / Motivation

The persistent SSH tunnel guide did not explain that the desktop app's supervised local gateway must be disabled when the app should act only as a client of the tunnel.

## Why it matters

Without the prerequisite and launch order, users can accidentally run a competing local gateway and misdiagnose tunnel connectivity or connect through the wrong mechanism.

## What changed (motivation → approach → change)

The guide now documents the required launch order and local-gateway toggle, clarifies that the toggle does not create or supervise the tunnel, and distinguishes the Connected Instance feature from the SSH-tunnel workflow.

## Tests

- `./scripts/docs-lint.sh` (212 Markdown files scanned; all checks passed)

## Manual verification

N/A — this is a documentation-only clarification and the documentation lint passes.

## Related Issues

Addresses #3810

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The repository's CLA placeholder remains pending OSPO wording.
