### PR TITLE
feat(babysit): emit a comparable progress key and stop on no-progress

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md
@@ -42,10 +42,117 @@ stretch this: a due fire waits for the user's turn to end, then delivers.
 
 `max_cycles` (default 24) is a **runaway backstop, not a finish line**. A loop
 that coasts into its cap did not complete — it ran out of rope, and whatever
-it was watching is still unresolved. Real loop stores show this is the common
-failure: two live babysit loops ended at exactly 24/24 and 20/20 delivered
-cycles, neither having called `autonudge_stop`. Evaluate the exit condition
-every single cycle and stop deliberately.
+it was watching is still unresolved. Evaluate the exit condition every single
+cycle and stop deliberately.
+
+**This is the dominant failure, not a rare one.** Measured on a real loop store
+(4 loops, 84 delivered cycles, 14.9h wall clock, 7.5h of model turn time):
+**4 of 4 ended at exactly their cap** — 24/24, 20/20, 28/28, 12/12 — with
+`stopped_reason` either empty or `cycle_cap`, and **0 of 4 carried an
+agent-supplied stop reason**. None set `max_runtime_secs`, so cycle count was
+the only bound on spend.
+
+The reason this is expensive rather than merely untidy: the cap is reached the
+same way whether the loop **converged early** and then re-polled for nothing, or
+**never converged** and stopped with the work still unresolved. The two are
+indistinguishable from outside — the loop simply goes inactive — so a loop that
+stops only at its cap tells you nothing about which happened, and bills you for
+the difference.
+
+### Stall tripwire — stop on no-progress, not just on success
+
+An exit condition keyed only on *success* cannot end a loop that is stuck, and
+stuck is the common case: a blocker needing a human decision, an upstream
+outage, a flake nobody owns. So carry a second exit condition.
+
+Each cycle, record the **progress key** — `pr_status.py --json` emits every
+field of it:
+
+| field | why it is in the key |
+|---|---|
+| `head_sha` | a new head means you pushed; work happened |
+| `failing_checks` (sorted, workflow-qualified) | *which* checks are red, not how many — qualified by workflow because two workflows can publish the same check name, and a name-only list stays identical when one starts failing as the other stops |
+| `checks_failing` | the count, as a cheap scalar |
+| `readiness_kind` | distinguishes running from failing from unpublished |
+| `exit_code` | collapses the whole verdict |
+| `status` | the verdict *reason* — a conflict and a failing check are both exit `20` and can carry an identical check set, so without this a changed blocker extends a stall streak instead of resetting it |
+
+If the key is byte-identical for **3 consecutive counting cycles** and you pushed
+nothing in that span, the loop is not making progress. **Stop it**: report what is
+blocking, why you could not move it, and what decision you need, then call
+`autonudge_stop` with that as the reason.
+
+**Only a settled cycle counts.** A cycle whose poll exits `10` is reporting work
+still in flight, and waiting is exactly what the loop is for — so an exit-`10`
+cycle neither counts toward the tripwire nor resets it; skip it and move on.
+**Both exit `0` and exit `20` are settled, and both count.** A PR can sit at exit
+`0` indefinitely — green checks, but not review-ready because a human-owned thread
+or an unanswered advisory concern is outstanding — and a tripwire that counted only
+`20` would never notice that kind of stall. Exit `2` is an environment fault:
+escalate it rather than counting it.
+
+This matters because a running PR yields a byte-identical key every cycle by
+construction (`failing_checks` empty, `readiness_kind` `running`, `exit_code` 10),
+so counting those would fire the tripwire after ~15 minutes of ordinary CI on a
+repo where a single gate can legitimately run an hour. Skipping rather than
+resetting is deliberate too: a PR that flickers between running and blocked would
+otherwise reset forever and never be recognised as stuck. What bounds a genuinely
+endless wait is not this tripwire but `max_runtime_secs`.
+
+**Persist the key AND the streak count — session memory is not durable enough.**
+A stalled loop is precisely the long-running case that walks into compaction (see
+above), which can summarise away the counter at the moment it matters; the loop
+then coasts to its cap exactly as before, which is the failure this tripwire
+exists to prevent. Storing only the last key is not enough: that tells the next
+cycle what the previous key was but not whether this is match one, two or three,
+so the streak itself would still live in memory and still be lost. Write BOTH to
+one file — the key plus an integer count — and read it first on every settled
+cycle, then:
+
+- key matches the stored key → increment the count, write it back, trip at 3;
+- key differs → overwrite with the new key and a count of 1.
+
+**Put that file where the loop's own state lives, not in temp.** A babysit runs
+for hours and `TMPDIR` is periodically reaped by the OS, which would silently
+reset the streak — the same erasure as compaction, just a different eraser. Use
+the data home beside the loop's stop sentinel, i.e.
+`${KIROCREW_HOME:-$HOME/.kiro/crew}/workspace/.babysit-key-<loop-id>`, which is the
+convention `stop_sentinel_path` already follows and is not machine-cleaned. Write
+`$HOME`, not `~`: a tilde inside a parameter-expansion default is not expanded, so
+the literal `~` would survive and the state would land in a `~/` directory
+relative to the current working directory — lost the moment that directory
+changes.
+
+Nothing in the monitor engine observes the key today, so that file is the only
+durable record; moving the counter into the loop store, so the engine itself could
+stop on it, is the follow-up that would make this enforceable rather than
+advisory.
+
+**The key is GitHub-only today.** `pr_status.py --json` is its only emitter, so on
+GitLab or Bitbucket you must first derive an equivalent key from that host's own
+verdict fields (the table above). The 3-cycle rule means nothing until something
+emits a comparable value.
+
+Two things deliberately stay OUT of the key:
+
+- **Finding counts.** A finding you rebutted or deferred keeps being re-raised,
+  so a key including it never stabilises and the tripwire never fires. Worse,
+  the count moves when a bot merely re-words a comment. Read findings to decide
+  *what to do*; do not let them decide *whether you are stuck*.
+- **Unresolved-thread counts.** `?` means "could not establish", and a transient
+  API blip would read as progress.
+
+Escalating early is correct — a stalled loop does not become unstuck by being
+re-run 18 more times; it becomes unstuck when a human answers the question. This
+is **not** licence to park on a *fixable* blocker: the tripwire fires only when
+nothing changed **because there was nothing you could change unilaterally**. A
+diagnosed, verified fix gets applied and pushed, which moves `head_sha` and
+resets the count by construction.
+
+Deliberate stops are the goal. `autonudge_stop` should carry a real sentence
+naming the exit condition, the tripwire, or a terminal PR state. A loop whose
+store row later reads `cycle_cap` is a defect in that loop's instructions, not
+a completed job.
 
 ### Context grows every cycle
 
