### PR TITLE
fix(sidebar): consolidate filter dimensions into one declaration (#4329)

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1227,6 +1227,36 @@ interface RevealBlockingFilter {
   hides: (slot: Slot) => boolean
   clear: (slot: Slot) => void
 }
+/** One sidebar filter dimension, declared exactly once (in the component's
+ *  `filterDimensions` memo) and consumed by the three sites that must agree on
+ *  which filters exist: `filteredSlots` (which rows render at all),
+ *  `listNarrowed` (is anything filtering right now), and
+ *  `revealBlockingFilters` (does THIS row fail an active filter). Every field
+ *  is required, so adding a dimension forces a decision for each consumer —
+ *  `null` records "deliberately not consulted here", never an omission. */
+interface FilterDimension {
+  /** Row predicate applied by `filteredSlots`. `null` = this dimension does
+   *  not filter the flat slot list (the folder filter drops whole folder
+   *  blocks/lanes at the render sites instead of filtering rows). */
+  filtersRow: ((slot: Slot) => boolean) | null
+  /** Is this dimension narrowing the list right now? Consulted by
+   *  `listNarrowed`. `null` = deliberately excluded from that question (the
+   *  folder filter: counting it would strand every folder as an empty
+   *  "New chat in <name>" shell while one is hidden). */
+  narrows: (() => boolean) | null
+  /** Does this dimension hide THIS row from a reveal? `excluded` reports list
+   *  membership, for dimensions (search, status) that rank against backend
+   *  state a single row cannot answer for alone. Non-nullable on purpose,
+   *  together with `clear`: every dimension can hide a reveal target today.
+   *  If one ever genuinely cannot, make the PAIR nullable in one move —
+   *  never stub `hides: () => false` beside a real `clear` (or a real
+   *  `hides` beside a no-op `clear`, which is silent reveal breakage). */
+  hides: (slot: Slot, excluded: (slot: Slot) => boolean) => boolean
+  /** Drop this dimension so the reveal target renders. Receives the row
+   *  because the folder filter un-hides that row's own ancestor chain rather
+   *  than clearing globally. */
+  clear: (slot: Slot) => void
+}
 
 function ChatSidebar({
   slots, activeSlot, unreadSlots, history, historyHasMore,
@@ -2126,41 +2156,6 @@ function ChatSidebar({
     [foldersWithActiveSubtree],
   )
 
-  // State and in the memo deps on purpose, not a ref: a frozen run caches its
-  // stale list against new deps, so clearing a ref would invalidate nothing.
-  const [dragFrozen, setDragFrozen] = useState(false)
-  const frozenSlotsRef = useRef<Slot[]>([])
-
-  const filteredSlots = useMemo(() => {
-    if (dragFrozen) return frozenSlotsRef.current
-    const activeFilterDefs = SESSION_FILTERS.filter(filterDef => activeFilters.has(filterDef.key))
-    // Active content search: order by the backend's relevance ranking instead
-    // of the sidebar sort (mirrors the Older Sessions lane and the command
-    // palette). Pinning stays a reachability promise for browsing, not a
-    // ranking hint inside explicit search results.
-    const searchRanked = slotFilter.trim().length >= SEARCH_MIN_CHARS ? slotSearchRanks : null
-    const next = slots
-      .filter(slot => {
-        if (activeFilterDefs.length > 0 && !activeFilterDefs.some(filterDef => _derivedLookup[filterDef.key](slot))) return false
-        // Unlike the folder filter this does NOT go inert while searching: it is a
-        // session property, so it behaves like the Unread/Pinned filters above.
-        if (activeTagIds.size > 0 && !(slot.tags ?? []).some(id => activeTagIds.has(id))) return false
-        if (!slotFilter) return true
-        // Scoped to title: that is the field a rename mutates, and widening it to
-        // key/agent appends rows the backend's content search deliberately excluded.
-        const titleMatch = (slot.title || '').toLowerCase().includes(slotFilter.toLowerCase())
-        if (searchRanked) return searchRanked.has(slot.key) || titleMatch
-        return ((slot.title || '') + slot.key + (slot.agent || '')).toLowerCase().includes(slotFilter.toLowerCase())
-      })
-      .sort((a, b) => searchRanked
-        ? (searchRanked.get(a.key) ?? Infinity) - (searchRanked.get(b.key) ?? Infinity)
-        : comparePinnedThenSort(a, b, sortKey, pinned))
-    frozenSlotsRef.current = next
-    return next
-  },
-    [slots, _derivedLookup, slotFilter, slotSearchRanks, pinned, sortKey, activeFilters, activeTagIds, dragFrozen]
-  )
-
   // Folder IDs whose sessions are excluded from the flat lane because the
   // folder — or any ancestor — is unchecked in the filter menu's folder list.
   // Unchecking a parent hides its whole subtree, matching what the user sees
@@ -2182,42 +2177,76 @@ function ChatSidebar({
     return hidden
   }, [folders, filterHiddenFolders])
 
-  // Which lane the sidebar is actually rendering. Mirrors the render branches
-  // below exactly: flat wins when there are folders to flatten, otherwise the
-  // tag-column board when columns exist, otherwise the folder tree. The folder
-  // filter applies to the flat lane and the tree, NOT to the board.
-  const flatLaneActive = flatView && folders.length > 0
-  const boardLaneActive = !flatLaneActive && orderedColumns.length > 0
+  // The backend relevance ranking, live only while the query is long enough to
+  // have been sent. Shared by the search dimension's row predicate and by
+  // filteredSlots' sort, so the two cannot disagree about when ranking is on.
+  const searchRanked = useMemo(
+    () => (slotFilter.trim().length >= SEARCH_MIN_CHARS ? slotSearchRanks : null),
+    [slotFilter, slotSearchRanks],
+  )
 
-  // The folder filter goes inert while searching, in BOTH views: a query must
-  // reach every match, so an unchecked folder can never become a search dead
-  // end. Everything that consults the filter routes through this flag.
-  const folderFilterActive = slotFilter.trim() === '' && filterHiddenFolders.size > 0
-
-  // Is the list narrowed at all? A new filter dimension must be added here too,
-  // or the folder lane strands its folders as empty "New chat in <name>" shells.
-  const listNarrowed = Boolean(slotFilter) || activeFilters.size > 0 || activeTagIds.size > 0
-
-  /** Every filter that can hide a reveal target, registered ONCE: the reveal
-   *  effect iterates this list instead of naming the dimensions by hand, so a
-   *  new filter opts in here and nowhere else. Deliberately NOT `listNarrowed`
-   *  above — that asks "is anything filtering?", this asks "does THIS row fail a
-   *  filter?", and the two lists differ (the folder filter is in this one only,
-   *  and tags enter raw here but resolved there). */
-  const revealBlockingFilters = useMemo<RevealBlockingFilter[]>(() => {
-    // Search and status defer to list membership: both rank against backend
-    // state (relevance, unread) that a single row cannot answer for alone.
-    const excluded = (slot: Slot) => !filteredSlots.some(s => s.key === slot.key)
+  /**
+   * THE single declaration of every filter dimension. `filteredSlots`,
+   * `listNarrowed`, and `revealBlockingFilters` all derive from this list, so
+   * adding a dimension is one entry here — the required fields force a
+   * decision per consumer, and THOSE THREE consumers cannot drift because
+   * none of them enumerates dimensions itself any more. The guard's limit:
+   * this declaration cannot see filtering done at the render sites (the
+   * folder dimension works that way), so a dimension that acts there must
+   * still answer `narrows` for real — writing `null` while narrowing the
+   * visible list at a render site re-creates the under-count this exists to
+   * prevent.
+   *
+   * The consumers legitimately answer different questions, and the per-field
+   * differences below are deliberate, not drift:
+   * - the folder dimension filters no rows (`filtersRow: null` — it drops
+   *   whole folder blocks/lanes at the render sites) and never narrows
+   *   (`narrows: null` — see the field docs on `FilterDimension`);
+   * - tags narrow by the RESOLVED `activeTagIds` but hide by the raw
+   *   `filterTagIds`, so a reveal arriving while the tag vocabulary is still
+   *   loading (when nothing is filtered yet) still clears the tag filter
+   *   instead of leaving the row to be re-hidden mid-flight.
+   *
+   * Bundling every consumer's state into one memo couples them: a change to
+   * reveal-only state (`filterTagIds`, `filterHiddenSubtree`, `folders`)
+   * re-derives `filteredSlots` — one extra filter+sort with content-identical
+   * rows. Accepted: no effect keys on `filteredSlots`, and its downstream
+   * memos already depend on that state themselves.
+   */
+  const filterDimensions = useMemo<FilterDimension[]>(() => {
+    const activeFilterDefs = SESSION_FILTERS.filter(filterDef => activeFilters.has(filterDef.key))
     return [
       {
+        // Tags. Unlike the folder filter this does NOT go inert while
+        // searching: it is a session property, so it behaves like the
+        // Unread/Pinned status chips.
+        filtersRow: slot => activeTagIds.size === 0 || (slot.tags ?? []).some(id => activeTagIds.has(id)),
+        narrows: () => activeTagIds.size > 0,
         // Raw `filterTagIds`, not resolved `activeTagIds`, and not behind
         // `excluded`: mid-flight nothing is filtered, so the row is re-hidden.
         hides: slot => filterTagIds.size > 0 && !(slot.tags ?? []).some(id => filterTagIds.has(id)),
         clear: () => clearTagFilter(),
       },
-      { hides: slot => Boolean(slotFilter) && excluded(slot), clear: () => setSlotFilter('') },
       {
-        hides: slot => activeFilters.size > 0 && excluded(slot),
+        // Text search. Scoped to title while the backend ranking is live: that
+        // is the field a rename mutates, and widening it to key/agent appends
+        // rows the backend's content search deliberately excluded.
+        filtersRow: slot => {
+          if (!slotFilter) return true
+          const titleMatch = (slot.title || '').toLowerCase().includes(slotFilter.toLowerCase())
+          if (searchRanked) return searchRanked.has(slot.key) || titleMatch
+          return ((slot.title || '') + slot.key + (slot.agent || '')).toLowerCase().includes(slotFilter.toLowerCase())
+        },
+        narrows: () => Boolean(slotFilter),
+        hides: (slot, excluded) => Boolean(slotFilter) && excluded(slot),
+        clear: () => setSlotFilter(''),
+      },
+      {
+        // Status chips (SESSION_FILTERS). Active chips OR together: a row
+        // passes when any active chip's predicate matches it.
+        filtersRow: slot => activeFilterDefs.length === 0 || activeFilterDefs.some(filterDef => _derivedLookup[filterDef.key](slot)),
+        narrows: () => activeFilters.size > 0,
+        hides: (slot, excluded) => activeFilters.size > 0 && excluded(slot),
         clear: () => {
           // Persisted like toggleFilter: remount re-reads the stored '1' and
           // would silently restore the filter that hides this row.
@@ -2228,6 +2257,12 @@ function ChatSidebar({
         },
       },
       {
+        // Folder filter. It filters no rows and never narrows (see the memo
+        // doc above). The folder-EXPANSION step lives outside the reveal
+        // registry on purpose: it runs whether or not this filter was hiding
+        // anything.
+        filtersRow: null,
+        narrows: null,
         hides: slot => !!slot.folder_id && filterHiddenSubtree.has(slot.folder_id),
         clear: slot => {
           // Un-hide the target's ancestor chain (persisted, mirroring
@@ -2248,7 +2283,65 @@ function ChatSidebar({
         },
       },
     ]
-  }, [filteredSlots, filterTagIds, clearTagFilter, slotFilter, activeFilters, filterHiddenSubtree, folders])
+  }, [activeFilters, activeTagIds, filterTagIds, clearTagFilter, slotFilter, searchRanked, _derivedLookup, filterHiddenSubtree, folders])
+
+  // State and in the memo deps on purpose, not a ref: a frozen run caches its
+  // stale list against new deps, so clearing a ref would invalidate nothing.
+  const [dragFrozen, setDragFrozen] = useState(false)
+  const frozenSlotsRef = useRef<Slot[]>([])
+
+  const filteredSlots = useMemo(() => {
+    if (dragFrozen) return frozenSlotsRef.current
+    const next = slots
+      // Derived from filterDimensions — the single declaration above — so this
+      // site cannot hold a filter dimension the other consumers miss.
+      .filter(slot => filterDimensions.every(d => d.filtersRow === null || d.filtersRow(slot)))
+      // Active content search: order by the backend's relevance ranking instead
+      // of the sidebar sort (mirrors the Older Sessions lane and the command
+      // palette). Pinning stays a reachability promise for browsing, not a
+      // ranking hint inside explicit search results.
+      .sort((a, b) => searchRanked
+        ? (searchRanked.get(a.key) ?? Infinity) - (searchRanked.get(b.key) ?? Infinity)
+        : comparePinnedThenSort(a, b, sortKey, pinned))
+    frozenSlotsRef.current = next
+    return next
+  },
+    [slots, filterDimensions, searchRanked, pinned, sortKey, dragFrozen]
+  )
+
+  // Which lane the sidebar is actually rendering. Mirrors the render branches
+  // below exactly: flat wins when there are folders to flatten, otherwise the
+  // tag-column board when columns exist, otherwise the folder tree. The folder
+  // filter applies to the flat lane and the tree, NOT to the board.
+  const flatLaneActive = flatView && folders.length > 0
+  const boardLaneActive = !flatLaneActive && orderedColumns.length > 0
+
+  // The folder filter goes inert while searching, in BOTH views: a query must
+  // reach every match, so an unchecked folder can never become a search dead
+  // end. Everything that consults the filter routes through this flag.
+  const folderFilterActive = slotFilter.trim() === '' && filterHiddenFolders.size > 0
+
+  // Is the list narrowed at all? Derived from filterDimensions: a dimension
+  // participates through its required `narrows` field, so this site cannot
+  // silently miss one (a missed dimension used to strand the folder lane's
+  // folders as empty "New chat in <name>" shells).
+  const listNarrowed = filterDimensions.some(d => d.narrows !== null && d.narrows())
+
+  /** Every filter that can hide a reveal target, derived from
+   *  `filterDimensions`: the reveal effect iterates this list instead of
+   *  naming the dimensions by hand. Deliberately NOT `listNarrowed` above —
+   *  that asks "is anything filtering?", this asks "does THIS row fail a
+   *  filter?", and each dimension answers the two questions separately
+   *  (`narrows` vs `hides`) in its one declaration. */
+  const revealBlockingFilters = useMemo<RevealBlockingFilter[]>(() => {
+    // Search and status defer to list membership: both rank against backend
+    // state (relevance, unread) that a single row cannot answer for alone.
+    const excluded = (slot: Slot) => !filteredSlots.some(s => s.key === slot.key)
+    return filterDimensions.map(d => ({
+      hides: (slot: Slot) => d.hides(slot, excluded),
+      clear: d.clear,
+    }))
+  }, [filterDimensions, filteredSlots])
 
   // List view (the folder tree) drops an unchecked folder's whole block —
   // header and sessions together. Only the folder's OWN id is checked here:

--- a/website/src/test/ChatSidebar.filterDimensions.test.tsx
+++ b/website/src/test/ChatSidebar.filterDimensions.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * The sidebar's filter dimensions are declared ONCE, in `filterDimensions`,
+ * and all three consumers derive from it: `filteredSlots` (which rows render),
+ * `listNarrowed` (is anything filtering), `revealBlockingFilters` (does THIS
+ * row fail a filter). Before the consolidation each site enumerated the
+ * dimensions by hand, so a new filter added to one and missed in the others
+ * failed silently — reveal-in-sidebar looked broken (#4141), or an empty-state
+ * branch showed a leftover container.
+ *
+ * The structural cases pin the derivation: each consumer names the single
+ * source and no filter state of its own, so a dimension cannot be added to a
+ * consumer directly. Adding one to `filterDimensions` itself is compiler-
+ * checked — every `FilterDimension` field is required, so an entry cannot skip
+ * a consumer's answer.
+ *
+ * The behavioural cases pin `listNarrowed` through the derivation — the one
+ * consumer the reveal tests do not touch — including the deliberate
+ * resolved-vs-raw tag distinction the declaration documents.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ tagColumnsEnabled: false, confirmCloseSession: false }),
+  saveChatConfig: vi.fn(),
+}))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: (_t, prop: string) => {
+      if (prop === 'chatTags') return vi.fn().mockResolvedValue([
+        { id: 't1', name: 'Alpha', color: '#ff0000', order: 0 },
+        { id: 't2', name: 'Beta', color: '#00ff00', order: 1 },
+      ])
+      return vi.fn().mockResolvedValue([])
+    },
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+const RUNNING_ONLY_LS_KEY = 'mc-session-running-only'
+const TAG_FILTER_LS_KEY = 'mc-session-tag-filter'
+
+/** Neither slot is running, so the Running status chip excludes both. */
+const SLOTS = [
+  { key: 'k-alpha', title: 'alpha session', running: false, messages: 2, tags: ['t1'] },
+  { key: 'k-beta', title: 'beta session', running: false, messages: 2, tags: ['t2'] },
+]
+
+function renderSidebar(slots: any[] = SLOTS) {
+  // Spread the real slice defaults: RTK REPLACES a slice with preloadedState
+  // rather than merging, so a partial drops keys the reducers assume exist.
+  const defaults = createTestStore().getState()
+  const store = createTestStore({
+    dashboard: {
+      ...defaults.dashboard,
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: {
+      ...defaults.chat,
+      activeSlot: null, slotStatusDetail: {},
+      revealRequest: null, revealNonce: 0,
+    } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], [])
+  const view = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={null} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { ...view, store }
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.clearAllMocks())
+
+describe('listNarrowed derives from the filter dimensions', () => {
+  it('a status chip that excludes every row narrows the list to its empty state', async () => {
+    localStorage.setItem(RUNNING_ONLY_LS_KEY, '1')
+    const utils = renderSidebar()
+    await waitFor(() => expect(utils.queryByText('No sessions match')).not.toBeNull())
+    expect(utils.queryByText('alpha session')).toBeNull()
+    expect(utils.queryByText('beta session')).toBeNull()
+  })
+
+  it('a search that matches nothing narrows the list to its empty state', async () => {
+    const utils = renderSidebar()
+    await waitFor(() => expect(utils.queryByText('alpha session')).not.toBeNull())
+    fireEvent.change(utils.getByPlaceholderText('Search sessions…'), { target: { value: 'zzz-no-such' } })
+    await waitFor(() => expect(utils.queryByText('No sessions match')).not.toBeNull())
+  })
+
+  it('no active dimension means no narrowing', async () => {
+    const utils = renderSidebar()
+    await waitFor(() => expect(utils.queryByText('alpha session')).not.toBeNull())
+    expect(utils.queryByText('beta session')).not.toBeNull()
+    expect(utils.queryByText('No sessions match')).toBeNull()
+  })
+
+  it('tags narrow by the RESOLVED vocabulary: a stored id it cannot resolve filters nothing', async () => {
+    // The declaration's documented raw-vs-resolved distinction: `hides` reads
+    // the raw stored ids (so a reveal mid-load still clears them — pinned by
+    // the reveal tests), but `narrows`/`filtersRow` use only ids the loaded
+    // vocabulary resolves. A stale id from a deleted tag must not narrow.
+    localStorage.setItem(TAG_FILTER_LS_KEY, JSON.stringify(['ghost-deleted-tag']))
+    const utils = renderSidebar()
+    await waitFor(() => expect(utils.queryByText('alpha session')).not.toBeNull())
+    expect(utils.queryByText('beta session')).not.toBeNull()
+    expect(utils.queryByText('No sessions match')).toBeNull()
+  })
+})
+
+const SRC = join(__dirname, '..', 'pages', 'ChatSidebar.tsx')
+// Flattened first: a line-by-line scan misses a construct the moment a
+// reformat splits it across lines.
+const raw = readFileSync(SRC, 'utf8')
+const flat = raw.replace(/\s+/g, ' ')
+
+describe('all three consumers derive from the single filterDimensions declaration', () => {
+  it('the declaration holds every dimension', () => {
+    const decl = flat.match(/const filterDimensions = useMemo<FilterDimension\[\]>.*?\}, \[[^\]]*\]\)/)?.[0]
+    expect(decl).toBeDefined()
+    // Tags, search, status, folder. One count suffices: the compiler already
+    // forces every entry to carry all four fields, so one field's occurrence
+    // count pins the number of dimensions declared here. Bump it in the same
+    // commit as a fifth entry so the addition is a decision, not drift.
+    expect([...decl!.matchAll(/\bfiltersRow:/g)]).toHaveLength(4)
+  })
+
+  // The consumer pins below hold the COMPLETE normalized expression, not
+  // fragments: a fragment check ("contains filterDimensions.every") is
+  // satisfied by an expression that ALSO smuggles in an undeclared operand
+  // (`&& ownerFilter(slot)`, `|| ownerFilterActive`, a second registry
+  // entry). Changing a consumer means changing its pinned string in the same
+  // commit — that is the point.
+
+  it('filteredSlots filters only through the declaration', () => {
+    const memo = flat.match(/const filteredSlots = useMemo\(.*?\}, \[[^\]]*\]\s*\)/)?.[0]
+    expect(memo).toBeDefined()
+    expect(memo).toContain(
+      '.filter(slot => filterDimensions.every(d => d.filtersRow === null || d.filtersRow(slot)))',
+    )
+    // Exactly one .filter pass, and it is the pinned one — a second pass is a
+    // dimension the other consumers cannot see.
+    expect([...memo!.matchAll(/\.filter\(/g)]).toHaveLength(1)
+  })
+
+  it('listNarrowed consults only the declaration', () => {
+    const line = raw.match(/const listNarrowed = [^\n]+/)?.[0]
+    expect(line).toBe(
+      'const listNarrowed = filterDimensions.some(d => d.narrows !== null && d.narrows())',
+    )
+  })
+
+  it('revealBlockingFilters adapts the declaration, declaring nothing of its own', () => {
+    const registry = flat.match(/const revealBlockingFilters = useMemo<RevealBlockingFilter\[\]>.*?\}, \[[^\]]*\]\)/)?.[0]
+    expect(registry).toBeDefined()
+    expect(registry).toContain(
+      'return filterDimensions.map(d => ({ hides: (slot: Slot) => d.hides(slot, excluded), clear: d.clear, }))',
+    )
+  })
+})

--- a/website/src/test/ChatSidebar.revealFilterDimensions.test.tsx
+++ b/website/src/test/ChatSidebar.revealFilterDimensions.test.tsx
@@ -8,9 +8,11 @@
  * the refactor, which deliberately changed no filter's behaviour.
  *
  * The structural cases are the before/after guard, and their reach is narrow:
- * they fail while the effect names filter state directly, and they pin the set
- * that IS registered. A filter added to filteredSlots' enumeration and never
- * registered here still reveals nothing -- one opt-in remains, not zero.
+ * they fail while the effect names filter state directly, and they pin that
+ * the registry adapts the single filterDimensions declaration rather than
+ * declaring dimensions of its own. The declaration's shape — and that
+ * filteredSlots and listNarrowed derive from the same source — is pinned by
+ * ChatSidebar.filterDimensions.test.tsx.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -217,14 +219,20 @@ describe('reveal filter dimensions are registered, not enumerated in the effect'
     expect(effect).toContain('revealBlockingFilters')
   })
 
-  it('the registry is the single place a dimension is declared', () => {
+  it('the registry derives from the single filterDimensions declaration', () => {
     const registry = flat.match(/const revealBlockingFilters = useMemo<RevealBlockingFilter\[\]>.*?\}, \[[^\]]*\]\)/)?.[0]
     expect(registry).toBeDefined()
-    // Search, status, tags, folder. Pins the REGISTERED set only: bump this in
-    // the same commit as a fifth entry so the addition is a decision, not drift.
-    expect([...registry!.matchAll(/\bhides:/g)]).toHaveLength(4)
-    // Every registered dimension carries the means to drop itself, so the
-    // effect never needs to know which state backs it.
-    expect([...registry!.matchAll(/\bclear:/g)]).toHaveLength(4)
+    // Dimensions are declared ONCE, in filterDimensions (whose shape
+    // ChatSidebar.filterDimensions.test.tsx pins); this registry only adapts
+    // them, so it can no longer hold a dimension the other consumers miss.
+    expect(registry).toContain('filterDimensions.map')
+    for (const named of [
+      'filterTagIds', 'clearTagFilter',
+      'slotFilter', 'setSlotFilter',
+      'activeFilters', 'setActiveFilters', 'SESSION_FILTERS',
+      'filterHiddenSubtree', 'setFilterHiddenFolders',
+    ]) {
+      expect(registry, `reveal registry must not name ${named} directly`).not.toContain(named)
+    }
   })
 })


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** Behavior-preserving consolidation: every predicate was traced old-vs-new as semantically identical (De Morgan-equivalent conditions, unchanged registry order, unchanged sort), so no pixel changes. Screenshot section omitted per the marker.

