### PR TITLE
fix: re-assert remote-pane drag gaps when the host re-engages

### DIFF
--- a/.github/coverage-baselines/frontend.txt
+++ b/.github/coverage-baselines/frontend.txt
@@ -69,7 +69,6 @@ src/components/AppIcon.tsx 51.1   # 24/47
 src/components/BottomTerminalPanel.tsx 55.1   # 49/89
 src/components/ChatPane.tsx 69.0   # 100/145
 src/components/CommentThreadPopover.tsx 59.0   # 46/78
-src/components/EmbeddedDragRegionReporter.tsx 13.9   # 5/36
 src/components/ExecutionsView.tsx 48.8   # 20/41
 src/components/FileArtifactComments.tsx 52.0   # 52/100
 src/components/GitPanel.tsx 0.0   # 0/44

--- a/website/src/components/EmbeddedDragRegionReporter.test.tsx
+++ b/website/src/components/EmbeddedDragRegionReporter.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, waitFor } from '@testing-library/react'
+import { renderWithProviders, createTestStore } from '../test/helpers'
+import EmbeddedDragRegionReporter from './EmbeddedDragRegionReporter'
+import { setHostModel, type HostModel } from '../store/instancesSlice'
+
+vi.mock('../lib/embedded', () => ({ isEmbeddedPane: vi.fn(() => true) }))
+import { isEmbeddedPane } from '../lib/embedded'
+
+function model(over: Partial<HostModel> = {}): HostModel {
+  return {
+    tabs: [],
+    activeId: null,
+    self: null,
+    macInset: false,
+    electron: true,
+    pinnedCrews: [],
+    ...over,
+  }
+}
+
+function storeWith(host: HostModel | null) {
+  return createTestStore({
+    instances: { warm: {}, activeId: null, mru: [], unread: {}, ready: {}, host },
+  })
+}
+
+describe('EmbeddedDragRegionReporter', () => {
+  let parentPost: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.mocked(isEmbeddedPane).mockReturnValue(true)
+    parentPost = vi.fn()
+    // The reporter bails unless it has a real (cross-frame) parent; give it one
+    // with a postMessage spy so we can observe the relay.
+    Object.defineProperty(window, 'parent', {
+      value: { postMessage: parentPost },
+      configurable: true,
+    })
+    // A laid-out header the reporter can measure (computeHeaderDragGaps yields a
+    // full-width gap here since happy-dom reports zero-size control rects). Built
+    // with the DOM API rather than `.innerHTML` (frontend-security AUTOSDE rule).
+    const header = document.createElement('header')
+    header.className = 'topbar-glass'
+    const btn = document.createElement('button')
+    btn.textContent = 'x'
+    header.appendChild(btn)
+    document.body.replaceChildren(header)
+  })
+
+  afterEach(() => {
+    delete (window as unknown as { parent?: unknown }).parent
+    document.body.replaceChildren()
+    // restoreAllMocks (not clearAllMocks) so the requestAnimationFrame spy the
+    // "stays silent" test installs is UNINSTALLED, not merely cleared — otherwise
+    // the spy lingers on the global for later tests. beforeEach re-asserts the
+    // isEmbeddedPane return value, so restoring it here is safe.
+    vi.restoreAllMocks()
+  })
+
+  const gapsPosts = () =>
+    parentPost.mock.calls.filter(c => (c[0] as { type?: string })?.type === 'mc-drag-gaps')
+
+  it('relays mc-drag-gaps to the parent when the host is an Electron window', async () => {
+    renderWithProviders(<EmbeddedDragRegionReporter />, { store: storeWith(model()) })
+    await waitFor(() => expect(gapsPosts().length).toBeGreaterThan(0))
+    expect(gapsPosts()[0][0]).toMatchObject({ type: 'mc-drag-gaps', v: 1 })
+    expect(Array.isArray((gapsPosts()[0][0] as { gaps: unknown }).gaps)).toBe(true)
+  })
+
+  it('stays silent when the host is not an Electron window', async () => {
+    // Assert the SHAPE, not a duration: a broken electron gate would schedule the
+    // post via requestAnimationFrame, so spy on it and require it was never
+    // called. A bare "0 posts" check could false-green on a post that is merely
+    // scheduled-but-not-yet-fired; asserting nothing was scheduled cannot.
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
+    renderWithProviders(<EmbeddedDragRegionReporter />, { store: storeWith(model({ electron: false })) })
+    expect(rafSpy).not.toHaveBeenCalled()
+    expect(gapsPosts().length).toBe(0)
+  })
+
+  it('re-asserts the gaps when the host relays a fresh model, even with unchanged geometry', async () => {
+    // Regression guard for the drop race: the geometry-change dedup must NOT
+    // suppress the re-post triggered by a new host model (tab switch / pane
+    // re-engagement). Without the re-assert, a host that missed the initial post
+    // never receives the gaps and the remote pane stays undraggable.
+    const store = storeWith(model())
+    renderWithProviders(<EmbeddedDragRegionReporter />, { store })
+    await waitFor(() => expect(gapsPosts().length).toBeGreaterThan(0))
+    const before = gapsPosts().length
+
+    // Same geometry, new model object — the host re-engaged this pane.
+    act(() => {
+      store.dispatch(setHostModel(model({ activeId: 'cd-9' })))
+    })
+
+    await waitFor(() => expect(gapsPosts().length).toBeGreaterThan(before))
+  })
+})

