### PR TITLE
refactor(auth): export internal path matcher

### DIFF
--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -80,6 +80,12 @@ from kiro_crew.mcp_gateway.socketsec import PeerCredResult, check_peer_is_self, 
 from kiro_crew.peer_resolve import resolve_peer_identity
 from kiro_crew.sel import sel as _sel_fn
 
+
+def internal_path_matches(path: str, entries: Iterable[str]) -> bool:
+    """Return whether *path* is an exact or child path of an internal route."""
+    return any(path == entry or path.startswith(entry + "/") for entry in entries)
+
+
 logger = logging.getLogger(__name__)
 
 # Alias of bump_revocation_gen: callers elsewhere import the private name
@@ -2072,13 +2078,8 @@ def token_auth_middleware(
         # Internal API paths: loopback + secret grants immediate access.
         # If the secret is missing (browser request), fall through to
         # normal cookie auth so dashboard pages can call these routes.
-        _matches_strict = internal_paths and (
-            path in internal_paths or any(path.startswith(p + "/") for p in internal_paths)
-        )
-        _matches_mixed = mixed_internal_paths and (
-            path in mixed_internal_paths
-            or any(path.startswith(p + "/") for p in mixed_internal_paths)
-        )
+        _matches_strict = internal_path_matches(path, internal_paths)
+        _matches_mixed = internal_path_matches(path, mixed_internal_paths)
         # local_only=False: treat ALL internal paths as mixed (backward compat
         # with mainline's local_only semantics — user opted into remote access)
         if not local_only and _matches_strict and not _matches_mixed:

--- a/test/test_mcp_call_site_auth_coverage.py
+++ b/test/test_mcp_call_site_auth_coverage.py
@@ -72,7 +72,7 @@ from kiro_crew.dashboard.server import (
     _MIXED_INTERNAL_API_PATHS,
     _STRICT_INTERNAL_API_PATHS,
 )
-from kiro_crew.dashboard.token_auth import _BYPASS_EXACT
+from kiro_crew.dashboard.token_auth import _BYPASS_EXACT, internal_path_matches
 
 _SRC = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
 _CORE = _SRC / "mcp_core.py"
@@ -468,9 +468,9 @@ def _unresolved_sites() -> set[str]:
 
 
 def _is_allowlisted(path: str) -> bool:
-    """Mirror the middleware's prefix-or-exact match over both internal sets."""
+    """Use the middleware's prefix-or-exact match over both internal sets."""
     allow = _STRICT_INTERNAL_API_PATHS | _MIXED_INTERNAL_API_PATHS
-    return any(path == entry or path.startswith(entry + "/") for entry in allow)
+    return internal_path_matches(path, allow)
 
 
 def _is_reachable(path: str) -> bool:


### PR DESCRIPTION
## Problem / Motivation

The middleware's internal-path decision ("is this request path an exact match or a child of an internal route?") existed in three hand-mirrored copies: two inline expressions in `token_auth_middleware()` (strict and mixed internal-path sets) and a third mirror inside `test/test_mcp_call_site_auth_coverage.py`'s `_is_allowlisted()`. Nothing coupled them — a change to the middleware's matching semantics would leave the test silently checking stale semantics.

## Why it matters

The CI guard added in #3996 is only as good as its mirror of the middleware. If the two drift, the guard keeps passing while the middleware's real behavior changes — exactly the class of silent auth-coverage gap that guard exists to catch. One shared, imported predicate removes the drift surface entirely.

## What changed (motivation → approach → change)

Symptom: three copies of the same prefix-or-exact match logic → root cause: the predicate was never exported, so the test could only mirror it → change: extract the logic into an exported `internal_path_matches(path, entries)` helper in `token_auth.py`; the middleware's two inline expressions and the test's `_is_allowlisted()` now all call it. Semantics are byte-equivalent (exact match, or `entry + "/"` prefix). No auth behavior change.

Follow-up fix in this PR (CI-red repair, no scope change): the helper was originally inserted above the module's remaining imports, tripping flake8 E305/E402 in Backend Lint; it now sits below the import block, body unchanged.

## Tests

`test/test_mcp_call_site_auth_coverage.py` now imports `internal_path_matches` and uses it in `_is_allowlisted()` — the coverage guard exercises the middleware's real predicate instead of a hand-written mirror, locking the two together. All 12 tests in the file pass; full backend suite green apart from known host-environment failures unrelated to this diff.

## Manual verification

N/A — unit coverage sufficient: the change is a pure extract-function refactor with byte-equivalent semantics, exercised by the existing auth-coverage suite.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only refactor (auth middleware + test); no rendered UI change.

## Related Issues

Addresses #4103 (item 1 of that issue: export the match predicate so tests import it).

no linked issue: #4103 stays open — its second, larger ask (derive the internal-API allowlist from route registration) is not part of this PR, so it must not close on merge.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc surface
- [x] No secrets, credentials, or internal references in the diff