@@ -192,8 +299,22 @@ talking about from your cwd):
 ```bash
 SKILL_DIR="${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/kirocrew-dev/prepare-pr"
 python3 "$SKILL_DIR/scripts/pr_status.py" <pr#>     # exit 0 clean / 10 running / 20 blocked / 2 env
+python3 "$SKILL_DIR/scripts/pr_status.py" <pr#> --json   # same exit code, plus the progress key on stdout
 python3 "$SKILL_DIR/scripts/pr_findings.py" <pr#>   # only after 20: failed steps, log tails, threads
 ```
+
+`--json` adds one machine-readable object to stdout and changes nothing else —
+same exit codes, same prose above it. Use it for the stall tripwire: the object
+carries the full 40-char `head_sha` (the prose only ever prints 12), the sorted
+`failing_checks` list, and `readiness_kind`, so two cycles can be compared
+byte-for-byte instead of by eyeballing a diff of human text.
+
+Its `advisory` half is what you read when checking the exit conditions below:
+`unresolved_threads` (`null` there is the same "could not establish" as a `?`),
+`findings` per reviewer, and `stale_reviewers` / `blocking_reviewers`. Nothing
+else is emitted — ambient PR state (mergeable, merge state, review decision,
+check totals) stays in the prose above, which is where those conditions already
+read it, so there is no second copy to keep in sync.
 
 Drive the cycle off the **exit code**, not off prose: `10` → report nothing and
 wait for the next cycle; `20` → drill in with `pr_findings.py` and act; `2` →
@@ -332,10 +453,15 @@ Two limits worth knowing before you trust it on an arbitrary PR:
    - what to do with findings (fix + push, summarize, escalate),
    - the exit condition, ending with: "when met, tell the user and call
      `autonudge_stop`".
-2. **Call `monitor_start`.** `interval_secs` default 300 suits CI/review
-   polling. `max_cycles` defaults to 24 (≈2h of idle gaps at 300s); raise it
-   for longer work, and pass `0` for unlimited only when the user explicitly
-   asks for an unbounded loop.
+2. **Call `monitor_start`, and always pass a wall-clock budget.**
+   `interval_secs` default 300 suits CI/review polling. `max_cycles` defaults to
+   24 (≈2h of idle gaps at 300s); raise it for longer work, and pass `0` for
+   unlimited only when the user explicitly asks for an unbounded loop.
+   **Set `max_runtime_secs` too.** It is the only bound that holds when
+   per-cycle work grows: measured cycles ran 124s–823s of model time *on top of*
+   the idle gap, so a 12-cycle cap took 4.1 hours. Cycle count does not bound
+   spend. Budget the wall clock you would actually accept (e.g. `14400` for four
+   hours) so a stalled loop dies on time rather than on arithmetic.
 3. **Confirm it armed.** Read `~/.kiro/crew/autonudge.json` and check your
    loop is there. The tool's reply is not evidence — see above.
 4. **Tell the user monitoring is active and END YOUR TURN.** The loop wakes
@@ -343,7 +469,17 @@ Two limits worth knowing before you trust it on an arbitrary PR:
 5. **Each cycle:** do the check, act, and report only real signals. Don't
    post "nothing new" every cycle. If the instruction no longer matches
    reality, `monitor_update` it rather than working around it.
