### PR TITLE
fix(skills): key the repo_scope gate on the session project, not the process cwd

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -396,7 +396,6 @@ src/kiro_crew/mcp_gateway/gatewayd.py
 src/kiro_crew/mcp_gateway/hazards.py
 src/kiro_crew/mcp_gateway/image_budget.py
 src/kiro_crew/mcp_gateway/manager.py
-src/kiro_crew/mcp_gateway/preflight.py
 src/kiro_crew/mcp_gateway/prewarm.py
 src/kiro_crew/mcp_gateway/rewriter.py
 src/kiro_crew/mcp_gateway/seed.py

--- a/skills/README.md
+++ b/skills/README.md
@@ -40,7 +40,7 @@ Instructions for the LLM agent...
 | `description` | yes | One-line summary — the LLM sees this to decide relevance |
 | `always` | no | `true` to inject into every session (default: `false`) |
 | `triggers` | no | Comma-separated keywords that auto-inject the skill. Prefix with `!` for negative triggers (e.g. `!test` excludes when "test" appears) |
-| `repo_scope` | no | Relative path (e.g. `src/kiro_crew`) that must exist in the CWD or an ancestor for the skill to be eligible. Mechanically suppresses repo-specific skills outside their repo — use for skills whose instructions would be wrong or destructive elsewhere. Fails closed. |
+| `repo_scope` | no | Relative path (e.g. `src/kiro_crew`) that must exist in the session's active project directory, or an ancestor of it, for the skill to be eligible. Mechanically suppresses repo-specific skills outside their repo — use for skills whose instructions would be wrong or destructive elsewhere. Fails closed: a session that names no project, and one whose project cannot be resolved, get neither the skill's body nor its index entry. The process working directory is never consulted. |
 
 ### Loading Behavior
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: pod-e2e
-description: "Run end-to-end tests (backend API + frontend Playwright) for a KiroCrew feature worktree against an ISOLATED throwaway pod instance, without touching the live gateway. Use when asked to e2e-test / smoke-test / verify a worktree's feature hands-off, run API + browser tests on a pod, or prove a new backend route + UI work together. NOT for testing the live instance."
+description: "ONLY for developing Kiro Crew itself -- if the project you are working on is anything else, ignore this skill: it drives Kiro Crew's own pod tooling, which does not exist in another repository. Runs end-to-end tests (backend API + frontend Playwright) for a Kiro Crew feature worktree against an ISOLATED throwaway pod instance, without touching the live gateway. Use when asked to e2e-test / smoke-test / verify a Kiro Crew worktree's feature hands-off, run API + browser tests on a pod, or prove a new backend route + UI work together. NOT for testing the live instance, and NOT a general-purpose e2e or smoke-test skill."
 triggers: e2e test, smoke test, pod test, verify worktree, test pod, run e2e, end to end
+repo_scope: src/kiro_crew
 ---
 
 # pod-e2e — test a worktree against an isolated full-stack pod

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -1711,6 +1711,7 @@ class ContextBuilder:
         model_window: int | None = None,
         context_groups: frozenset[str] | None = None,
         query_text: str = "",
