### PR TITLE
test(design_tweak): derive the write ceiling instead of probing it with 2080 writes

### DIFF
--- a/test/test_design_tweak_backend.py
+++ b/test/test_design_tweak_backend.py
@@ -548,24 +548,70 @@ class TestWhatIsWrittenStaysReadable:
         assert still["comments"] == [{"cid": "c1"}]
 
     def test_anything_the_writer_accepts_the_reader_returns(self, isolated_queue):
-        """Round-trip at the boundary, so an off-by-one cannot hide between them."""
-        rid = "1700000000000-atlimit"
-        fp = server._request_file(server.QUEUE_DIR, rid)
-        # Grow a record until the writer refuses, then prove the last accepted
-        # one is still readable — that is the invariant, not any single size.
-        pad = "a" * 1000
-        req: dict = {"id": rid, "notes": []}
-        for _ in range(4000):
-            req["notes"].append(pad)
-            try:
-                server._write_request(fp, req)
-            except server._RecordTooLarge:
-                req["notes"].pop()
-                break
-        else:
-            pytest.fail("never reached the ceiling — the guard may be inert")
+        """Round-trip AT the ceiling, so an off-by-one cannot hide between them.
+
+        The writer refuses `len(data) > max_bytes` and the reader refuses
+        `st_size > MAX_RECORD_BYTES`, so a record serialising to exactly the
+        ceiling is the single input both must accept. Either bound flipping to
+        `>=` rejects it, and no other test in this file writes a record of
+        exactly that size.
+        """
+        fp = server._request_file(server.QUEUE_DIR, _AT_LIMIT_RID)
+        at_ceiling = _record_serialising_to(_AT_LIMIT_RID, server.MAX_RECORD_BYTES)
+        server._write_request(fp, at_ceiling)
+        assert fp.stat().st_size == server.MAX_RECORD_BYTES, (
+            "the record no longer lands on the ceiling, so the boundary is untested"
+        )
         assert server._read_request(fp) is not None, (
             "the largest record the writer accepted is unreadable"
+        )
+
+    def test_one_byte_over_the_ceiling_is_refused(self, isolated_queue):
+        """Pins the ceiling exactly.
+
+        `test_an_oversized_write_is_refused` uses a grossly oversized record, which
+        an off-by-one bound still refuses; only the +1 case can tell the two apart.
+        """
+        fp = server._request_file(server.QUEUE_DIR, _AT_LIMIT_RID)
+        over = _record_serialising_to(_AT_LIMIT_RID, server.MAX_RECORD_BYTES + 1)
+        with pytest.raises(server._RecordTooLarge):
+            server._write_request(fp, over)
+
+    def test_the_boundary_round_trip_stays_inside_an_io_budget(
+        self, isolated_queue, monkeypatch
+    ):
+        """Bound the I/O, because a quadratic probe is invisible to a pass/fail assert.
+
+        Establishing the ceiling by growing a record and calling the real writer at
+        each step costs sum(k) bytes, not O(k): measured at 2081 writer calls and
+        2.03 GiB serialised and written to reach a 2 MiB answer. On windows-latest
+        that overran the 180s per-test timeout, and replacing the killed worker
+        pushed the whole shard past its 40-minute job cap, so every other test in
+        that shard went unreported. The ceiling is arithmetic on the serialised
+        bytes, so candidates must be measured in memory.
+        """
+        offered: list[int] = []
+        real_write_json = server._atomic_write_json
+
+        def counting(path: Path, payload: dict, **kw: Any) -> None:
+            offered.append(len(json.dumps(payload, indent=2).encode("utf-8")))
+            return real_write_json(path, payload, **kw)
+
+        monkeypatch.setattr(server, "_atomic_write_json", counting)
+
+        fp = server._request_file(server.QUEUE_DIR, _AT_LIMIT_RID)
+        server._write_request(
+            fp, _record_serialising_to(_AT_LIMIT_RID, server.MAX_RECORD_BYTES)
+        )
+        assert server._read_request(fp) is not None
+
+        assert len(offered) <= 2, (
+            f"{len(offered)} writer calls to establish one ceiling; a real write per "
+            "candidate size is quadratic and hangs the Windows shard"
+        )
+        assert sum(offered) <= 2 * server.MAX_RECORD_BYTES, (
+            f"the boundary round-trip pushed {sum(offered)} bytes through the writer "
+            f"for a {server.MAX_RECORD_BYTES}-byte answer"
         )
 
     def test_the_writer_bound_covers_every_route(self):
@@ -2667,6 +2713,29 @@ def _widen_the_race(monkeypatch, delay: float = 0.05):
         real_write(fp, req)
 
     monkeypatch.setattr(server, "_write_request", slow_write)
+
+
+_AT_LIMIT_RID = "1700000000000-atlimit"
+
+
+def _record_serialising_to(rid: str, size: int) -> dict:
+    """A queue record whose `json.dumps(..., indent=2)` encoding is exactly `size` bytes.
+
+    Solved, not searched. The writer's ceiling is a property of the serialised
+    bytes, so a candidate can be measured in memory; growing a record and calling
+    the real writer at each step spends O(n^2) bytes of fsynced disk I/O to learn
+    the same number. The pad is `a`, which JSON never escapes, so length is linear
+    in the pad and the correction below lands in one step.
+    """
+    req: dict = {"id": rid, "notes": [""]}
+    for _ in range(3):
+        have = len(json.dumps(req, indent=2).encode("utf-8"))
+        if have == size:
+            return req
+        if len(req["notes"][0]) + size - have < 0:
+            raise AssertionError(f"{size} bytes is below the record skeleton")
+        req["notes"][0] = "a" * (len(req["notes"][0]) + size - have)
+    raise AssertionError(f"could not serialise to exactly {size} bytes")
 
 
 def _submit(project_id: str, text: str, extra: dict | None = None) -> _JsonHandler:


