### PR TITLE
test(ui): pin chat gutter scan coverage

### DIFF
--- a/website/src/test/narrowFirstBaseline.test.ts
+++ b/website/src/test/narrowFirstBaseline.test.ts
@@ -258,6 +258,7 @@ describe('narrow-first layout baseline', () => {
     const CONTENT_WIDTH_VAR = '--mc-content-width'
     const NEAR = 200
     const offenders: string[] = []
+    const matchedWrappers: string[] = []
     for (const { file, src } of await SOURCES) {
       for (const m of src.matchAll(/className=(?:"([^"]*)"|\{`([^`]*)`\})/g)) {
         const tokens = (m[1] ?? m[2] ?? '').split(/\s+/)
@@ -265,6 +266,7 @@ describe('narrow-first layout baseline', () => {
         const near = src.slice(Math.max(0, m.index! - NEAR), m.index! + m[0].length + NEAR)
         if (!near.includes(CONTENT_WIDTH_VAR)) continue
         const px = tokens.find((t) => /^px-\d+(?:\.\d+)?$/.test(t))
+        if (px) matchedWrappers.push(file.slice(SRC.length + 1))
         if (px && px !== `px-${gutter![1]}`) {
           offenders.push(`${file.slice(SRC.length + 1)}: ${px}`)
         }
@@ -276,6 +278,16 @@ describe('narrow-first layout baseline', () => {
         + `${CONTENT_WIDTH_VAR}) but do not carry its gutter (px-${gutter![1]}), so they `
         + `render a second left edge inside one column`,
     ).toEqual([])
+    // The proximity scan is intentionally structural rather than a named-file
+    // allowlist, but that means a refactor can move the width declaration beyond
+    // NEAR (or into CSS) and silently make a wrapper disappear. Pin the measured
+    // floor so coverage shrinkage is an explicit review decision rather than a
+    // green test that now checks fewer surfaces.
+    expect(
+      matchedWrappers.length,
+      `the ${CONTENT_WIDTH_VAR} proximity scan covered fewer chat-column wrappers; `
+        + `inspect the moved wrappers before lowering this floor`,
+    ).toBeGreaterThanOrEqual(16)
   })
 
   it('lands the top bar glyphs on the page gutter, derived not hand-typed', async () => {


### PR DESCRIPTION
## Problem / Motivation

The narrow-first layout regression test verified matching wrappers but did not enforce how much of the chat column its proximity scan covered. A selector move could therefore shrink the scan to a trivial subset without failing.

## Why it matters

Silent erosion of this test would allow narrow-viewport gutter regressions to return across chat surfaces while preserving a misleading green check.

## What changed (motivation → approach → change)

Count chat-column wrappers that carry the content-width variable, require the scan to cover the current 16-wrapper baseline, and provide an actionable failure message when that floor drops.

## Tests

- `npm exec -- vitest run src/test/narrowFirstBaseline.test.ts` (8 passed)

## Manual verification

N/A — this is a regression-test-only change and the complete affected test file passes.

## Related Issues

Fixes #4224

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — test-only change)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository placeholder; no CLA text has been supplied.
