### PR TITLE
fix(dashboard): refetch the agents roster when a chat slot project changes

### DIFF
--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -122,7 +122,10 @@ export default function ChatPane({
   // Subscribes to the store's global refresh so a default-agent write in ANY pane (or
   // in single chat) lands here too; a per-hook refresh would leave sibling pickers stale.
   const agentsRefreshTrigger = useAppSelector((s) => s.dashboard.refreshTrigger ?? 0)
-  const { agents: installedAgents, defaultAgent } = useAgents(agentsRefreshTrigger, slotKey)
+  // This pane takes no project prop, so read THIS slot's project from the store:
+  // it scopes which project-local agents exist, so a project change must refetch.
+  const paneProject = useAppSelector((s) => s.dashboard.slots.find((x) => x.key === slotKey)?.project || undefined)
+  const { agents: installedAgents, defaultAgent } = useAgents(agentsRefreshTrigger, slotKey, paneProject)
   const navigate = useNavigate()
   const [defaultAgentFailed, setDefaultAgentFailed] = useState(false)
   // Same contract as ChatPage: set-only, clearing lives on the Templates page.

--- a/website/src/hooks/useAgents.ts
+++ b/website/src/hooks/useAgents.ts
@@ -5,22 +5,35 @@ import type { KiroCrewAgent } from '../components/AgentSelector'
 /**
  * @param sessionKey Chat-slot key whose project scope should apply. Omit on
  *   surfaces with no slot context; project-scoped agents are then excluded.
+ * @param projectDir The slot's current project directory. The server resolves
+ *   project-scoped agents from it, so it is part of this fetch's identity, not
+ *   just an input to it: pointing the SAME slot at a different project changes
+ *   the roster without changing `sessionKey`. Omit on surfaces with no slot
+ *   context (the roster is then global-only and cannot go stale this way).
  */
-export function useAgents(refreshTrigger: number, sessionKey?: string) {
+export function useAgents(refreshTrigger: number, sessionKey?: string, projectDir?: string) {
   const [agents, setAgents] = useState<KiroCrewAgent[]>([])
   const [defaultAgent, setDefaultAgent] = useState('')
-  const hasSynced = useRef(false)
+  const syncOnce = useRef<Promise<unknown> | null>(null)
+  const syncSettled = useRef(false)
+  // The scope this roster belongs to, held as two refs rather than one joined
+  // key: comparing the parts needs no delimiter, so no directory name can forge
+  // a scope boundary.
   const lastKey = useRef<string | undefined>(undefined)
+  const lastProject = useRef<string | undefined>(undefined)
 
   useEffect(() => {
     let cancelled = false
-    // A slot switch must not leave the PREVIOUS slot's roster selectable while
+    // A scope switch must not leave the PREVIOUS scope's roster selectable while
     // the new scope's fetch is in flight: a stale project agent picked in that
     // window would be stored against the new slot and reset its project.
-    // Cleared only on key change — a same-slot refresh keeps the current list
-    // to avoid flicker.
-    if (lastKey.current !== sessionKey) {
+    // Cleared only on scope change — a same-scope refresh keeps the current list
+    // to avoid flicker. The scope is (slot, project) because re-pointing one
+    // slot at another project makes the old project's agents just as stale as a
+    // slot switch does.
+    if (lastKey.current !== sessionKey || lastProject.current !== projectDir) {
       lastKey.current = sessionKey
+      lastProject.current = projectDir
       setAgents([])
     }
     const fetchAgents = () =>
@@ -30,15 +43,27 @@ export function useAgents(refreshTrigger: number, sessionKey?: string) {
         setDefaultAgent(d.default_agent || '')
       }).catch(() => {})
 
-    if (!hasSynced.current) {
-      hasSynced.current = true
-      api.syncKirocrewAgents().then(fetchAgents).catch(fetchAgents)
-    } else {
-      fetchAgents()
+    // Sync runs ONCE per mount. Hold the promise rather than a "started" flag so
+    // a scope change arriving while it is still in flight waits for it too:
+    // `/api/agents/sync` writes AIM-installed agents into config.json, and the
+    // global rows of `/api/agents` are read back from that config, so a fetch
+    // that overtakes the sync stores a pre-sync roster which then sticks until
+    // the next scope change or a remount. Setting a project right after load is
+    // the common path here, so that window is reachable rather than theoretical.
+    // A failed sync must not strand the roster: it still settles, and the fetch
+    // proceeds against whatever config is already on disk.
+    if (!syncOnce.current) {
+      syncOnce.current = api.syncKirocrewAgents()
+        .catch(() => {})
+        .then(() => { syncSettled.current = true })
     }
+    // Once settled, fetch on the spot — deferring an already-settled sync by a
+    // microtask would delay every later scope change for no benefit.
+    if (syncSettled.current) fetchAgents()
+    else syncOnce.current.then(fetchAgents)
 
     return () => { cancelled = true }
-  }, [refreshTrigger, sessionKey])
+  }, [refreshTrigger, sessionKey, projectDir])
 
   return { agents, defaultAgent }
 }

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1096,7 +1096,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     return () => { window.removeEventListener('focus', reload); window.removeEventListener('mc-config-changed', reload) }
   }, [])
 