+        project: str | None = None,
     ) -> str:
         """Build context for a new session (memory + skills + history).
 
@@ -2046,6 +2047,7 @@ class ContextBuilder:
             skills_ctx = self.skills.get_context(
                 budget=caps.skills if lazy_skills else None,
                 only=skill_globs or None,
+                project_dir=project,
             )
             if skills_ctx:
                 if lazy_skills and len(skills_ctx) > caps.skills:
@@ -2280,6 +2282,7 @@ class ContextBuilder:
                 model_window=model_window,
                 context_groups=context_groups,
                 query_text=text,
+                project=project,
             )
             if session_ctx:
                 # Scrub forgeable boundary markers from the UNTRUSTED content in
@@ -2348,6 +2351,7 @@ class ContextBuilder:
                 skills_ctx = self.skills.get_context(
                     budget=caps.skills if lazy_skills else None,
                     only=_globs or None,
+                    project_dir=project,
                 )
                 if skills_ctx:
                     if lazy_skills and len(skills_ctx) > caps.skills:
@@ -2563,7 +2567,7 @@ class ContextBuilder:
         # context, and ACP replays native history so a body already sent earlier
         # in the conversation is still in the window.
         if not is_custom and not minimal_context:
-            triggered = self.skills.get_triggered_skills(text)
+            triggered = self.skills.get_triggered_skills(text, project_dir=project)
             if triggered:
                 enforced, pointer_only = self.skills.split_triggered(triggered)
                 # Log the split, not just the match: a pointed-at skill the

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -1486,6 +1486,11 @@ class SkillsLoader:
                     "path": str(skill_file),
                     "dir": str(skill_file.parent),
                     "always": meta.get("always", "").lower() == "true",
+                    # Carried so a caller assembling context can drop a
+                    # repo-scoped skill from the INDEX, not just from the
+                    # injected body: a summary line the agent is told to read
+                    # advertises the skill just as effectively.
+                    "repo_scope": meta.get("repo_scope", ""),
                     # Mirrors split_triggered: only an explicit `false` opts out,
                     # so a malformed value reads as injecting, as it behaves.
                     "inject_on_trigger": (
@@ -2001,29 +2006,41 @@ class SkillsLoader:
         return [s for s in self.list_skills() if s["key"].startswith(f"{AUTO_SKILL_NAMESPACE}/")]
 
     @staticmethod
-    def _repo_scope_satisfied(relpath: str) -> bool:
+    def _repo_scope_satisfied(relpath: str, project_dir: str | Path | None) -> bool:
         """Mechanical gate for repo-scoped skills (``repo_scope:`` frontmatter).
 
         A skill carrying ``repo_scope: <relpath>`` is only eligible for
-        injection when the current working directory (or an ancestor) contains
-        *relpath* — e.g. ``repo_scope: src/kiro_crew`` restricts a skill to
-        sessions actually working inside the KiroCrew source tree. This is the
+        injection when *project_dir* (or an ancestor of it) contains *relpath*
+        — e.g. ``repo_scope: src/kiro_crew`` restricts a skill to sessions
+        whose active project IS the Kiro Crew source tree. This is the
         loader-enforced counterpart to a prose "ignore this skill elsewhere"
         scope guard: prose depends on probabilistic LLM obedience, while this
         check runs before the skill ever reaches the context (destructive
         repo-dev instructions must be mechanically contained).
 
-        Fails CLOSED on any error — a repo-scoped skill is suppressed unless
-        its scope is positively confirmed.
+        *project_dir* is the SESSION's active project — the same value the
+        ``[PROJECT]`` context block names. The process working directory is
+        deliberately NOT consulted: this runs in the gateway while it assembles
+        context, so ``Path.cwd()`` is the gateway's own working directory and
+        says nothing about the repository the session is working on. Reading it
+        made the gate answer by install shape rather than by work: a gateway
+        started from inside a checkout of the scoped repo admitted the skill
+        into EVERY session, while a packaged install whose cwd holds no marker
+        suppressed it for every session, contributors included.
+
+        Fails CLOSED — no project, an unusable one, or any error suppresses the
+        skill, so an un-scoped surface never inherits repo-specific rules.
         """
         rel = relpath.strip().strip("/")
         if not rel or ".." in rel.split("/"):
             return False
-        try:
-            cwd = Path.cwd().resolve()
-        except OSError:
+        if not project_dir:
             return False
-        for candidate in (cwd, *cwd.parents):
+        try:
+            root = Path(project_dir).resolve()
+        except (OSError, RuntimeError, ValueError):
+            return False
+        for candidate in (root, *root.parents):
             try:
                 if (candidate / rel).exists():
                     return True
@@ -3434,14 +3451,20 @@ class SkillsLoader:
                 pruned += 1
         return pruned
 
-    def get_always_skills(self) -> list[str]:
-        """Return names of skills marked ``always: true`` in frontmatter."""
+    def get_always_skills(self, project_dir: str | Path | None = None) -> list[str]:
+        """Return names of skills marked ``always: true`` in frontmatter.
+
+        *project_dir* is the session's active project, used only by the
+        ``repo_scope`` gate; omitting it suppresses every repo-scoped skill
+        (see :meth:`_repo_scope_satisfied` for why the gate cannot fall back
+        to the process working directory).
+        """
         result: list[str] = []
         for name, skill_file in self._iter():
             meta = self._cached_frontmatter(skill_file)
             if meta.get("always", "").lower() == "true":
                 scope = meta.get("repo_scope", "")
-                if scope and not self._repo_scope_satisfied(scope):
+                if scope and not self._repo_scope_satisfied(scope, project_dir):
                     continue
                 result.append(name)
         return result
@@ -3457,7 +3480,9 @@ class SkillsLoader:
         """
         _ensure_builtin_skills(self._dir)
 