### PR DESCRIPTION
## Problem / Motivation

`test/test_design_tweak_backend.py::test_anything_the_writer_accepts_the_reader_returns` hangs `Backend Tests (Windows)` shards. It grew a queue record one 1000-char note at a time and called the real `_write_request` after every append, so the work it did was quadratic in the record size: the bytes pushed through the writer are the sum of every intermediate size, not the final one.

Measured on this branch, instrumenting the unmodified test: **2081 writer calls, 2080 `os.fsync` calls, and 2.03 GiB serialised and written to disk** to establish a limit of 2 MiB. Arithmetic check: sum(k) * 1006 bytes over 2081 iterations = 2,179,318,926, against 2,181,662,080 measured.

This is a hang, not a flaky assertion. `backend-test-windows` runs `pytest --timeout=180` under a job-level `timeout-minutes: 40`. One test exceeding the 180s per-test timeout on a `windows-latest` runner, plus the xdist worker replacement that follows, is enough to push the shard past the 40-minute job cap, at which point the job is killed and reports `cancelled`.

## Why it matters

The cost is the whole shard, not one test. When the job is killed at the cap, every other test in that shard goes unreported, so any pull request unlucky enough to draw this test on Windows cannot go green through no fault of its own diff. The observed pass rate was roughly one in three, which means a fresh commit clears it only by luck, and on a fork each attempt spends a maintainer CI approval on a coin flip. The durable fix has to be in the code.

No open pull request owned this file, which is why this is a separate change rather than an amend.

## What changed

The ceiling is a property of the serialised bytes, so a candidate can be measured with `json.dumps` in memory instead of discovered by writing. A new module-level helper `_record_serialising_to(rid, size)` solves for a record whose `json.dumps(..., indent=2)` encoding is exactly `size` bytes; the pad is `a`, which JSON never escapes, so length is linear in the pad and the correction lands in one step. The round-trip now writes exactly one record: **1 fsync and 2 MiB, 0.02s instead of ~6.5s on Linux** — a 2080x reduction in fsync calls and 1040x in bytes.

This also closes a coverage gap rather than only trading runtime. The old loop's largest accepted record was **2,096,692 bytes, 460 short of the 2,097,152 ceiling**, so it never exercised the boundary it was named for. The writer refuses `len(data) > max_bytes` and the reader refuses `st_size > MAX_RECORD_BYTES`; a record at exactly the ceiling is the single input both must accept, and only that input can detect either bound flipping to `>=`.

**I rejected changing `_atomic_write_json`, and measured rather than assumed it.** The suspicion was that the write/`fsync`/rename path behaves badly on Windows at size. Attributing the cost on Linux by stubbing components: **fsync is 2% of the runtime, non-fsync disk writes 15%, and serialisation 83%**. Removing `fsync` would therefore not fix this, and it would trade a documented crash-safety guarantee — the loop-to-completion plus `fsync` exists so `os.replace` can never publish a truncated file — for test runtime. Per-call cost there is already proportional to the payload and bounded by `MAX_RECORD_BYTES`, and no production caller writes a record more than once. The pathology was the test's growth loop, so that is where the fix went.

Nothing was weakened to achieve this: no Windows skip, no `timeout-minutes` increase, and the two properties the old test carried (the guard is not inert, and the largest accepted record round-trips) are both still asserted.

## Tests

Three tests replace the one growth loop, in `TestWhatIsWrittenStaysReadable`:

- `test_anything_the_writer_accepts_the_reader_returns` — same name and same invariant, now at exactly `MAX_RECORD_BYTES`, and it asserts the on-disk size really is the ceiling so the fixture cannot silently drift off the boundary.
- `test_one_byte_over_the_ceiling_is_refused` — pins the bound at +1, which the existing grossly-oversized case cannot do because an off-by-one bound still refuses it.
- `test_the_boundary_round_trip_stays_inside_an_io_budget` — the regression guard. It counts writer invocations and bytes offered, so a future per-candidate probe loop fails loudly instead of merely running slowly.

Both directions were controlled:

- **The new assertion is stronger, not just faster.** Injecting `>=` into the reader's size guard makes the new at-ceiling test fail with "the largest record the writer accepted is unreadable", while the old growth loop still passes — because its largest record was 460 bytes short of the ceiling.
- **The budget guard would have caught this hang.** Re-inserting the pre-fix growth loop into it fails with `AssertionError: 2081 writer calls to establish one ceiling`.

543 passed across `test/test_design_tweak_*.py`; 292 passed in the changed file, which now completes in 6.7s with the boundary test no longer among the slowest durations. `isort --check-only` and `flake8` both clean, and `mypy src/kiro_crew/` clean. `mypy test/` reports 21 errors on this file, but it reports the identical 21 on the unmodified file at `upstream/main`, and CI type-checks `src/kiro_crew/` only.
