### PR TITLE
fix(cron): charge a job's timeout to execution, not pool queue wait

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -25,6 +25,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import random
 import re
 import time
@@ -50,7 +51,7 @@ from kiro_crew import cron_script, platform_compat, sel, shutdown_event
 from kiro_crew.config.loader import KiroCrewConfig, config_dir, data_home
 from kiro_crew.constants import env_flag_enabled
 from kiro_crew.cron_history import CronHistoryStore, CronRunRecord
-from kiro_crew.executors import subprocess_executor
+from kiro_crew.executors import _CRON_QUEUE_WAIT_SECS, cron_gate_budget, subprocess_executor
 from kiro_crew.resource_status import admission_check
 from kiro_crew.validation import MAX_CRON_MESSAGE
 
@@ -121,6 +122,121 @@ _TIMER_POLL_SECS = 30  # check for due cron-expr jobs
 _AUTO_PAUSE_THRESHOLD = 5  # consecutive failures before a script/command cron auto-pauses
 _REAPER_INTERVAL = 60  # seconds between reaper sweeps
 _REAPER_RESET_TIMEOUT = 30.0  # max seconds for session reset in reaper
+
+
+def _pool_queue_allowance(job: CronJob | None) -> int:
+    """Queue budget a command/script job may spend before its own code runs.
+
+    Single-sourced deliberately. TWO deadlines bound one run -- the execution
+    guard in :meth:`CronService._execute_with_timeout` and the reaper's
+    defence-in-depth sweep -- and the cron pool's queue wait happens inside both.
+    If only one of them accounts for that wait, the other pre-empts it, and the
+    two failures are opposite and both silent: a reaper that does not account for
+    it cancels a job that never executed (a skipped run), while an execution
+    deadline that does not account for it kills a job still sitting in the pool
+    queue and reports it as an overrun (the misdiagnosis this change exists to
+    remove, which also lets a claimed subprocess run on while the overlap guards
+    clear). Deriving both from this one function is what keeps them from drifting.
+
+    Only command and script jobs dispatch through the pool to EXECUTE, so only
+    they need the allowance; a message job gets none and neither deadline is
+    widened for it. That scoping holds only because the one piece of pool work
+    every job kind shares -- the fire-time governance gate -- is dispatched to
+    the GOVERNANCE pool rather than this one. Gating on the cron pool would put
+    a message job's gate behind job-duration work while its deadline was already
+    armed, spending an execution budget it has no allowance to cover; the fix
+    for that belongs at the gate's dispatch, not in a wider deadline here, since
+    widening would also delay the wedged-delivery backstop for runs that never
+    queue at all. See the gate sites in slack/gateway.py.
+    """
+    if job is None:
+        return 0
+    return _CRON_QUEUE_WAIT_SECS if (job.command or job.script) else 0
+
+
+def _gate_budget_allowance(job: CronJob | None) -> int:
+    """Seconds the fire-time gate may consume inside a pool-dispatching job's deadline.
+
+    A third term of the same shape as :func:`_pool_queue_allowance`.  The gate is
+    awaited BEFORE the pool dispatch and inside the deadline armed for the whole
+    run, so a gate that spends its full bound leaves the subprocess that much
+    less -- and a thread cannot be interrupted, so when the deadline then fires
+    with a worker already claimed, the overlap guards clear while the subprocess
+    runs on and the next wake duplicates its side effects.  That is the hazard
+    ``_SUBPROC_CLEANUP_ALLOWANCE_SECS`` exists for; the queue wait was a second
+    term it did not account for, and the gate bound is a third.
+
+    Scoped to command/script for the same reason the queue allowance is: only
+    those dispatch through the pool to EXECUTE, so only they carry the
+    claimed-worker hazard.  A message job's budget is left exactly as set -- its
+    protection is that :func:`cron_gate_budget` lands strictly below the wake
+    deadline and is the gate's TOTAL across both its phases, so the gate's own
+    bound fires first and the run is retained.
+
+    Rounded UP to an int: the value is added to a deadline that reaches the
+    operator as ``Timed out after {deadline}s``, and a float would render there
+    as ``2.0s``.  Up is the safe direction -- it can only add headroom.
+    """
+    if job is None or not (job.command or job.script):
+        return 0
+    return math.ceil(cron_gate_budget(effective_wake_budget(job)))
+
+
+def _vet_allowance(job: CronJob | None) -> int:
+    """Seconds the CLAIM-TIME vet may consume inside a pool-dispatching job's deadline.
+
+    A FOURTH term of the same shape as the three above, and it exists for the
+    same reason :func:`_gate_budget_allowance` does.  The fire-time gate runs
+    ``vet_job_at_fire_time`` BEFORE the pool dispatch; the claim-time vet runs
+    the SAME function again INSIDE the worker, ahead of the subprocess it
+    authorises -- so it too is spent inside the deadline armed for the whole run,
+    and a vet that spends its bound leaves the subprocess that much less.  A
+    thread cannot be interrupted, so when the deadline then fires with the
+    subprocess already started, the overlap guards clear while it runs on and the
+    next wake duplicates its side effects.  That is the hazard
+    :data:`_SUBPROC_CLEANUP_ALLOWANCE_SECS` exists for; the queue wait was a
+    second term it did not account for, the gate bound a third, and this a
+    fourth.
+
+    Sized from :func:`_gate_budget_allowance` rather than from a second copy of
+    its expression: it is the same work under the same bound, and two copies
+    would drift.  The direction of drift matters -- an allowance SMALLER than the
+    bound the vet is actually held to is exactly the unaccounted margin this
+    closes.
+
+    Scoped to command/script for the reason the other two are: only those
+    dispatch through the pool to EXECUTE, so only they carry the claimed-worker
+    hazard.  A message job never reaches ``_vet_at_claim_then`` at all.
+    """
+    return _gate_budget_allowance(job)
+
+
+def effective_wake_budget(job: CronJob) -> int:
+    """Seconds :meth:`CronService._execute_with_timeout` will allow this run.
+
+    Extracted so the fire-time gate can cap its own bound against the same
+    number rather than re-deriving the rule.  A second copy would drift, and the
+    direction it drifts matters: a gate bound that exceeded the real wake budget
+    would let the wake deadline fire first, which is the state where starvation
+    is indistinguishable from an overrun and a one-shot gets consumed by a run
+    that never dispatched.
+
+    Returns an int: the value reaches the operator through
+    ``last_error = f"Timed out after {deadline}s"``, and a float would render
+    there as ``2.0s``.
+
+    A non-numeric ``timeout_secs`` falls back to the default rather than raising.
+    ``_execute_with_timeout`` was the only caller when this rule lived inline, so
+    a duck-typed job never reached the comparison; the fire-time gate now derives
+    its own bound from this and runs on every job kind, so the rule has to
+    tolerate a store entry (or a test double) whose field is not a number.
+    """
+    raw = getattr(job, "timeout_secs", None)
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return _JOB_TIMEOUT_SECS
+    return int(raw) if 1 <= raw <= 86400 else _JOB_TIMEOUT_SECS
+
+
 # Bound skip_date advancement by a WALL-CLOCK horizon rather than an iteration
 # count. An iteration cap couples the bound to schedule granularity: sized for a
 # weekly cron (old 52) it broke daily crons; re-sized for daily it would then
@@ -243,6 +359,16 @@ class CronJob:
     # loosening. Recurring jobs need neither: they wait for their next slot.
     # Reset at the start of every run.
     fire_time_denied: bool = False
+    # Runtime-only (never serialized): set by the gateway when THIS run never
+    # started because every pool worker was busy for the whole queue budget.
+    # Deliberately NOT fire_time_denied, even though both must retain a one-shot:
+    # that flag ALSO forces an "at" job disabled and is documented as a *policy*
+    # refusal, so reusing it would park a starved job needing an operator to
+    # re-enable it and would mislabel pool saturation as a governance denial in
+    # history. Starvation clears on its own, so this field is retention-only --
+    # read solely where a one-shot would otherwise be consumed by a run it never
+    # had. Reset at the start of every run.
+    run_never_started: bool = False
     last_result: str | None = None
     # Runtime-only (never serialized): True once THIS run produced a result
     # via set_run_result(). For AGENT jobs ``last_result`` is a cross-run
@@ -930,6 +1056,10 @@ class CronService:
                     max(min(job.timeout_secs, 86400), _JOB_TIMEOUT_SECS)
                     if job
                     else _JOB_TIMEOUT_SECS
+                ) + (
+                    _pool_queue_allowance(job)
+                    + _gate_budget_allowance(job)
+                    + _vet_allowance(job)
                 )
                 jitter_allowance = self._job_jitter.get(job_id, 0.0)
                 if elapsed <= deadline + jitter_allowance:
@@ -2886,25 +3016,51 @@ class CronService:
 
     async def _execute_with_timeout(self, job: CronJob) -> None:
         """Execute a job with a timeout guard."""
-        timeout = job.timeout_secs if 1 <= job.timeout_secs <= 86400 else _JOB_TIMEOUT_SECS
+        timeout = effective_wake_budget(job)
+        # The cron pool's QUEUE WAIT happens inside this deadline, so the wake
+        # budget has to cover it as well as the execution.  Excluding queue wait
+        # from the per-call `timeout=` kwarg (see run_in_cron_pool) is not enough
+        # on its own: without the term below, a job still sitting in the pool
+        # queue is killed here and reported as an execution overrun, which is the
+        # exact misdiagnosis this whole change exists to remove.  Worse, a thread
+        # cannot be interrupted -- so if a worker claimed the call as this
+        # deadline fired, the subprocess runs on while the overlap guards clear
+        # and the next wake duplicates its side effects.  That is the hazard
+        # _SUBPROC_CLEANUP_ALLOWANCE_SECS was written for, and the queue wait is
+        # a second term it never accounted for, and the fire-time gate's own bound
+        # is a third -- it is awaited before the dispatch and inside this same
+        # deadline, so _gate_budget_allowance covers it.  The CLAIM-time vet is a
+        # fourth: the same vet again, inside the worker, ahead of the subprocess
+        # it authorises -- so _vet_allowance covers it, and without that term a
+        # widened inner backstop in the gateway is simply pre-empted here.
+        # All three allowances are
+        # shared with the reaper so the two deadlines cannot drift and pre-empt
+        # one another.  Only command/script jobs go through the pool, so a
+        # message job's budget is left exactly as set.
+        deadline = (
+            timeout
+            + _pool_queue_allowance(job)
+            + _gate_budget_allowance(job)
+            + _vet_allowance(job)
+        )
         # Fresh run: no failure counted yet. The timeout handler below reads
         # this to avoid double-counting a run that already recorded its
         # failure and then overran the deadline during cleanup.
         job.failure_recorded = False
         try:
-            await asyncio.wait_for(self._execute(job), timeout=timeout)
+            await asyncio.wait_for(self._execute(job), timeout=deadline)
         except asyncio.TimeoutError:
             # NB: Timeout bypasses _cron_callback's except block entirely —
             # which also means it bypasses all Slack notification logic. Adding
             # a timeout Slack alert is a separate feature and is intentionally
             # out of scope here.
             # Clear failure dedup state so a subsequent real error isn't
-            # suppressed as a dup of the pre-timeout failure, but STILL count
-            # the timeout toward the auto-pause threshold: a job that times out
-            # on every run must eventually auto-pause instead of running forever
-            # with zero user signal.
+            # suppressed as a dup of the pre-timeout failure, and count the
+            # timeout toward the auto-pause threshold for a run that actually
+            # DISPATCHED: a job that times out on every run must eventually
+            # auto-pause instead of running forever with zero user signal.
             job.last_status = "error"
-            job.last_error = f"Timed out after {timeout}s"
+            job.last_error = f"Timed out after {deadline}s"
             job.last_run_ts = time.time()
             job.last_failure_hash = ""
             job.last_failure_at = 0.0
@@ -2912,9 +3068,22 @@ class CronService:
             # delivery-path exception followed by cleanup overrunning the
             # deadline): one failed run is one failure, whichever handler
             # observes it last.
-            if not job.failure_recorded:
+            #
+            # Skip it too when the payload NEVER STARTED. A stall that pushes
+            # wall clock past the wake deadline while the fire-time gate is
+            # still awaited cancels this coroutine AT that await, so no handler
+            # inside the gate runs and the marker set before it survives -- and
+            # the timeout lands here on a run that dispatched nothing. Counting
+            # it would auto-pause at _AUTO_PAUSE_THRESHOLD, and a paused job
+            # never fires again, so repeated event-loop saturation durably
+            # disables a job that has not run a line. This is the same
+            # discriminator the starvation, gate-deny and vet-overrun paths
+            # already use: a state that PREVENTED the run is not a defect OF
+            # the run. A genuine execution overrun still counts, because
+            # _execute resets the marker to False before invoking the callback.
+            if not job.failure_recorded and not job.run_never_started:
                 job.record_failure()
-            logger.error("Cron job '%s' timed out after %ds", job.name, timeout)
+            logger.error("Cron job '%s' timed out after %ds", job.name, deadline)
 
     async def _execute(self, job: CronJob) -> None:
         """Run the job callback and update runtime fields (last_run_ts, last_status)."""
@@ -2923,6 +3092,7 @@ class CronService:
         # "ok" decision below. Same for the fire-time denial marker.
         job.last_status = None
         job.fire_time_denied = False
+        job.run_never_started = False
         try:
             if self._on_job:
                 await self._on_job(job)
@@ -3019,7 +3189,12 @@ class CronService:
             # A fire-time-DENIED run is a policy refusal, not a completed run:
             # deleting the one-shot here would make the documented
             # resume-on-policy-loosening semantic impossible for at-jobs.
-            if job.delete_after_run and not job.fire_time_denied:
+            # A run that never STARTED is the same story for a different reason --
+            # every pool worker was busy for the whole queue budget -- so consuming
+            # the one-shot would destroy scheduled work that never got a chance to
+            # run. Only the delete is suppressed: unlike a policy denial this needs
+            # no operator action, so the job stays enabled and simply retries.
+            if job.delete_after_run and not (job.fire_time_denied or job.run_never_started):
                 self._jobs = [j for j in self._jobs if j.id != job.id]
             self._save()
 

