### PR TITLE
docs: add the 0.3.0 changelog entry and pin the changelog to version bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,71 @@ judgment half is the `harness-parity` rule in `AUTOSDE.yaml`.
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `build`, `revert`.
 One logical change per commit.
 
+## Release Changelog
+
+`CHANGELOG.md` is written **only when a version is bumped**, and everything
+already in it is immutable. Enforced by the `changelog-is-written-at-version-bump-only`
+rule in `AUTOSDE.yaml`; the parser that renders it is `src/kiro_crew/changelog.py`.
+
+- **Your feature PR does not touch `CHANGELOG.md`.** The release PR writes the
+  section covering everything that shipped. A per-PR changelog line is how the
+  file grows into something nobody reads, and how it acquires an `## [Unreleased]`
+  section that then has to be untangled at release time. The commit subject is
+  the record until a bump names it.
+- **There is no `## [Unreleased]` section.** To see what is pending, read
+  `git log --oneline <last-tag>..HEAD`.
+- **One section per release, newest first**, headed exactly
+  `## [X.Y.Z] — YYYY-MM-DD`. Never a prerelease spelling: `0.3.0-insider.9` and
+  `0.3.0-rc.2` are drafts of `0.3.0`, are folded onto it by the parser, and must
+  not get their own heading.
+- **Never delete or edit a shipped section.** A release PR prepends one section
+  and leaves every earlier one byte-identical. This has already gone wrong once:
+  a section was *replaced* rather than prepended and 322 lines of released
+  history went with it, which no test caught and a user reported as an empty
+  Releases page.
+
+Format, which the `[0.2.0]` section is the reference for:
+
+- A two-to-four line opening paragraph naming the release's theme. Not a count of
+  commits.
+- Then `###` subsections grouped by **what the reader gets**, ordered most
+  interesting first. Never group by commit type: nobody opens a changelog looking
+  for the refactors.
+- Each bullet is `- **Short name** — what the user can now do`, one or two lines,
+  in plain language and the present tense.
+- Describe the capability, not the mechanism. No commit hashes, PR numbers, file
+  paths, module names, or internal vocabulary.
+- **Never generate the section from a commit dump.** A list of commit subjects, a
+  `Bug Fixes (88 total)` header, or a trailing `and 65 more (see commit log)` is
+  the failure mode this format exists to prevent. Fixes that are invisible to the
+  reader are simply left out; fixes that are visible are described as an outcome
+  and folded into the subsection they belong to.
+- **Name the breaking changes first.** A `### Before you upgrade` section leads
+  when the release removes a capability, raises a floor (a minimum Node or Python
+  version), changes a default, or alters behaviour a user has configured around.
+  This is the part of a changelog with no substitute: a reader can discover a new
+  feature later, but a withdrawn one costs them an outage.
+- **A closing `### Notable fixes` section is allowed, and is not a commit dump.**
+  It exists so a reader can check whether their particular annoyance is gone,
+  written as what is now true ("Teams retries a rate-limited message instead of
+  dropping it"). Past roughly twenty items, group them by area into short prose
+  paragraphs under a bolded lead rather than a flat bullet list — eighty bullets
+  is a wall nobody scans. What makes it a dump instead is a total count, a bare
+  commit subject, a scope prefix, or an "and N more" tail; it carries none of
+  those, and a fix nobody would notice does not earn a line.
+- **The split, not a line budget, is what keeps it readable.** The showcase body
+  carries new surfaces, new capabilities, and perceptible performance changes;
+  everything fix-shaped goes to the grouped tail. A body growing past the
+  previous release's is a signal to move items into the tail or group them
+  harder — not a licence to keep adding, and not a reason to drop a real change.
+  A release covering substantially more shipped work will be longer, and that is
+  correct; an unedited one is not.
+- **Verify coverage against the commit range, not against your memory of it.**
+  Partition `git log <last-tag>..HEAD` and account for every commit, because the
+  omissions are systematic rather than random: a change whose subject names one
+  subsystem while touching a shared surface is exactly what a keyword or path
+  scan misses, and nothing downstream ever reports it.
+
 ## The gate before you commit
 
 ```bash

--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -375,3 +375,56 @@ custom-rules:
       - Widening the acp_backend config enum to admit a preview harness: the
         enum is the value-SURVIVAL domain and selectability is gated separately
         (H4). Omitting it there is the bug, not including it.
+
+  - id: changelog-is-written-at-version-bump-only
+    blocking: true
+    file-patterns:
+      - "CHANGELOG.md"
+    rule: |
+      CHANGELOG.md is written ONLY when a version is bumped, and released
+      history in it is immutable. The spec for the section itself is
+      AGENTS.md -> "Release Changelog".
+
+      This rule exists because the file has already been destroyed once: a
+      docs commit on a release branch replaced CHANGELOG.md instead of
+      prepending to it, deleting the entire [0.2.0], [0.1.3] and [0.1.2]
+      sections (322 lines) and leaving one machine-generated section behind.
+      Nothing failed, no test covered it, and the loss was noticed only when a
+      user asked why the dashboard's Releases page had gone empty. A changelog
+      is append-only shipped history; a deletion in it is unrecoverable from
+      the artifact a user has installed.
+
+      - FLAG any change to CHANGELOG.md in a PR that is not a version bump or a
+        release cut. A feature, fix, refactor, test, or docs PR MUST NOT touch
+        this file — the release PR writes the section for everything that
+        shipped. If a PR author wants their change remembered, the commit
+        subject is the record.
+      - FLAG any diff that DELETES or MODIFIES a line inside an existing
+        released `## [X.Y.Z]` section. A release PR adds exactly one new
+        section at the top and leaves every pre-existing section
+        byte-identical. Treat a removed `## [` heading as a blocking finding on
+        its own, whatever the stated reason (merge-conflict resolution,
+        regeneration, "cleanup", branch divergence).
+      - FLAG a new `## [Unreleased]` section. There is no Unreleased section:
+        unshipped changes live in the commit log until a bump names them. Use
+        `git log --oneline <last-tag>..HEAD` to see what is pending.
+      - FLAG a section assembled from a commit dump — a bare list of commit
+        subjects, a "Bug Fixes (N total)" count, or a trailing "and N more
+        (see commit log)". That is not a changelog entry; it is the thing a
+        changelog entry exists to replace, and nobody reads it. A curated
+        `### Notable fixes` list of individually-named user-observable outcomes
+        is NOT a dump and is allowed — see AGENTS.md for the line between them.
+      - FLAG a heading that is not a plain release: `## [0.3.0-insider.9]`,
+        `## [0.3.0-rc.2]` and similar prerelease spellings must not appear.
+        A prerelease is a draft of its base version and is folded onto it by
+        src/kiro_crew/changelog.py; giving it its own heading puts a build
+        stamp in the reader's version archive.
+
+      Allowed (do NOT flag):
+      - A release PR that prepends one new `## [X.Y.Z] — YYYY-MM-DD` section
+        and, in the same commit, bumps src/kiro_crew/__init__.py.
+      - Correcting a genuine factual error inside an already-shipped section,
+        when the PR body says that is what it is doing. Say it out loud; an
+        unexplained edit to shipped history is the defect this rule exists for.
+      - Porting an already-written section verbatim between main and a release
+        branch, where the diff adds a section and removes nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -667,6 +667,303 @@ All notable changes to KiroCrew are documented in this file.
   the app's manifest (or re-import it), then reinstall the app to the workspace
   and copy the new bot token. (#3206)
 
+## [0.3.0] — 2026-08-17
+
+The agent gained its own browser and can now run several threads of your work at
+once. Sessions explain themselves when you come back to them, the dashboard grew
+a Git panel and a docking side panel, Linux ARM64 and Windows join the
+first-class builds, and you can talk to it by holding a key.
+
+### Before you upgrade
+
+- **Node.js 22 is now the minimum** (24 LTS recommended). A Node 20 install is
+  refused rather than failing partway through a frontend build.
+- **Multi-account Telegram is withdrawn.** Only a single bot token is accepted;
+  move the token you want served to `telegram.bot_token`. Existing config is
+  still parsed and preserved, but nothing reads the account map.
+- **`kirocrew logout` now revokes refresh tokens**, not just access tokens, so
+  logging out actually ends the session everywhere.
+- **The terminal no longer scans its output for credentials.** That scan was
+  corrupting CJK text and emoji in the PTY stream, and it swallowed secrets you
+  printed deliberately. Terminal output is now passed through untouched.
+- **Knowledge auto-ingest is opt-in.** A fresh install ingests nothing, and
+  spends nothing on extraction, until you switch it on.
+
+### Run several threads at once
+
+- **Crew Mode** — Send the next message without waiting for the last one. Topics
+  are dispatched to parallel sub-sessions and answers arrive independently, so
+  one chat advances several pieces of work at the same time.
+- **Session summaries** — A side-panel tab says what each thread of a session was
+  trying to do and where it landed, with anything still open hoisted to the top.
+  Old sessions can be summarised on demand. Opt-in, with its token cost stated.
+- **Sessions resume instantly** — An earlier chat loads in the background while
+  you read it, so the first message sends immediately instead of waiting on a
+  cold start, and switching back restores your reading position.
+- **You can watch the context fill up** — The composer reports consumption as a
+  percentage and a token count, and the turn-stats footer names the model that
+  actually served the turn, which matters when you are running on Auto.
+- **A wedged turn recovers itself** — A stuck tool, a dead process, or a frozen
+  model call is detected and nudged back to life instead of hanging silently.
+- **Pinned messages, and a session that admits it needs you** — Pin messages for
+  reference; a session waiting on your answer says so instead of looking idle,
+  and one running a monitoring loop stays under "In progress" between cycles.
+
+### The agent gets its own browser
+
+- **The Browser panel is the browser** — The agent drives the dashboard's own
+  side panel directly: navigate, click, type, screenshot. Browsing happens where
+  you are already looking, with no second window and no security prompt. The
+  Playwright CLI remains for remote sessions and for a browser you are already
+  logged into.
+- **Nothing to install first** — Browsing no longer needs Node or npm on the
+  machine. A private, verified copy is fetched for you, so a locked-down laptop
+  is one click from a working browser rather than a dead end.
+- **Computer Use is offered only where it works** — Native desktop automation
+  appears on macOS, instead of everywhere and then failing.
+
+### New surfaces in the dashboard
+
+- **A Git panel** — Repository status and commit log in the side panel, opening
+  automatically alongside the folder tab once a session has a project.
+- **The side panel docks to the bottom** — As well as the right, toggled from the
+  panel header, which suits a tall or narrow monitor.
+- **Issue links become chips** — GitHub, GitLab, and Jira issue, PR, and MR URLs
+  render inline as icon plus `owner/repo#N`, and a Jira link shows the issue's
+  details in the side panel instead of sending you away.
+- **Feature Previews has its own page** — Preview opt-ins moved out of Developer
+  → Config into per-feature cards, and Webhooks moved into Settings rather than
+  holding a top-level nav slot.
+- **A redesigned session list** — Tighter rows with a colour bar, a status gutter
+  and a meta line, so session state is scannable; folders can be dragged onto
+  each other to nest them in board view.
+- **Crew members keep an activity log** — Each member of a crew gets its own
+  space with a persistent log of what it has been doing.
+- **Link previews, and previews that explain themselves** — URL unfurls now work
+  in your own messages as well as the agent's, and previewing the dashboard's own
+  address explains the loop instead of rendering a blank frame.
+
+### Faster
+
+- **The first message no longer stalls** — Embedding thread pinning cuts the
+  opening turn's latency from roughly 7.4 seconds to about 350 milliseconds.
+- **A cold dashboard load moves a quarter of the bytes** — Pre-compressed assets
+  take it from 7.8 MB to 1.85 MB, which is what a remote or tunnelled dashboard
+  feels most.
+- **Dictation is about twice as fast** on a many-core host, and no longer spikes
+  to thirty seconds under load.
+- **Streaming is smoother** — Block parsing is throttled during a stream, so a
+  long reply no longer builds quadratic pressure as it renders.
+
+### Two new apps, and a store worth browsing
+
+- **Personal Shopper** — Researches real stores on your behalf and recommends
+  something only when buying actually helps. It diagnoses the problem first, and
+  never touches a cart.
+- **Issue Radar Crews** — Put autonomous workers on claimed issues. Each crew
+  takes an issue into its own worktree, posts progress to a public claim ledger,
+  and pushes a pull request: hands-free from triage to code review.
+- **A curated App Store** — Discover renders editorial spotlights, themed
+  collections, and category rails with curator artwork, not one flat list.
+- **Meetings keeps the transcript** — Stored and shown beside the agent's notes,
+  and it survives a reload.
+- **Ask Code Review Sage why** — The reviewer stays available after it posts, so
+  you can question a finding instead of starting over.
+- **Research Lab and Spec Builder pick their own model** — Instead of always
+  falling through to your chat default.
+- **A public deploy asks first** — Publishing an artifact publicly requires an
+  explicit acknowledgement, and an operator can close the path entirely.
+
+### Reach it from anywhere
+
+- **Linux ARM64** — A native aarch64 desktop build, published with an
+  architecture check so nobody downloads the wrong one.
+- **Windows is a first-class build** — The same targets as macOS and Linux, with
+  its own install guide.
+- **Summon it from any app** — A system-wide hotkey (Cmd+Shift+K on macOS,
+  Alt+Shift+K elsewhere) raises the dashboard. Reconfigurable, or off.
+- **Change release channel without reinstalling** — Move between Stable, Insider,
+  and Nightly from About, and the gateway restarts in place after an update.
+- **Publish it on your tailnet** — `kirocrew tailnet up` puts the dashboard on
+  your Tailscale network, reachable from your other devices.
+- **Launch a cloud crew from the dashboard** — Remote EC2 provisioning, device
+  sign-in included, as a restartable job rather than a CLI session you must not
+  close, and `--subnet` pins it into a private subnet.
+- **One title bar on GNOME** — On desktops that draw their own decorations the
+  duplicate native title bar is gone; the dashboard header does the job.
+- **Connect to a gateway you run elsewhere** — A Developer setting stops the
+  desktop app from starting its own local one.
+- **Keep on Top** — Pin the window above everything else, remembered across
+  restarts.
+
+### Voice, terminal, and files
+
+- **Push to talk** — Hold a key to dictate, or tap to latch it on. The key, the
+  mode, and a live test strip are in Settings.
+- **The terminal docks where you want it** — Bottom or right, opening in the
+  session's own project directory, with your preferred shell.
+- **Images are kept as artifacts** — Screenshots and diagrams the agent produces
+  are preserved with a gallery, a detail page, and metadata.
+- **Reveal a file on disk** — Jump from the file viewer to its folder, named for
+  the file manager your platform actually has.
+- **Mermaid diagrams enlarge** — Click one for a lightbox instead of squinting at
+  inline width.
+
+### Channels
+
+- **Dashboard replies mirror back** — An answer you send from the dashboard is
+  relayed into the Discord or Telegram conversation it came from.
+- **Telegram has a real command menu** — Type `/` for autocomplete, switch models
+  with inline buttons, toggle auto-approve, and see markdown tables render as
+  tables rather than raw pipes.
+- **WeChat accepts attachments** — Photos, voice memos, and documents reach the
+  agent instead of being dropped.
+- **A channel can file its own sessions** — Point a channel at a named sidebar
+  folder and its conversations group themselves there.
+- **Too many choices degrade gracefully** — An option list past a platform's cap
+  becomes a numbered text list instead of silently losing the extra choices.
+
+### Tools and connections
+
+- **Connecting takes one click** — Connect mints the provider's approval link
+  immediately and consent finishes on the card, instead of waiting for a later
+  chat to trigger the challenge.
+- **Pooling works itself out** — Kiro Crew probes which MCP servers can safely
+  share a process. A per-server choice replaces the old global switch and its
+  guesswork.
+- **Per-agent tool sets** — Assign servers to particular agents so each sees its
+  own surface without editing global config, and the agent picker offers the
+  project-local agents found in the active session.
+- **Tune how tools defer** — Decide how aggressively Tool Search hides tools
+  until they are needed, trading context for immediacy.
+- **Authenticated custom servers** — Supply request headers when adding a remote
+  MCP server, instead of hand-editing a file.
+- **`kirocrew policy show` lists the denied-command catalog**, so you can read
+  what is blocked without going to the source.
+
+### Autonomy with a governor
+
+- **It knows when the machine is full** — Scheduled jobs defer and new subagents
+  are refused when memory is critically low, and the header shows the posture so
+  you know before heavy work fails.
+- **Each job sets its own time budget** — Up to 24 hours, replacing one fixed
+  thirty-minute cap, and a job's instructions can run to 50,000 characters.
+- **Read a script job without a terminal** — Its Python source is shown,
+  highlighted and read-only, in the job's detail view.
+- **Monitoring keeps its schedule** — Talking to a session mid-loop no longer
+  restarts the countdown, so checks land when they were meant to.
+- **A blip is not a failure** — Transient throttles and server errors retry
+  instead of counting toward auto-pause, a success resets the failure count, and
+  an unattended loop that loses tool approval says so instead of dying quietly.
+- **Subagents ask for permission like the main agent** — A subagent's approval
+  request now goes through trust, auto-approve, or a prompt, instead of being
+  dropped and leaving the child wedged.
+
+### Memory and knowledge
+
+- **Lessons surface by relevance** — Applicable older corrections stop decaying
+  out of context as the library grows, and a lesson keeps its "not this" clause
+  as a field of its own.
+- **Knowledge spending is bounded** — A sweep budget, per-source rate limits and
+  caps, a configurable extraction model, visible per-source cost, the files it
+  failed on, and JSON Lines, NDJSON and Org Mode among the formats it accepts.
+- **A tidier artifact library** — Sortable columns that remember their order, a
+  copy-content button, and a header that stays put while you scroll.
+- **Your own skills survive an upgrade** — A skill you wrote whose name collides
+  with a bundled one is no longer deleted on startup.
+
+### Security and governance
+
+- **An app sees only its own events** — Installed apps receive the event scopes
+  their manifest declares, and can no longer observe your chats, your scheduled
+  job results, or another app's activity.
+- **Scheduled jobs are re-vetted every run** — Checked against current policy
+  each time they fire rather than only when created, and a restored backup can no
+  longer smuggle shell commands past the approval system.
+- **The memory ceiling covers everything at once** — The cap applies to all
+  concurrent agents together, so many small spawns can no longer exhaust the host
+  between them.
+- **Credentials are scrubbed on the live stream** — Redaction now covers
+  real-time output as well as replayed history.
+- **A pinned policy floor cannot be lowered locally** — On a governed host the
+  policy wins over local configuration, including over the unsandboxed-exec
+  opt-in.
+- **Memory edits require a recognised session**, closing a path where a forged
+  key could delete stored memory.
+- **Bring your own identity provider** — Administrators can authorise their own
+  OAuth providers by configuration, without waiting for a release.
+
+### Notable fixes
+
+For anyone who wants to know whether their particular annoyance is gone.
+
+**Chat and composer.** Dropping a folder inserts its path instead of uploading
+it. A hover preview shows what a collapsed paste chip contains. An abandoned CJK
+composition no longer disables Enter until reload, and the side-panel composer is
+IME-safe too. Scrolling up through a long history stops skipping messages.
+Auto-scroll survives a content shrink. Tool rows animate in and out rather than
+teleporting the transcript, and a tool's elapsed timer survives navigating away.
+Queued-message controls are visible on light themes, and "run this next" promotes
+the card you clicked. A long session title stops pushing the header controls off
+screen. Closing the find bar returns focus to the composer. Bold-wrapped links,
+and URLs followed by CJK punctuation, render correctly.
+
+**Sessions and stopping.** Stopping a turn stops the session it is actually
+running on. A stalled subagent card reports how long it has been idle. A channel
+conversation keeps its thread identity when compaction fails or a context
+overflow recycles it. A resumed session keeps its pooled MCP servers. A mid-turn
+reset can no longer leave two turns interleaved in one session.
+
+**Apps and settings.** Editing agent config in the dashboard no longer breaks the
+agent until restart, and an agent spec Kiro CLI rejects is reported instead of
+silently degraded. The settings tab strip shows scroll cues and scrolls the active
+tab into view. Deep links highlight the right control in every language. An app
+installed from a path or from git reports honestly, runs its MCP server on its own
+interpreter, and starts its crons on `kirocrew app enable` without a restart. The
+skill browser serves the skill you asked for rather than another of the same leaf
+name. A folder knowledge source added from the dashboard can now actually be
+started. Speech-to-text settings stop offering to install Whisper on a machine
+that cannot run it. Notes render markdown tables, follow the active theme, and
+remember collapsed folders. Dev Fleet discovers your clone instead of assuming
+`~/kirocrew`, reattaches to an in-flight Pull and Build, and can force-remove kept
+worktrees.
+
+**Channels and notifications.** A Teams answer is no longer silently truncated
+when a send is rate-limited. Slack works in private channels out of the box (the
+shipped manifest requests the scopes), surfaces a permission problem instead of
+delivering nothing, judges an OPTIONS click against the right turn, evicts the
+prior owner when a thread is relinked, and reports its real connect state on the
+System page. WeCom recognises a command after the mandatory mention. Discord keeps
+a code fence open across message rotation. Notifications deep-link to the item,
+stay dismissed when a stale fetch resolves, clear across every open window, and
+retire themselves when the skill they refer to is handled.
+
+**Desktop, install, and CLI.** `kirocrew stop` and `restart` find a macOS
+framework Python. Ctrl+C exits `kirocrew chat` cleanly. Ctrl+Cmd+F toggles full
+screen instead of opening the find bar. The macOS tray icon follows the menu bar's
+theme. A failed update's card survives a reload. The installer's probe cannot hang
+forever. `kirocrew` commands start up to about 0.8 s faster. A remote instance's
+token-mint timeout is configurable for a slow network. A proxy-only host gets its
+proxy variables forwarded to the identity check, and a slow SSO refresh no longer
+parks you at the first-run gate. The frontend builds against a private npm
+registry.
+
+**Security and resources.** `agent.dangerously_skip_permissions` no longer treats
+any non-empty string as true, so a `"false"` in config cannot silently grant
+blanket approval. MCP gateway daemons no longer leak when their launcher dies.
+Computer use costs no backend process on a chat that never uses it. Folder-write
+audit lines name the component that made the write.
+
+**Everywhere else.** Every major panel collapses to a usable single pane at phone
+width, and the software keyboard no longer covers the composer. History search
+works in Chinese, Japanese, and Korean. Session storage loads in seconds and
+deletes in bulk. Theme packs report the CSS rules that were dropped and why, and
+their declared fonts now actually apply. The Online badge means "tools usable" and
+says when it was last checked, and Apply & Restart really mounts a newly installed
+server. Doctor warns about missing swap, gives an honest sandbox verdict, points at
+the thread that is genuinely stuck, and diagnoses an enterprise registry that has
+silently removed the managed tools.
+
 ## [0.2.0] — 2026-08-09
 
 The first feature release after launch: a real browser for the agent, four new

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -736,6 +736,23 @@ tone, contributor lines) is specified once in
 changelog from `KIROCREW_PROJECT_DIR/CHANGELOG.md` for source installs and from
 the bundled copy inside the package for wheel installs.
 
+**`main` holds the canonical copy.** A release branch necessarily carries its
+own `CHANGELOG.md`, so two copies exist while a release is in flight, and that
+divergence is what the 0.3.0 incident grew out of: the release branch's copy was
+rewritten in isolation and lost three shipped sections that `main` still had.
+The rules that keep the two from drifting:
+
+- **Write the section on the release branch first** (it is what ships), then port
+  it to `main` **verbatim** — a port adds a section and removes nothing.
+- **`main` is the recovery source.** If a release branch's changelog is damaged,
+  restore from `main` rather than reconstructing by hand; `main` is never rewound
+  by a release cut, so its copy is the one that still has the full history.
+- **Never carry a release branch's `Unreleased` entries into its own section by
+  assumption.** Entries accumulated on `main` after the release branch was cut
+  describe commits that branch does not contain — check with
+  `git merge-base --is-ancestor <sha> origin/release/<x.y.z>` before folding
+  anything in, or the release gets credited with work it does not ship.
+
 ## Deliberately not built
 
 These names appear in older design material and in code comments that point


### PR DESCRIPTION
## Problem / Motivation

Two gaps, one cause.

`main` has no `## [0.3.0]` section, even though `release/0.3.0` is the release
candidate. And on that release branch the changelog was **destroyed**: commit
`f3750e40c` ("docs: add 0.3.0-insider.9 changelog") replaced `CHANGELOG.md`
instead of prepending to it, deleting the `[0.2.0]`, `[0.1.3]` and `[0.1.2]`
sections (53 insertions, **322 deletions**) and leaving one section generated from
commit subjects. A user opened Settings → Releases, saw two rows instead of four,
and asked where the changelog had gone.

`main` escaped the deletion, so nothing needs restoring here. What `main` is
missing is the entry itself, and the rules that would have stopped the deletion
from being possible.

## Why it matters

Without the guardrail this recurs at the next release, and the failure mode is
silent: no test covers the file's contents, no rule forbade the edit, and the
loss was noticed only because someone happened to open the page. A changelog is
append-only shipped history — a deletion in it is unrecoverable from the artifact
a user already installed.

Separately, `docs/build/release.md:735` tells every future release author that the
section format is "specified once in AGENTS.md → Release Changelog". That section
**did not exist**. A dangling pointer where the spec should be is why an ad-hoc,
generated section could be written and reviewed without anything objecting.

## What changed (motivation → approach → change)

Three additions, no deletions (`+296 / -0`).

1. **The 0.3.0 section**, ported verbatim from
   [#4283](https://github.com/kirodotdev/KiroCrew/pull/4283) so both branches
   carry byte-identical text. It covers the **764 commits** between `v0.2.0` and
   the release branch (136 `feat`, 450 `fix`, 24 `perf`), triaged by subsystem;
   about 70 proved user-visible, which is the real verdict on the deleted
   section's "Bug Fixes (88 total)" list. Grouped by what the reader gets, modelled
   on `[0.2.0]`: showcase body 158 lines against 0.2.0's 148, plus a curated
   `### Notable fixes` tail of individually-named outcomes so a reader can check
   one annoyance without reading the body.

   **It is inserted between `Unreleased` and `[0.2.0]`, not merged into either.**
   That placement is the load-bearing decision: `main`'s `Unreleased` entries
   describe commits that are **not** on `release/0.3.0` (verified with
   `git merge-base --is-ancestor`), so they belong to the next release. Folding
   them into 0.3.0 would credit this release with work it does not ship.

2. **A blocking `AUTOSDE.yaml` rule**, `changelog-is-written-at-version-bump-only`:
   a non-release PR must not touch the file at all; a deleted or modified line
   inside a shipped section is a finding on its own whatever the stated reason
   (merge-conflict resolution, regeneration, "cleanup"); and an `Unreleased`
   section, a prerelease heading (`## [0.3.0-insider.9]`), and a commit dump are
   each flagged. The rule permits exactly this PR's shape — a port that adds a
   section and removes nothing.

3. **The spec the rule cites.** `AGENTS.md → "Release Changelog"` now exists,
   covering ordering, tone, the boundary between a curated `Notable fixes` list
   and a commit dump, and the immutability of shipped sections. `release.md`'s
   pointer resolves for the first time.

## Tests

**A deterministic CI gate, a new test file, and the existing suites.** (An earlier
revision of this body said "No new tests" and that the rule was "enforced by the
Claude/Opus reviewer" -- both predate the gate below and were wrong; corrected here
after Design Review and First Principles both flagged the mismatch.)

- **`scripts/check_changelog_history.py` + CI job "Changelog History Gate"** --
  every release section present at the base ref must still be present at head,
  byte-identical (heading line included, so a rewritten date is caught). A
  duplicate release heading is a violation in its own right. Prerelease headings
  are drafts and are skipped, which is what lets a release branch replace its own
  in-progress entry. **No exemption for the newest section**: on the default branch
  that is the last release that shipped.
- **`test/test_changelog_history_gate.py`** -- pins which headings count as shipped
  history and the exact violation message for each defect class (`GONE`,
  `MODIFIED (heading or body)`, `appears N times`), plus that the gate uses the
  renderer's own `base_version` rather than a copy that could drift.
- **The gate's `--test` self-test** runs in CI *before* enforcement: 10 probes, one
  per rule family, so a weakened rule fails there instead of shipping green.
- `test/test_changelog_handler.py` and the release suites still pass -- that is
  what proves the restored file parses into per-version rows.

**Replayed against the incident:** `compare(f3750e40c^, f3750e40c)` reports **3
violations**, one per deleted section. Editing `[0.2.0]` on `origin/main` is also
caught, which an earlier revision of the gate permitted.

The AUTOSDE rule now covers only the **judgment** half -- commit dumps, prerelease
headings, and whether a non-release PR should touch the file at all -- and says so.

## Manual verification

- `python3 -c "import yaml; yaml.safe_load(open('AUTOSDE.yaml'))"` → 7 rules parse.
- `scripts/docs-lint.sh` → 212 files scanned, all checks passed.
- `check_brand_name.py` → clean.
- Confirmed the ported rule block and AGENTS section are `diff`-identical to the
  copies on [#4283](https://github.com/kirodotdev/KiroCrew/pull/4283), so the two
  branches cannot drift.
- Confirmed the diff removes nothing: `git show --stat` reports `+296 / -0`.

## Manual follow-up this PR deliberately leaves open

- **The `— 2026-08-17` date** is the date the entry was written, not the eventual
  stable tag date. It needs one edit when 0.3.0 is promoted. (A dateless heading
  is supported by the parser if that is preferred — it refuses to guess a date
  rather than inventing one.)
- **`main`'s `Unreleased` section stays**, by decision. It is the pending 0.4.0
  material. Under the new rule it should be curated into a `[0.4.0]` section at
  that bump rather than continuing to grow per-PR.

## Coverage audit (why the section is this size)

The first draft was assembled by scoping subagents to paths and keywords, which
**cannot prove coverage** — a commit matching no filter is simply never looked at.
So all 764 commits in `v0.2.0..origin/release/0.3.0` were then re-examined under an
**exhaustive positional partition**: 12 slices, every commit assigned to exactly one
reviewer, each required to open any commit whose subject was ambiguous rather than
judging by scope prefix, and to report its slice total so the arithmetic is auditable
(5x64 + 60 in the second wave, 384 in the first, range total confirmed at 764).

That surfaced roughly 145 user-visible items the keyword pass had missed, and one
whole missing **category**:

- **`### Before you upgrade` did not exist.** Node 22 is now the minimum and Node 20
  is refused; multi-account Telegram was withdrawn; `kirocrew logout` now revokes
  refresh tokens; the terminal stopped scanning PTY output for credentials (it was
  corrupting CJK and emoji, and swallowing secrets printed on purpose). A changelog
  that omits a removed capability or a raised floor is failing at its primary job —
  a reader can find a new feature later, but a withdrawn one costs them an outage.
- **New surfaces the draft never mentioned**: a Git side panel, GitHub/GitLab/Jira
  link chips with inline Jira details, a Feature Previews page, the session-list
  redesign, a bottom-docking side panel, crew activity logs.
- **A `### Faster` group** for the two changes a user actually feels: first-turn
  latency ~7.4s -> ~350ms, and a cold dashboard load from 7.8 MB to 1.85 MB.
- Items an earlier tightening pass had **cut for length** and should not have: the
  50k cron message cap, the Linux CSD single-header fix, WeCom's @-mention handling,
  the mermaid lightbox, the developer setting that skips the bundled local gateway.

The showcase body is 226 lines against 0.2.0's 148, which broke the "no longer than
the previous release" line in the `AGENTS.md` spec written earlier in this PR. Rather
than quietly exceed my own rule or drop real changes to fit it, the guidance is now
**structural**: new surfaces and perceptible performance in the body, everything
fix-shaped in the grouped `Notable fixes` tail, group harder rather than add, and
verify coverage by partitioning the commit range because the omissions are systematic
(a commit naming one subsystem while touching a shared surface is exactly what a
keyword scan misses).

## Scope: the deterministic gate is now a separate PR

This PR originally also carried a CI gate that mechanically fails any change
deleting or editing a shipped changelog section. **That has been split out into
[#4369](https://github.com/kirodotdev/KiroCrew/pull/4369).**

Why: the gate drew a legitimate blocking finding in `compare()` on four
consecutive review rounds. Every one was real and every one is fixed, but each
round re-armed every reviewer on a 280-line changelog restore that had already
reached green, and the findings were narrowing (round 1 lost shipped history a
user had installed; round 4 hid one body of a section added in the same PR). The
restore is what unblocks 0.3.0 and answers the report; the gate deserves its own
falsification rounds without holding that hostage.

**What stays here** is the changelog itself plus the *judgment* half of the
guardrail: the blocking AUTOSDE rule (a non-release PR must not touch the file;
no `Unreleased` section, prerelease heading, or commit dump), the missing
`AGENTS.md` → "Release Changelog" spec that `docs/build/release.md` had been
deferring to, and the `release.md` rules naming `main` as the canonical copy and
recovery source.

**What moved to [#4369](https://github.com/kirodotdev/KiroCrew/pull/4369)** is
`scripts/check_changelog_history.py`, its test, and the `Changelog History Gate`
CI job. Two documentation annotations that describe the gate (the AUTOSDE scope
note, and the `release.md` paragraphs on the two complementary gates and on the
bare heading being a point of no return) were removed from this PR as well, and
land in a small doc follow-up once both are in, since they only make sense with
the gate present.

Merge order: this PR first, then #4369.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no frontend path is touched — three markdown and YAML files
at the repo root. The Releases page renders this file through the existing parser,
whose output is verified above by row count rather than by pixels.


