### PR TITLE
refactor(dashboard): drop os import shadows and dedup fuzzy scanning

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -1932,8 +1932,6 @@ async def api_file_stream(request: web.Request) -> web.StreamResponse:
     (file-raw) performs no content scan at all. The probe exists to catch
     the honest-mistake shape: a text file wearing a forged media magic.
     """
-    import os  # noqa: F811
-
     import kiro_crew.dashboard.handlers as _h  # noqa: F811
 
     def _log(outcome: str, res: str) -> None:
@@ -2015,9 +2013,12 @@ async def api_file_stream(request: web.Request) -> web.StreamResponse:
     result = await asyncio.to_thread(_open_media, raw_path)
     if result[0] == "refused":
         _, code, res = result
-        outcome = "not_found" if code == "not_found" else (
-            "failure" if code == "read_failed" else "denied"
-        )
+        if code == "not_found":
+            outcome = "not_found"
+        elif code == "read_failed":
+            outcome = "failure"
+        else:
+            outcome = "denied"
         _log(outcome, res)
         # One literal response per refusal class: the error-response contract
         # requires the {"error", "code"} body and the status to be statically
@@ -2198,6 +2199,31 @@ async def api_file_write(request: web.Request) -> web.Response:
         return web.json_response({"error": "failed to write file"}, status=500)
 
 
+def _subsequence_run(q: str, haystack: str) -> tuple[int, int]:
+    """Greedily match ``q`` as a subsequence of ``haystack``.
+
+    Returns how many of ``q``'s characters were consumed in order, and the
+    longest run of matches that landed on consecutive ``haystack`` positions
+    within that single greedy pass -- NOT the longest contiguous occurrence of
+    ``q``, since the scan never backtracks over an earlier isolated match
+    (``q="ab"`` against ``"axxab"`` consumes both chars but reports a run of
+    1). A consumed count below ``len(q)`` means ``haystack`` does not contain
+    ``q`` as a subsequence at all; the caller normalizes the run length by
+    ``len(q)`` into the contiguity term of the fuzzy score.
+    """
+    qi = 0
+    consecutive = 0
+    max_run = 0
+    for ch in haystack:
+        if qi < len(q) and ch == q[qi]:
+            qi += 1
+            consecutive += 1
+            max_run = max(max_run, consecutive)
+        else:
+            consecutive = 0
+    return qi, max_run
+
+
 def _fuzzy_score(q: str, name: str, rel: str) -> float:
     """Score a file match. Higher = better. Returns 0 for no match."""
     nl = name.lower()
@@ -2215,31 +2241,14 @@ def _fuzzy_score(q: str, name: str, rel: str) -> float:
     elif q in rl:
         score += 10.0
     else:
-        # Fuzzy: check if query chars appear in order in filename
+        # Fuzzy: check whether the query chars appear in order in the
+        # filename, falling back to the search-root-relative path when the
+        # filename alone does not carry the query as an in-order subsequence.
         matched_on_name = True
-        qi = 0
-        consecutive = 0
-        max_run = 0
-        for ch in nl:
-            if qi < len(q) and ch == q[qi]:
-                qi += 1
-                consecutive += 1
-                max_run = max(max_run, consecutive)
-            else:
-                consecutive = 0
+        qi, max_run = _subsequence_run(q, nl)
         if qi < len(q):
-            # Try path if filename didn't match all chars
             matched_on_name = False
-            qi = 0
-            consecutive = 0
-            max_run = 0
-            for ch in rl:
-                if qi < len(q) and ch == q[qi]:
-                    qi += 1
-                    consecutive += 1
-                    max_run = max(max_run, consecutive)
-                else:
-                    consecutive = 0
+            qi, max_run = _subsequence_run(q, rl)
         if qi < len(q):
             return 0.0  # not all query chars found
         # Score based on coverage ratio and longest consecutive run
@@ -3425,8 +3434,6 @@ async def api_file_sheet(request: web.Request) -> web.Response:
     soft-imported: without it the endpoint answers 501 and the frontend
     degrades to the download card.
     """
