### PR TITLE
fix: name directive refusals and repair Slack stream team routing

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5284,21 +5284,48 @@ async def _run_chat(
                     else:
                         _dir_args = session_directive.decode(_out, _dir_tool)
                         if _dir_args is None and event.tool_final:
-                            # The gate already AUTHENTICATED this as a directive
-                            # tool via the canonical _meta identity, and this is
-                            # the FINAL frame — so a marker that does not decode
-                            # means the effect is being dropped outright. Never
-                            # let that be silent: this exact silence can hide a
-                            # rawOutput-envelope escaping bug.
-                            # Mid-stream frames legitimately decode to None and
-                            # are excluded by the tool_final guard.
-                            logger.warning(
-                                "session-directive decode FAILED for %r "
-                                "(tool_call_id=%s, out_len=%d) — effect dropped",
-                                _dir_tool,
-                                event.tool_call_id,
-                                len(_out or ""),
-                            )
+                            if session_directive.is_refusal(_out):
+                                # encode() refused to emit a marker because the
+                                # VALIDATED payload exceeded the delivery limit.
+                                # Nothing was applied and the result text already
+                                # told the model so, so this is the by-design
+                                # loud failure — it must not fire the warning
+                                # below, which exists to surface a lost marker.
+                                logger.info(
+                                    "session-directive REFUSED for %r "
+                                    "(tool_call_id=%s): payload over the %d-char "
+                                    "delivery limit; nothing applied",
+                                    _dir_tool,
+                                    event.tool_call_id,
+                                    session_directive.MAX_DIRECTIVE_CHARS,
+                                )
+                                # SINGLE-CONSUME + strip: a refusal is terminal,
+                                # so release the mapping and cache the
+                                # marker-free text for any later frame carrying
+                                # this same tool_call_id (which no longer
+                                # resolves _dir_tool).
+                                _pending_dir_tool.pop(event.tool_call_id, None)
+                                _out = _redact_tool_field(
+                                    session_directive.strip_marker(_out)
+                                )
+                                _dir_consumed_out[event.tool_call_id] = _out
+                            else:
+                                # The gate already AUTHENTICATED this as a
+                                # directive tool via the canonical _meta
+                                # identity, and this is the FINAL frame — so a
+                                # marker that does not decode means the effect is
+                                # being dropped outright. Never let that be
+                                # silent: this exact silence can hide a
+                                # rawOutput-envelope escaping bug.
+                                # Mid-stream frames legitimately decode to None
+                                # and are excluded by the tool_final guard.
+                                logger.warning(
+                                    "session-directive decode FAILED for %r "
+                                    "(tool_call_id=%s, out_len=%d) — effect dropped",
+                                    _dir_tool,
+                                    event.tool_call_id,
+                                    len(_out or ""),
+                                )
                         if _dir_args is not None:
                             # SINGLE-CONSUME (see the native branch above): drop
                             # the mapping BEFORE applying, so a second result

--- a/src/kiro_crew/session_directive.py
+++ b/src/kiro_crew/session_directive.py
@@ -85,6 +85,18 @@ _SENTINEL = "[[KIROCREW_SESSION_DIRECTIVE]]"
 # above this bound instead, leaving headroom under the transport cap.
 MAX_DIRECTIVE_CHARS = 3800
 
+# Stamped on an oversized :func:`encode` result INSTEAD of the directive marker,
+# so the consumer can tell a deliberate refusal apart from a marker that was lost
+# in transport. Both cases decode to "no directive", but only the second is a
+# bug, and the consumer's diagnostic for a lost marker is a WARNING that exists
+# to catch rawOutput-envelope escaping regressions — a by-design refusal firing
+# it trains operators to ignore the one signal that matters.
+#
+# Forgery-inert by construction: unlike the directive marker this token carries
+# no payload and grants no effect, so a model emitting the literal bytes can only
+# change how a log line reads, never what gets applied.
+_REFUSAL_SENTINEL = "[[KIROCREW_SESSION_DIRECTIVE_REFUSED]]"
+
 
 def encode(kind: str, args: dict[str, Any], human: str) -> str:
     """Build a tool-result string: a human confirmation + the directive marker.
@@ -93,9 +105,11 @@ def encode(kind: str, args: dict[str, Any], human: str) -> str:
     payload the consumer needs to apply the effect (never a session key).
 
     When the encoded directive would exceed :data:`MAX_DIRECTIVE_CHARS`, returns a
-    plain ``"Error: …"`` string carrying NO marker: the caller returns it to the
-    model verbatim, so an oversized request fails LOUDLY (and is audited failed)
-    instead of being silently truncated past its marker and dropped.
+    plain ``"Error: …"`` string carrying NO directive marker: the caller returns it
+    to the model verbatim, so an oversized request fails LOUDLY (and is audited
+    failed) instead of being silently truncated past its marker and dropped. The
+    refusal is tagged with :data:`_REFUSAL_SENTINEL` so the consumer reports it as
+    a refusal rather than as a lost marker (see :func:`is_refusal`).
     """
     payload = json.dumps({"kind": kind, "args": args}, separators=(",", ":"), default=str)
     out = f"{human}\n{_SENTINEL}{payload}"
@@ -104,9 +118,21 @@ def encode(kind: str, args: dict[str, Any], human: str) -> str:
             f"Error: {kind} arguments are too large to deliver "
             f"({len(out)} chars, limit {MAX_DIRECTIVE_CHARS}). Shorten them "
             "(e.g. a briefer message / fewer items) and call the tool again — "
-            "nothing was applied."
+            f"nothing was applied.\n{_REFUSAL_SENTINEL}"
         )
     return out
