### PR TITLE
fix(acp): preserve MCP context in client timeouts

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -437,7 +437,6 @@ test/test_acp_liveness.py
 test/test_acp_metadata_fields.py
 test/test_acp_offload.py
 test/test_acp_prompt_blocks.py
-test/test_acp_set_mode_all_agents.py
 test/test_acp_spawn_offload.py
 test/test_acp_stale_recovery.py
 test/test_acp_tool_identity.py

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -918,9 +918,9 @@ class AcpError(Exception):
 class AcpTimeoutError(AcpError):
     """Prompt timed out."""
 
-    def __init__(self, partial_output: str = ""):
+    def __init__(self, partial_output: str = "", *, message: str = "ACP prompt timed out"):
         self.partial_output = partial_output
-        super().__init__("ACP prompt timed out")
+        super().__init__(message)
 
 
 class AcpPermissionNeeded(AcpError):  # noqa: N818
@@ -3248,7 +3248,12 @@ class AcpClient:
 
         self._last_substitution_model = None
         session_id = await self._send_request(METHOD_SESSION_NEW, new_params)
-        session_resp = await self._wait_for_response(session_id, timeout=_INIT_TIMEOUT)
+        session_resp = await self._wait_for_response(
+            session_id,
+            timeout=_INIT_TIMEOUT,
+            method=METHOD_SESSION_NEW,
+            expected_mcp=new_params.get("mcpServers"),
+        )
 
         # Happy path: a real session came back.
         if session_resp.get("sessionId"):
@@ -3290,7 +3295,12 @@ class AcpClient:
                     logger.warning("re-seed of settings.local.json failed", exc_info=True)
             self._last_substitution_model = None
             retry_id = await self._send_request(METHOD_SESSION_NEW, new_params)
-            session_resp = await self._wait_for_response(retry_id, timeout=_INIT_TIMEOUT)
+            session_resp = await self._wait_for_response(
+                retry_id,
+                timeout=_INIT_TIMEOUT,
+                method=METHOD_SESSION_NEW,
+                expected_mcp=new_params.get("mcpServers"),
+            )
 
         return session_resp
 
@@ -3359,7 +3369,12 @@ class AcpClient:
                     else:
                         load_params["_meta"] = {"_kiro.dev/session_file": session_file}
                     load_id = await self._send_request(METHOD_SESSION_LOAD, load_params)
-                    load_resp = await self._wait_for_response(load_id, timeout=_INIT_TIMEOUT)
+                    load_resp = await self._wait_for_response(
+                        load_id,
+                        timeout=_INIT_TIMEOUT,
+                        method=METHOD_SESSION_LOAD,
+                        expected_mcp=load_params.get("mcpServers"),
+                    )
                     if "modes" in load_resp:
                         self._session_id = resume_sid
                         self._resumed = True
@@ -3692,7 +3707,14 @@ class AcpClient:
             params=data.get("params"),
         )
 
