### PR TITLE
fix(dashboard): reconcile stale in-memory slot window from disk on refresh

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -1173,6 +1173,96 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
             # Re-read the tail after the await: that suspension point lets a message
             # land mid-read, and the client replaces its list with this response.
             messages = older + list(slot.messages)
+        elif state.conversation_log:
+            # _disk_older_count == 0: the window is supposed to be the whole
+            # session. But disk can grow beyond the window (a concurrent writer,
+            # a foreign append, or a persistence race). Detect and include any
+            # rows the in-memory window is missing (#4373).
+            # Safety: skip when the slot has unflushed rows or pending rewrites.
+            _slot_idle = (
+                len(mem_msgs) <= getattr(slot, "_disk_window_len", 0)
+                and not getattr(slot, "_pending_rewrite", False)
+                and not getattr(slot, "_dirty_flag", False)
+            )
+            if _slot_idle:
+                history_key = slot_history_key(slot)
+                try:
+                    disk_msgs = await asyncio.to_thread(
+                        state.conversation_log.read_messages_chained, history_key
+                    )
+                except Exception:
+                    logger.warning(
+                        "read_messages_chained failed for %s", history_key, exc_info=True
+                    )
+                    disk_msgs = []
+                # Re-read after the await to capture anything that arrived mid-read.
+                current_mem = list(slot.messages)
+                # Post-await re-check: slot may have gained unflushed rows.
+                _slot_idle = (
+                    len(current_mem) <= getattr(slot, "_disk_window_len", 0)
+                    and not getattr(slot, "_pending_rewrite", False)
+                    and not getattr(slot, "_dirty_flag", False)
+                )
+                if _slot_idle and len(disk_msgs) > len(current_mem):
+                    # Validate alignment: if rotation shifted offsets, the disk
+                    # prefix no longer matches memory — skip reconciliation to
+                    # avoid appending the wrong slice (#4373 fix, GPT finding 2).
+                    _aligned = True
+                    if current_mem and disk_msgs:
+                        # Spot-check last memory row against its expected disk position.
+                        last_mem = current_mem[-1]
+                        disk_at = disk_msgs[len(current_mem) - 1] if len(current_mem) <= len(disk_msgs) else None
+                        if disk_at and (
+                            last_mem.get("ts", "") != disk_at.get("ts", "")
+                            or last_mem.get("role") != disk_at.get("role")
+                        ):
+                            _aligned = False
+                    if not _aligned:
+                        messages = current_mem
+                    else:
+                        # Disk has rows the window does not — reconcile by appending
+                        # the missing tail to the slot and returning the union.
+                        fresh = disk_msgs[len(current_mem):]
+                        for msg in fresh:
+                            role = msg.get("role", "assistant")
+                            cls = msg.get("cls") or (
+                                "msg msg-u" if role == "user" else "msg msg-a"
+                            )
+                            content = msg.get("content", "")
+                            if role != "user":
+                                content, _ = redact_exfiltration_urls(content)
+                                content, _ = redact_credentials(content)
+                            slot.append(
+                                role,
+                                content,
+                                cls,
+                                ts=msg.get("ts", ""),
+                                broadcast=False,
+                                meta=(
+                                    _redact_meta_for_role(role, msg["meta"])
+                                    if isinstance(msg.get("meta"), dict)
+                                    else None
+                                ),
+                            )
+                            carry_provenance(slot.messages[-1], msg)
+                            _attach_variants(slot, msg)
+                        # Replayed rows came from disk — drain the replay
+                        # frames and mark the window persisted (not dirty) so a
+                        # fork/SSE drain or the next save does not duplicate them.
+                        slot.drain()
+                        slot._resumed_count = len(slot.messages)
+                        slot._disk_window_len = len(slot.messages)
+                        slot._dirty = False
+                        # Use the full disk corpus (which includes the prefix
+                        # plus the reconciled tail) rather than slot.messages,
+                        # because slot.append may have trimmed the head under
+                        # _MAX_SLOT_MESSAGES — returning slot.messages alone
+                        # would lose older rows without signaling has_more.
+                        messages = disk_msgs
+                else:
+                    messages = current_mem
+            else:
+                messages = mem_msgs
         else:
             messages = mem_msgs
         total = len(messages)
@@ -3909,6 +3999,128 @@ async def api_recent_projects(request: web.Request) -> web.Response:
     return web.json_response({"dirs": dirs})
 
 
