### PR TITLE
fix: browse with the engine Kiro Crew installs, not the CLI default

### DIFF
--- a/docs/system-specs/modules/browser.md
+++ b/docs/system-specs/modules/browser.md
@@ -99,6 +99,40 @@ once, at install, so registry auth applies at install time only.
    directory instead of the workspace.
 5. Record that the install happened.
 
+### Readiness
+
+`browser_ok` answers "is a build at the revision the installed CLI requires on
+disk". A cache directory carries its revision (`chromium-1232`), and
+playwright-core launches only the exact revision bound to its own version, so the
+match is **exact** on the revision the CLI requires. A prefix match ignores the
+revision, and a stale
+`chromium-1208` left from before a CLI upgrade then reads as present while the
+launch fails `Browser "chromium" is not installed` — and because the gate reads
+ready, the panel never offers the download that would fix it. The prefix form also
+let `chromium_headless_shell-<rev>` satisfy `chromium`, which is a different
+artifact.
+
+The required revision comes from `playwright-core/browsers.json`, the file
+`install-browser` itself consults. Reading it is a plain file read, so readiness
+stays subprocess-free.
+
+**The manifest is attributed to a `@playwright/cli` package, never searched for.**
+Resolution anchors on that package — the hoisted sibling in the same
+`node_modules`, a copy nested under the package, or the standalone installer's
+known prefix (`KIROCREW_PLAYWRIGHT_CLI_HOME`, else `<data home>/playwright-cli`).
+Anchoring is a correctness property, not an optimization: walking ancestors
+instead passes through `$HOME` on the standalone layout, where one unrelated
+`~/node_modules/playwright-core` supplies a revision from a **different** install.
+That reports a working browser broken and keeps doing so after the offered
+download, because the gate goes on reading the foreign file. The standalone prefix
+is probed by path because that installer generates a **wrapper script** rather
+than a symlink, so its package tree is not an ancestor of the launcher at all.
+
+When no manifest can be attributed, the revision is unknown and readiness falls
+back to the older presence-only answer. Absent metadata is an unknown, not
+evidence of a stale cache, so it must not turn a working browser into a reported
+broken one.
+
 ### Command surface
 
 The full reference lives in the skill the CLI installs in step 4, which is why the
@@ -161,6 +195,58 @@ surrounding quotes are removed for the same reason. Normalization also runs on
 read, so a stored value holding the whole assignment repairs itself instead of
 reporting "stored" while the extension keeps prompting.
 
