### PR TITLE
docs: correct Windows installer status and set the SmartScreen expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ remote Gateway over an SSH tunnel. See the
 [desktop app guide](docs/build/desktop-app.md).
 
 - **macOS** (one universal DMG, Apple Silicon + Intel): [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew.dmg) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew.dmg) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew.dmg)
-- **Windows**: no desktop build yet, so run the Gateway from a [source install](#build-from-source) and open the dashboard in your browser
+- **Windows x64** (signed NSIS installer): [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-Setup.exe) — Insider publishes from its next release, Stable is not wired yet, and SmartScreen still prompts on first download until the signature accrues reputation; see the [Windows guide](docs/guides/windows-install.md#what-smartscreen-still-shows)
 
 **On Linux, start with the one-line install** — it is the smoothest path, works
 on every distro and both architectures, and puts `kirocrew` on your `PATH`,

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -331,8 +331,12 @@ excludes Ubuntu 20.04, Debian 11 and Amazon Linux 2 — on those, use the
 [one-line install](#a-one-line-install-fastest) instead.
 
 Prebuilt downloads for the release channels are linked from the
-[README](../../README.md#app-downloads). Windows has no desktop build yet:
-run the gateway from a source install and open the dashboard in a browser.
+[README](../../README.md#app-downloads). Windows ships a signed NSIS installer on
+nightly today, with insider following from its next release and stable not wired
+yet, and SmartScreen still prompts on first download until the signature accrues
+reputation — see the
+[Windows guide](windows-install.md#what-smartscreen-still-shows). The native
+source install remains the fully supported Windows path.
 
 See [desktop-app.md](../build/desktop-app.md) for the full pipeline (frontend,
 PBS provisioning, pip install, pruning, electron-builder) and how the app

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -5,7 +5,7 @@ The cross-platform process / signal / file-lock / metrics behavior is routed
 through `kiro_crew.platform_compat`, so macOS + Linux behavior is unchanged and
 the same code path also runs on Windows.
 
-## Desktop installer (preview, CI-built)
+## Desktop installer (preview)
 
 CI's Windows lane (`build-windows.yml`) also builds a Windows desktop app: an
 NSIS `KiroCrew Setup <version>.exe` with the backend bundled (no separate Python
@@ -15,22 +15,29 @@ build — the installer compresses its own already-signed executable — so that
 needs AWS credentials the shared build workflow deliberately does not hold.
 Current status:
 
-- **CI artifact only** — produced on nightly/release runs and the manual
-  `workflow_dispatch` probe; not yet published to the download CDN (that is
-  the upcoming `publish-windows.yml` lane).
-- **Signing wired but not yet active** — the AWS Signer path is in place and
-  skips cleanly until the signing profiles are provisioned, so today's
-  installers are still unsigned and SmartScreen shows an "unrecognized app"
-  interstitial (More info > Run anyway).
-- **No auto-update yet** — win32 remains outside `SUPPORTED_PLATFORMS` in
-  `auto-update.js`. The NSIS target removes the *packaging* blocker
-  (electron-updater's win32 path is `NsisUpdater`, and it has no
-  Squirrel.Windows support at all), but two prerequisites remain: a published
-  `latest.yml` feed alongside `latest-mac.yml`/`latest-linux.yml`, and active
-  signing — `NsisUpdater` verifies Authenticode fail-closed, so an unsigned
-  installer makes every update fail rather than merely warn. Tracked in
-  [issue #598](https://github.com/kirodotdev/KiroCrew/issues/598); until then,
-  installs update by running a newer Setup.exe.
+- **Published to the download CDN** — `publish-windows.yml` uploads the signed
+  installer and its `.blockmap` to an immutable versioned key and refreshes a
+  `latest/` alias plus the `latest.yml` update feed. The lane runs on the
+  **nightly and insider** channels; nightly is live, and insider publishes from
+  its next release because the lane landed after the most recent one. Stable has
+  no Windows installer at all, because stable republishes a promotion bundle that
+  carries no Windows role
+  ([issue #4181](https://github.com/kirodotdev/KiroCrew/issues/4181)).
+  - Nightly: <https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-Setup.exe>
+- **Authenticode signed** — every installer is signed through AWS Signer with an
+  `Amazon Web Services, Inc.` certificate, and the publish lane refuses to
+  publish one whose signer is not that publisher or which carries no RFC3161
+  timestamp. **Expect a SmartScreen prompt anyway** — see
+  [What SmartScreen still shows](#what-smartscreen-still-shows) below, because
+  signing does not remove it.
+- **Auto-updates on nightly and insider** — `win32` is in
+  `SUPPORTED_PLATFORMS`, `NsisUpdater` reads `latest.yml`, and the install is
+  silent (`/S`) so an update needs no click-through. `NsisUpdater` verifies the
+  download's Authenticode signature **fail-closed** against the `publisherName`
+  pinned in `website/electron/package.json`, which is why an unsigned installer
+  would make every update fail rather than merely warn. On a channel with no
+  Windows lane the updater reports itself unavailable instead of checking a feed
+  that was never written.
 - **Assisted installer, per user by default** — `nsis.oneClick` is false and
   `perMachine` is false, so the installer offers an install-mode page whose
   default is a per-user install into a directory named from the product name,
@@ -48,6 +55,46 @@ Current status:
   controls remain on the right.
 
 The source install below remains the fully supported path.
+
+### What SmartScreen still shows
+
+**A signed installer still triggers SmartScreen on first download.** This is the
+single most likely reason to think the signing is broken when it is not, so it is
+worth stating plainly: Microsoft
+[documents](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation)
+that a valid OV **or** EV certificate produces a warning "until reputation
+accumulates", and that EV certificates no longer bypass SmartScreen the way they
+did years ago. The only distribution path that is never warned about is the
+Microsoft Store, which re-signs with a Microsoft certificate.
+
+What signing does buy, on the same page:
+
+- **The verified publisher name is displayed** rather than an unknown-publisher
+  block, so a user can check that the installer really came from
+  `Amazon Web Services, Inc.` before continuing.
+- **Reputation can carry across versions.** SmartScreen weighs two signals, the
+  publisher certificate and the file hash, and reputation "cannot transfer from
+  previous versions unless both were signed using the same publisher identity".
+  Every release is signed with one identity, so a new nightly inherits the
+  certificate's standing instead of starting from zero. An unsigned build would
+  have to rebuild reputation on every single update, which nightly's daily new
+  hash would never manage.
+- **Windows 11 Smart App Control blocks unsigned executables outright** rather
+  than warning, and it applies to all executables, not only downloaded ones. That
+  is a hard failure signing avoids.
+
+Expect the prompt to fade rather than disappear on a date: Microsoft publishes no
+threshold, and says only that it "can take several weeks and hundreds of clean
+installs from a wide audience". There is no way to submit a file for consumer
+reputation review; it accrues from download volume. Enterprise administrators
+have two levers users do not: distribution from a Trusted Intranet location, and
+file submission through the
+[Microsoft Security Intelligence portal](https://www.microsoft.com/en-us/wdsi/filesubmission).
+
+One caveat worth tracking rather than discovering: the signing certificate
+auto-rotates annually, and Microsoft advises using "a consistent signing
+identity" because changing the certificate affects the publisher trust signal.
+Whether a rotation resets accumulated publisher reputation is not documented.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Problem / Motivation

Three docs still described the Windows desktop installer as an unpublished,
unsigned CI artifact with no auto-update. Every one of those statements went false
when the publish lane landed:

- `docs/guides/windows-install.md` — "**Signing wired but not yet active** ... so
  today's installers are still unsigned", "**CI artifact only** ... not yet
  published to the download CDN", "**No auto-update yet**".
- `README.md` — "**Windows**: no desktop build yet, so run the Gateway from a
  source install".
- `docs/guides/install.md` — "Windows has no desktop build yet".

Separately, and more usefully, **no doc set the SmartScreen expectation at all** —
which is the one thing a Windows user will actually experience.

## Why it matters

A user downloads the newly signed installer, sees "Windows protected your PC", and
concludes the signing did not work. That is a reasonable inference from the docs we
had, and it is wrong. Microsoft
[documents](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation)
that a valid **OV or EV** certificate warns "until reputation accumulates", and
that EV stopped bypassing SmartScreen years ago. The only never-warned path is the
Microsoft Store.

Getting this wrong in the other direction matters too: signing is not cosmetic, and
the docs should say why it was worth doing.

## What changed (motivation → approach → change)

**All three files, not just the guide.** Correcting only `windows-install.md`
would have left the README asserting the opposite, so the sibling claims are fixed
in the same change.

**A new `### What SmartScreen still shows` section**, sourced to Microsoft's page
rather than asserted, stating what signing does and does not buy:

- **Does not** remove the first-download prompt. No published threshold; Microsoft
  says only "several weeks and hundreds of clean installs from a wide audience",
  and there is no consumer submission mechanism.
- **Does** display the verified publisher name instead of an unknown-publisher
  block, so a user can check the installer came from `Amazon Web Services, Inc.`
- **Does** let reputation carry across versions: it "cannot transfer from previous
  versions unless both were signed using the same publisher identity". This is the
  load-bearing one for us — a daily nightly inherits the certificate's standing
  instead of starting from zero on every new hash, which an unsigned build could
  never do.
- **Does** avoid a hard failure: Windows 11 Smart App Control *blocks* unsigned
  executables rather than warning, and applies to all executables, not only
  downloaded ones.

It also records the caveat rather than leaving it to be discovered: the signing
certificate auto-rotates annually while Microsoft advises "a consistent signing
identity", and whether a rotation resets accumulated publisher reputation is not
documented. Enterprise levers users do not have (Trusted Intranet distribution,
Security Intelligence portal submission) are named.

## Tests

N/A — documentation only, no code paths touched. The gates that apply:

- `scripts/docs-lint.sh` clean (212 markdown files; index/link integrity, which is
  what catches a broken cross-file anchor)
- `check_brand_name.py` and `scrub-lint.sh --no-history` clean
- the new `#what-smartscreen-still-shows` anchor resolves from all three
  referencing locations

## Manual verification

**Every URL added was fetched; all return 200.** That is not ceremony here: the
first draft of this change linked the insider installer, and the fetch returned
**403** because the publish lane landed after the most recent insider release, so
that object does not exist yet. Linking it would have shipped a dead download link
into the README. The docs now link nightly only and say insider follows from its
next release.

Nightly's published state was confirmed directly on the CDN, not inferred from a
green job: `feed/nightly/latest.yml` carries `version: 0.3.0-nightly.20260818t004703`
with a base64 `sha512`, the installer and `.blockmap` are both on the immutable
versioned key, and the `latest/` alias serves byte-identical content.

## Related Issues

Context for the deferred stable channel: #4181. No issue closed here.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — docs)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** documentation-only change, no rendered UI surface.