+
+
+def is_refusal(text: str | None) -> bool:
+    """True iff *text* is an :func:`encode` refusal — a validated directive that
+    was deliberately NOT emitted because its payload exceeded
+    :data:`MAX_DIRECTIVE_CHARS`.
+
+    Distinguishes "refused before delivery, and the model was told" from "a marker
+    was expected and did not arrive", which are otherwise indistinguishable at the
+    consumer: both decode to ``None``.
+    """
+    return bool(text) and _REFUSAL_SENTINEL in (text or "")
 
 
 def decode(text: str, expected_tool: str) -> dict[str, Any] | None:
@@ -153,8 +179,12 @@ def match_tool(raw: str) -> str:
 
 
 def strip_marker(text: str) -> str:
-    """Remove the directive marker line from *text* for transcript display."""
-    idx = text.find(_SENTINEL)
+    """Remove the directive or refusal marker line from *text* for transcript display."""
+    idx = -1
+    for sentinel in (_SENTINEL, _REFUSAL_SENTINEL):
+        found = text.find(sentinel)
+        if found >= 0 and (idx < 0 or found < idx):
+            idx = found
     if idx < 0:
         return text
     # Drop the marker and any immediately-preceding blank separator line.

--- a/src/kiro_crew/slack/client.py
+++ b/src/kiro_crew/slack/client.py
@@ -474,8 +474,16 @@ class RealSlackClient(SlackClientOps):
             workspace_team = cached_team or team_id
             if workspace_team:
                 body["team_id"] = workspace_team
-            if team_id:
-                body["recipient_team_id"] = team_id
+            # An org-wide install rejects startStream with
+            # ``missing_recipient_team_id`` when the recipient's workspace is
+            # unknown, so fall back to the channel's cached team: for a channel
+            # message the recipient's workspace IS the channel's workspace.
+            # Without the fallback every caller that does not thread an explicit
+            # team_id (the renderer transport path) is rejected on each turn and
+            # silently demoted to the non-streaming chat.update surface.
+            recipient_team = team_id or cached_team
+            if recipient_team:
+                body["recipient_team_id"] = recipient_team
             if user_id:
                 body["recipient_user_id"] = user_id
             chunks: list[dict[str, Any]] = []