-    def get_triggered_skills(self, text: str) -> list[str]:
+    def get_triggered_skills(
+        self, text: str, project_dir: str | Path | None = None
+    ) -> list[str]:
         """Return names of skills whose triggers match the given text.
 
         Uses word-overlap matching with multi-word trigger phrases and
@@ -3465,6 +3490,9 @@ class SkillsLoader:
         ``triggers`` frontmatter field.  A phrase prefixed with ``!`` is a
         negative trigger — if *any* negative trigger matches, the skill is
         excluded regardless of positive matches.
+
+        *project_dir* is the session's active project, used only by the
+        ``repo_scope`` gate; omitting it suppresses every repo-scoped skill.
 
         Returns up to ``max_triggered`` skills sorted by best overlap score.
         """
@@ -3485,7 +3513,7 @@ class SkillsLoader:
             # repo — word-overlap can fire on ordinary user phrasing, and a
             # prose scope guard alone is probabilistic.
             scope = meta.get("repo_scope", "")
-            if scope and not self._repo_scope_satisfied(scope):
+            if scope and not self._repo_scope_satisfied(scope, project_dir):
                 continue
 
             # Split into positive and negative triggers
@@ -3634,7 +3662,12 @@ class SkillsLoader:
                 return skill_file
         return None
 
-    def get_context(self, budget: int | None = None, only: list[str] | None = None) -> str:
+    def get_context(
+        self,
+        budget: int | None = None,
+        only: list[str] | None = None,
+        project_dir: str | Path | None = None,
+    ) -> str:
         """Build skills context for prompt injection (lazy-loaded).
 
         Pinned skills (``always: true`` frontmatter) get full content, always —
@@ -3661,17 +3694,31 @@ class SkillsLoader:
         all_skills = self.list_skills()
         if only is not None:
             all_skills = [s for s in all_skills if _matches_any(s.get("path", ""), only)]
+        # Scope BEFORE anything is rendered. Dropping a repo-scoped skill only
+        # from the injected body still leaves its summary line in the index, and
+        # the index tells the agent to read the full file for anything related —
+        # so an out-of-scope skill stays one `cat` away and its repo-specific
+        # procedure gets applied to the wrong project. Filtering the list is the
+        # single place that covers the index, both renderers, and the pinned set.
+        all_skills = [
+            s
+            for s in all_skills
+            if not s.get("repo_scope")
+            or self._repo_scope_satisfied(str(s["repo_scope"]), project_dir)
+        ]
         if not all_skills:
             return ""
         if budget is None:
-            return self._legacy_context(all_skills, restricted=only is not None)
+            return self._legacy_context(
+                all_skills, restricted=only is not None, project_dir=project_dir
+            )
         # get_always_skills() returns the _iter() identifier — the same value
         # list_skills() exposes as "key" (the dir-relative path, e.g.
         # "team-capabilities/build-helper"), NOT the frontmatter "name". So the
         # pinned check below, _record_use() (also called with the _iter
         # identifier), and _rank_key()'s score(s["key"]) are all consistently
         # keyed by "key" — there is no key/name mismatch here.
-        pinned = set(self.get_always_skills())
+        pinned = set(self.get_always_skills(project_dir))
 
         parts: list[str] = []
 
@@ -3739,7 +3786,12 @@ class SkillsLoader:
 
         return "[Skills:]\n" + "\n\n---\n\n".join(parts) + "\n[End of skills]\n\n"
 
-    def _legacy_context(self, all_skills: list[dict], restricted: bool = False) -> str:
+    def _legacy_context(
+        self,
+        all_skills: list[dict],
+        restricted: bool = False,
+        project_dir: str | Path | None = None,
+    ) -> str:
         """Pre-lazy-load skills block (opt-in OFF, the default).
 
         Full content for pinned (``always: true``) skills + a one-line summary
@@ -3751,8 +3803,12 @@ class SkillsLoader:
         ``skill://`` mapping, so the always-loaded set is narrowed to match: a
         pinned skill outside the mapping must NOT be force-injected, or the
         mapping would not actually bound what the agent sees.
