### PR TITLE
fix(dashboard): extract useArmedDelete, fix concurrent deletes (#4342)

### DIFF
--- a/website/src/hooks/useArmedDelete.ts
+++ b/website/src/hooks/useArmedDelete.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * How long an armed Delete stays armed before decaying back to its disarmed
+ * label. Long enough to move the pointer back to the same button and click
+ * again; short enough that an accidental first click does not leave a live
+ * destructive button waiting on the row.
+ */
+export const ARM_REVERT_MS = 3000
+
+export interface ArmedDelete {
+  /** The row whose Delete is armed (showing its confirm label), or null. */
+  armedId: string | null
+  /** Rows whose delete request is still in flight. */
+  pendingIds: ReadonlySet<string>
+  /**
+   * First click: arm the row. Arming a row disarms any other armed row.
+   * A no-op while the same row's delete is pending — arming a row that is
+   * already deleting would paint a live confirm label whose second click
+   * does nothing.
+   */
+  arm: (id: string) => void
+  /**
+   * Second click: run the delete. A no-op unless this row is CURRENTLY
+   * armed, so a click that lands after the decay window (or any call for an
+   * unarmed row) can never delete — arming again is the only way back to a
+   * live confirm. Also a no-op while the same row is already pending, so a
+   * re-click can never fire a duplicate request even if the caller's
+   * `disabled` wiring lapses. Never rejects: `deleteFn` owns its error
+   * surfacing (see the hook doc).
+   */
+  confirm: (id: string) => Promise<void>
+  /** Whether this row's delete is still in flight (`pendingIds.has(id)`). */
+  isDeleting: (id: string) => boolean
+}
+
+/**
+ * The arm→Confirm→decay state machine for a row-level destructive button:
+ * the first click arms the row (its label states what the second click will
+ * destroy), a second click within the revert window deletes, and the armed
+ * state decays back to disarmed on its own.
+ *
+ * Why the in-flight set is a SET keyed by id, not a scalar "deleting id":
+ * two rows can be in flight at once, and a scalar is overwritten by the
+ * second delete — whichever settles first then clears it, re-enabling the
+ * other still-pending row so a re-click fires a duplicate request.
+ *
+ * Why `armedId` IS a scalar: only one row may be confirmable at a time, so
+ * arming a row deliberately disarms any other armed row. Settling a delete,
+ * however, disarms only its OWN row — a sweep (`setArmedId(null)`) would
+ * silently disarm an unrelated row the user had just armed.
+ *
+ * `deleteFn` owns its error surfacing (report failures to the user inside
+ * it); `confirm` drops a rejection after removing the pending id, so it
+ * never rejects — it is invoked from event handlers, where a rejection has
+ * no handler and would only surface as an unhandled-rejection report.
+ */
+export function useArmedDelete(deleteFn: (id: string) => Promise<unknown>): ArmedDelete {
+  const [armedId, setArmedId] = useState<string | null>(null)
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(new Set())
+  // Ref mirrors of both states, readable synchronously inside `confirm`: the
+  // re-entrancy guard and the keyed disarm cannot wait a render for state,
+  // and a setState-updater must stay side-effect free (StrictMode runs it
+  // twice), so the timer clear cannot live inside one either.
+  const armedRef = useRef<string | null>(null)
+  const pendingRef = useRef<Set<string>>(new Set())
+  const revertTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const setArmed = useCallback((id: string | null) => {
+    armedRef.current = id
+    setArmedId(id)
+  }, [])
+
+  const arm = useCallback((id: string) => {
+    if (pendingRef.current.has(id)) return
+    setArmed(id)
+    if (revertTimer.current) clearTimeout(revertTimer.current)
+    revertTimer.current = setTimeout(() => setArmed(null), ARM_REVERT_MS)
+  }, [setArmed])
+
+  useEffect(() => () => { if (revertTimer.current) clearTimeout(revertTimer.current) }, [])
+
+  const confirm = useCallback(async (id: string) => {
+    if (pendingRef.current.has(id)) return
+    // The machine enforces its own arm-before-delete contract: a click that
+    // lands after the decay timer fired but before React repaints the
+    // disarmed label reaches here with a stale armed closure, and must not
+    // delete. Only the currently armed row may confirm.
+    if (armedRef.current !== id) return
+    if (revertTimer.current) {
+      clearTimeout(revertTimer.current)
+      revertTimer.current = null
+    }
+    setArmed(null)
+    pendingRef.current.add(id)
+    setPendingIds(new Set(pendingRef.current))
+    try {
+      await deleteFn(id)
+    } catch {
+      // Dropped by contract: deleteFn owns its error surfacing (see hook doc).
+    } finally {
+      pendingRef.current.delete(id)
+      setPendingIds(new Set(pendingRef.current))
+    }
+  }, [deleteFn, setArmed])
+
+  const isDeleting = useCallback((id: string) => pendingIds.has(id), [pendingIds])
+
+  return { armedId, pendingIds, arm, confirm, isDeleting }
+}

--- a/website/src/pages/SchedulePage.tsx
+++ b/website/src/pages/SchedulePage.tsx
@@ -4,6 +4,7 @@ import Clickable from '../components/Clickable'
 import { List, CalendarDays, CalendarClock, Plus, ClipboardList, ChevronRight, Globe, History, Trash2, FolderPlus, MoreHorizontal, Pencil, Folder, LayoutGrid, GitPullRequestArrow, Download } from 'lucide-react'
 import { api } from '../api/client'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useArmedDelete } from '../hooks/useArmedDelete'
 import { PageHeader, Card, Btn, SendBtn, Badge, SearchInput, EmptyState, FilteredEmpty, Skeleton, Input } from '../components/ui'
 import { CodeBlock } from '../components/CodeBlock'
 import SegmentedControl from '../components/SegmentedControl'
