### PR TITLE
fix(dashboard): bound chat history by messages, not stream progress

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -55,6 +55,7 @@ from kiro_crew.dashboard.chat_utils import (
     _MANUAL_RESUME_MSG,
     SYNTHETIC_RECOVERY_KIND,
     _build_stream_chunk,
+    _collapse_wire_rows,
     _edit_queued_by_id,
     _emit_agent_assignment,
     _history_key_for,
@@ -1672,6 +1673,21 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
         all_msgs = await asyncio.to_thread(
             _append_unflushed_tail, slot, all_msgs, snapshot=tail_snapshot
         )
+        # One row must mean one displayed message BEFORE `limit` is applied. The
+        # owed rows above can include `chunk`/`streaming`, and a segment still
+        # streaming is hundreds of rows that render as one message, so slicing
+        # first spends the caller's budget on rows the response will not carry
+        # and returns a mid-sentence fragment.
+        #
+        # Reduce the whole corpus, not a trailing slice: the helper places owed
+        # rows at the disk index they belong to, so they are not a contiguous
+        # suffix and a slice-scoped fold would miss the interleaved ones. In a
+        # thread for the same reason the append is -- whole-corpus work does not
+        # belong on the event loop.
+        #
+        # `done` is already excluded upstream (`_UNOWED_WINDOW_ROLES`), so on
+        # this path the reduction's remaining job is folding the chunk runs.
+        all_msgs = await asyncio.to_thread(_collapse_wire_rows, all_msgs)
         total = len(all_msgs)
         if before is not None:
             end = max(0, min(before, total))
@@ -1681,9 +1697,9 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
         messages = all_msgs[start:end]
         has_more = start > 0
         # The cursor the client should send next, in the RAW index space this
-        # slice was taken in. The client cannot derive it from the response: the
-        # returned rows are _prepare_messages output, which collapses chunk runs
-        # and drops done, so their count is not the span consumed here.
+        # slice was taken in. The client cannot derive it from the response:
+        # `_prepare_messages` drops `done`, so the returned row count is not
+        # the span consumed here.
         next_before = start
 
     # Snapshot every slot field the response needs BEFORE leaving the event
@@ -4591,8 +4607,24 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
         # Reconcile: if disk grew beyond what the in-memory window covers,
         # append the missing tail so a page refresh self-heals (#4373).
         await _reconcile_slot_window(state, existing)
-        total = len(existing.messages)
-        recent = existing.messages[-200:] if total > 200 else existing.messages
+        # Reduce the wire-only rows before bounding, for the same reason the
+        # detail handler does: a segment still streaming is hundreds of `chunk`
+        # rows that render as one message, so a raw 200-row bound over the live
+        # window can be filled entirely by one unfinished reply -- and it then
+        # returns only that window's slice of the reply, dropping the text
+        # ahead of it. Reducing first makes the bound, `total` and the cursor
+        # below all count displayed messages.
+        #
+        # It also puts the cursor's two terms in the same unit: persisted rows
+        # carry no wire-only role, so `_disk_older_count` is already a message
+        # count, while a raw window length is not.
+        #
+        # O(window) on the event loop, and the window is capped -- the
+        # `_prepare_messages` redaction pass on the next line is the larger
+        # cost at this call site either way.
+        window = _collapse_wire_rows(existing.messages)
+        total = len(window)
+        recent = window[-200:] if total > 200 else window
         prepared = _prepare_messages(recent, existing.running)
         # Raw index this window starts at: the frozen on-disk prefix plus the
         # in-memory rows it skipped. has_more is derived from the same number so

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -1652,6 +1652,56 @@ def _dequeue_next_system_message(slot, *, exclude_cron: bool = False) -> tuple:
     return None, []
 
 
+def _collapse_wire_rows(messages: list[dict]) -> list[dict]:
+    """Reduce wire-only rows so that one row means one displayed message.
+
+    ``chunk`` and ``done`` are wire-only roles that are never persisted.
+    ``chunk`` is appended once per streamed delta, so a text segment still in
+    flight occupies hundreds of rows that render as a single message, and
+    ``done`` is a turn terminator that renders as nothing at all. A caller that
+    bounds by row count is therefore counting stream progress and terminators
+    rather than messages, and a bound taken before this reduction is spent on
+    rows the response will not contain.
+
+    Runs of ``chunk`` fold into one ``chunk`` row; ``done`` rows drop. Both are
+    output-equivalent to leaving them for :func:`_prepare_messages`, which
+    reads nothing from a ``chunk`` row but its ``content``, accumulates a run
+    into one output row, and skips ``done`` WITHOUT flushing that accumulator
+    -- so dropping a terminator here, rather than letting it split a run, is
+    what matches its behaviour. No redaction is applied and no other role is
+    rewritten, which is what lets this run ahead of a slice without changing
+    what the slice renders as.
+
+    Input dicts are never mutated: a merged row is a fresh dict, because these
+    rows are shared with the live window the event loop appends to.
+    """
+
+    def _merged(run: list[dict]) -> dict:
+        if len(run) == 1:
+            return run[0]
+        # One join across the run, not a new string per delta: a long reply is
+        # hundreds of deltas, and pairwise concatenation copies the text
+        # accumulated so far every time, which is quadratic in the reply size.
+        return {**run[0], "content": "".join(m.get("content", "") for m in run)}
+
+    out: list[dict] = []
+    run: list[dict] = []
+    for m in messages:
+        role = m.get("role")
+        if role == "chunk":
+            run.append(m)
+            continue
+        if role == "done":
+            continue
+        if run:
+            out.append(_merged(run))
+            run = []
+        out.append(m)
+    if run:
+        out.append(_merged(run))
+    return out
+
+
 def _prepare_messages(messages: list[dict], running: bool) -> list[dict]:
     """Prepare messages for API response."""
     out: list[dict] = []

--- a/test/test_slot_detail_inflight_tail.py
+++ b/test/test_slot_detail_inflight_tail.py
@@ -1,0 +1,262 @@
+"""A bounded slot-detail fetch counts messages, not stream progress.
+
+``chunk`` is a wire-only role appended once per streamed delta, so a text
+segment still in flight occupies hundreds of rows that render as ONE message.
+Those rows reach ``GET /api/chat/slots/{slot}`` only through the un-flushed
+in-memory tail the bounded branch appends -- they are never persisted -- and
+applying ``limit`` before folding them spends the caller's whole budget inside
+one unfinished message, so the response is a mid-sentence fragment instead of
+the last N messages.
+
+The caller that meets this on every request is a poller watching an agent work:
+mid-response is its normal condition, not an edge case. These tests pin the
+fold that makes one row mean one message before the slice is taken.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+from kiro_crew.dashboard.chat_utils import _collapse_wire_rows
+from kiro_crew.dashboard.state import _ChatSlot
+
+#: Deltas in the in-flight segment. Large enough that it alone overruns the
+#: bound below, which is the condition that produces the fragment.
+DELTAS = 300
+SETTLED = 10
+LIMIT = 5
+
+
+@pytest.fixture()
+def state(tmp_path: Any) -> Any:
+    st = _make_state(tmp_path)
+    st.push_slots_update = lambda: None  # type: ignore[method-assign]
+    return st
+
+
+def _slot_mid_stream(state: Any, name: str = "chat-1") -> Any:
+    """A slot whose newest rows are an un-flushed, still-streaming segment.
+
+    Mirrors the live shape: the settled turns are on disk AND in the window,
+    and the deltas of the segment being typed exist only in the window.
+    """
+    settled = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"} for i in range(SETTLED)
+    ]
+    deltas = [{"role": "chunk", "content": f"d{i} ", "cls": "chunk"} for i in range(DELTAS)]
+    slot = _ChatSlot(key=name)
+    slot.messages = settled + deltas
+    slot._disk_older_count = 0
+    state._slots[name] = slot
+    state.conversation_log.read_messages_chained = lambda _key: list(settled)  # type: ignore[method-assign]
+    return slot
+
+
+async def _get(state: Any, query: str, name: str = "chat-1") -> dict:
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.get(f"/api/chat/slots/{name}{query}")
+        assert resp.status == 200
+        return await resp.json()
+
+
+class TestBoundedFetchDuringAnInFlightSegment:
+    @pytest.mark.asyncio
+    async def test_returns_n_messages_rather_than_one_fragment(self, state: Any) -> None:
+        """`limit` must bound displayed messages, not raw stream rows.
+
+        Slicing before the fold returns a single ``streaming`` row -- the tail
+        of the in-flight run -- and none of the conversation behind it.
+        """
+        _slot_mid_stream(state)
+        data = await _get(state, f"?limit={LIMIT}")
+        assert len(data["messages"]) == LIMIT
+        roles = [m["role"] for m in data["messages"]]
+        # Exactly one row stands for the whole in-flight segment, and it is the
+        # newest; the rest of the budget goes to real conversation.
+        assert roles.count("streaming") == 1
+        assert roles[-1] == "streaming"
+
+    @pytest.mark.asyncio
+    async def test_the_in_flight_text_arrives_whole(self, state: Any) -> None:
+        """The one row carries the entire segment, not the last few deltas.
+
+        A viewer of a running slot needs the text as far as it has been typed,
+        which is what the unbounded branch already returns.
+        """
+        _slot_mid_stream(state)
+        data = await _get(state, f"?limit={LIMIT}")
+        streaming = [m for m in data["messages"] if m["role"] == "streaming"]
+        assert streaming[0]["content"] == "".join(f"d{i} " for i in range(DELTAS))
+
+    @pytest.mark.asyncio
+    async def test_total_counts_messages_not_stream_progress(self, state: Any) -> None:
+        """`total` feeds the client's cursor clamp, so it must not track deltas."""
+        _slot_mid_stream(state)
+        data = await _get(state, f"?limit={LIMIT}")
+        assert data["total"] == SETTLED + 1
+
+    @pytest.mark.asyncio
+    async def test_the_cursor_points_behind_the_returned_page(self, state: Any) -> None:
+        """Paging older still works from a page taken during a stream."""
+        _slot_mid_stream(state)
+        data = await _get(state, f"?limit={LIMIT}")
+        assert data["has_more"] is True
+        assert data["next_before"] == (SETTLED + 1) - LIMIT
+
+
+class TestUnaffectedShapes:
+    @pytest.mark.asyncio
+    async def test_a_slot_with_no_in_flight_segment_is_unchanged(self, state: Any) -> None:
+        """With no deltas in the window the fold is a no-op end to end."""
+        settled = [{"role": "assistant", "content": f"m{i}"} for i in range(SETTLED)]
+        slot = _ChatSlot(key="chat-2")
+        slot.messages = list(settled)
+        slot._disk_older_count = 0
+        state._slots["chat-2"] = slot
+        state.conversation_log.read_messages_chained = lambda _key: list(settled)  # type: ignore[method-assign]
+        data = await _get(state, f"?limit={LIMIT}", name="chat-2")
+        assert data["total"] == SETTLED
+        assert [m["content"] for m in data["messages"]] == [f"m{i}" for i in range(5, SETTLED)]
+
+    @pytest.mark.asyncio
+    async def test_folding_a_disk_resident_wire_row_is_output_equivalent(self, state: Any) -> None:
+        """The reduction covers the whole corpus, and that changes no output.
+
+        It cannot be scoped to a trailing slice: ``_append_unflushed_tail``
+        places an owed row at the disk index it belongs to, so owed rows are not
+        a contiguous suffix and a slice would miss the interleaved ones. Both
+        the append and the reduction run in a worker thread, so covering the
+        whole corpus keeps no extra work on the event loop.
+
+        Folding a disk-resident run is therefore harmless rather than merely
+        tolerated: ``_prepare_messages`` folds the same run at render time, so
+        the rendered rows below are identical either way. Persisted history does
+        not actually carry a ``chunk`` row -- ``_build_message_entry_uncached``
+        returns ``None`` for every wire-only role -- so this shape is
+        constructed, not reachable; the assertion pins the equivalence, and
+        ``total`` records that the run now folds before the bound rather than
+        after it.
+        """
+        disk = [
+            {"role": "assistant", "content": "settled"},
+            {"role": "chunk", "content": "a"},
+            {"role": "chunk", "content": "b"},
+        ]
+        slot = _ChatSlot(key="chat-3")
+        slot.messages = disk + [{"role": "user", "content": "unflushed"}]
+        slot._disk_older_count = 0
+        state._slots["chat-3"] = slot
+        state.conversation_log.read_messages_chained = lambda _key: list(disk)  # type: ignore[method-assign]
+        data = await _get(state, "?limit=50", name="chat-3")
+        # The two-row disk run folds to one, so the corpus is one shorter than
+        # the raw rows -- counted before `limit` is applied, which is the point.
+        assert data["total"] == len(disk) + 1 - 1
+        # Unchanged from the raw-row placement: one message per turn either way.
+        assert [m["role"] for m in data["messages"]] == ["assistant", "streaming", "user"]
+
+    @pytest.mark.asyncio
+    async def test_a_done_terminator_does_not_shrink_the_page(self, state: Any) -> None:
+        """A settled turn leaves a `done` row in the window forever.
+
+        Nothing removes it -- it is appended at turn end and never persisted --
+        so it accumulates one per turn and reaches the slice through the
+        un-flushed tail. Counted as a row it consumes one slot and renders as
+        nothing, so a completed `limit=N` fetch would come back with N-1
+        messages.
+        """
+        settled = [{"role": "assistant", "content": f"m{i}"} for i in range(SETTLED)]
+        slot = _ChatSlot(key="chat-4")
+        slot.messages = settled + [{"role": "done", "content": ""}]
+        slot._disk_older_count = 0
+        state._slots["chat-4"] = slot
+        state.conversation_log.read_messages_chained = lambda _key: list(settled)  # type: ignore[method-assign]
+        data = await _get(state, f"?limit={LIMIT}", name="chat-4")
+        assert len(data["messages"]) == LIMIT
+        assert data["total"] == SETTLED
+
+
+class TestResumeDuringAnInFlightSegment:
+    """The resume path bounds the same live window by raw row count.
+
+    ``api_chat_slot_resume`` returns the newest 200 rows of the window. Taken
+    before the reduction, an in-flight segment longer than that bound fills it
+    entirely, so the response carries one ``streaming`` row holding only the
+    bound's slice of the reply and drops the text ahead of it -- a worse outcome
+    than the detail handler's, which loses surrounding messages rather than the
+    reply itself.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_in_flight_text_is_not_truncated_by_the_bound(self, state: Any) -> None:
+        slot = _slot_mid_stream(state, name="chat-5")
+        slot._disk_older_count = 0
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/chat-5/resume", json={"key": "chat-5"})
+            assert resp.status == 200
+            data = await resp.json()
+        streaming = [m for m in data["messages"] if m["role"] == "streaming"]
+        assert len(streaming) == 1
+        assert streaming[0]["content"] == "".join(f"d{i} " for i in range(DELTAS))
+
+    @pytest.mark.asyncio
+    async def test_total_and_cursor_count_messages(self, state: Any) -> None:
+        """Both cursor terms end up in message units, not raw rows.
+
+        `_disk_older_count` is a count of persisted rows, which carry no
+        wire-only role, so pairing it with a raw window length mixes units.
+        """
+        slot = _slot_mid_stream(state, name="chat-6")
+        slot._disk_older_count = 0
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/chat-6/resume", json={"key": "chat-6"})
+            data = await resp.json()
+        assert data["total"] == SETTLED + 1
+        assert data["next_before"] == 0
+        assert data["has_more"] is False
+
+
+class TestTheFoldItself:
+    def test_a_non_chunk_row_breaks_the_run(self) -> None:
+        """Two segments split by a tool row stay two rows, as _prepare_messages folds."""
+        rows = [
+            {"role": "chunk", "content": "a"},
+            {"role": "chunk", "content": "b"},
+            {"role": "tool", "content": "t"},
+            {"role": "chunk", "content": "c"},
+        ]
+        out = _collapse_wire_rows(rows)
+        assert [(m["role"], m["content"]) for m in out] == [
+            ("chunk", "ab"),
+            ("tool", "t"),
+            ("chunk", "c"),
+        ]
+
+    def test_done_rows_drop(self) -> None:
+        """A terminator renders as nothing, so it must not occupy a row here."""
+        rows = [{"role": "chunk", "content": "a"}, {"role": "done", "content": ""}]
+        assert [m["role"] for m in _collapse_wire_rows(rows)] == ["chunk"]
+
+    def test_a_done_row_does_not_split_a_run(self) -> None:
+        """_prepare_messages skips `done` without flushing its accumulator.
+
+        A terminator landing between two deltas therefore does not split the
+        message there, and this reduction must agree rather than emit two rows.
+        """
+        rows = [
+            {"role": "chunk", "content": "a"},
+            {"role": "done", "content": ""},
+            {"role": "chunk", "content": "b"},
+        ]
+        out = _collapse_wire_rows(rows)
+        assert [(m["role"], m["content"]) for m in out] == [("chunk", "ab")]
+
+    def test_the_live_window_is_not_mutated(self) -> None:
+        """These dicts are shared with the window the event loop appends to."""
+        rows = [{"role": "chunk", "content": "a"}, {"role": "chunk", "content": "b"}]
+        before = [dict(m) for m in rows]
+        _collapse_wire_rows(rows)
+        assert rows == before


### PR DESCRIPTION
## 1. What is the problem?

`chunk` is a wire-only role appended once per streamed delta, so a reply still
being typed occupies hundreds of rows that render as a single message. Two
endpoints bounded the live message window by **raw row count before reducing
it**, so a bound meant to count messages counted stream progress instead:

- `GET /api/chat/slots/{slot}` applied `limit` to raw rows. A caller asking for
  the last N messages of a running session spent its whole budget inside the
  unfinished reply and got a mid-sentence fragment with none of the conversation
  behind it.
- `POST /api/chat/slots/{slot}/resume` filled its 200-row bound the same way.
  This one is worse: it truncates the in-flight reply *itself* to the newest 200
  deltas, so the reply comes back beginning mid-sentence.

Fixes #4306.

## 2. Why this issue matters to the user

Mid-response is the *normal* condition for anything watching an agent work, not
an edge case. The Worlds scene thread popover polls this endpoint on a 2s
interval (`useSceneInteraction.tsx`), so the fragment is what it sees for the
whole duration of every reply. On resume, a user reloading the page while a
reply is streaming gets that reply with its opening cut off.

## 3. How our fix solves it

Reduce the wire-only rows **before** bounding, on both paths: consecutive
`chunk` runs fold to one row, `done` terminators drop. A bound then counts
displayed messages, the in-flight text arrives whole, and `total` and the paging
cursor stop counting stream progress.

Chain from symptom to root cause:

1. Symptom: a bounded read during streaming returns a fragment.
2. Because `limit` selected raw rows, and hundreds of them belong to one message.
3. Because the reduction that makes one row mean one message (`_prepare_messages`)
   ran *after* the bound, at render time.
4. Root cause: the bound and the reduction were in the wrong order. The fix
   reorders them rather than adding a second notion of size.

`_collapse_wire_rows` (new, in `chat_utils.py` beside `_prepare_messages`) is
output-equivalent to leaving those rows for the render pass, so the rendered
response shape is unchanged -- it only moves the fold to before the bound, where
it can decide what the bound counts. It applies no redaction, rewrites no other
role, and never mutates the live window (a folded row is a new dict, and those
rows are shared with the running slot).

On the **detail** path the reduction runs inside the same worker thread as
`_append_unflushed_tail` (#4137) and covers the whole corpus, because that helper
places an owed row at the disk index it belongs to -- owed rows are not a
contiguous suffix, so a slice-scoped reduction would miss the interleaved ones.
`done` is already excluded there by `_UNOWED_WINDOW_ROLES`, so the remaining work
on that path is folding the chunk runs. The `done` drop stays load-bearing on
**resume**, which reads the window directly.

On resume this also puts both cursor terms in message units, since persisted rows
carry no wire-only role. Persisted history never carries these rows at all
(`_build_message_entry_uncached` returns `None` for every wire-only role), so the
scroll-back paging path is unaffected and `next_before` keeps its meaning as a
raw index. No cursor-space change, and no frontend change.

## 4. What tests we did

`test/test_slot_detail_inflight_tail.py` -- 13 tests over a fixture of 10 settled
turns plus a 300-delta in-flight segment: the bounded detail branch, the resume
branch, the fold itself, and the shapes that must not change.

Mutation-verified per mutant rather than by coverage:

- dropping the detail reduction -> 5 tests fail
- dropping the resume reduction -> 2 resume tests fail
- keeping `done` -> the terminator and run-splitting tests fail
- widening the fold over chained history -> caught by the output-equivalence test

Also re-ran the duplication probe from the review thread below (two settled
turns, all four rows persisted, window carrying those four plus one `done` per
turn, `?limit=50`): the response is exactly `['u1','a1','u2','a2']` with no
repeat. That defect was pre-existing on `main` and is fixed by #4137, which has
now landed; this branch is rebased on it.

Gates: 13/13 on the new file; 13729 passed / 42 skipped across all 208 test files
referencing `chat_utils`, `chat_handlers`, `_prepare_messages`, `slot_detail` or
`resume` (including #4137's own tests); isort, flake8, black gate, and mypy
(1003 files) clean.

## 5. Any other suggestions on the work

The disk-side cost of a long transcript -- reading the whole chained history on
the unbounded branch -- is a separate concern and belongs to #4134. This PR only
changes what a bound counts, not how much is read.

`done` rows accumulate one per settled turn in the live window and nothing ever
removes them (appended at 9 turn-end sites, never persisted). Dropping them at
read time is correct for these endpoints, but the accumulation itself looks worth
a follow-up: the window carries one dead row per turn for the life of the slot.