+### Launch config
+
+Kiro Crew installs, gates on, and offers downloads for **Chromium**:
+`install-browser` fetches the Chromium build, `browser_ok` is
+`browsers_present()["chromium"]`, and `attach --extension` supports that family
+alone. The CLI's own default is a different browser — the branded Chrome
+*channel*, an OS-level install at a path like `/opt/google/chrome/chrome` that
+Kiro Crew never provisions and cannot install without root. So on a host that did
+everything the product asked, the first browse fails with
+
+```
+Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
+```
+
+while every readiness signal is honestly green, because the Chromium build really
+is downloaded. `browser_cli/launch.py` closes that gap by naming the engine.
+
+**Why a config file rather than a flag or a browser env var.** All three exist and
+only the file works for a whole session:
+
+| Mechanism | Why it cannot carry this |
+|---|---|
+| `--browser` | takes `chrome, firefox, webkit, msedge` — `chromium` is not accepted |
+| `PLAYWRIGHT_MCP_BROWSER` | the same four values, so it cannot name the installed engine either |
+| `--config` | accepted only on the session-establishing commands (`open`, `attach`) and rejected by the follow-up commands that make up most of a session |
+| `PLAYWRIGHT_MCP_CONFIG` | names a config **file** and applies to every invocation uniformly |
+
+The last one is the mechanism used, and for the same reason as
+[snapshot retention](#snapshot-retention): the agent runs the CLI as a shell
+command, so an inherited environment variable is the only channel that reaches an
+invocation Kiro Crew never constructs. The config is written under the data home
+at a fixed absolute path, independent of whichever working directory a turn ran in.
+
+The schema is **nested** under a `browser` key — `{"browser": {"browserName":
+"chromium"}}`. A flat top-level `browserName` parses without error and selects
+nothing, which presents as the branded-Chrome failure above rather than as a
+config error.
+
+**The generated config names the engine and nothing else.** Every added key
+becomes a default an operator must discover in order to override, and the engine
+is the only one the install flow already decided.
+
+**The browser sandbox is deliberately untouched.** Chromium's sandbox is a
+security boundary, so no generated default removes it. A host that cannot run it —
+a container lacking the kernel permissions, where the failure is
+`No usable sandbox!` — needs an operator decision rather than a default that
+quietly drops the boundary for every host. That is what the escape hatch is for:
+when `PLAYWRIGHT_MCP_CONFIG` is **already set** in the environment, Kiro Crew adds
+nothing and the operator's file wins entirely. Naming a config is how an operator
+selects a different engine, pins an `executablePath`, or accepts the sandbox
+trade-off on a host that requires it.
+
 ### Snapshot retention
 
 The CLI writes one timestamped YAML per command and documents no pruning, so the
@@ -206,6 +292,7 @@ exposes an interactive takeover surface to the network.
 | Capability grant | Presence of `playwright-cli` on PATH; see [Capability model](#capability-model) for what this does and does not cover |
 | Dashboard exposure | `show` is bound to `127.0.0.1`; `0.0.0.0` is never passed, because the served view carries remote input |
 | Saved state files | Owner-only permissions; they hold live session credentials |
+| Launch config | Write-protected from the agent on both the file-edit and shell gates, and readable. Deliberately anchored rather than bare-token: the filename is not itself the grant, since the agent can name its own `PLAYWRIGHT_MCP_CONFIG` — so what the entry removes is the durable form (rewriting the config the product installed), and a `cd`-relative write is the accepted residual, exactly as for `.data-home-ready` |
 | Page content | Treated as untrusted input. A URL, instruction, or form target read off a page never decides the next navigation |
 | Attach mode | Operates the operator's real logged-in browser, so it is the strongest form of the capability and the reason the accepted risk is recorded |
 | Approval | Page-scoped verbs run without a prompt; verbs that reach the local machine do not. Matched on the real command from `tool_input`, never the model-authored title. Verb AND flag allowlists, so both `eval` and `screenshot --filename=<path>` keep interactive approval. Logged as `reason: "browser_cli"` |

--- a/src/kiro_crew/browser_cli/install.py
+++ b/src/kiro_crew/browser_cli/install.py
@@ -34,6 +34,7 @@ from typing import Any
 
 from kiro_crew import platform_compat
 from kiro_crew.browser_cli import os_deps
+from kiro_crew.config.paths import config_dir
 from kiro_crew.env import augmented_path, find_node_tool, node_augmented_path
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -214,42 +215,130 @@ def _cached_browser_names() -> set[str] | None:
 _BROWSERS_MANIFEST = "browsers.json"
 _PLAYWRIGHT_CORE_PKG = "playwright-core"
 
+#: The CLI's own package coordinates. The manifest is only trusted when it is
+#: served to THIS package, so the scope and name are what anchors the search.
+_CLI_PKG_SCOPE = "@playwright"
+_CLI_PKG_NAME = "cli"
+
+#: Where the standalone installer puts the package tree. `npm --global --prefix`
+#: writes under ``<prefix>/lib/node_modules`` on POSIX and ``<prefix>/node_modules``
+#: on Windows, so both are probed.
+_STANDALONE_PREFIX_ENV = "KIROCREW_PLAYWRIGHT_CLI_HOME"
+_STANDALONE_PREFIX_DIR = "playwright-cli"
+_NODE_MODULES = "node_modules"
+
+
+def _standalone_node_modules() -> list[Path]:
+    """``node_modules`` roots of a standalone (unprivileged) CLI install.
+
+    Probed by KNOWN PATH rather than found by searching, because the standalone
+    installer generates a **wrapper script** instead of a symlink: the package
+    tree is not an ancestor of the launcher on PATH, so no walk up from the
+    resolved launcher can reach it. Without this the revision could not be read
+    for that install shape at all, and the check would silently degrade to the
+    presence-only answer whose false positives it exists to remove.
+    """
+    prefix_override = os.environ.get(_STANDALONE_PREFIX_ENV, "").strip()
+    prefix = Path(prefix_override) if prefix_override else config_dir() / _STANDALONE_PREFIX_DIR
+    return [prefix / "lib" / _NODE_MODULES, prefix / _NODE_MODULES]
+
+
+def _launcher_node_modules(anchor: Path) -> list[Path]:
+    """``node_modules`` roots to probe relative to the resolved launcher.
+
+    A launcher that is a SYMLINK resolves INTO the package tree, so an ancestor is
+    already the package directory and none of these are needed. A launcher that is
+    a real FILE resolves to itself, and then the tree has to be found beside it:
+    ``npm install -g`` writes a ``.cmd`` batch wrapper on Windows, and a generated
+    shell wrapper is what the standalone installer produces. Without this, those
+    shapes read no revision at all and fall back to presence-only -- the exact
+    false positive the revision gate exists to remove.
+
+    Bounded to the launcher's own install prefix rather than walked toward the
+    filesystem root, because an unbounded walk is what allowed a foreign tree to
+    supply the revision. Every candidate still has to hold ``@playwright/cli``
+    (see :func:`_cli_package_dirs`), so a stray ``playwright-core`` from an
+    unrelated install is still unreachable.
+    """
+    return [
+        # <prefix>/playwright-cli.cmd  ->  <prefix>/node_modules  (npm -g, Windows)
+        anchor.parent / _NODE_MODULES,
+        # <prefix>/bin/playwright-cli  ->  <prefix>/node_modules
+        anchor.parent.parent / _NODE_MODULES,
+        # <prefix>/bin/playwright-cli  ->  <prefix>/lib/node_modules  (npm -g, POSIX)
+        anchor.parent.parent / "lib" / _NODE_MODULES,
+    ]
+
+
+def _cli_package_dirs() -> list[Path]:
+    """``@playwright/cli`` package directories on this host, most specific first.
+
+    Three sources, in priority order: an ancestor of the resolved launcher (an
+    ``npm install -g`` symlink resolves into the package tree), a ``node_modules``
+    beside the launcher (a real-file wrapper resolves to itself, so nothing in its
+    ancestry is the package), and the standalone installer's known prefix.
+    """
+    dirs: list[Path] = []
+    cli = cli_path()
+    if cli is not None:
+        try:
+            anchor: Path | None = Path(cli).resolve()
+        except OSError:
+            anchor = None
+        if anchor is not None:
+            for parent in anchor.parents:
+                if parent.name == _CLI_PKG_NAME and parent.parent.name == _CLI_PKG_SCOPE:
+                    dirs.append(parent)
+                    break
+            for node_modules in _launcher_node_modules(anchor):
+                package = node_modules / _CLI_PKG_SCOPE / _CLI_PKG_NAME
+                if package.is_dir():
+                    dirs.append(package)
+    for node_modules in _standalone_node_modules():
+        package = node_modules / _CLI_PKG_SCOPE / _CLI_PKG_NAME
+        if package.is_dir():
+            dirs.append(package)
+    return dirs
+
+
+def _manifest_for_cli_package(package: Path) -> Path | None:
+    """The ``browsers.json`` of the ``playwright-core`` serving *package*.
+
+    Two layouts, both anchored ON the package so the manifest can only come from
+    the tree that will launch the browser: nested inside the package's own
+    ``node_modules``, or hoisted as a sibling in the ``node_modules`` that holds
+    ``@playwright/cli`` (``<pkg>/../..`` — up past ``@playwright``).
+    """
+    for candidate in (
+        package / _NODE_MODULES / _PLAYWRIGHT_CORE_PKG / _BROWSERS_MANIFEST,
+        package.parent.parent / _PLAYWRIGHT_CORE_PKG / _BROWSERS_MANIFEST,
+    ):
+        if candidate.is_file():
+            return candidate
+    return None
+
 
 def _browsers_manifest_path() -> Path | None:
     """Locate the installed ``playwright-core/browsers.json``, or ``None``.
 
-    Anchored on the resolved CLI so it finds the manifest for the SAME install
-    the launch will use, not some other copy on the host. Two on-disk layouts
-    reach the same sibling ``node_modules``:
+    Resolution is anchored on the ``@playwright/cli`` package
+    (:func:`_cli_package_dirs`) rather than walked up from the launcher toward
+    the filesystem root. The anchor is the correctness property, not a
+    shortcut: an unbounded walk passes through ``$HOME`` on the standalone
+    layout, where a single unrelated ``~/node_modules/playwright-core`` would
+    supply a revision from a DIFFERENT install. That reports a **working**
+    browser broken, and keeps reporting it after the download the panel offers,
+    because the gate goes on reading the foreign manifest. Requiring the
+    manifest to be served to the CLI package makes a foreign tree unreachable.
 
-    * ``npm install -g`` leaves ``playwright-cli`` as a symlink into
-      ``.../node_modules/@playwright/cli/playwright-cli.js``; resolving the link
-      lands inside the package tree.
-    * the standalone launcher is a shell script at ``<root>/bin/playwright-cli``
-      whose sibling is ``<root>/node_modules``.
-
-    Both are covered by walking up from the resolved path and, at each ancestor,
-    probing ``<ancestor>/node_modules/playwright-core/browsers.json`` as well as a
-    ``<ancestor>/playwright-core/browsers.json`` (the ancestor already being a
-    ``node_modules`` dir, as when the resolved symlink sits inside the package).
+    ``None`` when no manifest can be attributed to a CLI package, which callers
+    treat as "revision unknown" and answer with the documented presence-only
+    fallback.
     """
-    cli = cli_path()
-    if cli is None:
-        return None
-    try:
-        # Follow a symlink (npm-global) to the real entry point; a shell-script
-        # launcher resolves to itself, which is fine -- its ancestors still hold
-        # the sibling node_modules.
-        anchor = Path(cli).resolve()
-    except OSError:
-        return None
-    for parent in [anchor, *anchor.parents]:
-        for candidate in (
-            parent / "node_modules" / _PLAYWRIGHT_CORE_PKG / _BROWSERS_MANIFEST,
-            parent / _PLAYWRIGHT_CORE_PKG / _BROWSERS_MANIFEST,
-        ):
-            if candidate.is_file():
-                return candidate
+    for package in _cli_package_dirs():
+        manifest = _manifest_for_cli_package(package)
+        if manifest is not None:
+            return manifest
     return None
 
 
@@ -282,21 +371,20 @@ def _required_revisions() -> dict[str, str] | None:
             continue
         name = entry.get("name")
         revision = entry.get("revision")
-        if isinstance(name, str) and isinstance(revision, (str, int)):
-            revisions[name] = str(revision)
+        if isinstance(name, str) and isinstance(revision, str):
+            revisions[name] = revision
     return revisions or None
 
 
-def _cache_dir_names_for(engine: str, revision: str) -> tuple[str, ...]:
-    """Cache directory names that satisfy *engine* at *revision*.
+def _cache_dir_name_for(engine: str, revision: str) -> str:
+    """The cache directory name that satisfies *engine* at *revision*.
 
-    Playwright names a cache dir ``<manifest-name>-<revision>``, and separately
-    stores ``<manifest-name>_headless_shell-<revision>`` with the hyphens in the
-    manifest name turned to underscores (e.g. ``chromium-headless-shell`` ->
-    ``chromium_headless_shell-1232``). Accept the underscore form of the same
-    name too, so a manifest name that carries hyphens still matches its dir.
+    Playwright names the directory ``<engine>-<revision>`` (``chromium-1232``).
+    One name, not a set: the only caller passes engines from
+    :data:`BROWSER_ENGINES`, none of which contains a hyphen, so an underscore
+    variant of the same name could never match anything.
     """
-    return (f"{engine}-{revision}", f"{engine.replace('-', '_')}-{revision}")
+    return f"{engine}-{revision}"
 
 
 def browsers_present() -> dict[str, bool]:
@@ -337,8 +425,8 @@ def browsers_present() -> dict[str, bool]:
             # revision it needs, so degrade to presence-only for this one engine.
             result[engine] = any(name.startswith(engine) for name in names)
             continue
-        wanted = set(_cache_dir_names_for(engine, revision))
-        result[engine] = bool(wanted & names)
+        wanted = _cache_dir_name_for(engine, revision)
+        result[engine] = wanted in names
     return result
 
 

--- a/src/kiro_crew/browser_cli/launch.py
+++ b/src/kiro_crew/browser_cli/launch.py
@@ -1,0 +1,135 @@
+"""The launch config that makes `playwright-cli` open the browser Kiro Crew provisions.
+
+Kiro Crew installs, gates on, and offers downloads for **Chromium**:
+``install-browser`` fetches the Chromium build, ``browser_ok`` is
+``browsers_present()["chromium"]``, and ``attach --extension`` supports that
+family alone. The CLI's own default is a different browser -- the branded Chrome
+*channel*, an OS-level install at a path like ``/opt/google/chrome/chrome`` that
+Kiro Crew never provisions and cannot install without root. So on a host that has
+done everything the product asked, the first browse fails with
+
+    Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
+
+while every readiness signal is honestly green: the Chromium build really is
+downloaded. Selecting the engine is what closes that gap, and it is a
+configuration fact rather than a defect in the readiness gate.
+
+**Why a config file and not a flag or an env var.** All three exist; only the
+file works for a whole session.
+
+- ``--browser`` and ``PLAYWRIGHT_MCP_BROWSER`` take ``chrome, firefox, webkit,
+  msedge``. Neither accepts ``chromium``, so neither can name the engine that is
+  actually installed. Verified against the CLI's own help and env table.
+- ``--config`` is accepted only on the session-establishing commands (``open``,
+  ``attach``) and is rejected by the follow-up commands that make up most of a
+  session, the same constraint that makes
+  :func:`kiro_crew.browser_cli.snapshots.cli_env_overrides` use an env var.
+- ``PLAYWRIGHT_MCP_CONFIG`` names a config FILE and applies to every invocation
+  uniformly. That is the one channel that reaches a command line Kiro Crew never
+  constructs, which is the whole shape of this capability: the agent runs the CLI
+  as a shell command.
+
+The config schema is nested under a ``browser`` key
+(``{"browser": {"browserName": ...}}``); a flat ``browserName`` at the top level
+parses without error and selects nothing.
+
+**The browser sandbox is left alone.** Chromium's own sandbox is a security
+boundary, so this module never writes ``chromiumSandbox``. A host that cannot
+run it -- a container without the needed kernel permissions -- needs an operator
+decision, not a default that quietly removes a boundary for everyone. That is
+what :func:`cli_env_overrides` deferring to an operator-set variable is for.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.paths import config_dir
+
+logger = logging.getLogger(__name__)
+
+#: The variable `playwright-cli` reads to locate its config file. Its name is
+#: fixed by the CLI, not by us.
+CONFIG_ENV = "PLAYWRIGHT_MCP_CONFIG"
+
+#: The engine Kiro Crew provisions and gates on. Kept as one named constant so
+#: the config can never disagree with what ``install-browser`` fetched.
+LAUNCH_ENGINE = "chromium"
+
+_CONFIG_FILE = "playwright-cli-config.json"
+
+
+def launch_config_path() -> Path:
+    """Where the generated launch config lives.
+
+    Under the data home, so it is a fixed absolute path independent of whichever
+    working directory an agent turn ran in, and so an isolated ``KIROCREW_HOME``
+    (a pod, a test) stays isolated here too.
+    """
+    return config_dir() / _CONFIG_FILE
+
+
+def desired_config() -> dict[str, object]:
+    """The config Kiro Crew generates.
+
+    Deliberately minimal: it names the engine and nothing else. Every key added
+    here becomes a default an operator has to discover in order to override, and
+    the engine is the only one the product's own install flow already decided.
+    """
+    return {"browser": {"browserName": LAUNCH_ENGINE}}
+
+
+def write_config() -> Path | None:
+    """Write the launch config, returning its path (``None`` if it could not be written).
+
+    Rewritten whenever it does not already match :func:`desired_config`, so a
+    file left by an older version converges. Best-effort by contract: this runs
+    on the gateway's startup path with nothing waiting on it, and a config that
+    cannot be written must not stop the gateway from coming up -- browsing then
+    behaves as it did before this file existed.
+    """
+    path = launch_config_path()
+    payload = json.dumps(desired_config(), indent=2) + "\n"
+    try:
+        if path.is_file() and path.read_text(encoding="utf-8") == payload:
+            return path
+    except (OSError, UnicodeDecodeError):
+        # Unreadable is not a reason to skip the write; it is a reason to do it.
+        pass
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(path, payload)
+    except OSError:
+        logger.warning(
+            "could not write the browser launch config at %s; playwright-cli will "
+            "fall back to its own default browser channel, which Kiro Crew does "
+            "not install",
+            path,
+        )
+        return None
+    return path
+
+
+def cli_env_overrides() -> dict[str, str]:
+    """Environment additions pointing the CLI at :func:`launch_config_path`.
+
+    Empty when :data:`CONFIG_ENV` is already set in the environment. An operator
+    who named their own config file has made a deliberate choice -- a different
+    engine, a pinned ``executablePath``, launch options for a container that
+    cannot run the browser sandbox -- and silently replacing it would both
+    override that choice and remove the escape hatch this module's narrow
+    defaults depend on.
+
+    Empty as well when the file could not be written, because pointing the CLI at
+    a path that does not exist is worse than leaving it on its own default: the
+    CLI fails on the missing config instead of on the missing browser, which is a
+    strictly less diagnosable error for the same broken outcome.
+    """
+    if os.environ.get(CONFIG_ENV, "").strip():
+        return {}
+    path = write_config()
+    return {CONFIG_ENV: str(path)} if path is not None else {}

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -26,6 +26,7 @@ from kiro_crew.apps.hooks_integration import (
 from kiro_crew.apps.manager import cleanup_migrated_builtin, register_builtin_apps
 from kiro_crew.autonudge import get_instance as _autonudge_get
 from kiro_crew.autonudge_authz import authorize_and_add_nudge
+from kiro_crew.browser_cli import launch as browser_cli_launch
 from kiro_crew.browser_cli import snapshots as browser_cli_snapshots
 from kiro_crew.browser_cli import token as browser_cli_token
 from kiro_crew.browser_cli import view as browser_cli_view
@@ -3197,6 +3198,15 @@ async def start_dashboard(
     # agent runs the CLI as a shell command, so only an inherited environment
     # reaches it. Absent by default, in which case this adds nothing.
     os.environ.update(browser_cli_token.cli_env_overrides())
+    # Name the engine Kiro Crew actually installs. The CLI's own default is the
+    # branded Chrome channel at an OS path the product never provisions, so
+    # without this the first browse fails on a host where every readiness signal
+    # is honestly green. Same channel and same reason as the two above; defers to
+    # an operator who set the variable themselves.
+    #
+    # Off the event loop: computing the override writes the config file, and this
+    # runs on the gateway's startup path.
+    os.environ.update(await asyncio.to_thread(browser_cli_launch.cli_env_overrides))
     _snap_pruner = asyncio.create_task(_prune_browser_snapshots_loop())
     _snap_pruner.add_done_callback(lambda t: t.result() if not t.cancelled() else None)
     state._browser_snapshot_pruner = _snap_pruner  # prevent GC

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4478,7 +4478,17 @@ _WRITE_PROTECTED_HOME_PATHS: list[str] = [
     # would make the next boot skip migration and ignore the legacy home's
     # governance policy + secrets. The migration code writes it directly and
     # does NOT route through this gate, so legitimate stamping still works.
-    for leaf in ("config.json", "config.local.json", ".data-home-ready")
+    # playwright-cli-config.json: the browse launch config
+    # (browser_cli/launch.py). It holds no secret and the CLI must READ it on
+    # every invocation, so it is write-protected rather than sensitive. But it is
+    # an INPUT TO A SECURITY DECISION: the schema accepts
+    # ``launchOptions.chromiumSandbox``, so an agent that could rewrite it would
+    # turn the browser sandbox OFF for every later browse, and the change persists
+    # until the next gateway start re-converges the file. Kiro Crew generates it
+    # directly and does NOT route through this gate, so its own write still works.
+    # Paired with the same leaf in _WRITE_PROTECTED_BASH_LEAVES — protected on one
+    # path only is not protected.
+    for leaf in ("config.json", "config.local.json", ".data-home-ready", "playwright-cli-config.json")
 ] + [
     # Ops Mission Control's on-call schedule. WRITE-protected, not read+write
     # sensitive: it holds no secret and every teammate's instance must READ it to
@@ -4636,6 +4646,20 @@ _WRITE_PROTECTED_BASH_LEAVES: tuple[str, ...] = (
     "apps/ops-mission-control/data/rotation.yaml",
     "apps/ops-mission-control/data/incidents/index.json",
     "connections-tool-aliases.json",
+    # The browse launch config (browser_cli/launch.py), paired with the same leaf
+    # in _WRITE_PROTECTED_HOME_PATHS so the file-edit and shell paths agree — a
+    # leaf on only one of the two is reachable through the other.
+    #
+    # Deliberately ANCHORED, not bare-token (see the SCOPE note below). The name
+    # is distinctive enough to qualify on that test, but it does not earn the wider
+    # blast radius, for the same shape of reason ``.data-home-ready`` does not: the
+    # agent can already point PLAYWRIGHT_MCP_CONFIG at a file of its own, so this
+    # filename is not the grant the way the alias record's is. What the anchored
+    # entry removes is the DURABLE form — silently rewriting the config the product
+    # installed, which every later browse consumes until the next gateway start
+    # re-converges it. The residual ``cd``-relative form is the low-severity case
+    # the scope note already accepts on purpose.
+    "playwright-cli-config.json",
 )
 
 # ── Anchor-INDEPENDENT leaf matching ──

--- a/test/test_browser_cli_install.py
+++ b/test/test_browser_cli_install.py
@@ -913,9 +913,9 @@ _MANIFEST = {
 }
 
 
-def _write_manifest(root: Path, data: object) -> Path:
-    """Write *data* as ``<root>/node_modules/playwright-core/browsers.json``."""
-    core = root / "node_modules" / "playwright-core"
+def _write_manifest(node_modules: Path, data: object) -> Path:
+    """Write *data* as ``<node_modules>/playwright-core/browsers.json``."""
+    core = node_modules / "playwright-core"
     core.mkdir(parents=True, exist_ok=True)
     path = core / "browsers.json"
     path.write_text(json.dumps(data), encoding="utf-8")
@@ -923,20 +923,21 @@ def _write_manifest(root: Path, data: object) -> Path:
 
 
 def _install_root(root: Path, data: object) -> str:
-    """Model a standalone install under *root*: launcher + manifest.
+    """Model an `npm install -g` tree under *root*; return the CLI entry path.
 
-    Writes ``<root>/bin/playwright-cli`` and the ``playwright-core`` manifest,
-    and returns the launcher path to stub ``cli_path`` with -- a real on-disk
-    file, so ``Path(cli).resolve()`` canonicalises the same tree the manifest
-    was written into (a bare non-existent path can resolve a symlinked temp dir
-    to a different canonical root than the one the file physically lives under).
+    ``<root>/lib/node_modules/@playwright/cli/playwright-cli.js`` with
+    ``playwright-core`` hoisted beside it in the same ``node_modules``. That is
+    the layout the manifest resolution anchors on, and the entry point is a real
+    on-disk file so ``Path(cli).resolve()`` canonicalises the same tree the
+    manifest was written into.
     """
-    _write_manifest(root, data)
-    bindir = root / "bin"
-    bindir.mkdir(parents=True, exist_ok=True)
-    launcher = bindir / "playwright-cli"
-    launcher.write_text("#!/bin/sh\n", encoding="utf-8")
-    return str(launcher)
+    node_modules = root / "lib" / "node_modules"
+    _write_manifest(node_modules, data)
+    package = node_modules / "@playwright" / "cli"
+    package.mkdir(parents=True, exist_ok=True)
+    entry = package / "playwright-cli.js"
+    entry.write_text("// entry\n", encoding="utf-8")
+    return str(entry)
 
 
 class TestRequiredRevisionMatch:
@@ -993,14 +994,34 @@ class TestRequiredRevisionMatch:
         assert mod.browsers_present()["chromium"] is False
         assert mod._browser_present() is False
 
-    def test_headless_shell_underscore_dir_matches_its_own_hyphenated_name(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    def test_cache_dir_name_is_the_hyphenated_revision_form(self) -> None:
+        """One name per engine-revision pair, and never an underscore variant.
+
+        The only caller passes engines from `BROWSER_ENGINES`, none of which
+        contains a hyphen, so an underscored form of the same name could not
+        match any directory -- and accepting one would let
+        `chromium_headless_shell-<rev>` satisfy `chromium`, which is the very
+        false positive this gate exists to reject.
+        """
+        assert mod._cache_dir_name_for("chromium", "1232") == "chromium-1232"
+        assert "_" not in mod._cache_dir_name_for("chromium", "1232")
+
+    def test_an_underscored_cache_dir_does_not_satisfy_the_engine(
+        self, monkeypatch: pytest.MonkeyPatch, isolated_browser_cache: Path, tmp_path: Path
     ) -> None:
-        """The manifest name `chromium-headless-shell` is stored on disk as
-        `chromium_headless_shell-<rev>`; `_cache_dir_names_for` must accept it so
-        a hyphenated manifest name still resolves to its underscored dir."""
-        names = mod._cache_dir_names_for("chromium-headless-shell", "1232")
-        assert "chromium_headless_shell-1232" in names
+        """The same rejection asserted through `browsers_present`, not the helper.
+
+        Testing only `_cache_dir_name_for` would still pass if a future change
+        re-added an underscore fallback in the caller instead of the helper, which
+        is where the original prefix match lived.
+        """
+        launcher = _install_root(tmp_path / "cli-root", _MANIFEST)
+        monkeypatch.setattr(mod, "cli_path", lambda: launcher)
+        monkeypatch.setattr(mod, "_required_revisions", _REAL_REQUIRED_REVISIONS)
+        (isolated_browser_cache / "chromium_1232").mkdir()
+
+        assert mod.browsers_present()["chromium"] is False
+        assert mod._browser_present() is False
 
     def test_each_engine_matched_against_its_own_revision(
         self, monkeypatch: pytest.MonkeyPatch, isolated_browser_cache: Path, tmp_path: Path
@@ -1107,7 +1128,8 @@ class TestRevisionDegradation:
                     "not-a-dict",
                     {"name": "chromium"},  # no revision
                     {"revision": "1"},  # no name
-                    {"name": "firefox", "revision": 1534},  # int revision is accepted
+                    {"name": "webkit", "revision": 2327},  # int revision -> skipped
+                    {"name": "firefox", "revision": "1534"},
                 ]
             },
         )
@@ -1115,6 +1137,10 @@ class TestRevisionDegradation:
         monkeypatch.setattr(mod, "_required_revisions", _REAL_REQUIRED_REVISIONS)
 
         rev = _REAL_REQUIRED_REVISIONS()
+        # playwright-core ships string revisions, so a non-string is a malformed
+        # row like any other rather than a value to coerce. Skipping it leaves the
+        # engine without a required revision, which degrades to presence-only for
+        # that engine -- the safe direction.
         assert rev == {"firefox": "1534"}
 
     def test_manifest_without_browsers_list_is_none(
@@ -1129,33 +1155,48 @@ class TestRevisionDegradation:
 
 
 class TestManifestResolution:
-    """The manifest is found for BOTH on-disk layouts, anchored on the CLI."""
+    """The manifest is attributed to a `@playwright/cli` package, never searched for.
 
-    def test_standalone_launcher_layout(
+    Anchoring is the correctness property. An unbounded walk up from the launcher
+    passes through `$HOME` on the standalone layout, where one unrelated
+    `~/node_modules/playwright-core` would supply a revision from a DIFFERENT
+    install -- reporting a WORKING browser broken, and continuing to after the
+    download the panel offers, because the gate keeps reading the foreign file.
+    """
+
+    def test_npm_global_hoisted_sibling_layout(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """`<root>/bin/playwright-cli` -> `<root>/node_modules/playwright-core`."""
+        """`playwright-core` hoisted beside `@playwright/cli` in one node_modules."""
         root = tmp_path / "cli-root"
-        (root / "bin").mkdir(parents=True)
-        launcher = root / "bin" / "playwright-cli"
-        launcher.write_text("#!/bin/sh\n", encoding="utf-8")
-        manifest = _write_manifest(root, _MANIFEST)
-        monkeypatch.setattr(mod, "cli_path", lambda: str(launcher))
+        entry = _install_root(root, _MANIFEST)
+        monkeypatch.setattr(mod, "cli_path", lambda: entry)
 
-        assert mod._browsers_manifest_path() == manifest
+        assert mod._browsers_manifest_path() == (
+            root / "lib" / "node_modules" / "playwright-core" / "browsers.json"
+        )
 
-    def test_npm_global_symlink_layout(
+    def test_nested_playwright_core_layout(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """A symlinked bin resolves into the package tree; the sibling
-        playwright-core under the same node_modules is found by walking up."""
-        node_modules = tmp_path / "lib" / "node_modules"
-        pkg = node_modules / "@playwright" / "cli"
-        pkg.mkdir(parents=True)
-        entry = pkg / "playwright-cli.js"
-        entry.write_text("// entry\n", encoding="utf-8")
-        manifest = _write_manifest(node_modules.parent, _MANIFEST)  # node_modules/playwright-core
+        """npm nests a conflicting version under the package's own node_modules.
 
+        The nested copy is the one that serves this CLI, so it wins over a
+        hoisted sibling.
+        """
+        root = tmp_path / "cli-root"
+        entry = Path(_install_root(root, {"browsers": [{"name": "chromium", "revision": "1"}]}))
+        nested = _write_manifest(entry.parent / "node_modules", _MANIFEST)
+        monkeypatch.setattr(mod, "cli_path", lambda: str(entry))
+
+        assert mod._browsers_manifest_path() == nested
+
+    def test_npm_global_symlinked_bin_resolves_into_the_package(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """`npm install -g` leaves a symlink; resolving it lands in the tree."""
+        root = tmp_path / "cli-root"
+        entry = _install_root(root, _MANIFEST)
         bindir = tmp_path / "bin"
         bindir.mkdir()
         link = bindir / "playwright-cli"
@@ -1165,9 +1206,132 @@ class TestManifestResolution:
             pytest.skip("symlinks not supported on this host")
         monkeypatch.setattr(mod, "cli_path", lambda: str(link))
 
+        assert mod._browsers_manifest_path() == (
+            root / "lib" / "node_modules" / "playwright-core" / "browsers.json"
+        )
+
+    def test_standalone_wrapper_resolves_via_its_known_prefix(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The standalone installer generates a WRAPPER SCRIPT, not a symlink.
+
+        The package tree is therefore not an ancestor of the launcher on PATH, so
+        no walk up from it can reach the manifest. The prefix is known, so it is
+        probed by path -- without which this install shape could never read a
+        revision and would silently keep the presence-only false positives.
+        """
+        prefix = tmp_path / "standalone"
+        _install_root(prefix, _MANIFEST)
+        monkeypatch.setenv("KIROCREW_PLAYWRIGHT_CLI_HOME", str(prefix))
+        wrapper = tmp_path / "elsewhere" / "bin" / "playwright-cli"
+        wrapper.parent.mkdir(parents=True)
+        wrapper.write_text("#!/bin/sh\nexec node ...\n", encoding="utf-8")
+        monkeypatch.setattr(mod, "cli_path", lambda: str(wrapper))
+
+        assert mod._browsers_manifest_path() == (
+            prefix / "lib" / "node_modules" / "playwright-core" / "browsers.json"
+        )
+
+    def test_windows_npm_global_cmd_wrapper_finds_the_sibling_package(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """`npm install -g` writes a .cmd BATCH WRAPPER on Windows, not a symlink.
+
+        It resolves to itself, so nothing in its ancestry is the package dir and
+        the package sits at <prefix>/node_modules/@playwright/cli beside it. Left
+        unreachable, this shape reads no revision and silently falls back to the
+        presence-only match the gate exists to replace.
+        """
+        prefix = tmp_path / "npm-prefix"
+        node_modules = prefix / "node_modules"
+        manifest = _write_manifest(node_modules, _MANIFEST)
+        package = node_modules / "@playwright" / "cli"
+        package.mkdir(parents=True)
+        (package / "playwright-cli.js").write_text("// entry\n", encoding="utf-8")
+        wrapper = prefix / "playwright-cli.cmd"
+        wrapper.write_text("@echo off\r\nnode ...\r\n", encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_PLAYWRIGHT_CLI_HOME", str(tmp_path / "absent-prefix"))
+        monkeypatch.setattr(mod, "cli_path", lambda: str(wrapper))
+
         assert mod._browsers_manifest_path() == manifest
+
+    def test_posix_bin_wrapper_finds_the_lib_node_modules_package(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A non-symlink launcher at <prefix>/bin resolves to itself too."""
+        prefix = tmp_path / "posix-prefix"
+        manifest_root = prefix / "lib" / "node_modules"
+        manifest = _write_manifest(manifest_root, _MANIFEST)
+        package = manifest_root / "@playwright" / "cli"
+        package.mkdir(parents=True)
+        wrapper = prefix / "bin" / "playwright-cli"
+        wrapper.parent.mkdir(parents=True)
+        wrapper.write_text("#!/bin/sh\nexec node ...\n", encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_PLAYWRIGHT_CLI_HOME", str(tmp_path / "absent-prefix"))
+        monkeypatch.setattr(mod, "cli_path", lambda: str(wrapper))
+
+        assert mod._browsers_manifest_path() == manifest
+
+    def test_standalone_windows_prefix_without_lib_resolves(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """`npm --global --prefix` writes <prefix>/node_modules on Windows.
+
+        The POSIX form is <prefix>/lib/node_modules, so both are probed.
+        """
+        prefix = tmp_path / "standalone-win"
+        node_modules = prefix / "node_modules"
+        manifest = _write_manifest(node_modules, _MANIFEST)
+        (node_modules / "@playwright" / "cli").mkdir(parents=True)
+        monkeypatch.setenv("KIROCREW_PLAYWRIGHT_CLI_HOME", str(prefix))
+        monkeypatch.setattr(mod, "cli_path", lambda: None)
+
+        assert mod._browsers_manifest_path() == manifest
+
+    def test_a_foreign_manifest_up_the_tree_is_never_adopted(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """THE false-broken regression, and the inverse of the stale-cache one.
+
+        A stray `playwright-core` from an unrelated `npm i playwright` sits in an
+        ANCESTOR of the launcher, with no `@playwright/cli` beside it. Adopting it
+        would hand the gate a revision from a different install and flip a working
+        browser to reported-broken. Unattributable means None, which takes the
+        documented presence-only fallback instead.
+        """
+        home = tmp_path / "home"
+        _write_manifest(
+            home / "node_modules", {"browsers": [{"name": "chromium", "revision": "9"}]}
+        )
+        monkeypatch.setenv("KIROCREW_PLAYWRIGHT_CLI_HOME", str(tmp_path / "absent-prefix"))
+        wrapper = home / "bin" / "playwright-cli"
+        wrapper.parent.mkdir(parents=True)
+        wrapper.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setattr(mod, "cli_path", lambda: str(wrapper))
+
+        assert mod._browsers_manifest_path() is None
+        assert _REAL_REQUIRED_REVISIONS() is None
+
+    def test_a_working_browser_is_not_reported_broken_by_a_foreign_manifest(
+        self, monkeypatch: pytest.MonkeyPatch, isolated_browser_cache: Path, tmp_path: Path
+    ) -> None:
+        """The invariant the anchoring protects, asserted end to end."""
+        home = tmp_path / "home"
+        _write_manifest(
+            home / "node_modules", {"browsers": [{"name": "chromium", "revision": "9999"}]}
+        )
+        monkeypatch.setenv("KIROCREW_PLAYWRIGHT_CLI_HOME", str(tmp_path / "absent-prefix"))
+        wrapper = home / "bin" / "playwright-cli"
+        wrapper.parent.mkdir(parents=True)
+        wrapper.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setattr(mod, "cli_path", lambda: str(wrapper))
+        monkeypatch.setattr(mod, "_required_revisions", _REAL_REQUIRED_REVISIONS)
+        (isolated_browser_cache / "chromium-1232").mkdir()
+
+        assert mod.browsers_present()["chromium"] is True
 
     def test_no_cli_means_no_manifest(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(mod, "cli_path", lambda: None)
+        monkeypatch.setenv("KIROCREW_PLAYWRIGHT_CLI_HOME", "/nonexistent-prefix")
         assert mod._browsers_manifest_path() is None
         assert _REAL_REQUIRED_REVISIONS() is None

--- a/test/test_browser_cli_journeys.py
+++ b/test/test_browser_cli_journeys.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 
 from kiro_crew import platform_compat
-from kiro_crew.browser_cli import install, snapshots, view
+from kiro_crew.browser_cli import install, launch, snapshots, view
 
 
 @pytest.fixture()
@@ -47,17 +47,30 @@ def _operator_cli_config(home: Path) -> Path:
 
 
 class TestOperatorConfigIsNotOurs:
-    """The CLI's config file belongs to the operator, so we never write it."""
+    """The CLI's config file belongs to the operator, so we never write THEIRS.
+
+    Kiro Crew writes its OWN config under the data home and points
+    ``PLAYWRIGHT_MCP_CONFIG`` at it, which is a different file. Precedence,
+    measured against the real CLI, is what keeps that from becoming an override:
+    a ``<cwd>/.playwright/cli.config.json`` beats the env-named file, so an
+    operator's proxy and viewport survive. Their file is never read or rewritten.
+    """
 
     def test_the_package_has_exactly_one_destructive_operation(self):
         # A guard on the property the other cases depend on: if a future change adds
         # a config write, this fails and the reviewer has to justify it rather than
         # discovering it from a support report.
         #
-        # Exactly ONE write is sanctioned: token.py persists the optional attach
-        # token, which has to survive a restart to be worth configuring. It is
-        # named by module so that a second write in token.py still fails here.
-        sanctioned = {"token.py"}
+        # TWO writes are sanctioned, named by module so a SECOND write in either
+        # still fails here:
+        #   token.py  -- persists the optional attach token, which has to survive a
+        #                restart to be worth configuring.
+        #   launch.py -- generates Kiro Crew's OWN launch config under the data
+        #                home, naming the engine the product installs. It never
+        #                writes, reads, or supersedes the operator's
+        #                .playwright/cli.config.json; see
+        #                test_the_operator_config_path_is_never_written.
+        sanctioned = {"token.py", "launch.py"}
         pkg = Path(install.__file__).parent
         writes = []
         for source in sorted(pkg.glob("*.py")):
@@ -69,17 +82,43 @@ class TestOperatorConfigIsNotOurs:
                     writes.append(f"{source.name}:{lineno}")
         unexpected = [w for w in writes if w.split(":", 1)[0] not in sanctioned]
         assert unexpected == [], f"browser_cli must not write files: {unexpected}"
-        # And the sanctioned one must still be there: a token that stopped being
-        # persisted would silently stop working across restarts.
+        # And the sanctioned ones must still be there: a token that stopped being
+        # persisted would silently stop working across restarts, and a launch config
+        # that stopped being written would put browsing back on the CLI's default
+        # browser channel, which Kiro Crew does not install.
         assert any(w.startswith("token.py:") for w in writes), "token.py must persist the token"
+        assert any(w.startswith("launch.py:") for w in writes), "launch.py must write the config"
 
-    def test_a_gateway_restart_leaves_the_config_alone(self, home: Path):
+    def test_the_operator_config_path_is_never_written(self, home: Path):
+        """Ours goes under the data home, never at the CLI's discovered path."""
         config = _operator_cli_config(home)
         before = config.read_text(encoding="utf-8")
 
-        # What a restart actually does for browsing: republish the output directory
-        # and prune. Neither reads nor writes operator config.
-        os.environ.update(snapshots.cli_env_overrides())
+        written = launch.write_config()
+
+        assert written is not None
+        assert written != config
+        assert written.name != "cli.config.json"
+        assert ".playwright" not in written.parts
+        assert config.read_text(encoding="utf-8") == before
+
+    def test_a_gateway_restart_leaves_the_config_alone(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        config = _operator_cli_config(home)
+        before = config.read_text(encoding="utf-8")
+
+        # What a restart actually does for browsing: republish the output directory,
+        # publish the launch config, and prune. None of it touches operator config.
+        # Applied through monkeypatch so the variables do not outlive the test -- a
+        # bare os.environ.update would leak them to every later test on this xdist
+        # worker, where one expecting PLAYWRIGHT_MCP_CONFIG unset would then pass or
+        # fail on worker assignment.
+        for key, value in {
+            **snapshots.cli_env_overrides(),
+            **launch.cli_env_overrides(),
+        }.items():
+            monkeypatch.setenv(key, value)
         snapshots.prune()
 
         assert config.read_text(encoding="utf-8") == before

--- a/test/test_browser_cli_launch.py
+++ b/test/test_browser_cli_launch.py
@@ -1,0 +1,277 @@
+"""The launch config that selects the engine Kiro Crew actually installs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.browser_cli import launch as mod
+
+
+def test_launch_config_path_is_under_the_data_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+
+    assert mod.launch_config_path() == home / "playwright-cli-config.json"
+
+
+def test_launch_config_path_is_independent_of_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The agent runs the CLI from wherever its turn happened to be.
+
+    A cwd-derived config would apply to some turns and not others.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    first = tmp_path / "somewhere"
+    second = tmp_path / "elsewhere"
+    first.mkdir()
+    second.mkdir()
+
+    monkeypatch.chdir(first)
+    from_first = mod.launch_config_path()
+    monkeypatch.chdir(second)
+    from_second = mod.launch_config_path()
+
+    assert from_first == from_second
+    assert first not in from_first.parents
+    assert second not in from_second.parents
+
+
+def test_config_names_the_engine_under_the_nested_browser_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The schema is nested. A flat top-level `browserName` parses and selects nothing.
+
+    That is why this asserts the shape and not merely that the value appears
+    somewhere in the file.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+
+    path = mod.write_config()
+
+    assert path is not None
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert written == {"browser": {"browserName": "chromium"}}
+
+
+def test_engine_is_the_one_the_capability_gate_requires(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The config must name the engine `install-browser` fetched and `browser_ok`
+    gates on, or the product would install one browser and launch another --
+    which is the whole defect this module exists to close."""
+    from kiro_crew.browser_cli import install
+
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+
+    assert mod.LAUNCH_ENGINE in install.BROWSER_ENGINES
+    engine = mod.desired_config()["browser"]
+    assert isinstance(engine, dict)
+    assert engine["browserName"] == mod.LAUNCH_ENGINE
+
+
+def test_config_does_not_touch_the_browser_sandbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Chromium's sandbox is a security boundary, so no generated default removes it.
+
+    A host that cannot run it needs an operator decision, which is what deferring
+    to an operator-set `PLAYWRIGHT_MCP_CONFIG` provides.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+
+    body = json.dumps(mod.desired_config())
+
+    assert "chromiumSandbox" not in body
+    assert "no-sandbox" not in body
+
+
+def test_cli_env_overrides_points_the_cli_at_the_generated_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    monkeypatch.delenv(mod.CONFIG_ENV, raising=False)
+
+    env = mod.cli_env_overrides()
+
+    assert env == {"PLAYWRIGHT_MCP_CONFIG": str(mod.launch_config_path())}
+    assert mod.launch_config_path().is_file()
+
+
+def test_cli_env_override_value_is_absolute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI resolves a relative config path against its own working directory."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    monkeypatch.delenv(mod.CONFIG_ENV, raising=False)
+
+    value = mod.cli_env_overrides()[mod.CONFIG_ENV]
+
+    assert Path(value).is_absolute()
+
+
+def test_an_operator_set_config_is_never_overridden(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator naming their own config chose an engine, an executablePath, or
+    launch options for a host that cannot run the browser sandbox. Replacing it
+    would both override that choice and remove the escape hatch these narrow
+    defaults rely on."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv(mod.CONFIG_ENV, "/operator/owned.json")
+
+    assert mod.cli_env_overrides() == {}
+
+
+def test_a_blank_operator_value_is_not_treated_as_a_choice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty or whitespace value selects no config, so it is not a preference
+    to preserve -- honouring it would leave the CLI on its own default browser."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv(mod.CONFIG_ENV, "   ")
+
+    assert mod.cli_env_overrides() == {mod.CONFIG_ENV: str(mod.launch_config_path())}
+
+
+def test_write_is_idempotent_and_converges_a_stale_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+
+    first = mod.write_config()
+    assert first is not None
+    stamp = first.stat().st_mtime_ns
+    assert mod.write_config() == first
+    assert first.stat().st_mtime_ns == stamp, "an unchanged config is not rewritten"
+
+    first.write_text('{"browser": {"browserName": "webkit"}}\n', encoding="utf-8")
+    mod.write_config()
+
+    assert json.loads(first.read_text(encoding="utf-8")) == mod.desired_config()
+
+
+def test_an_unreadable_existing_config_is_rewritten(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Undecodable bytes are a reason to write, not a reason to skip."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    path = mod.launch_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\xff\xfe not utf-8")
+
+    assert mod.write_config() == path
+    assert json.loads(path.read_text(encoding="utf-8")) == mod.desired_config()
+
+
+def test_an_unwritable_config_yields_no_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pointing the CLI at a path that does not exist is worse than leaving it on
+    its own default: it fails on the missing config instead of the missing
+    browser, which is less diagnosable for the same broken outcome."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    monkeypatch.delenv(mod.CONFIG_ENV, raising=False)
+    monkeypatch.setattr(mod, "write_config", lambda: None)
+
+    assert mod.cli_env_overrides() == {}
+
+
+def test_the_launch_config_is_write_protected_from_the_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Defense-in-depth on both agent write paths, at parity with existing leaves.
+
+    The config's schema accepts ``launchOptions.chromiumSandbox``, so an agent
+    that rewrote it would turn the browser sandbox off for every later browse and
+    the change would persist until the next gateway start. This does not create a
+    capability the agent lacked -- it can point ``PLAYWRIGHT_MCP_CONFIG`` at a file
+    of its own -- it removes the durable form of silently rewriting the config the
+    product installed.
+
+    Asserted on BOTH paths, because a leaf on only one is reachable through the
+    other, and the two gates are separate matchers.
+    """
+    from kiro_crew import security
+
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    path = str(mod.launch_config_path())
+
+    # 1. the file-edit gate
+    assert security.is_sensitive_write_path(path) is True
+    # 2. the shell gate, across the spellings it does cover
+    for command in (
+        "echo x > ~/.kiro/crew/playwright-cli-config.json",
+        "echo x > $HOME/.kiro/crew/playwright-cli-config.json",
+        "echo x > ~/.kirocrew/playwright-cli-config.json",  # legacy data home
+        "tee ~/.kiro/crew/playwright-cli-config.json",
+        "cp /tmp/evil.json ~/.kiro/crew/playwright-cli-config.json",
+    ):
+        assert security.is_sensitive_bash_command(command) is not None, command
+    # Readable through Python: the CLI opens it on every invocation.
+    assert security.is_sensitive_path(path) is False
+
+
+def test_launch_config_shell_protection_matches_an_existing_protected_leaf() -> None:
+    """The shell gate treats this leaf exactly as it treats a long-standing one.
+
+    Parity is the honest assertion, and the durable one. The leaf is deliberately
+    ANCHORED rather than bare-token: per the scope note on
+    ``_BARE_TOKEN_PROTECTED_LEAVES``, a leaf earns anchor-independent matching only
+    when the filename IS the grant, and here it is not -- the agent can point
+    ``PLAYWRIGHT_MCP_CONFIG`` at a file of its own. So a ``cd``-relative write is
+    the accepted residual, exactly as it is for ``.data-home-ready``.
+
+    Asserting parity is what protects the invariant: it fails if someone protects
+    one leaf and not the other, and it does not pretend a gap is closed.
+    """
+    from kiro_crew import security
+
+    ours = "playwright-cli-config.json"
+    existing = ".data-home-ready"
+    for form in (
+        "echo x > ~/.kiro/crew/{leaf}",
+        "echo x > $HOME/.kiro/crew/{leaf}",
+        "echo x > ~/.kirocrew/{leaf}",
+        "tee ~/.kiro/crew/{leaf}",
+        "cd ~/.kiro/crew && printf x > {leaf}",
+    ):
+        assert (
+            security.is_sensitive_bash_command(form.format(leaf=ours)) is not None
+        ) == (
+            security.is_sensitive_bash_command(form.format(leaf=existing)) is not None
+        ), form
+
+
+def test_gateway_startup_merges_the_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The variable has to reach a command line Kiro Crew never constructs, so the
+    wiring is what delivers the fix -- an unwired module changes nothing."""
+    import inspect
+
+    from kiro_crew.dashboard import server
+
+    source = inspect.getsource(server)
+
+    assert "browser_cli_launch.cli_env_overrides" in source
+
+
+def test_gateway_startup_does_not_write_the_config_on_the_event_loop() -> None:
+    """Computing the override writes a file, and the wiring site is `async def`.
+
+    A bare call there blocks the loop during boot, so the dispatch must stay
+    off-thread -- asserted on the source because the cost is invisible in a
+    functional test.
+    """
+    import inspect
+
+    from kiro_crew.dashboard import server
+
+    source = inspect.getsource(server)
+
+    assert "asyncio.to_thread(browser_cli_launch.cli_env_overrides)" in source
+    assert "os.environ.update(browser_cli_launch.cli_env_overrides())" not in source


### PR DESCRIPTION
## Problem / Motivation

Browsing fails on the first attempt on a host that did everything the product asked, and every readiness signal stays honestly green while it does.

Kiro Crew installs, gates on, and offers downloads for **Chromium**: `install-browser` fetches the Chromium build, `browser_ok` is `browsers_present()["chromium"]`, and `attach --extension` supports that family alone. But `@playwright/cli` defaults to a *different* browser — the branded Chrome **channel**, an OS-level install at a path like `/opt/google/chrome/chrome` that Kiro Crew never provisions and cannot install without root. So the first browse fails with

```
Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
```

even though the Chromium build really is downloaded.

A second, narrower defect sits next to it. The browser-revision gate reads `playwright-core/browsers.json` by walking up from the resolved launcher toward the filesystem root. On the standalone layout that walk passes through `$HOME`, so a single unrelated `~/node_modules/playwright-core` — one stray `npm i playwright` — supplies a revision from a **different** install. That reports a **working** browser broken, and keeps reporting it after the download the panel offers, because the gate goes on reading the foreign manifest.

## Why it matters

The first defect makes the browse capability unusable out of the box while looking installed, which is the worst combination for diagnosis: nothing is red, so there is nothing to act on. The user is told the browser is ready and simply cannot browse.

The second inverts the readiness signal in the other direction and is self-sustaining: the offered download cannot clear it, so a user with a perfectly good browser has no path back to working except discovering the foreign directory themselves.

## What changed (motivation → approach → change)

**Engine selection.** The product already decided which engine it installs, so the fix is to say so at launch. `browser_cli/launch.py` generates a config naming the engine and exports `PLAYWRIGHT_MCP_CONFIG`.

Four mechanisms could carry that, and only one works for a whole session:

| Mechanism | Why it cannot carry this |
|---|---|
| `--browser` | takes `chrome, firefox, webkit, msedge` — `chromium` is not accepted |
| `PLAYWRIGHT_MCP_BROWSER` | the same four values, so it cannot name the installed engine either |
| `--config` | accepted only on the session-establishing commands (`open`, `attach`), rejected by the follow-up commands that make up most of a session |
| `PLAYWRIGHT_MCP_CONFIG` | names a config **file** and applies to every invocation uniformly |

An inherited environment variable is also the only channel that reaches an invocation Kiro Crew never constructs, which is the shape of this capability: the agent runs the CLI as a shell command. Same channel, and the same reason, as the existing snapshot-directory and attach-token overrides it sits beside.

Verified against the real CLI rather than assumed: an operator's own `<cwd>/.playwright/cli.config.json` **beats** the env-named file, so their proxy and viewport survive untouched; and an already-set `PLAYWRIGHT_MCP_CONFIG` is left entirely alone, which is the escape hatch for a host that cannot run the browser sandbox. The generated config names the engine and nothing else, and never writes `chromiumSandbox` — that is a security boundary, and a host unable to run it needs an operator decision rather than a default that drops the boundary for everyone.

**Revision manifest.** Resolution is now anchored on the `@playwright/cli` package instead of walked toward the filesystem root, so a foreign tree is unreachable. Because `npm install -g` writes a `.cmd` **wrapper** on Windows (not a symlink), the package tree is not an ancestor of the launcher there — so a bounded set of launcher-relative `node_modules` roots is probed too, plus the standalone installer's known prefix. Without that, those shapes read no revision at all and fall back to the presence-only match the gate exists to replace.

Two subtractions came out of the same reading: the underscore cache-name variant could never match any engine the gate checks (none contains a hyphen), and playwright-core ships string revisions, so the integer tolerance existed only for a fixture.

**Config write-protection.** The config's schema accepts `launchOptions.chromiumSandbox`, so the generated file is write-protected from the agent on **both** paths that reach it — the file-edit gate and the shell gate — since a leaf on only one is reachable through the other. It is deliberately *anchored* rather than bare-token: per the scope note on `_BARE_TOKEN_PROTECTED_LEAVES`, a leaf earns anchor-independent matching only when the filename **is** the grant, and this one is not (the agent can name its own `PLAYWRIGHT_MCP_CONFIG`). What the entry removes is the durable form — silently rewriting the config the product installed. A `cd`-relative write is therefore the accepted residual, exactly as for `.data-home-ready`, and a test pins **parity** with that leaf rather than asserting a closure that does not hold.

## Tests

`test/test_browser_cli_launch.py` (new) and additions to `test/test_browser_cli_install.py` / `test/test_browser_cli_journeys.py`:

- the config names the engine under the **nested** `browser` key — a flat top-level `browserName` parses and selects nothing, so the shape is asserted rather than the value appearing somewhere
- the engine is one the capability gate actually requires, so the product cannot install one browser and launch another
- no generated default disables the browser sandbox
- an operator-set `PLAYWRIGHT_MCP_CONFIG` is never overridden; a blank value is not treated as a preference
- the write is idempotent, converges a stale file, and rewrites an undecodable one; an unwritable config yields no override
- the override is wired into gateway startup, and dispatched off the event loop
- the config is write-protected on the file-edit **and** shell gates, readable, and at parity with `.data-home-ready`
- manifest resolution for the hoisted-sibling, nested, symlinked-bin, Windows `.cmd`-wrapper, POSIX bin-wrapper, and standalone-prefix layouts
- a foreign manifest up the tree is never adopted, and a working browser is not reported broken by one
- an underscored cache dir does not satisfy the engine, asserted through `browsers_present` and not only the helper

Eight mutation probes were run, each injecting one defect this change fixes (unbounded walk, missing wiring, operator-config override, sandbox-disabling default, underscore variant, removed launcher-relative probing, and each write-protection path separately). All eight are caught, and the two protection paths fail independently.

## Manual verification

Exercised end to end against the real CLI on Linux, since the whole defect is an interaction with the CLI's own resolution that unit tests mock:

- with the generated config, a bare `playwright-cli open` renders; without it, the same invocation fails on `/opt/google/chrome/chrome`
- `PLAYWRIGHT_MCP_CONFIG` is honoured for a whole session
- precedence measured directly: with an operator `<cwd>/.playwright/cli.config.json` carrying a proxy, the proxy still applies, confirming the generated config does not override operator config
- the required revision read from the real `browsers.json` matches what `install-browser chromium --dry-run` reports, and a cache holding only a stale revision reads as not-ready

## Related Issues

no linked issue: found while making the browse capability work end to end on a host that had completed the documented install.

<!-- no-visual-delta -->
**Why no screenshot:** backend, docs and tests only — no `website/` path is touched and nothing rendered changes.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
