### PR TITLE
fix(subagent): keep the exception type and request id in a failed subagent's error

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -1069,6 +1069,28 @@ def _redact_acp_string(s: str) -> str:
     return s
 
 
+# Native subagent cards carry a short error string only, so a long provider
+# message is clipped. The request id is what identifies the failure
+# server-side and the formatter appends it LAST, so a plain head-slice drops
+# precisely the part worth keeping.
+_MAX_NATIVE_CARD_ERROR = 200
+_RE_TRAILING_REQUEST_ID = re.compile(r"\(request_id:\s*[0-9a-fA-F-]+\)\s*$")
+
+
+def _clip_card_error(text: str, limit: int = _MAX_NATIVE_CARD_ERROR) -> str:
+    """Clip *text* to *limit* characters, keeping any trailing request id."""
+    if len(text) <= limit:
+        return text
+    match = _RE_TRAILING_REQUEST_ID.search(text)
+    if not match:
+        return text[:limit]
+    suffix = match.group(0).strip()
+    head = limit - len(suffix) - 4  # room for the elision marker and a space
+    if head <= 0:
+        return text[:limit]
+    return f"{text[:head]}... {suffix}"
+
+
 def _emit_mcp_oauth_request(
     state: "DashboardState",
     slot: "_ChatSlot",
@@ -1574,7 +1596,7 @@ def _native_subagent_sync(state, slot, subagents, tracker, card_output=None) -> 
             if stype in ("failed", "error") and smsg:
                 err, _ = redact_exfiltration_urls(smsg)
                 err, _ = redact_credentials(err)
-                err = err[:200]
+                err = _clip_card_error(err)
             info["done"] = True
             _feed = _native_card_feed(card_output, card_id)
             _elapsed = time.time() - info["started"]

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -238,6 +238,48 @@ def _redact(text: str) -> str:
     return text
 
 
+# Bounds for a rendered exception chain. The rendering reaches a WS frame, a
+# tombstone and the Subagents panel, so it is capped rather than trusted.
+_MAX_ERROR_DETAIL_LEN = 2_000
+_MAX_ERROR_CHAIN = 4
+
+
+def _describe_exception(exc: BaseException) -> str:
+    """Render *exc* as ``Type: message``, following its cause chain.
+
+    A bare ``str(exc)`` drops the class, and for a whole family of failures the
+    message alone cannot be attributed to a subsystem: ``bad parameter or other
+    API misuse`` is unreadable prose until ``sqlite3.InterfaceError`` names
+    what raised it. The module is included for anything outside ``builtins``,
+    because the bare class name is frequently just as ambiguous as the message.
+
+    The chain is followed because the outermost exception is often a generic
+    wrapper whose ``__cause__`` holds the real fault. ``__context__`` is
+    followed only when it was not suppressed, matching how a traceback decides
+    the same question, so an unrelated exception that merely happened to be in
+    flight is not reported as this one's cause.
+    """
+    parts: list[str] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and len(parts) < _MAX_ERROR_CHAIN:
+        if id(current) in seen:
+            break
+        seen.add(id(current))
+        cls = type(current)
+        name = cls.__qualname__
+        module = getattr(cls, "__module__", "")
+        if module and module != "builtins":
+            name = f"{module}.{name}"
+        message = str(current).strip()
+        parts.append(f"{name}: {message}" if message else name)
+        nxt = current.__cause__
+        if nxt is None and not current.__suppress_context__:
+            nxt = current.__context__
+        current = nxt
+    return " <- caused by ".join(parts)[:_MAX_ERROR_DETAIL_LEN]
+
+
 _MAX_DONE_RESULT_LEN = 50_000  # cap subagent_done payload to avoid bloating WS frames
 
 
@@ -4560,7 +4602,7 @@ class SubagentManager:
             logger.info("Subagent %s cancelled", info.id)
         except Exception as exc:
             if not info.reaped:
-                info.error = str(exc)
+                info.error = _describe_exception(exc)
                 info.done = True
                 Stats().inc_subagent_failed()
                 self._write_tombstone(info, "error")
@@ -4880,6 +4922,11 @@ class SubagentManager:
                 turns=info.turns,
                 last_tool=info.last_tool,
                 outcome=info.outcome,
+                # ``cause`` is a coarse bucket ("error", "timeout"), which is
+                # not enough to act on. ``info.error`` is in-memory only and
+                # dies with the gateway, so without this the specific reason is
+                # recoverable from nothing but the log.
+                detail=(_redact(info.error)[:_MAX_ERROR_DETAIL_LEN] if info.error else ""),
             )
         except Exception:
             logger.debug("Failed to write tombstone for %s", info.id, exc_info=True)

