### PR TITLE
chore: drop runtime sys.frozen support

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -408,16 +408,19 @@ def _resolve_kirocrew_bin() -> str:
 
     Resolution order (first existing + executable wins):
 
-    0. Frozen/PyInstaller app (the shipped desktop app): ``sys.executable``
-       *is* the kirocrew CLI — e.g. ``.../kirocrew-backend`` — which accepts
-       the ``mcp-core`` / ``mcp-cron`` subcommands. The bundle has no
-       ``bin/kirocrew`` and nothing named ``kirocrew`` on PATH, so this is the
-       only reliable handle; without it kirocrew-core/kirocrew-cron are dropped.
-    1. Same install as the current process: walk up from ``kiro_crew.__file__``
-       looking for a ``bin/kirocrew`` sibling. Covers venv-based installs and
-       source-tree dev trees.
-    2. ``shutil.which('kirocrew')`` — respects PATH order.
-    3. Bare ``"kirocrew"`` — last resort, may fail but surfaces the problem
+    1. A sibling ``.venv`` entrypoint, for a source-tree install (an editable
+       install next to its own venv, e.g. ``project/src/kiro_crew`` plus
+       ``project/.venv``). Bounded by the first ``pyvenv.cfg`` walking up, so a
+       pip-into-venv install falls through to step 2 instead.
+    2. Same install as the current process: walk up from ``kiro_crew.__file__``
+       looking for a sibling console script (see
+       :func:`_kirocrew_bin_subpath` for the per-OS layout). Covers venv-based
+       installs, pip installs, source-tree dev trees, and the desktop app —
+       whose bundled interpreter is a python-build-standalone tree exposing a
+       launcher at its root, reached by this walk from the bundle's
+       ``site-packages``.
+    3. ``shutil.which('kirocrew')`` — respects PATH order.
+    4. Bare ``"kirocrew"`` — last resort, may fail but surfaces the problem
        instead of caching a known-bad absolute path.
 
     Every candidate is validated with ``is_file()`` and ``os.access(X_OK)``
@@ -434,23 +437,11 @@ def _resolve_kirocrew_bin() -> str:
         # the shared predicate, so the two cannot drift apart.
         return bool(sp) and _launcher_works(Path(sp))
 
-    # Frozen/PyInstaller app (shipped desktop app): ``sys.executable`` is the
-    # bundled ``kirocrew-backend`` binary, which *is* the kirocrew CLI and
-    # accepts the ``mcp-core`` / ``mcp-cron`` subcommands. The bundle ships no
-    # ``bin/kirocrew`` and nothing named ``kirocrew`` on PATH, so this is the
-    # only reliable handle — without it kirocrew-core / kirocrew-cron (and
-    # therefore spawn_run / cron_add / learn_add …) get dropped.
-    if getattr(sys, "frozen", False):
-        exe = sys.executable
-        if _usable(exe):
-            _KIROCREW_BIN = exe
-            return _KIROCREW_BIN
-
-    # 0. Prefer the venv entrypoint for source-tree installs (editable
+    # 1. Prefer the venv entrypoint for source-tree installs (editable
     #    install with a sibling .venv directory, e.g. project/src/kiro_crew
     #    + project/.venv/bin/kirocrew).
     #    NOTE: For pip-into-venv installs where pkg_dir is inside .venv/,
-    #    the pyvenv.cfg guard below breaks early and step 1 handles it.
+    #    the pyvenv.cfg guard below breaks early and step 2 handles it.
     try:
         # Circular import: kiro_crew.agent is loaded during kiro_crew
         # package initialization, so importing kiro_crew at module level
@@ -469,7 +460,7 @@ def _resolve_kirocrew_bin() -> str:
     except Exception:
         logger.debug("kirocrew venv bin check failed", exc_info=True)
 
-    # 1. Walk up from the running package to find bin/kirocrew
+    # 2. Walk up from the running package to find the console script
     try:
         import kiro_crew as _mc  # noqa: PLC0415  circular import
 
@@ -484,13 +475,13 @@ def _resolve_kirocrew_bin() -> str:
     except Exception:
         logger.debug("kirocrew bin walk failed", exc_info=True)
 
-    # 2. PATH lookup (also validated)
+    # 3. PATH lookup (also validated)
     found = shutil.which("kirocrew")
     if found and _usable(found):
         _KIROCREW_BIN = found
         return _KIROCREW_BIN
 
