### PR TITLE
fix: stop stamping origin onto external registry rows by name (#4397)

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -76,6 +76,17 @@ zero-width rendering of our name does not silently lose it. Folding WIDENS the
 match, which is safe only because the `_registry` short-circuit runs first:
 the author is consulted exclusively for rows whose index we ship or sign.
 
+`origin` on a registry row is stamped under the same rule. The install-status
+enrichment matches installed apps by NAME alone, so it withholds the `origin`
+copy from external rows (`_is_external_row`): an external index publishing an
+app named after an installed built-in must not inherit `origin: "builtin"`
+beside the `provenance: "external"` stamped on the same row.
+`_apply_trust_fields` additionally scrubs any `origin` other than the
+server-stamped `"external"` (a `detectInstalled` hit) from `_registry` rows,
+because an index-published `origin` key survives a failed manifest fetch —
+`_resolve_manifest` returns the row unprojected on that path — and would
+otherwise reach the wire.
+
 `"official"` means "an app WE list". The bundled `app-registry.json` is one
 delivery of that list — the offline seed shipped inside the wheel — so it
 carries the same value a signed remote catalog will, not a second one. Two

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -1178,6 +1178,20 @@ def _merge_manifest(entry: dict[str, Any], manifest: dict[str, Any]) -> dict[str
     return result
 
 
+def _is_external_row(entry: dict[str, Any]) -> bool:
+    """Whether *entry* is an EXTERNAL registry's row, for trust-field stamping.
+
+    Refuses on the PRESENCE of an external marker rather than granting from its
+    absence: ``_registry`` is attached server-side per configured registry and
+    cannot be forged by index content, and ``provenance == "external"`` is the
+    server-computed stamp derived from it. Deliberately NOT
+    :func:`_remote_controlled_url`: a ``_catalog`` row is remote-controlled for
+    CREDENTIAL purposes but is still an app WE list, so its trust fields are
+    first-party.
+    """
+    return bool(entry.get("_registry")) or entry.get("provenance") == "external"
+
+
 def _enrich_with_install_status(
     entries: list[dict[str, Any]],
     installed_map: dict[str, dict[str, Any]],
@@ -1198,7 +1212,15 @@ def _enrich_with_install_status(
         if existing:
             entry["installedVersion"] = existing.get("version", "")
             entry["enabled"] = existing.get("enabled", False)
-            entry["origin"] = existing.get("origin", "registry")
+            # ``origin`` is trust-adjacent (surfaces read ``"builtin"`` as
+            # first-party), and ``installed_map`` matches by NAME alone — so an
+            # external registry's row named after an installed built-in must not
+            # inherit that app's ``origin``, or the gateway emits a row whose
+            # ``origin`` contradicts the ``provenance: "external"`` stamped
+            # beside it by ``_apply_trust_fields``. External rows keep whatever
+            # the trust boundary decides for them instead.
+            if not _is_external_row(entry):
+                entry["origin"] = existing.get("origin", "registry")
             entry["resources"] = existing.get("resources", "gateway")
             entry["lifecycle"] = existing.get("lifecycle", "gateway")
             entry["updateAvailable"] = _version_newer(
@@ -1297,6 +1319,10 @@ def _apply_trust_fields(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     - ``featured``: dropped entirely from external rows so an external index
       can never self-flag into the Discover spotlight, regardless of client
       logic. Core-entry ``featured`` flags are preserved.
+    - ``origin``: on external rows, any value other than the server-stamped
+      ``"external"`` is dropped, so the wire never carries an ``origin`` that
+      contradicts ``provenance: "external"`` — neither an index-published one
+      nor one cross-stamped from an installed same-named app.
     """
     for entry in entries:
         index_author = entry.pop("_index_author", None)
@@ -1305,6 +1331,19 @@ def _apply_trust_fields(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
             entry["provenance"] = "external"
             entry["verified"] = False
             entry.pop("featured", None)
+            # ``origin`` is trust-adjacent (``"builtin"`` reads as first-party
+            # to every consumer), and on an external row it can arrive from
+            # untrusted content: an index may publish the key itself, and it
+            # survives a failed manifest fetch because ``_resolve_manifest``
+            # returns the row as-is on that path. The only value the server
+            # itself stamps on an external row is ``"external"``
+            # (``detectInstalled`` hits in ``_enrich_with_install_status``);
+            # anything else must not go on the wire beside
+            # ``provenance: "external"``. Scrubbed HERE and not only at the
+            # sources because this function is the trust boundary — a rule
+            # stated anywhere else is a rule some later assignment can undo.
+            if entry.get("origin") != "external":
+                entry.pop("origin", None)
         else:
             builtin = entry.get("origin") == "builtin"
             entry["provenance"] = "builtin" if builtin else "official"

--- a/test/test_apps_registry_coverage.py
+++ b/test/test_apps_registry_coverage.py
@@ -953,6 +953,36 @@ class TestEnrichWithInstallStatus:
         assert rows[0]["installed"] is False
         assert rows[0]["updateAvailable"] is False
 
+    def test_external_row_never_inherits_origin_from_a_same_named_install(self):
+        """Regression: an external registry row named after an installed
+        built-in must not get that app's ``origin`` cross-stamped by name —
+        the wire value would contradict the ``provenance: "external"`` stamped
+        beside it."""
+        rows = registry._enrich_with_install_status(
+            [{"name": "meetings", "_registry": "third-party", "version": "9.0.0"}],
+            {"meetings": {"version": "1.0.0", "enabled": True, "origin": "builtin"}},
+        )
+        row = rows[0]
+        assert "origin" not in row
+        # Install-state facts about the machine still flow: only the
+        # trust-adjacent field is withheld.
+        assert row["installed"] is True
+        assert row["installedVersion"] == "1.0.0"
+
+    def test_provenance_external_row_is_also_refused_the_origin_copy(self):
+        rows = registry._enrich_with_install_status(
+            [{"name": "demo", "provenance": "external"}],
+            {"demo": {"version": "1.0.0", "origin": "builtin"}},
+        )
+        assert "origin" not in rows[0]
+
+    def test_non_external_row_still_receives_origin(self):
+        rows = registry._enrich_with_install_status(
+            [{"name": "demo"}],
+            {"demo": {"version": "1.0.0", "origin": "builtin"}},
+        )
+        assert rows[0]["origin"] == "builtin"
+
 
 class TestApplyTrustFields:
     def test_external_row_can_never_self_verify_or_self_feature(self):
@@ -988,6 +1018,23 @@ class TestApplyTrustFields:
         )
         assert [r["verified"] for r in rows] == [True, False, False]
         assert all(r["provenance"] == "official" for r in rows)
+
+    def test_external_row_origin_is_scrubbed_at_the_trust_boundary(self):
+        """Regression: an index-published (or name-collision-inherited)
+        ``origin`` on an external row is dropped, so the wire never carries
+        ``origin: "builtin"`` beside ``provenance: "external"``."""
+        rows = registry._apply_trust_fields(
+            [{"name": "demo", "_registry": "third-party", "origin": "builtin"}]
+        )
+        assert rows[0]["provenance"] == "external"
+        assert "origin" not in rows[0]
+
+    def test_external_row_keeps_the_server_stamped_external_origin(self):
+        rows = registry._apply_trust_fields(
+            [{"name": "demo", "_registry": "third-party", "origin": "external"}]
+        )
+        assert rows[0]["origin"] == "external"
+        assert rows[0]["provenance"] == "external"
 
 
 class TestVersionNewer:


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

`_enrich_with_install_status` in `src/kiro_crew/apps/registry.py` copies `origin` onto a registry row from the **installed app of the same name**, with no check on where the row came from. An external, user-added registry that publishes an app named after an installed built-in (`meetings`, `papyrus`, …) gets `origin: "builtin"` stamped on its row, while `_registry` and `provenance: "external"` on the same row say external. `GET /api/apps/registry` puts a row on the wire whose `origin` contradicts its own provenance fields.

## Why it matters

`origin` is what surfaces read to decide "is this first-party": the store's built-in label, the Sources rail's built-in bucket, and any future consumer. Every one of them has to know that `origin` alone is not trustworthy and re-apply a predicate over `_registry` / `provenance` — a rule living in N places, forgotten twice while building #4200. This PR makes the field the gateway emits agree with the trust fields it emits beside it.

## What changed (motivation → approach → change)

Symptom: an external row's `origin` says builtin while its provenance says external. Root cause: `origin` — a trust-adjacent field — was stamped by NAME match alone, outside the rule that trust fields derive from the server-attached `_registry` tag. Change, in two layers under that one rule:

1. **`_enrich_with_install_status`** skips the `origin` copy for external rows, via a new `_is_external_row` predicate that refuses on the PRESENCE of an external marker (`_registry` or `provenance: "external"`) and never grants from absence. Install-state facts (`installed`, `installedVersion`, `enabled`) still flow — they describe the machine, not trust.
2. **`_apply_trust_fields`** — the declared trust boundary for these rows — additionally scrubs any `origin` other than the server-stamped `"external"` (a `detectInstalled` hit) from `_registry` rows. This closes the sibling path the enrich guard alone cannot: an index-published `origin` key survives a failed manifest fetch (`_resolve_manifest` returns the row unprojected on that path) and would otherwise ride to the wire beside `provenance: "external"`. The rule lives at the boundary because a rule stated anywhere else is a rule some later assignment can undo.

The client-side predicate (`isBuiltinServerRow`) deliberately **stays**: it refuses on marker presence, which is the correct shape for a trust boundary, and is worth having as a second independent layer. Consumers verified: `sourceLabel` checks `_registry` before falling back to `origin`; the `origin === 'registry'` branches in `AppsPage`/`InstalledAppCard` read installed-app records from `GET /api/apps`, not registry rows.

`docs/system-specs/modules/app-kit-platform.md` is updated in the same commit — it documents exactly this stamping boundary.

## Tests

Five regression tests in `test/test_apps_registry_coverage.py`, all proven red on base before the fix:

- `test_external_row_never_inherits_origin_from_a_same_named_install` — the issue's exact scenario: external row named after an installed built-in gets no `origin`, while install-state facts still flow.
- `test_provenance_external_row_is_also_refused_the_origin_copy` — the predicate's second marker.
- `test_non_external_row_still_receives_origin` — the normal path is unchanged.
- `test_external_row_origin_is_scrubbed_at_the_trust_boundary` — an index-published `origin: "builtin"` on a `_registry` row is dropped by `_apply_trust_fields`.
- `test_external_row_keeps_the_server_stamped_external_origin` — the one server-stamped external value survives.

Full backend suite: 56,527 passed; the 35 failures are byte-identical on base (verified by stash roundtrip) — zero regressions.

## Manual verification

N/A — unit coverage sufficient: both changed functions are pure dict transforms exercised directly by the tests, and the affected wire consumers were audited statically (see above).

## Related Issues

Closes #4397

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change — no frontend file touched; the wire fix removes a misleading field value, rendering is unchanged (client guard already demoted these rows).
