### PR TITLE
fix(acp): classify a rejected Kiro credential as terminal, not a backend fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **Switching Kiro accounts mid-session no longer leaves the chat showing a raw
+  `The bearer token included in the request is invalid.` with no way out.** A
+  `kiro-cli` child holds its credential for the life of the session, so an
+  external account switch invalidates it underneath a running session. That
+  rejection carries no status code and never uses expiry wording, so it matched
+  none of the auth classifiers: it reached the user as the raw upstream string
+  with no sign-in affordance, and counted as a retryable backend fault that
+  spent the whole retry ladder on a credential no retry can revive. A rejected
+  credential is now classified alongside session expiry — terminal, and carrying
+  the existing actionable "run `kiro-cli login`, then start a new chat"
+  guidance. (#3393)
+
 - **xlsx files now render inline in the file viewer** instead of a
   download-only card. A new `GET /api/file-sheet` endpoint parses OOXML
   workbooks server-side with openpyxl (read-only, worker thread, ZIP

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1046,16 +1046,33 @@ _RE_SESSION_EXPIRED = re.compile(
     r"|re-?authenticate|login\s+required|auth(?:entication)?\s+required)\b",
     re.IGNORECASE,
 )
+# Credential REJECTED rather than expired. Switching the active Kiro account
+# invalidates the credential a long-lived kiro-cli child still holds, and the
+# upstream rejection reports only that the bearer token is invalid: it carries
+# no status code and never uses expiry wording, so neither _RE_AUTH_STATUS nor
+# _RE_SESSION_EXPIRED matches it and the failure reaches the user as the raw
+# upstream string with no sign-in affordance. Grouped with session expiry
+# because the remedy is identical — sign in again; no retry can make a rejected
+# credential valid. The gap between the two words is fenced to one sentence and
+# one line so the pattern cannot span unrelated errors in a combined haystack.
+_RE_INVALID_BEARER = re.compile(
+    r"\b(?:bearer\s+token\b[^.\n]{0,80}?\binvalid|invalid\s+bearer\s+token)\b",
+    re.IGNORECASE,
+)
 
 
 def _is_session_expired(haystack: str) -> bool:
-    """True when the failure is an expired session rather than a backend fault.
+    """True when the session credential is expired or rejected, not a backend fault.
 
-    Both signals are terminal: retrying cannot refresh a login. Checked before
-    the 5xx family so an aborted request's transport error does not shadow the
-    real cause.
+    All three signals are terminal: retrying can neither refresh a login nor
+    revive a credential the upstream has rejected. Checked before the 5xx family
+    so an aborted request's transport error does not shadow the real cause.
     """
-    return bool(_RE_AUTH_STATUS.search(haystack) or _RE_SESSION_EXPIRED.search(haystack))
+    return bool(
+        _RE_AUTH_STATUS.search(haystack)
+        or _RE_SESSION_EXPIRED.search(haystack)
+        or _RE_INVALID_BEARER.search(haystack)
+    )
 
 
 # Account/plan capacity is EXHAUSTED — terminal. Distinct from a throttle: a

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -7598,6 +7598,48 @@ class TestFormatAcpError:
         assert "transient error" not in out.lower()
         assert "retry in a moment" not in out.lower()
 
+    def test_invalid_bearer_token_rewrite(self):
+        """The account-switch rejection: a credential the running child still
+        holds is rejected as invalid, with no status code and no expiry wording,
+        so it must still reach the sign-in guidance instead of the raw string."""
+        err = {
+            "code": -32603,
+            "message": "Internal error",
+            "data": "The bearer token included in the request is invalid.",
+        }
+        out = _format_acp_error(err)
+        assert "kiro-cli login" in out.lower()
+        assert "retry" in out.lower() and "will not help" in out.lower()
+        # Must NOT show the misleading transient-5xx advice.
+        assert "transient error" not in out.lower()
+        assert "retry in a moment" not in out.lower()
+
+    def test_invalid_bearer_token_wins_over_transport_error(self):
+        """An aborted request leaves a transport error beside the rejection; the
+        credential branch is checked first so the 5xx family cannot win."""
+        err = {
+            "code": -32603,
+            "message": "Encountered an error in the response stream",
+            "data": "DispatchFailure ConnectionResetError: the bearer token is invalid",
+        }
+        out = _format_acp_error(err)
+        assert "kiro-cli login" in out.lower()
+        assert "transient error" not in out.lower()
+
+    def test_unrelated_invalid_does_not_read_as_credential_failure(self):
+        """The fenced gap must not let an unrelated 'invalid' in a combined
+        haystack turn a validation fault into a sign-in prompt."""
+        err = {
+            "code": -32603,
+            "message": "Internal error",
+            "data": (
+                "ValidationException: refreshed the bearer token successfully. "
+                "Field 'temperature' is invalid"
+            ),
+        }
+        out = _format_acp_error(err)
+        assert "kiro-cli login" not in out.lower()
+
     def test_genuine_5xx_still_transient_with_auth_absent(self):
         """The new auth-status branch must not swallow real 5xx errors."""
         err = {
@@ -7706,6 +7748,41 @@ class TestIsTransientRawError:
         )
         assert _is_transient_raw_error(None) is False
         assert _is_transient_raw_error("boom") is False
+
+    def test_invalid_bearer_token_is_not_transient(self):
+        """A rejected credential must be terminal, not fed to the retry ladder.
+
+        The rejection carries no status code and no expiry wording, so without
+        its own pattern it reaches the 5xx family — and a co-occurring transport
+        error is enough to make it look retryable, spending the whole ladder on
+        a credential no retry can revive.
+        """
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        assert (
+            _is_transient_raw_error(
+                {"data": "The bearer token included in the request is invalid."}
+            )
+            is False
+        )
+        assert _is_transient_raw_error({"data": "invalid bearer token"}) is False
+        # A co-occurring transport error must not flip it to retryable.
+        assert (
+            _is_transient_raw_error(
+                {
+                    "message": "Encountered an error in the response stream",
+                    "data": "ConnectionResetError: the bearer token is invalid",
+                }
+            )
+            is False
+        )
+        # An unrelated 'invalid' must stay out of the credential class.
+        assert (
+            _is_transient_raw_error(
+                {"data": "ServiceUnavailableException: HTTP 503, invalid window"}
+            )
+            is True
+        )
 
     def test_session_expired_is_not_transient(self):
         """Regression test: kiro-cli session expiry must be terminal.


### PR DESCRIPTION
## What is the problem?

Switching the active Kiro account while KiroCrew is running leaves every prompt in an
existing session failing with a raw upstream string and no way out:

> The bearer token included in the request is invalid.

There are two layers to this. The first is that a `kiro-cli` child is spawned once per
chat session and holds its credential in-process for that session's whole lifetime, so
an external account switch invalidates it underneath a running session. This PR does
**not** address that layer.

The second layer is why the failure is unreadable, and that is what this PR fixes.
`acp/client.py` already has an actionable path for credential failures, but the
rejection matches none of its four classifiers. Checked against the reported string:

| Pattern | Matches? | What it recognises |
|---|---|---|
| `_RE_AUTH` | no | Bedrock named exceptions (`AccessDenied`, `ExpiredToken`) |
| `_RE_AUTH_STATUS` | no | literal `HTTP 401` / `status 403` in the text |
| `_RE_SESSION_EXPIRED` | no | `session expired`, `not logged in`, `login required` |
| `_NOT_LOGGED_IN_RE` | no | the `not logged in` stderr banner |

The rejection carries no status code and never uses expiry wording, so it fell through
every one of them.

## Why this issue matters to the user

The fall-through costs the user twice, and the second cost is the worse one.

It reaches the chat as the raw upstream string with no re-authenticate affordance, so a
user who just switched accounts is told a bearer token is invalid and given nothing to
act on.

Worse, it is never classified terminal, so `_is_transient_raw_error` lets it reach the
5xx family, where a co-occurring transport error from the aborted request is enough to
make it look retryable. The retry ladder is then spent in full on a credential no retry
can revive, and the user is advised to retry or switch models, neither of which can
succeed. That is precisely the trap the module's own comment warns about for the
status-code branch: *"neither of which can succeed against an expired login"*.

## How our fix solves it

The chain from symptom to root cause: raw unactionable error, because no auth classifier
matched, because the rejection's wording is a distinct signal none of the four patterns
covered.

So the fix adds that one missing signal rather than touching any existing pattern. A new
`_RE_INVALID_BEARER` is OR'd into `_is_session_expired`, which is the single source of
truth both consumers already key off, so one addition corrects both behaviours at once:

- `_format_acp_error` now produces the existing actionable "run `kiro-cli login`, then
  start a new chat. Retrying or switching models will not help" guidance.
- `_is_transient_raw_error` now returns `False`, so the retry ladder is not spent.

Grouping it with session expiry is deliberate: the remedy is identical, and the
docstring is generalised from "expired session" to expired **or rejected** to keep the
helper's name honest about what it now covers.

The pattern is fenced rather than loose. The gap between "bearer token" and "invalid" is
bounded and excludes both `.` and newline, so it cannot span sentences or unrelated
errors in a combined `message + data` haystack: a validation fault that merely mentions
an invalid field near a successful credential refresh must not become a sign-in prompt.
A test pins that.

Deliberately out of scope: the shared message still opens "Your session has expired."
For an account switch the diagnosis is slightly off while the instruction is exactly
right, and a second message branch would widen this beyond one classification fix.

## What tests we did

Four tests added, all three fix-proving ones mutation-verified. Reverting the one-line
OR makes exactly those three fail and leaves the six pre-existing auth tests passing:

- `test_invalid_bearer_token_rewrite` - the reported string reaches the sign-in guidance.
- `test_invalid_bearer_token_wins_over_transport_error` - the credential branch beats a
  co-occurring `DispatchFailure`/`ConnectionResetError`.
- `test_invalid_bearer_token_is_not_transient` - terminal in the retry classifier.
- `test_unrelated_invalid_does_not_read_as_credential_failure` - the fenced gap does not
  misclassify a validation fault (a guard, so it passes with and without the fix).

Gates: `isort` and `flake8` clean. `mypy`: `acp/client.py` clean; the 4 reported errors
are in `transcribe.py` and `ops_mission_control/.../cloudwatch.py`, reproduce identically
on clean `main`, and come from `boto3-stubs` being present locally where CI does not
install it. Full backend suite: 56408 passed, 32 failed, and all 32 re-run identically on
clean `main` (missing optional `qrcode`, subprocess tests needing an editable install,
HOME-layout and real-stub integration tests). `TestFormatAcpError` plus
`TestIsTransientRawError` are 49/49 green.

`tsc -b` and `vitest` were not run locally: the diff is two Python files plus CHANGELOG
and touches no frontend source, so neither gate can observe it. CI runs both.

## Any other suggestions on the work

The staleness layer is the real defect and is untouched here: detecting the on-disk
credential change and retiring or respawning the child. This PR only stops the failure
from being unreadable and from burning the retry ladder; a user still has to start a new
chat after switching accounts. That layer needs a design call, and it overlaps the
credential trust-boundary decision in #4184.

While verifying, one inaccuracy in #3393's body: it references `AcpNotAuthenticatedError`
and `AcpAuthError`, neither of which exists. The real class is `AcpAuthRequired`.

#3390 is the sibling symptom of the same untouched staleness layer, an external
`kiro-cli logout` going undetected. It is not fixed here; that path already matches
`_NOT_LOGGED_IN_RE`, so its problem is detection, not classification.

Refs #3393
