### PR TITLE
test: fail on leaked temp directories

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1738,20 +1738,21 @@ _TMP_RESIDUE_ALLOWED_PREFIXES: tuple[str, ...] = (
     ".org.chromium.",
 )
 
-#: Make temp residue FAIL the run rather than warn.
+#: Make ALL temp residue fail the run rather than warning for leftover files.
 #:
-#: Off by default, and that is a staged rollout rather than a soft opinion. The guard
-#: found real residue on CI surfaces this host cannot reach, and the entries that remain
-#: after the exclusions above are single ``mkstemp`` FILES rather than the ``mkdtemp``
-#: directories the rule is written about -- one inode each, several of them created by
-#: production code a test merely reached. Failing the suite on that set today would block
-#: every unrelated change while the set is attributed, and a guard that blocks unrelated
-#: work is a guard somebody deletes.
+#: Directory residue is fatal by default on Linux and macOS: it is the recursively
+#: unbounded leak class this guard exists to stop. Windows retains the staged warning for
+#: directory residue too, because its full-suite shards still produce unattributed
+#: anonymous temporary directories -- enabling the same default there today would block
+#: unrelated changes; see ``_tmp_residue_is_windows``. Single ``mkstemp`` FILES stay
+#: warning-only on every platform -- one inode each, several created by production
+#: behaviour a test legitimately reaches.
 #:
 #: So: the residue is removed either way (which is the whole inode win), and it is
-#: REPORTED either way. Set this to make it fatal -- in a burn-down branch, or in CI once
-#: the remaining set is empty. Same shape as ``windows-expected-failures.txt``: a known
-#: set, visible, with a way to hold the line once it is closed.
+#: REPORTED either way. Set this to make it fatal on every platform -- in a burn-down
+#: branch, or once the remaining Windows set is attributed. Same shape as
+#: ``windows-expected-failures.txt``: a known set, visible, with a way to hold the line
+#: once it is closed.
 _TMP_RESIDUE_STRICT_ENV = "KIROCREW_TMP_RESIDUE_STRICT"
 
 
@@ -1880,13 +1881,14 @@ def _isolate_tempfile_base(tmp_path_factory):
                 os.environ[name] = value
         per_test = bool(os.environ.get(_TMP_PER_TEST_ENV))
         leaked = _tmp_residue(base, per_test=per_test)
+        directory_leaks = _tmp_residue_directories(base, leaked)
         # Removed even when it is empty, and even when the report below raises:
         # leaving the root behind would itself be the accumulation this guards.
         _remove_tree(base)
         if not leaked:
             return
         report = _tmp_residue_report(base, leaked, per_test=per_test)
-        if os.environ.get(_TMP_RESIDUE_STRICT_ENV):
+        if _tmp_residue_is_fatal(directory_leaks, is_windows=_tmp_residue_is_windows()):
             raise AssertionError(report)
         warnings.warn(report, stacklevel=1)
 
@@ -1915,6 +1917,39 @@ def _tmp_residue(base: pathlib.Path, *, per_test: bool) -> list[str]:
         except OSError:
             continue
     return residue
