### PR TITLE
refactor(workflows): drop dead clamps, dedupe, fix false comments

### DIFF
--- a/docs/system-specs/modules/workflows.md
+++ b/docs/system-specs/modules/workflows.md
@@ -804,12 +804,20 @@ The neighbouring suites carry the same rule for their own invariants: never rela
 `tests/workflows/malicious/` corpus, and never relax the layering without
 `test_workflows_architecture.py`.
 
-> Open question: several module docstrings and test docstrings cite a gate catalog
-> at `docs/system-specs/modules/workflow-gates.md` (and short-form "GATES.md")
-> using labels like A4, B5, C1, D1, F1, F2, G1. That file does not exist in this
-> repo, so the labels are unresolvable. Each gate's actual enforcement is the named
-> test, and this spec states the invariants directly rather than by label. Either
-> write the catalog or drop the label references from the code comments.
+The gate labels cited by the engine's docstrings and by the `test_workflows_*`
+docstrings (A4, B5, C1, D1, F1, F2, G1, …) are defined in
+[workflow-gates.md](workflow-gates.md), which names the test pinning each. A gate
+is closed by that test, not by either document: where a row and its test disagree,
+the test is right. This spec states the invariants directly rather than by label,
+so the catalog is a lookup table for the ids, not a second contract.
+
+> Open question: `M<n>` milestone markers (`M5`, `M6`, `M6.7`, …) still appear on
+> comments and docstrings across every workflow surface — the engine's tests, the
+> MCP tools, the validators, the gateway wiring, and the Workflows UI. They are
+> delivery markers, not gates, so nothing defines them, and
+> `grep -rnE '\bM(5|6)(\.[0-9]+)?\b'` is the live list rather than an inventory
+> kept here, which would go stale on the next edit. Clearing them belongs to each
+> file's own pass.
 
 ## Related
 

--- a/src/kiro_crew/workflows/__init__.py
+++ b/src/kiro_crew/workflows/__init__.py
@@ -1,13 +1,14 @@
-"""Dynamic workflows for KiroCrew — the FROZEN CONTRACT (no implementation yet).
+"""Dynamic workflows for Kiro Crew — the FROZEN CONTRACT.
 
-This package defines the interface-first freeze for the dynamic-workflows feature:
+This module defines the interface-first freeze for the dynamic-workflows feature:
 the ``WorkflowContext`` Protocol (the ``ctx`` DSL surface an authored workflow
-script calls) and the run-event types that drive the UI and future resume.
+script calls) and the run-event types that drive the UI and resume.
 
-Everything else — the runner, the UI builtin app, schema enforcement, and the
-KiroCrew-native primitive wrappers — is built in parallel against this contract.
-Changing a signature or event shape here is a re-freeze and must update the
-conformance test (GATE F2 in ``docs/system-specs/modules/workflow-gates.md``).
+The runner, schema enforcement, the Workflows UI app, and the wrappers for the
+ports native to Kiro Crew are all written against this contract — several of them
+without importing it, so nothing but the conformance test catches a drift.
+Changing a signature or event shape here is a re-freeze and must update that test
+(GATE F2 in ``docs/system-specs/modules/workflow-gates.md``).
 
 Spec: ``docs/system-specs/modules/workflows.md``.
 Gate catalog: ``docs/system-specs/modules/workflow-gates.md``.
@@ -165,7 +166,7 @@ class WorkflowContext(Protocol):
 
     budget: Budget
 
-    # --- KiroCrew-native (M4); None when not permitted for this run ---
+    # --- ports native to Kiro Crew; None when not permitted for this run ---
     cron: Optional[CronPort]
     memory: Optional[MemoryPort]
     learn: Optional[LearnPort]
