### PR TITLE
fix(chat): exempt a note breadcrumb from the turn-start voice and status effects

### DIFF
--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { isArtifactEditing } from '../utils/artifactEditGuard'
+import { isReconcileNote } from '../lib/noteContract'
 import { useAppDispatch } from '../store'
 import { store } from '../store'
 import { sseStatus, sseConnected, sseDisconnected, sseSlots, sseTodoUpdate, setChannelTrusted, sseSlotTitle, triggerRefresh, fetchSlots, markSlotUnread, setUpdateProgress, sseSubagentStatus, sseSubagentText, touchSlotActivity, patchSlotSourceLinks, type SubagentDetail } from '../store/dashboardSlice'
@@ -953,8 +954,11 @@ export function useWebSocket() {
             // trigger (no-op unless an L2 theme with that manifest sound is
             // active + unmuted). User/tool messages don't chime.
             if (data.role === 'assistant') emitThemeSound('message-received')
-            if (data.role === 'user' || data.role === 'inject' || data.role === 'subagent') { stopVoice(); voiceProgressRef.current = null; synthChainRef.current = Promise.resolve() }
-            if (data.slot && (data.role === 'user' || data.role === 'inject' || data.role === 'subagent')) {
+            // A note breadcrumb starts no turn, so no chat_done arrives to undo either
+            // effect: cutting speech would strand it and a thinking status would never clear.
+            const isPassiveNote = data.role === 'inject' && isReconcileNote(data.cls)
+            if (!isPassiveNote && (data.role === 'user' || data.role === 'inject' || data.role === 'subagent')) { stopVoice(); voiceProgressRef.current = null; synthChainRef.current = Promise.resolve() }
+            if (!isPassiveNote && data.slot && (data.role === 'user' || data.role === 'inject' || data.role === 'subagent')) {
               dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'thinking', text: 'Thinking…', ts: Date.now() }))
             }
             break

--- a/website/src/lib/noteContract.ts
+++ b/website/src/lib/noteContract.ts
@@ -1,0 +1,24 @@
+/**
+ * Wire contract for the `cls` token that marks a note breadcrumb.
+ *
+ * `cls` is a space-separated class list — `msg msg-a`, `msg msg-a crew-reply` —
+ * and other consumers already match a single class with a whitespace-bounded
+ * test. Today's producer emits this token on its own, so equality would match
+ * too; membership is defensive against the token later arriving alongside
+ * others, which would silently kill the guard while tests stayed green.
+ *
+ * The value lives here rather than inline at the call site so the tree has
+ * exactly one spelling of it.
+ */
+export const RECONCILE_NOTE_CLS = 'reconcile-note'
+
+/**
+ * True when `cls` carries the note class as a whole class.
+ *
+ * Splitting is what makes this a class test rather than a substring test:
+ * `reconcile-note-draft` contains the token but is a different class.
+ */
+export function isReconcileNote(cls: string | undefined | null): boolean {
+  if (typeof cls !== 'string' || cls.length === 0) return false
+  return cls.trim().split(/\s+/).includes(RECONCILE_NOTE_CLS)
+}