-    async def _wait_for_response(self, req_id: int, timeout: float = 50.0) -> dict:
+    async def _wait_for_response(
+        self,
+        req_id: int,
+        timeout: float = 50.0,
+        *,
+        method: str = "",
+        expected_mcp: object = None,
+    ) -> dict:
         """Block until a JSON-RPC response matching *req_id* arrives.
 
         Explicitly classifies JSON-RPC 2.0 messages with the same method-aware
@@ -3805,7 +3827,64 @@ class AcpClient:
             deferred.append(msg)
 
         _reinject()
-        raise AcpTimeoutError()
+        label = method or f"request {req_id}"
+        message = f"ACP {label} timed out after {timeout:.0f}s"
+        if method in {METHOD_SESSION_NEW, METHOD_SESSION_LOAD}:
+            progress = self._mcp_timeout_progress(expected_mcp)
+            if progress:
+                message += f" ({progress})"
+        raise AcpTimeoutError(message=message)
+
+    def _mcp_timeout_progress(self, expected: object) -> str:
+        """Summarize the MCP notifications buffered during a stalled session start."""
+
+        def clean(value: object, cap: int = 64) -> str:
+            text, _ = redact_exfiltration_urls(str(value or ""))
+            text, _ = redact_credentials(text)
+            return "".join(ch for ch in " ".join(text.split()) if ch.isprintable())[:cap]
+
+        roster = [
+            clean(item.get("name"))
+            for item in (expected if isinstance(expected, list) else [])
+            if isinstance(item, dict) and item.get("name")
+        ]
+        ready: set[str] = set()
+        failed: dict[str, str] = {}
+        auth: set[str] = set()
+        for msg in self._mcp_notifications:
+            params = msg.params if isinstance(msg.params, dict) else {}
+            name = clean(params.get("serverName") or params.get("name"))
+            if not name:
+                continue
+            if msg.is_method(METHOD_MCP_SERVER_INITIALIZED):
+                ready.add(name)
+            elif msg.is_method(METHOD_MCP_SERVER_INIT_FAILURE):
+                failed[name] = clean(params.get("error"), 120)
+            elif msg.is_method(METHOD_MCP_OAUTH_REQUEST):
+                auth.add(name)
+
+        def names(values: list[str]) -> str:
+            head = values[:8]
+            suffix = f" (+{len(values) - 8} more)" if len(values) > 8 else ""
+            return ", ".join(head) + suffix
+
+        reported = ready | set(failed)
+        parts = (
+            [f"{len(reported & set(roster))}/{len(roster)} MCP server(s) reported"]
+            if roster
+            else []
+        )
+        missing = [name for name in roster if name not in reported]
+        if missing:
+            parts.append(f"no report from {names(missing)}")
+        if failed:
+            parts.append(
+                "failed: "
+                + names([f"{name} ({error})" if error else name for name, error in failed.items()])
+            )
+        if auth:
+            parts.append(f"awaiting authorization: {names(sorted(auth))}")
+        return "; ".join(parts)
 
     async def _drain_notifications(
         self,

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -931,7 +931,7 @@ class TestAcpClientBackendSelection:
                     _sent.update(params)
                 return 1
 
-            async def fake_wait(_req_id, timeout=0):
+            async def fake_wait(_req_id, timeout=0, *, method="", expected_mcp=None):
                 return {"protocolVersion": expected, "agentCapabilities": {}}
 
             client._send_request = fake_send_request  # type: ignore[assignment]
@@ -4262,7 +4262,7 @@ class TestInitializeSession:
             2: {"sessionId": "sess-abc"},
         }
 
-        async def fake_wait(req_id, timeout=50.0):
+        async def fake_wait(req_id, timeout=50.0, *, method="", expected_mcp=None):
             return responses.get(req_id, {})
 
         client._wait_for_response = AsyncMock(side_effect=fake_wait)
@@ -4291,7 +4291,7 @@ class TestInitializeSession:
             2: {"modes": ["chat"]},  # load success
         }
 
-        async def fake_wait(req_id, timeout=50.0):
+        async def fake_wait(req_id, timeout=50.0, *, method="", expected_mcp=None):
             return responses.get(req_id, {})
 
         client._wait_for_response = AsyncMock(side_effect=fake_wait)
@@ -4319,7 +4319,7 @@ class TestInitializeSession:
 
         call_idx = [0]
 
-        async def fake_wait(req_id, timeout=50.0):
+        async def fake_wait(req_id, timeout=50.0, *, method="", expected_mcp=None):
             call_idx[0] += 1
             if call_idx[0] == 1:
                 return {"protocolVersion": "2025-08-22", "agentCapabilities": {"loadSession": True}}
@@ -4351,7 +4351,7 @@ class TestInitializeSession:
 
         call_idx = [0]
 
-        async def fake_wait(req_id, timeout=50.0):
+        async def fake_wait(req_id, timeout=50.0, *, method="", expected_mcp=None):
             call_idx[0] += 1
             if call_idx[0] == 1:
                 return {"protocolVersion": "2025-08-22", "agentCapabilities": {"loadSession": True}}
@@ -4373,7 +4373,7 @@ class TestInitializeSession:
 
         send_calls = []
 
-        async def fake_wait(req_id, timeout=50.0):
+        async def fake_wait(req_id, timeout=50.0, *, method="", expected_mcp=None):
             if req_id == 1:
                 return {"protocolVersion": "2025-08-22", "agentCapabilities": {}}
             if req_id == 2:
@@ -4404,7 +4404,7 @@ class TestInitializeSession:
 
         send_calls = []
 
-        async def fake_wait(req_id, timeout=50.0):
+        async def fake_wait(req_id, timeout=50.0, *, method="", expected_mcp=None):
             if req_id == 1:
                 return {"protocolVersion": "2025-08-22", "agentCapabilities": {}}
             if req_id == 2:
@@ -7157,6 +7157,34 @@ class TestWaitForResponseDeferral:
         assert m0.method == "session/request_permission"
         assert m1.id == 88
 
+    def test_session_timeout_progress_names_missing_failed_and_oauth_servers(self, tmp_path):
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        client = AcpClient(work_dir=tmp_path)
+        client._mcp_notifications = [
+            JsonRpcMessage(
+                method="_kiro.dev/mcp/server_initialized", params={"serverName": "ready"}
+            ),
+            JsonRpcMessage(
+                method="_kiro.dev/mcp/server_init_failure",
+                params={
+                    "serverName": "broken",
+                    "error": "aws_secret_access_key=supersecret connection failed",
+                },
+            ),
+            JsonRpcMessage(method="_kiro.dev/mcp/oauth_request", params={"serverName": "oauth"}),
+        ]
+
+        progress = client._mcp_timeout_progress(
+            [{"name": "ready"}, {"name": "broken"}, {"name": "silent"}]
+        )
+
+        assert "2/3 MCP server(s) reported" in progress
+        assert "no report from silent" in progress
+        assert "failed: broken" in progress
+        assert "supersecret" not in progress
+        assert "awaiting authorization: oauth" in progress
+
 
 class TestWaitForResponseActivityDeadline:
     """Low-A: a steady stream of notifications keeps _wait_for_response alive