--- a/src/kiro_crew/executors.py
+++ b/src/kiro_crew/executors.py
@@ -65,6 +65,7 @@ from typing import Any, Callable, TypeVar
 _T = TypeVar("_T")
 
 __all__ = [
+    "CronQueueTimeout",
     "maintenance_executor",
     "subprocess_executor",
     "cron_executor",
@@ -72,6 +73,12 @@ __all__ = [
     "embed_executor",
     "image_executor",
     "governance_executor",
+    "cron_gate_executor",
+    "CronGateTimeout",
+    "CronGateWorkTimeout",
+    "run_in_cron_pool",
+    "run_in_cron_gate_pool",
+    "cron_gate_budget",
     "run_in_embed_pool",
     "shutdown_maintenance_executor",
 ]
@@ -97,6 +104,15 @@ _MAX_SUBPROCESS_WORKERS = 8
 # thread starts, so this also caps how many concurrent cron subprocesses we hold
 # threads for; excess jobs queue here instead of starving anything else.
 _MAX_CRON_WORKERS = 4
+
+# How long a cron call may sit in the pool's queue before we give up and report
+# it as never-started.  Deliberately much larger than a typical job.timeout:
+# waiting behind a busy worker and then running is CORRECT, so this exists only
+# to bound the pathological case (a wedged job holding a worker indefinitely)
+# so an entry cannot sit un-failed forever.  Reaching it means the pool was
+# starved for a quarter of an hour, which is a fleet problem, not a job defect
+# -- and the distinct CronQueueTimeout text is what makes that legible.
+_CRON_QUEUE_WAIT_SECS = 900
 
 # Dashboard discovery scans (skills/agents/SOP listing) are read-only but can
 # take seconds on a large catalog, and each is browser-triggerable so several
@@ -130,6 +146,63 @@ _MAX_EMBED_WORKERS = 8
 # queues among ITSELF, never evicting the maintenance sweeps.
 _MAX_GOVERNANCE_WORKERS = 4
 
+# Cron FIRE-TIME governance gates get their OWN pool, deliberately not the
+# governance one above.  The distinction is who paces the queue: that pool is
+# driven by REMOTE senders (one submit per inbound message across five
+# transports, plus the dashboard GETs), so a burst of inbound traffic puts an
+# unbounded FIFO backlog ahead of a cron gate.  A cron gate is awaited INSIDE
+# the job's already-armed wake deadline, so a backlog it did not cause is
+# charged to the job's own execution budget -- and a message job carries no
+# _pool_queue_allowance to cover it, so the wake deadline can expire before the
+# job ever dispatches.  Here the only thing a cron gate queues behind is
+# another cron gate, which is self-paced by the schedule.
+_MAX_CRON_GATE_WORKERS = 4
+
+# Ceiling on how long a fire-time gate may spend QUEUED before we call it
+# starvation.  Unlike _CRON_QUEUE_WAIT_SECS this is small and is additionally
+# capped against the job's own wake budget at the call site: for the EXECUTION
+# pool, waiting past the budget and then running is the correct outcome, but a
+# gate that outlives the wake deadline is never useful -- the deadline kills the
+# run regardless, and the caller then cannot tell starvation from an overrun.
+# So the gate's bound must fire FIRST, which is what makes the run legible as
+# "never started" and keeps a one-shot from being consumed by a run that never
+# dispatched.
+_CRON_GATE_WAIT_SECS = 30
+
+# The gate's bound must land STRICTLY below the wake deadline, and a bare floor
+# cannot do that: max(1.0, ...) returns 1.0 for a 1s wake budget, so the two
+# coincide and the OUTER deadline wins the race -- the one state in which
+# starvation is indistinguishable from an overrun, which is how an undispatched
+# one-shot gets consumed.  Removing the floor instead is the opposite error: the
+# gate would get 0.25s at a 2s budget and could time out on a HEALTHY pool,
+# converting a job that would have run into a never-started one.  Both failures
+# are silent and point opposite ways, so keep the floor for budgets that can
+# afford it and clamp it against a fraction of the budget, which is what makes
+# "strictly below" hold for every budget rather than for typical ones.
+_CRON_GATE_MIN_SECS = 1.0
+_CRON_GATE_HEADROOM = 0.75
+
+# How the gate's single budget is DIVIDED between waiting for a worker and
+# running.  It has to be divided rather than handed to both phases, because
+# :func:`run_in_cron_pool` treats its two bounds as independent budgets --
+# *timeout* is charged to EXECUTION alone -- so passing one value to both spends
+# it twice and lets the gate run for 2x it.  The budget is already
+# :func:`cron_gate_budget`, sized to land strictly below the wake deadline, so a
+# gate that outran it put the DEADLINE first and neither phase bound was ever
+# reached: nothing raised, the caller's retention handler never ran, and a
+# one-shot was consumed by a run that never dispatched.  The two shares
+# therefore sum to exactly 1.0 and no more.
+#
+# Weighted toward EXECUTION deliberately.  Queueing is the cheap phase -- gates
+# queue only behind other gates, which the schedule paces, so a healthy claim
+# costs microseconds and the queue bound binds only under starvation.  Execution
+# is the useful work, and starving it is the OPPOSITE failure with an opposite
+# symptom: a claimed gate cut off near zero raises :class:`CronGateTimeout`, a
+# :class:`CronQueueTimeout` subclass, so the one-shot is RETAINED and never
+# fires.  A fixed share rather than "whatever the queue left over" is what makes
+# execution's slice a floor instead of a race.
+_CRON_GATE_QUEUE_SHARE = 0.25
+
 # Pillow work for the gateway's tool-result image budget is CPU-bound (a
 # decode plus up to seven LANCZOS resize+encode passes per oversized raster,
 # seconds each) and paced by whatever a brokered MCP server returns.  Two
@@ -146,6 +219,7 @@ _discovery_pool: ThreadPoolExecutor | None = None
 _embed_pool: ThreadPoolExecutor | None = None
 _image_pool: ThreadPoolExecutor | None = None
 _governance_pool: ThreadPoolExecutor | None = None
+_cron_gate_pool: ThreadPoolExecutor | None = None
 
 
 def maintenance_executor() -> ThreadPoolExecutor:
@@ -290,6 +364,307 @@ def governance_executor() -> ThreadPoolExecutor:
     return _governance_pool
 
 
+def cron_gate_executor() -> ThreadPoolExecutor:
+    """Return the process-wide cron fire-time gate pool, creating it on first use.
+
+    Threads are named ``mc-crongate``.  Separate from :func:`governance_executor`
+    because the two are paced by different things: that pool's rate is set by
+    remote senders, this one's by the cron schedule.  A cron gate awaited inside
+    an already-armed wake deadline must not queue behind an inbound-traffic
+    burst, so it queues among other cron gates instead.  See
+    :data:`_MAX_CRON_GATE_WORKERS`.
+    """
+    global _cron_gate_pool
+    if _cron_gate_pool is None:
+        with _lock:
+            if _cron_gate_pool is None:
+                _cron_gate_pool = ThreadPoolExecutor(
+                    max_workers=_MAX_CRON_GATE_WORKERS,
+                    thread_name_prefix="mc-crongate",
+                )
+                atexit.register(shutdown_maintenance_executor)
+    return _cron_gate_pool
+
+
+class CronQueueTimeout(asyncio.TimeoutError):
+    """A cron job never got a worker slot before its queue budget ran out.
+
+    Subclasses :class:`asyncio.TimeoutError` on purpose: a caller that has not
+    been taught about the queue phase still lands in its existing timeout
+    handling rather than raising something nothing catches.  Callers that DO
+    distinguish the two must order ``except CronQueueTimeout`` first.
+    """
+
+    def __init__(self, waited: float) -> None:
+        # Sub-second waits get decimals: `:.0f` floored a 0.3s wait to "queued
+        # 0s", which reads as "did not wait at all" and blunts the very
+        # diagnostic this exception exists to carry.
+        shown = f"{waited:.2f}" if waited < 10 else f"{waited:.0f}"
+        super().__init__(f"queued {shown}s, never ran")
+        self.waited = waited
+
+
+class CronGateTimeout(CronQueueTimeout):
+    """A fire-time gate exhausted its own EXECUTION bound without a verdict.
+
+    Subclasses :class:`CronQueueTimeout` deliberately.  The gate's two bounds
+    mean the same thing to a caller -- no verdict was reached, so the run never
+    got to its dispatch decision -- and the callers already translate
+    ``CronQueueTimeout`` into the ``run_never_started`` retention marker.  Making
+    this a subclass is what reaches that handler WITHOUT widening it to every
+    :class:`asyncio.TimeoutError`, which would also swallow
+    :class:`CronGateWorkTimeout` below and retain a job that did reach its
+    decision.
+    """
+
+    def __init__(self, waited: float) -> None:
+        shown = f"{waited:.2f}" if waited < 10 else f"{waited:.0f}"
+        # Deliberately NOT the "queued ..., never ran" wording: this call DID get
+        # a worker, so reporting it as queued would misdescribe the fault.
+        Exception.__init__(self, f"ran {shown}s without a verdict")
+        self.waited = waited
+
+
+class CronGateWorkTimeout(asyncio.TimeoutError):
+    """The gate's own work raised a timeout -- it reached its work and failed there.
+
+    Still an :class:`asyncio.TimeoutError` so any caller that already handles
+    timeouts is unaffected, but deliberately NOT a :class:`CronQueueTimeout`: the
+    gate got a worker and ran, so this is a failed dispatch DECISION, not a run
+    that never started.  Marking it never-started would retain a job whose gate
+    did execute, which is the opposite error to the one
+    :class:`CronGateTimeout` fixes.
+    """
+
+
+async def run_in_cron_pool(
+    func: Callable[..., _T],
+    /,
+    *args: Any,
+    timeout: float,
+    queue_timeout: float | None = None,
+    executor: ThreadPoolExecutor | None = None,
+) -> _T:
+    """Run *func* on :func:`cron_executor`, charging *timeout* to EXECUTION only.
+
+    ``loop.run_in_executor`` only SUBMITS work.  The cron pool is bounded at
+    ``_MAX_CRON_WORKERS``, so when every worker is busy the call sits in the
+    pool's queue having run no code at all -- yet ``asyncio.wait_for`` starts
+    its stopwatch the moment it is awaited.  Timing the whole await therefore
+    spends the job's own budget on queue wait and kills jobs that never ran a
+    line, reporting them as if the job itself had overrun.
+
+    So wait for a worker to actually pick the call up FIRST, untimed by
+    *timeout*, and only then apply *timeout* to the execution.  A job delayed
+    by transient contention now runs instead of dying.
+
+    The two phases fail differently, which is the other half of the point: a
+    pool starved for the whole *queue_timeout* raises
+    :class:`CronQueueTimeout` (``queued Ns, never ran``) rather than
+    masquerading as N separate jobs that each overran.
+
+    A call a worker claims right AT the deadline is routed to the execution
+    phase rather than reported as a queue timeout.  It really did get a worker,
+    and a thread cannot be interrupted, so calling it "never ran" would both
+    misreport it and free the caller to start an overlapping run beside the one
+    still executing.
+
+    *queue_timeout* defaults to :data:`_CRON_QUEUE_WAIT_SECS`.  It is
+    deliberately NOT derived from *timeout*: a 30s job behind a wedged worker
+    should wait well past 30s and then run, not be killed on its own clock for
+    something it did not do.
+
+    *executor* defaults to :func:`cron_executor`.  It exists so the fire-time
+    gate can reuse this two-phase discipline on its own pool
+    (:func:`run_in_cron_gate_pool`) rather than carry a second copy of it: only
+    the CONCURRENT future's ``cancel()`` can tell queued from claimed, and that
+    is the subtle part worth having in one place.
+    """
+    loop = asyncio.get_running_loop()
+    if queue_timeout is None:
+        queue_timeout = _CRON_QUEUE_WAIT_SECS
+    started: asyncio.Future[None] = loop.create_future()
+
+    def _mark_started() -> None:
+        # May already be cancelled if the queue budget expired in the meantime.
+        if not started.done():
+            started.set_result(None)
+
+    def _signal_then_run() -> _T:
+        loop.call_soon_threadsafe(_mark_started)
+        return func(*args)
+
+    # submit() + wrap_future() is precisely what run_in_executor does
+    # internally; spelled out here to keep a reference to the CONCURRENT
+    # future.  Only its cancel() reports whether a worker had already claimed
+    # the call: the asyncio wrapper's cancel() returns True either way, because
+    # it cancels the wrapper locally while the worker thread runs on.
+    call = (executor or cron_executor()).submit(_signal_then_run)
+    fut = asyncio.wrap_future(call, loop=loop)
+    queued_at = loop.time()
+    deadline = queued_at + queue_timeout
+    while not started.done():
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        try:
+            # shield: a wait_for timeout cancels whatever it was waiting on,
+            # and this future has to survive to be waited on again.
+            await asyncio.wait_for(asyncio.shield(started), timeout=remaining)
+        except asyncio.TimeoutError:
+            # A wake is NOT proof the deadline passed.  BaseEventLoop._run_once
+            # dispatches a timer once `handle._when < time() + _clock_resolution`,
+            # so it may fire up to one clock resolution EARLY -- 15.6ms on
+            # Windows, ~0 on Linux.  Re-check the deadline instead of trusting
+            # it, which is what makes `waited >= queue_timeout` hold by
+            # construction rather than by tolerance.
+            pass
+        except asyncio.CancelledError:
+            # The shield above absorbs a cancel so `started` survives to be
+            # re-waited, which also means a caller cancelling this coroutine
+            # would otherwise escape with the call still sitting in the pool
+            # queue -- it would then run long after the caller gave up.  Cancel
+            # the submitted call before re-raising; that is a no-op once a
+            # worker has claimed it, so a job already in flight is never killed.
+            call.cancel()
+            raise
+    if not started.done() and call.cancel():
+        # Raise only when the cancel WON.  On the concurrent future that means
+        # no worker had claimed the call, which is the one case where "never
+        # ran" is true.  `started` cannot decide it alone: _mark_started is
+        # delivered by call_soon_threadsafe, so it trails the worker's real
+        # claim and still reads False for a call that is already executing.
+        raise CronQueueTimeout(loop.time() - queued_at)
+    # Cancel lost, so a worker claimed the call and it IS running.  A thread
+    # cannot be interrupted, so it will run to completion whatever we report --
+    # and reporting a queue timeout here would release the caller's overlap
+    # guard while the command runs, letting the next fire duplicate its side
+    # effects.  It got a worker, so it belongs in the execution phase, bounded
+    # by `timeout` exactly as a call claimed a millisecond earlier would be.
+    return await asyncio.wait_for(fut, timeout=timeout)
+
+
+def cron_gate_budget(wake_budget: float) -> float:
+    """Total seconds a fire-time gate may spend queued, given the job's wake budget.
+
+    Capped against the wake budget on purpose, and this is the one place the
+    codebase derives a queue bound from the caller's own clock -- the opposite of
+    :func:`run_in_cron_pool`'s default, for a stated reason.  There, waiting past
+    the budget and then running is the outcome you want.  Here the gate is
+    awaited INSIDE the already-armed wake deadline, so a gate that outlives that
+    deadline cannot help: the deadline kills the run either way, and the caller
+    is then left unable to distinguish starvation from a genuine overrun -- which
+    is exactly the state in which a ``delete_after_run`` job is consumed by a run
+    that never dispatched.  Bounding below the wake budget makes the gate's own
+    bound fire first, so the run is reported as never-started and retained.
+
+    A quarter of the budget leaves the remaining three quarters for the dispatch
+    the gate is a precondition for.
+
+    The result is STRICTLY below *wake_budget* for every positive budget, which
+    the previous ``max(1.0, ...)`` floor did not achieve: at a 1s budget it
+    returned 1.0, so the gate and the wake deadline expired together and the
+    outer one won.  The floor is kept for budgets that can afford it -- dropping
+    it entirely would hand a 2s job a 0.5s gate and time out on a healthy pool --
+    and is clamped by :data:`_CRON_GATE_HEADROOM` so the ordering holds anyway.
+    """
+    if wake_budget <= 0:
+        return 0.0
+    preferred = min(float(_CRON_GATE_WAIT_SECS), max(_CRON_GATE_MIN_SECS, wake_budget / 4.0))
+    return min(preferred, wake_budget * _CRON_GATE_HEADROOM)
+
+
+async def run_in_cron_gate_pool(func: Callable[..., _T], /, *args: Any, timeout: float) -> _T:
+    """Run a cron fire-time gate on :func:`cron_gate_executor`, bounded both ways.
+
+    Two changes from awaiting ``run_in_executor`` directly, which is what the
+    gate sites used to do:
+
+    * the gate no longer shares a pool with externally-paced inbound traffic, so
+      an inbound burst cannot put a FIFO backlog ahead of it; and
+    * the wait is BOUNDED, raising :class:`CronQueueTimeout` when the gate never
+      got a worker, which is the signal the callers translate into a
+      retention marker so an undispatched one-shot is not consumed.
+
+    *timeout* is the gate's TOTAL, split across the two phases by
+    :data:`_CRON_GATE_QUEUE_SHARE` rather than handed to each of them: for a
+    policy check there is no equivalent of "wait a long time, then run" -- a
+    verdict that arrives after the wake deadline is worthless either way -- and
+    ``run_in_cron_pool`` charges *timeout* to EXECUTION alone, so giving it to
+    both bounds spent the budget twice and let the gate outlive the very deadline
+    it was sized to stay inside.  Abandoning a CLAIMED gate is safe in a way
+    abandoning a claimed command is not: the gate dispatches no job work, so
+    nothing duplicates.  The residual is audit noise only -- a gate thread that
+    completes after we stopped waiting may still emit its SEL
+    ``governance_decision`` for a run that then did not dispatch.
+
+    Which exception surfaces matters, because the callers key the retention
+    marker off it.  ``run_in_cron_pool`` raises :class:`CronQueueTimeout` for the
+    queue phase but a PLAIN :class:`asyncio.TimeoutError` for the execution
+    phase, so a gate that got a worker and then overran its bound bypassed the
+    callers' ``except CronQueueTimeout`` entirely and its one-shot was consumed.
+    The execution bound is therefore re-raised as :class:`CronGateTimeout`, a
+    subclass, so it reaches that handler.  A timeout raised from INSIDE the
+    gate's own work is wrapped as :class:`CronGateWorkTimeout` in the worker
+    thread first, so it can never be mistaken for this bound -- that one is a
+    failed dispatch decision, not a run that never started.
+    """
+
+    def _guard_gate_work(*args: Any) -> _T:
+        try:
+            return func(*args)
+        except CronGateWorkTimeout:
+            raise
+        except asyncio.TimeoutError as exc:
+            # Wrapped in the WORKER THREAD, before the bound below can see it:
+            # asyncio.TimeoutError is builtins.TimeoutError on 3.11+, so a socket
+            # or subprocess timeout inside a governance check is otherwise
+            # type-identical to our own bound expiring.
+            raise CronGateWorkTimeout(str(exc) or repr(exc)) from exc
+        except TimeoutError as exc:
+            # The SAME wrapping, as a second clause, because that 3.11+ identity is
+            # a premise and not a given. Measured: on 3.10 -- which is in this
+            # repo's CI matrix -- asyncio.TimeoutError is a DISTINCT class from
+            # builtins.TimeoutError, so the clause above cannot see the plain
+            # TimeoutError that a store or socket read raises there (socket.timeout
+            # aliases it from 3.10 on), and the raw error escaped the gate
+            # unwrapped: no CronGateWorkTimeout, and the caller could not tell a
+            # failed dispatch DECISION from a bound expiring. On 3.11+ the two
+            # classes are one, so this clause is simply unreachable there.
+            #
+            # A separate clause rather than `except (asyncio.TimeoutError,
+            # TimeoutError)`: under --target-version py314 black rewrites
+            # `except (A, B):` into PEP 758's `except A, B:`, a SyntaxError on
+            # <=3.13 -- that is, on the exact interpreter this clause exists for.
+            raise CronGateWorkTimeout(str(exc) or repr(exc)) from exc
+
+    queued_at = asyncio.get_running_loop().time()
+    # Split, not duplicated -- see :data:`_CRON_GATE_QUEUE_SHARE`.  The two bounds
+    # sum to exactly *timeout*, so the gate's TOTAL stays inside the budget that
+    # was sized to land below the wake deadline; subtracting rather than scaling
+    # the second share is what keeps that sum exact.
+    queue_bound = timeout * _CRON_GATE_QUEUE_SHARE
+    try:
+        return await run_in_cron_pool(
+            _guard_gate_work,
+            *args,
+            timeout=timeout - queue_bound,
+            queue_timeout=queue_bound,
+            executor=cron_gate_executor(),
+        )
+    except CronQueueTimeout:
+        # Queue starvation already carries the right type and wording.
+        raise
+    except CronGateWorkTimeout:
+        # The gate's own work failing must stay distinguishable from the bound.
+        # Kept as a separate clause rather than a tuple: under --target-version
+        # py314 black rewrites `except (A, B):` to PEP 758's `except A, B:`, which
+        # the interpreters this still runs on cannot parse.
+        raise
+    except asyncio.TimeoutError as exc:
+        raise CronGateTimeout(asyncio.get_running_loop().time() - queued_at) from exc
+
+
 async def run_in_embed_pool(func: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
     """Run a blocking Ollama embed/probe callable on :func:`embed_executor`.
 
@@ -304,7 +679,7 @@ async def run_in_embed_pool(func: Callable[..., _T], /, *args: Any, **kwargs: An
 def shutdown_maintenance_executor() -> None:
     """Shut down all maintenance pools if they were created.  Idempotent."""
     global _pool, _subprocess_pool, _cron_pool, _discovery_pool, _embed_pool
-    global _governance_pool, _image_pool
+    global _governance_pool, _image_pool, _cron_gate_pool
     with _lock:
         pool, _pool = _pool, None
         subprocess_pool, _subprocess_pool = _subprocess_pool, None
@@ -313,6 +688,7 @@ def shutdown_maintenance_executor() -> None:
         embed_pool, _embed_pool = _embed_pool, None
         governance_pool, _governance_pool = _governance_pool, None
         image_pool, _image_pool = _image_pool, None
+        cron_gate_pool, _cron_gate_pool = _cron_gate_pool, None
     if pool is not None:
         pool.shutdown(wait=False, cancel_futures=True)
     if subprocess_pool is not None:
@@ -327,3 +703,5 @@ def shutdown_maintenance_executor() -> None:
         governance_pool.shutdown(wait=False, cancel_futures=True)
     if image_pool is not None:
         image_pool.shutdown(wait=False, cancel_futures=True)
+    if cron_gate_pool is not None:
+        cron_gate_pool.shutdown(wait=False, cancel_futures=True)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -80,7 +80,14 @@ from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.constants import DATA_WARNING, SUBAGENT_COMPLETION_META_KEY
 from kiro_crew.context import ContextBuilder
 from kiro_crew.context_management import summarize_result
-from kiro_crew.cron import CronJob, CronService, CronStoreBusy, build_cron_session_context
+from kiro_crew.cron import (
+    _SUBPROC_CLEANUP_ALLOWANCE_SECS,
+    CronJob,
+    CronService,
+    CronStoreBusy,
+    build_cron_session_context,
+    effective_wake_budget,
+)
 from kiro_crew.cron_script import run_command_sandboxed, run_script_sandboxed
 from kiro_crew.dashboard import cautious_boot, start_dashboard
 from kiro_crew.dashboard.chat_persistence import rehydrate_slot_from_history_async
@@ -130,8 +137,11 @@ from kiro_crew.embeddings import (
     start_background_model_download,
 )
 from kiro_crew.executors import (
-    cron_executor,
+    CronQueueTimeout,
+    cron_gate_budget,
     maintenance_executor,
+    run_in_cron_gate_pool,
+    run_in_cron_pool,
     run_in_embed_pool,
     subprocess_executor,
 )
@@ -759,6 +769,298 @@ def _apply_gate_verdict(job: CronJob, tally: _GateTally) -> bool:
     job.last_failure_at = 0.0
     job.record_success()
     return False
+
+
+async def _await_cron_fire_time_gate(
+    job: CronJob, *, tool_name: str, tool_kind: str
+) -> tuple[str | None, bool]:
+    """Await the fire-time governance gate, bounded, returning ``(reason, starved)``.
+
+    The gate used to be awaited as a bare ``run_in_executor`` on the shared
+    governance pool, with no timeout of its own, INSIDE the wake deadline
+    ``_execute_with_timeout`` has already armed.  Two things followed, and a
+    review lane raised both:
+
+    * that pool is paced by REMOTE senders, so an inbound burst put an unbounded
+      FIFO backlog ahead of a cron gate; and
+    * a message job carries no ``_pool_queue_allowance``, so the whole backlog
+      was charged to its execution budget.  When the wake deadline expired
+      first, ``_execute_with_timeout`` caught the ``TimeoutError`` and returned
+      normally, so ``_merge_job_result`` saw an ordinary finished run -- and a
+      ``delete_after_run`` job was consumed by a run that never dispatched.
+
+    The gate now runs on its own pool and its TOTAL wait -- queue plus execution,
+    which is why the budget is split across those phases rather than given to
+    each -- is bounded below the wake budget, so starvation surfaces as
+    ``CronQueueTimeout`` BEFORE the deadline can fire.  That is what makes the
+    retention marker reachable: ``starved`` is reported to the caller and
+    ``run_never_started`` is set here, which ``cron.py``'s delete site already
+    honours.  The marker is deliberately not
+    ``fire_time_denied`` -- that flag also parks an at-job disabled and records
+    the event as a policy denial, and pool capacity is neither.
+
+    ``record_failure()`` is deliberately NOT called, matching both the deny path
+    and the command/script starvation handlers: a fleet-capacity state must not
+    auto-pause a job that never ran a line.
+    """
+    budget = cron_gate_budget(effective_wake_budget(job))
+    # Default to RETAIN for exactly the duration of the await.  The marker used to
+    # be set only INSIDE the handler below -- that is, only when the await raised
+    # something that handler catches.  A recoverable event-loop stall can carry
+    # wall clock past the gate's own bounds AND the wake deadline, and the
+    # ``asyncio.wait_for`` in ``_execute_with_timeout`` then cancels this coroutine
+    # AT the await: no handler runs, the marker stays False, that timeout is caught
+    # and returns normally, and ``_merge_job_result`` consumes a
+    # ``delete_after_run`` job that never dispatched.  Sizing the internal bounds
+    # correctly cannot prevent it, because nothing inside the call is scheduled to
+    # notice.  ``CancelledError`` is a ``BaseException`` on both interpreters in
+    # this matrix, so it escapes the ``except Exception`` below and the marker
+    # survives -- which is the fix.
+    job.run_never_started = True
+    try:
+        reason = await run_in_cron_gate_pool(vet_job_at_fire_time, job, timeout=budget)
+    except CronQueueTimeout as exc:
+        # Scoped exactly as _run_job_isolated's own result-less clear
+        # (cron.py:2852). For an agent/message job ``last_result`` is the
+        # cross-run dedup context build_cron_session_context prepends as "do
+        # NOT repeat", and a run starved here produced no result to replace it
+        # -- clearing it made the NEXT run repeat content it had already sent.
+        # Command and script jobs still clear: the prompt built for them is
+        # discarded, so a carried value could only show a previous run's output
+        # beside this run's status. The message fire-time deny path below never
+        # clears either, so all three sites now agree.
+        if job.command or job.script:
+            job.clear_carried_result()
+        job.last_status = "error"
+        # Distinct from the pool-starvation text so the two are not conflated:
+        # this run never even reached its own dispatch decision.
+        job.last_error = f"fire-time gate {exc}"
+        # Already True from above; kept so this handler still reads correctly on
+        # its own and a later reordering cannot silently drop the retention.
+        job.run_never_started = True
+        try:
+            sel().log_tool_invocation(
+                session_key=f"cron:{job.id}",
+                tool_name=tool_name,
+                tool_kind=tool_kind,
+                outcome="error",
+                error=job.last_error,
+            )
+        except Exception:
+            logger.debug("SEL logging failed in cron fire-time gate starvation path", exc_info=True)
+        return None, True
+    except Exception:
+        # The gate reached its own WORK and failed there -- a failed dispatch
+        # DECISION, not a run that never started.  Clearing preserves the very
+        # distinction :class:`CronGateWorkTimeout` was introduced to make.
+        job.run_never_started = False
+        raise
+    # A verdict came back, so this run reached its dispatch decision.  Clearing is
+    # not optional: hold the marker past a verdict and a HEALTHY one-shot is
+    # retained instead, so it fires again or never leaves the queue -- the same
+    # data-integrity failure pointing the other way.  A DENY clears it too, because
+    # its retention is owned by ``fire_time_denied``, whose readers also park an
+    # at-job disabled; conflating them would park a job for a policy decision that
+    # was never made.
+    job.run_never_started = False
+    return reason, False
+
+
+class CronClaimTimeDenied(Exception):
+    """Governance refused the job when the worker CLAIMED its execution.
+
+    Distinct from the fire-time deny, which happens before the execution is
+    submitted at all.  Deliberately a plain ``Exception``: it must not be caught
+    by the :class:`CronQueueTimeout` clause (whose retention semantics are for
+    runs that never got a worker) nor by ``asyncio.TimeoutError``, and it must
+    be handled BEFORE the generic ``except Exception`` arm, which calls
+    ``record_failure()`` and would feed a policy decision into the auto-pause
+    counter.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class CronClaimAbandoned(Exception):
+    """The awaiter gave up before the worker reached the payload, so it must not run.
+
+    Deliberately NOT a :class:`CronClaimTimeDenied` subclass -- an abandoned call
+    is a deadline, not a policy decision, and recording it as a denial would
+    misreport it.  Deliberately NOT a :class:`CronQueueTimeout` or
+    ``asyncio.TimeoutError`` subclass either: by the time this is raised the
+    awaiter has already left, so nothing catches it and it exists to say in the
+    logs which of the two timeout shapes happened.
+    """
+
+
+class _ClaimHandoff:
+    """Serialises a worker starting its payload against its awaiter giving up.
+
+    :func:`run_in_cron_pool` reaches its execution phase only once a worker has
+    CLAIMED the call, and a thread cannot be interrupted -- so when that phase
+    times out the submitted callable keeps running.  That was tolerable while
+    the claimed thread was already inside the sandbox, whose own ``timeout``
+    bounds it.  With the claim-time vet the vet runs FIRST, so the deadline can
+    land while the payload has not started, and it would then start after the
+    caller's ``finally`` released the overlap guard -- running alongside the
+    next fire.  ``run_in_cron_pool``'s own docstring names that harm for the
+    queue phase ("reporting a queue timeout here would release the caller's
+    overlap guard while the command runs, letting the next fire duplicate its
+    side effects"); this closes the same hole for a deadline landing mid-vet.
+
+    The lock is what makes the outcome DETERMINISTIC rather than a race.
+    Exactly one of :meth:`claim` and :meth:`abandon` observes an unset flag, so
+    a payload either starts -- and is reported as still running, which is the
+    pre-existing claimed-and-running case -- or never starts at all.  Without
+    it ``claim`` could read an unset flag that ``abandon`` sets an instant
+    later, and the refusal would silently not happen.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._abandoned = False
+        self._started = False
+
+    def abandon(self) -> bool:
+        """Record that the awaiter gave up; True if the payload had already started.
+
+        Idempotent, because the ``finally`` that releases the overlap guard runs
+        on every exit path including the ones that already called this.
+        """
+        with self._lock:
+            self._abandoned = True
+            return self._started
+
+    def claim(self) -> bool:
+        """Ask permission to start the payload.  False means refuse."""
+        with self._lock:
+            if self._abandoned:
+                return False
+            self._started = True
+            return True
+
+
+class CronVetOverran(Exception):
+    """The claim-time vet spent more than the allowance the deadline carries for it.
+
+    Starting the payload anyway is the harm: the remaining budget no longer
+    covers the subprocess bound plus
+    :data:`~kiro_crew.cron._SUBPROC_CLEANUP_ALLOWANCE_SECS`, so the deadline
+    would fire with the subprocess already running -- and a thread cannot be
+    interrupted, so the overlap guard would clear while it runs on and the next
+    fire would duplicate its side effects.  Refusing before the payload starts
+    trades a reported missed run for a silent duplicate execution.
+
+    Deliberately NOT a :class:`CronClaimTimeDenied` subclass -- an overrun is a
+    budget fact, not a policy decision, and recording it as a denial would park
+    an at-job disabled for a decision never made.  Deliberately NOT a
+    :class:`CronQueueTimeout` subclass either: that arm reports "never got a
+    worker slot", which a vet that ran for its full bound plainly did.
+    """
+
+    def __init__(self, elapsed: float, bound: float) -> None:
+        super().__init__(f"claim-time vet took {elapsed:.2f}s of a {bound:.2f}s allowance")
+        self.elapsed = elapsed
+        self.bound = bound
+
+
+def claim_vet_bound(job: CronJob) -> float:
+    """Seconds the claim-time vet may spend before its payload must be refused.
+
+    The same bound the FIRE-time gate is held to for the same
+    ``vet_job_at_fire_time`` work, so the two do not drift, and the number
+    ``kiro_crew.cron._vet_allowance`` adds to the run deadline.  Read from
+    :func:`cron_gate_budget` rather than kept as a literal, which is what makes
+    the widened backstop below a guarantee instead of a hope.
+    """
+    return cron_gate_budget(effective_wake_budget(job))
+
+
+def _claim_backstop(job: CronJob, subprocess_bound: int) -> float:
+    """The inner ``run_in_cron_pool`` bound: subprocess + teardown + vet.
+
+    One budget covers all three serially, so each needs a term.  ``+ 5`` used to
+    be written here as a literal duplicate of
+    :data:`~kiro_crew.cron._SUBPROC_CLEANUP_ALLOWANCE_SECS`; reading the constant
+    keeps the teardown margin single-sourced, and adding
+    :func:`claim_vet_bound` stops the vet spending the teardown's share of it.
+    """
+    return subprocess_bound + _SUBPROC_CLEANUP_ALLOWANCE_SECS + claim_vet_bound(job)
+
+
+def _vet_at_claim_then(
+    handoff: _ClaimHandoff, job: CronJob, fn: Callable[..., Any], *args: Any
+) -> Any:
+    """Re-vet inside the worker, immediately before the execution it authorises.
+
+    The fire-time gate authorises a run and then the execution is submitted to
+    the cron pool, whose queue wait is deliberately NOT charged to the job's
+    deadline (that uncharging is this change's sibling and the point of the
+    surrounding work).  So the authorisation and the use it authorises are
+    separated by a wait bounded only by ``_CRON_QUEUE_WAIT_SECS`` -- and both
+    inputs to the decision can change inside it:
+
+    * a script's BODY, because ``run_script_sandboxed``'s launcher re-reads the
+      file in the sandboxed child (``open`` + ``compile`` + ``exec``), so the
+      bytes that run are whatever is on disk when the worker gets there, not
+      the bytes the gate scanned;
+    * the governance POLICY, which applies to ``command`` jobs too even though
+      a command's text is already captured in ``job.command``.
+
+    Running the vet here closes that window to nil: the queue wait now happens
+    BEFORE the decision, and the decision holds at the moment of use.
+
+    This is deliberately an ADDITIONAL vet, not a moved one.  Keeping the
+    fire-time gate means a denial is still refused early and cheaply, without
+    occupying a cron worker for the queue's duration, and it leaves the gate's
+    starvation/retention plumbing (``gate_starved`` ->
+    ``run_never_started``) untouched.  The cost is one extra governance
+    evaluation, and for scripts one extra capped body read, per EXECUTED run.
+    That work runs inside a worker this job already holds, so unlike gating on
+    this pool it puts no policy check behind other jobs' queue -- the property
+    the governance-pool split at the call sites protects.  It does count against
+    the ``+5s`` backstop the call sites arm, which is why the vet must stay
+    short and bounded.
+
+    Consequence for the audit trail, by design: an EXECUTED command/script run
+    now leaves TWO ``governance_decision`` events per gate (gate time and claim
+    time) rather than one.  They are genuinely distinct decisions -- the second
+    is the one that authorised the bytes that ran -- and
+    ``vet_job_at_fire_time`` already audits every decision "in its own right so
+    the SEL trail shows every permission decision that authorized this
+    execution".  A reader counting events per run should expect the pair.
+
+    Because the vet now runs BEFORE the payload inside the same budget, the
+    caller's deadline can land while the vet is still going -- with the payload
+    not yet started.  ``handoff`` is what stops that call dispatching anyway
+    once the caller has given up and released its overlap guard; see
+    :class:`_ClaimHandoff`.  The check sits immediately before the dispatch and
+    nowhere earlier on purpose: the vet itself takes time, so a check made
+    before it would be stale by the time it mattered.
+
+    The vet is also BOUNDED here rather than merely asked to "stay short".  The
+    caller's backstop carries an allowance for it (:func:`_claim_backstop`), and
+    an allowance is only a guarantee if the thing it covers cannot exceed it --
+    so a vet that overruns refuses its payload instead of starting one whose
+    remaining margin no longer covers the subprocess and its teardown.  Measured
+    on ``monotonic`` so a clock adjustment cannot make an overrun look fine.
+    """
+    started_at = time.monotonic()
+    reason = vet_job_at_fire_time(job)
+    if reason:
+        raise CronClaimTimeDenied(reason)
+    elapsed = time.monotonic() - started_at
+    bound = claim_vet_bound(job)
+    if elapsed > bound:
+        raise CronVetOverran(elapsed, bound)
+    if not handoff.claim():
+        raise CronClaimAbandoned(
+            f"cron '{job.name}': awaiter gave up during the claim-time vet; "
+            "payload refused rather than run beside the next fire"
+        )
+    return fn(*args)
 
 
 async def _cron_stream_with_posttoken_resume(
@@ -2529,6 +2831,11 @@ class GatewayOrchestrator:
             # ── Command mode: direct shell execution (sandboxed) ──
             if job.command:
                 self._running_script_ids.add(job.id)
+                # Bound to the overlap guard's own lifetime, and created HERE rather
+                # than at the submit below so the ``finally`` that releases the guard
+                # can always reach it -- including on the fire-time deny paths that
+                # return before anything is submitted.
+                handoff = _ClaimHandoff()
                 try:
                     try:
                         sel().log_tool_invocation(
@@ -2552,9 +2859,30 @@ class GatewayOrchestrator:
                     # Off-loop: the script variant of this gate reads the script
                     # file from disk, and governance profile resolution can touch
                     # the filesystem too — neither may block the event loop.
-                    gate_reason = await asyncio.get_running_loop().run_in_executor(
-                        cron_executor(), vet_job_at_fire_time, job
+                    #
+                    # On the GOVERNANCE pool, deliberately NOT the cron pool. This
+                    # await sits inside the deadline _execute_with_timeout arms
+                    # BEFORE the callback runs, so whatever this gate waits for is
+                    # charged to the job's own execution budget. The cron pool is
+                    # bounded at _MAX_CRON_WORKERS and its workers are held for a
+                    # whole job's DURATION, so gating there puts a short policy
+                    # check behind however many long-running command/script jobs
+                    # currently occupy it -- and a job whose budget is spent that
+                    # way is killed having run no code, reported as an overrun,
+                    # and (if delete_after_run) deleted without ever dispatching.
+                    # The governance pool holds only short, bounded policy work,
+                    # which is what makes the residual wait here proportionate.
+                    #
+                    # The alternative -- widening every job's deadline by the pool
+                    # allowance instead -- is the wrong lever twice over: it would
+                    # delay the wedged-delivery backstop by that allowance for
+                    # runs that never queue, and it would leave THIS wait
+                    # unbounded and still misreported, merely later.
+                    gate_reason, gate_starved = await _await_cron_fire_time_gate(
+                        job, tool_name="cron_command_exec", tool_kind="cron_command"
                     )
+                    if gate_starved:
+                        return None
                     if gate_reason:
                         # Deliberately NOT record_failure(): a governance denial
                         # is a policy state, not a job defect. Counting it would
@@ -2581,15 +2909,26 @@ class GatewayOrchestrator:
                             )
                         return None
                     cmd_timeout = job.timeout or 300
-                    result = await asyncio.wait_for(
-                        asyncio.get_running_loop().run_in_executor(
-                            cron_executor(),
-                            run_command_sandboxed,
-                            job.command,
-                            cmd_timeout,
-                            job.id,
-                        ),
-                        timeout=cmd_timeout + 5,
+                    # Queue wait is NOT charged to cmd_timeout: see
+                    # run_in_cron_pool.  The timeout here is a backstop only --
+                    # run_command_sandboxed already enforces cmd_timeout on the
+                    # subprocess itself -- but it must stay, or a wedged worker
+                    # leaves this entry un-failed forever.
+                    #
+                    # Submitted through _vet_at_claim_then for the same reason as
+                    # the script site: the command TEXT cannot be substituted
+                    # (it is already captured in job.command), but the governance
+                    # POLICY it was vetted against can tighten during the queue
+                    # wait, and the gate above ran before that wait.
+                    result = await run_in_cron_pool(
+                        _vet_at_claim_then,
+                        handoff,
+                        job,
+                        run_command_sandboxed,
+                        job.command,
+                        cmd_timeout,
+                        job.id,
+                        timeout=_claim_backstop(job, cmd_timeout),
                     )
                     if result.get("status") == "cancelled":
                         # User-initiated cancel: CronService.cancel() owns the
@@ -2634,11 +2973,81 @@ class GatewayOrchestrator:
                             "SEL logging failed in cron command result path", exc_info=True
                         )
                     return job.last_result
+                except CronQueueTimeout as exc:
+                    # Pool starvation, not a broken command: every worker was
+                    # busy for the whole budget so this never started.  Say so,
+                    # or the next saturation reads as N independent failures.
+                    job.clear_carried_result()
+                    job.last_error = str(exc)
+                    job.last_status = "error"
+                    # Retention-only marker: a one-shot must not be consumed by a
+                    # run it never had.  NOT fire_time_denied -- that would also
+                    # park an at-job disabled and call this a policy denial.
+                    job.run_never_started = True
+                    # Deliberately NOT record_failure(): starvation is a fleet
+                    # state, not a job defect, exactly as a fire-time governance
+                    # denial is a policy state.  Counting it would auto-pause the
+                    # job after _AUTO_PAUSE_THRESHOLD starved wakes, and a paused
+                    # job never fires again -- so a pool that recovers would leave
+                    # a perfectly healthy job disabled and its work unscheduled.
+                    # The distinct error text above is what makes the saturation
+                    # legible; the counter is for runs that actually ran.
+                    try:
+                        sel().log_tool_invocation(
+                            session_key=f"cron:{job.id}",
+                            tool_name="cron_command_exec",
+                            tool_kind="cron_command",
+                            outcome="error",
+                            error=str(exc),
+                        )
+                    except Exception:
+                        logger.debug(
+                            "SEL logging failed in cron command queue-timeout path",
+                            exc_info=True,
+                        )
+                    return None
                 except asyncio.TimeoutError:
+                    # Retain the one-shot when the payload never started. This arm
+                    # is the CLAIM BACKSTOP expiring, and it fires for two
+                    # different runs: a slow claim-time vet that burned the bound
+                    # before ``claim()`` was ever granted, and a payload that DID
+                    # start and then overran. Only the first is a never-started
+                    # run, and ``abandon()`` is the only thing that can tell them
+                    # apart -- it returns whether the payload had started, and
+                    # ``claim()`` refuses once it has been called, so a False here
+                    # can never become True later. Without this the marker stayed
+                    # unset and ``_merge_job_result`` consumed a
+                    # ``delete_after_run`` job that dispatched nothing.
+                    #
+                    # Deliberately scoped to THIS arm rather than to the shared
+                    # ``finally`` below, which also runs on the fire-time deny
+                    # path: a deny reaches it with the payload equally unstarted,
+                    # but its retention is owned by ``fire_time_denied``, whose
+                    # readers park an at-job disabled. Setting this marker there
+                    # would park a job for a policy decision never made -- the
+                    # opposite silent failure. ``abandon()`` is documented
+                    # idempotent, so calling it here and again in the ``finally``
+                    # is safe.
+                    started = handoff.abandon()
+                    job.run_never_started = not started
                     job.clear_carried_result()
                     job.last_error = f"timeout ({cmd_timeout + 5}s)"
                     job.last_status = "error"
-                    job.record_failure()
+                    # Count only a run that DISPATCHED. The same reasoning the
+                    # starvation, gate-deny and vet-overrun arms above already
+                    # apply: a backstop that expired before ``claim()`` means no
+                    # line of this job ran, so it is a fleet state rather than a
+                    # job defect, and counting it auto-pauses at
+                    # _AUTO_PAUSE_THRESHOLD -- a paused job never fires again, so
+                    # repeated wedged wakes would permanently disable a healthy
+                    # job and leave its work unscheduled. ``cron.py``'s
+                    # _execute_with_timeout guard already refuses to count a
+                    # never-started run, but this arm calls record_failure()
+                    # DIRECTLY and so never reaches it. A genuine overrun (the
+                    # payload started, then ran long) still counts, which is what
+                    # keeps this a discriminator rather than a deletion.
+                    if started:
+                        job.record_failure()
                     try:
                         sel().log_tool_invocation(
                             session_key=f"cron:{job.id}",
@@ -2651,6 +3060,83 @@ class GatewayOrchestrator:
                             "SEL logging failed in cron command timeout path", exc_info=True
                         )
                     return None
+                except CronClaimTimeDenied as exc:
+                    # Governance refused this run when the worker claimed it --
+                    # the policy tightened during the queue wait.  Same
+                    # disposition as the fire-time deny above, deliberately:
+                    # result-less, keeps the job, and NOT record_failure(),
+                    # because a policy state must not feed the auto-pause
+                    # counter.  This clause exists so the run cannot reach the
+                    # generic arm below, which does count it.
+                    job.clear_carried_result()
+                    job.last_status = "error"
+                    job.last_error = redact(exc.reason)
+                    job.fire_time_denied = True
+                    try:
+                        sel().log_tool_invocation(
+                            session_key=f"cron:{job.id}",
+                            tool_name="cron_command_exec",
+                            tool_kind="cron_command",
+                            outcome="denied",
+                        )
+                    except Exception:
+                        logger.debug(
+                            "SEL logging failed in cron command claim-time deny path",
+                            exc_info=True,
+                        )
+                    return None
+                except CronVetOverran as exc:
+                    # The vet outran the allowance the deadline carries for it, so
+                    # the payload was REFUSED rather than started with a margin
+                    # that no longer covers its own bound plus teardown.  Nothing
+                    # ran, so this is retention-shaped like starvation: mark the
+                    # run never-started and deliberately do NOT record_failure() --
+                    # a slow governance read is a fleet state, not a job defect,
+                    # and counting it would auto-pause a healthy job at
+                    # _AUTO_PAUSE_THRESHOLD.  NOT fire_time_denied: no policy
+                    # decision was made, and that flag also parks an at-job.
+                    logger.warning("Cron '%s': %s; payload refused", job.name, exc)
+                    job.clear_carried_result()
+                    job.last_error = str(exc)
+                    job.last_status = "error"
+                    job.run_never_started = True
+                    try:
+                        sel().log_tool_invocation(
+                            session_key=f"cron:{job.id}",
+                            tool_name="cron_command_exec",
+                            tool_kind="cron_command",
+                            outcome="error",
+                            error=str(exc),
+                        )
+                    except Exception:
+                        logger.debug(
+                            "SEL logging failed in cron command vet-overrun path", exc_info=True
+                        )
+                    return None
+                except asyncio.CancelledError:
+                    # The wake deadline cancelled this callback outright, so none of
+                    # the arms above ran: CancelledError is a BaseException, which
+                    # the ``except Exception`` below deliberately does not catch.
+                    # Without this the run reaches cron.py's delete site with
+                    # neither retention flag set, so a ``delete_after_run`` one-shot
+                    # is consumed having never executed.
+                    #
+                    # ``abandon()`` is the discriminator, exactly as the claim
+                    # backstop above uses it: it reports whether the payload had
+                    # already started, and ``claim()`` refuses once abandoned, so a
+                    # False can never later become True.  Assigning ``not started``
+                    # rather than setting True unconditionally is what keeps the
+                    # opposite failure closed -- a payload that DID run reports True,
+                    # so the marker stays clear and the one-shot is still consumed
+                    # instead of firing a second time.
+                    #
+                    # Deliberately NOT in the shared ``finally`` below, which the
+                    # fire-time deny path also reaches with the payload equally
+                    # unstarted: retention there is owned by ``fire_time_denied``,
+                    # and setting this marker would park an at-job disabled for a
+                    # policy decision that was never made.
+                    job.run_never_started = not handoff.abandon()
+                    raise
                 except Exception as exc:
                     logger.exception("Command cron '%s' failed: %s", job.name, exc)
                     job.clear_carried_result()
@@ -2669,11 +3155,24 @@ class GatewayOrchestrator:
                         logger.debug("SEL logging failed in cron command error path", exc_info=True)
                     return None
                 finally:
+                    # Abandon BEFORE releasing the overlap guard, and do it here
+                    # rather than in the timeout arm because this ``finally`` is the
+                    # single place the guard is released -- so it also covers any
+                    # exit no ``except`` arm above handles.  A no-op on the success
+                    # path: the payload already ran.  ``abandon()`` is idempotent,
+                    # so the cancellation arm above having already called it changes
+                    # nothing observed here.
+                    handoff.abandon()
                     self._running_script_ids.discard(job.id)
 
             # ── Code-based script execution (deterministic, no LLM) ──
             if job.script:
                 self._running_script_ids.add(job.id)
+                # Bound to the overlap guard's own lifetime, and created HERE rather
+                # than at the submit below so the ``finally`` that releases the guard
+                # can always reach it -- including on the fire-time deny paths that
+                # return before anything is submitted.
+                handoff = _ClaimHandoff()
                 try:
                     try:
                         sel().log_tool_invocation(
@@ -2696,9 +3195,12 @@ class GatewayOrchestrator:
                     # policy loosening lets it resume on its own.
                     # Off-loop: reads the script body from disk (up to the scan
                     # cap) — must not block the event loop on a wedged FS.
-                    gate_reason = await asyncio.get_running_loop().run_in_executor(
-                        cron_executor(), vet_job_at_fire_time, job
+                    # Governance pool, not the cron pool: see the command site.
+                    gate_reason, gate_starved = await _await_cron_fire_time_gate(
+                        job, tool_name="cron_script_exec", tool_kind="cron_script"
                     )
+                    if gate_starved:
+                        return None
                     if gate_reason:
                         # No record_failure() — see the command-path deny above:
                         # a policy denial must not feed the auto-pause counter.
@@ -2723,16 +3225,29 @@ class GatewayOrchestrator:
                         return None
                     # Run in sandboxed subprocess via wrap_argv()
                     script_timeout = job.timeout or 30
-                    result = await asyncio.wait_for(
-                        asyncio.get_running_loop().run_in_executor(
-                            cron_executor(),
-                            run_script_sandboxed,
-                            job.script,
-                            job.id,
-                            job.message,
-                            script_timeout,
-                        ),
-                        timeout=script_timeout + 5,
+                    # Queue wait is NOT charged to script_timeout: see
+                    # run_in_cron_pool.  The timeout here is a backstop only --
+                    # run_script_sandboxed already enforces script_timeout on
+                    # the subprocess itself -- but it must stay, or a wedged
+                    # worker leaves this entry un-failed forever.
+                    #
+                    # Submitted through _vet_at_claim_then, not bare: the gate
+                    # above ran before the queue wait, and the launcher re-reads
+                    # the body from disk in the child, so the gate's scan alone
+                    # authorises bytes that may no longer be there.  The re-vet
+                    # runs inside the worker, after the wait, so the decision
+                    # holds at the moment of use.  It also now shares the
+                    # backstop below, which is why it must stay short.
+                    result = await run_in_cron_pool(
+                        _vet_at_claim_then,
+                        handoff,
+                        job,
+                        run_script_sandboxed,
+                        job.script,
+                        job.id,
+                        job.message,
+                        script_timeout,
+                        timeout=_claim_backstop(job, script_timeout),
                     )
                     status = result.get("status", "error")
                     if status == "cancelled":
@@ -2826,14 +3341,59 @@ class GatewayOrchestrator:
                     else:
                         err = result.get("error", "unknown error")
                         raise RuntimeError(err)
+                except CronQueueTimeout as exc:
+                    # Pool starvation, not a broken script: every worker was
+                    # busy for the whole budget so this never ran a line.  The
+                    # distinct text is what makes the next saturation legible
+                    # instead of looking like N scripts that each overran.
+                    logger.warning(
+                        "Script cron '%s' never got a worker slot: %s", job.name, exc
+                    )
+                    job.clear_carried_result()
+                    job.last_error = str(exc)
+                    job.last_status = "error"
+                    # Retention-only marker: see the command path.
+                    job.run_never_started = True
+                    # Deliberately NOT record_failure(): see the command path.
+                    # Starvation means the script never ran a line, so counting it
+                    # would auto-pause a healthy job after _AUTO_PAUSE_THRESHOLD
+                    # starved wakes and leave it disabled once the pool recovered.
+                    # The auto-pause log that used to sit here went with it: this
+                    # path can no longer reach the threshold.
+                    try:
+                        sel().log_tool_invocation(
+                            session_key=f"cron:{job.id}",
+                            tool_name=job.script,
+                            tool_kind="cron_script",
+                            outcome="error",
+                            error=str(exc),
+                        )
+                    except Exception:
+                        logger.debug(
+                            "SEL logging failed in cron script queue-timeout path",
+                            exc_info=True,
+                        )
+                    return None
                 except asyncio.TimeoutError:
+                    # See the command path above: this is the claim backstop, and
+                    # only ``abandon()`` distinguishes a vet that burned the bound
+                    # before ``claim()`` from a payload that started and overran.
+                    # Scoped to this arm, not the shared ``finally``, so the
+                    # fire-time deny path keeps its retention in
+                    # ``fire_time_denied`` instead of parking an at-job disabled.
+                    started = handoff.abandon()
+                    job.run_never_started = not started
                     logger.warning(
                         "Script cron '%s' timed out after %ds", job.name, script_timeout + 5
                     )
                     job.clear_carried_result()
                     job.last_error = f"timeout ({script_timeout + 5}s)"
                     job.last_status = "error"
-                    job.record_failure()
+                    # See the command path: count only a run that DISPATCHED, so a
+                    # backstop that expired before ``claim()`` cannot auto-pause a
+                    # job that never ran a line. A genuine overrun still counts.
+                    if started:
+                        job.record_failure()
                     if job.auto_paused:
                         logger.warning(
                             "Script cron '%s' auto-paused after %d consecutive errors",
@@ -2853,6 +3413,70 @@ class GatewayOrchestrator:
                             "SEL logging failed in cron script timeout path", exc_info=True
                         )
                     return None
+                except CronClaimTimeDenied as exc:
+                    # Governance refused this run when the worker claimed it --
+                    # the body on disk, or the policy, changed during the queue
+                    # wait.  Same disposition as the fire-time deny above,
+                    # deliberately: result-less, keeps the job, and NOT
+                    # record_failure(), because a policy state must not feed the
+                    # auto-pause counter.  This clause exists so the run cannot
+                    # reach the generic arm below, which does count it.
+                    job.clear_carried_result()
+                    job.last_status = "error"
+                    job.last_error = redact(exc.reason)
+                    job.fire_time_denied = True
+                    try:
+                        sel().log_tool_invocation(
+                            session_key=f"cron:{job.id}",
+                            tool_name=job.script,
+                            tool_kind="cron_script",
+                            outcome="denied",
+                        )
+                    except Exception:
+                        logger.debug(
+                            "SEL logging failed in cron script claim-time deny path",
+                            exc_info=True,
+                        )
+                    return None
+                except CronVetOverran as exc:
+                    # The vet outran the allowance the deadline carries for it, so
+                    # the payload was REFUSED rather than started with a margin
+                    # that no longer covers its own bound plus teardown.  Nothing
+                    # ran, so this is retention-shaped like starvation: mark the
+                    # run never-started and deliberately do NOT record_failure() --
+                    # a slow governance read is a fleet state, not a job defect,
+                    # and counting it would auto-pause a healthy job at
+                    # _AUTO_PAUSE_THRESHOLD.  NOT fire_time_denied: no policy
+                    # decision was made, and that flag also parks an at-job.
+                    logger.warning("Cron '%s': %s; payload refused", job.name, exc)
+                    job.clear_carried_result()
+                    job.last_error = str(exc)
+                    job.last_status = "error"
+                    job.run_never_started = True
+                    try:
+                        sel().log_tool_invocation(
+                            session_key=f"cron:{job.id}",
+                            tool_name=job.script,
+                            tool_kind="cron_script",
+                            outcome="error",
+                            error=str(exc),
+                        )
+                    except Exception:
+                        logger.debug(
+                            "SEL logging failed in cron script vet-overrun path", exc_info=True
+                        )
+                    return None
+                except asyncio.CancelledError:
+                    # See the command path above: a wake deadline cancelling this
+                    # callback runs no ``except`` arm, because CancelledError is a
+                    # BaseException, so without this the delete site consumes a
+                    # one-shot that never executed.  ``abandon()`` reports whether
+                    # the payload had started, so ``not started`` retains only the
+                    # run that dispatched nothing and leaves a completed run
+                    # deletable.  Not in the shared ``finally``, whose deny path
+                    # retention belongs to ``fire_time_denied``.
+                    job.run_never_started = not handoff.abandon()
+                    raise
                 except Exception as exc:
                     logger.exception("Script cron '%s' failed: %s", job.name, exc)
                     job.clear_carried_result()
@@ -2878,6 +3502,14 @@ class GatewayOrchestrator:
                         logger.debug("SEL logging failed in cron script error path", exc_info=True)
                     return None
                 finally:
+                    # Abandon BEFORE releasing the overlap guard, and do it here
+                    # rather than in the timeout arm because this ``finally`` is the
+                    # single place the guard is released -- so it also covers any
+                    # exit no ``except`` arm above handles.  A no-op on the success
+                    # path: the payload already ran.  ``abandon()`` is idempotent,
+                    # so the cancellation arm above having already called it changes
+                    # nothing observed here.
+                    handoff.abandon()
                     self._running_script_ids.discard(job.id)
 
             # ── Fire-time governance gate: message (LLM) jobs ──
@@ -2886,10 +3518,15 @@ class GatewayOrchestrator:
             # had NO fire-time capabilities.cron check at all, so disabling the
             # cron capability after scheduling never affected them. Same deny
             # semantics as the other kinds: mark the run failed, keep the job.
-            # Off-loop for the same reason as the command/script sites above.
-            gate_reason = await asyncio.get_running_loop().run_in_executor(
-                cron_executor(), vet_job_at_fire_time, job
+            # Off-loop for the same reason as the command/script sites above, and
+            # on the GOVERNANCE pool for the same reason: a message job gets no
+            # pool allowance on either deadline, so gating it on the cron pool
+            # charged a saturated pool's queue directly to its execution budget.
+            gate_reason, gate_starved = await _await_cron_fire_time_gate(
+                job, tool_name="cron_message_dispatch", tool_kind="cron_message"
             )
+            if gate_starved:
+                return None
             if gate_reason:
                 # No record_failure() — see the command-path deny above: a
                 # policy denial must not feed the auto-pause counter.

--- a/test/test_cron_gateway_integration.py
+++ b/test/test_cron_gateway_integration.py
@@ -7,12 +7,26 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import threading
 from contextlib import nullcontext
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import kiro_crew.executors as ex
 from kiro_crew.cron import CronJob, CronSchedule
+
+
+async def _stalled_gate(*_args, **_kwargs):
+    """Stand in for a fire-time gate that outlives the wake deadline.
+
+    Models a recoverable event-loop stall rather than a slow gate: it is the
+    whole ``run_in_cron_gate_pool`` call that fails to complete, so neither of
+    the gate's OWN bounds is what stops it. That is the only way to reach the
+    state where ``asyncio.wait_for`` in ``_execute_with_timeout`` cancels the
+    coroutine AT the await -- no internal deadline sizing can prevent it.
+    """
+    await asyncio.sleep(30)
 
 
 def _make_gw():
@@ -1301,3 +1315,1232 @@ def test_shutdown_cancel_keeps_the_last_completed_result(tmp_path) -> None:
 
     job = asyncio.run(_drive())
     assert job.last_result == "42 widgets", "a shutdown cancel wiped a completed result"
+
+
+async def _run_script_callback_behind_a_busy_worker(gw, job, script_result, hold_secs):
+    """Drive the script branch with the cron pool's only worker already busy.
+
+    The blocker is submitted from INSIDE the fire-time gate. That ordering is
+    what puts it ahead of the script in the cron pool's FIFO queue, so the script
+    genuinely waits for a worker -- the production condition. Submitting it up
+    front would let the gate run first and the script would then find a free
+    worker and never queue.
+
+    The gate itself no longer touches this pool: it runs on the dedicated
+    ``mc-crongate`` pool with a bound of its own, so starving the cron pool
+    cannot starve the gate. That independence is the point -- it is why this
+    fixture can saturate the cron pool without perturbing the gate under test.
+    """
+    captured_cb = None
+    release = threading.Event()
+
+    def _occupy() -> None:
+        release.wait(timeout=60)
+
+    def _vet(_job):
+        ex.cron_executor().submit(_occupy)
+        return None
+
+    ex.shutdown_maintenance_executor()
+    with (
+        patch.object(ex, "_MAX_CRON_WORKERS", 1),
+        patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls,
+        patch(
+            "kiro_crew.slack.gateway.run_script_sandboxed", return_value=script_result
+        ) as mock_run,
+        patch("kiro_crew.slack.gateway.vet_job_at_fire_time", side_effect=_vet),
+        patch("kiro_crew.slack.gateway.sel"),
+    ):
+
+        def capture_cron(on_job=None, **kw):
+            nonlocal captured_cb
+            captured_cb = on_job
+            svc = MagicMock()
+            svc.start = AsyncMock()
+            svc.remove_job_async = AsyncMock(return_value=True)
+            return svc
+
+        mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+        try:
+            await gw._init_cron()
+            assert captured_cb is not None
+            asyncio.get_running_loop().call_later(hold_secs, release.set)
+            return await captured_cb(job), mock_run
+        finally:
+            release.set()
+            ex.shutdown_maintenance_executor()
+
+
+class TestCronPoolQueueWait:
+    """Queue time in the bounded cron pool must not be charged to the job.
+
+    ``run_in_executor`` only SUBMITS. The cron pool is bounded at
+    ``_MAX_CRON_WORKERS``, so a job whose workers are all busy sits in the
+    pool's queue having run nothing -- while the old
+    ``wait_for(run_in_executor(...), timeout=job_timeout + 5)`` counted from the
+    moment it was awaited. Queue time was therefore spent out of the job's own
+    budget, and the kill was recorded as ``timeout (Ns)`` naming the script, so
+    one wedged job reads as N broken ones.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fast_script_waiting_for_a_worker_is_not_killed_as_a_script_timeout(self):
+        """Negative control: fails pre-fix, for the reason the defect describes.
+
+        The script here is instant (mocked ok) but the only worker is held for
+        6.5s, past the 6s the pre-fix budget allowed a 1s-timeout job. Pre-fix
+        this is killed and labelled ``timeout (6s)``; the fix lets it wait for a
+        worker untimed and then run.
+        """
+        gw = _make_gw()
+        job = _make_script_job(timeout=1)  # pre-fix budget: 1 + 5 = 6s
+
+        result, mock_run = await _run_script_callback_behind_a_busy_worker(
+            gw, job, {"status": "ok"}, hold_secs=6.5
+        )
+
+        assert mock_run.called, "the script never ran -- it was killed while queued"
+        assert job.last_status == "ok", f"expected ok, got {job.last_status}: {job.last_error}"
+        assert job.last_error == ""
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_starved_script_says_queued_never_ran_not_timeout(self):
+        """The distinct text is the point: saturation must not read as N defects."""
+        gw = _make_gw()
+        job = _make_script_job(last_result="42 widgets")
+        result, _ = await _run_script_callback(gw, job, side_effect=ex.CronQueueTimeout(300.0))
+        assert result is None
+        assert job.last_status == "error"
+        assert job.last_error == "queued 300s, never ran"
+        # Must NOT be mistakable for the script itself overrunning.
+        assert "timeout (" not in job.last_error
+        # A failed run must not present the previous run's output as its own.
+        assert job.last_result == ""
+
+    @pytest.mark.asyncio
+    async def test_starved_command_says_queued_never_ran_not_timeout(self):
+        """The command branch carries the same defect and the same fix."""
+        gw = _make_gw()
+        job = _make_command_job(last_result="42 widgets")
+        result, _ = await _run_command_callback(
+            gw, job, side_effect=ex.CronQueueTimeout(300.0), vet_reason=None
+        )
+        assert result is None
+        assert job.last_status == "error"
+        assert job.last_error == "queued 300s, never ran"
+        assert "timeout (" not in job.last_error
+        assert job.last_result == ""
+
+    @pytest.mark.asyncio
+    async def test_a_real_script_overrun_is_still_reported_as_a_timeout(self):
+        """The backstop label must survive: only the QUEUE case gets new text.
+
+        CronQueueTimeout subclasses asyncio.TimeoutError, so this also pins the
+        except-order -- a plain TimeoutError must not be captured by the queue
+        branch and mislabelled.
+        """
+        gw = _make_gw()
+        job = _make_script_job(timeout=30)
+        result, _ = await _run_script_callback(gw, job, side_effect=asyncio.TimeoutError())
+        assert result is None
+        assert job.last_status == "error"
+        assert job.last_error == "timeout (35s)"
+        assert "queued" not in job.last_error
+
+    @pytest.mark.asyncio
+    async def test_repeated_starvation_never_auto_pauses_a_healthy_script(self):
+        """Starvation must not consume the auto-pause budget.
+
+        ``record_failure`` auto-pauses at ``_AUTO_PAUSE_THRESHOLD`` by clearing
+        ``enabled``, and a paused job never fires again. Counting a queue timeout
+        there means a saturated pool permanently disables jobs that never ran a
+        line, so when the pool recovers the work is silently unscheduled. The
+        fire-time governance deny path already declines to count for exactly this
+        reason. Asserts the counter and the pause flag, not merely the absence of
+        an exception.
+        """
+        from kiro_crew.cron import _AUTO_PAUSE_THRESHOLD
+
+        gw = _make_gw()
+        job = _make_script_job()
+        for _ in range(_AUTO_PAUSE_THRESHOLD + 2):
+            result, _ = await _run_script_callback(gw, job, side_effect=ex.CronQueueTimeout(300.0))
+            assert result is None
+        assert job.consecutive_failures == 0, "starvation must not consume the auto-pause budget"
+        assert not job.auto_paused, "a job that never ran must not be auto-paused"
+        assert job.enabled, "auto-pause clears enabled -- the job would never fire again"
+        # Still reported as an error, with the legible starvation text.
+        assert job.last_status == "error"
+        assert job.last_error == "queued 300s, never ran"
+
+    @pytest.mark.asyncio
+    async def test_repeated_starvation_never_auto_pauses_a_healthy_command(self):
+        """The command branch carries the same counter and the same fix."""
+        from kiro_crew.cron import _AUTO_PAUSE_THRESHOLD
+
+        gw = _make_gw()
+        job = _make_command_job()
+        for _ in range(_AUTO_PAUSE_THRESHOLD + 2):
+            result, _ = await _run_command_callback(
+                gw, job, side_effect=ex.CronQueueTimeout(300.0), vet_reason=None
+            )
+            assert result is None
+        assert job.consecutive_failures == 0
+        assert not job.auto_paused
+        assert job.enabled
+
+    @pytest.mark.asyncio
+    async def test_the_enclosing_wake_deadline_also_excludes_queue_wait(self, tmp_path):
+        """Excluding queue wait from the per-call kwarg is only half the job.
+
+        ``CronService._execute_with_timeout`` wraps the whole run and the pool's
+        queue wait happens inside it, so without a queue term there a job still
+        sitting in the queue is killed by the WAKE deadline and reported as an
+        execution overrun -- the same misdiagnosis, one frame out. Worse, a thread
+        cannot be interrupted, so a worker that claimed the call as the deadline
+        fired keeps running while the overlap guards clear.
+
+        Fails pre-fix: the command job below is killed at its 2s wake budget with
+        ``Timed out after 2s`` and its payload never runs.
+        """
+        from kiro_crew.cron import CronService
+
+        ex.shutdown_maintenance_executor()
+        release = threading.Event()
+        try:
+            svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+            job = _make_command_job(timeout_secs=2)
+            for _ in range(ex._MAX_CRON_WORKERS):
+                ex.cron_executor().submit(release.wait, 3.0)
+            await asyncio.sleep(0.2)
+
+            ran = threading.Event()
+
+            async def _execute(_job):
+                return await ex.run_in_cron_pool(ran.set, timeout=30, queue_timeout=60)
+
+            svc._execute = _execute  # type: ignore[method-assign]
+            await svc._execute_with_timeout(job)
+
+            assert ran.is_set(), "the job was killed by the wake deadline while still queued"
+            assert job.last_error != "Timed out after 2s"
+        finally:
+            release.set()
+            await asyncio.sleep(0.05)
+            ex.shutdown_maintenance_executor()
+
+    @pytest.mark.asyncio
+    async def test_a_message_job_wake_budget_is_not_widened(self, tmp_path):
+        """The queue term is scoped: a message job never touches the pool.
+
+        Widening every job's wake budget would loosen the backstop that exists so
+        a wedged worker cannot leave an entry un-failed forever. Only command and
+        script jobs dispatch through the pool, so only they get the allowance.
+        """
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+        job = CronJob(
+            id="mj1",
+            name="msg-job",
+            message="hello",
+            schedule=CronSchedule(kind="every", every_secs=60),
+        )
+        job.timeout_secs = 2
+
+        async def _slow(_job):
+            await asyncio.sleep(30)
+
+        svc._execute = _slow  # type: ignore[method-assign]
+        await svc._execute_with_timeout(job)
+        assert job.last_status == "error"
+        assert job.last_error == "Timed out after 2s"
+
+    @pytest.mark.asyncio
+    async def test_a_starved_one_shot_job_is_retained_not_deleted(self, tmp_path):
+        """A one-shot that never ran must not be consumed by the run it never had.
+
+        ``_merge_job_result`` deletes a ``delete_after_run`` job unless the run was
+        refused, and the queue-timeout paths return without marking a refusal -- so
+        a job that never got a worker is destroyed exactly as if it had completed,
+        and its scheduled work is gone with it. The fire-time deny path already
+        carries the retain-on-refusal property; starvation needs the same one for
+        the same reason, without borrowing the *policy* meaning of that flag.
+        """
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+        svc._load()
+        created = svc.add_job(
+            name="one-shot",
+            message="",
+            every_secs=300,
+            command="echo hi",
+            delete_after_run=True,
+        )
+        assert any(j.id == created.id for j in svc.list_jobs())
+
+        gw = _make_gw()
+        result, _ = await _run_command_callback(
+            gw, created, side_effect=ex.CronQueueTimeout(300.0), vet_reason=None
+        )
+        assert result is None
+        assert created.last_error == "queued 300s, never ran"
+
+        # Off-loop: _merge_job_result enters the bounded sync store lock.
+        await asyncio.to_thread(svc._merge_job_result, created)
+        assert any(j.id == created.id for j in svc.list_jobs()), (
+            "a one-shot that never ran was deleted as though it had run"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_starved_one_shot_at_job_is_not_parked_disabled(self, tmp_path):
+        """Retention must not borrow the policy-denial meaning.
+
+        ``fire_time_denied`` is read in three places: besides suppressing the
+        one-shot delete it also forces an ``at`` job disabled, and it is documented
+        as a governance refusal. Reusing it for a capacity event would park a
+        starved one-shot needing an operator to re-enable it, and would mislabel
+        pool saturation as a policy denial in history. Starvation clears on its own,
+        so the job must stay schedulable.
+        """
+        import time
+
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+        svc._load()
+        created = svc.add_job(
+            name="one-shot-at",
+            message="",
+            at_ts=time.time() + 3600,
+            command="echo hi",
+            delete_after_run=True,
+        )
+
+        gw = _make_gw()
+        result, _ = await _run_command_callback(
+            gw, created, side_effect=ex.CronQueueTimeout(300.0), vet_reason=None
+        )
+        assert result is None
+        assert not created.fire_time_denied, "starvation is not a governance denial"
+
+        await asyncio.to_thread(svc._merge_job_result, created)
+        survivors = [j for j in svc.list_jobs(include_disabled=True) if j.id == created.id]
+        assert survivors, "the starved one-shot at-job was deleted"
+        assert survivors[0].enabled, "a starved job must stay schedulable, not be parked"
+        assert not survivors[0].user_paused
+
+    @staticmethod
+    async def _one_reaper_sweep(svc, job, elapsed_secs):
+        """Drive exactly one reaper sweep and report whether it force-killed.
+
+        Registers the job as in-flight for ``elapsed_secs`` with a task that is
+        NOT done, so the loop's ``task.done()`` early-continue cannot mask the
+        decision, then runs the loop just long enough for one sweep.
+        """
+        import time as _time
+        from unittest.mock import AsyncMock as _AsyncMock
+
+        never = asyncio.get_running_loop().create_future()  # a task that is not done
+        holder = asyncio.ensure_future(asyncio.wait_for(never, timeout=30))
+        svc._job_start_times[job.id] = _time.time() - elapsed_secs
+        svc._running_tasks[job.id] = holder
+        svc._jobs = [job]
+        reaped = _AsyncMock()
+        svc._force_reap = reaped  # type: ignore[method-assign]
+        with patch("kiro_crew.cron._REAPER_INTERVAL", 0.01):
+            loop_task = asyncio.ensure_future(svc._reaper_loop())
+            await asyncio.sleep(0.25)
+            loop_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await loop_task
+        never.cancel()
+        holder.cancel()
+        with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+            await holder
+        return reaped.called
+
+    @pytest.mark.asyncio
+    async def test_the_reaper_does_not_preempt_a_job_inside_the_widened_window(self, tmp_path):
+        """The reaper must account for queue wait too, or it cancels a queued job.
+
+        Two deadlines bound one run. Widening only the execution guard leaves the
+        reaper's own threshold 900s lower for every command/script job at or above
+        the default wake budget, so a job whose gate and payload queued through
+        that window is force-killed and the firing is skipped without ever
+        executing -- the mirror image of the misdiagnosis the widening removed.
+
+        Fails pre-fix: with the reaper unchanged its deadline is 1800s, the job
+        below has been in flight 1850s, and it is reaped.
+        """
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+        job = _make_command_job(timeout_secs=1800)  # the default wake budget
+        # 1850s: past the reaper's un-widened 1800s, inside the 2700s execution
+        # deadline the job is actually entitled to.
+        assert await self._one_reaper_sweep(svc, job, 1850) is False, (
+            "the reaper force-killed a job still inside its own execution deadline"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_reaper_still_kills_a_job_past_the_widened_deadline(self, tmp_path):
+        """The defence-in-depth sweep must keep its teeth.
+
+        The point of the reaper is to catch a run whose ``wait_for`` never fired.
+        Accounting for queue wait must move that threshold, not remove it.
+        """
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+        job = _make_command_job(timeout_secs=1800)
+        assert await self._one_reaper_sweep(svc, job, 2800) is True, (
+            "the reaper stopped killing a genuinely overrunning job"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_reaper_window_is_not_widened_for_a_message_job(self, tmp_path):
+        """Scoped, like the execution deadline: a message job never uses the pool.
+
+        Widening the reaper for every job would delay the force-kill backstop by a
+        quarter of an hour for runs that can never have queued.
+        """
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+        job = CronJob(
+            id="mj-reap",
+            name="msg-job",
+            message="hello",
+            schedule=CronSchedule(kind="every", every_secs=60),
+        )
+        job.timeout_secs = 1800
+        assert await self._one_reaper_sweep(svc, job, 1850) is True, (
+            "a message job got a pool queue allowance it can never use"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_message_jobs_fire_time_gate_does_not_spend_its_execution_budget(
+        self, tmp_path
+    ):
+        """The fire-time governance gate must not queue behind long-running cron work.
+
+        Both deadlines deliberately withhold the pool allowance from a message job,
+        on the premise that it never touches the pool. The FIRE-TIME GOVERNANCE GATE
+        breaks that premise. ``vet_job_at_fire_time`` is dispatched off-loop for
+        every job kind, and dispatching it to the CRON pool puts it behind however
+        many long-running command/script jobs hold that pool's
+        ``_MAX_CRON_WORKERS`` workers. The wait happens inside the deadline
+        ``_execute_with_timeout`` arms BEFORE the callback runs, so a saturated pool
+        can spend a message job's entire execution budget before its own dispatch is
+        even reached -- and a one-shot is then deleted having never run.
+
+        Widening the message job's budget is the wrong lever: it would delay the
+        wedged-delivery backstop by the whole allowance for every message job,
+        which is exactly what the two "not widened" tests above pin. The gate
+        belongs off the pool that long-running work occupies -- it is a short,
+        bounded policy check, not job execution.
+
+        Fails pre-fix: with every cron worker held, the gate queues and the job is
+        killed at its 2s budget without ever dispatching.
+        """
+        from kiro_crew.cron import CronService
+
+        ex.shutdown_maintenance_executor()
+        release = threading.Event()
+        try:
+            gw = _make_gw()
+            captured_cb = None
+
+            with (
+                patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls,
+                patch("kiro_crew.mcp_cron._vet_cron_capability_governance", return_value=None),
+                patch("kiro_crew.slack.gateway.sel"),
+            ):
+
+                def capture_cron(on_job=None, **kw):
+                    nonlocal captured_cb
+                    captured_cb = on_job
+                    svc = MagicMock()
+                    svc.start = AsyncMock()
+                    svc.remove_job_async = AsyncMock(return_value=True)
+                    return svc
+
+                mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+                await gw._init_cron()
+                assert captured_cb is not None
+
+                # The defect's own premise: long-running pool jobs holding every
+                # worker, held well past the message job's whole 2s budget.
+                for _ in range(ex._MAX_CRON_WORKERS):
+                    ex.cron_executor().submit(release.wait, 5.0)
+                await asyncio.sleep(0.2)
+
+                job = CronJob(
+                    id="mj-gate",
+                    name="msg-job",
+                    message="hello",
+                    schedule=CronSchedule(kind="every", every_secs=60),
+                )
+                job.timeout_secs = 2
+
+                svc = CronService(base_dir=tmp_path, on_job=captured_cb)
+                await svc._execute_with_timeout(job)
+
+            assert gw.sessions.get_or_create.called, (
+                "the fire-time gate wait consumed the message job's whole execution "
+                "budget: it was killed before its own dispatch was reached"
+            )
+            assert job.last_error != "Timed out after 2s"
+        finally:
+            release.set()
+            await asyncio.sleep(0.05)
+            ex.shutdown_maintenance_executor()
+
+    @pytest.fixture
+    def gate_pool(self):
+        """Fresh pools, plus a release event so a starved gate never outlives the test."""
+        ex.shutdown_maintenance_executor()
+        release = threading.Event()
+        try:
+            yield release
+        finally:
+            release.set()
+            ex.shutdown_maintenance_executor()
+
+    async def _message_one_shot_run(
+        self,
+        tmp_path,
+        release,
+        *,
+        starve: bool,
+        budget: int = 8,
+        slow_gate: bool = False,
+        cancel_gate: bool = False,
+    ):
+        """Drive the REAL message callback under the REAL wake deadline.
+
+        Returns ``(svc, job, gw)`` after ``_execute_with_timeout`` has returned, so
+        the caller can run the real ``_merge_job_result`` and inspect retention.
+        ``starve`` occupies the gate pool so the call never gets a worker (the
+        QUEUE bound). ``slow_gate`` leaves the pool free and makes the gate's own
+        work overrun (the EXECUTION bound). Those two bounds fail differently
+        inside ``run_in_cron_pool``, which is the whole reason both are driven.
+        ``cancel_gate`` stalls the whole gate call so NEITHER bound fires and the
+        real wake deadline cancels the await instead -- a third outcome the other
+        two are structurally blind to, because they raise something the caller's
+        ``except`` clause catches and a ``CancelledError`` is not caught there.
+        """
+        from kiro_crew.cron import CronService
+
+        gw = _make_gw()
+        captured_cb = None
+        with (
+            patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls,
+            patch("kiro_crew.mcp_cron._vet_cron_capability_governance", return_value=None),
+            patch("kiro_crew.slack.gateway.sel"),
+        ):
+
+            def capture_cron(on_job=None, **kw):
+                nonlocal captured_cb
+                captured_cb = on_job
+                stub = MagicMock()
+                stub.start = AsyncMock()
+                stub.remove_job_async = AsyncMock(return_value=True)
+                return stub
+
+            mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+            await gw._init_cron()
+            assert captured_cb is not None
+
+            if starve:
+                for _ in range(ex._MAX_CRON_GATE_WORKERS):
+                    ex.cron_gate_executor().submit(release.wait, 20.0)
+                await asyncio.sleep(0.2)
+
+            svc = CronService(base_dir=tmp_path, on_job=captured_cb)
+            svc._load()
+            job = svc.add_job(
+                name="msg-one-shot",
+                message="hello",
+                every_secs=300,
+                delete_after_run=True,
+            )
+            job.timeout_secs = budget
+            assert any(j.id == job.id for j in svc.list_jobs())
+            # slow_gate leaves the pool FREE, so the call is claimed at once and
+            # then overruns its own bound -- the execution phase, not the queue
+            # phase, and the two raise different exception types.
+            gate_work = (
+                patch(
+                    "kiro_crew.slack.gateway.vet_job_at_fire_time",
+                    lambda job: release.wait(20.0),
+                )
+                if slow_gate
+                else nullcontext()
+            )
+            gate_stall = (
+                patch("kiro_crew.slack.gateway.run_in_cron_gate_pool", _stalled_gate)
+                if cancel_gate
+                else nullcontext()
+            )
+            with gate_work, gate_stall:
+                await svc._execute_with_timeout(job)
+        return svc, job, gw
+
+    @pytest.mark.asyncio
+    async def test_a_starved_message_one_shot_survives_the_wake_deadline(self, tmp_path, gate_pool):
+        """A message one-shot whose GATE is starved must not be consumed.
+
+        The fire-time gate is awaited inside the wake deadline
+        ``_execute_with_timeout`` has already armed, and a message job carries no
+        ``_pool_queue_allowance`` to cover it. Pre-fix the gate had no bound of its
+        own, so a busy pool let the WAKE deadline expire first --
+        ``_execute_with_timeout`` then caught the ``TimeoutError`` and returned
+        normally, ``_merge_job_result`` saw an ordinary finished run, and the
+        ``delete_after_run`` job was deleted having never dispatched.
+
+        The gate's bound is now capped below the wake budget so starvation
+        surfaces as ``CronQueueTimeout`` FIRST, which is what makes the existing
+        ``run_never_started`` retention marker reachable on this path.
+
+        Fails pre-fix: with the gate unbounded the job is gone from the store.
+        """
+        svc, job, gw = await self._message_one_shot_run(tmp_path, gate_pool, starve=True)
+
+        assert job.run_never_started is True, "starvation did not mark the run as never started"
+        assert job.last_error.startswith("fire-time gate "), (
+            f"gate starvation was not reported as such: {job.last_error!r}"
+        )
+        assert not gw.sessions.get_or_create.called, "the job dispatched; this is not a starved run"
+
+        # Off-loop: _merge_job_result enters the bounded sync store lock.
+        await asyncio.to_thread(svc._merge_job_result, job)
+        assert any(j.id == job.id for j in svc.list_jobs()), (
+            "the starved message one-shot was deleted by a run that never dispatched"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_dispatched_message_one_shot_is_still_deleted(self, tmp_path, gate_pool):
+        """Negative control: retention must not leak onto a run that DID dispatch.
+
+        Same path with the gate pool free. The one-shot reaches its dispatch and
+        must then be consumed exactly as before -- otherwise the retention marker
+        has stopped meaning "never started" and every message one-shot would
+        survive forever. This fails for that reason if the marker is set
+        unconditionally rather than only on ``CronQueueTimeout``.
+        """
+        svc, job, gw = await self._message_one_shot_run(tmp_path, gate_pool, starve=False)
+
+        assert gw.sessions.get_or_create.called, "the control never dispatched, so it proves nothing"
+        assert job.run_never_started is False, "a dispatched run was marked never-started"
+
+        await asyncio.to_thread(svc._merge_job_result, job)
+        assert not any(j.id == job.id for j in svc.list_jobs()), (
+            "a message one-shot that DID dispatch was retained; the marker is too broad"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_execution_deadline_accounts_for_the_gate_bound(self, tmp_path):
+        """The gate's bound is a THIRD term the run deadline has to carry.
+
+        The gate is awaited before the pool dispatch and INSIDE the deadline armed
+        for the whole run, so a gate spending its full bound leaves the subprocess
+        that much less. A thread cannot be interrupted, so when the deadline then
+        fires with a worker already claimed, the overlap guards clear while the
+        subprocess runs on and the next wake duplicates its side effects. That is
+        the hazard ``_SUBPROC_CLEANUP_ALLOWANCE_SECS`` exists for; the queue wait
+        was a second term it did not account for, and this is a third.
+
+        Observes the deadline the code actually arms, by capturing the ``timeout``
+        handed to the enclosing ``wait_for`` -- asserting on the allowance helper
+        instead would pass with the term missing from the deadline entirely.
+
+        Fails pre-fix: 2700s armed where 2730s is owed.
+        """
+        import math
+
+        import kiro_crew.cron as cron_mod
+        from kiro_crew.cron import (
+            CronService,
+            _pool_queue_allowance,
+            _vet_allowance,
+            effective_wake_budget,
+        )
+
+        real_wait_for = asyncio.wait_for
+
+        async def _capture(aw, timeout=None):
+            captured.setdefault("timeout", timeout)
+            return await real_wait_for(aw, timeout=timeout)
+
+        for job in (_make_command_job(timeout_secs=1800), _make_command_job(timeout_secs=8)):
+            captured: dict[str, object] = {}
+            svc = CronService(base_dir=tmp_path, on_job=AsyncMock(return_value=None))
+            with patch.object(cron_mod.asyncio, "wait_for", _capture):
+                await svc._execute_with_timeout(job)
+            wake = effective_wake_budget(job)
+            gate = ex.cron_gate_budget(wake)
+            owed = (
+                wake
+                + _pool_queue_allowance(job)
+                + math.ceil(gate)
+                + _vet_allowance(job)
+            )
+            assert captured["timeout"] == owed, (
+                f"armed {captured['timeout']}s for a run owed {owed}s "
+                f"(wake {wake} + queue {_pool_queue_allowance(job)} + gate {gate} "
+                f"+ claim-time vet {_vet_allowance(job)})"
+            )
+            # Integer, or "Timed out after 2s" reaches the operator as "2.0s".
+            assert isinstance(captured["timeout"], int)
+
+        # A message job dispatches nothing through the pool, so it carries no
+        # claimed-worker hazard and its budget stays exactly as set -- its
+        # protection is that the gate's bound lands strictly below it.
+        captured = {}
+        msg = CronJob(id="m", name="n", message="hi", timeout_secs=8)
+        svc = CronService(base_dir=tmp_path, on_job=AsyncMock(return_value=None))
+        with patch.object(cron_mod.asyncio, "wait_for", _capture):
+            await svc._execute_with_timeout(msg)
+        assert captured["timeout"] == 8, "a message job's wake budget was widened"
+        assert ex.cron_gate_budget(8) < 8
+
+    @pytest.mark.asyncio
+    async def test_the_reaper_window_also_accounts_for_the_gate_bound(self, tmp_path):
+        """Both deadlines must move together or one pre-empts the other.
+
+        This branch already fixed that once for the queue allowance: widening only
+        the execution guard left the reaper lower, so it force-killed runs still
+        inside their own deadline. Adding the gate term to one and not the other
+        re-opens exactly that gap, 30s wide at the default budget.
+
+        Fails pre-fix: the reaper's threshold is 2700s, the job below has been in
+        flight 2715s, and it is reaped while still inside its execution deadline.
+        """
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+        job = _make_command_job(timeout_secs=1800)
+        assert await self._one_reaper_sweep(svc, job, 2715) is False, (
+            "the reaper force-killed a job inside the gate-inclusive execution deadline"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_slow_gate_does_not_consume_a_message_one_shot(self, tmp_path, gate_pool):
+        """A gate that RUNS but overruns its bound must retain its one-shot.
+
+        The sibling case covers a STARVED gate, which never gets a worker and
+        raises ``CronQueueTimeout``. This one gets a worker immediately and then
+        overruns -- ``run_in_cron_pool``'s execution phase, which raised a plain
+        ``asyncio.TimeoutError``. That bypassed the caller's
+        ``except CronQueueTimeout``, so ``run_never_started`` stayed false, the
+        wake deadline caught the bare timeout as an ordinary overrun, and the
+        ``delete_after_run`` job was deleted having never dispatched.
+
+        Fails pre-fix on the job being gone from the store.
+        """
+        svc, job, gw = await self._message_one_shot_run(
+            tmp_path, gate_pool, starve=False, slow_gate=True
+        )
+
+        assert job.run_never_started is True, "a gate that overran its bound was not retained"
+        assert not gw.sessions.get_or_create.called, "the job dispatched; the gate did not overrun"
+        await asyncio.to_thread(svc._merge_job_result, job)
+        assert any(j.id == job.id for j in svc.list_jobs()), (
+            "a message one-shot was deleted by a gate that overran its own bound"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_gate_cancelled_by_the_wake_deadline_keeps_its_one_shot(
+        self, tmp_path, gate_pool
+    ):
+        """A cancellation landing ON the gate await must still retain the one-shot.
+
+        The gate's bounds are sized to fire before the wake deadline, but no
+        internal sizing survives a stall that pushes wall clock past BOTH of them:
+        ``asyncio.wait_for`` in ``_execute_with_timeout`` then cancels this
+        coroutine AT the await, and a ``CancelledError`` is not a
+        ``CronQueueTimeout``, so the ``except`` clause that sets the retention
+        marker never executes at all. ``_execute_with_timeout`` catches the
+        timeout and returns normally, so ``_merge_job_result`` saw an ordinary
+        finished run and consumed a ``delete_after_run`` job that never
+        dispatched.
+
+        The starvation and overrun siblings both RAISE something the handler
+        catches, which is exactly why they are blind to this: they can only prove
+        the handler works, never that it runs. The marker is therefore set BEFORE
+        the await and cleared only once a verdict comes back.
+
+        Fails pre-fix on the job being gone from the store.
+        """
+        svc, job, gw = await self._message_one_shot_run(
+            tmp_path, gate_pool, starve=False, budget=1, cancel_gate=True
+        )
+
+        assert not gw.sessions.get_or_create.called, (
+            "the job dispatched, so the gate was never cancelled and this proves nothing"
+        )
+        assert job.run_never_started is True, (
+            "a run cancelled at the fire-time gate was not marked never-started"
+        )
+
+        # Off-loop: _merge_job_result enters the bounded sync store lock.
+        await asyncio.to_thread(svc._merge_job_result, job)
+        assert any(j.id == job.id for j in svc.list_jobs()), (
+            "the one-shot was deleted by a run cancelled at the gate before it dispatched"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_returned_verdict_clears_the_retention_marker(self, tmp_path):
+        """The opposite direction: pre-setting the marker must not leak.
+
+        Defaulting to retain is only safe if every path that reaches a verdict
+        clears it again. Miss one and a HEALTHY gate leaves the marker set, so the
+        delete site retains a one-shot that already ran -- silent duplicate firing
+        or a job that never leaves the queue, which is the same class of bug
+        pointing the other way.
+
+        Both verdict shapes are driven, since an allow and a deny leave the gate
+        by the same return: the deny still has to clear this marker, because its
+        retention is owned by ``fire_time_denied``, whose readers also park an
+        at-job disabled. Conflating them would park a job for a policy decision
+        that was never made.
+        """
+        from kiro_crew.slack.gateway import _await_cron_fire_time_gate
+
+        for verdict in (None, "denied by policy"):
+            job = CronJob(
+                id="j1",
+                name="n",
+                message="hello",
+                schedule=CronSchedule(kind="every", every_secs=300),
+            )
+            job.run_never_started = True  # a stale True must not survive a verdict
+
+            async def _verdict_gate(*_a, _v=verdict, **_kw):
+                return _v
+
+            with patch("kiro_crew.slack.gateway.run_in_cron_gate_pool", _verdict_gate):
+                reason, starved = await _await_cron_fire_time_gate(
+                    job, tool_name="t", tool_kind="k"
+                )
+
+            assert reason == verdict
+            assert starved is False
+            assert job.run_never_started is False, (
+                f"a returned verdict ({verdict!r}) left the retention marker set"
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kind,extra,retained",
+        [
+            ("message", {}, True),
+            ("command", {"command": "echo hi"}, False),
+            ("script", {"script": "~/.meshclaw/crons/f.py:g"}, False),
+        ],
+    )
+    async def test_gate_starvation_clears_the_carried_result_only_for_command_and_script(
+        self, kind, extra, retained
+    ):
+        """Starvation at the gate must not drop a message job's dedup context.
+
+        ``last_result`` is a CROSS-RUN field: build_cron_session_context prepends
+        it as "[Previous run result -- do NOT repeat the same content]" for a
+        persistent-session job, so a result-less run deliberately leaves it in
+        place. ``_run_job_isolated`` scopes its own clear to
+        ``job.command or job.script`` for exactly that reason, and the message
+        fire-time deny path never clears at all -- but the shared gate helper
+        cleared for ALL kinds, so a message cron starved at the gate lost the
+        context and the next run repeated content it had already sent.
+
+        Parametrised over all three kinds because asserting retention ALONE
+        would also pass if the clear were deleted outright: the command and
+        script cases are what pin the clear still firing where it belongs.
+        """
+        import kiro_crew.executors as ex
+        from kiro_crew.slack.gateway import _await_cron_fire_time_gate
+
+        job = CronJob(
+            id="j1",
+            name="n",
+            message="hello",
+            schedule=CronSchedule(kind="every", every_secs=300),
+            **extra,
+        )
+        job.last_result = "previously sent content"
+        assert job.result_produced is False, "this run produced nothing; the clear must be live"
+
+        async def _starved_gate(*_a, **_kw):
+            raise ex.CronQueueTimeout(300.0)
+
+        with patch("kiro_crew.slack.gateway.run_in_cron_gate_pool", _starved_gate):
+            reason, starved = await _await_cron_fire_time_gate(job, tool_name="t", tool_kind="k")
+
+        assert starved is True and reason is None, "starvation did not report as starved"
+        assert job.run_never_started is True, "a starved run was not marked never-started"
+        if retained:
+            assert job.last_result == "previously sent content", (
+                f"a starved {kind} job lost its cross-run dedup context, so the next run "
+                "repeats content it already sent"
+            )
+        else:
+            assert job.last_result == "", (
+                f"a starved {kind} job kept a previous run's output, which would display "
+                "beside this run's status"
+            )
+
+
+class TestClaimBackstopRetainsAnUnstartedOneShot:
+    """The claim backstop must not consume a one-shot whose payload never ran.
+
+    ``_claim_backstop`` bounds the whole submitted call -- the claim-time vet AND
+    the payload. When it expires the caller lands in ``except
+    asyncio.TimeoutError``, and that arm fires for two materially different runs:
+
+    * the vet burned the bound before ``handoff.claim()`` was ever granted, so
+      NOTHING executed; and
+    * ``claim()`` was granted, the payload started, and the subprocess overran.
+
+    Only the first is a never-started run. ``abandon()`` is the sole thing that
+    separates them -- it reports whether the payload had started -- and
+    ``cron.py``'s delete site reads ``run_never_started`` to decide whether a
+    ``delete_after_run`` job is retained or consumed.
+
+    Both directions are asserted, plus the deny path, because each of the three
+    is a silent failure pointing a different way: retain a run that DID dispatch
+    and the one-shot fires twice or never leaves the queue; set this marker on a
+    deny and an at-job is parked disabled for a policy decision never made,
+    whose retention belongs to ``fire_time_denied``.
+    """
+
+    @staticmethod
+    def _pool(*, grant_claim: bool):
+        """Stand in for run_in_cron_pool, deciding whether claim() is reached.
+
+        grant_claim=False models the backstop expiring DURING the vet: the
+        submitted wrapper is never invoked, so ``_started`` stays False.
+        grant_claim=True models a payload that started and then overran: the
+        wrapper runs (reaching ``handoff.claim()``) before the bound expires.
+        """
+
+        async def _fake(func, /, *args, timeout, **kw):
+            if grant_claim:
+                func(*args)
+            raise asyncio.TimeoutError
+
+        return _fake
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("grant_claim,expect_retained", [(False, True), (True, False)])
+    async def test_backstop_retains_only_the_run_that_never_started(
+        self, tmp_path, grant_claim, expect_retained
+    ):
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+        svc._load()
+        created = svc.add_job(
+            name="one-shot",
+            message="",
+            every_secs=300,
+            command="echo hi",
+            delete_after_run=True,
+        )
+        assert any(j.id == created.id for j in svc.list_jobs())
+
+        gw = _make_gw()
+        with patch("kiro_crew.slack.gateway.run_in_cron_pool", self._pool(grant_claim=grant_claim)):
+            await _run_command_callback(gw, created, {"status": "ok", "output": "x"})
+
+        assert created.run_never_started is expect_retained, (
+            "the claim backstop expired before claim() yet the run was not marked "
+            "never-started, so _merge_job_result will delete a one-shot that "
+            "dispatched nothing"
+            if expect_retained
+            else "a payload that DID start was marked never-started, so a healthy "
+            "one-shot is retained and will fire again or never leave the queue"
+        )
+
+        # Off-loop: _merge_job_result enters the bounded sync store lock.
+        await asyncio.to_thread(svc._merge_job_result, created)
+        still_present = any(j.id == created.id for j in svc.list_jobs())
+        assert still_present is expect_retained, (
+            "the one-shot was deleted by a run that never dispatched"
+            if expect_retained
+            else "the one-shot survived a run that did dispatch"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_deny_leaves_retention_to_fire_time_denied(self, tmp_path):
+        """A deny must NOT borrow this marker -- its readers park an at-job disabled."""
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+        svc._load()
+        created = svc.add_job(
+            name="one-shot-denied",
+            message="",
+            every_secs=300,
+            command="echo hi",
+            delete_after_run=True,
+        )
+
+        async def _denying_pool(func, /, *args, timeout, **kw):
+            return func(*args)  # the wrapper raises CronClaimTimeDenied itself
+
+        gw = _make_gw()
+        with patch("kiro_crew.slack.gateway.run_in_cron_pool", _denying_pool):
+            await _run_command_callback(
+                gw, created, {"status": "ok", "output": "x"}, vet_reason="denied by policy"
+            )
+
+        assert created.fire_time_denied is True, "a policy deny did not record fire_time_denied"
+        assert created.run_never_started is False, (
+            "a policy deny set run_never_started, conflating a governance refusal with "
+            "a never-started run -- that parks an at-job disabled for a decision never made"
+        )
+        # Retained either way, but by the RIGHT owner.
+        await asyncio.to_thread(svc._merge_job_result, created)
+        assert any(j.id == created.id for j in svc.list_jobs()), "a denied one-shot was consumed"
+
+
+class TestClaimBackstopDoesNotConsumeTheFailureBudget:
+    """A claim-backstop timeout must only count when the payload dispatched.
+
+    ``_claim_backstop`` bounds the vet AND the payload, so its
+    ``asyncio.TimeoutError`` arm fires for two different runs: a vet that burned
+    the bound before ``handoff.claim()`` (nothing executed), and a payload that
+    started and then overran. Counting the first auto-pauses at
+    ``_AUTO_PAUSE_THRESHOLD`` -- and a paused job never fires again -- so
+    repeated wedged wakes would permanently disable a healthy job that has not
+    run a line, exactly the harm the starvation, gate-deny and vet-overrun arms
+    already decline to cause.
+
+    NOTE ON WHY THIS LIVES HERE. ``test_cron_timeout_autopause_424.py`` pins the
+    same invariant one layer down, but it monkeypatches ``asyncio.wait_for`` and
+    drives ``CronService._execute_with_timeout`` directly -- it never enters
+    ``gateway.py``, so it is structurally blind to these two arms and would pass
+    whether or not they are fixed. This test drives the gateway callback so the
+    arm itself is what is measured.
+
+    Parametrised over BOTH arms and BOTH directions: asserting only the
+    exemption would also pass if the count were deleted outright, so the
+    started=True cases are what pin the counter still firing for a real overrun.
+    """
+
+    @staticmethod
+    def _pool(*, grant_claim: bool):
+        """Stand in for run_in_cron_pool, choosing whether claim() is reached.
+
+        grant_claim=False models the backstop expiring DURING the vet: the
+        submitted wrapper is never invoked, so ``_started`` stays False and
+        ``abandon()`` reports the payload as never started. grant_claim=True
+        invokes the wrapper first (reaching ``handoff.claim()``) and only then
+        expires, modelling a payload that ran and overran.
+        """
+
+        async def _fake(func, /, *args, timeout, **kw):
+            if grant_claim:
+                func(*args)
+            raise asyncio.TimeoutError
+
+        return _fake
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("grant_claim,expected_count", [(False, 3), (True, 4)])
+    async def test_command_backstop_counts_only_a_dispatched_run(self, grant_claim, expected_count):
+        gw = _make_gw()
+        job = _make_command_job(consecutive_failures=3)
+
+        with patch("kiro_crew.slack.gateway.run_in_cron_pool", self._pool(grant_claim=grant_claim)):
+            await _run_command_callback(gw, job, {"status": "ok", "output": "x"})
+
+        assert job.consecutive_failures == expected_count, (
+            "a claim-backstop timeout whose payload never started incremented the "
+            "failure budget, so repeated wedged wakes will auto-pause a job that "
+            "has not run a line"
+            if not grant_claim
+            else "a genuine execution overrun stopped counting, so a job that times "
+            "out on every run would never auto-pause"
+        )
+        assert job.auto_paused is False, "the job was auto-paused by this single run"
+        # The run is still reported as an error either way -- only the counter differs.
+        assert job.last_status == "error"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("grant_claim,expected_count", [(False, 3), (True, 4)])
+    async def test_script_backstop_counts_only_a_dispatched_run(self, grant_claim, expected_count):
+        gw = _make_gw()
+        job = _make_script_job(consecutive_failures=3)
+
+        with patch("kiro_crew.slack.gateway.run_in_cron_pool", self._pool(grant_claim=grant_claim)):
+            await _run_script_callback(gw, job, {"status": "ok"})
+
+        assert job.consecutive_failures == expected_count, (
+            "the SCRIPT claim-backstop arm counted a run whose payload never "
+            "started -- the command arm was fixed and this one was not"
+            if not grant_claim
+            else "the script arm stopped counting a genuine execution overrun"
+        )
+        assert job.auto_paused is False, "the job was auto-paused by this single run"
+        assert job.last_status == "error"
+
+
+class TestACancellationAtTheClaimAwaitKeepsItsOneShot:
+    """A cancellation landing on the claim await must not consume a one-shot.
+
+    ``asyncio.CancelledError`` is a ``BaseException``, so none of the command or
+    script block's ``except`` arms caught it -- not the claim backstop's
+    ``asyncio.TimeoutError``, and not the trailing ``except Exception``. The
+    shared ``finally`` did call ``handoff.abandon()``, but DISCARDED its return,
+    which is the one bit separating "the payload never started" from "the payload
+    ran". So a shutdown or wake deadline landing mid-vet reached ``cron.py``'s
+    delete site with neither ``run_never_started`` nor ``fire_time_denied`` set,
+    and a ``delete_after_run`` job was consumed having never executed.
+
+    The same class of bug was already cured one path over for the message-job
+    fire-time gate (see
+    ``test_a_gate_cancelled_by_the_wake_deadline_keeps_its_one_shot``, whose
+    docstring names this exact mechanism); the command and script claim awaits
+    were the ones still exposed.
+
+    NOTE ON PLACEMENT, which is what the tests below actually pin. The fix is an
+    ``except asyncio.CancelledError`` arm, NOT an assignment in the shared
+    ``finally``: the fire-time deny path reaches that ``finally`` with the
+    payload equally unstarted, and setting this marker there would park an at-job
+    disabled for a policy decision that was never made -- retention on that path
+    is owned by ``fire_time_denied``. ``test_deny`` below is what keeps that
+    closed, and ``grant_claim=True`` is what keeps the mirror closed: a payload
+    that DID run must stay deletable, or the one-shot fires twice.
+    """
+
+    @staticmethod
+    def _cancelling_pool(*, grant_claim: bool):
+        """Stand in for run_in_cron_pool, cancelling instead of timing out.
+
+        grant_claim=False models the deadline cancelling the await DURING the
+        claim-time vet: the submitted wrapper is never invoked, so ``_started``
+        stays False and ``abandon()`` reports the payload as never started.
+        grant_claim=True invokes the wrapper first, reaching ``handoff.claim()``,
+        so the cancellation lands on a run that did dispatch.
+        """
+
+        async def _fake(func, /, *args, timeout, **kw):
+            if grant_claim:
+                func(*args)
+            raise asyncio.CancelledError
+
+        return _fake
+
+    @staticmethod
+    def _one_shot(tmp_path, **kw):
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path, on_job=lambda *a, **k: None)
+        svc._load()
+        created = svc.add_job(
+            name="one-shot", message="", every_secs=300, delete_after_run=True, **kw
+        )
+        assert any(j.id == created.id for j in svc.list_jobs()), "fixture did not store the job"
+        return svc, created
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("grant_claim,expect_retained", [(False, True), (True, False)])
+    async def test_command_cancellation_retains_only_the_run_that_never_started(
+        self, tmp_path, grant_claim, expect_retained
+    ):
+        svc, created = self._one_shot(tmp_path, command="echo hi")
+        gw = _make_gw()
+
+        # Re-raised, so cooperative cancellation is preserved: swallowing it here
+        # would leave the caller believing the run completed.
+        with patch(
+            "kiro_crew.slack.gateway.run_in_cron_pool",
+            self._cancelling_pool(grant_claim=grant_claim),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _run_command_callback(gw, created, {"status": "ok", "output": "x"})
+
+        assert created.run_never_started is expect_retained, (
+            "a cancellation landed on the claim await before claim() yet the run "
+            "was not marked never-started, so _merge_job_result will delete a "
+            "one-shot that dispatched nothing"
+            if expect_retained
+            else "a payload that DID start was marked never-started, so a healthy "
+            "one-shot is retained and will fire again or never leave the queue"
+        )
+        assert created.fire_time_denied is False, "a cancellation recorded a denial it never made"
+
+        # Off-loop: _merge_job_result enters the bounded sync store lock.
+        await asyncio.to_thread(svc._merge_job_result, created)
+        survived = any(j.id == created.id for j in svc.list_jobs())
+        assert survived is expect_retained, (
+            "the one-shot was deleted by a run cancelled before it dispatched"
+            if expect_retained
+            else "a one-shot that DID execute was retained, so it fires a second time"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("grant_claim,expect_retained", [(False, True), (True, False)])
+    async def test_script_cancellation_retains_only_the_run_that_never_started(
+        self, tmp_path, grant_claim, expect_retained
+    ):
+        svc, created = self._one_shot(tmp_path, script="~/.kirocrew/crons/monitor.py:run")
+        gw = _make_gw()
+
+        with patch(
+            "kiro_crew.slack.gateway.run_in_cron_pool",
+            self._cancelling_pool(grant_claim=grant_claim),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _run_script_callback(gw, created, {"status": "ok"})
+
+        assert created.run_never_started is expect_retained, (
+            "the SCRIPT claim await was cancelled before claim() yet the run was "
+            "not marked never-started -- the command arm was fixed and this one "
+            "was not"
+            if expect_retained
+            else "the script arm marked a payload that DID start as never-started"
+        )
+
+        await asyncio.to_thread(svc._merge_job_result, created)
+        survived = any(j.id == created.id for j in svc.list_jobs())
+        assert survived is expect_retained, (
+            "the script one-shot was deleted by a run cancelled before it dispatched"
+            if expect_retained
+            else "a script one-shot that DID execute was retained"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_deny_still_leaves_retention_to_fire_time_denied(self, tmp_path):
+        """The placement guard: the deny path must not acquire this marker.
+
+        A deny reaches the same shared ``finally`` with the payload unstarted, so
+        an assignment placed THERE would set ``run_never_started`` here too. That
+        is why the fix lives in the cancellation arm instead, and this is the
+        test that would go red if it were ever moved.
+        """
+        svc, created = self._one_shot(tmp_path, command="echo hi")
+
+        async def _denying_pool(func, /, *args, timeout, **kw):
+            return func(*args)  # the wrapper raises CronClaimTimeDenied itself
+
+        gw = _make_gw()
+        with patch("kiro_crew.slack.gateway.run_in_cron_pool", _denying_pool):
+            await _run_command_callback(
+                gw, created, {"status": "ok", "output": "x"}, vet_reason="denied by policy"
+            )
+
+        assert created.fire_time_denied is True, "a policy deny did not record fire_time_denied"
+        assert created.run_never_started is False, (
+            "a policy deny set run_never_started, conflating a governance refusal "
+            "with a never-started run -- that parks an at-job disabled for a "
+            "decision never made"
+        )
+
+        await asyncio.to_thread(svc._merge_job_result, created)
+        assert any(j.id == created.id for j in svc.list_jobs()), "a denied one-shot was consumed"

--- a/test/test_cron_timeout_autopause_424.py
+++ b/test/test_cron_timeout_autopause_424.py
@@ -80,3 +80,48 @@ async def test_timeout_after_recorded_failure_counts_once(tmp_path, monkeypatch)
     await svc._execute_with_timeout(job)
     assert job.consecutive_failures == 1
     assert job.last_status == "error"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("never_started,expected_count", [(True, 0), (False, 1)])
+async def test_a_never_started_run_does_not_consume_the_failure_budget(
+    tmp_path, monkeypatch, never_started, expected_count
+):
+    """A run that dispatched nothing must not count toward auto-pause.
+
+    A stall that pushes wall clock past the wake deadline while the fire-time
+    gate is still awaited cancels the coroutine AT that await, so no handler
+    inside the gate runs and the marker set before it survives -- and the
+    TimeoutError lands here on a run that executed no payload. Counting it
+    auto-pauses at _AUTO_PAUSE_THRESHOLD, and a paused job never fires again,
+    so repeated event-loop saturation durably disables a job that has not run a
+    line. The starvation, gate-deny and vet-overrun paths already decline for
+    this reason; this handler was the one that did not.
+
+    Parametrised over BOTH directions on purpose: asserting only the exemption
+    would also pass if the count were deleted outright, so the never_started
+    =False case is what pins the count still firing for a genuine overrun.
+    """
+    svc = CronService(base_dir=tmp_path)
+    job = CronJob(id="j4", name="slow", message="hi", timeout_secs=1)
+
+    async def _timeout_immediately(coro, timeout, _m=never_started):
+        coro.close()
+        # _execute resets this to False before invoking the callback; the
+        # gateway's gate helper sets it True before its own await.
+        job.run_never_started = _m
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(cron_mod.asyncio, "wait_for", _timeout_immediately)
+    await svc._execute_with_timeout(job)
+
+    assert job.consecutive_failures == expected_count, (
+        "a never-started run consumed the failure budget, so repeated gate "
+        "stalls will auto-pause a job that dispatched nothing"
+        if never_started
+        else "a genuine execution overrun stopped counting, so a job that times "
+        "out on every run would never auto-pause"
+    )
+    # The run is still reported as an error either way -- only the counter differs.
+    assert job.last_status == "error"
+    assert job.auto_paused is False

--- a/test/test_executors.py
+++ b/test/test_executors.py
@@ -8,6 +8,12 @@ kiro-cli/MCP children (the documented root cause of the loop wedge).
 
 from __future__ import annotations
 
+import asyncio
+import threading
+from unittest import mock
+
+import pytest
+
 import kiro_crew.executors as ex
 
 
@@ -91,3 +97,525 @@ def test_governance_pool_is_isolated_bounded_and_reset() -> None:
     # Shutdown resets it (fresh pool next use).
     ex.shutdown_maintenance_executor()
     assert ex.governance_executor() is not gov
+
+
+# --- run_in_cron_pool: queue wait must not be charged to the job's timeout ----
+#
+# The defect these cover: loop.run_in_executor only SUBMITS. With the cron pool
+# bounded at _MAX_CRON_WORKERS, a call whose workers are all busy waits in the
+# pool's queue having run no code -- but asyncio.wait_for starts counting when
+# awaited, so wrapping the whole submit+run in one wait_for spends the job's own
+# budget on queue time and then reports the job as having timed out itself.
+
+
+@pytest.fixture
+def single_worker_cron_pool(monkeypatch):
+    """Give the cron pool exactly ONE worker, so one blocker starves it.
+
+    The pool is memoized process-wide, so it has to be torn down both before
+    (to drop any pool built at the default width) and after (so later tests
+    don't inherit a 1-worker pool).
+    """
+    ex.shutdown_maintenance_executor()
+    monkeypatch.setattr(ex, "_MAX_CRON_WORKERS", 1)
+    release = threading.Event()
+    entered = threading.Event()
+
+    def _occupy() -> None:
+        entered.set()
+        release.wait(timeout=30)
+
+    ex.cron_executor().submit(_occupy)
+    assert entered.wait(timeout=5), "blocker never claimed the only worker"
+    try:
+        yield release
+    finally:
+        release.set()
+        ex.shutdown_maintenance_executor()
+
+
+@pytest.mark.asyncio
+async def test_queue_wait_is_not_charged_to_the_execution_timeout(single_worker_cron_pool):
+    """A FAST call queued behind a busy worker must still run.
+
+    Negative control for the defect: the execution timeout here (0.2s) is far
+    shorter than the queue wait (~0.5s), so the pre-fix construct
+    ``wait_for(run_in_executor(...), timeout=0.2)`` would kill this call and
+    report it as the callable overrunning -- even though the callable is
+    instant. Charging queue time to execution is the bug; this asserts it isn't.
+    """
+    release = single_worker_cron_pool
+    loop = asyncio.get_running_loop()
+    loop.call_later(0.5, release.set)
+
+    result = await ex.run_in_cron_pool(lambda: "ran", timeout=0.2, queue_timeout=10)
+
+    assert result == "ran"
+
+
+@pytest.mark.asyncio
+async def test_starved_pool_reports_queued_never_ran_not_a_timeout(single_worker_cron_pool):
+    """Exhausting the QUEUE budget is reported as its own thing.
+
+    This is the misdiagnosis half: without a distinct error the next pool
+    saturation reads as N separate jobs that each overran, which is what makes
+    it cost days to spot.
+    """
+    with pytest.raises(ex.CronQueueTimeout) as excinfo:
+        await ex.run_in_cron_pool(lambda: "ran", timeout=30, queue_timeout=0.3)
+
+    assert "never ran" in str(excinfo.value)
+    assert excinfo.value.waited >= 0.3
+
+
+@pytest.mark.asyncio
+async def test_waited_still_covers_the_budget_when_the_timer_fires_early(
+    single_worker_cron_pool,
+):
+    """The reported wait must cover the budget even on a coarse-clock platform.
+
+    ``BaseEventLoop._run_once`` dispatches a timer once
+    ``handle._when < time() + _clock_resolution``, so a wake can arrive up to one
+    clock resolution EARLY -- about 15.6ms on Windows, ~0 on Linux. A queue phase
+    that trusted that wake reported a wait SHORTER than the budget it had just
+    exhausted (observed on CI: 0.297 against a 0.3 bound), so the deadline has to
+    be re-checked rather than believed.
+
+    Both knobs below are patched to model that platform on any host, because the
+    defect is unreachable on a fine-clock one.
+    """
+    loop = asyncio.get_running_loop()
+    win_resolution = 0.015625
+    selector = loop._selector
+    original_select = selector.select
+    loop._clock_resolution = win_resolution
+    # Return inside the early-fire window, which is what makes _run_once
+    # dispatch the timer before the deadline.
+    selector.select = lambda t=None: original_select(
+        None if t is None else max(0.0, t - win_resolution)
+    )
+    try:
+        with pytest.raises(ex.CronQueueTimeout) as excinfo:
+            await ex.run_in_cron_pool(lambda: "ran", timeout=30, queue_timeout=0.3)
+    finally:
+        selector.select = original_select
+
+    # The invariant, held by construction rather than by tolerance.
+    assert excinfo.value.waited >= 0.3
+    # And the classification must still be the queue phase, not an overrun.
+    assert "never ran" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_a_call_claimed_at_the_deadline_is_not_reported_as_never_ran():
+    """A worker claiming the call right AT the budget must not read as a queue timeout.
+
+    ``_mark_started`` is delivered by ``call_soon_threadsafe``, which only
+    ENQUEUES, so it trails the worker's real claim: ``started`` can still be
+    unresolved for a call that is already executing.  Reporting "never ran"
+    there is not merely inaccurate -- the caller's overlap guard is released on
+    that error, so the next fire starts a second run beside the one still
+    executing, and a thread cannot be interrupted to prevent it.
+    """
+    ex.shutdown_maintenance_executor()
+    loop = asyncio.get_running_loop()
+    ran = threading.Event()
+
+    def payload() -> str:
+        ran.set()
+        return "completed"
+
+    # Model the loop's ready-queue lag deterministically, and ONLY for the claim
+    # signal -- wrap_future uses call_soon_threadsafe for its own completion
+    # plumbing, so deferring everything would just make this test slow.  The
+    # real window is the gap between the worker enqueueing _mark_started and the
+    # loop running it, which is widest exactly when the loop is saturated -- the
+    # same condition under which the pool is saturated and budgets expire.
+    real_call_soon_threadsafe = loop.call_soon_threadsafe
+
+    def lagging(cb, *a):  # type: ignore[no-untyped-def]
+        if getattr(cb, "__name__", "") == "_mark_started":
+            return real_call_soon_threadsafe(loop.call_later, 0.5, cb, *a)
+        return real_call_soon_threadsafe(cb, *a)
+
+    loop.call_soon_threadsafe = lagging  # type: ignore[method-assign]
+    try:
+        result = await ex.run_in_cron_pool(payload, timeout=30, queue_timeout=0.3)
+    finally:
+        loop.call_soon_threadsafe = real_call_soon_threadsafe  # type: ignore[method-assign]
+        ex.shutdown_maintenance_executor()
+
+    assert ran.is_set(), "precondition: a worker must have claimed and run the call"
+    assert result == "completed"
+
+
+@pytest.mark.asyncio
+async def test_execution_timeout_is_still_enforced_as_a_backstop():
+    """With a free pool, an overrunning callable still trips *timeout*.
+
+    The backstop must survive: without it a wedged worker leaves the job entry
+    un-failed forever. It must also NOT be reported as a queue timeout.
+    """
+    ex.shutdown_maintenance_executor()
+    release = threading.Event()
+    try:
+        with pytest.raises(asyncio.TimeoutError) as excinfo:
+            await ex.run_in_cron_pool(lambda: release.wait(5), timeout=0.3, queue_timeout=10)
+        assert not isinstance(excinfo.value, ex.CronQueueTimeout)
+    finally:
+        # Release the worker BEFORE shutting the pool down: shutdown uses
+        # wait=False with cancel_futures=True, which drops queued futures but
+        # cannot stop a callable a worker has already started.  Without this the
+        # thread outlives the test by the remainder of its sleep and leaks into
+        # whatever runs next.
+        release.set()
+        ex.shutdown_maintenance_executor()
+
+
+@pytest.mark.asyncio
+async def test_result_and_exception_pass_through():
+    ex.shutdown_maintenance_executor()
+    try:
+        assert await ex.run_in_cron_pool(lambda: 6 * 7, timeout=5, queue_timeout=5) == 42
+
+        def _boom() -> None:
+            raise ValueError("from the worker")
+
+        with pytest.raises(ValueError, match="from the worker"):
+            await ex.run_in_cron_pool(_boom, timeout=5, queue_timeout=5)
+    finally:
+        ex.shutdown_maintenance_executor()
+
+
+@pytest.mark.asyncio
+async def test_positional_args_reach_the_callable():
+    ex.shutdown_maintenance_executor()
+    try:
+        seen: list[tuple] = []
+        assert (
+            await ex.run_in_cron_pool(
+                lambda *a: seen.append(a) or "ok", 1, "two", timeout=5, queue_timeout=5
+            )
+            == "ok"
+        )
+        assert seen == [(1, "two")]
+    finally:
+        ex.shutdown_maintenance_executor()
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_caller_does_not_leave_the_call_queued(single_worker_cron_pool):
+    """A cancelled cron call must not execute later.
+
+    The queue phase shields its started-signal future so it survives a wake and
+    can be re-waited. That shield also swallows the cancel, so without an
+    explicit handler a caller cancelling this coroutine escapes while the
+    submitted call is still sitting in the pool queue -- and it then runs long
+    after the caller gave up. A cancelled cron command executing anyway is the
+    defect this pins.
+    """
+    release = single_worker_cron_pool  # the fixture holds the pool's only worker
+    ran = threading.Event()
+
+    task = asyncio.create_task(ex.run_in_cron_pool(lambda: ran.set(), timeout=30, queue_timeout=30))
+    await asyncio.sleep(0.2)
+    assert not ran.is_set(), "precondition: the call must still be queued"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    release.set()
+    ex.cron_executor().shutdown(wait=True)  # drain, so a queued call would surface
+    assert not ran.is_set(), "a cancelled call executed anyway"
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_caller_does_not_kill_a_job_already_running():
+    """The other direction: cancellation must not abort work already in flight.
+
+    Propagating the cancel to the pool call has to stay a no-op once a worker
+    has claimed it -- otherwise closing the queued-call leak would start killing
+    jobs mid-execution, which is just as silent and worse.
+    """
+    ex.shutdown_maintenance_executor()
+    entered = threading.Event()
+    finished = threading.Event()
+
+    def slow() -> str:
+        entered.set()
+        threading.Event().wait(0.5)
+        finished.set()
+        return "done"
+
+    try:
+        task = asyncio.create_task(ex.run_in_cron_pool(slow, timeout=30, queue_timeout=30))
+        for _ in range(300):
+            if entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert entered.is_set(), "precondition: the job must have started"
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        ex.cron_executor().shutdown(wait=True)
+        assert finished.is_set(), "cancellation killed a job that was already running"
+    finally:
+        ex.shutdown_maintenance_executor()
+
+
+def test_cron_queue_timeout_is_a_timeout_error() -> None:
+    """Fail-safe: a caller that hasn't been taught the queue phase still copes.
+
+    CronQueueTimeout subclasses asyncio.TimeoutError so an un-updated call site
+    degrades to its existing timeout handling rather than raising something
+    nothing catches. Callers that DO distinguish must order this except first.
+    """
+    exc = ex.CronQueueTimeout(12.4)
+    assert isinstance(exc, asyncio.TimeoutError)
+    assert str(exc) == "queued 12s, never ran"
+    assert exc.waited == 12.4
+
+
+def test_a_sub_second_queue_wait_is_not_rendered_as_zero() -> None:
+    """A floored message read as "did not wait at all" and lost the diagnostic.
+
+    The whole point of the distinct error is telling an operator how long the job
+    sat behind a busy worker, so a real 0.3s wait must not print as ``queued 0s``.
+    """
+    assert str(ex.CronQueueTimeout(0.297)) == "queued 0.30s, never ran"
+    assert str(ex.CronQueueTimeout(0.004)) == "queued 0.00s, never ran"
+    # Whole-second rendering is unchanged above the sub-second range.
+    assert str(ex.CronQueueTimeout(300.0)) == "queued 300s, never ran"
+
+
+def test_cron_queue_wait_budget_is_far_larger_than_a_typical_job_timeout() -> None:
+    """The queue budget must NOT be the job's own timeout.
+
+    Deriving it from job.timeout would still kill a fast job queued behind a
+    wedged worker -- just with a better label. Waiting and then running is the
+    correct outcome; this budget only bounds the pathological case.
+    """
+    assert ex._CRON_QUEUE_WAIT_SECS >= 600
+
+
+def test_cron_gate_pool_is_isolated_from_the_externally_paced_governance_pool() -> None:
+    """The fire-time gate must not queue behind remote inbound traffic.
+
+    Both pools do governance work, so sharing one looks natural -- but they are
+    paced by different things. The governance pool takes one submit per inbound
+    message across five transports plus the dashboard GETs, so a remote burst
+    puts an unbounded FIFO backlog ahead of anything else on it. A cron gate is
+    awaited INSIDE the job's already-armed wake deadline, so a backlog it did not
+    cause is charged to the job's own budget. Here a cron gate queues only behind
+    another cron gate, which the schedule paces.
+    """
+    gate = ex.cron_gate_executor()
+    assert gate is not ex.governance_executor()
+    assert gate is not ex.cron_executor()
+    assert gate is not ex.maintenance_executor()
+    assert gate is not ex.subprocess_executor()
+    # Memoized, named, bounded.
+    assert ex.cron_gate_executor() is gate
+    assert gate._max_workers == ex._MAX_CRON_GATE_WORKERS
+    worker = gate.submit(threading.current_thread).result(timeout=5)
+    assert worker.name.startswith("mc-crongate"), f"gate ran on {worker.name!r}"
+    # Reset by the shared shutdown, or a later test inherits a saturated pool.
+    ex.shutdown_maintenance_executor()
+    assert ex.cron_gate_executor() is not gate
+
+
+def test_the_gate_budget_is_capped_below_the_wake_budget() -> None:
+    """The gate's bound must fire BEFORE the deadline it is awaited inside.
+
+    This is the one place a queue bound is derived from the caller's own clock,
+    and the inversion is deliberate: for the execution pool, waiting past the
+    budget and then running is correct, but a gate verdict arriving after the
+    wake deadline is worthless -- the deadline kills the run either way, and the
+    caller can then no longer tell starvation from an overrun. That ambiguity is
+    precisely the state in which a one-shot is consumed by a run that never
+    dispatched, so the cap is what keeps the retention marker reachable.
+
+    The 1s case is the one that mattered and an earlier revision of this test
+    excused it as an accepted residual. It is not acceptable: a bare
+    ``max(1.0, ...)`` floor returns 1.0 there, so the gate and the wake deadline
+    expire together and the OUTER one wins -- exactly the ambiguity above, at the
+    budget where a one-shot is most likely to be starved.
+    """
+    # Strictly below, for EVERY positive budget including the degenerate ones.
+    for budget in (0.5, 1, 2, 3, 4, 8, 60, 1800, 86400):
+        gate = ex.cron_gate_budget(budget)
+        assert gate < budget, f"gate {gate}s could outlive a {budget}s deadline"
+    # But not collapsed to a vanishing window either, which is the opposite error:
+    # dropping the floor outright hands a 2s job a 0.5s gate and times it out on a
+    # HEALTHY pool, turning a job that would have run into a never-started one.
+    for budget in (2, 3, 4):
+        assert ex.cron_gate_budget(budget) == ex._CRON_GATE_MIN_SECS
+    # A sub-floor budget keeps a usable fraction rather than the floor.
+    assert ex.cron_gate_budget(1) == pytest.approx(1 * ex._CRON_GATE_HEADROOM)
+    # Degenerate input is defined, not an exception or a negative wait.
+    assert ex.cron_gate_budget(0) == 0.0
+    # And it never grows without limit: a long-running job still gets a prompt
+    # verdict instead of a gate allowed to sit for hours.
+    assert ex.cron_gate_budget(86400) == float(ex._CRON_GATE_WAIT_SECS)
+
+
+@pytest.mark.asyncio
+async def test_both_gate_bounds_reach_the_retention_handler() -> None:
+    """Either gate bound expiring must be catchable as CronQueueTimeout.
+
+    ``run_in_cron_pool`` raises ``CronQueueTimeout`` for its QUEUE phase but a
+    plain ``asyncio.TimeoutError`` for its EXECUTION phase. The gate callers key
+    the ``run_never_started`` retention marker off ``except CronQueueTimeout``, so
+    a gate that got a worker and then overran its own bound bypassed that handler
+    entirely and its one-shot was deleted as though the run had happened.
+
+    Both bounds mean the same thing for a gate -- no verdict was reached -- so
+    both must reach the handler. Fails pre-fix on the execution bound with a bare
+    ``TimeoutError`` that is not a ``CronQueueTimeout``.
+    """
+    ex.shutdown_maintenance_executor()
+    release = threading.Event()
+    try:
+        # EXECUTION bound: pool is free, so the call IS claimed and only its own
+        # bound can fire.
+        with pytest.raises(ex.CronQueueTimeout) as ei:
+            await ex.run_in_cron_gate_pool(release.wait, 5.0, timeout=0.3)
+        assert isinstance(ei.value, ex.CronGateTimeout)
+        # Distinct wording: this call did get a worker, so "queued" would lie.
+        assert "queued" not in str(ei.value), str(ei.value)
+
+        # QUEUE bound: saturate so nothing is claimed. Still the base type.
+        release.set()
+        ex.shutdown_maintenance_executor()
+        held = threading.Event()
+        for _ in range(ex._MAX_CRON_GATE_WORKERS):
+            ex.cron_gate_executor().submit(held.wait, 10.0)
+        await asyncio.sleep(0.2)
+        try:
+            with pytest.raises(ex.CronQueueTimeout) as ei2:
+                await ex.run_in_cron_gate_pool(lambda: None, timeout=0.3)
+            assert not isinstance(ei2.value, ex.CronGateTimeout)
+            assert "never ran" in str(ei2.value)
+        finally:
+            held.set()
+    finally:
+        release.set()
+        ex.shutdown_maintenance_executor()
+
+
+@pytest.mark.asyncio
+async def test_a_timeout_from_the_gates_own_work_is_not_a_never_started_run() -> None:
+    """The opposite error to the one above, and it is why the handler stays narrow.
+
+    ``asyncio.TimeoutError`` IS ``builtins.TimeoutError`` on 3.11+, so a socket or
+    subprocess timeout raised INSIDE a governance check is type-identical to the
+    gate's own bound expiring. Widening the caller's handler to every
+    ``asyncio.TimeoutError`` -- the obvious fix for the case above -- would mark
+    that never-started and retain a one-shot whose gate DID reach its work.
+
+    So the gate's own timeout is wrapped in the worker thread before the bound can
+    see it, and stays a ``TimeoutError`` (callers that handle timeouts are
+    unaffected) while NOT being a ``CronQueueTimeout``.
+    """
+    ex.shutdown_maintenance_executor()
+
+    def _gate_that_times_out_internally() -> None:
+        raise TimeoutError("governance store read timed out")
+
+    try:
+        with pytest.raises(asyncio.TimeoutError) as ei:
+            await ex.run_in_cron_gate_pool(_gate_that_times_out_internally, timeout=5.0)
+        assert isinstance(ei.value, ex.CronGateWorkTimeout)
+        assert not isinstance(
+            ei.value, ex.CronQueueTimeout
+        ), "a failed dispatch DECISION was reported as a run that never started"
+        assert "governance store read timed out" in str(ei.value)
+    finally:
+        ex.shutdown_maintenance_executor()
+
+
+@pytest.mark.asyncio
+async def test_the_gate_spends_its_single_budget_once_across_both_phases() -> None:
+    """The gate's queue and execution bounds must SUM to within its own budget.
+
+    ``run_in_cron_pool`` treats *timeout* and *queue_timeout* as two independent
+    budgets -- it charges *timeout* to EXECUTION alone and takes *queue_timeout*
+    as a separate bound -- so handing the same value to both let the gate run for
+    twice the budget it was given. That budget is already
+    ``cron_gate_budget(...)``, sized to land strictly BELOW the job's wake
+    deadline, so spending it twice put the gate's total ABOVE that deadline and
+    the deadline won the race. A 0.6s queue wait followed by a 0.4s run reached
+    neither 0.75s phase bound, so nothing raised, the caller's ``except
+    CronQueueTimeout`` never ran, and a ``delete_after_run`` one-shot was
+    consumed by a run that never dispatched -- the exact regression this module's
+    queue accounting exists to prevent.
+
+    Observed at the enforcing call rather than recomputed here. Re-deriving the
+    split from the same constants would measure the arithmetic and pass whatever
+    the call site actually arms.
+    """
+    budget = 1.0
+    seen: dict[str, float | None] = {}
+
+    async def _spy(func, /, *args, timeout, queue_timeout=None, executor=None):
+        seen["timeout"] = timeout
+        seen["queue_timeout"] = queue_timeout
+        return "verdict"
+
+    with mock.patch.object(ex, "run_in_cron_pool", _spy):
+        assert await ex.run_in_cron_gate_pool(lambda: "verdict", timeout=budget) == "verdict"
+
+    assert seen["queue_timeout"] is not None, "the gate must bound its own queue phase"
+    total = seen["queue_timeout"] + seen["timeout"]
+    assert total <= budget, (
+        f"gate arms {seen['queue_timeout']}s queue + {seen['timeout']}s execution "
+        f"= {total}s total against a {budget}s budget it must stay inside"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_gate_keeps_most_of_its_budget_for_a_claimed_call() -> None:
+    """Splitting the budget must not starve EXECUTION -- the opposite failure.
+
+    Bounding the total is only half the requirement. Hand execution "whatever the
+    queue left over" and a gate a worker has ALREADY claimed -- one that would
+    have answered in milliseconds -- gets a near-zero bound and raises
+    ``CronGateTimeout``. That is a ``CronQueueTimeout`` subclass, so it reaches
+    the retention handler and the one-shot is RETAINED and never fires.
+    Over-deletion would become silent non-dispatch, which is why the execution
+    share is a fixed floor rather than a remainder. The queue bound must stay
+    positive too, or starvation stops being detectable before the total expires.
+    """
+    budget = 1.0
+    seen: dict[str, float | None] = {}
+
+    async def _spy(func, /, *args, timeout, queue_timeout=None, executor=None):
+        seen["timeout"] = timeout
+        seen["queue_timeout"] = queue_timeout
+        return None
+
+    with mock.patch.object(ex, "run_in_cron_pool", _spy):
+        await ex.run_in_cron_gate_pool(lambda: None, timeout=budget)
+
+    assert (
+        seen["timeout"] >= budget / 2
+    ), f"a claimed gate is left only {seen['timeout']}s of its {budget}s budget to answer in"
+    assert seen["queue_timeout"] > 0, "starvation must still be detectable before the total"
+
+    # End to end, with the real pool: a claimed gate that never answers has to
+    # burn a real share of the budget before bailing, not be cut off at once.
+    ex.shutdown_maintenance_executor()
+    release = threading.Event()
+    try:
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        with pytest.raises(ex.CronQueueTimeout):
+            await ex.run_in_cron_gate_pool(release.wait, 30.0, timeout=budget)
+        elapsed = loop.time() - started
+        assert elapsed >= budget / 2, f"claimed gate gave up after only {elapsed:.3f}s"
+    finally:
+        release.set()
+        ex.shutdown_maintenance_executor()

--- a/test/test_slack_gateway_cron_exec_coverage.py
+++ b/test/test_slack_gateway_cron_exec_coverage.py
@@ -30,8 +30,12 @@ socket and no write outside the per-test ``KIROCREW_HOME`` (pinned by
 
 from __future__ import annotations
 
+import ast
 import asyncio
-from contextlib import asynccontextmanager
+import threading
+import time
+from contextlib import ExitStack, asynccontextmanager
+from pathlib import Path
 from typing import Any, AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -135,10 +139,11 @@ async def _cron_cb(
     orch: Any,
     *,
     svc: MagicMock | None = None,
-    gate_reason: str = "",
+    gate_reason: Any = "",
     sel_obj: MagicMock | None = None,
     command_result: Any = None,
     script_result: Any = None,
+    queue_hook: Any = None,
 ) -> AsyncIterator[Any]:
     """Run ``_init_cron`` with every collaborator patched and yield ``on_job``.
 
@@ -146,6 +151,20 @@ async def _cron_cb(
     runners from module globals at CALL time, so it must be invoked while these
     patches are still active — hence a context manager rather than a plain
     factory.
+
+    ``gate_reason`` may be a plain string (a fixed verdict, the common case) or
+    a ``job -> str`` callable, for the cases where the verdict must CHANGE
+    between the fire-time gate and a later re-vet — a script body edited on
+    disk, or a policy tightened, while the call sat in the pool queue.
+
+    ``queue_hook`` models that queue wait. When given, the execution dispatch
+    (``run_in_cron_pool``) is replaced by a double that runs the hook and only
+    THEN invokes whatever callable production code submitted. That is the
+    window the queue wait opens: it is deliberately not charged to the job's
+    deadline, so the world can change inside it. Note it patches only the
+    EXECUTION dispatch — the fire-time gate goes through
+    ``run_in_cron_gate_pool`` and still runs for real, keeping the two seams
+    distinct.
     """
     service = svc if svc is not None else _cron_service_double()
     captured: dict[str, Any] = {}
@@ -154,19 +173,32 @@ async def _cron_cb(
         captured["on_job"] = kw["on_job"]
         return service
 
+    _vet = gate_reason if callable(gate_reason) else (lambda job: gate_reason)
+
+    async def _queued_pool(fn: Any, *args: Any, **_kwargs: Any) -> Any:
+        queue_hook()
+        return fn(*args)
+
     _sel = sel_obj if sel_obj is not None else MagicMock()
-    with (
-        patch.object(gw.CronService, "create", AsyncMock(side_effect=_create)),
-        patch.object(gw, "cron_executor", lambda: None),
-        patch.object(gw, "vet_job_at_fire_time", lambda job: gate_reason),
-        patch.object(gw, "sel", lambda: _sel),
-        patch.object(gw, "run_command_sandboxed", _sandboxed(command_result)),
-        patch.object(gw, "run_script_sandboxed", _sandboxed(script_result)),
-        patch.object(
-            gw, "build_cron_session_context", lambda job: (f"cron:{job.id}", job.message)
-        ),
-        patch("kiro_crew.apps.bridges.reconcile_app_crons_for_execution", AsyncMock()),
-    ):
+    with ExitStack() as stack:
+        for patcher in (
+            patch.object(gw.CronService, "create", AsyncMock(side_effect=_create)),
+            # No executor patch: the fire-time gate no longer resolves a pool from
+            # this module -- it goes through run_in_cron_gate_pool, which owns its
+            # own bounded pool. `vet_job_at_fire_time` is still patched below, so the
+            # gate submits a trivial callable and returns immediately.
+            patch.object(gw, "vet_job_at_fire_time", _vet),
+            patch.object(gw, "sel", lambda: _sel),
+            patch.object(gw, "run_command_sandboxed", _sandboxed(command_result)),
+            patch.object(gw, "run_script_sandboxed", _sandboxed(script_result)),
+            patch.object(
+                gw, "build_cron_session_context", lambda job: (f"cron:{job.id}", job.message)
+            ),
+            patch("kiro_crew.apps.bridges.reconcile_app_crons_for_execution", AsyncMock()),
+        ):
+            stack.enter_context(patcher)
+        if queue_hook is not None:
+            stack.enter_context(patch.object(gw, "run_in_cron_pool", _queued_pool))
         await orch._init_cron()
         assert "on_job" in captured
         yield captured["on_job"]
@@ -415,6 +447,640 @@ class TestCronScriptMode:
             assert await cb(job) is None
         assert job.last_status == "error"
         assert "callable exploded" in (job.last_error or "")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Vetting must hold at the moment the worker claims the execution
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestVettingHoldsAtClaimTime:
+    """The queue wait must not open a window between vetting and execution.
+
+    The fire-time gate authorises a run, then the execution is submitted to a
+    pool whose queue wait is deliberately NOT charged to the job's deadline. So
+    the authorisation and the use it authorises are separated by a wait bounded
+    only by ``_CRON_QUEUE_WAIT_SECS``. Two things change inside that window:
+
+    * a script's BODY, which ``run_script_sandboxed``'s launcher re-reads from
+      disk in the sandboxed child (``open`` + ``compile`` + ``exec``), so the
+      bytes that execute are whatever is on disk when the worker gets there —
+      not the bytes the gate scanned;
+    * the governance POLICY, which applies to command jobs too even though a
+      command's text is already captured in ``job.command``.
+
+    Both are refused only if the vet holds when the worker claims the call.
+    """
+
+    @staticmethod
+    def _script_on_disk(tmp_path: Any) -> Any:
+        """A real file whose CURRENT content is what a vet or a run would see."""
+        path = tmp_path / "probe.py"
+        path.write_text("def check(ctx):\n    return 'benign'\n", encoding="utf-8")
+        return path
+
+    @staticmethod
+    def _body_scanning_vet(path: Any) -> Any:
+        """A ``job -> str`` vet that re-reads the body, as ``_vet_script_file`` does."""
+
+        def _vet(_job: Any) -> str:
+            if "EXFILTRATE" in path.read_text(encoding="utf-8"):
+                return "Error: script body denied by policy"
+            return ""
+
+        return _vet
+
+    @staticmethod
+    def _recording_runner(path: Any, executed: list[str]) -> Any:
+        """A sandbox double that reads the body from disk, as the launcher does."""
+
+        def _run(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+            executed.append(path.read_text(encoding="utf-8"))
+            return {"status": "ok"}
+
+        return _run
+
+    @pytest.mark.asyncio
+    async def test_a_script_edited_during_the_queue_wait_does_not_execute(self, tmp_path):
+        """The cited defect: benign at gate time, hostile by the time it runs.
+
+        The edit lands while the call is queued, which is exactly the interval
+        the gate cannot see. Asserting on what the sandbox was handed — rather
+        than on a budget helper — is what makes this measure the wiring.
+        """
+        orch = _make_orchestrator()
+        path = self._script_on_disk(tmp_path)
+        executed: list[str] = []
+        job = _job(script=f"{path}:check")
+
+        def _edit_during_queue() -> None:
+            path.write_text(
+                "def check(ctx):\n    EXFILTRATE = open('/etc/passwd').read()\n",
+                encoding="utf-8",
+            )
+
+        async with _cron_cb(
+            orch,
+            gate_reason=self._body_scanning_vet(path),
+            queue_hook=_edit_during_queue,
+        ) as cb:
+            with patch.object(gw, "run_script_sandboxed", self._recording_runner(path, executed)):
+                await cb(job)
+
+        assert not any("EXFILTRATE" in body for body in executed), (
+            "the script body edited during the queue wait was executed: "
+            "the fire-time vet authorised a body that is no longer on disk"
+        )
+        assert job.fire_time_denied is True, "a refused run must be recorded as a policy denial"
+
+    @pytest.mark.asyncio
+    async def test_an_unmodified_script_still_runs(self, tmp_path):
+        """Opposite direction: re-vetting must not refuse a legitimate run."""
+        orch = _make_orchestrator()
+        path = self._script_on_disk(tmp_path)
+        executed: list[str] = []
+        job = _job(script=f"{path}:check")
+
+        async with _cron_cb(
+            orch,
+            gate_reason=self._body_scanning_vet(path),
+            queue_hook=lambda: None,
+        ) as cb:
+            with patch.object(gw, "run_script_sandboxed", self._recording_runner(path, executed)):
+                assert await cb(job) == "ok"
+
+        assert len(executed) == 1, "an unmodified, vetted script must still reach the sandbox"
+        assert "benign" in executed[0]
+        assert job.last_status == "ok"
+        assert job.fire_time_denied is False
+        assert job.consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_a_claim_time_denial_does_not_feed_the_auto_pause_counter(self, tmp_path):
+        """A denial is a policy state, so it must not count toward auto-pause.
+
+        Counting it would disable the job at ``_AUTO_PAUSE_THRESHOLD`` and a
+        paused job never fires again — breaking the resume-on-policy-loosening
+        semantic the fire-time deny path is careful to preserve. The generic
+        error arm DOES call ``record_failure``, so a claim-time denial that
+        fell through to it would be silently destructive.
+        """
+        orch = _make_orchestrator()
+        path = self._script_on_disk(tmp_path)
+        job = _job(script=f"{path}:check", consecutive_failures=2, last_result="42 widgets")
+
+        def _edit_during_queue() -> None:
+            path.write_text("EXFILTRATE = 1\n", encoding="utf-8")
+
+        async with _cron_cb(
+            orch,
+            gate_reason=self._body_scanning_vet(path),
+            queue_hook=_edit_during_queue,
+            script_result={"status": "ok"},
+        ) as cb:
+            assert await cb(job) is None
+
+        assert job.consecutive_failures == 2, "a policy denial must not count as a job failure"
+        assert job.fire_time_denied is True
+        assert job.last_status == "error"
+        assert "denied" in (job.last_error or "")
+        assert job.last_result == "", "a denial is result-less: it must not carry prior output"
+
+    @pytest.mark.asyncio
+    async def test_a_policy_tightened_during_the_queue_wait_stops_a_command(self):
+        """The command sibling: same shape, and policy still changes under it.
+
+        A command's text is already captured in ``job.command``, so file
+        substitution does not apply here — but a governance ceiling tightened
+        while the call sat in the queue does, exactly as for a script.
+        """
+        orch = _make_orchestrator()
+        calls: list[int] = []
+        ran: list[str] = []
+
+        def _tightening_vet(_job: Any) -> str:
+            calls.append(1)
+            return "" if len(calls) == 1 else "Error: command denied by policy"
+
+        def _runner(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+            ran.append("ran")
+            return {"status": "ok", "output": "done"}
+
+        job = _job(command="curl example.com", consecutive_failures=1)
+        async with _cron_cb(
+            orch,
+            gate_reason=_tightening_vet,
+            queue_hook=lambda: None,
+        ) as cb:
+            with patch.object(gw, "run_command_sandboxed", _runner):
+                assert await cb(job) is None
+
+        assert ran == [], "a command denied at claim time must not reach the sandbox"
+        assert job.fire_time_denied is True
+        assert job.consecutive_failures == 1, "a policy denial must not count as a job failure"
+
+    def test_the_message_arm_has_no_pool_queue_between_vet_and_dispatch(self):
+        """Disposition for the third gate site, by measurement not assertion.
+
+        ``gateway.py`` has exactly three fire-time gate sites and exactly two
+        execution-pool dispatches. Both dispatches sit in the command/script
+        blocks, which return before the message gate is reached — so the
+        message arm has no queue between its vet and its LLM dispatch and the
+        defect class cannot apply to it. Pinned here so a future dispatch added
+        after the message gate fails this test rather than shipping unnoticed.
+        """
+        source = Path(gw.__file__).read_text(encoding="utf-8")
+        gate_sites = source.count("await _await_cron_fire_time_gate(")
+        pool_sites = source.count("await run_in_cron_pool(")
+        assert gate_sites == 3, f"gate-site count changed ({gate_sites}); re-audit the sweep"
+        assert pool_sites == 2, f"pool-dispatch count changed ({pool_sites}); re-audit the sweep"
+        message_gate = source.index('tool_name="cron_message_dispatch"')
+        assert (
+            source.find("await run_in_cron_pool(", message_gate) == -1
+        ), "a pool dispatch now follows the message gate: it needs claim-time vetting too"
+
+    def test_no_text_io_here_relies_on_the_platform_default_encoding(self):
+        """Every text read/write in this module must name its encoding.
+
+        A bare ``read_text()`` takes the PLATFORM default, which is UTF-8 on the
+        Linux shards and ``cp1252`` on the Windows ones.  So a module that reads
+        a UTF-8 source file without saying so passes every Linux shard and fails
+        only on Windows -- the defect is invisible where it is cheap to catch.
+        ``gateway.py`` carries em dashes and box-drawing characters, and
+        ``cp1252`` has no mapping for the continuation bytes of those sequences.
+
+        Enforced statically rather than by driving a hostile locale: the runtime
+        failure cannot be provoked in-process (``TextIOWrapper`` resolves the
+        default at the C level, so patching ``locale.getpreferredencoding`` does
+        not steer it), and a subprocess that sets ``LC_ALL`` would reproduce it
+        only where the default is already UTF-8 -- while this check fails
+        identically on every platform.  Parsed with ``ast`` so a call written
+        inside a fixture's script BODY (this module has one) is not mistaken for
+        a real call site.
+        """
+        tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+        naive = [
+            (node.lineno, getattr(node.func, "attr", None) or getattr(node.func, "id", ""))
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and (getattr(node.func, "attr", None) or getattr(node.func, "id", ""))
+            in {"read_text", "write_text", "open"}
+            and not any(kw.arg == "encoding" for kw in node.keywords)
+        ]
+        assert naive == [], (
+            "text I/O without an explicit encoding, which passes on Linux and "
+            f"fails on the Windows shards: {naive}"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# An abandoned claim-time vet must not license a later execution
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAnAbandonedVetDoesNotExecute:
+    """A deadline that lands mid-vet must not leave a payload free to start.
+
+    ``run_in_cron_pool`` only reaches its execution phase once a worker has
+    CLAIMED the call, and a thread cannot be interrupted -- so when that phase
+    times out the submitted callable keeps running. Before the claim-time vet
+    existed the claimed thread was already inside the sandbox, whose own
+    ``timeout`` bounds it. Now the vet runs FIRST, so the deadline can land
+    while the payload has not started, and it would otherwise start after the
+    caller's ``finally`` released the overlap guard -- running alongside the
+    next fire. ``run_in_cron_pool``'s own docstring names that harm for the
+    queue phase; these pin it closed for a deadline landing mid-vet.
+
+    ``run_in_cron_pool`` is doubled here on purpose: its two-phase behaviour is
+    pinned in ``test_executors.py``, and what needs exercising is what the
+    GATEWAY does when the execution phase times out with the callable still in
+    flight. Everything under test -- the wrapper, the hand-off, the ``finally``
+    -- is the real thing.
+    """
+
+    @staticmethod
+    def _abandoning_pool(started: threading.Event, done: list[str]):
+        """A pool double whose execution phase times out with the call in flight.
+
+        Models the one reachable shape: a worker HAS claimed the call (the
+        execution phase is reached in no other case), so the thread runs on
+        after the awaiter gives up.
+        """
+
+        async def _pool(fn: Any, *args: Any, **_kwargs: Any) -> Any:
+            def _worker() -> None:
+                try:
+                    fn(*args)
+                    done.append("dispatched")
+                except gw.CronClaimAbandoned:
+                    done.append("refused")
+                except BaseException as exc:  # noqa: BLE001 - recorded, not handled
+                    done.append(f"raised:{type(exc).__name__}")
+
+            thread = threading.Thread(target=_worker, daemon=True)
+            thread.start()
+            assert started.wait(timeout=5), "the claim-time vet never began"
+            raise asyncio.TimeoutError
+
+        return _pool
+
+    @staticmethod
+    def _slow_vet(started: threading.Event, release: threading.Event):
+        """Fast at fire time, still running at claim time, and then ALLOWS.
+
+        One patched name serves both gates, so the FIRE-TIME call must return
+        at once -- blocking there would starve the gate instead of exercising
+        the window under test, which opens only after a worker claims the call.
+        """
+        calls: list[int] = []
+
+        def _vet(_job: Any) -> str:
+            calls.append(1)
+            if len(calls) == 1:
+                return ""
+            started.set()
+            assert release.wait(timeout=5), "the vet was never released"
+            return ""
+
+        return _vet
+
+    @pytest.mark.asyncio
+    async def test_a_script_payload_does_not_run_after_its_awaiter_gave_up(self):
+        orch = _make_orchestrator()
+        started, release = threading.Event(), threading.Event()
+        done: list[str] = []
+        executed: list[str] = []
+        job = _job(script="probes.py:check")
+
+        def _payload(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+            executed.append("ran")
+            return {"status": "ok"}
+
+        async with _cron_cb(orch, gate_reason=self._slow_vet(started, release)) as cb:
+            with (
+                patch.object(gw, "run_in_cron_pool", self._abandoning_pool(started, done)),
+                patch.object(gw, "run_script_sandboxed", _payload),
+            ):
+                assert await cb(job) is None
+                # Only NOW let the abandoned vet finish, so it reaches its
+                # dispatch decision strictly after the caller released the guard.
+                release.set()
+                for _ in range(500):
+                    if done:
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert executed == [], (
+            "the payload executed after its awaiter gave up and released the "
+            "overlap guard, so it can run alongside the next fire"
+        )
+        assert done == ["refused"], f"the abandoned call did not refuse its payload: {done}"
+
+    @pytest.mark.asyncio
+    async def test_a_command_payload_does_not_run_after_its_awaiter_gave_up(self):
+        """The sibling call site, which shares the shape exactly."""
+        orch = _make_orchestrator()
+        started, release = threading.Event(), threading.Event()
+        done: list[str] = []
+        executed: list[str] = []
+        job = _job(command="curl example.com")
+
+        def _payload(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+            executed.append("ran")
+            return {"status": "ok", "output": "done"}
+
+        async with _cron_cb(orch, gate_reason=self._slow_vet(started, release)) as cb:
+            with (
+                patch.object(gw, "run_in_cron_pool", self._abandoning_pool(started, done)),
+                patch.object(gw, "run_command_sandboxed", _payload),
+            ):
+                assert await cb(job) is None
+                release.set()
+                for _ in range(500):
+                    if done:
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert executed == [], "the command executed after its awaiter gave up"
+        assert done == ["refused"], f"the abandoned call did not refuse its payload: {done}"
+
+    @pytest.mark.asyncio
+    async def test_the_overlap_guard_is_still_released_so_the_job_fires_again(self):
+        """The opposite direction, which is what the chosen remedy could break.
+
+        Refusing the abandoned payload is the fix; PINNING the guard set would
+        also stop the overlap, but a payload that never starts would then hold
+        the guard forever and the job would never fire again -- a permanent
+        silent stall, strictly worse than the harm. So the guard must still be
+        released, and the refusal is what makes releasing it safe.
+        """
+        orch = _make_orchestrator()
+        started, release = threading.Event(), threading.Event()
+        done: list[str] = []
+        job = _job(script="probes.py:check")
+
+        async with _cron_cb(orch, gate_reason=self._slow_vet(started, release)) as cb:
+            with (
+                patch.object(gw, "run_in_cron_pool", self._abandoning_pool(started, done)),
+                patch.object(gw, "run_script_sandboxed", lambda *_a, **_k: {"status": "ok"}),
+            ):
+                assert await cb(job) is None
+                release.set()
+
+        assert job.id not in orch._running_script_ids, (
+            "the overlap guard was left held after an abandoned run, so this job "
+            "can never fire again"
+        )
+
+    def test_the_hand_off_resolves_deterministically_in_both_orders(self):
+        """Exactly one of claim/abandon may win, so the outcome is not a race.
+
+        Without the lock a payload could start after the awaiter gave up:
+        ``claim`` would read an unset flag that ``abandon`` sets an instant
+        later, and the refusal would silently not happen.
+        """
+        abandoned_first = gw._ClaimHandoff()
+        assert abandoned_first.abandon() is False, "nothing had started yet"
+        assert abandoned_first.claim() is False, "a payload started after abandonment"
+
+        claimed_first = gw._ClaimHandoff()
+        assert claimed_first.claim() is True, "an unabandoned call must be allowed to start"
+        assert claimed_first.abandon() is True, "abandon must report the payload as started"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# The claim-time vet must not eat the subprocess cleanup margin
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTheVetIsAnAccountedBudgetTerm:
+    """A vet spending part of the payload's margin must not orphan the payload.
+
+    ``timeout=cmd_timeout + 5`` is one budget covering, serially, the vet, the
+    subprocess, and the subprocess's teardown -- and ``cron.py``'s
+    ``_SUBPROC_CLEANUP_ALLOWANCE_SECS`` comment says what the 5s is for: "the
+    wake deadline cancels only the executor FUTURE (threads are not
+    interruptible), so a budget shorter than the subprocess bound leaves the
+    subprocess running while the guards clear and later wakes duplicate it."
+
+    So when the deadline lands with the payload ALREADY started, nothing can
+    stop the thread; the guard releases while the subprocess runs on, and the
+    next fire duplicates its side effects.  Distinct from the abandoned-vet
+    case above, which is a payload that has NOT started and is curable by
+    refusing it -- here it is running, so the only cure is budget accounting.
+
+    Deliberately drives the REAL ``run_in_cron_pool``: the sibling class doubles
+    it and ignores ``timeout``, so nothing there evaluates the arithmetic this
+    turns on.  Durations are derived from the live budget functions rather than
+    hardcoded, so the test follows the constants if they move.
+    """
+
+    @staticmethod
+    def _budgets(job: Any) -> tuple[float, float]:
+        """(vet bound, pre-fix inner backstop) from the live functions."""
+        from kiro_crew.cron import effective_wake_budget
+        from kiro_crew.executors import cron_gate_budget
+
+        return cron_gate_budget(effective_wake_budget(job)), float((job.timeout or 300) + 5)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kind,runner",
+        [("command", "run_command_sandboxed"), ("script", "run_script_sandboxed")],
+    )
+    async def test_the_guard_outlives_a_payload_started_after_a_slow_vet(self, kind, runner):
+        """The guard must still be held when the payload finishes.
+
+        If it is not, the deadline fired mid-subprocess and the next fire is
+        free to run the same non-idempotent command concurrently.
+
+        Parametrised over BOTH call sites deliberately.  They share the shape,
+        and the script site is the worse of the two -- ``script_timeout =
+        job.timeout or 30`` against ``cmd_timeout = job.timeout or 300``, so the
+        same fixed teardown margin is proportionally far larger a share of it,
+        while the script vet does strictly MORE work (it adds a capped body read
+        from disk).  A fix pinned at one site only would let the other be
+        reverted silently.
+        """
+        orch = _make_orchestrator()
+        job = _job(**{kind: "probes.py:check" if kind == "script" else "curl example.com"},
+                   timeout=1, timeout_secs=8)
+        vet_bound, pre_fix_budget = self._budgets(job)
+
+        # A vet inside its own bound, and a payload that then runs past the
+        # PRE-FIX budget but inside the post-fix one -- so the only thing that
+        # decides the outcome is whether the vet is accounted for.
+        vet_secs = vet_bound * 0.75
+        payload_secs = (pre_fix_budget - vet_secs) + 1.0
+        assert vet_secs < vet_bound, "the vet must sit inside its own bound"
+        assert vet_secs + payload_secs > pre_fix_budget, "must overrun the pre-fix budget"
+
+        calls: list[int] = []
+        guard_at_exit: list[bool] = []
+        concurrent, peak = [0], [0]
+
+        def _vet(_job: Any) -> str:
+            calls.append(1)
+            if len(calls) > 1:  # the CLAIM-time call; fire-time stays instant
+                time.sleep(vet_secs)
+            return ""
+
+        def _payload(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+            concurrent[0] += 1
+            peak[0] = max(peak[0], concurrent[0])
+            try:
+                time.sleep(payload_secs)
+                guard_at_exit.append(job.id in orch._running_script_ids)
+                return {"status": "ok", "output": "done"}
+            finally:
+                concurrent[0] -= 1
+
+        async with _cron_cb(orch, gate_reason=_vet) as cb:
+            with patch.object(gw, runner, _payload):
+                await cb(job)
+                # Let an orphaned subprocess finish so its observation lands.
+                for _ in range(400):
+                    if guard_at_exit:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert guard_at_exit == [True], (
+            f"the {kind} overlap guard was released while the payload was still "
+            f"running (vet {vet_secs:.2f}s + payload {payload_secs:.2f}s against a "
+            f"{pre_fix_budget:.0f}s backstop), so the next fire can duplicate "
+            "its non-idempotent side effects"
+        )
+        assert peak[0] == 1, f"payload ran concurrently with itself: peak {peak[0]}"
+
+    @pytest.mark.asyncio
+    async def test_a_vet_that_outruns_its_allowance_refuses_the_payload(self):
+        """An allowance is only a guarantee if the thing it covers cannot exceed it.
+
+        The widened backstop carries a term for the vet; a vet that spends MORE
+        than that term has eaten into the subprocess's own bound plus teardown,
+        so starting the payload would recreate exactly the harm above.  Refusing
+        before it starts trades a reported missed run for a silent duplicate.
+
+        The disposition matters as much as the refusal: nothing ran, so the run
+        is retention-shaped like starvation -- marked never-started, and
+        deliberately NOT counted toward auto-pause, because a slow governance
+        read is a fleet state rather than a job defect and
+        ``_AUTO_PAUSE_THRESHOLD`` consecutive counts would disable a healthy job.
+        """
+        orch = _make_orchestrator()
+        job = _job(command="curl example.com", timeout=1, timeout_secs=8, consecutive_failures=2)
+        vet_bound, _ = self._budgets(job)
+        calls: list[int] = []
+        executed: list[str] = []
+
+        def _vet(_job: Any) -> str:
+            calls.append(1)
+            if len(calls) > 1:
+                time.sleep(vet_bound * 1.5)  # deliberately past the allowance
+            return ""
+
+        def _payload(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+            executed.append("ran")
+            return {"status": "ok", "output": "done"}
+
+        async with _cron_cb(orch, gate_reason=_vet) as cb:
+            with patch.object(gw, "run_command_sandboxed", _payload):
+                result = await cb(job)
+
+        assert executed == [], (
+            "the payload started after a vet that had already spent more than the "
+            "allowance the deadline carries for it"
+        )
+        assert result is None
+        assert job.run_never_started is True, "a refused payload never started"
+        assert job.last_status == "error"
+        assert job.consecutive_failures == 2, "a slow vet must not count toward auto-pause"
+        assert job.fire_time_denied is False, "no policy decision was made"
+
+    @pytest.mark.asyncio
+    async def test_the_harness_can_observe_a_duplicate_at_all(self):
+        """Positive control: two overlapping fires must show a peak of 2.
+
+        Without this, a peak of 1 above could mean the harness simply cannot
+        see concurrency rather than that the fix works.
+        """
+        orch = _make_orchestrator()
+        job = _job(command="curl example.com", timeout=1, timeout_secs=8)
+        concurrent, peak = [0], [0]
+        entered = threading.Event()
+
+        def _payload(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+            concurrent[0] += 1
+            peak[0] = max(peak[0], concurrent[0])
+            entered.set()
+            try:
+                time.sleep(0.4)
+                return {"status": "ok", "output": "done"}
+            finally:
+                concurrent[0] -= 1
+
+        async with _cron_cb(orch, gate_reason=lambda _j: "") as cb:
+            with patch.object(gw, "run_command_sandboxed", _payload):
+                # Bypass the overlap guard by firing two DISTINCT job ids, which
+                # is what the guard is keyed on -- so this measures the counter,
+                # not the guard.
+                other = _job(id="j2", command="curl example.com", timeout=1, timeout_secs=8)
+                await asyncio.gather(cb(job), cb(other))
+
+        assert peak[0] == 2, f"the harness cannot observe concurrency: peak {peak[0]}"
+
+    def test_every_term_spent_inside_the_run_budget_is_accounted_for(self):
+        """Every deadline bounding a run must carry a term for each thing spent inside it.
+
+        ``cron.py``'s own accounting names three: the subprocess bound, the pool
+        queue wait, and the fire-time gate.  The claim-time vet is a fourth --
+        it runs inside the worker, inside the same deadline -- and asserting on
+        the helper alone would pass with the term missing from the deadline, so
+        this reads the DEADLINE EXPRESSIONS themselves.
+
+        Checks BOTH of them.  The execution guard and the reaper's
+        defence-in-depth sweep bound the same run, and the helpers' own
+        docstrings say why they are shared: "if only one of them accounts for
+        that wait, the other pre-empts it, and the two failures are opposite and
+        both silent".  A fourth term added to one and not the other reintroduces
+        exactly that drift.  Parsed with ``ast`` so the assertion survives the
+        expression being wrapped across lines.
+        """
+        from kiro_crew import cron as cron_mod
+
+        tree = ast.parse(Path(cron_mod.__file__).read_text(encoding="utf-8"))
+        owed = {"_pool_queue_allowance", "_gate_budget_allowance", "_vet_allowance"}
+        run_deadlines: list[tuple[int, set[str]]] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(
+                isinstance(t, ast.Name) and t.id == "deadline" for t in node.targets
+            ):
+                continue
+            called = {
+                child.func.id
+                for child in ast.walk(node.value)
+                if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+            }
+            # A RUN deadline is one that already accounts for at least one term.
+            # That excludes the file-lock spin deadline (``time.monotonic() +
+            # timeout``), which bounds a lock acquisition rather than a run, and
+            # it needs no magic count that would rot as the file changes.
+            if called & owed:
+                run_deadlines.append((node.lineno, called & owed))
+
+        assert len(run_deadlines) >= 2, (
+            "expected at least the execution guard and the reaper sweep to bound "
+            f"a run; found {len(run_deadlines)} -- this check may have gone vacuous"
+        )
+        for lineno, terms in run_deadlines:
+            missing = owed - terms
+            assert not missing, (
+                f"the run deadline at cron.py:{lineno} does not account for "
+                f"{sorted(missing)}; a term spent inside it but absent from it means "
+                "this deadline pre-empts the one that does carry it"
+            )
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Problem / Motivation

`loop.run_in_executor` only **submits** work. `cron_executor()` is a `ThreadPoolExecutor(max_workers=_MAX_CRON_WORKERS)` with `_MAX_CRON_WORKERS = 4` (`src/kiro_crew/executors.py:99`), so when all four workers are busy a cron job sits in the pool's queue having run no code at all. But `asyncio.wait_for` starts its stopwatch the moment it is awaited, so both cron launch sites wrapped *submit and run* in a single `wait_for` and spent queue time out of the job's own budget:

- **Script crons** — `src/kiro_crew/slack/gateway.py:2524-2533`, `timeout=script_timeout + 5`, recorded at `:2632` and `:2647` as `job.last_error = f"timeout ({script_timeout + 5}s)"`.
- **Command crons** — `src/kiro_crew/slack/gateway.py:2382-2390`, `timeout=cmd_timeout + 5`, recorded at `:2437`.

(Line numbers as of `54c8ffdee`.)


## Why it matters

Two consequences, and the second is what makes this expensive:

1. A job is killed for time it spent **queued**, not running. The script or command named in the error may never have executed a line.
2. One wedged job holding a worker makes every job behind it fail, so a single fault reads as **N independent broken jobs**.

A third consumer of the same 4 slots mattered more than this description first allowed. The fire-time governance gate `vet_job_at_fire_time` was also dispatched to `cron_executor()` for all three job kinds, with no timeout on that await at all -- and since that gate runs inside the execution deadline, a saturated pool spent a job's own budget on it. This branch now dispatches the gate to a dedicated pool with a bound of its own; see **What changed**. An earlier revision of this description listed it only as a note for readers, which understated it: for a message job it was the whole defect.

## Measured evidence

From a live instance running this code:

- **Every** failure fired at exactly `configured_timeout + 5` seconds — 17 of 17, across configured values 35, 65, 125, 155, 185, 245, 305 and 485. That is the `wait_for` budget expiring on schedule, not 17 jobs each coincidentally overrunning.
- **Proven by contrast in one experiment.** A script that completes in **3 seconds** standalone (rc=0) was killed at 305s in cron **ten times**. In the same experiment a *different* script genuinely hung, holding a worker for its full 485s budget on a 600s interval — that one job is what saturated the pool.
- **Blast radius was under-reported by roughly 5x**, because the registry keeps only the last status: the gateway log showed **104 kill events across 25 distinct jobs** while the registry showed 19 error rows. Jobs killed ten times read `last=ok`.
- The watchdog meant to catch this condition was itself killed six times and auto-paused, so the pool stayed starved for two days in silence.

## What changed

Wait for a worker to actually pick the call up **first, untimed**, and only then apply the budget to execution. A job delayed by transient contention now runs instead of dying.

The two phases now fail differently, which is the other half of the fix. Exhausting the queue budget raises `CronQueueTimeout` — `queued Ns, never ran` — so pool starvation is legible instead of masquerading as unrelated job failures. Diagnosing this from `timeout (Ns)` alone is what cost two days.

The **queue deadline is authoritative, not the wake**. `BaseEventLoop._run_once` dispatches a timer once `handle._when < time() + _clock_resolution`, so a wake can arrive up to one clock resolution early — `time.get_clock_info('monotonic').resolution` is ~1e-09 on Linux but **15.625ms on Windows**. Trusting it reported a wait *shorter* than the budget just exhausted, so the queue phase re-checks `loop.time()` against the deadline and only raises once it has genuinely passed. That makes `waited >= queue_timeout` hold by construction rather than by tolerance, on every platform. Both the deadline and `waited` read `loop.time()`, so the two were never on different clocks — the gap was purely the loop's early-fire window.

The rendered message no longer floors to whole seconds. `queued {waited:.0f}s` printed a real 0.3s wait as `queued 0s`, which reads as "did not wait at all" and blunts the one diagnostic this exception exists to carry; sub-second waits now render with decimals (`queued 0.30s`), and whole-second rendering above 10s is unchanged.

`_CRON_QUEUE_WAIT_SECS = 900` is deliberately **not** derived from `job.timeout`. Deriving it would still kill a fast job queued behind a wedged worker, just with a better label; waiting and then running is the correct outcome, so this budget exists only to bound the pathological case so an entry cannot sit un-failed forever.

The outer `timeout` is **kept** as a backstop. Both `run_script_sandboxed` and `run_command_sandboxed` already enforce the timeout on their own subprocess (`cron_script.py:696`, `:893`), so it is no longer the primary clock — but without it a wedged worker would leave the job entry un-failed forever.

`CronQueueTimeout` subclasses `asyncio.TimeoutError`, so a call site that has not been taught about the queue phase degrades to its existing timeout handling rather than raising something nothing catches. Both gateway sites order the queue branch first.

Caller cancellation reaches the pool call. The shield that lets the started-signal future survive a wake also swallows a cancel, so without an explicit handler a caller cancelling this coroutine escaped while the submitted call was still queued -- and it then ran long after the caller gave up, i.e. a cancelled cron command executing anyway. Measured before the fix: the callable ran after the awaiting task was cancelled. An `except asyncio.CancelledError` now cancels the submitted call and re-raises. That stays a no-op once a worker has claimed the call, so a job already in flight is never killed -- also measured, in both directions.

A call a worker claims right at the deadline is routed to the execution phase instead of being reported as a queue timeout. The started-signal future cannot decide that on its own: it is resolved from the worker thread through `loop.call_soon_threadsafe`, which only enqueues, so it still reads unresolved for a call that is already executing. Measured before the fix, the callable ran while the caller was told `queued 0.30s, never ran`. The damage is not only the misreport. Driven against a real `CronService`, that error releases the job's overlap guard -- `_executing`, claimed when the timer fires and dropped in the `finally` of `_run_job_isolated` -- while the command is still running, after which the due-scan admits the next fire alongside it and the side effects happen twice. That is the same hazard `_SUBPROC_CLEANUP_ALLOWANCE_SECS` exists to prevent on the execution path, and the queue-timeout path bypassed that margin entirely. Deciding it correctly needs the right arbiter: only the **concurrent** future's `cancel()` tells queued apart from running, returning `False` once a worker holds the call. The asyncio wrapper's `cancel()` returns `True` in both states, because it cancels the wrapper locally while the thread runs on -- measured, and the reason a gate written against the wrapper would have changed nothing at all. So `run_in_cron_pool` now keeps the concurrent future (`submit` plus `wrap_future`, which is precisely what `run_in_executor` does internally) and raises only when that cancel wins. Genuine starvation is untouched: no worker claimed the call, the cancel wins, and `CronQueueTimeout` carries the same `waited` figure as before. A claimed call is instead bounded by the execution timeout every caller already accepts for a call that does get a worker, with the job-level guard bounding it again above that. An earlier revision of this description defended leaving the raise unconditional on the grounds that the queue-wait figure stays true either way; that weighed only whether the number was accurate, when the deciding question is what the error does to the overlap guard.

Excluding the queue wait from the per-call budget turned out to be only half the job, and a review lane was right to press on it. `CronService._execute_with_timeout` wraps the whole run in `wait_for(..., timeout=job.timeout_secs)`, and the pool's queue wait happens inside that, so a job still sitting in the queue was killed by the **wake** deadline and reported as `Timed out after Ns` -- the same misdiagnosis, one frame out. Measured before the fix: a command job with a 2s wake budget behind a 3s-busy pool never ran its payload and was labelled an execution overrun. Worse, a thread cannot be interrupted, so a worker that claimed the call as that deadline fired keeps running while the overlap guards clear, which is the duplicate-side-effects hazard `_SUBPROC_CLEANUP_ALLOWANCE_SECS` was written for -- and the queue wait is a second term that invariant never accounted for. So `src/kiro_crew/cron.py` now adds the pool's queue allowance to the wake deadline, scoped to the jobs that actually dispatch through the pool. A message job does not dispatch through the pool to EXECUTE and keeps its budget exactly as set, which matters because widening every job's deadline would loosen the backstop that stops a wedged worker leaving an entry un-failed forever. That scoping was stated here as "never touches the pool", which was not true while the fire-time gate was dispatched to the cron pool; the paragraph below closes that gap rather than widening the deadline.

Starvation also stopped counting toward auto-pause. `record_failure()` auto-pauses at `_AUTO_PAUSE_THRESHOLD` by clearing `enabled`, and a paused job never fires again -- so five starved wakes permanently disabled a job that had never run a line, and the work stayed unscheduled after the pool recovered. Both `CronQueueTimeout` handlers now decline to count, matching the fire-time governance deny path, which already declines for the same reason: a state that prevented the run is not a defect of the run. The run is still reported as an error carrying the legible `queued Ns, never ran` text; only the counter changed. The `asyncio.TimeoutError` handlers still count, because those are real overruns.

One more consequence of the starvation path needed closing, and a review lane found it. `_merge_job_result` deletes a `delete_after_run` job unless the run was refused, and the queue-timeout returns marked no refusal -- so a one-shot that never got a worker was destroyed exactly as if it had completed, taking its scheduled work with it. Measured before the fix: the job was gone from the store after a starved run. The fix is a retention-only runtime marker, `run_never_started`, read solely where the one-shot would otherwise be consumed. It is deliberately not `fire_time_denied`: that flag has three readers, two of which force an `at` job disabled, and it is documented as a *policy* refusal -- so reusing it would park a starved job until an operator re-enabled it and would record pool saturation as a governance denial. Starvation clears on its own, so the job stays enabled and simply retries. A control confirms the distinction bites: applying the flag-reuse shape retains the job but fails the at-job test on `starvation is not a governance denial`.

Widening one deadline turned out to expose a second, and a review lane caught it. TWO deadlines bound a single run: the execution guard above, and the reaper's defence-in-depth sweep, whose own threshold is `max(min(timeout_secs, 86400), _JOB_TIMEOUT_SECS)`. Widening only the first left the reaper 900s lower for every command/script job at or above the default wake budget -- measured across `timeout_secs` values, the reaper fired first at 0, 1800, 3600 and 86400, i.e. including the default -- so a job whose gate and payload queued through that window was force-killed and the firing skipped without ever executing. That is the mirror image of the misdiagnosis the widening removed, and just as silent. The allowance is now single-sourced in `_pool_queue_allowance` and both deadlines derive from it, so they cannot drift apart again; the reaper's floor-at-`_JOB_TIMEOUT_SECS` base is untouched, and after the change the reaper is greater than or equal to the execution deadline at every value, restoring the relationship the two had before this branch. A message job gets no allowance on either side -- which holds only because the one piece of pool work every job kind shares is no longer dispatched to this pool.

Scoping the allowance to command/script jobs then exposed the premise it rested on, and a review lane pressed exactly there. `vet_job_at_fire_time` is dispatched off-loop for every job kind, and all three sites submitted it to `cron_executor()` -- the same pool bounded at `_MAX_CRON_WORKERS = 4` whose workers are held for a whole job's DURATION. That await sits inside the deadline `_execute_with_timeout` arms BEFORE the callback runs, so a message job, holding no allowance on either deadline, could have its entire execution budget consumed by the gate queueing behind long-running command/script work -- killed having run no code, reported as an overrun, and if `delete_after_run` deleted without ever dispatching. Measured before the fix, driving the real gateway message callback with all four workers held: the job was killed at its 2s budget and `sessions.get_or_create` was never reached. The first fix moved the gate to `governance_executor()`, which exists for short, bounded policy work, so no deadline is widened. That narrowed the exposure without closing it, and a later review lane was right to press again -- see the next paragraph. The lane's own remedy -- return the allowance for message jobs too -- was measured and rejected: it does clear this defect but breaks two pre-existing tests, loosening the wedged-delivery backstop by the full 900s (`assert None == 'error'`, i.e. a hung message job no longer killed at its budget) and widening the reaper for a job that cannot use it. Both directions are silent, so the narrower lever is the honest one. `cron_executor` is no longer referenced in `slack/gateway.py` at all, and its now-dead import is removed.

Moving the gate to `governance_executor()` traded one shared pool for another, and a review lane named the difference precisely: that pool is paced by **remote senders** -- one submit per inbound message across five transports, plus the dashboard governance GETs (`messaging/identity.py:150-167`, called at the top of `handle_message`) -- so an inbound burst puts an unbounded FIFO backlog ahead of a cron gate, and a message job still holds no allowance to cover it. Two things are done about it, and both, deliberately; the outer deadline is **not** widened, because `_pool_queue_allowance`'s own note says widening would also delay the wedged-delivery backstop, so the fix belongs at the gate's dispatch.

**Relocate.** The gate gets its own bounded `mc-crongate` pool (`cron_gate_executor()`), where a cron gate queues only behind another cron gate -- self-paced by the schedule rather than by remote traffic.

**Bound.** The gate is dispatched through `run_in_cron_gate_pool`, which reuses `run_in_cron_pool`'s claim-vs-queued discipline rather than copying it, since only the **concurrent** future's `cancel()` can tell "never got a worker" from "already running". Its bound is capped **strictly** below the job's own wake budget by `cron_gate_budget()`. A review lane caught that an earlier revision only nearly achieved that: a bare `max(1.0, ...)` floor returned 1.0 for a 1s wake budget, so the two expired together and the OUTER deadline won -- reintroducing exactly the ambiguity the cap exists to remove, at the budget where a one-shot is most likely to be starved. Deleting the floor is the opposite error, handing a 2s job a 0.5s gate that times out on a HEALTHY pool and converts a job that would have run into a never-started one; both failures are silent and point opposite ways. So the floor is kept for budgets that can afford it and clamped by a fraction of the budget, which makes "strictly below" hold for every budget rather than for typical ones. Deriving a queue bound from the caller's clock is the opposite of the cron pool's documented default, and that inversion is the point: waiting past the budget and then running is correct for *execution*, but a gate verdict arriving after the wake deadline cannot help -- the deadline kills the run either way -- and the ambiguity it leaves behind is what destroys a one-shot. The residual is audit noise only: a gate thread that finishes after we stopped waiting may still emit its SEL `governance_decision` for a run that did not dispatch.

**Both gate bounds reach the retention handler.** `run_in_cron_pool` raises `CronQueueTimeout` for its QUEUE phase but a plain `asyncio.TimeoutError` for its EXECUTION phase, so a gate that got a worker and then overran its own bound bypassed the caller's `except CronQueueTimeout` entirely, `run_never_started` stayed false, the wake deadline caught the bare timeout as an ordinary overrun, and the one-shot was deleted having never dispatched. The execution bound is now re-raised as `CronGateTimeout`, a **subclass**, so it reaches that handler without widening it. Widening was the tempting fix and is unsafe: `asyncio.TimeoutError` IS `builtins.TimeoutError` on 3.11+, so a socket or store timeout raised INSIDE a governance check is type-identical to the bound expiring, and catching it would mark never-started a run whose gate DID reach its decision. That case is wrapped in the worker thread as `CronGateWorkTimeout` before the bound can see it -- still a `TimeoutError`, deliberately not a `CronQueueTimeout`.

**The gate bound is a third term on both run deadlines.** The gate is awaited before the pool dispatch and inside the deadline armed for the whole run, so a gate spending its full bound leaves the subprocess that much less -- and a thread cannot be interrupted, so when the deadline fires with a worker already claimed, the overlap guards clear while the subprocess runs on and the next wake duplicates its side effects. That is the hazard `_SUBPROC_CLEANUP_ALLOWANCE_SECS` exists for; the queue wait was a second term it did not account for, and the gate bound is a third. `_gate_budget_allowance` single-sources it and BOTH deadlines derive from it, so they cannot drift and pre-empt one another -- the reaper regression this branch already fixed once. Scoped to command/script for the same reason the queue allowance is, and rounded up to an int so `Timed out after Ns` does not become `2.0s`.

**Retention on the message path.** `run_never_started` was set only in the command and script `CronQueueTimeout` handlers; the message branch had no such handler, so an undispatched message one-shot was deleted by the `delete_after_run` site as though it had run. All three branches now go through one `_await_cron_fire_time_gate` helper that sets that **existing** marker rather than a parallel flag, and declines `record_failure()` for the same reason the deny and starvation paths do.

**The same helper's result-less clear is scoped too.** Folding all three branches into `_await_cron_fire_time_gate` centralised a second decision that was not uniform: its `except CronQueueTimeout` arm cleared `job.last_result` for every job kind. For an agent/message job that field is not this run's output, it is CROSS-RUN context -- `build_cron_session_context` prepends it as a "do not repeat the same content" block for a persistent-session job, and `clear_carried_result` is guarded on `result_produced`, which a starved run never sets. So a message cron starved at the gate silently lost its dedup context and the next run repeated content it had already sent. `_run_job_isolated` scopes its own result-less clear to `job.command or job.script` for exactly this reason (`cron.py:2892`, whose comment notes that scattering the clear over exit sites is what previously let the deny and Skip paths keep a result), and the message fire-time deny path never clears at all -- so the shared helper was the one site of three that disagreed. It now carries the same guard (`slack/gateway.py:832`), which makes the three agree rather than adding a new rule. Command and script jobs still clear, because the prompt built for them is discarded and a carried value could only show a previous run's output beside this run's status. Pinned in both directions by one parametrised test over all three kinds: a starved message job must retain the context, and a starved command or script job must still lose it -- asserting retention alone would also pass if the clear were deleted outright. Verified by removing the guard: the message case fails naming the harm while the command and script cases keep passing.

**A never-started run no longer consumes the failure budget.** The marker above is set BEFORE the gate await precisely so a cancellation at that await survives, but one reader had not been taught to consult it. `_execute_with_timeout`'s `except asyncio.TimeoutError` arm called `record_failure()` for every timeout, and that arm is exactly where a wake-deadline cancellation lands: the stall pushes wall clock past the deadline while the gate is still awaited, `CancelledError` propagates out as the `wait_for` timeout, and no handler inside the gate runs -- so the timeout was counted against a run that dispatched no payload. `record_failure()` auto-pauses at `_AUTO_PAUSE_THRESHOLD` by clearing `enabled`, and a paused job never fires again, so repeated event-loop saturation durably disabled a job that had not run a line. The guard is now `not job.failure_recorded and not job.run_never_started` (`cron.py:3084`), which is the same discriminator the starvation, gate-deny and vet-overrun paths already apply -- a state that PREVENTED the run is not a defect OF the run -- making this handler agree with the three that already decline rather than adding a new rule. A genuine execution overrun still counts and still auto-pauses, because `_execute` resets the marker to False before invoking the callback; the pre-existing comment claiming the timeout is counted unconditionally is corrected in the same hunk rather than left to contradict the code. Pinned in both directions by one parametrised test in `test/test_cron_timeout_autopause_424.py`: marker set means the counter stays 0, marker clear means it still reaches 1 -- asserting only the exemption would also pass if the count were deleted outright. Verified by removing the guard at the call site: the never-started case fails naming the harm while the overrun case keeps passing, and the file's three pre-existing auto-pause tests pass unchanged throughout.

Stated plainly, because it bears on how much this PR is claiming: this branch **narrows** the exposure rather than introducing it. On `main` all three gates run on the 4-worker *cron* pool, contending with job-duration subprocess work, which is strictly worse. The **mechanism** is measured -- the destructive delete reproduces under a control that removes only the gate's bound, and the fix removes it. The **exposure** is inferred: it is not measured that the governance pool saturates for longer than a message job's `timeout_secs` (default 1800s).

**Re-vetting at claim, because this change is what opens the window.** Not charging the queue wait to the execution budget is the thesis of this branch, and it has a consequence on the governance path: the fire-time gate authorises a run, the execution is then submitted to the pool, and that queue wait is deliberately uncharged -- so the authorisation and the use it authorises are now separated by a wait bounded only by `_CRON_QUEUE_WAIT_SECS = 900` rather than by the run deadline. Both inputs to the decision can change inside that window. A script's BODY can: `run_script_sandboxed`'s launcher re-reads the file in the sandboxed child (`cron_script.py:625`), so the bytes that execute are whatever is on disk when the worker gets there, not the bytes the gate scanned. The governance POLICY can, which applies to `command` jobs too even though a command's text is already captured in `job.command`. So the command and script sites submit their payload through `_vet_at_claim_then` (`slack/gateway.py:993`) rather than bare: it runs the same `vet_job_at_fire_time` a second time, inside the worker, and dispatches the payload only after that (`:1063`). The queue wait now falls BEFORE the decision, and the decision holds at the moment of use. The fire-time gate is KEPT, not moved -- a denial is still refused early and cheaply without occupying a cron worker for the queue's duration, and the gate's starvation/retention plumbing above is untouched. A `message` job never reaches this path at all.

**What a deadline landing mid-vet does.** `run_in_cron_pool` reaches its execution phase only once a worker has CLAIMED the call, and a thread cannot be interrupted, so a timeout there leaves the submitted callable running. That was tolerable while the claimed thread was already inside the sandbox, whose own timeout bounds it. With the vet running first the deadline can land with the payload NOT yet started, and it would then start after the caller's `finally` had released the overlap guard -- running alongside the next fire, which is the duplicate-side-effects hazard `_SUBPROC_CLEANUP_ALLOWANCE_SECS` exists for, reached from a new direction. `_ClaimHandoff` (`:898`) closes it: a lock-serialised `claim()`/`abandon()` pair where exactly one side observes an unset flag, so a payload either starts -- and is reported as still running -- or never starts at all, with no third state. The caller abandons the handoff before releasing the guard (`:3102` and `:3424`, each immediately above its `_running_script_ids.discard`), and a worker arriving after that raises `CronClaimAbandoned` instead of dispatching. That call sits in the `finally` rather than in the timeout arm on purpose: the `finally` is the single place the guard is released, so it also covers a wake deadline cancelling the callback, where no `except` runs at all.

**The vet is bounded, not asked to stay short.** An allowance is only a guarantee if the thing it covers cannot exceed it. `claim_vet_bound` (`:969`) is the same `cron_gate_budget(effective_wake_budget(job))` the fire-time gate is held to for the identical work, so the two cannot drift; `_vet_at_claim_then` measures its own elapsed time on `monotonic` and raises `CronVetOverran` rather than starting a payload whose remaining margin no longer covers the subprocess bound plus its teardown. Refusing before the payload starts trades a reported missed run for a silent duplicate execution. Both sites handle that separately from `CronClaimTimeDenied`, and separately from the generic error arm: an overrun marks the run never-started and declines `record_failure()`, for the reason starvation already declines -- a slow governance read is a fleet state, not a defect of the run -- and deliberately does not set `fire_time_denied`, because no policy decision was made and that flag also parks an `at` job disabled.

**A fourth term on both run deadlines, and the inner backstop.** The inner bound at each submit is now `_claim_backstop` (`:981`) -- the subprocess bound plus `_SUBPROC_CLEANUP_ALLOWANCE_SECS` plus `claim_vet_bound(job)` -- so the vet no longer spends the teardown margin's share of one budget, and the cleanup margin is read from the constant in `cron.py` instead of being duplicated as a `+ 5` literal. On the run deadlines the vet is `_vet_allowance`, a fourth term beside the subprocess bound, `_pool_queue_allowance` and `_gate_budget_allowance`, added to BOTH the execution guard (`cron.py:3040`) and the reaper's sweep (`cron.py:1055`). Adding it to one and not the other is precisely the drift that produced the reaper regression described above, so both derive it from the same helper; it is sized from `_gate_budget_allowance` rather than a second copy of that expression, and scoped to command/script for the same reason the other two are.

**Audit-trail consequence, stated rather than buried.** An executed command or script run now emits TWO `governance_decision` SEL events per gate -- one at fire time, one at claim time -- where it previously emitted one. They are genuinely distinct decisions, and the second is the one that authorised the bytes that actually ran, so the trail is more complete rather than noisier. But anyone counting governance events per run, or alarming on their rate, should expect the pair.

**Why this is in this PR rather than its own.** Because this PR is what creates the window it closes. The vet-to-execution gap is a direct consequence of not charging the queue wait to the execution budget: on `main` that wait IS charged, so the gap is bounded by the run deadline instead of by `_CRON_QUEUE_WAIT_SECS`. Shipping the two separately would land the change that widens the window in one PR and the re-check that closes it in another, leaving the widened window shipped on its own in between. The fourth deadline term has the same property -- it exists only because the re-vet spends time inside a budget this branch re-shaped. This is a governance-behaviour change riding inside a `fix:`, and it is called out here for that reason rather than left to be discovered in the diff.

**Not** done here: a bounded *queue*. These pools are unbounded-queue `ThreadPoolExecutor`s, so a submit cannot be rejected under load and bounding the *wait* is what is available at the call site; a bounded queue in `executors.py` would be a structural change to a pool that pre-exists this PR.

**Not** done here: raising `_MAX_CRON_WORKERS`. A hung job saturates any pool size, just more slowly, and it would leave the misreporting untouched. The separate hang that saturated the pool on the measured instance is its own defect and is out of scope.

## Tests

`test/test_executors.py` — unit coverage of `run_in_cron_pool`: queue wait not charged to the execution timeout, starvation raising `CronQueueTimeout` with its own text, the execution backstop still firing and *not* as a queue timeout, result/exception/arg pass-through, the `TimeoutError` subclass relationship, and the queue budget not being job-scale.

Two further cases cover the early-fire and the message. `test_waited_still_covers_the_budget_when_the_timer_fires_early` models a coarse-clock platform on any host — it sets the loop's `_clock_resolution` to the Windows 15.625ms and has the selector return inside that window, which is what makes `_run_once` dispatch the timer before the deadline; the defect is otherwise unreachable on a fine-clock host. `test_a_sub_second_queue_wait_is_not_rendered_as_zero` pins `0.297 -> "queued 0.30s"` while holding `300.0 -> "queued 300s"`.

Two more cover cancellation in opposite directions, because both failure modes are silent: `test_cancelling_the_caller_does_not_leave_the_call_queued` (a cancelled call must never execute) and `test_cancelling_the_caller_does_not_kill_a_job_already_running` (closing that leak must not start aborting work in flight).

`test_a_call_claimed_at_the_deadline_is_not_reported_as_never_ran` covers the claim-at-deadline case. It models the loop's ready-queue lag for the claim signal alone -- deferring every `call_soon_threadsafe` callback would only make the test slow, because `wrap_future` uses the same mechanism for its own completion plumbing -- so the claim is invisible to the started-signal future exactly when the budget expires. With only the claim gate reverted it fails with `CronQueueTimeout: queued 0.30s, never ran`, which is the defect itself.

`test_execution_timeout_is_still_enforced_as_a_backstop` now holds its worker on a local event and sets that event before shutting the pool down. `shutdown_maintenance_executor` calls `shutdown(wait=False, cancel_futures=True)`, which drops queued futures but cannot stop a callable a worker has already started, so the previous form left a thread sleeping out the rest of its five seconds after the assertion had already passed. Releasing it first cuts that test's process wall time from ~9.2s to ~4.7s and removes the leak into whatever runs next.

`test/test_cron_gateway_integration.py` — a new `TestCronPoolQueueWait` class: the end-to-end negative control, plus both branches reporting `queued Ns, never ran`, plus a genuine overrun still reporting `timeout (35s)` (which also pins the `except` order).

**Both negative controls were verified to fail against the unpatched code, for the intended reason:**

- Unit: with the pre-fix single-phase `wait_for(run_in_executor(...), timeout=0.2)` restored, `test_queue_wait_is_not_charged_to_the_execution_timeout` fails with `TimeoutError` at a 0.20s call duration — an *instant* callable killed by a 0.5s queue wait.
- Integration: with only the script launch site reverted, `test_fast_script_waiting_for_a_worker_is_not_killed_as_a_script_timeout` fails on `assert mock_run.called` — "the script never ran, it was killed while queued". That is the production symptom reproduced.

Four further cases cover the two fixes above, each verified to fail with only its own change reverted. `test_the_enclosing_wake_deadline_also_excludes_queue_wait` fails on `the job was killed by the wake deadline while still queued`; `test_a_message_job_wake_budget_is_not_widened` still passes on that same reverted tree, so the scoping is pinned independently. `test_repeated_starvation_never_auto_pauses_a_healthy_script` and `..._command` drive `_AUTO_PAUSE_THRESHOLD + 2` consecutive starvation events and assert on the counter and the pause flag rather than merely the absence of an exception; reverting either handler fails only its own test.

Two further cases cover the one-shot retention: `test_a_starved_one_shot_job_is_retained_not_deleted` drives the real gateway command callback into a queue timeout and then the real merge, and fails pre-fix on `a one-shot that never ran was deleted as though it had run`; `test_a_starved_one_shot_at_job_is_not_parked_disabled` pins the other direction, asserting the job stays enabled and un-paused so the retention cannot be implemented by borrowing the policy-denial flag. Reverting either half of the fix -- the marker or its read -- fails both.

Three cases pin the reaper side, each driving one real sweep with a not-done task so the loop's `task.done()` early-continue cannot mask the decision. `test_the_reaper_does_not_preempt_a_job_inside_the_widened_window` fails pre-fix on `the reaper force-killed a job still inside its own execution deadline`; `test_the_reaper_still_kills_a_job_past_the_widened_deadline` keeps the backstop's teeth, so accounting for queue wait moves the threshold rather than removing it; `test_the_reaper_window_is_not_widened_for_a_message_job` pins the scoping. Reverting only the reaper's allowance fails the first and leaves the other two green.

`test_a_message_jobs_fire_time_gate_does_not_spend_its_execution_budget` covers the gate dispatch. It drives the REAL gateway message callback (captured through `_init_cron`, with only the mcp_cron privates patched, so the production dispatch runs) under the REAL `_execute_with_timeout`, with all `_MAX_CRON_WORKERS` workers held past the job's whole budget, and asserts the job reached its own dispatch rather than merely that nothing raised. Reverting only the message-path dispatch fails it on `the fire-time gate wait consumed the message job's whole execution budget`, and only it -- the other 13 cases in that class stay green. Applying the lane's remedy instead fails `test_a_message_job_wake_budget_is_not_widened` and `test_the_reaper_window_is_not_widened_for_a_message_job`, which is what rules that shape out.

Four cases cover the gate bound and the message-path retention. `test_a_starved_message_one_shot_survives_the_wake_deadline` drives the REAL gateway message callback under the REAL `_execute_with_timeout` with the gate pool held past the gate's bound, and asserts the job is still in the store after the real merge; with only the gate's bound removed it fails on `starvation did not mark the run as never started`, and with the early assertions bypassed so execution reaches the merge, on `the starved message one-shot was deleted by a run that never dispatched` -- the destructive outcome itself, measured rather than inferred. `test_a_dispatched_message_one_shot_is_still_deleted` is the negative control: a message one-shot that does dispatch must still be consumed, and setting the marker unconditionally fails it on `a dispatched run was marked never-started`. In `test/test_executors.py`, `test_cron_gate_pool_is_isolated_from_the_externally_paced_governance_pool` pins the relocation and `test_the_gate_budget_is_capped_below_the_wake_budget` pins the cap at every realistic budget, noting the accepted residual that at a 1s budget the floor and the budget coincide.

Five further cases cover the three bounds above, each verified to fail with only its own change reverted. `test_the_gate_budget_is_capped_below_the_wake_budget` fails on `gate 1.0s could outlive a 0.5s deadline` with the bare floor restored, and also pins the opposite direction (a 2s budget keeps the full floor, not a 0.5s window). `test_both_gate_bounds_reach_the_retention_handler` fails when the execution bound is left as a plain `TimeoutError`; `test_a_slow_gate_does_not_consume_a_message_one_shot` is its end-to-end form, driving the real message callback with a gate that overruns on a FREE pool, and fails on `a gate that overran its bound was not retained`. `test_a_timeout_from_the_gates_own_work_is_not_a_never_started_run` is the opposite-direction control: with the worker-thread wrapping removed it fails because a failed dispatch DECISION is reported as a run that never started. `test_the_execution_deadline_accounts_for_the_gate_bound` captures the `timeout` actually handed to the enclosing `wait_for` -- an earlier draft asserted on the allowance helper instead and passed with the term missing from the deadline entirely, so it was replaced -- and fails on `armed 2700s for a run owed 2730s`; `test_the_reaper_window_also_accounts_for_the_gate_bound` fails on `the reaper force-killed a job inside the gate-inclusive execution deadline`.

One implementation note for reviewers of the integration test: the blocker that occupies the worker is submitted from *inside* the mocked fire-time gate, which is what puts it ahead of the script in the cron pool's FIFO queue. The gate itself no longer touches that pool -- it runs bounded on `mc-crongate` -- so saturating the cron pool cannot starve the gate, and that independence is why the fixture can saturate it without perturbing the gate under test. The one test that patched an executor name on the gateway module no longer does: the gate resolves its pool inside `run_in_cron_gate_pool`, so patching it there was inert.

## Verification

Against current `upstream/main`:

- The eight modules this change touches or bears on (`test_executors.py`, `test_cron_script.py`, `test_cron_gateway_integration.py`, `test_cron.py`, `test_cron_wake_budget.py`, `test_cron_timeout_autopause_424.py`, `test_cron_reaper.py`, `test_slack_gateway_cron_exec_coverage.py`) — **389 passed, 1 skipped**.
- Broader sweep across every cron/executor/gateway/reaper/autopause/wake/slack/autonudge/auth-named test module — **6634 passed, 18 skipped, 1 xfailed, 1 failed**. The one failure is `test_gateway_lock_diagnosis.py::test_flock_is_held_by_a_fork_orphan` (`assert 284433 == 1`), which **reproduces identically with this change's files reverted on the current tree** (same `assert 284433 == 1`), and whose test module contains none of the symbols this change touches against a positive control of 13 in the test file this change edits: it asserts an orphaned process is reparented to PID 1, which does not happen in this container. Pre-existing and environmental, not caused by this change.
- Each of the three changes was reverted in isolation to confirm its test bites: dropping the deadline re-check fails the new test with `assert 0.2865 >= 0.3` (the CI shape); regressing the queue phase to a plain `TimeoutError` fails **both** the new test and the original starvation test, so the control still has teeth on the classification its name asserts; restoring the floored formatter fails the message test with `'queued 0s' == 'queued 0.30s'`. Reverting only the claim gate fails `test_a_call_claimed_at_the_deadline_is_not_reported_as_never_ran` with `CronQueueTimeout: queued 0.30s, never ran` while the other 19 cases in that file still pass, so the two are independent and neither masks the other.
- `flake8` and `isort` clean on all six changed files; `mypy` clean on `executors.py`, `slack/gateway.py` and `cron.py`. Two lint failures introduced along the way (an `E305` after the new helper and an isort violation) were fixed rather than shipped.
- `scripts/check_black_formatting.py` reports **13 offenders and 0 graduated entries**, none of them among the six files this change touches (intersection empty, and the comparison positive-controlled against a known offender). The count moved 14 -> 13 because `main` reformatted `five-whys/scripts/five_whys.py` in `2c4380a19` and pruned its baseline line; that is `main`'s change, not this one. Four of the six files it touches (`cron.py`, `slack/gateway.py`, `test_cron_gateway_integration.py`, `test_slack_gateway_cron_exec_coverage.py`) are baselined and were already not `black --check` clean before this change; the other two (`executors.py`, `test_executors.py`) are required to be clean and are. The gate therefore fails on `main` as it stands, independently of this PR.

## What I could not verify

I checked all **263 open PRs** at file-list level -- the full open set, and the one PR that hit GitHub's `files(first: 100)` GraphQL ceiling (#4305, exactly 100 returned) was re-pulled via paginated REST at 149 filenames and cleared. None touches `src/kiro_crew/executors.py` or `test/test_cron_gateway_integration.py`. Across the ten that do touch `slack/gateway.py`, no changed line contains `cron_executor`, `cmd_timeout`, `script_timeout`, `_MAX_CRON_WORKERS`, `last_error` or the literal `+ 5`, and **no hunk overlaps lines 2300-2720**; the three that match `wait_for`/`run_in_executor` at all are `maintenance_executor()` or client-shutdown sites 3,000+ lines from the cron dispatch. So no competing fix is in flight and nothing collides with these edits. What that does **not** cover: PR descriptions or comments proposing this fix without code, and merged-but-unpulled upstream work, since the sweep was of open PRs only.

The measured evidence above comes from one instance running identical code; I have not reproduced the 104-kill-event figure in CI, only the mechanism.