+async def _reconcile_slot_window(
+    state: DashboardState, slot: "_ChatSlot"
+) -> None:
+    """Detect and reconcile stale in-memory window from disk.
+
+    A live slot's window can fall behind disk when messages are written to the
+    session file by a path that does not (or cannot) also push into the
+    in-memory window — e.g. a concurrent subagent flush, a channel-origin
+    append, or a persistence race during heavy traffic.
+
+    This function compares the slot's believed disk coverage
+    (``_disk_older_count + len(messages)``) against the actual on-disk message
+    count. If disk has grown beyond what the slot accounts for, the missing
+    tail is read and appended to the in-memory window, making the next detail
+    or resume response self-healing on refresh.
+
+    Safety: skips reconciliation when the slot has unflushed in-memory rows
+    beyond what the last save persisted (``len(messages) > _disk_window_len``),
+    because a concurrent flush could persist those rows between the
+    ``represented`` snapshot and the disk read, leading to a duplicate
+    append. Re-validates after the await to guard against appends that landed
+    during the disk read.
+    """
+    if not state.conversation_log:
+        return
+    # Safety gate: do not reconcile a slot that has in-memory rows the last
+    # flush has not yet persisted, or that is mid-rewind, or that has unsaved
+    # in-place edits (dirty) — clearing dirty at the end would erase the edit.
+    if len(slot.messages) > getattr(slot, "_disk_window_len", 0):
+        return
+    if getattr(slot, "_pending_rewrite", False):
+        return
+    if getattr(slot, "_dirty_flag", False):
+        return
+    history_key = slot_history_key(slot)
+    represented = (getattr(slot, "_disk_older_count", 0) or 0) + len(slot.messages)
+    try:
+        disk_msgs = await asyncio.to_thread(
+            state.conversation_log.read_messages_chained, history_key
+        )
+    except Exception:
+        logger.warning(
+            "reconcile: read_messages_chained failed for %s", history_key, exc_info=True
+        )
+        return
+    disk_total = len(disk_msgs)
+    if disk_total <= represented:
+        return
+    # Post-await safety: the slot may have received appends (and a flush) while
+    # we were reading disk. Re-check and recompute represented to avoid
+    # duplicating rows that arrived during the await.
+    if len(slot.messages) > getattr(slot, "_disk_window_len", 0):
+        return
+    if getattr(slot, "_pending_rewrite", False):
+        return
+    if getattr(slot, "_dirty_flag", False):
+        return
+    represented = (getattr(slot, "_disk_older_count", 0) or 0) + len(slot.messages)
+    if disk_total <= represented:
+        return
+    # Validate alignment: if transcript rotation shifted offsets, the disk
+    # prefix no longer matches memory — abort to avoid appending wrong rows.
+    # The slot's window starts at disk offset _disk_older_count, so we compare
+    # the last memory row against its expected position on disk.
+    disk_older = getattr(slot, "_disk_older_count", 0) or 0
+    if slot.messages and (disk_older + len(slot.messages)) <= len(disk_msgs):
+        last_mem = slot.messages[-1]
+        expected_pos = disk_older + len(slot.messages) - 1
+        disk_at = disk_msgs[expected_pos]
+        if (
+            last_mem.get("ts", "") != disk_at.get("ts", "")
+            or last_mem.get("role") != disk_at.get("role")
+        ):
+            logger.info(
+                "reconcile: slot %s alignment mismatch at offset %d — skipping "
+                "(possible transcript rotation)",
+                slot.key,
+                expected_pos,
+            )
+            return
+    # Disk has rows the slot does not know about — append the tail.
+    fresh = disk_msgs[represented:]
+    logger.info(
+        "reconcile: slot %s has %d messages in memory + %d older on disk = %d represented, "
+        "but disk has %d; appending %d missing rows",
+        slot.key,
+        len(slot.messages),
+        getattr(slot, "_disk_older_count", 0) or 0,
+        represented,
+        disk_total,
+        len(fresh),
+    )
+    for msg in fresh:
+        role = msg.get("role", "assistant")
+        cls = msg.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
+        content = msg.get("content", "")
+        if role != "user":
+            content, _ = redact_exfiltration_urls(content)
+            content, _ = redact_credentials(content)
+        slot.append(
+            role,
+            content,
+            cls,
+            ts=msg.get("ts", ""),
+            broadcast=False,
+            meta=(
+                _redact_meta_for_role(role, msg["meta"])
+                if isinstance(msg.get("meta"), dict)
+                else None
+            ),
+        )
+        carry_provenance(slot.messages[-1], msg)
+        _attach_variants(slot, msg)
+    # The appended rows came from the file, so drain the replay frames and
+    # mark the window as persisted (not dirty) — the next save must not
+    # re-serialize them, and a fork/SSE drain must not treat them as new.
+    slot.drain()
+    slot._resumed_count = len(slot.messages)
+    slot._disk_window_len = len(slot.messages)
+    slot._dirty = False
+
+
 def _resume_session_identity(state: DashboardState, history_key: str) -> str:
     """The session a transcript runs under, spelled as a slot spells its own.
 
@@ -3987,6 +4199,9 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
                     error="app does not own this slot",
                 )
                 return web.json_response({"error": "not found"}, status=404)
+        # Reconcile: if disk grew beyond what the in-memory window covers,
+        # append the missing tail so a page refresh self-heals (#4373).
+        await _reconcile_slot_window(state, existing)
         total = len(existing.messages)
         recent = existing.messages[-200:] if total > 200 else existing.messages
         prepared = _prepare_messages(recent, existing.running)

--- a/test/test_stale_slot_reconcile.py
+++ b/test/test_stale_slot_reconcile.py
@@ -1,0 +1,177 @@
+"""Tests for live slot stale-window reconciliation (#4373).
+
+When a live slot's in-memory window diverges from disk (messages on disk that
+the slot does not know about), both the resume and detail endpoints must
+self-heal on the next request by appending the missing tail from disk.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+
+@pytest.mark.asyncio
+async def test_resume_reconciles_stale_slot_from_disk(tmp_path, monkeypatch):
+    """Resume of a live slot detects new on-disk messages and appends them."""
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+
+    # Seed the transcript with 3 messages.
+    log.append("dashboard:s1", "user", "msg1")
+    log.append("dashboard:s1", "assistant", "reply1")
+    log.append("dashboard:s1", "user", "msg2")
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        # First resume loads 3 messages into the slot.
+        r1 = await (
+            await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+        ).json()
+        assert r1["ok"] is True
+        assert r1["total"] == 3
+
+        # Now write 2 more messages directly to disk WITHOUT going through
+        # the slot's append — simulating the divergence scenario.
+        log.append("dashboard:s1", "assistant", "reply2")
+        log.append("dashboard:s1", "user", "msg3")
+
+        # The slot still thinks it has only 3 messages.
+        slot = state._slots["s1"]
+        assert len(slot.messages) == 3
+
+        # Simulate the periodic flush having persisted the slot (clears dirty).
+        slot._dirty = False
+
+        # Second resume (page refresh) should reconcile and return all 5.
+        r2 = await (
+            await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+        ).json()
+        assert r2["ok"] is True
+        assert r2["total"] == 5, f"Expected 5 messages after reconciliation, got {r2['total']}"
+        # The slot's in-memory window should now have all 5.
+        assert len(slot.messages) == 5
+
+
+@pytest.mark.asyncio
+async def test_detail_reconciles_stale_slot_from_disk(tmp_path, monkeypatch):
+    """Detail endpoint detects stale window and includes missing disk rows."""
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+
+    # Seed the transcript.
+    log.append("dashboard:s1", "user", "msg1")
+    log.append("dashboard:s1", "assistant", "reply1")
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        # Resume to create the live slot.
+        await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+        slot = state._slots["s1"]
+        assert len(slot.messages) == 2
+
+        # Simulate the periodic flush having persisted the slot (clears dirty).
+        slot._dirty = False
+
+        # Write directly to disk — bypassing the in-memory slot.
+        log.append("dashboard:s1", "assistant", "reply2")
+        log.append("dashboard:s1", "user", "msg2")
+        log.append("dashboard:s1", "assistant", "reply3")
+
+        # Detail request should reconcile and include all 5 messages.
+        r = await (await client.get("/api/chat/slots/s1")).json()
+        # Total includes all messages (memory reconciled from disk).
+        assert (
+            r["total"] == 5
+        ), f"Expected 5 messages in detail after reconciliation, got {r['total']}"
+        # The slot should also be updated in memory.
+        assert len(slot.messages) == 5
+
+
+@pytest.mark.asyncio
+async def test_reconcile_no_op_when_not_stale(tmp_path, monkeypatch):
+    """Reconciliation is a no-op when disk and memory are in sync."""
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+
+    log.append("dashboard:s1", "user", "msg1")
+    log.append("dashboard:s1", "assistant", "reply1")
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        # Resume loads both messages.
+        await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+        slot = state._slots["s1"]
+        assert len(slot.messages) == 2
+
+        # Resume again — no divergence, should be a no-op.
+        r = await (
+            await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+        ).json()
+        assert r["ok"] is True
+        assert r["total"] == 2
+        assert len(slot.messages) == 2
+
+
+@pytest.mark.asyncio
+async def test_reconcile_preserves_disk_window_len(tmp_path, monkeypatch):
+    """After reconciliation, _disk_window_len covers the full window."""
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+
+    log.append("dashboard:s1", "user", "msg1")
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+        slot = state._slots["s1"]
+
+        # Simulate the periodic flush having persisted the slot (clears dirty).
+        slot._dirty = False
+
+        # Write directly to disk.
+        log.append("dashboard:s1", "assistant", "reply1")
+        log.append("dashboard:s1", "user", "msg2")
+
+        # Trigger reconciliation via detail.
+        await client.get("/api/chat/slots/s1")
+
+        # _disk_window_len must cover all messages so the next save does not
+        # duplicate them.
+        assert slot._disk_window_len == len(slot.messages) == 3
+
+
+@pytest.mark.asyncio
+async def test_reconcile_with_disk_older_count(tmp_path, monkeypatch):
+    """Reconciliation works when slot has a non-zero _disk_older_count."""
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+
+    # Write 6 messages to disk.
+    for i in range(6):
+        log.append("dashboard:s1", "user" if i % 2 == 0 else "assistant", f"msg{i}")
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+        slot = state._slots["s1"]
+        assert len(slot.messages) == 6
+
+        # Simulate a truncated window by setting _disk_older_count to 2
+        # and removing the first 2 messages from the slot window (consistent state).
+        del slot.messages[:2]
+        slot._disk_older_count = 2
+        slot._disk_window_len = len(slot.messages)  # 4
+        slot._dirty = False  # Simulate flush
+
+        # Slot now represents 2 + 4 = 6 lines, which matches disk (6 total).
+        # Add messages to disk beyond what the slot covers.
+        log.append("dashboard:s1", "user", "extra1")
+        # Disk = 7, slot covers 2 + 4 = 6. Should reconcile 1.
+
+        r = await (
+            await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+        ).json()
+        assert r["ok"] is True
+        assert len(slot.messages) == 5  # 4 + 1 reconciled


