### PR TITLE
docs: restore the deleted changelog history and write the 0.3.0 entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,71 @@ judgment half is the `harness-parity` rule in `AUTOSDE.yaml`.
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `build`, `revert`.
 One logical change per commit.
 
+## Release Changelog
+
+`CHANGELOG.md` is written **only when a version is bumped**, and everything
+already in it is immutable. Enforced by the `changelog-is-written-at-version-bump-only`
+rule in `AUTOSDE.yaml`; the parser that renders it is `src/kiro_crew/changelog.py`.
+
+- **Your feature PR does not touch `CHANGELOG.md`.** The release PR writes the
+  section covering everything that shipped. A per-PR changelog line is how the
+  file grows into something nobody reads, and how it acquires an `## [Unreleased]`
+  section that then has to be untangled at release time. The commit subject is
+  the record until a bump names it.
+- **There is no `## [Unreleased]` section.** To see what is pending, read
+  `git log --oneline <last-tag>..HEAD`.
+- **One section per release, newest first**, headed exactly
+  `## [X.Y.Z] — YYYY-MM-DD`. Never a prerelease spelling: `0.3.0-insider.9` and
+  `0.3.0-rc.2` are drafts of `0.3.0`, are folded onto it by the parser, and must
+  not get their own heading.
+- **Never delete or edit a shipped section.** A release PR prepends one section
+  and leaves every earlier one byte-identical. This has already gone wrong once:
+  a section was *replaced* rather than prepended and 322 lines of released
+  history went with it, which no test caught and a user reported as an empty
+  Releases page.
+
+Format, which the `[0.2.0]` section is the reference for:
+
+- A two-to-four line opening paragraph naming the release's theme. Not a count of
+  commits.
+- Then `###` subsections grouped by **what the reader gets**, ordered most
+  interesting first. Never group by commit type: nobody opens a changelog looking
+  for the refactors.
+- Each bullet is `- **Short name** — what the user can now do`, one or two lines,
+  in plain language and the present tense.
+- Describe the capability, not the mechanism. No commit hashes, PR numbers, file
+  paths, module names, or internal vocabulary.
+- **Never generate the section from a commit dump.** A list of commit subjects, a
+  `Bug Fixes (88 total)` header, or a trailing `and 65 more (see commit log)` is
+  the failure mode this format exists to prevent. Fixes that are invisible to the
+  reader are simply left out; fixes that are visible are described as an outcome
+  and folded into the subsection they belong to.
+- **Name the breaking changes first.** A `### Before you upgrade` section leads
+  when the release removes a capability, raises a floor (a minimum Node or Python
+  version), changes a default, or alters behaviour a user has configured around.
+  This is the part of a changelog with no substitute: a reader can discover a new
+  feature later, but a withdrawn one costs them an outage.
+- **A closing `### Notable fixes` section is allowed, and is not a commit dump.**
+  It exists so a reader can check whether their particular annoyance is gone,
+  written as what is now true ("Teams retries a rate-limited message instead of
+  dropping it"). Past roughly twenty items, group them by area into short prose
+  paragraphs under a bolded lead rather than a flat bullet list — eighty bullets
+  is a wall nobody scans. What makes it a dump instead is a total count, a bare
+  commit subject, a scope prefix, or an "and N more" tail; it carries none of
+  those, and a fix nobody would notice does not earn a line.
+- **The split, not a line budget, is what keeps it readable.** The showcase body
+  carries new surfaces, new capabilities, and perceptible performance changes;
+  everything fix-shaped goes to the grouped tail. A body growing past the
+  previous release's is a signal to move items into the tail or group them
+  harder — not a licence to keep adding, and not a reason to drop a real change.
+  A release covering substantially more shipped work will be longer, and that is
+  correct; an unedited one is not.
+- **Verify coverage against the commit range, not against your memory of it.**
+  Partition `git log <last-tag>..HEAD` and account for every commit, because the
+  omissions are systematic rather than random: a change whose subject names one
+  subsystem while touching a shared surface is exactly what a keyword or path
+  scan misses, and nothing downstream ever reports it.
+
 ## The gate before you commit
 
 ```bash

--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -310,3 +310,56 @@ custom-rules:
       - Widening the acp_backend config enum to admit a preview harness: the
         enum is the value-SURVIVAL domain and selectability is gated separately
         (H4). Omitting it there is the bug, not including it.
+
+  - id: changelog-is-written-at-version-bump-only
+    blocking: true
+    file-patterns:
+      - "CHANGELOG.md"
+    rule: |
+      CHANGELOG.md is written ONLY when a version is bumped, and released
+      history in it is immutable. The spec for the section itself is
+      AGENTS.md -> "Release Changelog".
+
+      This rule exists because the file has already been destroyed once: a
+      docs commit on a release branch replaced CHANGELOG.md instead of
+      prepending to it, deleting the entire [0.2.0], [0.1.3] and [0.1.2]
+      sections (322 lines) and leaving one machine-generated section behind.
+      Nothing failed, no test covered it, and the loss was noticed only when a
+      user asked why the dashboard's Releases page had gone empty. A changelog
+      is append-only shipped history; a deletion in it is unrecoverable from
+      the artifact a user has installed.
+
+      - FLAG any change to CHANGELOG.md in a PR that is not a version bump or a
+        release cut. A feature, fix, refactor, test, or docs PR MUST NOT touch
+        this file — the release PR writes the section for everything that
+        shipped. If a PR author wants their change remembered, the commit
+        subject is the record.
+      - FLAG any diff that DELETES or MODIFIES a line inside an existing
+        released `## [X.Y.Z]` section. A release PR adds exactly one new
+        section at the top and leaves every pre-existing section
+        byte-identical. Treat a removed `## [` heading as a blocking finding on
+        its own, whatever the stated reason (merge-conflict resolution,
+        regeneration, "cleanup", branch divergence).
+      - FLAG a new `## [Unreleased]` section. There is no Unreleased section:
+        unshipped changes live in the commit log until a bump names them. Use
+        `git log --oneline <last-tag>..HEAD` to see what is pending.
+      - FLAG a section assembled from a commit dump — a bare list of commit
+        subjects, a "Bug Fixes (N total)" count, or a trailing "and N more
+        (see commit log)". That is not a changelog entry; it is the thing a
+        changelog entry exists to replace, and nobody reads it. A curated
+        `### Notable fixes` list of individually-named user-observable outcomes
+        is NOT a dump and is allowed — see AGENTS.md for the line between them.
+      - FLAG a heading that is not a plain release: `## [0.3.0-insider.9]`,
+        `## [0.3.0-rc.2]` and similar prerelease spellings must not appear.
+        A prerelease is a draft of its base version and is folded onto it by
+        src/kiro_crew/changelog.py; giving it its own heading puts a build
+        stamp in the reader's version archive.
+
+      Allowed (do NOT flag):
+      - A release PR that prepends one new `## [X.Y.Z] — YYYY-MM-DD` section
+        and, in the same commit, bumps src/kiro_crew/__init__.py.
+      - Correcting a genuine factual error inside an already-shipped section,
+        when the PR body says that is what it is doing. Say it out loud; an
+        unexplained edit to shipped history is the defect this rule exists for.
+      - Porting an already-written section verbatim between main and a release
+        branch, where the diff adds a section and removes nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,446 +2,622 @@
 
 All notable changes to KiroCrew are documented in this file.
 
-## [Unreleased]
+## [0.3.0] — 2026-08-17
 
-- **`test_redaction_timing_scales_linearly` no longer fails CI
-  intermittently** (observed "Redaction scaled super-linearly: 3.2x, limit
-  3.0x" on an otherwise-healthy matcher). The test took ONE
-  `perf_counter` sample per input size, so it billed itself for whatever
-  the OS gave the core to the sibling pytest-xdist workers — and one
-  unlucky reading of the SMALL input, the ratio's denominator, was enough
-  to push it over the bound. It now measures with `time.thread_time()`
-  (redaction is single-threaded pure-regex work, so per-thread CPU is its
-  complete cost) and takes best-of-3 per size, since scheduler noise only
-  ever adds and the minimum is the closest estimate of the true cost —
-  the same two techniques `TestIsDeniedReDoSResistance` already uses for
-  this class of assertion. The 3.0x bound is unchanged and detection is
-  intact: a genuinely quadratic implementation still measures ~4.3x.
+The agent gained its own browser and can now run several threads of your work at
+once. Sessions explain themselves when you come back to them, the dashboard grew
+a Git panel and a docking side panel, Linux ARM64 and Windows join the
+first-class builds, and you can talk to it by holding a key.
 
-- **Opted-in MCP servers no longer silently fall back to unpooled backends.**
-  On one live host, 988 degradations accrued in 15 hours with no signal: 79%
-  were guaranteed-ENOENT pooled spawns of bare commands the gateway daemon's
-  systemd PATH cannot resolve, and 20% were crash-loops of servers whose
-  declared `env` the shared backend deliberately withholds
-  (`mcp_gateway.forward_declared_env` off). The rewriter now resolves bare
-  commands through the same augmented search path the MCP probe uses and
-  refuses to emit a stub it can prove will degrade — such servers are left
-  for the session to launch directly, with a warning naming the fix (absolute
-  path / the forwarding knob). The fallback audit log gains the reader it
-  never had: gatewayd's `stats` reply now carries per-server fallback counts
-  for the last 24 h, and the log rotates at 1 MiB instead of growing without
-  bound. (#3495)
+### Before you upgrade
 
-- **`TestIsDeniedReDoSResistance::test_cpu_cost_is_immune_to_other_threads_where_process_time_is_not`
-  no longer intermittently fails CI** (observed "process_time did not exceed
-  thread_time under a 2-spinner burst"). The test's 5-sample loop required
-  every single process-time/thread-time comparison to succeed, so one sample
-  where a shared CI runner's scheduler didn't interleave the burst threads
-  within the narrow measurement window failed the whole test even though the
-  invariant it checks — that `_cpu_cost` doesn't see other threads' CPU —
-  held on every other sample. Now tolerates a minority (≤1 of 5) of failed
-  samples; a genuine break in `_cpu_cost` still fails every sample. (The
-  companion flake in `test_mid_dotstar_chain_spam_stays_linear`, tracked in
-  the same upstream issue kirodotdev/KiroCrew#3080, was independently fixed
-  by #3692 while this PR was open — this change covers the one flaky
-  assertion #3692 didn't touch.)
+- **Node.js 22 is now the minimum** (24 LTS recommended). A Node 20 install is
+  refused rather than failing partway through a frontend build.
+- **Multi-account Telegram is withdrawn.** Only a single bot token is accepted;
+  move the token you want served to `telegram.bot_token`. Existing config is
+  still parsed and preserved, but nothing reads the account map.
+- **`kirocrew logout` now revokes refresh tokens**, not just access tokens, so
+  logging out actually ends the session everywhere.
+- **The terminal no longer scans its output for credentials.** That scan was
+  corrupting CJK text and emoji in the PTY stream, and it swallowed secrets you
+  printed deliberately. Terminal output is now passed through untouched.
+- **Knowledge auto-ingest is opt-in.** A fresh install ingests nothing, and
+  spends nothing on extraction, until you switch it on.
 
-- **The instance token-mint timeout is now user-configurable.** The remote
-  `kirocrew token` mint ran with a hardcoded 30s budget, so a user behind a
-  slow ProxyCommand/jump host timed out in the mint step even when the ssh
-  forward itself came up (the connect flow spawns two proxy-bound ssh
-  children, and the mint is the second one). A new
-  `instances.mint_timeout_secs` (unset by default: SSH 30s, SSM 90s; clamped
-  to [10, 120]) now threads through the tunnel manager to both the SSH and
-  SSM mint paths; an explicit value applies to both transports, including a
-  value equal to either transport's default. (#3566)
+### Run several threads at once
 
-- **A Teams answer no longer gets silently truncated by a rate-limited
-  chunk.** The Bot Framework Connector API enforces per-bot rate limits and
-  can return HTTP 429, but the Teams outbound send raised immediately with
-  no retry, unlike the Discord/Telegram/Webex clients (which all absorb a
-  single 429 honoring the server's back-off hint). A multi-chunk answer
-  stops at its first failed chunk, so a throttled chunk dropped it and
-  everything after it, with only a backend log line. Outbound sends now
-  retry once on 429, honoring the Connector API's `Retry-After` header. (#3738)
+- **Crew Mode** — Send the next message without waiting for the last one. Topics
+  are dispatched to parallel sub-sessions and answers arrive independently, so
+  one chat advances several pieces of work at the same time.
+- **Session summaries** — A side-panel tab says what each thread of a session was
+  trying to do and where it landed, with anything still open hoisted to the top.
+  Old sessions can be summarised on demand. Opt-in, with its token cost stated.
+- **Sessions resume instantly** — An earlier chat loads in the background while
+  you read it, so the first message sends immediately instead of waiting on a
+  cold start, and switching back restores your reading position.
+- **You can watch the context fill up** — The composer reports consumption as a
+  percentage and a token count, and the turn-stats footer names the model that
+  actually served the turn, which matters when you are running on Auto.
+- **A wedged turn recovers itself** — A stuck tool, a dead process, or a frozen
+  model call is detected and nudged back to life instead of hanging silently.
+- **Pinned messages, and a session that admits it needs you** — Pin messages for
+  reference; a session waiting on your answer says so instead of looking idle,
+  and one running a monitoring loop stays under "In progress" between cycles.
 
-- **Telegram slash commands (`/new`, `/compact`, `/model`, `/yolo`, `/link`,
-  `/unlink`, `/stop`, `/help`, `/queue`, `/steer`) no longer silently break
-  in a group or forum-topic chat — without executing a command addressed to
-  a different bot in the same group.** Telegram's own clients append
-  `@BotUsername` to a slash command in any chat with more than one
-  participant/bot — standard client behavior triggered by registering a
-  command menu, not something the bot's UI controls — but the command
-  parser matched the raw token verbatim against alias sets defined without
-  that suffix. In the forum-topic supergroups this integration explicitly
-  supports, every command fell through to being sent to the LLM as ordinary
-  chat text with no error. A trailing `@BotUsername` is now stripped before
-  alias matching — but only when it names THIS bot: Telegram fans a command
-  addressed to a different bot in the same group out to every bot present
-  (Bot API convention is to ignore what isn't addressed to you), so
-  stripping any mention unconditionally would let e.g. `/yolo@OtherBot on`
-  match this bot's own alias and enable auto-approval here. The gateway now
-  resolves its own username via `getMe` at startup and only strips a mention
-  that matches it (case-insensitively); any other mention, or none resolved
-  yet, is left attached and falls through as unrecognized. (#3734)
+### The agent gets its own browser
 
-- **`agent.dangerously_skip_permissions` no longer treats a string value as an
-  affirmative grant.** The config loader coerced this field with a bare
-  `bool(...)`, so a plausible config shape like `"dangerously_skip_permissions":
-  "false"` (any non-empty string is truthy in Python) silently activated the
-  standing, unattended tool-auto-approve grant this key controls — every tool
-  call gets auto-approved with no confirmation prompt — instead of the
-  explicit disable the value said. Now requires a real boolean, matching
-  every other boolean field in the loader; a non-bool value falls through to
-  the next accepted spelling instead of being read as a grant. (#3730)
+- **The Browser panel is the browser** — The agent drives the dashboard's own
+  side panel directly: navigate, click, type, screenshot. Browsing happens where
+  you are already looking, with no second window and no security prompt. The
+  Playwright CLI remains for remote sessions and for a browser you are already
+  logged into.
+- **Nothing to install first** — Browsing no longer needs Node or npm on the
+  machine. A private, verified copy is fetched for you, so a locked-down laptop
+  is one click from a working browser rather than a dead end.
+- **Computer Use is offered only where it works** — Native desktop automation
+  appears on macOS, instead of everywhere and then failing.
 
-- **A session no longer risks two interleaved turns after a mid-turn reset.**
-  `record_failure`'s circuit breaker calls `reset(key)` while the failing
-  caller still nominally holds that session's turn semaphore; `reset` pops the
-  session and tears it down without touching the semaphore. If a concurrent
-  `get_or_create` for the same key registered a replacement session in that
-  window, the original caller's later `release(key)` — a fresh lookup by key,
-  not the specific session object it acquired — released the REPLACEMENT's
-  semaphore instead, an over-release that could hand out a surplus permit and
-  let a third message start a turn while a second was still in flight on the
-  same live provider session. The per-session semaphore is now a
-  `BoundedSemaphore`, so a stray release beyond its one permit raises instead
-  of silently succeeding; `release()` catches that specific error and logs a
-  warning rather than propagating into a caller's `finally`. (#3749)
+### New surfaces in the dashboard
 
-- **Notes: a failed GitHub token Save/Clear in Settings no longer gets stuck
-  disabled with no explanation.** Neither the Save/Clear button handlers nor
-  the `savePat` action they call had any error handling, so a rejected
-  request (an invalid token, a transient network error) left `busy` stuck
-  `true` — the button permanently disabled — with neither the success
-  confirmation nor any error shown, an unhandled promise rejection, and the
-  only recovery being to close and reopen Settings. Failures are now caught
-  and reported inline next to the button, styled like the sibling per-vault
-  knowledge-toggle error state, and the button always recovers. A review
-  pass caught a sibling with the same root cause: the vault Remove confirm
-  button's `onForget` call still swallowed its failure into the shared
-  `error` banner, which only renders in the main-editor branch and is
-  invisible while Settings is open — the confirm bar also dismissed itself
-  immediately, so nothing indicated the removal was even attempted. Remove
-  now catches inline too, keeps the confirm bar up on failure so the user
-  can retry without reopening it, and clears on success. (#3743)
+- **A Git panel** — Repository status and commit log in the side panel, opening
+  automatically alongside the folder tab once a session has a project.
+- **The side panel docks to the bottom** — As well as the right, toggled from the
+  panel header, which suits a tall or narrow monitor.
+- **Issue links become chips** — GitHub, GitLab, and Jira issue, PR, and MR URLs
+  render inline as icon plus `owner/repo#N`, and a Jira link shows the issue's
+  details in the side panel instead of sending you away.
+- **Feature Previews has its own page** — Preview opt-ins moved out of Developer
+  → Config into per-feature cards, and Webhooks moved into Settings rather than
+  holding a top-level nav slot.
+- **A redesigned session list** — Tighter rows with a colour bar, a status gutter
+  and a meta line, so session state is scannable; folders can be dragged onto
+  each other to nest them in board view.
+- **Crew members keep an activity log** — Each member of a crew gets its own
+  space with a persistent log of what it has been doing.
+- **Link previews, and previews that explain themselves** — URL unfurls now work
+  in your own messages as well as the agent's, and previewing the dashboard's own
+  address explains the loop instead of rendering a blank frame.
 
-- **A folder knowledge source added from the dashboard can now be started.**
-  The row's `sync_status` was stored twice — as a table column and inside the
-  properties JSON — and the create path wrote `pending_confirmation` only into
-  the JSON, leaving the column at its `pending` default. The dashboard list
-  reads the column, so a freshly-added `local_folder` / `obsidian_vault` source
-  showed a Pause button instead of the Confirm button that starts the scan and
-  sat at "pending · 0 items · never synced" forever (the workaround was Pause
-  then Resume). Both insert paths (`add_source` and the auto-source path used
-  by drop-folder and project-docs sources) now derive the column from the
-  passed properties, and the store migration repairs already-divergent rows on
-  open, so existing stuck sources become startable without the workaround. (#3701)
+### Faster
 
-- **The Speech-to-Text settings page no longer offers to install Whisper when
-  the provider is AWS Transcribe.** With `stt.provider = "transcribe"` the page
-  showed an "Install Whisper" button (installing an engine Transcribe never
-  uses, so Status stayed "Not installed" forever), listed a Python/Whisper
-  prerequisite toolchain that is irrelevant to Transcribe, and rendered a
-  Runtime row that could only ever read "Native" because the backend never
-  serves `docker_mode`. The install button is now hidden for Transcribe, the
-  prerequisite block surfaces the real requirement — installing the `voice`
-  extra into the gateway's own interpreter, plus a restart hint — the backend
-  refuses `POST /api/stt/install` for Transcribe instead of silently installing
-  the wrong package, and the dead Runtime row is gone. Where no install channel
-  can make the extra importable (frozen build, pip-less interpreter, PEP 668
-  externally-managed python) the page shows an honest unsupported notice
-  instead of a command that cannot succeed, and a missing ffmpeg — which
-  Transcribe's availability check treats as optional even though browser
-  recordings need it — is now flagged with its install command even while the
-  status reads ready. (#3559)
+- **The first message no longer stalls** — Embedding thread pinning cuts the
+  opening turn's latency from roughly 7.4 seconds to about 350 milliseconds.
+- **A cold dashboard load moves a quarter of the bytes** — Pre-compressed assets
+  take it from 7.8 MB to 1.85 MB, which is what a remote or tunnelled dashboard
+  feels most.
+- **Dictation is about twice as fast** on a many-core host, and no longer spikes
+  to thirty seconds under load.
+- **Streaming is smoother** — Block parsing is throttled during a stream, so a
+  long reply no longer builds quadratic pressure as it renders.
 
-- **`kirocrew` commands start up to ~0.8 s faster, and each MCP stdio server
-  drops ~58 MB of resident memory.** `cli.py` imported its full 132-subcommand
-  dispatch table at module scope — including the Slack gateway, the dashboard
-  state module and (through it) numpy — so every CLI invocation and every
-  long-lived MCP backend process (`mcp-core`, `mcp-cron`, `mcp-computer`) paid
-  ~1.3 s and ~112 MB for subcommands that never run. The four heavy import
-  statements now execute inside the one dispatch branch that uses each name,
-  cutting a fresh `import kiro_crew.cli` to ~0.5 s / ~54 MB. Each command now
-  pays only for the modules its own branch uses: the MCP stdio servers and
-  most verbs save the full ~0.8 s / ~58 MB, while commands that dispatch into
-  the deferred modules (e.g. `gateway`, `cron`) save the portion they don't
-  touch. A ratchet test keeps the deferred modules out of module scope and
-  verifies every deferred import still resolves. Behavior is unchanged: the
-  entry point, the fail-closed security prelude, and all subcommand dispatch
-  are untouched. (#3504)
+### Two new apps, and a store worth browsing
 
-- **A managed deployment can now withhold the external services the core offers
-  unconditionally.**
-  Three surfaces had no composition point. Two are installable-content registries
-  — skill discovery (skills.sh) and MCP server discovery (the official MCP
-  registry) — which fetch from the public internet and then offer to install what
-  they return, but hardcoded their public provider at registration time. The third
-  is cloud deployment: `kiro_crew/deploy/` provisions S3, CloudFront, IAM roles and
-  a reaper Lambda in the operator's own account and carried no capability gate at
-  all, so `capabilities.publish` (which bounds publish-provider destinations) did
-  not reach it. Together that made "source installable code only from our own
-  registry, and never provision cloud infrastructure" impossible to express without
-  patching the core — a hard blocker for any deployment where third-party code must
-  be reviewed first, or where provisioning is centrally controlled. A new
-  `external_access` platform slot adds `admits_registry(kind, name, api_base)` and
-  `admits_cloud_deployment(target)`. A refused registry is never registered, so it
-  is absent rather than failing per request; a refused cloud deployment makes the
-  deploy surface report itself disabled — so the UI hides the console instead of
-  rendering one whose every button 403s — and refuses every mutating route, wrapped
-  at registration so a new endpoint is gated by being listed rather than by
-  remembering an in-handler check. Both decisions take the concrete target as well
-  as a label, because a name is self-chosen while the URL or target determines
-  where bytes go, so an allowlist stops admitting a provider that later repoints at
-  a different host instead of letting it inherit trust from its name. Both outcomes
-  are SEL-audited: a log carrying only denials cannot show whether the permitted
-  path was ever taken. The public default admits everything, so an ordinary install
-  is unchanged.
+- **Personal Shopper** — Researches real stores on your behalf and recommends
+  something only when buying actually helps. It diagnoses the problem first, and
+  never touches a cart.
+- **Issue Radar Crews** — Put autonomous workers on claimed issues. Each crew
+  takes an issue into its own worktree, posts progress to a public claim ledger,
+  and pushes a pull request: hands-free from triage to code review.
+- **A curated App Store** — Discover renders editorial spotlights, themed
+  collections, and category rails with curator artwork, not one flat list.
+- **Meetings keeps the transcript** — Stored and shown beside the agent's notes,
+  and it survives a reload.
+- **Ask Code Review Sage why** — The reviewer stays available after it posts, so
+  you can question a finding instead of starting over.
+- **Research Lab and Spec Builder pick their own model** — Instead of always
+  falling through to your chat default.
+- **A public deploy asks first** — Publishing an artifact publicly requires an
+  explicit acknowledgement, and an operator can close the path entirely.
 
-- **An MCP server that declares `env.PATH` no longer loses its inherited PATH.**
-  A spec's `env` is applied per key, so naming one directory to add — a Node
-  version manager's shim dir, say — replaced the child's PATH instead of
-  extending it, leaving the server with only that one directory. A launcher that
-  execs a sibling binary then died with "not found" for a binary that was
-  plainly installed, while the dashboard probe — which merged rather than
-  replaced — reported the same server healthy, so nothing in the UI
-  distinguished it from a working server. The full effective PATH (the spec's
-  own entries first, deduped) now backs the probe, command resolution, and the
-  value written into the agent config, so "probes healthy" and "works in a
-  session" can no longer disagree.
+### Reach it from anywhere
 
-- **Every emitted MCP config surface now goes through one env normalization
-  point (`env.emit_env`).** The agent config, the kiro-global entries the sync
-  creates, and the Claude Code `~/.mcp.json` sidecar all expand a declared
-  `env.PATH` the same way, so a server can no longer work under one consumer
-  and die under another. The cosmetic `kiro-cli mcp add` subprocess inside the
-  sync — an unsynchronized second writer whose output the rebuild overwrote —
-  is removed, and the discover→write sequence is a single mutex-serialized
-  entry point (`sync_discovered_servers`) shared by the sync endpoint, the
-  restart pre-sync, and the config watcher, closing their read-modify-write
-  race.
+- **Linux ARM64** — A native aarch64 desktop build, published with an
+  architecture check so nobody downloads the wrong one.
+- **Windows is a first-class build** — The same targets as macOS and Linux, with
+  its own install guide.
+- **Summon it from any app** — A system-wide hotkey (Cmd+Shift+K on macOS,
+  Alt+Shift+K elsewhere) raises the dashboard. Reconfigurable, or off.
+- **Change release channel without reinstalling** — Move between Stable, Insider,
+  and Nightly from About, and the gateway restarts in place after an update.
+- **Publish it on your tailnet** — `kirocrew tailnet up` puts the dashboard on
+  your Tailscale network, reachable from your other devices.
+- **Launch a cloud crew from the dashboard** — Remote EC2 provisioning, device
+  sign-in included, as a restartable job rather than a CLI session you must not
+  close, and `--subnet` pins it into a private subnet.
+- **One title bar on GNOME** — On desktops that draw their own decorations the
+  duplicate native title bar is gone; the dashboard header does the job.
+- **Connect to a gateway you run elsewhere** — A Developer setting stops the
+  desktop app from starting its own local one.
+- **Keep on Top** — Pin the window above everything else, remembered across
+  restarts.
 
-- **The Online badge now means "tools usable", dated.** A probe whose
-  `initialize` succeeds but whose `tools/list` fails reports an error instead
-  of `ok` with an empty list; every probe result carries `probedAt` so the
-  dashboard can show when a status was established instead of presenting a
-  cached one as current; and a managed server served from its in-process
-  declaration is marked `declared` — the tool list is correct, but nothing
-  verified the server can start — instead of rendering identically to a
-  handshake-proven server.
+### Voice, terminal, and files
 
-- **Apply & Restart now really mounts a newly installed server, and says so
-  honestly when it cannot.** The restart path runs the one serialized
-  discover→write entry point and reconciles the consumed agent config
-  unconditionally, so an edit that produces an empty discovery delta (a
-  `disabled: true` flip, a changed `env`) is still written out instead of
-  being skipped as "nothing new". A reconcile that FAILS is reported through
-  `mcp_sync_ok` on the restart response rather than being dressed up as a
-  successful apply.
+- **Push to talk** — Hold a key to dictate, or tap to latch it on. The key, the
+  mode, and a live test strip are in Settings.
+- **The terminal docks where you want it** — Bottom or right, opening in the
+  session's own project directory, with your preferred shell.
+- **Images are kept as artifacts** — Screenshots and diagrams the agent produces
+  are preserved with a gallery, a detail page, and metadata.
+- **Reveal a file on disk** — Jump from the file viewer to its folder, named for
+  the file manager your platform actually has.
+- **Mermaid diagrams enlarge** — Click one for a lightbox instead of squinting at
+  inline width.
 
-- **Publishing an artifact to the public internet now requires an explicit
-  acknowledgment, and an operator can remove the path entirely.** The warning
-  next to each confirm button could be scrolled past and read as decoration, and
-  the public-web destination was the one publish destination exempt from the
-  operator's publish policy — `deploy-web-aws` was appended to
-  `/api/publish-providers` unconditionally and `POST /api/deploy/deploy` consulted
-  no ceiling, so a team that had closed every other destination still had a
-  one-click path to a world-readable URL. Every surface that creates the public
-  resource (the Publish panel, its scan-override branch, and **Confirm deploy** on
-  a pending entry) now ends at a blocking dialog that names the artifact, states
-  that anyone with the link can view it, states how long the link stays public,
-  and requires pressing **I understand, publish publicly** — a button that is
-  neither pre-focused nor the default action, so no keystroke that dismisses an
-  ordinary dialog can publish by accident. The destination itself now goes through
-  the same `capabilities.publish` chokepoint as artifact publish: closing it in the
-  trust-root policy (or narrowing `publish.allowed_destinations` in `config.json`)
-  removes the button from the provider registry **and** answers 403 from
-  `/api/deploy/deploy` and `/api/deploy/pending/{id}/confirm`, including for the
-  agent-mediated `deploy_artifact` preview. Operators who had already narrowed
-  `publish.allowed_destinations` must add `deploy-web-aws` to keep deploying. (#3599)
+### Channels
 
-- **The Linux desktop app no longer shows two title bars on GNOME-family
-  Wayland desktops.** The window manager's native decoration used to stack on
-  top of the dashboard's own 42px header, wasting vertical space and
-  duplicating controls. On Wayland sessions of desktops that prefer
-  client-side decorations (GNOME, Ubuntu, Unity, Pantheon, Budgie) the window
-  now drops the native frame: the header doubles as the title bar via an
-  injected drag region, and a minimize/maximize/close cluster is injected at
-  the header's top-right (frameless Linux gets no OS-painted controls, unlike
-  the macOS traffic lights and the Windows caption overlay). X11 sessions,
-  desktops that expect server-side decorations (KDE, XFCE, tiling window
-  managers — including hybrids like Regolith that also report a GNOME token),
-  and unknown environments keep the native frame: frameless X11 windows lose
-  mouse edge-resize, which would be worse than the doubled bar. The
-  `linuxFrameless` key in the desktop app's own config (Connection → Open
-  Config File, also in the tray menu; read once at launch) forces either
-  shape. On frameless windows the menu bar auto-hides (press Alt to reveal
-  it) — kept visible it would re-create the stacked-bars problem, removed it
-  would take the menu away entirely. Connection windows follow the same
-  decision. (#3606)
+- **Dashboard replies mirror back** — An answer you send from the dashboard is
+  relayed into the Discord or Telegram conversation it came from.
+- **Telegram has a real command menu** — Type `/` for autocomplete, switch models
+  with inline buttons, toggle auto-approve, and see markdown tables render as
+  tables rather than raw pipes.
+- **WeChat accepts attachments** — Photos, voice memos, and documents reach the
+  agent instead of being dropped.
+- **A channel can file its own sessions** — Point a channel at a named sidebar
+  folder and its conversations group themselves there.
+- **Too many choices degrade gracefully** — An option list past a platform's cap
+  becomes a numbered text list instead of silently losing the extra choices.
 
-- **A lesson from a previous embedding-model generation could no longer get
-  silently deleted or offered as a false contradiction.** `write_lesson`'s
-  semantic dedup and `find_contradiction_candidates` compared raw embeddings
-  with a cosine helper that silently truncated a dimension mismatch to the
-  shorter vector instead of rejecting it, so a row embedded at a different
-  dimensionality (e.g. left over from an old embedding model) could score a
-  plausible-looking ~0.5 similarity against an unrelated new rule — landing
-  either past the 0.85 dedup line (deleting the old lesson as a "duplicate")
-  or inside the [0.4, 0.85) contradiction band (offered as a false
-  contradiction candidate). Both paths now converge onto the same
-  dimension-checked, float64-precision scorer the ranking paths already use,
-  which also removes a per-row query re-derivation from both loops. (#3466)
+### Tools and connections
 
-- **Computer use no longer costs a 109 MB backend process per chat when it is
-  off — or on platforms where it cannot run at all.** `kirocrew-computer` was
-  registered into the agent spec unconditionally, and the keystone enable was
-  only checked *inside* the process the spec had already caused kiro-cli to
-  spawn: it suppressed the tool list, never the process. Every chat process paid
-  ~109 MB for a disabled capability, including every `spawn_run` subagent, and
-  on Linux/Windows it paid that for a feature with no driver (macOS is the only
-  supported platform) — measured at 16 processes / 1.75 GB on one Linux host.
-  The server is now withheld from the emitted spec, unless this is macOS *and*
-  the keystone is on; enabling it from Settings rebuilds the spec before
-  restarting sessions, so the tools still appear in the session you are sitting
-  in. Your `tools` entries are left untouched — a ref whose server the spec does
-  not define resolves to nothing, so a mount you had narrowed to a single tool
-  comes back exactly as you left it. Only the entry's own `autoApprove` and
-  custom `env` keys are reset by an off/on cycle and need re-applying,
-  deliberately: restoring an approval from a file the agent can write would
-  bypass the PreToolUse gate. The two in-process checks are kept as defence in
-  depth for a mid-session disable. (#3482)
+- **Connecting takes one click** — Connect mints the provider's approval link
+  immediately and consent finishes on the card, instead of waiting for a later
+  chat to trigger the challenge.
+- **Pooling works itself out** — Kiro Crew probes which MCP servers can safely
+  share a process. A per-server choice replaces the old global switch and its
+  guesswork.
+- **Per-agent tool sets** — Assign servers to particular agents so each sees its
+  own surface without editing global config, and the agent picker offers the
+  project-local agents found in the active session.
+- **Tune how tools defer** — Decide how aggressively Tool Search hides tools
+  until they are needed, trading context for immediacy.
+- **Authenticated custom servers** — Supply request headers when adding a remote
+  MCP server, instead of hand-editing a file.
+- **`kirocrew policy show` lists the denied-command catalog**, so you can read
+  what is blocked without going to the source.
 
-- **Folder-write audit lines now name the internal component that made the
-  write, instead of inferring the caller's identity from the internal secret's
-  presence.** Every MCP stdio server now declares its component name on
-  loopback gateway requests (`X-Internal-Caller`, attached centrally by the
-  shared request helpers), and the folder endpoints validate it against a
-  known-caller set before trusting it into the security event log's `caller`
-  field — `source` stays in SEL's interface vocabulary (`mcp`), so operator
-  queries over `source == "mcp"` keep matching folder writes. The old
-  inference was correct only while exactly one internal caller existed — a
-  second internal caller would have silently inherited the same label. An
-  authenticated internal write with a missing or unrecognized caller name is
-  audited as `caller="unknown-internal"` with a warning, so a new caller shows
-  up loudly until it is added to the known set alongside its own test. Browser
-  writes still audit as `dashboard`; the caller header alone grants nothing.
-  (#3503)
+### Autonomy with a governor
 
-- **`kirocrew policy show` no longer hides the 139 built-in denied-command
-  rules from the agent.** The rules are visible and configurable to the
-  user (Settings → Security), but the agent's only way to discover them was
-  to attempt a command and be refused — so it could plan multi-step work
-  that turned out to be impossible from the first step, walking the user
-  through setup effort (e.g. exporting AWS credentials) for a task a
-  hard-denied command would block later anyway. `policy show` now prints
-  the rule count grouped by category on every install, enterprise policy or
-  not; `--ids` lists each category's rule ids for citing a specific rule
-  when relaying a refusal. (#3454)
+- **It knows when the machine is full** — Scheduled jobs defer and new subagents
+  are refused when memory is critically low, and the header shows the posture so
+  you know before heavy work fails.
+- **Each job sets its own time budget** — Up to 24 hours, replacing one fixed
+  thirty-minute cap, and a job's instructions can run to 50,000 characters.
+- **Read a script job without a terminal** — Its Python source is shown,
+  highlighted and read-only, in the job's detail view.
+- **Monitoring keeps its schedule** — Talking to a session mid-loop no longer
+  restarts the countdown, so checks land when they were meant to.
+- **A blip is not a failure** — Transient throttles and server errors retry
+  instead of counting toward auto-pause, a success resets the failure count, and
+  an unattended loop that loses tool approval says so instead of dying quietly.
+- **Subagents ask for permission like the main agent** — A subagent's approval
+  request now goes through trust, auto-approve, or a prompt, instead of being
+  dropped and leaving the child wedged.
 
-- **Side-panel oversize-question refusal now reports an accurate character
-  target for every script, not just emoji.** The refusal derived its
-  character count from a fixed worst-case floor (4 bytes/char, the emoji
-  case), so an ASCII user over the byte budget was told to cut to ~8,192
-  characters when trimming a single character would do (4x over-deletion),
-  and a zh-CN user (3 bytes/char) was told 8,192 when ~10,922 actually fit.
-  The target is now derived from the submitted question's own byte density,
-  so it's accurate per script — the all-emoji case is unaffected (it already
-  sat at the 4-byte floor). (#3432)
+### Memory and knowledge
 
-- **The skill browser no longer serves a different skill than the one you asked
-  for.** Three `package/` lookups compared a bare leaf name and returned the
-  first hit, so a request for `package/<name>` could answer with a file under
-  `<root>/<Pkg>/<name>`, or with whichever of two identically named files the
-  filesystem happened to yield. Exact keys now decide first, leaf matching
-  survives only where it is unambiguous, and a real collision resolves to
-  nothing — a 404, with the competing candidates logged — because the
-  `package/<path>` key cannot express which of the two files was meant. Every
-  lookup that previously resolved correctly still resolves to the same file.
-  **Edition maintainers:** roots the core already keys itself (`~/.kiro/skills`,
-  the data home, configured extra paths) are no longer *also* enumerated under
-  `package/`, which previously presented an editable skill as a read-only
-  package one. A stored reference to one of those duplicate `package/` keys
-  stops resolving; the file itself is untouched and still reachable under its
-  canonical key, but the stored reference has to be re-pointed. (#3369)
+- **Lessons surface by relevance** — Applicable older corrections stop decaying
+  out of context as the library grows, and a lesson keeps its "not this" clause
+  as a field of its own.
+- **Knowledge spending is bounded** — A sweep budget, per-source rate limits and
+  caps, a configurable extraction model, visible per-source cost, the files it
+  failed on, and JSON Lines, NDJSON and Org Mode among the formats it accepts.
+- **A tidier artifact library** — Sortable columns that remember their order, a
+  copy-content button, and a header that stays put while you scroll.
+- **Your own skills survive an upgrade** — A skill you wrote whose name collides
+  with a bundled one is no longer deleted on startup.
 
-- **MCP gateway daemons no longer leak when their launcher dies.** A `gatewayd`
-  whose launcher exited without signalling it (a torn-down `pytest` run, for
-  example) used to stay resident forever — invisible to every sweep, ~27 MB
-  each, accumulating without bound. The daemon now watches its own listening
-  socket path and gracefully self-exits once the path is gone (three
-  consecutive checks, POSIX only), and the untracked-orphan sweep reaps any
-  gatewayd whose `--socket` path no longer exists on disk, TERM-first so
-  pooled backends drain cleanly. (#3315)
+### Security and governance
 
-- **Aggregate memory ceiling across all concurrent agent spawns.** The cgroup
-  memory limit was per-spawn only (65% of RAM each), so many concurrent
-  subagents could collectively request several times host RAM without any
-  single limit breaching. The gateway now also caps their shared parent slice
-  (`kirocrew-agents.slice`) at 80% of RAM plus an aggregate task ceiling —
-  override via `resource_limits.max_total_memory_mb` /
-  `max_total_processes` — and logs which scopes were OOM-killed when the
-  aggregate ceiling engages. (#3316)
+- **An app sees only its own events** — Installed apps receive the event scopes
+  their manifest declares, and can no longer observe your chats, your scheduled
+  job results, or another app's activity.
+- **Scheduled jobs are re-vetted every run** — Checked against current policy
+  each time they fire rather than only when created, and a restored backup can no
+  longer smuggle shell commands past the approval system.
+- **The memory ceiling covers everything at once** — The cap applies to all
+  concurrent agents together, so many small spawns can no longer exhaust the host
+  between them.
+- **Credentials are scrubbed on the live stream** — Redaction now covers
+  real-time output as well as replayed history.
+- **A pinned policy floor cannot be lowered locally** — On a governed host the
+  policy wins over local configuration, including over the unsandboxed-exec
+  opt-in.
+- **Memory edits require a recognised session**, closing a path where a forged
+  key could delete stored memory.
+- **Bring your own identity provider** — Administrators can authorise their own
+  OAuth providers by configuration, without waiting for a release.
 
-- **Slack manifest: private channels now work out of the box.** The shipped app
-  manifest adds the `groups:history` and `users:read` bot scopes and subscribes
-  to the `message.groups` event, so a tracked private channel actually delivers
-  messages and profile lookups resolve real names. **Existing installs are not
-  fixed by upgrading alone**: Slack only grants new scopes on reinstall — update
-  the app's manifest (or re-import it), then reinstall the app to the workspace
-  and copy the new bot token. (#3206)
+### Notable fixes
 
+For anyone who wants to know whether their particular annoyance is gone.
 
-## [0.3.0-insider.9] — 2026-08-16
+**Chat and composer.** Dropping a folder inserts its path instead of uploading
+it. A hover preview shows what a collapsed paste chip contains. An abandoned CJK
+composition no longer disables Enter until reload, and the side-panel composer is
+IME-safe too. Scrolling up through a long history stops skipping messages.
+Auto-scroll survives a content shrink. Tool rows animate in and out rather than
+teleporting the transcript, and a tool's elapsed timer survives navigating away.
+Queued-message controls are visible on light themes, and "run this next" promotes
+the card you clicked. A long session title stops pushing the header controls off
+screen. Closing the find bar returns focus to the composer. Bold-wrapped links,
+and URLs followed by CJK punctuation, render correctly.
 
-### Highlights
+**Sessions and stopping.** Stopping a turn stops the session it is actually
+running on. A stalled subagent card reports how long it has been idle. A channel
+conversation keeps its thread identity when compaction fails or a context
+overflow recycles it. A resumed session keeps its pooled MCP servers. A mid-turn
+reset can no longer leave two turns interleaved in one session.
 
-- **Browser MCP tool**: native command-bus gateway + browser panel integration
-- **Session list redesign**: new row layout with colour bar, tighter spacing
-- **Phone-width responsive**: 20+ layout fixes for narrow viewports
-- **Memory posture**: defer crons and refuse spawns under critical memory
-- **Agent resource limits**: cap agent memory via dedicated user slice
-- **Test suite robustness**: full local suite passes without external dependencies
+**Apps and settings.** Editing agent config in the dashboard no longer breaks the
+agent until restart, and an agent spec Kiro CLI rejects is reported instead of
+silently degraded. The settings tab strip shows scroll cues and scrolls the active
+tab into view. Deep links highlight the right control in every language. An app
+installed from a path or from git reports honestly, runs its MCP server on its own
+interpreter, and starts its crons on `kirocrew app enable` without a restart. The
+skill browser serves the skill you asked for rather than another of the same leaf
+name. A folder knowledge source added from the dashboard can now actually be
+started. Speech-to-text settings stop offering to install Whisper on a machine
+that cannot run it. Notes render markdown tables, follow the active theme, and
+remember collapsed folders. Dev Fleet discovers your clone instead of assuming
+`~/kirocrew`, reattaches to an in-flight Pull and Build, and can force-remove kept
+worktrees.
 
-### Features
+**Channels and notifications.** A Teams answer is no longer silently truncated
+when a send is rate-limited. Slack works in private channels out of the box (the
+shipped manifest requests the scopes), surfaces a permission problem instead of
+delivering nothing, judges an OPTIONS click against the right turn, evicts the
+prior owner when a thread is relinked, and reports its real connect state on the
+System page. WeCom recognises a command after the mandatory mention. Discord keeps
+a code fence open across message rotation. Notifications deep-link to the item,
+stay dismissed when a stale fetch resolves, clear across every open window, and
+retire themselves when the skill they refer to is handled.
 
-- **browser**: native command-bus gateway + browser MCP tool
-- **sessions**: redesign the session list rows
-- **jira**: show linked issues and render Jira issue details in side panel
-- **dev-fleet**: allow force-removing kept worktrees in Prune modal
-- **mcp**: dashboard-control server as an assignable per-agent set
-- **cli**: surface the built-in denied-command catalog in policy show
-- **cron**: show a script cron's source in the job detail view
-- **chat**: flag a conflicted pull request on its session chip
-- **chat**: show an indicator while older messages are loading
-- Cap agent memory via dedicated user slice
-- Defer crons and refuse spawns under critical memory posture
-- Preview notification sound on per-category dropdown change
-- Render the app storefront from the published catalog
-- **prepare-pr**: extract local reviewer briefs from CI workflows
+**Desktop, install, and CLI.** `kirocrew stop` and `restart` find a macOS
+framework Python. Ctrl+C exits `kirocrew chat` cleanly. Ctrl+Cmd+F toggles full
+screen instead of opening the find bar. The macOS tray icon follows the menu bar's
+theme. A failed update's card survives a reload. The installer's probe cannot hang
+forever. `kirocrew` commands start up to about 0.8 s faster. A remote instance's
+token-mint timeout is configurable for a slow network. A proxy-only host gets its
+proxy variables forwarded to the identity check, and a slow SSO refresh no longer
+parks you at the first-run gate. The frontend builds against a private npm
+registry.
 
-### Bug Fixes (88 total)
+**Security and resources.** `agent.dangerously_skip_permissions` no longer treats
+any non-empty string as true, so a `"false"` in config cannot silently grant
+blanket approval. MCP gateway daemons no longer leak when their launcher dies.
+Computer use costs no backend process on a chat that never uses it. Folder-write
+audit lines name the component that made the write.
 
-- **security**: lock the revoked-nonce store down through restrict_to_owner
-- **memory**: apply the session-recognition gate to the mutating memory routes
-- **kas**: mirror context_usage into SSE stream via the single writer
-- **acp**: give backend-subagent permission requests main-agent mode parity
-- **sandbox**: apply resource limits to synchronous spawns after exec
-- **mcp-gateway**: stop opted-in servers from silently degrading to unpooled backends
-- **mobile**: pin the command palette to the visual viewport, not the layout one
-- **mobile**: let the software keyboard resize the layout viewport
-- **dashboard**: strip agent bookkeeping keys on config PUT
-- **tests**: make full local test suite pass without external dependencies
-- **tests**: eliminate orphan temp dirs and add AUTOSDE rule
-- 20+ phone-width responsive layout fixes across all panels
-- … and 65 more bug fixes (see commit log)
+**Everywhere else.** Every major panel collapses to a usable single pane at phone
+width, and the software keyboard no longer covers the composer. History search
+works in Chinese, Japanese, and Korean. Session storage loads in seconds and
+deletes in bulk. Theme packs report the CSS rules that were dropped and why, and
+their declared fonts now actually apply. The Online badge means "tools usable" and
+says when it was last checked, and Apply & Restart really mounts a newly installed
+server. Doctor warns about missing swap, gives an honest sandbox verdict, points at
+the thread that is genuinely stuck, and diagnoses an enterprise registry that has
+silently removed the managed tools.
 
-### Refactoring
+## [0.2.0] — 2026-08-09
 
-- **acp**: consolidate KAS wire parsing + declare provider H14 caps
-- **acp**: convert harness-identity negatives to positive form (KAS Group C)
-- **terminal**: unify panel shell, remove dead transfer plumbing
-- Flatten nested guards and drop dead code in toplevel
-- Lay the top bar out in three tracks
+The first feature release after launch: a real browser for the agent, four new
+built-in apps, a native Windows desktop build, Korean and Japanese interfaces,
+setup that no longer assumes Slack, and several hundred fixes from the first
+weeks in the open.
 
+### The agent gets a browser
+
+- **Persistent Browser Mode** — Flip one switch in Settings and the agent can
+  operate a real browser: navigate, click, type, and fill forms, with the live
+  view streaming into the dashboard's Browser panel. Installation happens for
+  you and recovers on its own — enabling it never errors out — and the agent can
+  also serve browser work from the native embedded view.
+
+### Eight new built-in apps
+
+- **Spec Builder** — a spec-driven development surface: shape requirements into
+  a spec, then hand it to the agent to implement.
+- **Ops Mission Control** — an autonomous ops first responder with an incident
+  board and a knowledge ledger of fix patterns.
+- **Crew Companion** — a desk companion that reflects what your agent is doing.
+- **Auto-Improvement** — measurement-first self-improvement that proposes,
+  lands, and verifies its own changes GitHub-natively.
+- **Meetings** — transcribes a live meeting, keeps structured notes and diagrams
+  as it goes, and extracts action items you can review afterwards. Recordings
+  and notes can now be deleted from the app.
+- **Papyrus** — a LaTeX paper editor with a split-pane view, live PDF preview,
+  and an AI co-author.
+- **Mochi** — a desktop companion that lives on your screen in its own panel,
+  watches pages and feeds for you, and plans its day around your schedule.
+- **PPTX Maker** — describe the deck you want in chat and get a real `.pptx`
+  back, by way of an agent that interviews you and writes a brief, an outline,
+  and an art direction first.
+- Every one of these is **opt-in**: install it from the App Store and enable it
+  before it does anything.
+- Installed apps are searchable and launchable from the command palette, and
+  third-party apps now run under **per-app trust grants**, with a denial that
+  tells you exactly what to do about it.
+- **MCP Apps has its own switch** instead of riding the connection-pooling
+  toggle, and the shared MCP gateway follows it.
+- **Connections** gained a provider registry, so an integration declares what it
+  is asking for and its consent URL is validated before you are sent to it.
+- Pasting an OAuth return address for an approval that has already expired now
+  says so, instead of blaming the paste — a spent approval is told apart from a
+  failed delivery, so you know to start a fresh one rather than re-copy a dead
+  address.
+- Clicking **Connect** now asks for the provider's approval link instead of
+  waiting for one, so the card offers it within seconds rather than only after
+  some later chat happens to reach that server.
+- Code Review Sage works against **GitHub Enterprise Server** hosts.
+- An MCP server that authenticates with OAuth now receives the scope list and
+  client id in the fields kiro-cli actually reads, so those connections
+  authorize instead of silently failing.
+
+### Windows, properly
+
+- The desktop build moved to an **NSIS installer** with an integrated titlebar,
+  launcher spawn/stop fixes, and a configurable sandbox tier for agent
+  subprocesses. Skills, the usage ledger, and build tooling all learned the
+  platform's rules.
+
+### A dashboard you can operate
+
+- **System is now a task manager** — live per-session resource usage, plus a
+  **Storage** screen that reports what sessions cost on disk and reclaims space
+  to a trash, with an inventory that no longer calls idle sessions "in use".
+- **Releases tab** — this changelog, rendered per version in Settings.
+- **Webhooks** — named tokens, HMAC signing, and a kill switch for inbound
+  automation. The page is still being finished, so it now sits behind a
+  per-device **Preview pages** toggle under Developer and is hidden by default.
+- Redesigned sidebar folders, drag a session into an open chat to reference it,
+  suggested folders for new sessions, consistent empty states with a next step,
+  and a notification sound when an approval prompt needs you.
+- **Continue instead of retyping** — resume an interrupted turn from where it
+  stopped, on any idle session, and recover cleanly from tool-hook blocks and
+  failed restores. Queued messages can be reordered before they send.
+- The terminal panel pops out into its own window, completes subcommands and
+  flags (not just paths), and takes a configurable font.
+- **Agent Templates became a two-pane inspector**, and agents defined in the
+  project you are working in are discovered alongside your user-level ones.
+- **Send a copy of a session to another instance** — hand a conversation, with
+  its context, to a different Kiro Crew you run.
+- Jira issue URLs and setting references render as **link chips** you can click
+  straight through.
+- Stale auto-titles refresh in the background, the command palette tells a
+  failed scoped search apart from an empty one, sidebar search keeps its
+  relevance order, and the chat action footer grows to 40px targets on touch
+  devices.
+- Bold, italic, and strikethrough now render correctly in **CJK prose**.
+- While the agent is waiting on something, the wait shows a **live countdown**
+  with a button to end it early instead of leaving you guessing.
+
+### Channels, and setup that no longer assumes Slack
+
+- **`kirocrew setup` stops asking for Slack tokens.** The wizard finishes on the
+  dashboard and points at the full set of chat channels; walk through the Slack
+  credentials only when you ask for them with `kirocrew setup --slack`. Docs and
+  in-app copy describe Kiro Crew as multi-channel rather than Slack-first.
+- **Telegram** accepts inbound attachments — images for vision, documents, and
+  audio that is transcribed on arrival. Serving **multiple bot accounts per
+  gateway** was withdrawn before this release: a second bot is a second inbound
+  door, and it is only worth having once a bot can be turned off, given its own
+  security posture, and named honestly in the audit log on its own. A
+  `telegram.accounts` entry written by an earlier release candidate is preserved
+  in config but no longer starts a bot — move the token you want served to
+  `telegram.bot_token`.
+- A sub-agent's completion now reports back into **non-Slack** parent sessions,
+  Discord continues the connected session when a reply arrives, and Slack
+  renders an `OPTIONS` prompt as a real control everywhere it appears.
+
+### Voice, language, and models
+
+- **Korean and Japanese** join the dashboard — twelve interface languages.
+- **On-device Apple speech-to-text** with live streaming; switch the microphone
+  mid-recording; dictation lands at the cursor.
+- The model picker shows each model's **credit multiplier** and scopes itself to
+  what the account can actually use; background and sub-agent work take a
+  **configurable per-role model** and reasoning effort.
+
+### Autonomy with a governor
+
+- Sub-agents can be steered with queued follow-ups, scoped to exactly the
+  context a task needs, and report completions as cards in the chat.
+- Monitoring loops accept a **wall-clock runtime budget**; cron jobs group into
+  collapsible folders and start from a **template gallery** of 15 presets.
+- Skills show their **per-injection context cost** on a budget screen, can opt
+  out of injection, and the knowledge library adds documents automatically,
+  dedupes per document, and honors `.kiroignore`.
+
+### Diagnostics and trust
+
+- **Report a Problem** collects a support bundle from the CLI or the UI, and
+  every error message carries an "Ask the agent" hand-off.
+- Loopback requests no longer leak the internal secret to a proxy; sensitive
+  paths and credential redaction got faster without getting looser.
+- The ACP runtime survives oversize output frames, worker sessions are no longer
+  reaped as orphans, and `kirocrew update` works for wheel and `cli.sh` installs.
+- A refusal from one of **your own** deny patterns can carry your note
+  explaining it, and the seven always-on git-publish rules now render locked in
+  Settings instead of offering a toggle that never took effect.
+- The gateway **refuses to boot when its data home cannot persist state**,
+  rather than running and losing your work silently.
+- The tool-approval window and the watchdog's stall windows are both bounded by
+  the turn ceiling, so neither outlives the turn it belongs to.
+
+Plus roughly 280 further fixes across the dashboard, chat, the chat channels,
+ACP transport, history consolidation, packaging, and CI.
+
+## [0.1.3] — 2026-08-07
+
+A hot patch for model entitlement: the model picker scopes itself to what the
+account can use, a model the account cannot use is never sent, and an
+unavailable model is reported as an access problem instead of a capacity error
+or a raw JSON-RPC dump.
+
+## [0.1.2] — 2026-07-30
+
+First public release of KiroCrew — an open-source personal AI agent that runs on
+your own machine, driving [kiro-cli](https://kiro.dev) over the Agent Client
+Protocol. Install it, sign in once, and it is yours: no server to rent, no
+account to create, and your conversations, memory, and files stay on your disk.
+
+### Chat from wherever you already are
+
+- **One agent, ten ways in** — A web dashboard, a native desktop app, a terminal
+  CLI (`kirocrew chat`, plus a full TUI), and bots for **Slack, Discord,
+  Telegram, Microsoft Teams, Webex, WeCom (企业微信), and WeChat** all drive the
+  same gateway with the same memory and the same tools. Start
+  something at your desk, follow up from your phone. Each Slack thread or
+  Discord DM is its own isolated session, and a dashboard session can be handed
+  off to a Slack thread and stay in sync both ways.
+- **A dashboard built for long sessions** — Multiple concurrent chats with
+  auto-generated titles, live streaming tool status, and a context-usage ring.
+  Edit and resend an earlier message, rewind a conversation to any point, fork a
+  session into a new tab with its full context, or regenerate a reply and browse
+  the variants. Organize with project folders, tags, Trello-style columns, and
+  per-session colors; search across every session by content. 18 color themes,
+  a Monaco code editor, `@filename` fuzzy file attach, and an incognito mode
+  whose sessions never write to memory.
+- **Speak and be spoken to** — Live streaming speech-to-text over WebSocket,
+  voice memos transcribed on arrival, and local Piper text-to-speech for replies
+  with no cloud round-trip.
+- **Ten languages** — The interface ships in English, German, Spanish, French,
+  Italian, Portuguese, Russian, Hindi, Bengali, and Chinese.
+
+### Work that continues while you are away
+
+- **Unattended multi-step tasks** — Hand it a spec and it decomposes, executes,
+  tests, and retries (`kirocrew run TASK.md`), designed for 10+ hour runs. It
+  checkpoints to disk, so a crash or Ctrl+C resumes where it stopped; if
+  kiro-cli dies it rebuilds the session and carries on; a watchdog catches
+  stalls; and an LLM reviewer checks the result against the spec before calling
+  it done. Failed steps become lessons it keeps.
+- **Autopilot** — A per-session toggle that turns ordinary chat into
+  plan-then-execute, with visible, editable plans, for when a request is bigger
+  than one turn.
+- **Cron scheduling** — Recurring jobs with per-job timezones, skip-dates for
+  holidays, per-job timeouts, and jitter to spread load. Each job chooses
+  whether it remembers the previous run. A job that finds a broken build at 3am
+  can fix it and tell you over breakfast.
+- **Parallel subagents** — Split one job across background agents
+  (`kirocrew spawn run`), blocking or fire-and-forget, with progress visible in
+  the chat header and completions delivered back into the conversation.
+- **Dynamic workflows** — For work too structured for one agent, an authored
+  Python script drives many agents through fan-out, pipelines, and
+  judge-and-verify stages. An agent will usually write the script for you from a
+  plain-English goal.
+- **Proactive push** — The agent can pause mid-session to poll something, or
+  register a webhook so an external system (CI, an alert, an inbox) wakes it up
+  later.
+
+### It remembers, and it learns
+
+- **Memory that survives restarts** — Preferences, project context, and daily
+  conversation history persist and are searched both by keyword and by meaning.
+  Embeddings run **locally and in-process**, so nothing leaves your machine to
+  make memory work. A graph explorer shows how memories relate.
+- **Corrections stick** — Correct the agent once and it is kept as a lesson
+  injected into every future session, so the same mistake does not return next
+  week.
+- **Knowledge Library** — Ingest your own documents and code into a searchable
+  personal knowledge graph the agent can consult.
+- **Snapshot and restore** — One command backs up config, memory, lessons,
+  crons, skills, and history; restore all of it or just selected components,
+  with a dry-run preview.
+
+### Extend it
+
+- **Apps, with six built in** — An App Store in the dashboard, an `app.json`
+  manifest, TypeScript and Python SDKs, and gateway lifecycle hooks. Shipping in
+  the box: **Auto Research** (multi-cycle research campaigns that keep going
+  after you walk away), **Code Review Sage** (reviews each changed file of a PR
+  in its own agent session), **Issue Radar** (GitHub/GitLab triage that
+  remembers its notes), **Workflows**, **File Explorer**, and **Dev Fleet**.
+- **Skills** — Plain markdown files that teach the agent a workflow, loaded
+  automatically when a message matches or on demand when it decides it needs
+  one. Twelve ship built in; write your own with no code and no rebuild.
+- **Any MCP server** — Discover, probe, enable, and disable MCP servers from the
+  dashboard. KiroCrew's own capabilities are exposed the same way, so the agent
+  calls structured tools instead of shelling out.
+- **Artifacts** — Documents, code files, and interactive widgets with a stable
+  identity, version history, and a dashboard library. Deploy a webapp artifact
+  to **your own** AWS account and get a public HTTPS link with a TTL.
+
+### Drive your desktop, not just a browser tab
+
+- **Computer use** — The agent can read a native application through the
+  accessibility layer and operate it: take a window as a numbered outline of its
+  buttons, fields, and rows, then press, type, set a value, scroll, or drag.
+  This reaches work with no web UI — pulling a figure out of a spreadsheet,
+  walking a desktop-only internal tool, reading an error dialog and telling you
+  what it says. **Your mouse pointer never moves by accident**: actions are
+  delivered to the target app, so a background window works without stealing
+  your cursor or focus, and the one path that does take your real pointer has to
+  be named explicitly by the model — the automatic choice never resolves onto it.
+  **Off by default and macOS-only in this release**; enable it in Settings →
+  Computer Use. Password fields are never read and a window holding one is never
+  photographed, destructive-command-shaped text is refused rather than typed, and
+  every call — allowed or refused — is written to the audit log.
+- **Browser automation** — Playwright-driven navigation, form filling, and
+  screenshots, including the ability to look at its own front-end changes and
+  judge them.
+
+### Security you can reason about
+
+- **An OS sandbox you can switch on** — kiro-cli subprocesses can be confined by
+  Linux namespaces or macOS Seatbelt, with three modes controlling which
+  credential directories are even visible. This ships **opt-in**: the default
+  (`agent.sandbox: "off"`) defers to whatever sandboxing kiro-cli applies itself,
+  so set `agent.sandbox` to `"auto"` to have KiroCrew wrap the subprocess.
+- **Layered controls** — 137 built-in denied-command patterns that hold even in
+  YOLO mode, credential redaction scanning everything the model emits, blocked
+  access to `~/.aws` and `~/.ssh`, XSS sanitization with CSP, and an audit log of
+  every command.
+- **A ceiling the agent cannot raise** — A two-level governance model
+  (`POLICY ∩ PROFILE`, tightest-wins) enforced at KiroCrew's own tool gate. The
+  policy files live where the agent can neither read nor write them, so a
+  prompt-injected agent cannot widen its own limits. Tool calls are auto-approved
+  by default (`agent.approval_mode: "auto"`) with the deny and governance gates
+  still applied first — set it to `"interactive"` to be asked before each call.
+  The dashboard is loopback-only and the Slack bot is locked to its owner.
+
+### Run it your way
+
+- **Install however suits you** — A signed and notarized universal macOS DMG, a
+  Linux AppImage, a multi-arch Docker image for always-on servers, and a
+  `pip`-installable wheel. The desktop app bundles its own Python, so end users
+  need no toolchain. Runs on **macOS, Linux, and Windows**.
+- **Three release channels** — **stable** is the default; **insider** gets
+  release candidates a week or two early and is a switch away in Settings, since
+  the two share one app and just follow different update lanes; **nightly**
+  tracks the latest code and installs alongside your production app rather than
+  replacing it, so you can run both. The desktop app updates itself, and nothing
+  downloads or installs without you asking.
+- **Always on** — Install as a systemd or launchd service, and manage several
+  remote instances (dev boxes, EC2, a home server) from one hub over SSH.
+
+### For app developers
+
+- **`ctx.cron` mutators stay synchronous, with `*_async` siblings.** The App Kit
+  surface (`add_job` / `remove_job` / `update_job` / `remove_all`) is
+  synchronous, as published. Called from a genuinely loop-less context (CLI, MCP
+  process, worker thread — what apps overwhelmingly use) they run inline as
+  before. Called from a **running event loop** — an on-loop `on_startup` hook or
+  route handler — they now raise `CronSyncOnLoopError` instead of parking the
+  gateway loop for the cron-store lock window and stalling chat, timers, and
+  heartbeats for every session. Migration is one line:
+  `ctx.cron.add_job(...)` → `await ctx.cron.add_job_async(...)`, identical
+  arguments and return value. The error is raised before any mutation, so a
+  refused call never half-applies.
+
+### Notes
+
+- **kiro-cli is required** — KiroCrew orchestrates it. `kirocrew setup` walks you
+  through installing and signing in; `kirocrew doctor` verifies the whole wiring.
+- **Data lives in `~/.kiro/crew`** — override with `KIROCREW_HOME`. Installs
+  using the earlier `~/.kirocrew` layout migrate automatically on first launch.
+- **The dashboard defaults to `http://localhost:5476`** — override with
+  `KIROCREW_PORT`.
+- **Optional extras** — speech-to-text needs `pip install kirocrew[voice]`; the
+  OS sandbox is POSIX-only; computer use is macOS-only in this release.

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -645,6 +645,23 @@ tone, contributor lines) is specified once in
 changelog from `KIROCREW_PROJECT_DIR/CHANGELOG.md` for source installs and from
 the bundled copy inside the package for wheel installs.
 
+**`main` holds the canonical copy.** A release branch necessarily carries its
+own `CHANGELOG.md`, so two copies exist while a release is in flight, and that
+divergence is what the 0.3.0 incident grew out of: the release branch's copy was
+rewritten in isolation and lost three shipped sections that `main` still had.
+The rules that keep the two from drifting:
+
+- **Write the section on the release branch first** (it is what ships), then port
+  it to `main` **verbatim** — a port adds a section and removes nothing.
+- **`main` is the recovery source.** If a release branch's changelog is damaged,
+  restore from `main` rather than reconstructing by hand; `main` is never rewound
+  by a release cut, so its copy is the one that still has the full history.
+- **Never carry a release branch's `Unreleased` entries into its own section by
+  assumption.** Entries accumulated on `main` after the release branch was cut
+  describe commits that branch does not contain — check with
+  `git merge-base --is-ancestor <sha> origin/release/<x.y.z>` before folding
+  anything in, or the release gets credited with work it does not ship.
+
 ## Deliberately not built
 
 These names appear in older design material and in code comments that point


### PR DESCRIPTION
## Problem / Motivation

The dashboard's Releases page lost its history. A user opened Settings → Releases
and saw two rows (`0.3.0` and an `Unreleased` marked "no changelog written")
where there should be four: `0.2.0`, `0.1.3` and `0.1.2` were gone.

The cause is on this branch. Commit `f3750e40c` ("docs: add 0.3.0-insider.9
changelog") **replaced** `CHANGELOG.md` instead of prepending to it: 53
insertions against **322 deletions**, removing the `## [0.2.0]`, `## [0.1.3]`
and `## [0.1.2]` sections outright and leaving behind a single section generated
from commit subjects. `main` was never touched, so every deleted line was still
recoverable byte-identical.

What replaced them was also the wrong shape for a changelog: a bare list of
commit subjects under `### Features`, a `### Bug Fixes (88 total)` header, and a
closing `… and 65 more bug fixes (see commit log)`.

## Why it matters

`release/0.3.0` is the release candidate, so this is what 0.3.0 ships. A user on
0.3.0 would install a build whose entire version history is one machine-generated
section, with no record of the two releases before it. The changelog is also the
only place a user can check whether an annoyance they hit was fixed, and a commit
dump ending in "and 65 more" cannot answer that.

Nothing caught it: no test covers the file's contents, no rule forbade the edit,
and the loss surfaced only because someone happened to open the page.

## What changed (motivation → approach → change)

**Restore, then rewrite, then prevent the recurrence.**

1. **Restored history.** All three deleted sections are recovered verbatim from
   `f3750e40c^` (verified byte-identical to the copy still on `main`, which is
   why this is a restore and not a rewrite).

2. **Wrote the 0.3.0 entry properly.** The generated section is replaced with a
   written entry covering the **764 commits** between `v0.2.0` and this branch
   (136 `feat`, 450 `fix`, 24 `perf`). Every commit was read and triaged by
   subsystem; roughly 70 turned out to be user-visible, which is the real verdict
   on the "88 bug fixes" list. The entry is grouped by what the reader gets
   (Crew Mode and parallel threads, the built-in browser, the two new apps,
   platform reach, channels, autonomy, security), modelled on the `[0.2.0]`
   section's shape: showcase body 158 lines against 0.2.0's 148.

   A closing **`### Notable fixes`** section lists individually-named,
   user-observable outcomes, one line each, so a reader can check one annoyance
   without reading the body. It deliberately carries no totals, no commit
   subjects, no scope prefixes and no "and N more" tail — that distinction is
   written into the spec below.

3. **No `Unreleased` section on this branch.** Nothing on a release branch is
   unreleased, and the 28 per-PR entries it had accumulated are all part of 0.3.0
   and are covered by the new section.

4. **Added the guardrail.** A new blocking `AUTOSDE.yaml` rule,
   `changelog-is-written-at-version-bump-only`: a non-release PR must not touch
   the file at all; a deleted or modified line inside a shipped section is a
   finding on its own whatever the stated reason; an `Unreleased` section, a
   prerelease heading (`## [0.3.0-insider.9]`), and a commit dump are each
   flagged.

5. **Wrote the spec the rule cites.** `docs/build/release.md:735` already
   deferred the section format to **AGENTS.md → "Release Changelog"** — a section
   that never existed. That dangling pointer is why an ad-hoc generated section
   could pass review at all. It now exists and covers ordering, tone, the
   `### Notable fixes` boundary, and the immutability of shipped sections.

## Tests

**A deterministic CI gate, a new test file, and the existing suites.** (An earlier
revision of this body said "No new tests" and that the rule was "enforced by the
Claude/Opus reviewer" -- both predate the gate below and were wrong; corrected here
after Design Review and First Principles both flagged the mismatch.)

- **`scripts/check_changelog_history.py` + CI job "Changelog History Gate"** --
  every release section present at the base ref must still be present at head,
  byte-identical (heading line included, so a rewritten date is caught). A
  duplicate release heading is a violation in its own right. Prerelease headings
  are drafts and are skipped, which is what lets a release branch replace its own
  in-progress entry. **No exemption for the newest section**: on the default branch
  that is the last release that shipped.
- **`test/test_changelog_history_gate.py`** -- pins which headings count as shipped
  history and the exact violation message for each defect class (`GONE`,
  `MODIFIED (heading or body)`, `appears N times`), plus that the gate uses the
  renderer's own `base_version` rather than a copy that could drift.
- **The gate's `--test` self-test** runs in CI *before* enforcement: 10 probes, one
  per rule family, so a weakened rule fails there instead of shipping green.
- `test/test_changelog_handler.py` and the release suites still pass -- that is
  what proves the restored file parses into per-version rows.

**Replayed against the incident:** `compare(f3750e40c^, f3750e40c)` reports **3
violations**, one per deleted section. Editing `[0.2.0]` on `origin/main` is also
caught, which an earlier revision of the gate permitted.

The AUTOSDE rule now covers only the **judgment** half -- commit dumps, prerelease
headings, and whether a non-release PR should touch the file at all -- and says so.

## Manual verification

- `build_release_list()` against the new file → 4 rows, dates parsed, bodies
  non-empty (0.3.0 = 8.4KB, 0.2.0 = 8.6KB).
- `python -m pytest test/test_changelog_handler.py test/test_release*.py` → 84
  passed.
- `scripts/docs-lint.sh` → 209 files scanned, all checks passed.
- `python3 -c "import yaml; yaml.safe_load(open('AUTOSDE.yaml'))"` → 7 rules
  parse.
- Restored text confirmed byte-identical to `main`'s copy
  (`diff` of `main`'s tail against `f3750e40c^`'s tail → empty).

Two pre-existing gate notes, neither introduced here:

- `scripts/scrub-lint.sh` fails identically on untouched `main` (the git-history
  author-email item it reports as tracked separately).
- `check_brand_name.py` flags one line, `- **kiro-cli is required** — KiroCrew
  orchestrates it`, inside the restored `[0.1.2]` section. It is verbatim shipped
  text that exists unchanged on `main`; it registers as "added" only because this
  branch had deleted it. Against `origin/main` as base the gate passes clean.
  Editing it would mean modifying a shipped section, which is exactly what the
  new rule forbids.

## Coverage audit (why the section is this size)

The first draft was assembled by scoping subagents to paths and keywords, which
**cannot prove coverage** — a commit matching no filter is simply never looked at.
So all 764 commits in `v0.2.0..origin/release/0.3.0` were then re-examined under an
**exhaustive positional partition**: 12 slices, every commit assigned to exactly one
reviewer, each required to open any commit whose subject was ambiguous rather than
judging by scope prefix, and to report its slice total so the arithmetic is auditable
(5x64 + 60 in the second wave, 384 in the first, range total confirmed at 764).

That surfaced roughly 145 user-visible items the keyword pass had missed, and one
whole missing **category**:

- **`### Before you upgrade` did not exist.** Node 22 is now the minimum and Node 20
  is refused; multi-account Telegram was withdrawn; `kirocrew logout` now revokes
  refresh tokens; the terminal stopped scanning PTY output for credentials (it was
  corrupting CJK and emoji, and swallowing secrets printed on purpose). A changelog
  that omits a removed capability or a raised floor is failing at its primary job —
  a reader can find a new feature later, but a withdrawn one costs them an outage.
- **New surfaces the draft never mentioned**: a Git side panel, GitHub/GitLab/Jira
  link chips with inline Jira details, a Feature Previews page, the session-list
  redesign, a bottom-docking side panel, crew activity logs.
- **A `### Faster` group** for the two changes a user actually feels: first-turn
  latency ~7.4s -> ~350ms, and a cold dashboard load from 7.8 MB to 1.85 MB.
- Items an earlier tightening pass had **cut for length** and should not have: the
  50k cron message cap, the Linux CSD single-header fix, WeCom's @-mention handling,
  the mermaid lightbox, the developer setting that skips the bundled local gateway.

The showcase body is 226 lines against 0.2.0's 148, which broke the "no longer than
the previous release" line in the `AGENTS.md` spec written earlier in this PR. Rather
than quietly exceed my own rule or drop real changes to fit it, the guidance is now
**structural**: new surfaces and perceptible performance in the body, everything
fix-shaped in the grouped `Notable fixes` tail, group harder rather than add, and
verify coverage by partitioning the commit range because the omissions are systematic
(a commit naming one subsystem while touching a shared surface is exactly what a
keyword scan misses).

## Scope: the deterministic gate is now a separate PR

This PR originally also carried a CI gate that mechanically fails any change
deleting or editing a shipped changelog section. **That has been split out into
[#4369](https://github.com/kirodotdev/KiroCrew/pull/4369).**

Why: the gate drew a legitimate blocking finding in `compare()` on four
consecutive review rounds. Every one was real and every one is fixed, but each
round re-armed every reviewer on a 280-line changelog restore that had already
reached green, and the findings were narrowing (round 1 lost shipped history a
user had installed; round 4 hid one body of a section added in the same PR). The
restore is what unblocks 0.3.0 and answers the report; the gate deserves its own
falsification rounds without holding that hostage.

**What stays here** is the changelog itself plus the *judgment* half of the
guardrail: the blocking AUTOSDE rule (a non-release PR must not touch the file;
no `Unreleased` section, prerelease heading, or commit dump), the missing
`AGENTS.md` → "Release Changelog" spec that `docs/build/release.md` had been
deferring to, and the `release.md` rules naming `main` as the canonical copy and
recovery source.

**What moved to [#4369](https://github.com/kirodotdev/KiroCrew/pull/4369)** is
`scripts/check_changelog_history.py`, its test, and the `Changelog History Gate`
CI job. Two documentation annotations that describe the gate (the AUTOSDE scope
note, and the `release.md` paragraphs on the two complementary gates and on the
bare heading being a point of no return) were removed from this PR as well, and
land in a small doc follow-up once both are in, since they only make sense with
the gate present.

Merge order: this PR first, then #4369.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no frontend path is touched — the diff is three markdown
and YAML files at the repo root. The Releases page renders this file through the
existing parser, and the parser's output is verified above by row count and body
size rather than by pixels.


