### PR TITLE
fix(voice): keep an in-flight transcription when Chat unmounts

### DIFF
--- a/website/src/hooks/useVoiceInput.ts
+++ b/website/src/hooks/useVoiceInput.ts
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import { api } from '../api/client'
 import { streamingSupported, useStreamingStt } from './useStreamingStt'
 import { acquireMicStream, activeDeviceId, humanizeMicError, createLevelMeter, createAudioSample, getPreferredMicId, setPreferredMicId } from './mic'
+import { beginTranscription, settleTranscription, subscribeTranscripts } from './voiceTranscriptInbox'
 import { i18nT } from '../i18n/t'
 
 function pickMimeType(): string {
@@ -34,7 +35,14 @@ interface Opts {
   sessionId?: string | null
 }
 
-export function useVoiceInput(onText: (text: string, sessionId: string | null) => void, opts: Opts = {}) {
+/** Which capture path produced a transcript. The caller's disarm flags are all
+ *  streaming-only concepts, so a batch transcript must be recognisable as such
+ *  rather than inferred from whichever mode happens to be selected when it
+ *  arrives — the two differ once a transcription outlives the page that
+ *  started it. */
+export type TranscriptOrigin = 'batch' | 'stream'
+
+export function useVoiceInput(onText: (text: string, sessionId: string | null, origin: TranscriptOrigin) => void, opts: Opts = {}) {
   const [recording, setRecording] = useState(false)
   const [transcribing, setTranscribing] = useState(false)
   // The slot that owns the current voice session — set when a recording
@@ -115,7 +123,7 @@ export function useVoiceInput(onText: (text: string, sessionId: string | null) =
     [optsPartial],
   )
   const streamOnFinal = useCallback(
-    (text: string) => { setPartial(''); if (text) onText(text, streamSessionRef.current) },
+    (text: string) => { setPartial(''); if (text) onText(text, streamSessionRef.current, 'stream') },
     [onText],
   )
   const optsEndpoint = opts.onEndpoint
@@ -167,6 +175,50 @@ export function useVoiceInput(onText: (text: string, sessionId: string | null) =
 
   // Cleanup on unmount — stop mic stream
   useEffect(() => () => { stopStream() }, [stopStream])
+
+  // Latest delivery callback, so a transcription that settles after this
+  // instance mounted (including one started by an earlier one) reaches the
+  // current consumer rather than a captured stale closure.
+  const onTextRef = useRef(onText)
+  onTextRef.current = onText
+  // Live capture in THIS instance. A transcription reported through the inbox
+  // may belong to an earlier instance, and its bookkeeping must never blank the
+  // busy state of a recording running here. The batch recorder's own state is
+  // read directly (not a mirror) because the two can change in the same tick.
+  const streamRecordingRef = useRef(false)
+  streamRecordingRef.current = streamRecording
+  const capturing = useCallback(
+    () => mediaRef.current?.state === 'recording' || streamRecordingRef.current,
+    [],
+  )
+  // The inbox request this instance currently displays as busy, if any.
+  const shownRef = useRef<number | null>(null)
+
+  // A batch transcription outlives the component that started it (see
+  // voiceTranscriptInbox): leaving Chat unmounts this hook while `/api/stt` is
+  // still in flight, so its progress and result are routed through the inbox
+  // instead of into a dead closure. Whichever instance is mounted delivers it —
+  // restoring the busy indicator for the slot still waiting — and a result that
+  // settled with none mounted is drained here on the next mount.
+  useEffect(() => subscribeTranscripts({
+    begin: request => {
+      if (capturing()) return
+      shownRef.current = request.id
+      setTranscribing(true)
+      setSessionOwner(request.sessionId)
+    },
+    settle: result => {
+      // Only the request actually on display releases the busy state, and only
+      // while nothing is capturing here: a transcription that settles after this
+      // instance started its own session must not blank that session's mic UI.
+      if (shownRef.current === result.id) {
+        shownRef.current = null
+        if (!capturing()) { setTranscribing(false); setSessionOwner(null) }
+      }
+      if (result.error) setError(result.error)
+      else if (result.text) onTextRef.current(result.text, result.sessionId, 'batch')
+    },
+  }), [capturing])
 
   // Acquire (or reuse) a live mic stream and attach the level meter + device
   // label exactly once. A single in-flight getUserMedia is shared so a
@@ -335,25 +387,27 @@ export function useVoiceInput(onText: (text: string, sessionId: string | null) =
         const ext = mimeType.includes('mp4') ? 'mp4' : mimeType.includes('ogg') ? 'ogg' : 'webm'
         const blob = new Blob(chunksRef.current, { type: mimeType || 'audio/webm' })
         if (blob.size < 100) { setSessionOwner(null); return }
-        setTranscribing(true)
+        // Announced to the inbox rather than tracked only here: whichever hook
+        // instance is mounted shows the busy state for the slot that is waiting,
+        // including one that mounts after this recorder's page is gone.
+        const request = beginTranscription(sessionAtStart)
         try {
           const res = await api.sttTranscribe(blob, ext)
           if (res.error) {
             // eslint-disable-next-line no-console -- surface STT failures for debugging
             console.error('[voice] STT error:', res.error)
-            setError(i18nT('hooks.useVoiceInput.transcription_failed', { error: res.error }))
-          } else if (res.text) onText(res.text, sessionAtStart)
+            settleTranscription({ id: request.id, error: i18nT('hooks.useVoiceInput.transcription_failed', { error: res.error }), sessionId: sessionAtStart })
+          } else settleTranscription({ id: request.id, text: res.text, sessionId: sessionAtStart })
         } catch (err) {
           // eslint-disable-next-line no-console -- surface transcription failures for debugging
           console.error('[voice] transcription failed:', err)
-          setError(i18nT('hooks.useVoiceInput.transcription_request_failed'))
+          settleTranscription({ id: request.id, error: i18nT('hooks.useVoiceInput.transcription_request_failed'), sessionId: sessionAtStart })
         }
-        // Session over (recording ended, transcription done) — release ownership
-        // so another slot can start. Exclusivity (one session at a time) is
-        // enforced by the caller, so there is never a second in-flight request
-        // whose state this could clobber.
-        setTranscribing(false)
-        setSessionOwner(null)
+        // The session ends when the transcription settles, and releasing
+        // `transcribing`/`sessionOwner` is the subscriber's job — this recorder's
+        // own hook instance while it is still mounted, or the next one to mount.
+        // Releasing it a second time here would bypass that subscriber's guard
+        // and blank the mic UI of a session started since.
       }
       mr.start()
       mediaRef.current = mr
@@ -387,7 +441,7 @@ export function useVoiceInput(onText: (text: string, sessionId: string | null) =
       setError(humanizeMicError(e))
     }
     if (gen === startGenRef.current) startingRef.current = false
-  }, [onText, streamEnabled, streamStart, acquireWarm])
+  }, [streamEnabled, streamStart, acquireWarm])
 
   const stop = useCallback(() => {
     if (streamEnabled) { streamStop(); setSessionOwner(null); return }

--- a/website/src/hooks/voiceTranscriptInbox.ts
+++ b/website/src/hooks/voiceTranscriptInbox.ts
@@ -1,0 +1,117 @@
+/**
+ * Module-scoped hand-off for a batch transcription that outlives the component
+ * which started it.
+ *
+ * Navigating away from Chat unmounts the voice hook while the `/api/stt`
+ * request is still in flight. The request is a plain fetch, so it completes
+ * regardless — only its DELIVERY needs somewhere to land, because the callback
+ * it was going to invoke belongs to a page that no longer exists. Progress and
+ * results are routed here instead: to the hook instance that is mounted at the
+ * time if there is one, otherwise held until the next instance subscribes.
+ * That is what carries a transcript across a trip to Settings.
+ *
+ * Every request carries an id, and a subscriber is told when one BEGINS as well
+ * as when it settles. Both exist for the same reason: an instance must be able
+ * to tell "the request I am displaying as busy" from "some other request", so a
+ * late settlement can never blank the state of a session that has started since.
+ *
+ * Deliberately NOT a mic owner and NOT a persistence layer: the microphone, the
+ * MediaRecorder and the streaming socket still stop on unmount, so leaving Chat
+ * never leaves a recording running without any UI to see or stop it. Only the
+ * pending request lives here, and only until the tab unloads.
+ *
+ * Two invariants, both resting on the same fact — the controls that start a voice
+ * session live only in Chat, and the caller refuses to start one while a
+ * transcription is in flight:
+ *   - at most one request is ever waiting, so a single result slot is enough;
+ *   - at most one subscriber is ever live, so `sink` is a slot rather than a set.
+ * Route exclusivity is what upholds the second one today: `ChatPage` also mounts
+ * embedded (`ArtifactChatPanel`, the app-sdk `ChatPanel`), and if two instances
+ * ever co-mounted the later would silently detach the earlier.
+ */
+
+/** A transcription request in flight. */
+export interface PendingTranscription {
+  id: number
+  /** Slot that owned the recording, so the busy state shows on the right session. */
+  sessionId: string | null
+}
+
+/** Terminal outcome of one request. Exactly one is delivered per `beginTranscription`. */
+export interface TranscriptResult {
+  /** Matches the `PendingTranscription` this settles. */
+  id: number
+  /** Transcribed text. Absent when the request failed or returned nothing. */
+  text?: string
+  /** Already-localized failure message, surfaced as the hook's `error`. */
+  error?: string
+  sessionId: string | null
+}
+
+export interface TranscriptSink {
+  begin: (request: PendingTranscription) => void
+  settle: (result: TranscriptResult) => void
+}
+
+let sink: TranscriptSink | null = null
+/** Result waiting for a subscriber. A newer one replaces it: the invariant allows
+ *  only one, and the newer utterance is the one a user still wants. */
+let pending: TranscriptResult | null = null
+let inFlight: PendingTranscription | null = null
+let nextId = 0
+
+/**
+ * Register the delivery target. An already-running request is replayed as a
+ * `begin` so a returning instance restores the busy indicator, and a result that
+ * settled while no instance existed is handed over.
+ *
+ * The hand-over is deferred to a microtask rather than applied inline. A
+ * subscriber mounts inside a page whose own prefill and draft effects commit in
+ * the same pass, and a transcript applied before those have run is written
+ * against composer state they are about to replace — so it lands in a
+ * half-settled slot and can be overwritten by the very next persist. A microtask
+ * runs after the whole effect flush, which is when the composer knows which slot
+ * it holds.
+ *
+ * It delivers to whichever sink is current when it runs, not to the one that
+ * scheduled it: StrictMode subscribes, tears down and resubscribes within that
+ * window, so keying on the scheduling subscription would strand the text on
+ * every mount in development.
+ */
+export function subscribeTranscripts(next: TranscriptSink): () => void {
+  sink = next
+  if (inFlight) next.begin(inFlight)
+  const handover = pending
+  pending = null
+  if (handover) {
+    queueMicrotask(() => {
+      const target = sink
+      // Nothing mounted any more: keep holding the text for the next instance
+      // rather than delivering into a sink that is gone. A result that arrived
+      // in the meantime is newer and wins.
+      if (!target) { pending = pending ?? handover; return }
+      target.settle(handover)
+    })
+  }
+  return () => {
+    // Only if still ours: a newer subscriber has already taken the slot and
+    // clearing it here would leave that live instance unreachable.
+    if (sink === next) sink = null
+  }
+}
+
+/** Announce a started transcription and return its identity. */
+export function beginTranscription(sessionId: string | null): PendingTranscription {
+  inFlight = { id: ++nextId, sessionId }
+  sink?.begin(inFlight)
+  return inFlight
+}
+
+/** Deliver a request's outcome to the live subscriber, or hold it for the next. */
+export function settleTranscription(result: TranscriptResult): void {
+  // Guarded so a straggler cannot clear a NEWER request's in-flight record and
+  // leave a returning instance showing idle while that one is still running.
+  if (inFlight?.id === result.id) inFlight = null
+  if (sink) { sink.settle(result); return }
+  pending = result
+}

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -115,7 +115,7 @@ import { pickSearchScrollBehavior, scrollCurrentMatchIntoView, pollRowSettled, g
 import QueueStack, { SubagentDeliveryProgress, isSystemDelivery, isNonInteractiveQueued } from '../components/QueueStack'
 import { runBelongsToSlot } from '../apps/workflows/runModel'
 import { TipCard, useTipTrigger } from '../components/TipCard'
-import { useVoiceInput, voiceInputSupported } from '../hooks/useVoiceInput'
+import { useVoiceInput, voiceInputSupported, type TranscriptOrigin } from '../hooks/useVoiceInput'
 import { usePushToTalk } from '../hooks/usePushToTalk'
 import VoiceDisabledModal from '../components/VoiceDisabledModal'
 import { ChatFooter, AssistantMessage, UserMessage, PinnedPrompt } from './chat'
@@ -1766,7 +1766,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     const insert = lead + text
     return { value: before + insert + trail + after, caret: before.length + insert.length }
   }, [])
-  const applyVoiceText = useCallback((text: string, sessionId: string | null) => {
+  const applyVoiceText = useCallback((text: string, sessionId: string | null, origin: TranscriptOrigin) => {
     // Disarmed after a send (streaming) — the transcript was already sent, so
     // drop it for EVERY route. Checked FIRST (before the cross-slot branch) so a
     // late final can't slip the already-sent text back into the originating
@@ -1775,7 +1775,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // `sttAppendDisarmedRef` covers the narrower case: a manual stop whose
     // hypothesis is already in the composer. This route APPENDS, so letting the
     // close-time final through there would duplicate the utterance.
-    if (sttDisarmedRef.current || sttAppendDisarmedRef.current) return
+    //
+    // Both are STREAMING-only states — every site that arms them is gated on
+    // streaming — so they are keyed on where the text came from, not on the mode
+    // selected right now. A batch transcription can outlive the page that started
+    // it and land after streaming was switched on, and its onstop transcript is
+    // always the only copy: suppressing it would delete what the user said.
+    if (origin === 'stream' && (sttDisarmedRef.current || sttAppendDisarmedRef.current)) return
     const target = sessionId ?? activeSlotRef.current
     const append = (base: string) => (base ? (base.endsWith(' ') ? base + text : base + ' ' + text) : text)
     // Splice into the LIVE composer only when the target slot is both the active
@@ -1790,8 +1796,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       // its live hypothesis into `input`, which is flushed into the draft on
       // switch, so a cross-slot append would double it — a streaming final that
       // lands off its slot is dropped (pre-existing behaviour). Batch has no
-      // partial, so appending to the slot's draft is unambiguous.
-      if (!target || streamEnabledRef.current) return
+      // partial, so appending to the slot's draft is unambiguous. Keyed on the
+      // text's origin rather than the live streaming setting, which is a proxy
+      // that goes wrong for a batch transcript arriving after the mode changed.
+      if (!target || origin === 'stream') return
       const next = append(drafts.current[target] ?? '')
       setDraft(drafts.current, target, next)
       // Mid-switch guard: if the composer still belongs to `target` (activeSlot

--- a/website/src/test/ChatPage.sendDuringDictation.test.tsx
+++ b/website/src/test/ChatPage.sendDuringDictation.test.tsx
@@ -3,6 +3,7 @@
 // pre-fill the composer, requiring an explicit human gesture (Enter) to send.
 // When the user does send pre-filled text, the turn is tagged meta.origin=widget.
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { TranscriptOrigin } from '../hooks/useVoiceInput'
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
@@ -46,7 +47,10 @@ const voice = vi.hoisted(() => {
     partial: '',
     onPartial: null as ((t: string) => void) | null,
     onEndpoint: null as (() => void) | null,
-    onText: null as ((t: string) => void) | null,
+    onText: null as ((t: string, sessionId: string | null, origin: TranscriptOrigin) => void) | null,
+    /** Mode the page configured, so a delivered transcript can carry the origin
+     *  the real hook would attach to it. */
+    streaming: false,
     toggle: (() => {}) as () => void,
     start: (() => {}) as () => void,
     stop: (() => {}) as () => void,
@@ -59,10 +63,11 @@ voice.start = vi.fn(() => { voice.recording = true })
 voice.stop = vi.fn(() => { voice.recording = false })
 voice.cancel = vi.fn(() => { voice.recording = false })
 vi.mock('../hooks/useVoiceInput', () => ({
-  useVoiceInput: (onText: (t: string) => void, opts?: { onPartial?: (t: string) => void; onEndpoint?: () => void; streaming?: boolean }) => {
+  useVoiceInput: (onText: (t: string, sessionId: string | null, origin: TranscriptOrigin) => void, opts?: { onPartial?: (t: string) => void; onEndpoint?: () => void; streaming?: boolean }) => {
     voice.onPartial = opts?.onPartial ?? null
     voice.onEndpoint = opts?.onEndpoint ?? null
     voice.onText = onText
+    voice.streaming = !!opts?.streaming
     return ({
     recording: voice.recording,
     transcribing: false,
@@ -83,6 +88,10 @@ vi.mock('../hooks/useVoiceInput', () => ({
   },
   voiceInputSupported: true,
 }))
+
+/** Hand ChatPage a transcript exactly as `useVoiceInput` would: the origin is the
+ *  capture path that produced it, which is the mode the page is configured for. */
+const deliverText = (text: string) => voice.onText?.(text, null, voice.streaming ? 'stream' : 'batch')
 vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
 vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: 'default' }) }))
 vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
@@ -224,7 +233,7 @@ describe('ChatPage — sending while dictating', () => {
     expect(ta.value).toBe('')
 
     // Capture was NOT disarmed, so the transcript still lands.
-    await act(async () => { voice.onText?.('dictated words') })
+    await act(async () => { deliverText('dictated words') })
     expect(ta.value).toBe('dictated words')
   })
 
@@ -253,7 +262,7 @@ describe('ChatPage — sending while dictating', () => {
     await act(async () => { fireEvent.change(ta, { target: { value: 'Hello world' } }) })
     await act(async () => { ta.setSelectionRange(5, 5); fireEvent.select(ta) })
 
-    await act(async () => { voice.onText?.('there') })
+    await act(async () => { deliverText('there') })
     expect(ta.value).toBe('Hello there world')
   })
 
@@ -267,7 +276,7 @@ describe('ChatPage — sending while dictating', () => {
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: /voice input/i })) })
     await act(async () => { fireEvent.change(ta, { target: { value: 'world' } }) })
     await act(async () => { ta.setSelectionRange(0, 0); fireEvent.select(ta) })
-    await act(async () => { voice.onText?.('hello') })
+    await act(async () => { deliverText('hello') })
     expect(ta.value).toBe('hello world')
   })
 
@@ -281,7 +290,7 @@ describe('ChatPage — sending while dictating', () => {
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: /voice input/i })) })
     await act(async () => { fireEvent.change(ta, { target: { value: 'keep me' } }) })
     await act(async () => { ta.setSelectionRange(0, 7); fireEvent.select(ta) })