+
+
+def _tmp_residue_directories(base: pathlib.Path, leaked: list[str]) -> list[str]:
+    """Return residue entries whose on-disk target is a directory."""
+    return [name for name in leaked if (base / name).is_dir()]
+
+
+def _tmp_residue_is_windows() -> bool:
+    """Whether this host is Windows, for staging the directory-residue default.
+
+    Mirrors the ``platform_compat_or_none()`` check ``pytest_collection_modifyitems``
+    already uses for ``windows-expected-failures.txt``: a partial checkout that cannot
+    import the package under test is not staging anything, so it is treated as not
+    Windows rather than raising here.
+    """
+    compat = platform_compat_or_none()
+    return bool(compat and compat.IS_WINDOWS)
+
+
+def _tmp_residue_is_fatal(directory_leaks: list[str], *, is_windows: bool) -> bool:
+    """Whether residue should fail the run rather than warn.
+
+    Directory residue is fatal on Linux and macOS by default -- it is the recursively
+    unbounded leak class this guard exists to stop. Windows keeps the staged warning for
+    directory residue until its existing anonymous leaks are attributed, unless
+    ``KIROCREW_TMP_RESIDUE_STRICT`` overrides the stage on every platform. Single-file
+    residue never makes this True on its own; the caller only reaches this function when
+    ``leaked`` is non-empty, and *directory_leaks* is the subset of that this function
+    actually branches on.
+    """
+    if os.environ.get(_TMP_RESIDUE_STRICT_ENV):
+        return True
+    return bool(directory_leaks) and not is_windows
 
 
 def _tmp_residue_report(base: pathlib.Path, leaked: list[str], *, per_test: bool) -> str:

--- a/conftest.py
+++ b/conftest.py
@@ -1817,8 +1817,10 @@ def _isolate_tempfile_base(tmp_path_factory):
     can both NAME it (residue is still a defect) and REMOVE it (so the accumulation stops
     regardless of whether anyone acts on the report).
 
-    The report WARNS by default and fails only under ``KIROCREW_TMP_RESIDUE_STRICT`` --
-    see ``_TMP_RESIDUE_STRICT_ENV`` for why that is a staged rollout and not a shrug.
+    Directory residue fails by default on Linux and macOS, while Windows retains a
+    staged warning until its existing anonymous directory leaks are attributed. File
+    residue warns by default on every platform. ``KIROCREW_TMP_RESIDUE_STRICT`` makes
+    every residue class fatal; see ``_TMP_RESIDUE_STRICT_ENV`` for the rollout rationale.
 
     Under ``-n auto`` each xdist worker is its own process, so each gets its own
     root and reports only its own leaks; the controller runs no tests and creates

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -497,17 +497,17 @@ which testpath asked for the workers.
   tmpfs cleared on reboot. That reliance is deliberate and is worth knowing if you own a
   long-lived CI host: it is bounded at one directory per killed run.
 
-  Reported, not yet fatal, and that split is a staged rollout rather than a soft opinion.
+  Directory residue is fatal by default on Linux and macOS. Windows retains a staged
+  warning for directory residue while its existing anonymous leaks are attributed;
+  file residue remains warning-only by default on every platform. This split is a staged
+  rollout rather than a soft opinion.
   Two classes under that root are deliberately **not** residue and are excluded by name:
   the computer-use screenshot spool, which production keeps as a persistent ring buffer,
   and the scratch that Chromium and the Playwright driver create because a child inherits
-  the redirected `TMPDIR`. What remains is a handful of single `mkstemp` **files**, some
-  of them written by production code a test merely reached — one inode each, not the
-  `mkdtemp` directories the rule is about. Failing the suite on that set today would
-  block every unrelated change while it is attributed, and a guard that blocks unrelated
-  work is a guard somebody deletes. Set `KIROCREW_TMP_RESIDUE_STRICT=1` to make it fatal,
-  which is how the remaining set gets burned down and how the line gets held afterwards —
-  the same shape as `windows-expected-failures.txt`.
+  the redirected `TMPDIR`. Set `KIROCREW_TMP_RESIDUE_STRICT=1` to make files fatal on all
+  platforms and directories fatal on Windows too. That strict mode is how the remaining
+  staged set gets burned down and how the line gets held afterwards — the same shape as
+  `windows-expected-failures.txt`.
 
   Why it is worth a guard rather than a convention: `/tmp` is commonly a tmpfs with a
   fixed **inode** budget (1,048,576 on the hosts this was measured on), and it returns

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
@@ -80,8 +80,10 @@ watches. The before/after example is in testing-conventions.md § Rules.
 
 `ignore_errors=True` also **hides** a cleanup that could not finish, so it is not proof
 of anything. The floor helps, but it is not your discipline: the rootdir conftest redirects