@@ -205,7 +206,7 @@ EVENT_TYPES = (
 
 @dataclass
 class WorkflowEvent:
-    """One run event. Serialized to/from JSON only (BSC12 — no pickle).
+    """One run event. Serialized to/from JSON only — never pickle.
 
     ``data`` carries the event-specific fields documented in
     ``docs/system-specs/modules/workflows.md`` (run event stream table).

--- a/src/kiro_crew/workflows/agent_exec.py
+++ b/src/kiro_crew/workflows/agent_exec.py
@@ -1,4 +1,4 @@
-"""Production ``agent_fn`` for workflow ``ctx.agent()`` calls (M6.2).
+"""Production ``agent_fn`` for workflow ``ctx.agent()`` calls.
 
 The runner takes an injected ``agent_fn(prompt, opts) -> result`` so it stays
 testable with stubs and never spawns ``kiro-cli`` in tests. This module builds the

--- a/src/kiro_crew/workflows/agent_pool.py
+++ b/src/kiro_crew/workflows/agent_pool.py
@@ -40,8 +40,8 @@ from kiro_crew.llm_helpers import ToolApprovalPolicy, stream_and_collect
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 # Per-step tool-call ceiling — shared with the per-call path (agent_exec) so a
-# single edit retunes both; a hand-duplicated copy here would silently diverge
-# the pooled vs fallback ceilings (no test pins them equal).
+# single edit retunes both; a hand-duplicated copy here would silently diverge the
+# pooled vs fallback ceilings. ``test_workflows_agent_pool.py`` pins them equal.
 from kiro_crew.workflows.agent_exec import _MAX_TURNS_PER_STEP
 
 logger = logging.getLogger(__name__)
@@ -240,12 +240,9 @@ def build_pooled_agent_fn(
         # ``agent=None`` on the call means "use the run default" — identical to
         # build_agent_fn's ``opts.get("agent") or default_agent``. Resolve first
         # so a call that explicitly asks for the default reuses the default pool.
-        eff_agent = agent or default_agent
-        eff_model = model or default_model
-        eff_cwd = work_dir or cwd
-        if (eff_agent, eff_model, eff_cwd) == (default_agent, default_model, cwd):
+        key = (agent or default_agent, model or default_model, work_dir or cwd)
+        if key == (default_agent, default_model, cwd):
             return default_pool
-        key = (eff_agent, eff_model, eff_cwd)
         sp = subpools.get(key)
         if sp is not None:
             return sp
@@ -259,7 +256,7 @@ def build_pooled_agent_fn(
         # ``(max_identities + 1) * max_workers``.
         if len(subpools) >= max(1, max_identities):
             return None
-        sp = _make_pool(eff_agent, eff_model, eff_cwd)
+        sp = _make_pool(*key)
         subpools[key] = sp
         return sp
 

--- a/src/kiro_crew/workflows/context.py
+++ b/src/kiro_crew/workflows/context.py
@@ -14,8 +14,8 @@ within ceilings, WITHOUT importing the runner or any heavy gateway code:
   run time (B3 runtime half) and there is no filesystem/socket capability (B7).
 
 The concrete ``WorkflowContext`` that wires ``dsl.parallel/pipeline``, agents,
-and the event stream is assembled by ``runner.py`` (next unit) using these parts;
-keeping them here lets the runner stay thin and keeps this layer dependency-light.
+and the event stream is assembled by ``runner.py`` from these parts; keeping them
+here lets the runner stay thin and keeps this layer dependency-light.
 
 Spec: ``docs/system-specs/modules/workflows.md``.
 """

--- a/src/kiro_crew/workflows/dsl.py
+++ b/src/kiro_crew/workflows/dsl.py
@@ -71,7 +71,9 @@ async def _maybe_await(value: Any) -> Any:
 async def _call_stage(stage: Stage, prev: Any, item: Any, index: int) -> Any:
     arity = _positional_arity(stage)
     all_args = (prev, item, index)
-    args = all_args if arity is None else all_args[: max(0, min(arity, 3))]
+    # ``arity`` is None (accepts everything) or a non-negative count, and slicing
+    # past the end of the tuple already yields all three, so the count needs no clamp.
+    args = all_args if arity is None else all_args[:arity]
     return await _maybe_await(stage(*args))
 
 
@@ -103,12 +105,11 @@ async def parallel(thunks: Sequence[Thunk], *, limit: Optional[int] = None) -> l
     if not thunks:
         return []
 
-    if limit is None or limit <= 0:
-        return list(await asyncio.gather(*[_run_thunk(t) for t in thunks]))
-
-    sem = asyncio.Semaphore(limit)
+    sem = asyncio.Semaphore(limit) if (limit and limit > 0) else None
 
     async def _guarded(t: Thunk) -> Any:
+        if sem is None:
+            return await _run_thunk(t)
         async with sem:
             return await _run_thunk(t)
 

--- a/src/kiro_crew/workflows/registry.py
+++ b/src/kiro_crew/workflows/registry.py
@@ -125,19 +125,20 @@ class RunHandle:
                 snap["agent_errors"] = _str_keyed(self.agent_errors)
         return snap
 
+    def _latest(self, event_type: str, key: str) -> str:
+        """``data[key]`` of the most recent event of ``event_type``, else ``""``."""
+        for e in reversed(self.events):
+            if e.type == event_type:
+                return e.data.get(key, "")
+        return ""
+
     def _current_phase(self) -> str:
         """Title of the most recent ``phase_started`` event (live progress)."""
-        for e in reversed(self.events):
-            if e.type == "phase_started":
-                return e.data.get("title", "")
-        return ""
+        return self._latest("phase_started", "title")
 
     def _last_log(self) -> str:
         """Most recent narrator ``log`` message (live progress)."""
-        for e in reversed(self.events):
-            if e.type == "log":
-                return e.data.get("message", "")
-        return ""
+        return self._latest("log", "message")
 
     # --- durable persistence: full JSON form for the on-disk store ---
     # Distinct from ``snapshot`` (a UI view): this round-trips the COMPLETE run so a

--- a/src/kiro_crew/workflows/runner.py
+++ b/src/kiro_crew/workflows/runner.py
@@ -15,9 +15,9 @@ Gates closed here:
 * (consumes A4/B6 from ``context``: ``Budget`` ceiling, ``AgentCounter`` cap.)
 
 Agent execution is injected as ``agent_fn`` so the runner is testable against a
-stub now; the real wiring (subagent-by-default via ``SubagentManager``, ``session=``
-via ``SessionManager``) drops in later WITHOUT changing the frozen ``ctx`` contract.
-The runner never spawns real ``kiro-cli`` — that is the caller's ``agent_fn``.
+stub; production supplies ``agent_exec.build_agent_fn`` (a fresh isolated session
+per call) or ``agent_pool.build_pooled_agent_fn`` (warm sessions). The runner never
+spawns real ``kiro-cli`` — that is the caller's ``agent_fn``.
 
 ``now`` is a fixed run-start stamp supplied by the caller (NOT ``time`` inside the
 script's scope) so the stream stays deterministic / resume-stable. ``time`` is used
@@ -213,7 +213,7 @@ class RunResult:
     events: list[WorkflowEvent]
     error: Optional[str] = None
     # Per-agent-call results (call_index → result), so a resume/restart-subtree
-    # can replay the unchanged prefix (M6.6). Populated on EVERY terminal path —
+    # can replay the unchanged prefix. Populated on EVERY terminal path —
     # success, ceiling, cancel, budget, and script crash — so an interrupted run
     # still hands back the work it already finished. ``result`` is the script's own
     # return value and stays None when the script never got to return one; these
@@ -223,12 +223,12 @@ class RunResult:
     # ``describe_agent_error``). Empty for runs where every call succeeded.
     agent_errors: dict = field(default_factory=dict)
     # The script actually executed. Equals the input ``source`` unless the run
-    # authored it from an ``intent`` (M6.7) — surfaced so a background run can
+    # authored it from an ``intent`` — surfaced so a background run can
     # store the authored script on its handle for rerun/restart.
     source: str = ""
 
 
-# Signature of the injected authoring step (M6.7): intent -> {ok, source, errors}.
+# Signature of the injected authoring step: intent -> {ok, source, errors}.
 # Kept as a narrow injected callable (NOT a hard import of the service) so the
 # runner stays at the top of the layering and authoring uses the host's model
 # plumbing. ``on_progress(msg)`` lets authoring stream human-readable progress.
@@ -266,8 +266,8 @@ class _RunContext:
     """Concrete ``WorkflowContext`` assembled per run (satisfies the frozen Protocol).
 
     Wires ``dsl.parallel/pipeline`` + ``Budget`` + ``AgentCounter`` + ``EventStream``.
-    KiroCrew-native ports (cron/memory/learn/knowledge) are None until M4; ``agent``
-    delegates to the injected ``agent_fn`` (stub in tests, real spawner in prod).
+    The ports native to Kiro Crew (cron/memory/learn/knowledge) are None unless the host
+    wired them; ``agent`` delegates to the injected ``agent_fn``.
     """
 
     def __init__(
@@ -302,7 +302,7 @@ class _RunContext:
         # when the run was not launched from a nudge-able session.
         self._session_key = session_key
 
-        # KiroCrew-native ports (M4) — injected per run; None when the host did
+        # Ports native to Kiro Crew — injected per run; None when the host did
         # not grant/wire them (the frozen contract allows None, like AppContext).
         ports = ports or {}
         self.cron = ports.get("cron")
@@ -325,7 +325,7 @@ class _RunContext:
         self._current_phase = ""
         self._events: list[WorkflowEvent] = []
         self._on_event = on_event
-        # Resume / restart-subtree (M6.6): cached agent results from a prior run,
+        # Resume / restart-subtree: cached agent results from a prior run,
         # replayed for call_index < replay_before; calls at/after re-execute live.
         # ``agent_results`` collects THIS run's results for the next resume.
         self._replay_results: dict[int, Any] = replay_results or {}
@@ -350,7 +350,7 @@ class _RunContext:
     # --- event sink (shared with the runner) ---
     def _record(self, event: WorkflowEvent) -> None:
         self._events.append(event)
-        # Live fan-out (M6): the registry / WS push consumes events as they happen.
+        # Live fan-out: the registry / WS push consumes events as they happen.
         if self._on_event is not None:
             try:
                 self._on_event(event)
@@ -404,7 +404,7 @@ class _RunContext:
         error = ""
         try:
             if call_index < self._replay_before and call_index in self._replay_results:
-                # Resume (M6.6): replay the cached result from the prior run instead
+                # Resume: replay the cached result from the prior run instead
                 # of re-calling the model. Determinism (no time/random + stable
                 # call_index) makes this sound — same script+args ⇒ same call order.
                 result = self._replay_results[call_index]
@@ -489,8 +489,11 @@ class _RunContext:
         return await _pipeline(items, *stages, limit=self._concurrency)
 
     async def workflow(self, name: str, args: Optional[dict] = None) -> Any:
-        # Nested workflow execution lands with the registry (M5); contract present now.
-        raise NotImplementedError("nested ctx.workflow() arrives with the registry (M5)")
+        # Contract-only. ``workflow`` is not in CORE_CTX_SURFACE and no shipped host
+        # wires a ``workflow`` port, so the pre-exec surface check rejects a script
+        # that names it in the entrypoint. This stays reachable through the gap that
+        # check leaves open on purpose: a helper handed the real ctx is not scanned.
+        raise NotImplementedError("nested ctx.workflow() is not implemented")
 
     # --- progress / UI ---
     def phase(self, title: str) -> "_PhaseContextManager":
@@ -517,7 +520,7 @@ class _RunContext:
         self._record(self._stream.log(self.now, message=message))
         return _NoOpContextManager()
 
-    # --- KiroCrew-native (M4): delegate to injected port fns; clear error if a
+    # --- ports native to Kiro Crew: delegate to injected port fns; clear error if a
     #     workflow uses a primitive the host did not wire/permit for this run. ---
     def nudge(self, *, idle_secs: int, message: str, max_cycles: int = 0) -> "_NoOpContextManager":
         if self._nudge_fn is None:
@@ -585,7 +588,7 @@ class WorkflowRunner:
         self._timeout_secs = timeout_secs
         self._max_agents = max_agents_per_run
         self._concurrency = concurrency
-        # B10 audit sink (default = real SEL) + M4 native ports (default = none wired).
+        # B10 audit sink (default = real SEL) + native ports (default = none wired).
         self._audit = _guarded_audit(audit or _default_audit)
         self._ports = ports or {}
         # Optional async teardown fired once when a background run reaches its
@@ -620,15 +623,15 @@ class WorkflowRunner:
     ) -> RunResult:
         """Execute a workflow script end-to-end, returning result + event stream.
 
-        ``on_event`` (M6) is fired for every event as it is produced — lifecycle
+        ``on_event`` is fired for every event as it is produced — lifecycle
         (run_started/finished/…) AND in-script (phase/log/agent) — so a background
         registry / WS push can monitor the run live. It must never raise.
 
-        ``replay_results`` + ``replay_before`` (M6.6) drive resume / restart-subtree:
+        ``replay_results`` + ``replay_before`` drive resume / restart-subtree:
         agent calls with ``call_index < replay_before`` reuse the cached prior
         result instead of re-calling the model; calls at/after re-execute live.
 
-        ``intent`` + ``author_fn`` (M6.7) author the script *inside the run* when no
+        ``intent`` + ``author_fn`` author the script *inside the run* when no
         ``source`` is given: authoring becomes a visible "Authoring" phase whose
         progress streams to ``on_event`` (sidebar + chat) — so ``workflow_run`` can
         return a run_id instantly instead of blocking on a slow synchronous author.
@@ -660,7 +663,7 @@ class WorkflowRunner:
             },
         )
 
-        # 0. Author-in-run (M6.7): if we were handed an intent and no source, turn
+        # 0. Author-in-run: if we were handed an intent and no source, turn
         # the intent into a validated script HERE, as a visible "Authoring" phase.
         # This is why workflow_run(intent=…) can return a run_id instantly: the slow
         # model call(s) happen in the background run, streaming progress, not behind
@@ -991,17 +994,17 @@ class WorkflowRunner:
         intent: str = "",
         author_fn: Optional[AuthorFn] = None,
     ) -> str:
