### PR TITLE
fix(sidebar): rebuild the relative-time day cache when the timezone changes

### DIFF
--- a/website/src/pages/chat/sessionOrder.ts
+++ b/website/src/pages/chat/sessionOrder.ts
@@ -97,35 +97,31 @@ export function comparePinnedThenSort(
 }
 
 /**
- * The local-midnight instants `fmtRelativeTime` classifies against, in epoch ms.
+ * How many local calendar days back an instant falls, seen from `now`.
  *
- * Every visible session row compares against the same boundaries, so they are
- * built once per day rather than once per call. `dayEnd` is the next local
- * midnight, which is when they stop being true.
+ * `Date.UTC` projects the LOCAL calendar fields onto fixed-length UTC days, so
+ * the result counts civil days rather than elapsed time. That is what makes it
+ * survive DST: a local day is not always 86_400_000 ms long, but its
+ * (year, month, date) triple is unambiguous, and both sides are projected the
+ * same way. Negative for a future instant, which the caller folds into today.
  *
- * The lower bound matters as much as the upper one: a clock that moves BACKWARDS
- * is also outside the cached day, and must not be served boundaries from a day
- * that has not happened yet.
+ * Deliberately stateless. An earlier revision of this file cached the
+ * local-midnight instants and kept them honest with a growing set of validity
+ * terms: the clock leaving the cached day in either direction, the zone
+ * changing under it, and then the offset at each cached midnight moving
+ * independently of the others. Each boundary added to such a cache needs its
+ * own offset probe or it silently serves a label from a day that no longer
+ * begins where it did. Deriving the day index per call retires that whole class
+ * -- nothing is retained, so nothing can outlive the zone it was built in --
+ * and measures cheaper than the guarded cache it replaces, because comparing
+ * two day indices allocates no `Date` where re-probing three midnights did.
+ * It is the shape the command palette's own relative-time formatter already uses.
  */
