### PR TITLE
fix(website): bump brace-expansion overrides past DoS CVEs

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "kirocrew-website",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dicebear/core": "9.4.3",
@@ -4826,9 +4827,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10265,9 +10266,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -152,12 +152,12 @@
     "@typescript-eslint/visitor-keys": "8.58.0",
     "ajv": "6.14.0",
     "baseline-browser-mapping": "2.10.13",
-    "brace-expansion": "1.1.13",
+    "brace-expansion": "1.1.18",
     "dompurify": "3.4.13",
     "esbuild": "0.25.12",
     "test-exclude": "8.0.0",
     "minimatch@>=10": {
-      "brace-expansion": "5.0.8"
+      "brace-expansion": "5.0.9"
     },
     "caniuse-lite": "1.0.30001782",
     "chevrotain-allstar": "0.3.1",


### PR DESCRIPTION
## Summary
- Bump the website `overrides` pin of `brace-expansion` from `1.1.13` → `1.1.18` and `minimatch@>=10`'s nested pin from `5.0.8` → `5.0.9`.
- Closes Dependabot [alert 103](https://github.com/kirodotdev/KiroCrew/security/dependabot/103) ([CVE-2026-13149](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)); `1.1.18` / `5.0.9` also cover the follow-up [CVE-2026-69152](https://github.com/advisories/GHSA-rgw5-rvv9-x895).
- Dev/lint only (eslint's minimatch). Does not ship in the dashboard bundle. Versions match the Electron lockfile.

## Test plan
- [ ] `cd website && npm audit` no longer reports `brace-expansion`
- [ ] Dependabot alert 103 auto-closes after merge
- [ ] Website lint/test still pass (`cd website && npm run lint` is enough; this is a transitive pin)


Made with [Cursor](https://cursor.com)