-        """Start this workflow as a BACKGROUND run tracked in ``registry`` (M6).
+        """Start this workflow as a BACKGROUND run tracked in ``registry``.
 
         Returns the ``run_id`` immediately; the run drives on the event loop and
         streams its events into the registry handle (so chat MCP tools and the
         Workflows tab can monitor/cancel it by id). On terminal state the registry
-        fires its ``on_done`` (M6.4 result-to-chat injection).
+        fires its ``on_done`` (result-to-chat injection).
 
-        ``replay_results``/``replay_before`` (M6.6) let a restart-subtree re-run
+        ``replay_results``/``replay_before`` let a restart-subtree re-run
         replay the unchanged prefix from a prior run's cached agent results.
 
-        ``intent``/``author_fn`` (M6.7): when ``source`` is empty, the script is
+        ``intent``/``author_fn``: when ``source`` is empty, the script is
         authored *inside* the run (a visible "Authoring" phase) so this returns a
         run_id instantly instead of blocking on a slow synchronous author. The
         authored script is written back onto the handle for rerun/restart.

--- a/src/kiro_crew/workflows/schema.py
+++ b/src/kiro_crew/workflows/schema.py
@@ -1,4 +1,4 @@
-"""Structured-output validation + bounded retry for ``ctx.agent(schema=...)`` (M2, C1–C3).
+"""Structured-output validation + bounded retry for ``ctx.agent(schema=...)`` (GATES C1–C3).
 
 The frozen contract says ``ctx.agent(prompt, schema=<JSON Schema>)`` returns a
 *validated dict* (or ``None`` after retries). KiroCrew's provider layer has no