--- a/test/test_subagent_error_detail.py
+++ b/test/test_subagent_error_detail.py
@@ -1,0 +1,252 @@
+"""Failure-reporting fidelity for subagents.
+
+A subagent that dies must say WHAT killed it. These tests pin the three places
+that previously flattened that information: the exception rendering, the
+durable tombstone, and the native-card truncation.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from kiro_crew.dashboard.chat_runner import _MAX_NATIVE_CARD_ERROR, _clip_card_error
+from kiro_crew.subagent import (
+    _MAX_ERROR_CHAIN,
+    _MAX_ERROR_DETAIL_LEN,
+    SubagentInfo,
+    SubagentManager,
+    _describe_exception,
+)
+
+
+@pytest.fixture()
+def agent_root(tmp_path, monkeypatch):
+    """Point persistence at a temp directory."""
+    monkeypatch.setattr("kiro_crew.subagent_persistence._SUBAGENTS_DIR", tmp_path)
+    return tmp_path
+
+
+class TestDescribeException:
+    def test_names_the_subsystem_for_an_unattributable_message(self):
+        """The message alone cannot be attributed; the type is the whole point.
+
+        ``bad parameter or other API misuse`` is sqlite's wording for
+        SQLITE_MISUSE. Rendered without its class it reads as an unspecified
+        argument bug and sends a reader looking in the wrong subsystem.
+        """
+        rendered = _describe_exception(
+            sqlite3.InterfaceError("bad parameter or other API misuse")
+        )
+        assert rendered == "sqlite3.InterfaceError: bad parameter or other API misuse"
+
+    def test_builtins_are_not_module_qualified(self):
+        assert _describe_exception(ValueError("nope")) == "ValueError: nope"
+
+    def test_follows_an_explicit_cause(self):
+        try:
+            try:
+                raise sqlite3.InterfaceError("bad parameter or other API misuse")
+            except sqlite3.InterfaceError as inner:
+                raise RuntimeError("context build failed") from inner
+        except RuntimeError as outer:
+            rendered = _describe_exception(outer)
+        assert rendered == (
+            "RuntimeError: context build failed <- caused by "
+            "sqlite3.InterfaceError: bad parameter or other API misuse"
+        )
+
+    def test_follows_an_unsuppressed_context(self):
+        """A bare ``raise`` inside an except block sets __context__, not __cause__."""
+        try:
+            try:
+                raise KeyError("lessons")
+            except KeyError:
+                raise RuntimeError("wrapper")
+        except RuntimeError as outer:
+            rendered = _describe_exception(outer)
+        assert rendered == "RuntimeError: wrapper <- caused by KeyError: 'lessons'"
+
+    def test_suppressed_context_is_not_reported_as_a_cause(self):
+        """``from None`` means the author said the context is unrelated."""
+        try:
+            try:
+                raise KeyError("unrelated")
+            except KeyError:
+                raise RuntimeError("wrapper") from None
+        except RuntimeError as outer:
+            rendered = _describe_exception(outer)
+        assert rendered == "RuntimeError: wrapper"
+
+    def test_empty_message_renders_the_bare_type(self):
+        assert _describe_exception(RuntimeError()) == "RuntimeError"
+
+    def test_output_is_bounded(self):
+        rendered = _describe_exception(ValueError("x" * (_MAX_ERROR_DETAIL_LEN * 3)))
+        assert len(rendered) == _MAX_ERROR_DETAIL_LEN
+
+    def test_chain_is_capped(self):
+        exc = ValueError("link0")
+        for depth in range(1, _MAX_ERROR_CHAIN + 5):
+            nxt = ValueError(f"link{depth}")
+            nxt.__cause__ = exc
+            exc = nxt
+        rendered = _describe_exception(exc)
+        assert rendered.count("<- caused by") == _MAX_ERROR_CHAIN - 1
+
+    def test_self_referential_chain_terminates(self):
+        """A cycle must not spin; ``__cause__`` is writable so this is reachable."""
+        exc = ValueError("loop")
+        exc.__cause__ = exc
+        assert _describe_exception(exc) == "ValueError: loop"
+
+
+class TestTombstoneCarriesTheReason:
+    def _tombstone(self, agent_root, agent_id):
+        return json.loads(
+            (agent_root / agent_id / "tombstone.json").read_text(encoding="utf-8")
+        )
+
+    def test_records_the_specific_reason_not_just_the_bucket(self, agent_root):
+        """``cause`` is a bucket; without ``detail`` the reason dies with the process."""
+        from kiro_crew.subagent_persistence import create_agent_folder
+
+        create_agent_folder("deadbeef", task="t")
+        info = SubagentInfo(id="deadbeef", task="t")
+        info.error = "sqlite3.InterfaceError: bad parameter or other API misuse"
+
+        SubagentManager._write_tombstone(info, "error")
+
+        tomb = self._tombstone(agent_root, "deadbeef")
+        assert tomb["cause"] == "error"
+        assert tomb["detail"] == "sqlite3.InterfaceError: bad parameter or other API misuse"
+
+    def test_absent_error_yields_an_empty_detail(self, agent_root):
+        from kiro_crew.subagent_persistence import create_agent_folder
+
+        create_agent_folder("nodetail", task="t")
+        SubagentManager._write_tombstone(SubagentInfo(id="nodetail", task="t"), "reaped")
+
+        assert self._tombstone(agent_root, "nodetail")["detail"] == ""
+
+    def test_detail_is_bounded(self, agent_root):
+        from kiro_crew.subagent_persistence import create_agent_folder
+
+        create_agent_folder("longone", task="t")
+        info = SubagentInfo(id="longone", task="t")
+        info.error = "E" * (_MAX_ERROR_DETAIL_LEN * 3)
+
+        SubagentManager._write_tombstone(info, "error")
+
+        assert len(self._tombstone(agent_root, "longone")["detail"]) == _MAX_ERROR_DETAIL_LEN
+
+
+class TestTerminalArmUsesTheDescription:
+    """The rendering is only useful if the arm that stores the error calls it."""
+
+    @pytest.mark.asyncio
+    async def test_run_records_the_exception_type(self, agent_root):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from kiro_crew.subagent_persistence import create_agent_folder
+
+        sessions = MagicMock()
+        sessions.release = MagicMock()
+        sessions.reset = AsyncMock()
+        manager = SubagentManager(sessions=sessions, ctx_builder=MagicMock())
+
+        info = SubagentInfo(id="sqlitedeath", task="t", parent_session_key="dashboard:default")
+        create_agent_folder("sqlitedeath", task="t")
+        manager._agents["sqlitedeath"] = info
+        manager._running_count = 1
+
+        async def _raise_sqlite_misuse(*_a, **_kw):
+            raise sqlite3.InterfaceError("bad parameter or other API misuse")
+
+        with patch.object(manager, "_run_inner", _raise_sqlite_misuse), \
+             patch("kiro_crew.subagent.Stats"), \
+             patch("kiro_crew.subagent.sel"), \
+             patch.object(manager, "_fire_event", new_callable=AsyncMock), \
+             patch.object(manager, "_on_done", new_callable=AsyncMock):
+            await asyncio.wait_for(manager._run(info), timeout=10)
+
+        assert info.error == "sqlite3.InterfaceError: bad parameter or other API misuse"
+        tomb = json.loads(
+            (agent_root / "sqlitedeath" / "tombstone.json").read_text(encoding="utf-8")
+        )
+        assert tomb["cause"] == "error"
+        assert tomb["detail"] == "sqlite3.InterfaceError: bad parameter or other API misuse"
+
+
+class TestClipCardError:
+    def test_short_error_is_unchanged(self):
+        assert _clip_card_error("boom") == "boom"
+
+    def test_long_error_without_a_request_id_is_head_sliced(self):
+        clipped = _clip_card_error("y" * 500)
+        assert clipped == "y" * _MAX_NATIVE_CARD_ERROR
+
+    def test_trailing_request_id_survives_truncation(self):
+        """The request id is the only part support can act on, and it sits last."""
+        text = (
+            "Your account does not have access to model 'claude-opus-4-8'. "
+            + "filler " * 40
+            + "(request_id: 596ec62b-e3e8-4d66-9afb-2ad3a2217172)"
+        )
+        assert len(text) > _MAX_NATIVE_CARD_ERROR
+
+        clipped = _clip_card_error(text)
+
+        assert "(request_id: 596ec62b-e3e8-4d66-9afb-2ad3a2217172)" in clipped
+        assert clipped.startswith("Your account does not have access to model")
+        assert len(clipped) <= _MAX_NATIVE_CARD_ERROR
+
+    def test_request_id_not_at_the_end_is_not_preserved(self):
+        """Only a trailing id is the formatter's suffix; mid-string is prose."""
+        text = "(request_id: abc-123) " + "z" * 500
+        clipped = _clip_card_error(text)
+        assert len(clipped) == _MAX_NATIVE_CARD_ERROR
+        assert clipped.endswith("z")
+
+    def test_native_sync_publishes_an_error_keeping_the_request_id(self):
+        """Pins the call site: the native card is where the clip is applied."""
+        from unittest.mock import MagicMock
+
+        from kiro_crew.dashboard.chat_runner import _native_subagent_sync
+
+        state = MagicMock()
+        state.broadcast_ws = MagicMock()
+        slot = MagicMock()
+        slot.key = "slot-1"
+        slot._native_subagent_tracker = {}
+        slot._native_subagent_output = {}
+        tracker: dict = {}
+
+        def _sub(status_type, message=""):
+            return {
+                "sessionId": "s1",
+                "sessionName": "n",
+                "agentName": "worker",
+                "role": "worker",
+                "initialQuery": "q",
+                "status": {"type": status_type, "message": message},
+            }
+
+        _native_subagent_sync(state, slot, [_sub("working")], tracker)
+        long_error = (
+            "Your account does not have access to model 'claude-opus-4-8'. "
+            + "filler " * 40
+            + "(request_id: 596ec62b-e3e8-4d66-9afb-2ad3a2217172)"
+        )
+        _native_subagent_sync(state, slot, [_sub("failed", long_error)], tracker)
+
+        errors = [
+            call.args[1]["error"]
+            for call in state.broadcast_ws.call_args_list
+            if call.args[0] == "subagent_done" and call.args[1].get("error")
+        ]
+        assert errors, "no terminal frame carried an error"
+        assert "(request_id: 596ec62b-e3e8-4d66-9afb-2ad3a2217172)" in errors[-1]


