### PR TITLE
test(crew): stop two durability asserts reading the whole store

### DIFF
--- a/test/test_crew_chat.py
+++ b/test/test_crew_chat.py
@@ -78,6 +78,23 @@ def _slot_save(side_effect: BaseException | None = None):
     )
 
 
+def _durable_store_file(slot_key: str, name: str) -> list[dict[str, Any]]:
+    """Read ONE named store file, WITHOUT building a `CrewStore`.
+
+    The mechanism the named readers below share. `CrewStore.__init__` reads all
+    three store files, so building one to answer a single-file question also
+    opens the two files nothing awaited, and on Windows an open that lands in a
+    `Path.replace()` window fails with `PermissionError` — issue #4142. Missing
+    is empty here for the same reason it is in `CrewStore._load`: a file that
+    was never written means nothing has been recorded yet.
+    """
+    path = crew_mod.data_home() / "crew" / crew_mod._store_name(slot_key) / name
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return []
+
+
 def _durable_queue(slot_key: str = "s1") -> list[dict[str, Any]]:
     """Read one slot's queue file, WITHOUT building a `CrewStore`.
 
@@ -90,11 +107,18 @@ def _durable_queue(slot_key: str = "s1") -> list[dict[str, Any]]:
     `PermissionError` — issue #4142. Reading the one file the product promises
     is durable keeps the assertion and drops the unpromised dependency.
     """
-    path = crew_mod.data_home() / "crew" / crew_mod._store_name(slot_key) / "queue.json"
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        return []                      # nothing enqueued yet, as `_load` reads it
+    return _durable_store_file(slot_key, "queue.json")
+
+
+def _durable_forwards(slot_key: str = "s1") -> list[dict[str, Any]]:
+    """Read one slot's forwards file — see :func:`_durable_queue` for the why.
+
+    The closed-slot completion path is the caller that promises this file is on
+    disk before it returns, so a "the forward is durable" assertion can be
+    answered from `forwards.json` alone and need not depend on the durability of
+    `topics.json` and `queue.json`, which no caller there promises.
+    """
+    return _durable_store_file(slot_key, "forwards.json")
 
 
 def _durable_entry(slot_key: str, msg_id: str) -> dict[str, Any] | None:
@@ -431,6 +455,7 @@ class TestIngest:
         assert secret not in body and secret not in title
         # Same text, same treatment, on the two paths that persist it.
         assert secret not in (st.topic("r1") or {}).get("digest", "")
+        await orch._store("s1").wait_writes()      # reads below are ON-DISK
         assert not any(secret in f.get("body", "") for f in CrewStore("s1").forwards)
 
     @pytest.mark.asyncio
@@ -2098,8 +2123,9 @@ class TestGptRoundFive:
         orch._owned["r1"] = "s1"
         orch._state.get_slot = MagicMock(return_value=None)      # tab closed
         await orch.on_subagent_done(_spawn_info("r1", done=True, result="the result body"))
-        # Read from a FRESH store: the forward must already be on disk.
-        assert any("the result body" in f["body"] for f in CrewStore("s1").forwards)
+        # Read the FILE, not a store: awaiting here would prove nothing, since the
+        # property under test is that the PRODUCT awaited before returning.
+        assert any("the result body" in f["body"] for f in _durable_forwards("s1"))
 
 
 class TestLiveRunIsReOwned:


### PR DESCRIPTION
## Problem / Motivation

A `Backend Tests (Windows)` shard goes red on a diff that touched no Python at all, with `RuntimeError: crew store: C:\...\crew\s1-<hash>\topics.json is unreadable ([Errno 13] Permission denied)`. On a fork PR each occurrence costs a fresh head sha and therefore a maintainer CI approval, so a test-only flake is expensive out of proportion to its cause.

The mechanism is issue #4142. `CrewStore` publishes each of its three JSON files by writing a temp file and calling `Path.replace()`. That is atomic on both platforms, but only POSIX makes it invisible to a concurrent opener: on Windows the destination is briefly unopenable and `open()` fails with `PermissionError` (errno 13). `CrewStore._load` re-raises that as `RuntimeError` on purpose — collapsing read errors to `[]` made the store silently destructive, because the next `save()` wrote the emptiness back over the real file — so the read error surfaces as a hard failure rather than an empty list.

The writes are in flight because nothing awaits them. `CrewStore.save()` hands `queue.json`, `topics.json` and `forwards.json` to the default executor and returns; `CrewStoreOrchestrator._store()` builds a cold `CrewStore` and then calls `_reconcile()`, which ends in a bare `save()`. So merely touching a slot for the first time leaves three unawaited writes outstanding. A test assertion that constructs a fresh whole `CrewStore(...)` opens all three of those files, and on Windows one of the two nobody promised can be mid-replace.

PR #4150 removed that dependency at six assertion sites by reading only the single file the code under test promises is durable (`_durable_queue()` / `_durable_entry()`). Two whole-store reads in `test/test_crew_chat.py` were left behind. This change closes both.