### PR DESCRIPTION
## Problem / Motivation

A session that stays live in the gateway's memory can serve a **stale message window** to the dashboard: the newest turns are on disk, but the open tab shows the conversation frozen at an earlier point — and **a page refresh does not recover**, because while the slot is live, refresh serves the in-memory window instead of re-reading disk.

From the user's perspective, turns of work "disappear." The data is safe on disk, but the natural recovery action (refresh) is the one that cannot work.

## Why it matters

Silent, invisible data divergence in the primary chat surface. Users lose trust in the system when ~60 turns of work appear to vanish and no user-accessible action (refresh, close/reopen) recovers them until a gateway restart rebuilds slots from disk.

## What changed (motivation → approach → change)

**Root cause:** Two code paths serve the in-memory window without verifying it matches disk:
1. `api_chat_slot_resume` — when a slot already exists, returns `existing.messages[-200:]` directly, no disk check.
2. `api_chat_slot_detail` — when `_disk_older_count == 0`, returns only the in-memory window via `else: messages = mem_msgs`.

Neither path detects that the disk file has grown beyond what `_disk_older_count + len(messages)` accounts for.

**Fix — two reconciliation points:**

1. **Resume path:** Added `_reconcile_slot_window()` — an async helper that compares the slot's believed disk coverage against the actual on-disk message count via `read_messages_chained`. If disk has grown, it appends the missing tail to the in-memory window and updates `_disk_window_len` so the next save does not duplicate them. Called before returning the existing-slot response.

