### PR TITLE
fix(cron): report the terminal stderr, not the leading one

### DIFF
--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -713,8 +713,15 @@ def run_script_sandboxed(
             return {"status": "cancelled", "error": "Cancelled by user"}
 
         if proc.returncode != 0 and not stdout.strip():
-            error_text = stderr[:500] or f"exit {proc.returncode}"
-            error_text = redact(error_text)
+            # A process that dies hard (e.g. an unhandled module-level exception)
+            # leaves its diagnosis last: the traceback is the final thing written.
+            # Report the tail, not the head, so a chatty startup warning on stderr
+            # can't displace the actual cause of the failure.
+            # Redact the complete stderr BEFORE truncating: slicing first could
+            # cut off a credential's detectable prefix (e.g. the scheme of a
+            # token-bearing URL), letting the raw secret tail through redaction.
+            tail = redact(stderr.rstrip())
+            error_text = tail[-500:] if tail else f"exit {proc.returncode}"
             return {"status": "error", "error": error_text}
 
         try:

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -1141,6 +1141,79 @@ class TestRunScriptSandboxedErrorPaths:
         assert result["status"] == "error"
         assert "segfault" in result.get("error", "")
 
+    def test_nonzero_exit_reports_stderr_tail_not_head(self, tmp_path):
+        """A leading startup warning must not displace the terminal traceback."""
+        leading_warning = "startup warning: " + ("x" * 500)
+        traceback_tail = "Traceback (most recent call last):\nValueError: actual cause"
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", leading_warning + "\n" + traceback_tail)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "actual cause" in result["error"]
+        assert "startup warning" not in result["error"]
+
+    def test_nonzero_exit_redacts_before_truncating(self, tmp_path):
+        """A credential straddling the 500-char boundary must not leak its tail.
+
+        Redaction must run on the WHOLE stderr before the tail slice: slicing
+        first can cut off a secret's detectable prefix, so the pattern no
+        longer matches and the raw tail reaches cron alerts.
+        """
+        # Built at runtime so no credential-shaped literal lands in the repo.
+        fake_key = "AKIA" + "B" * 16  # matches the AWS access-key-id pattern
+        # Sized so the 500-char window starts 2 chars into the credential:
+        # a slice-then-redact order keeps "IA" + all 16 B's but drops the
+        # "AK" prefix, so the pattern no longer matches and the tail leaks.
+        padding = "p" * 100
+        trailing = "e" * 482
+        stderr_text = padding + fake_key + trailing
+        assert len(stderr_text) - 500 == len(padding) + 2
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "B" * 16 not in result["error"]
+        assert fake_key not in result["error"]
+        assert len(result["error"]) <= 500
+
+    def test_nonzero_exit_short_stderr_stays_whole(self, tmp_path):
+        """A stderr already shorter than the 500-byte bound is not truncated."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", "short failure\n")
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["error"] == "short failure"
+
+    def test_nonzero_exit_empty_stderr_falls_back_to_exit_code(self, tmp_path):
+        """No stderr at all still yields a usable message, not an empty string."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 3
+        mock_proc.communicate.return_value = ("", "")
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["error"] == "exit 3"
+
     def test_bad_json_output(self, tmp_path):
         """Lines 337-338: stdout is not valid JSON."""
         mock_proc = MagicMock()


### PR DESCRIPTION
## Problem / Motivation

When a script cron's subprocess dies without producing structured stdout, `run_script_sandboxed` reports the **first** 500 bytes of its stderr as the job's failure text. A process that dies hard (unhandled module-level exception, bad import, a raise during setup) leaves its diagnosis at the **end** — the traceback is the final thing written — so anything logged to stderr earlier (e.g. `paths.py`'s ~300-character data-home-conflict advisory warning, a common post-upgrade state) displaces the actual cause. The operator sees a truncated, unrelated warning instead of the traceback that explains why the job failed.

## Why it matters

Anyone running script crons on an install with any chatty startup-path stderr output gets a misleading `last_error` / Slack failure message that points them at the wrong thing (e.g. "go delete this legacy directory") instead of the real defect in their script. The actual cause is silently truncated away, making these failures much harder to diagnose from the reported error alone.

## What changed (motivation → approach → change)

Observed symptom → root cause → fix:
- Symptom: cron failure messages sometimes describe an unrelated advisory warning instead of the traceback that actually killed the job.
- Root cause: `error_text = stderr[:500]` in `cron_script.py`'s failure branch takes the *head* of stderr, but a hard crash's diagnosis is at the *tail*.
- Change: take the last 500 bytes of stderr instead of the first, keeping the same bound and the same `exit <returncode>` fallback when stderr is empty. Two deliberate companions to the tail slice: `redact()` now runs on the *complete* stderr **before** truncation (slice-then-redact could leave the unredacted tail of a credential that straddles the 500-byte boundary), and trailing whitespace is stripped so the tail slice isn't wasted on a terminal newline. Scoped to `run_script_sandboxed`'s failure-reporting branch only — no change to stdout JSON parsing, gateway delivery/notification semantics, auto-pause, or the data-home migration warning itself (which remains correct as advisory output).

## Tests

Added to `test/test_cron_script.py::TestRunScriptSandboxedErrorPaths`:
- `test_nonzero_exit_reports_stderr_tail_not_head` — a leading chatty warning no longer displaces a trailing traceback in the reported error.
- `test_nonzero_exit_short_stderr_stays_whole` — stderr already shorter than the 500-byte bound is reported whole, unchanged.
- `test_nonzero_exit_empty_stderr_falls_back_to_exit_code` — empty stderr still falls back to `exit <returncode>`.

`python -m pytest test/test_cron_script.py -q` — 104 passed, 1 skipped. `black`/`isort`/`flake8`/`mypy` clean on the touched files.

## Manual verification

N/A — unit coverage sufficient; this is a pure string-selection change in a subprocess-failure branch, fully exercised by mocked-subprocess unit tests above.

## Related Issues

Fixes #4344.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, this behavior was not previously documented in the module spec
- [x] No secrets, credentials, or internal references in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