-    await act(async () => { voice.onText?.('') })
+    await act(async () => { deliverText('') })
     expect(ta.value).toBe('keep me')
   })
 
@@ -312,7 +321,7 @@ describe('ChatPage — sending while dictating', () => {
     expect(voice.recording).toBe(false)
 
     // The final drains in after the stop and must still reach the composer.
-    await act(async () => { voice.onText?.('hello there') })
+    await act(async () => { deliverText('hello there') })
     expect(ta.value).toBe('note: hello there')
   })
 
@@ -406,7 +415,7 @@ describe('ChatPage — sending while dictating', () => {
 
     // The user edits while the socket drains, then the final arrives.
     await act(async () => { fireEvent.change(ta, { target: { value: 'edited by hand' } }) })
-    await act(async () => { voice.onText?.('hello there') })
+    await act(async () => { deliverText('hello there') })
     expect(ta.value).toBe('edited by hand')
   })
 
@@ -436,7 +445,7 @@ describe('ChatPage — sending while dictating', () => {
 
     // The close-time route still APPENDS, so it must stay suppressed — otherwise
     // the composer would read "remind me to call Ana remind me to call Ana".
-    await act(async () => { voice.onText?.('remind me to call Ana') })
+    await act(async () => { deliverText('remind me to call Ana') })
     expect(ta.value).toBe('remind me to call Ana')
   })
 
