### PR TITLE
docs(chat): record the in-house virtualizer decision in the module header

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -42,12 +42,12 @@
 //   - Place `topSentinelRef` / `bottomSentinelRef` at the list ends for
 //     window expansion.
 //
-// WHY THIS IS IN-HOUSE (build-vs-buy — recorded, not assumed)
-// ===========================================================
+// WHY THIS IS IN-HOUSE (build-vs-buy — decided, not assumed)
+// ==========================================================
 // This module re-implements machinery that react-virtuoso and @tanstack/virtual
 // ship battle-tested (dynamic measurement, prefix-sum offsets, follow-output
-// pinning, anchor stability), so the choice to keep owning it needs to be a
-// decision on the record rather than a default. The chat-specific requirements a
+// pinning, anchor stability). Owning it is a deliberate maintainer decision
+// rather than a default that accumulated. The chat-specific requirements a
 // drop-in library does not cover today:
 //   - Widget iframes: rows contain sandboxed iframes that lose all internal
 //     state on unmount and rebuild slowly (PROGRAMMATIC_BUILD_DELAY_MS), which
@@ -61,10 +61,18 @@
 //   - Cross-session persistence: heights survive in localStorage per session,
 //     partitioned by `sessionId`, so a revisit is warm.
 // None of these is proven *fundamental* — they are integration costs, not
-// impossibilities. The maintainers' open question is therefore whether to keep
-// investing here or schedule a migration; this comment records the constraints
-// that a migration would have to satisfy, so the next scroll fix is a choice
-// rather than a default. It does NOT itself decide the direction.
+// impossibilities, so the decision is revisitable and this list is what any
+// future migration would have to satisfy. Such a revisit should weigh that
+// react-virtuoso is already a dependency serving other virtualized surfaces, so
+// the question is convergence between two strategies rather than first-time
+// adoption.
+//
+// The decision carries one obligation. Height truth spans the DOM, `HeightCache`,
+// `OffsetIndex` and the memos derived from them, and stays coherent by convention
+// — a version counter in the memo deps, plus a session guard held separately by
+// the cache and by the offset tree — rather than by construction. Collapsing that
+// to a single seam, with `OffsetIndex` the only read surface for heights and
+// `HeightCache` purely its persistence backend, is the standing follow-through.
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { isRailSettling, RAIL_SETTLE_MS } from '../useRailWidth'


### PR DESCRIPTION
## What is the problem?

`useVirtualChat.ts`'s header carried a block titled "WHY THIS IS IN-HOUSE
(build-vs-buy -- recorded, not assumed)" whose closing paragraph said the direction
was still an open maintainer question and that the comment "does NOT itself decide
the direction."

That is no longer true. The decision has been made: the chat virtualizer stays
in-house (see #412). The comment now contradicts the state of the world, in the one
place a contributor looks before touching this module.

## Why this issue matters to the user

Not user-visible, but it is load-bearing for anyone who edits chat scrolling. The
header is the module's only recorded rationale -- there is no separate architecture
doc for virtualization strategy. A contributor reading "the maintainers' open
question is whether to keep investing here or schedule a migration" reasonably
concludes that a structural fix here may be wasted effort, which is precisely the
hesitation the decision was made to remove.

## How our fix solves it

Comment-only, one file. Three changes to the closing half of that block:

- It states that owning the module is a deliberate decision rather than a default
  that accumulated. The four constraints stay exactly as they were, re-framed as
  what any future migration would have to satisfy, so the decision remains
  revisitable on evidence.
- It records the correction that surfaced while the decision was being made:
  `react-virtuoso` is already a dependency serving other virtualized surfaces, so a
  revisit is a convergence question between two strategies already running side by
  side, not first-time adoption. That is the framing a future reader needs and the
  one the original block got wrong.
- It names the obligation the decision carries. Height truth spans the DOM,
  `HeightCache`, `OffsetIndex` and the memos derived from them, and stays coherent
  by convention -- a version counter in the memo deps, plus a session guard held
  separately by the cache and by the offset tree -- rather than by construction.
  Collapsing that to a single seam is recorded as the standing follow-through.

The description of the current seam is deliberately written as it actually is: the
per-structure session guards do hold today, so the comment states them as an
asserted-by-convention property rather than implying a live defect.

## What tests we did

- `npx tsc -b` clean.
- `npx vitest run` on the three suites covering this module --
  `useVirtualChat.integration.test.tsx`, `WindowCalculator.test.ts`,
  `HeightCache.test.ts` -- 87/87 pass.
- No behaviour to test: the diff is 16 added and 8 removed comment lines, zero
  executable statements. No backend test references this path. The full frontend
  suite runs in CI.

## Any other suggestions on the work?

The follow-through this comment now names is worth doing rather than leaving as a
note. #4307 already tracks the neighbouring instance of the same shape (two
scroll-anchor compensation paths that should be one), and the height-seam
consolidation is filed separately.