-let dayStart = 0
-let yesterdayStart = 0
-let sixDaysAgoStart = 0
-let dayEnd = 0
-let dayYear = 0
-
-function ensureDayBoundaries(nowMs: number): void {
-  if (nowMs >= dayStart && nowMs < dayEnd) return
-  const now = new Date(nowMs)
-  const y = now.getFullYear()
-  const m = now.getMonth()
-  const day = now.getDate()
-  // Day arithmetic goes through the Date constructor rather than ms subtraction
-  // because it has to survive DST: a local day is not always 86_400_000 ms long.
-  dayStart = new Date(y, m, day).getTime()
-  yesterdayStart = new Date(y, m, day - 1).getTime()
-  sixDaysAgoStart = new Date(y, m, day - 6).getTime()
-  dayEnd = new Date(y, m, day + 1).getTime()
-  dayYear = y
+function localDaysAgo(now: Date, then: Date): number {
+  const DAY_MS = 86_400_000
+  const nowDay = Math.floor(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()) / DAY_MS)
+  const thenDay = Math.floor(Date.UTC(then.getFullYear(), then.getMonth(), then.getDate()) / DAY_MS)
+  return nowDay - thenDay
 }
 
 /** Relative timestamp for a session row.
@@ -133,19 +129,19 @@ function ensureDayBoundaries(nowMs: number): void {
 export function fmtRelativeTime(ts: string | number | undefined): string {
   if (ts == null) return ''
   const d = typeof ts === 'number' ? new Date(ts * 1000) : new Date(ts)
-  const at = d.getTime()
-  if (isNaN(at)) return ''
-  ensureDayBoundaries(Date.now())
+  if (isNaN(d.getTime())) return ''
+  const now = new Date()
+  const daysAgo = localDaysAgo(now, d)
   // Every branch read the BROWSER's locale before this, so a zh dashboard on an
   // en-US browser showed "3:04 PM" and "Jul 30". This is the twin of
   // `commandPalette/providers/recentsProvider.ts`; the two are now consistent.
   const time = fmtDateFields(d, { hour: '2-digit', minute: '2-digit' })
-  if (at >= dayStart) return time
+  if (daysAgo <= 0) return time
   // The existing catalog key, NOT `fmtRelative`: CLDR returns a lowercase
   // "yesterday", which clashed with the capitalized group header in ChatSidebar
   // that already uses this same key. One key, one casing.
-  if (at >= yesterdayStart) return `${i18nT('pages.chatSidebar.yesterday')} ${time}`
-  if (at >= sixDaysAgoStart) return `${fmtDateFields(d, { weekday: 'short' })} ${time}`
-  if (d.getFullYear() === dayYear) return fmtDateFields(d, { month: 'short', day: 'numeric' })
+  if (daysAgo === 1) return `${i18nT('pages.chatSidebar.yesterday')} ${time}`
+  if (daysAgo <= 6) return `${fmtDateFields(d, { weekday: 'short' })} ${time}`
+  if (d.getFullYear() === now.getFullYear()) return fmtDateFields(d, { month: 'short', day: 'numeric' })
   return fmtDateFields(d, { year: 'numeric', month: 'short', day: 'numeric' })
 }

--- a/website/src/test/sessionOrder.test.ts
+++ b/website/src/test/sessionOrder.test.ts
@@ -12,8 +12,10 @@
  *      not shift with the app language.
  *  (5) A running session ranks by `last_turn_ts` (its prompt), so mid-turn rows
  *      moving `last_ts` cannot reshuffle the list.
- *  (6) `fmtRelativeTime` shares one set of day boundaries across a whole list,
- *      and rebuilds them when the clock leaves that day in either direction.
+ *  (6) `fmtRelativeTime` classifies a row by the difference in LOCAL CALENDAR
+ *      DAYS between it and now, holding no state between calls, so the label
+ *      follows the active timezone immediately and cannot be served from a day
+ *      that has stopped being true.
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { compareBySort, comparePinnedThenSort, fmtRelativeTime, lastActivityEpoch, slotActivityTs } from '../pages/chat/sessionOrder'
@@ -165,11 +167,11 @@ describe('compareBySort created-*', () => {
 /**
  * Count `new Date(...)` constructions performed inside `fn`.
  *
- * The day-boundary cache is not visible in the string `fmtRelativeTime` returns,
- * so the allocation count is the only direct evidence it is doing anything. The
- * subclass is restored in `finally` so a failed assertion cannot leak it into a
- * later test. `Date.now()` is a static and is inherited, so reading the clock is
- * deliberately not counted — only allocation is.
+ * Per-call cost is not visible in the string `fmtRelativeTime` returns, so the
+ * allocation count is the direct evidence of it. The subclass is restored in
+ * `finally` so a failed assertion cannot leak it into a later test. `Date.now()`
+ * and `Date.UTC()` are statics and are inherited, so reading the clock and
+ * projecting a calendar day are deliberately not counted — only allocation is.
  */
 function countDateConstructions(fn: () => void): number {
   const Real = globalThis.Date
@@ -190,27 +192,45 @@ function countDateConstructions(fn: () => void): number {
   return made
 }
 
+/** Run `fn` with the process timezone set to `tz`, restoring it afterwards.
+ *  A real zone, not a stubbed offset: only a real zone moves what the `Date`
+ *  constructor itself produces, which is what the label is derived from. */
+function inZone<T>(tz: string, fn: () => T): T {
+  const prev = process.env.TZ
+  process.env.TZ = tz
+  try {
+    return fn()
+  } finally {
+    process.env.TZ = prev
+  }
+}
+
+/** The catalog's rendering of the yesterday prefix, read out of a row that is
+ *  unambiguously yesterday in `tz`, so assertions do not hardcode a locale. */
+const yesterdayPrefixIn = (tz: string, ts: string) =>
+  inZone(tz, () => fmtRelativeTime(ts)).split(' ')[0]
+
 describe('fmtRelativeTime day boundaries', () => {
   afterEach(() => {
     vi.useRealTimers()
   })
 
-  it('builds the day boundaries once for a whole list, not once per row', () => {
+  it('costs a flat two Date allocations per row, with no warm-up pass', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-17T12:00:00Z'))
     const rows = Array.from({ length: 20 }, (_, i) => `2026-08-17T0${i % 9}:30:00Z`)
 
-    const cold = countDateConstructions(() => {
+    const first = countDateConstructions(() => {
       for (const ts of rows) fmtRelativeTime(ts)
     })
-    const warm = countDateConstructions(() => {
+    const second = countDateConstructions(() => {
       for (const ts of rows) fmtRelativeTime(ts)
     })
 
-    // A rebuild costs 5 (the clock reading plus four boundaries), so a cold list
-    // pays it once and a warm one not at all. Per-row it would be 5 every row.
-    expect(cold).toBeLessThanOrEqual(rows.length + 5)
-    expect(warm).toEqual(rows.length)
+    // One Date for the row, one for the clock; `Date.UTC` allocates nothing. Flat
+    // cost means no retained instant exists that a later call could find stale.
+    expect(first).toEqual(rows.length * 2)
+    expect(second).toEqual(first)
   })
 
   it('reclassifies a timestamp once the local day rolls over', () => {
@@ -228,7 +248,7 @@ describe('fmtRelativeTime day boundaries', () => {
     expect(asYesterday).toContain(asToday)
   })
 
-  it('rebuilds when the clock moves backwards, so a future day is not reused', () => {
+  it('does not reuse a future day when the clock moves backwards', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-17T12:00:00Z'))
     const asToday = fmtRelativeTime('2026-08-17T10:00:00Z')
@@ -237,9 +257,49 @@ describe('fmtRelativeTime day boundaries', () => {
     fmtRelativeTime('2026-08-20T10:00:00Z')
 
     vi.setSystemTime(new Date('2026-08-17T12:00:00Z'))
-    // Held at the Aug 20 boundaries, Aug 17 would fall in the within-6-days
-    // branch and gain a weekday prefix.
+    // Held at the Aug 20 day, Aug 17 would fall in the within-6-days branch and
+    // gain a weekday prefix.
     expect(fmtRelativeTime('2026-08-17T10:00:00Z')).toEqual(asToday)
+  })
+
+  it('classifies by the local day of the active zone, an hour apart all year', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-06T12:00:00Z'))
+    // 18:30Z is 23:30 on Sep 5 in Almaty (UTC+5) but 00:30 on Sep 6 in Bishkek
+    // (UTC+6), so the same instant is yesterday in one zone and today in the other.
+    const ts = '2026-09-05T18:30:00Z'
+    const yesterday = yesterdayPrefixIn('Asia/Almaty', '2026-09-05T06:00:00Z')
+
+    expect(inZone('Asia/Almaty', () => fmtRelativeTime(ts)).startsWith(yesterday)).toBe(true)
+    expect(inZone('Asia/Bishkek', () => fmtRelativeTime(ts)).startsWith(yesterday)).toBe(false)
+  })
+
+  it('follows a zone whose midnight offset differs from its offset at noon', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-15T12:00:00Z'))
+    // Casablanca is +00:00 by noon on this date but +01:00 at local midnight, so
+    // 23:30Z is Feb 14 in UTC and Feb 15 there while both agree on the time of day.
+    const ts = '2026-02-14T23:30:00Z'
+    const yesterday = yesterdayPrefixIn('UTC', '2026-02-14T06:00:00Z')
+
+    expect(inZone('UTC', () => fmtRelativeTime(ts)).startsWith(yesterday)).toBe(true)
+    expect(inZone('Africa/Casablanca', () => fmtRelativeTime(ts)).startsWith(yesterday)).toBe(false)
+  })
+
+  it('follows a zone that agrees on today but not on when yesterday began', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-06T12:00:00Z'))
+    // The zones agree at this instant and at today's midnight, diverging only
+    // further back: 05:30Z is Sep 5 in Winnipeg but still Sep 4 on Easter.
+    const ts = '2026-09-05T05:30:00Z'
+    const yesterday = yesterdayPrefixIn('America/Winnipeg', '2026-09-05T12:00:00Z')
+
+    const winnipeg = inZone('America/Winnipeg', () => fmtRelativeTime(ts))
+    const easter = inZone('Pacific/Easter', () => fmtRelativeTime(ts))
+
+    expect(winnipeg.startsWith(yesterday)).toBe(true)
+    expect(easter.startsWith(yesterday)).toBe(false)
+    expect(easter).not.toEqual(winnipeg)
   })
 
   it('still returns empty for a missing or unparseable timestamp', () => {


### PR DESCRIPTION
## Problem / Motivation

The sidebar's relative timestamps ("today", "yesterday", "Mon 15:04") stop following the operating system's timezone once it changes, and never recover until the next local midnight.

#4146 made `fmtRelativeTime` cheaper by caching the local-midnight instants it classifies each row against, instead of recomputing them for every row. The cache's validity check is `website/src/pages/chat/sessionOrder.ts:117` on `main`:

```ts
if (nowMs >= dayStart && nowMs < dayEnd) return
```

The two cached boundaries are built with the `Date` constructor (`:124-127`), so they encode whatever timezone was active the last time the cache was rebuilt. `nowMs` is a Unix epoch millisecond count, which is the same number in every timezone. Changing the OS timezone therefore moves neither side of that comparison, `nowMs` never falls outside `[dayStart, dayEnd)`, and the rebuild never fires — so rows keep being labelled against the *old* zone's midnight.

Reproduced at one fixed instant (`2026-08-17T12:00:00Z`) against a row at `03:00Z`, using the exact validity check from `main`:

| Zone | `getTimezoneOffset()` | cached `dayStart` | row labelled | `nowMs` still inside window? |
| ----------------- | --------------------: | -------------------- | ------------ | ---------------------------- |
| `UTC`             |                     0 | `2026-08-17T00:00Z`  | today        | yes, so no rebuild           |
| `Pacific/Auckland`|                  -720 | `2026-08-17T12:00Z`  | yesterday    | yes, so no rebuild           |

The same instant and the same row produce two different labels depending only on which zone was active at the last rebuild, and in both cases the clock stays inside the stale window. The offset is the only value in scope that differs (0 vs -720), which is what makes it a usable rebuild key.

This is a regression introduced by #4146, not a pre-existing bug. Before that change `fmtRelativeTime` computed `startOfToday` / `startOfYesterday` / `startOf6DaysAgo` inline on every call from a fresh `new Date()`, so it always read the current zone; there was no cache to go stale. On `main` today, `getTimezoneOffset` and `dayOffset` each occur 0 times in `sessionOrder.ts`, while `ensureDayBoundaries` occurs 2, `dayStart` 7 and `fmtRelativeTime` 2 — so the absence of any zone handling is real, not a failed search.

## Why it matters

Low severity, and stated plainly so it can be prioritised accordingly: the effect is a cosmetic mislabel confined to the sidebar's relative timestamps, and it self-corrects at the next local midnight or on any other event that rebuilds the cache. Sort order is unaffected — ordering comes from `lastActivityEpoch`, which compares epoch values and never consults these boundaries.

It is still worth fixing rather than leaving: a timezone change is not an exotic state. It happens when a laptop is opened in a new zone after travel, and the same stale-cache path is reached by a daylight-saving transition, which shifts the offset without the calendar day changing. In both cases the user sees timestamps that disagree with their clock, with nothing on screen explaining why, and the only remedy is to wait.

## What changed

`fmtRelativeTime` no longer caches anything. The module-level day boundaries, the offsets recorded alongside them, and the helper that decided whether they were still usable are all removed; `ensureDayBoundaries` and `boundaryOffsetsUnchanged` are gone and the file now holds no mutable module state at all. Each call derives how many local calendar days separate the row from now, from the two `Date` objects the function already has.

That retires the defect by construction rather than guarding against it. Nothing is retained between calls, so nothing can outlive the timezone it was built in, and there is no longer any boundary that could be correct at one moment and stale at the next. `Date.UTC` projects each side's local year, month and date onto fixed-length UTC days, which is what lets the difference survive DST: a local day is not always 86,400,000 ms long, but its calendar triple is unambiguous, and both sides are projected the same way.

Earlier revisions of this section argued the opposite — that the cache should be kept and its validity check extended with additional offset probes. Two review lanes pushed against that from opposite directions, one asking for still more probes to close a remaining gap and two others asking whether the cache was worth its cost at all. Removing the cache answers both at once: a gap in a validity check cannot matter when there is no retained value to validate, and the cost question stops being a trade because the stateless form is measurably cheaper than the cache was. Those earlier arguments and their figures are superseded and have been removed rather than left standing alongside the shipped code.

Cost, measured in one harness across all three shapes so the rows are comparable (400,000 calls per cell, JIT warmed, boundary logic only):

| variant | `UTC` | `Africa/Casablanca` | `America/Winnipeg` | `Asia/Almaty` | `Pacific/Easter` |
| --------------------------------- | -----: | -----: | -----: | -----: | -----: |
| inline, before #4146 landed        | 324 ns | 1487 ns | 707 ns | 413 ns | 728 ns |
| the cache, with its offset guards  | 221 ns | 1278 ns | 456 ns | 266 ns | 493 ns |
| **this branch, stateless**         | **130 ns** | **392 ns** | **192 ns** | **137 ns** | **186 ns** |

The stateless form is the cheapest of the three in every zone measured — 91 to 886 ns/call below the guarded cache, and 194 to 1096 ns/call below the code that predated the cache. It wins because comparing two day indices allocates no `Date` and reads no timezone offset, whereas keeping a cache honest meant re-reading the offset at each retained boundary on every call. Per-row `Date` allocations drop from 3 to 2, asserted by a test rather than estimated. Absolute cost for a 50-row render is 0.0065 ms under UTC and 0.020 ms under Casablanca against a 16.67 ms frame, so this is not a hot path either way; the point is that the simpler shape is not being bought at a price.

Timings measure the day-classification logic in isolation, not all of `fmtRelativeTime` — the real function also calls locale formatting, which dominates. Treat them as an upper bound on what this change can cost.

Equivalence with the previous logic was differential-tested rather than assumed, over every case where the old cache was fresh and therefore correct: 1,709,400 comparisons across 10 timezones including Casablanca, Easter Island, Lord Howe, Chatham, Kathmandu and Santiago, with zero disagreements. The command-palette formatter already classified rows without a cache, so the two are now the same *shape* — neither retains a boundary. They remain two separate implementations, though, and this change does not merge them: day classification still exists in both files and a future change to it would still have to be made in each. That is pre-existing and out of scope here, not something this PR fixes.

## Tests

`website/src/test/sessionOrder.test.ts` keeps 21 tests. The day-classification block still has seven, but four of them now assert the **label a user would see** instead of counting internal work, which is possible only because there is no longer any internal state to count.

`costs a flat two Date allocations per row, with no warm-up pass` pins the cost claim above. Both passes over the same 20 rows allocate identically, because there is no cheaper second pass to warm into.

Three tests switch the **real process timezone** rather than stubbing an offset. That matters: stubbing `getTimezoneOffset` changes what a guard reads but not what the `Date` constructor produces, so a stubbed test can only ever observe bookkeeping, never a label. With a real zone the label itself moves, so these tests assert the user-visible outcome:

- `classifies by the local day of the active zone, an hour apart all year` — Almaty and Bishkek. `2026-09-05T18:30Z` is 23:30 on Sep 5 in one and 00:30 on Sep 6 in the other, so the same instant is yesterday in one zone and today in the other. These two zones never share an offset — they are an hour apart at every one of 2026's 8,760 hours — which is worth recording because it means a switch between them was already caught before this change; the test pins the case rather than reproducing a defect.
- `follows a zone whose midnight offset differs from its offset at noon` — Casablanca on a date where it reads +00:00 at noon and +01:00 at local midnight, so `2026-02-14T23:30Z` falls on different calendar days in it and in UTC.
- `follows a zone that agrees on today but not on when yesterday began` — Winnipeg and Easter Island, which hold the same offset at the test instant *and* at today's midnight and diverge only further back, so `2026-09-05T05:30Z` is yesterday in one and earlier in the week in the other.

Each reads the catalog's own rendering of the yesterday label out of a row that is unambiguously yesterday in that zone, so no assertion hardcodes a locale.

Verified on this branch, based on `8af4e9dbd`:

- Fail-then-pass ordering checked by execution, not assumed: run against the unmodified previous code the cost test fails with a count of 64 against the 40 the stateless form produces for the same 20 rows. After the change, 21/21.
- Negative control, to prove the three zone tests are not vacuous: making the day difference zone-blind — differencing raw epoch time instead of projected local calendar fields — fails exactly those three and nothing else. Restoring returns 21/21.
- Full website suite — 1368 files, 21375 tests passed, 0 failures, plus 2 expected failures and 3 skips that are unrelated to this diff.
- `tsc --noEmit` clean; `eslint` clean on both files; comment lint reports 0 errors.
- i18n ratchet — passes with `I18N_BASE_REF` set. Set deliberately: without it the diff-scoped gates report that no base commit was supplied and validate nothing, which is a green result that means nothing.

## CI note: the cancelled E2E job is a starved step, not a hang in this change

`CI / E2E (stub ACP backend, offline)` came back `cancelled` on this commit. It is not caused by this change and no code fix is warranted. Three measurements, taken on this run and on four passing runs of the same job (PRs 3997, 4138, 3998 and 3240 — referenced without a link so this note does not spam their timelines):

**1. The step ran out of budget before it could finish.** Step 9, `Install Playwright browser (Chromium)`, took 10m59s here against 17–21s on all four comparison runs — a Chromium download cache miss, which is infrastructure. That pushed the pre-test steps to 18m20s of the job's 25-minute cap, leaving roughly 6m40s for a step that needs about 8m30s. It was cancelled at 6m57s.

| run      | Chromium install | i18n gate | E2E step          | job total | result    |
| -------- | ---------------- | --------- | ----------------- | --------- | --------- |
| this one | 10m59s           | 5m08s     | 6m57s (cancelled) | 25m21s    | cancelled |
| 3997     | 0m19s            | 2m40s     | 8m21s             | 13m26s    | success   |
| 4138     | 0m19s            | 2m32s     | 8m37s             | 13m29s    | success   |
| 3998     | 0m21s            | 2m41s     | 8m45s             | 13m56s    | success   |
| 3240     | 0m17s            | 5m09s     | 8m23s             | 15m49s    | success   |

**2. The silent gap in the log is this test's normal signature, not a symptom.** The item running at cancellation was `test/test_playwright_e2e.py::test_dashboard_playwright_suite`. It is a single pytest item that blocks on a `playwright test` subprocess, and `setup.py test_e2e` passes no `-s`, so pytest captures that subprocess's output and prints nothing at all until the item returns. Evidence it never streams: the test's own `[test:e2e:playwright]` marker line does not appear in this job's log, and on the passing run it appears only at the very end when capture is flushed. On PR 3997's passing run the same gap is 7m54.6s (12:08:12.534 to 12:16:07.117) before the test reports `PASSED`. The gap here was 6m31.8s — 83 seconds **shorter**. At the moment of cancellation this run had not yet reached the point where a healthy run reports, so there is no anomaly left to explain.

**3. Nothing in this diff can spin.** The code this change ships holds no state, contains no loop and no recursion, and does one bounded arithmetic comparison per row, so a runaway-recompute explanation is unavailable by construction. This was also measured against the previous shape while it still existed — 100,000 consecutive calls at a fixed clock showed a flat two allocations per call and no repeated rebuilding — so the concern did not hold before this change either.

Everything that exercises this diff passed on this same commit: `Frontend Tests` shards 1–4 (which run `sessionOrder.test.ts`), `Frontend Lint & Type Check`, `Frontend Coverage Merge`, and the `i18n render-time gate` that is step 10 of the very job that was cancelled. Across the run, 31 jobs succeeded, 2 skipped downstream of the cancelled step, and 1 was cancelled.

Resolved by re-running. An in-place job re-run is not available on a fork, so the job was re-triggered on a fresh sha. On that run the Chromium install took 19s rather than 10m59s, the E2E step ran to completion in 8m24s — inside the 8m21s-8m45s band measured on the four comparison runs — and the job passed. It has since passed on two further shas, most recently with the install at 0m18s and the E2E step at 8m26s. That settles the point: the earlier cancellation was starvation, not a defect in this change.

<!-- no-visual-delta -->

**Why no screenshot:** To be accurate rather than convenient, this change does alter rendered output — a row mislabelled "today" becomes "yesterday" — so the marker above should be read as "not capturable", not as "nothing changes". The delta only appears *after* the OS timezone changes while the cache is already warm and the epoch clock still sits inside the previously cached local day. A static before/after capture cannot show it: the two states differ by host timezone and cache age, not by anything on the page, and the "before" state is the stale-cache bug, which has to be induced by changing the host's zone mid-session rather than by navigating the app. The table under Problem / Motivation is the evidence in the form this defect can actually be shown in, and the new test asserts the corrected behaviour mechanically.







