### PR TITLE
fix(fork): inherit the parent session's tags

### DIFF
--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -214,6 +214,8 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
     new_slot.reasoning_effort = slot.reasoning_effort
     # Inherit project folder so the fork appears next to its parent in the sidebar.
     new_slot.folder_id = slot.folder_id
+    # Inherit tags (copied, so later edits to either slot's list stay independent).
+    new_slot.tags = list(slot.tags)
     parent_title = slot.title if slot._titled else "Untitled"
     parent_title, _ = redact_exfiltration_urls(parent_title)
     parent_title, _ = redact_credentials(parent_title)

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -10029,6 +10029,44 @@ class TestForkSlot:
         assert new_slot.folder_id == ""
 
     @pytest.mark.asyncio
+    async def test_fork_inherits_tags(self, tmp_path):
+        """Fork must carry the source slot's assigned tag ids."""
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("src")
+        slot.tags = ["tag-a", "tag-b"]
+        slot.append("user", "hi", "msg msg-u")
+        slot.drain()
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/chat/slots/src/fork", json={})
+            assert resp.status == 200
+            data = await resp.json()
+
+        new_slot = state._slots.get(data["key"])
+        assert new_slot is not None
+        assert new_slot.tags == ["tag-a", "tag-b"]
+        # Copied, not aliased: mutating the fork's list must not touch the parent.
+        new_slot.tags.append("tag-c")
+        assert slot.tags == ["tag-a", "tag-b"]
+
+    @pytest.mark.asyncio
+    async def test_fork_inherits_empty_tags(self, tmp_path):
+        """Fork of an untagged slot stays untagged."""
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("src")
+        slot.append("user", "hi", "msg msg-u")
+        slot.drain()
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/chat/slots/src/fork", json={})
+            data = await resp.json()
+
+        new_slot = state._slots.get(data["key"])
+        assert new_slot.tags == []
+
+    @pytest.mark.asyncio
     async def test_fork_with_prompt(self, tmp_path):
         state = _make_state(tmp_path)
         slot = state.get_or_create_slot("src")


### PR DESCRIPTION
## Problem / Motivation

A forked session starts with an empty tag list. `fork_slot` copies `forked_from`, `reasoning_effort`, `folder_id`, and the title from the source slot, but not `slot.tags` — so a user who tags a session and then forks it loses the tags on the fork and has to reapply them by hand.

## Why it matters

Tags are how sessions are organized in the sidebar and the Trello-style status lanes. A fork is a continuation of the parent's work, so it silently vanishing from every tag filter and lane the parent was in makes the fork hard to find and breaks the board view's picture of in-flight work. Same attribute-inheritance gap class as #3298 (scope/folder) and #3767 (project directory); the auto-pipeline's triage on #3298 framed this as one decision over "which session attributes are inherited during fork" — this PR covers the tags attribute.

## What changed (motivation → approach → change)

**Symptom** — a fork of a tagged session shows no tags.

**Root cause** — `fork_slot` in `src/kiro_crew/dashboard/chat_fork.py` copies `forked_from`, `reasoning_effort`, and `folder_id` from the source slot, but never `slot.tags`, so the new slot keeps its default empty list.

**Change** — copy the source slot's tag ids onto the fork: `new_slot.tags = list(slot.tags)`. A list copy, not an alias, so later edits to either slot's tag list stay independent.

## Tests

- `test_fork_inherits_tags` — tags carry over, and mutating the fork's list does not touch the parent (aliasing guard).
- `test_fork_inherits_empty_tags` — a fork of an untagged slot stays untagged.

All 43 `TestForkSlot` tests pass (41 pre-existing + 2 new). isort / flake8 clean on the touched files; mypy clean on `chat_fork.py`.

## Manual verification

Not run — backend-only change with no UI surface of its own; the tag rendering path is unchanged and covered by the existing slot-tags tests.

## Screenshots / video

N/A — no visual change.

## Related Issues

- #3298 — fork should preserve scope/folder (same inheritance-gap class)
- #3767 — fork inherits project directory (sibling fix)

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, behavior fix with no documented surface
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

---

**Note for review:** status-lane tags are copied too: `api_chat_slot_drop` treats status-flagged tags as mutually exclusive lanes, so a fork of a "Done"-lane session lands in "Done". If forks should instead shed status tags and keep only topic tags, the filter belongs here — happy to adjust if maintainers prefer that semantics.