## Problem / Motivation

Adding a session filter to the chat sidebar required hand-editing three separate sites in `ChatSidebar.tsx` — `filteredSlots` (which rows render), `listNarrowed` (is anything filtering right now), and `revealBlockingFilters` (does THIS row fail an active filter). They had to agree, but nothing linked them: a fifth filter added to one and missed in the others failed silently, with no error and no failing test. Miss `listNarrowed` and an empty-state/collapse branch shows the wrong thing; miss `revealBlockingFilters` and reveal-in-sidebar appears to do nothing (the #4141 report — that fix covered only the reveal path and deferred this consolidation).

## Why it matters

The failure mode is silent and lands on whoever adds the next filter dimension: the issue measured that injecting an unregistered fifth filter kept all five existing reveal tests green. The sidebar is the dashboard's primary navigation surface, so a stranded empty-state or a reveal button that "does nothing" reads as product breakage.

## What changed (motivation → approach → change)

Goal: one declaration per filter dimension that all three consumers derive from, so adding a filter is a single edit and an incomplete one is caught by the compiler.

- New `FilterDimension` interface: required fields `filtersRow`, `narrows`, `hides`, `clear`. Adding a dimension forces a decision per consumer; `null` records "deliberately not consulted here" (allowed only on `filtersRow`/`narrows`), never an omission.
- New `filterDimensions` memo declares the four dimensions (tags, search, status chips, folder) exactly once. All three consumers derive: `filteredSlots` applies `d.filtersRow`, `listNarrowed` is `some(d.narrows)`, `revealBlockingFilters` maps `d.hides`/`d.clear`.
- The deliberate per-site differences the issue mandates are preserved and now colocated with the declaration: the folder dimension filters no rows and never narrows; tags narrow by the resolved `activeTagIds` but hide by the raw `filterTagIds` (a reveal arriving mid-vocabulary-load still clears tag filters); the folder-EXPANSION step stays outside the reveal registry.
- Mechanical enablers: `filterHiddenSubtree` moved above the declaration (initialization order), `searchRanked` hoisted to a shared memo so the search predicate and the sort can never disagree about when backend ranking is live.

Pre-push dual-model review dispositions (no BLOCKING findings from either lane):
- Taken: structural tests tightened to pin the complete normalized consumer expressions (a fragment check could be satisfied while smuggling in an undeclared operand).
- Taken: docblocks now state the guard's limit (render-site filtering, which the folder dimension exemplifies, is invisible to the declaration — a dimension acting there must still answer `narrows` for real), the accepted memo-state coupling (reveal-only state now re-derives `filteredSlots`; traced contained — no effect keys on it and downstream memos already carried that state), and why `hides`/`clear` are deliberately non-nullable.
- Declined: extracting the shared test harness — `vi.mock` hoisting keeps the mocks per-file, and per-file harness copies are the established pattern across the ~50 ChatSidebar suites.

## Tests

- `website/src/test/ChatSidebar.filterDimensions.test.tsx` (new):
  - Behavioral, pinning `listNarrowed` through the derivation (the consumer the reveal tests do not touch): a status chip excluding every row shows the narrowed empty state; a search matching nothing shows it; no active dimension shows no narrowing; a stored tag id the vocabulary cannot resolve filters nothing (the documented resolved-vs-raw distinction).
  - Source-contract: the declaration holds exactly four dimensions; each consumer's complete normalized expression is pinned, so a dimension cannot be added to a consumer directly — changing a consumer means changing its pinned string in the same commit.
- `website/src/test/ChatSidebar.revealFilterDimensions.test.tsx` (updated): the structural test now pins that the reveal registry adapts `filterDimensions` and names no filter state of its own; the five behavioral reveal tests pass unchanged — the refactor deliberately changed no filter's behavior.

## Manual verification

N/A — the change is behavior-preserving by construction (each predicate traced old-vs-new as equivalent in review) and the affected behaviors (row filtering, narrowing, reveal) are covered by the behavioral suites above plus the full frontend gate (`npx tsc -b` clean, vitest 21380 passed locally).

## Related Issues

Closes #4329. Deferred from #4141 (merged as `110643ca`).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no spec under docs/ covers the sidebar filter internals; behavior is unchanged
- [x] No secrets, credentials, or internal references in the diff