@@ -98,7 +98,7 @@ def parse_json(text: str) -> Any:
 
     Handles the common cases of a fenced ```json block or surrounding prose by
     extracting the outermost ``{...}`` / ``[...]`` span. Never executes anything
-    (no ``eval`` — BSC12).
+    (no ``eval``).
     """
     if not isinstance(text, str):
         raise ValueError("model output is not text")

--- a/src/kiro_crew/workflows/service.py
+++ b/src/kiro_crew/workflows/service.py
@@ -1,5 +1,5 @@
 """Gateway-side workflow service: the shared registry + runner the chat tools,
-the Workflows app, and result-to-chat injection all talk to (M6.3/M6.4/M6.5).
+the Workflows app, and result-to-chat injection all talk to.
 
 This is the single place the gateway wires the dynamic-workflows engine into the
 live process: one ``RunRegistry``, a ``WorkflowRunner`` whose ``agent_fn`` runs
@@ -336,7 +336,7 @@ class WorkflowService:
         # remove it). None → the service default.
         ceiling = clamp_run_timeout(timeout_secs, default=self._timeout_secs)
 
-        # M4 native ports wired for every run of this service. ``nudge`` bridges
+        # Native ports wired for every run of this service. ``nudge`` bridges
         # ``ctx.nudge`` to AutoNudge (the port is session-agnostic — the runner
         # supplies each run's originating session_key at call time; the closure
         # binds run_id so arms are tracked per run and drained at teardown).
@@ -350,6 +350,8 @@ class WorkflowService:
             # logs land inside the stream contract (terminal events are last).
             await self._drain_nudge_tasks(run_id)
 
+        agent_fn: Optional[Callable[[str, dict], Any]] = None
+        pool: Any = None
         if self._pool_agents:
             try:
                 # Size the warm pool to the run's fan-out cap so a fully-parallel
@@ -361,31 +363,24 @@ class WorkflowService:
                     max_workers=workers,
                     max_starting=min(workers, 2),
                 )
-
-                async def _teardown_pooled() -> None:
-                    # Safety net (drain is a no-op if pre_terminal already ran;
-                    # covers pre-exec failure paths), then release the pool.
-                    await self._drain_nudge_tasks(run_id)
-                    await pool.shutdown()
-
-                return WorkflowRunner(
-                    agent_fn=agent_fn,
-                    concurrency=self._concurrency,
-                    timeout_secs=ceiling,
-                    ports=ports,
-                    pre_terminal=_drain,
-                    on_complete=_teardown_pooled,
-                )
             except Exception:  # noqa: BLE001 - never let pooling break run start
+                agent_fn, pool = None, None
                 logger.warning(
                     "workflow agent pool init failed for %s; falling back to per-call sessions",
                     run_id,
                     exc_info=True,
                 )
-        agent_fn = build_agent_fn(self._sessions, run_id=run_id)
+        # Pooling off, or its init raised: cold-start a session per call instead.
+        # Keyed on ``agent_fn``, so a pool that yields no executor is not used.
+        if agent_fn is None:
+            agent_fn = build_agent_fn(self._sessions, run_id=run_id)
 
         async def _teardown() -> None:
+            # Safety net (drain is a no-op if pre_terminal already ran; covers
+            # pre-exec failure paths), then release the warm pool if there is one.
             await self._drain_nudge_tasks(run_id)
+            if pool is not None:
+                await pool.shutdown()
 
         return WorkflowRunner(
             agent_fn=agent_fn,
@@ -405,7 +400,7 @@ class WorkflowService:
     ) -> dict:
         """Turn a NL intent into a validated workflow script (or report errors).
 
-        ``on_progress(msg)`` (M6.7) streams human-readable authoring progress (each
+        ``on_progress(msg)`` streams human-readable authoring progress (each
         attempt, retries) so author-in-run can surface it live in the sidebar/chat.
         """
 
@@ -472,7 +467,7 @@ class WorkflowService:
         budget_total: Optional[int] = None,
         timeout_secs: Optional[int] = None,
     ) -> dict:
-        """Launch a background run that AUTHORS its own script from ``intent`` (M6.7).
+        """Launch a background run that AUTHORS its own script from ``intent``.
 
         Returns ``{run_id}`` immediately — authoring happens inside the run as a
         visible "Authoring" phase, so the slow model call(s) never block this call
@@ -560,7 +555,7 @@ class WorkflowService:
         timeout_secs: Optional[int] = None,
     ) -> dict:
         """Re-run a prior workflow, replaying agent calls BEFORE ``from_index`` from
-        cache and re-executing from there ("restart parts" at runtime, M6.6).
+        cache and re-executing from there ("restart parts" at runtime).
 
         ``from_index`` is the agent ``call_index`` to restart at: calls 0..from_index-1
         reuse the prior run's cached results, calls >= from_index re-call the model.
@@ -575,10 +570,9 @@ class WorkflowService:
         prior = self.registry.get(run_id)
         if prior is None:
             return {"error": f"no such run: {run_id}"}
-        edited = bool(
-            source is not None and source.strip() and source.strip() != (prior.source or "").strip()
-        )
-        run_source = source if (source is not None and source.strip()) else prior.source
+        stripped = (source or "").strip()
+        edited = bool(stripped and stripped != (prior.source or "").strip())
+        run_source = source if stripped else prior.source
         if not run_source:
             return {"error": f"run {run_id} has no stored source to re-run"}
         if edited:

--- a/src/kiro_crew/workflows/store.py
+++ b/src/kiro_crew/workflows/store.py
@@ -8,7 +8,7 @@ rerun / restart-subtree all keep working — and a successful run's script stays
 reusable.
 
 Layout: ``<workflows.dir>/runs/<run_id>.json`` — one self-contained file per run
-(``RunHandle.to_store_json``). JSON only (BSC12 — never pickle/marshal). Writes are
+(``RunHandle.to_store_json``). JSON only — never pickle/marshal. Writes are
 atomic (temp file + ``os.replace``) so a crash mid-write can't corrupt a run file.
 
 The store is a thin, side-effect-only persistence layer: the registry owns the


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only — the diff touches `src/kiro_crew/workflows/`
and that module's own spec, with no rendered delta in the browser.

## Problem / Motivation

`src/kiro_crew/workflows/` (the dynamic-workflow engine, 12 modules) carries three
kinds of accumulated noise that make it slower to read than it needs to be:

- **Comments as a delivery log.** 30 `M<n>` milestone markers (`M6.6`,
  `M6.7`, …) are scattered through the engine's comments and docstrings. Nothing
  defines them — `workflow-gates.md` says so explicitly ("delivery milestone
  markers, not gates, and have no entry here") — so a reader hits an id, looks for
  a catalog, and finds none. `AGENTS.md` bans exactly this shape (no milestone
  tags in comments).
- **Comments that are provably false.** Three examples: `agent_pool.py` says "no
  test pins them equal" about `_MAX_TURNS_PER_STEP` while
  `test_workflows_agent_pool.py:553` asserts precisely that; `runner.py`'s module
  docstring says the real agent wiring "drops in later" though both adapters ship;
  `__init__.py` opens with "no implementation yet" for a package with 12 modules.
  And `workflows.md` carries an Open question claiming `workflow-gates.md` "does
  not exist in this repo" — it does, 129 lines, defining every id the code cites.
- **Duplicated logic and unreachable clamps.** Two identical `gather` shapes in
  `dsl.parallel`, two identical `WorkflowRunner(...)` constructions plus two
  near-identical teardown closures in `service._runner`, an identity tuple built
  twice in `agent_pool._pool_for`, one condition evaluated twice in
  `service.rerun_subtree`, two copies of the same reversed-event scan in
  `registry.RunHandle`, and a `max(0, min(arity, 3))` clamp in `dsl._call_stage`
  where neither bound can ever bind.

Three internal control-id markers (`BSC12`) also survive in this module's comments;
this is the de-Amazoned public fork, where those ids resolve to nothing.

## Why it matters

This is the engine that `exec`s LLM-authored code, so it is read under pressure —
during a sandbox review, or when a run wedges. A comment that asserts the opposite
of what a test does is worse than no comment: it is the kind of claim a reader
acts on. Unresolvable ids cost every reader a search that cannot succeed, and each
duplicated construction is a place where a future fix lands on one copy only —
`service._runner` in particular had two `WorkflowRunner(...)` call sites that had
to be kept in step by hand.

## What changed (motivation → approach → change)

Behavior-preserving only. Nothing about what the engine does changes; the
`workflows` test suite (868 tests across all 30 files that touch the engine) is
unmodified and green.

**Dead code**
- `dsl._call_stage`: `all_args[: max(0, min(arity, 3))]` → `all_args[:arity]`.
  `_positional_arity` returns `None` or a non-negative count, and slicing a
  3-tuple past its end already yields all three, so neither bound is reachable.

**Duplication**
- `dsl.parallel`: the `limit is None or limit <= 0` early-return `gather` is gone;
  it now uses the same `sem`-or-`None` + `_guarded` shape `pipeline` already had,
  so the two combinators read identically. `(limit and limit > 0)` selects the
  bounded path for exactly the same inputs the old `limit is None or limit <= 0`
  excluded.
- `service._runner`: one `WorkflowRunner(...)` construction and one `_teardown`
  closure instead of two of each. The pooled branch now resolves `agent_fn` and
  `pool`, falls back to `build_agent_fn` when pooling is off or its init raised,
  and the single teardown drains nudges then shuts the pool down only when one
  exists. The `try` narrows to `build_pooled_agent_fn`; `WorkflowRunner.__init__`
  is pure attribute assignment and cannot raise, so the fallback still triggers on
  every failure it did before.
- `agent_pool._pool_for`: the `(agent, model, cwd)` identity tuple is built once
  and reused for the default-pool comparison, the sub-pool lookup, and
  `_make_pool(*key)`.
- `service.rerun_subtree`: `source is not None and source.strip()` was evaluated
  twice; one `stripped = (source or "").strip()` local now feeds both `edited` and
  `run_source`.
- `registry.RunHandle`: `_current_phase` / `_last_log` were the same reversed scan
  with different keys; both now delegate to one `_latest(event_type, key)`.

**Comment hygiene** (only in files edited above, plus the module's own spec)
- 30 `M<n>` markers dropped from `src/kiro_crew/workflows/`, each comment restated
  in present tense. Two survive: the ones in `test/test_workflows_*.py` and
  `mcp_tools/workflows.py` (outside this module), and one comment in `validate.py`
  — see below for why that file is untouched. `workflows.md` now records where
  they still live.
- The false claims above corrected against the code they describe, and the stale
  Open question in `workflows.md` replaced with what `workflow-gates.md` actually
  is (a lookup table for the ids, with the test as the authority).
- One output string changes, disclosed deliberately: `_RunContext.workflow`'s
  `NotImplementedError` read `"nested ctx.workflow() arrives with the registry
  (M5)"` and now reads `"nested ctx.workflow() is not implemented"`. Leaving a
  milestone marker in a message that reaches `RunResult.error` and the `run_failed`
  event the UI renders is the worst place for one. No test pins either string.