### PR DESCRIPTION
## Problem

Two users reported subagent failure storms this week. In both cases the failure
itself was quick to fix once identified — and identifying it required reading
source, because the dashboard reported almost nothing.

One user's Subagents panel showed a failed subagent whose entire error text was:

```
bad parameter or other API misuse
```

That is `str(sqlite3.InterfaceError)` — SQLITE_MISUSE. Nothing in the UI said
"sqlite", so the string reads as an unspecified argument bug and sends the
reader into the wrong subsystem entirely. The real cause was a known
`VectorMemoryStore` concurrency fault that fires during context assembly,
before the model is ever contacted.

Three places flatten a subagent's failure reason. None is the root cause of
either incident; together they are why neither incident could be triaged from
the dashboard.

### 1. The terminal arm dropped the exception class

`SubagentManager._run`'s catch-all stored a bare `str(exc)`, wrapping ~790
lines of `_run_inner`. The class name — frequently the only unambiguous part of
the failure — was discarded.

Now rendered as `Type: message`, module-qualified outside `builtins`, following
the cause chain because the outermost exception is often a generic wrapper whose
`__cause__` holds the real fault. `__context__` is followed only when it was not
suppressed, matching how a traceback decides the same question, so an unrelated
exception that merely happened to be in flight is not reported as this one's
cause. Output is bounded and the chain is capped.

