### PR TITLE
fix(mcp): reload the target table so a stub change needs no broker restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **Toggling one MCP server's stub no longer restarts the whole broker.** The
+  switch on Developer -> MCP Management froze the page for seconds to tens of
+  seconds, with every other switch disabled, because the apply tore the daemon
+  down and respawned it -- draining every pooled backend and every in-flight
+  call for a one-bit change, and buying nothing, since an open session's MCP
+  toolset is fixed when the session starts. The daemon had to be respawned only
+  because it read a stubbed server's real launch command out of its own
+  environment, which a live process cannot change. That mapping is now published
+  beside the gateway socket as an owner-only `targets.json` whenever it is built,
+  so an apply is a rewrite plus one atomic file write and the broker keeps
+  serving. Because a published table can never be older than the environment of
+  a daemon that could read it, the daemon needs no freshness arithmetic; it
+  reloads the table off the event loop immediately before spawning a backend, so
+  a backend is always spawned from the mapping on disk at that moment. Precedence
+  is per table, not per key, so unstubbing takes effect; a missing, untrusted or
+  unparseable table falls back to the spawn environment exactly as before, and a
+  publish that does not land fails closed rather than serving stale routing.
+  (#4317)
+
 - **xlsx files now render inline in the file viewer** instead of a
   download-only card. A new `GET /api/file-sheet` endpoint parses OOXML
   workbooks server-side with openpyxl (read-only, worker thread, ZIP

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -39,7 +39,7 @@ import sys
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Callable, Iterator, Optional
+from typing import Any, Awaitable, Callable, Iterator, Optional
 
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.config.loader import config_dir as _config_dir
@@ -75,6 +75,12 @@ from kiro_crew.mcp_gateway.rewriter import (
 from kiro_crew.mcp_gateway.shutdown_budget import DRAIN_SECS, POOL_SHUTDOWN_SECS
 from kiro_crew.mcp_gateway.spill import cleanup_old_spill_files
 from kiro_crew.mcp_gateway.stub import fallback_counts as stub_fallback_counts
+from kiro_crew.mcp_gateway.target_table import (
+    TargetTableCache,
+    TargetTableReader,
+    default_target_table_path,
+    lookup_target,
+)
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.peer_resolve import resolve_peer_identity
 from kiro_crew.platform_compat import IS_WINDOWS
@@ -202,10 +208,10 @@ _DEFAULT_SOCKET_NAME = "mcp-gateway.sock"
 
 #: A ``target_resolver`` takes a :class:`PoolKey` and returns the
 #: ``(command, args, env, work_dir)`` tuple used to spawn the backend, or
-#: ``None`` if the server is unknown. The default resolver looks up
-#: ``KIROCREW_MCP_TARGET_<SERVER>`` env vars (accepts legacy ``MC_MCP_TARGET_<SERVER>``
-#: for backward compatibility; matches the Rust PoC and existing
-#: rewriter wiring); tests inject their own resolver to avoid env-coupling.
+#: ``None`` if the server is unknown. The default reads the published target
+#: table and falls back to ``KIROCREW_MCP_TARGET_<SERVER>`` env vars (accepts
+#: legacy ``MC_MCP_TARGET_<SERVER>`` for backward compatibility); tests inject
+#: their own resolver to avoid coupling to either.
 TargetResolver = Callable[
     [PoolKey],
     Optional[tuple[str, list[str], dict[str, str], str]],
@@ -213,6 +219,15 @@ TargetResolver = Callable[
 
 
 # --- Public API -------------------------------------------------------------
+
+
+def default_target_cache(socket_path: Path) -> TargetTableCache:
+    """The daemon's own target-table cache for ``socket_path``.
+
+    Named and separate from the serve loop so what the daemon reads is reachable
+    from a test without booting one.
+    """
+    return TargetTableCache(TargetTableReader(default_target_table_path(socket_path)))
 
 
 def _default_cli_socket_path() -> Path:
@@ -272,9 +287,11 @@ async def run_gatewayd(
             ``_SHUTDOWN_DRAIN_SECS`` to finish, then everything cancels,
             the pool shuts down, and the socket is unlinked.
         target_resolver: Callable mapping :class:`PoolKey` to the spawn
-            4-tuple ``(command, args, env, work_dir)``. Pass ``None`` to
-            use the default :func:`env_target_resolver`. Tests supply a
-            custom resolver to avoid coupling to environment variables.
+            4-tuple ``(command, args, env, work_dir)``. Pass ``None`` to use
+            the default built by :func:`make_target_table_resolver`, which
+            reads the target table published beside the socket and falls back
+            to :func:`env_target_resolver`. Tests supply a custom resolver to
+            avoid coupling to either source.
         prewarm_count: Number of hottest observed PoolKeys to spawn at
             startup before the first stub connects, closing the
             cold-after-restart / cold-after-idle new-chat latency gap. The
@@ -325,7 +342,22 @@ async def run_gatewayd(
         return
     await transport.remove_stale(socket_path)
 
-    resolver = target_resolver if target_resolver is not None else env_target_resolver
+    # The default answers from the target table when one has been published
+    # since this daemon started, and from this process's environment otherwise,
+    # so the stub set can change under a serving daemon without a respawn. An
+    # explicit resolver (tests, embedders) still wins, and then no table is
+    # read at all.
+    target_cache: Optional[TargetTableCache] = None
+    refresh_targets: Optional[Callable[[], Awaitable[None]]] = None
+    if target_resolver is not None:
+        resolver = target_resolver
+    else:
+        target_cache = default_target_cache(socket_path)
+        resolver = make_target_table_resolver(target_cache)
+
+        async def refresh_targets() -> None:  # noqa: F811 — the wired form
+            """Reload the table off the loop, for the pre-rejection re-check."""
+            await asyncio.to_thread(target_cache.refresh)  # type: ignore[union-attr]
     # Shared circuit breaker keyed by server name: a server
     # that crash-loops on spawn trips OPEN and get_or_create rejects further
     # spawns so the stub falls back to per-session exec instead of churning.
@@ -379,7 +411,10 @@ async def run_gatewayd(
     async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         task = asyncio.current_task()
         try:
-            await _handle_connection(reader, writer, pool, resolver, socket_path, hot_keys)
+            await _handle_connection(
+                reader, writer, pool, resolver, socket_path, hot_keys,
+                refresh_targets=refresh_targets,
+            )
         except asyncio.CancelledError:
             # Normal on shutdown — propagate for the gather() below.
             raise
@@ -1221,31 +1256,63 @@ def env_target_resolver(pool_key: PoolKey) -> Optional[tuple[str, list[str], dic
     spawn tuple, or ``None`` if no mapping is set.
 
     Wire format: ``KIROCREW_MCP_TARGET_SLACK_MCP="slack-mcp --stdio"``.
-    The server name is upper-cased with ``-`` replaced by ``_``. Env is
-    inherited from the gateway process with ``KIROCREW_CHANNEL_ID``
-    overlaid when the pool key carries one — this keeps cron / send_message
-    fallbacks pointed at the correct channel on a per-pool-key basis.
+    The server name is upper-cased with ``-`` replaced by ``_``.
+
+    This is the FALLBACK source. The published target table
+    (:mod:`kiro_crew.mcp_gateway.target_table`) is consulted first when one
+    exists, because the environment is fixed at spawn and cannot describe a
+    stub set that changed since. The environment stays as the floor: it is
+    always present, so a missing or untrustworthy table degrades to exactly
+    the behaviour of a daemon that has only ever read its own env.
 
     Defense-in-depth: env is scrubbed through
     :func:`kiro_crew.mcp_gateway.manager._scrub_sensitive_env` so even if
     the gateway process somehow inherited credential vars, backends won't.
     """
-    base = "KIROCREW_MCP_TARGET_" + pool_key.server_name.upper().replace("-", "_")
-    # Accept the legacy MC_MCP_TARGET_ prefix for overlays/daemons written by
-    # older versions that haven't been regenerated (#928).
-    legacy_base = "MC_MCP_TARGET_" + pool_key.server_name.upper().replace("-", "_")
-    # Prefer the args-disambiguated entry (written by
-    # rewriter._collect_target_env) so two agents that share a server name but
-    # declare different --target-args each spawn their OWN backend command,
-    # instead of resolving to whichever agent sorted first alphabetically. Fall
-    # back to the bare server-name entry for older overlays predating the
-    # disambiguated keys.
-    spec = (
-        os.environ.get(base + "__" + pool_key.command_args_hash)
-        or os.environ.get(base)
-        or os.environ.get(legacy_base + "__" + pool_key.command_args_hash)
-        or os.environ.get(legacy_base)
+    spec = lookup_target(
+        os.environ, pool_key.server_name, pool_key.command_args_hash
     )
+    if not spec:
+        return None
+    return _spawn_tuple(spec, pool_key)
+
+
+def make_target_table_resolver(cache: TargetTableCache) -> TargetResolver:
+    """A resolver that prefers the loaded target table over the env.
+
+    Precedence is per table, not per key: a table that loaded answers on its
+    own, so a server the operator just unstubbed stops resolving even though
+    the daemon's environment still names it. Only when there is no trustworthy
+    table at all does this fall through to the environment.
+
+    Reads only memory. The filesystem side is the refresh task's job, because
+    this runs inside a backend spawn on the event loop.
+    """
+
+    def _resolve(
+        pool_key: PoolKey,
+    ) -> Optional[tuple[str, list[str], dict[str, str], str]]:
+        targets = cache.current()
+        if targets is None:
+            return env_target_resolver(pool_key)
+        spec = lookup_target(
+            targets, pool_key.server_name, pool_key.command_args_hash
+        )
+        if not spec:
+            return None
+        return _spawn_tuple(spec, pool_key)
+
+    return _resolve
+
+
+def _spawn_tuple(
+    spec: str, pool_key: PoolKey
+) -> Optional[tuple[str, list[str], dict[str, str], str]]:
+    """Turn a target spec into the ``(command, args, env, work_dir)`` tuple.
+
+    Shared by both sources so the environment a backend is spawned with cannot
+    depend on which one resolved it.
+    """
     if not spec:
         return None
     parts = shlex.split(spec)
@@ -1875,6 +1942,7 @@ async def _handle_connection(
     resolver: TargetResolver,
     socket_path: Path,
     hot_keys: Optional[HotKeyStore] = None,
+    refresh_targets: Optional[Callable[[], Awaitable[None]]] = None,
 ) -> None:
     """Process one stub connection end-to-end.
 
@@ -2357,6 +2425,7 @@ async def _handle_connection(
                         backend, _was_spawned = await _acquire_backend(
                             pool, pool_key, resolver,
                             exclusive_stub_uuid=exclusive_stub_uuid,
+                            refresh_targets=refresh_targets,
                         )
                         # acquire-only duration, captured before the attach_stub
                         # + create_task overhead so the metric stays true to name.
@@ -2457,6 +2526,7 @@ async def _handle_connection(
                     backend, _lazy_was_spawned = await _acquire_backend(
                         pool, pool_key, resolver,
                         exclusive_stub_uuid=exclusive_stub_uuid,
+                        refresh_targets=refresh_targets,
                     )
                     # acquire/spawn-only duration, captured before the attach +
                     # create_task overhead.
@@ -2655,6 +2725,7 @@ async def _acquire_backend(
     resolver: TargetResolver,
     *,
     exclusive_stub_uuid: str = "",
+    refresh_targets: Optional[Callable[[], Awaitable[None]]] = None,
 ) -> tuple[Backend, bool]:
     """Return ``(backend, was_spawned)`` for ``pool_key`` — spawning one via
     the resolver if absent.
@@ -2670,9 +2741,26 @@ async def _acquire_backend(
     when the connection ends. ``was_spawned`` is then always ``True``, because a
     private backend has nothing to reuse by construction.
 
+    ``refresh_targets`` reloads the published target mapping, and is awaited
+    BEFORE resolving -- not only when the first lookup misses. A spawn is the
+    only consumer of the mapping and is already an expensive operation (it forks
+    a process), so paying one off-loop stat here buys an exact answer: the
+    mapping a backend is spawned from is the one on disk at that moment.
+
+    Refreshing only on a miss would leave a stale SUCCESS unfixed -- a server
+    whose target command changed would keep resolving to the previous command
+    for as long as the cached copy survived, because a successful lookup never
+    triggered the reload. And an unknown target must be exact for a different
+    reason: the stub treats it as TERMINAL and deliberately does not fall back
+    to a per-session exec, so that a genuinely broken backend cannot crash-loop
+    per session. A server stubbed moments ago would otherwise be reported
+    unknown and lost for the whole life of the session that asked for it.
+
     Raises :class:`_TargetUnknown` when the resolver has no mapping for the
     server (a clean rejection, not a crash).
     """
+    if refresh_targets is not None:
+        await refresh_targets()
     target = resolver(pool_key)
     if target is None:
         raise _TargetUnknown(

--- a/src/kiro_crew/mcp_gateway/target_table.py
+++ b/src/kiro_crew/mcp_gateway/target_table.py
@@ -1,0 +1,249 @@
+"""The stubbed-server -> real-launch-command mapping, published as a file.
+
+The daemon resolves a stubbed server's real command from
+``KIROCREW_MCP_TARGET_<SERVER>``, and a live process's environment cannot be
+changed. That makes the mapping immutable for the daemon's lifetime, so
+changing WHICH servers are stubbed can only be applied by respawning it --
+draining every pooled backend and every in-flight call for what is a one-bit
+change to one server. This module carries the same mapping, in the same wire
+format, in a file the daemon re-reads, so the stub set becomes mutable
+in place.
+
+Precedence is per TABLE, never per key. A table that loads is the whole
+answer, so a server absent from it does not resolve; the environment is
+consulted only when no trustworthy table exists at all. Merging the two
+key-by-key would let the environment captured at spawn -- which still names
+every server stubbed back then -- keep resolving a server the operator has
+since unstubbed, so the removal would appear to do nothing.
+
+Trust matters more here than for a cache: this mapping decides which
+executables the daemon launches. The environment was safe to read precisely
+because only whoever spawns the daemon can set it, and a file that is re-read
+at runtime does not inherit that property. So a table is honoured only when
+this process owns it and no other account can write it; anything else is
+ignored in favour of the environment. Values are command lines only --
+backend environment is assembled separately and must never travel here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from pathlib import Path
+from typing import Mapping, Optional
+
+from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
+
+logger = logging.getLogger(__name__)
+
+#: Sibling of the gateway socket, like the hot-keys file.
+TARGET_TABLE_FILENAME = "targets.json"
+
+#: Payload version. Bumped only for a change a reader cannot absorb; an
+#: unrecognised version is treated as untrustworthy rather than guessed at.
+TARGET_TABLE_VERSION = 1
+
+#: The env-var prefix the mapping is keyed by, and the prefix older overlays
+#: and daemons wrote. Both are accepted at lookup so a table written by this
+#: version resolves for a pool key built by either.
+_KEY_PREFIX = "KIROCREW_MCP_TARGET_"
+_LEGACY_KEY_PREFIX = "MC_MCP_TARGET_"
+
+
+def default_target_table_path(socket_path: Path | str) -> Path:
+    """Target-table location derived from the gateway socket path."""
+    return Path(socket_path).parent / TARGET_TABLE_FILENAME
+
+
+def _env_key_base(server_name: str, prefix: str) -> str:
+    """The un-hashed lookup key for *server_name* under *prefix*.
+
+    Mirrors the rewriter's key construction; both sides must agree or a
+    published target silently fails to resolve.
+    """
+    return prefix + server_name.replace("-", "_").upper()
+
+
+def lookup_target(
+    mapping: Mapping[str, str], server_name: str, command_args_hash: str
+) -> Optional[str]:
+    """Return the target spec for a server, or ``None`` when unmapped.
+
+    The one implementation of the lookup ORDER, shared by both sources so they
+    cannot disagree about which entry wins:
+
+    1. the args-disambiguated key, so two agents that declare the same server
+       name with different target args each reach their own command instead of
+       whichever sorted first;
+    2. the bare server-name key, the first-wins fallback for a pool key whose
+       hash has no entry;
+    3. and 4. the same two under the legacy prefix, for an overlay or daemon
+       written before the rename.
+    """
+    for prefix in (_KEY_PREFIX, _LEGACY_KEY_PREFIX):
+        base = _env_key_base(server_name, prefix)
+        spec = mapping.get(base + "__" + command_args_hash) or mapping.get(base)
+        if spec:
+            return spec
+    return None
+
+
+def write_target_table(path: Path, targets: Mapping[str, str]) -> bool:
+    """Publish *targets* to *path*, owner-only and atomically.
+
+    Returns whether the write landed. A failure is logged and reported rather
+    than raised: the caller decides what an unpublished mapping means, and for
+    a running broker that is "the new routing is not live yet" rather than
+    anything that should take the broker down.
+    """
+    payload = {
+        "version": TARGET_TABLE_VERSION,
+        "targets": {str(k): str(v) for k, v in targets.items()},
+    }
+    try:
+        # mode on mkdir, not a chmod afterwards: the directory holds the
+        # socket and the hot-keys file, and a window where it is readable is
+        # a window in which this table can be read.
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        atomic_write(path, json.dumps(payload), mode=0o600, restrict_to_owner=True)
+    except OSError as exc:
+        logger.warning("mcp-gateway: could not publish target table %s: %s", path, exc)
+        return False
+    return True
+
+
+def _untrusted_reason(path: Path, st: os.stat_result) -> Optional[str]:
+    """Why *path* must not be honoured, or ``None`` when it is trustworthy.
+
+    POSIX-only by construction: on Windows ``st_uid`` is a constant and the
+    mode bits carry no ACL information, so neither check can say anything and
+    a refusal built on them would reject every table on that platform.
+    """
+    if not platform_compat.IS_POSIX:
+        return None
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None and st.st_uid != getuid():
+        return f"owned by uid {st.st_uid}"
+    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        return f"writable beyond its owner (mode {stat.S_IMODE(st.st_mode):04o})"
+    return None
+
+
+class TargetTableReader:
+    """Reads the published table, re-reading only when the file changes.
+
+    The table is published whenever the mapping is built -- at broker startup
+    and on every stub change -- so a table that exists is by construction at
+    least as current as the daemon's own spawn environment. That is what lets
+    this be a plain read with no freshness arithmetic: there is no "is my copy
+    newer than the environment" question to get wrong, and so no clock,
+    generation or process-start comparison to be skewed by an NTP step, a VM
+    restore, or a supervisor respawn.
+
+    Identity is (inode, size, mtime), used only to skip re-parsing an unchanged
+    file. A rename-into-place gives a new inode, which an mtime-only check can
+    miss when two writes land inside one filesystem timestamp tick.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._fingerprint: Optional[tuple[int, int, int]] = None
+        self._targets: Optional[dict[str, str]] = None
+        # Rate-limits the log line, not the read: a resolver that logged every
+        # spawn against a bad table would flood, and one that logged only once
+        # per process would hide a table that went bad later.
+        self._warned_for: Optional[tuple[int, int, int]] = None
+
+    def load(self) -> Optional[dict[str, str]]:
+        """Return the published mapping, or ``None`` to fall back to the env.
+
+        BLOCKING: stats and may read a file. Callers must run it off the event
+        loop, like the sibling filesystem reads on the spawn path.
+
+        ``None`` covers every "no trustworthy table" case -- absent, owned by
+        another account, group/world-writable, unparseable, wrong shape, unknown
+        version -- because they all warrant the same answer, and distinguishing
+        them at the call site would invite treating some as an empty table. An
+        empty table is a real state that means "nothing is stubbed" and is
+        reported as ``{}``, not ``None``.
+        """
+        try:
+            st = self._path.stat()
+        except OSError:
+            self._fingerprint = None
+            self._targets = None
+            return None
+
+        fingerprint = (st.st_ino, st.st_size, st.st_mtime_ns)
+
+        if fingerprint == self._fingerprint:
+            return self._targets
+
+        reason = _untrusted_reason(self._path, st)
+        if reason is None:
+            try:
+                payload = json.loads(self._path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                reason = f"unreadable ({exc})"
+            else:
+                targets = payload.get("targets") if isinstance(payload, dict) else None
+                if not isinstance(payload, dict) or payload.get(
+                    "version"
+                ) != TARGET_TABLE_VERSION:
+                    reason = "unrecognised payload version"
+                elif not isinstance(targets, dict) or not all(
+                    isinstance(k, str) and isinstance(v, str) for k, v in targets.items()
+                ):
+                    reason = "targets is not a mapping of strings"
+                else:
+                    self._fingerprint = fingerprint
+                    self._targets = dict(targets)
+                    self._warned_for = None
+                    return self._targets
+
+        if self._warned_for != fingerprint:
+            logger.warning(
+                "mcp-gateway: ignoring target table %s (%s); resolving targets "
+                "from the spawn environment instead",
+                self._path,
+                reason,
+            )
+            self._warned_for = fingerprint
+        self._fingerprint = fingerprint
+        self._targets = None
+        return None
+
+
+class TargetTableCache:
+    """The last loaded table, held in memory for the spawn path.
+
+    The split exists because the two sides have different constraints: loading
+    touches the filesystem and so must happen off the event loop, while the
+    resolver runs inside a backend spawn on the loop and must not block. So a
+    refresh task owns :meth:`refresh` and the resolver only ever reads
+    :meth:`current`.
+
+    Not locked. A refresh publishes a finished dict by rebinding one attribute,
+    which is atomic under the GIL, so a concurrent reader sees either the old
+    table or the new one and never a half-populated one.
+    """
+
+    __slots__ = ("_reader", "_targets")
+
+    def __init__(self, reader: TargetTableReader) -> None:
+        self._reader = reader
+        self._targets: Optional[dict[str, str]] = None
+
+    def current(self) -> Optional[dict[str, str]]:
+        """The last loaded mapping, or ``None`` for "use the environment".
+
+        Non-blocking, so the resolver can call it on the event loop.
+        """
+        return self._targets
+
+    def refresh(self) -> None:
+        """Re-read the table. BLOCKING: run this off the event loop."""
+        self._targets = self._reader.load()

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4510,6 +4510,23 @@ _WRITE_PROTECTED_HOME_PATHS: list[str] = [
     for prefix in _CREW_HOME_PREFIXES
 ]
 _WRITE_PROTECTED_HOME_PATHS += [
+    # The MCP target table (mcp_gateway/target_table.py). WRITE-protected rather
+    # than sensitive for the same reason as the browse launch config: it holds no
+    # secret and the broker must READ it before every backend spawn, so
+    # classifying it sensitive would break routing. But it is an INPUT TO A
+    # SECURITY DECISION -- it maps a stubbed server name to the command the
+    # broker execs, and the broker does not run under the agent's sandbox, so an
+    # agent that could rewrite this file would get an arbitrary command executed
+    # unconfined at the next spawn. The reader's owner/mode checks only refuse
+    # OTHER accounts; they cannot refuse a same-uid write, which is what this
+    # gate is for. Kiro Crew publishes the file directly via atomic_write and
+    # does NOT route through this gate, so its own writes still work.
+    # Paired with the same leaf in _WRITE_PROTECTED_BASH_LEAVES -- protected on
+    # one path only is not protected.
+    f"{prefix}/mcp-gateway/targets.json"
+    for prefix in _CREW_HOME_PREFIXES
+]
+_WRITE_PROTECTED_HOME_PATHS += [
     # The Ops Mission Control incident INDEX, for the same reason as the schedule above and
     # with the same read/write asymmetry: every teammate's instance reads it constantly (it is
     # the claim ledger and the board), so classifying it sensitive would break the app, but it
@@ -4646,6 +4663,13 @@ _WRITE_PROTECTED_BASH_LEAVES: tuple[str, ...] = (
     "apps/ops-mission-control/data/rotation.yaml",
     "apps/ops-mission-control/data/incidents/index.json",
     "connections-tool-aliases.json",
+    # The MCP target table, paired with the same leaf in
+    # _WRITE_PROTECTED_HOME_PATHS so the file-edit and shell paths agree -- a
+    # leaf on only one of the two is reachable through the other. Anchored, not
+    # bare-token, for the same reason the browse launch config below is: what the
+    # entry removes is the DURABLE form, silently rewriting the table the broker
+    # execs from until the next publish re-converges it.
+    "mcp-gateway/targets.json",
     # The browse launch config (browser_cli/launch.py), paired with the same leaf
     # in _WRITE_PROTECTED_HOME_PATHS so the file-edit and shell paths agree — a
     # leaf on only one of the two is reachable through the other.

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -162,6 +162,10 @@ from kiro_crew.mcp_gateway.rewriter import (
     resolve_overlay_dir,
     rewrite_agents,
 )
+from kiro_crew.mcp_gateway.target_table import (
+    default_target_table_path,
+    write_target_table,
+)
 from kiro_crew.memory import MemoryStore
 from kiro_crew.messaging import registry
 from kiro_crew.messaging.identity import publish_turn_identity
@@ -6220,6 +6224,79 @@ class GatewayOrchestrator:
     # ------------------------------------------------------------------
     # MCP Gateway
     # ------------------------------------------------------------------
+    def _mcp_socket_path(self) -> Path:
+        """Where the broker's socket lives, per config."""
+        cfg_gw = self._cfg.mcp_gateway
+        return Path(cfg_gw.socket_path) if cfg_gw.socket_path else default_socket_path()
+
+    async def _rewrite_mcp_overlay(self) -> dict[str, str] | None:
+        """Re-emit the agent overlay and publish the target table.
+
+        Separate from starting the broker because they answer different
+        questions: the overlay and the table describe the stub set as it is
+        now, while the daemon is a process that serves whatever they say. While
+        these were one call, the only way to get a fresh rewrite was to respawn
+        the daemon -- so changing one server's stub bit drained every pooled
+        backend to re-read a file the daemon can simply re-read in place.
+
+        The table is published on EVERY build of the mapping, including the one
+        that precedes a broker start. That is what makes a published table
+        authoritative with no freshness arithmetic: it cannot be older than the
+        environment of any daemon that could read it, so the daemon needs no
+        generation, clock or process-start comparison to decide whether its copy
+        is current -- and none of those can be skewed by a clock step, a VM
+        restore, or a supervisor respawn.
+
+        Returns the target mapping, or ``None`` when the rewrite failed or the
+        publish did not land. Both mean the daemon would serve routing this call
+        did not intend, so the caller must neither start a broker on it nor
+        report the change as applied.
+        """
+        cfg_gw = self._cfg.mcp_gateway
+        socket_path = self._mcp_socket_path()
+        loop = asyncio.get_running_loop()
+        try:
+            # rewrite_agents() walks ~/.kiro/agents, parses every JSON spec and
+            # rewrites the overlay — pure-sync file I/O.  Offload to the bounded
+            # maintenance pool so it can't block the event loop when triggered
+            # post-startup.
+            _rewrite_result, target_env = await loop.run_in_executor(
+                maintenance_executor(),
+                functools.partial(
+                    rewrite_agents,
+                    source_dir=kiro_agents_dir(),
+                    overlay_dir=resolve_overlay_dir(cfg_gw.overlay_dir),
+                    socket_path=socket_path,
+                    work_dir=_session_work_dir(None),
+                    sandbox_mode=self._cfg.agent.sandbox,
+                    approval_mode=self._cfg.agent.approval_mode,
+                    stub_servers=frozenset(cfg_gw.stub_servers),
+                    pooling_enabled=cfg_gw.enabled,
+                ),
+            )
+        except Exception:
+            logger.exception("mcp-gateway rewriter failed — falling back")
+            return None
+        # Offloaded for the same reason as the rewrite above. One bounded
+        # small-file write beside a full agent-spec walk.
+        published = await loop.run_in_executor(
+            maintenance_executor(),
+            functools.partial(
+                write_target_table,
+                default_target_table_path(socket_path),
+                target_env,
+            ),
+        )
+        if not published:
+            # write_target_table has already logged the IO error. Fail closed:
+            # a daemon reads the table as authoritative, so serving on an
+            # unpublished or half-written one would route from a stub set nobody
+            # asked for.
+            logger.warning(
+                "mcp-gateway: target table not published; routing is unchanged"
+            )
+            return None
+        return target_env
 
     async def _init_mcp_gateway(self) -> None:
         """Start the MCP gateway sidecar and populate the agent-JSON overlay.
@@ -6243,33 +6320,10 @@ class GatewayOrchestrator:
         if not is_gateway_supported():
             return
 
-        overlay_dir = resolve_overlay_dir(cfg_gw.overlay_dir)
-        socket_path = Path(cfg_gw.socket_path) if cfg_gw.socket_path else default_socket_path()
-        agents_source_dir = kiro_agents_dir()
-        workspace_default = _session_work_dir(None)
-
-        try:
-            # rewrite_agents() walks ~/.kiro/agents, parses every JSON spec and
-            # rewrites the overlay — pure-sync file I/O.  Offload to the bounded
-            # maintenance pool so it can't block the event loop when triggered
-            # post-startup.
-            _rewrite_result, target_env = await asyncio.get_running_loop().run_in_executor(
-                maintenance_executor(),
-                functools.partial(
-                    rewrite_agents,
-                    source_dir=agents_source_dir,
-                    overlay_dir=overlay_dir,
-                    socket_path=socket_path,
-                    work_dir=workspace_default,
-                    sandbox_mode=self._cfg.agent.sandbox,
-                    approval_mode=self._cfg.agent.approval_mode,
-                    stub_servers=frozenset(cfg_gw.stub_servers),
-                    pooling_enabled=cfg_gw.enabled,
-                ),
-            )
-        except Exception:
-            logger.exception("mcp-gateway rewriter failed — falling back")
+        target_env = await self._rewrite_mcp_overlay()
+        if target_env is None:
             return
+        socket_path = self._mcp_socket_path()
 
         manager = GatewayManager(
             GatewaySpec(
@@ -6354,8 +6408,13 @@ class GatewayOrchestrator:
         * nothing stubbed -> something stubbed: START. There is no manager yet, so
           a restart-only path would leave the operator's first stubbed server
           inert until they happened to touch another switch.
-        * stubbed -> stubbed: RESTART, so the rewriter re-runs with the new set and
-          the daemon re-spawns with updated ``MC_MCP_TARGET_*`` env.
+        * stubbed -> stubbed: REPUBLISH. The rewriter re-runs and the target
+          table is written; the daemon reloads that table before its next
+          backend spawn, so the new stub set goes live without touching the
+          process. This used to be a full respawn, which drained every pooled
+          backend and every in-flight call to change one server's bit -- and
+          bought nothing, since an open session's MCP toolset is fixed at
+          ``session/new`` and cannot pick up a new stub set either way.
         * something stubbed -> nothing stubbed: STOP, because an empty stub set
           means there is nothing for a broker to serve.
         """
@@ -6363,10 +6422,16 @@ class GatewayOrchestrator:
 
         self._cfg = KiroCrewConfig.load()
         want_broker = bool(self._cfg.mcp_gateway.stub_servers)
-        if self._mcp_gateway_manager is not None:
+        applied = True
+        if not want_broker:
             await self._stop_mcp_broker()
-        if want_broker:
+        elif self._mcp_gateway_manager is None:
             await self._init_mcp_gateway()
+        else:
+            # A rewrite or publish that failed leaves the previous routing in
+            # place, so it is not applied — reporting otherwise would draw a
+            # live-looking switch over a change the broker never saw.
+            applied = await self._rewrite_mcp_overlay() is not None
         if self.dashboard_state is not None:
             self.dashboard_state._mcp_gateway_manager = self._mcp_gateway_manager
         # The overlay and socket paths are resolved during config load and then
@@ -6377,7 +6442,8 @@ class GatewayOrchestrator:
         if self.sessions is not None:
             await self.sessions.refresh_defaults()
         return {
-            "applied": (self._mcp_gateway_manager is not None) == want_broker,
+            "applied": applied
+            and (self._mcp_gateway_manager is not None) == want_broker,
             "stub_servers": sorted(self._cfg.mcp_gateway.stub_servers),
         }
 

--- a/test/test_mcp_stub_apply.py
+++ b/test/test_mcp_stub_apply.py
@@ -84,33 +84,74 @@ async def test_unstubbing_the_last_server_stops_the_broker(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_changing_the_set_restarts_so_the_rewriter_reruns(monkeypatch) -> None:
-    """Restart, not no-op: the rewriter reads the stub set at broker start, so
-    re-running it is what actually re-emits the stubs."""
+async def test_changing_the_set_republishes_without_restarting(monkeypatch) -> None:
+    """The rewriter still re-runs, but the daemon is left alone.
+
+    The rewriter reads the stub set, so re-running it is what re-emits the
+    stubs and republishes the target table. Respawning the daemon to achieve
+    that drained every pooled backend and every in-flight call for one
+    server's bit -- and could not help the sessions that were already open,
+    whose toolset is fixed at ``session/new``.
+    """
     orch = _orch(["alpha-mcp", "beta-mcp"])
-    first, second = MagicMock(name="old"), MagicMock(name="new")
-    orch._mcp_gateway_manager = first
+    serving = MagicMock(name="serving")
+    orch._mcp_gateway_manager = serving
     calls: list[str] = []
 
-    async def _init() -> None:
+    async def _init() -> None:  # pragma: no cover - must not run
         calls.append("init")
-        orch._mcp_gateway_manager = second
 
-    async def _stop() -> None:
+    async def _stop() -> None:  # pragma: no cover - must not run
         calls.append("stop")
-        orch._mcp_gateway_manager = None
+
+    async def _rewrite() -> dict[str, str]:
+        calls.append("rewrite")
+        return {"KIROCREW_MCP_TARGET_ALPHA_MCP": "alpha-mcp"}
 
     monkeypatch.setattr(orch, "_init_mcp_gateway", _init)
     monkeypatch.setattr(orch, "_stop_mcp_broker", _stop)
+    monkeypatch.setattr(orch, "_rewrite_mcp_overlay", _rewrite)
     monkeypatch.setattr(
         "kiro_crew.config.loader.KiroCrewConfig.load", staticmethod(lambda: orch._cfg)
     )
 
     out = await orch._apply_mcp_stub()
 
-    assert calls == ["stop", "init"]
-    assert orch.dashboard_state._mcp_gateway_manager is second
+    # The rewrite still runs -- it is what republishes the table a serving
+    # daemon reads -- but the daemon itself is left alone.
+    assert calls == ["rewrite"], "a serving broker must not be torn down to re-route"
+    assert orch._mcp_gateway_manager is serving
+    assert orch.dashboard_state._mcp_gateway_manager is serving
+    assert out["applied"] is True
     assert out["stub_servers"] == ["alpha-mcp", "beta-mcp"]
+    orch.sessions.refresh_defaults.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_rewrite_is_not_reported_as_applied(monkeypatch) -> None:
+    """A rewrite that failed leaves the previous routing live.
+
+    Reporting it as applied would draw a settled switch over a change the
+    broker never saw, which is worse than the error the dashboard shows.
+    """
+    orch = _orch(["alpha-mcp"])
+    serving = MagicMock(name="serving")
+    orch._mcp_gateway_manager = serving
+
+    async def _rewrite() -> None:
+        return None
+
+    monkeypatch.setattr(orch, "_rewrite_mcp_overlay", _rewrite)
+    monkeypatch.setattr(orch, "_init_mcp_gateway", AsyncMock())
+    monkeypatch.setattr(orch, "_stop_mcp_broker", AsyncMock())
+    monkeypatch.setattr(
+        "kiro_crew.config.loader.KiroCrewConfig.load", staticmethod(lambda: orch._cfg)
+    )
+
+    out = await orch._apply_mcp_stub()
+
+    assert out["applied"] is False
+    assert orch._mcp_gateway_manager is serving
 
 
 @pytest.mark.asyncio
@@ -132,3 +173,92 @@ async def test_the_response_names_the_routed_set_not_the_deprecated_key(monkeypa
 
     assert "stub_servers" in out
     assert "poolable_servers" not in out
+
+
+# ── _rewrite_mcp_overlay itself ────────────────────────────────────────────
+# The tests above mock this method out to exercise the apply's branching, so
+# its OWN two decisions -- whether to publish, and what a failed publish means
+# -- need exercising here or they are untested.
+
+
+def _rewrite_orch(tmp_path) -> GatewayOrchestrator:
+    orch = GatewayOrchestrator.__new__(GatewayOrchestrator)
+    orch._cfg = SimpleNamespace(
+        mcp_gateway=SimpleNamespace(
+            stub_servers=["alpha-mcp"],
+            socket_path=str(tmp_path / "gateway.sock"),
+            overlay_dir=str(tmp_path / "overlay"),
+            enabled=True,
+        ),
+        agent=SimpleNamespace(sandbox="off", approval_mode="interactive"),
+    )
+    return orch
+
+
+@pytest.mark.asyncio
+async def test_the_mapping_is_published_on_every_build(monkeypatch, tmp_path) -> None:
+    """Publishing on EVERY build is what removes the freshness question.
+
+    A table that exists cannot be older than the environment of any daemon that
+    could read it, so the daemon needs no generation, clock or process-start
+    comparison to decide whether its copy is current -- and none of those can be
+    skewed by a clock step, a VM restore, or a supervisor respawn.
+    """
+    orch = _rewrite_orch(tmp_path)
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        "kiro_crew.slack.gateway.rewrite_agents",
+        lambda **_kw: (None, {"KIROCREW_MCP_TARGET_ALPHA_MCP": "alpha-mcp"}),
+    )
+
+    def _write(path, targets):
+        seen["path"] = path
+        seen["targets"] = targets
+        return True
+
+    monkeypatch.setattr("kiro_crew.slack.gateway.write_target_table", _write)
+
+    out = await orch._rewrite_mcp_overlay()
+
+    assert out == {"KIROCREW_MCP_TARGET_ALPHA_MCP": "alpha-mcp"}
+    assert seen["path"] == tmp_path / "targets.json"
+    assert seen["targets"] == {"KIROCREW_MCP_TARGET_ALPHA_MCP": "alpha-mcp"}
+
+
+@pytest.mark.asyncio
+async def test_a_publish_that_fails_returns_none(monkeypatch, tmp_path) -> None:
+    """Fail closed: a daemon reads the table as authoritative.
+
+    Serving on an unpublished or half-written table would route from a stub set
+    nobody asked for, so neither a broker start nor an applied report may
+    proceed on one.
+    """
+    orch = _rewrite_orch(tmp_path)
+    monkeypatch.setattr(
+        "kiro_crew.slack.gateway.rewrite_agents",
+        lambda **_kw: (None, {"KIROCREW_MCP_TARGET_ALPHA_MCP": "alpha-mcp"}),
+    )
+    monkeypatch.setattr(
+        "kiro_crew.slack.gateway.write_target_table", lambda path, targets: False
+    )
+
+    assert await orch._rewrite_mcp_overlay() is None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_rewrite_never_publishes(monkeypatch, tmp_path) -> None:
+    """A half-built mapping must not reach the daemon."""
+    orch = _rewrite_orch(tmp_path)
+    writes: list[object] = []
+
+    def _boom(**_kw):
+        raise RuntimeError("rewriter exploded")
+
+    monkeypatch.setattr("kiro_crew.slack.gateway.rewrite_agents", _boom)
+    monkeypatch.setattr(
+        "kiro_crew.slack.gateway.write_target_table",
+        lambda path, targets: writes.append(path) or True,
+    )
+
+    assert await orch._rewrite_mcp_overlay() is None
+    assert writes == []

--- a/test/test_mcp_target_table.py
+++ b/test/test_mcp_target_table.py
@@ -1,0 +1,438 @@
+"""The published target table, and what it is allowed to override.
+
+The daemon used to read its routing only from its own environment, which a live
+process cannot change -- so changing which servers are stubbed meant respawning
+it and draining every pooled backend. These tests pin the file that replaces
+that.
+
+Two properties carry the design, and both are here because getting either wrong
+is silent. Precedence is per TABLE, so unstubbing takes effect. And a backend is
+spawned from the mapping on disk AT THAT MOMENT: the acquisition reloads before
+resolving, so neither a just-published server nor a just-changed command can be
+served from a stale cached copy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.mcp_gateway.gatewayd import (
+    _acquire_backend,
+    _TargetUnknown,
+    default_target_cache,
+    env_target_resolver,
+    make_target_table_resolver,
+)
+from kiro_crew.mcp_gateway.pool import BackendPool, PoolKey
+from kiro_crew.mcp_gateway.target_table import (
+    TARGET_TABLE_VERSION,
+    TargetTableCache,
+    TargetTableReader,
+    default_target_table_path,
+    lookup_target,
+    write_target_table,
+)
+from kiro_crew.platform_compat import IS_POSIX
+
+_HASH = "abc123"
+
+
+def _pool_key(server_name: str = "test-srv") -> PoolKey:
+    return PoolKey(
+        server_name=server_name,
+        agent_name="kirocrew",
+        command_args_hash=_HASH,
+        effective_env_hash="e",
+        work_dir="/tmp/w",
+        binary_version="1",
+        os_uid=1000,
+        sandbox_mode="off",
+        autoapprove_set_hash="a",
+        approval_mode="interactive",
+        trust_all_tools=False,
+        config_snapshot_hash="c",
+    )
+
+
+def _cache(path: Path) -> TargetTableCache:
+    """A cache refreshed once, the way the acquisition would.
+
+    The resolver deliberately cannot load the file itself, so a test that never
+    refreshed would assert against an empty cache instead of the table.
+    """
+    cache = TargetTableCache(TargetTableReader(path))
+    cache.refresh()
+    return cache
+
+
+def _write_raw(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _clear_env() -> None:
+    """Remove every key the env resolver could read for the test server."""
+    for key in (
+        "KIROCREW_MCP_TARGET_TEST_SRV",
+        f"KIROCREW_MCP_TARGET_TEST_SRV__{_HASH}",
+        "MC_MCP_TARGET_TEST_SRV",
+        f"MC_MCP_TARGET_TEST_SRV__{_HASH}",
+    ):
+        os.environ.pop(key, None)
+
+
+# ── Precedence ────────────────────────────────────────────────────────────
+
+
+def test_table_resolves_a_server_the_env_does_not_name(tmp_path: Path) -> None:
+    """A server stubbed after the daemon started must still resolve."""
+    table = tmp_path / "targets.json"
+    assert write_target_table(table, {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/srv --stdio"})
+    resolve = make_target_table_resolver(_cache(table))
+
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_env()
+        result = resolve(_pool_key())
+
+    assert result is not None, "the published table is the daemon's live routing"
+    command, args, _env, _work_dir = result
+    assert command == "/usr/bin/srv"
+    assert args == ["--stdio"]
+
+
+def test_table_miss_does_not_fall_back_to_the_env(tmp_path: Path) -> None:
+    """Precedence is per table, which is what makes UNSTUBBING take effect.
+
+    A daemon's environment still names every server that was stubbed when it
+    spawned. Merging the two sources key-by-key would let that entry keep
+    resolving a server the operator just unstubbed, so the removal would appear
+    to do nothing until the next restart -- the exact coupling this file exists
+    to remove.
+    """
+    table = tmp_path / "targets.json"
+    assert write_target_table(table, {"KIROCREW_MCP_TARGET_OTHER_SRV": "/usr/bin/other"})
+    resolve = make_target_table_resolver(_cache(table))
+
+    with patch.dict(
+        os.environ, {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/stale"}, clear=False
+    ):
+        assert resolve(_pool_key()) is None
+
+
+def test_absent_table_falls_back_to_the_env(tmp_path: Path) -> None:
+    """The environment is the floor.
+
+    It is always present at spawn, so a daemon whose publish failed, or one from
+    a build that never wrote a table, keeps resolving exactly as before rather
+    than failing every spawn.
+    """
+    resolve = make_target_table_resolver(_cache(tmp_path / "missing.json"))
+
+    with patch.dict(
+        os.environ, {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/from-env"}, clear=False
+    ):
+        result = resolve(_pool_key())
+
+    assert result is not None
+    assert result[0] == "/usr/bin/from-env"
+
+
+def test_an_empty_table_resolves_nothing(tmp_path: Path) -> None:
+    """An empty table is a real state -- nothing is stubbed -- not a fallback."""
+    table = tmp_path / "targets.json"
+    assert write_target_table(table, {})
+    resolve = make_target_table_resolver(_cache(table))
+
+    with patch.dict(
+        os.environ, {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/stale"}, clear=False
+    ):
+        assert resolve(_pool_key()) is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param("not json at all", id="unparseable"),
+        pytest.param({"version": TARGET_TABLE_VERSION + 99, "targets": {}}, id="version"),
+        pytest.param({"version": TARGET_TABLE_VERSION, "targets": []}, id="shape"),
+        pytest.param(
+            {"version": TARGET_TABLE_VERSION, "targets": {"KIROCREW_MCP_TARGET_TEST_SRV": 7}},
+            id="non-string-value",
+        ),
+    ],
+)
+def test_an_unusable_table_is_ignored_in_favour_of_the_env(
+    tmp_path: Path, payload: object
+) -> None:
+    """Every "cannot trust this file" case degrades to the environment."""
+    table = tmp_path / "targets.json"
+    if isinstance(payload, str):
+        table.write_text(payload, encoding="utf-8")
+    else:
+        _write_raw(table, payload)
+    resolve = make_target_table_resolver(_cache(table))
+
+    with patch.dict(
+        os.environ, {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/from-env"}, clear=False
+    ):
+        result = resolve(_pool_key())
+
+    assert result is not None, "an unusable table must not break every spawn"
+    assert result[0] == "/usr/bin/from-env"
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="mode bits carry no ACL information here")
+def test_a_group_writable_table_is_refused(tmp_path: Path) -> None:
+    """The table decides which executables the daemon launches.
+
+    A file another account can write must not be honoured, so the check refuses
+    it and the environment -- which only whoever spawns the daemon can set --
+    remains the answer.
+    """
+    table = tmp_path / "targets.json"
+    _write_raw(
+        table,
+        {
+            "version": TARGET_TABLE_VERSION,
+            "targets": {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/attacker"},
+        },
+    )
+    table.chmod(0o660)
+    resolve = make_target_table_resolver(_cache(table))
+
+    with patch.dict(
+        os.environ, {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/from-env"}, clear=False
+    ):
+        result = resolve(_pool_key())
+
+    assert result is not None
+    assert result[0] == "/usr/bin/from-env", "a group-writable table must not be trusted"
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="mode bits carry no ACL information here")
+def test_the_published_table_is_owner_only(tmp_path: Path) -> None:
+    table = tmp_path / "nested" / "targets.json"
+    assert write_target_table(table, {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/srv"})
+    assert stat.S_IMODE(table.stat().st_mode) == 0o600
+
+
+# ── Freshness: the acquisition reads the table AT SPAWN TIME ──────────────
+
+
+def test_the_resolver_itself_does_no_filesystem_io(tmp_path: Path) -> None:
+    """The resolver runs on the event loop, so the read is not its job.
+
+    Reloading belongs to the acquisition, which is async and offloads it -- the
+    same split the sibling declared-env read on this path already uses.
+    """
+    table = tmp_path / "targets.json"
+    assert write_target_table(table, {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/srv"})
+    resolve = make_target_table_resolver(_cache(table))
+
+    def _boom(*_a: object, **_k: object) -> object:
+        raise AssertionError("the resolver must not touch the filesystem")
+
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_env()
+        with patch.object(Path, "stat", _boom), patch.object(Path, "read_text", _boom):
+            result = resolve(_pool_key())
+
+    assert result is not None
+    assert result[0] == "/usr/bin/srv"
+
+
+def test_a_refresh_picks_up_a_rewritten_table(tmp_path: Path) -> None:
+    """Routing changes under a daemon that keeps serving."""
+    table = tmp_path / "targets.json"
+    assert write_target_table(table, {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/first"})
+    cache = _cache(table)
+    resolve = make_target_table_resolver(cache)
+
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_env()
+        first = resolve(_pool_key())
+        assert write_target_table(
+            table, {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/second"}
+        )
+        cache.refresh()
+        second = resolve(_pool_key())
+
+    assert first is not None and first[0] == "/usr/bin/first"
+    assert second is not None and second[0] == "/usr/bin/second"
+
+
+async def _acquire(cache: TargetTableCache, *, wired: bool):
+    async def _refresh() -> None:
+        await asyncio.to_thread(cache.refresh)
+
+    return await _acquire_backend(
+        BackendPool(max_backends=1),
+        _pool_key(),
+        make_target_table_resolver(cache),
+        refresh_targets=_refresh if wired else None,
+    )
+
+
+def test_a_spawn_reloads_before_resolving_an_unknown_target(tmp_path: Path) -> None:
+    """A server stubbed since the last reload must not be reported unknown.
+
+    The stub treats an unknown target as TERMINAL and deliberately does NOT fall
+    back to a per-session exec, so that a genuinely broken backend cannot
+    crash-loop per session. An unknown target must therefore be exact: a session
+    that asked for a just-stubbed server would otherwise lose it for its whole
+    life.
+    """
+    table = tmp_path / "targets.json"
+    cache = _cache(table)  # nothing published when the cache was loaded
+
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_env()
+        assert write_target_table(
+            table, {"KIROCREW_MCP_TARGET_TEST_SRV": "/nonexistent/srv"}
+        )
+
+        with pytest.raises(_TargetUnknown):
+            asyncio.run(_acquire(_cache(tmp_path / "missing.json"), wired=False))
+
+        # With the reload wired, the mapping is found. The spawn then fails on
+        # the bogus command, which is a DIFFERENT error -- reaching it proves the
+        # target resolved rather than being rejected as unknown.
+        with pytest.raises(Exception) as seen:
+            asyncio.run(_acquire(cache, wired=True))
+        assert not isinstance(seen.value, _TargetUnknown)
+
+
+def test_a_spawn_reloads_even_when_the_cached_lookup_would_succeed(
+    tmp_path: Path,
+) -> None:
+    """A STALE SUCCESS is the case a miss-only reload leaves broken.
+
+    When a server's target command changes, the cached copy still resolves --
+    successfully, to the previous command. Reloading only on a miss would spawn
+    that old executable for as long as the cached copy survived, so the reload
+    happens before resolving rather than after a failure.
+    """
+    table = tmp_path / "targets.json"
+    assert write_target_table(table, {"KIROCREW_MCP_TARGET_TEST_SRV": "/bin/old-cmd"})
+    cache = _cache(table)
+    # The operator changes the target; the cache still holds the old one.
+    assert write_target_table(table, {"KIROCREW_MCP_TARGET_TEST_SRV": "/bin/new-cmd"})
+    assert cache.current() == {"KIROCREW_MCP_TARGET_TEST_SRV": "/bin/old-cmd"}
+
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_env()
+        with pytest.raises(Exception):
+            asyncio.run(_acquire(cache, wired=True))
+
+    # The reload ran as part of the acquisition, not as a retry after a miss.
+    assert cache.current() == {"KIROCREW_MCP_TARGET_TEST_SRV": "/bin/new-cmd"}
+
+
+def test_the_daemon_reads_the_table_beside_its_socket(tmp_path: Path) -> None:
+    """The WIRING: the writer is the gateway, the reader is the daemon.
+
+    Both derive the path from the same socket, so a mismatch would silently
+    disable the file rather than fail.
+    """
+    socket_path = tmp_path / "gateway.sock"
+    assert write_target_table(
+        default_target_table_path(socket_path),
+        {"KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/published"},
+    )
+    cache = default_target_cache(socket_path)
+    cache.refresh()
+
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_env()
+        result = make_target_table_resolver(cache)(_pool_key())
+
+    assert result is not None
+    assert result[0] == "/usr/bin/published"
+
+
+# ── Lookup order, shared by both sources ──────────────────────────────────
+
+
+def test_the_table_is_write_gated_against_the_agent_on_both_paths() -> None:
+    """The reader's owner/mode check cannot refuse a SAME-UID write.
+
+    It refuses other accounts, which is what makes a foreign-owned table
+    untrusted -- but the table maps a server name to a command the broker execs,
+    and the broker does not run under the agent's sandbox. So the agent's own
+    file and shell tools are refused the write by the same registry that already
+    covers the browse launch config and the on-call schedule: inputs to a
+    security or authorization decision that must stay readable. Kiro Crew
+    publishes the file directly, not through the gate, so its own write works.
+
+    Both registries are asserted because a leaf protected on one path only is
+    reachable through the other, and the gated path is derived from
+    ``default_target_table_path`` rather than written out again -- otherwise
+    renaming the runtime directory would silently move the file out from under
+    the gate while every other test still passed.
+    """
+    from kiro_crew import security
+    from kiro_crew.mcp_gateway.rewriter import default_socket_path
+
+    table = default_target_table_path(default_socket_path())
+    leaf = f"{table.parent.name}/{table.name}"
+
+    assert leaf in security._WRITE_PROTECTED_BASH_LEAVES
+    for prefix in security.crew_home_prefixes():
+        assert f"{prefix}/{leaf}" in security._WRITE_PROTECTED_HOME_PATHS
+
+
+def test_lookup_prefers_the_args_hashed_key() -> None:
+    """Two agents sharing a server name with different target args."""
+    mapping = {
+        "KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/bare",
+        f"KIROCREW_MCP_TARGET_TEST_SRV__{_HASH}": "/usr/bin/hashed",
+    }
+    assert lookup_target(mapping, "test-srv", _HASH) == "/usr/bin/hashed"
+
+
+def test_lookup_accepts_the_legacy_prefix() -> None:
+    """An overlay written before the rename still resolves."""
+    mapping = {"MC_MCP_TARGET_TEST_SRV": "/usr/bin/legacy"}
+    assert lookup_target(mapping, "test-srv", _HASH) == "/usr/bin/legacy"
+
+
+def test_lookup_prefers_the_current_prefix_over_the_legacy_one() -> None:
+    mapping = {
+        "KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/current",
+        "MC_MCP_TARGET_TEST_SRV": "/usr/bin/legacy",
+    }
+    assert lookup_target(mapping, "test-srv", _HASH) == "/usr/bin/current"
+
+
+def test_both_sources_share_one_lookup_order(tmp_path: Path) -> None:
+    """The env resolver and the table resolver must agree about which key wins.
+
+    They are two callers of the same lookup; a second copy of the order in
+    either one would be free to drift, and the symptom would be a server that
+    resolves to another agent's command.
+    """
+    resolve = make_target_table_resolver(_cache(tmp_path / "missing.json"))
+    env = {
+        "KIROCREW_MCP_TARGET_TEST_SRV": "/usr/bin/bare",
+        f"KIROCREW_MCP_TARGET_TEST_SRV__{_HASH}": "/usr/bin/hashed",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        via_table_resolver = resolve(_pool_key())
+        via_env_resolver = env_target_resolver(_pool_key())
+
+    assert via_table_resolver == via_env_resolver
+    assert via_env_resolver is not None
+    assert via_env_resolver[0] == "/usr/bin/hashed"
+
+
+def test_default_path_sits_beside_the_socket() -> None:
+    assert default_target_table_path(Path("/run/kc/gateway.sock")) == Path(
+        "/run/kc/targets.json"
+    )

--- a/test/test_slack_gateway_coverage.py
+++ b/test/test_slack_gateway_coverage.py
@@ -990,29 +990,31 @@ class TestStopAndApplyMcpBroker:
         assert out == {"applied": False, "stub_servers": ["alpha", "beta"]}
 
     @pytest.mark.asyncio
-    async def test_apply_stub_restarts_the_broker_and_republishes_it(self):
+    async def test_apply_stub_republishes_without_touching_the_broker(self):
         orch = _make_orchestrator()
-        old = MagicMock()
-        old.shutdown = AsyncMock()
-        orch._mcp_gateway_manager = old
+        serving = MagicMock()
+        serving.shutdown = AsyncMock()
+        orch._mcp_gateway_manager = serving
         ds = _mock_dashboard_state()
         orch.dashboard_state = ds
 
-        new = MagicMock()
+        async def _fake_init() -> None:  # pragma: no cover - must not run
+            raise AssertionError("a serving broker must not be restarted")
 
-        async def _fake_init() -> None:
-            orch._mcp_gateway_manager = new
+        async def _fake_rewrite() -> dict[str, str]:
+            return {"KIROCREW_MCP_TARGET_ALPHA": "alpha"}
 
         orch._init_mcp_gateway = _fake_init
+        orch._rewrite_mcp_overlay = _fake_rewrite
 
         cfg = KiroCrewConfig()
         cfg.mcp_gateway.stub_servers = ["alpha"]
         with patch.object(KiroCrewConfig, "load", return_value=cfg):
             out = await orch._apply_mcp_stub()
 
-        old.shutdown.assert_awaited_once()
+        serving.shutdown.assert_not_awaited()
         assert out == {"applied": True, "stub_servers": ["alpha"]}
-        assert ds._mcp_gateway_manager is new
+        assert ds._mcp_gateway_manager is serving
 
     def test_wire_dashboard_is_a_noop_without_dashboard_state(self):
         orch = _make_orchestrator()


### PR DESCRIPTION
## Problem / Motivation

On **Developer -> MCP Management -> Servers**, flipping one server's stub switch freezes the page for seconds to tens of seconds, and every other switch on the page -- including the global sharing switch -- is disabled for the whole time, with no progress indication. It reads as a hung UI.

`POST /api/mcp-gateway/servers/stub` persists the allowlist and then awaits `_apply_mcp_stub()`, which stopped the broker, re-ran the rewriter over every agent spec, respawned the daemon, and rebuilt the warm pool -- all inside the request. The stop alone has a 20s upper bound derived from the daemon's own drain budget (`DRAIN_SECS 10 + POOL_SHUTDOWN_SECS 5 + SIGNAL_MARGIN_SECS 5`), and its real cost scales with the live fleet, because every pooled backend and in-flight connection has to be torn down.

## Why it matters

Changing one server's stub bit is a one-bit configuration edit, and it costs a full broker cycle: every pooled backend drained, every in-flight tool call cancelled, the warm pool rebuilt. The respawn also bought nothing for the sessions the operator has open -- a session's MCP toolset is fixed at `session/new`, so an already-running session cannot pick up a new stub set no matter what the broker does, and a new session connects to the daemon fresh either way. The whole cycle was paid and discarded.

## What changed (motivation -> approach -> change)

**Root cause.** The daemon resolved a stubbed server's real launch command from **its own process environment** (`env_target_resolver` reading `KIROCREW_MCP_TARGET_<SERVER>`). A live process's environment cannot be changed, so the routing table was immutable for the daemon's lifetime and the only way to change it was to respawn.

**Approach.** The resolution seam was already pluggable -- `gatewayd` calls `resolver(pool_key)` and its own error text advertises `or pass a target_resolver`, so reading the environment was a default implementation, not a constraint. The rewriter already computes the whole mapping. So the mapping is published beside the gateway socket as an owner-only `targets.json`, and the daemon reads it instead. An apply becomes a rewrite plus one atomic file write, with the broker left serving.

**The shipped design, and the two properties that make it simple:**

- **The mapping is published on EVERY build**, including the one that precedes a broker start. That is what removes freshness reasoning entirely: a published table can never be older than the environment of any daemon that could read it, so the daemon needs no generation, clock or process-start comparison to decide whether its copy is current -- and so nothing for a clock step, a VM restore or a supervisor respawn to skew. The file's (inode, size, mtime) fingerprint is used only to skip re-parsing an unchanged file, not as a freshness gate.
- **The daemon reloads the table immediately before resolving a backend spawn**, off the event loop, in `_acquire_backend`. Before resolving rather than only after a miss, because a stale SUCCESS is the harder case: a server whose target command changed would otherwise keep resolving to the previous command for as long as the cached copy survived. Exactness matters for a miss too, because the stub treats an unknown target as terminal and deliberately does not fall back to a per-session exec (so a broken backend cannot crash-loop per session) -- a server stubbed moments earlier would otherwise be reported unknown and lost for the whole life of the session that asked for it. A spawn already forks a process, so one stat there is not a cost worth trading against correctness.

**Precedence is per table, never per key.** A table that loads is the whole answer, so a server the operator just unstubbed stops resolving even though the daemon's environment still names it. Merging the two sources key-by-key would have let that entry keep resolving it, making unstubbing a no-op until the next restart.

**Failure handling.** The environment remains the floor: a missing, foreign-owned, group-writable, unparseable or wrong-version table falls back to it, so the worst case is the previous behaviour rather than a failed spawn. A publish that does not land returns `None`, so neither a broker start nor an `applied: true` report proceeds on routing the broker never saw.

**Trust.** `targets.json` maps a server name to a command the broker execs, and the broker does not run under the agent's sandbox. The reader refuses a table owned by another account or writable beyond its owner, but those checks cannot refuse a same-uid write -- so the path is also registered in `security._WRITE_PROTECTED_HOME_PATHS` and `security._WRITE_PROTECTED_BASH_LEAVES`, the same registry that already covers the browse launch config and the on-call schedule as inputs to a security or authorization decision. Kiro Crew publishes the file directly and does not route through that gate, so its own writes still work. The table carries command lines only; backend environment keeps its own separate assembly path.

## Tests

`test/test_mcp_target_table.py` (new, 21 tests) and `test/test_mcp_stub_apply.py` (extended). Mutation-verified -- 9 mutants applied across the design, all killed:

- the published table resolves a server the environment does not name;
- a table **miss** does not fall back to the environment (the property that makes unstubbing take effect);
- an absent table does fall back, and an empty table (`{}`) is a real "nothing stubbed" state rather than a fallback;
- an unusable table (unparseable / wrong version / wrong shape / non-string value) degrades to the environment;
- a group-writable table is refused; the published file is `0o600`; the path is write-gated on **both** the file-edit and shell paths, with the gated path derived from `default_target_table_path` so renaming the runtime directory cannot silently move the file out from under the gate;
- the resolver itself performs no filesystem IO (asserted by making `Path.stat`/`Path.read_text` raise);
- a spawn reloads before resolving an unknown target, **and** reloads even when the cached lookup would have succeeded (the stale-success case);
- the daemon reads the table beside its own socket;
- both sources share one lookup order (args-hashed key beats bare, current prefix beats legacy);
- the mapping is published on every build; a failed publish returns `None`; a failed rewrite never publishes;
- a serving broker is not torn down to re-route, and a failed rewrite is not reported as applied.

Two existing tests pinned the old restart contract (`test_mcp_stub_apply.py`, `test_slack_gateway_coverage.py`) and were retargeted to the republish contract, keeping the reason each existed -- the rewriter must still re-run.

## Manual verification

N/A -- unit coverage sufficient. The change is backend-only with no rendered delta, and each load-bearing property (per-table precedence, reload-before-resolve including the stale-success case, fail-closed publish, the write gate on both paths) is pinned by a mutation-verified test rather than a click-through.

Full local floor green: `isort`, `flake8`, `mypy` (987 files), and `pytest` at 56456 passed. Nine failures on this host are pre-existing and reproduce identically on a clean checkout of the base (they depend on the host's `/tmp` layout, a real `gh` on `PATH`, and a live flock holder), so they are environmental rather than introduced here.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no frontend path is touched and nothing rendered changes. The UI's page-wide disable during the apply is deliberately left alone here and tracked separately.

## Related Issues

Closes #4317

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (CHANGELOG entry added)
- [x] No secrets, credentials, or internal references in the diff