## Why it matters

The two sites need opposite treatment, and the asymmetry is the substance of this change.

`TestIngest::test_closed_slot_notification_is_redacted` asks whether a credential leaked into a persisted forward. It does not care whether the product awaited its own write, so it can simply wait: an `await orch._store("s1").wait_writes()` barrier makes every store file durable before the read. Sibling tests in the same file already do exactly this, one of them with the comment `# reads below are ON-DISK`.

`TestGptRoundFive::test_closed_slot_completion_awaits_its_write` cannot use a barrier. Its entire purpose is to prove that the product awaits its write before returning, because the completion callback's return is what tells the subagent layer the result was handled. Awaiting on the test's behalf would make it pass even after the product regressed — a vacuous test that reads as coverage. So the fix there keeps the unawaited read and narrows only which file it opens, from all three to the one the closed-slot path actually promises: `forwards.json`.

Worth stating plainly, because a reviewer will check it: on today's `main` neither read is failing, because the closed-slot completion path's barrier is a full `st.wait_writes()` and so happens to cover all three files. What this change removes is the *dependency* on that remaining true. `CrewStore.wait_for`'s own docstring tells a caller that needs "the row I just wrote is on disk" to name that write rather than await the shared pending set — so narrowing that barrier to the forwards write alone is a refactor the codebase actively recommends, and it would silently re-open both sites on Windows only. Both assertions become answerable from what the product promises rather than from an implementation detail of how widely it currently waits.

## What changed

Two assertion sites in `test/test_crew_chat.py`, plus one test helper. No production code and no test semantics change.

Site 1, `TestIngest::test_closed_slot_notification_is_redacted`: added `await orch._store("s1").wait_writes()` immediately before the forwards read.

Site 2, `TestGptRoundFive::test_closed_slot_completion_awaits_its_write`: the read is now `_durable_forwards("s1")` instead of `CrewStore("s1").forwards`. The unawaited read is preserved deliberately, and the one-line comment there says why, so a later reader does not "helpfully" add a barrier and hollow the test out.

Helper: added `_durable_forwards()` beside `_durable_queue()`, and factored the shared path-resolve-and-parse into `_durable_store_file(slot_key, name)` that both now call. Two named wrappers were preferred over a single parametrised helper called at each site, because `_durable_queue()` reads better at a call site than `_durable_file("s1", "queue.json")` and because it leaves the six call sites from #4150 untouched. Sharing the body rather than copying it keeps the missing-file semantics — empty for a file never written, matching `CrewStore._load` — in one place instead of two that can drift.

## Tests

`TestWindowsReplaceWindow` in this file emulates the Windows replace window, so the bug has a deterministic reproduction on every platform. It parks a named file's write on a gate and makes that path unopenable until the gate releases.

Reaching the defect needed one extra step, and it is worth recording. With the emulation armed on `topics.json` against unmodified `main`, both old reads still passed and no write was in flight at the read — because the closed-slot path's `st.wait_writes()` drains all three files first. The emulator was confirmed armed rather than inert by the 50-60s runtimes, i.e. five to six 10s gate timeouts per case. Narrowing that barrier to the named forwards write — the shape `CrewStore.wait_for` recommends, and the regression this change defends against — makes the window reachable, and then both directions show up cleanly:

| case | read shape | result |
| ----------------------------- | -------------------------------- | ------------------------------------------------------------ |
| site 1, before                | whole `CrewStore("s1")`           | FAIL `RuntimeError: crew store: .../topics.json is unreadable ([Errno 13] Permission denied)` |
| site 1, after                 | barrier, then whole store         | PASS                                                         |
| site 2, before                | whole `CrewStore("s1")`           | FAIL `RuntimeError: crew store: .../topics.json is unreadable ([Errno 13] Permission denied)` |
| site 2, after                 | `_durable_forwards("s1")`         | PASS                                                         |

Each case also asserted the emulated window was open at the moment of the read, so a pass cannot come from an emulator that never armed. The two "before" rows are the revert-one-thing controls: they are this change with only the site 1 barrier removed, and with only the site 2 narrowed read reverted, and each fails on `topics.json` — the file nobody awaits — rather than on something incidental.

Site 2 is still non-vacuous after the change. Removing the product's `await st.wait_writes()` from the closed-slot completion path makes it fail 8 runs out of 8 on `assert False`, so the narrowed read still detects the regression the test exists to catch.

Suite runs: the two tests by name plus `TestWindowsReplaceWindow` pass (3 passed); the whole of `test/test_crew_chat.py` passes (150 passed); the full backend gate as CI invokes it (`pytest -q -n auto --timeout=120 --cov=kiro_crew --cov=sage_lib`) gives 56415 passed with 47 failures and 21 errors confined to the `auto_improvement` suites and one gateway-lock test, all of which reproduce identically (same 47 and 21, same files) on an unmodified `main` checkout on this host, where the namespace sandbox those suites need is unavailable. None are in `test/test_crew_chat.py`.

No screenshots: there is no user-visible change.