+
+        *project_dir* is forwarded to the ``repo_scope`` gate so this path
+        scopes pinned skills exactly as the lazy-load path does — the default
+        block must not be the one that leaks a repo-scoped skill.
         """
-        always = self.get_always_skills()
+        always = self.get_always_skills(project_dir)
         if restricted:
             allowed = {s["key"] for s in all_skills} | {s["name"] for s in all_skills}
             always = [a for a in always if a in allowed]

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -5133,11 +5133,19 @@ class SubagentManager:
         # is on, so build_message applies one code path for sub-agents.
         _groups = _context_groups_of(info)
         # Off-loop: build_message embeds the episodic query (blocking urllib).
+        # A run's explicitly-given cwd IS its project for skill scoping: a
+        # dashboard spawn inherits the parent slot's project as its cwd, so the
+        # hands-off surface keeps the repo-scoped skills that surface exists for.
+        # The pool default is deliberately NOT substituted -- it is the
+        # workspace directory, not a checkout, so it can only ever mean "this
+        # run named no project", which is exactly the fail-closed case. Keeping
+        # one meaning for that makes the rule the same on every surface.
         full_message, _ = await run_in_embed_pool(
             self._ctx_builder.build_message,
             message,
             is_new,
             session_key,
+            project=info.cwd or None,
             provider_type=self._provider_label_of(client),
             model_window=_sub_window,
             context_groups=_groups,

--- a/src/kiro_crew/task_executor.py
+++ b/src/kiro_crew/task_executor.py
@@ -335,6 +335,7 @@ async def execute_task(
                     is_new,
                     session_key,
                     agent=agent or None,
+                    project=str(work_dir) if work_dir else None,
                     provider_type=KiroCrewConfig.load().agent.provider,
                 )
             else:

--- a/src/kiro_crew/task_planner.py
+++ b/src/kiro_crew/task_planner.py
@@ -251,7 +251,12 @@ async def decompose(
         if ctx:
             # Off-loop: build_message embeds the episodic query (blocking urllib).
             full_prompt, _ = await run_in_embed_pool(
-                ctx.build_message, prompt, is_new, session_key, agent=agent or None
+                ctx.build_message,
+                prompt,
+                is_new,
+                session_key,
+                agent=agent or None,
+                project=work_dir or None,
             )
         else:
             full_prompt = prompt

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -320,65 +320,147 @@ class TestSkillsLoader:
 
 class TestRepoScope:
     """``repo_scope:`` frontmatter mechanically suppresses a skill unless the
-    CWD (or an ancestor) contains the named relative path — the loader-enforced
-    gate for repo-specific skills with destructive instructions (PR #353
-    arbiter: prose scope guards are probabilistic; containment must be
-    mechanical before shipping to every install)."""
+    SESSION's active project directory (or an ancestor) contains the named
+    relative path — the loader-enforced gate for repo-specific skills with
+    destructive instructions (PR #353 arbiter: prose scope guards are
+    probabilistic; containment must be mechanical before shipping to every
+    install).
 
-    def _write_skill(self, root: Path, name: str, scope: str | None) -> None:
+    The gate is keyed on the project, never on the process working directory:
+    this runs in the gateway while it assembles context, so ``Path.cwd()`` is
+    the gateway's own directory and answers by install shape rather than by the
+    work the session is doing (issue #4322)."""
+
+    def _write_skill(
+        self, root: Path, name: str, scope: str | None, always: bool = False
+    ) -> None:
         d = root / name
         d.mkdir(parents=True)
         fm = f"---\nname: {name}\ntriggers: zebra quokka\n"
         if scope:
             fm += f"repo_scope: {scope}\n"
+        if always:
+            fm += "always: true\n"
         (d / "SKILL.md").write_text(fm + "---\nbody")
 
