### PR TITLE
fix(cli): resolve secrets for listener port

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -52,6 +52,7 @@ from kiro_crew.config.loader import (
     config_local_path,
     config_path,
     read_config_for_update,
+    read_local_secret,
     update_config_locked,
 )
 from kiro_crew.cron import CronSchedule, CronService, format_schedule
@@ -169,7 +170,7 @@ def _format_schedule(schedule: object) -> str:
     return format_schedule(schedule)
 
 
-def _internal_secret() -> str:
+def _internal_secret(port: int) -> str:
     """Read the per-session IPC secret written by the gateway.
 
     The gateway writes ``~/.kiro/crew/.local_secret`` (mode 0600) after a
@@ -182,10 +183,7 @@ def _internal_secret() -> str:
     server then rejects the request with 403, which is the correct
     failure mode.
     """
-    try:
-        return (config_dir() / ".local_secret").read_text().strip()
-    except Exception:
-        return ""
+    return read_local_secret(port)
 
 
 def _spawn(args: argparse.Namespace) -> None:
@@ -196,7 +194,7 @@ def _spawn(args: argparse.Namespace) -> None:
     if action == "list":
         req = urllib.request.Request(
             f"{base}/api/spawn",
-            headers={"X-Internal-Secret": _internal_secret()},
+            headers={"X-Internal-Secret": _internal_secret(args.port)},
         )
         try:
             with loopback_urlopen(req, timeout=5) as resp:
@@ -235,7 +233,7 @@ def _spawn_run(args: argparse.Namespace, base: str) -> None:
         data=data,
         headers={
             "Content-Type": "application/json",
-            "X-Internal-Secret": _internal_secret(),
+            "X-Internal-Secret": _internal_secret(args.port),
         },
     )
     try:
@@ -262,7 +260,7 @@ def _spawn_run(args: argparse.Namespace, base: str) -> None:
 
     print(f"Spawned subagent {agent_id}, waiting for result...", file=sys.stderr)
     poll_url = f"{base}/api/spawn/{agent_id}"
-    secret = _internal_secret()
+    secret = _internal_secret(args.port)
     while True:
         _time.sleep(2)
         poll_req = urllib.request.Request(poll_url, headers={"X-Internal-Secret": secret})
@@ -1641,7 +1639,7 @@ def _artifact(args: argparse.Namespace) -> None:
 
     action = getattr(args, "artifact_action", None) or "list"
 
-    headers: dict[str, str] = {"X-Internal-Secret": _internal_secret()}
+    headers: dict[str, str] = {"X-Internal-Secret": _internal_secret(port)}
 
     def _request(method: str, path: str, body: dict | None = None) -> dict:
         data = json.dumps(body).encode() if body is not None else None

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -25,6 +25,7 @@ from kiro_crew.config.loader import (
     build_provider_factory,
     config_dir,
     config_path,
+    read_local_secret,
 )
 from kiro_crew.constants import DATA_WARNING
 from kiro_crew.context import ContextBuilder
