### PR TITLE
test(config): prevent generated baseline drift

### DIFF
--- a/test/test_config_baseline.py
+++ b/test/test_config_baseline.py
@@ -81,6 +81,17 @@ class TestBaselineGenerator:
             SCHEMA_REGISTRY
         ), f"Expected {len(SCHEMA_REGISTRY)} entries, got {len(data['entries'])}"
 
+    def test_committed_baseline_matches_generator(self, tmp_path: str) -> None:
+        """The tracked artifact must not drift from the schema registry again."""
+        generated = _run_generator(tmp_path)
+        with open(os.path.join(_REPO_ROOT, "config-baseline.json"), encoding="utf-8") as f:
+            committed = json.load(f)
+
+        assert committed == generated, (
+            "config-baseline.json is stale; run "
+            "`python scripts/generate_config_baseline.py` and commit the result"
+        )
+
     def test_entries_have_expected_fields(self, tmp_path: str) -> None:
         """Each entry dict has all expected ConfigEntry fields."""
         data = _run_generator(tmp_path)


### PR DESCRIPTION
## Problem / Motivation

The generated `config-baseline.json` previously drifted from the settings registry. Although the current artifact has since been corrected upstream, no test prevents the same drift from recurring.

## Why it matters

An outdated committed baseline publishes incorrect defaults and can make downstream configuration checks silently validate against stale data.

## What changed (motivation → approach → change)

Add a regression test that runs the canonical baseline generator and compares its parsed output with the committed `config-baseline.json`. The failure message identifies the exact regeneration command.

## Tests

- `PYTHONPATH=src python3 -m pytest -q -o addopts='' test/test_config_baseline.py` (11 passed)

## Manual verification

N/A — the new test exercises the production generator and tracked artifact directly.

## Related Issues

Follow-up to #2862

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — test-only change)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository placeholder; no CLA text has been supplied.
