### PR TITLE
fix(prepare-pr): resolve profile from base ref

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/local_review.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/local_review.py
@@ -1113,7 +1113,7 @@ def assemble(
     """Assemble every reviewer brief the profile declares. Raises ParityError."""
     resolve_profile = _load_sibling("_lr_resolve_profile", "resolve_profile.py")
     try:
-        profile = resolve_profile.resolve(worktree)
+        profile = resolve_profile.resolve(worktree, base_ref=base_ref)
     except (EnvironmentError, ParityError):
         raise
     except Exception as exc:

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/resolve_profile.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/resolve_profile.py
@@ -30,7 +30,8 @@ tomllib (Python 3.11+) or an importable `tomli`; on older interpreters without
 either, a PRESENT .prepare-pr.toml is a hard error (exit 2) rather than being
 silently ignored (so the profile is never quietly wrong).
 
-Usage:  python3 resolve_profile.py [repo_root]   (default: git toplevel or CWD)
+Usage:  python3 resolve_profile.py [repo_root] [base_ref]
+        (repo defaults to git toplevel or CWD; base_ref pins .prepare-pr.toml)
 Exit:   0 resolved (JSON on stdout) - 2 env / parse error
 """
 import glob
@@ -116,6 +117,23 @@ def load_toml(path):
         )
     with open(path, "rb") as fh:
         return toml.load(fh)
+
+
+def load_toml_bytes(data, source):
+    """Parse TOML bytes obtained from a pinned git object."""
+    toml = None
+    for name in ("tomllib", "tomli"):
+        try:
+            toml = importlib.import_module(name)
+            break
+        except ImportError:
+            continue
+    if toml is None:
+        raise RuntimeError(
+            "found {} but this Python has no TOML parser "
+            "(need 3.11+ tomllib or the `tomli` package)".format(source)
+        )
+    return toml.loads(data.decode("utf-8"))
 
 
 def normalize(raw, source):
@@ -233,11 +251,26 @@ def detect_reviewers(root):
     return reviewers
 
 
-def resolve(root):
+def resolve(root, base_ref=None):
     """Apply the resolution order and return a normalized profile dict."""
     toml_path = os.path.join(root, ".prepare-pr.toml")
-    if _safe_regular_file(toml_path):
-        profile = normalize(load_toml(toml_path), "config")
+    raw_config = None
+    if base_ref:
+        rc, out, stderr = run(
+            ["git", "-C", root, "show", "{}:.prepare-pr.toml".format(base_ref)]
+        )
+        if rc == 0:
+            raw_config = load_toml_bytes(out.encode("utf-8"), "{}:.prepare-pr.toml".format(base_ref))
+        elif "does not exist" not in stderr and "exists on disk" not in stderr:
+            # A missing file is a defined fallback; an unreadable ref is not.
+            check_rc, _, _ = run(["git", "-C", root, "rev-parse", "--verify", base_ref])
+            if check_rc != 0:
+                raise RuntimeError("cannot resolve base ref {!r}".format(base_ref))
+    elif _safe_regular_file(toml_path):
+        raw_config = load_toml(toml_path)
+
+    if raw_config is not None:
+        profile = normalize(raw_config, "config")
         # A partial config must not silently blank out gates/reviewers (which
         # would make the Phase 2 local gate a no-op) — fill any omitted section
         # from auto-detection.
@@ -257,9 +290,10 @@ def resolve(root):
 
 def main(argv):
     start = argv[1] if len(argv) > 1 else os.getcwd()
+    base_ref = argv[2] if len(argv) > 2 else None
     root = find_repo_root(start)
     try:
-        profile = resolve(root)
+        profile = resolve(root, base_ref=base_ref)
     except RuntimeError as exc:
         err("ERROR: " + str(exc))
         return 2

--- a/test/test_prepare_pr_profiles.py
+++ b/test/test_prepare_pr_profiles.py
@@ -15,6 +15,7 @@ import importlib.util
 import json
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -61,6 +62,37 @@ def test_generic_fallback_on_empty_repo(tmp_path):
     assert prof["reviewers"] == []
     assert prof["readiness"] == {"status_context": None, "defer_label": None}
     assert prof["single_commit"] is False
+
+
+def test_profile_is_loaded_from_base_ref_not_worktree(tmp_path):
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    profile = tmp_path / ".prepare-pr.toml"
+    profile.write_text("[project]\nsingle_commit = true\n")
+    subprocess.run(["git", "add", ".prepare-pr.toml"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=tmp_path, check=True)
+    profile.write_text("[project]\nsingle_commit = false\n")
+
+    resolved = resolve_profile.resolve(str(tmp_path), base_ref="HEAD")
+
+    assert resolved["source"] == "config"
+    assert resolved["single_commit"] is True
+
+
+def test_branch_only_profile_is_ignored_when_base_has_none(tmp_path):
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    (tmp_path / "README.md").write_text("base\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=tmp_path, check=True)
+    (tmp_path / ".prepare-pr.toml").write_text("[project]\nsingle_commit = true\n")
+
+    resolved = resolve_profile.resolve(str(tmp_path), base_ref="HEAD")
+
+    assert resolved["source"] == "generic"
+    assert resolved["single_commit"] is False
 
 
 def test_autodetect_python_stack(tmp_path):


### PR DESCRIPTION
## Problem / Motivation

`prepare-pr`'s local review gate resolves its project profile (reviewers, contracts, gates) from the **worktree's** `.prepare-pr.toml`. A branch under review can therefore commit — or an attacker-shaped diff can simply edit — a `.prepare-pr.toml` that drops a reviewer, swaps a contract, or otherwise steers the very review that is supposed to judge that branch. The contract *files* are already read from the base commit ("a workflow present only in the checkout is not authority"), but the profile that names them was still taken from the checkout, so the provenance guarantee had a hole (#3704).

## Why it matters

The local review gate exists to mirror the server-side AI review lanes before a push. If the branch being reviewed can choose its own reviewers, the gate reports "locally green" against a review the branch itself configured — silently weaker than the server's, and exactly the injection class the base-ref contract pinning was built to stop.

## What changed (motivation → approach → change)

Symptom → root cause: profile resolution (`resolve_profile.resolve()`) read `.prepare-pr.toml` via the filesystem, so worktree/branch edits were authoritative. Approach: extend the same base-ref provenance already used for contract files to the profile itself, without changing the resolution ladder. Change:

- `resolve_profile.resolve(root, base_ref=None)`: when a `base_ref` is given, `.prepare-pr.toml` is read from that ref via `git show <ref>:.prepare-pr.toml`, never from the checkout. A file missing at the ref falls through to the existing marker/auto-detect ladder (the defined fallback); an unresolvable ref is a hard error rather than a silent skip. The CLI gains an optional second `base_ref` argument.
- `local_review.assemble()` passes its base ref through to `resolve()`, so brief assembly pins both the profile and the contracts to the base.

## Tests

- `test_profile_is_loaded_from_base_ref_not_worktree` — a worktree edit to `.prepare-pr.toml` does not override the base-ref copy.
- `test_branch_only_profile_is_ignored_when_base_has_none` — a profile that exists only in the checkout is ignored; resolution falls through to the ladder.

Known: ~27 fixtures in `test/test_prepare_pr_local_review.py` predate the pinned semantics (they write worktree-only profiles) and fail on this head; a reconciliation commit is staged and tracked in the PR comments.

## Manual verification

N/A — unit coverage sufficient: the changed behavior is pure profile resolution, exercised end-to-end through the `local_review.py` CLI in the test suite.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to prepare-pr helper scripts and their tests; no rendered UI is touched.

## Related Issues

Fixes #3704

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
