### PR TITLE
fix: recover Windows desktop gateway ports

### DIFF
--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -290,6 +290,13 @@ stay Windows-skipped in `test/windows-expected-failures.txt`.
 
 ## Troubleshooting
 
+- **Desktop gateway recovery refuses to force-stop the port** - the Electron
+  launcher uses `netstat -ano` to identify the listener, PowerShell
+  (`Get-CimInstance`) with a WMIC fallback to read its command line, and
+  `taskkill /F /PID` only after confirming a Kiro Crew executable or
+  `python -m kiro_crew` process. Localized listener-state text is ignored.
+  SSH forwards and unrelated processes are never terminated, and a failed or
+  timed-out `netstat` probe is treated as unknown rather than as a free port.
 - **`ModuleNotFoundError: No module named 'fcntl'`** — you installed a
   branch/commit that predates the Windows port. `fcntl` is a Unix-only Python
   stdlib module; it cannot be pip-installed on Windows. Update to a build that

--- a/website/electron/gateway-recovery.js
+++ b/website/electron/gateway-recovery.js
@@ -145,12 +145,97 @@ async function waitForProcessExit({ pids, isAlive, sleep, timeoutMs = INCUMBENT_
   }
 }
 
+// Capture listener PIDs while the port is still bound. The draining process may
+// release its socket before dropping gateway.lock, so recovery needs its PID to
+// wait for process exit rather than treating "port free" as "lock free". A null
+// result means the snapshot is unsafe: the probe failed or the listener vanished
+// before it could be captured.
+async function snapshotPortPids({
+  port,
+  isWindows = false,
+  getWindowsPids,
+  getPosixPids,
+}) {
+  const getListenPids = isWindows ? getWindowsPids : getPosixPids;
+  if (typeof getListenPids !== "function") return null;
+  try {
+    const pids = await getListenPids(port);
+    return Array.isArray(pids) && pids.length ? pids : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Does an unusable incumbent snapshot have to stop an automatic respawn?
+ *
+ * A `null` snapshot means the listener probe could not name the draining
+ * process. On Windows that is anomalous — netstat ships in-box — so recovery
+ * fails closed rather than respawning into the incumbent's `gateway.lock`. On
+ * POSIX a missing or blocked `lsof` degrades to a no-op wait, and the
+ * replacement's own lock refusal is an honest arbiter, so a host without `lsof`
+ * must still be able to boot.
+ */
+function incumbentSnapshotBlocksRespawn({ pids, isWindows = false }) {
+  return pids === null && isWindows;
+}
+
+/**
+ * Build the terminal recovery dialog without loading Electron.
+ *
+ * @param {object} o
+ * @param {number|string} o.port
+ * @param {"wedged"|"held"} [o.variant]
+ * @param {boolean} [o.probeFailed]
+ * @param {boolean} [o.isPrimaryWindow]
+ * @returns {{
+ *   title:string, message:string, portConflict:false,
+ *   primaryAction:"quit", primaryLabel:string, showQuitButton:false
+ * }}
+ */
+function unrecoverableGatewayDialog({
+  port,
+  variant = "wedged",
+  probeFailed = false,
+  isPrimaryWindow = false,
+}) {
+  const held = variant === "held";
+  return {
+    title: probeFailed
+      ? `Kiro Crew: can't verify what's using port ${port}`
+      : held
+        ? `Kiro Crew: port ${port} is in use`
+        : `Kiro Crew: backend stuck on port ${port}`,
+    message: probeFailed
+      ? `Kiro Crew could not verify which process owns port ${port}, so it did not `
+        + `risk terminating an unrelated process or starting a second gateway. `
+        + `Quit and reopen Kiro Crew to try again. If the port is still blocked, `
+        + `restart your computer.`
+      : held
+        ? `Another process is holding port ${port}, so Kiro Crew can't reconnect to `
+          + `it or start its own backend there. Quit the process using port ${port} `
+          + `(the launch log below names it; look for the "port-owner:" line), `
+          + `then reopen this app.`
+        : `The Kiro Crew backend is wedged and cannot be stopped. It is in an `
+          + `uninterruptible state and is still holding port ${port}, so it can't be `
+          + `force-stopped or restarted in place. Restart your computer to clear it. `
+          + `(This is a known backend hang; see the launch log below for the cause.)`,
+    portConflict: false,
+    primaryAction: "quit",
+    primaryLabel: isPrimaryWindow ? "Quit Kiro Crew" : "Close",
+    showQuitButton: false,
+  };
+}
+
 module.exports = {
   chooseRecoveryStrategy,
   classifyAdoptedGateway,
   GATEWAY_OWNERSHIP_STATES,
   waitForServiceRebind,
   waitForProcessExit,
+  snapshotPortPids,
+  incumbentSnapshotBlocksRespawn,
+  unrecoverableGatewayDialog,
   SERVICE_REBIND_GRACE_MS,
   INCUMBENT_EXIT_GRACE_MS,
 };

--- a/website/electron/gateway-stop.js
+++ b/website/electron/gateway-stop.js
@@ -14,19 +14,115 @@ const http = require("http");
 const fs = require("fs");
 const path = require("path");
 
-// The single definition of "this LISTEN owner is one of ours". Shared by
-// forceStopPort (which may only ever SIGKILL our own processes) and
-// classifyPortOwner (which may only ever authorise an eviction of one).
-// Keep it in one place: a drift between the two would let one of them
-// mis-target a stranger's process.
-// Match a Kiro Crew PROCESS from a command line, not a mere path substring.
-// Two shapes only: the `kirocrew`/`kirocrew-backend` executable as a command
-// token (optionally `.exe`, ending at whitespace/quote/EOL — so a
-// `/Users/kirocrew/…` or `C:\Users\kirocrew\other.exe` user directory does NOT
-// match), or the `-m kiro_crew` python-module invocation. Anything else (an ssh
-// forward, an unrelated app under a `kirocrew` home dir) is foreign.
-const KIROCREW_PROC_RE =
-  /(?:^|[\s"'/\\])kirocrew(?:-backend)?(?:\.exe)?(?=$|[\s"'])|-m\s+kiro_crew(?=$|[\s"'.])/i;
+const KIROCREW_EXE_NAMES = new Set(["kirocrew", "kirocrew-backend"]);
+const PYTHON_EXE_RE = /^(?:python(?:\d+(?:\.\d+)*)?w?|py)$/i;
+
+function commandLineTokens(commandLine) {
+  const tokens = [];
+  const input = String(commandLine || "").replace(/^\s*CommandLine=/i, "").trim();
+  const tokenRe = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let match;
+  while ((match = tokenRe.exec(input)) !== null) {
+    tokens.push(match[1] ?? match[2] ?? match[3]);
+  }
+  return tokens;
+}
+
+function executableName(token) {
+  const basename = String(token || "").replace(/\\/g, "/").split("/").pop().toLowerCase();
+  return basename.endsWith(".exe") ? basename.slice(0, -4) : basename;
+}
+
+function normalizedWindowsPath(token) {
+  return String(token || "").replace(/\//g, "\\").toLowerCase();
+}
+
+function normalizedWindowsAbsolutePath(token) {
+  const value = String(token || "").replace(/\//g, "\\");
+  if (!/^(?:[A-Za-z]:\\|\\\\)/.test(value)) return "";
+  return path.win32.normalize(value).toLowerCase();
+}
+
+/**
+ * Resolve the executable selector a command line starts with.
+ *
+ * A POSIX `ps -o command=` line is unquoted, so an executable path containing a
+ * space arrives split across tokens: an install under `/Users/Jane Doe/...`
+ * would otherwise resolve to the executable name "jane" and classify our own
+ * gateway as foreign. Rejoin leading tokens while they can still be path
+ * continuations, and stop at the first option (`-x`) or second absolute path, so
+ * a later ARGUMENT can never pose as the executable.
+ *
+ * @returns {{name:string, next:number}} the selector's executable name and the
+ *   index of the first token after it.
+ */
+function executableSelector(tokens) {
+  const first = tokens[0] || "";
+  const fallback = { name: executableName(first), next: 1 };
+  if (!first.startsWith("/")) return fallback;
+  let candidate = first;
+  for (let index = 1; ; index++) {
+    const name = executableName(candidate);
+    if (KIROCREW_EXE_NAMES.has(name) || PYTHON_EXE_RE.test(name)) return { name, next: index };
+    const token = tokens[index];
+    if (token === undefined || token.startsWith("-") || token.startsWith("/")) return fallback;
+    candidate += ` ${token}`;
+  }
+}
+
+/**
+ * Match only a Kiro Crew executable, or a Python process whose first execution
+ * selector invokes the `kiro_crew` module or a Kiro Crew script. Later process
+ * arguments never establish ownership, so SSH aliases and unrelated script
+ * arguments cannot authorize a kill. Absolute Windows executables must also
+ * match the exact path selected by the launch resolver.
+ */
+function isKirocrewCommand(commandLine, { trustedExecutablePaths = [] } = {}) {
+  const tokens = commandLineTokens(commandLine);
+  if (!tokens.length) return false;
+
+  const windowsExecutablePath = normalizedWindowsAbsolutePath(tokens[0]);
+  if (windowsExecutablePath) {
+    const trusted = new Set(
+      trustedExecutablePaths
+        .map(normalizedWindowsAbsolutePath)
+        .filter(Boolean)
+    );
+    if (!trusted.has(windowsExecutablePath)) return false;
+  }
+
+  const selector = windowsExecutablePath
+    ? { name: executableName(tokens[0]), next: 1 }
+    : executableSelector(tokens);
+  if (KIROCREW_EXE_NAMES.has(selector.name)) return true;
+  if (!PYTHON_EXE_RE.test(selector.name)) return false;
+
+  let index = selector.next;
+  // Windows process identity prefixes ExecutablePath to the OS command line.
+  // Skip that exact duplicate without skipping a Python-named script argument.
+  if (normalizedWindowsPath(tokens[index]) === normalizedWindowsPath(tokens[0])) {
+    index += 1;
+  }
+
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (token === "-m") return tokens[index + 1] === "kiro_crew";
+    if (token === "-c" || token === "-") return false;
+    if (token === "--") {
+      index += 1;
+      break;
+    }
+    if (token === "-W" || token === "-X") {
+      index += 2;
+      continue;
+    }
+    if (!token.startsWith("-")) break;
+    index += 1;
+  }
+
+  const script = tokens[index];
+  return /[\\/]/.test(script || "") && KIROCREW_EXE_NAMES.has(executableName(script));
+}
 
 // A gateway whose parent is init (PID 1) is owned by the OS service manager —
 // a launchd LaunchAgent on macOS, a systemd unit on Linux — not by this app.
@@ -163,6 +259,9 @@ async function stopGatewayGracefully(
  * `freed === false` means a respawn would just fail to bind — the caller MUST
  * NOT respawn; it should tell the user a restart is required (`survivors`, an
  * unkillable wedge) or that another app holds the port (`foreignHolder`).
+ * With `failClosedOnProbeError`, an unavailable owner probe returns
+ * `probeFailed:true, freed:false` instead of throwing or claiming the port is
+ * free. Windows uses this because netstat failures must block a blind respawn.
  *
  * All side effects are injected so this is unit-testable without Electron or a
  * real OS process:
@@ -171,7 +270,7 @@ async function stopGatewayGracefully(
  *   - kill(pid, signal)                          (process.kill; may throw)
  *   - sleep(ms)           -> Promise<void>
  *
- * @returns {Promise<{killed:number, freed:boolean, survivors:number[], foreignHolder:boolean}>}
+ * @returns {Promise<{killed:number, freed:boolean, survivors:number[], foreignHolder:boolean, probeFailed?:boolean}>}
  */
 async function forceStopPort(
   port,
@@ -181,13 +280,24 @@ async function forceStopPort(
     kill,
     sleep,
     getPpid = null,
-    isKirocrew = KIROCREW_PROC_RE,
+    isKirocrew = isKirocrewCommand,
     verifyTimeoutMs = 4000,
     pollIntervalMs = 250,
+    failClosedOnProbeError = false,
     log = () => {},
   }
 ) {
-  const owners = await getListenPids(port);
+  let owners;
+  try {
+    owners = await getListenPids(port);
+  } catch (e) {
+    if (!failClosedOnProbeError) throw e;
+    log(`force-stop: LISTEN probe failed on :${port} (${e && e.message})`);
+    return {
+      killed: 0, freed: false, survivors: [], foreignHolder: false,
+      serviceHolder: false, probeFailed: true,
+    };
+  }
   if (!owners.length) {
     log(`force-stop: no LISTEN owner found on :${port}`);
     return { killed: 0, freed: true, survivors: [], foreignHolder: false, serviceHolder: false };
@@ -199,7 +309,8 @@ async function forceStopPort(
   let serviceHolder = false;
   for (const pid of owners) {
     const cmd = (await getCommand(pid)).trim();
-    if (isKirocrew.test(cmd)) {
+    const ours = isKirocrew(cmd);
+    if (ours) {
       // A service-managed gateway is respawned by launchd/systemd the moment we
       // kill it, so evicting it cannot free the port — it only makes the retry
       // race the respawn. Leave it alone and tell the caller why.
@@ -209,7 +320,7 @@ async function forceStopPort(
         continue;
       }
       try {
-        kill(pid, "SIGKILL");
+        await kill(pid, "SIGKILL");
         targets.push(pid);
         log(`force-stop: SIGKILL pid=${pid} (${cmd.slice(0, 80)})`);
       } catch (e) {
@@ -231,7 +342,16 @@ async function forceStopPort(
   while (survivors.length && waited < deadline) {
     await sleep(pollIntervalMs);
     waited += pollIntervalMs;
-    remaining = new Set(await getListenPids(port));
+    try {
+      remaining = new Set(await getListenPids(port));
+    } catch (e) {
+      if (!failClosedOnProbeError) throw e;
+      log(`force-stop: verify LISTEN probe failed on :${port} (${e && e.message})`);
+      return {
+        killed, freed: false, survivors: [], foreignHolder: false,
+        serviceHolder, probeFailed: true,
+      };
+    }
     survivors = survivors.filter((pid) => remaining.has(pid));
   }
 
@@ -239,7 +359,16 @@ async function forceStopPort(
   // loop above didn't re-probe — do one explicit check so `freed` reflects the
   // real port state instead of vacuously claiming free because WE killed nothing.
   if (!targets.length) {
-    remaining = new Set(await getListenPids(port));
+    try {
+      remaining = new Set(await getListenPids(port));
+    } catch (e) {
+      if (!failClosedOnProbeError) throw e;
+      log(`force-stop: verify LISTEN probe failed on :${port} (${e && e.message})`);
+      return {
+        killed, freed: false, survivors: [], foreignHolder: false,
+        serviceHolder, probeFailed: true,
+      };
+    }
   }
 
   // `freed` means the port is genuinely free, NOT just "our targets died". A
@@ -272,7 +401,7 @@ async function forceStopPort(
  *
  * Deliberately fail-safe: every outcome except a positively identified local
  * KiroCrew process is a reason NOT to evict.
- *   "kirocrew" — a local LISTEN owner matching KIROCREW_PROC_RE. Only this
+ *   "kirocrew" — a local LISTEN owner matching isKirocrewCommand. Only this
  *                value may authorise a takeover.
  *   "foreign"  — a local LISTEN owner exists but is not ours (e.g. `ssh`).
  *   "none"     — nothing is listening locally, yet something answered. A race,
@@ -291,7 +420,7 @@ async function forceStopPort(
  */
 async function classifyPortOwner(
   port,
-  { getListenPids, getCommand, getPpid = null, isKirocrew = KIROCREW_PROC_RE, log = () => {} }
+  { getListenPids, getCommand, getPpid = null, isKirocrew = isKirocrewCommand, log = () => {} }
 ) {
   let pids;
   try {
@@ -306,7 +435,8 @@ async function classifyPortOwner(
   }
   for (const pid of pids) {
     const cmd = (await getCommand(pid)).trim();
-    if (isKirocrew.test(cmd)) {
+    const ours = isKirocrew(cmd);
+    if (ours) {
       if (await isServiceManaged(pid, getPpid)) {
         log(`port-owner: :${port} held by SERVICE-MANAGED KiroCrew pid=${pid} (${cmd.slice(0, 80)}) — reuse, never evict`);
         return "service";
@@ -344,6 +474,6 @@ module.exports = {
   forceStopPort,
   classifyPortOwner,
   isServiceManaged,
-  KIROCREW_PROC_RE,
+  isKirocrewCommand,
   INIT_PPID,
 };

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -27,7 +27,18 @@ const {
   shouldOfferRelocation,
   describeLocation,
 } = require("./bundle-location");
-const { stopGatewayGracefully: _stopGatewayGracefully, forceStopPort, classifyPortOwner } = require("./gateway-stop");
+const {
+  stopGatewayGracefully: _stopGatewayGracefully,
+  forceStopPort,
+  classifyPortOwner,
+  isKirocrewCommand,
+} = require("./gateway-stop");
+const {
+  windowsGatewayExecutablePaths,
+  windowsListenPids,
+  windowsProcessCommand,
+  windowsTaskkill,
+} = require("./windows-port");
 const { waitForGateway, describeGatewayFailure, tailLines, isPortInUse } = require("./gateway-wait");
 const { describeSandboxProfileNeed } = require("./sandbox-profile");
 const { sanitizeWindowState, captureWindowState } = require("./window-state");
@@ -40,7 +51,15 @@ const {
   setGlobalHotkeyLogger,
 } = require("./global-hotkey");
 const { createLivenessMonitor } = require("./gateway-liveness");
-const { chooseRecoveryStrategy, classifyAdoptedGateway, waitForServiceRebind, waitForProcessExit } = require("./gateway-recovery");
+const {
+  chooseRecoveryStrategy,
+  classifyAdoptedGateway,
+  waitForServiceRebind,
+  waitForProcessExit,
+  snapshotPortPids,
+  incumbentSnapshotBlocksRespawn,
+  unrecoverableGatewayDialog,
+} = require("./gateway-recovery");
 const { capturePySpyDump } = require("./pyspy-dump");
 const { createMetricsRecorder } = require("./perf-metrics");
 const { identityFamily, decideGatewayAction, classifyGatewayReadiness, FAMILY_META, HEALTH_IDENTITY_PATH, READY_PATH } = require("./instance-guard");
@@ -280,10 +299,6 @@ let gatewayProcess = null;
 //                      rebind grace before spawning locally — spawning
 //                      immediately races the manager for the bind and one side
 //                      dies with EADDRINUSE.
-// KNOWN RESIDUAL (Windows): classifyPortOwner cannot positively identify
-// owners there (no lsof/ps), so the reused-* states never set and an adopted
-// draining gateway still falls into the indefinite "reconnect" wait —
-// deliberately conservative until the Windows-native owner probe lands.
 let gatewayOwnership = "none";
 // Post-handoff backend liveness monitor (primary window only). Detects a wedged
 // gateway — alive TCP socket, frozen event loop — that the spawn 'exit' watcher
@@ -401,11 +416,28 @@ function quitOtherApp(appName) {
 // Function declarations are hoisted, so the helpers defined further down this
 // file are available here.
 //
-// On Windows there is no lsof/ps, so classifyPortOwner returns "unknown" and
-// the caller reuses the port rather than force-killing an owner it cannot
-// identify. A Windows-native netstat/taskkill owner probe is a follow-up
-// (tracked separately) — it needs runtime verification on real Windows.
+function isTrustedWindowsGatewayCommand(command) {
+  const gatewayBin = findKirocrewBin(
+    fs,
+    os,
+    path,
+    process.resourcesPath,
+    __dirname
+  );
+  return isKirocrewCommand(command, {
+    trustedExecutablePaths: windowsGatewayExecutablePaths(gatewayBin),
+  });
+}
+
 function probeGatewayPortOwner(port) {
+  if (IS_WIN) {
+    return classifyPortOwner(port, {
+      getListenPids: windowsListenPids,
+      getCommand: windowsProcessCommand,
+      isKirocrew: isTrustedWindowsGatewayCommand,
+      log: glog,
+    });
+  }
   return classifyPortOwner(port, {
     getListenPids: _lsofListenPids,
     getCommand: _psCommand,
@@ -421,12 +453,22 @@ function _pidAlive(pid) {
   catch (e) { return !!(e && e.code === "EPERM"); }
 }
 
-// Best-effort capture of the pids LISTENing on our port, for the incumbent-exit
-// wait below. Must be called while the port is still bound — after it clears,
-// lsof can no longer name the draining process. Empty on probe failure or
-// Windows (no lsof): the exit wait then degrades to a no-op, same as today.
-async function snapshotPortPids(port) {
-  try { return await _lsofListenPids(port); } catch { return []; }
+// Best-effort capture of the PIDs LISTENing on our port, for the incumbent-exit
+// wait below. It must happen while the port is still bound: after it clears,
+// neither lsof nor netstat can name the draining process.
+function snapshotGatewayPortPids(port) {
+  return snapshotPortPids({
+    port,
+    isWindows: IS_WIN,
+    getWindowsPids: windowsListenPids,
+    getPosixPids: _lsofListenPids,
+  });
+}
+
+// A snapshot the probe could not take blocks an automatic respawn only where a
+// working probe is guaranteed (see incumbentSnapshotBlocksRespawn).
+function unverifiedIncumbent(pids) {
+  return incumbentSnapshotBlocksRespawn({ pids, isWindows: IS_WIN });
 }
 
 // A draining gateway releases its LISTEN socket EARLY but holds the exclusive
@@ -506,7 +548,11 @@ async function resolveGatewayConflict(rebindDepth = 0) {
       sendStatus("Waiting for the previous gateway to exit…");
       // Capture the draining process NOW, while it still owns the LISTEN
       // socket — needed below to wait out its gateway.lock after the port clears.
-      const drainingPids = await snapshotPortPids(PORT);
+      const drainingPids = await snapshotGatewayPortPids(PORT);
+      if (unverifiedIncumbent(drainingPids)) {
+        glog(`drain: could not capture the incumbent PID on :${PORT} — refusing an automatic respawn that could race gateway.lock`);
+        return "probe-failed";
+      }
       if (await waitForPortFree()) {
         if (localOwner === "service") {
           // A SERVICE-classified holder that released its port may be mid-restart
@@ -693,6 +739,13 @@ function startGateway() {
         // channel app triggers the takeover prompt.
         const outcome = await resolveGatewayConflict();
         if (outcome === "reuse") { resolve(true); return; }
+        if (outcome === "probe-failed") {
+          gatewayStartFailure = {
+            error: `could not verify the previous gateway process on port ${PORT}`,
+          };
+          resolve(false);
+          return;
+        }
         if (outcome === "abort") {
           isQuitting = true;
           app.quit();
@@ -2142,7 +2195,19 @@ function fadeLoadingScreen(wc, timeoutMs = 8000) {
  * @returns {Promise<'retry'|'force-retry'|'reveal'|'quit'>}
  */
 function showGatewayErrorDialog(parentWin, opts) {
-  const { title, message, logTail, logPath, portConflict, noRetry = false, localGatewayOff = false } = opts;
+  const {
+    title,
+    message,
+    logTail,
+    logPath,
+    portConflict,
+    noRetry = false,
+    localGatewayOff = false,
+    primaryAction: configuredPrimaryAction,
+    primaryLabel: configuredPrimaryLabel,
+    showQuitButton: configuredShowQuitButton,
+  } = opts;
+  const showQuitButton = configuredShowQuitButton ?? !noRetry;
   return new Promise((resolve) => {
     const dark = nativeTheme.shouldUseDarkColors;
     const hasParent = parentWin && !parentWin.isDestroyed();
@@ -2162,8 +2227,10 @@ function showGatewayErrorDialog(parentWin, opts) {
     // can't clear a port conflict, so offer force-stop instead. A TERMINAL
     // caller (one that quits on every action) passes noRetry — showing a
     // "Retry" button it would ignore contradicts the dialog's own message.
-    const primaryAction = noRetry ? "quit" : (portConflict ? "force-retry" : "retry");
-    const primaryLabel = noRetry ? "Quit" : (portConflict ? "Force-stop &amp; Retry" : "Retry");
+    const primaryAction = configuredPrimaryAction
+      || (noRetry ? "quit" : (portConflict ? "force-retry" : "retry"));
+    const primaryLabel = configuredPrimaryLabel
+      || (noRetry ? "Quit" : (portConflict ? "Force-stop & Retry" : "Retry"));
     // A client-only install whose remote is unreachable needs an in-app way to
     // change its mind: Settings lives inside the dashboard, which a gateway has
     // to serve, so the page holding the switch is exactly what it cannot reach.
@@ -2196,10 +2263,10 @@ function showGatewayErrorDialog(parentWin, opts) {
       <div class="pathline">${esc(logPath)}</div>
       <pre class="log">${esc(logTail || "(launch log is empty)")}</pre>
       <div class="row">
-        <button class="ok" onclick="act('${primaryAction}')">${primaryLabel}</button>
+        <button class="ok" onclick="act('${primaryAction}')">${esc(primaryLabel)}</button>
         ${enableButton}
         <button class="cancel" onclick="act('reveal')">Reveal Log</button>
-        ${noRetry ? "" : `<button class="cancel" onclick="act('quit')">Quit</button>`}
+        ${showQuitButton ? '<button class="cancel" onclick="act(\'quit\')">Quit</button>' : ""}
       </div>
       <script>
         function act(a){ document.title = 'mc-action:' + a; window.close(); }
@@ -2278,6 +2345,19 @@ function _psPpid(pid) {
  * @returns {Promise<{killed:number, freed:boolean, survivors:number[]}>}
  */
 function forceStopGatewayPort(port) {
+  if (IS_WIN) {
+    return forceStopPort(port, {
+      getListenPids: windowsListenPids,
+      getCommand: windowsProcessCommand,
+      kill: (pid) => windowsTaskkill(pid, {
+        isTrustedCommand: isTrustedWindowsGatewayCommand,
+      }),
+      sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+      isKirocrew: isTrustedWindowsGatewayCommand,
+      failClosedOnProbeError: true,
+      log: glog,
+    });
+  }
   return forceStopPort(port, {
     getListenPids: _lsofListenPids,
     getCommand: _psCommand,
@@ -2360,7 +2440,8 @@ async function recoverWedgedGateway(win) {
   gatewayProcess = null;
   let freed = true;
   let foreignHolder = false;
-  try { ({ freed, foreignHolder } = await forceStopGatewayPort(PORT)); }
+  let probeFailed = false;
+  try { ({ freed, foreignHolder, probeFailed = false } = await forceStopGatewayPort(PORT)); }
   catch (e) {
     // We couldn't even probe the port (lsof failed to exec). Don't silently
     // assume freed — let the respawn's bind be the arbiter, but say so loudly.
@@ -2372,8 +2453,10 @@ async function recoverWedgedGateway(win) {
   // recovered — show the honest error path so the user learns a restart (or
   // freeing the other app) is required.
   if (!freed) {
-    glog(`liveness: port still held after force-stop (${foreignHolder ? "foreign holder" : "unkillable wedge"}); surfacing restart-required`);
-    return showUnrecoverableGatewayError(win, PORT);
+    const reason = probeFailed ? "probe failed"
+      : (foreignHolder ? "foreign holder" : "unkillable wedge");
+    glog(`liveness: port not confirmed free after force-stop (${reason}); surfacing restart-required`);
+    return showUnrecoverableGatewayError(win, PORT, { probeFailed });
   }
   gatewayStartFailure = null; // re-arm so waitForGateway doesn't fail-fast on the kill we just did
   await startGateway(); // spawn a fresh child before re-waiting
@@ -2453,7 +2536,11 @@ async function reconnectOrRespawnAdoptedGateway(win) {
   sendStatus("Waiting for the previous gateway to exit…");
   // Capture the incumbent NOW, while it may still own the LISTEN socket —
   // needed below to wait out its gateway.lock after the port clears.
-  const incumbentPids = await snapshotPortPids(PORT);
+  const incumbentPids = await snapshotGatewayPortPids(PORT);
+  if (unverifiedIncumbent(incumbentPids)) {
+    glog(`liveness: could not capture the incumbent PID on :${PORT} — refusing an automatic respawn that could race gateway.lock`);
+    return showUnrecoverableGatewayError(win, PORT, { probeFailed: true });
+  }
   if (!(await waitForPortFree())) {
     glog(`liveness: :${PORT} still held by a process we did not spawn — surfacing port-held instead of waiting forever`);
     // No stop was attempted on this path (the holder is not ours to evict), so
@@ -2505,7 +2592,7 @@ async function reconnectOrRespawnAdoptedGateway(win) {
 }
 
 /**
- * Terminal state, two variants:
+ * Terminal state, three variants:
  *  - "wedged" (default): a force-stop was actually attempted and the holder
  *    survived it (uninterruptible kernel sleep). Only a machine restart clears
  *    it, and the copy says so.
@@ -2514,32 +2601,28 @@ async function reconnectOrRespawnAdoptedGateway(win) {
  *    gateway that grabbed the port). No stop was attempted — telling the user
  *    to reboot would be false and needlessly heavy; quitting the holder and
  *    relaunching suffices.
+ *  - probeFailed: ownership could not be verified, so no process was terminated.
+ *    Ask the user to reopen first and restart only if the port remains blocked.
  */
-async function showUnrecoverableGatewayError(win, port, variant = "wedged") {
+async function showUnrecoverableGatewayError(win, port, options = {}) {
+  const { variant = "wedged", probeFailed = false } = typeof options === "string"
+    ? { variant: options }
+    : options;
   if (!win || win.isDestroyed()) return;
   let logTail = "";
   try { logTail = tailLines(fs.readFileSync(gatewayLogPath(), "utf8"), 60); } catch { /* no log yet */ }
-  const wedged = variant === "wedged";
   const action = await showGatewayErrorDialog(win, {
-    title: wedged
-      ? `Kiro Crew — backend stuck on port ${port}`
-      : `Kiro Crew — port ${port} is in use`,
-    message: wedged
-      ? `The Kiro Crew backend is wedged and cannot be stopped — it is in an `
-        + `uninterruptible state and is still holding port ${port}, so it can't be `
-        + `force-stopped or restarted in place. Restart your computer to clear it. `
-        + `(This is a known backend hang; see the launch log below for the cause.)`
-      : `Another process is holding port ${port}, so Kiro Crew can't reconnect to `
-        + `it or start its own backend there. Quit the process using port ${port} `
-        + `(the launch log below names it — look for the "port-owner:" line), `
-        + `then reopen this app.`,
+    ...unrecoverableGatewayDialog({
+      port,
+      variant,
+      probeFailed,
+      isPrimaryWindow: win === mainWindow,
+    }),
     logTail,
     logPath: gatewayLogPath(),
-    portConflict: false,
-    // This caller is TERMINAL — it quits on every action — so never render a
-    // "Retry" primary it would ignore: the truthful primary here is Quit.
-    noRetry: true,
     port,
+    // This caller is terminal and quits on every action.
+    noRetry: true,
   });
   if (win.isDestroyed()) return;
   if (action === "reveal") {
@@ -2711,14 +2794,15 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
       }
       if (action === "force-retry") {
         let freed = true;
-        try { ({ freed } = await forceStopGatewayPort(PORT)); }
+        let probeFailed = false;
+        try { ({ freed, probeFailed = false } = await forceStopGatewayPort(PORT)); }
         catch (e) { glog(`force-stop: port probe failed (${e && e.message}); letting retry's bind confirm`); }
         if (win.isDestroyed()) return;
         if (!freed) {
           // The port is still held — by an unkillable wedge or a foreign app.
           // Either way a retry would just re-hit "address already in use", so
           // tell the user a restart is required rather than looping the failure.
-          return showUnrecoverableGatewayError(win, PORT);
+          return showUnrecoverableGatewayError(win, PORT, { probeFailed });
         }
       }
       if (action === "retry" || action === "force-retry" || action === "enable-retry") {

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -129,6 +129,7 @@
       "gateway-stop.js",
       "gateway-wait.js",
       "sandbox-profile.js",
+      "windows-port.js",
       "home-dir.js",
       "local-token.js",
       "local-gateway.js",

--- a/website/electron/test/gateway-recovery.test.js
+++ b/website/electron/test/gateway-recovery.test.js
@@ -6,6 +6,9 @@ const {
   GATEWAY_OWNERSHIP_STATES,
   waitForServiceRebind,
   waitForProcessExit,
+  snapshotPortPids,
+  incumbentSnapshotBlocksRespawn,
+  unrecoverableGatewayDialog,
 } = require("../gateway-recovery");
 
 describe("chooseRecoveryStrategy", () => {
@@ -179,8 +182,8 @@ describe("waitForProcessExit", () => {
     }
   });
 
-  // Empty/invalid pid sets (probe failed, Windows without lsof) degrade to a
-  // no-op — same behavior as before this gate existed, never a hang.
+  // Empty/invalid pid sets (for example, a failed listener probe) degrade to a
+  // no-op rather than hanging recovery.
   it("degrades to exited immediately with no watchable pids", async () => {
     let slept = false;
     for (const pids of [[], null, undefined, [0, -3, NaN]]) {
@@ -192,5 +195,101 @@ describe("waitForProcessExit", () => {
       assert.equal(verdict, "exited");
     }
     assert.equal(slept, false);
+  });
+});
+
+describe("snapshotPortPids", () => {
+  it("uses the Windows listener probe so recovery can wait for gateway.lock", async () => {
+    const calls = [];
+    const pids = await snapshotPortPids({
+      port: 5476,
+      isWindows: true,
+      getWindowsPids: async (port) => {
+        calls.push(["windows", port]);
+        return [4242];
+      },
+      getPosixPids: async (port) => {
+        calls.push(["posix", port]);
+        return [9999];
+      },
+    });
+    assert.deepEqual(pids, [4242]);
+    assert.deepEqual(calls, [["windows", 5476]]);
+  });
+
+  it("returns unknown when the selected probe fails or misses the listener", async () => {
+    const failed = await snapshotPortPids({
+      port: 5476,
+      isWindows: true,
+      getWindowsPids: async () => { throw new Error("netstat unavailable"); },
+      getPosixPids: async () => [9999],
+    });
+    const missed = await snapshotPortPids({
+      port: 5476,
+      isWindows: true,
+      getWindowsPids: async () => [],
+      getPosixPids: async () => [9999],
+    });
+    assert.equal(failed, null);
+    assert.equal(missed, null);
+  });
+});
+
+describe("unrecoverableGatewayDialog", () => {
+  it("offers a real quit action for an unkillable primary gateway", () => {
+    const model = unrecoverableGatewayDialog({
+      port: 5476,
+      isPrimaryWindow: true,
+    });
+    assert.equal(model.title, "Kiro Crew: backend stuck on port 5476");
+    assert.equal(model.primaryAction, "quit");
+    assert.equal(model.primaryLabel, "Quit Kiro Crew");
+    assert.equal(model.showQuitButton, false);
+    assert.equal(model.portConflict, false);
+    assert.match(model.message, /Restart your computer/);
+  });
+
+  it("tells a probe-failure user to reopen before restarting", () => {
+    const model = unrecoverableGatewayDialog({
+      port: 5476,
+      probeFailed: true,
+      isPrimaryWindow: false,
+    });
+    assert.equal(model.title, "Kiro Crew: can't verify what's using port 5476");
+    assert.equal(model.primaryAction, "quit");
+    assert.equal(model.primaryLabel, "Close");
+    assert.equal(model.showQuitButton, false);
+    assert.match(model.message, /Quit and reopen Kiro Crew to try again/);
+    assert.match(model.message, /If the port is still blocked, restart your computer/);
+  });
+
+  it("tells a user to quit an unowned process that still holds the port", () => {
+    const model = unrecoverableGatewayDialog({
+      port: 5476,
+      variant: "held",
+      isPrimaryWindow: true,
+    });
+    assert.equal(model.title, "Kiro Crew: port 5476 is in use");
+    assert.equal(model.primaryAction, "quit");
+    assert.equal(model.primaryLabel, "Quit Kiro Crew");
+    assert.equal(model.showQuitButton, false);
+    assert.match(model.message, /Quit the process using port 5476/);
+    assert.doesNotMatch(model.message, /Restart your computer/);
+  });
+});
+
+describe("incumbentSnapshotBlocksRespawn", () => {
+  it("refuses an automatic respawn when the Windows probe named nothing", () => {
+    assert.equal(incumbentSnapshotBlocksRespawn({ pids: null, isWindows: true }), true);
+  });
+
+  it("still boots a POSIX host whose lsof is missing or blocked", () => {
+    assert.equal(incumbentSnapshotBlocksRespawn({ pids: null, isWindows: false }), false);
+  });
+
+  it("never blocks when the incumbent was actually captured", () => {
+    for (const isWindows of [true, false]) {
+      assert.equal(incumbentSnapshotBlocksRespawn({ pids: [4242], isWindows }), false);
+    }
   });
 });

--- a/website/electron/test/gateway-stop.test.js
+++ b/website/electron/test/gateway-stop.test.js
@@ -5,7 +5,13 @@ const os = require("os");
 const fs = require("fs");
 const path = require("path");
 const { spawn } = require("child_process");
-const { postShutdown, stopGatewayGracefully, forceStopPort, classifyPortOwner, KIROCREW_PROC_RE } = require("../gateway-stop");
+const {
+  postShutdown,
+  stopGatewayGracefully,
+  forceStopPort,
+  classifyPortOwner,
+  isKirocrewCommand,
+} = require("../gateway-stop");
 
 // Helper: temp KIROCREW_HOME containing a .local_secret file.
 function tmpHomeWithSecret(secret) {
@@ -245,6 +251,59 @@ test("forceStopPort: freed reflects real port state even after killing our targe
   assert.strictEqual(r.freed, false); // but the port is still held by 777
 });
 
+test("forceStopPort: awaits an asynchronous Windows kill before verifying", async () => {
+  let killFinished = false;
+  let probes = 0;
+  const r = await forceStopPort(7788, {
+    getListenPids: async () => {
+      probes += 1;
+      if (probes === 1) return [4242];
+      assert.strictEqual(killFinished, true, "verification raced taskkill completion");
+      return [];
+    },
+    getCommand: async () => "C:\\bundle\\kirocrew.exe gateway",
+    kill: async () => { killFinished = true; },
+    sleep: async () => {},
+    isKirocrew: (command) => command.includes("kirocrew.exe"),
+  });
+  assert.strictEqual(r.killed, 1);
+  assert.strictEqual(r.freed, true);
+});
+
+test("forceStopPort: a failed initial Windows probe is not a free port", async () => {
+  const probeError = new Error("netstat timed out");
+  const r = await forceStopPort(7788, {
+    getListenPids: async () => { throw probeError; },
+    getCommand: async () => "",
+    kill: async () => {},
+    sleep: async () => {},
+    failClosedOnProbeError: true,
+  });
+  assert.deepStrictEqual(r, {
+    killed: 0, freed: false, survivors: [], foreignHolder: false,
+    serviceHolder: false, probeFailed: true,
+  });
+});
+
+test("forceStopPort: a failed Windows verification never claims recovery", async () => {
+  let probes = 0;
+  const r = await forceStopPort(7788, {
+    getListenPids: async () => {
+      if (probes++ === 0) return [4242];
+      throw new Error("netstat verify timed out");
+    },
+    getCommand: async () => "C:\\bundle\\kirocrew.exe gateway",
+    kill: async () => {},
+    sleep: async () => {},
+    isKirocrew: (command) => command.includes("kirocrew.exe"),
+    failClosedOnProbeError: true,
+  });
+  assert.deepStrictEqual(r, {
+    killed: 1, freed: false, survivors: [], foreignHolder: false,
+    serviceHolder: false, probeFailed: true,
+  });
+});
+
 // ── classifyPortOwner ───────────────────────────────────────────────────────
 // Ground truth for "is the thing on our port local, or a tunnel?". Every
 // outcome except a positively identified local KiroCrew process must be
@@ -371,16 +430,40 @@ test("classifyPortOwner: ours wins when a mixed set holds the port", async () =>
 
 test("classifyPortOwner and forceStopPort share one KiroCrew matcher", async () => {
   // Drift between the two would let one mis-target a stranger's process.
-  assert.ok(KIROCREW_PROC_RE.test("python -m kiro_crew gateway"));
-  assert.ok(KIROCREW_PROC_RE.test("/Applications/KiroCrew.app/.../kirocrew"));
-  assert.ok(!KIROCREW_PROC_RE.test("ssh -NL 5476:localhost:5476 host"));
+  assert.ok(isKirocrewCommand("python -m kiro_crew gateway"));
+  assert.ok(isKirocrewCommand("/Applications/KiroCrew.app/.../kirocrew"));
+  assert.ok(!isKirocrewCommand("ssh -NL 5476:localhost:5476 host"));
+  assert.ok(!isKirocrewCommand("ssh -NL 5476:localhost:5476 kirocrew"));
   // The matcher keys on the executable/module TOKEN, not a path substring:
   // an unrelated process merely living under a `kirocrew` home dir is foreign.
-  assert.ok(!KIROCREW_PROC_RE.test("C:\\Users\\kirocrew\\OtherApp\\server.exe --port 5476"));
-  assert.ok(!KIROCREW_PROC_RE.test("/home/kirocrew/some-other-server --port 5476"));
-  assert.ok(!KIROCREW_PROC_RE.test("C:\\Users\\kirocrew\\python.exe -m http.server 5476"));
-  // …but the real Windows executable / backend / module invocation still match.
-  assert.ok(KIROCREW_PROC_RE.test("C:\\Program Files\\KiroCrew\\kirocrew.exe"));
-  assert.ok(KIROCREW_PROC_RE.test("C:\\Program Files\\KiroCrew\\kirocrew-backend.exe --gateway"));
-  assert.ok(KIROCREW_PROC_RE.test("C:\\Python\\python.exe -m kiro_crew gateway"));
+  assert.ok(!isKirocrewCommand("C:\\Users\\kirocrew\\OtherApp\\server.exe --port 5476"));
+  assert.ok(!isKirocrewCommand("/home/kirocrew/some-other-server --port 5476"));
+  assert.ok(!isKirocrewCommand("C:\\Users\\kirocrew\\python.exe -m http.server 5476"));
+  assert.ok(!isKirocrewCommand("python app.py C:\\tmp\\kirocrew"));
+  assert.ok(!isKirocrewCommand("python app.py -m kiro_crew"));
+  // A POSIX `ps` line is unquoted, so an install path with a space arrives
+  // split across tokens. Our own gateway must still be identified there, and a
+  // later argument must still never pose as the executable.
+  assert.ok(isKirocrewCommand("/Users/Jane Doe/Apps/KiroCrew.app/Contents/Resources/bin/kirocrew gateway --port 5476"));
+  assert.ok(isKirocrewCommand("/Users/Jane Doe/venv/bin/python -m kiro_crew gateway"));
+  assert.ok(!isKirocrewCommand("/tmp/evil --spoof /usr/local/bin/kirocrew"));
+  assert.ok(!isKirocrewCommand("/tmp/evil /usr/local/bin/kirocrew"));
+  assert.ok(!isKirocrewCommand("/tmp/dir with space/evil kirocrew --port 5476"));
+  // Windows identity is path-bound: a matching basename at any other location
+  // remains foreign and can never authorize taskkill.
+  const trustedCli = "C:\\Program Files\\KiroCrew\\kirocrew.exe";
+  const trustedBackend = "C:\\Program Files\\KiroCrew\\kirocrew-backend.exe";
+  const trustedPython = "C:\\Program Files\\KiroCrew\\python.exe";
+  assert.ok(isKirocrewCommand(`"${trustedCli}"`, {
+    trustedExecutablePaths: [trustedCli],
+  }));
+  assert.ok(isKirocrewCommand(`"${trustedBackend}" --gateway`, {
+    trustedExecutablePaths: [trustedBackend],
+  }));
+  assert.ok(isKirocrewCommand(`"${trustedPython}" -m kiro_crew gateway`, {
+    trustedExecutablePaths: [trustedPython],
+  }));
+  assert.ok(!isKirocrewCommand("C:\\Temp\\kirocrew.exe gateway", {
+    trustedExecutablePaths: [trustedCli],
+  }));
 });

--- a/website/electron/test/windows-port.test.js
+++ b/website/electron/test/windows-port.test.js
@@ -1,0 +1,416 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const {
+  parseNetstatListenPids,
+  windowsGatewayExecutablePaths,
+  windowsSystemToolPaths,
+  windowsListenPids,
+  windowsProcessCommand,
+  windowsTaskkill,
+} = require("../windows-port");
+const {
+  classifyPortOwner,
+  forceStopPort,
+  isKirocrewCommand,
+} = require("../gateway-stop");
+
+const TEST_TOOLS = windowsSystemToolPaths("D:\\Windows");
+
+test("windowsSystemToolPaths resolves every utility beneath the system root", () => {
+  assert.deepStrictEqual(TEST_TOOLS, {
+    netstat: "D:\\Windows\\System32\\netstat.exe",
+    powershell:
+      "D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    wmic: "D:\\Windows\\System32\\wbem\\wmic.exe",
+    taskkill: "D:\\Windows\\System32\\taskkill.exe",
+  });
+  assert.throws(
+    () => windowsSystemToolPaths(".\\hostile"),
+    /system root must be a drive-root Windows directory/
+  );
+  assert.throws(
+    () => windowsSystemToolPaths("D:\\hostile\\Windows"),
+    /system root must be a drive-root Windows directory/
+  );
+});
+
+test("windowsGatewayExecutablePaths resolves the executables a launcher can spawn", () => {
+  assert.deepStrictEqual(
+    windowsGatewayExecutablePaths(
+      "D:\\KiroCrew\\resources\\backend-dist\\kirocrew-backend\\bin\\kirocrew.cmd"
+    ),
+    ["D:\\KiroCrew\\resources\\backend-dist\\kirocrew-backend\\python.exe"]
+  );
+  assert.deepStrictEqual(
+    windowsGatewayExecutablePaths("D:\\venv\\Scripts\\kirocrew.exe"),
+    [
+      "D:\\venv\\Scripts\\kirocrew.exe",
+      "D:\\venv\\Scripts\\python.exe",
+      "D:\\venv\\python.exe",
+    ]
+  );
+  assert.deepStrictEqual(
+    windowsGatewayExecutablePaths("kirocrew.exe", { pathEnv: "" }),
+    []
+  );
+});
+
+test("windowsGatewayExecutablePaths resolves a PATH-launched executable", () => {
+  const expected = "D:\\Kiro Crew\\Scripts\\kirocrew.exe";
+  const probed = [];
+  const resolved = windowsGatewayExecutablePaths("kirocrew.exe", {
+    pathEnv: 'C:\\Other;"D:\\Kiro Crew\\Scripts"',
+    accessSync: (candidate) => {
+      probed.push(candidate);
+      if (candidate !== expected) throw new Error("ENOENT");
+    },
+  });
+  assert.deepStrictEqual(resolved, [
+    expected,
+    "D:\\Kiro Crew\\Scripts\\python.exe",
+    "D:\\Kiro Crew\\python.exe",
+  ]);
+  assert.deepStrictEqual(probed, [
+    "C:\\Other\\kirocrew.exe",
+    expected,
+  ]);
+});
+
+test("a venv launcher trusts the Python listener it delegates to", () => {
+  const launcher = "D:\\venv\\Scripts\\kirocrew.exe";
+  const trustedExecutablePaths = windowsGatewayExecutablePaths(launcher);
+  assert.strictEqual(
+    isKirocrewCommand(
+      '"D:\\venv\\Scripts\\python.exe" '
+        + '"D:\\venv\\Scripts\\python.exe" -s -m kiro_crew gateway',
+      { trustedExecutablePaths }
+    ),
+    true
+  );
+});
+
+test("parseNetstatListenPids finds IPv4 and IPv6 listeners without reading state text", () => {
+  const output = [
+    "  Proto  Local Address          Foreign Address        State           PID",
+    "  TCP    127.0.0.1:5476        0.0.0.0:0              ABHÖREN         4242",
+    "  TCP    [::1]:5476            [::]:0                 ÉCOUTE          4343",
+    "  TCP    0.0.0.0:5476          0.0.0.0:0              ESCUCHANDO      4242",
+  ].join("\r\n");
+  assert.deepStrictEqual(parseNetstatListenPids(output, 5476), [4242, 4343]);
+});
+
+test("parseNetstatListenPids requires the exact local port and a wildcard peer", () => {
+  const output = [
+    "  TCP    127.0.0.1:54760       0.0.0.0:0              LISTENING       1111",
+    "  TCP    127.0.0.1:5476        10.0.0.5:443           ESTABLISHED     2222",
+    "  UDP    127.0.0.1:5476        *:*                                    3333",
+  ].join("\r\n");
+  assert.deepStrictEqual(parseNetstatListenPids(output, 5476), []);
+});
+
+test("windowsListenPids queries both address families with a bounded timeout", async () => {
+  let invocation;
+  const execFileFn = (command, args, options, callback) => {
+    invocation = { command, args, options };
+    callback(null, "TCP  [::1]:5476  [::]:0  ECOUTE  4343");
+  };
+  const pids = await windowsListenPids(5476, {
+    execFileFn,
+    timeoutMs: 1234,
+    tools: TEST_TOOLS,
+  });
+  assert.deepStrictEqual(pids, [4343]);
+  assert.deepStrictEqual(invocation, {
+    command: TEST_TOOLS.netstat,
+    args: ["-ano"],
+    options: { timeout: 1234 },
+  });
+});
+
+test("windowsListenPids rejects netstat errors and timeouts", async () => {
+  const timeout = Object.assign(new Error("netstat timed out"), { code: "ETIMEDOUT" });
+  const execFileFn = (_command, _args, _options, callback) => callback(timeout, "");
+  await assert.rejects(
+    windowsListenPids(5476, { execFileFn, tools: TEST_TOOLS }),
+    /netstat timed out/
+  );
+});
+
+test("windowsProcessCommand prefers PowerShell command-line output", async () => {
+  const calls = [];
+  const execFileFn = (command, args, options, callback) => {
+    calls.push({ command, args, options });
+    callback(null, '"C:\\Program Files\\KiroCrew\\kirocrew.exe" gateway\r\n');
+  };
+  const command = await windowsProcessCommand(4242, {
+    execFileFn,
+    tools: TEST_TOOLS,
+  });
+  assert.strictEqual(command, '"C:\\Program Files\\KiroCrew\\kirocrew.exe" gateway');
+  assert.strictEqual(calls.length, 1);
+  assert.strictEqual(calls[0].command, TEST_TOOLS.powershell);
+  assert.match(calls[0].args.at(-1), /ProcessId = 4242/);
+  assert.match(calls[0].args.at(-1), /ExecutablePath/);
+});
+
+test("windowsProcessCommand falls back to WMIC and unwraps its value", async () => {
+  const calls = [];
+  const execFileFn = (command, args, _options, callback) => {
+    calls.push({ command, args });
+    if (command === TEST_TOOLS.powershell) {
+      callback(new Error("PowerShell unavailable"), "");
+      return;
+    }
+    callback(
+      null,
+      "\r\nExecutablePath=C:\\Python\\python.exe\r\n"
+        + "CommandLine=C:\\Python\\python.exe -m kiro_crew gateway\r\n\r\n"
+    );
+  };
+  const command = await windowsProcessCommand(4242, {
+    execFileFn,
+    tools: TEST_TOOLS,
+  });
+  assert.strictEqual(
+    command,
+    '"C:\\Python\\python.exe" C:\\Python\\python.exe -m kiro_crew gateway'
+  );
+  assert.deepStrictEqual(
+    calls.map(({ command: name }) => name),
+    [TEST_TOOLS.powershell, TEST_TOOLS.wmic]
+  );
+  assert.deepStrictEqual(calls[1].args, [
+    "process", "where", "ProcessId=4242", "get",
+    "ExecutablePath,CommandLine", "/FORMAT:LIST",
+  ]);
+});
+
+test("windowsProcessCommand fails closed when neither identity probe works", async () => {
+  const execFileFn = (_command, _args, _options, callback) =>
+    callback(new Error("not available"), "");
+  assert.strictEqual(
+    await windowsProcessCommand(4242, { execFileFn, tools: TEST_TOOLS }),
+    ""
+  );
+});
+
+test("windowsProcessCommand fails closed when WMIC cannot prove the executable path", async () => {
+  const execFileFn = (command, _args, _options, callback) => {
+    if (command === TEST_TOOLS.powershell) {
+      callback(new Error("PowerShell unavailable"), "");
+      return;
+    }
+    callback(null, "CommandLine=kirocrew gateway\r\n");
+  };
+  assert.strictEqual(
+    await windowsProcessCommand(4242, { execFileFn, tools: TEST_TOOLS }),
+    ""
+  );
+});
+
+test("isKirocrewCommand accepts Windows executable and module shapes", () => {
+  const trustedCli = "C:\\Program Files\\KiroCrew\\kirocrew.exe";
+  const trustedBackend = "C:\\bundle\\kirocrew-backend.exe";
+  const trustedPython = "C:\\Python\\python.exe";
+  assert.strictEqual(
+    isKirocrewCommand(`"${trustedCli}" gateway`, {
+      trustedExecutablePaths: [trustedCli],
+    }),
+    true
+  );
+  assert.strictEqual(
+    isKirocrewCommand(`${trustedBackend} gateway`, {
+      trustedExecutablePaths: [trustedBackend],
+    }),
+    true
+  );
+  assert.strictEqual(
+    isKirocrewCommand(`${trustedPython} -s -m kiro_crew gateway`, {
+      trustedExecutablePaths: [trustedPython],
+    }),
+    true
+  );
+  assert.strictEqual(
+    isKirocrewCommand(
+      `${trustedPython} C:\\venv\\Scripts\\kirocrew gateway`,
+      { trustedExecutablePaths: [trustedPython] }
+    ),
+    true
+  );
+  assert.strictEqual(
+    isKirocrewCommand(
+      `"${trustedPython}" ${trustedPython} -s -m kiro_crew gateway`,
+      { trustedExecutablePaths: [trustedPython] }
+    ),
+    true
+  );
+});
+
+test("isKirocrewCommand rejects Windows path substrings and unrelated Python", () => {
+  assert.strictEqual(
+    isKirocrewCommand("C:\\Users\\kirocrew\\OtherApp\\server.exe --port 5476"),
+    false
+  );
+  assert.strictEqual(
+    isKirocrewCommand("C:\\Users\\kirocrew\\python.exe -m http.server 5476"),
+    false
+  );
+  assert.strictEqual(
+    isKirocrewCommand("C:\\Python\\python.exe app.py kirocrew"),
+    false
+  );
+  assert.strictEqual(
+    isKirocrewCommand("C:\\Python\\python.exe app.py C:\\tmp\\kirocrew"),
+    false
+  );
+  assert.strictEqual(
+    isKirocrewCommand("C:\\Python\\python.exe app.py -m kiro_crew"),
+    false
+  );
+  assert.strictEqual(
+    isKirocrewCommand("C:\\Temp\\kirocrew.exe gateway", {
+      trustedExecutablePaths: [
+        "C:\\Program Files\\KiroCrew\\kirocrew.exe",
+      ],
+    }),
+    false
+  );
+});
+
+test("isKirocrewCommand rejects SSH aliases and remote gateway commands", () => {
+  assert.strictEqual(
+    isKirocrewCommand("C:\\Windows\\System32\\OpenSSH\\ssh.exe -NL 5476:localhost:5476 kirocrew"),
+    false
+  );
+  assert.strictEqual(
+    isKirocrewCommand("ssh.exe host python.exe -m kiro_crew gateway"),
+    false
+  );
+});
+
+test("Windows owner classification returns unknown when netstat cannot run", async () => {
+  const owner = await classifyPortOwner(5476, {
+    getListenPids: async () => { throw new Error("netstat unavailable"); },
+    getCommand: async () => "",
+  });
+  assert.strictEqual(owner, "unknown");
+});
+
+test("Windows force-stop refuses an SSH holder even when its alias is kirocrew", async () => {
+  const killed = [];
+  const result = await forceStopPort(5476, {
+    getListenPids: async () => [909],
+    getCommand: async () =>
+      "C:\\Windows\\System32\\OpenSSH\\ssh.exe -NL 5476:localhost:5476 kirocrew",
+    kill: async (pid) => killed.push(pid),
+    sleep: async () => {},
+    failClosedOnProbeError: true,
+  });
+  assert.deepStrictEqual(killed, []);
+  assert.strictEqual(result.freed, false);
+  assert.strictEqual(result.foreignHolder, true);
+});
+
+test("Windows force-stop refuses unrelated Python with a later kirocrew path", async () => {
+  const killed = [];
+  const result = await forceStopPort(5476, {
+    getListenPids: async () => [910],
+    getCommand: async () => "C:\\Python\\python.exe app.py C:\\tmp\\kirocrew",
+    kill: async (pid) => killed.push(pid),
+    sleep: async () => {},
+    failClosedOnProbeError: true,
+  });
+  assert.deepStrictEqual(killed, []);
+  assert.strictEqual(result.freed, false);
+  assert.strictEqual(result.foreignHolder, true);
+});
+
+test("Windows force-stop refuses an untrusted kirocrew.exe basename", async () => {
+  const killed = [];
+  const trustedCli = "C:\\Program Files\\KiroCrew\\kirocrew.exe";
+  const result = await forceStopPort(5476, {
+    getListenPids: async () => [911],
+    getCommand: async () => "C:\\Temp\\kirocrew.exe gateway",
+    kill: async (pid) => killed.push(pid),
+    sleep: async () => {},
+    isKirocrew: (command) => isKirocrewCommand(command, {
+      trustedExecutablePaths: [trustedCli],
+    }),
+    failClosedOnProbeError: true,
+  });
+  assert.deepStrictEqual(killed, []);
+  assert.strictEqual(result.freed, false);
+  assert.strictEqual(result.foreignHolder, true);
+});
+
+test("windowsTaskkill revalidates identity before using force on the PID", async () => {
+  let invocation;
+  const trustedCli = "C:\\Program Files\\KiroCrew\\kirocrew.exe";
+  const execFileFn = (command, args, options, callback) => {
+    invocation = { command, args, options };
+    callback(null, "SUCCESS");
+  };
+  await windowsTaskkill(4242, {
+    execFileFn,
+    timeoutMs: 2345,
+    tools: TEST_TOOLS,
+    getCommandFn: async () => `"${trustedCli}" gateway`,
+    isTrustedCommand: (command) => isKirocrewCommand(command, {
+      trustedExecutablePaths: [trustedCli],
+    }),
+  });
+  assert.deepStrictEqual(invocation, {
+    command: TEST_TOOLS.taskkill,
+    args: ["/F", "/PID", "4242"],
+    options: { timeout: 2345 },
+  });
+});
+
+test("windowsTaskkill refuses a PID reused by an unrelated process", async () => {
+  let invoked = false;
+  const trustedCli = "C:\\Program Files\\KiroCrew\\kirocrew.exe";
+  await assert.rejects(
+    windowsTaskkill(4242, {
+      execFileFn: () => { invoked = true; },
+      tools: TEST_TOOLS,
+      getCommandFn: async () => "C:\\Windows\\System32\\notepad.exe",
+      isTrustedCommand: (command) => isKirocrewCommand(command, {
+        trustedExecutablePaths: [trustedCli],
+      }),
+    }),
+    /process identity changed/
+  );
+  assert.strictEqual(invoked, false);
+});
+
+test("Windows force-stop cannot taskkill a PID that changes owners", async () => {
+  const trustedCli = "C:\\Program Files\\KiroCrew\\kirocrew.exe";
+  let taskkillInvoked = false;
+  const result = await forceStopPort(5476, {
+    getListenPids: async () => [4242],
+    getCommand: async () => `"${trustedCli}" gateway`,
+    kill: (pid) => windowsTaskkill(pid, {
+      execFileFn: () => { taskkillInvoked = true; },
+      tools: TEST_TOOLS,
+      getCommandFn: async () => "C:\\Windows\\System32\\notepad.exe",
+      isTrustedCommand: (command) => isKirocrewCommand(command, {
+        trustedExecutablePaths: [trustedCli],
+      }),
+    }),
+    sleep: async () => {},
+    isKirocrew: (command) => isKirocrewCommand(command, {
+      trustedExecutablePaths: [trustedCli],
+    }),
+    failClosedOnProbeError: true,
+  });
+  assert.strictEqual(taskkillInvoked, false);
+  assert.strictEqual(result.killed, 0);
+  assert.strictEqual(result.freed, false);
+  assert.strictEqual(result.foreignHolder, true);
+});
+
+test("Windows process tools reject invalid numeric identifiers", async () => {
+  assert.throws(() => parseNetstatListenPids("", 0), /port must be a positive integer/);
+  await assert.rejects(windowsProcessCommand("4; Stop-Process", {}), /pid must be a positive integer/);
+  await assert.rejects(windowsTaskkill(-1, {}), /pid must be a positive integer/);
+});

--- a/website/electron/windows-port.js
+++ b/website/electron/windows-port.js
@@ -1,0 +1,241 @@
+/**
+ * Windows-native port ownership and process-control adapters.
+ *
+ * The parsing and identity checks live outside main.js so they can be tested
+ * on every CI host. Runtime effects are limited to netstat, PowerShell/WMIC,
+ * and taskkill, with execFile injection for deterministic tests.
+ */
+
+const { execFile } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const FALLBACK_WINDOWS_ROOT = "C:\\Windows";
+const CONFIGURED_WINDOWS_ROOT = process.platform === "win32"
+  ? process.env.SystemRoot || process.env.WINDIR || FALLBACK_WINDOWS_ROOT
+  : FALLBACK_WINDOWS_ROOT;
+
+function windowsSystemToolPaths(
+  systemRoot = CONFIGURED_WINDOWS_ROOT
+) {
+  const root = path.win32.normalize(String(systemRoot || "")).replace(/[\\/]+$/, "");
+  if (!/^[A-Za-z]:\\Windows$/i.test(root)) {
+    throw new TypeError("Windows system root must be a drive-root Windows directory");
+  }
+  const system32 = path.win32.join(root, "System32");
+  return Object.freeze({
+    netstat: path.win32.join(system32, "netstat.exe"),
+    powershell: path.win32.join(
+      system32,
+      "WindowsPowerShell",
+      "v1.0",
+      "powershell.exe"
+    ),
+    wmic: path.win32.join(system32, "wbem", "wmic.exe"),
+    taskkill: path.win32.join(system32, "taskkill.exe"),
+  });
+}
+
+function windowsGatewayExecutablePaths(
+  gatewayBin,
+  {
+    pathEnv = process.env.Path || process.env.PATH || "",
+    accessSync = fs.accessSync,
+  } = {}
+) {
+  const bin = String(gatewayBin || "").replace(/\//g, "\\");
+  let resolved = bin;
+  if (!path.win32.isAbsolute(resolved)) {
+    if (!resolved || /[\\/]/.test(resolved)) return [];
+    resolved = "";
+    for (const rawDir of String(pathEnv).split(path.win32.delimiter)) {
+      const dir = rawDir.trim().replace(/^"(.*)"$/, "$1");
+      if (!path.win32.isAbsolute(dir)) continue;
+      const candidate = path.win32.join(dir, bin);
+      try {
+        accessSync(candidate, fs.constants.X_OK);
+        resolved = candidate;
+        break;
+      } catch { /* try the next PATH entry */ }
+    }
+    if (!resolved) return [];
+  }
+  const normalized = path.win32.normalize(resolved);
+  if (/\.cmd$/i.test(normalized)) {
+    return [path.win32.resolve(path.win32.dirname(normalized), "..", "python.exe")];
+  }
+  const trusted = [normalized];
+  if (
+    /^kirocrew\.exe$/i.test(path.win32.basename(normalized))
+    && /^scripts$/i.test(path.win32.basename(path.win32.dirname(normalized)))
+  ) {
+    // A distlib console launcher delegates to the venv interpreter. Source
+    // venvs keep it beside the launcher; bundled target installs keep it at
+    // the environment root.
+    trusted.push(
+      path.win32.join(path.win32.dirname(normalized), "python.exe"),
+      path.win32.resolve(path.win32.dirname(normalized), "..", "python.exe")
+    );
+  }
+  return [...new Set(trusted.map((candidate) => path.win32.normalize(candidate)))];
+}
+
+let WINDOWS_SYSTEM_TOOLS;
+try {
+  WINDOWS_SYSTEM_TOOLS = windowsSystemToolPaths();
+} catch {
+  WINDOWS_SYSTEM_TOOLS = windowsSystemToolPaths(FALLBACK_WINDOWS_ROOT);
+}
+
+function positiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new TypeError(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function endpointPort(endpoint) {
+  const separator = String(endpoint || "").lastIndexOf(":");
+  if (separator < 0) return null;
+  const parsed = Number(String(endpoint).slice(separator + 1));
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+/**
+ * Parse `netstat -ano` without depending on the localized state text.
+ * A TCP listener is identified by its local port and wildcard foreign endpoint.
+ */
+function parseNetstatListenPids(stdout, port) {
+  const wantedPort = positiveInteger(port, "port");
+  const pids = new Set();
+  for (const line of String(stdout || "").split(/\r?\n/)) {
+    const columns = line.trim().split(/\s+/);
+    if (columns.length < 5 || columns[0].toUpperCase() !== "TCP") continue;
+    if (endpointPort(columns[1]) !== wantedPort) continue;
+    if (columns[2] !== "0.0.0.0:0" && columns[2] !== "[::]:0") continue;
+    const pid = Number(columns[columns.length - 1]);
+    if (Number.isInteger(pid) && pid > 0) pids.add(pid);
+  }
+  return [...pids];
+}
+
+function execFileText(execFileFn, command, args, timeout) {
+  return new Promise((resolve, reject) => {
+    execFileFn(command, args, { timeout }, (err, stdout) => {
+      if (err) return reject(err);
+      resolve(String(stdout || ""));
+    });
+  });
+}
+
+async function windowsListenPids(
+  port,
+  { execFileFn = execFile, timeoutMs = 5000, tools = WINDOWS_SYSTEM_TOOLS } = {}
+) {
+  const stdout = await execFileText(
+    execFileFn,
+    tools.netstat,
+    // `-p TCP` restricts Windows output to IPv4 and hides IPv6-only listeners.
+    ["-ano"],
+    timeoutMs
+  );
+  return parseNetstatListenPids(stdout, port);
+}
+
+function processIdentity(executablePath, commandLine) {
+  const executable = String(executablePath || "").trim();
+  const command = String(commandLine || "").trim();
+  if (!executable) return "";
+  return `"${executable}" ${command}`.trim();
+}
+
+function unwrapWmicProcessIdentity(stdout) {
+  let executablePath = "";
+  let commandLine = "";
+  for (const line of String(stdout || "").split(/\r?\n/)) {
+    if (/^\s*ExecutablePath=/i.test(line)) {
+      executablePath = line.replace(/^\s*ExecutablePath=/i, "").trim();
+    } else if (/^\s*CommandLine=/i.test(line)) {
+      commandLine = line.replace(/^\s*CommandLine=/i, "").trim();
+    }
+  }
+  return processIdentity(executablePath, commandLine);
+}
+
+/**
+ * Return a process command line. PowerShell is preferred because WMIC is
+ * optional on current Windows releases; WMIC remains the compatibility
+ * fallback. Failure to identify a process returns an empty string so callers
+ * classify it as foreign and never terminate it.
+ */
+async function windowsProcessCommand(
+  pid,
+  {
+    execFileFn = execFile,
+    powershellTimeoutMs = 8000,
+    wmicTimeoutMs = 5000,
+    tools = WINDOWS_SYSTEM_TOOLS,
+  } = {}
+) {
+  const safePid = positiveInteger(pid, "pid");
+  const script = `$p = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = ${safePid}"; `
+    + `if ($null -ne $p -and $p.ExecutablePath) { `
+    + `[Console]::Out.Write(('"' + $p.ExecutablePath + '" ' + $p.CommandLine).Trim()) }`;
+  try {
+    const command = (await execFileText(
+      execFileFn,
+      tools.powershell,
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+      powershellTimeoutMs
+    )).trim();
+    if (command) return command;
+  } catch { /* try WMIC */ }
+
+  try {
+    const output = await execFileText(
+      execFileFn,
+      tools.wmic,
+      [
+        "process", "where", `ProcessId=${safePid}`, "get",
+        "ExecutablePath,CommandLine", "/FORMAT:LIST",
+      ],
+      wmicTimeoutMs
+    );
+    return unwrapWmicProcessIdentity(output);
+  } catch {
+    return "";
+  }
+}
+
+async function windowsTaskkill(
+  pid,
+  {
+    execFileFn = execFile,
+    timeoutMs = 10000,
+    tools = WINDOWS_SYSTEM_TOOLS,
+    getCommandFn = windowsProcessCommand,
+    isTrustedCommand = () => false,
+  } = {}
+) {
+  const safePid = positiveInteger(pid, "pid");
+  const command = await getCommandFn(safePid);
+  if (!isTrustedCommand(command)) {
+    throw new Error(`Refusing taskkill for pid ${safePid}: process identity changed`);
+  }
+  await execFileText(
+    execFileFn,
+    tools.taskkill,
+    ["/F", "/PID", String(safePid)],
+    timeoutMs
+  );
+}
+
+module.exports = {
+  parseNetstatListenPids,
+  windowsSystemToolPaths,
+  windowsGatewayExecutablePaths,
+  windowsListenPids,
+  windowsProcessCommand,
+  windowsTaskkill,
+};


### PR DESCRIPTION
## Problem

On Windows the desktop launcher cannot run the POSIX `lsof`/`ps` probes, so
`classifyPortOwner` always answers `"unknown"`. A gateway that stays on the
desktop port therefore cannot be identified, and the shell has no way to recover
from a wedged backend — `main.js` carried this as an explicit
`KNOWN RESIDUAL (Windows)` note. The naive fix is worse than the gap: a broad
process-name match would terminate an unrelated application, or an `ssh -L`
forward that happens to own the port.

## Why this PR exists

This recreates #1628 (@ktreharrison) on current `main`. That branch is 482
commits behind and conflicts; its shared-matcher groundwork has since landed
separately, so only the Windows adapter layer was missing. Original authorship is
preserved on the commit.

## Fix

- **Listener probe.** A Windows adapter finds TCP listeners with
  `netstat.exe -ano`, identifying a listener by local port plus wildcard peer
  (`0.0.0.0:0` / `[::]:0`) so localized state text is never parsed. `-p TCP` is
  deliberately not passed — it hides IPv6-only listeners.
- **Identity probe.** Each listener is resolved through PowerShell
  `Get-CimInstance`, with WMIC as the compatibility fallback (WMIC is optional on
  current Windows). An unidentifiable process resolves to `""` and is classified
  foreign.
- **Path-bound trust.** Bare gateway executable names resolve through Windows
  `PATH`, including quoted entries, and a Windows absolute executable is ours
  only when it equals the exact path the launch resolver selected — a matching
  basename anywhere else stays foreign.
- **One positional matcher on every platform.** A Python process is ours only
  when its *first execution selector* invokes `-m kiro_crew` or a Kiro Crew
  script, so later arguments and SSH aliases can never authorize a kill. The
  selector also rejoins a space-containing POSIX executable path (`ps -o
  command=` is unquoted, so `/Users/Jane Doe/.../kirocrew` arrives split across
  tokens) while still refusing to let a later argument pose as the executable.
- **Termination.** `taskkill.exe /F /PID` runs only against a positively
  identified Kiro Crew process, revalidates identity immediately before the kill
  so a recycled PID cannot be hit, awaits completion, then verifies the port
  actually freed.
- **Fail closed.** An initial or verification probe that errors or times out
  reports the port held, never free. An incumbent snapshot the probe could not
  take blocks an automatic respawn **only on Windows**, where `netstat` ships
  in-box; POSIX keeps degrading to the existing no-op wait so a host without
  `lsof` still boots and the replacement's own lock refusal stays the arbiter.
- **Dialogs.** The terminal recovery dialogs get real Quit/Close actions, and a
  probe failure now reads as unverified ownership rather than claiming the
  backend is known to be stuck.
- `windows-port.js` is packaged with the Electron shell; the Windows install
  guide documents the recovery behavior. No dependency and no lockfile change.

SSH forwards, unrelated applications, and service-managed gateways remain
untouched on every path.

## Tests

- `website/electron`: **1033/1033** pass (`npm test`), including 22 new
  `windows-port` cases and new coverage for the async kill, both fail-closed
  probe paths, the space-containing POSIX executable path, and the
  Windows-only respawn-blocking policy.
- `node --check` on every touched shell file.
- Brand Name Gate, Harness Parity Gate, Docs Lint (212 files), and scrub lint
  (`--no-history`) all pass locally.
- Backend `pytest`, `tsc -b` and website `vitest` were not run locally: the diff
  is confined to `website/electron/*.js` plus one Markdown bullet, and
  `website/electron/**` is outside the `tsc`/`eslint`/`jscpd` scopes. CI covers
  them.

Runtime verification on real Windows (localized `netstat`, a live foreign
listener, a live OpenSSH local forward) was reported on the original PR; this
recreation is behaviour-identical there apart from the POSIX-degradation scoping
called out above.

Recreates #1628. Fixes #1589.