@@ -8939,7 +8967,7 @@ class TestSubstitutionFollow:
         # _wait_for_response does. Second wait: real session on the substitute.
         calls = {"n": 0}
 
-        async def _wait(req_id, timeout=0.0):
+        async def _wait(req_id, timeout=0.0, *, method="", expected_mcp=None):
             calls["n"] += 1
             if calls["n"] == 1:
                 client._last_substitution_model = "global.anthropic.claude-sonnet-4-6[1m]"
@@ -8971,7 +8999,7 @@ class TestSubstitutionFollow:
             sent.append(method)
             return len(sent)
 
-        async def _wait(req_id, timeout=0.0):
+        async def _wait(req_id, timeout=0.0, *, method="", expected_mcp=None):
             return {"sessionId": "sess-ok"}
 
         client._send_request = _send  # type: ignore[assignment]
@@ -8999,7 +9027,7 @@ class TestSubstitutionFollow:
             sent.append(method)
             return len(sent)
 
-        async def _wait(req_id, timeout=0.0):
+        async def _wait(req_id, timeout=0.0, *, method="", expected_mcp=None):
             client._last_substitution_model = None  # unparseable
             return {}
 
@@ -9027,7 +9055,7 @@ class TestSubstitutionFollow:
             sent.append(method)
             return len(sent)
 
-        async def _wait(req_id, timeout=0.0):
+        async def _wait(req_id, timeout=0.0, *, method="", expected_mcp=None):
             client._last_substitution_model = "global.anthropic.claude-sonnet-4-6[1m]"
             return {}
 
