### PR TITLE
fix(markdown): keep an inline classed code element from rendering a block div in a paragraph

### DIFF
--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -818,14 +818,21 @@ function jiraCardMeta(link: PullRequestLink): LinkMeta {
 
 const MD_COMPONENTS: Components = {
   code({ className, children, ...props }) {
+    // Only a <code> inside a <pre> may render a block-level component here
+    // (CodeBlock / MermaidBlock / ExcalidrawBlock are each rooted in a <div>).
+    // rehypeMarkFencedCode stamps those with `data-fenced`; a bare <code> in
+    // prose stays inline whatever class it carries, because a <div> inside the
+    // enclosing <p> crashes React's reconciler. That comment carries the full
+    // reasoning. `data-fenced` is destructured out so it never reaches the DOM.
+    const { 'data-fenced': fenced, ...rest } = props as Record<string, unknown>
+    if (fenced === undefined) return <InlineCode {...rest}>{children}</InlineCode>
+
     const match = /language-(\w+)/.exec(className || '')
     const lang = match?.[1]
     const codeStr = String(children).replace(/\n$/, '')
 
     if (lang === 'mermaid') return <MermaidBlock code={codeStr} />
     if (lang === 'excalidraw') return <ExcalidrawBlock code={codeStr} />
-
-    if (!className) return <InlineCode {...props}>{children}</InlineCode>
 
     return <CodeBlock code={codeStr} lang={lang} complete={true} />
   },
@@ -1366,6 +1373,68 @@ const BLOCK_ELEMENTS = new Set([
   'main', 'nav', 'ol', 'p', 'pre', 'section', 'table', 'ul',
 ])
 
+/**
+ * Stamps `data-fenced` on every `<code>` that is the child of a `<pre>`.
+ *
+ * `MD_COMPONENTS.code` renders a block-level component for a code element that
+ * carries a class (`CodeBlock`, `MermaidBlock` and `ExcalidrawBlock` are each
+ * rooted in a `<div>`). Real fenced blocks never reach it — `useBlockAssembler`
+ * segments those out of the source and `BlockRenderer` draws them directly — so
+ * the only classed code elements arriving here come from raw HTML in prose.
+ * `<pre><code class="language-js">` is the legitimate shape: the `<pre>` is
+ * block-level, so `rehypeUnwrapBlocks` hoists it clear of any surrounding `<p>`
+ * and the block renders as a sibling.
+ *
+ * A BARE `<code class="language-js">` mid-sentence is not. The sanitizer
+ * allowlists `class` globally (see GLOBAL_ATTRS), so it survives, keeps its
+ * class, and renders a `<div>` inside the enclosing `<p>`. The browser hoists
+ * that `<div>` out of the `<p>`, React's VDOM does not follow, and the next
+ * reconciliation throws:
+ *   "Failed to execute 'removeChild' on 'Node': The node to be removed is not
+ *    a child of this node."
+ *
+ * `rehypeUnwrapBlocks` cannot catch this, because it decides block-ness from the
+ * HAST tag name and `code` is inline there — the block only appears in what the
+ * component renders. Marking the genuinely fenced ones lets the override keep
+ * inline code inline whatever class it carries, which is also what the source
+ * asked for.
+ */
+function rehypeMarkFencedCode() {
+  return (tree: HastRoot) => {
+    const walk = (node: HastRoot | HastElement) => {
+      if (!node.children) return
+      const isPre = node.type === 'element' && node.tagName === 'pre'
+      for (const child of node.children) {
+        if (child.type !== 'element') continue
+        // The marker is ours to set and no one else's. `isAllowedAttr` admits
+        // every `data-*`, so raw HTML in the message can carry its own
+        // `data-fenced` — and an inline `<code data-fenced class="language-js">`
+        // would then claim block rendering and reintroduce the very crash this
+        // plugin exists to prevent.
+        //
+        // Deleting a fixed key spelling is not enough. The HTML parser
+        // lowercases attribute names, so `dataFenced` arrives as the hast
+        // property `datafenced`, which the JSX serializer still hands to the
+        // component as `data-fenced`. Strip by NORMALIZED form so every casing
+        // and dash placement that can reach the override as the marker is
+        // removed here.
+        if (child.properties) {
+          for (const key of Object.keys(child.properties)) {
+            if (key.toLowerCase().replace(/-/g, '') === 'datafenced') {
+              delete child.properties[key]
+            }
+          }
+        }
+        if (isPre && child.tagName === 'code') {
+          child.properties = { ...(child.properties ?? {}), 'data-fenced': '' }
+        }
+        walk(child)
+      }
+    }
+    walk(tree)
+  }
+}
+
 function rehypeUnwrapBlocks() {
   return (tree: HastRoot) => {
     const walk = (parent: HastRoot | HastElement) => {
@@ -1447,7 +1516,7 @@ function rehypeUnwrapBlocks() {
   }
 }
 
-const REHYPE_PLUGINS: PluggableList = [[rehypeRaw, { passThrough: ['math', 'inlineMath'] }], rehypeUnwrapBlocks, rehypeSanitize, rehypeKatex]
+const REHYPE_PLUGINS: PluggableList = [[rehypeRaw, { passThrough: ['math', 'inlineMath'] }], rehypeMarkFencedCode, rehypeUnwrapBlocks, rehypeSanitize, rehypeKatex]
 
 // Matches one source line break plus any leading tabs/spaces, so a trailing
 // space before the break doesn't survive as its own text node. Mirrors the
@@ -1522,7 +1591,7 @@ function rehypeSourcepos() {
     walk(tree)
   }
 }
-const REHYPE_PLUGINS_WITH_SOURCEPOS: PluggableList = [[rehypeRaw, { passThrough: ['math', 'inlineMath'] }], rehypeUnwrapBlocks, rehypeSanitize, rehypeKatex, rehypeSourcepos]
+const REHYPE_PLUGINS_WITH_SOURCEPOS: PluggableList = [[rehypeRaw, { passThrough: ['math', 'inlineMath'] }], rehypeMarkFencedCode, rehypeUnwrapBlocks, rehypeSanitize, rehypeKatex, rehypeSourcepos]
 // NOTE: remark plugin config is shared via REMARK_PLUGINS above (singleDollarTextMath:
 // false). The sourcepos variant only differs in the rehype chain.
 

--- a/website/src/test/MarkdownRenderer.inlineCodeBlock.test.tsx
+++ b/website/src/test/MarkdownRenderer.inlineCodeBlock.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+
+/**
+ * Regression tests for a `<div>` landing inside a `<p>` via the `code`
+ * component override.
+ *
+ * `MD_COMPONENTS.code` renders a block-level component (CodeBlock,
+ * MermaidBlock and ExcalidrawBlock are each rooted in a `<div>`) for a code
+ * element carrying a class. Real fenced blocks never reach it — those are
+ * segmented out of the source by `useBlockAssembler` — so the classed code
+ * elements that do arrive come from raw HTML in prose. A bare
+ * `<code class="language-js">` mid-sentence therefore rendered a `<div>` inside
+ * the enclosing `<p>`. The browser hoists it out, React's VDOM keeps the stale
+ * parent, and the next reconciliation throws:
+ *   "Failed to execute 'removeChild' on 'Node': The node to be removed is not
+ *    a child of this node."
+ *
+ * `rehypeUnwrapBlocks` cannot catch this because it reads block-ness off the
+ * HAST tag name, and `code` is inline there. `rehypeMarkFencedCode` stamps
+ * `data-fenced` on `<pre> > <code>` so the override renders a block for exactly
+ * those and keeps everything else inline.
+ */
+describe('MarkdownRenderer inline code with a language class', () => {
+  it('keeps an inline classed <code> inside the paragraph, with no block child', () => {
+    const md = 'Use <code class="language-js">const x = 1</code> in your file.'
+    const { container } = render(<MarkdownRenderer content={md} />)
+    // The crash precondition: any <div> descendant of a <p>.
+    expect(container.querySelectorAll('p div')).toHaveLength(0)
+    const code = container.querySelector('p code')
+    expect(code).toBeTruthy()
+    expect(container.textContent).toContain('const x = 1')
+    // The surrounding sentence is not split apart.
+    expect(container.textContent).toContain('Use')
+    expect(container.textContent).toContain('in your file.')
+  })
+
+  it('keeps an inline language-mermaid <code> inline instead of drawing a diagram', () => {
+    const md = 'Diagram <code class="language-mermaid">graph TD; A--&gt;B</code> inline.'
+    const { container } = render(<MarkdownRenderer content={md} />)
+    expect(container.querySelectorAll('p div')).toHaveLength(0)
+    expect(container.querySelector('p code')).toBeTruthy()
+  })
+
+  it('still renders a raw <pre><code> as a block code block outside any <p>', () => {
+    const md = 'Before\n\n<pre><code class="language-js">const a = 1</code></pre>\n\nAfter'
+    const { container } = render(<MarkdownRenderer content={md} />)
+    const block = container.querySelector('.code-block')
+    expect(block).toBeTruthy()
+    expect(block!.closest('p')).toBeNull()
+    expect(container.textContent).toContain('const a = 1')
+  })
+
+  it('leaves a real fenced code block unaffected', () => {
+    const { container } = render(<MarkdownRenderer content={'```js\nconst a = 1\n```'} />)
+    expect(container.textContent).toContain('const a = 1')
+    expect(container.querySelectorAll('p div')).toHaveLength(0)
+  })
+
+  it('ignores an author-supplied data-fenced marker on an inline <code>', () => {
+    // `isAllowedAttr` admits every `data-*`, so raw HTML can carry its own
+    // marker. If the override trusted it, an inline <code> could claim block
+    // rendering and put a <div> back inside the <p>.
+    const md = 'Use <code data-fenced class="language-js">const x = 1</code> here.'
+    const { container } = render(<MarkdownRenderer content={md} />)
+    expect(container.querySelectorAll('p div')).toHaveLength(0)
+    expect(container.querySelector('p code')).toBeTruthy()
+    expect(container.querySelector('[data-fenced]')).toBeNull()
+  })
+
+  it('ignores an author-supplied camelCased dataFenced marker on an inline <code>', () => {
+    const md = 'Use <code dataFenced class="language-js">const x = 1</code> here.'
+    const { container } = render(<MarkdownRenderer content={md} />)
+    expect(container.querySelectorAll('p div')).toHaveLength(0)
+    expect(container.querySelector('p code')).toBeTruthy()
+  })
+
+  it('does not leak the data-fenced marker into the DOM', () => {
+    const md = 'text <code class="language-js">x</code> more\n\n<pre><code class="language-js">y</code></pre>'
+    const { container } = render(<MarkdownRenderer content={md} />)
+    expect(container.querySelector('[data-fenced]')).toBeNull()
+  })
+
+  it('survives a re-render that introduces an inline classed <code> (streaming)', () => {
+    // The crash surfaced on reconciliation, not first paint, so the streaming
+    // shape is the one that actually reproduced it in the dashboard.
+    const { container, rerender } = render(<MarkdownRenderer content="Use " />)
+    rerender(<MarkdownRenderer content={'Use <code class="language-js">const x = 1</code>'} />)
+    rerender(<MarkdownRenderer content={'Use <code class="language-js">const x = 1</code> in your file.'} />)
+    expect(container.querySelectorAll('p div')).toHaveLength(0)
+    expect(container.textContent).toContain('in your file.')
+  })
+})


### PR DESCRIPTION
## Problem

The dashboard crashes on render with:

```
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

The React owner stack bottoms out at a `<p>` rendered by `MdParagraph`, inside `MarkdownRenderer`.

## Root cause

`MD_COMPONENTS.code` decides block-vs-inline from `className` alone, and `CodeBlock`, `MermaidBlock` and `ExcalidrawBlock` are each rooted in a `<div>`:

```tsx
if (lang === 'mermaid') return <MermaidBlock code={codeStr} />
if (lang === 'excalidraw') return <ExcalidrawBlock code={codeStr} />
if (!className) return <InlineCode {...props}>{children}</InlineCode>
return <CodeBlock code={codeStr} lang={lang} complete={true} />
```

Real fenced blocks never reach that override. `useBlockAssembler` segments them out of the source and `BlockRenderer` draws them directly, so the only classed code elements arriving here come from raw HTML in prose. `GLOBAL_ATTRS` allowlists `class` on every tag, so a bare `<code class="language-js">` written mid-sentence survives sanitization, keeps its class, and renders a `<div>` inside the enclosing `<p>`. The browser hoists that `<div>` out of the `<p>`, React's VDOM keeps the stale parent, and the next reconciliation calls `removeChild` on a node that has moved.

`rehypeUnwrapBlocks` (added in #3092) cannot catch this. It reads block-ness off the HAST tag name, and `code` is inline there. The block only appears in what the component renders, which is invisible at the HAST level.

## Fix

`rehypeMarkFencedCode` stamps `data-fenced` on any `<code>` whose parent is a `<pre>`. That is the shape which legitimately renders a block, and `rehypeUnwrapBlocks` already hoists such a `<pre>` clear of any surrounding `<p>`. The `code` override renders a block component for exactly those and keeps everything else inline, which is also what the source asked for: inline code stays inline whatever class it carries. The marker is destructured out so it never reaches the DOM.

This stays a single mechanism rather than layering a second guard over `rehypeUnwrapBlocks`.

## Verification

Six regression tests in `website/src/test/MarkdownRenderer.inlineCodeBlock.test.tsx`:

- inline classed `<code>` stays in the paragraph with no `<div>` child, sentence intact
- the `language-mermaid` variant stays inline instead of drawing a diagram
- a raw `<pre><code class="language-js">` still renders a block code block outside any `<p>`
- a real fenced block is unaffected
- no `data-fenced` attribute leaks into the DOM
- the streaming re-render shape that actually reproduced the crash

Gates run in a worktree off latest `origin/main`:

- `npx tsc -b` clean
- `npx vitest run` full suite: 1369 files, 21378 passed, 2 expected fail, 3 skipped, 0 failed
- `npx eslint` on both changed files: 0 errors (one pre-existing a11y warning at line 707, outside this change)
