### PR TITLE
fix(test): make the probe HOME sentinel an absolute path (#4267)

### DIFF
--- a/test/test_terminal_commands.py
+++ b/test/test_terminal_commands.py
@@ -1122,13 +1122,21 @@ class TestRunProbe:
         assert out.strip() == "[]"
 
     @pytest.mark.asyncio
-    async def test_the_environment_is_an_allowlist_not_a_filtered_inherit(self, monkeypatch):
+    async def test_the_environment_is_an_allowlist_not_a_filtered_inherit(self, monkeypatch, tmp_path):
         # A denylist covers the credential names it knows and, by construction,
         # cannot cover the ones it does not — `GH_TOKEN`, `KUBECONFIG`, `NPM_TOKEN`
         # and every future tool's variable would have reached the child. So the
         # environment is built from nothing instead of filtered down.
-        for name in ("GH_TOKEN", "GITHUB_TOKEN", "KUBECONFIG", "NPM_TOKEN", "HOME"):
+        for name in ("GH_TOKEN", "GITHUB_TOKEN", "KUBECONFIG", "NPM_TOKEN"):
             monkeypatch.setenv(name, f"leaked-{name}")
+        # HOME keeps the `leaked-` marker but must be an ABSOLUTE path: on hosts
+        # where the userns sandbox is unavailable the probe child runs unsandboxed
+        # and inherits pytest's CWD (the repo root), and the workspace resolver
+        # mkdirs $HOME/workplace/... — a relative sentinel like "leaked-HOME"
+        # lands that tree inside the checkout and trips the conftest
+        # root-residue guard. Anchoring it under tmp_path keeps the leak
+        # assertion at full strength while any stray resolution stays in tmp.
+        monkeypatch.setenv("HOME", str(tmp_path / "leaked-HOME"))
         out = await tc._run_probe(["/bin/sh", "-c", "env"], None)
         assert out is not None
         assert "leaked-" not in out


### PR DESCRIPTION
## Summary

Closes #4267

The environment-allowlist probe test
(`TestProbeEnvironment::test_the_environment_is_an_allowlist_not_a_filtered_inherit`)
set `HOME=leaked-HOME`, a **relative** path. On hosts where the userns sandbox is
unavailable (`unshare(CLONE_NEWUSER)` -> EPERM), the probe child runs unsandboxed and
inherits pytest's CWD (the repository root), and the workspace resolver mkdirs
`$HOME/workplace/kirocrew-workspace` relative to it -- landing an empty
`leaked-HOME/` tree inside the checkout. `git status` never shows it (git tracks
files, not directories), but the `conftest.py` root-residue guard lists directory
entries and promotes an otherwise fully-green run (~56k passed) to `TESTS_FAILED`,
so the blocking local floor could never go green on such a host, even on unmodified main.

## Change

One file, one test: anchor the `HOME` sentinel to an **absolute** path under
`tmp_path` (`str(tmp_path / "leaked-HOME")`).

- The value still contains the `leaked-` marker, so the assertion
  `"leaked-" not in out` keeps exactly its current strength -- if the allowlist
  ever regresses to a filtered inherit, `env` output contains
  `HOME=/tmp/.../leaked-HOME` and still matches.
- `HOME` stays covered (set before the probe, checked by the same assertion);
  only the resolution root moves out of the repository.
- `GH_TOKEN` / `GITHUB_TOKEN` / `KUBECONFIG` / `NPM_TOKEN` are not path-resolved
  by the probe and are unchanged.
- No `tmp_path` false-pass risk: pytest's tmp dir name derives from the test name
  and does not contain `leaked-`.

## Sibling check (per issue instruction)

Audited every `setenv` in `test/test_terminal_commands.py` (22 sites). No other
test sets `HOME` or another path-valued variable to a relative sentinel reachable
by a child process: the three relative `PATH` values (lines ~281, ~285, ~566) are
either consumed in-process by the PATH sanitizer under test (no child spawned) or
run after `monkeypatch.chdir(tmp_path)`. All `KIROCREW_PROJECT_DIR` and remaining
`PATH` values are absolute or `tmp_path`-based. **No sibling fix was needed.**

One pre-existing, out-of-scope observation from review: `TestRunProbeReal` runs
real probe children with the developer's real `HOME`, which can leave residue
under the real home (invisible to the repo-root guard). Will be filed as a
separate issue rather than widened into this diff.

## Verification

On an affected host (`unshare(CLONE_NEWUSER)` fails with EPERM, unsandboxed probe path):

- **Fail-before**: with the original code, `rm -rf leaked-HOME` + isolated run of the
  test -> `leaked-HOME/` reappears at the repo root.
- **Fixed**: same isolated run -> `ls -d leaked-HOME` reports *No such file or directory*.
- Full local floor: `isort` / `flake8` / `mypy` exit 0; full `python -m pytest`
  exit **0**, 56090 passed, **no "repository root residue" section**.
- Pre-push review: GPT 5.6 Sol NO-BLOCKING; Opus 5 NO-BLOCKING (0/2 budget).

## Scope discipline

Test-only change. The conftest root-residue guard, `_run_probe`, and the
sandbox/userns fallback logic are untouched -- the guard caught a real leak and is
working as designed.
