### PR TITLE
chore: drop the legacy frozen-bundle probe from find-bin

### DIFF
--- a/website/electron/find-bin.js
+++ b/website/electron/find-bin.js
@@ -49,16 +49,16 @@ function findKirocrewBin(
       path.resolve(dirname, "backend-dist", archBackend, "bin", "kirocrew")
     );
   }
-  // 0b. Windows SOURCE CHECKOUT: a pip/venv install exposes `kirocrew.exe`
-  //     under `Scripts\` (not the POSIX `bin/kirocrew` launcher). Probed before
-  //     the bundled candidates so a developer running from a checkout gets
-  //     their own venv, and as an absolute `.exe` that `spawn()` can launch
-  //     without a shell. On POSIX these are skipped entirely so mac/Linux
-  //     behavior is unchanged.
+  // 1. Windows SOURCE CHECKOUT: a pip/venv install exposes `kirocrew.exe`
+  //    under `Scripts\` (not the POSIX `bin/kirocrew` launcher). Probed before
+  //    the bundled candidates so a developer running from a checkout gets
+  //    their own venv, and as an absolute `.exe` that `spawn()` can launch
+  //    without a shell. On POSIX these are skipped entirely so mac/Linux
+  //    behavior is unchanged.
   //
-  //     Only the checkout venvs are ranked here. The BUNDLE's own
-  //     Scripts\kirocrew.exe is ranked further down, below the .cmd shim --
-  //     see the note there.
+  //    Only the checkout venvs are ranked here. The BUNDLE's own
+  //    Scripts\kirocrew.exe is ranked further down, below the .cmd shim --
+  //    see the note there.
   if (isWindows) {
     candidates.push(
       // Source checkout: repo-root `.venv` — electron/ is <repo>/website/electron,
@@ -68,54 +68,49 @@ function findKirocrewBin(
     );
   }
   candidates.push(
-    // 0b. Windows bundled layout (packaging/build-desktop.sh
-    //     build_backend_windows): the PBS interpreter ships python.exe at
-    //     the tree root with a bin\kirocrew.cmd launcher shim. Probed on
-    //     every platform (costs one ENOENT elsewhere) so this function
-    //     stays platform-agnostic and testable; only a Windows bundle
-    //     actually contains the .cmd. Keep in sync with
-    //     build-desktop.sh's bin/kirocrew.cmd.
+    // 2. Windows bundled layout (packaging/build-desktop.sh
+    //    build_backend_windows): the PBS interpreter ships python.exe at
+    //    the tree root with a bin\kirocrew.cmd launcher shim. Probed on
+    //    every platform (costs one ENOENT elsewhere) so this function
+    //    stays platform-agnostic and testable; only a Windows bundle
+    //    actually contains the .cmd. Keep in sync with
+    //    build-desktop.sh's bin/kirocrew.cmd.
     //
-    //     This MUST outrank backend-dist/.../Scripts/kirocrew.exe below.
-    //     `pip install` also drops a console-script .exe in the bundle's
-    //     Scripts\ dir, but distlib embeds the ABSOLUTE interpreter path of
-    //     the machine that built it, so inside a shipped bundle that .exe
-    //     points at a build-agent path (D:\a\KiroCrew\...) that does not
-    //     exist on the user's machine. The .cmd shim resolves the
-    //     interpreter via %~dp0 and is the only relocatable launcher of the
-    //     two. Ranking them the other way round both broke the build-time
-    //     resolver gate and, had the gate not caught it, would have shipped
-    //     an app whose backend could never start.
+    //    This MUST outrank backend-dist/.../Scripts/kirocrew.exe below.
+    //    `pip install` also drops a console-script .exe in the bundle's
+    //    Scripts\ dir, but distlib embeds the ABSOLUTE interpreter path of
+    //    the machine that built it, so inside a shipped bundle that .exe
+    //    points at a build-agent path (D:\a\KiroCrew\...) that does not
+    //    exist on the user's machine. The .cmd shim resolves the
+    //    interpreter via %~dp0 and is the only relocatable launcher of the
+    //    two. Ranking them the other way round both broke the build-time
+    //    resolver gate and, had the gate not caught it, would have shipped
+    //    an app whose backend could never start.
     path.join(resourcesPath || "", "backend-dist", "kirocrew-backend", "bin", "kirocrew.cmd"),
     path.resolve(dirname, "backend-dist", "kirocrew-backend", "bin", "kirocrew.cmd"),
-    // 1. Legacy PyInstaller layout: a flat frozen executable at the root of the
-    //    bundle. The current builder (packaging/build-desktop.sh) no longer
-    //    emits this; kept first only for backward-compat with older bundles.
-    path.join(resourcesPath || "", "backend-dist", "kirocrew-backend", "kirocrew-backend"),
-    path.resolve(dirname, "backend-dist", "kirocrew-backend", "kirocrew-backend"),
-    // 1b. CURRENT bundled layout (packaging/build-desktop.sh): a
-    //     python-build-standalone interpreter copied into backend-dist with a
-    //     `bin/kirocrew` launcher wrapper (exec python3.12 -s -m kiro_crew).
-    //     This is what a freshly-built .app actually ships. Keep this in sync
-    //     with build-desktop.sh's BACKEND_OUT/bin/kirocrew path.
+    // 3. Bundled POSIX layout (packaging/build-desktop.sh): a
+    //    python-build-standalone interpreter copied into backend-dist with a
+    //    `bin/kirocrew` launcher wrapper (exec python3.12 -s -m kiro_crew).
+    //    This is what a freshly-built .app actually ships. Keep this in sync
+    //    with build-desktop.sh's BACKEND_OUT/bin/kirocrew path.
     path.join(resourcesPath || "", "backend-dist", "kirocrew-backend", "bin", "kirocrew"),
     path.resolve(dirname, "backend-dist", "kirocrew-backend", "bin", "kirocrew"),
     path.resolve(dirname, "..", "bin", "kirocrew")
   );
   if (isWindows) {
-    // 1c. The bundle's pip console-script .exe. Ranked BELOW the .cmd shim
-    //     (distlib bakes the building machine's absolute interpreter path into
-    //     it, so in a shipped bundle it points at a path that does not exist)
-    //     but still ABOVE the user-level install paths below: a bundled app
-    //     must prefer its own backend over whatever happens to be installed on
-    //     the machine. It is correct for a bundle built where it runs (a local
-    //     `make desktop`), which is why it is probed at all.
+    // 4. The bundle's pip console-script .exe. Ranked BELOW the .cmd shim
+    //    (distlib bakes the building machine's absolute interpreter path into
+    //    it, so in a shipped bundle it points at a path that does not exist)
+    //    but still ABOVE the user-level install paths below: a bundled app
+    //    must prefer its own backend over whatever happens to be installed on
+    //    the machine. It is correct for a bundle built where it runs (a local
+    //    `make desktop`), which is why it is probed at all.
     candidates.push(
       path.join(resourcesPath || "", "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe"),
       path.resolve(dirname, "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe")
     );
   }
-  // 2. Well-known install paths (toolbox, installer symlink, and venv). Last,
+  // 5. Well-known install paths (toolbox, installer symlink, and venv). Last,
   //    so a packaged app never prefers a stray user-level install over the
   //    backend it shipped with.
   candidates.push(

--- a/website/electron/test/find-bin.test.js
+++ b/website/electron/test/find-bin.test.js
@@ -21,29 +21,11 @@ const none = {
 };
 
 describe("findKirocrewBin", () => {
-  it("returns bundled path when it exists", () => {
-    const bundled = path.join(RESOURCES, "backend-dist", "kirocrew-backend", "kirocrew-backend");
-    const fakeFs = only(bundled);
-    const result = findKirocrewBin(fakeFs, fakeOs, path, RESOURCES, DIRNAME);
-    assert.equal(result, bundled);
-  });
-
-  it("returns bundled venv layout (backend-dist/.../bin/kirocrew) when the flat PyInstaller exe is absent", () => {
+  it("returns the bundled backend launcher (backend-dist/.../bin/kirocrew) when it exists", () => {
     const venvLayout = path.join(RESOURCES, "backend-dist", "kirocrew-backend", "bin", "kirocrew");
     const fakeFs = only(venvLayout);
     const result = findKirocrewBin(fakeFs, fakeOs, path, RESOURCES, DIRNAME);
     assert.equal(result, venvLayout);
-  });
-
-  it("prefers the flat PyInstaller exe over the venv-layout bin/kirocrew", () => {
-    const bundled = path.join(RESOURCES, "backend-dist", "kirocrew-backend", "kirocrew-backend");
-    const venvLayout = path.join(RESOURCES, "backend-dist", "kirocrew-backend", "bin", "kirocrew");
-    const fakeFs = {
-      accessSync: (p) => { if (p !== bundled && p !== venvLayout) throw new Error("ENOENT"); },
-      constants: { X_OK: fs.constants.X_OK },
-    };
-    const result = findKirocrewBin(fakeFs, fakeOs, path, RESOURCES, DIRNAME);
-    assert.equal(result, bundled);
   });
 
   it("returns ~/.toolbox/bin/kirocrew when bundled paths don't exist", () => {
@@ -163,7 +145,7 @@ describe("findKirocrewBin", () => {
   });
 
   it("returns first match when multiple candidates exist", () => {
-    const bundled = path.join(RESOURCES, "backend-dist", "kirocrew-backend", "kirocrew-backend");
+    const bundled = path.join(RESOURCES, "backend-dist", "kirocrew-backend", "bin", "kirocrew");
     const localBin = path.join(HOME, ".local", "bin", "kirocrew");
     const fakeFs = {
       accessSync: (p) => { if (p !== bundled && p !== localBin) throw new Error("ENOENT"); },
@@ -181,7 +163,7 @@ describe("findKirocrewBin", () => {
   });
 
   it("resolves dirname-relative dev path correctly", () => {
-    const devBin = path.resolve(DIRNAME, "backend-dist", "kirocrew-backend", "kirocrew-backend");
+    const devBin = path.resolve(DIRNAME, "backend-dist", "kirocrew-backend", "bin", "kirocrew");
     const fakeFs = only(devBin);
     const result = findKirocrewBin(fakeFs, fakeOs, path, RESOURCES, DIRNAME);
     assert.equal(result, devBin);


### PR DESCRIPTION
## Summary

The Electron half of the PyInstaller cleanup, after #4229 (dead build path) and
#4409 (runtime `sys.frozen` branches). This removes the last probe that still
looks for a frozen artifact.

`website/electron/find-bin.js` probed a flat
`backend-dist/kirocrew-backend/kirocrew-backend` executable — the PyInstaller
one-file layout — and ranked it **above** the `bin/kirocrew` launcher the current
builder actually emits. The comment kept it "only for backward-compat with older
bundles", but no such bundle was ever released:

| Event | Date |
|---|---|
| Switch to python-build-standalone + uv (#11, `21259fcf1`) | 2026-07-08 |
| First tag, `v0.1.0-insider.1` | 2026-07-20 |
| First public `v0.1.0` | 2026-07-22 |

There is no shipped artifact for the probe to be compatible with. What it *can*
match is a stale `kirocrew-backend` file left in a developer's tree — and because
it was ranked first, such a file would win over the real launcher.

## The renumber is forced, not incidental

Most of the diff's line count is comment reindentation, so flagging it explicitly.
The ladder's step labels were already inconsistent:

```
0.  universal-bundle layout
0b. Windows source checkout      <-- duplicate label
0b. Windows bundled layout       <-- duplicate label
1.  legacy PyInstaller           <-- deleted here
1b. current bundled layout
1c. bundle's Scripts\kirocrew.exe
2.  well-known install paths
```

Deleting `1.` would have left the duplicate `0b` *and* a gap where `1` used to be,
so the labels are renumbered to a clean `0`-`5`. That numbering is the only
navigational value those comments carry. **No candidate order changes** apart from
the deletion itself.

## Tests re-aimed, not dropped

Two of the five references were about the legacy path as a *subject*; three were
using it incidentally to test something that is still true.

| Test | Disposition |
|---|---|
| `returns bundled path when it exists` | **Merged** — it used the flat path as the canonical bundled path, which the `bin/kirocrew` case already covers |
| `prefers the flat PyInstaller exe over the venv-layout bin/kirocrew` | **Deleted** — legacy-first ranking was its whole subject |
| `returns first match when multiple candidates exist` | **Re-aimed** to `bin/kirocrew`; still asserts that a bundle outranks a user-level install |
| `resolves dirname-relative dev path correctly` | **Re-aimed** to `bin/kirocrew`; still asserts dirname-relative resolution |

The ranking invariants the deleted test sat beside are each covered by their own
test and are untouched: `bin\kirocrew.cmd` over the bundle's
`Scripts\kirocrew.exe`, that `.exe` over a user-level install, and the
arch-suffixed tree over the unsuffixed one.

## Testing

`node --test website/electron/test/find-bin.test.js` — **22/22 pass** locally (24
before, minus the two deleted).

The full `npm test --prefix electron` run reports 970/985 with 14 failures, all of
them `Cannot find module` for `electron`, `electron-updater`, and
`app-builder-lib` in a fresh worktree with no `node_modules` installed. None
involve `find-bin`; `find-bin.test.js` needs only Node built-ins, which is why it
runs standalone.

`eslint` does not cover this directory (`website/package.json`'s lint script is
`eslint src --ext .ts,.tsx`), so there is no lint delta to report.

## Related

- #4229 — removed the dead PyInstaller build path
- #4409 — removed the runtime `sys.frozen` branches
- #4439 — a separate, pre-existing Windows launcher-resolution defect found while
  reviewing this area; not touched here