-    import os  # noqa: F811
-
     import kiro_crew.dashboard.handlers as _h  # noqa: F811
 
     def _log(outcome: str, res: str) -> None:


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/dashboard/handlers/files.py` carried three mechanically
decidable readability defects, and the module-simplification detector reports
it as the only module in the tree with actionable sites left:

- Two in-function `import os  # noqa: F811` statements (in `api_file_stream`
  and `api_file_sheet`) shadowing the unconditional module-scope `import os`
  at line 14. Each re-bound the same `sys.modules` singleton, so both were
  no-ops that read as if the handler needed a deferred import.
- A nested ternary deriving `api_file_stream`'s SEL audit `outcome`, where the
  refusal-code mapping it encodes is not visible at a glance.
- `_fuzzy_score` containing the same greedy subsequence-scan loop twice,
  verbatim, nested seven levels deep.

## Why it matters

Each one costs a reader time on a hot request path. The `# noqa: F811` in
particular is actively misleading: it signals "this shadow is deliberate" when
pyflakes never had anything to report — F811 fires only for a shadow whose
outer binding is *unused*, and the module-level `os` is used long before
either handler. The duplicated scan is worse than verbose: a future fix to the
scoring loop has to be applied twice, and a fix applied to only one copy
changes filename ranking but not path ranking.

## What changed (motivation → approach → change)

Behavior preservation is the whole point here — this changes how the code
reads, never what it does. No test was added, weakened, or removed.

1. **Deleted the two `import os` shadows.** `os` is imported unconditionally at
   module scope (not under `if TYPE_CHECKING:`, not in a platform `if`, not in
   a `try/except ImportError`), so after the deletion every use resolves to the
   same module object. The one observable difference is that inside these two
   handlers `os` becomes a `LOAD_GLOBAL` instead of a closure cell, which
   matters only if a test substitutes the `os` *attribute* on this module. None
   does: the five tests that reach `os` through this module patch attributes
   *on* the shared `os`/`os.path` object
   (`…files.os.path.isfile`, `…files.os.scandir`, `…files.os.path.realpath`,
   `setattr(files_mod.os.path, "isdir", …)`, `patch.object(files_mod.os, "walk", …)`),
   which behaves identically under either binding. This is the safe direction of
   the sweep's Rule 2a — no in-function `from X import Y` was touched, and the
   deliberately lazy `import kiro_crew.dashboard.handlers as _h` and
   `from kiro_crew.security import is_sensitive_path as _isp` imports are left
   alone.
2. **Flattened the audit-outcome ternary** into `if`/`elif`/`else`. All ten
   `code` values `_open_media` can return (`cannot_resolve`, `outside_project`,
   `invalid_path`, `sensitive_path`, `not_found`, `symlink_refused`,
   `read_failed`, `file_too_large`, `not_media`, `content_redacted`) map to the
   same `outcome` as before, and an unrecognized code still falls through to
   `denied` — the fail-closed direction. The emitted outcome set is unchanged:
   `{denied, failure, not_found}`.
3. **Extracted `_subsequence_run(q, haystack)`** and called it twice from
   `_fuzzy_score`, dropping that function from seven nesting levels to four.
   The helper initializes its counters at entry, which reproduces the
   original's explicit re-zeroing before the path scan — including the
   original's behavior of *discarding* the filename scan's run length when it
   falls back to the path. Its docstring spells out the non-obvious property a
   future caller could get wrong: the run length is the longest run within that
   single greedy pass, not the longest contiguous occurrence of `q`, because
   the scan never backtracks.

Scope note: this is one module, one commit, per the campaign's one-module-per-PR
rule. The judgment-class work is confined to the single file the mechanical
detector already sent me into.

## Tests

No new tests — this is a pure refactor with no new behavior to lock in, and the
existing suites already cover all three touched paths (`test_file_search.py`,
`test_file_search_dirs.py`, `test_file_stream.py`, `test_file_sheet.py`,
`test_dashboard_files_coverage.py`). The per-file coverage gate passes
unchanged.

Equivalence was proven rather than assumed:

- `_fuzzy_score` old-vs-new differential over **684,220** `(q, name, rel)`
  triples — exhaustive over all inputs up to length 4 from `{a, b, c, ., /}`
  plus 200k seeded random cases including empty strings, path-wins and
  name-wins: **0 mismatches**. Two independent reviewers reproduced this at
  93k and 200k cases respectively, also 0 mismatches.