@@ -9062,7 +9090,7 @@ class TestSubstitutionWrappersAndRedaction:
         async def _send(method, params):
             return 1
 
-        async def _wait(req_id, timeout=0.0):
+        async def _wait(req_id, timeout=0.0, *, method="", expected_mcp=None):
             return {"protocolVersion": 1, "agentCapabilities": {"loadSession": False}}
 
         client._send_request = _send  # type: ignore[assignment]
@@ -9093,7 +9121,7 @@ class TestSubstitutionWrappersAndRedaction:
         async def _send(method, params):
             return 1
 
-        async def _wait(req_id, timeout=0.0):
+        async def _wait(req_id, timeout=0.0, *, method="", expected_mcp=None):
             return {"protocolVersion": 1, "agentCapabilities": {"loadSession": False}}
 
         client._send_request = _send  # type: ignore[assignment]
@@ -9124,7 +9152,7 @@ class TestSubstitutionWrappersAndRedaction:
         async def _send(method, params):
             return 1
 
-        async def _wait(req_id, timeout=0.0):
+        async def _wait(req_id, timeout=0.0, *, method="", expected_mcp=None):
             return {"protocolVersion": 1, "agentCapabilities": {"loadSession": False}}
 
         client._send_request = _send  # type: ignore[assignment]
@@ -9171,7 +9199,7 @@ class TestSubstitutionWrappersAndRedaction:
 
         wait_calls = {"n": 0}
 
-        async def _wait(req_id, timeout=0.0):
+        async def _wait(req_id, timeout=0.0, *, method="", expected_mcp=None):
             wait_calls["n"] += 1
             if wait_calls["n"] == 1:
                 client._last_substitution_model = url_shaped
@@ -9225,7 +9253,7 @@ class TestSubstitutionWrappersAndRedaction:
         async def _send(method, params):
             return 1
 
-        async def _wait(req_id, timeout=0.0):
+        async def _wait(req_id, timeout=0.0, *, method="", expected_mcp=None):
             return {"protocolVersion": 1, "agentCapabilities": {"loadSession": False}}
 
         client._send_request = _send  # type: ignore[assignment]
@@ -9284,7 +9312,7 @@ class TestSubstitutionWrappersAndRedaction:
         async def _send(method, params):
             return 1
 
-        async def _wait(req_id, timeout=0.0):
+        async def _wait(req_id, timeout=0.0, *, method="", expected_mcp=None):
             return {"protocolVersion": 1, "agentCapabilities": {"loadSession": False}}
 
         client._send_request = _send  # type: ignore[assignment]

--- a/test/test_acp_set_mode_all_agents.py
+++ b/test/test_acp_set_mode_all_agents.py
@@ -23,7 +23,7 @@ def _make_client(agent: str, tmp_path) -> AcpClient:
     return c
 
 
-async def _fake_wait(rid, timeout=None):
+async def _fake_wait(rid, timeout=None, *, method="", expected_mcp=None):
     """Return minimal valid responses for each init step."""
     return {"protocolVersion": "1.0", "sessionId": "sess-123"}
 
@@ -37,24 +37,22 @@ async def test_set_mode_called_for_all_agents(agent, tmp_path):
     client._wait_for_response = AsyncMock(side_effect=_fake_wait)
     client._drain_notifications = AsyncMock()
 
-    with patch("pathlib.Path.exists", return_value=False), \
-         patch("pathlib.Path.stat"):
+    with patch("pathlib.Path.exists", return_value=False), patch("pathlib.Path.stat"):
         await client._initialize_session()
 
     set_mode_calls = [
-        c for c in client._send_request.call_args_list
-        if c.args[0] == METHOD_SET_MODE
+        c for c in client._send_request.call_args_list if c.args[0] == METHOD_SET_MODE
     ]
