### PR TITLE
fix(cron): preserve terminal stderr on script failure

### DIFF
--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -713,8 +713,25 @@ def run_script_sandboxed(
             return {"status": "cancelled", "error": "Cancelled by user"}
 
         if proc.returncode != 0 and not stdout.strip():
-            error_text = stderr[:500] or f"exit {proc.returncode}"
-            error_text = redact(error_text)
+            # Report the TERMINAL stderr context, not the head. A process that
+            # dies hard leaves its diagnosis LAST -- the traceback is the final
+            # thing written -- while whatever a startup path logged first (a
+            # data-home migration warning, a deprecation notice, an import
+            # banner) sits in front of it. Bounding from the head therefore
+            # reports the noise and truncates the cause, and the operator reads
+            # a cron failure whose message describes something that did not kill
+            # the job.
+            #
+            # ``rstrip`` first so a trailing newline does not spend part of the
+            # budget, and so an all-whitespace stderr still falls through to the
+            # exit-code fallback rather than reporting blank text.
+            #
+            # Redact the WHOLE stream before bounding: slicing first would cut
+            # a credential that straddles the 500-char boundary in half, and
+            # ``redact`` cannot recognise the surviving fragment, so it would
+            # reach logs and the persisted ``last_error`` unmasked.
+            tail = redact(stderr.rstrip())
+            error_text = tail[-500:] if tail else f"exit {proc.returncode}"
             return {"status": "error", "error": error_text}
 
         try:

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -355,6 +355,140 @@ class TestRunScriptSandboxed:
         script.write_text(code)
         return str(script)
 
+    # ── Terminal stderr context on a hard failure ──
+    # These five drive the real ``proc.returncode != 0 and not stdout.strip()``
+    # branch through a real subprocess. The launcher ``exec``s the user module
+    # OUTSIDE its try/except, so a module-level raise is exactly the shape that
+    # reaches that branch: unhandled traceback on stderr, non-zero exit, and no
+    # structured stdout to parse.
+
+    TERMINAL_SENTINEL = "REAL_TERMINAL_FAILURE_9f3a"
+
+    def test_a_terminal_failure_survives_leading_stderr_noise(self, tmp_path):
+        """The reported error must name why the script died, not what it warned about.
+
+        A process that dies hard leaves its diagnosis at the END of stderr — the
+        traceback is the last thing written. Anything a startup path logged
+        first (a migration warning, a deprecation notice, an import-time banner)
+        sits in front of it, so reporting the HEAD of stderr reports the noise
+        and truncates the cause. The operator then reads a cron failure whose
+        message describes something that did not kill the job.
+
+        900 characters of leading noise is deliberately past the 500-byte bound,
+        so a head-anchored report cannot contain the sentinel by accident.
+        """
+        script_path = self._write_script(
+            tmp_path,
+            'import sys\n'
+            'sys.stderr.write("W" * 900 + "\\n")\n'
+            'sys.stderr.flush()\n'
+            f'raise RuntimeError("{self.TERMINAL_SENTINEL}")\n',
+        )
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = run_script_sandboxed(script_path + ":run", "test-job-id")
+
+        assert result["status"] == "error"
+        assert self.TERMINAL_SENTINEL in result["error"], (
+            "the reported error is the head of stderr, so the terminal failure "
+            f"was truncated away: {result['error'][:120]!r}"
+        )
+
+    def test_a_short_stderr_is_reported_whole(self, tmp_path):
+        """Bounding must not start cutting output that already fits.
+
+        The bound exists to cap a runaway stderr, not to reshape the ordinary
+        case, so a diagnosis shorter than the cap keeps both ends. This one is a
+        CONTROL: it must pass identically before and after the change, which is
+        why the child exits WITHOUT a traceback -- an interpreter traceback
+        carries two absolute temp paths, and on Windows those alone push even a
+        one-line diagnosis past the bound, which would quietly turn this control
+        into a second copy of the case above.
+        """
+        script_path = self._write_script(
+            tmp_path,
+            'import os, sys\n'
+            'sys.stderr.write("LEADING_CONTEXT\\n")\n'
+            f'sys.stderr.write("{self.TERMINAL_SENTINEL}\\n")\n'
+            'sys.stderr.flush()\n'
+            'os._exit(2)\n',
+        )
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = run_script_sandboxed(script_path + ":run", "test-job-id")
+
+        assert result["status"] == "error"
+        assert "LEADING_CONTEXT" in result["error"]
+        assert self.TERMINAL_SENTINEL in result["error"]
+
+    def test_a_silent_hard_exit_still_reports_the_exit_code(self, tmp_path):
+        """With nothing on either stream, the exit code is the only diagnosis.
+
+        ``os._exit`` skips the launcher's handlers entirely, which is what a
+        killed or self-terminating child looks like. The fallback must survive
+        the change, or those failures become an empty error string.
+        """
+        script_path = self._write_script(tmp_path, 'import os\nos._exit(3)\n')
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = run_script_sandboxed(script_path + ":run", "test-job-id")
+
+        assert result["status"] == "error"
+        assert result["error"] == "exit 3"
+
+    def test_a_credential_in_the_terminal_stderr_is_redacted(self, tmp_path):
+        """The reported text still leaves the box, so redaction still applies.
+
+        Moving WHICH slice of stderr is reported must not move it out from
+        behind ``redact`` — a traceback can carry a key in a repr just as a
+        startup warning can.
+        """
+        script_path = self._write_script(
+            tmp_path,
+            'import sys\n'
+            'sys.stderr.write("W" * 900 + "\\n")\n'
+            'sys.stderr.flush()\n'
+            'raise RuntimeError("boom AKIAIOSFODNN7EXAMPLE")\n',
+        )
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = run_script_sandboxed(script_path + ":run", "test-job-id")
+
+        assert result["status"] == "error"
+        assert "AKIAIOSFODNN7EXAMPLE" not in result["error"]
+        assert "[REDACTED" in result["error"]
+
+    def test_a_credential_straddling_the_bound_does_not_leak_a_fragment(
+        self, tmp_path
+    ):
+        """Redaction must see the WHOLE stream before the 500-char bound cuts it.
+
+        If the suffix is sliced first, a credential that straddles the cut
+        point loses its leading characters before ``redact`` runs — and the
+        surviving fragment no longer matches any credential pattern, so it
+        reaches logs and the persisted ``last_error`` unmasked.
+
+        Byte layout (written verbatim, ``os._exit`` so no traceback shifts
+        it): 300 noise + a 20-char AWS key + 481 trailing chars = 801 total.
+        The -500 cut lands ONE character into the key, so slice-then-redact
+        leaks the 19-char fragment ``KIAIOSFODNN7EXAMPLE``; redact-then-slice
+        replaces the whole key with the tag, whose tail stays in the report.
+        """
+        script_path = self._write_script(
+            tmp_path,
+            'import os, sys\n'
+            'sys.stderr.write("W" * 300)\n'
+            'sys.stderr.write("AKIAIOSFODNN7EXAMPLE")\n'
+            'sys.stderr.write("X" * 481)\n'
+            'sys.stderr.flush()\n'
+            'os._exit(2)\n',
+        )
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = run_script_sandboxed(script_path + ":run", "test-job-id")
+
+        assert result["status"] == "error"
+        assert "AKIAIOSFODNN7EXAMPLE" not in result["error"]
+        # The discriminator: the exact fragment the slice-then-redact order
+        # leaves behind. Absent under redact-then-slice; present under the bug.
+        assert "KIAIOSFODNN7EXAMPLE" not in result["error"]
+        assert "credential]" in result["error"]
+
     def test_ok_status(self, tmp_path):
         script_path = self._write_script(
             tmp_path,


### PR DESCRIPTION
## Problem / Motivation

When a script cron's subprocess dies without producing structured stdout, the
reported failure text is the **first** 500 bytes of its stderr
(`src/kiro_crew/cron_script.py:708`):

```python
if proc.returncode != 0 and not stdout.strip():
    error_text = stderr[:500] or f"exit {proc.returncode}"
    error_text = redact(error_text)
    return {"status": "error", "error": error_text}
```

A process that dies hard leaves its diagnosis **last** — the traceback is the
final thing written. The launcher `exec`s the user module **outside** its
`try`/`except` (`cron_script.py:624`), so a module-level failure (a bad import, a
missing dependency, a raise during setup) reaches this branch with an unhandled
traceback on stderr, a non-zero exit, and nothing on stdout. That traceback is
what identifies the failure, and it is at the end.

Anything written to stderr *before* it competes for the same 500 bytes. That
value then becomes the job's user-visible failure: `slack/gateway.py:2625` turns
it into `raise RuntimeError(err)`, and `:2654` records it as `job.last_error` and
logs `Script cron '<name>' failed: <err>`.

## Why it matters

The data-home conflict warning is the worked example. `config/paths.py:255`
emits a ~300-character advisory `logger.warning` to stderr when a non-empty
legacy `~/.kirocrew` survives alongside the migrated home — a common
post-upgrade state. It stops nothing: nothing on the cron path consults
`detect_data_home_conflict()` (its only caller in the tree is `cli_doctor.py`),
and `paths.py` contains no `raise` at all. But it lands first, so a cron that
failed for an unrelated reason reports:

```
Script cron 'x' failed: data-home conflict: completion marker present at ... but a
non-empty legacy home ... also exists — the new home is authoritative ... Investigate
and remove it manually once confirmed stale (kirocrew doctor surfaces this).
RuntimeError: data-home conflict: ...
```

The operator is sent to delete a directory that is not why their job died, and
the reason it did die was truncated away. Any sufficiently chatty startup
warning produces the same effect; the migration warning is simply the one that
is easy to reproduce today.

## What changed (motivation → approach → change)

**Motivation** — make the reported error name the failure, without changing how
much text is reported or where it goes.

**Approach** — report the terminal stderr context rather than the leading one,
at the same bound. Redaction now runs over the **whole** rstripped stream
*before* the bound is applied (previously it ran on the already-sliced text):
slicing first would cut a credential straddling the 500-char boundary in half,
and the surviving fragment no longer matches any credential pattern, so it
would reach logs and the persisted `last_error` unmasked. This matches the
redact-then-truncate invariant `security.py::redact_and_truncate` documents.

Deliberately **not** a filter for the migration warning's text: that would put
knowledge of one config-layer message inside the cron runner, and would not help
with the next warning. The generalisation that fits is about which end of a
failing process's output carries its diagnosis.

**Change** — one hunk:

```python
tail = redact(stderr.rstrip())
error_text = tail[-500:] if tail else f"exit {proc.returncode}"
```

(The previously separate `error_text = redact(error_text)` line is dropped —
redaction happens once, over the full stream, before the slice.)

`rstrip` runs first so a trailing newline does not spend part of the budget, and
so an all-whitespace stderr still falls through to the exit-code fallback rather
than reporting blank text.

## Tests

Five cases drive the real `returncode != 0 and not stdout.strip()` branch through
a real subprocess, using the existing `TestRunScriptSandboxed`
passthrough-sandbox fixture — not a unit test of a helper.

| Test | Behavior locked in |
|---|---|
| `test_a_terminal_failure_survives_leading_stderr_noise` | A terminal failure behind 900 characters of leading stderr noise is still the reported error. The noise is deliberately past the bound, so a head-anchored report cannot contain the sentinel by accident |
| `test_a_credential_in_the_terminal_stderr_is_redacted` | Moving *which* slice is reported does not move it out from behind `redact` — a traceback can carry a key in a repr just as a startup warning can |
| `test_a_credential_straddling_the_bound_does_not_leak_a_fragment` | Redaction sees the whole stream **before** the bound cuts it: a 20-char AWS key laid exactly across the −500 cut point must not leak its 19-char unredactable fragment (mutation-verified: fails under slice-then-redact) |
| `test_a_short_stderr_is_reported_whole` | **Control.** A stderr already shorter than the bound keeps both ends |
| `test_a_silent_hard_exit_still_reports_the_exit_code` | **Control.** With nothing on either stream, `exit <returncode>` is still the diagnosis |

The short-stderr control exits **without** a traceback on purpose: an
interpreter traceback carries two absolute temp paths, and on Windows those
alone push even a one-line diagnosis past the bound, which would quietly turn
the control into a second copy of the first case.

**Fail-before / pass-after.** Against the unmodified tree: **2 failed, 2
passed** — and the two that pass are exactly the two controls. With the change:
**4 passed**.

**Regression**, run with `-p no:randomly`: `test_cron_script.py`,
`test_cron_script_more_coverage.py`, `test_cron_gateway_integration.py`,
`test_slack_gateway_cron_exec_coverage.py` — **304 passed, 4 skipped**.

`flake8`, `isort --check-only` and `mypy --platform linux` clean on both changed
files.

## Manual verification

N/A — the change is a pure string-slice contract on a code path the four tests
drive end to end through a real subprocess, including the redaction and
exit-code fallback branches. There is no UI or external service involved.

## Scope

`run_script_sandboxed`'s failure-reporting branch only. Untouched: the stdout
JSON parsing path, the gateway's delivery and notification semantics,
auto-pause, and the data-home migration and its warning — that warning is
correct as advisory output and is left alone.

## Related Issues

Fixes #4344

Discovered while investigating #4157, whose reported symptom this explains. The
causal chain in that issue is not the one it describes — the data-home conflict
does not kill a cron on `main`, it displaces the reason in the report — so this
is filed and fixed separately rather than as an implementation of it.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff