### PR TITLE
ci: fail a PR that deletes or edits a shipped changelog section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,45 @@ jobs:
           python3 scripts/check_brand_name.py --test
           python3 scripts/check_brand_name.py
 
+  changelog-history:
+    name: Changelog History Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check that shipped changelog sections survived this change
+        # CHANGELOG.md is append-only history: every section already in it
+        # describes software a user has installed, so a line deleted from one is
+        # unrecoverable from that user's artifact. This has already happened
+        # once — a commit titled "docs: add 0.3.0-insider.9 changelog" REPLACED
+        # the file instead of prepending to it (53 insertions, 322 deletions),
+        # taking [0.2.0], [0.1.3] and [0.1.2] with it. It read as plausible in
+        # review because the insertions are what a reader looks at, and the
+        # deletions sat in the same hunk. Nothing failed; a user noticed the
+        # Releases page had gone nearly empty.
+        #
+        # So the judgment half of the rule (commit dumps, prerelease headings,
+        # whether this PR should touch the file at all) stays in AUTOSDE.yaml
+        # where a reviewer applies it, and the mechanical half runs here, where
+        # nobody has to notice anything. release.yml's stable gate is the
+        # complement: it checks the NEW section exists, not that the old ones
+        # survived — which is the half that actually failed.
+        env:
+          # base.sha, not origin/<base>: the merge ref this run checks out was
+          # computed against that exact commit, so the comparison cannot pick up
+          # base moves that landed after the run started. Same reasoning as the
+          # brand-name and i18n gates above.
+          CHANGELOG_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          CHANGELOG_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
+            "$CHANGELOG_BASE_REF" 'the changelog-history gate')" || exit 1
+          export CHANGELOG_BASE_REF
+          # Self-test first: one probe per rule family, so a weakened rule fails
+          # here instead of shipping green and letting a deletion through.
+          python3 scripts/check_changelog_history.py --test
+          python3 scripts/check_changelog_history.py
+
   harness-parity:
     name: Harness Parity Gate
     runs-on: ubuntu-latest