-    def test_scoped_skill_suppressed_outside_repo(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def _repo(self, tmp_path: Path, name: str = "checkout") -> Path:
+        repo = tmp_path / name
+        (repo / "src" / "kiro_crew").mkdir(parents=True)
+        return repo
+
+    def test_scoped_skill_suppressed_without_a_project(self, tmp_path: Path) -> None:
+        # No project named at all -> fail closed. An un-scoped surface (eval
+        # harness, a session with no project set) never inherits repo rules.
+        skills = tmp_path / "skills"
+        self._write_skill(skills, "repo-only", "src/kiro_crew")
+        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        assert loader.get_triggered_skills("zebra quokka") == []
+
+    def test_scoped_skill_suppressed_outside_repo(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
         self._write_skill(skills, "repo-only", "src/kiro_crew")
         loader = SkillsLoader(skills_path=skills, install_builtins=False)
         outside = tmp_path / "elsewhere"
         outside.mkdir()
-        monkeypatch.chdir(outside)
-        assert loader.get_triggered_skills("zebra quokka") == []
+        assert loader.get_triggered_skills("zebra quokka", project_dir=str(outside)) == []
 
-    def test_scoped_skill_eligible_inside_repo(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_scoped_skill_eligible_inside_repo(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
         self._write_skill(skills, "repo-only", "src/kiro_crew")
         cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=3))
         loader = SkillsLoader(skills_path=skills, install_builtins=False, config=cfg)
-        repo = tmp_path / "checkout"
-        (repo / "src" / "kiro_crew").mkdir(parents=True)
-        subdir = repo / "website"
+        subdir = self._repo(tmp_path) / "website"
         subdir.mkdir()
-        monkeypatch.chdir(subdir)  # ancestor contains src/kiro_crew
-        assert loader.get_triggered_skills("zebra quokka") == ["repo-only"]
+        # ancestor of the project dir contains src/kiro_crew
+        assert loader.get_triggered_skills("zebra quokka", project_dir=str(subdir)) == [
+            "repo-only"
+        ]
 
-    def test_unscoped_skill_unaffected(
+    def test_process_cwd_does_not_admit_the_skill(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # The regression this gate had: a gateway whose OWN cwd sits inside a
+        # scoped checkout admitted the skill into every session, whatever the
+        # session was working on. Standing in the repo must decide nothing.
+        skills = tmp_path / "skills"
+        self._write_skill(skills, "repo-only", "src/kiro_crew")
+        cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=3))
+        loader = SkillsLoader(skills_path=skills, install_builtins=False, config=cfg)
+        monkeypatch.chdir(self._repo(tmp_path))
+        other = tmp_path / "some-rust-project"
+        other.mkdir()
+        assert loader.get_triggered_skills("zebra quokka") == []
+        assert loader.get_triggered_skills("zebra quokka", project_dir=str(other)) == []
+
+    def test_always_path_is_gated_identically(self, tmp_path: Path) -> None:
+        # Both injection paths share one helper; a pinned skill must not be a
+        # way around the gate.
+        skills = tmp_path / "skills"
+        self._write_skill(skills, "repo-only", "src/kiro_crew", always=True)
+        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        other = tmp_path / "some-rust-project"
+        other.mkdir()
+        assert loader.get_always_skills() == []
+        assert loader.get_always_skills(str(other)) == []
+        assert loader.get_always_skills(str(self._repo(tmp_path))) == ["repo-only"]
+
+    def test_unscoped_skill_unaffected(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
         self._write_skill(skills, "anywhere", None)
         cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=3))
         loader = SkillsLoader(skills_path=skills, install_builtins=False, config=cfg)
-        outside = tmp_path / "elsewhere"
-        outside.mkdir()
-        monkeypatch.chdir(outside)
         assert loader.get_triggered_skills("zebra quokka") == ["anywhere"]
 
-    def test_traversal_scope_fails_closed(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_traversal_scope_fails_closed(self, tmp_path: Path) -> None:
         # ".." in the scope must never widen the check — fails closed.
         skills = tmp_path / "skills"
         self._write_skill(skills, "sneaky", "../..")
         loader = SkillsLoader(skills_path=skills, install_builtins=False)
-        monkeypatch.chdir(tmp_path)
-        assert loader.get_triggered_skills("zebra quokka") == []
+        assert loader.get_triggered_skills("zebra quokka", project_dir=str(tmp_path)) == []
+
+    def test_scoped_skill_is_absent_from_the_index_too(self, tmp_path: Path) -> None:
+        # Dropping only the BODY leaves the summary line in the skill index, and
+        # the index tells the agent to read the full file for anything related -
+        # so the repo-specific procedure stays one `cat` away.
+        skills = tmp_path / "skills"
+        self._write_skill(skills, "repo-only", "src/kiro_crew")
+        self._write_skill(skills, "anywhere", None)
+        cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=3))
+        loader = SkillsLoader(skills_path=skills, install_builtins=False, config=cfg)
+        other = tmp_path / "some-rust-project"
+        other.mkdir()
+        for block in (
+            loader.get_context(project_dir=str(other)),
+            loader.get_context(budget=100_000, project_dir=str(other)),
+            loader.get_context(),
+        ):
+            assert "repo-only" not in block
+            assert "anywhere" in block
+        # ...and present once the project is the scoped tree.
+        inside = loader.get_context(project_dir=str(self._repo(tmp_path)))
+        assert "repo-only" in inside
+
+    def test_pod_e2e_declares_a_repo_scope(self) -> None:
+        # pod-e2e drives this repo's pod tooling and its triggers are matched by
+        # word overlap, so it must carry the gate rather than rely on prose.
+        # The description carries the applicability statement as well: the gate
+        # covers the injection paths, and the description is what an agent reads
+        # on the paths it does not cover (an explicit `$name` load, a
+        # `skill_search` hit, or reading the file directly).
+        from kiro_crew import skills as skills_mod
+
+        skill_md = (
+            Path(skills_mod.__file__).parent
+            / "apps"
+            / "builtins"
+            / "dev_fleet"
+            / "skills"
+            / "pod-e2e"
+            / "SKILL.md"
+        )
+        head = skill_md.read_text(encoding="utf-8")[:2048]
+        assert "repo_scope: src/kiro_crew" in head
+        assert "ONLY for developing Kiro Crew itself" in head
 
 
 class TestRelocatedSkillCleanup:


