### PR TITLE
fix(electron): set Linux taskbar icon

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -1881,10 +1881,11 @@ function createWindow() {
     // out of the resting chrome while Alt still reveals it.
     opts.autoHideMenuBar = true;
   }
-  // Window + taskbar icon (Windows only): running unpackaged (`electron .`)
-  // otherwise shows the default Electron icon. macOS takes its icon from the
-  // .app bundle and Linux from the .desktop/AppImage, so leave those untouched.
-  if (IS_WIN) {
+  // Window + taskbar icon: the explicit BrowserWindow icon is required on
+  // Linux too. Some GNOME/AppImage launches do not associate the generated
+  // desktop entry with the live window and otherwise fall back to Electron's
+  // generic X icon. macOS takes its icon from the .app bundle.
+  if (IS_WIN || IS_LINUX) {
     const iconFile = identityFamily(app.getVersion()) === "nightly"
       && fs.existsSync(path.join(__dirname, "icon-nightly.png"))
       ? "icon-nightly.png" : "icon.png";

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -3,6 +3,11 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 
+it("Linux BrowserWindows carry the packaged application icon", () => {
+  const main = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+  assert.match(main, /if \(IS_WIN \|\| IS_LINUX\) \{[\s\S]*?opts\.icon = path\.join\(__dirname, iconFile\)/);
+});
+
 const ROOT = path.resolve(__dirname, "..");
 
 describe("electron-builder files list", () => {


### PR DESCRIPTION
## Summary
- pass the packaged application icon to Electron BrowserWindow on Linux as well as Windows
- preserve macOS dock-icon handling
- add a packaging source-contract regression test

## Testing
- `node --test website/electron/test/packaging.test.js`

Fixes #3620
