### PR TITLE
refactor(dashboard): retire refreshTrigger from 13 React Query keys (#4179)

### DIFF
--- a/website/src/components/ExecutionsView.tsx
+++ b/website/src/components/ExecutionsView.tsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query'
 import { ChevronRight } from 'lucide-react'
 import { api } from '../api/client'
 import { Badge, Btn, Skeleton } from './ui'
-import { useAppSelector } from '../store'
 
 import { i18nT } from '../i18n/t'
 import { fmtDateTimeNumeric, fmtDuration as fmtDurationParts, fmtUnit } from '../i18n/format'
@@ -32,16 +31,14 @@ const fmtTime = (ts: number) => fmtDateTimeNumeric(ts)
 export default function ExecutionsView({ selectedJobId }: { selectedJobId?: string }) {
   const [page, setPage] = useState(0)
   const [expanded, setExpanded] = useState<string | null>(null)
-  const refreshTrigger = useAppSelector(s => s.dashboard.refreshTrigger)
-
   const { data: jobsData } = useQuery({
-    queryKey: ['cron-jobs', refreshTrigger],
+    queryKey: ['cron-jobs'],
     queryFn: () => api.crons().then(r => r.jobs || []),
   })
   const jobIds = new Set((jobsData || []).map((j: { id: string }) => j.id))
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['cron-history-all', page, selectedJobId, refreshTrigger],
+    queryKey: ['cron-history-all', page, selectedJobId],
     queryFn: async () => {
       const res = await api.cronHistoryAll({ offset: page * PAGE_SIZE, limit: PAGE_SIZE + 1, jobId: selectedJobId })
       const items: HistoryEntry[] = res.runs || []

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { isArtifactEditing } from '../utils/artifactEditGuard'
 import { useAppDispatch } from '../store'
 import { store } from '../store'
@@ -31,6 +31,27 @@ function voiceMessageId(message: ChatMessage): string {
   if (message.ts) return message.ts
   const serverId = message.meta?.mid
   return typeof serverId === 'string' ? serverId : ''
+}
+
+/**
+ * Invalidate React Query caches for keys that previously relied on the
+ * `refreshTrigger` counter being part of their queryKey.  Calling
+ * `invalidateQueries` refetches **in-place** (keeping the cached data visible
+ * to the UI) instead of minting a brand-new cache entry with `undefined` data
+ * — which is what caused the flash-to-empty bug (#4132, #4179).
+ */
+function invalidateRefreshQueries(qc: QueryClient): void {
+  qc.invalidateQueries({ queryKey: ['cron-jobs'] })
+  qc.invalidateQueries({ queryKey: ['cron-history-all'] })
+  qc.invalidateQueries({ queryKey: ['spawn-list'] })
+  qc.invalidateQueries({ queryKey: ['sessions-context'] })
+  qc.invalidateQueries({ queryKey: ['sessions-usage'] })
+  qc.invalidateQueries({ queryKey: ['agents-installed'] })
+  qc.invalidateQueries({ queryKey: ['mcp-tools'] })
+  qc.invalidateQueries({ queryKey: ['kirocrew-agents'] })
+  qc.invalidateQueries({ queryKey: ['default-agent'] })
+  qc.invalidateQueries({ queryKey: ['workspaces'] })
+  qc.invalidateQueries({ queryKey: ['kirocrewConfig'] })
 }
 
 /** Single multiplexed WebSocket replacing all SSE + polling connections. */
@@ -918,6 +939,7 @@ export function useWebSocket() {
           case 'refresh': {
             const kinds: string[] = data.kinds || []
             dispatch(triggerRefresh())
+            invalidateRefreshQueries(queryClient)
             if (kinds.includes('history')) dispatch(fetchHistory(false))
             break
           }
@@ -1413,6 +1435,7 @@ export function useWebSocket() {
           case 'sessions_restarting':
             // Backend pushed session restart status (restarting/ready)
             dispatch(triggerRefresh())
+            invalidateRefreshQueries(queryClient)
             break
           case 'update_progress': {
             const prog = data as { step: string; detail: string }
@@ -1432,6 +1455,7 @@ export function useWebSocket() {
           case 'refine':
             // Handled by ProjectsPage via Redux
             dispatch(triggerRefresh())
+            invalidateRefreshQueries(queryClient)
             break
           case 'channel_message':
           case 'channel_agent_status':

--- a/website/src/pages/AgentsPage.tsx
+++ b/website/src/pages/AgentsPage.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useLayoutEffect, useMemo, useRef, type ReactNode }
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { Star, Brain, Plug, Pin, Package, Lock, Hourglass, Bot, ChevronDown, LayoutTemplate, X } from 'lucide-react'
 import { createPortal } from 'react-dom'
-import { useAppSelector } from '../store'
 import { api } from '../api/client'
 import type { SubagentInfo } from '../types'
 import Clickable from '../components/Clickable'
@@ -364,27 +363,25 @@ function SubagentsCard({ agents, onClear, onDelete }: { agents: SubagentInfo[]; 
 }
 
 export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
-  const refreshTrigger = useAppSelector(s => s.dashboard.refreshTrigger)
-
   const { data: spawnData, refetch: refetchSpawn } = useQuery({
-    queryKey: ['spawn-list', refreshTrigger],
+    queryKey: ['spawn-list'],
     queryFn: () => api.spawnList(),
   })
   const agents: SubagentInfo[] = spawnData?.agents || []
 
   const { data: ctx = [] } = useQuery<CtxSession[]>({
-    queryKey: ['sessions-context', refreshTrigger],
+    queryKey: ['sessions-context'],
     queryFn: () => api.sessionsContext().then(d => d.sessions || []),
     refetchInterval: 15000,
   })
 
   const { data: usage = null } = useQuery({
-    queryKey: ['sessions-usage', refreshTrigger],
+    queryKey: ['sessions-usage'],
     queryFn: () => api.sessionsUsage().then(d => (d.usage && Number.isFinite(d.usage.credits_plan)) ? d.usage : null).catch(() => null),
   })
 
   const { data: installed = [], isPending: installedLoading, refetch: refetchInstalled } = useQuery({
-    queryKey: ['agents-installed', refreshTrigger],
+    queryKey: ['agents-installed'],
     queryFn: async () => {
       const a = await api.agentsInstalled()
       if (!Array.isArray(a)) return []
@@ -398,7 +395,7 @@ export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
   })
 
   const { data: mcpTools = {} } = useQuery({
-    queryKey: ['mcp-tools', refreshTrigger],
+    queryKey: ['mcp-tools'],
     queryFn: async () => {
       const probed = await api.mcpProbeCache()
       if (!Array.isArray(probed)) return {}
@@ -418,13 +415,13 @@ export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
    *  this one (`crews.filter` on an object throws during render). Storing the
    *  response verbatim and selecting from it also dedupes the fetch. */
   const { data: crewsData, isError: crewsFailed, refetch: refetchCrews } = useQuery<{ agents?: KiroCrewAgent[]; default_agent?: string }>({
-    queryKey: ['kirocrew-agents', refreshTrigger],
+    queryKey: ['kirocrew-agents'],
     queryFn: () => api.kirocrewAgents(),
   })
   const crews = useMemo(() => crewsData?.agents ?? [], [crewsData])
 
   const { data: defaultAgentData, isError: defaultFailed, refetch: refetchDefault } = useQuery({
-    queryKey: ['default-agent', refreshTrigger],
+    queryKey: ['default-agent'],
     queryFn: () => api.defaultAgent().then(d => d.default_agent || ''),
   })
   const defaultAgent = defaultAgentData ?? ''

--- a/website/src/pages/KiroCrewAgentsPage.tsx
+++ b/website/src/pages/KiroCrewAgentsPage.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Boxes, FolderOpen, Database, Sparkles, Plus, MessageSquare, Users, Star, LayoutGrid, Rows3 } from 'lucide-react'
 import Clickable from '../components/Clickable'
-import { useQuery, useMutation, keepPreviousData } from '@tanstack/react-query'
-import { useAppSelector, useAppDispatch } from '../store'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { useAppDispatch } from '../store'
 import { createSlot } from '../store/chatSlice'
 import { api } from '../api/client'
 import { useProvider } from '../providers'
@@ -488,37 +488,27 @@ export default function KiroCrewAgentsPage({ embedded }: { embedded?: boolean } 
   const provider = useProvider()
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
-  const refreshTrigger = useAppSelector(s => s.dashboard.refreshTrigger)
-
   const { data: agentsData, refetch: refetchAgents } = useQuery({
-    queryKey: ['kirocrew-agents', refreshTrigger],
+    queryKey: ['kirocrew-agents'],
     queryFn: () => api.kirocrewAgents(),
-    // `refreshTrigger` is part of the key, so every WS-driven bump (a `refresh`,
-    // `sessions_restarting`, or `refine` frame from ANY session, not this page)
-    // mints a fresh query whose `data` starts `undefined`. Without this the
-    // roster would collapse to `[]` for the refetch window and the
-    // `agents.length === 0` branch below would flash the "No crews yet" empty
-    // state on a populated install. Retaining the prior roster keeps the page
-    // stable across those unrelated refreshes.
-    placeholderData: keepPreviousData,
   })
   const agents: KiroCrewAgent[] = agentsData?.agents || []
   const defaultAgent = agentsData?.default_agent || ''
 
   const { data: installedAgents } = useQuery({
-    queryKey: ['agents-installed', refreshTrigger],
+    queryKey: ['agents-installed'],
     queryFn: () => api.agentsInstalled(),
   })
   const kiroAgentOptions = Array.isArray(installedAgents) ? installedAgents.map((x: { name: string }) => x.name).filter(Boolean) : ['kirocrew']
 
   const { data: workspacesData, refetch: refetchWorkspaces } = useQuery({
-    queryKey: ['workspaces', refreshTrigger],
+    queryKey: ['workspaces'],
     queryFn: () => api.workspaces(),
   })
   const workspaceOptions = workspacesData?.workspaces?.map((w: { name: string }) => w.name) || ['default']
 
   const { data: kirocrewCfg } = useQuery({
-    queryKey: ['kirocrewConfig', refreshTrigger],
+    queryKey: ['kirocrewConfig'],
     queryFn: () => api.kirocrewConfig(),
   })
   const memoryStoreOptions = kirocrewCfg?.memory_stores ? Object.keys(kirocrewCfg.memory_stores) : ['default']

--- a/website/src/test/AgentsPageInspector.test.tsx
+++ b/website/src/test/AgentsPageInspector.test.tsx
@@ -237,7 +237,7 @@ describe('agent templates inspector — shared crews cache', () => {
      Crews roster. Both directions are asserted. */
   it('reads and leaves the cache in the shape the Crews tab stores', async () => {
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-    qc.setQueryData(['kirocrew-agents', 0], {
+    qc.setQueryData(['kirocrew-agents'], {
       agents: [{ name: 'default', kiro_agent: 'kirocrew', workspace: 'default', memory_store: 'default', description: '', source: 'user' }],
       default_agent: 'default',
     })
@@ -247,7 +247,7 @@ describe('agent templates inspector — shared crews cache', () => {
 
     expect(await screen.findByText('Used By')).toBeInTheDocument()
     expect(screen.getByText('default')).toBeInTheDocument()
-    const cached = qc.getQueryData(['kirocrew-agents', 0])
+    const cached = qc.getQueryData(['kirocrew-agents'])
     expect(Array.isArray(cached)).toBe(false)
     expect(cached).toMatchObject({ default_agent: 'default' })
   })
@@ -438,14 +438,14 @@ describe('agent templates inspector — delete', () => {
     // settles and `crewsData` stays defined — an undefined-check alone would
     // keep comparing against a roster the server may no longer agree with.
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-    qc.setQueryData(['kirocrew-agents', 0], { agents: [], default_agent: '' })
+    qc.setQueryData(['kirocrew-agents'], { agents: [], default_agent: '' })
 
     renderPage(qc)
     await open('scratch')
     expect(await screen.findByTestId('delete-template')).toBeInTheDocument()
 
     mockApi.kirocrewAgents.mockRejectedValue(new Error('network'))
-    await qc.refetchQueries({ queryKey: ['kirocrew-agents', 0] })
+    await qc.refetchQueries({ queryKey: ['kirocrew-agents'] })
 
     await waitFor(() => expect(screen.queryByTestId('delete-template')).not.toBeInTheDocument())
   })

--- a/website/src/test/CrewRoster.test.tsx
+++ b/website/src/test/CrewRoster.test.tsx
@@ -307,13 +307,12 @@ describe('crew roster — filtering', () => {
     expect(screen.queryAllByTestId('crew-card')).toHaveLength(0)
   })
 
-  it('does not flash the empty state while a refreshTrigger-driven refetch is in flight', async () => {
-    // `refreshTrigger` is part of the roster query key, so any WS-driven bump
-    // (a `refresh` / `sessions_restarting` / `refine` frame from ANOTHER
-    // session, a cron, or a restart) mints a fresh query whose `data` starts
-    // `undefined`. Without `placeholderData: keepPreviousData` that collapses
-    // `agents` to `[]` for the refetch window and the roster flashes the
-    // "No crews yet" empty state on a populated install — the reported bug.
+  it('does not flash the empty state while an invalidateQueries-driven refetch is in flight', async () => {
+    // After retiring the refreshTrigger-in-queryKey pattern (#4179), the
+    // roster query key is stable (`['kirocrew-agents']`) and refetches are
+    // triggered by `queryClient.invalidateQueries` from the WS handler.
+    // `invalidateQueries` keeps the cached data visible during the refetch,
+    // so the roster must never collapse to the empty state.
     let resolveSecond: (v: unknown) => void = () => {}
     mockApi.kirocrewAgents
       .mockResolvedValueOnce(AGENTS_RESPONSE)
@@ -332,10 +331,8 @@ describe('crew roster — filtering', () => {
     )
     await waitFor(() => expect(screen.getAllByTestId('crew-card')).toHaveLength(2))
 
-    // Bump refreshTrigger → the roster query key changes and refetches. The
-    // second fetch is deliberately left pending so the "no data yet" window is
-    // observable rather than a sub-millisecond flicker.
-    act(() => { store.dispatch({ type: 'dashboard/triggerRefresh' }) })
+    // Simulate the WS handler: invalidate the query in-place (no key change).
+    act(() => { qc.invalidateQueries({ queryKey: ['kirocrew-agents'] }) })
 
     // The prior roster must remain on screen throughout the pending refetch —
     // no empty state, cards intact.


### PR DESCRIPTION
## Problem / Motivation

13 React Query call sites bake the global `refreshTrigger` counter into their `queryKey`. Because `refreshTrigger` is part of the key, every WebSocket-driven bump (`refresh` / `sessions_restarting` / `refine` frame) mints a **brand-new query with no cached data** — so `data` is `undefined` during the refetch and the UI transiently renders its empty/loading fallback before new data arrives.

This is the root-cause pattern behind #4132 (the Crews roster flashing "No crews yet"). PR #4144 fixed that one site with `placeholderData: keepPreviousData`; this PR fixes all 13 sites at the cause level.

## Why it matters

Each site is a latent flicker/blank bug surfacing whenever unrelated background activity bumps `refreshTrigger`. The edit-sheet option lists on the Crews tab collapse to fallback values (`['kirocrew']`, `['default']`), the Executions table blanks to a skeleton, and the Agents page's 7 queries all suffer the same undefined-data window.

## What changed (motivation → approach → change)

**Root cause:** `refreshTrigger`-in-key churns the cache to force a refetch.

**Approach:** React Query's `queryClient.invalidateQueries({ queryKey: [...] })` refetches **in place, keeping cached data visible** — exactly what avoids the collapse. This is already the established pattern in `useWebSocket.ts` for ~18 other keys.

**Changes:**
1. Added `invalidateRefreshQueries(qc)` helper in `useWebSocket.ts` that invalidates all 13 affected query keys.
2. Called the helper at the three `dispatch(triggerRefresh())` sites (`refresh`, `sessions_restarting`, `refine` events).
3. Removed `refreshTrigger` from the 13 `queryKey` arrays across `ExecutionsView.tsx` (2), `AgentsPage.tsx` (7), and `KiroCrewAgentsPage.tsx` (4).
4. Removed the per-site `placeholderData: keepPreviousData` workaround from `KiroCrewAgentsPage.tsx` (no longer needed).
5. Kept `dispatch(triggerRefresh())` in place for other consumers that use it as a `useEffect` dependency (ChatPane, SchedulePage, OverviewPage, useAgents).

## Tests

- Updated `CrewRoster.test.tsx` regression test: verifies that `queryClient.invalidateQueries` (simulating the new WS handler path) does not flash the empty state during a pending refetch.
- Updated `AgentsPageInspector.test.tsx`: aligned query key references to the new stable keys (no `refreshTrigger` suffix).

## Manual verification

N/A — unit coverage sufficient. The behavior (no empty-state flash during WS-driven refetch) is directly asserted by the CrewRoster regression test. No new UI surfaces are added.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** This is a pure refactoring of React Query key composition with no visible rendered delta — the fix *prevents* a transient flash that is untriggerable in a static screenshot.

Closes #4179