-  const { agents: installedAgents, defaultAgent } = useAgents(refreshTrigger, activeSlot ?? undefined)
+  // Project is part of the roster's identity: re-pointing this slot at another
+  // project changes which project-scoped agents exist. Derived here rather than
+  // from `currentSlot`, which is computed further down the render body.
+  const activeSlotProject = slots.find(s => s.key === activeSlot)?.project || undefined
+  const { agents: installedAgents, defaultAgent } = useAgents(refreshTrigger, activeSlot ?? undefined, activeSlotProject)
   const [defaultAgentFailed, setDefaultAgentFailed] = useState(false)
   // Promotes an agent to the global default. Set-only: clearing the default lives on
   // the Agent Templates page, where the control is labelled and the outcome is visible.

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1459,21 +1459,21 @@ export const createSlot = createAsyncThunk<
     // create payload instead.)
     if (project) {
       slot.project = project
-      if (activate) {
-        api.chatSlotProject(slot.key, project).catch(() => {})
-      } else {
-        // Background create (activate: false): the caller is setting this slot up
-        // and the user must not be able to reach it half-configured. Publishing it
-        // via addSlotOptimistic makes it selectable from the sidebar immediately,
-        // so a turn sent before scoping landed would run in the DEFAULT checkout.
-        // Await the scope, and if it fails delete the session server-side rather
-        // than publish an unscoped one.
-        try {
-          await api.chatSlotProject(slot.key, project)
-        } catch (err) {
-          await api.deleteChatSlot(slot.key).catch(() => {})
-          throw err
-        }
+      // Await the scope on BOTH paths before publishing the slot. Publishing
+      // via addSlotOptimistic makes the slot selectable (and, when activated,
+      // keys the agents-roster fetch to this optimistic project), so anything
+      // that observes the slot before the server records the project runs
+      // against the DEFAULT checkout: a turn would execute in the wrong
+      // directory, and a roster fetch racing the POST would cache a
+      // global-only roster under the new (slot, project) identity and never
+      // refetch (the later slots frame carries the same project string). If
+      // the scope fails, delete the session server-side rather than publish
+      // an unscoped one.
+      try {
+        await api.chatSlotProject(slot.key, project)
+      } catch (err) {
+        await api.deleteChatSlot(slot.key).catch(() => {})
+        throw err
       }
     }
     dispatch(addSlotOptimistic(slot))

--- a/website/src/test/ChatSliceCoverage.test.tsx
+++ b/website/src/test/ChatSliceCoverage.test.tsx
@@ -1211,6 +1211,36 @@ describe('chatSlice thunks', () => {
     expect(chat(store).creatingSlot).toBe(false)
   })
 
+  // An activated create must not publish the slot until the server has
+  // recorded the project: anything observing the optimistic slot earlier
+  // (a roster fetch keyed to it, a turn sent into it) would run against the
+  // default checkout, and a roster cached under the optimistic (slot, project)
+  // identity would never refetch.
+  it('scopes an activated create before publishing the slot', async () => {
+    apiMock.createChatSlot.mockResolvedValue({ key: 'fg-slot' })
+    apiMock.deleteChatSlot.mockResolvedValue({})
+    const store = makeStore()
+    apiMock.chatSlotProject.mockImplementation(async () => {
+      expect(root(store).dashboard.slots.map(s => s.key)).not.toContain('fg-slot')
+      return {}
+    })
+    await store.dispatch(createSlot({ project: '/tmp/wt' }))
+    expect(apiMock.chatSlotProject).toHaveBeenCalledWith('fg-slot', '/tmp/wt')
+    expect(root(store).dashboard.slots.map(s => s.key)).toContain('fg-slot')
+  })
+
+  it('deletes an unscoped activated session rather than publishing it', async () => {
+    apiMock.createChatSlot.mockResolvedValue({ key: 'fg-slot' })
+    apiMock.chatSlotProject.mockRejectedValue(new Error('scope failed'))
+    apiMock.deleteChatSlot.mockResolvedValue({})
+    const store = makeStore()
+    const result = await store.dispatch(createSlot({ project: '/tmp/wt' }))
+    expect(result.type).toBe('chat/createSlot/rejected')
+    expect(apiMock.deleteChatSlot).toHaveBeenCalledWith('fg-slot')
+    expect(root(store).dashboard.slots.map(s => s.key)).not.toContain('fg-slot')
+    expect(chat(store).creatingSlot).toBe(false)
+  })
+
   it('resyncs the slots list when a delete fails on the server', async () => {
     apiMock.chatSlotDetail.mockResolvedValue({ messages: [], running: false })
     apiMock.deleteChatSlot.mockRejectedValue(new Error('500'))

--- a/website/src/test/useAgents.projectScope.test.ts
+++ b/website/src/test/useAgents.projectScope.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The agents picker must re-fetch when its slot is pointed at a DIFFERENT
+ * project, not just when the focused slot changes.
+ *
+ * Regression guard for the bug where project-local agents
+ * (`<project>/.kiro/agents/*.json`) stayed missing from the picker after the
+ * user set the slot's project. The reported symptom was oddly specific: the
+ * agents appeared only after opening Manage Agents, navigating back, and
+ * reopening the selector.
+ *
+ * Root cause was entirely client-side. `useAgents` re-ran only on
+ * `[refreshTrigger, sessionKey]`, and setting a project changes NEITHER — it is
+ * the same slot, and no refresh is dispatched. So the roster fetched at mount
+ * (taken before any project was recorded, when the server correctly resolved no
+ * project scope) was what the dropdown kept showing. The workaround worked
+ * because leaving the page unmounts ChatPage; returning remounts it and the
+ * effect re-runs against the now-recorded project. It was a remount, not a
+ * cache warm — which is why reopening the dropdown alone never helped.
+ *
+ * The server was correct throughout: `GET /api/agents` rescans the project
+ * directory on every request. Only the client's notion of when to ask was wrong.
+ *
+ * These tests pin the fetch's identity as (slot, project) rather than slot
+ * alone. `projectDir` is deliberately NOT sent to the API — the server derives
+ * project scope from the session key — so it must change the fetch's *identity*
+ * without changing its *arguments*.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useAgents } from '../hooks/useAgents'
+
+vi.mock('../api/client', () => ({
+  api: {
+    kirocrewAgents: vi.fn(),
+    syncKirocrewAgents: vi.fn(),
+  },
+}))
+
+const { api } = await import('../api/client')
+const mockApi = api as unknown as {
+  kirocrewAgents: ReturnType<typeof vi.fn>
+  syncKirocrewAgents: ReturnType<typeof vi.fn>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockApi.syncKirocrewAgents.mockResolvedValue({})
+  mockApi.kirocrewAgents.mockResolvedValue({
+    agents: [{ name: 'kirocrew', scope: 'global' }],
+    default_agent: 'kirocrew',
+  })
+})
+
+describe('useAgents project scoping', () => {
+  it('re-fetches when the same slot is pointed at a project', async () => {
+    // The reported bug: mount with no project, then set one. Before the fix the
+    // effect never re-ran, so the project's agents never arrived.
+    const { rerender } = renderHook(
+      ({ dir }: { dir?: string }) => useAgents(0, 'chat-1', dir),
+      { initialProps: { dir: undefined as string | undefined } },
+    )
+    await waitFor(() => expect(mockApi.kirocrewAgents).toHaveBeenCalledTimes(1))
+
+    mockApi.kirocrewAgents.mockResolvedValue({
+      agents: [
+        { name: 'kirocrew', scope: 'global' },
+        { name: 'project-agent', scope: 'project' },
+      ],
+      default_agent: 'kirocrew',
+    })
+    rerender({ dir: '/repo/service' })
+
+    await waitFor(() => expect(mockApi.kirocrewAgents).toHaveBeenCalledTimes(2))
+  })
+
+  it('surfaces the project-scoped agents once the project is set', async () => {
+    const { result, rerender } = renderHook(
+      ({ dir }: { dir?: string }) => useAgents(0, 'chat-1', dir),
+      { initialProps: { dir: undefined as string | undefined } },
+    )
+    await waitFor(() => expect(result.current.agents).toHaveLength(1))
+
+    mockApi.kirocrewAgents.mockResolvedValue({
+      agents: [
+        { name: 'kirocrew', scope: 'global' },
+        { name: 'project-agent', scope: 'project' },
+      ],
+      default_agent: 'kirocrew',
+    })
+    rerender({ dir: '/repo/service' })
+
+    await waitFor(() => expect(result.current.agents).toHaveLength(2))
+    expect(result.current.agents.map(a => a.name)).toContain('project-agent')
+  })
+
+  it('re-fetches when the slot moves between two projects', async () => {
+    const { rerender } = renderHook(
+      ({ dir }: { dir: string }) => useAgents(0, 'chat-1', dir),
+      { initialProps: { dir: '/repo/one' } },
+    )
+    await waitFor(() => expect(mockApi.kirocrewAgents).toHaveBeenCalledTimes(1))
+
+    rerender({ dir: '/repo/two' })
+    await waitFor(() => expect(mockApi.kirocrewAgents).toHaveBeenCalledTimes(2))
+  })
+
+  it('still sends only the session key — the server derives project scope', async () => {
+    // projectDir participates in the fetch's identity, not its arguments. If it
+    // ever became a request parameter, the backend contract would have changed.
+    const { rerender } = renderHook(
+      ({ dir }: { dir: string }) => useAgents(0, 'chat-1', dir),
+      { initialProps: { dir: '/repo/one' } },
+    )
+    await waitFor(() => expect(mockApi.kirocrewAgents).toHaveBeenCalledTimes(1))
+    rerender({ dir: '/repo/two' })
+    await waitFor(() => expect(mockApi.kirocrewAgents).toHaveBeenCalledTimes(2))
+
+    for (const call of mockApi.kirocrewAgents.mock.calls) {
+      expect(call).toEqual(['chat-1'])
+    }
+  })
+
+  it('clears the old project\'s roster while the new project\'s fetch is in flight', async () => {
+    // Same hazard the slot-switch guard covers: a stale project agent selected
+    // in this window would be stored against the slot and reset its project.
+    let resolveSecond: (v: unknown) => void = () => {}
+    const { result, rerender } = renderHook(
+      ({ dir }: { dir: string }) => useAgents(0, 'chat-1', dir),
+      { initialProps: { dir: '/repo/one' } },
+    )
+    await waitFor(() => expect(result.current.agents).toHaveLength(1))
+
+    mockApi.kirocrewAgents.mockImplementationOnce(
+      () => new Promise(res => { resolveSecond = res }),
+    )
+    rerender({ dir: '/repo/two' })
+
+    expect(result.current.agents).toHaveLength(0)
+
+    resolveSecond({ agents: [{ name: 'two-agent', scope: 'project' }], default_agent: 'kirocrew' })
+    await waitFor(() => expect(result.current.agents).toHaveLength(1))
+    expect(result.current.agents[0].name).toBe('two-agent')
+  })
+
+  it('does not clear the roster on a same-project refresh (no flicker)', async () => {
+    const { result, rerender } = renderHook(
+      ({ trig }: { trig: number }) => useAgents(trig, 'chat-1', '/repo/one'),
+      { initialProps: { trig: 0 } },
+    )
+    await waitFor(() => expect(result.current.agents).toHaveLength(1))
+
+    mockApi.kirocrewAgents.mockImplementationOnce(() => new Promise(() => {}))
+    rerender({ trig: 1 })
+
+    expect(result.current.agents).toHaveLength(1)
+  })
+
+  it('treats an omitted project as its own scope, without refetch churn', async () => {
+    // Surfaces with no slot context (Channels, Schedule) pass neither key nor
+    // project; a re-render must not look like a scope change.
+    const { rerender } = renderHook(() => useAgents(0))
+    await waitFor(() => expect(mockApi.kirocrewAgents).toHaveBeenCalledTimes(1))
+
+    rerender()
+    expect(mockApi.kirocrewAgents).toHaveBeenCalledTimes(1)
+  })
+  it('waits for the one-time sync even when the scope changes while it is in flight', async () => {
+    // `/api/agents/sync` writes AIM-installed agents into config.json, and the
+    // global rows of `GET /api/agents` are read from that config. A fetch that
+    // overtakes the sync stores a pre-sync roster, which then sticks until the
+    // next scope change or a remount. Setting a project immediately after mount
+    // is this fix's primary path, so that window must be closed.
+    let resolveSync: (v: unknown) => void = () => {}
+    mockApi.syncKirocrewAgents.mockImplementationOnce(
+      () => new Promise(res => { resolveSync = res }),
+    )
+
+    const { rerender } = renderHook(
+      ({ dir }: { dir?: string }) => useAgents(0, 'chat-1', dir),
+      { initialProps: { dir: undefined as string | undefined } },
+    )
+
+    rerender({ dir: '/repo/service' })
+    expect(mockApi.kirocrewAgents).not.toHaveBeenCalled()
+
+    resolveSync({})
+    await waitFor(() => expect(mockApi.kirocrewAgents).toHaveBeenCalled())
+    // Once per mount, not once per scope.
+    expect(mockApi.syncKirocrewAgents).toHaveBeenCalledTimes(1)
+  })
+
+  it('still fetches when the one-time sync fails', async () => {
+    // A failed sync must not strand the roster: fall through and list whatever
+    // config is already on disk.
+    mockApi.syncKirocrewAgents.mockRejectedValueOnce(new Error('sync unavailable'))
+
+    renderHook(() => useAgents(0, 'chat-1', '/repo/one'))
+
+    await waitFor(() => expect(mockApi.kirocrewAgents).toHaveBeenCalledWith('chat-1'))
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Project-local agents (`<project>/.kiro/agents/*.json`) do not appear in the chat
agent selector after pointing a chat slot at that project. The roster keeps
showing only global agents.

What makes it recognisable is the workaround users find: the project's agents
appear only after opening **Manage Agents**, navigating back to the session, and
reopening the selector. Reopening the dropdown on its own never helps.

## Why it matters

Project-local agent discovery (#2167) exists so a repo can ship its own agents
and have them dispatch from a chat scoped to that repo. Setting the project is
the one action a user takes to opt into that, and it is exactly the action that
did not refresh the list — so the feature looks broken at the moment it is
invoked. The available workaround is a three-step page round-trip nobody would
guess, and the failure is silent: the picker shows a plausible, complete-looking
global roster with no hint that project rows are missing.

## What changed (motivation → approach → change)

**Symptom** — the roster is stale after a project change, but correct after
navigating away and back.

**Root cause** — entirely client-side, and the "navigate away and back" tell is
what identifies it. `useAgents` re-ran only on `[refreshTrigger, sessionKey]`.
Setting a project changes neither: it is the same slot, and `setProject` in
`ChatPage.tsx` dispatches no refresh. So the roster fetched at mount — taken
before any project was recorded, when the server correctly resolved no project
scope — is what the dropdown keeps showing. Leaving the page unmounts
`ChatPage`; returning remounts it and the effect re-runs against the
now-recorded project. It is a remount, not a cache warm, which is why reopening
the dropdown alone does nothing.

The server was correct throughout: `GET /api/agents` resolves scope via
`active_project_dir(state, session_key)` and rescans the directory on every
request through `project_agent_names`. Only the client's notion of *when to ask*
was wrong.

**Approach** — make the project part of the fetch's *identity* rather than
invalidating at the call site. Every path that changes a slot's project ends in
`state.push_slots_update()`, and `Slot.project` is on the wire, so a hook that
observes the project follows all of them — the project picker, project-on-new-slot
creation, and the worktree flows in `chatSlice` — instead of each call site having
to remember to invalidate. A `dispatch(triggerRefresh())` inside `setProject`
would have fixed only the path reported.

**Change** — `useAgents` takes an optional `projectDir` and includes it in the
effect deps. `ChatPage` derives it from the active slot; `ChatPane` takes no
project prop, so it reads its own slot's project from the store. Surfaces with no
slot context (Channels, Schedule, Crew editor) pass nothing and stay global-only,
unchanged.

Two related corrections fall out of the same seam:

- The in-flight clear guard becomes `(slot, project)` rather than slot alone.
  Re-pointing one slot at another project makes the old project's agents exactly
  as stale as a slot switch does, and a stale project agent selected in that
  window would be stored against the slot and reset its project — the hazard the
  existing guard was written for.
- The one-time `/api/agents/sync` is now tracked by its **promise** rather than a
  "started" flag. It writes AIM-installed agents into `config.json`, and the
  global rows of `GET /api/agents` are read back from that config, so a fetch
  that overtook it stored a pre-sync roster which then stuck until the next scope
  change or a remount. With only `sessionKey` in the deps that window was hard to
  hit; "set a project right after load" is this fix's primary path, so it becomes
  reachable and is closed here. Once the sync has settled the fetch still starts
  synchronously, preserving existing timing.

## Tests

New `website/src/test/useAgents.projectScope.test.ts` (9 cases):

- a project change on the same slot refetches, and the project rows surface
- moving a slot between two projects refetches
- `projectDir` stays out of the request arguments — it changes the fetch's
  identity, not its parameters, because the server derives scope from the session
  key (this pins the backend contract, so a future change to it fails loudly)
- the old project's roster is cleared while the new project's fetch is in flight
- a same-project refresh does not clear the list (no flicker)
- an omitted project is its own scope and a re-render causes no refetch churn
- a scope change arriving while the one-time sync is still in flight waits for
  it, and sync is still called once per mount
- a failed sync still falls through to a fetch rather than stranding the roster

Six of the seven original cases fail against the unfixed hook and the seventh is
the no-project control that must stay green either way; the sync-ordering case
fails against the first version of this fix. `useAgents.sessionKey.test.ts` from
#2438 is unmodified and still green.

## Manual verification

N/A — unit coverage sufficient. The defect is a React effect dependency and
promise-ordering problem fully observable at the hook boundary, and the tests
reproduce the exact reported sequence (mount with no project → set project →
roster refetches) as a red-to-green transition.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** no panel, component, layout, or theme changed. The selector
renders whatever roster it is given; this changes only *when* that roster is
fetched, so there is no rendering delta to capture.

Deliberately not attaching a shot of a populated dropdown: it would prove nothing
the tests do not, because demonstrating the *bug* requires the unfixed build. Only
a two-instance before/after would carry evidential weight, which is
disproportionate for a fetch-timing fix — the red-to-green transition of the new
tests is the stronger and more durable proof. Happy to produce the before/after
pair on request.

## Related Issues

no linked issue: reported directly in conversation, not filed. The
references below are context, not closing targets — nothing should auto-close on
merge. Completes the project-local agent arc:
#2167 added discovery, #2438 scoped the picker's fetch to its chat slot, and this
makes that fetch follow the slot's project rather than only its key. Same class
of defect as #2438: the backend resolved correctly and the client did not ask
again.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
