### PR TITLE
fix(dashboard): route guard-less Enter-submit inputs through the IME guard (#4234)

### DIFF
--- a/website/src/app-sdk/ChatEmbed.tsx
+++ b/website/src/app-sdk/ChatEmbed.tsx
@@ -8,6 +8,7 @@
  * Poll faster during streaming (1s), slower when idle (5s).
  */
 import { useState, useRef, useCallback, useEffect } from 'react'
+import { useImeGuard } from '../hooks/useImeGuard'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { ArrowUp, Loader2 } from 'lucide-react'
 import ChatMessageList from './ChatMessageList'
@@ -57,6 +58,7 @@ interface ChatSlotData {
 
 function ChatEmbed({ slotKey, agent, placeholder, frameless, startAtBottom, onSend }: ChatEmbedProps) {
   const api = useAppApi()
+  const ime = useImeGuard()
   const [input, setInput] = useState('')
   const endRef = useRef<HTMLDivElement>(null)
   const scrollerRef = useRef<HTMLDivElement>(null)
@@ -181,7 +183,13 @@ function ChatEmbed({ slotKey, agent, placeholder, frameless, startAtBottom, onSe
           className="flex-1 min-w-0 px-3 py-2 text-sm bg-bg-elevated border border-border rounded-md text-text outline-none focus:border-accent transition-colors"
           value={input}
           onChange={e => setInput(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey && input.trim()) { e.preventDefault(); send() } }}
+          {...ime.bindComposition()}
+          onKeyDown={e => {
+            if (e.key !== 'Enter' || e.shiftKey) return
+            // Rule 1: single-line input; the emptiness test stays outside the guard.
+            if (ime.isComposing(e)) return
+            if (input.trim()) { e.preventDefault(); send() }
+          }}
           placeholder={running ? i18nT('appSdk.chatEmbed.agent_is_working') : (placeholder || i18nT('appSdk.chatEmbed.message'))}
           disabled={sendMutation.isPending}
         />

--- a/website/src/components/ProjectPicker.tsx
+++ b/website/src/components/ProjectPicker.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, RefObject } from 'react'
+import { useImeGuard } from '../hooks/useImeGuard'
 import { createPortal } from 'react-dom'
 import { FolderOpen, ChevronRight, ChevronLeft, Clock, Search } from 'lucide-react'
 import { api } from '../api/client'
@@ -16,6 +17,7 @@ interface Props {
 export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRect, onSelect }: Props) {
   const [tab, setTab] = useState<'recent' | 'browse'>('recent')
   const [input, setInput] = useState('')
+  const ime = useImeGuard()
   const [browsePath, setBrowsePath] = useState('')
   const [browseParent, setBrowseParent] = useState('')
   const [browseDirs, setBrowseDirs] = useState<{ name: string; path: string }[]>([])
@@ -237,12 +239,17 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
               placeholder={i18nT('components.projectPicker.path_to_project')}
               value={input}
               onChange={e => setInput(e.target.value)}
+              {...ime.bindComposition()}
+              onFocus={() => ime.reset()}
               onKeyDown={e => {
                 const n = filteredBrowse.length
                 const commit = () => { const p = input.trim() || browsePath; if (p) select(p) }
                 if (e.key === 'ArrowDown') { e.preventDefault(); setBrowseSel(s => (n ? Math.min(s + 1, n - 1) : 0)) }
                 else if (e.key === 'ArrowUp') { e.preventDefault(); setBrowseSel(s => Math.max(s - 1, 0)) }
                 else if (e.key === 'Enter') {
+                  // Rule 2: the handler also carries the arrow keys, so only the
+                  // Enter path is gated — claiming would break list navigation.
+                  if (ime.isComposing(e)) return
                   e.preventDefault()
                   if (e.metaKey || e.ctrlKey) commit()                               // ⌘/Ctrl+Enter commits the current dir
                   else if (n > 0 && filteredBrowse[browseSel]) browse(filteredBrowse[browseSel].path)  // Enter drills into the highlighted folder

--- a/website/src/components/QuestionCard.tsx
+++ b/website/src/components/QuestionCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, memo } from 'react'
+import { useImeGuard } from '../hooks/useImeGuard'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { ChevronDown, ChevronRight, ChevronsDownUp, ChevronsUpDown, MessageSquare } from 'lucide-react'
 
@@ -35,6 +36,7 @@ interface QuestionCardProps {
 }
 
 function QuestionCard({ questions, onSubmit, onDismiss, busy = false, onDraftChange }: QuestionCardProps) {
+  const ime = useImeGuard()
   const [selections, setSelections] = useState<Record<number, Set<string>>>({})
   const [customInputs, setCustomInputs] = useState<Record<number, string>>({})
   const reduceMotion = useReducedMotion()
@@ -233,7 +235,14 @@ function QuestionCard({ questions, onSubmit, onDismiss, busy = false, onDraftCha
                     setCustomInputs(prev => ({ ...prev, [qIdx]: e.target.value }))
                     setSelections(prev => ({ ...prev, [qIdx]: new Set() }))
                   }}
-                  onKeyDown={e => { if (e.key === 'Enter' && allAnswered && !busy) handleSubmit() }}
+                  {...ime.bindComposition()}
+                  onFocus={() => ime.reset()}
+                  onKeyDown={e => {
+                    if (e.key !== 'Enter') return
+                    // Rule 1: single-line input; the readiness test stays outside.
+                    if (ime.isComposing(e)) return
+                    if (allAnswered && !busy) handleSubmit()
+                  }}
                   className="mt-2 w-full px-3 py-2 rounded-lg border border-border bg-bg text-text text-[13px] placeholder:text-muted focus:border-accent focus:outline-none"
                 />
                 </motion.div>

--- a/website/src/components/QueueStack.tsx
+++ b/website/src/components/QueueStack.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, memo } from 'react'
 import { AnimatePresence, motion, useMotionValue, useSpring } from 'framer-motion'
 import { Hourglass, ChevronUp, X, Zap, Pencil, Check, Bot, Loader2, ArrowUp, ArrowDown } from 'lucide-react'
 import type { ChatMessage } from '../types'
+import { useImeGuard } from '../hooks/useImeGuard'
 
 import { i18nT } from '../i18n/t'
 import { parseRecoveryMessage } from '../pages/chat/RecoveryCard'
@@ -98,6 +99,7 @@ function EditInput({ initial, onCommit, onCancel }: {
   onCancel: () => void
 }) {
   const ref = useRef<HTMLInputElement>(null)
+  const ime = useImeGuard()
   const [value, setValue] = useState(initial)
   // Guard so blur and an explicit save/Enter don't both fire onCommit.
   const committedRef = useRef(false)
@@ -123,10 +125,14 @@ function EditInput({ initial, onCommit, onCancel }: {
         onClick={e => e.stopPropagation()}
         onKeyDown={e => {
           e.stopPropagation()
-          if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); commit() }
-          else if (e.key === 'Escape') { e.preventDefault(); cancel() }
+          if (e.key === 'Enter' && !e.shiftKey) {
+            // Rule 1: single-line input — decline the IME's committing Enter,
+            // nothing else. The commit's own emptiness check stays in commit().
+            if (ime.isComposing(e)) return
+            e.preventDefault(); commit()
+          } else if (e.key === 'Escape') { e.preventDefault(); ime.reset(); cancel() }
         }}
-        onBlur={commit}
+        {...ime.bindComposition({ onBlur: commit })}
         className="flex-1 min-w-0 bg-[var(--bg)] text-[var(--text)] placeholder:text-[var(--muted)] rounded px-1.5 py-0.5 text-[13px] outline-none border border-[var(--border)] focus:border-[var(--accent)]"
         aria-label={i18nT('components.queueStack.edit_queued_message')}
       />

--- a/website/src/components/RegistryManager.tsx
+++ b/website/src/components/RegistryManager.tsx
@@ -14,6 +14,7 @@ import { api } from '../api/client'
 import { Card, CardTitle, Btn, Input, EmptyState, Badge } from './ui'
 import InfoTip from './InfoTip'
 import Clickable from './Clickable'
+import { useImeGuard } from '../hooks/useImeGuard'
 import { recordEvent } from '../rum'
 
 import { i18nT } from '../i18n/t'
@@ -64,6 +65,7 @@ function repoWebUrl(repo: string): string {
  */
 export default function RegistryManager({ bare = false }: { bare?: boolean } = {}) {
   const queryClient = useQueryClient()
+  const ime = useImeGuard()
   const [adding, setAdding] = useState(false)
   const [editName, setEditName] = useState('')
   const [editRepo, setEditRepo] = useState('')
@@ -259,7 +261,13 @@ export default function RegistryManager({ bare = false }: { bare?: boolean } = {
                 placeholder={i18nT('components.registryManager.https_github_com_org_app_registry')}
                 value={editRepo}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEditRepo(e.target.value)}
-                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && handleAdd()}
+                {...ime.bindComposition()}
+                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                  if (e.key !== 'Enter') return
+                  // Rule 1: single-line input — decline the IME's committing Enter only.
+                  if (ime.isComposing(e)) return
+                  handleAdd()
+                }}
               />
             </div>
             <div>
@@ -271,7 +279,13 @@ export default function RegistryManager({ bare = false }: { bare?: boolean } = {
                 placeholder={i18nT('components.registryManager.main')}
                 value={editBranch}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEditBranch(e.target.value)}
-                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && handleAdd()}
+                {...ime.bindComposition()}
+                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                  if (e.key !== 'Enter') return
+                  // Rule 1: single-line input — one shared instance covers both fields.
+                  if (ime.isComposing(e)) return
+                  handleAdd()
+                }}
               />
             </div>
           </div>

--- a/website/src/components/TagManagerList.tsx
+++ b/website/src/components/TagManagerList.tsx
@@ -2,6 +2,7 @@ import { Fragment, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Check, Plus, X, Zap } from 'lucide-react'
 import type { ChatTag } from '../types'
+import { useImeGuard } from '../hooks/useImeGuard'
 import { api } from '../api/client'
 import { FOLDER_COLOR_PALETTE } from './folderColorCatalog'
 
@@ -38,6 +39,7 @@ export interface TagManagerListProps {
  */
 export default function TagManagerList({ mode, selectedIds = [], onToggleTag, createTestId = 'tag-create' }: TagManagerListProps) {
   const queryClient = useQueryClient()
+  const ime = useImeGuard()
   const { data: tags = [] } = useQuery<ChatTag[]>({ queryKey: ['chat-tags'], queryFn: () => api.chatTags() })
   /** Tag id whose inline colour palette is expanded (manage mode only). */
   const [openColorId, setOpenColorId] = useState<string | null>(null)
@@ -189,14 +191,16 @@ export default function TagManagerList({ mode, selectedIds = [], onToggleTag, cr
           data-testid={createTestId}
           placeholder={i18nT('components.tagManagerList.new_tag')}
           className="flex-1 min-w-0 bg-transparent border-none outline-none text-[12px] text-text py-0 px-0.5 placeholder:text-muted/60"
+          {...ime.bindComposition()}
           onKeyDown={e => {
-            if (e.key === 'Enter') {
-              const el = e.currentTarget as HTMLInputElement
-              const v = el.value.trim()
-              if (!v) return
-              createTagMutation.mutate({ name: v })
-              el.value = ''
-            }
+            if (e.key !== 'Enter') return
+            // Rule 1: single-line input — the guard alone; emptiness stays outside.
+            if (ime.isComposing(e)) return
+            const el = e.currentTarget as HTMLInputElement
+            const v = el.value.trim()
+            if (!v) return
+            createTagMutation.mutate({ name: v })
+            el.value = ''
           }}
           onClick={e => e.stopPropagation()}
         />

--- a/website/src/hooks/useSceneInteraction.tsx
+++ b/website/src/hooks/useSceneInteraction.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch } from '../store'
 import { switchSlot } from '../store/chatSlice'
 import { api } from '../api/client'
 import type { AgentSource } from './useAgentSync'
+import { useImeGuard } from './useImeGuard'
 import { KIRO_GHOST_PIXELS } from './sceneText'
 
 import { i18nT } from '../i18n/t'
@@ -116,6 +117,7 @@ export function useSceneInteraction(
 ) {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
+  const ime = useImeGuard()
   const [tooltip, setTooltip] = useState<TooltipState | null>(null)
   const [threadView, setThreadView] = useState<ThreadViewState | null>(null)
   const sourcesRef = useRef<AgentSource[] | undefined>(sources)
@@ -445,7 +447,14 @@ export function useSceneInteraction(
         <input
           value={draft}
           onChange={e => setDraft(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendToAgent(threadView.agent, draft) } }}
+          {...ime.bindComposition()}
+          onFocus={() => ime.reset()}
+          onKeyDown={e => {
+            if (e.key !== 'Enter' || e.shiftKey) return
+            // Rule 1: single-line input — the guard alone is enough here.
+            if (ime.isComposing(e)) return
+            e.preventDefault(); sendToAgent(threadView.agent, draft)
+          }}
           placeholder={sourceFor(threadView.agent)?.running ? i18nT('hooks.useSceneInteraction.steer_this_agent') : i18nT('hooks.useSceneInteraction.message_this_agent')}
           aria-label={i18nT('hooks.useSceneInteraction.message', { name: threadView.agent.name })}
           style={{ flex: 1, background: '#0d0d15', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 11, padding: '4px 7px', outline: 'none' }}

--- a/website/src/pages/ArtifactDetailPage.tsx
+++ b/website/src/pages/ArtifactDetailPage.tsx
@@ -1,5 +1,6 @@
 import { safeSetItem } from '../utils/safeStorage'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useImeGuard } from '../hooks/useImeGuard'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import WebAppArtifactCard from '../components/WebAppArtifactCard'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -352,6 +353,7 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
   // posts metadata-only (no version bump). Removing a tag works the same way.
   const [addingTag, setAddingTag] = useState(false)
   const [newTag, setNewTag] = useState('')
+  const ime = useImeGuard()
   // ── Inline-comment state (durable via /api/artifacts/:slug/comments) ──
   const commentsQuery = useQuery<{ comments: ArtifactComment[]; remote_sync_error?: string | null }>({
     queryKey: ['artifact-comments', slug],
@@ -1561,17 +1563,28 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
               value={newTag}
               onChange={e => setNewTag(e.target.value)}
               onKeyDown={e => {
-                if (e.key === 'Enter') addTag(newTag)
+                if (e.key === 'Enter') {
+                  // Rule 2 shape: this handler carries more than Enter (comma/space
+                  // also commit), so only the Enter path is gated. Rule 1: single-line
+                  // input, so the guard alone is enough.
+                  if (ime.isComposing(e)) return
+                  addTag(newTag)
+                }
                 if (e.key === ',' || e.key === ' ') {
+                  // Space cycles IME candidates mid-composition; committing here
+                  // would post the composing buffer and kill candidate selection.
+                  if (ime.isComposing(e)) return
                   e.preventDefault()
                   if (newTag.trim()) addTag(newTag)
                 }
-                if (e.key === 'Escape') { setNewTag(''); setAddingTag(false) }
+                if (e.key === 'Escape') { ime.reset(); setNewTag(''); setAddingTag(false) }
               }}
-              onBlur={() => {
-                if (newTag.trim()) addTag(newTag)
-                else setAddingTag(false)
-              }}
+              {...ime.bindComposition({
+                onBlur: () => {
+                  if (newTag.trim()) addTag(newTag)
+                  else setAddingTag(false)
+                },
+              })}
               autoFocus
               placeholder={i18nT('pages.artifactDetailPage.tag')}
               className="text-[11px] px-1.5 py-0.5 rounded bg-bg-elevated border border-accent text-text outline-none"

--- a/website/src/pages/ChannelPage.tsx
+++ b/website/src/pages/ChannelPage.tsx
@@ -380,6 +380,7 @@ function MentionInput({ agents, value, onChange, onSend }: {
 // ── Add Agent Form ──
 
 function AddAgentForm({ onAdd, onCancel }: { onAdd: (role: string, task: string, agent: string) => void; onCancel: () => void }) {
+  const ime = useImeGuard()
   const [role, setRole] = useState('')
   const [task, setTask] = useState('')
   const { agents, defaultAgent } = useAgents(0)
@@ -394,7 +395,14 @@ function AddAgentForm({ onAdd, onCancel }: { onAdd: (role: string, task: string,
         className="w-full text-[13px]" />
       <Input value={task} onChange={e => setTask(e.target.value)} placeholder={i18nT('pages.channelPage.task_e_g_search_cloudwatch_logs')} aria-label={i18nT('pages.channelPage.task')}
         className="w-full text-[13px]"
-        onKeyDown={e => { if (e.key === 'Enter' && role.trim()) onAdd(role.trim(), task.trim(), agent || defaultAgent) }} />
+        {...ime.bindComposition()}
+        onKeyDown={e => {
+          if (e.key !== 'Enter') return
+          // Rule 1: single-line input — the guard alone is enough; claiming would
+          // suppress an implicit form submit where one is wanted.
+          if (ime.isComposing(e)) return
+          if (role.trim()) onAdd(role.trim(), task.trim(), agent || defaultAgent)
+        }} />
       <div className="flex gap-1">
         <Btn onClick={() => { if (role.trim()) onAdd(role.trim(), task.trim(), agent || defaultAgent) }} disabled={!role.trim()} primary className="flex-1">{i18nT('pages.channelPage.add')}</Btn>
         <Btn onClick={onCancel}>{i18nT('pages.channelPage.cancel')}</Btn>

--- a/website/src/pages/SchedulePage.tsx
+++ b/website/src/pages/SchedulePage.tsx
@@ -1,5 +1,6 @@
 import { safeSetItem } from '../utils/safeStorage'
 import { useState, useEffect, useCallback, useRef, useMemo, Fragment } from 'react'
+import { useImeGuard } from '../hooks/useImeGuard'
 import Clickable from '../components/Clickable'
 import { List, CalendarDays, CalendarClock, Plus, ClipboardList, ChevronRight, Globe, History, Trash2, FolderPlus, MoreHorizontal, Pencil, Folder, LayoutGrid, GitPullRequestArrow, Download } from 'lucide-react'
 import { api } from '../api/client'
@@ -270,6 +271,7 @@ export default function SchedulePage() {
   const [collapsedFolders, setCollapsedFolders] = useState<Set<string>>(loadCollapsedFolders)
   const [folderModal, setFolderModal] = useState<{ mode: 'create'; resolve?: (id: string | undefined) => void } | null>(null)
   const [folderModalName, setFolderModalName] = useState('')
+  const folderNameIme = useImeGuard()
   const [folderModalError, setFolderModalError] = useState<string | null>(null)
   const toggleFolderCollapse = useCallback((folderId: string) => {
     setCollapsedFolders(prev => {
@@ -913,7 +915,14 @@ export default function SchedulePage() {
               aria-label={i18nT('pages.schedulePage.cronFolders.new_folder_name')}
               value={folderModalName}
               onChange={e => setFolderModalName(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter' && folderModalName.trim()) handleFolderModalSubmit() }}
+              {...folderNameIme.bindComposition()}
+              onFocus={() => folderNameIme.reset()}
+              onKeyDown={e => {
+                if (e.key !== 'Enter') return
+                // Rule 1: single-line input; emptiness stays outside the guard.
+                if (folderNameIme.isComposing(e)) return
+                if (folderModalName.trim()) handleFolderModalSubmit()
+              }}
               placeholder={i18nT('pages.schedulePage.cronFolders.new_folder_name')}
               className="w-full"
             />

--- a/website/src/pages/chat/UserMessage.tsx
+++ b/website/src/pages/chat/UserMessage.tsx
@@ -5,6 +5,7 @@ import { copyToClipboard } from '../../utils/clipboard'
 import { copySessionLink } from '../../utils/shareUrl'
 import { HOVER_NONE_ACTIONS_ROW_CLS } from '../../utils/touchActions'
 import { useSearchHighlight, useCurrentOcc } from '../../hooks/SearchHighlightContext'
+import { useImeGuard } from '../../hooks/useImeGuard'
 import { applySearchHighlights } from '../../utils/domHighlight'
 import { scrollCurrentMatchIntoView } from '../../utils/searchScroll'
 import { type PasteBlock, expandAll as expandPasteTokens } from '../../utils/pasteTokens'
@@ -35,6 +36,7 @@ interface UserMessageProps {
 
 const UserMessage = memo(function UserMessage({ content, meta, timestamp, timestampTitle, renderContent, canEdit, messageIndex, messageTs, onEditResend, slotKey, slotTitle, mode, pinned, onTogglePin }: UserMessageProps) {
   const [editing, setEditing] = useState(false)
+  const ime = useImeGuard()
   const [draft, setDraft] = useState(content)
   const [copied, setCopied] = useState(false)
   const [linkCopied, setLinkCopied] = useState(false)
@@ -152,7 +154,13 @@ const UserMessage = memo(function UserMessage({ content, meta, timestamp, timest
             className="bg-transparent text-card-fg resize-none overflow-hidden focus:outline-none text-sm leading-relaxed"
             value={draft}
             onChange={e => setDraft(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submit() } if (e.key === 'Escape') cancel() }}
+            {...ime.bindComposition()}
+            onKeyDown={e => {
+              // Rule 1: textarea — claim the key, so a declined (IME) Enter is
+              // still consumed instead of inserting a newline into the draft.
+              if (e.key === 'Enter' && !e.shiftKey) { if (ime.claimEnter(e)) submit() }
+              if (e.key === 'Escape') { ime.reset(); cancel() }
+            }}
           />
         </div>
         {/* Actions sit BELOW the bubble (like the read-only action row) so they

--- a/website/src/pages/settings/SecurityPanel.tsx
+++ b/website/src/pages/settings/SecurityPanel.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ShieldCheck, ShieldAlert, Lock, Eye, EyeOff, FileWarning, Terminal, Globe, Fingerprint, KeyRound, ScanLine, Layers, AlertTriangle, CheckCircle2, Circle, Clock, ExternalLink, ChevronRight, ChevronDown, Plus, Trash2, Gavel, Building2, Gauge, ToggleRight, MessageSquare, ListChecks, ArrowLeft, Boxes, BookOpen, Network, Copy, Check, Package } from 'lucide-react'
 import { useAppSelector } from '../../store'
 import { useContainerWidth } from '../../hooks/useContainerWidth'
+import { useImeGuard } from '../../hooks/useImeGuard'
 import { Badge, Btn, Input, Toggle, Checkbox } from '../../components/ui'
 import { SettingsSection, SettingsCard, SettingsToggle } from '../../components/settings'
 import Modal from '../../components/Modal'
@@ -379,6 +380,7 @@ function CustomDenyRow({ rule, onToggle, onDelete }: { rule: DeniedUserRule; onT
  *  `error` stays local: it is derived from the value and costs nothing to
  *  recompute. */
 function AddDenyInput({ value, onChange, note, onNoteChange, onAdd, busy, submitError }: { value: string; onChange: (next: string) => void; note: string; onNoteChange: (next: string) => void; onAdd: (pattern: string, note: string) => void; busy: boolean; submitError: string }) {
+  const ime = useImeGuard()
   const [error, setError] = useState('')
 
   const submit = () => {
@@ -403,7 +405,13 @@ function AddDenyInput({ value, onChange, note, onNoteChange, onAdd, busy, submit
         <Input
           value={value}
           onChange={e => { onChange(e.target.value); if (error) setError('') }}
-          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); submit() } }}
+          {...ime.bindComposition()}
+          onKeyDown={e => {
+            if (e.key !== 'Enter') return
+            // Rule 1: single-line input — decline the IME's committing Enter only.
+            if (ime.isComposing(e)) return
+            e.preventDefault(); submit()
+          }}
           placeholder={i18nT('pages.settings.securityPanel.add_a_custom_deny_pattern_regex_e_g_rm_rf_tmp_mi')}
           aria-label={i18nT('pages.settings.securityPanel.custom_deny_pattern')}
         />
@@ -420,7 +428,14 @@ function AddDenyInput({ value, onChange, note, onNoteChange, onAdd, busy, submit
         <Input
           value={note}
           onChange={e => onNoteChange(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); submit() } }}
+          {...ime.bindComposition()}
+          onKeyDown={e => {
+            if (e.key !== 'Enter') return
+            // Rule 1: single-line input — one shared instance covers both fields;
+            // the binding's blur reset makes that safe.
+            if (ime.isComposing(e)) return
+            e.preventDefault(); submit()
+          }}
           placeholder={i18nT('pages.settings.securityPanel.optional_why_shown_to_the_agent_when_this_rule_fir')}
           aria-label={i18nT('pages.settings.securityPanel.custom_deny_note')}
           maxLength={200}

--- a/website/src/pages/settings/SlackPanel.tsx
+++ b/website/src/pages/settings/SlackPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { useImeGuard } from '../../hooks/useImeGuard'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ExternalLink, Check, AlertTriangle, Plus, X, Lock } from 'lucide-react'
 import { SlackIcon } from '../../components/SlackIcon'
@@ -78,6 +79,7 @@ export function TagListEditor({ label, description, values, placeholder, onChang
 }) {
   const [draft, setDraft] = useState('')
   const [err, setErr] = useState('')
+  const ime = useImeGuard()
   const add = () => {
     const v = draft.trim()
     if (!v) return
@@ -111,7 +113,13 @@ export function TagListEditor({ label, description, values, placeholder, onChang
         <div className="flex items-center gap-2">
           <Input value={draft} placeholder={placeholder} className="flex-none font-mono"
             onChange={e => { setDraft(e.target.value); setErr('') }}
-            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add() } }} />
+            {...ime.bindComposition()}
+            onKeyDown={e => {
+              if (e.key !== 'Enter') return
+              // Rule 1: single-line input — decline the IME's committing Enter only.
+              if (ime.isComposing(e)) return
+              e.preventDefault(); add()
+            }} />
           <Btn onClick={add} disabled={!draft.trim()}><Plus size={13} /> {i18nT('pages.settings.slackPanel.add')}</Btn>
         </div>
       )}

--- a/website/src/test/ImeEnterGuardSites.test.tsx
+++ b/website/src/test/ImeEnterGuardSites.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * IME Enter guard — site-level behaviour for the guard-less Enter-submit inputs
+ * routed through `useImeGuard`.
+ *
+ * On WebKit the keydown that commits an IME candidate is dispatched AFTER
+ * `compositionend`, where `KeyboardEvent.isComposing` already reads false. The
+ * hook's 50ms latch is the only signal that survives into that window, so each
+ * test arms the latch with compositionStart→compositionEnd and then fires the
+ * committing Enter exactly as WebKit delivers it (native flag clear).
+ *
+ * One site per remedy, because the remedies differ and a regression in one is
+ * invisible from the other:
+ *  - textarea → `claimEnter` (UserMessage edit box): a declined Enter must ALSO
+ *    be consumed, or the browser inserts a newline into the draft.
+ *  - single-line input → `isComposing` early-return (TagManagerList create box):
+ *    a declined Enter must NOT be consumed — nothing would be inserted, and
+ *    claiming would suppress an implicit form submit where one is wanted.
+ *  - picker input carrying arrows (ProjectPicker): only the Enter path is
+ *    gated; arrow navigation keeps working with the latch armed.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore, renderWithProviders } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import UserMessage from '../pages/chat/UserMessage'
+
+vi.mock('../utils/clipboard', () => ({ copyToClipboard: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('../utils/shareUrl', () => ({ copySessionLink: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('../api/client', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...mod,
+    api: {
+      ...mod.api,
+      chatTags: vi.fn().mockResolvedValue([]),
+      createChatTag: vi.fn().mockResolvedValue({ ok: true }),
+      chatFolders: vi.fn().mockResolvedValue([]),
+      recentProjects: vi.fn().mockResolvedValue({ dirs: [] }),
+      browseDirs: vi.fn().mockResolvedValue({ path: '/home/u', parent: '/home', dirs: [] }),
+    },
+  }
+})
+
+import { api } from '../api/client'
+import TagManagerList from '../components/TagManagerList'
+import ProjectPicker from '../components/ProjectPicker'
+
+/** Arm the hook's post-composition latch: the WebKit commit-Enter window. */
+function armLatch(el: Element) {
+  fireEvent.compositionStart(el)
+  fireEvent.compositionEnd(el)
+}
+
+const renderContent = (content: string) => <span data-testid="content">{content}</span>
+
+describe('UserMessage edit textarea — rule 1 textarea: claimEnter', () => {
+  function openEditor(onEditResend = vi.fn()) {
+    render(<UserMessage content="original" renderContent={renderContent} canEdit onEditResend={onEditResend} messageIndex={0} />)
+    fireEvent.click(screen.getByTitle('Edit & Resend'))
+    const ta = screen.getByLabelText('Edit message') as HTMLTextAreaElement
+    return { ta, onEditResend }
+  }
+
+  it('declines the committing Enter in the post-composition window AND consumes it (no newline)', () => {
+    const { ta, onEditResend } = openEditor()
+    fireEvent.change(ta, { target: { value: '你好' } })
+    armLatch(ta)
+    // WebKit shape: compositionend already fired, native isComposing is false.
+    const defaultNotPrevented = fireEvent.keyDown(ta, { key: 'Enter' })
+    expect(onEditResend).not.toHaveBeenCalled()
+    // claimEnter consumed the declined key — an unclaimed Enter would insert a
+    // literal newline into the draft the user is about to send.
+    expect(defaultNotPrevented).toBe(false)
+  })
+
+  it('leaves a mid-composition Enter to the IME (native flag set → no preventDefault)', () => {
+    const { ta, onEditResend } = openEditor()
+    fireEvent.change(ta, { target: { value: '你好' } })
+    fireEvent.compositionStart(ta)
+    const defaultNotPrevented = fireEvent.keyDown(ta, { key: 'Enter', isComposing: true })
+    expect(onEditResend).not.toHaveBeenCalled()
+    // Cancelling the default here would risk the candidate commit the same
+    // keypress carries; the guard must not touch a key the IME is consuming.
+    expect(defaultNotPrevented).toBe(true)
+  })
+
+  it('submits on a plain Enter (positive control)', () => {
+    const { ta, onEditResend } = openEditor()
+    fireEvent.change(ta, { target: { value: 'edited text' } })
+    fireEvent.keyDown(ta, { key: 'Enter' })
+    expect(onEditResend).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('TagManagerList create input — rule 1 single-line input: isComposing only', () => {
+  function renderList() {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <Provider store={createTestStore()}>
+        <MemoryRouter>
+          <QueryClientProvider client={qc}>
+            <ThemeProvider>
+              <TagManagerList mode="manage" />
+            </ThemeProvider>
+          </QueryClientProvider>
+        </MemoryRouter>
+      </Provider>,
+    )
+    return screen.findByTestId('tag-create') as Promise<HTMLInputElement>
+  }
+
+  it('does NOT create a tag on the committing Enter in the post-composition window', async () => {
+    const input = await renderList()
+    fireEvent.change(input, { target: { value: 'タグ' } })
+    armLatch(input)
+    const defaultNotPrevented = fireEvent.keyDown(input, { key: 'Enter' })
+    // Flush the mutation's microtask queue — react-query's mutate() defers the
+    // mutationFn, so a synchronous not-called assertion would pass vacuously.
+    await act(async () => { await Promise.resolve() })
+    expect(vi.mocked(api.createChatTag)).not.toHaveBeenCalled()
+    // Single-line input: the guard declines, it does not claim. Consuming the
+    // key here would be over-reach (it would suppress an implicit form submit
+    // on form-hosted inputs of this shape).
+    expect(defaultNotPrevented).toBe(true)
+  })
+
+  it('creates the tag on a plain Enter without consuming the key (implicit submit preserved)', async () => {
+    const input = await renderList()
+    fireEvent.change(input, { target: { value: 'ops' } })
+    const defaultNotPrevented = fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(vi.mocked(api.createChatTag)).toHaveBeenCalledWith('ops', undefined, undefined))
+    expect(defaultNotPrevented).toBe(true)
+  })
+})
+
+describe('ProjectPicker path input — rule 2: gate the Enter path only', () => {
+  const rect = (top: number, left: number, width = 80, height = 24): DOMRect => ({
+    top, left, width, height,
+    bottom: top + height,
+    right: left + width,
+    x: left, y: top,
+    toJSON: () => ({}),
+  } as DOMRect)
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(api.recentProjects).mockResolvedValue({ dirs: [] })
+    vi.mocked(api.browseDirs).mockResolvedValue({
+      path: '/home/u',
+      parent: '/home',
+      dirs: [
+        { name: 'alpha', path: '/home/u/alpha' },
+        { name: 'beta', path: '/home/u/beta' },
+      ],
+    })
+  })
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  async function openBrowse() {
+    renderWithProviders(
+      <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />,
+    )
+    // Drain the initial browse() + recentProjects() promises (empty recents
+    // auto-switch the picker to the Browse tab).
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+    return screen.getByPlaceholderText('/path/to/project') as HTMLInputElement
+  }
+
+  it('keeps arrow-key list navigation working while the latch is armed', async () => {
+    const input = await openBrowse()
+    armLatch(input)
+    expect(input.getAttribute('aria-activedescendant')).toBe('pp-dir-0')
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    // Claiming the whole handler would have broken this: only Enter is gated.
+    expect(input.getAttribute('aria-activedescendant')).toBe('pp-dir-1')
+  })
+
+  it('does NOT drill into the highlighted folder on the committing Enter', async () => {
+    const input = await openBrowse()
+    armLatch(input)
+    vi.mocked(api.browseDirs).mockClear()
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+    expect(vi.mocked(api.browseDirs)).not.toHaveBeenCalled()
+  })
+
+  it('drills into the highlighted folder on a plain Enter (positive control)', async () => {
+    const input = await openBrowse()
+    vi.mocked(api.browseDirs).mockClear()
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+    expect(vi.mocked(api.browseDirs)).toHaveBeenCalledWith('/home/u/alpha')
+  })
+
+  it('lets Enter through again once the 50ms post-composition window expires', async () => {
+    const input = await openBrowse()
+    armLatch(input)
+    // Advance past the latch window — the WebKit commit-Enter hazard is over,
+    // so the next Enter is a deliberate one and must act normally.
+    await act(async () => { await vi.advanceTimersByTimeAsync(60) })
+    vi.mocked(api.browseDirs).mockClear()
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+    expect(vi.mocked(api.browseDirs)).toHaveBeenCalledWith('/home/u/alpha')
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Typing with an IME (Japanese, Chinese, Korean, and other composition-based input methods) into many dashboard inputs and pressing Enter to confirm the composition **submits the field instead of committing the candidate text**. Fifteen Enter-submit sites across the dashboard read `e.key === 'Enter'` without any IME guard, so the composition-confirming Enter is indistinguishable from a submit Enter. Users lose half-composed text or fire actions (send message, create tag, rename folder, submit answer) they never intended.

## Why it matters

Every CJK-input user hits this on core surfaces — the chat composer, channel search, tag managers, security panel inputs, the schedule folder creator, question cards, and the project picker. It makes the dashboard effectively hostile to composition-based input: the most basic flow (type text, confirm candidate with Enter) misfires on every guard-less field. This is a correctness bug on the normal input path for a large class of users.

## What changed (motivation → approach → change)

Symptom: Enter during IME composition triggers submit. Root cause: 15 keydown handlers gate only on `e.key === 'Enter'`, ignoring composition state. Fix: route every site through the existing `useImeGuard` machinery (introduced by #4216), applying the repo's three remediation rules from #4234:

| Rule | Remedy | Sites |
|---|---|---|
| 1 (textarea, WebKit-safe) | `ime.claimEnter()` — WebKit fires keydown *after* compositionend, so `isComposing` alone is insufficient for textareas | UserMessage |
| 1 (single-line input) | `isComposing` check via the guard | ChannelPage, QueueStack, useSceneInteraction, SecurityPanel ×2, RegistryManager ×2, ChatEmbed, TagManagerList, QuestionCard, ArtifactDetailPage (tag input), SchedulePage (folder input), SlackPanel |
| 2 (Enter-only gating in a multi-key handler) | Gate only the Enter branch through the guard; arrow-key handling untouched | ProjectPicker |

Design invariants preserved: Shift+Enter newline behavior unchanged; emptiness/validation checks stay outside the IME guard; arrow-key handlers gate the Enter path only. Includes a stale-latch `onFocus` reset on the 4 hoisted guard hooks and coverage of the comma/space branch in the tag input.

Deferred follow-ups (out of scope by design):
- Arrow keys mid-composition (issue #4234 F3) — needs a hook-level change the issue's remediation spec excludes.
- Remaining same-shape sites outside this PR's 15: the `apps/` tree + rename-input family, plus 9 additional core-tree inputs identified in review (SearchBar, knowledge DetailView, OnboardingFlow, VectorMemoryCard ×3, DisplayPanel, SourcesPopover, KiroCrewCfgTab) — all tracked in #4292, together with consolidating the simple sites onto `bindEnter`, widening the guard ratchet regex, and moving the stale-latch reset into `bindComposition`.

## Tests

`test/ImeEnterGuardSites.test.tsx` — 8 cases covering: composing-Enter is swallowed at representative rule-1 input sites; UserMessage textarea `claimEnter` swallows the post-compositionend WebKit Enter; ProjectPicker Enter-only gating leaves arrow navigation intact; latch expiry after the claim window; and the tag-input comma/space branch stays guarded. Four of the cases were proven failing on the unguarded base before the fix.

Full gates on the rebased commit: `npx tsc -b` clean, `npx vitest run` 21,469 passed / 0 failed.

## Manual verification

N/A — unit coverage sufficient: the guard is a pure keyboard-event predicate exercised directly by the new tests via synthetic composition + keydown sequences; there is no rendered or async behavior the tests cannot reach.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** keyboard-event guard only -- no pixel changes in any state

## Related Issues

Closes #4234

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior-level fix with no doc surface
- [x] No secrets, credentials, or internal references in the diff
