### PR TITLE
test(apps): ratchet against decoded proxy-target reconstruction

### DIFF
--- a/test/test_app_proxy_target_ratchet.py
+++ b/test/test_app_proxy_target_ratchet.py
@@ -1,0 +1,60 @@
+"""Ratchet: app backends must not rebuild the signed proxy target DECODED.
+
+The gateway signs the WIRE form of the forwarded request-target
+(``apps/routes.py`` signs ``yarl.URL(..., encoded=True).raw_path_qs``), so
+percent-escapes reach the backend still escaped. aiohttp's ``request.path``
+and ``request.query_string`` are DECODED, so a backend that reconstructs the
+target from them hashes a different string for any target carrying a space,
+comma, ``+``, ``#`` or non-ASCII byte -- and its HMAC check fails closed with
+401 "invalid or missing proxy signature" (issue #4192: in Notes, every note
+whose filename holds a space was unopenable while the app shell loaded fine).
+
+The trap is invisible in review and in manual testing, because the decoded
+and encoded forms coincide for every plain-ASCII path -- which is exactly how
+two backends shipped with it. The correct reconstruction is
+``proxy_auth.raw_request_target(request)`` (aiohttp) or ``self.path``
+(``BaseHTTPRequestHandler``, already raw). This test scans every builtin
+backend that verifies the proxy HMAC and fails on a decoded reconstruction,
+so a future backend cannot reintroduce the bug.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_BUILTINS_DIR = Path(__file__).resolve().parent.parent / "src" / "kiro_crew" / "apps" / "builtins"
+
+#: Only files that participate in proxy-HMAC verification are in scope; a
+#: backend is recognised by the shared verifier import or the header name.
+_HMAC_MARKERS = ("verify_proxy_request", "X-KiroCrew-Proxy")
+
+#: The two spellings of the decoded reconstruction that shipped the bug.
+#: ``request.query_string`` has no legitimate use next to the proxy HMAC --
+#: the wire form is ``raw_request_target(request)`` / ``self.path``.
+_DECODED_RECONSTRUCTION = ("request.query_string", "request.path +")
+
+
+def test_no_builtin_rebuilds_the_signed_target_from_decoded_request() -> None:
+    offenders: list[str] = []
+    scanned = 0
+    for server in sorted(_BUILTINS_DIR.glob("**/server.py")):
+        text = server.read_text(encoding="utf-8")
+        if not any(marker in text for marker in _HMAC_MARKERS):
+            continue
+        scanned += 1
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if line.lstrip().startswith("#"):
+                continue
+            if any(pattern in line for pattern in _DECODED_RECONSTRUCTION):
+                offenders.append(f"{server.relative_to(_BUILTINS_DIR)}:{lineno}: {line.strip()}")
+    # If the glob or the markers ever stop matching anything, the ratchet is
+    # dead and would pass vacuously -- fail loudly instead.
+    assert scanned >= 2, (
+        f"expected to scan at least the md_notebook and dev_fleet backends, scanned {scanned}; "
+        "the discovery glob or the HMAC markers no longer match the tree"
+    )
+    assert not offenders, (
+        "app backend rebuilds the signed proxy target from aiohttp's DECODED "
+        "request.path / request.query_string; use proxy_auth.raw_request_target(request) "
+        "so the verified string matches the wire form the gateway signed:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Problem / Motivation

The proxy-HMAC target bug fixed in #4206 (a backend verifying the gateway's signature against aiohttp's DECODED `request.path` + `request.query_string` instead of the wire form the gateway signs) shipped in two builtin backends because it is invisible in review and in manual testing: the decoded and encoded forms coincide for every plain-ASCII path, and only diverge on a space, comma, `+`, `#`, or non-ASCII byte (issue #4192 — Notes returned 401 for every note whose filename holds a space).

#4206's tests pin the two backends it fixed. Nothing stops a **third** backend from repeating the same reconstruction — which is exactly how the second copy of the bug shipped after the gateway side was fixed for a different app's benefit.

## Why it matters

Any future builtin backend that verifies the proxy HMAC and rebuilds the target the decoded way will pass review, pass its own tests (nobody hand-tests filenames with spaces), and fail closed in production for users whose file names or query values carry escapable characters — presenting as "the whole app is broken", as in #4192.

## What changed (motivation → approach → change)

Symptom → root cause → guard: the bug class is a one-line reconstruction mistake with a stable textual signature — `request.query_string` (or `request.path +` concatenation) appearing in a backend that participates in proxy-HMAC verification. There is no legitimate use of the decoded pair next to the HMAC; the correct form is `proxy_auth.raw_request_target(request)` (aiohttp) or `self.path` (`BaseHTTPRequestHandler`, already raw).

Added one source-ratchet test that scans every `src/kiro_crew/apps/builtins/**/server.py` containing the shared verifier import or the `X-KiroCrew-Proxy` header name, and fails on the decoded reconstruction with a message pointing at `raw_request_target`. The scan asserts it matched at least the two known backends, so it cannot rot into a vacuous pass if the glob or markers drift.

## Tests

- `test/test_app_proxy_target_ratchet.py::test_no_builtin_rebuilds_the_signed_target_from_decoded_request` — the ratchet itself.
- Verified live in both directions: passes on `main` at `c9e46d449` (post-#4206), fails on `c9e46d449^` (the pre-fix tree), naming both offending lines.

## Manual verification

N/A — the test is a pure source scan; the two-direction run above is the verification.

## Related Issues

Related to #4192 and #4206 (hardening follow-up; both already closed/merged — this closes nothing).

no linked issue: the fix itself landed in #4206; this PR only adds the guard against reintroduction.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, test-only change
- [x] No secrets, credentials, or internal references in the diff
