### PR TITLE
fix(cron): validate name on PATCH /api/crons/{id}

### DIFF
--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -412,6 +412,19 @@ async def api_cron_update(request: web.Request) -> web.Response:
     ):
         if key in body:
             kwargs[key] = body[key]
+    # name routes through the same validator as POST (type check +
+    # sanitize_string + length cap) so the two REST surfaces cannot diverge:
+    # PATCH previously passed it through entirely unvalidated, letting a
+    # non-string or oversize name persist verbatim into crons.json.
+    if "name" in kwargs:
+        try:
+            kwargs["name"] = validate_string_field(
+                body, "name", max_len=MAX_SHORT_STRING
+            )
+        except ValidationError as exc:
+            return web.json_response(
+                {"error": str(exc), "code": "invalid_name"}, status=400
+            )
     # message routes through the same validator as POST (type check +
     # sanitize_string + length cap) so the two REST surfaces cannot diverge:
     # PATCH previously passed it through entirely unvalidated. Sanitizing here

--- a/test/test_cron_patch_name_validation.py
+++ b/test/test_cron_patch_name_validation.py
@@ -1,0 +1,95 @@
+"""Tests for cron ``name`` validation on the dashboard PATCH surface (issue #3831).
+
+``POST /api/crons`` caps ``name`` at ``MAX_SHORT_STRING`` via
+``validate_string_field``, but ``PATCH /api/crons/{id}`` previously copied the
+raw body value straight to ``job.name`` with only a truthiness check — a
+non-string or oversize name was persisted verbatim into ``crons.json``. This
+is the same surface-divergence defect class fixed for ``message`` in #3829.
+
+Locks in that PATCH now routes ``name`` through the same validator as POST:
+type check + ``sanitize_string`` + length cap, so the two REST surfaces cannot
+diverge.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.cron import CronService
+from kiro_crew.dashboard.handlers import api_cron_update
+from kiro_crew.validation import MAX_SHORT_STRING
+
+OVERSIZE_NAME = "x" * (MAX_SHORT_STRING + 1)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cron_store(monkeypatch, tmp_path):
+    monkeypatch.setattr("kiro_crew.cron._DEFAULT_DIR", tmp_path)
+    yield
+
+
+def _create_request(body: dict, crons: CronService) -> MagicMock:
+    state = MagicMock()
+    state.crons = crons
+    request = MagicMock()
+    request.app = {"state": state}
+    request.json = AsyncMock(return_value=body)
+    return request
+
+
+def _update_request(body: dict, crons: CronService, job_id: str) -> MagicMock:
+    request = _create_request(body, crons)
+    request.match_info = {"job_id": job_id}
+    return request
+
+
+class TestDashboardUpdateName:
+    @pytest.mark.asyncio
+    async def test_patch_accepts_valid_name(self, tmp_path):
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="old", message="m", every_secs=3600)
+        resp = await api_cron_update(_update_request({"name": "renamed"}, crons, job.id))
+        assert resp.status == 200
+        assert crons.list_jobs()[0].name == "renamed"
+
+    @pytest.mark.asyncio
+    async def test_patch_rejects_name_beyond_cap(self, tmp_path):
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="old", message="m", every_secs=3600)
+        resp = await api_cron_update(_update_request({"name": OVERSIZE_NAME}, crons, job.id))
+        assert resp.status == 400
+        assert b"invalid_name" in resp.body
+        assert crons.list_jobs()[0].name == "old"
+
+    @pytest.mark.asyncio
+    async def test_patch_rejects_non_string_name(self, tmp_path):
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="old", message="m", every_secs=3600)
+        resp = await api_cron_update(_update_request({"name": [1, 2]}, crons, job.id))
+        assert resp.status == 400
+        assert b"invalid_name" in resp.body
+        assert crons.list_jobs()[0].name == "old"
+
+    @pytest.mark.asyncio
+    async def test_patch_rejects_falsy_non_string_name(self, tmp_path):
+        """A falsy non-string (0) must 400, not silently no-op with a 200."""
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="old", message="m", every_secs=3600)
+        resp = await api_cron_update(_update_request({"name": 0}, crons, job.id))
+        assert resp.status == 400
+        assert b"invalid_name" in resp.body
+        assert crons.list_jobs()[0].name == "old"
+
+    @pytest.mark.asyncio
+    async def test_patch_sanitizes_name_like_post(self, tmp_path):
+        """PATCH routes through the same sanitizer as POST: hidden unicode
+        (zero-width space) is stripped before persistence, matching create."""
+        crons = CronService(base_dir=tmp_path)
+        job = crons.add_job(name="old", message="m", every_secs=3600)
+        resp = await api_cron_update(
+            _update_request({"name": "new\u200bname"}, crons, job.id)
+        )
+        assert resp.status == 200
+        assert crons.list_jobs()[0].name == "newname"


### PR DESCRIPTION
## Problem / Motivation

`PATCH /api/crons/{id}` copied the raw request-body `name` straight to
`job.name` with only a truthiness check (`if "name" in kwargs and kwargs["name"]`),
while `POST /api/crons` caps `name` at `MAX_SHORT_STRING` (500) via
`validate_string_field`. A non-string or oversize `name` PATCHed there was
persisted verbatim into `crons.json`. This is the same surface-divergence
defect class already fixed for `message` in #3829.

## Why it matters

- A non-string or over-length `name` reaching `_update_job_locked` is written
  unvalidated to disk, corrupting the cron schema for later reads.
- POST and PATCH enforced different contracts on the same field — a scripted
  PATCH could persist a value the create path would reject.
- The old truthiness guard also silently no-op'd a falsy non-string like `0`
  (returning `200` without persisting), which is now correctly a `400`.

## What changed (motivation → approach → change)

- **Root cause:** the PATCH handler had no validation on `name`; the create
  path's `validate_string_field` contract was never applied on update.
- **Approach:** reuse the exact pattern already added for `message` in #3829
  rather than inventing a new check, so both REST surfaces share one validator
  and cannot diverge again.
- **Change:** in `api_cron_update` (`src/kiro_crew/dashboard/handlers/cron.py`),
  route `name` through `validate_string_field(body, "name", max_len=MAX_SHORT_STRING)`
  (type check + `sanitize_string` + length cap), returning
  `400 {"code": "invalid_name"}` on a bad value.

## Tests

`test/test_cron_patch_name_validation.py` — 5 tests mirroring the
`test_cron_message_cap.py` PATCH coverage, each locking in a behavior:

- valid rename is accepted and persisted;
- an oversize (>500-char) `name` is rejected `400` and the job is unchanged;
- a non-string `name` (`[1, 2]`) is rejected `400`, unchanged;
- a falsy non-string (`0`) is rejected `400` (not silently no-op'd), unchanged;
- hidden unicode (zero-width space) is sanitized before persistence, matching POST.

`pytest test/test_cron_patch_name_validation.py test/test_cron_message_cap.py`
→ 25 passed (5 new + 20 existing sibling tests, confirming the shared pattern
still holds). `isort --check-only`, `flake8`, and `mypy` on the changed source
are all clean.

## Manual verification

Integration-tested the real `PATCH /api/crons/{job_id}` route over HTTP (an
aiohttp test server wired to the actual handler + a real `CronService` writing
to a temp dir), driving each case over the wire and reading the persisted
`crons.json` back: valid rename → `200` / persisted; oversize → `400` /
unchanged; non-string → `400` / unchanged; falsy `0` → `400` / unchanged;
zero-width-unicode → `200` / sanitized. All five matched expectations.

## Related Issues

Fixes #3831