@@ -700,7 +709,7 @@ describe('ChatPage — sending while dictating', () => {
     // append — so letting it through here would delete the typed ' NOW'. The
     // drain already put the stabilised text in the composer, so the final has
     // nothing to add and must be suppressed.
-    await act(async () => { voice.onText?.('remind me to call Ana') })
+    await act(async () => { deliverText('remind me to call Ana') })
     expect(ta.value).toBe('draft remind me to call Ana NOW')
   })
 

--- a/website/src/test/useVoiceInput.transcriptSurvivesUnmount.test.tsx
+++ b/website/src/test/useVoiceInput.transcriptSurvivesUnmount.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * Regression tests for issue #1882: navigating away from Chat cancelled an
+ * active voice transcription.
+ *
+ * The `/api/stt` request survives the unmount on its own — it is a plain fetch.
+ * What was lost is its DELIVERY: the callback it resolved into belonged to the
+ * unmounted page, so the transcript went nowhere. These tests drive the real
+ * hook through unmount → remount and assert the transcript (and the busy
+ * indicator, and a failure) reach the instance that is mounted when the request
+ * settles.
+ *
+ * They also pin the SCOPE of the fix: leaving Chat must still stop the
+ * microphone. Keeping the mic alive across navigation would leave a recording
+ * running with no indicator and no stop control, since both live in Chat.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+// Batch capture path only: stub the streaming hook so streamEnabled is false.
+vi.mock('../hooks/useStreamingStt', () => ({
+  streamingSupported: false,
+  useStreamingStt: () => ({ recording: false, start: vi.fn(), stop: vi.fn(), cancel: vi.fn() }),
+}))
+
+// Transcription is resolved by hand so a test can hold the request open across
+// the unmount — the exact window the bug lived in.
+let settleStt: (res: { text?: string; error?: string }) => void = () => {}
+const sttTranscribe = vi.fn(() => new Promise(resolve => { settleStt = resolve as typeof settleStt }))
+vi.mock('../api/client', () => ({ api: { sttTranscribe: (...a: unknown[]) => sttTranscribe(...a) } }))
+
+interface FakeTrack { stop: ReturnType<typeof vi.fn>; readyState: string; label: string }
+let lastTrack: FakeTrack | null = null
+function makeStream() {
+  const track: FakeTrack = { stop: vi.fn(), readyState: 'live', label: 'Mock Mic' }
+  lastTrack = track
+  return { _track: track, getAudioTracks: () => [track], getTracks: () => [track] }
+}
+
+const recorders: MockMediaRecorder[] = []
+const lastRecorderRef = () => recorders[recorders.length - 1] ?? null
+class MockMediaRecorder {
+  static isTypeSupported() { return true }
+  state: 'inactive' | 'recording' = 'inactive'
+  stream: unknown
+  ondataavailable: ((e: { data: Blob }) => void) | null = null
+  onstop: (() => void) | null = null
+  constructor(stream: unknown) { this.stream = stream; recorders.push(this) }
+  start() { this.state = 'recording' }
+  stop() { this.state = 'inactive'; this.onstop?.() }
+  /** Simulate a real recorder emitting a captured chunk big enough to transcribe. */
+  feed(bytes = 200) { this.ondataavailable?.({ data: new Blob(['x'.repeat(bytes)]) }) }
+}
+
+class MockAudioContext {
+  createMediaStreamSource() { return { connect() {} } }
+  createAnalyser() {
+    return { fftSize: 0, frequencyBinCount: 16, getByteTimeDomainData() {}, getByteFrequencyData() {}, connect() {} }
+  }
+  close() { return Promise.resolve() }
+}
+
+let getUserMedia: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  recorders.length = 0
+  lastTrack = null
+  sttTranscribe.mockClear()
+  getUserMedia = vi.fn().mockImplementation(() => Promise.resolve(makeStream()))
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia, enumerateDevices: vi.fn().mockResolvedValue([]) },
+    configurable: true,
+    writable: true,
+  })
+  vi.stubGlobal('MediaRecorder', MockMediaRecorder as unknown as typeof MediaRecorder)
+  vi.stubGlobal('AudioContext', MockAudioContext as unknown as typeof AudioContext)
+  // The inbox holds module state; a fresh registry per test keeps one test's
+  // pending transcript out of the next.
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+async function loadHook() {
+  const mod = await import('../hooks/useVoiceInput')
+  return mod.useVoiceInput
+}
+
+/** Record a real utterance and press stop, leaving the transcription in flight. */
+async function dictateAndStop(hook: { current: { start: () => Promise<void>; stop: () => void; recording: boolean } }) {
+  await act(async () => { await hook.current.start() })
+  await waitFor(() => expect(hook.current.recording).toBe(true))
+  act(() => { lastRecorderRef()?.feed() })
+  act(() => { hook.current.stop() })
+  await waitFor(() => expect(sttTranscribe).toHaveBeenCalledTimes(1))
+}
+
+describe('useVoiceInput — a transcription survives the page unmounting', () => {
+  it('releases the busy state on the recording instance when it settles', async () => {
+    const useVoiceInput = await loadHook()
+    const onText = vi.fn()
+    const { result } = renderHook(() => useVoiceInput(onText, { sessionId: 'chat-a' }))
+    await dictateAndStop(result as never)
+    expect(result.current.transcribing).toBe(true)
+    expect(result.current.sessionOwner).toBe('chat-a')
+
+    await act(async () => { settleStt({ text: 'hello world' }) })
+
+    // The subscriber is the ONLY release path, so the ordinary
+    // record-stop-transcribe round trip has to clear through it.
+    await waitFor(() => expect(result.current.transcribing).toBe(false))
+    expect(result.current.sessionOwner).toBeNull()
+    expect(onText).toHaveBeenCalledWith('hello world', 'chat-a', 'batch')
+  })
+
+  it('delivers a transcript that settles after unmount to the next instance', async () => {
+    const useVoiceInput = await loadHook()
+    const onTextA = vi.fn()
+    const first = renderHook(() => useVoiceInput(onTextA, { sessionId: 'chat-a' }))
+    await dictateAndStop(first.result as never)
+
+    // Navigate away from Chat while the request is still open.
+    first.unmount()
+
+    const onTextB = vi.fn()
+    renderHook(() => useVoiceInput(onTextB, { sessionId: 'chat-a' }))
+
+    await act(async () => { settleStt({ text: 'hello world' }) })
+
+    // The mounted instance receives it, still attributed to the slot that spoke,
+    // and tagged as batch so the caller's streaming-only disarm flags don't
+    // suppress it if streaming was switched on while Chat was away.
+    await waitFor(() => expect(onTextB).toHaveBeenCalledWith('hello world', 'chat-a', 'batch'))
+    expect(onTextA).not.toHaveBeenCalled()
+  })
+
+  it('restores the transcribing indicator on the instance that returns', async () => {
+    const useVoiceInput = await loadHook()
+    const first = renderHook(() => useVoiceInput(vi.fn(), { sessionId: 'chat-a' }))
+    await dictateAndStop(first.result as never)
+    expect(first.result.current.transcribing).toBe(true)
+    first.unmount()
+
+    // Coming back mid-request must show the session as still busy, not idle.
+    const second = renderHook(() => useVoiceInput(vi.fn(), { sessionId: 'chat-a' }))
+    expect(second.result.current.transcribing).toBe(true)
+    expect(second.result.current.sessionOwner).toBe('chat-a')
+
+    await act(async () => { settleStt({ text: 'hello world' }) })
+    await waitFor(() => expect(second.result.current.transcribing).toBe(false))
+    expect(second.result.current.sessionOwner).toBeNull()
+  })
+
+  it('surfaces a failure that settles after unmount instead of hanging busy', async () => {
+    const useVoiceInput = await loadHook()
+    const onTextA = vi.fn()
+    const first = renderHook(() => useVoiceInput(onTextA, { sessionId: 'chat-a' }))
+    await dictateAndStop(first.result as never)
+    first.unmount()
+
+    const onTextB = vi.fn()
+    const second = renderHook(() => useVoiceInput(onTextB, { sessionId: 'chat-a' }))
+    await act(async () => { settleStt({ error: 'model unavailable' }) })
+
+    await waitFor(() => expect(second.result.current.error).toBeTruthy())
+    expect(second.result.current.transcribing).toBe(false)
+    expect(onTextB).not.toHaveBeenCalled()
+  })
+  it('does not blank a new recording when an older transcription settles', async () => {
+    const useVoiceInput = await loadHook()
+    const first = renderHook(() => useVoiceInput(vi.fn(), { sessionId: 'chat-a' }))
+    await dictateAndStop(first.result as never)
+    first.unmount()
+
+    // Back in Chat, in a different session, the user starts dictating again while
+    // the earlier request is still open. Its settlement belongs to a session that
+    // is over, so it must not clear the live recording's owner — that owner is what
+    // gates the mic indicator and the stop control for a microphone that is
+    // actually running.
+    const onTextB = vi.fn()
+    const second = renderHook(() => useVoiceInput(onTextB, { sessionId: 'chat-b' }))
+    await act(async () => { await second.result.current.start() })
+    await waitFor(() => expect(second.result.current.recording).toBe(true))
+
+    await act(async () => { settleStt({ text: 'hello world' }) })
+
+    expect(second.result.current.recording).toBe(true)
+    expect(second.result.current.sessionOwner).toBe('chat-b')
+    // The older transcript is still handed over, attributed to its own slot.
+    await waitFor(() => expect(onTextB).toHaveBeenCalledWith('hello world', 'chat-a', 'batch'))
+  })
+
+
+  it('drains a transcript that settled while no instance was mounted', async () => {
+    const useVoiceInput = await loadHook()
+    const onTextA = vi.fn()
+    const first = renderHook(() => useVoiceInput(onTextA, { sessionId: 'chat-a' }))
+    await dictateAndStop(first.result as never)
+    first.unmount()
+
+    // Settles with Chat closed: nothing can take it, so it waits.
+    await act(async () => { settleStt({ text: 'hello world' }) })
+    expect(onTextA).not.toHaveBeenCalled()
+
+    // Mounting hands it over — but only after the mount pass has committed, so
+    // the page's own prefill/draft effects are not raced.
+    const onTextB = vi.fn()
+    renderHook(() => useVoiceInput(onTextB, { sessionId: 'chat-a' }))
+    expect(onTextB).not.toHaveBeenCalled()
+    await act(async () => { await Promise.resolve() })
+    expect(onTextB).toHaveBeenCalledWith('hello world', 'chat-a', 'batch')
+  })
+
+  it('hands a pending drain to the instance that is current when it runs', async () => {
+    const useVoiceInput = await loadHook()
+    const first = renderHook(() => useVoiceInput(vi.fn(), { sessionId: 'chat-a' }))
+    await dictateAndStop(first.result as never)
+    first.unmount()
+    await act(async () => { settleStt({ text: 'hello world' }) })
+
+    // Subscribe, tear down and resubscribe before the deferred drain runs — the
+    // shape StrictMode produces on every mount in development. The text must
+    // follow the live instance instead of being stranded by the subscription
+    // that happened to schedule the drain.
+    const onTextB = vi.fn()
+    const second = renderHook(() => useVoiceInput(onTextB, { sessionId: 'chat-a' }))
+    second.unmount()
+    const onTextC = vi.fn()
+    renderHook(() => useVoiceInput(onTextC, { sessionId: 'chat-a' }))
+
+    await act(async () => { await Promise.resolve() })
+    expect(onTextC).toHaveBeenCalledWith('hello world', 'chat-a', 'batch')
+    expect(onTextB).not.toHaveBeenCalled()
+  })
+
+  it('still stops the microphone when the page unmounts mid-recording', async () => {
+    const useVoiceInput = await loadHook()
+    const { result, unmount } = renderHook(() => useVoiceInput(vi.fn(), { sessionId: 'chat-a' }))
+    await act(async () => { await result.current.start() })
+    await waitFor(() => expect(result.current.recording).toBe(true))
+    const track = lastTrack
+    act(() => { lastRecorderRef()?.feed() })
+
+    unmount()
+
+    // The mic is released and the recorder is closed — leaving Chat never leaves
+    // capture running behind a UI that no longer exists. The utterance already
+    // captured is committed to transcription rather than discarded.
+    expect(track?.stop).toHaveBeenCalled()
+    expect(lastRecorderRef()?.state).toBe('inactive')
+    await waitFor(() => expect(sttTranscribe).toHaveBeenCalledTimes(1))
+  })
+})