-`tempfile`'s base per run, removes it, and **reports** residue — as a warning today, fatal
-under `KIROCREW_TMP_RESIDUE_STRICT=1`. So a leak of yours will not necessarily turn CI red;
+`tempfile`'s base per run, removes it, and **reports** residue. Directory residue is fatal
+by default on Linux and macOS but staged as a warning on Windows; file residue warns by
+default everywhere. `KIROCREW_TMP_RESIDUE_STRICT=1` makes every class fatal. A directory
+leak of yours will therefore turn Linux and macOS CI red even without strict mode;
 clean up anyway. (Staged rollout and its owner: testing-conventions.md § Rules.)
 
 Why it earns a guard: `/tmp` is often a tmpfs with a fixed **inode** budget

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -862,6 +862,37 @@ class TestTheTempResidueReport:
         then it protects nothing."""
         assert _root._tmp_residue(tmp_path / "does-not-exist", per_test=False) == []
 
+    def test_directory_residue_is_distinguished_from_single_files(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        (tmp_path / "tree").mkdir()
+        (tmp_path / "one.tmp").write_text("x")
+
+        leaked = _root._tmp_residue(tmp_path, per_test=False)
+        assert _root._tmp_residue_directories(tmp_path, leaked) == ["tree"]
+
+    def test_directory_residue_is_fatal_on_posix(self) -> None:
+        """The default floor: a leaked directory fails Linux and macOS runs."""
+        assert _root._tmp_residue_is_fatal(["tree"], is_windows=False) is True
+
+    def test_directory_residue_stays_a_warning_on_windows(self) -> None:
+        """Staged rollout: Windows keeps warning until its own leaks are attributed."""
+        assert _root._tmp_residue_is_fatal(["tree"], is_windows=True) is False
+
+    def test_file_only_residue_is_never_fatal_on_its_own(self) -> None:
+        """No directories leaked means nothing here has crossed the fatal line."""
+        assert _root._tmp_residue_is_fatal([], is_windows=False) is False
+        assert _root._tmp_residue_is_fatal([], is_windows=True) is False
+
+    def test_strict_env_makes_windows_fatal_too(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``KIROCREW_TMP_RESIDUE_STRICT`` overrides the Windows stage entirely."""
+        monkeypatch.setenv(_root._TMP_RESIDUE_STRICT_ENV, "1")
+
+        assert _root._tmp_residue_is_fatal([], is_windows=True) is True
+        assert _root._tmp_residue_is_fatal(["tree"], is_windows=True) is True
+
 
 # ── the process working directory ──────────────────────────────────────────
 


### PR DESCRIPTION
## Problem / Motivation

The temporary-residue guard removes and reports leaked entries but warns by default, so recursively unbounded directory leaks can pass the local test floor unnoticed.

## Why it matters

Directories can contain arbitrarily many files and allow test runs to accumulate significant host residue. Windows full-suite shards still produce unattributed anonymous temporary directories, so enabling the same default there would currently block unrelated changes.

## What changed (motivation → approach → change)

Classify leaked entries before deleting the isolated temporary root. Directory residue now fails the default floor on Linux and macOS, while Windows retains the staged warning until its existing anonymous leaks are attributed. `KIROCREW_TMP_RESIDUE_STRICT=1` continues to make every residue type fatal on every platform. Single-file residue remains warning-only by default.

## Tests

- Extended `TestTheTempResidueReport` to distinguish directory residue from files.
- Added explicit coverage for strict POSIX behavior and staged Windows behavior.
- Ran `PYTHONPATH=src python3 -m pytest -q -o addopts='' test/test_host_isolation_floor.py` (71 passed).

## Manual verification

N/A — the platform policy and residue classification are covered directly by unit tests.

## Related Issues

Addresses #4081

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository placeholder; no CLA text has been supplied.