--- a/website/src/components/EmbeddedDragRegionReporter.tsx
+++ b/website/src/components/EmbeddedDragRegionReporter.tsx
@@ -13,22 +13,36 @@
  * (relayed via the host model) — a browser host has no native window to drag, so
  * there is nothing to report. No-op everywhere else.
  */
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useAppSelector } from '../store'
 import { isEmbeddedPane } from '../lib/embedded'
 import { computeHeaderDragGaps } from '../lib/dragGaps'
 
 export default function EmbeddedDragRegionReporter() {
   // The host model tells the pane whether its host is an Electron window; only
-  // then is a draggable title bar meaningful.
-  const hostElectron = useAppSelector(s => !!s.instances.host?.electron)
+  // then is a draggable title bar meaningful. We also watch the model OBJECT
+  // itself (not just the electron flag): the host relays a fresh model every
+  // time it re-engages this pane (tab switch, pane readiness, the instances
+  // poll), and each such relay is our cue to RE-ASSERT the gaps.
+  const hostModel = useAppSelector(s => s.instances.host)
+  const hostElectron = !!hostModel?.electron
+
+  // A single mc-drag-gaps post is fire-and-forget: if the host drops it (its
+  // listener/port map not yet ready when a pane first shows) the geometry-change
+  // dedup below means nothing re-sends it, so the pane silently stays undraggable
+  // until an incidental header reflow. These refs let a second effect force a
+  // re-post whenever the host re-engages, closing that race.
+  const lastJsonRef = useRef('')
+  const scheduleRef = useRef<() => void>(() => {})
 
   useEffect(() => {
     if (!isEmbeddedPane() || !hostElectron) return
     const parent = window.parent
     if (!parent || parent === window) return
 
-    let lastJson = ''
+    // A fresh (re)subscription re-asserts: clear the dedup so the first post
+    // always fires even if the geometry is unchanged from a prior mount.
+    lastJsonRef.current = ''
     let raf = 0
     const post = () => {
       raf = 0
@@ -39,8 +53,8 @@ export default function EmbeddedDragRegionReporter() {
       if (!header || window.innerWidth === 0) return
       const gaps = computeHeaderDragGaps(header, window.innerWidth)
       const json = JSON.stringify(gaps)
-      if (json === lastJson) return
-      lastJson = json
+      if (json === lastJsonRef.current) return
+      lastJsonRef.current = json
       try {
         // The host validates our loopback ORIGIN (resolveTunnelOrigin), so the
         // wildcard target is safe and matches the sibling mc-embedded-ready ping.
@@ -61,6 +75,9 @@ export default function EmbeddedDragRegionReporter() {
       if (raf) window.cancelAnimationFrame(raf)
       raf = window.requestAnimationFrame(post)
     }
+    // Expose the live scheduler so the re-engagement effect below can trigger a
+    // re-post without tearing down and re-attaching the observers.
+    scheduleRef.current = schedule
 
     const header = document.querySelector('header.topbar-glass')
     // Header-scoped observers only — cheap, and they catch every reflow that
@@ -87,8 +104,22 @@ export default function EmbeddedDragRegionReporter() {
       ro.disconnect()
       mo.disconnect()
       window.removeEventListener('resize', schedule)
+      scheduleRef.current = () => {}
     }
   }, [hostElectron])
+
+  // Re-assert the gaps whenever the host relays a fresh model. The host
+  // rebroadcasts on every tab switch / pane-ready / poll (InstancesViewport's
+  // broadcast effect), so this fires exactly when the host has (re)started
+  // listening — the moment a previously-dropped initial post would otherwise be
+  // lost forever. Clearing the dedup makes the re-post fire even if the geometry
+  // is byte-identical to what we last sent. Cheap: the host reads only the active
+  // pane's gaps, so an extra post to a background pane is harmless.
+  useEffect(() => {
+    if (!isEmbeddedPane() || !hostElectron) return
+    lastJsonRef.current = ''
+    scheduleRef.current()
+  }, [hostModel, hostElectron])
 
   return null
 }


### PR DESCRIPTION
## Problem / Motivation

Dragging the desktop window by the top bar works on the Local tab but is intermittent on a remote-instance tab: sometimes the window drags, sometimes it doesn't, with no obvious trigger. Once it fails for a session it stays stuck until some unrelated header reflow happens to fix it.

## Why it matters

The top bar is the primary way to move a frameless desktop window. On a remote tab the user is left with a window they can't reposition — an inconsistent, hard-to-report papercut that behaves differently from Local for no visible reason.

## What changed (motivation → approach → change)

- **Symptom:** remote-tab window drag works intermittently.
- **Root cause:** a remote pane is a cross-origin iframe, so its title bar can only move the window via drag strips the host overlays in the control-free gaps the pane reports over `mc-drag-gaps` (Electron has no native drag-over-iframe — electron#18057). That relay was fire-and-forget with a geometry-change dedup and no host-driven re-request: if the host wasn't ready to receive when the pane fired its single post (message listener not attached / warm-port map not yet built), the post was dropped, and the dedup meant the reporter never re-sent it. Whether the one post landed depended on load-time timing — hence the intermittency.
- **Change:** re-assert the gaps whenever the host relays a fresh host model. The host rebroadcasts `mc-host-model` on every tab switch / pane-ready / instances poll, which is a reliable "the host is listening now" signal. On each relay the reporter clears its dedup and re-posts the current gaps (even if the geometry is byte-identical), so a dropped initial post is re-delivered the next time the host engages the pane. The overlay-relay mechanism is unchanged; only delivery is hardened.

## Tests

`website/src/components/EmbeddedDragRegionReporter.test.tsx` (new):

- relays `mc-drag-gaps` to the parent when the host is an Electron window;
- stays silent when the host is not Electron (asserts nothing is even scheduled, not just "0 posts");
- **regression guard:** re-asserts the gaps on a fresh host model even when the geometry is unchanged (fails without the fix).

## Manual verification

Verified in the macOS desktop app: switching to a remote-instance tab now makes the window draggable every time, where it was previously intermittent.

## Related Issues

N/A

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc documents this relay
- [x] No secrets, credentials, or internal references in the diff


<!-- no-visual-delta -->

**Why no screenshot:** the fix only toggles an invisible `-webkit-app-region: drag` overlay (pointer-events:none, nothing rendered changes); the sole observable effect is native OS window dragging, which a screenshot or recording cannot meaningfully demonstrate.
