### PR TITLE
fix(ci): regenerate website lockfile for @pierre/theme@1.1.0 (#4417)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1310,6 +1310,17 @@
         "react-dom": "^18.3.1 || ^19.0.0"
       }
     },
+    "node_modules/@pierre/trees/node_modules/@pierre/theme": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.1.0.tgz",
+      "integrity": "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "vscode": "^1.0.0"
+      }
+    },
     "node_modules/@pierre/trees/node_modules/@pierre/theming": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@pierre/theming/-/theming-1.0.0.tgz",


### PR DESCRIPTION
## Summary
`npm ci` in `website/` fails on current main with `Missing: @pierre/theme@1.1.0 from lock file`: `@pierre/trees` pins `@pierre/theme@^1.1.0` as an optional peer, which the hoisted `@pierre/theme@2.0.0` entry does not satisfy, and the lockfile was never regenerated when those dependencies landed.

This regenerates `website/package-lock.json` via `npm install` — an 11-line diff adding the single missing nested entry `node_modules/@pierre/trees/node_modules/@pierre/theme` @ 1.1.0 (optional peer). No other package added, removed, or bumped.

## Verification
- Reproduced the failure on main (`npm ci` exit 1, `Missing: @pierre/theme@1.1.0 from lock file`)
- After regeneration: `npm ci` exit 0
- `npx tsc -b` clean
- Integrity hash in the new entry verified byte-identical to the npm registry metadata for `@pierre/theme@1.1.0`
- `git diff origin/main --name-only` = only `website/package-lock.json`

<!-- no-visual-delta --> Lockfile-only dependency metadata change; no UI surface touched, so no screenshots.

Closes #4417