@@ -145,10 +146,8 @@ def _token(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     port = resolve_client_port(args.port)
-    secret_path = config_dir() / ".local_secret"
-    try:
-        secret = secret_path.read_text().strip()
-    except FileNotFoundError:
+    secret = read_local_secret(port)
+    if not secret:
         print("❌ Gateway not running — start it with: kirocrew gateway", file=sys.stderr)
         sys.exit(1)
 
@@ -273,10 +272,8 @@ def _emit_session_urls(port: int, token: str) -> None:
 
 def _logout(port: int) -> None:
     """Revoke all dashboard sessions by calling the gateway's /api/logout endpoint."""
-    secret_path = config_dir() / ".local_secret"
-    try:
-        secret = secret_path.read_text().strip()
-    except FileNotFoundError:
+    secret = read_local_secret(port)
+    if not secret:
         print("❌ Gateway not running — start it with: kirocrew gateway")
         sys.exit(1)
 
@@ -772,11 +769,13 @@ def _wait_gateway_ready(
 
 def _print_token_url(port: int) -> None:
     """Wait for the gateway to come up, then print a fresh token URL."""
-    secret_path = config_dir() / ".local_secret"
     deadline = time.monotonic() + _RESTART_READY_TIMEOUT
     while time.monotonic() < deadline:
         try:
-            secret = secret_path.read_text().strip()
+            secret = read_local_secret(port)
+            if not secret:
+                time.sleep(_RESTART_READY_POLL_INTERVAL)
+                continue
             url = f"http://{_CLI_LOOPBACK}:{port}/api/token/local?ttl={_RESTART_TOKEN_TTL}"
             req = urllib.request.Request(url, headers={"X-Local-Secret": secret})
             with loopback_urlopen(req, timeout=3) as resp:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1533,7 +1533,7 @@ class TestLogout:
         """Successful logout prints success message."""
         secret_file = tmp_path / ".local_secret"
         secret_file.write_text("test-secret")
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.cli_server.read_local_secret", lambda _port: "test-secret")
 
         from kiro_crew.cli_server import _logout
 
@@ -1547,7 +1547,7 @@ class TestLogout:
 
     def test_logout_gateway_not_running(self, tmp_path, monkeypatch):
         """Missing secret file means gateway not running."""
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.cli_server.read_local_secret", lambda _port: "")
 
         from kiro_crew.cli_server import _logout
 
@@ -1561,7 +1561,7 @@ class TestLogout:
         """HTTP error from gateway is handled."""
         secret_file = tmp_path / ".local_secret"
         secret_file.write_text("test-secret")
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.cli_server.read_local_secret", lambda _port: "test-secret")
 
         from kiro_crew.cli_server import _logout
 
@@ -1581,6 +1581,7 @@ class TestLogout:
         secret_file.parent.mkdir(parents=True, exist_ok=True)
         secret_file.write_text("test-secret")
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.cli_server.read_local_secret", lambda _port: "test-secret")
 
         from kiro_crew.cli_server import _logout
 
@@ -3777,11 +3778,10 @@ class TestConfigDirOverride:
 
         assert _detect_project_dir() == str(proj.resolve())
 
-    def test_logout_reads_secret_from_config_dir(self, tmp_path, monkeypatch):
-        """_logout reads .local_secret from config_dir(), not ~/.kirocrew."""
-        secret_file = tmp_path / ".local_secret"
-        secret_file.write_text("test-secret")
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+    def test_logout_reads_secret_for_listener_port(self, monkeypatch):
+        """_logout resolves the secret paired with the requested listener."""
+        read_secret = MagicMock(return_value="test-secret")
+        monkeypatch.setattr("kiro_crew.cli_server.read_local_secret", read_secret)
 
         from kiro_crew.cli_server import _logout
 
@@ -3792,6 +3792,7 @@ class TestConfigDirOverride:
 
         with patch("kiro_crew.cli_server.loopback_urlopen", return_value=mock_resp):
             _logout(5476)
+        read_secret.assert_called_once_with(5476)
 
     def test_setup_slack_tokens_writes_to_config_dir(self, tmp_path, monkeypatch):
         """_setup_slack_tokens writes .env to config_dir(), not ~/.kirocrew."""
@@ -3901,23 +3902,23 @@ class TestSpawnCliAuth:
     """
 
     def test_internal_secret_reads_local_secret_file(self, tmp_path, monkeypatch):
-        (tmp_path / ".local_secret").write_text("abc123\n")
-        monkeypatch.setattr("kiro_crew.cli_commands.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.cli_commands.read_local_secret", lambda _port: "abc123")
 
         from kiro_crew.cli_commands import _internal_secret
 
-        assert _internal_secret() == "abc123"
+        assert _internal_secret(5476) == "abc123"
 
     def test_internal_secret_returns_empty_when_missing(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("kiro_crew.cli_commands.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.cli_commands.read_local_secret", lambda _port: "")
 
         from kiro_crew.cli_commands import _internal_secret
 
-        assert _internal_secret() == ""
+        assert _internal_secret(5476) == ""
 
     def test_spawn_list_sends_internal_secret_header(self, tmp_path, monkeypatch, capsys):
-        (tmp_path / ".local_secret").write_text("test-secret-xyz")
-        monkeypatch.setattr("kiro_crew.cli_commands.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "kiro_crew.cli_commands.read_local_secret", lambda _port: "test-secret-xyz"
+        )
 
         captured: list[urllib.request.Request] = []
         mock_resp = MagicMock()
@@ -3943,8 +3944,9 @@ class TestSpawnCliAuth:
         assert headers_lower["x-internal-secret"] == "test-secret-xyz"
 
     def test_spawn_run_sends_internal_secret_header(self, tmp_path, monkeypatch, capsys):
-        (tmp_path / ".local_secret").write_text("run-secret-abc")
-        monkeypatch.setattr("kiro_crew.cli_commands.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "kiro_crew.cli_commands.read_local_secret", lambda _port: "run-secret-abc"
+        )
 
         captured: list[urllib.request.Request] = []
         mock_resp = MagicMock()
@@ -3973,8 +3975,7 @@ class TestSpawnCliAuth:
 
     def test_spawn_list_403_prints_token_required(self, tmp_path, monkeypatch, capsys):
         """A bare 403 from the gateway is reported, not masked as 'not running'."""
-        (tmp_path / ".local_secret").write_text("")
-        monkeypatch.setattr("kiro_crew.cli_commands.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.cli_commands.read_local_secret", lambda _port: "")
 
         def fake_urlopen(*_args: object, **_kwargs: object) -> None:
             raise urllib.error.HTTPError(
@@ -4654,9 +4655,9 @@ class TestPrintTokenUrl:
     def test_prints_token_on_success(self, tmp_path, capsys, monkeypatch):
         from kiro_crew.cli_server import _print_token_url
 
-        secret_file = tmp_path / ".local_secret"
-        secret_file.write_text("test-secret")
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "kiro_crew.cli_server.read_local_secret", lambda _port: "test-secret"
+        )
         monkeypatch.setattr(
             "kiro_crew.cli_server.KiroCrewConfig.load",
             lambda: MagicMock(dashboard=MagicMock(url="")),
@@ -4685,9 +4686,9 @@ class TestPrintTokenUrl:
     def test_prints_custom_origin(self, tmp_path, capsys, monkeypatch):
         from kiro_crew.cli_server import _print_token_url
 
-        secret_file = tmp_path / ".local_secret"
-        secret_file.write_text("test-secret")
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "kiro_crew.cli_server.read_local_secret", lambda _port: "test-secret"
+        )
         monkeypatch.setattr(
             "kiro_crew.cli_server.KiroCrewConfig.load",
             lambda: MagicMock(dashboard=MagicMock(url="http://kirocrew.dev:7777")),
@@ -4710,9 +4711,9 @@ class TestPrintTokenUrl:
     def test_fallback_on_timeout(self, tmp_path, capsys, monkeypatch):
         from kiro_crew.cli_server import _print_token_url
 
-        secret_file = tmp_path / ".local_secret"
-        secret_file.write_text("test-secret")
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "kiro_crew.cli_server.read_local_secret", lambda _port: "test-secret"
+        )
         monkeypatch.setattr("kiro_crew.cli_server._RESTART_READY_TIMEOUT", 0)
 
         _print_token_url(7777)
@@ -4723,7 +4724,7 @@ class TestPrintTokenUrl:
     def test_fallback_on_no_secret(self, tmp_path, capsys, monkeypatch):
         from kiro_crew.cli_server import _print_token_url
 
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.cli_server.read_local_secret", lambda _port: "")
         monkeypatch.setattr("kiro_crew.cli_server._RESTART_READY_TIMEOUT", 0)
 
         _print_token_url(7777)
@@ -5067,8 +5068,9 @@ class TestTokenCommand:
     def test_prints_loopback_only(self, tmp_path, capsys, monkeypatch):
         from kiro_crew.cli_server import _token
 
-        (tmp_path / ".local_secret").write_text("test-secret")
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "kiro_crew.cli_server.read_local_secret", lambda _port: "test-secret"
+        )
         monkeypatch.setattr(
             "kiro_crew.cli_server.KiroCrewConfig.load",
             lambda: MagicMock(dashboard=MagicMock(url="")),
@@ -5098,8 +5100,9 @@ class TestTokenCommand:
     def test_separates_custom_origin_with_blank_line(self, tmp_path, capsys, monkeypatch):
         from kiro_crew.cli_server import _token
 
-        (tmp_path / ".local_secret").write_text("test-secret")
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "kiro_crew.cli_server.read_local_secret", lambda _port: "test-secret"
+        )
         monkeypatch.setattr(
             "kiro_crew.cli_server.KiroCrewConfig.load",
             lambda: MagicMock(dashboard=MagicMock(url="https://kirocrew.dev:7777")),
@@ -5136,9 +5139,8 @@ class TestTokenCommand:
     # a bare "<no stderr>".
 
     def _stub_token_env(self, tmp_path, monkeypatch, *, secret: bool = True) -> None:
-        if secret:
-            (tmp_path / ".local_secret").write_text("test-secret")
-        monkeypatch.setattr("kiro_crew.cli_server.config_dir", lambda: tmp_path)
+        value = "test-secret" if secret else ""
+        monkeypatch.setattr("kiro_crew.cli_server.read_local_secret", lambda _port: value)
         monkeypatch.setattr(
             "kiro_crew.cli_server.KiroCrewConfig.load",
             lambda: MagicMock(dashboard=MagicMock(url="")),

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -93,13 +93,14 @@ def _cfg_with(
 class TestSmallHelpers:
     def test_internal_secret_reads_file(self, tmp_path: Path) -> None:
         (tmp_path / ".local_secret").write_text("  s3cr3t\n", encoding="utf-8")
-        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
-            assert cc._internal_secret() == "s3cr3t"
+        with patch("kiro_crew.cli_commands.read_local_secret", return_value="s3cr3t") as read:
+            assert cc._internal_secret(6123) == "s3cr3t"
+        read.assert_called_once_with(6123)
 
     def test_internal_secret_missing_file_is_empty(self, tmp_path: Path) -> None:
         """A missing secret must yield "" so the server answers 403, not a crash."""
-        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
-            assert cc._internal_secret() == ""
+        with patch("kiro_crew.cli_commands.read_local_secret", return_value=""):
+            assert cc._internal_secret(6123) == ""
 
     def test_format_schedule_non_schedule_falls_back_to_str(self) -> None:
         assert cc._format_schedule("weekly-ish") == "weekly-ish"

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -144,11 +144,11 @@ class TestLogout:
     @pytest.fixture
     def secret_home(self, monkeypatch, tmp_path):
         (tmp_path / ".local_secret").write_text("s3cr3t\n", encoding="utf-8", newline="\n")
-        monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(cli_server, "read_local_secret", lambda _port: "s3cr3t")
         return tmp_path
 
     def test_missing_secret_reports_gateway_down(self, monkeypatch, tmp_path, capsys) -> None:
-        monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(cli_server, "read_local_secret", lambda _port: "")
         with pytest.raises(SystemExit) as exc:
             cli_server._logout(5476)
         assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- resolve CLI internal secrets through the port-paired listener registry
- migrate spawn, artifact, token, logout, and restart URL paths to the paired resolver
- update CLI coverage to assert listener-port resolution

## Testing
- focused CLI auth, token, logout, artifact, and spawn coverage (55 passed)

Fixes #3890