- `BSC12` replaced by the reason it stood for ("never pickle/marshal", "no
  `eval`"). One such marker survives repo-wide, a `BSC1` in top-level
  `context.py`; that is a different module, so it is left for that module's own
  pass rather than widening this diff.

**Reviewed and left alone**
- `dsl.parallel` and `service.rerun_subtree` now select their branch on truthiness
  (`limit and limit > 0`; `(source or "").strip()`) where they previously used an
  explicit `is not None`. For a non-`int` `limit` or a non-`str` `source` that
  changes a `TypeError`/`AttributeError` into a silent unbounded run or a fallback
  to `prior.source`. Both are outside the declared types (`Optional[int]`,
  `Optional[str]`), unreachable through the typed API, and `parallel` now matches
  the shape `pipeline` already shipped with on `main`. Equivalence over the
  declared domain is exhaustive: all 32 `(source, prior.source)` shapes and every
  `limit` in `{None, 0, -1, 1, 2, 5, 1000}` produce identical results.

**Deliberately NOT touched**
- `validate.py` — not one line, not even a comment. CI runs `black` as a
  baselined gate scoped to the diff's file set, and `validate.py` is in the
  not-black-clean baseline. Touching it pulls it into the gate, and `black` would
  then explode `FORBIDDEN_ATTRS` (the sandbox's frame/generator introspection
  denylist) to one name per line, destroying the grouping-by-object-kind its own
  "re-audit on every Python version bump" note depends on. That is a security
  denylist; the churn is not worth a comment. Its one `M5` marker stays; the
  spec records that clearing these markers belongs to each file's own pass, and
  the reason this particular file is excluded lives here rather than in the spec,
  where a per-file formatting status would rot. (A mechanical dedup also exists
  there — `_try_fold_str_binop` vs `_fold_str_operand` — and is likewise left:
  restructuring a sandbox guard to save a helper is not a trade worth making.)
- `store.py`'s bare `os.chmod(path, 0o600)`, which `AGENTS.md` says should route
  through `platform_compat.chmod_safe`. That is a cross-platform behaviour fix,
  not a simplification, so it does not belong in this PR.

## Tests

No test changes — that is the point of the class of change. Verification is that
the existing suite still passes unmodified:

- `test/test_workflows_*.py` — 418 passed.
- Every test file that references the engine (`kiro_crew.workflows`,
  `workflow_service`, `WorkflowService`) — 30 files, 868 passed.

This PR is 11 files (`validate.py` excluded per above). The invariant suites that
would catch a contract slip specifically are in that set:
`test_workflows_conformance.py` (pins `__all__`, the `ctx` method set, every
signature, `EVENT_TYPES`), `test_workflows_architecture.py` (import layering),
`test_workflows_presence.py`, `test_workflows_invariants.py` and
`test_workflows_malicious.py` (the sandbox), and
`test_workflows_agent_pool.py::test_max_turns_constant_is_shared_with_agent_exec`
(the ceiling this PR's comment now cites).

## Manual verification

N/A — unit coverage sufficient. There is no runtime behaviour change to exercise:
the only non-comment edits are a tuple built once instead of twice, one condition
hoisted into a local, two `gather` shapes collapsed into the one already in use by
the sibling combinator, an unreachable slice clamp removed, and two
`WorkflowRunner` constructions merged. Each is argued for equivalence above and
covered by the suites listed.

## Related Issues

no linked issue: routine readability pass on one module, nothing filed.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass; no new functionality, so no new tests
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`docs/system-specs/modules/workflows.md`)
- [x] No secrets, credentials, or internal references in the diff (this PR removes
      three internal control-id markers)

