### PR TITLE
fix(issue-radar): localize AI summaries to the dashboard language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ All notable changes to KiroCrew are documented in this file.
   the existing actionable "run `kiro-cli login`, then start a new chat"
   guidance. (#3393)
 
+- **Issue Radar's AI summaries now follow the dashboard language.** The issue
+  triage summary, the PR summary, and the label-taxonomy recommendation always
+  produced English prose regardless of `dashboard.language`, making the AI card
+  the one unlocalized surface in an otherwise localized UI. When a dashboard
+  language is configured, each one-shot prompt now carries an output-language
+  directive for its prose (summary, per-label `reason`, recommendation
+  `rationale`) while label names — and a recommendation's `name`/`description`,
+  which become repo content on GitHub — stay untranslated. Caches regenerate on
+  a language switch instead of serving the old language: the PR-summary cache
+  folds the tag into its fingerprint, and the issue-AI cache stores the tag
+  beside the payload and treats a mismatch as a miss (recommendations remain
+  regenerate-only via their explicit button). Installs with no configured
+  language send byte-identical prompts and keep their cached digests. (#4290)
+
 - **xlsx files now render inline in the file viewer** instead of a
   download-only card. A new `GET /api/file-sheet` endpoint parses OOXML
   workbooks server-side with openpyxl (read-only, worker thread, ZIP

--- a/docs/system-specs/modules/issue-radar.md
+++ b/docs/system-specs/modules/issue-radar.md
@@ -40,7 +40,7 @@ wrapped in `_require_enabled` (returns 403 when the app is disabled).
 | GET | `/pulls` | List open/closed PRs (cached, `poll=1` probe-gated as for `/issues`; `first_page=1` (open only) takes the progressive first-paint fast path — see First Paint; rows enriched with diff size + check tally via one GraphQL call and merge readiness via a second, lean one run CONCURRENTLY, each topped up by number for rows outside its `first:100` window). Rows whose enrichment failed carry `null` (unknown, not zero) and are deliberately NOT written to the cache, so the next read retries |
 | GET | `/pulls/search` | PRs matching a per-person filter, resolved server-side by GitHub search (escapes the list's page cap). Paginates only as far as its own cap and reports `truncated` so the UI says "newest N" rather than implying completeness |
 | GET | `/pull` | Full PR detail + conversation (issue timeline merged with inline review comments) + automated checks on the head commit. Cache-first with a short server-side TTL (`PR_DETAIL_CACHE_TTL_SEC`), so a plain GET self-refreshes and no caller has to pass `refresh=1` to stay current |
-| GET | `/pull-ai` | AI summary of a PR (description + whole conversation + check state), cached against a fingerprint that hashes the conversation's CONTENT — so an edited comment invalidates it, not just a new one |
+| GET | `/pull-ai` | AI summary of a PR (description + whole conversation + check state), cached against a fingerprint that hashes the conversation's CONTENT — so an edited comment invalidates it, not just a new one. The configured dashboard language (when set) is folded into the fingerprint too, so switching languages earns a fresh summary instead of serving the cached one in the old language |
 | POST | `/labels/apply` | Apply label changes (add/remove) |
 | POST | `/issue/state` | Close/reopen an issue |
 | GET/PUT | `/investigation` | Per-issue investigation record. The PUT is the ONE app route also reachable with the gateway internal secret (`_MIXED_INTERNAL_API_PATHS`), because it is the write behind the `issue_radar_record_investigation` MCP tool — see [Recording findings](#recording-findings) |
@@ -662,6 +662,18 @@ the parent RUN and needs its id.
   output is redacted. Issue label suggestions are additionally intersected with the
   repo's real label set, so injected text cannot invent a label; a PR summary is
   prose that nothing downstream acts on.
+- **Output language**: when `dashboard.language` names a shipped catalog, each AI
+  prompt appends a directive (outside the untrusted fence) to write its PROSE —
+  the summaries, per-label `reason`, and recommendation `rationale` — in that
+  language. Label names stay verbatim (the intersection above still matches), and
+  a recommendation's `name`/`description` stay in the repo's own language because
+  `/labels/create` writes them onto GitHub. With no configured language the
+  prompts are byte-identical to before and the model defaults to English.
+  Caches follow suit: the PR-summary fingerprint folds the tag in, and the
+  issue-AI cache stores the tag beside the payload and treats a mismatch as a
+  miss, so a language switch regenerates both on next open. The recommendations
+  cache is regenerate-only by design — it renders the last explicitly generated
+  proposal until the user presses "Recommend labels" again.
 
 ## Background Watcher
 

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
@@ -67,6 +67,8 @@ from aiohttp import web
 
 from kiro_crew.apps.builtins.issue_radar.backend import github_client, provider, store, watch
 from kiro_crew.apps.manager import is_app_enabled
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.context import ui_language_tag
 from kiro_crew.sel import sel
 
 logger = logging.getLogger("kirocrew.app.issue-radar")
@@ -1392,14 +1394,75 @@ _AI_BODY_MAX_CHARS = 6000
 _AI_MAX_SUGGESTIONS = 6
 
 
-def _build_ai_prompt(owner: str, repo: str, detail: dict, labels: list[dict], current_names: list[str]) -> str:
+def _ui_language() -> str:
+    """Dashboard UI language as a validated BCP-47 tag, or ``""`` when unknown.
+
+    ``""`` covers both "never chosen" (the config's follow-the-browser sentinel,
+    resolved in the SPA where the backend cannot see it) and a malformed or
+    unshipped stored value — see :func:`kiro_crew.context.ui_language_tag`. The
+    prompt then carries no language directive at all, byte-identical to what it
+    always sent, and the model keeps answering in English.
+
+    Read per generation (the load is mtime-cached) rather than captured at
+    import, so changing the language in Settings applies to the next summary
+    without restarting the gateway. Best-effort: any failure summarizes without
+    a directive rather than failing the request.
+
+    **Call this OFF the event loop** (``asyncio.to_thread``): ``KiroCrewConfig
+    .load()`` stats, reads and JSON-parses a file, which ``AUTOSDE.yaml``'s
+    ``no-blocking-call-on-event-loop`` prohibits on the gateway's single loop —
+    the same discipline ``chat_title._ui_language`` follows.
+    """
+    try:
+        return ui_language_tag(KiroCrewConfig.load())
+    except Exception:
+        logger.debug("issue-radar ai: UI language lookup failed; prompting without a directive")
+        return ""
+
+
+def _language_directive(ui_language: str, fields: str) -> str:
+    """The output-language instruction appended to a one-shot AI prompt.
+
+    ``""`` when no UI language is configured, which keeps every prompt
+    BYTE-IDENTICAL to what unconfigured installs have always sent (the model
+    then defaults to English exactly as before). ``fields`` names the JSON
+    fields whose PROSE localizes — everything structural (JSON keys, label
+    names, code spans, identifiers, file paths) is explicitly excluded, so the
+    downstream label-intersection and validation paths see unchanged tokens.
+
+    Appended AFTER the fenced untrusted block on purpose, mirroring
+    ``chat_title._TITLE_LANGUAGE_TEMPLATE``'s placement rationale: issue/PR
+    text that quotes or contradicts the directive stays data inside the fence
+    and cannot restate it.
+    """
+    if not ui_language:
+        return ""
+    return (
+        f"\nWrite {fields} in the language of BCP-47 tag {ui_language} — that is "
+        "the dashboard language the text renders in, even when the material "
+        "above is written in another language. Everything else is never "
+        "translated: JSON keys, label names, code spans, identifiers, file "
+        "paths, branch names, and product names stay verbatim."
+    )
+
+
+def _build_ai_prompt(
+    owner: str, repo: str, detail: dict, labels: list[dict], current_names: list[str],
+    *, ui_language: str = "",
+) -> str:
     """Assemble the single-call triage prompt.
 
     The issue body is UNTRUSTED (an attacker can open an issue containing
     prompt-injection text), so it is fenced in an explicit delimiter and the
     instructions tell the model to treat everything inside as data. The output
     is further constrained downstream: suggested labels are intersected with the
-    repo's real label set, so an injected "add label X" cannot invent a label."""
+    repo's real label set, so an injected "add label X" cannot invent a label.
+
+    ``ui_language`` is a validated BCP-47 tag (see :func:`_ui_language`); ``""``
+    omits the language directive entirely, leaving the prompt byte-identical to
+    what unconfigured installs have always sent. The ``summary`` and each
+    ``reason`` localize — both render as prose in the dashboard — while label
+    NAMES stay verbatim so the downstream intersection still matches."""
     title = detail.get("title") or "(no title)"
     body = (detail.get("body") or "").strip()
     if len(body) > _AI_BODY_MAX_CHARS:
@@ -1437,6 +1500,7 @@ def _build_ai_prompt(owner: str, repo: str, detail: dict, labels: list[dict], cu
         "</issue>\n\n"
         'Respond with ONLY the JSON object, e.g. {"summary": "...", '
         '"suggested_labels": [{"name": "bug", "reason": "..."}]}.'
+        + _language_directive(ui_language, 'the "summary" and each "reason"')
     )
 
 
@@ -1475,20 +1539,25 @@ async def _run_oneshot_model(request: web.Request, key: str, prompt: str) -> str
 
 
 async def _compute_issue_ai(
-    request: web.Request, owner: str, repo: str, number: int, detail: dict, labels: list[dict]
+    request: web.Request, owner: str, repo: str, number: int, detail: dict, labels: list[dict],
+    *, ui_language: str = "",
 ) -> dict:
     """Run the one-shot triage model call and return ``{"summary", "suggested_labels"}``.
 
     See :func:`_run_oneshot_model` for how the call is isolated. Output is
     validated: the summary is redacted; suggested labels are intersected with the
-    repo's real label set and de-duplicated against what is already on the issue."""
+    repo's real label set and de-duplicated against what is already on the issue.
+
+    ``ui_language`` is resolved by the caller (``_handle_issue_ai``) rather than
+    here because the same tag also keys the cached result — one read keeps the
+    prompt and the cache entry agreeing on the language."""
     import uuid
 
     from kiro_crew.llm_helpers import parse_llm_json
     from kiro_crew.security import redact
 
     current_names = [lab.get("name") for lab in (detail.get("labels") or []) if lab.get("name")]
-    prompt = _build_ai_prompt(owner, repo, detail, labels, current_names)
+    prompt = _build_ai_prompt(owner, repo, detail, labels, current_names, ui_language=ui_language)
 
     key = f"issue-radar-ai:{owner}/{repo}#{int(number)}:{uuid.uuid4().hex}"
     text = await _run_oneshot_model(request, key, prompt)
@@ -1573,9 +1642,21 @@ async def _handle_issue_ai(request: web.Request) -> web.Response:
         )
 
     force_refresh = request.query.get("refresh") == "1"
+    # Resolved once per request, off-loop (config-file I/O — see _ui_language),
+    # and used BOTH to validate the cache hit and to steer a fresh generation.
+    lang = await asyncio.to_thread(_ui_language)
     cached = None if force_refresh else await _st(
         key, store.read_issue_ai_cache, owner, repo, number
     )
+    # A cached summary is only servable if it was generated for the CURRENT
+    # dashboard language — otherwise a language switch would keep rendering the
+    # old-language card indefinitely (the pull-ai path gets this from its
+    # fingerprint; this cache has no fingerprint, so the tag is stored beside
+    # the payload and compared here). Legacy entries carry no tag and read as
+    # "" — identical to the unconfigured sentinel — so installs that never set
+    # a language keep every cached entry across the upgrade.
+    if cached is not None and str(cached.get("ui_language") or "") != lang:
+        cached = None
     if cached is not None:
         return web.json_response({
             "owner": owner, "repo": repo, "number": number,
@@ -1592,7 +1673,7 @@ async def _handle_issue_ai(request: web.Request) -> web.Response:
         return web.json_response({"error": str(exc)}, status=502)
 
     try:
-        ai = await _compute_issue_ai(request, owner, repo, number, detail, labels)
+        ai = await _compute_issue_ai(request, owner, repo, number, detail, labels, ui_language=lang)
     except Exception:
         logger.exception("issue-ai: computation failed for %s/%s#%s", owner, repo, number)
         return web.json_response(
@@ -1605,7 +1686,10 @@ async def _handle_issue_ai(request: web.Request) -> web.Response:
     # caching that would strand the user on an empty card until they manually
     # regenerate, so instead we skip the cache and let the next open retry.
     if ai.get("summary") or ai.get("suggested_labels"):
-        await _st(key, store.write_issue_ai_cache, owner, repo, number, ai)
+        await _st(
+            key, store.write_issue_ai_cache, owner, repo, number,
+            {**ai, "ui_language": lang},
+        )
     return web.json_response({
         "owner": owner, "repo": repo, "number": number,
         "summary": ai["summary"], "suggested_labels": ai["suggested_labels"],
@@ -1680,7 +1764,9 @@ def _pr_ai_comment_rows(timeline: list[dict]) -> list[dict]:
     return kept
 
 
-def _pr_ai_fingerprint(detail: dict, timeline: list[dict], checks: list[dict]) -> str:
+def _pr_ai_fingerprint(
+    detail: dict, timeline: list[dict], checks: list[dict], *, ui_language: str = ""
+) -> str:
     """A short digest of everything the summary was built from.
 
     Stored beside the cached summary so the cache self-invalidates when the PR
@@ -1692,7 +1778,13 @@ def _pr_ai_fingerprint(detail: dict, timeline: list[dict], checks: list[dict]) -
     comment changes neither its ``created_at`` nor the comment count, so a
     metadata-only digest would keep serving a summary written from text that no
     longer exists. Hashing the same bounded rows the prompt actually receives ties
-    the cache key to the real input."""
+    the cache key to the real input.
+
+    ``ui_language`` is an input too: the tag steers the summary's output
+    language, so switching the dashboard language must earn a fresh summary the
+    same way a new comment does. It is folded in only when non-empty so that
+    installs with no configured language keep byte-identical digests across the
+    upgrade (no one-time invalidation of every cached summary)."""
     comments = _pr_ai_comment_rows(timeline)
     convo = hashlib.sha256()
     for c in comments:
@@ -1714,6 +1806,8 @@ def _pr_ai_fingerprint(detail: dict, timeline: list[dict], checks: list[dict]) -
         convo.hexdigest(),
         ",".join(sorted(f"{c.get('name')}:{c.get('bucket')}" for c in checks if isinstance(c, dict))),
     ]
+    if ui_language:
+        parts.append(ui_language)
     return hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()[:32]
 
 
@@ -1727,7 +1821,8 @@ def _pr_lifecycle(detail: dict) -> str:
 
 
 def _build_pr_ai_prompt(
-    owner: str, repo: str, detail: dict, timeline: list[dict], checks: list[dict]
+    owner: str, repo: str, detail: dict, timeline: list[dict], checks: list[dict],
+    *, ui_language: str = "",
 ) -> str:
     """Assemble the single-call PR summary prompt.
 
@@ -1736,7 +1831,11 @@ def _build_pr_ai_prompt(
     prompt-injection text — so the whole payload is fenced in explicit markers and
     the instruction says to treat it as data. The output is prose only: there is
     no tool access and nothing downstream acts on it, so an injected instruction
-    has no mechanism to do anything beyond distorting one summary."""
+    has no mechanism to do anything beyond distorting one summary.
+
+    ``ui_language`` is a validated BCP-47 tag (see :func:`_ui_language`); ``""``
+    omits the language directive entirely, leaving the prompt byte-identical to
+    what unconfigured installs have always sent."""
     title = detail.get("title") or "(no title)"
     body = (detail.get("body") or "").strip() or "(no description)"
     if len(body) > _PR_AI_BODY_MAX_CHARS:
@@ -1822,20 +1921,26 @@ def _build_pr_ai_prompt(
         f"CONVERSATION (oldest first, newest last):\n{comments_block}\n"
         "</pull-request>\n\n"
         'Respond with ONLY the JSON object, e.g. {"summary": "..."}.'
+        + _language_directive(ui_language, 'the "summary"')
     )
 
 
 async def _compute_pr_ai(
     request: web.Request, owner: str, repo: str, number: int,
     detail: dict, timeline: list[dict], checks: list[dict],
+    *, ui_language: str = "",
 ) -> str:
-    """Run the one-shot PR summary call and return the redacted summary text."""
+    """Run the one-shot PR summary call and return the redacted summary text.
+
+    ``ui_language`` is resolved by the caller (``_handle_pull_ai``) rather than
+    here because the same tag must also feed :func:`_pr_ai_fingerprint` — one
+    read keeps the prompt and the cache key agreeing on the language."""
     import uuid
 
     from kiro_crew.llm_helpers import parse_llm_json
     from kiro_crew.security import redact
 
-    prompt = _build_pr_ai_prompt(owner, repo, detail, timeline, checks)
+    prompt = _build_pr_ai_prompt(owner, repo, detail, timeline, checks, ui_language=ui_language)
     key = f"issue-radar-pr-ai:{owner}/{repo}#{int(number)}:{uuid.uuid4().hex}"
     text = await _run_oneshot_model(request, key, prompt)
     data = parse_llm_json(text) or {}
@@ -1901,7 +2006,11 @@ async def _handle_pull_ai(request: web.Request) -> web.Response:
             key, store.write_pr_detail_cache, owner, repo, number, detail, timeline, checks
         )
 
-    fingerprint = _pr_ai_fingerprint(detail, timeline, checks)
+    # Resolved once per request, off-loop (config-file I/O — see _ui_language),
+    # and fed to BOTH the fingerprint and the prompt so the cached summary's
+    # language always matches the key it is stored under.
+    lang = await asyncio.to_thread(_ui_language)
+    fingerprint = _pr_ai_fingerprint(detail, timeline, checks, ui_language=lang)
     cached = None if force_refresh else await _st(
         key, store.read_pr_ai_cache, owner, repo, number, fingerprint=fingerprint
     )
@@ -1914,7 +2023,9 @@ async def _handle_pull_ai(request: web.Request) -> web.Response:
         })
 
     try:
-        summary = await _compute_pr_ai(request, owner, repo, number, detail, timeline, checks)
+        summary = await _compute_pr_ai(
+            request, owner, repo, number, detail, timeline, checks, ui_language=lang
+        )
     except Exception:
         logger.exception("pull-ai: computation failed for %s/%s#%s", owner, repo, number)
         return web.json_response(
@@ -2378,11 +2489,22 @@ def _short_rationale(raw: object) -> str:
     return redact(text)[:_RATIONALE_MAX_CHARS]
 
 
-def _build_reco_prompt(owner: str, repo: str, existing_labels: list[dict], issues: list[dict]) -> str:
+def _build_reco_prompt(
+    owner: str, repo: str, existing_labels: list[dict], issues: list[dict],
+    *, ui_language: str = "",
+) -> str:
     """Assemble the taxonomy-proposal prompt. Open-issue text is UNTRUSTED
     (prompt-injection surface), so it is fenced and marked as data; the output is
     further constrained downstream (names intersected AGAINST the existing set to
     guarantee 'new', category constrained to the known set, colors validated).
+
+    ``ui_language`` is a validated BCP-47 tag (see :func:`_ui_language`); ``""``
+    omits the language directive entirely, leaving the prompt byte-identical to
+    what unconfigured installs have always sent. ONLY the ``rationale``
+    localizes — it renders purely as dashboard prose. ``name`` and
+    ``description`` are deliberately excluded: /labels/create writes both onto
+    the GitHub repo itself when a proposal is applied, and repo content should
+    follow the repo's own label language, not one operator's dashboard setting.
 
     The prompt deliberately presets NO naming style. Real repos are split across
     several mutually incompatible conventions — flat (`bug`), slash namespaces
@@ -2451,6 +2573,12 @@ def _build_reco_prompt(owner: str, repo: str, existing_labels: list[dict], issue
         '{"recommendations": [{"name": "<name in this repo\'s style>", "category": '
         '"priority", "color": "d73a4a", "description": "Urgent, address first", '
         '"rationale": "...", "examples": [12]}]}'
+        + _language_directive(
+            ui_language,
+            'each "rationale" — and ONLY the rationale; "name" and "description" '
+            "become repo content on GitHub when applied, so keep them consistent "
+            "with the EXISTING LABELS language",
+        )
     )
 
 
@@ -2474,7 +2602,9 @@ async def _compute_label_recommendations(
         raise RuntimeError("session manager unavailable")
 
     kiro_agent = "kirocrew-lite"
-    prompt = _build_reco_prompt(owner, repo, existing_labels, issues)
+    # Off-loop: the language read is config-file I/O (see _ui_language).
+    lang = await asyncio.to_thread(_ui_language)
+    prompt = _build_reco_prompt(owner, repo, existing_labels, issues, ui_language=lang)
 
     import uuid
 

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
@@ -1057,7 +1057,13 @@ def write_issue_ai_cache(
 
     Stamped with ``generated_at`` so the UI can show how old the summary is —
     without it a cached card gives no hint whether it was written minutes or
-    months ago."""
+    months ago.
+
+    ``ui_language`` (the BCP-47 tag the prose was generated under, ``""`` for
+    English-default installs) rides along because a cached result is only
+    servable for the language it was written in — the route compares it on
+    read and treats a mismatch as a miss, so a dashboard-language switch
+    regenerates instead of serving the old language."""
     atomic_write(
         issue_ai_cache_path(owner, repo, number, root),
         json.dumps(
@@ -1065,6 +1071,7 @@ def write_issue_ai_cache(
                 "owner": owner, "repo": repo, "number": int(number),
                 "summary": payload.get("summary", ""),
                 "suggested_labels": payload.get("suggested_labels", []),
+                "ui_language": str(payload.get("ui_language") or ""),
                 "generated_at": _now_iso(),
             },
             indent=2,
@@ -1073,9 +1080,11 @@ def write_issue_ai_cache(
 
 
 def read_issue_ai_cache(owner: str, repo: str, number: int, root: Path | None = None) -> dict | None:
-    """Return ``{"summary", "suggested_labels", "generated_at"}`` for a cached
-    issue, or None. Caches written before the stamp existed fall back to the
-    file's mtime (see _cache_generated_at)."""
+    """Return ``{"summary", "suggested_labels", "ui_language", "generated_at"}``
+    for a cached issue, or None. Caches written before the stamp existed fall
+    back to the file's mtime (see _cache_generated_at); ones written before
+    ``ui_language`` existed read as ``""``, which matches the English-default
+    sentinel so legacy entries stay servable on unconfigured installs."""
     path = issue_ai_cache_path(owner, repo, number, root)
     if not path.is_file():
         return None
@@ -1086,6 +1095,7 @@ def read_issue_ai_cache(owner: str, repo: str, number: int, root: Path | None = 
     return {
         "summary": data.get("summary", ""),
         "suggested_labels": data.get("suggested_labels", []),
+        "ui_language": str(data.get("ui_language") or ""),
         "generated_at": _cache_generated_at(data, path),
     }
 

--- a/test/test_issue_radar_routes_ai_coverage.py
+++ b/test/test_issue_radar_routes_ai_coverage.py
@@ -34,7 +34,9 @@ touched, and nothing is written outside the per-test ``KIROCREW_HOME`` that
 """
 import contextlib
 import json
+import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
@@ -1152,6 +1154,214 @@ class TestBuildRecoPrompt(unittest.TestCase):
 
     def test_an_empty_sample_is_named(self):
         self.assertIn("(no open issues)", routes._build_reco_prompt("o", "r", LABELS, []))
+
+
+# ── AI output-language localization (#4290) ──────────────────────────────────
+
+
+class TestAiPromptLocalization(unittest.TestCase):
+    """The three one-shot prompts localize their PROSE to the dashboard language.
+
+    Two invariants: an EMPTY tag (the follow-the-browser sentinel) leaves each
+    prompt BYTE-IDENTICAL to what unconfigured installs have always sent, and a
+    non-empty tag appends the directive AFTER the fenced untrusted block, so
+    issue/PR text cannot restate it as data."""
+
+    DETAIL = {"number": 7, "title": "crash", "body": "boom", "labels": []}
+    PR_DETAIL = {"number": 12, "title": "t", "body": "b", "state": "open"}
+    RECO_ISSUES = [{"number": 7, "title": "t", "body": "b", "labels": ["bug"]}]
+
+    def test_an_empty_tag_leaves_the_issue_prompt_byte_identical(self):
+        legacy = routes._build_ai_prompt("o", "r", self.DETAIL, LABELS, [])
+        self.assertEqual(
+            routes._build_ai_prompt("o", "r", self.DETAIL, LABELS, [], ui_language=""),
+            legacy,
+        )
+
+    def test_a_tag_appends_the_language_line_to_the_issue_prompt(self):
+        legacy = routes._build_ai_prompt("o", "r", self.DETAIL, LABELS, [])
+        got = routes._build_ai_prompt("o", "r", self.DETAIL, LABELS, [], ui_language="ko")
+        # Append-only: the fenced block and every instruction above it is
+        # untouched, and the directive sits after the closing fence.
+        self.assertTrue(got.startswith(legacy))
+        tail = got[len(legacy):]
+        self.assertIn("BCP-47 tag ko", tail)
+        self.assertIn('"summary"', tail)
+        self.assertIn('"reason"', tail)
+        self.assertIn("label names", tail)
+
+    def test_an_empty_tag_leaves_the_pr_prompt_byte_identical(self):
+        legacy = routes._build_pr_ai_prompt("o", "r", self.PR_DETAIL, [], [])
+        self.assertEqual(
+            routes._build_pr_ai_prompt("o", "r", self.PR_DETAIL, [], [], ui_language=""),
+            legacy,
+        )
+
+    def test_a_tag_appends_the_language_line_to_the_pr_prompt(self):
+        legacy = routes._build_pr_ai_prompt("o", "r", self.PR_DETAIL, [], [])
+        got = routes._build_pr_ai_prompt("o", "r", self.PR_DETAIL, [], [], ui_language="ja")
+        self.assertTrue(got.startswith(legacy))
+        self.assertIn("BCP-47 tag ja", got[len(legacy):])
+
+    def test_an_empty_tag_leaves_the_reco_prompt_byte_identical(self):
+        legacy = routes._build_reco_prompt("o", "r", LABELS, self.RECO_ISSUES)
+        self.assertEqual(
+            routes._build_reco_prompt("o", "r", LABELS, self.RECO_ISSUES, ui_language=""),
+            legacy,
+        )
+
+    def test_a_tag_localizes_only_the_reco_rationale(self):
+        legacy = routes._build_reco_prompt("o", "r", LABELS, self.RECO_ISSUES)
+        got = routes._build_reco_prompt("o", "r", LABELS, self.RECO_ISSUES, ui_language="de")
+        self.assertTrue(got.startswith(legacy))
+        tail = got[len(legacy):]
+        self.assertIn("BCP-47 tag de", tail)
+        self.assertIn('"rationale"', tail)
+        # name/description become repo content via /labels/create when a
+        # proposal is applied, so the directive must explicitly exempt them.
+        self.assertIn('"name" and "description"', tail)
+
+
+class TestPrAiFingerprintLanguage(unittest.TestCase):
+    """The dashboard language is a summary INPUT, so it must key the cache."""
+
+    DETAIL = {"number": 12, "state": "open", "head_sha": "a" * 40}
+
+    def test_an_empty_tag_keeps_the_legacy_digest(self):
+        # No one-time invalidation of every cached summary on upgrade.
+        legacy = routes._pr_ai_fingerprint(self.DETAIL, [], [])
+        self.assertEqual(routes._pr_ai_fingerprint(self.DETAIL, [], [], ui_language=""), legacy)
+
+    def test_a_language_switch_changes_the_digest(self):
+        base = routes._pr_ai_fingerprint(self.DETAIL, [], [])
+        ko = routes._pr_ai_fingerprint(self.DETAIL, [], [], ui_language="ko")
+        ja = routes._pr_ai_fingerprint(self.DETAIL, [], [], ui_language="ja")
+        self.assertNotEqual(ko, base)
+        self.assertNotEqual(ko, ja)
+
+
+class TestIssueAiCacheLanguageRoundTrip(unittest.TestCase):
+    """The REAL store must persist and return the tag — a writer that drops it
+    would make every configured-language open a cache miss (one model call per
+    open), invisible to the route tests because they mock the store."""
+
+    def test_the_tag_survives_a_real_write_read_round_trip(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            store.write_issue_ai_cache(
+                "o", "r", 7,
+                {"summary": "s", "suggested_labels": [], "ui_language": "ko"},
+                root=root,
+            )
+            got = store.read_issue_ai_cache("o", "r", 7, root=root)
+        assert got is not None
+        self.assertEqual(got["ui_language"], "ko")
+        self.assertEqual(got["summary"], "s")
+
+    def test_a_legacy_entry_without_the_field_reads_as_the_empty_sentinel(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            path = store.issue_ai_cache_path("o", "r", 7, root)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps({"summary": "old", "suggested_labels": []}), encoding="utf-8"
+            )
+            got = store.read_issue_ai_cache("o", "r", 7, root=root)
+        assert got is not None
+        # "" matches the unconfigured sentinel, so legacy caches stay servable.
+        self.assertEqual(got["ui_language"], "")
+
+
+class TestAiLanguageWiring(unittest.IsolatedAsyncioTestCase):
+    """Each compute path threads the RESOLVED tag into the prompt it sends."""
+
+    DETAIL = {"number": 7, "title": "crash", "body": "boom", "labels": []}
+
+    async def test_compute_issue_ai_threads_the_language_it_was_given(self):
+        with _oneshot('{"summary": "s"}') as model:
+            await routes._compute_issue_ai(
+                _get("issue-ai"), "o", "r", 7, self.DETAIL, LABELS, ui_language="ko"
+            )
+        prompt = model.call_args[0][2]
+        self.assertIn("BCP-47 tag ko", prompt)
+
+    async def test_issue_ai_handler_invalidates_a_cache_entry_from_another_language(self):
+        # An English summary cached before the user switched the dashboard to ko
+        # must NOT be served — it regenerates under the new tag, and the fresh
+        # write records the tag so the next open is a plain hit.
+        cached = {"summary": "old english", "suggested_labels": [], "ui_language": ""}
+        compute = AsyncMock(return_value={"summary": "fresh", "suggested_labels": []})
+        with _connected(), \
+                mock.patch.object(routes, "_ui_language", return_value="ko"), \
+                mock.patch.object(store, "read_issue_ai_cache", return_value=cached), \
+                mock.patch.object(
+                    routes, "_load_detail_for_ai", new=AsyncMock(return_value={"number": 7})
+                ), \
+                mock.patch.object(routes, "_load_labels_for_ai", new=AsyncMock(return_value=LABELS)), \
+                mock.patch.object(routes, "_compute_issue_ai", new=compute), \
+                mock.patch.object(store, "write_issue_ai_cache") as write:
+            response = await routes._handle_issue_ai(
+                _get("issue-ai", {"owner": "o", "repo": "r", "number": "7"})
+            )
+        payload = _body(response)
+        self.assertFalse(payload["from_cache"])
+        self.assertEqual(payload["summary"], "fresh")
+        self.assertEqual(compute.call_args.kwargs["ui_language"], "ko")
+        # The stored payload carries the tag it was generated under.
+        self.assertEqual(write.call_args[0][3]["ui_language"], "ko")
+
+    async def test_issue_ai_handler_serves_a_cache_entry_matching_the_language(self):
+        cached = {"summary": "cached ko", "suggested_labels": [], "ui_language": "ko"}
+        with _connected(), \
+                mock.patch.object(routes, "_ui_language", return_value="ko"), \
+                mock.patch.object(store, "read_issue_ai_cache", return_value=cached), \
+                _oneshot() as model:
+            response = await routes._handle_issue_ai(
+                _get("issue-ai", {"owner": "o", "repo": "r", "number": "7"})
+            )
+        payload = _body(response)
+        self.assertTrue(payload["from_cache"])
+        self.assertEqual(payload["summary"], "cached ko")
+        model.assert_not_called()
+
+    async def test_compute_pr_ai_threads_the_language_it_was_given(self):
+        with _oneshot('{"summary": "s"}') as model:
+            await routes._compute_pr_ai(
+                _get("pull-ai"), "o", "r", 12,
+                {"number": 12, "state": "open"}, [], [], ui_language="ja",
+            )
+        self.assertIn("BCP-47 tag ja", model.call_args[0][2])
+
+    async def test_pull_ai_handler_feeds_one_resolved_tag_to_prompt_and_cache_key(self):
+        # The handler resolves the tag ONCE and hands it to both the fingerprint
+        # (cache key) and the model prompt — dropping either wire regresses:
+        # prompt-only keeps serving stale-language cache, key-only re-keys the
+        # cache but keeps generating English.
+        detail = {"number": 12, "title": "t", "body": "b", "state": "open", "head_sha": "a" * 40}
+        with _connected(), \
+                mock.patch.object(routes, "_ui_language", return_value="ko"), \
+                mock.patch.object(
+                    store, "read_pr_detail_cache",
+                    return_value={"detail": detail, "timeline": [], "checks": []},
+                ), \
+                mock.patch.object(store, "read_pr_ai_cache", return_value=None) as read_ai, \
+                mock.patch.object(store, "write_pr_ai_cache"), \
+                _oneshot('{"summary": "s"}') as model:
+            request = _get("pull-ai", {"owner": "o", "repo": "r", "number": "12"})
+            response = await routes._handle_pull_ai(request)
+        self.assertEqual(response.status, 200)
+        self.assertIn("BCP-47 tag ko", model.call_args[0][2])
+        expected = routes._pr_ai_fingerprint(detail, [], [], ui_language="ko")
+        self.assertEqual(read_ai.call_args.kwargs["fingerprint"], expected)
+
+    async def test_compute_label_recommendations_threads_the_dashboard_language(self):
+        state = _sessions()
+        request = _json_request("POST", "recommendations", {"owner": "o", "repo": "r"}, state=state)
+        with mock.patch.object(routes, "_ui_language", return_value="de"), \
+                _stream('{"recommendations": []}') as stream:
+            await routes._compute_label_recommendations(request, "o", "r", LABELS, [])
+        prompt = stream.call_args[0][1]
+        self.assertIn("BCP-47 tag de", prompt)
 
 
 class TestGetRecommendationsRoute(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A -- ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Issue Radar's three AI features -- the issue triage summary, the PR summary, and the label-taxonomy recommendation -- always produce their prose in English, regardless of the configured `dashboard.language`. The three one-shot prompt builders (`_build_ai_prompt`, `_build_pr_ai_prompt`, `_build_reco_prompt` in `src/kiro_crew/apps/builtins/issue_radar/backend/routes.py`) are hand-built and carry no output-language instruction, and they run through `_run_oneshot_model()` in an ephemeral `kirocrew-lite` session that never receives the `[UI LANGUAGE]` steering block normal chat sessions get from `context._build_ui_language_section()`.

## Why it matters

When the dashboard runs in a non-English locale (`ko`, `ja`, `zh-CN`, ...), the AI summary card is the only surface that stays English, clashing with the fully-localized UI around it (12 shipped locales). Distinct from #1004 (static-catalog UI i18n): this is model-generated content.

## What changed (motivation -> approach -> change)

Symptom -> root cause: the prompts carry no language directive, so the model defaults to English. Approach: reuse the already-validated `context.ui_language_tag(cfg)` resolver (the same one the chat auto-titler uses) rather than inventing a second language source, and follow `chat_title.py`'s precedent for placement and back-compat.

- Each of the three builders takes a keyword-only `ui_language: str = ""` and appends a shared directive (`_language_directive`) naming the BCP-47 tag. The directive is placed **after** the fenced untrusted block, so issue/PR text cannot restate it as data. An **empty tag** (the "follow the browser" sentinel, malformed values, or unshipped catalogs) appends nothing -- the prompts stay **byte-identical** to what unconfigured installs have always sent.
- Only prose localizes. Issue triage: the `summary` and each suggested-label `reason` (both render as dashboard prose; downstream only redacts + length-clamps them). PR summary: the `summary`. Recommendations: **only** the `rationale` -- `name` and `description` are deliberately excluded because `/labels/create` writes both onto the GitHub repo when a proposal is applied, and repo content should follow the repo's own label language, not one operator's dashboard setting. Label names stay verbatim so the downstream label-intersection validation is unaffected. (This resolves the issue's open question on `reason` strings: localized, since they surface purely as UI prose.)
- The tag is resolved once per request in the route handlers, off the event loop (`asyncio.to_thread`; `KiroCrewConfig.load()` is file I/O and `AUTOSDE.yaml`'s `no-blocking-call-on-event-loop` applies), read per generation so a Settings change applies without a gateway restart, and any failure degrades to no directive rather than failing the request.
- Caches regenerate on a language switch instead of serving the old language: `_pr_ai_fingerprint` folds the tag in as an input (only when non-empty, so existing digests survive the upgrade), and the issue-AI cache stores the tag beside the payload (`store.write_issue_ai_cache` / `read_issue_ai_cache` persist and return it) with the handler treating a mismatch as a miss. Legacy cache files with no tag read as `""`, which matches the unconfigured sentinel, so installs that never set a language keep every cached entry. The recommendations cache stays regenerate-only by design: it renders the last explicitly generated proposal until the user presses "Recommend labels" again -- auto-blanking a displayed list on a GET would be worse UX than showing the last result.
- `docs/system-specs/modules/issue-radar.md` updated in the same commit (route table `/pull-ai` row + the prompt-injection/output-language section).

## Tests

All in `test/test_issue_radar_routes_ai_coverage.py`, mutation-verified (each new wire was reverted and the matching test confirmed to fail):

- `TestAiPromptLocalization` -- for each of the three builders: an empty tag leaves the prompt **byte-identical** (the back-compat guard), and a non-empty tag appends the directive after the fence (append-only, names the tag, names the localized fields; the reco variant asserts `name`/`description` are explicitly exempted).
- `TestPrAiFingerprintLanguage` -- empty tag keeps the legacy digest (no one-time invalidation on upgrade); a language switch (and a switch between two languages) changes the digest.
- `TestAiLanguageWiring` -- `_compute_issue_ai` / `_compute_pr_ai` / `_compute_label_recommendations` each thread the resolved tag into the prompt they send; `_handle_pull_ai` feeds one resolved tag to **both** the fingerprint (cache key) and the model prompt; `_handle_issue_ai` invalidates a cached entry from another language and serves one that matches.
- `TestIssueAiCacheLanguageRoundTrip` -- drives the **real** store (tempfile root, no mocks): the tag survives a write/read round trip, and a legacy entry with no tag reads as the `""` sentinel so legacy caches stay servable.

## Manual verification

N/A -- unit coverage sufficient: the change is prompt text + cache keying, both locked by byte-identity and round-trip assertions; the model's compliance with the directive is best-effort steering identical in kind to the shipped `chat_title.py` mechanism.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (prompt builders, cache keying, store persistence); no frontend file touched and no rendered pixel changes.

## Related Issues

Closes #4290

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