-    # 3. Last resort — don't cache, so a future call can retry
+    # 4. Last resort — don't cache, so a future call can retry
     logger.warning(
         "Could not resolve kirocrew binary to an existing file; "
         "falling back to bare 'kirocrew' (MCP probes may fail)"

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/provision.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/provision.py
@@ -36,8 +36,6 @@ import logging
 import os
 import shutil
 import subprocess
-import sys
-import sysconfig
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -60,8 +58,8 @@ ENGINE_COMMIT = engine_source.ENGINE_COMMIT
 UV_SYNC_TIMEOUT = 900
 UV_INSTALL_TIMEOUT = 300
 
-# The `uv` executable name, per platform. `sysconfig`'s EXE is "" on POSIX and
-# ".exe" on Windows, which is exactly the suffix the uv wheel's own locator uses.
+# The `uv` executable basename. No platform suffix is appended: the wheel's own
+# locator returns a full path, and `shutil.which` applies Windows `PATHEXT`.
 _UV_BASENAME = "uv"
 
 # Placeholders substituted into the shipped agent configs. The engine's absolute
@@ -109,24 +107,6 @@ _uv_path_cache: str | None = None
 _uv_path_resolved = False
 
 
-def _frozen_bundle_dirs() -> list[str]:
-    """Candidate directories for a bundled ``uv`` in a frozen build.
-
-    A frozen one-folder bundle has neither a scripts dir nor site-packages, so
-    the uv wheel's own locator cannot find the binary there (it walks
-    ``sysconfig`` paths only) — it raises ``UvNotFound``. Such a build stages the
-    binary at the bundle root, which is ``sys._MEIPASS`` at runtime and, for a
-    one-folder build, the directory holding ``sys.executable``. Both are checked
-    because the two differ for a one-FILE build (``_MEIPASS`` is the extraction
-    temp dir). Returns ``[]`` on the current desktop bundle, which ships a real
-    python-build-standalone interpreter tree that the locator walks.
-    """
-    if not getattr(sys, "frozen", False):
-        return []
-    candidates = [getattr(sys, "_MEIPASS", ""), os.path.dirname(sys.executable or "")]
-    return [c for c in candidates if c]
-
-
 def resolve_uv() -> str | None:
     """Absolute path to a usable ``uv``, or ``None`` when genuinely absent.
 
@@ -141,17 +121,15 @@ def resolve_uv() -> str | None:
     1. ``uv.find_uv_bin()`` — the wheel's own locator, the normal pip case. It
        raises ``UvNotFound`` (a ``FileNotFoundError`` subclass) when the binary
        is missing, e.g. an odd repackaging;
-    2. the frozen-bundle location — the DMG/Electron install, where there is no
-       scripts dir for the locator to walk (see :func:`_frozen_bundle_dirs`);
-    3. ``shutil.which("uv")`` — a user's own, possibly newer, uv still works;
-    4. ``None``.
+    2. ``shutil.which("uv")`` — a user's own, possibly newer, uv still works;
+    3. ``None``.
 
     Never raises: an absent uv is a reportable condition, so the caller can fail
     with an actionable message instead of a traceback in a background job.
 
     Cached process-wide: this runs on every provision and the answer cannot
-    change within a process (the interpreter's own site-packages and the frozen
-    bundle are both fixed at startup).
+    change within a process (the interpreter's own site-packages are fixed at
+    startup).
     """
     global _uv_path_cache, _uv_path_resolved
     if _uv_path_resolved:
@@ -175,12 +153,6 @@ def _resolve_uv_uncached() -> str | None:
             return found
     except (ImportError, FileNotFoundError, OSError) as exc:
         logger.debug("pptx-maker: uv.find_uv_bin() did not resolve: %s", exc)
-
-    executable = _UV_BASENAME + (sysconfig.get_config_var("EXE") or "")
-    for directory in _frozen_bundle_dirs():
-        candidate = os.path.join(directory, executable)
-        if os.path.isfile(candidate):
-            return candidate
 
     return shutil.which(_UV_BASENAME)
 

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -115,9 +115,9 @@ def _child_argv() -> "list[str]":
     """The argv the jail should re-exec — this same kirocrew invocation.
 
     Reuses ``agent._resolve_kirocrew_bin`` (the same self-invocation resolver
-    kirocrew-core/kirocrew-cron use) so the jailed child inherits its
-    frozen/PyInstaller, venv ``bin/`` walk, and ``os.access(X_OK)`` validation —
-    rather than re-implementing a bare ``shutil.which`` that misses those cases.
+    kirocrew-core/kirocrew-cron use) so the jailed child inherits its venv
+    ``bin/`` walk and ``os.access(X_OK)`` validation — rather than
+    re-implementing a bare ``shutil.which`` that misses those cases.
     The resolver returns the bare ``"kirocrew"`` sentinel when it finds no usable
     binary; in that case fall back to ``python -m kiro_crew`` so a non-PATH /
     editable run still re-execs correctly.

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1312,7 +1312,7 @@ def _status(args: argparse.Namespace) -> None:
 def _should_reconcile_launchd_launcher() -> bool:
     """Whether this gateway may repair the shared launchd launcher.
 
-    Only a non-frozen production instance may.
+    Only a production instance running outside the desktop bundle may.
 
     ``LIVE_PROGRAM`` is a per-user path under Application Support that
     ``KIROCREW_HOME`` does not scope, so a dev, pod, or worktree gateway
@@ -1322,16 +1322,22 @@ def _should_reconcile_launchd_launcher() -> bool:
     ``is_default_home`` is reused rather than re-derived so the two cannot drift
     on what counts as the real home.
 
-    A frozen build is excluded for a different reason: the launchd agent is a
-    ``service install`` artifact belonging to a source or pip install, while a
+    A bundled interpreter is excluded for a different reason: the launchd agent is
+    a ``service install`` artifact belonging to a source or pip install, while a
     packaged app manages its own backend lifecycle and supplies environment its
     interpreter needs — notably ``PYTHONPYCACHEPREFIX``, which keeps bytecode out
     of the signed bundle. A launcher naming the bundled executable would be run by
     launchd WITHOUT that environment, so the interpreter would write
     ``__pycache__`` inside the app and invalidate its signature. The packaged app
-    has no business owning this artifact at all.
+    has no business owning this artifact at all. The bundle is identified by its
+    interpreter's location (:func:`platform_compat.is_bundled_interpreter`), which
+    is the one runtime reading of the packaging layout.
     """
-    return sys.platform == "darwin" and not getattr(sys, "frozen", False) and is_default_home()
+    return (
+        sys.platform == "darwin"
+        and not platform_compat.is_bundled_interpreter()
+        and is_default_home()
+    )
 
 
 async def _gateway(

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -694,8 +694,6 @@ def _pip_install_channel_available() -> bool:
     it there recreates the press-and-nothing-changes failure this surface
     exists to avoid:
 
-    - a frozen backend: its import set is fixed at build time (the packaging
-      spec excludes the voice extra), so no install can become importable;
     - the desktop app's bundled interpreter (see
       :func:`platform_compat.is_bundled_interpreter`): pip may exist, but a
       pip install writes into the code-signed bundle — breaking launches and
@@ -706,8 +704,6 @@ def _pip_install_channel_available() -> bool:
       pip refuses to install. Checked only outside a venv: inside one, pip
       works and deliberately ignores the marker, so a venv returns True.
     """
-    if getattr(sys, "frozen", False):
-        return False
     if platform_compat.is_bundled_interpreter():
         return False
     if importlib.util.find_spec("pip") is None:
@@ -921,8 +917,10 @@ async def api_stt_install(request: web.Request) -> web.Response:
         return web.json_response(
             {
                 "code": "stt_no_local_install",
-                "error": "AWS Transcribe has no local install;"
-                " run the prerequisite command to add the 'voice' extra instead",
+                "error": (
+                    "AWS Transcribe has no local install;"
+                    " run the prerequisite command to add the 'voice' extra instead"
+                ),
             },
             status=400,
         )
@@ -1001,8 +999,10 @@ async def api_stt_install(request: web.Request) -> web.Response:
         return web.json_response(
             {
                 "ok": True,
-                "ffmpeg": shutil.which("ffmpeg") is not None
-                or os.path.isfile(os.path.expanduser("~/ffmpeg/ffmpeg")),
+                "ffmpeg": (
+                    shutil.which("ffmpeg") is not None
+                    or os.path.isfile(os.path.expanduser("~/ffmpeg/ffmpeg"))
+                ),
             }
         )
     except asyncio.TimeoutError:
@@ -1078,9 +1078,7 @@ def _build_stt_install_script(provider: str = "whisper") -> str:
     if provider in ("mlx", "parakeet"):
         pipx_pkg = "parakeet-mlx" if provider == "parakeet" else "mlx-whisper"
         verify_bin = "parakeet-mlx" if provider == "parakeet" else "mlx_whisper"
-        return (
-            prelude
-            + rf"""
+        return prelude + rf"""
 [ -d "$HOME/ffmpeg" ] && export PATH="$HOME/ffmpeg:$PATH"
 
 if ! command -v brew >/dev/null 2>&1; then
@@ -1101,7 +1099,6 @@ pipx install --force {pipx_pkg} 2>&1 || {{ echo "ERROR: pipx install {pipx_pkg} 
 
 echo "Done. {verify_bin}=$(command -v {verify_bin} 2>/dev/null || echo 'check PATH') ffmpeg=$(command -v ffmpeg 2>/dev/null || echo 'MISSING')"
 """
-        )
     return prelude + r"""
 # Pick up ffmpeg from ~/ffmpeg if installed there
 [ -d "$HOME/ffmpeg" ] && export PATH="$HOME/ffmpeg:$PATH"
@@ -1919,8 +1916,10 @@ async def api_kirocrew_config_patch(request: web.Request) -> web.Response:
             _log_sel("denied", f"{path_key}={value}")
             return web.json_response(
                 {
-                    "error": "must be an executable shell (an absolute path or a "
-                    "command on PATH); leave empty to use the system default",
+                    "error": (
+                        "must be an executable shell (an absolute path or a "
+                        "command on PATH); leave empty to use the system default"
+                    ),
                     "code": "shell_not_executable",
                 },
                 status=400,

--- a/src/kiro_crew/embeddings.py
+++ b/src/kiro_crew/embeddings.py
@@ -1641,7 +1641,7 @@ _SSL_CA_PATHS = (
 def _make_ssl_context() -> ssl.SSLContext:
     """Create an SSL context that finds system CA certs on all supported platforms.
 
-    Bundled Python runtimes (like the PyInstaller desktop backend) may not ship
+    Bundled Python runtimes (like the desktop backend's interpreter) may not ship
     their own CA bundle and rely on ``ssl.SSLContext.load_default_certs()`` which
     calls OpenSSL's defaults — those can miss when the compiled-in cert path
     doesn't match the host OS (common on AL2 with cross-compiled Python).

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -320,10 +320,10 @@ class TestSttPrereqCommands:
         assert cmds == [f'& "{core_mod.sys.executable}" -m pip install "kirocrew[voice]"']
 
     def test_transcribe_prereq_without_install_channel_is_empty(self, monkeypatch) -> None:
-        """When no install channel can make the extra importable (frozen build,
-        pip-less interpreter, PEP 668), emitting a pip command would recreate
-        the press-and-nothing-changes dead end — the UI shows the unsupported
-        notice via `transcribe_unsupported` instead."""
+        """When no install channel can make the extra importable (bundled
+        interpreter, pip-less interpreter, PEP 668), emitting a pip command would
+        recreate the press-and-nothing-changes dead end — the UI shows the
+        unsupported notice via `transcribe_unsupported` instead."""
         monkeypatch.setattr(core_mod, "_pip_install_channel_available", lambda: False)
         monkeypatch.setattr(core_mod, "_voice_extra_importable", lambda: False)
         monkeypatch.setattr(core_mod.shutil, "which", lambda _n: None)
@@ -419,15 +419,10 @@ class TestPipInstallChannel:
             core_mod.platform_compat, "is_bundled_interpreter", lambda: False
         )
 
-    def test_frozen_build_has_no_channel(self, monkeypatch) -> None:
-        monkeypatch.setattr(core_mod.sys, "frozen", True, raising=False)
-        assert core_mod._pip_install_channel_available() is False
-
     def test_bundled_desktop_interpreter_has_no_channel(self, monkeypatch) -> None:
         """A pip install into the desktop app's code-signed bundle breaks
         launches/updates and is discarded on every app update — the command
         must not be offered there even though pip itself may exist."""
-        monkeypatch.delattr(core_mod.sys, "frozen", raising=False)
         monkeypatch.setattr(
             core_mod.platform_compat, "is_bundled_interpreter", lambda: True
         )
@@ -436,7 +431,6 @@ class TestPipInstallChannel:
     def test_pipless_interpreter_has_no_channel(self, monkeypatch) -> None:
         """uv tool installs and some pipx layouts ship no `pip` module, so
         `<python> -m pip` fails immediately — the command must not be shown."""
-        monkeypatch.delattr(core_mod.sys, "frozen", raising=False)
         real = core_mod.importlib.util.find_spec
         monkeypatch.setattr(
             core_mod.importlib.util,
@@ -448,7 +442,6 @@ class TestPipInstallChannel:
     def test_externally_managed_python_has_no_channel(self, monkeypatch, tmp_path) -> None:
         """PEP 668: pip refuses installs into an externally-managed
         interpreter (distro/brew pythons) — but only outside a venv."""
-        monkeypatch.delattr(core_mod.sys, "frozen", raising=False)
         monkeypatch.setattr(core_mod.sys, "prefix", core_mod.sys.base_prefix)
         (tmp_path / "EXTERNALLY-MANAGED").write_text("", encoding="utf-8")
         monkeypatch.setattr(core_mod.sysconfig, "get_path", lambda name: str(tmp_path))
@@ -459,7 +452,6 @@ class TestPipInstallChannel:
         resolves to the BASE interpreter's directory where distro pythons put
         the marker — the recommended install layout (venv on a Debian/brew
         python) must not be misread as unsupported."""
-        monkeypatch.delattr(core_mod.sys, "frozen", raising=False)
         monkeypatch.setattr(core_mod.sys, "prefix", str(tmp_path / "venv"))
         monkeypatch.setattr(core_mod.sys, "base_prefix", str(tmp_path / "base"))
         (tmp_path / "EXTERNALLY-MANAGED").write_text("", encoding="utf-8")
@@ -467,7 +459,6 @@ class TestPipInstallChannel:
         assert core_mod._pip_install_channel_available() is True
 
     def test_ordinary_venv_has_a_channel(self, monkeypatch, tmp_path) -> None:
-        monkeypatch.delattr(core_mod.sys, "frozen", raising=False)
         monkeypatch.setattr(core_mod.sys, "prefix", core_mod.sys.base_prefix)
         monkeypatch.setattr(core_mod.sysconfig, "get_path", lambda name: str(tmp_path))
         assert core_mod._pip_install_channel_available() is True

--- a/test/test_installer_shim_and_cleanup.py
+++ b/test/test_installer_shim_and_cleanup.py
@@ -1,23 +1,23 @@
-"""Red->green harness for the KiroCrew installer fixes.
+"""Regression gates for the packaged-install path of the Kiro Crew installer.
 
-These tests pin down the two defects that silently degrade the *packaged*
-(PyInstaller / Electron) install — the dev/source tree masks both:
+Two properties only a *packaged* install can violate — a dev or source tree
+satisfies both by accident, which is why these gates exist:
 
-Defect A — frozen-app binary resolution
-    ``_resolve_kirocrew_bin()`` walks the source tree for ``bin/kirocrew`` and
-    consults ``PATH``, but never looks at ``sys.executable``.  In the shipped
-    app the package lives at ``.../kirocrew-backend/_internal/kiro_crew`` and
-    the executable is ``kirocrew-backend`` (not ``bin/kirocrew``), so every
-    step misses and it falls back to the bare string ``"kirocrew"``.  Because
-    that bare command is not on ``PATH``, ``build_agent_config`` /
-    ``rebuild_agent_config`` then DROP ``kirocrew-core`` and ``kirocrew-cron``
-    — taking ``spawn_run``, ``cron_add``, ``learn_add`` … offline.
+Property A — the packaged launcher must resolve
+    ``_resolve_kirocrew_bin()`` reaches the desktop bundle's launcher by walking
+    up from ``kiro_crew.__file__``: the bundle is a python-build-standalone
+    interpreter tree carrying the package under ``lib/*/site-packages`` and
+    exposing a launcher at its root. When that walk misses, the resolver falls
+    back to the bare string ``"kirocrew"`` — which is not on ``PATH`` inside a
+    bundle — and ``build_agent_config`` / ``rebuild_agent_config`` then DROP
+    ``kirocrew-core`` and ``kirocrew-cron``, taking ``spawn_run``, ``cron_add``,
+    ``learn_add`` … offline.
 
-    NOTE: a live ``kirocrew mcp-core`` stdio handshake would PASS even with the
-    bug present (the server code is healthy — it just never gets launched).
-    The real regression gate is at the *resolution / wiring* level, which is
-    what these tests assert: the managed-server command must be an absolute,
-    existing, executable path so the validation loop keeps it.
+    NOTE: a live ``kirocrew mcp-core`` stdio handshake PASSES even when this is
+    broken — the server code is healthy, it just never gets launched. The gate
+    is at the *resolution / wiring* level, which is what these tests assert: the
+    managed-server command must be an absolute, existing, executable path so the
+    validation loop keeps it.
 
 Defect B — stale predecessor MCP entries
     ``clean_stale_managed_mcp()`` only removes ``kirocrew-*`` entries unless an
@@ -40,6 +40,7 @@ from unittest.mock import patch
 
 import pytest
 
+import kiro_crew
 import kiro_crew.agent as agent
 import kiro_crew.mcp_cleanup as mcp_cleanup
 from kiro_crew.config.loader import KiroCrewConfig
@@ -95,12 +96,20 @@ def _clean_context():
 # --------------------------------------------------------------------------
 # helpers
 # --------------------------------------------------------------------------
-def _fake_frozen_exe(tmp_path: Path) -> Path:
-    """A real, executable stand-in for the bundled ``kirocrew-backend``."""
-    exe = tmp_path / "kirocrew-backend"
-    exe.write_text("#!/bin/sh\nexit 0\n")
-    exe.chmod(0o755)
-    return exe
+def _fake_bundle_launcher(tmp_path: Path) -> Path:
+    """The desktop bundle's launcher, at the root of a python-build-standalone tree.
+
+    The path comes from :func:`agent._kirocrew_bin_subpath`, the same helper the
+    resolver uses, so the fixture cannot drift from the layout under test (or from
+    the per-OS naming: ``bin/kirocrew`` on POSIX, ``Scripts\\kirocrew.exe`` on
+    Windows).
+    """
+    root = tmp_path / "backend-dist" / "kirocrew-backend"
+    launcher = agent._kirocrew_bin_subpath(root)
+    launcher.parent.mkdir(parents=True, exist_ok=True)
+    launcher.write_text("#!/bin/sh\nexit 0\n")
+    launcher.chmod(0o755)
+    return launcher
 
 
 def _bundled_defaults(tmp_path: Path) -> Path:
@@ -120,16 +129,23 @@ def _bundled_defaults(tmp_path: Path) -> Path:
     return cfg_dir
 
 
-def _simulate_frozen_app(monkeypatch, exe: Path) -> None:
-    """Make the running process look like the shipped PyInstaller app:
-    a real ``sys.executable``, nothing usable in the source tree, and no
-    ``kirocrew`` on PATH."""
+def _simulate_bundled_app(monkeypatch, launcher: Path) -> None:
+    """Make the running process look like the shipped desktop app.
+
+    Nothing marks the bundle at runtime — it is an ordinary python-build-standalone
+    interpreter — so what distinguishes it is WHERE the package sits: the
+    resolver's walk-up from ``kiro_crew.__file__`` is what reaches the bundle's
+    launcher. Point the package at the bundle's ``site-packages`` so that walk runs
+    against the shipped layout, reject every other candidate so the test does not
+    depend on the tree it runs in, and leave nothing named ``kirocrew`` on PATH.
+    """
+    root = launcher.parent.parent
+    pkg_init = root / "lib" / "python3.12" / "site-packages" / "kiro_crew" / "__init__.py"
+    pkg_init.parent.mkdir(parents=True, exist_ok=True)
+    pkg_init.touch()
     monkeypatch.setattr(agent, "_KIROCREW_BIN", "", raising=False)
-    monkeypatch.setattr(sys, "frozen", True, raising=False)
-    monkeypatch.setattr(sys, "executable", str(exe))
-    # No `bin/kirocrew` / `.venv/bin/kirocrew` is usable (force the dev tree
-    # candidates to be rejected so the test is independent of where it runs).
-    monkeypatch.setattr(agent, "_bin_is_usable", lambda p: str(p) == str(exe))
+    monkeypatch.setattr(kiro_crew, "__file__", str(pkg_init))
+    monkeypatch.setattr(agent, "_bin_is_usable", lambda p: str(p) == str(launcher))
     # `kirocrew` is not on PATH; only absolute paths resolve.
     monkeypatch.setattr(
         agent.shutil, "which", lambda c, **kw: c if str(c).startswith("/") else None
@@ -139,29 +155,30 @@ def _simulate_frozen_app(monkeypatch, exe: Path) -> None:
 # --------------------------------------------------------------------------
 # Defect A — resolver
 # --------------------------------------------------------------------------
-def test_resolver_prefers_frozen_executable(tmp_path, monkeypatch):
-    """In a frozen app, the resolver must return ``sys.executable`` (the
-    bundled ``kirocrew-backend``) instead of the bare ``"kirocrew"``."""
-    exe = _fake_frozen_exe(tmp_path)
-    _simulate_frozen_app(monkeypatch, exe)
+def test_resolver_finds_the_bundled_launcher(tmp_path, monkeypatch):
+    """In the desktop bundle, the walk-up from the package must reach the
+    bundle's own launcher instead of the bare ``"kirocrew"`` sentinel."""
+    launcher = _fake_bundle_launcher(tmp_path)
+    _simulate_bundled_app(monkeypatch, launcher)
 
     resolved = agent._resolve_kirocrew_bin()
 
-    assert resolved == str(exe), (
-        "frozen app must resolve to sys.executable, not bare 'kirocrew' " f"(got {resolved!r})"
+    assert resolved == str(launcher), (
+        "bundled app must resolve to its own launcher, not bare 'kirocrew' "
+        f"(got {resolved!r})"
     )
 
 
 # --------------------------------------------------------------------------
 # Defect A — managed servers survive (no longer dropped)
 # --------------------------------------------------------------------------
-def test_managed_servers_survive_in_frozen_app(tmp_path, monkeypatch):
+def test_managed_servers_survive_in_the_desktop_bundle(tmp_path, monkeypatch):
     """build_agent_config() must give kirocrew-core/kirocrew-cron an absolute,
     existing, executable command — the exact predicate the rebuild validation
     loop uses to KEEP (vs. drop) a server."""
-    exe = _fake_frozen_exe(tmp_path)
+    launcher = _fake_bundle_launcher(tmp_path)
     cfg_dir = _bundled_defaults(tmp_path)
-    _simulate_frozen_app(monkeypatch, exe)
+    _simulate_bundled_app(monkeypatch, launcher)
 
     with ExitStack() as stack:
         stack.enter_context(
@@ -184,12 +201,12 @@ def test_managed_servers_survive_in_frozen_app(tmp_path, monkeypatch):
     for name in ("kirocrew-core", "kirocrew-cron"):
         assert name in servers, f"{name} missing from generated config"
         cmd = servers[name]["command"]
-        assert cmd == str(exe), f"{name} command should be the frozen exe, got {cmd!r}"
+        assert cmd == str(launcher), f"{name} command should be the bundle launcher, got {cmd!r}"
         # This is the literal keep-condition from rebuild_agent_config's
         # validation loop; if it fails the server would be DROPPED.
         assert (
             os.path.isabs(cmd) and os.path.isfile(cmd) and os.access(cmd, os.X_OK)
-        ), f"{name} command {cmd!r} would be DROPPED by validation in the frozen app"
+        ), f"{name} command {cmd!r} would be DROPPED by validation in the bundle"
 
 
 # --------------------------------------------------------------------------
@@ -197,10 +214,10 @@ def test_managed_servers_survive_in_frozen_app(tmp_path, monkeypatch):
 # --------------------------------------------------------------------------
 @_posix_shim_only
 def test_ensure_kirocrew_on_path_creates_shim(tmp_path, monkeypatch):
-    """A frozen app with no `kirocrew` on PATH must get a shim pointing at the
-    bundled binary."""
-    exe = _fake_frozen_exe(tmp_path)
-    _simulate_frozen_app(monkeypatch, exe)
+    """A bundled app with no `kirocrew` on PATH must get a shim pointing at the
+    bundle's launcher."""
+    exe = _fake_bundle_launcher(tmp_path)
+    _simulate_bundled_app(monkeypatch, exe)
     bin_dir = tmp_path / "localbin"
 
     created = agent.ensure_kirocrew_on_path(bin_dir=bin_dir)
@@ -215,8 +232,8 @@ def test_ensure_kirocrew_on_path_creates_shim(tmp_path, monkeypatch):
 @_posix_shim_only
 def test_ensure_kirocrew_on_path_idempotent(tmp_path, monkeypatch):
     """Re-running setup when the shim is already correct is a no-op."""
-    exe = _fake_frozen_exe(tmp_path)
-    _simulate_frozen_app(monkeypatch, exe)
+    exe = _fake_bundle_launcher(tmp_path)
+    _simulate_bundled_app(monkeypatch, exe)
     bin_dir = tmp_path / "localbin"
 
     assert agent.ensure_kirocrew_on_path(bin_dir=bin_dir) is not None
@@ -277,12 +294,12 @@ def _sandbox_first_run(tmp_path, monkeypatch, exe):
     monkeypatch.setattr(agent, "_migrations_dir", lambda: mig)
     monkeypatch.setattr(agent, "_stale_mcp_purge_marker", lambda: marker)
     monkeypatch.setattr(mcp_cleanup, "_KIRO_MCP_JSON", mcp)
-    _simulate_frozen_app(monkeypatch, exe)
+    _simulate_bundled_app(monkeypatch, exe)
     return marker, mcp
 
 
 def test_first_run_delivers_shim_and_purge(tmp_path, monkeypatch):
-    exe = _fake_frozen_exe(tmp_path)
+    exe = _fake_bundle_launcher(tmp_path)
     marker, mcp = _sandbox_first_run(tmp_path, monkeypatch, exe)
     _seed_global_mcp(mcp)
     # Register a superseded predecessor so its entries are purgeable.
@@ -307,7 +324,7 @@ def test_first_run_delivers_shim_and_purge(tmp_path, monkeypatch):
 
 
 def test_first_run_purge_is_one_time(tmp_path, monkeypatch):
-    exe = _fake_frozen_exe(tmp_path)
+    exe = _fake_bundle_launcher(tmp_path)
     marker, mcp = _sandbox_first_run(tmp_path, monkeypatch, exe)
     # Already migrated: marker present.
     marker.parent.mkdir(parents=True, exist_ok=True)
@@ -332,7 +349,7 @@ def test_first_run_purge_is_one_time(tmp_path, monkeypatch):
 
 
 def test_first_run_is_best_effort(tmp_path, monkeypatch):
-    exe = _fake_frozen_exe(tmp_path)
+    exe = _fake_bundle_launcher(tmp_path)
     marker, mcp = _sandbox_first_run(tmp_path, monkeypatch, exe)
     _seed_global_mcp(mcp)
 
@@ -350,17 +367,19 @@ def test_first_run_is_best_effort(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------
-# Resolver: the frozen branch must NOT hijack non-frozen (source/dev) installs
+# Resolver: the running interpreter is never the answer
 # --------------------------------------------------------------------------
-def test_resolver_nonfrozen_ignores_sys_executable(tmp_path, monkeypatch):
+def test_resolver_never_returns_the_interpreter(tmp_path, monkeypatch):
+    """The resolver must return a ``kirocrew`` launcher, never whatever
+    interpreter happens to be running — a source install with the launcher only
+    on PATH must resolve through PATH."""
     path_bin = tmp_path / "kirocrew"
     path_bin.write_text("#!/bin/sh\n")
     path_bin.chmod(0o755)
-    interp = tmp_path / "python-interp"  # sys.executable when NOT frozen
+    interp = tmp_path / "python-interp"  # the running interpreter
     interp.write_text("x")
     interp.chmod(0o755)
     monkeypatch.setattr(agent, "_KIROCREW_BIN", "", raising=False)
-    monkeypatch.setattr(sys, "frozen", False, raising=False)
     monkeypatch.setattr(sys, "executable", str(interp))
     # venv + bin-walk find nothing usable; only PATH resolves to path_bin.
     monkeypatch.setattr(agent, "_bin_is_usable", lambda p: str(p) == str(path_bin))
@@ -370,7 +389,7 @@ def test_resolver_nonfrozen_ignores_sys_executable(tmp_path, monkeypatch):
 
     resolved = agent._resolve_kirocrew_bin()
     assert resolved == str(path_bin)
-    assert resolved != str(interp), "frozen branch must not fire when not frozen"
+    assert resolved != str(interp), "the resolver must not return sys.executable"
 
 
 # --------------------------------------------------------------------------
@@ -378,7 +397,6 @@ def test_resolver_nonfrozen_ignores_sys_executable(tmp_path, monkeypatch):
 # --------------------------------------------------------------------------
 def test_ensure_shim_noop_when_no_binary(tmp_path, monkeypatch):
     monkeypatch.setattr(agent, "_KIROCREW_BIN", "", raising=False)
-    monkeypatch.setattr(sys, "frozen", False, raising=False)
     monkeypatch.setattr(agent, "_bin_is_usable", lambda p: False)
     monkeypatch.setattr(agent.shutil, "which", lambda c, **kw: None)
     bin_dir = tmp_path / "localbin"
@@ -388,8 +406,8 @@ def test_ensure_shim_noop_when_no_binary(tmp_path, monkeypatch):
 
 @_posix_shim_only
 def test_ensure_shim_refreshes_stale_symlink(tmp_path, monkeypatch):
-    exe = _fake_frozen_exe(tmp_path)
-    _simulate_frozen_app(monkeypatch, exe)
+    exe = _fake_bundle_launcher(tmp_path)
+    _simulate_bundled_app(monkeypatch, exe)
     bin_dir = tmp_path / "localbin"
     bin_dir.mkdir()
     stale = tmp_path / "old-binary"
@@ -403,10 +421,8 @@ def test_ensure_shim_refreshes_stale_symlink(tmp_path, monkeypatch):
 
 
 def test_ensure_shim_noop_when_already_on_path(tmp_path, monkeypatch):
-    exe = _fake_frozen_exe(tmp_path)
+    exe = _fake_bundle_launcher(tmp_path)
     monkeypatch.setattr(agent, "_KIROCREW_BIN", "", raising=False)
-    monkeypatch.setattr(sys, "frozen", True, raising=False)
-    monkeypatch.setattr(sys, "executable", str(exe))
     monkeypatch.setattr(agent, "_bin_is_usable", lambda p: str(p) == str(exe))
     # `kirocrew` already resolves on PATH to the SAME binary.
     monkeypatch.setattr(
@@ -449,7 +465,6 @@ def _checkout_with_kirocrew(root: Path, *, linked_worktree: bool, bare_parent: b
 def _resolve_to(monkeypatch, binary: Path) -> None:
     """Make resolution land on *binary* and leave nothing else on PATH."""
     monkeypatch.setattr(agent, "_KIROCREW_BIN", "", raising=False)
-    monkeypatch.setattr(sys, "frozen", False, raising=False)
     monkeypatch.setattr(agent, "_resolve_kirocrew_bin", lambda: str(binary))
     monkeypatch.setattr(agent.shutil, "which", lambda c, **kw: None)
 
@@ -628,7 +643,7 @@ def test_clean_stale_purges_deleted_playwright_proxy(tmp_path, monkeypatch):
 
 
 def test_first_run_no_global_mcp(tmp_path, monkeypatch):
-    exe = _fake_frozen_exe(tmp_path)
+    exe = _fake_bundle_launcher(tmp_path)
     marker, mcp = _sandbox_first_run(tmp_path, monkeypatch, exe)
     # No global mcp.json at all (clean fresh install).
     agent.run_first_run_setup()
@@ -852,11 +867,11 @@ def test_launcher_naming_no_interpreter_stays_usable(tmp_path):
 # desktop shell) puts a wheel launcher and a package launcher on ONE machine,
 # and `ensure_kirocrew_on_path` runs on every gateway start.
 # --------------------------------------------------------------------------
-def _simulate_frozen_app_honest(monkeypatch, tmp_path, exe):
-    """``_simulate_frozen_app``, but launchers under *tmp_path* are judged for real.
+def _simulate_bundled_app_honest(monkeypatch, tmp_path, exe):
+    """``_simulate_bundled_app``, but launchers under *tmp_path* are judged for real.
 
-    The shared helper stubs ``_bin_is_usable`` to accept ONLY the frozen exe. That
-    is right for the resolver tests -- it makes them independent of whatever dev
+    The shared helper stubs ``_bin_is_usable`` to accept ONLY the bundle launcher.
+    That is right for the resolver tests -- it makes them independent of whatever dev
     tree they run in -- but wrong for these, which turn entirely on whether
     ANOTHER install's launcher is judged alive or dead. A stub that calls every
     foreign launcher dead would report ownership working while the product still
@@ -864,7 +879,7 @@ def _simulate_frozen_app_honest(monkeypatch, tmp_path, exe):
     from the real predicate.
     """
     real_usable = agent._bin_is_usable
-    _simulate_frozen_app(monkeypatch, exe)
+    _simulate_bundled_app(monkeypatch, exe)
     monkeypatch.setattr(
         agent,
         "_bin_is_usable",
@@ -893,8 +908,8 @@ def test_gateway_start_leaves_another_installs_working_launcher(tmp_path, monkey
     so claiming the name would make the last install to boot win -- and the other
     installer's upgrades would then land on a path nothing points at.
     """
-    exe = _fake_frozen_exe(tmp_path)
-    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    exe = _fake_bundle_launcher(tmp_path)
+    _simulate_bundled_app_honest(monkeypatch, tmp_path, exe)
     foreign = _foreign_working_launcher(tmp_path)
     bin_dir = tmp_path / "localbin"
     bin_dir.mkdir()
@@ -908,8 +923,8 @@ def test_gateway_start_leaves_another_installs_working_launcher(tmp_path, monkey
 @_posix_shim_only
 def test_explicit_setup_claims_the_name(tmp_path, monkeypatch):
     """`kirocrew setup` names an install deliberately, so it MAY take over."""
-    exe = _fake_frozen_exe(tmp_path)
-    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    exe = _fake_bundle_launcher(tmp_path)
+    _simulate_bundled_app_honest(monkeypatch, tmp_path, exe)
     foreign = _foreign_working_launcher(tmp_path)
     bin_dir = tmp_path / "localbin"
     bin_dir.mkdir()
@@ -925,8 +940,8 @@ def test_explicit_setup_claims_the_name(tmp_path, monkeypatch):
 @_posix_shim_only
 def test_gateway_start_repairs_a_dangling_launcher(tmp_path, monkeypatch):
     """Filling a BROKEN slot is the whole point -- ownership must not block it."""
-    exe = _fake_frozen_exe(tmp_path)
-    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    exe = _fake_bundle_launcher(tmp_path)
+    _simulate_bundled_app_honest(monkeypatch, tmp_path, exe)
     bin_dir = tmp_path / "localbin"
     bin_dir.mkdir()
     link = bin_dir / "kirocrew"
@@ -945,8 +960,8 @@ def test_gateway_start_replaces_launcher_whose_interpreter_vanished(tmp_path, mo
     This is the shape that made the live host's `kirocrew` fail -- a readable,
     executable console script whose interpreter no longer exists.
     """
-    exe = _fake_frozen_exe(tmp_path)
-    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    exe = _fake_bundle_launcher(tmp_path)
+    _simulate_bundled_app_honest(monkeypatch, tmp_path, exe)
     stale_bin = tmp_path / "reaped-venv" / "bin"
     stale_bin.mkdir(parents=True)
     stale = stale_bin / "kirocrew"
@@ -1003,9 +1018,9 @@ def test_gateway_start_does_not_shadow_a_working_launcher_elsewhere_on_path(tmp_
     or be shadowed by it depending on PATH order -- not a choice an unattended
     gateway start gets to make.
     """
-    exe = _fake_frozen_exe(tmp_path)
+    exe = _fake_bundle_launcher(tmp_path)
     foreign = _foreign_working_launcher(tmp_path)
-    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    _simulate_bundled_app_honest(monkeypatch, tmp_path, exe)
     # `kirocrew` resolves on PATH to the other install, and nothing is in bin_dir.
     monkeypatch.setattr(
         agent.shutil, "which", lambda c, **kw: str(foreign) if c == "kirocrew" else None
@@ -1019,9 +1034,9 @@ def test_gateway_start_does_not_shadow_a_working_launcher_elsewhere_on_path(tmp_
 @_posix_shim_only
 def test_explicit_setup_may_shadow_a_launcher_elsewhere_on_path(tmp_path, monkeypatch):
     """`kirocrew setup` names this install, so it may publish into bin_dir."""
-    exe = _fake_frozen_exe(tmp_path)
+    exe = _fake_bundle_launcher(tmp_path)
     foreign = _foreign_working_launcher(tmp_path)
-    _simulate_frozen_app_honest(monkeypatch, tmp_path, exe)
+    _simulate_bundled_app_honest(monkeypatch, tmp_path, exe)
     monkeypatch.setattr(
         agent.shutil, "which", lambda c, **kw: str(foreign) if c == "kirocrew" else None
     )

--- a/test/test_pptx_maker_provision.py
+++ b/test/test_pptx_maker_provision.py
@@ -266,59 +266,15 @@ class TestResolveUv:
         ):
             assert provision.resolve_uv() == "/usr/bin/uv"
 
-    def test_finds_the_binary_staged_next_to_a_frozen_executable(self, tmp_path: Path):
-        """The DMG path. PyInstaller's bundle has no scripts dir, so
-        `find_uv_bin()` raises there; the spec stages uv at the bundle root."""
-        bundled = tmp_path / ("uv" + (provision.sysconfig.get_config_var("EXE") or ""))
-        bundled.write_text("#!/bin/sh", encoding="utf-8")
-        fake_uv = mock.Mock(find_uv_bin=mock.Mock(side_effect=FileNotFoundError("frozen")))
+    def test_falls_through_to_path_when_find_uv_bin_raises(self, tmp_path: Path):
+        """`find_uv_bin()` raises `UvNotFound` on an install repackaged without the
+        binary — a system uv must still be used rather than reporting none."""
+        fake_uv = mock.Mock(find_uv_bin=mock.Mock(side_effect=FileNotFoundError("no binary")))
         with (
             mock.patch.dict(sys.modules, {"uv": fake_uv}),
-            mock.patch.object(sys, "frozen", True, create=True),
-            mock.patch.object(sys, "_MEIPASS", str(tmp_path), create=True),
-            mock.patch.object(provision.shutil, "which") as which,
-        ):
-            assert provision.resolve_uv() == str(bundled)
-        assert not which.called, "the bundled binary must win over PATH"
-
-    def test_finds_the_binary_beside_sys_executable_in_a_one_folder_build(self, tmp_path: Path):
-        """`_MEIPASS` and `dirname(sys.executable)` differ for a one-FILE build,
-        so both are probed."""
-        bundled = tmp_path / ("uv" + (provision.sysconfig.get_config_var("EXE") or ""))
-        bundled.write_text("#!/bin/sh", encoding="utf-8")
-        fake_uv = mock.Mock(find_uv_bin=mock.Mock(side_effect=FileNotFoundError("frozen")))
-        with (
-            mock.patch.dict(sys.modules, {"uv": fake_uv}),
-            mock.patch.object(sys, "frozen", True, create=True),
-            mock.patch.object(sys, "executable", str(tmp_path / "kirocrew-backend")),
-            mock.patch.object(provision.shutil, "which"),
-        ):
-            assert provision.resolve_uv() == str(bundled)
-
-    def test_falls_through_to_path_when_the_frozen_location_is_empty(self, tmp_path: Path):
-        """A frozen build whose bundle did NOT stage uv still uses a system one."""
-        empty = tmp_path / "bundle"
-        empty.mkdir()
-        fake_uv = mock.Mock(find_uv_bin=mock.Mock(side_effect=FileNotFoundError("frozen")))
-        with (
-            mock.patch.dict(sys.modules, {"uv": fake_uv}),
-            mock.patch.object(sys, "frozen", True, create=True),
-            mock.patch.object(sys, "_MEIPASS", str(empty), create=True),
-            mock.patch.object(
-                # Both frozen candidates must be empty, or the interpreter's own
-                # scripts dir (which really does hold a uv here) satisfies the probe.
-                sys,
-                "executable",
-                str(empty / "kirocrew-backend"),
-            ),
             mock.patch.object(provision.shutil, "which", return_value="/opt/homebrew/bin/uv"),
         ):
             assert provision.resolve_uv() == "/opt/homebrew/bin/uv"
-
-    def test_the_frozen_location_is_ignored_when_not_frozen(self, tmp_path: Path):
-        """A stray `uv` next to a normal interpreter must not be picked up as if
-        it were a bundled one — only `sys.frozen` opens that door."""
-        assert provision._frozen_bundle_dirs() == []
 
     def test_returns_none_when_uv_is_absent_everywhere_and_never_raises(self):
         """The contract `provision()` depends on: an absent uv is a reportable

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -2144,7 +2144,7 @@ class TestLauncherReconcileIsProductionOnly:
 
         assert cli_server._should_reconcile_launchd_launcher() is False
 
-    def test_a_frozen_build_never_reconciles(self, monkeypatch):
+    def test_the_desktop_bundle_never_reconciles(self, monkeypatch, tmp_path):
         """The packaged app must not own this artifact.
 
         launchd would run the bundled interpreter WITHOUT the environment the app
@@ -2152,11 +2152,21 @@ class TestLauncherReconcileIsProductionOnly:
         the signed bundle and invalidate its signature. The launchd agent belongs
         to a `service install`, not to an app that manages its own backend.
         """
-        from kiro_crew import cli_server
+        from kiro_crew import cli_server, platform_compat
 
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.setattr(cli_server.sys, "platform", "darwin")
-        monkeypatch.setattr(cli_server.sys, "frozen", True, raising=False)
+        # Drive the real predicate with a bundle-shaped interpreter path rather
+        # than stubbing it, so this test and the packaging layout cannot agree on
+        # a shape the build never ships.
+        bundled_python = (
+            tmp_path
+            / platform_compat.BUNDLED_BACKEND_DIST_DIRNAME
+            / "kirocrew-backend"
+            / "bin"
+            / "python3.12"
+        )
+        monkeypatch.setattr(cli_server.sys, "executable", str(bundled_python))
 
         assert cli_server._should_reconcile_launchd_launcher() is False
 


### PR DESCRIPTION
## Summary

The deferred half of #4229, which removed only the dead PyInstaller *build*
path. This removes the runtime side: every branch that reads `sys.frozen`.

The desktop backend ships a python-build-standalone interpreter plus uv, and no
released artifact was ever PyInstaller-frozen. Nothing in the tree sets
`sys.frozen`, so each of these branches is unreachable.

| Site | Disposition |
|---|---|
| `agent.py` `_resolve_kirocrew_bin()` | **Delete.** The bundle's interpreter tree exposes its own launcher at the tree root, already reached by the walk-up from `kiro_crew.__file__`. |
| `dashboard/handlers/core.py` `_pip_install_channel_available()` | **Delete.** The `is_bundled_interpreter()` check on the next line already covers it. |
| `cli_server.py` `_should_reconcile_launchd_launcher()` | **Retarget** to `is_bundled_interpreter()`. Not a removal — see below. |
| `pptx_maker/backend/provision.py` `_frozen_bundle_dirs()` | **Delete** the function and its call site. |

Two changes are deliberately not deletions:

**`cli_server.py` is retargeted, not removed.** The exclusion exists so launchd
never runs the bundled interpreter without `PYTHONPYCACHEPREFIX`, which would
write `__pycache__` into the code-signed bundle and invalidate its signature.
That hazard applies to the current bundle too, so the predicate moves to
`is_bundled_interpreter()` rather than disappearing.

**The tests are re-aimed, not deleted.** The installer fixtures now build a real
python-build-standalone layout — package under `lib/*/site-packages`, launcher at
the tree root, placed through the resolver's own `_kirocrew_bin_subpath()` so the
fixture cannot drift from the layout or its per-OS naming — instead of setting
`sys.frozen`. This preserves the invariants those tests actually guard:

- managed `kirocrew-core` / `kirocrew-cron` surviving config validation (whose
  failure mode is `spawn_run` / `cron_add` / `learn_add` going offline)
- shim creation, idempotence, and stale-link repair
- first-run delivery and the one-time migration
- launcher ownership across a co-installed foreign install

Only tests whose subject was the deleted code itself are dropped. One pptx test
is re-aimed onto the `find_uv_bin()`-raises branch so that path stays covered,
and the launchd test drives `is_bundled_interpreter()` through a bundle-shaped
interpreter path rather than a stub.

Dropping the `sysconfig.get_config_var("EXE")` suffix loses no Windows
behaviour: `find_uv_bin()` returns a full path, and `shutil.which()` applies
`PATHEXT`. The suffix only ever mattered for the bundle probe being removed.

## One declared rider: formatting-only hunks in `core.py`

`src/kiro_crew/dashboard/handlers/core.py` carries **6 formatting-only hunks
(28 lines)** that have nothing to do with `sys.frozen`: parentheses added around
three multiline string/boolean values (in `api_stt_transcribe`'s error body, the
ffmpeg probe response, and a shell-validation error body) and removed around
`return prelude + r"""..."""` in `_stt_prereq_commands`.

They are not optional. The baselined black gate judges a changed file **in
full**, this file is not in the baseline, and it was already not black-clean
under the pinned `black==26.3.1` before this change touched it — so any PR that
edits `core.py` at all must first make the whole file clean. Landing the SITE 2
deletion required it. The gate deliberately offers no way to exempt a file
(`--update-baseline` only ever deletes entries), which is the right design and
is not worked around here.

## Adversarial review

Reviewed by a four-model cross-vendor panel before implementation. Its
load-bearing finding changed the shape of this change: deleting the frozen test
fixtures would have silently unguarded the four invariants listed above, and CI
could not have caught it, because each guard would have disappeared together
with its test. The re-aim is that finding applied.

Two BLOCKERs were adjudicated as misclassified rather than accepted:

- One rested on `_kirocrew_bin_subpath()` returning a POSIX-only path. It
  branches on the platform and returns `Scripts/kirocrew.exe` on Windows.
- Both Windows objections describe a **pre-existing** gap: pip's
  `Scripts/kirocrew.exe` in the bundle embeds the build machine's interpreter
  path, while the relocatable launcher the build also writes is
  `bin/kirocrew.cmd`, which the Python-side resolver does not prefer the way
  `find-bin.js` does. `sys.frozen` is false on the bundle either way, so the
  deleted branch never fired on Windows and this change does not touch that
  behaviour. Filed separately rather than folded in here.

## Testing

Verified locally: `flake8`, `isort`, and this repo's own
`scripts/check_brand_name.py` all pass against this change. Static checks done by
hand: no `sys.frozen` reader remains in `src/` or `test/`, no reference to any
deleted symbol remains, and every touched file parses.

Two gates could **not** be verified locally and are delegated to CI: the pinned
`black==26.3.1` is not obtainable on the machine this was written on (its index
tops out at 25.11.0), and local `mypy` resolves to a Python 3.9 interpreter and
emits phantom `X | Y syntax requires Python 3.10` errors.

## Not in scope

`website/electron/find-bin.js` still probes the legacy flat-exe layout, with
five test fixtures pinning it (one deliberately pins legacy-first ranking).
The panel rated its removal safe, but it is a separable JS-side change and is
left for a follow-up.
