### PR TITLE
fix(slack): stop mangling markdown images into broken Slack links

### DIFF
--- a/src/kiro_crew/slack/format.py
+++ b/src/kiro_crew/slack/format.py
@@ -412,8 +412,13 @@ def to_slack_mrkdwn(text: str, *, keep_tables: bool = False, in_code: bool = Fal
 
 # ── Inline conversions (outside code blocks) ──
 
-# Markdown link [text](url) → Slack <url|text>
-_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+# Markdown link [text](url) → Slack <url|text>. The lookbehind holds IMAGE
+# syntax out of the rewrite: Slack mrkdwn has no image form, so converting
+# ``![alt](dest)`` yields a stray ``!`` plus a clickable link to a destination
+# Slack cannot open — a local screenshot path is not even reachable from its
+# servers. Images pass through raw instead, as they do on Discord, until the
+# outbound upload path claims them.
+_LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)")
 # Headings: # text → *text*
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$")
 # Horizontal rule: --- or *** or ___ (3+ chars)

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -2392,6 +2392,63 @@ class TestToSlackMrkdwnKeepTables:
         assert "```mermaid" not in result
 
 
+class TestToSlackMrkdwnImages:
+    """Markdown IMAGE syntax must survive conversion untouched.
+
+    Slack mrkdwn has no image form, so running an image through the
+    ``[text](url)`` -> ``<url|text>`` rewrite emits a stray ``!`` in front of a
+    clickable link to a destination Slack cannot open (a local path is not even
+    reachable from Slack's servers). Raw passthrough is what the reader can act
+    on, and it matches Discord, whose renderer rewrites no links at all.
+    """
+
+    def test_image_with_local_path_is_untouched(self):
+        from kiro_crew.slack.format import to_slack_mrkdwn
+
+        assert to_slack_mrkdwn("![shot](/tmp/x.png)") == "![shot](/tmp/x.png)"
+
+    def test_image_with_http_url_is_untouched(self):
+        from kiro_crew.slack.format import to_slack_mrkdwn
+
+        text = "![diagram](https://example.com/d.png)"
+        assert to_slack_mrkdwn(text) == text
+
+    def test_regular_link_still_converts(self):
+        from kiro_crew.slack.format import to_slack_mrkdwn
+
+        assert to_slack_mrkdwn("[docs](https://example.com)") == "<https://example.com|docs>"
+
+    def test_mixed_line_converts_only_the_link(self):
+        from kiro_crew.slack.format import to_slack_mrkdwn
+
+        out = to_slack_mrkdwn("see ![a](/x.png) and [b](https://y)")
+        assert out == "see ![a](/x.png) and <https://y|b>"
+
+    def test_escaped_bang_is_still_treated_as_an_image(self):
+        from kiro_crew.slack.format import to_slack_mrkdwn
+
+        # CommonMark reads ``\![x](p)`` as an escaped literal ``!`` followed by a
+        # LINK, so a strict reader would convert it. This converter has no
+        # backslash-unescaping layer, so honouring that in detection alone would
+        # emit ``\!<p|x>`` -- a stray literal backslash in place of a stray ``!``.
+        # Passing it through raw also matches ``image_artifacts._IMAGE_MD_RE``,
+        # which registers ``\![x](p)`` as an image on the dashboard side.
+        assert to_slack_mrkdwn(r"\![x](p)") == r"\![x](p)"
+
+    def test_sentence_bang_before_a_link_is_an_image_per_commonmark(self):
+        from kiro_crew.slack.format import to_slack_mrkdwn
+
+        # No space between ``!`` and ``[``: CommonMark binds the ``!`` into image
+        # syntax, so this is an image, not "exclamation mark, then link".
+        assert to_slack_mrkdwn("Wow![click](https://x)") == "Wow![click](https://x)"
+
+    def test_image_inside_a_code_fence_is_untouched(self):
+        from kiro_crew.slack.format import to_slack_mrkdwn
+
+        text = "```\n![a](/x.png)\n```"
+        assert to_slack_mrkdwn(text) == text
+
+
 class TestMermaidSequenceArrows:
     """Regression: dashed sequence-diagram arrows were rendered by a dead branch.
 


### PR DESCRIPTION
## Problem

Any markdown image in an agent reply came out of Slack broken. `slack/format.py`
rewrites `[text](dest)` into Slack's `<dest|text>` link form, but the regex never
looked at a leading `!`, so image syntax was swept into the same rewrite:

| input | on Slack before | after |
|---|---|---|
| `![shot](/tmp/x.png)` | `!</tmp/x.png\|shot>` | `![shot](/tmp/x.png)` |
| `![diagram](https://example.com/d.png)` | `!<https://example.com/d.png\|diagram>` | unchanged |
| `[docs](https://example.com)` | `<https://example.com\|docs>` | unchanged |

The reader got a stray `!` in front of a clickable link that goes nowhere useful —
a local screenshot path is not reachable from Slack's servers at all, so the link
either dead-ends or, on a `file://`-ish path, is silently dropped by Slack.

## Why it matters

Agents emit `![...](...)` routinely (screenshots, generated diagrams, image
artifacts), and the dashboard already treats that syntax as a first-class
attachment marker (`image_artifacts._IMAGE_MD_RE`). On Slack the same reply
turned into visible junk, and the junk was actively misleading: it looked like a
working link.

## Fix

Symptom → root cause → change:

- Symptom: `!</tmp/x.png|shot>` on the wire.
- Root cause: `_LINK_RE` matches `[text](dest)` with no guard on the character
  before `[`, and `_convert_inline` applies it with `.sub`, so `![alt](dest)`
  matches on its inner `[alt](dest)` and the `!` is left stranded outside the
  replacement.
- Change: a negative lookbehind, `(?<!!)`, keeps image syntax out of the rewrite.

Images now pass through raw. That is the right interim behaviour, not a
placeholder:

- **Slack mrkdwn has no image form.** There is nothing correct to convert
  `![alt](dest)` *into* at this layer — an image belongs in an upload or an image
  block, not in a text rewrite.
- **Cross-channel consistency.** Discord's renderer rewrites no links at all, so
  images already pass through there untouched. Telegram's `_LINK_RE` only matches
  `https?://` destinations, so local-path images pass through there too. Slack was
  the outlier.
- **Upload wiring follows.** Slack declares `files_outbound=True` via the
  `/api/slack/upload-file` external-upload flow, but the render path does not
  route image markdown into it. Claiming `![...](...)` and uploading the file is a
  follow-up PR in the outbound-attachments wave; until then, showing the author's
  literal text beats emitting a broken link.

Regular link conversion is untouched, and so is behaviour inside code fences
(`to_slack_mrkdwn` already skips fenced lines).

Redaction is unaffected. `render_for_slack` redacts on both sides of conversion,
and the display-canonicalisation the scan uses (`display_safety._MD_LINK`) has no
`!` exclusion, so image markup is still collapsed to its label before the
credential scan runs — a key split across image markup is caught exactly as it was
before.

## Tests

New `TestToSlackMrkdwnImages` in `test/test_slack_handler.py`, written red first
(5 of 7 failed on the unfixed code with exactly the mangled strings above):

- image with an absolute local path — unchanged
- image with an `https` destination — unchanged
- `[docs](https://example.com)` — still converts to `<https://example.com|docs>`
- mixed line `see ![a](/x.png) and [b](https://y)` — image raw, link converted
- `Wow![click](https://x)` — no space before `[`, so CommonMark binds the `!` into
  image syntax; treated as an image
- `\![x](p)` — documented decision in a test comment: CommonMark reads the escaped
  `!` as a literal followed by a *link*, but this converter has no
  backslash-unescaping layer, so honouring that in detection alone would emit
  `\!<p|x>` — a stray backslash in place of a stray `!`. Raw passthrough also
  matches `image_artifacts._IMAGE_MD_RE`, which ignores the backslash too.
- image inside a code fence — unchanged

No existing test asserted the mangled form (grepped the tree for `!<…|`), so
nothing needed updating.

## Manual verification

N/A — this is a pure string transform and the unit tests assert exact output,
including the two mixed cases where a substring check would have passed on wrong
placement.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no frontend path is touched, so the
Screenshot Evidence gate does not fire and there is no rendered delta.

no issue closed: found while auditing the Slack render path for the
outbound-attachment-streaming wave.

## Gates run locally

`pytest` (25 slack / render / mirror / messaging modules + `test_security_posture.py`
+ `test_spawn_audit.py`, 1,622 tests) · `isort` · `flake8` · `mypy` (CI-parity venv,
986 files) · `scripts/scrub-lint.sh` — all green.