--- a/test/test_review_mode.py
+++ b/test/test_review_mode.py
@@ -357,6 +357,21 @@ class TestTeamIdInjection:
         assert "team_id" not in body
         assert "recipient_team_id" not in body
 
+    @pytest.mark.asyncio
+    async def test_start_stream_derives_recipient_team_from_cache(self) -> None:
+        """Regression: an org-wide install answers startStream with
+        ``missing_recipient_team_id`` when the recipient's workspace is absent,
+        and the renderer transport path never threads an explicit ``team_id`` —
+        so the cached channel team must also satisfy ``recipient_team_id``. For a
+        channel message the recipient's workspace IS the channel's workspace."""
+        c = self._client()
+        c._web.api_call = AsyncMock(return_value={"ts": "1"})
+        c.record_channel_team("C1", "TCHANNEL_A")
+        await c.start_stream("C1", "thread1")
+        body = c._web.api_call.await_args.kwargs["json"]
+        assert body["team_id"] == "TCHANNEL_A"
+        assert body["recipient_team_id"] == "TCHANNEL_A"
+
     # ── Streaming append/stop ────────────────────────────────────────
 
     @pytest.mark.asyncio

--- a/test/test_session_directive.py
+++ b/test/test_session_directive.py
@@ -70,6 +70,32 @@ def test_encode_refuses_a_payload_too_large_for_the_transport():
     assert sd.decode(out, "monitor_start") is None
 
 
+def test_encode_refusal_is_tagged_so_the_consumer_can_name_the_cause():
+    """A refusal and a marker LOST in transport both decode to None, but only the
+    second is a bug — the consumer's diagnostic for a lost marker is a WARNING
+    guarding against rawOutput-envelope escaping regressions. is_refusal() is what
+    keeps a by-design refusal from firing (and desensitising) that signal."""
+    huge = "x" * (sd.MAX_DIRECTIVE_CHARS + 500)
+    refusal = sd.encode("monitor_start", {"message": huge}, "armed")
+    assert sd.is_refusal(refusal)
+    # A directive whose marker was stripped in transit is NOT a refusal.
+    lost = sd.strip_marker(sd.encode("monitor_start", {"message": "watch CI"}, "armed"))
+    assert not sd.is_refusal(lost)
+    assert not sd.is_refusal("")
+    assert not sd.is_refusal(None)
+
+
+def test_strip_marker_removes_the_refusal_marker():
+    """The refusal marker reaches the transcript on the same path the directive
+    marker does, so it must be stripped too or the raw token renders to the user."""
+    huge = "x" * (sd.MAX_DIRECTIVE_CHARS + 500)
+    refusal = sd.encode("monitor_start", {"message": huge}, "armed")
+    stripped = sd.strip_marker(refusal)
+    assert sd._REFUSAL_SENTINEL not in stripped
+    assert stripped.startswith("Error:")
+    assert stripped.endswith("nothing was applied.")
+
+
 def test_encode_allows_a_payload_at_the_limit():
     """A directive comfortably under the cap still encodes normally."""
     out = sd.encode("monitor_start", {"message": "watch CI", "idle_secs": 300}, "armed")

--- a/test/test_session_directive_transport.py
+++ b/test/test_session_directive_transport.py
@@ -134,3 +134,36 @@ class TestUserContentNotCorrupted:
     def test_bidi_override_still_stripped(self):
         out = build_tool_response("safe\u202etxet-detrevr")
         assert "\u202e" not in out["content"][0]["text"]