--- a/scripts/check_changelog_history.py
+++ b/scripts/check_changelog_history.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""check_changelog_history.py — shipped changelog sections are immutable.
+
+``CHANGELOG.md`` is append-only history. A release prepends one
+``## [X.Y.Z] — YYYY-MM-DD`` section; every section already in the file describes
+software a user has already installed, so a line deleted from one is
+unrecoverable from that user's artifact.
+
+## Why this is a deterministic gate and not a review rule
+
+This exact loss already happened. A commit titled ``docs: add 0.3.0-insider.9
+changelog`` *replaced* the file instead of prepending to it: 53 insertions and
+322 deletions, taking the entire ``[0.2.0]``, ``[0.1.3]`` and ``[0.1.2]``
+sections with it. It read as plausible in review, because the insertions are
+what a reader looks at and the deletions were buried in the same hunk. Nothing
+failed; the loss surfaced only when a user noticed the dashboard's Releases page
+had gone nearly empty.
+
+So the judgment half of the rule (is this a commit dump? is this heading a
+prerelease? should this PR be touching the file at all?) stays in
+``AUTOSDE.yaml`` where a reviewer applies it, and the **mechanically checkable**
+half lives here, where no reviewer has to notice anything:
+
+    every version section present at the base ref must still be present at head,
+    byte-identical
+
+with **no exemptions**. A section whose heading is a bare ``X.Y.Z`` describes
+shipped software and is immutable, full stop.
+
+A **prerelease** heading (``## [0.3.0-insider.9]``, ``## [0.3.0-rc.2]``) is not a
+shipped section at all -- it is a draft of a release that has not happened -- so it
+is skipped here exactly like ``## [Unreleased]``. That is what lets a release
+branch replace its own in-progress ``[0.3.0-insider.9]`` heading with the written
+``[0.3.0]`` entry: nothing shipped is being touched.
+
+An earlier version of this check exempted "the newest section at the base ref" so
+a release branch could redraft its own entry. That was wrong in a way worth
+recording: on ``main`` the newest section at base is the **last shipped release**,
+so the exemption made the most recently shipped section -- the one the most users
+are running -- the single editable one. Keying on "newest" confused *position in
+the file* with *not yet released*. Prerelease-versus-bare is the property that
+actually distinguishes a draft from history, and it needs no tag lookup, so it
+works in a shallow CI checkout.
+
+Correcting a genuine factual error inside a shipped section is still possible; it
+is simply not silent. The gate flags it, and the author says in the PR body that
+this is what they are doing (the AUTOSDE rule's stated allowance) so a human
+approves it deliberately.
+
+``release.yml``'s stable gate is the complement of this check: it verifies the
+new section *exists*. It does not verify the old ones survived, which is the
+half that actually failed.
+
+## One source of truth for folding
+
+``0.3.0-insider.9``, ``0.3.0-rc.2`` and ``0.3.0`` are one release. The renderer
+(``src/kiro_crew/changelog.py``) owns that folding, and this gate **loads it from
+there** by path rather than re-implementing it. ``changelog.py`` imports only
+``re`` and ``typing``, so it loads in a CI job that checked the tree out without
+installing the package. A second copy of the regex was the earlier design and it
+failed in the dangerous direction: a spelling the renderer folds but the gate does
+not would make a legitimate release-branch rewrite read as a deleted section, or
+let a real deletion pass.
+
+## Usage
+
+    # enforce against a base ref (exit 1 on any violation)
+    CHANGELOG_BASE_REF="$(git merge-base HEAD origin/main)" \
+        python3 scripts/check_changelog_history.py
+
+    # self-test: one probe per rule family, assert each verdict
+    python3 scripts/check_changelog_history.py --test
+
+With no ``CHANGELOG_BASE_REF`` the check has nothing to compare against and
+exits 0 with a note, so running it locally without a base is not a failure.
+
+Pass the MERGE BASE, not the base branch's moving tip. CI passes
+``pull_request.base.sha`` and tests the merge ref, so the two agree there; locally
+they do not. A branch that is merely BEHIND a base which has since gained a release
+reports that release as ``GONE`` -- the section is missing from the head being
+compared, which is true and useless. The merge base is the commit the branch
+actually departed from, so it answers "did THIS branch remove anything".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable, NamedTuple
+
+CHANGELOG = "CHANGELOG.md"
+
+#: The renderer, loaded by path so this gate cannot drift from it. Kept as a
+#: by-path load rather than a package import because CI checks the tree out
+#: without installing ``kiro_crew``; ``changelog.py`` has no third-party imports,
+#: so the module loads standalone.
+RENDERER_PATH = "src/kiro_crew/changelog.py"
+_RENDERER = Path(__file__).resolve().parents[1] / RENDERER_PATH
+
+
+def _load_renderer_source(source: str) -> object:
+    """Load ``changelog.py`` source read from a git ref as a throwaway module.
+
+    Routed through the same import machinery as the in-tree renderer rather than
+    ``exec``: one loading mechanism instead of two, and the module gets a real
+    spec, so a syntax error surfaces with a filename and a line number instead of
+    a bare traceback.
+
+    The base ref is the merge target -- the branch this change is asking to land
+    on -- so its renderer is trusted here exactly as the checked-out one is.
+    ``changelog.py`` imports only ``re`` and ``typing``, so loading it has no side
+    effects and needs nothing installed.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "changelog_at_base.py"
+        path.write_text(source, encoding="utf-8")
+        return _load_module_at(path)
+
+
+def _load_module_at(path: Path) -> object:
+    """Import a standalone ``changelog.py`` from ``path``."""
+    spec = importlib.util.spec_from_file_location(f"_kc_changelog_renderer_{path.stem}", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - unreachable in-tree
+        raise RuntimeError(f"cannot load the changelog renderer at {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_renderer() -> object:
+    return _load_module_at(_RENDERER)
+
+
+_renderer = _load_renderer()
+#: ``base_version("0.3.0-insider.9") == "0.3.0"``; an unparseable string returns
+#: itself, which is what keeps a malformed heading from folding onto a real
+#: release and silently replacing its notes.
+fold_version = _renderer.base_version  # type: ignore[attr-defined]
+#: The renderer's own list builder. Used ONLY by the self-test, to pin the fold
+#: DIRECTION against the renderer rather than against a hardcoded expectation --
+#: the one thing a second copy of the logic here could not check.
+render_releases = _renderer.build_release_list  # type: ignore[attr-defined]
+
+
+# The heading grammar is a VALUE, not a module global, because the base ref and the
+# head can legitimately disagree about it: a PR is allowed to change the renderer.
+# Parsing base history with the HEAD's grammar is what let a narrowed regex shrink
+# the protected set -- see :func:`compare`.
+class Grammar(NamedTuple):
+    """One checkout's changelog grammar: how it finds headings and folds versions."""
+
+    section_re: "re.Pattern[str]"
+    h2_re: "re.Pattern[str]"
+    fold: Callable[[str], str]
+
+
+def grammar_of(renderer: object) -> Grammar:
+    """Build a :class:`Grammar` from a loaded ``changelog.py`` module.
+
+    Taken from the renderer, never copied. These are private names, and reaching
+    for them is the deliberate choice: the alternative is a second copy of the
+    heading grammar, and this gate's whole premise is that a spelling the renderer
+    folds but the gate does not is a silent hole. A copy that starts byte-identical
+    is exactly the failure mode -- it stays correct until someone widens one side.
+    """
+    return Grammar(
+        section_re=renderer._SECTION_RE,  # type: ignore[attr-defined]
+        h2_re=renderer._H2_RE,  # type: ignore[attr-defined]
+        fold=renderer.base_version,  # type: ignore[attr-defined]
+    )
+
+
+#: The grammar of the checkout being tested. Used for head text, and as the base
+#: grammar only when the base's own renderer cannot be read (see :func:`main`).
+HEAD_GRAMMAR = grammar_of(_renderer)
+
+
+def is_shipped_heading(version: str, grammar: Grammar = HEAD_GRAMMAR) -> bool:
+    """True when ``version`` is a bare release (``X.Y.Z``), not a draft.
+
+    A prerelease spelling folds onto a release it is only a *draft* of, so a
+    prerelease heading documents nothing shipped. A malformed spelling keeps its
+    own identity in the renderer, so it is its own fold and reads as shipped --
+    the safe direction, since it cannot collide with a real release and the only
+    consequence is that it is also protected from silent edits.
+    """
+    stripped = version.strip()
+    if not stripped or not stripped[0].isdigit():
+        return False
+    return bool(grammar.fold(stripped) == stripped)
+
+
+def _headings(text: str, grammar: Grammar = HEAD_GRAMMAR) -> list[tuple[str, str, str]]:
+    """Return ``[(raw_version, folded_version, section_text)]`` in document order.
+
+    EVERY level-2 version heading, prerelease and malformed included -- the
+    filtering happens in :func:`compare`, deliberately. ``section_text`` includes
+    the heading line, because the heading carries the release date and a rewritten
+    date is a rewritten record.
+    """
+    out: list[tuple[str, str, str]] = []
+    lines = text.splitlines(keepends=True)
+    index = 0
+    while index < len(lines):
+        heading_line = lines[index]
+        heading = grammar.section_re.match(heading_line.rstrip("\n"))
+        if not heading:
+            index += 1
+            continue
+        raw = heading.group("version").strip()
+        index += 1
+        body: list[str] = []
+        while index < len(lines) and not grammar.h2_re.match(lines[index].rstrip("\n")):
+            body.append(lines[index])
+            index += 1
+        out.append((raw, grammar.fold(raw), heading_line + "".join(body)))
+    return out
+
+
+def resolve_as_rendered(text: str, grammar: Grammar = HEAD_GRAMMAR) -> dict[str, str]:
+    """Return ``{release: the section the RENDERER will display}``.
+
+    This is the load-bearing function, and its fold direction is not a detail.
+    ``changelog.py``'s ``build_release_list`` resolves with ``dict.setdefault``, so
+    **the FIRST body in document order wins** -- which under keep-a-changelog's
+    newest-first ordering means the topmost spelling of a release is what a user
+    sees. That direction is itself a fix: last-wins let a ``## [0.2.0-rc.1]``
+    draft lower in the file replace the released ``## [0.2.0]`` body and date,
+    with the fold being correct so nothing looked wrong.
+
+    Mirror it exactly. Folding the other way here would compare a section the
+    renderer never displays, which is the same class of blind spot this gate
+    exists to close -- only harder to see, because the gate would look right.
+    """
+    resolved: dict[str, str] = {}
+    for _raw, folded, section in _headings(text, grammar):
+        if folded:
+            resolved.setdefault(folded, section)
+    return resolved
+
+
+def parse_sections(text: str, grammar: Grammar = HEAD_GRAMMAR) -> list[tuple[str, str]]:
+    """Return ``[(version, section_text)]`` for the SHIPPED releases only."""
+    return [
+        (raw, section)
+        for raw, folded, section in _headings(text, grammar)
+        if is_shipped_heading(raw, grammar)
+    ]
+
+
+#: Matches a bracketed level-2 heading under ANY plausible grammar. Used only to
+#: decide whether a base text that parsed to zero shipped releases is genuinely
+#: empty or was mis-parsed -- never to extract a version.
+_ANY_BRACKET_H2 = re.compile(r"^##\s+\[", re.MULTILINE)
+
+
+def compare(
+    base_text: str,
+    head_text: str,
+    base_grammar: Grammar = HEAD_GRAMMAR,
+    head_grammar: Grammar = HEAD_GRAMMAR,
+) -> list[str]:
+    """Return a violation per shipped release whose rendered notes changed.
+
+    ONE invariant, replacing three separate filters that each leaked a variant of
+    the same defect: *for every release the base ref documents as shipped, the
+    section the renderer displays at head must be byte-identical to the one it
+    displayed at base.* Comparing the RENDERED resolution rather than the sections
+    a filter happened to keep is what makes shadowing unreachable -- a duplicate
+    bare heading, a rewritten date, and a prerelease heading folding onto a
+    shipped release are all just "the resolved section changed".
+
+    Pure, so the self-test can exercise every rule family without git.
+    """
+    base_shipped = {raw for raw, _section in parse_sections(base_text, base_grammar)}
+    if not base_shipped:
+        # Fail CLOSED. An empty protected set is indistinguishable, from here,
+        # between "the base genuinely shipped nothing" and "the base was mis-parsed
+        # and every release just left the protected set" -- and the second reading
+        # silently disables the whole gate. A base carrying bracketed level-2
+        # headings that yields zero shipped releases is the second case.
+        if _ANY_BRACKET_H2.search(base_text):
+            return [
+                "the base ref's changelog has version headings but NONE parsed as a "
+                "shipped release, so there is nothing to protect and every deletion "
+                "would pass. This is a parser problem, not a changelog problem: "
+                "check what this change does to changelog.py's heading grammar."
+            ]
+        return []
+    base_resolved = resolve_as_rendered(base_text, base_grammar)
+    head_resolved = resolve_as_rendered(head_text, head_grammar)
+    problems: list[str] = []
+
+    for version in sorted(base_shipped):
+        if version not in head_resolved:
+            problems.append(
+                f"[{version}] was present at the base ref and is GONE at head. "
+                f"A shipped changelog section is history a user already "
+                f"installed; a release prepends a new section and leaves every "
+                f"earlier one untouched."
+            )
+        elif head_resolved[version] != base_resolved.get(version):
+            problems.append(
+                f"[{version}] renders DIFFERENT notes than it did at the base "
+                f"ref. A shipped section is immutable, heading and body -- and it "
+                f"is the section the renderer RESOLVES that matters, so a "
+                f"duplicate or prerelease heading folding onto [{version}] counts "
+                f"even when the original text is still in the file."
+            )
+
+    # Second rule, and it is not redundant with the first: a release must be
+    # documented by EXACTLY ONE heading at head. The check above compares only
+    # what the renderer RESOLVES, and first-wins means a second copy placed BELOW
+    # the original resolves to the original -- clean by that measure, while the
+    # file now carries a second, divergent account of shipped history that a human
+    # reading the file sees. Counting headings per release catches that copy
+    # wherever it sits, so neither rule depends on the other's ordering luck.
+    #
+    # A draft spelling counts as such a copy: ANY additional heading folding onto
+    # a release that also has a bare heading is a violation, whichever order they
+    # appear in. Order deciding which body a user sees is precisely the ambiguity
+    # worth refusing -- a prerelease heading above the bare one wins the fold and
+    # publishes draft notes under a release number.
+    #
+    # Counted across EVERY release at head, not only the ones the base documents:
+    # a release being added by this very change can carry the same ambiguity, and
+    # the resolved comparison cannot see it (there is no base section to differ
+    # from), so one of its two bodies would silently go unread.
+    head_folds: dict[str, list[str]] = {}
+    for raw, folded, _section in _headings(head_text, head_grammar):
+        if folded:
+            head_folds.setdefault(folded, []).append(raw)
+    for version in sorted(head_folds):
+        raws = head_folds[version]
+        bare = [r for r in raws if r == version]
+        if len(raws) > 1 and (version in base_shipped or bare):
+            problems.append(
+                f"[{version}] is documented by {len(raws)} headings at head "
+                f"({', '.join(raws)}). A release gets exactly one: the renderer "
+                f"keeps a single body per release, so the others are invisible on "
+                f"the Releases page while their text stays in the file."
+            )
+        elif version in base_shipped and raws[0] != version:
+            problems.append(
+                f"[{raws[0]}] folds onto shipped release [{version}] and has "
+                f"replaced its heading. A draft spelling must not stand in for "
+                f"shipped history."
+            )
+    return problems
+
+
+def _git_show(ref: str, path: str) -> str | None:
+    """Return ``path`` at ``ref``, or ``None`` when it does not exist there."""
+    try:
+        return subprocess.run(
+            ["git", "show", f"{ref}:{path}"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _self_test() -> int:
+    """One probe per defect class this gate has actually been shown to miss.
+
+    Five review rounds each found a different way for two headings to map onto
+    one rendered release while a check reported the file intact. All of them are
+    probed here against the single resolved-section invariant, so a regression in
+    any fails before enforcement. The last probe is different in kind: it asks
+    ``changelog.py`` which body a release resolves to, because round 5 found the
+    gate folding the opposite direction from the renderer with every rule still
+    green.
+    """
+    shipped = "## [0.2.0] \u2014 2026-08-09\n\nold body\n\n"
+    latest = "## [0.3.0] \u2014 2026-08-17\n\nreleased body\n\n"
+    base = f"# Changelog\n\n{latest}{shipped}"
+    cases: list[tuple[str, str, bool]] = [
+        ("a deleted shipped section is caught", f"# Changelog\n\n{latest}", True),
+        (
+            "a modified shipped body is caught",
+            f"# Changelog\n\n{latest}## [0.2.0] \u2014 2026-08-09\n\nEDITED\n\n",
+            True,
+        ),
+        (
+            "round 1a: a rewritten shipped DATE is caught (heading is the record)",
+            f"# Changelog\n\n{latest}## [0.2.0] \u2014 2026-01-01\n\nold body\n\n",
+            True,
+        ),
+        (
+            "round 1b: edit-plus-untouched-copy (duplicate bare heading)",
+            f"# Changelog\n\n{latest}## [0.2.0] \u2014 2026-08-09\n\nEDITED\n\n{shipped}",
+            True,
+        ),
+        (
+            "round 2: editing the NEWEST shipped section (no exemption)",
+            f"# Changelog\n\n## [0.3.0] \u2014 2026-08-17\n\nrewritten\n\n{shipped}",
+            True,
+        ),
+        (
+            "round 3: a prerelease heading shadowing a shipped release",
+            f"# Changelog\n\n{latest}## [0.2.0-rc.2]\n\ndraft notes\n\n{shipped}",
+            True,
+        ),
+        (
+            "round 3b: ...and in the order where the draft wins the fold",
+            f"# Changelog\n\n{latest}{shipped}## [0.2.0-rc.2]\n\ndraft notes\n\n",
+            True,
+        ),
+        (
+            "prepending a new release is allowed",
+            f"# Changelog\n\n## [0.4.0] \u2014 2026-09-01\n\nnew\n\n{latest}{shipped}",
+            False,
+        ),
+        (
+            "an Unreleased section is ignored, not treated as shipped",
+            f"# Changelog\n\n## [Unreleased]\n\npending\n\n{latest}{shipped}",
+            False,
+        ),
+        (
+            "a prerelease for a release NOT yet shipped is allowed",
+            f"# Changelog\n\n## [0.4.0-rc.1]\n\ndrafting\n\n{latest}{shipped}",
+            False,
+        ),
+        (
+            "round 4: a duplicate heading for a NEWLY ADDED release is caught",
+            f"# Changelog\n\n## [0.4.0]\n\nfirst\n\n## [0.4.0]\n\nsecond\n\n{latest}{shipped}",
+            True,
+        ),
+        (
+            "round 5: a draft heading ABOVE a newly added release wins the fold",
+            f"# Changelog\n\n## [0.4.0-rc.2]\n\ndraft\n\n## [0.4.0]\n\nreal\n\n{latest}{shipped}",
+            True,
+        ),
+        (
+            "round 5b: ...and below it, where order alone decided which body shows",
+            f"# Changelog\n\n## [0.4.0]\n\nreal\n\n## [0.4.0-rc.2]\n\ndraft\n\n{latest}{shipped}",
+            True,
+        ),
+    ]
+    failures: list[str] = []
+    for name, head_text, expect in cases:
+        got = bool(compare(base, head_text))
+        if got != expect:
+            failures.append(f"{name}: expected violation={expect}, got {got}")
+
+    # A release branch whose base documents no shipped release may rewrite its own
+    # in-progress prerelease entry into the written release entry.
+    pre_base = f"# Changelog\n\n## [0.3.0-insider.9] \u2014 2026-08-16\n\ngenerated\n\n{shipped}"
+    if compare(pre_base, f"# Changelog\n\n{latest}{shipped}"):
+        failures.append("replacing a prerelease draft heading is wrongly flagged")
+    if not compare(pre_base, f"# Changelog\n\n{latest}"):
+        failures.append("deleting a shipped section past a prerelease draft is not caught")
+
+    # The fold DIRECTION is pinned against the renderer itself, not against a
+    # hardcoded expectation. Round 5 found the gate folding last-wins while
+    # ``build_release_list`` folds first-wins (``dict.setdefault``); every rule
+    # was still covering the documents in this suite, so nothing went red and the
+    # gate merely compared a section no user is shown. Asking the renderer removes
+    # the chance of both sides drifting to the same wrong answer.
+    dup = "# Changelog\n\n## [0.5.0]\n\nTOPMOST\n\n## [0.5.0-rc.1]\n\nLOWER\n\n"
+    try:
+        rendered = {r.version: r.body for r in render_releases(dup, "0.5.0")}
+    except Exception as exc:  # pragma: no cover - renderer import is checked above
+        failures.append(f"could not consult the renderer for fold direction: {exc}")
+    else:
+        mine = resolve_as_rendered(dup)
+        if "TOPMOST" not in mine.get("0.5.0", ""):
+            failures.append("resolve_as_rendered does not fold FIRST-wins like build_release_list")
+        if ("TOPMOST" in rendered.get("0.5.0", "")) != ("TOPMOST" in mine.get("0.5.0", "")):
+            failures.append(
+                "the gate and the renderer disagree on which body a release resolves to"
+            )
+
+    # Round 6: the head's grammar must not be able to shrink what the BASE
+    # documents. A PR may narrow changelog.py's heading regex; parsing base history
+    # with the narrowed grammar drops those releases out of the protected set, and a
+    # deletion in the same PR then passes unseen. Both probes fail under the earlier
+    # single-grammar code, which is the point.
+    narrowed = Grammar(
+        # requires a date, so a dateless ``## [0.1.2]`` heading stops being seen
+        section_re=re.compile(
+            r"^##\s+\[(?P<version>[^\]]+)\]\s*[—–-]\s*(?P<date>[0-9]{4}-[0-9]{2}-[0-9]{2})\s*$"
+        ),
+        h2_re=HEAD_GRAMMAR.h2_re,
+        fold=HEAD_GRAMMAR.fold,
+    )
+    dateless_base = (
+        "# Changelog\n\n## [0.2.0] \u2014 2026-08-09\n\nkept\n\n## [0.1.2]\n\nshipped\n\n"
+    )
+    dateless_head = "# Changelog\n\n## [0.2.0] \u2014 2026-08-09\n\nkept\n\n"
+    if not compare(dateless_base, dateless_head, HEAD_GRAMMAR, narrowed):
+        failures.append(
+            "round 6: a narrowed HEAD grammar hid the deletion of a section the base "
+            "documents as shipped"
+        )
+    # and the mis-parse guard: a base that yields zero shipped releases while
+    # carrying version headings means the parser lost them, not that nothing shipped
+    blind = Grammar(
+        section_re=re.compile(r"^##\s+NEVER-MATCHES-(?P<version>x)$"),
+        h2_re=HEAD_GRAMMAR.h2_re,
+        fold=HEAD_GRAMMAR.fold,
+    )
+    if not compare(dateless_base, dateless_head, blind, HEAD_GRAMMAR):
+        failures.append(
+            "round 6b: a base that parsed to zero shipped releases despite having "
+            "version headings did not fail closed"
+        )
+    # ...but a base with genuinely no version headings is still a clean no-op
+    if compare("# Changelog\n\n## Unreleased\n\npending\n", dateless_head):
+        failures.append("a base with no version headings at all is wrongly flagged")
+
+    if failures:
+        for line in failures:
+            print(f"self-test FAILED: {line}", file=sys.stderr)
+        return 1
+    print(f"changelog-history self-test: {len(cases) + 2} probes, all correct")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--test" in argv:
+        return _self_test()
+
+    base_ref = os.environ.get("CHANGELOG_BASE_REF", "").strip()
+    if not base_ref:
+        print(
+            "changelog-history: no CHANGELOG_BASE_REF, nothing to compare against "
+            "(set it to enforce, e.g. CHANGELOG_BASE_REF=origin/main)"
+        )
+        return 0
+
+    base_text = _git_show(base_ref, CHANGELOG)
+    if base_text is None:
+        print(
+            f"changelog-history: {CHANGELOG} does not exist at {base_ref}; "
+            f"nothing shipped to protect"
+        )
+        return 0
+    try:
+        with open(CHANGELOG, encoding="utf-8") as handle:
+            head_text = handle.read()
+    except FileNotFoundError:
+        print(
+            f"::error::{CHANGELOG} is missing at head but exists at {base_ref}. "
+            f"The changelog is append-only history and cannot be deleted.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Parse base history with the BASE's grammar, not this checkout's. A PR may
+    # legitimately change changelog.py; if it narrows the heading regex, parsing
+    # base text with the narrowed grammar drops those releases out of the protected
+    # set and a deletion in the same PR passes unseen. The base ref is the merge
+    # target, so its renderer is the authority on what the base documents.
+    base_grammar = HEAD_GRAMMAR
+    base_renderer_src = _git_show(base_ref, RENDERER_PATH)
+    if base_renderer_src is None:
+        print(
+            f"changelog-history: note: {RENDERER_PATH} does not exist at {base_ref}; "
+            f"parsing base history with this checkout's grammar. The mis-parse guard "
+            f"below is what keeps that fail-closed."
+        )
+    else:
+        try:
+            base_grammar = grammar_of(_load_renderer_source(base_renderer_src))
+        except Exception as exc:
+            print(
+                f"::error::changelog-history: could not load {RENDERER_PATH} from "
+                f"{base_ref} ({exc}). Refusing to parse shipped history with a "
+                f"grammar that may not be the one it was written under.",
+                file=sys.stderr,
+            )
+            return 1
+
+    problems = compare(base_text, head_text, base_grammar, HEAD_GRAMMAR)
+    if problems:
+        for problem in problems:
+            print(f"::error::changelog-history: {problem}", file=sys.stderr)
+        print(
+            "\nIf a shipped section genuinely must change (a factual "
+            "correction), say so explicitly in the PR body — but prefer leaving "
+            'shipped history alone. See AGENTS.md -> "Release Changelog".',
+            file=sys.stderr,
+        )
+        return 1
+
+    kept = len(parse_sections(base_text, base_grammar))
+    print(f"changelog-history: {kept} shipped section(s) at {base_ref} are intact " f"at head ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
@@ -12,6 +12,8 @@
     "BASE=\"$(git merge-base HEAD origin/main)\" && BRAND_BASE_REF=\"$BASE\" python3 scripts/check_brand_name.py",
     "python3 scripts/check_harness_parity.py --test",
     "BASE=\"$(git merge-base HEAD origin/main)\" && HARNESS_BASE_REF=\"$BASE\" python3 scripts/check_harness_parity.py",
+    "python3 scripts/check_changelog_history.py --test",
+    "BASE=\"$(git merge-base HEAD origin/main)\" && CHANGELOG_BASE_REF=\"$BASE\" python3 scripts/check_changelog_history.py",
     "python3 scripts/docs_lint.py --test",
     "./scripts/docs-lint.sh",
     "python3 scripts/check_per_file_coverage.py --test",

--- a/test/test_changelog_history_gate.py
+++ b/test/test_changelog_history_gate.py
@@ -1,0 +1,292 @@
+"""The changelog-history gate must protect exactly the shipped sections.
+
+``scripts/check_changelog_history.py`` loads its version folding from
+:mod:`kiro_crew.changelog` by path rather than re-implementing it, so there is no
+second copy to drift. What still needs pinning is the gate's own judgment: which
+headings count as shipped history, and which diffs against them are violations.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.changelog import base_version
+
+_REPO = Path(__file__).resolve().parents[1]
+_GATE = _REPO / "scripts" / "check_changelog_history.py"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("_changelog_history_gate", _GATE)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_gate()
+
+
+def test_the_gate_uses_the_renderers_own_folding() -> None:
+    """Not a maintained copy -- the renderer's own function, loaded by path.
+
+    The earlier design duplicated the fold regex, which fails in the dangerous
+    direction: a spelling the renderer folds but the gate does not makes a
+    legitimate release-branch rewrite read as a deleted section. Identity is
+    asserted by name and by agreement rather than by ``is``, because the gate
+    loads ``changelog.py`` as its own module object (CI checks the tree out
+    without installing the package), so the two function objects are distinct
+    even though the code is the same.
+    """
+    assert gate.fold_version.__name__ == base_version.__name__ == "base_version"
+    for spelling in (
+        "0.3.0",
+        "0.3.0-rc.2",
+        "0.3.0-insider.11",
+        "0.3.0-nightly.20260806t065257",
+        "0.3.0rc4",
+        "0.3.0.dev20260806065257",
+        "0.3.0+local",
+        "1.2.3.4",
+        "0.3.0rc4junk",
+    ):
+        assert gate.fold_version(spelling) == base_version(spelling)
+
+
+@pytest.mark.parametrize(
+    "version,shipped",
+    [
+        ("0.3.0", True),
+        ("1.2", True),
+        ("1.2.3.4", True),
+        ("0.3.0-insider.9", False),
+        ("0.3.0-rc.2", False),
+        ("0.3.0rc4", False),
+        ("0.3.0.dev20260806065257", False),
+        ("0.3.0-nightly.20260806t065257", False),
+        ("0.3.0+local", False),
+        ("Unreleased", False),
+        ("", False),
+        # A malformed spelling keeps its own identity in the renderer, so it is
+        # its own fold and reads as shipped here. That is the safe direction: it
+        # cannot collide with the real 0.3.0 (the hazard the renderer documents),
+        # and the only consequence is that a junk heading is also protected from
+        # silent edits.
+        ("0.3.0rc4junk", True),
+    ],
+)
+def test_only_a_bare_release_counts_as_shipped(version: str, shipped: bool) -> None:
+    assert gate.is_shipped_heading(version) is shipped
+
+
+def test_the_gates_own_self_test_passes() -> None:
+    """CI runs ``--test`` before enforcing; pin it so a weakened rule fails here."""
+    assert gate._self_test() == 0
+
+
+def test_deleting_a_shipped_section_is_a_violation() -> None:
+    base = "# Changelog\n\n## [0.3.0]\n\nd\n\n## [0.2.0]\n\nshipped\n\n"
+    head = "# Changelog\n\n## [0.3.0]\n\nd\n\n"
+    problems = gate.compare(base, head)
+    assert len(problems) == 1
+    assert "[0.2.0]" in problems[0] and "GONE" in problems[0]
+
+
+def test_modifying_a_shipped_section_is_a_violation() -> None:
+    base = "# Changelog\n\n## [0.3.0]\n\nd\n\n## [0.2.0]\n\nshipped\n\n"
+    head = "# Changelog\n\n## [0.3.0]\n\nd\n\n## [0.2.0]\n\nEDITED\n\n"
+    problems = gate.compare(base, head)
+    assert len(problems) == 1
+    assert "[0.2.0]" in problems[0] and "renders DIFFERENT notes" in problems[0]
+
+
+def test_rewriting_a_shipped_sections_date_is_a_violation() -> None:
+    """The heading is part of the shipped record, not decoration.
+
+    Comparing bodies alone let a shipped release's date be rewritten while the
+    gate reported the section intact.
+    """
+    base = "# Changelog\n\n## [0.3.0]\n\nd\n\n## [0.2.0] — 2026-08-09\n\nshipped\n\n"
+    head = "# Changelog\n\n## [0.3.0]\n\nd\n\n## [0.2.0] — 2026-01-01\n\nshipped\n\n"
+    problems = gate.compare(base, head)
+    assert len(problems) == 1
+    assert "[0.2.0]" in problems[0] and "renders DIFFERENT notes" in problems[0]
+
+
+def test_a_duplicate_release_heading_is_a_violation() -> None:
+    """Two sections for one release is a defect, and it can mask an edit.
+
+    Edit the real section, append an untouched copy, and any check that folds
+    the two together reports no change while the file carries altered history.
+    """
+    base = "# Changelog\n\n## [0.3.0]\n\nd\n\n## [0.2.0]\n\nshipped\n\n"
+    head = "# Changelog\n\n## [0.3.0]\n\nd\n\n" "## [0.2.0]\n\nEDITED\n\n## [0.2.0]\n\nshipped\n\n"
+    problems = gate.compare(base, head)
+    # TWO findings, and both are wanted. Folding first-wins, the edited copy sits
+    # above the untouched one and therefore becomes what the renderer displays --
+    # so the resolved comparison sees changed notes, and the heading count sees the
+    # duplicate. Under the earlier last-wins fold only the count fired, which is
+    # what let an inverted fold direction look correct.
+    assert len(problems) == 2
+    assert any("renders DIFFERENT notes" in p for p in problems)
+    assert any("documented by 2 headings" in p for p in problems)
+    assert all("[0.2.0]" in p for p in problems)
+
+
+def test_editing_the_newest_shipped_section_is_a_violation() -> None:
+    """There is no "most recent section" exemption, and that is the point.
+
+    An earlier version exempted the newest section at base so a release branch
+    could redraft its own entry. On the default branch the newest section is the
+    LAST SHIPPED release, so that exemption made the section the most users are
+    running the only editable one. Prerelease-versus-bare distinguishes a draft
+    from history; position in the file does not.
+    """
+    base = "# Changelog\n\n## [0.3.0]\n\nreleased\n\n## [0.2.0]\n\nshipped\n\n"
+    head = "# Changelog\n\n## [0.3.0]\n\nREWRITTEN\n\n## [0.2.0]\n\nshipped\n\n"
+    problems = gate.compare(base, head)
+    assert len(problems) == 1
+    assert "[0.3.0]" in problems[0] and "renders DIFFERENT notes" in problems[0]
+
+
+def test_a_prerelease_heading_is_a_draft_not_shipped_history() -> None:
+    """A release branch may replace its own in-progress entry.
+
+    Nothing shipped is documented under a prerelease heading, so swapping
+    ``[0.3.0-insider.9]`` for the written ``[0.3.0]`` is not a deletion.
+    """
+    base = "# Changelog\n\n## [0.3.0-insider.9]\n\ngenerated\n\n## [0.2.0]\n\nshipped\n\n"
+    head = "# Changelog\n\n## [0.3.0] — 2026-08-17\n\nwritten\n\n## [0.2.0]\n\nshipped\n\n"
+    assert gate.compare(base, head) == []
+    # And it is not parsed as protectable history in the first place.
+    assert [v for v, _ in gate.parse_sections(base)] == ["0.2.0"]
+
+
+def test_the_original_incident_shape_is_caught() -> None:
+    """A section replaced rather than prepended: insertions masking deletions."""
+    base = (
+        "# Changelog\n\n## [Unreleased]\n\npending\n\n"
+        "## [0.2.0]\n\na\n\n## [0.1.3]\n\nb\n\n## [0.1.2]\n\nc\n\n"
+    )
+    head = "# Changelog\n\n## [Unreleased]\n\npending\n\n## [0.3.0-insider.9]\n\ngenerated\n\n"
+    problems = gate.compare(base, head)
+    assert len(problems) == 3
+    assert {"[0.2.0]", "[0.1.3]", "[0.1.2]"} == {p.split(" ")[0] for p in problems}
+
+
+def test_a_prerelease_heading_cannot_shadow_a_shipped_release() -> None:
+    """The third defect class: two headings, one rendered release.
+
+    Adding ``[0.2.0-rc.2]`` beside a shipped ``[0.2.0]`` left the earlier
+    filter-then-compare check reporting the file intact, while the renderer folds
+    both onto 0.2.0 and keeps one body -- so which notes a user sees depended on
+    document order. Caught in BOTH orders, because the harmless-looking order is
+    still a file whose rendered history is order-dependent.
+    """
+    base = "# Changelog\n\n## [0.3.0]\n\nr\n\n## [0.2.0]\n\nshipped\n\n"
+    for head in (
+        "# Changelog\n\n## [0.3.0]\n\nr\n\n## [0.2.0-rc.2]\n\nDRAFT\n\n## [0.2.0]\n\nshipped\n\n",
+        "# Changelog\n\n## [0.3.0]\n\nr\n\n## [0.2.0]\n\nshipped\n\n## [0.2.0-rc.2]\n\nDRAFT\n\n",
+    ):
+        problems = gate.compare(base, head)
+        assert problems, "a draft heading folding onto shipped history must be caught"
+        assert any("0.2.0-rc.2" in p or "documented by 2 headings" in p for p in problems)
+
+
+def test_a_prerelease_for_an_unshipped_release_is_allowed() -> None:
+    """Only a collision with SHIPPED history is a defect, not drafting itself."""
+    base = "# Changelog\n\n## [0.2.0]\n\nshipped\n\n"
+    head = "# Changelog\n\n## [0.4.0-rc.1]\n\ndrafting\n\n## [0.2.0]\n\nshipped\n\n"
+    assert gate.compare(base, head) == []
+
+
+def test_resolve_as_rendered_folds_first_wins_like_the_renderer() -> None:
+    """The gate must resolve a release the way the renderer displays it.
+
+    ``build_release_list`` uses ``dict.setdefault``, so the FIRST body in document
+    order wins -- which under newest-first ordering is the topmost spelling. This
+    test asserted the opposite for several rounds and stayed green, because every
+    other rule happened to cover the documents in this suite; the gate was merely
+    comparing a section no user is ever shown. So assert the direction explicitly
+    AND against the renderer, which is the only party that cannot be wrong here.
+    """
+    text = "# Changelog\n\n## [0.2.0]\n\ntopmost\n\n## [0.2.0-rc.9]\n\nlower\n\n"
+    resolved = gate.resolve_as_rendered(text)["0.2.0"]
+    assert "topmost" in resolved
+    assert "lower" not in resolved
+
+    rendered = {r.version: r.body for r in gate.render_releases(text, "0.2.0")}
+    assert ("topmost" in rendered["0.2.0"]) == ("topmost" in resolved)
+
+
+def _narrowed_grammar() -> "gate.Grammar":
+    """A grammar that requires a date, so a dateless heading stops being seen."""
+    return gate.Grammar(
+        section_re=re.compile(
+            r"^##\s+\[(?P<version>[^\]]+)\]\s*[—–-]\s*" r"(?P<date>[0-9]{4}-[0-9]{2}-[0-9]{2})\s*$"
+        ),
+        h2_re=gate.HEAD_GRAMMAR.h2_re,
+        fold=gate.HEAD_GRAMMAR.fold,
+    )
+
+
+def test_a_narrowed_head_grammar_cannot_shrink_the_protected_set() -> None:
+    """The base's grammar decides what the base documents, not the head's.
+
+    A PR may legitimately change ``changelog.py``. If it narrows the heading regex,
+    parsing base history with the narrowed grammar drops those releases out of the
+    protected set — and a deletion in the same PR then passes unseen. That is a
+    silent loss of a section a user already installed, so the base ref's own
+    renderer is the authority on what the base shipped.
+    """
+    base = "# Changelog\n\n## [0.2.0] — 2026-08-09\n\nkept\n\n## [0.1.2]\n\nshipped\n\n"
+    head = "# Changelog\n\n## [0.2.0] — 2026-08-09\n\nkept\n\n"
+
+    problems = gate.compare(base, head, gate.HEAD_GRAMMAR, _narrowed_grammar())
+    assert any("[0.1.2]" in p and "GONE" in p for p in problems)
+
+    # the same document under ONE grammar is exactly the hole: the narrowed grammar
+    # never saw [0.1.2] at base, so it had nothing to miss
+    narrowed = _narrowed_grammar()
+    assert gate.compare(base, head, narrowed, narrowed) == []
+
+
+def test_a_base_that_parses_to_zero_shipped_releases_fails_closed() -> None:
+    """Zero protected sections is only safe when the base really shipped nothing.
+
+    A base carrying version headings that yields no shipped release means the parser
+    lost them. Returning "no violations" there silently disables the whole gate, so
+    it is reported instead.
+    """
+    blind = gate.Grammar(
+        section_re=re.compile(r"^##\s+NEVER-MATCHES-(?P<version>x)$"),
+        h2_re=gate.HEAD_GRAMMAR.h2_re,
+        fold=gate.HEAD_GRAMMAR.fold,
+    )
+    base = "# Changelog\n\n## [0.2.0] — 2026-08-09\n\nshipped\n\n"
+    problems = gate.compare(base, "# Changelog\n", blind, gate.HEAD_GRAMMAR)
+    assert len(problems) == 1
+    assert "NONE parsed as a shipped release" in problems[0]
+
+
+def test_a_base_with_no_version_headings_is_still_a_clean_no_op() -> None:
+    """The fail-closed guard must not fire on a genuinely release-less base."""
+    base = "# Changelog\n\n## Unreleased\n\npending\n"
+    assert gate.compare(base, "# Changelog\n\n## [0.1.0] — 2026-01-01\n\nfirst\n") == []
+
+
+def test_the_gate_reads_the_grammar_from_the_renderer_it_is_given() -> None:
+    """`grammar_of` takes the heading grammar, never a second copy of it."""
+    # Anchored to the repo, never to the process CWD: pytest can be invoked from
+    # anywhere and a CWD-relative read would fail with FileNotFoundError.
+    renderer = gate._load_renderer_source(
+        (_REPO / "src" / "kiro_crew" / "changelog.py").read_text(encoding="utf-8")
+    )
+    grammar = gate.grammar_of(renderer)
+    assert grammar.section_re is renderer._SECTION_RE
+    assert grammar.h2_re is renderer._H2_RE
+    assert grammar.fold("0.3.0-insider.9") == "0.3.0"

--- a/website/src/test/renderVerdict.test.ts
+++ b/website/src/test/renderVerdict.test.ts
@@ -331,7 +331,7 @@ describe('CI supplies a base commit on both paths', () => {
     // A count, not a set: the point is that a gate ADDED to ci.yml cannot skip
     // this file's `base.sha` assertion below by going unnoticed. Bump it when a
     // diff-scoped gate lands, and check the new wiring is in the loop.
-    expect(wirings).toHaveLength(5)
+    expect(wirings).toHaveLength(6)
   })
 
   it('diffs a PR against the commit its merge ref was built on, not the branch tip', () => {


### PR DESCRIPTION
## Problem / Motivation

`CHANGELOG.md` is append-only history. Every section already in it describes
software a user has installed, so a line deleted from one is unrecoverable from
that user's artifact.

**This has already happened.** Commit `f3750e40c` ("docs: add 0.3.0-insider.9
changelog") *replaced* the file instead of prepending to it: 53 insertions and
**322 deletions**, taking the entire `[0.2.0]`, `[0.1.3]` and `[0.1.2]` sections
with it. It read as plausible in review, because the insertions are what a reader
looks at and the deletions sat in the same hunk. Nothing failed; the loss surfaced
only when a user asked why the dashboard's Releases page had gone nearly empty.

The restore itself is [#4283](https://github.com/kirodotdev/KiroCrew/pull/4283)
(release branch) and [#4284](https://github.com/kirodotdev/KiroCrew/pull/4284)
(main). Those carry the **judgment** half of the guardrail: an AUTOSDE rule a
reviewer applies. This PR carries the **mechanical** half.

## Why it matters

The stated cause of the incident is that no test covers the file's contents — so a
rule a reviewer must notice is the wrong shape for the deletion half specifically.
That rule already failed once, on this exact commit, for the reason named above.
`release.yml`'s `stable-gate` is the complement of this check: it verifies the
**new** section exists, and does not verify the old ones survived, which is the
half that actually broke.

## What changed (motivation → approach → change)

Five files: the gate, its test, one CI job, the prepare-pr gate floor
(`profiles/kirocrew.json`) so the same scan runs locally before a push, and a
one-line count in `website/src/test/renderVerdict.test.ts` — that test reads
`ci.yml` and asserts how many diff-scoped gates are wired through the shared
base-ref resolver, precisely so a gate added to CI cannot skip its `base.sha`
assertion by going unnoticed. `changelog-history` is the sixth.

**One invariant, not a pile of filters.** Four review rounds on the original PR
each found a different way for two headings to map onto one rendered release while
a filter-then-compare check reported the file intact. Rather than adding a fifth
filter, the gate enforces:

> For every release the base ref documents as shipped, the section the **renderer
> resolves** at head must be byte-identical to the one it resolved at base — and
> that release must be documented by **exactly one heading**.

`resolve_as_rendered()` folds every heading the way `src/kiro_crew/changelog.py`
does -- **first in document order wins** (`build_release_list` resolves with
`dict.setdefault`), so the comparison is against what a user will actually see
rather than whatever a filter happened to keep. The direction is load-bearing, not
incidental: the gate originally folded last-wins, and because every other rule
happened to cover the documents in the suite, nothing went red while the central
comparison ran against a section no user is shown. The self-test now asks the
renderer itself which body a release resolves to. The four shapes that
invariant subsumes, each of which was a real finding:

| Shape | Why a naive check misses it |
|---|---|
| Rewritten release **date** | the heading, not just the body, is the shipped record |
| Edited copy behind an untouched duplicate | last-wins resolves to the untouched text |
| `[0.2.0-rc.2]` beside shipped `[0.2.0]` | a draft heading folds onto shipped history |
| Duplicate heading for a **newly added** release | no base section to differ from |

**No "newest section" exemption.** An earlier revision exempted the newest section
at base so a release branch could redraft its own entry. On the default branch the
newest section is the **last release that shipped**, which made the section the
most users are running the only editable one. Draft-versus-shipped now comes from
the heading spelling (a prerelease is a draft and is skipped), which needs no tag
lookup and therefore works in a shallow CI checkout.

**Folding has one source of truth.** It is loaded from `changelog.py` by path
rather than re-implemented, so there is no second copy to drift. `changelog.py`
imports only `re` and `typing`, so it loads standalone in a job that checked the
tree out without installing the package.

## Tests

- **`test/test_changelog_history_gate.py`** — 24 tests pinning which headings count
  as shipped history, the exact violation message per defect class (`GONE`,
  `renders DIFFERENT notes`, `documented by N headings`), and that the gate uses
  the renderer's own `base_version`.
- **The gate's `--test` self-test runs in CI *before* enforcement** — 13 probes,
  one per defect class, each labelled with the review round that found it. A
  weakened rule fails there instead of shipping green. This is not decorative: it
  caught a regression in the final restructure (the resolved comparison alone
  missed the duplicate-bare-heading shape) before CI did.

## Manual verification

Replayed against real history and against the restore PR:

```
incident f3750e40c : 3 violations   (one per deleted section)
r1a shipped date   : caught
r1b dup + untouched: caught
r3  prerelease     : caught (both orderings)
r4  dup new release: caught
legit restore PR   : passes
```

Also: `--test` → 13/13, 24 tests pass, `flake8` / `isort` / `mypy` clean, and the
gate run against this PR's own base is trivially clean since the PR touches no
`CHANGELOG.md`.

## The AGENTS.md pointer is no longer dangling

The gate's failure text points authors at `AGENTS.md` -> "Release Changelog".
That section did not exist on `main` when this PR opened, which Design Review and
First Principles both flagged. #4284 merged at 17:03Z and the section is now on
`main` (1 hit in `AGENTS.md`), so the pointer resolves. The two AUTOSDE/release.md
annotations that describe this gate can now be written against real text; they are
prose-only and land in a small doc follow-up rather than re-arming every reviewer on
this diff.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the one frontend file is a test-only expectation count
(`renderVerdict.test.ts`, `5` -> `6`) with no rendered delta — no component, style,
layout or string changes. The gate itself has no UI; its observable output is the CI
check result and the error text shown above.


