### PR TITLE
ci: fail Windows build on installer without its blockmap (#4301)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -243,6 +243,45 @@ jobs:
           # policy requires it as sts:ExternalId.
           WINDOWS_SIGNING_EXTERNAL_ID: ${{ env.HAS_WINDOWS_SIGNING && 'KiroCrewWindows' || '' }}
 
+      # The installer and its blockmap are one artifact in two files: without
+      # the .blockmap, electron-updater silently falls back to a FULL download
+      # on every update. Failing HERE, before the upload, refuses to ship a
+      # corrupt artifact set at all (#4301): the publish lane then takes its
+      # documented build-produced-nothing skip path, exactly as for any other
+      # build failure, instead of hard-failing downstream -- where a missing
+      # blockmap on an insider run would block stable promotion of the mac,
+      # Linux and CLI artifacts (see the NOTE on release.yml's
+      # publish-windows-x64 job), the cross-platform coupling soft_fail exists
+      # to prevent. The Windows lane still goes visibly red, the step summary
+      # below carries the reason onto the run page even when soft_fail keeps
+      # the run green, and the workflow_dispatch packaging probe (soft_fail
+      # defaults false) hard-fails on this before merge.
+      # publish-windows.yml's own pairing check stays as the safety net for
+      # any artifact that reaches it by another path.
+      #
+      # The empty-glob case fails too: upload-artifact's if-no-files-found
+      # only errors when NO pattern matches, so a stray latest.yml alone would
+      # satisfy it and an installer-less artifact set would upload cleanly.
+      - name: Verify installer/blockmap pairing
+        shell: bash
+        run: |
+          shopt -s nullglob
+          fail() {
+            echo "::error::$1"
+            echo "**build-windows:** $1" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+          installers=(website/electron/dist/*.exe)
+          if [ "${#installers[@]}" -eq 0 ]; then
+            fail "no installer produced: website/electron/dist contains no .exe"
+          fi
+          for exe in "${installers[@]}"; do
+            if [ ! -f "${exe}.blockmap" ]; then
+              fail "orphaned installer: ${exe} has no sibling ${exe##*/}.blockmap -- electron-updater would silently fall back to full downloads"
+            fi
+          done
+          echo "installer/blockmap pairing verified for ${#installers[@]} installer(s)"
+
       # NSIS output: electron-builder emits the installer flat into dist/ as
       # "<productName> Setup <version>.exe", alongside a .blockmap (the
       # differential-download index electron-updater consumes) and latest.yml

--- a/test/test_windows_signing_contract.py
+++ b/test/test_windows_signing_contract.py
@@ -505,6 +505,35 @@ def test_the_signing_gate_also_requires_the_prod_environment() -> None:
     )
 
 
+def test_the_pairing_guard_runs_before_the_upload_and_fails_hard() -> None:
+    """An orphaned installer must never be uploaded (#4301).
+
+    The guard exists so an .exe with no .blockmap beside it fails the build
+    BEFORE the artifact is produced: the publish lane then takes its
+    documented build-produced-nothing skip path instead of hard-failing an
+    insider run, which would block stable promotion of the mac, Linux and CLI
+    artifacts (the coupling soft_fail exists to prevent). Nothing else fails
+    at PR time if the step is deleted or reordered, so it is pinned here like
+    the other load-bearing properties of this workflow.
+    """
+    guard = _step("installer/blockmap")
+    run = guard["run"]
+    assert "exit 1" in run, "the guard must fail the job, not merely annotate"
+    assert "::error::" in run, "the failure must annotate the run"
+    assert "GITHUB_STEP_SUMMARY" in run, (
+        "soft_fail keeps the run green, so the reason must reach the run "
+        "summary page rather than living only in the job log"
+    )
+    names = [s.get("name", "") for s in _build_job()["steps"]]
+    guard_i = next(i for i, n in enumerate(names) if "installer/blockmap" in n)
+    upload_i = names.index("Upload desktop artifact")
+    build_i = names.index("Build desktop app")
+    assert build_i < guard_i < upload_i, (
+        f"expected build({build_i}) < guard({guard_i}) < upload({upload_i}): "
+        "the guard must inspect the built dist and refuse the upload"
+    )
+
+
 def test_artifact_paths_contain_no_yaml_comments() -> None:
     """`path:` is a block scalar, where a '#' line is a glob, not a comment.
 


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

`build-windows.yml` builds the NSIS installer and uploads `website/electron/dist/*.exe` plus `*.exe.blockmap` as one artifact, but nothing verifies the pair at the producer. If electron-builder stops emitting blockmaps (a plausible persistent regression), the upload succeeds with only the `.exe`. The blockmap is the differential-download index: without it beside the installer, electron-updater silently falls back to a full download on every update for every client.

## Why it matters

Where the failure surfaces today is the worst place for it. On an insider release run, the exe-only artifact reaches `publish-windows.yml`, whose pairing check hard-fails a job with no `continue-on-error` — making the whole run unsuccessful, and `release_promotion.py` then refuses to promote that commit's mac, Linux, and CLI artifacts (the exact cross-platform coupling `soft_fail` exists to prevent; see the NOTE on `release.yml`'s `publish-windows-x64` job). And on the stable path, `record-promotion` drops the incomplete pair inside a green job, so a persistent regression would strip Windows from stable candidates with only an annotation nobody watches. Issue #4301 (a Design Review follow-up on #4244) asks for the check at the producer: refuse to upload an `.exe` with no `.blockmap` beside it.

## What changed (motivation → approach → change)

Symptom: an orphaned installer can leave the build green and detonate downstream. Root cause: the pair invariant has no producer-side enforcement — `upload-artifact`'s `if-no-files-found: error` is satisfied by `latest.yml` alone, so it guards nothing here. Change: one new `Verify installer/blockmap pairing` step in `build-windows.yml`, immediately before `Upload desktop artifact`. It globs `website/electron/dist/*.exe` (`nullglob`, array-quoted for the spaced NSIS filename), fails when the glob is empty (no installer at all is equally a corrupt artifact set), and fails when any `.exe` lacks its sibling `.blockmap` — emitting an `::error::` annotation and a `$GITHUB_STEP_SUMMARY` line so the reason lands on the run page even when `soft_fail` keeps the run green.

Because the job carries `continue-on-error: ${{ inputs.soft_fail == true }}` and both publishing callers pass `soft_fail: true`, the failure turns the Windows lane visibly red without blocking mac/Linux/CLI publishes or stable promotion: the publish lane takes its documented build-produced-nothing skip path, exactly as for any other Windows build failure. The `workflow_dispatch` packaging probe (where `soft_fail` defaults false) hard-fails on this before merge. `nightly.yml` and `release.yml` need no changes (verified: both already pass `soft_fail: true` and probe for the artifact rather than trusting the job result). `publish-windows.yml`'s own pairing check stays as the safety net for any artifact reaching it by another path. `docs/build/release.md` describes the invariant but does not enumerate enforcement points, so it is left alone.

## Tests

`test/test_windows_signing_contract.py::test_the_pairing_guard_runs_before_the_upload_and_fails_hard` pins the guard the same way that file pins the workflow's other load-bearing properties: the step exists, it `exit 1`s (fails rather than annotates), it writes both the `::error::` annotation and `$GITHUB_STEP_SUMMARY`, and it is ordered strictly between `Build desktop app` and `Upload desktop artifact`. Deleting or reordering the step now fails at PR time. Full file: 27 passed.

## Manual verification

The guard's bash was executed standalone against a fixture dist dir covering all three branches: orphaned `.exe` (with electron-builder's real spaced filename shape, `Kiro Crew Setup 1.0.0.exe`) → exit 1 + summary line written; complete pair → exit 0; `latest.yml` only → exit 1. YAML well-formedness and step placement asserted by parsing the workflow. There is no other unit-test surface for workflow YAML (no actionlint in CI); the reusable workflow's own `workflow_dispatch` probe is the post-merge validation path.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** CI workflow + test change only; nothing renders in the browser.

## Related Issues

Closes #4301

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, see above
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