### PR DESCRIPTION
## Problem / Motivation

A skill can declare `repo_scope: <relpath>` to mean "these instructions only
make sense inside a repository containing this path". The loader is supposed to
suppress it everywhere else, and `skills/README.md` promises it fails closed.

It resolved the marker against `Path.cwd()`. That check runs in the gateway
while it assembles context, so `Path.cwd()` is the gateway's own working
directory and says nothing about the repository the session is working on. The
session's active project directory was never consulted, so the gate answered by
install shape rather than by the work:

- Gateway started from inside a checkout of the scoped repo (the ordinary
  editable/service install): the marker is found, the gate is **permanently
  open**, and every session passes it including one working on an unrelated
  project.
- Gateway running from a packaged install whose working directory is `/` or an
  app bundle: the marker is never found, the gate is **permanently closed**, and
  the skill is suppressed even for contributors who need it.

A second, independent gap made the first one worse: the bundled `pod-e2e` skill
declared **no** `repo_scope` at all, while its triggers are ordinary English
(`e2e test`, `smoke test`, `run e2e`, `end to end`) that a QA session in any
project will say.

## Why it matters

Someone who works on this project *and* another project on the same machine gets
this project's repo-specific instructions injected into sessions working on the
other one. Concretely: a QA subagent on a Rust or Java repository says "run the
e2e tests", word-overlap matches `pod-e2e`, the body is injected, and the agent
attempts pod commands that do not exist there. The failure reads as a broken
project rather than a mis-scoped skill.

Enabling an app is not a substitute: app enablement is per data home, not per
project, so once enabled an app's skills are visible to every session on the
machine.

## What changed (motivation → approach → change)

Symptom (repo-specific skill loads in an unrelated project) -> mechanism
(word-overlap matched it and the scope gate admitted it) -> root cause (the gate
read the gateway process's working directory, a value structurally unrelated to
the work) -> fix (key the gate on the session's active project, and fail closed
when there is none).

The value was already in hand at the call site: `build_message` takes `project`
and renders it as the `[PROJECT]` block a few dozen lines above where it calls
`get_triggered_skills`; it simply never passed it down.

- `_repo_scope_satisfied(relpath, project_dir)` no longer reads `Path.cwd()`. It
  resolves the marker against the supplied project root only and returns `False`
  when none was supplied, preserving the documented fail-closed contract.
- `get_context` filters the whole skill list through the gate before either
  renderer, so a repo-scoped skill is absent from the INDEX as well as from the
  injected body. `list_skills()` carries `repo_scope` for that (free: the
  frontmatter is already read there). Dropping only the body leaves a summary
  line the index tells the agent to read, which advertises the skill just as
  effectively and leaves its procedure one `cat` away.
- `get_always_skills`, `get_triggered_skills` and `_legacy_context` take an
  optional `project_dir` and forward it to the one helper, so the default
  (non-lazy) block is gated identically to the lazy one.