+
+
+class TestRefusalMarkerSurvivesTransport:
+    """The refusal marker rides the SAME sanitizer + parser path as the directive
+    marker, so if it does not survive, the consumer cannot tell a by-design
+    oversize refusal from a marker lost in transport and logs every refusal as a
+    suspected escaping bug."""
+
+    def _refusal(self) -> str:
+        huge = "x" * (sd.MAX_DIRECTIVE_CHARS + 500)
+        return sd.encode("ask_question", {"questions": [{"question": huge}]}, "asked")
+
+    def test_refusal_marker_is_pure_ascii_and_survives_the_sanitizer(self):
+        # The prose carries an em dash, but the framing TOKEN must stay ASCII —
+        # the sanitizer strips category Cf, which is what destroyed an earlier
+        # invisible-separator prefix on the directive marker.
+        assert sd._REFUSAL_SENTINEL.isascii()
+        refusal = self._refusal()
+        assert strip_hidden_unicode(refusal) == refusal
+        text = build_tool_response(refusal)["content"][0]["text"]
+        assert sd.is_refusal(text)
+        assert sd.decode(text, "ask_question") is None
+
+    def test_refusal_survives_raw_output_json_envelope(self):
+        update = {
+            "toolCallId": "tc-refusal",
+            "status": "completed",
+            "rawOutput": {"items": [{"Json": _mcp_envelope(self._refusal())}]},
+        }
+        event = _build_tool_result_event(update)
+        assert event is not None
+        assert event.tool_final is True
+        assert sd.is_refusal(event.tool_output)


### PR DESCRIPTION
## Problem / Motivation

Two paths degraded quietly, and the gateway log described neither of them
accurately.

**1. A refused session directive was reported as a lost one.** An operator
reading the gateway log saw this:

```
WARNING kiro_crew.dashboard.chat_runner: session-directive decode FAILED for
'monitor_start' (tool_call_id=toolu_bdrk_013R1qno9jQvPqQu5wtmn12J, out_len=180)
-- effect dropped
```

`out_len=180` is exactly the length of `session_directive.encode()`'s
oversize-refusal string. So nothing was lost in transport: `encode()` had
deliberately refused to emit a marker because the validated `monitor_start`
payload exceeded `MAX_DIRECTIVE_CHARS`, and the model was told so in the result
text. But the warning that fired is the one whose stated purpose is catching a
`rawOutput`-envelope escaping regression, and a by-design refusal is
indistinguishable from a genuine lost marker at the consumer: both decode to
`None`.

**2. `chat.startStream` was rejected on every turn of the renderer path.**

```
WARNING kiro_crew.slack.client: chat.startStream failed
slack_sdk.errors.SlackApiError: The request to the Slack API failed.
The server responded with: {'ok': False, 'error': 'missing_recipient_team_id'}
```

`start_stream` set `recipient_team_id` only from an explicitly passed `team_id`,
and the renderer transport path (`slack/renderer.py:307`, `:324`) passes none.

## Why it matters

**1.** The warning is the only signal that would surface a marker-escaping bug,
and it now fires on a condition that is working as designed. An operator who
learns to scroll past it has lost the signal, and the two causes need opposite
responses: shorten the instruction, versus investigate a transport regression.
The refusal itself is not silent to the model, so this is purely a
diagnosability defect, but it degrades the one alarm that guards a class of bug
which previously broke every directive silently.

**2.** `handler.py:3047` threads `team_id`, so the native handler path was fine;
the renderer transport path was rejected on every turn of an org-wide install,
paying a wasted API round trip plus a logged traceback and silently demoting the
reply from live streaming to the `chat.update` cursor fallback.

## What changed (motivation → approach → change)

**1. Tag the refusal instead of inferring it.** The information needed to tell
the two cases apart exists at `encode()` time and was being discarded before the
consumer saw it, so the fix puts it on the wire. `encode()`'s oversize refusal
now carries `_REFUSAL_SENTINEL`, a second ASCII marker, and
`session_directive.is_refusal()` recognises it. The consumer's final-frame branch
splits: a refusal logs at INFO naming the character limit, while a marker that
genuinely did not arrive still logs the original WARNING, so the escaping-bug
alarm keeps its meaning.

