### PR TITLE
fix(agents): add reactive model fallback for "auto" on GovCloud

### DIFF
--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -6656,7 +6656,10 @@ class HistoryConsolidator:
             # learn_add, spawn_run). REJECT_ALL keeps both providers tool-free.
             try:
                 result = await stream_and_collect_json(
-                    client, prompt, approval_policy=ToolApprovalPolicy.REJECT_ALL
+                    client,
+                    prompt,
+                    approval_policy=ToolApprovalPolicy.REJECT_ALL,
+                    model_fallback=True,
                 )
             except Exception:
                 logger.warning(

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -152,6 +152,26 @@ def transient_retry_delay(attempt: int) -> float:
     return base + _JITTER_RNG.random() * 0.25 * base
 
 
+def first_advertised_fallback(advertised: Any, rejected: str | None) -> str | None:
+    """First advertised model that is neither *rejected* nor ``"auto"``.
+
+    Used as the reactive replacement when the configured model (often ``"auto"``)
+    is refused mid-prompt — e.g. on a GovCloud partition that does not serve the
+    ``"auto"`` sentinel.  Shared by :func:`run_bg_oneliner` and
+    :func:`stream_and_collect` so every background LLM path has the same
+    fallback behaviour.
+    """
+    rej = (rejected or "").strip().lower()
+    for m in advertised or []:
+        if not isinstance(m, str) or not m.strip():
+            continue
+        low = m.strip().lower()
+        if low == rej or low == "auto":
+            continue
+        return m
+    return None
+
+
 class PromptBusyExhaustedError(Exception):
     """Provider was shut down after prompt-busy retries were exhausted."""
 
@@ -291,20 +311,6 @@ async def run_bg_oneliner(
     """
     session = await sessions.get_bg_session()
 
-    def _first_advertised_fallback(advertised: Any, rejected: str | None) -> str | None:
-        """First advertised model that is neither the rejected id nor the
-        ``"auto"`` sentinel — the reactive replacement when the preferred model
-        is refused mid-prompt."""
-        rej = (rejected or "").strip().lower()
-        for m in advertised or []:
-            if not isinstance(m, str) or not m.strip():
-                continue
-            low = m.strip().lower()
-            if low == rej or low == "auto":
-                continue
-            return m
-        return None
-
     async def _drive(model_to_use: str | None) -> str:
         text = ""
         set_model = getattr(session, "set_model", None)
@@ -400,7 +406,7 @@ async def run_bg_oneliner(
             rejected = getattr(exc, "rejected_model", None)
             advertised = getattr(exc, "advertised", None) or []
             fallback = (
-                _first_advertised_fallback(advertised, rejected)
+                first_advertised_fallback(advertised, rejected)
                 if rejected and not strict_model
                 else None
             )
@@ -455,6 +461,7 @@ async def stream_and_collect(
     session_key: str = "",
     agent: str = "",
     app: str = "",
+    model_fallback: bool = False,
 ) -> str:
     """Stream a message through an LLM provider and collect the full response.
 
@@ -513,6 +520,7 @@ async def stream_and_collect(
         The complete response text.
     """
     transient_attempts = 0
+    _model_fallback_attempted = False
     attempt = 0
     while True:
         result_text = ""
@@ -681,6 +689,50 @@ async def stream_and_collect(
                 retrying = True
                 continue
 
+            # ── Case 2.5: model rejected (e.g. "auto" on GovCloud) — retry once
+            # with the first advertised model. ──
+            # Same reactive fallback as run_bg_oneliner: some partitions do not
+            # serve the "auto" sentinel, and the advertised list cannot gate it
+            # statically. When the backend rejects a model AND names available
+            # alternatives, retry ONCE with the first usable advertised model.
+            # Only fires when no tokens have streamed (safe to replay) and the
+            # error carries rejection metadata.
+            #
+            # OPT-IN (model_fallback=True): a silent model swap is only correct
+            # for a caller that did NOT choose the model — a background/system
+            # turn on the governed "auto" (history consolidation). An interactive
+            # turn where the user picked a model must surface the rejection, not
+            # swap underneath them (AGENTS.md), so the default is off.
+            rejected = getattr(exc, "rejected_model", None)
+            advertised = getattr(exc, "advertised", None) or []
+            if (
+                model_fallback
+                and not result_text
+                and rejected
+                and advertised
+                and not _model_fallback_attempted
+            ):
+                fallback = first_advertised_fallback(advertised, rejected)
+                if fallback:
+                    _model_fallback_attempted = True
+                    set_model_fn = getattr(provider, "set_model", None)
+                    if set_model_fn:
+                        try:
+                            await set_model_fn(fallback)
+                        except Exception:
+                            logger.debug(
+                                "set_model(%r) failed during model fallback",
+                                fallback,
+                                exc_info=True,
+                            )
+                    logger.warning(
+                        "stream_and_collect: model %r rejected; " "retrying once with %r",
+                        rejected,
+                        fallback,
+                    )
+                    retrying = True
+                    continue
+
             # ── Case 3: fatal (auth, validation, exhausted retries) — propagate. ──
             raise
         finally:
@@ -717,13 +769,20 @@ async def stream_and_collect_json(
     *,
     approval_policy: ToolApprovalPolicy = ToolApprovalPolicy.AUTO_APPROVE,
     hooks: HookManager | None = None,
+    model_fallback: bool = False,
 ) -> dict | None:
     """Stream a message and parse the response as JSON.
 
     Combines ``stream_and_collect`` with ``parse_llm_json``.
     Returns parsed dict or None on failure.
     """
-    text = await stream_and_collect(provider, message, approval_policy=approval_policy, hooks=hooks)
+    text = await stream_and_collect(
+        provider,
+        message,
+        approval_policy=approval_policy,
+        hooks=hooks,
+        model_fallback=model_fallback,
+    )
     return parse_llm_json(text)
 
 

--- a/src/kiro_crew/suggestions.py
+++ b/src/kiro_crew/suggestions.py
@@ -13,9 +13,8 @@ from typing import TYPE_CHECKING
 from aiohttp import web
 
 from kiro_crew.context import ContextBuilder
-from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_PERMISSION_REQUEST, EVENT_TEXT_CHUNK
+from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-from kiro_crew.sel import sel
 
 if TYPE_CHECKING:
     from kiro_crew.dashboard.state import DashboardState
@@ -174,32 +173,19 @@ async def generate_suggestions(state: DashboardState) -> list[str]:
 
     prompt = _PROMPT_TEMPLATE.replace("{context}", context)
 
-    session = await state.sessions.get_bg_session()
-    text = ""
+    # run_bg_oneliner owns the shared background-session skeleton (acquire _bg,
+    # reject + SEL-audit any tool call, drive the event loop, destroy in finally)
+    # and its reactive rejected-model fallback — so a partition that does not
+    # serve "auto" (e.g. GovCloud) retries once with an advertised model instead
+    # of failing permanently. Best-effort: on any error fall back to the static
+    # suggestions rather than surfacing it.
     try:
-        async def _stream() -> str:
-            nonlocal text
-            async for event in session.prompt(prompt):
-                if event.kind == EVENT_TEXT_CHUNK:
-                    text += event.text
-                elif event.kind == EVENT_PERMISSION_REQUEST:
-                    sel().log_tool_invocation(
-                        session_key="_bg",
-                        tool_name=getattr(event, "title", "unknown"),
-                        outcome="denied",
-                        source="suggestions",
-                    )
-                    await session.reject_tool(event.request_id)
-                elif event.kind == EVENT_COMPLETE:
-                    break
-            return text
-
-        await asyncio.wait_for(_stream(), timeout=60)
-    except asyncio.TimeoutError:
-        logger.warning("Suggestions generation timed out")
+        text = await run_bg_oneliner(
+            state.sessions, prompt, sel_source="suggestions", timeout=60
+        )
+    except Exception:
+        logger.warning("Suggestions generation failed", exc_info=True)
         return list(_FALLBACK_SUGGESTIONS)
-    finally:
-        await session.destroy()
 
     suggestions = _parse_suggestions(text)
     if suggestions:

--- a/test/test_llm_helpers.py
+++ b/test/test_llm_helpers.py
@@ -10,6 +10,7 @@ from kiro_crew.acp.client import AcpError, AcpPromptBusy
 from kiro_crew.llm_helpers import (
     PromptBusyExhaustedError,
     ToolApprovalPolicy,
+    first_advertised_fallback,
     parse_llm_json,
     parse_llm_json_list,
     record_interaction_event,
@@ -17,6 +18,32 @@ from kiro_crew.llm_helpers import (
     stream_and_collect,
 )
 from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+
+class TestFirstAdvertisedFallback:
+    """Unit tests for the shared model-fallback helper."""
+
+    def test_skips_rejected_and_auto(self) -> None:
+        result = first_advertised_fallback(["auto", "claude-opus-5", "claude-sonnet-5"], "auto")
+        assert result == "claude-opus-5"
+
+    def test_skips_rejected_concrete(self) -> None:
+        result = first_advertised_fallback(["claude-opus-5", "claude-sonnet-5"], "claude-opus-5")
+        assert result == "claude-sonnet-5"
+
+    def test_returns_none_when_empty(self) -> None:
+        assert first_advertised_fallback([], "auto") is None
+
+    def test_returns_none_when_only_auto_and_rejected(self) -> None:
+        assert first_advertised_fallback(["auto"], "auto") is None
+
+    def test_none_rejected(self) -> None:
+        result = first_advertised_fallback(["claude-opus-5"], None)
+        assert result == "claude-opus-5"
+
+    def test_case_insensitive(self) -> None:
+        result = first_advertised_fallback(["Auto", "Claude-Opus-5"], "auto")
+        assert result == "Claude-Opus-5"
 
 
 class TestParseLlmJson:
@@ -519,6 +546,112 @@ class TestStreamAndCollectTransient:
             await stream_and_collect(provider, "test", retry_transient=False)
 
         assert call_count == 1  # opt-out → no inner retry
+
+
+class TestStreamAndCollectModelFallback:
+    """Model-rejection reactive fallback (e.g. "auto" on GovCloud)."""
+
+    @pytest.mark.asyncio
+    async def test_model_rejected_retries_with_fallback(self) -> None:
+        """When 'auto' is rejected with an advertised list, retry once with
+        the first advertised model after calling set_model."""
+        call_count = 0
+
+        async def _stream(msg):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                exc = AcpError("model 'auto' not available")
+                exc.rejected_model = "auto"
+                exc.advertised = ["claude-opus-5", "claude-sonnet-5"]
+                raise exc
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="success")
+            yield LLMEvent(kind=EVENT_COMPLETE)
+
+        provider = AsyncMock()
+        provider.cancel = AsyncMock()
+        provider.shutdown = AsyncMock()
+        provider.stream = _stream
+        provider.set_model = AsyncMock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await stream_and_collect(provider, "test", model_fallback=True)
+
+        assert result == "success"
+        assert call_count == 2
+        provider.set_model.assert_awaited_once_with("claude-opus-5")
+
+    @pytest.mark.asyncio
+    async def test_model_rejected_default_propagates_no_swap(self) -> None:
+        """Without model_fallback=True, a rejected model propagates and is NOT
+        silently swapped — an interactive user pick must surface the error."""
+        call_count = 0
+
+        async def _stream(msg):
+            nonlocal call_count
+            call_count += 1
+            exc = AcpError("model 'auto' not available")
+            exc.rejected_model = "auto"
+            exc.advertised = ["claude-opus-5", "claude-sonnet-5"]
+            raise exc
+            yield  # pragma: no cover
+
+        provider = AsyncMock()
+        provider.cancel = AsyncMock()
+        provider.shutdown = AsyncMock()
+        provider.stream = _stream
+        provider.set_model = AsyncMock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock), pytest.raises(AcpError):
+            await stream_and_collect(provider, "test")
+
+        assert call_count == 1  # no retry
+        provider.set_model.assert_not_awaited()  # no silent swap
+
+    @pytest.mark.asyncio
+    async def test_model_rejected_no_advertised_propagates(self) -> None:
+        """When 'auto' is rejected but no advertised list, propagate."""
+
+        async def _stream(msg):
+            exc = AcpError("model 'auto' not available")
+            exc.rejected_model = "auto"
+            exc.advertised = []
+            raise exc
+            yield  # pragma: no cover
+
+        provider = AsyncMock()
+        provider.cancel = AsyncMock()
+        provider.shutdown = AsyncMock()
+        provider.stream = _stream
+
+        with patch("asyncio.sleep", new_callable=AsyncMock), pytest.raises(AcpError):
+            await stream_and_collect(provider, "test", model_fallback=True)
+
+    @pytest.mark.asyncio
+    async def test_model_fallback_only_once(self) -> None:
+        """Fallback retries only once — a second rejection propagates."""
+        call_count = 0
+
+        async def _stream(msg):
+            nonlocal call_count
+            call_count += 1
+            exc = AcpError("model rejected")
+            exc.rejected_model = "auto"
+            exc.advertised = ["claude-opus-5"]
+            raise exc
+            yield  # pragma: no cover
+
+        provider = AsyncMock()
+        provider.cancel = AsyncMock()
+        provider.shutdown = AsyncMock()
+        provider.stream = _stream
+        provider.set_model = AsyncMock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock), pytest.raises(AcpError):
+            await stream_and_collect(provider, "test", model_fallback=True)
+
+        # First call triggers fallback, second call propagates.
+        assert call_count == 2
 
 
 class TestRecordInteractionEvent:


### PR DESCRIPTION
## Problem / Motivation

When using Kiro Crew with kiro-cli logged into GovCloud, the "Auto" model
selection throws a permanent error in background LLM paths (suggestions
generation and history consolidation):

> Your account does not have access to model 'auto'. Available to you:
> claude-opus-5, claude-sonnet-5, ...

The `run_bg_oneliner` path (chat titles, nav links) already had a working
reactive fallback, but the other background paths did not — they classified
the rejection as fatal and propagated without retry, causing repeated failures
every few minutes with exponential backoff that never recovers.

## Why it matters

Every GovCloud user running with "Auto" model selection has a broken background
experience: suggestions never generate, history consolidation fails repeatedly
(consuming retry budget), and the AcpRuntime dies and respawns in a loop. The
dashboard is functional but degraded — these background features are permanently
broken until the user manually changes their model setting.

## What changed (motivation → approach → change)

Root cause: the `"auto"` model sentinel is not served on GovCloud partitions.
The ACP backend rejects it with a structured error carrying `rejected_model`
and an `advertised` list. `run_bg_oneliner` already caught this and retried with
the first advertised model — but history consolidation (via `stream_and_collect`)
and suggestions had no such fallback.

The fix reuses the existing mechanism rather than duplicating it:

1. **Extract `first_advertised_fallback` to module level** in `llm_helpers.py`
   so `run_bg_oneliner` and `stream_and_collect` share one implementation.

2. **Add an OPT-IN `model_fallback` retry to `stream_and_collect`** — a
   "Case 2.5: model rejected" branch between the transient-retry and the
   fatal-propagate. It is **off by default**: a silent model swap is only
   correct for a caller that did NOT choose the model (a background/system turn
   on the governed `"auto"`). Interactive turns where the user picked a model
   still surface the rejection rather than swapping underneath them (AGENTS.md).
   History consolidation opts in via `stream_and_collect_json(..., model_fallback=True)`.

3. **Refactor `generate_suggestions` to call `run_bg_oneliner`** instead of
   hand-rolling the `_bg` session loop. `run_bg_oneliner` already owns the
   "acquire `_bg` → reject + SEL-audit tools → drive the loop → destroy in
   finally" skeleton AND the rejected-model fallback, so suggestions now gets
   the GovCloud fix for free with a net-negative diff — and picks up the
   `EVENT_TOOL_CALL` audit the hand-rolled loop was missing.

## Tests

- `TestFirstAdvertisedFallback` — 6 unit tests for the extracted helper.
- `TestStreamAndCollectModelFallback` — 4 tests:
  - `model_fallback=True` retries with the first advertised model (asserts `set_model`).
  - **Default (no flag) propagates and does NOT swap** — proves interactive picks
    are never silently swapped.
  - No advertised list propagates.
  - Retries only once.

## Manual verification

N/A — the fix is in background async paths that cannot be triggered without a
GovCloud partition. The unit tests exercise the exact error shape reported in
the issue. The existing `run_bg_oneliner` fallback (which suggestions now reuses)
is production-validated on GovCloud (visible in the issue's logs:
`bg oneliner: model 'auto' rejected; retrying once with 'claude-opus-5'`).

<!-- no-visual-delta -->
**Why no screenshot:** Pure backend change — no UI surface is modified.

## Related Issues

Fixes #4384

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
