### PR TITLE
ci: raise coverage floors to 90% on both lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,14 +788,20 @@ jobs:
     # on ordinary noise. Raise a floor only after main has held the higher
     # number for a while, and never above the LOWEST recent main measurement.
     #
-    #   Backend  measured 90.57% on main (2026-08-18) -> floor 88%
-    #   Frontend measured 91.32-91.34% on main (2026-08-18) -> floor 89%
+    #   Backend  measured 90.57% on main (2026-08-18) -> floor 90%
+    #   Frontend measured 91.32-91.47% on main (2026-08-18) -> floor 90%
     #
     # Both were sampled across three consecutive successful main runs, because
     # the policy above is written against the LOWEST recent measurement and one
-    # sample cannot establish that. Frontend's floor sits HIGHER than backend's
-    # because its measured rate is higher, not because it is held to a stricter
-    # standard -- each lane keeps roughly 2.3pp.
+    # sample cannot establish that.
+    #
+    # The headroom is deliberately THIN, and asymmetrically so: frontend keeps
+    # ~1.5pp, backend only ~0.6pp. At 0.6pp a single merge that adds a few
+    # hundred uncovered statements reds the gate, so backend coverage now has to
+    # be maintained with each change rather than recovered in later waves. That
+    # is the intended trade: the two lanes are held at the round number they
+    # actually reached. If backend does start bouncing off 90, the fix is to
+    # lower THAT floor to 89 and say why -- not to weaken the gate's logic.
     #
     # Why not 85%, which is where this change started: the lanes crossed 90%
     # while it sat unmerged, and a floor 5-6pp under main protects almost
@@ -824,14 +830,14 @@ jobs:
     #   88.29%  #3132, where three surfaces starting at or near 0% produced 739
     #           of its 1,470 statements while ChatPage.tsx -- the single largest
     #           target by uncovered count, 481 -- produced nothing measurable
-    #   91.32%  work merged since
+    #   91.47%  work merged since
     # Two lessons in those two lines, both of which cost a wave to learn: rank
     # candidates by how UNCOVERED a file is and not merely by its uncovered
     # count, because a file near 0% converts far better than a large page
     # already at 80%; and do not size a frontend wave off a backend one.
     env:
-      BACKEND_MIN: 88
-      FRONTEND_MIN: 89
+      BACKEND_MIN: 90
+      FRONTEND_MIN: 90
       # The per-file floor, applied to BOTH lanes with a per-lane baseline of
       # the files that were already below it. A project-wide average lets a
       # well-covered large file pay for a bare small one, so it can be satisfied
@@ -951,7 +957,7 @@ jobs:
           F=backend-cov/coverage.xml
           test -f "$F" || { echo "::error::coverage.xml missing from coverage-backend artifact"; exit 1; }
           # Compare the raw line-rate against the threshold; round only for
-          # display (a round-then-compare would let 87.95%..87.99% pass 88%).
+          # display (a round-then-compare would let 89.95%..89.99% pass 90%).
           python3 - "$F" "$BACKEND_MIN" Backend <<'PY'
           import sys, xml.etree.ElementTree as ET
           path, floor, label = sys.argv[1], float(sys.argv[2]), sys.argv[3]

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -202,7 +202,7 @@ jobs:
           cfn-lint, Semgrep, CodeQL, Dependency Audit, 12 pytest shards
           (Linux 3.10/3.12 + Windows), an offline Playwright e2e suite with
           strict on-loop-persist assertions, and a FAIL-CLOSED Coverage Gate
-          (backend 88% / frontend 89%).
+          (backend 90% / frontend 90%).
 
           NEVER report anything those tools own: style, formatting, naming,
           import order, typing, lint warnings, dead code, duplication,

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -391,7 +391,7 @@ jobs:
           cfn-lint, Semgrep, Dependency Audit, 12 pytest shards
           (Linux 3.10/3.12 + Windows), an offline Playwright e2e suite with
           strict on-loop-persist assertions, and a FAIL-CLOSED Coverage Gate
-          (backend 88% / frontend 89%).
+          (backend 90% / frontend 90%).
 
           NOTE — FORK LANE: CodeQL does NOT run on fork PRs (fork tokens lack
           security-events:write), so the deep-dataflow security analysis it

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -117,7 +117,7 @@ Details worth knowing:
 - **`coverage-gate` is fail-closed.** It runs `if: always()` and its first step
   converts any non-success upstream result into an explicit failure, because GitHub
   treats a **skipped** required check as satisfied. It also compares the raw
-  line-rate and rounds only for display, so 87.95% cannot pass an 88% floor.
+  line-rate and rounds only for display, so 89.95% cannot pass a 90% floor.
 - **`coverage-gate` enforces two different shapes.** The project floors
   (`BACKEND_MIN`, `FRONTEND_MIN`) compare one lane-wide average; the per-file floor
   (`PER_FILE_MIN`, `scripts/check_per_file_coverage.py`) requires *every measured


### PR DESCRIPTION
## What

Raise the Coverage Gate's project floors to **90% on both lanes**:

| Lane | Before (#3104) | Now | Measured on main | Headroom |
|---|---|---|---|---|
| `BACKEND_MIN` | 88 | **90** | 90.57% | ~0.6pp |
| `FRONTEND_MIN` | 89 | **90** | 91.32–91.47% | ~1.5pp |

`PER_FILE_MIN` stays at **80** — see below.

## Why

#3104 took the floors from 80/60 to 88/89. The lanes actually sit at 90.57% and
91.32–91.47%, so 90 is the round number both have reached and held. Numbers were
sampled across three consecutive successful main runs plus #3104's own Coverage
Gate run, because the ratchet policy is written against the *lowest* recent
measurement and one sample cannot establish that.

## The headroom is thin, and that is the trade

Frontend keeps ~1.5pp; backend keeps only ~0.6pp. At 0.6pp a single merge that
adds a few hundred uncovered statements turns the gate red, so backend coverage
now has to be **maintained per change** rather than recovered in a later wave.

The `RATCHET POLICY` comment says this explicitly and names the remedy if
backend starts bouncing off the floor: lower **that one floor** to 89 with a
stated reason — not weaken the gate's logic, not add slack to both lanes.

## Why `PER_FILE_MIN` is untouched

It is a different shape: every measured file must clear it, with no lane-wide
averaging to subsidise a bare file. #3104's run measured 1085 frontend files —
1000 at or above 80%, 85 baselined. Raising it is a separate decision that needs
its own baseline pass.

## Also updated

So the numbers cannot rot in three places at once:

- the `RATCHET POLICY` floor mapping and headroom note in `ci.yml`
- the rounding examples in `ci.yml` and `docs/ci/ci-and-reviews.md` — the gate
  compares the raw line-rate and rounds only for display, so **89.95% must not
  pass a 90% floor**
- the floor text in the `codex-review` and `fork-gpt-review` reviewer prompts,
  which still quoted `(backend 88% / frontend 89%)`

## Verification

- three edited workflows parse as YAML
- `test_coverage_omit_contract.py` — 8 passed
- no test or script pins the floor values (grepped `test/`, `scripts/`)
- diff is YAML + one doc; it cannot affect any test outcome
