### PR TITLE
fix(dashboard): accept signed local bootstrap subject as owner when owner_id is set

### DIFF
--- a/src/kiro_crew/dashboard/handlers/kiro_prerequisite.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_prerequisite.py
@@ -69,9 +69,12 @@ def _is_dashboard_owner(request: web.Request) -> bool:
     state = request.app["state"]
     owner_id = str(getattr(state, "owner_id", "") or "")
     caller = str(request.get("user") or "")
-    return request.get("app") == "" and (
-        (owner_id and caller == owner_id)
-        or (not owner_id and caller in _LOCAL_DASHBOARD_OWNER_SUBJECTS)
+    # A signed local bootstrap subject (local-app / local-startup) is
+    # owner-equivalent — host-local and gateway-minted — so accept it whether
+    # or not a (Slack) owner_id is also configured (see #4418).
+    return request.get("app") == "" and bool(caller) and (
+        caller in _LOCAL_DASHBOARD_OWNER_SUBJECTS
+        or (bool(owner_id) and caller == owner_id)
     )
 
 

--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -4031,9 +4031,17 @@ def is_owner_dashboard_request(request: web.Request) -> bool:
     caller = str(request.get("user") or "")
     if "app" not in request or request["app"] != "" or not caller:
         return False
-    if owner_id:
-        return caller == owner_id
-    return caller in _LOCAL_DASHBOARD_OWNER_SUBJECTS
+    # A signed local bootstrap subject (local-app / local-startup) is
+    # owner-equivalent: it is mintable only via the loopback + local-secret
+    # token endpoint or the gateway's own startup output — i.e. the host owner.
+    # Accept it whether or not a (Slack) owner_id is also configured. The two
+    # are different names for the same single principal; comparing them directly
+    # locks a bootstrap-seeded dashboard session out of its own owner endpoints
+    # the moment owner_id is set, because the session subject is baked at mint
+    # time and never re-derived from owner_id (see #4418).
+    if caller in _LOCAL_DASHBOARD_OWNER_SUBJECTS:
+        return True
+    return bool(owner_id) and caller == owner_id
 
 
 def _audit_source_api(
@@ -4063,7 +4071,10 @@ def _authorize_owner_request(
 
     When no owner is configured, read-only operations may allow either signed
     standalone-local bootstrap identity. Mutations remain owner-only. Once an
-    owner is configured, every operation requires an exact owner match.
+    owner is configured, every operation requires the owner — an exact
+    ``owner_id`` match OR a signed ``local-app`` / ``local-startup`` bootstrap
+    subject, which is a host-local, gateway-minted principal that is
+    owner-equivalent (see #4418).
     """
     state = request.app["state"]
     owner_id = str(getattr(state, "owner_id", "") or "")
@@ -4083,7 +4094,7 @@ def _authorize_owner_request(
     if not caller:
         _audit_source_api(request, operation, "denied", "non_owner")
         return web.json_response({"error": "forbidden"}, status=403)
-    if caller != owner_id:
+    if caller != owner_id and caller not in _LOCAL_DASHBOARD_OWNER_SUBJECTS:
         _audit_source_api(request, operation, "denied", "non_owner")
         return web.json_response({"error": "forbidden"}, status=403)
     return None

--- a/src/kiro_crew/docs/agent-questions.md
+++ b/src/kiro_crew/docs/agent-questions.md
@@ -181,7 +181,8 @@ answer out of its own blocked response — or resolve a card the owner is still
 looking at, feeding the agent an answer the owner never gave.
 `is_owner_dashboard_request` is reused rather than re-derived so "owner" has one
 definition: an exact `owner_id` match, or a signed `local-app` / `local-startup`
-bootstrap subject when no owner is configured. That is also the identity the
+bootstrap subject — a host-local, gateway-minted principal that is
+owner-equivalent even when an `owner_id` is also configured. That is also the identity the
 `ask_question` tool itself carries, since its token is minted as
 `generate_token(owner_id or "local-app")`.
 

--- a/test/test_owner_gate_bootstrap_subject.py
+++ b/test/test_owner_gate_bootstrap_subject.py
@@ -1,0 +1,117 @@
+"""Regression tests for #4418 — a signed local bootstrap subject
+(``local-app`` / ``local-startup``) is owner-equivalent even when a (Slack)
+``owner_id`` is configured.
+
+Before the fix, ``is_owner_dashboard_request`` (and its siblings
+``_authorize_owner_request`` and ``kiro_prerequisite._is_dashboard_owner``)
+accepted the bootstrap subjects ONLY when no ``owner_id`` was configured. Because
+a browser session's subject is baked at mint time and never re-derived from
+``owner_id``, setting ``KIROCREW_OWNER_ID`` afterward locked a bootstrap-seeded
+dashboard out of every owner-gated endpoint (e.g. ``POST /api/chat/mode``).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.dashboard.handlers import kiro_prerequisite
+from kiro_crew.dashboard.handlers import source_providers as source
+
+
+class _FakeRequest:
+    """Minimal stand-in matching the attribute surface the predicates read."""
+
+    def __init__(self, *, user="U_OWNER", app="", owner_id="U_OWNER", has_app=True):
+        state = MagicMock()
+        state.owner_id = owner_id
+        self.app = {"state": state}
+        self._claims = {"user": user}
+        if has_app:
+            self._claims["app"] = app
+
+    def get(self, key, default=None):
+        return self._claims.get(key, default)
+
+    def __getitem__(self, key):
+        return self._claims[key]
+
+    def __contains__(self, key):
+        return key in self._claims
+
+
+# (user, app, owner_id, has_app) -> expected owner?
+_MATRIX = [
+    # The regression: owner configured, session carries a bootstrap subject.
+    ("local-app", "", "U_OWNER", True, True),
+    ("local-startup", "", "U_OWNER", True, True),
+    # Owner configured, session carries the owner subject.
+    ("U_OWNER", "", "U_OWNER", True, True),
+    # Owner configured, a different (non-owner) dashboard subject.
+    ("U_OTHER", "", "U_OWNER", True, False),
+    # No owner configured — bootstrap subject accepted (unchanged behavior).
+    ("local-app", "", "", True, True),
+    ("U_OTHER", "", "", True, False),
+    # App tokens are NEVER the owner, even carrying a bootstrap-looking subject
+    # (this is the #3836 Finding-02 guard — must stay closed).
+    ("local-app", "some-app", "U_OWNER", True, False),
+    ("local-app", "some-app", "", True, False),
+    # Missing user claim / missing app claim => not the owner.
+    ("", "", "U_OWNER", True, False),
+    ("local-app", "", "U_OWNER", False, False),
+]
+
+
+@pytest.mark.parametrize(("user", "app", "owner_id", "has_app", "expected"), _MATRIX)
+def test_is_owner_dashboard_request(user, app, owner_id, has_app, expected):
+    req = _FakeRequest(user=user, app=app, owner_id=owner_id, has_app=has_app)
+    assert source.is_owner_dashboard_request(req) is expected  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(("user", "app", "owner_id", "has_app", "expected"), _MATRIX)
+def test_is_dashboard_owner_kiro_prerequisite(user, app, owner_id, has_app, expected):
+    req = _FakeRequest(user=user, app=app, owner_id=owner_id, has_app=has_app)
+    assert kiro_prerequisite._is_dashboard_owner(req) is expected  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("subject", ["local-app", "local-startup"])
+def test_authorize_owner_request_accepts_bootstrap_subject_with_owner_set(
+    monkeypatch, subject
+):
+    """The #4418 fix: with an owner configured, a signed bootstrap subject is
+    authorized rather than 403'd."""
+    monkeypatch.setattr(source, "_sel", lambda: MagicMock())
+    req = _FakeRequest(user=subject, app="", owner_id="U_OWNER")
+    assert source._authorize_owner_request(req, "op") is None  # type: ignore[arg-type]
+
+
+def test_authorize_owner_request_still_rejects_non_owner(monkeypatch):
+    monkeypatch.setattr(source, "_sel", lambda: MagicMock())
+    req = _FakeRequest(user="U_OTHER", app="", owner_id="U_OWNER")
+    resp = source._authorize_owner_request(req, "op")  # type: ignore[arg-type]
+    assert resp is not None and resp.status == 403
+
+
+def test_authorize_owner_request_still_rejects_app_token(monkeypatch):
+    monkeypatch.setattr(source, "_sel", lambda: MagicMock())
+    req = _FakeRequest(user="local-app", app="some-app", owner_id="U_OWNER")
+    resp = source._authorize_owner_request(req, "op")  # type: ignore[arg-type]
+    assert resp is not None and resp.status == 403
+
+
+def test_authorize_owner_request_no_owner_mutation_lockdown_preserved(monkeypatch):
+    """With no owner configured, a bootstrap subject is still refused when
+    ``allow_local_no_owner`` is False (the deliberate mutation lockdown)."""
+    monkeypatch.setattr(source, "_sel", lambda: MagicMock())
+    req = _FakeRequest(user="local-app", app="", owner_id="")
+    resp = source._authorize_owner_request(req, "op", allow_local_no_owner=False)
+    assert resp is not None and resp.status == 403
+
+
+def test_authorize_owner_request_no_owner_readonly_allowed(monkeypatch):
+    """With no owner and ``allow_local_no_owner`` True, bootstrap subject passes
+    (unchanged read-only behavior)."""
+    monkeypatch.setattr(source, "_sel", lambda: MagicMock())
+    req = _FakeRequest(user="local-startup", app="", owner_id="")
+    assert (
+        source._authorize_owner_request(req, "op", allow_local_no_owner=True) is None
+    )  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #4418

## Problem

On any browser dashboard, once `KIROCREW_OWNER_ID` is configured, every **owner-gated** endpoint returns `403 {"error":"forbidden"}` for the actual host owner. The visible symptom is the Trust / YOLO tool-approval switch (`POST /api/chat/mode -> 403`), but the same gate also fronts `api_chat_slot_approve`, `worktree_create`, the cloud EC2-setup mutations, MCP app grants, `ask_question`, and the owner-only messaging operations.

## Why it happens

`is_owner_dashboard_request` (and its structural siblings `_is_dashboard_owner` and `_authorize_owner_request`) accept the signed local bootstrap subjects `local-app` / `local-startup` as the owner **only when no `owner_id` is configured**:

```python
if owner_id:
    return caller == owner_id
return caller in _LOCAL_DASHBOARD_OWNER_SUBJECTS
```

But a browser session's subject is baked at mint time and is sticky:

- The owner-bearing mints (`/api/token/local`, the gateway startup link, the `--json-ready` token) use `owner_id or "local-app"` / `owner_id or "local-startup"`, evaluated **at mint time**.
- The refresh path and the one-time-link -> session exchange both re-mint with the **incoming** `user_id` and never re-derive it from the current `owner_id`.

So a dashboard session seeded while `owner_id` was empty (the common case — `KIROCREW_OWNER_ID` is typically added later, e.g. when connecting Slack) carries a `local-startup`/`local-app` subject for its entire refresh lifetime. Setting `owner_id` afterward flips the gate to requiring `caller == owner_id`, and the session is locked out. It does not self-heal on reload.

The category error: `local-app` / `local-startup` are **gateway-signed, host-local** subjects (mintable only via loopback + local-secret, or the gateway's own startup output — i.e. the host owner), and `owner_id` (a Slack member ID) is a *second name for the same single principal*.

## Fix

Accept the signed bootstrap subjects as owner-equivalent **regardless of** whether `owner_id` is configured, in all three predicates.

This does **not** reopen the finding that added the gate to `api_chat_mode` (PR #3836, Finding 02: "prevent app tokens from flipping global yolo mode"):

- App tokens have `request["app"] != ""` and still fail the first conjunct.
- App tokens are minted with `subject = app_name` and `app` set, so they can never carry a bootstrap subject.
- Non-owner allowed Slack users carry `subject = their own user_id`, never a bootstrap subject, so they remain correctly rejected.

`_authorize_owner_request` gets the surgical edit only (bootstrap acceptance in the owner-*set* path); its deliberate no-owner mutation lockdown (`allow_local_no_owner=False`) is unchanged. The canonical definition in `docs/agent-questions.md` is updated to match.

## Tests

New `test/test_owner_gate_bootstrap_subject.py` — a parametrized matrix across all three predicates covering:
- owner-set × `{local-app, local-startup}` -> owner (the fix)
- owner-set × exact `owner_id` -> owner
- owner-set × other subject -> not owner
- app token (`app != ""`) carrying a bootstrap subject -> not owner (the #3836 guard stays closed)
- no-owner mutation lockdown in `_authorize_owner_request` preserved

## Verification

Local gates green: `pytest` (465 passed — new matrix + full `test_source_providers.py`), `isort`, `flake8`, `mypy` (no issues).