### PR DESCRIPTION
## Problem

Navigating away from Chat cancels an active voice transcription (#1882). Start dictation, stop recording so the UI enters "transcribing", go to Settings / Dev Fleet / Task Runner, come back — the transcript is gone, and so is the busy indicator.

The `/api/stt` request itself was never the casualty: it is a plain fetch and completes regardless of React. What was lost is its **delivery**. `useVoiceInput` lives inside `ChatPage`, so leaving Chat unmounts it while the request is still open; when the request resolves it calls an `onText` closure that belongs to a page that no longer exists, and the text is dropped on the floor.

## What changed

A small module-scoped inbox (`website/src/hooks/voiceTranscriptInbox.ts`) owns a batch transcription's *progress and outcome* instead of the component that started it:

- Each request gets an id. `beginTranscription()` announces it and `settleTranscription()` delivers exactly one terminal result (text **or** error) for it.
- Each mounted hook instance subscribes as the delivery target. A result that settles while an instance is mounted goes straight to it — including a *different* instance from the one that recorded, which is the fix. A result that settles with nothing mounted is buffered and drained by the next subscriber, and an already-running request is replayed as a `begin` so a returning instance restores `transcribing` / `sessionOwner` for the slot still waiting.
- An instance releases the busy state only for the request it is actually displaying, and only while nothing is capturing locally — so a transcription belonging to a finished session can never blank the mic indicator of a recording that has started since.
- A buffered result is drained one microtask after the subscriber mounts, not inline: the subscriber mounts inside a page whose prefill and draft effects commit in the same pass, and a transcript applied before those run is written against composer state they are about to replace. That drain delivers to whichever instance is current when it runs, so `StrictMode`'s subscribe / teardown / resubscribe cannot strand it.
- `sessionId` travels with the delivery, so the transcript still lands in the session that spoke it via the existing cross-slot draft route.

The delivery callback also carries where the text came from: `onText(text, sessionId, origin: 'batch' | 'stream')`. `applyVoiceText`'s two suppression guards previously used the *currently selected* STT mode as a proxy for *the path that produced the text*; they now key on the origin. Every site that arms `sttDisarmedRef` / `sttAppendDisarmedRef` / `sttEndpointDisarmedRef` is gated on streaming, and the code states the intent in three places (`"STREAMING ONLY, deliberately"`, `"Batch is NOT disarmed"`, `"Batch is likewise never suppressed here: its onstop transcript is always the only copy"`). The proxy only diverges from that intent once a transcription outlives the page that started it — which is exactly what this PR makes possible: mounting Chat with streaming switched on arms the disarm flag and would otherwise discard the batch transcript still in flight.

## Scope: the transcription survives, the recording does not

Leaving Chat still stops the microphone, the `MediaRecorder` and the streaming socket — unchanged. That is deliberate and pinned by a test.

Hoisting the whole voice lifecycle to the app root (the shape #1929 took, which this supersedes) also keeps the **mic** alive across navigation, and the only recording indicator, stop button and Esc-cancel handler live in `ChatPage`. A user who leaves Chat mid-dictation would then have a live mic and a live Amazon Transcribe streaming session with nothing in-app to see or stop, until they came back or the dashboard unloaded. Design Review on #1929 raised the same concern independently. Keeping only the pending request avoids that entirely: no provider, no `App.tsx` change, no change to when capture stops.

Streaming dictation is otherwise unaffected by design. It has no separate "transcribing" phase — its text is spliced into the composer as partials arrive and is already persisted to the slot's draft on unmount — so navigating away while streaming remains equivalent to stopping dictation.

Credit to @bayshanhai-dev for finding, filing and diagnosing #1882 in #1929; this is the same diagnosis with the fix narrowed to the delivery path.

## Tests

`website/src/test/useVoiceInput.transcriptSurvivesUnmount.test.tsx` drives the real hook through unmount → remount with the transcription held open by hand:

1. a transcript that settles after unmount reaches the next instance, still attributed to the originating slot and tagged `batch`
2. the returning instance restores the `transcribing` / `sessionOwner` indicator mid-request
3. a *failure* that settles after unmount surfaces as an error instead of hanging busy forever
4. an older transcription settling while a new recording is live does not blank that recording's owner, and its transcript is still delivered
5. a transcript that settled with nothing mounted is drained on the next mount, and only after that mount pass has committed
6. a pending drain follows whichever instance is current when it runs — the subscribe / teardown / resubscribe shape `StrictMode` produces on every mount
7. unmounting mid-recording still stops the mic track and closes the recorder (the scope guard)

Revert-checked: dropping the request-ownership guard fails 4; applying the buffered drain inline instead of after the mount pass fails 5; keying that drain on the subscription that scheduled it fails 6; undoing the inbox delivery entirely fails 1–4. Test 7 passes either way — it guards behavior this PR deliberately leaves alone.

`ChatPage.sendDuringDictation.test.tsx` now delivers through a helper that attaches the origin the real hook would, so its 22 tests (including *does NOT disarm batch capture*) still assert the streaming suppression paths suppress.

Local gates: `tsc --noEmit` clean; 49 files / 410 tests green across `ChatPage*` and every voice suite; `eslint` unchanged from `origin/main` (same 12 pre-existing warnings, including the `streamStop` exhaustive-deps one); `i18n:check` OK with `I18N_BASE_REF` set; full frontend vitest 21286 passed on the first revision; backend cross-surface guards pass apart from `test_playwright_cli_installer.py` / `test_platform_compat.py`, which fail identically on a clean `origin/main` checkout on this host (no Node ≥ 20 on PATH, `/proc` process-tree tests).

## Manual verification

Not yet run on a live dashboard: dictate, stop, navigate to Settings, return, confirm the transcript arrives in the originating session and the indicator is restored mid-request.

<!-- no-visual-delta -->

**Why no screenshot:** the only `pages/` change is two suppression predicates in `applyVoiceText` swapping `streamEnabledRef.current` for the transcript's origin — no component, markup, style or copy is touched, so there is nothing rendered to capture; the user-visible effect is a transcript arriving where it previously vanished, which a still frame cannot show.

Fixes #1882