### 2. The tombstone recorded a bucket, not a reason

`tombstone.json` carried `cause="error"` and nothing else. The specific reason
lived only on the in-memory `SubagentInfo.error`, so once the gateway restarted
it was recoverable from nothing but `gateway.log`. Tombstones now carry a
redacted, bounded `detail`.

### 3. Native card truncation dropped the request id

Native subagent cards head-sliced the error at 200 characters. The provider's
error formatter appends `(request_id: ...)` **last**, so a plain head-slice
drops precisely the token support needs to find the failure server-side.
Truncation now preserves that suffix.

## Testing

`test/test_subagent_error_detail.py` — 18 tests. Each of the three fixes is
pinned at its **call site**, not just at its helper, so a revert cannot pass:

| Mutation | Result |
|---|---|
| error capture back to `str(exc)` | caught |
| tombstone loses `detail` | caught |
| native clip back to `err[:200]` | caught |

Verified with a mutation harness that also checks anchor uniqueness, so a
vacuous mutation is reported rather than counted as a pass. The sqlite case is a
positive control reproducing the exact reported string.

## Gates

- `pytest`: 56,481 passed. 38 failures A/B-proven pre-existing — identical
  38 failed / 963 passed on the clean baseline and on this branch, all
  host-environmental (an old `jq`, no Node >= 20, `ps` parsing). None in the
  touched files.
- `isort`, `flake8`: clean at CI scope.
- `mypy`: clean, 987 source files, faiss-free CI-parity venv on the pinned
  1.14.1.
- Backend-only diff, so `tsc`/`vitest` are out of scope.

## Scope

Deliberately narrow: this makes failures **legible**. It does not fix the
underlying defects found in the same investigation — no pre-spawn validation of
an invalid model pin, no change to the entitlement/retry classification, and no
change to the panel's stale-card behaviour. Those are separate PRs against
separate layers.