-6. **On the exit condition** (or the user saying stop): report, then call
+   **Keep a no-signal cycle cheap.** On exit `10` the correct cycle is: read the
+   exit code, write nothing, end the turn. Do not re-read review-bot bodies, job
+   logs, or diffs on a cycle whose own status call already said nothing changed —
+   that is where a watch loop turns into a spend loop. One `pr_status.py` run is
+   6–8 `gh` invocations; the expensive reads belong to exit `20`.
+6. **Persist the progress key and its streak count to a file** (not session
+   memory — compaction eats both) and apply the stall tripwire above: 3
+   byte-identical keys on *settled* cycles (exit `0` or `20`) with no push means
+   stop and escalate. Exit-`10` cycles are skipped, not counted and not reset;
+   exit `2` escalates.
+7. **On the exit condition** (or the user saying stop): report, then call
    `autonudge_stop` with a reason. Do not let the cap do this for you.
 
 ## Example
@@ -357,9 +493,15 @@ monitor_start(
            rules 6 and 7 of the babysit skill govern what each value means.
            Then run
            python3 \"${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/kirocrew-dev/prepare-pr/scripts/pr_status.py\" 247
-           and act on its exit code (10 = still running, report nothing;
+           and act on its exit code, passing --json so the progress key is
+           machine-comparable (10 = still running, report nothing and do not
+           read bot bodies or job logs;
            20 = drill in with pr_findings.py, or stop if the reason is a
-           terminal PR state). If this repo's reviewer conclusions are on the
+           terminal PR state). Keep the progress_key AND a consecutive-match
+           count in the data home beside the loop's stop sentinel, reading that
+           file rather than trusting memory: 3 byte-identical keys on settled
+           cycles (exit 0 or 20) with no push in that span means stop and
+           escalate. If this repo's reviewer conclusions are on the
            unreliable list you established for it, resolve the AI review lane
            from the job log plus the comment body for the current head SHA
            rather than the conclusion; where the conclusion is trustworthy, use
@@ -375,6 +517,7 @@ monitor_start(
            user the PR is review-ready and call autonudge_stop.",
   interval_secs=300,
   max_cycles=20,
+  max_runtime_secs=14400,
 )
 ```
 

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
@@ -7,14 +7,18 @@ authoritative when present; older PRs fall back to the full check rollup.
 Stdlib only; portable.
 
 Usage:  python3 pr_status.py [pr-number] [--readiness-context NAME]
-                             [--reviewers NAME1,NAME2]
+                             [--reviewers NAME1,NAME2] [--json]
         (no number -> auto-detect the PR for the current branch;
          --readiness-context / PREPARE_PR_READINESS_CONTEXT override the
          aggregate status-context name, default "PR Readiness";
          --reviewers / PREPARE_PR_REVIEWERS pin the reviewer fleet: only the
          named stamps are evaluated AND each named reviewer must have a fresh
          stamp; by default, every ``[<NAME>-REVIEWED]`` stamp found in bot
-         comments is held to freshness, and absence is not required)
+         comments is held to freshness, and absence is not required;
+         --json appends one machine-readable object as the LAST line of stdout
+         and changes nothing else -- same exit codes, same prose. Its
+         ``progress_key`` sub-object is the only part safe to compare between
+         runs; a monitoring loop uses it to tell a stalled PR from a moving one)
 
 Exit codes:
    0  CLEAN     - open, non-draft, MERGEABLE, no CHANGES_REQUESTED, aggregate
@@ -340,14 +344,21 @@ _VALUE_FLAGS = (
     "--marker-bindings",
 )
 
+# Flags that take NO value. positional_args must drop these too: a bare
+# --json left in the positional list is read as the PR number, which silently
+# resolves the wrong PR (or fails env-check) instead of erroring.
+_BOOL_FLAGS = ("--json",)
+
 
 def positional_args(argv):
-    """Return argv with the value-taking flags (and their values) removed."""
+    """Return argv with the flags (and any values they take) removed."""
     out = []
     skip = False
     for a in argv:
         if skip:
             skip = False
+            continue
+        if a in _BOOL_FLAGS:
             continue
         if a in _VALUE_FLAGS:
             skip = True
@@ -390,6 +401,24 @@ def classify_check(entry):
             return "running"
         return "fail"
     return "fail"  # unknown shape -> fail closed
+
+
+def failing_check_identity(entry):
+    """Workflow-qualified label for a failing check, for ``progress_key``.
+
+    Mirrors ``collapse_superseded()``'s identity notion -- a StatusContext is
+    keyed by its context name, a CheckRun by (workflow, name) -- because a
+    display name alone is not an identity: two workflows can publish the same
+    check name. If one workflow's copy starts failing while the other's stops,
+    a name-only list is byte-identical across that change, and a stall streak
+    would run straight through a PR whose blocking check actually moved.
+    """
+    context = entry.get("context")
+    if context:
+        return sanitize(context)
+    workflow = sanitize(entry.get("workflowName") or "")
+    name = sanitize(entry.get("name") or "check")
+    return "{} / {}".format(workflow, name) if workflow else name
 
 
 def collapse_superseded(rollup):
@@ -626,6 +655,74 @@ def head_run_exists(repo, head_sha):
     return False
 
 
+def build_report(
+    *,
+    number,
+    url,
+    head_sha,
+    readiness_kind,
+    failing_checks,
+    n_fail,
+    n_unresolved,
+    marker_eval,
+    code,
+    status,
+):
+    """Build the --json report.
+
+    Every field here has a named consumer in the babysit skill; nothing is
+    emitted speculatively. The shape is split because the whole object is NOT
+    safe to compare between runs:
+
+    ``progress_key`` holds only fields that change when real progress happens,
+    so a polling loop can compare it byte-for-byte to tell "still stuck" from
+    "something moved". Everything unstable lives under ``advisory``, which the
+    loop reads when checking its exit conditions but never includes in the
+    comparison:
+
+    * a finding a writer rebutted or deferred is re-raised every round, so a key
+      including finding counts would never stabilise and a stall would never be
+      recognised -- and the count also moves when a bot merely re-words a comment;
+    * ``unresolved_threads`` degrades to null on any API error or page cap, so a
+      transient blip would read as progress.
+
+    Ambient PR state (mergeable, merge_state, review_decision, check totals) is
+    deliberately NOT emitted: the prose above already prints all of it, the loop
+    reads it there, and ``pr_findings.py`` owns the exit-20 drill-in. A second
+    machine-readable copy with no reader is a surface to keep in sync for nothing.
+    """
+    return {
+        "exit_code": code,
+        "pr": number,
+        "status": status,
+        "url": url,
+        # Compare THIS between cycles -- nothing else.
+        "progress_key": {
+            "checks_failing": n_fail,
+            "exit_code": code,
+            "failing_checks": sorted(failing_checks),
+            "head_sha": head_sha,
+            "readiness_kind": readiness_kind,
+            # The verdict reason, so a CHANGED blocker cannot read as an
+            # unchanged one. exit_code and the failing-check set do not
+            # distinguish "blocked by a conflict" from "blocked by a review
+            # marker": both are exit 20 and can carry an identical check set, so
+            # without this a real change in what blocks the PR would extend a
+            # stall streak instead of resetting it. Deterministic by
+            # construction -- decide() joins its reasons in a fixed order from
+            # sorted inputs.
+            "status": status,
+        },
+        "advisory": {
+            "blocking_reviewers": sorted(marker_eval.get("blocking") or []),
+            "bot_comments_readable": bool(marker_eval.get("ok")),
+            "findings": dict(marker_eval.get("findings") or {}),
+            "stale_reviewers": sorted(marker_eval.get("stale") or []),
+            "unresolved_threads": n_unresolved,
+        },
+    }
+
+
 def decide(
     state,
     mergeable,
@@ -704,9 +801,15 @@ def decide(
             reasons.append("reviewer comments could not be read (fail-closed)")
         else:
             if marker_eval.get("blocking"):
+                # sorted(): ``blocking`` is a set, and joining a set of strings
+                # is only order-stable WITHIN one process. This status string is
+                # part of progress_key, which a polling loop compares
+                # byte-for-byte across separate runs, so an unsorted join would
+                # make two identical states differ whenever more than one
+                # reviewer blocks.
                 reasons.append(
                     "blocking review marker [BLOCK-MERGE] on current head from: "
-                    + ", ".join(marker_eval["blocking"])
+                    + ", ".join(sorted(marker_eval["blocking"]))
                 )
             if marker_eval.get("stale"):
                 reasons.append(
@@ -787,6 +890,7 @@ def main(argv):
 
     print("-- CI checks " + "-" * 40)
     n_running = n_fail = 0
+    failing_checks = []
     readiness_kind = None
     for e in rollup:
         kind = classify_check(e)
@@ -795,6 +899,8 @@ def main(argv):
         elif kind == "fail":
             n_fail += 1
         name = sanitize(e.get("name") or e.get("context") or "check")
+        if kind == "fail":
+            failing_checks.append(failing_check_identity(e))
         # Only the legacy StatusContext we publish is authoritative. A CheckRun
         # can share the display name but is a different, independently writable
         # namespace and must remain part of the ordinary rollup.
@@ -902,6 +1008,28 @@ def main(argv):
         head_run=head_run,
     )
     print(status)
+    if "--json" in argv[1:]:
+        # Last line of stdout, one compact line, keys sorted: a polling loop
+        # compares consecutive runs byte-for-byte, so the serialization has to
+        # be stable for an unchanged PR.
+        print(
+            json.dumps(
+                build_report(
+                    number=d.get("number"),
+                    url=d.get("url") or "",
+                    head_sha=head_sha,
+                    readiness_kind=readiness_kind,
+                    failing_checks=failing_checks,
+                    n_fail=n_fail,
+                    n_unresolved=n_unresolved,
+                    marker_eval=marker_eval,
+                    code=code,
+                    status=status,
+                ),
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
     return code
 
 

--- a/test/test_prepare_pr_status.py
+++ b/test/test_prepare_pr_status.py
@@ -70,6 +70,259 @@ def _install_fake_gh(
     module.unresolved_thread_count = lambda _number: 3
 
 
+def _last_line_json(capsys) -> dict:
+    """Parse the --json object, which is contracted to be the LAST stdout line."""
+    lines = [ln for ln in capsys.readouterr().out.strip().splitlines() if ln.strip()]
+    return json.loads(lines[-1])
+
+
+def test_json_flag_does_not_change_the_exit_code(capsys) -> None:
+    clean = _pr_payload([{"context": "PR Readiness", "state": "SUCCESS"}])
+    blocked = _pr_payload([{"name": "CI", "status": "COMPLETED", "conclusion": "FAILURE"}])
+
+    for payload, expected in ((clean, 0), (blocked, 20)):
+        module = _load_script()
+        _install_fake_gh(module, payload)
+        assert module.main(["pr_status.py", "42"]) == expected
+        capsys.readouterr()
+
+        module = _load_script()
+        _install_fake_gh(module, payload)
+        assert module.main(["pr_status.py", "42", "--json"]) == expected
+        assert _last_line_json(capsys)["exit_code"] == expected
+
+
+def test_json_report_carries_the_full_head_sha_not_the_truncated_prose_one(capsys) -> None:
+    module = _load_script()
+    _install_fake_gh(module, _pr_payload([{"context": "PR Readiness", "state": "SUCCESS"}]))
+
+    module.main(["pr_status.py", "42", "--json"])
+
+    head = _last_line_json(capsys)["progress_key"]["head_sha"]
+    assert head == "f" * 40
+    assert len(head) == 40
+
+
+def test_bare_json_flag_is_not_read_as_the_pr_number() -> None:
+    """A boolean flag left in the positional list would resolve the wrong PR."""
+    module = _load_script()
+    payload = _pr_payload([{"context": "PR Readiness", "state": "SUCCESS"}])
+    seen: list[list[str]] = []
+
+    def fake_run(args: list[str]) -> tuple[int, str, str]:
+        seen.append(args)
+        if args[:3] == ["gh", "auth", "status"]:
+            return 0, "", ""
+        if args[:5] == ["gh", "pr", "view", "--json", "number"]:
+            return 0, "42", ""
+        if args[:3] == ["gh", "pr", "view"]:
+            return 0, payload, ""
+        if args[:3] == ["gh", "repo", "view"]:
+            return 0, "example/repo", ""
+        if args[:2] == ["gh", "api"] and "/issues/" in args[2] and "/comments" in args[2]:
+            return 0, "[]", ""
+        if args[:2] == ["gh", "api"] and "/actions/runs" in args[2]:
+            return 0, json.dumps({"total_count": 1, "workflow_runs": [{"event": "pull_request"}]}), ""
+        raise AssertionError("unexpected command: {}".format(args))
+
+    module.run = fake_run
+    module.unresolved_thread_count = lambda _number: 0
+
+    assert module.main(["pr_status.py", "--json"]) == 0
+
+    # The auto-detect branch must have run, i.e. --json was NOT taken as the PR.
+    assert ["gh", "pr", "view", "--json", "number", "-q", ".number"] in seen
+    detail = [c for c in seen if c[:3] == ["gh", "pr", "view"] and c[3:4] not in ([], ["--json"])]
+    assert detail and detail[0][3] == "42"
+
+
+def test_progress_key_is_identical_for_an_unchanged_pr(capsys) -> None:
+    payload = _pr_payload([{"name": "CI", "status": "COMPLETED", "conclusion": "FAILURE"}])
+
+    keys = []
+    for _ in range(2):
+        module = _load_script()
+        _install_fake_gh(module, payload)
+        module.main(["pr_status.py", "42", "--json"])
+        keys.append(json.dumps(_last_line_json(capsys)["progress_key"], sort_keys=True))
+
+    assert keys[0] == keys[1]
+
+
+def test_progress_key_changes_when_the_head_moves(capsys) -> None:
+    checks = [{"name": "CI", "status": "COMPLETED", "conclusion": "FAILURE"}]
+
+    module = _load_script()
+    _install_fake_gh(module, _pr_payload(checks))
+    module.main(["pr_status.py", "42", "--json"])
+    before = _last_line_json(capsys)["progress_key"]
+
+    module = _load_script()
+    _install_fake_gh(module, _pr_payload(checks, headRefOid="a" * 40))
+    module.main(["pr_status.py", "42", "--json"])
+    after = _last_line_json(capsys)["progress_key"]
+
+    assert before != after
+    assert after["head_sha"] == "a" * 40
+
+
+def test_progress_key_ignores_the_unresolved_thread_count(capsys) -> None:
+    """A thread count degrades to null on an API blip; it must not read as progress."""
+    payload = _pr_payload([{"name": "CI", "status": "COMPLETED", "conclusion": "FAILURE"}])
+
+    module = _load_script()
+    _install_fake_gh(module, payload)
+    module.unresolved_thread_count = lambda _number: 3
+    module.main(["pr_status.py", "42", "--json"])
+    first = _last_line_json(capsys)
+
+    module = _load_script()
+    _install_fake_gh(module, payload)
+    module.unresolved_thread_count = lambda _number: None
+    module.main(["pr_status.py", "42", "--json"])
+    second = _last_line_json(capsys)
+
+    assert first["progress_key"] == second["progress_key"]
+    assert first["advisory"]["unresolved_threads"] == 3
+    assert second["advisory"]["unresolved_threads"] is None
+
+
+def test_failing_checks_are_listed_sorted_and_exclude_passing_ones(capsys) -> None:
+    module = _load_script()
+    _install_fake_gh(
+        module,
+        _pr_payload(
+            [
+                {"name": "zeta lint", "status": "COMPLETED", "conclusion": "FAILURE"},
+                {"name": "alpha tests", "status": "COMPLETED", "conclusion": "FAILURE"},
+                {"name": "passing build", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ]
+        ),
+    )
+
+    module.main(["pr_status.py", "42", "--json"])
+
+    key = _last_line_json(capsys)["progress_key"]
+    assert key["failing_checks"] == ["alpha tests", "zeta lint"]
+    assert key["checks_failing"] == 2
+
+
+def test_same_check_name_in_two_workflows_does_not_collide_in_the_key(capsys) -> None:
+    """A failing check's identity must carry its workflow, not just its name.
+
+    Two workflows can publish the same check name. If one workflow's copy starts
+    failing while the other's stops, a name-only list is byte-identical across
+    that change and a stall streak would run through a PR whose blocking check
+    actually moved.
+    """
+    def payload(ci_fails: bool) -> str:
+        return _pr_payload(
+            [
+                {
+                    "name": "Tests",
+                    "workflowName": "CI",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE" if ci_fails else "SUCCESS",
+                },
+                {
+                    "name": "Tests",
+                    "workflowName": "Nightly",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS" if ci_fails else "FAILURE",
+                },
+            ]
+        )
+
+    keys = []
+    for ci_fails in (True, False):
+        module = _load_script()
+        _install_fake_gh(module, payload(ci_fails))
+        assert module.main(["pr_status.py", "42", "--json"]) == 20
+        keys.append(_last_line_json(capsys)["progress_key"])
+
+    assert keys[0]["failing_checks"] == ["CI / Tests"]
+    assert keys[1]["failing_checks"] == ["Nightly / Tests"]
+    assert keys[0] != keys[1]
+    # The rest of the key is identical, so the workflow qualifier is the only
+    # thing distinguishing these two states -- strip it and they collide.
+    assert {k: v for k, v in keys[0].items() if k != "failing_checks"} == {
+        k: v for k, v in keys[1].items() if k != "failing_checks"
+    }
+
+
+def test_a_status_context_keeps_its_bare_context_name(capsys) -> None:
+    """StatusContexts have no workflow; their context name IS the identity."""
+    module = _load_script()
+    _install_fake_gh(module, _pr_payload([{"context": "legacy/build", "state": "FAILURE"}]))
+
+    module.main(["pr_status.py", "42", "--json"])
+
+    assert _last_line_json(capsys)["progress_key"]["failing_checks"] == ["legacy/build"]
+
+
+def test_a_changed_blocker_changes_the_key_even_with_an_identical_check_set(capsys) -> None:
+    """A different reason for being blocked must reset a stall streak, not extend it.
+
+    exit_code and the failing-check set cannot tell "blocked by a failing check"
+    from "blocked by a merge conflict": both are exit 20 and here carry a
+    byte-identical check set, head and readiness. Only the verdict reason
+    distinguishes them, which is why `status` is part of the key.
+    """
+    checks = [{"name": "CI", "status": "COMPLETED", "conclusion": "FAILURE"}]
+
+    module = _load_script()
+    _install_fake_gh(module, _pr_payload(checks))
+    assert module.main(["pr_status.py", "42", "--json"]) == 20
+    failing_check = _last_line_json(capsys)["progress_key"]
+
+    module = _load_script()
+    _install_fake_gh(
+        module,
+        _pr_payload(checks, mergeable="CONFLICTING", mergeStateStatus="DIRTY"),
+    )
+    assert module.main(["pr_status.py", "42", "--json"]) == 20
+    conflicted = _last_line_json(capsys)["progress_key"]
+
+    assert failing_check != conflicted
+    # And prove `status` is what discriminates: strip it and they collide, which
+    # is the false stall-streak completion this field exists to prevent.
+    assert {k: v for k, v in failing_check.items() if k != "status"} == {
+        k: v for k, v in conflicted.items() if k != "status"
+    }
+
+
+def test_report_emits_only_the_consumed_surface(capsys) -> None:
+    """Every emitted field has a named consumer in the babysit skill.
+
+    Pins the absence of ambient PR state (mergeable / merge_state /
+    review_decision / check totals / head_run): the prose above already prints
+    it and the skill reads it there, so a second machine-readable copy with no
+    reader would be a surface to keep in sync for nothing.
+    """
+    module = _load_script()
+    _install_fake_gh(module, _pr_payload([{"context": "PR Readiness", "state": "SUCCESS"}]))
+
+    module.main(["pr_status.py", "42", "--json"])
+    report = _last_line_json(capsys)
+
+    assert set(report) == {"exit_code", "pr", "status", "url", "progress_key", "advisory"}
+    assert set(report["progress_key"]) == {
+        "checks_failing",
+        "exit_code",
+        "failing_checks",
+        "head_sha",
+        "readiness_kind",
+        "status",
+    }
+    assert set(report["advisory"]) == {
+        "blocking_reviewers",
+        "bot_comments_readable",
+        "findings",
+        "stale_reviewers",
+        "unresolved_threads",
+    }
+
+
 def test_passed_aggregate_overrides_old_failures_and_advisory_threads() -> None:
     module = _load_script()
     payload = _pr_payload(


### PR DESCRIPTION
## Problem / Motivation

A babysit / `monitor_start` loop can only stop two ways today: the agent recognises success and calls `autonudge_stop`, or the loop runs out of `max_cycles`. There is no way to stop because *nothing is moving*.

That matters because a cap-stop and a finish are indistinguishable after the fact. Measured on a real loop store (`~/.kiro/crew/autonudge.json`, 4 loops, 84 delivered cycles, 14.9h wall clock, ~7.5h of model turn time): **4 of 4 loops ended at exactly their cap** — 24/24, 20/20, 28/28, 12/12 — with `stopped_reason` either empty or `cycle_cap`, and **0 of 4 carrying an agent-supplied stop reason**. None set `max_runtime_secs`, so cycle count was the only bound on spend.

So for each of those loops, either it converged early and then re-polled for nothing, or it never converged and quietly gave up with the work unresolved — and the store cannot say which.

There is also a smaller, concrete defect underneath: the loop's read step (`pr_status.py`) emits human prose only. Two cycles cannot be compared mechanically, the head SHA is printed truncated to 12 chars, and check rows can reorder between runs with no real change.

## Why it matters

Every author who babysits a PR pays for this twice: once for the wasted cycles after convergence, and once when a genuinely stuck PR is abandoned at the cap with nobody told what blocked it. The existing skill prose already said "the cap is not a finish line" — and compliance was 0 of 4, which is the evidence that guidance alone does not fix it. The loop needs a signal it can actually compute.

## What changed (motivation → approach → change)

**Goal:** let a loop stop because it is stuck, not only because it succeeded or ran out of rope.

**Approach.** A stall test needs a value that is stable when nothing happens and changes when something does. Findings and thread counts look like obvious inputs and are actively wrong ones: a finding you rebutted or deferred is re-raised every round (so a key including it never stabilises and a stall could never be recognised), the count also moves when a bot merely re-words a comment, and `unresolved_threads` degrades to `?`/null on any API error or page cap — which would read as progress. So rather than emit a flat object and document which fields to compare, the payload is *split*, making the safe comparison the easy one.

**What was built:**

- `pr_status.py --json` appends one compact, key-sorted object as the **last line of stdout** and changes nothing else — same exit codes, same prose above it. Serialization is a new pure `build_report()`; no decision logic moved.
- `progress_key` is the only part contracted as comparable: full 40-char `head_sha`, sorted `failing_checks`, `checks_failing`, `readiness_kind`, `exit_code`, and `status` — the verdict *reason*, because a merge conflict and a failing check are both exit `20` and can carry a byte-identical check set, so without it a changed blocker would extend a stall streak instead of resetting it.
- `advisory` carries the unstable fields the loop reads for its **exit conditions** but never compares: `unresolved_threads`, per-reviewer `findings`, `stale_reviewers`, `blocking_reviewers`.
- **Nothing else is emitted.** Ambient PR state (mergeable, merge state, review decision, check totals) stays in the prose above, which is where the skill's exit conditions already read it; a second machine-readable copy with no reader would be a surface to keep in sync for nothing. `test_report_emits_only_the_consumed_surface` pins the emitted key sets so this does not erode.
- **Bug fix:** `positional_args()` stripped only value-taking flags, so a bare `--json` stayed in the positional list and was read as the PR number — producing a malformed `gh pr view --json --json <fields>` call. It now drops no-value flags via `_BOOL_FLAGS`.
- The **babysit skill** gains the matching tripwire (3 byte-identical keys on settled cycles with no push ⇒ stop and escalate), requires a `max_runtime_secs` budget, and states that a no-signal cycle must not re-read bot bodies or job logs.

**Only a settled cycle counts toward the tripwire.** A running PR yields a byte-identical key every cycle *by construction* (`failing_checks` empty, `readiness_kind` `running`, `exit_code` 10), so counting those would fire the tripwire after roughly 15 minutes of ordinary CI on a repo where a single gate can legitimately run an hour. An exit-`10` cycle is therefore **skipped** rather than reset — resetting would let a PR flickering between running and blocked defer the tripwire forever. An endless wait is bounded by `max_runtime_secs`, not by this tripwire.

**The counter is persisted to a file, not held in session memory.** A stalled loop is exactly the long-running case that walks into compaction, which can summarise away the counter at the moment it matters — leaving the loop to coast to its cap, the very failure the tripwire exists to prevent. The file holds the key **and** the consecutive-match count, because storing only the last key would leave the streak itself in memory. It lives beside the loop's stop sentinel in the data home rather than in `TMPDIR`, which the OS reaps periodically — the same erasure as compaction with a different eraser. Nothing in the monitor engine observes the key today, so that file is the only durable record.

Why the skill and the script ship together: the tripwire is not executable until the script emits comparable state, and a skill instructing agents to compare a field the script does not emit would be its own defect. The six keys the skill documents are exactly the six `build_report()` emits.

Deliberately out of scope, and stated so the gaps are visible rather than implied: `max_runtime_secs` still defaults to unlimited at the tool boundary, the dashboard still discards a capped-out loop's row, and moving the streak counter into the loop store — which is what would make the stop *enforceable* rather than advisory — is backend work for a follow-up. `pr_status.py` is also the key's only emitter, so the tripwire is GitHub-only in practice until GitLab/Bitbucket gain one; the skill says so rather than implying cross-host coverage.

### One rider, declared

`.github/black-baseline.txt` loses one line: `src/kiro_crew/mcp_gateway/preflight.py`. That file is **not** otherwise touched here, and the removal is not a formatting change — it is a stale baseline entry. `preflight.py` became black-clean on main without its entry being pruned, and the graduation half of `check_black_formatting.py` is not diff-scoped, so it reddens every PR whose lint job runs until someone removes the line. It failed `Backend Lint & Type Check (3.10)` on this branch at head `8e42c07b8`; after rebasing onto current main the failure reproduced locally, confirming it is main-side rather than specific to this change. The fix is the gate's own `--update-baseline`, which only ever deletes lines, and it deleted exactly one. It cannot be moved to another PR without leaving this one red.

## Tests

10 new tests in `test/test_prepare_pr_status.py` (file total 60 passing):

- `--json` does not change the exit code — asserted on both a CLEAN (0) and a BLOCKED (20) fixture, which is the core contract.
- The report carries the **full 40-char** head SHA, not the truncated 12 the prose prints.
- A bare `--json` is not read as the PR number: asserts the auto-detect branch (`gh pr view --json number`) actually ran.
- The progress key is byte-identical across two runs of an unchanged PR.
- The progress key changes when the head moves.
- The progress key ignores the unresolved-thread count (3 vs `None` yields an identical key, while `advisory` still reports both).
- `failing_checks` is sorted and excludes passing checks.
- The report emits **only** the consumed surface — pins the top-level, `progress_key` and `advisory` key sets, so ambient state cannot be re-added without a reader.
- A **changed blocker changes the key** even with a byte-identical check set: a failing-check block and a merge-conflict block are compared, and the test also strips `status` to prove they collide without it — the false stall-streak completion the field prevents.

**Three revert-verified**, each failing for its named reason with the guard removed:
- Setting `_BOOL_FLAGS = ()` fails the flag test, and the failure output shows the exact malformed call `['gh','pr','view','--json','--json',<fields>]`.
- Admitting `unresolved_threads` into `progress_key` fails the stability test.
- Renaming `status` out of `progress_key` fails both the changed-blocker test and the key-set test.

## Manual verification

N/A — unit coverage sufficient. The changed surface is a stdlib CLI script whose only I/O is `gh` subprocess calls, which the tests stub, plus a prose-only skill file.

Gate results: 41 test files coupled to the diff (found by grepping the test tree for `builtin_skills|prepare_pr|babysit|pr_status`, including `test_builtin_skill_packaging`, `test_builtin_skill_sync_safety`, `test_skills`, `test_push_guard`, `test_autonudge`, `test_spawn_audit`) — **2844 passed, 0 failed**. `isort`, `flake8`, `tsc -b`, brand gate, harness-parity gate and docs-lint (213 markdown files) all clean. `mypy` 1.14.1 (matching the `pyproject.toml` pin) reports **0 errors on the changed file**; its single error is the pre-existing faiss-only one in `vector_memory.py`, which appears because the local venv has faiss installed and CI does not.

Two disclosures rather than claims:

1. The **full** 26k-test backend suite and the 21372-test frontend suite both ran green on identical diff content, with 75 failures A/B-proven pre-existing (reverting the three files produced the identical failing set — the branch-only delta was empty; they are host-environment: no Node, an old `jq`, faiss present, pty timeouts). A later full re-run did **not** complete locally: host load was 1.89/core on 16 cores from concurrent work. The coupled subset above was run instead. CI tests the merge ref, which closes that gap.
2. The local review gate (GPT `gpt-5.6-sol` mirroring `codex-review.yml`, Opus `claude-opus-4.8` mirroring `claude-review.yml` + base-ref AUTOSDE) ran on every pushed head. On the current head it raised one finding — that persisting only the key would still leave the streak count in session memory — which is fixed above, and Opus returned no findings.

<!-- no-visual-delta -->
**Why no screenshot:** no user-visible UI change — the diff touches a CLI script, its tests, and a skill markdown file; nothing renders in the browser.

## Related Issues

no linked issue: found while investigating why babysit loops were consuming budget without converging; the measurement above is the whole of the report.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