Sniffing the `Error:` prefix at the consumer was rejected as the alternative: it
couples the consumer to the refusal's prose. A dedicated token is also
forgery-inert by construction, which the prefix is not reasoning about at all:
unlike the directive marker it carries no payload and grants no effect, and
`is_refusal` is consulted only when `decode()` already returned `None`, so a
model emitting the literal bytes can change how a log line reads and nothing
else. `strip_marker()` strips whichever sentinel appears first, and the refusal
branch reuses the existing SINGLE-CONSUME protocol (`_pending_dir_tool.pop` plus
a `_dir_consumed_out` write) and re-redacts through `_redact_tool_field`, so the
token cannot reach the persisted transcript.

`MAX_DIRECTIVE_CHARS` is deliberately unchanged. The 3800 limit exists because
the ACP tool-result parser truncates each output part at 4000 chars and the
marker is the tail, so raising it would reintroduce the silent-truncation defect
the limit was added to prevent.

**2. Derive the recipient team from the channel.** For a channel message the
recipient's workspace *is* the channel's workspace, so `recipient_team_id` now
falls back to the same cached channel team that already drives `team_id`
routing. The explicitly-passed-`team_id` branch is untouched; the fallback fires
only when `team_id is None`, which is exactly the rejected case.

No behaviour changes for a single-workspace install, where the cache is empty
and both fields stay absent as before.

## Tests

`test/test_session_directive.py`
- `test_encode_refusal_is_tagged_so_the_consumer_can_name_the_cause` — the
  refusal is recognised by `is_refusal()`, and a directive whose marker was
  *stripped* is **not**, which is the distinction the whole change exists to
  make. Also pins `None` and `""` as not-refusals.
- `test_strip_marker_removes_the_refusal_marker` — the new token is stripped
  from transcript text, so it cannot render to the user.

`test/test_session_directive_transport.py`
- `TestRefusalMarkerSurvivesTransport` — the refusal marker survives
  `build_tool_response()` and the ACP `rawOutput` Json envelope, and the token is
  pure ASCII. This is the load-bearing one: the same sanitizer strips category
  `Cf`, which is what destroyed an earlier invisible-separator prefix on the
  directive marker and made every directive silently fail. A classification
  signal that does not survive the transport is no signal.

`test/test_review_mode.py`
- `test_start_stream_derives_recipient_team_from_cache` — with no explicit
  `team_id`, `recipient_team_id` comes from the cached channel team. The three
  existing `start_stream` team-routing tests still pin the explicit-`team_id`
  precedence and the both-unknown case, so the fallback is proven additive.

All three new tests fail on `main` (`AttributeError` for the two directive ones,
`KeyError` for the Slack one).

## Manual verification

N/A — unit coverage sufficient. Both defects were diagnosed from the gateway log
quoted above, and each is a pure decision on values already reaching the changed
functions, so the tests exercise the same inputs the live failures carried.

Local floor, run after rebasing onto current `main`: `isort`, `flake8`, `mypy`
all exit 0; full backend suite **56106 passed, 262 skipped, 6 xfailed, 0 failed**.

The run's exit code is 1 for an unrelated reason: the repository-root residue
guard trips on `leaked-HOME/`, left in the checkout by
`test_terminal_commands.py::test_the_environment_is_an_allowlist_not_a_filtered_inherit`,
which sets `HOME` to a relative sentinel. It reproduces with that single test in
isolation and none of this PR's modules loaded. Filed as #4267.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change — one log level, one wire token, and
one Slack API request field; no rendered surface is touched.

## Related Issues

Follow-ups filed from this work, neither of which this PR closes:

- #4267 — the `leaked-HOME` test leak described above.
- #4268 — the Slack channel-team cache records the message author's workspace
  rather than the channel's home team. It predates this PR; the
  `recipient_team_id` fallback only reads the already-cached value in one more
  place. In a Slack Connect shared channel a message from an external
  participant can flip that cache, in which case `startStream` is rejected and
  degrades to the same non-streaming fallback as before. Never a misdelivery,
  and fixing the cache's source of truth needs a `conversations.info` lookup
  that belongs on its own merits.

no linked issue: both defects were found by reading gateway logs, not from a
filed report.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented API or schema changed
- [x] No secrets, credentials, or internal references in the diff