--- a/website/src/test/useWebSocket.passiveNote.test.ts
+++ b/website/src/test/useWebSocket.passiveNote.test.ts
@@ -1,0 +1,216 @@
+/**
+ * A note breadcrumb arrives as `role: 'inject'` with `cls: 'reconcile-note'`. It
+ * records something on the transcript but starts no agent turn, so no
+ * `chat_done` ever follows it.
+ *
+ * Two effects on the inbound-prompt path assume a turn is beginning: they stop
+ * text-to-speech, and they set a "Thinking…" status that only turn completion
+ * clears. Applied to a note, the first cuts speech off mid-sentence and the
+ * second leaves a status stuck on the slot forever. Both directions are pinned
+ * here — a note is exempt, a plain inject still triggers both.
+ *
+ * `stopVoice()` is a hook-local callback with nothing to spy on, so it is
+ * observed through its one store write, `setVoicePlaying(false)`: inside the
+ * `chat_message` case that dispatch has no other caller.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { store } from '../store'
+import { setActiveSlot, clearMessages, clearSlotState, setVoicePlaying } from '../store/chatSlice'
+import { RECONCILE_NOTE_CLS, isReconcileNote } from '../lib/noteContract'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: true }),
+    voiceSynthesize: vi.fn().mockResolvedValue({}),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() { WS_INSTANCES.push(this) }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+// A true -> false flip of voicePlaying means stopVoice ran: inside the
+// chat_message case that dispatch has no other caller.
+const voicePlaying = () => store.getState().chat.voicePlaying
+const statusKind = (slot: string) => store.getState().chat.slotStatusDetail[slot]?.kind
+
+describe('useWebSocket passive note (role=inject, cls=reconcile-note)', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    // clearMessages does NOT reset slotStatusDetail, so a "Thinking…" set by one
+    // test would otherwise leak forward and make these assertions order-dependent.
+    store.dispatch(clearSlotState())
+    store.dispatch(setActiveSlot('slot-1'))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    store.dispatch(clearMessages())
+    store.dispatch(clearSlotState())
+    store.dispatch(setActiveSlot(null))
+    store.dispatch(setVoicePlaying(false))
+  })
+
+  async function mount() {
+    function wrapper({ children }: { children: React.ReactNode }) {
+      return createElement(Provider, { store },
+        createElement(QueryClientProvider, { client: queryClient }, children))
+    }
+    const hook = renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    await act(async () => {})
+    return { hook, ws }
+  }
+
+  it('leaves speech running and sets no thinking status', async () => {
+    const { hook, ws } = await mount()
+
+    // Speech is in progress when the note lands.
+    act(() => { store.dispatch(setVoicePlaying(true)) })
+    expect(voicePlaying()).toBe(true)
+
+    act(() => {
+      ws.simulateMessage({
+        type: 'chat_message',
+        data: { slot: 'slot-1', role: 'inject', cls: RECONCILE_NOTE_CLS, content: 'a note', ts: '10.0' },
+      })
+    })
+    await act(async () => {})
+
+    expect(voicePlaying()).toBe(true)
+    expect(statusKind('slot-1')).toBeUndefined()
+
+    hook.unmount()
+  })
+
+  it('still stops speech and sets a thinking status for a plain inject', async () => {
+    const { hook, ws } = await mount()
+
+    act(() => { store.dispatch(setVoicePlaying(true)) })
+    expect(voicePlaying()).toBe(true)
+
+    // A queued prompt: no cls, a real turn follows, so both effects are correct.
+    act(() => {
+      ws.simulateMessage({
+        type: 'chat_message',
+        data: { slot: 'slot-1', role: 'inject', content: 'a queued prompt', ts: '11.0' },
+      })
+    })
+    await act(async () => {})
+
+    expect(voicePlaying()).toBe(false)
+    expect(statusKind('slot-1')).toBe('thinking')
+
+    hook.unmount()
+  })
+
+  it('records the note on the transcript and bumps slot recency', async () => {
+    const { hook, ws } = await mount()
+
+    // The exemption is scoped to the two turn-scoped effects: a note is still a
+    // visible row, and still counts as activity on the slot.
+    act(() => {
+      ws.simulateMessage({
+        type: 'chat_message',
+        data: { slot: 'slot-1', role: 'inject', cls: RECONCILE_NOTE_CLS, content: 'a visible note', ts: '12.0' },
+      })
+    })
+    await act(async () => {})
+
+    const messages = store.getState().chat.messages
+    expect(messages.some(m => m.content === 'a visible note')).toBe(true)
+
+    hook.unmount()
+  })
+
+  it('is exempt when the token arrives alongside other classes', async () => {
+    const { hook, ws } = await mount()
+
+    act(() => { store.dispatch(setVoicePlaying(true)) })
+
+    // `cls` is a class LIST — most rows in the tree look like `msg msg-a`. A
+    // producer emitting the token as one class among several is the same note.
+    act(() => {
+      ws.simulateMessage({
+        type: 'chat_message',
+        data: { slot: 'slot-1', role: 'inject', cls: `msg ${RECONCILE_NOTE_CLS}`, content: 'a wrapped note', ts: '13.0' },
+      })
+    })
+    await act(async () => {})
+
+    expect(voicePlaying()).toBe(true)
+    expect(statusKind('slot-1')).toBeUndefined()
+
+    hook.unmount()
+  })
+
+  it('is not exempt for a different class that merely contains the token', async () => {
+    const { hook, ws } = await mount()
+
+    act(() => { store.dispatch(setVoicePlaying(true)) })
+
+    // Membership, not substring: a longer class name is a different class.
+    act(() => {
+      ws.simulateMessage({
+        type: 'chat_message',
+        data: { slot: 'slot-1', role: 'inject', cls: `msg ${RECONCILE_NOTE_CLS}-draft`, content: 'not a note', ts: '14.0' },
+      })
+    })
+    await act(async () => {})
+
+    expect(voicePlaying()).toBe(false)
+    expect(statusKind('slot-1')).toBe('thinking')
+
+    hook.unmount()
+  })
+
+  it('pins the sentinel spelling and the membership rule', () => {
+    // The tests above build their frames from the constant, so they would follow
+    // a rename silently. This pins the wire value the producer must emit.
+    expect(RECONCILE_NOTE_CLS).toBe('reconcile-note')
+
+    expect(isReconcileNote('reconcile-note')).toBe(true)
+    expect(isReconcileNote('msg reconcile-note')).toBe(true)
+    expect(isReconcileNote('  msg   reconcile-note  ')).toBe(true)
+    expect(isReconcileNote('msg reconcile-note-draft')).toBe(false)
+    expect(isReconcileNote('msg msg-u')).toBe(false)
+    expect(isReconcileNote(undefined)).toBe(false)
+    expect(isReconcileNote('')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

A note breadcrumb arrives over the websocket as a `chat_message` with `role: 'inject'` and a `cls` carrying `reconcile-note`. It records a visible row on the transcript, but unlike a queued prompt it does **not** start an agent turn — so no `chat_done` frame ever follows it.

Two effects in the `chat_message` handler in `website/src/hooks/useWebSocket.ts` fire for every inbound prompt role (`user`, `inject`, `subagent`) on the assumption that a turn is beginning, and both are meant to be undone by turn completion:

- **Speech is stopped.** `stopVoice()` runs, the voice progress ref is cleared and the synthesis chain is reset. This is right for a real prompt — you interrupted the agent, so stop reading its previous reply aloud.
- **A "Thinking…" status is set** on the slot via `setSlotStatusDetail`. Only turn completion clears it.

Applied to a note, both are wrong, and nothing arrives to repair either one.

## Why it matters

This becomes user-visible the moment something starts emitting those rows. #3248 (`POST /api/chat/slots/{slot}/note`) is the change that does exactly that: its visible half appends `role="inject"` with the `reconcile-note` class. Once it merges, every note posted while the agent is being read aloud would cut text-to-speech off mid-sentence, and would leave a "Thinking…" status pinned to the slot indefinitely — a spinner for a turn that was never running. The guard needs to be in place before or alongside #3248 rather than after it, so there is no window where notes strand the UI.

## What changed

Three files.

`website/src/lib/noteContract.ts` (new) owns the wire contract: `RECONCILE_NOTE_CLS` holds the class name, and `isReconcileNote(cls)` answers whether a frame carries it. The token lives in exactly one place in this tree, so there is one spelling to change rather than several to keep in sync.

`website/src/hooks/useWebSocket.ts` gates the two turn-scoped effects on that predicate:

```ts
const isPassiveNote = data.role === 'inject' && isReconcileNote(data.cls)
```

**Why membership and not string equality.** `cls` on a chat message is a space-separated class list — `msg msg-a` and `msg msg-a crew-reply` are ordinary values, and other consumers in the tree already match a single class with a whitespace-bounded test rather than comparing the whole string. To be clear about the strength of this: #3248's producer currently emits the token **on its own**, so exact equality would match today too. Membership is defensive rather than load-bearing — it means the guard keeps working if the token is later emitted alongside other classes, which would otherwise silently disable it while every test here still passed. `isReconcileNote` splits on whitespace, so a longer class name that merely contains the token (`reconcile-note-draft`) is correctly treated as a different class.

Deliberately **not** changed: the slot-recency bump a few lines above already includes `inject` and is left exactly as it is. A note *is* activity on the slot and should move it up the ordering, and it stays a visible transcript row. The exemption is scoped strictly to the two effects that depend on a turn completing.

## Tests

`website/src/test/useWebSocket.passiveNote.test.ts` — 6 tests, using the existing `renderHook` + mock-websocket + real-store harness already used by the other `useWebSocket.*` tests. Every frame is built from `RECONCILE_NOTE_CLS` rather than a retyped string, so a frame can never drift from the value the guard accepts.

`stopVoice()` is a hook-local callback with nothing to spy on, so it is observed through the one store write it makes: `setVoicePlaying(false)`. Inside the `chat_message` case that dispatch has no other caller, and the `sseChatMessage` reducer never writes `voicePlaying` — so a `true -> false` flip is attributable to `stopVoice()` having run. The status effect is read directly off `slotStatusDetail[slot].kind`.

What the tests pin:

- a note leaves speech running and sets no status;
- a plain `role: 'inject'` with no class still stops speech and still sets `thinking` — the behaviour that was already correct and must not regress;
- a note still lands on the transcript;
- the token arriving alongside other classes (`msg reconcile-note`) is still treated as a note;
- a different class that merely contains the token (`msg reconcile-note-draft`) is **not** treated as a note, so the widening is membership and not substring matching;
- one test asserts the constant's literal value. Because the frames are built from the constant, they would follow a rename without complaint; this assertion is what makes a change to the wire value fail loudly instead.

Since the frames build from the constant, the membership rule was verified by perturbing the guard directly: with the constant in place but the comparison left as exact equality, the wrapped-class test fails with `expected false to be true` (speech was cut), and it passes once the predicate tests membership. The substring case stays failing-as-expected in both, which is what rules out an over-broad `includes`.

Suite on this branch: 20 test files, 207 tests, 0 failures across the touched file and every `useWebSocket.*` suite (the hook is shared, so that scope includes the thinking-status and auto-speak suites). `tsc --noEmit` clean. ESLint on the touched files reports 4 warnings, all pre-existing — the identical set appears on the `main` baseline (`no-console` x3 and one `react-hooks/exhaustive-deps`).

## Note on an earlier revision of this description

An earlier version of this description argued for keeping the class name written inline at the call site and repeated in the test frames, on the grounds that repeating it acted as a tripwire. That reasoning has been superseded and the paragraph making it is gone: the change now centralises the token in `noteContract.ts` and the tests import it, with an explicit assertion on the literal value serving the tripwire role instead. That earlier text also described a single-file change with three tests, which no longer matches what ships. Anything still reading as an argument against the shared constant is stale wording, not the current design.