@@ -379,29 +380,17 @@ export default function SchedulePage() {
     }
   }, [load, refreshFolders, setActionError])
 
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
-  const [deletingId, setDeletingId] = useState<string | null>(null)
-  const confirmRevertTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const armDelete = useCallback((id: string) => {
-    setConfirmDeleteId(id)
-    if (confirmRevertTimer.current) clearTimeout(confirmRevertTimer.current)
-    confirmRevertTimer.current = setTimeout(() => setConfirmDeleteId(null), 3000)
-  }, [])
-  useEffect(() => () => { if (confirmRevertTimer.current) clearTimeout(confirmRevertTimer.current) }, [])
-  const deleteJob = useCallback(async (id: string) => {
+  // performDelete reports its own errors, so confirmDelete never rejects.
+  const performDelete = useCallback(async (id: string) => {
     try {
-      if (confirmRevertTimer.current) clearTimeout(confirmRevertTimer.current)
-      setDeletingId(id)
       await api.deleteCron(id)
       setSelected(prev => prev?.id === id ? null : prev)
       await load()
     } catch (e: unknown) {
       setActionError({ id, msg: e instanceof Error ? e.message : i18nT('pages.schedulePage.delete_failed') })
-    } finally {
-      setDeletingId(null)
-      setConfirmDeleteId(null)
     }
   }, [load, setActionError])
+  const { armedId: confirmDeleteId, arm: armDelete, confirm: confirmDelete, isDeleting } = useArmedDelete(performDelete)
   const filteredJobs = useMemo(() => sanitizedJobs.filter(j => !cronFilter || (j.name+' '+j.safeMessage+' '+(j.agent||'')+' '+(j.model||'')).toLowerCase().includes(cronFilter.toLowerCase())), [sanitizedJobs, cronFilter])
   const scheduleComparators = useMemo(() => ({
     name: (a: CronJob, b: CronJob) => a.name.localeCompare(b.name),
@@ -850,10 +839,10 @@ export default function SchedulePage() {
                         ChatInput's Continue/Send buttons. */}
                     <Btn
                       danger
-                      disabled={deletingId === j.id}
+                      disabled={isDeleting(j.id)}
                       title={confirmDeleteId === j.id ? i18nT('pages.schedulePage.click_again_to_confirm') : i18nT('pages.schedulePage.delete_job')}
-                      onClick={() => confirmDeleteId === j.id ? deleteJob(j.id) : armDelete(j.id)}
-                    >{deletingId === j.id ? '...' : confirmDeleteId === j.id ? i18nT('pages.schedulePage.confirm_delete_job') : i18nT('pages.schedulePage.delete')}</Btn>
+                      onClick={() => { if (confirmDeleteId === j.id) void confirmDelete(j.id); else armDelete(j.id) }}
+                    >{isDeleting(j.id) ? '...' : confirmDeleteId === j.id ? i18nT('pages.schedulePage.confirm_delete_job') : i18nT('pages.schedulePage.delete')}</Btn>
                     <CronRowActions
                       job={j}
                       folders={cronFolders}

--- a/website/src/test/useArmedDelete.test.tsx
+++ b/website/src/test/useArmedDelete.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useArmedDelete, ARM_REVERT_MS } from '../hooks/useArmedDelete'
+
+/**
+ * Regression guards for the shared arm→Confirm row-delete machine.
+ *
+ * The defect that motivated the hook: SchedulePage held the in-flight delete
+ * in a single `deletingId` scalar, so a second row's confirmed delete
+ * overwrote it while the first was still in flight — whichever settled first
+ * then cleared the scalar, re-enabling the other still-pending row and
+ * letting a re-click fire a duplicate DELETE. The same scalar's `finally`
+ * also swept the armed state of WHATEVER row was armed when any delete
+ * settled. These tests pin the set-keyed fixes for both, plus the machine's
+ * own arm-before-delete enforcement.
+ */
+
+/** A deleteFn whose settlement the test controls, per id. */
+function makeGate() {
+  const resolvers = new Map<string, () => void>()
+  const rejecters = new Map<string, (e: Error) => void>()
+  const calls: string[] = []
+  const deleteFn = vi.fn((id: string) => {
+    calls.push(id)
+    return new Promise<void>((resolve, reject) => {
+      resolvers.set(id, resolve)
+      rejecters.set(id, reject)
+    })
+  })
+  return {
+    deleteFn,
+    calls,
+    settle: (id: string) => act(async () => { resolvers.get(id)!() }),
+    fail: (id: string) => act(async () => { rejecters.get(id)!(new Error('boom')) }),
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useArmedDelete', () => {
+  it('a second in-flight delete does not re-enable the first still-pending row', async () => {
+    const gate = makeGate()
+    const { result } = renderHook(() => useArmedDelete(gate.deleteFn))
+
+    // Arm and confirm row a, then row b while a is still in flight.
+    let pA: Promise<void>
+    let pB: Promise<void>
+    act(() => { result.current.arm('a') })
+    act(() => { pA = result.current.confirm('a') })
+    act(() => { result.current.arm('b') })
+    act(() => { pB = result.current.confirm('b') })
+    expect(result.current.isDeleting('a')).toBe(true)
+    expect(result.current.isDeleting('b')).toBe(true)
+
+    // b settles first: a must STAY pending — the scalar version re-enabled it
+    // here, which is exactly the duplicate-delete window.
+    await gate.settle('b')
+    await act(async () => { await pB! })
+    expect(result.current.isDeleting('b')).toBe(false)
+    expect(result.current.isDeleting('a')).toBe(true)
+    expect(result.current.pendingIds.has('a')).toBe(true)
+
+    await gate.settle('a')
+    await act(async () => { await pA! })
+    expect(result.current.isDeleting('a')).toBe(false)
+    expect(result.current.pendingIds.size).toBe(0)
+  })
+
+  it('a settling delete disarms only its own row', async () => {
+    const gate = makeGate()
+    const { result } = renderHook(() => useArmedDelete(gate.deleteFn))
+
+    // Row a's delete is in flight; the user arms row b meanwhile.
+    let pA: Promise<void>
+    act(() => { result.current.arm('a') })
+    act(() => { pA = result.current.confirm('a') })
+    act(() => { result.current.arm('b') })
+    expect(result.current.armedId).toBe('b')
+
+    // a settling must not sweep b's armed state (the old `finally
+    // { setConfirmDeleteId(null) }` did).
+    await gate.settle('a')
+    await act(async () => { await pA! })
+    expect(result.current.armedId).toBe('b')
+  })
+
+  it('arm reverts to normal after the decay timeout', () => {
+    vi.useFakeTimers()
+    const gate = makeGate()
+    const { result } = renderHook(() => useArmedDelete(gate.deleteFn))
+
+    act(() => { result.current.arm('a') })
+    expect(result.current.armedId).toBe('a')
+
+    act(() => { vi.advanceTimersByTime(ARM_REVERT_MS - 1) })
+    expect(result.current.armedId).toBe('a')
+    act(() => { vi.advanceTimersByTime(1) })
+    expect(result.current.armedId).toBeNull()
+    expect(gate.deleteFn).not.toHaveBeenCalled()
+  })
+
+  it('re-arming restarts the decay window and moves the armed slot', () => {
+    vi.useFakeTimers()
+    const gate = makeGate()
+    const { result } = renderHook(() => useArmedDelete(gate.deleteFn))
+
+    act(() => { result.current.arm('a') })
+    act(() => { vi.advanceTimersByTime(ARM_REVERT_MS - 1) })
+    // Arming b right before a's decay: one armed slot — b replaces a — and
+    // the window restarts, so b must survive past a's original deadline.
+    act(() => { result.current.arm('b') })
+    expect(result.current.armedId).toBe('b')
+    act(() => { vi.advanceTimersByTime(ARM_REVERT_MS - 1) })
+    expect(result.current.armedId).toBe('b')
+    act(() => { vi.advanceTimersByTime(1) })
+    expect(result.current.armedId).toBeNull()
+  })
+
+  it('confirm is a no-op unless the row is currently armed', async () => {
+    vi.useFakeTimers()
+    const gate = makeGate()
+    const { result } = renderHook(() => useArmedDelete(gate.deleteFn))
+
+    // Never armed: no delete.
+    await act(async () => { await result.current.confirm('a') })
+    expect(gate.deleteFn).not.toHaveBeenCalled()
+
+    // Armed but decayed: the click that lands after the revert window (with a
+    // stale armed closure) must not delete — this is the safety the 3s decay
+    // promises, enforced by the machine itself rather than caller wiring.
+    act(() => { result.current.arm('a') })
+    act(() => { vi.advanceTimersByTime(ARM_REVERT_MS) })
+    expect(result.current.armedId).toBeNull()
+    await act(async () => { await result.current.confirm('a') })
+    expect(gate.deleteFn).not.toHaveBeenCalled()
+
+    // A different row is armed: confirming this one is a no-op and must not
+    // disturb the other row's armed state.
+    act(() => { result.current.arm('b') })
+    await act(async () => { await result.current.confirm('a') })
+    expect(gate.deleteFn).not.toHaveBeenCalled()
+    expect(result.current.armedId).toBe('b')
+  })
+
+  it('confirm is a no-op while the same row is already pending (no duplicate request)', async () => {
+    const gate = makeGate()
+    const { result } = renderHook(() => useArmedDelete(gate.deleteFn))
+
+    let pA: Promise<void>
+    act(() => { result.current.arm('a') })
+    act(() => { pA = result.current.confirm('a') })
+    // A re-click on the same pending row must not fire a second request —
+    // this holds even if the caller's `disabled` wiring lapses.
+    await act(async () => { await result.current.confirm('a') })
+    expect(gate.calls).toEqual(['a'])
+
+    await gate.settle('a')
+    await act(async () => { await pA! })
+    expect(result.current.isDeleting('a')).toBe(false)
+  })
+
+  it('arm is a no-op while the same row is already pending', async () => {
+    const gate = makeGate()
+    const { result } = renderHook(() => useArmedDelete(gate.deleteFn))
+
+    let pA: Promise<void>
+    act(() => { result.current.arm('a') })
+    act(() => { pA = result.current.confirm('a') })
+    // Arming a deleting row would paint a live confirm label whose second
+    // click does nothing for the whole decay window.
+    act(() => { result.current.arm('a') })
+    expect(result.current.armedId).toBeNull()
+
+    await gate.settle('a')
+    await act(async () => { await pA! })
+  })
+
+  it('confirming disarms its own row and cancels the decay timer', async () => {
+    vi.useFakeTimers()
+    const gate = makeGate()
+    const { result } = renderHook(() => useArmedDelete(gate.deleteFn))
+
+    act(() => { result.current.arm('a') })
+    let pA: Promise<void>
+    act(() => { pA = result.current.confirm('a') })
+    // Armed state clears immediately (the button shows pending, not armed) …
+    expect(result.current.armedId).toBeNull()
+    expect(result.current.isDeleting('a')).toBe(true)
+
+    // … and a's dead timer must not fire later to disarm a row armed after it.
+    act(() => { result.current.arm('b') })
+    act(() => { vi.advanceTimersByTime(1) })
+    expect(result.current.armedId).toBe('b')
+
+    await gate.settle('a')
+    await act(async () => { await pA! })
+  })
+
+  it('resolves (never rejects) and clears pending when deleteFn rejects', async () => {
+    const gate = makeGate()
+    const { result } = renderHook(() => useArmedDelete(gate.deleteFn))
+
+    let pA: Promise<void>
+    act(() => { result.current.arm('a') })
+    act(() => { pA = result.current.confirm('a') })
+    // confirm's contract: deleteFn owns its error surfacing, so the promise
+    // handed back to an event handler must never reject.
+    const outcome = pA!.then(() => 'resolved', () => 'rejected')
+    expect(result.current.isDeleting('a')).toBe(true)
+
+    await gate.fail('a')
+    await act(async () => { expect(await outcome).toBe('resolved') })
+    // The row must come back deletable after a failure, never stuck pending.
+    expect(result.current.isDeleting('a')).toBe(false)
+    expect(result.current.pendingIds.size).toBe(0)
+  })
+})


### PR DESCRIPTION
<!-- no-visual-delta -->

## Problem / Motivation

SchedulePage holds the in-flight row delete in a single `deletingId` scalar. Confirming a second row's delete while the first is still in flight overwrites the scalar, which re-enables the first still-pending row's Delete button — a re-click there fires a duplicate DELETE for a job whose deletion is already in progress. The same code's `finally` block (`setConfirmDeleteId(null)`) also sweeps the armed state of *whatever* row happens to be armed when *any* delete settles, disarming an unrelated row the user had just armed.

Separately, the arm→Confirm→3s-decay delete machine was about to exist twice and diverge: SchedulePage carries it inline, and PR #4334 introduces a second inline copy on HooksPage.

## Why it matters

Duplicate destructive requests against a row mid-deletion, and armed-state loss on unrelated rows, on the dashboard's primary cron-management surface. Both races need only two rows and ordinary click timing — no unusual conditions.

## What changed (motivation → approach → change)

Symptom → root cause: both defects are the same shape — per-row state held in a page-level scalar, so any row's transition clobbers every other row's.

Change: extract the machine into a shared `useArmedDelete(deleteFn)` hook (`website/src/hooks/useArmedDelete.ts`) and port SchedulePage onto it.

- **In-flight deletes are an id-keyed `Set`** — two rows can be pending at once; one settling removes only its own id.
- **`armedId` stays a scalar deliberately** — one confirmable row at a time; arming a row disarms any other. But a *settling delete* disarms only its own row.
- **The machine enforces its own contract rather than trusting caller wiring** (per pre-push review): `confirm` is a no-op unless the row is *currently* armed — a click that lands after the decay timer fires but before React repaints the disarmed label cannot delete; `arm` and `confirm` are no-ops while that row's delete is pending, so a duplicate request cannot fire even if a caller's `disabled` wiring lapses; `confirm` never rejects (`deleteFn` owns its error surfacing — it runs from event handlers where a rejection has no handler).

Scope: **HooksPage is deliberately not ported here.** On main it still uses `window.confirm`; its arm→Confirm rewrite is in-flight on PR #4334, so porting it in this PR would collide with that open PR. HooksPage adopts this hook once #4334 lands.

## Tests

New `website/src/test/useArmedDelete.test.tsx` (9 tests), each pinning one contract facet:

- a second in-flight delete does not re-enable the first still-pending row (the motivating race)
- a settling delete disarms only its own row (the `finally`-sweep defect)
- arm decays back to disarmed after the revert window; re-arming moves the slot and restarts the window
- `confirm` is a no-op unless the row is currently armed (never armed / decayed / different row armed)
- `confirm` and `arm` are no-ops while the same row is pending (no duplicate request)
- confirming disarms its own row and cancels the decay timer (a dead timer cannot disarm a later-armed row)
- `confirm` resolves (never rejects) and clears pending when `deleteFn` rejects

The four pre-existing SchedulePage delete-state-machine tests (arm-on-first-click, revert-on-failure, decay-timeout, one-row-armed-at-a-time) are unmodified and still pass through the hook, pinning behavior parity at the page level.

## Manual verification

N/A — the page-level vitest suite drives the real button through arm/confirm/fail/decay against a mocked API, and the hook suite covers the concurrency interleavings unit tests can control deterministically. Full local gates: `npx tsc -b` clean, full vitest 21379 passed, integration suite 304 passed, jscpd 0 clones.

## Screenshots / video

**Why no screenshot:** behavior-only refactor of the delete state machine — same buttons, same labels, same rendered states; only the concurrency keying changes.

N/A — no visual delta: same buttons, same labels, same states (`Delete` → `Delete?` → `...`); this changes only which row those states are keyed to under concurrency. The 14 electron-suite failures observed locally reproduce identically on pristine main (environment-specific, unrelated).

## Related Issues

Fixes #4342

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented API/schema change
- [x] No secrets, credentials, or internal references in the diff

