### PR TITLE
fix(dashboard): stop a per-slot mode change revoking the global YOLO grant

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1226,6 +1226,8 @@ Permanent YOLO mode has been eliminated. All activations go through the `SafetyO
 
 After expiry, re-authorization is required. A 5-minute grace window allows `!yolo renew` (Slack) or the dashboard re-auth button to extend the session without creating a new one. Outside the grace window, a fresh activation is needed.
 
+**The grant is process-global; approval modes are per-slot.** `POST /api/chat/mode` sets `normal` / `trust_reads` / `trust` against the slot named in `slot` (or every slot when it is omitted), while `yolo` is the global grant and ignores `slot`. Because the grant covers every slot, a **slot-scoped** `trust`/`trust_reads` does NOT revoke it: that request asks for auto-approval on one slot and cannot be answered by withdrawing authority from slots it never named (the shape that let a programmatic per-slot `trust` end an operator's live grant). Every other mode change still revokes, so `normal` remains the off-switch at any scope. A grant DECLARED in owner-only config is exempt from the narrowing — it has no TTL, and selecting another approval mode is the one action documented to end it. That exemption keys on the grant's **source** (`SafetyOverride.is_declared`), never its permanence: an `until_shutdown` ad-hoc pick is equally permanent and keeps the scope protection, while a declared grant the governance ceiling refused to make permanent is timed and still counts as declared.
+
 SEL audit events are emitted on every lifecycle transition:
 - `safety_override:activate` — override enabled
 - `safety_override:renew` — session extended within grace window

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -112,6 +112,12 @@ _SESSION_RELOAD_NOTICE = (
     "agent spec, environment, and MCP servers. The conversation is preserved."
 )
 
+# Approval modes that grant auto-approval to the SLOT they name, as opposed to
+# the process-global YOLO grant. A tuple, not a set: membership is tested against
+# a request-supplied value, and tuple `in` compares by equality rather than
+# hashing, so a non-string body value answers False instead of raising.
+_SLOT_SCOPED_TRUST_MODES = ("trust", "trust_reads")
+
 
 def _sweep_stale_permissions(slot: "_ChatSlot") -> None:
     """Mark unresolved permissions from prior turns as stale.
@@ -4217,6 +4223,26 @@ async def api_chat_mode(request: web.Request) -> web.Response:
     mode = body.get("mode", "normal")
     slot_key = body.get("slot") or None
 
+    # The safety override (YOLO) is PROCESS-GLOBAL while an approval mode is
+    # per-slot, so revoking it on behalf of a request that named ONE slot drops
+    # every OTHER slot out of YOLO too. That is how a programmatic per-slot
+    # `trust` — the call an automation makes when it creates a session — silently
+    # ends an operator's live grant minutes after they enabled it.
+    #
+    # A slot-scoped `trust`/`trust_reads` therefore leaves the grant alone: it
+    # asks for auto-approval on one slot and cannot be answered by withdrawing
+    # authority elsewhere. Everything else still revokes, so `normal` remains the
+    # off-switch at any scope and the dashboard picker (which always names its own
+    # slot) keeps working.
+    #
+    # A grant DECLARED in owner-only config is exempt from the narrowing: it has
+    # no TTL, and selecting another approval mode is the one action documented to
+    # end it. Identity is the grant's source, never its permanence — an
+    # `until_shutdown` ad-hoc pick is equally permanent and must stay protected.
+    slot_scoped_trust = slot_key is not None and mode in _SLOT_SCOPED_TRUST_MODES
+    if mode != "yolo" and (not slot_scoped_trust or safety_override().is_declared):
+        safety_override().deactivate("dashboard")
+
     if mode == "yolo":
         result = await asyncio.to_thread(safety_override().activate, "dashboard")
         if not result.active:
@@ -4234,7 +4260,6 @@ async def api_chat_mode(request: web.Request) -> web.Response:
         except Exception:
             logger.warning("SEL audit failed for YOLO mode activation", exc_info=True)
     elif mode == "trust_reads":
-        safety_override().deactivate("dashboard")
         if slot_key and slot_key in state._slots:
             state._slots[slot_key]._trust = False
             state._slots[slot_key]._trust_reads = True
@@ -4254,7 +4279,6 @@ async def api_chat_mode(request: web.Request) -> web.Response:
         except Exception:
             logger.warning("SEL audit failed for trust_reads mode activation", exc_info=True)
     elif mode == "trust":
-        safety_override().deactivate("dashboard")
         mgr = getattr(state, "channel_manager", None)
         if slot_key is not None:
             if slot_key not in state._slots:
@@ -4287,7 +4311,6 @@ async def api_chat_mode(request: web.Request) -> web.Response:
         except Exception:
             logger.warning("SEL audit failed for trust mode activation", exc_info=True)
     else:  # normal
-        safety_override().deactivate("dashboard")
         mgr = getattr(state, "channel_manager", None)
         if slot_key is not None:
             if slot_key not in state._slots:

--- a/src/kiro_crew/safety_override.py
+++ b/src/kiro_crew/safety_override.py
@@ -249,6 +249,17 @@ class SafetyOverride:
         """True when the live grant has no expiry at all."""
         return bool(self._permanent) and bool(self._active)
 
+    @property
+    def is_declared(self) -> bool:
+        """True when the live grant is the operator's DECLARED config grant.
+
+        Identity is the grant's SOURCE, not the absence of a deadline. Permanence
+        does not separate the two cases in either direction: an ad-hoc grant under
+        ``yolo_duration: until_shutdown`` also has no expiry, and a declared grant
+        the governance ceiling refused to make permanent is timed.
+        """
+        return bool(self._active) and self._source == self._DECLARED_SOURCE
+
     # ── Public API ───────────────────────────────────────────────────────────
 
     def activate(self, source: str, ttl: Optional[int] = None) -> ActivationResult:

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -6379,6 +6379,127 @@ class TestApiChatModePropagation:
         state.sessions.set_approval_policy.assert_any_call("dashboard:s2", "auto")
 
 
+class TestApiChatModeGlobalOverrideScope:
+    """A slot-scoped mode change must not revoke the process-global YOLO grant.
+
+    The grant covers every slot, so ending it on behalf of a request that named
+    ONE slot changes slots the request never mentioned — the shape that let a
+    per-slot `trust` setup call drop the whole gateway out of YOLO.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["trust", "trust_reads"])
+    async def test_slot_scoped_trust_preserves_global_grant(self, mode, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.safety_override import safety_override
+
+        safety_override().activate("dashboard")
+        state = _make_state(tmp_path)
+        state.push_slots_update = MagicMock()
+        state.get_or_create_slot("s1")
+        state.get_or_create_slot("s2")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/mode", json={"mode": mode, "slot": "s1"})
+            assert (await resp.json())["ok"] is True
+
+        assert safety_override().is_active() is True
+        # The regression itself: a slot the request never named keeps auto-approving.
+        state.sessions.set_approval_policy.assert_any_call("dashboard:s2", "auto")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["trust", "trust_reads"])
+    async def test_global_trust_revokes_global_grant(self, mode, tmp_path, monkeypatch):
+        """Without a slot the request IS global, so it may end the grant."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.safety_override import safety_override
+
+        safety_override().activate("dashboard")
+        state = _make_state(tmp_path)
+        state.push_slots_update = MagicMock()
+        state.get_or_create_slot("s1")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await client.post("/api/chat/mode", json={"mode": mode})
+
+        assert safety_override().is_active() is False
+
+    @pytest.mark.asyncio
+    async def test_slot_scoped_normal_revokes_global_grant(self, tmp_path, monkeypatch):
+        """`normal` asks for NO auto-approval, so it revokes at any scope.
+
+        This is the dashboard picker's YOLO off-switch: the picker always names
+        the slot it is attached to.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.safety_override import safety_override
+
+        safety_override().activate("dashboard")
+        state = _make_state(tmp_path)
+        state.push_slots_update = MagicMock()
+        state.get_or_create_slot("s1")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await client.post("/api/chat/mode", json={"mode": "normal", "slot": "s1"})
+
+        assert safety_override().is_active() is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["trust", "trust_reads"])
+    async def test_declared_grant_is_revoked_at_any_scope(self, mode, tmp_path, monkeypatch):
+        """A declared grant has no TTL, so any mode selection is its off-switch."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.safety_override import safety_override
+
+        safety_override().activate_declared()
+        assert safety_override().is_declared is True
+        state = _make_state(tmp_path)
+        state.push_slots_update = MagicMock()
+        state.get_or_create_slot("s1")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await client.post("/api/chat/mode", json={"mode": mode, "slot": "s1"})
+
+        assert safety_override().is_active() is False
+
+    @pytest.mark.asyncio
+    async def test_until_shutdown_grant_is_ad_hoc_and_protected(self, tmp_path, monkeypatch):
+        """`until_shutdown` is permanent but AD HOC, so the scope rule applies.
+
+        Classifying it by permanence instead of source would revoke the grant of
+        every operator who picked "until Kiro Crew restarts".
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.safety_override import safety_override
+
+        so = safety_override()
+        so.adhoc_until_shutdown = True
+        so.activate("dashboard")
+        assert so.is_permanent is True
+        assert so.is_declared is False
+        state = _make_state(tmp_path)
+        state.push_slots_update = MagicMock()
+        state.get_or_create_slot("s1")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await client.post("/api/chat/mode", json={"mode": "trust", "slot": "s1"})
+
+        assert so.is_active() is True
+
+    @pytest.mark.asyncio
+    async def test_non_string_mode_does_not_raise(self, tmp_path, monkeypatch):
+        """The membership test must answer for an unhashable body value."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.push_slots_update = MagicMock()
+        state.get_or_create_slot("s1")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/mode", json={"mode": {}, "slot": "s1"})
+
+        assert resp.status == 200  # falls through to the normal branch, as before
+
+
 class TestApproveYoloPropagation:
     """api_chat_slot_approve with yolo action propagates policy to all slots."""
 


### PR DESCRIPTION
## What broke

`POST /api/chat/mode` revoked the process-global safety override (YOLO) unconditionally in its `normal`, `trust` and `trust_reads` branches. That grant covers **every** slot, while an approval mode is **per-slot** — so any request naming ONE slot ended auto-approval everywhere.

The reproducing shape is a programmatic setup call: an automation creates a gateway chat session and POSTs `{"mode": "trust", "slot": "<new session>"}` before seeding it. That is a request about one brand-new slot, and it dropped the whole gateway out of YOLO.

From the operator's side this reads as "YOLO keeps reverting to Normal even though I set 24 hours". It is not a TTL bug — the grant never reaches its deadline. On the instance where this was found, the SEL log shows 17 `mode_change:yolo` activations against 130 `mode_change:trust`, and every activation is followed by a `trust` from a newly created session, with gaps of 3 minutes to 9 hours that track the dispatch cadence rather than any configured duration. Nothing tells the operator why the posture changed.

## What changed

One decision point replaces the three unconditional `deactivate()` calls:

- **A slot-scoped `trust`/`trust_reads` no longer revokes the grant.** Such a request asks for auto-approval *on that slot*; it cannot be answered by withdrawing authority from slots it never named.
- **Everything else still revokes**, so `normal` remains the off-switch at any scope and the dashboard picker — which always names the slot it is attached to — keeps working, including for a browser holding an older cached bundle.
- **A DECLARED grant is exempt from the narrowing.** `agent.dangerously_skip_permissions` has no TTL, so selecting another approval mode is the one action documented to end it. The exemption keys on the grant's **source** via a new `SafetyOverride.is_declared`, not on permanence: an `until_shutdown` ad-hoc pick is equally permanent and must keep the scope protection, while a declared grant the governance ceiling refused to make permanent is timed and still counts as declared.

No branch body changes, no new request or response fields, no new error paths. 4 files, +160/-3.

## Testing

`TestApiChatModeGlobalOverrideScope` in `test/test_dashboard_chat.py` covers slot-scoped `trust`/`trust_reads` preserving a live grant (including the regression itself — a sibling slot keeping its `auto` policy), global no-slot `trust`/`trust_reads` revoking it, slot-scoped `normal` revoking it, a declared grant revoked at any scope, an `until_shutdown` grant protected as ad-hoc, and a non-string `mode` answering rather than raising. CI runs the suite.

## Scope

An earlier revision of this PR also front-moved the unknown-slot validation, made `trust_reads` consistent with its siblings, offloaded `deactivate()`'s SEL write, and added a `clear_global_override` request field plus a `global_override` response field. All of that was removed: none of it was required by this bug, and every GPT blocking finding across three rounds landed on one of those auxiliary changes rather than on the scope rule itself, which was never challenged.

The genuine defects among them are filed as #4454 (the `trust_reads` unknown-slot widening is a real bug in the same class as this one) so they can land on their own merits.

## Note for reviewers, unrelated to this diff

The `Black Formatting` gate is currently red on `main` itself: `src/kiro_crew/mcp_gateway/preflight.py` has become black-clean while still listed in `.github/black-baseline.txt`, so the gate asks for a baseline prune. Verified by running `scripts/check_black_formatting.py` on a clean `origin/main` checkout (exit 1, same message). This PR does not touch that file.

Separately, `npm ci` fails on `main` in `website/` (`Missing: @pierre/theme@1.1.0 from lock file`) — filed as #4417. This PR no longer touches `website/` at all.