- Every surface that knows its working directory forwards it: `build_message`
  passes its existing `project` (and into `build_session_context`, which gains
  the same parameter), a sub-agent passes the cwd its run executes in, and the
  task runner and planner pass their `work_dir`. A surface with no project to
  name - a channel turn, a webhook, an eval scenario - gets the fail-closed
  answer, because there is no repository to name and substituting the workspace
  directory would only reach the same answer by a longer route.
- `pod-e2e` gains `repo_scope: src/kiro_crew`. Its triggers are left as they are:
  the gate is what closes the defect, and because the skill list is filtered
  before trigger matching, an out-of-scope session cannot reach the skill whatever
  its triggers say. Narrowing them would only cost in-repo users the generic
  phrasing that surfaces the skill where it is correct.
- `skills/README.md` states the keyed-on-project contract, since that row is the
  documented promise this change alters.

Both halves are required and neither is sufficient alone: fixing the gate does
nothing for a skill that never declared a scope, and declaring a scope does
nothing while the gate admits everything.

One hunk here is unrelated to the gate and is called out so it does not read as
churn: `.github/black-baseline.txt` drops `src/kiro_crew/mcp_gateway/preflight.py`.
`scripts/check_black_formatting.py` fails closed when a baselined file has become
formatted, and that file is byte-identical to the base while already passing
`black --check`, so the entry is stale and the gate requires the next change
touching Python to prune it. One deletion, zero additions, as produced by the
gate's own `--update-baseline` remedy.

## Tests

`test/test_skills.py::TestRepoScope`, rewritten to drive the project parameter
rather than `monkeypatch.chdir`:

- `test_scoped_skill_suppressed_without_a_project`  -  no project named at all
  suppresses the skill (fail-closed), so an un-scoped surface never inherits
  repo rules.
- `test_scoped_skill_suppressed_outside_repo`  -  a project without the marker
  suppresses it.
- `test_scoped_skill_eligible_inside_repo`  -  a project whose ancestor holds the
  marker admits it.
- `test_process_cwd_does_not_admit_the_skill`  -  pins the regression itself:
  standing in a scoped checkout decides nothing, with `project_dir` absent and
  with it pointing elsewhere.
- `test_always_path_is_gated_identically`  -  a pinned (`always: true`) skill is
  not a way around the gate.
- `test_unscoped_skill_unaffected`, `test_traversal_scope_fails_closed`  -  carried
  over.
- `test_scoped_skill_is_absent_from_the_index_too`  -  the skill name appears in
  no block (default, lazy, and no-project) while an unscoped sibling still does,
  and returns once the project is the scoped tree.
- `test_pod_e2e_declares_a_repo_scope`  -  the declaration cannot be dropped
  silently.

Each new assertion was mutation-verified; reverting the corresponding line makes
exactly the intended test fail:

| mutation | test that failed |
|---|---|
| gate falls back to `Path.cwd()` | `test_process_cwd_does_not_admit_the_skill` |
| `pod-e2e` loses its `repo_scope` | `test_pod_e2e_declares_a_repo_scope` |
| always-path stops forwarding the project | `test_always_path_is_gated_identically` |

Gates run locally: `pytest test/test_skills.py` (126 passed), the context and
skill-injection suites (`test_context`, `test_context_budget`,
`test_context_dynamic_budget`, `test_skill_listing_cost`, `test_skill_budget`,
`test_skill_trigger_pointer`, `test_skills_frontmatter`,
`test_subagent_context_groups`, `test_side_context`, `test_workflows_context`,
`test_cron_minimal_context`  -  270 passed), the builtin-skill packaging and
sync-safety suites (63 passed), `isort --check-only`, `flake8`, and `mypy
src/kiro_crew/` (no issues in 986 files).

## Manual verification

N/A  -  unit coverage is sufficient. The behaviour is a loader-side eligibility
decision with no rendered surface, and the decisive case (process cwd must not
decide) is asserted directly rather than observed.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change plus one skill frontmatter edit; no
watched frontend path is touched and nothing renders differently.

## Related Issues

Closes #4322

## Checklist

- [x] Single commit
- [x] No `CHANGELOG.md` change - per `AGENTS.md` -> "Release Changelog", a feature PR does not touch it
- [x] Tests added and mutation-verified
- [x] `isort` / `flake8` / `mypy` clean