-    assert len(set_mode_calls) == 1, (
-        f"set_mode not called for agent={agent!r}; calls: {client._send_request.call_args_list}"
-    )
+    assert (
+        len(set_mode_calls) == 1
+    ), f"set_mode not called for agent={agent!r}; calls: {client._send_request.call_args_list}"
     assert set_mode_calls[0].args[1]["modeId"] == agent
 
 
 async def _wait_with_modes(mode_ids):
     """Init-step response factory that advertises a `modes` payload."""
 
-    async def _fake(rid, timeout=None):
+    async def _fake(rid, timeout=None, *, method="", expected_mcp=None):
         return {
             "protocolVersion": "1.0",
             "sessionId": "sess-123",


### PR DESCRIPTION
## Problem / Motivation

When a `session/new` or `session/load` request stalls past its client-side timeout, the ACP client raised a bare `AcpTimeoutError` with no context: not which request timed out, and nothing about the MCP servers the session was waiting on. A session start that hangs because one MCP server never initializes (or is stuck waiting for OAuth authorization) reports the same opaque timeout as any other failure, so the user cannot tell which server to fix.

## Why it matters

MCP server startup is the dominant cause of slow/stuck session starts, and the timeout message is often the only signal the user sees. Without naming the unresponsive/failed/auth-pending servers, every session-start timeout turns into a manual debugging session instead of an actionable one-line diagnosis ("no report from server X", "awaiting authorization: Y").

## What changed (motivation → approach → change)

Symptom: opaque `ACP prompt timed out` on session-start timeouts. Root cause: `_wait_for_response` had no knowledge of which method it was waiting on or which MCP servers were expected, so it could not summarize progress. Change:

- `_wait_for_response` gains keyword-only `method` and `expected_mcp` params; the three session-start call sites (`session/new`, its retry, `session/load`) thread the method name and the request's `mcpServers` roster through.
- On timeout, the message now names the method (`ACP session/new timed out after Ns`), and for session-start methods appends a progress summary built by the new `_mcp_timeout_progress`: it cross-references the expected roster against buffered MCP notifications to report counts, servers that never reported, servers that failed init (with their error), and servers awaiting OAuth authorization.
- All names/errors in that summary pass through `redact_exfiltration_urls` + `redact_credentials`, are stripped to printable characters, and capped in length — the summary adds redaction, never widens what can leak.
- `AcpTimeoutError` accepts an explicit `message` so the enriched text reaches the caller.

Maintenance fixes added while driving this PR green (test-only + formatting; production behavior unchanged):
- ~19 pre-existing test fakes that monkeypatch `_wait_for_response` were updated to accept the new keyword-only params (`method=""`, `expected_mcp=None`) in `test/test_acp_client.py` and `test/test_acp_set_mode_all_agents.py` — these were failing with deterministic `TypeError`s on CI.
- `black` formatting applied to the three touched files to satisfy the black gate; `test/test_acp_set_mode_all_agents.py` became black-clean and was pruned from `.github/black-baseline.txt` per the ratchet.

## Tests

- `test_session_timeout_progress_names_missing_failed_and_oauth_servers` (new, in `TestWaitForResponseDeferral`): locks in that a session-start timeout message names the missing server, the failed server with its error text, and the OAuth-pending server, with redaction applied.
- Updated ~19 existing fakes so the pre-existing suites (`TestInitializeSession`, `TestSubstitutionFollow`, `TestSubstitutionWrappersAndRedaction`, `test_acp_set_mode_all_agents.py`) exercise the new signature; full `test/test_acp_client.py` + `test/test_acp_set_mode_all_agents.py` pass locally (524 tests).

## Manual verification

N/A — unit coverage sufficient: the change is message construction on an existing timeout path, fully exercised by the new test.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (ACP client timeout message); no rendered UI delta.

## Related Issues

Fixes #4245

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc surface
- [x] No secrets, credentials, or internal references in the diff