2. **Detail no-limit path:** Added an `elif` branch (when `_disk_older_count == 0`) that reads disk and checks if it has grown beyond the in-memory window. If so, reconciles inline — appending missing messages and returning the full corpus. This preserves the existing "message arriving mid-read" contract (the `_disk_older_count > 0` path is unchanged).

Both paths are safe to call on a slot with a turn in flight: appended rows come from disk (already committed) and do not race the live turn's own appends.

## Tests

Added `test/test_stale_slot_reconcile.py` with 5 regression tests:
- `test_resume_reconciles_stale_slot_from_disk` — verifies resume self-heals when disk outgrows in-memory.
- `test_detail_reconciles_stale_slot_from_disk` — verifies detail self-heals on the same divergence.
- `test_reconcile_no_op_when_not_stale` — confirms reconciliation is a no-op when in sync.
- `test_reconcile_preserves_disk_window_len` — ensures `_disk_window_len` is updated to prevent save duplication.
- `test_reconcile_with_disk_older_count` — verifies reconciliation works with a non-zero frozen prefix.

All existing `test_dashboard_chat.py` tests pass (590 tests), including `test_message_arriving_during_the_disk_read_is_not_dropped` which exercises the mid-read append contract.

## Manual verification

N/A — unit coverage sufficient. The fix is entirely in the message-serving code path with no UI change; the 5 new tests reproduce the exact divergence scenario described in the issue.

<!-- no-visual-delta -->
**Why no screenshot:** This is a backend-only fix to the message serving path. No rendered UI changes — the fix makes the existing chat view show the correct (complete) message list instead of a stale subset.

## Related Issues

Fixes #4373

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