- The refusal-code → audit-outcome mapping enumerated exhaustively over all
  ten reachable codes plus an unknown one: identical before and after.

## Manual verification

N/A — unit coverage sufficient. This is a behavior-preserving backend refactor
with no user-visible surface; correctness is established by the differential
equivalence tests above plus the existing endpoint suites, not by clicking
through the file viewer.

## Local gate results

Run on the Python 3.12 CI-parity venv from the worktree root:

| Gate | Result |
|---|---|
| `flake8 src/kiro_crew test` | 0 |
| `isort --check-only src/kiro_crew test` | 0 |
| `mypy src/kiro_crew` | 0 |
| `scripts/check_brand_name.py` | 0 |
| `scripts/check_harness_parity.py` | 0 |
| `scripts/docs_lint.py --test` / `scripts/docs-lint.sh` | 0 / 0 |
| `scripts/check_per_file_coverage.py --test` | 0 |
| `scripts/verify_vendor_manifest.py` | 0 |
| `scripts/scrub-lint.sh --no-history` | 0 |
| targeted pytest (36 files touching these handlers) | 900 passed, 16 env-only |

The 16 failures are all `test_file_sheet.py` raising
`ModuleNotFoundError: No module named 'openpyxl'` — that package is absent from
the local parity venv, so `api_file_sheet` degrades to its 501
`preview_unavailable` branch. `origin/main` fails the same 16 with the same
error in the same venv, so they are environmental and not attributable to this
diff. Frontend suites were not run: the diff touches nothing under `website/`,
`.github/` or `scripts/`, so CI's `changes` job reports `only_backend=true` and
the frontend surfaces cannot newly fail.

## Pre-review fleet

Five read-only reviewers were run against this diff before opening the PR, each
with a distinct lens, and every finding was adversarially re-checked before
being acted on.

**Confirmed and fixed (2)** — both in docstring/comment text this PR itself
adds, both reproduced mechanically before the fix:

- The `_subsequence_run` docstring said "the longest consecutive matched run",
  which over-claims: `_subsequence_run("ab", "axxab")` returns `(2, 1)` even
  though `"ab"` occurs contiguously at index 3, because `qi` never backtracks.
  Reworded to state the single-greedy-pass semantics and the non-backtracking
  caveat explicitly, with that counter-example inline.
- The `_fuzzy_score` comment said the path fallback fires when the filename
  "does not carry every query char". False: the trigger is subsequence failure,
  not char presence — `q="ba"` against `nl="ab.txt"` contains both characters
  yet falls back. Also corrected "whole relative path" to
  "search-root-relative path", since the call site passes
  `os.path.relpath(full, root_dir)`.

**Clean (3)** — AUTOSDE + blocking rules (every `blocking: true` rule whose
`file-patterns` match this file, plus the deterministic `code-review.yml` greps);
behavior preservation; import semantics (an exhaustive sweep of every
module-attribute patch idiom across the test tree).

**Dropped / not acted on (2):**

- A reviewer noted the retained `import kiro_crew.dashboard.handlers as _h  #
  noqa: F811` also does not need its `noqa`. True but out of scope — that line
  is pre-existing untouched context repeated file-wide, and churning it would
  widen the diff without changing behavior.
- A reviewer suggested this file arguably belongs in the sweep detector's
  keystone set, because it *defines* `_open_rb_nofollow` and the
  `_MAGIC_PREFIXES` magic-byte check rather than only calling keystone controls.
  That set lives in the campaign's tooling, not in this repo, so it cannot ride
  in this PR, and widening it is a campaign-policy call for the maintainer
  rather than a change to make silently. The same reviewer explicitly
  recommended *not* reverting the ternary hunk, having proven it equivalent over
  all ten reachable refusal codes; I agree, and it kept the fail-closed
  `denied` default.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to `src/kiro_crew/dashboard/handlers/files.py`; no rendered output, response body, status code, or user-visible string changes.

## Related Issues

no linked issue: routine module-simplification sweep, nothing filed.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
