### PR TITLE
fix(knowledge): take created ids from writes, not source diffs (#4431)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -396,7 +396,6 @@ src/kiro_crew/mcp_gateway/gatewayd.py
 src/kiro_crew/mcp_gateway/hazards.py
 src/kiro_crew/mcp_gateway/image_budget.py
 src/kiro_crew/mcp_gateway/manager.py
-src/kiro_crew/mcp_gateway/preflight.py
 src/kiro_crew/mcp_gateway/prewarm.py
 src/kiro_crew/mcp_gateway/rewriter.py
 src/kiro_crew/mcp_gateway/seed.py

--- a/src/kiro_crew/knowledge/artifact_ingest.py
+++ b/src/kiro_crew/knowledge/artifact_ingest.py
@@ -401,16 +401,41 @@ async def ingest_artifact(
         # (e.g. someone configured an unsupported kind). Skip rather than guess.
         return None
 
-    # Capture the source's items before/after so we can attribute exactly this
-    # slug's newly-created items (the only ones the call below adds; the old
-    # group is deleted inside ingest_file). The caller serializes events, so
-    # nothing else mutates this source concurrently.
-    before_ids = {
-        r["id"]
-        for r in kstore.db.execute(
-            "SELECT id FROM items WHERE source_id = ?", (source_id,)
-        ).fetchall()
-    }
+    # The ids this slug's ingest creates, reported by the pipeline through
+    # ``on_committed`` from INSIDE the finalize hop that commits them (the same
+    # contract agent_source.py consumes). Collected at the write, not inferred
+    # from a before/after snapshot of the source: a snapshot diff costs a full
+    # per-source id read on the event loop and would also attribute anything a
+    # concurrent writer (e.g. import_bundle) commits into the same aggregate
+    # source while this ingest is awaiting.
+    committed_ids: list[str] = []
+    ownership_persisted = False
+
+    def _record_ownership(new_ids: list[str]) -> None:
+        # Runs INSIDE the pipeline's finalize hop, on its worker thread -- the
+        # same uncancellable unit that commits the group. Persisting the state
+        # row HERE, not after ingest_file returns, closes the orphan window:
+        # the awaits between the commit and the status check below (temp-file
+        # cleanup, the job-status read) are cancellation points, and a
+        # shutdown landing there would leave committed items no state row
+        # names -- the next reconcile re-ingests the artifact alongside them.
+        nonlocal ownership_persisted
+        committed_ids.extend(new_ids)
+        # Fail-safe, never fail-closed: this write is a durability UPGRADE over
+        # the in-memory capture, not a precondition. A raise escaping here would
+        # poison the finalize hop AFTER the group committed and the old group
+        # was deleted, making the pipeline report the whole ingest failed. On a
+        # swallowed error the fallback write below still lands on the
+        # uncancelled path.
+        try:
+            _set_state(kstore, source_id, slug, content_hash, new_ids, title,
+                       kind=art.kind)
+            ownership_persisted = True
+        except Exception:
+            logger.warning(
+                "could not persist artifact ownership for %s inside the commit "
+                "callback; deferring to the post-ingest state write",
+                slug, exc_info=True)
     # Route through the SAME path as folders/uploads: write the redacted content
     # to a temp file with the kind's real extension and hand it to
     # ingest_file -> FileReader. This gives html artifacts the ``_read_html``
@@ -434,6 +459,10 @@ async def ingest_artifact(
             original_name=f"{title}{ext}",
             source_id=source_id,
             old_item_ids=old_item_ids,
+            # Fires inside the finalize hop, only on the fully-committed branch
+            # -- the same branch that reports status 'completed' below -- and
+            # persists the ownership row there (see _record_ownership).
+            on_committed=_record_ownership,
             # Recorded inside the gate's own hop: by the time it reports a refusal
             # it has already committed the delete and the location claim, and a
             # cancellation between here and a post-hoc write would leave both
@@ -458,21 +487,28 @@ async def ingest_artifact(
         # the new items. Leave the recorded state untouched so the next event
         # retries from the prior good group.
         return job_id
-    after_ids = {
-        r["id"]
-        for r in kstore.db.execute(
-            "SELECT id FROM items WHERE source_id = ?", (source_id,)
-        ).fetchall()
-    }
-    new_ids = list(after_ids - before_ids)
-    _set_state(kstore, source_id, slug, content_hash, new_ids, title, kind=art.kind)
+    if not ownership_persisted:
+        # Fallback ONLY for a hop write that failed and was swallowed as
+        # fail-safe. Never an unconditional re-write: the awaits between the
+        # finalize hop and here (temp-file cleanup, job-status read) are windows
+        # where a concurrent dedup sweep may legitimately rewrite this slug's
+        # state row (collapse the group, mark it deduped), and blindly restoring
+        # the captured ids would resurrect an 'active' row over that result --
+        # unchanged ingests would then short-circuit against stale ids forever.
+        # Offloaded: the plausible reason the hop write failed is writer-lock
+        # contention, and retrying the same blocking SQLite write (busy_timeout
+        # up to 10s) on the event loop would stall the gateway loop.
+        await asyncio.to_thread(
+            _set_state, kstore, source_id, slug, content_hash,
+            list(committed_ids), title, kind=art.kind)
     sel().log_tool_invocation(
         session_key="gateway",
         agent="knowledge-artifacts",
         tool_name="knowledge.artifact_ingest",
         outcome="completed",
         resources=str(
-            {"slug": slug, "items": len(new_ids), "content_hash": content_hash[:16]}
+            {"slug": slug, "items": len(committed_ids),
+             "content_hash": content_hash[:16]}
         ),
     )
     return job_id

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -631,9 +631,6 @@ class IngestionPipeline:
         self.store.db.commit()
 
         # 5. Extract all chunks in batch via pool
-        # Capture existing items before ingestion (for safe partial-failure rollback)
-        _before_ids = {r["id"] for r in self.store.db.execute(
-            "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()}
         chunk_contents = [chunk['content'] for chunk in chunks]
         extractions = await self.extractor.extract_batch(chunk_contents)
 
@@ -714,11 +711,19 @@ class IngestionPipeline:
                 self.store.db.execute("UPDATE sources SET sync_status = 'synced' WHERE id = ?", (source_id,))
                 self.store.update_source(source_id, last_synced=now)
             elif processed < total:
-                # Partial failure: remove only items created during THIS ingestion call
-                after_ids = {r["id"] for r in self.store.db.execute(
-                    "SELECT id FROM items WHERE source_id = ?", (source_id,),
-                ).fetchall()}
-                self.store.delete_items_batch(list(after_ids - _before_ids))
+                # Partial failure: remove only items created during THIS ingestion
+                # call, taken from the write itself -- a before/after re-read of
+                # the source would also sweep anything a concurrent import_bundle
+                # committed into the same aggregate source while this ingest was
+                # awaiting. Deliberately NOT owner-scoped: these are chunks of an
+                # INCOMPLETE write, and a concurrent identical ingest whose
+                # duplicate gate attached to them mid-flight recorded the whole-
+                # document hash as satisfied -- detaching would leave it holding
+                # a truncated document that no rescan ever repairs (hash reads
+                # unchanged). Destroyed outright, its claim ends up naming an
+                # empty group, which the doc-state recovery paths treat as "re-
+                # attempt", so the next scan restores a complete copy.
+                self.store.delete_items_batch(list(created_item_ids))
                 self.store.db.execute("UPDATE sources SET sync_status = 'error' WHERE id = ?", (source_id,))
             self.store.db.execute(
                 "UPDATE ingestion_jobs SET status = ?, items_processed = ?, updated_at = ? WHERE id = ?",
@@ -804,15 +809,17 @@ class IngestionPipeline:
         chunks = await asyncio.to_thread(self.chunker.chunk, text)
         total = len(chunks)
 
-        # Snapshot items present before this call so a partial failure removes
-        # only what THIS call created -- never another item group that shares
-        # the same source_id (critical for the aggregate Artifacts source).
-        _before_ids = {r["id"] for r in self.store.db.execute(
-            "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()}
-
         chunk_contents = [chunk['content'] for chunk in chunks]
         extractions = await self.extractor.extract_batch(chunk_contents)
 
+        # What THIS call wrote, collected at the write itself rather than
+        # inferred from a before/after comparison of the source -- a snapshot
+        # diff would also attribute anything a concurrent writer (e.g.
+        # import_bundle) commits into the same aggregate source while this
+        # ingest is awaiting, handing this call delete authority over
+        # knowledge it never created (critical for the aggregate Artifacts
+        # source, where many item groups share one source_id).
+        created_item_ids: list[str] = []
         processed = 0
         for i, (chunk, extraction) in enumerate(zip(chunks, extractions)):
             try:
@@ -829,6 +836,10 @@ class IngestionPipeline:
                     summary=extraction.get('summary'),
                     content_hash=content_hash,
                 )
+                # Appended BEFORE add_source_location/_store_entities/_embed_item
+                # so a chunk that raises partway through is still captured for
+                # the partial-failure rollback (mirrors _ingest_file_body).
+                created_item_ids.append(item_id)
                 self.store.add_source_location(
                     item_id=item_id, source_id=source_id,
                     chunk_range=f"{chunk.get('line_start', 0)}-{chunk.get('line_end', 0)}",
@@ -867,11 +878,14 @@ class IngestionPipeline:
                 self.store.update_source(source_id, last_synced=now)
             elif processed < total:
                 # Partial failure: remove only items created during THIS call so we
-                # never delete another item group sharing this source_id.
-                after_ids = {r["id"] for r in self.store.db.execute(
-                    "SELECT id FROM items WHERE source_id = ?", (source_id,),
-                ).fetchall()}
-                self.store.delete_items_batch(list(after_ids - _before_ids))
+                # never delete another item group sharing this source_id. Taken
+                # from the write itself, not a before/after re-read of the source
+                # (which would misattribute concurrent writers' items).
+                # Deliberately NOT owner-scoped -- see _ingest_file_body: chunks
+                # of an incomplete write must be destroyed, not detached to a
+                # duplicate-gate attacher, or that attacher keeps a truncated
+                # document its unchanged hash never lets a rescan repair.
+                self.store.delete_items_batch(list(created_item_ids))
                 self.store.db.execute("UPDATE sources SET sync_status = 'error' WHERE id = ?", (source_id,))
             self.store.db.execute(
                 "UPDATE ingestion_jobs SET status = ?, items_total = ?, items_processed = ?, updated_at = ? WHERE id = ?",

--- a/test/test_knowledge_ingest_created_ids.py
+++ b/test/test_knowledge_ingest_created_ids.py
@@ -1,0 +1,392 @@
+"""Created-item ids come from the write, never a before/after source diff (#4431).
+
+Three ingestion sites used to learn "what this call wrote" by snapshotting the
+source's full item-id set before the work and diffing a second snapshot
+afterwards. Each snapshot was a ``SELECT id FROM items WHERE source_id = ?``
+materializing one row per item in the SOURCE (~20k rows on a large library,
+over a second of blocking SQLite), and the "before" read ran ON the asyncio
+event loop once per ingested file -- the same per-file loop stall PR #3397
+removed from the folder-scan caller.
+
+The diff was also WRONG, not just slow: ``import_bundle`` writes into the same
+aggregate source in its own transaction under no shared lock, so anything it
+committed while an ingest was awaiting got attributed to that ingest -- handing
+a document delete authority over knowledge it never created. Ids appended at
+``add_item`` (or reported through the pipeline's ``on_committed`` callback,
+which fires inside the finalize hop that commits them) cannot misattribute
+that way.
+
+This file ratchets the conversion for the three sites:
+  1. ``ingestion.py::_ingest_file_body`` -- partial-failure rollback uses
+     ``created_item_ids``.
+  2. ``ingestion.py::ingest_text`` -- same, with the collection newly added.
+  3. ``artifact_ingest.py::_ingest_artifact`` -- ``on_committed`` replaces the
+     before/after diff feeding ``_set_state``.
+
+The ``_old_item_ids`` reads that share the query TEXT but mean "the
+pre-existing item group this call must delete" are deliberately out of scope
+(no callback can supply them); the ratchet pins their count so a re-introduced
+snapshot still fails the test.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.artifacts import ArtifactStore
+from kiro_crew.knowledge import artifact_ingest
+from kiro_crew.knowledge.artifact_ingest import (
+    ensure_artifact_source,
+    ingest_artifact,
+)
+from kiro_crew.knowledge.ingestion import IngestionPipeline
+from kiro_crew.knowledge.readers import FileReader
+from kiro_crew.knowledge.store import KnowledgeStore
+
+_KNOWLEDGE_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "knowledge"
+
+# The retired snapshot's query text. The remaining occurrences pinned below are
+# the _old_item_ids reads: same text, different meaning (the PRIOR group this
+# call must delete -- not what it created), tracked separately from #4431.
+_SNAPSHOT_QUERY = "SELECT id FROM items WHERE source_id"
+
+
+def _two_chunks(text, **kw):
+    half = max(1, len(text) // 2)
+    return [
+        {
+            "content": text[:half],
+            "chunk_index": 0,
+            "section_title": None,
+            "line_start": 0,
+            "line_end": 0,
+        },
+        {
+            "content": text[half:],
+            "chunk_index": 1,
+            "section_title": None,
+            "line_start": 1,
+            "line_end": 1,
+        },
+    ]
+
+
+@pytest.fixture()
+def kstore(tmp_path):
+    s = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    yield s
+    s.close()
+
+
+def _extraction():
+    return {"category": "document", "summary": "s", "entities": []}
+
+
+@pytest.fixture()
+def pipeline(kstore):
+    """Pipeline with a two-chunk chunker so a partial failure is reachable."""
+    extractor = MagicMock()
+    extractor._pool = None
+    extractor.extract_batch = AsyncMock(return_value=[_extraction(), _extraction()])
+    chunker = MagicMock()
+    chunker.chunk.side_effect = _two_chunks
+    chunker.chunk_markdown.side_effect = _two_chunks
+    chunker.chunk_code.side_effect = _two_chunks
+    chunker.chunk_slides.side_effect = _two_chunks
+    return IngestionPipeline(
+        store=kstore,
+        extractor=extractor,
+        chunker=chunker,
+        reader=FileReader(),
+        embedder=None,
+    )
+
+
+def _item_ids(kstore, source_id):
+    return {
+        r["id"]
+        for r in kstore.db.execute(
+            "SELECT id FROM items WHERE source_id = ?", (source_id,)
+        ).fetchall()
+    }
+
+
+def _fail_second_embed(pipeline):
+    """Make the SECOND chunk's embed raise: both items are created (the append
+    happens right after add_item), processed stays 1 < total 2 -> the
+    partial-failure branch of _finalize runs."""
+    calls = {"n": 0}
+
+    async def _embed(item_id, *a, **kw):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise RuntimeError("boom: embed failed for chunk 2")
+
+    pipeline._embed_item = _embed
+
+
+def _inject_foreign_item_during_extract(pipeline, kstore, source_id):
+    """Land a foreign item in the same source WHILE the ingest is in flight.
+
+    The retired ``_before_ids`` snapshot was taken just before
+    ``extract_batch``, so an item committed inside it (as a concurrent
+    ``import_bundle`` would) landed strictly after the "before" read and was
+    misattributed to the ingest by the after-diff. With ids collected at the
+    write, it must survive the rollback.
+    """
+    foreign: dict[str, str] = {}
+
+    async def _extract(contents):
+        foreign["id"] = kstore.add_item(
+            "foreign", "committed by a concurrent writer", "document", source_id=source_id
+        )
+        return [_extraction() for _ in contents]
+
+    pipeline.extractor.extract_batch = AsyncMock(side_effect=_extract)
+    return foreign
+
+
+class TestIngestFilePartialFailureRollback:
+    """Site 1: _ingest_file_body's rollback deletes exactly what it created."""
+
+    @pytest.mark.asyncio
+    async def test_rollback_spares_foreign_and_preexisting_items(self, pipeline, kstore, tmp_path):
+        source_id = kstore.add_source("agg", "local_folder", str(tmp_path))
+        preexisting = kstore.add_item(
+            "other group", "another document's item", "document", source_id=source_id
+        )
+        foreign = _inject_foreign_item_during_extract(pipeline, kstore, source_id)
+        _fail_second_embed(pipeline)
+
+        f = tmp_path / "doc.md"
+        f.write_text("# heading\nbody text long enough to split", encoding="utf-8")
+        job_id = await pipeline.ingest_file(str(f), source_id=source_id, old_item_ids=[])
+
+        assert job_id is not None
+        status = (pipeline.get_job_status(job_id) or {}).get("status")
+        assert status != "completed"
+        remaining = _item_ids(kstore, source_id)
+        # Both survivors: the pre-existing sibling group AND the item a
+        # concurrent writer committed mid-ingest (the case the diff got wrong).
+        assert preexisting in remaining
+        assert foreign["id"] in remaining
+        # ... and nothing else: everything THIS call created was rolled back.
+        assert remaining == {preexisting, foreign["id"]}
+        row = kstore.db.execute(
+            "SELECT sync_status FROM sources WHERE id = ?", (source_id,)
+        ).fetchone()
+        assert row["sync_status"] == "error"
+
+
+class TestIngestTextPartialFailureRollback:
+    """Site 2: ingest_text now collects its ids and rolls back exactly those."""
+
+    @pytest.mark.asyncio
+    async def test_rollback_spares_foreign_and_preexisting_items(self, pipeline, kstore, tmp_path):
+        source_id = kstore.add_source("agg", "artifacts", "kc://artifacts")
+        preexisting = kstore.add_item(
+            "other group", "another artifact's item", "document", source_id=source_id
+        )
+        foreign = _inject_foreign_item_during_extract(pipeline, kstore, source_id)
+        _fail_second_embed(pipeline)
+
+        job_id = await pipeline.ingest_text(
+            "body text long enough to split into two chunks",
+            "Doc",
+            source_id=source_id,
+            old_item_ids=[],
+        )
+
+        assert job_id is not None
+        status = (pipeline.get_job_status(job_id) or {}).get("status")
+        assert status != "completed"
+        remaining = _item_ids(kstore, source_id)
+        assert preexisting in remaining
+        assert foreign["id"] in remaining
+        assert remaining == {preexisting, foreign["id"]}
+        row = kstore.db.execute(
+            "SELECT sync_status FROM sources WHERE id = ?", (source_id,)
+        ).fetchone()
+        assert row["sync_status"] == "error"
+
+
+class TestArtifactIngestRecordsPipelineIds:
+    """Site 3: _set_state records the ids the pipeline reported, non-empty."""
+
+    @pytest.fixture()
+    def one_chunk_pipeline(self, kstore):
+        extractor = MagicMock()
+        extractor._pool = None
+        extractor.extract_batch = AsyncMock(return_value=[_extraction()])
+
+        def _one(text, **kw):
+            return [
+                {
+                    "content": text,
+                    "chunk_index": 0,
+                    "section_title": None,
+                    "line_start": 0,
+                    "line_end": 0,
+                }
+            ]
+
+        chunker = MagicMock()
+        chunker.chunk.side_effect = _one
+        chunker.chunk_markdown.side_effect = _one
+        chunker.chunk_code.side_effect = _one
+        chunker.chunk_slides.side_effect = _one
+        return IngestionPipeline(
+            store=kstore,
+            extractor=extractor,
+            chunker=chunker,
+            reader=FileReader(),
+            embedder=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_completed_path_pins_nonempty_callback_ids(
+        self, one_chunk_pipeline, kstore, tmp_path, monkeypatch
+    ):
+        pipeline = one_chunk_pipeline
+        art_store = ArtifactStore(root=tmp_path / "artifacts")
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Notes", content="# H\nbody", kind="markdown")
+
+        # Spy on the callback wiring: record what the pipeline actually reports
+        # through on_committed, so the assertion pins "state == reported", not
+        # merely "state == whatever is in the table now".
+        reported: list[str] = []
+        real_ingest_file = pipeline.ingest_file
+
+        async def _spy(path, **kw):
+            inner = kw.get("on_committed")
+            assert inner is not None, (
+                "_ingest_artifact no longer passes on_committed to "
+                "ingest_file -- a completed ingest whose callback never fires "
+                "would write an EMPTY item list into _set_state, losing the "
+                "slug's claim/ownership record"
+            )
+
+            def _wrap(ids):
+                reported.extend(ids)
+                inner(ids)
+
+            kw["on_committed"] = _wrap
+            result = await real_ingest_file(path, **kw)
+            # Durability pin: the ownership row must already be persisted when
+            # ingest_file returns -- i.e. it was written INSIDE the finalize
+            # hop by the callback, not by the caller's post-ingest write. The
+            # awaits after this point (temp-file cleanup, job-status read) are
+            # cancellation points; a shutdown landing there must not leave
+            # committed items that no state row names.
+            _, hop_ids = artifact_ingest._get_state(kstore, sid, art.slug)
+            assert hop_ids == reported and hop_ids != [], (
+                "artifact ownership was not persisted inside the pipeline's "
+                "finalize hop -- a cancellation between ingest_file returning "
+                "and the caller's _set_state would orphan the committed group"
+            )
+            return result
+
+        pipeline.ingest_file = _spy
+
+        # Count _set_state calls: when the hop write succeeds it must be the
+        # ONLY write. An unconditional post-ingest re-write would race a
+        # concurrent dedup sweep in the awaits after the hop and resurrect an
+        # 'active' row with stale ids over the sweep's result.
+        set_state_calls: list[tuple] = []
+        real_set_state = artifact_ingest._set_state
+
+        def _counting_set_state(*a, **kw):
+            set_state_calls.append((a, kw))
+            return real_set_state(*a, **kw)
+
+        monkeypatch.setattr(artifact_ingest, "_set_state", _counting_set_state)
+
+        job = await ingest_artifact(
+            pipeline, art_store, art.slug, sid, {"markdown", "text", "html", "json"}
+        )
+
+        assert job is not None
+        assert (pipeline.get_job_status(job) or {}).get("status") == "completed"
+        # The completed path must never record an empty group: an empty list in
+        # _set_state loses the slug's ownership record while its items remain.
+        assert reported != []
+        _, state_ids = artifact_ingest._get_state(kstore, sid, art.slug)
+        assert sorted(state_ids) == sorted(reported)
+        assert set(state_ids) <= _item_ids(kstore, sid)
+        assert len(set_state_calls) == 1, (
+            "the post-ingest _set_state ran even though the finalize-hop write "
+            "succeeded -- that unconditional re-write can overwrite a concurrent "
+            "dedup's state row with stale ids"
+        )
+
+
+def _count_snapshot_literals(fn: ast.AST) -> list[int]:
+    """Line numbers of every string literal in *fn* (nested scopes included)
+    containing the retired snapshot query text."""
+    out = []
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and _SNAPSHOT_QUERY in node.value
+        ):
+            out.append(node.lineno)
+    return sorted(out)
+
+
+def _find_def(tree: ast.Module, name: str) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(
+        f"def {name} no longer exists -- this ratchet is guarding nothing and "
+        "must be repointed at whatever replaced it"
+    )
+
+
+class TestSnapshotQueryRatchet:
+    """The retired full-source id snapshot must not creep back in (#4431).
+
+    Counted per function, nested scopes included, so re-adding the read either
+    on the loop (function body) or inside the off-loop ``_finalize`` closure
+    trips the same assertion. Pinned as exact line lists, not booleans, so a
+    failure names the offending line.
+    """
+
+    def test_ingest_file_body_has_no_source_snapshot(self):
+        tree = ast.parse((_KNOWLEDGE_SRC / "ingestion.py").read_text(errors="replace"))
+        hits = _count_snapshot_literals(_find_def(tree, "_ingest_file_body"))
+        assert hits == [], (
+            f"_ingest_file_body reads the source's full item-id set again at "
+            f"lines {hits}. It must not: created_item_ids is collected at "
+            "add_item, and a before/after diff both blocks the loop (~20k rows "
+            "per read on a large source) and misattributes concurrent "
+            "import_bundle writes."
+        )
+
+    def test_ingest_text_keeps_only_the_old_group_reads(self):
+        tree = ast.parse((_KNOWLEDGE_SRC / "ingestion.py").read_text(errors="replace"))
+        hits = _count_snapshot_literals(_find_def(tree, "ingest_text"))
+        assert len(hits) == 2, (
+            f"ingest_text contains {len(hits)} '{_SNAPSHOT_QUERY}' literals at "
+            f"lines {hits}; exactly 2 are expected -- the _old_item_ids "
+            "resolution reads (the PRIOR group this call replaces, which no "
+            "callback can supply). More means the before/after created-ids "
+            "snapshot came back; fewer means the old-group reads moved and "
+            "this ratchet must be repointed."
+        )
+
+    def test_ingest_artifact_has_no_source_snapshot(self):
+        tree = ast.parse((_KNOWLEDGE_SRC / "artifact_ingest.py").read_text(errors="replace"))
+        hits = _count_snapshot_literals(_find_def(tree, "ingest_artifact"))
+        assert hits == [], (
+            f"ingest_artifact reads the source's full item-id set again at "
+            f"lines {hits}. It must not: the pipeline reports the created ids "
+            "through on_committed from inside the finalize hop that commits "
+            "them -- the same contract agent_source.py consumes."
+        )


### PR DESCRIPTION
## Problem / Motivation

Three knowledge-ingestion sites still derive "what this call wrote" by snapshotting the source's full item-id set before the work and diffing a second snapshot afterwards. Each snapshot is a `SELECT id FROM items WHERE source_id = ?` materializing one row per item in the SOURCE (~20k rows, over a second of blocking SQLite on a large library), and the "before" read runs ON the asyncio event loop, once per ingested file — the same per-file loop stall open PR #3397 removes from the folder-scan caller:

1. `ingestion.py::_ingest_file_body` — `_before_ids` captured on the loop, consumed only by the partial-failure branch of `_finalize`.
2. `ingestion.py::ingest_text` — same shape, and this function did not yet collect the ids it writes.
3. `artifact_ingest.py::ingest_artifact` — full before/after diff feeding `_set_state`, while the pipeline it calls already reports created ids through `on_committed` (the contract `agent_source.py` consumes today).

## Why it matters

Beyond the loop stall, the diff is **wrong**, not just slow: `import_bundle` writes into the same aggregate source in its own transaction under no shared lock, so anything it commits while an ingest is awaiting gets attributed to that ingest — handing a document delete authority over knowledge it never created. The comment at the site 1 collection already records this; sites 2 and 3 still had the defect.

## What changed (motivation → approach → change)

Ids are now collected at the write, never inferred from a source snapshot — the same conversion #3397 applies to the folder-scan caller, extended to the remaining three sites:

- **Site 1** (`_ingest_file_body`): deleted the `_before_ids` capture; the partial-failure branch passes `list(created_item_ids)` (already collected immediately after `add_item`, before `add_source_location`/`_store_entities`/`_embed_item`, so a chunk that raises partway is still captured) instead of `after_ids - _before_ids`, dropping the `after_ids` re-read too.
- **Site 2** (`ingest_text`): added `created_item_ids` collection mirroring site 1's ordering exactly; deleted the `_before_ids` capture and the `after_ids` re-read.
- **Site 3** (`ingest_artifact`): deleted both snapshot reads; the ids come from `pipeline.ingest_file(..., on_committed=_record_ownership)`, which fires inside the finalize hop only on the `processed == total` branch — the same branch that reports job status `completed`, which is the only path that consumes `new_ids`. The callback also persists `_set_state` there (GPT round-1 finding): the awaits between the pipeline's commit and the caller's own state write (temp-file cleanup, job-status read) are cancellation points, and a shutdown landing there would orphan the committed group; the write is fail-safe (a swallowed error defers to the caller's idempotent post-ingest write). The duplicate and partial/failed early returns are untouched.

**Strictly out of scope** (deliberately not widened): the `_old_item_ids` reads in `ingest_file`/`ingest_text` share the query text but mean "the pre-existing item group this call must delete" — no callback can supply them, and moving them off the loop changes the transactional shape of the delete. Filed as follow-up #4441. Also untouched: `folder_watcher.py` and `test/test_knowledge_ingest_scan_off_loop.py` (owned by open PR #3397 — this diff has zero file overlap with it), the `processed == total` success path and the duplicate gate. The partial-failure rollback calls deliberately do NOT pass `owner_source_id` (adjudicated across GPT rounds 2-3, which prescribed opposite fixes for this span): the rolled-back items are chunks of an INCOMPLETE write, and detaching them to a concurrent duplicate-gate attacher would leave that attacher holding a truncated document whose recorded whole-document hash reads as satisfied, so no rescan ever repairs it. Destroying them outright leaves the attacher's claim naming an empty group, which the doc-state recovery paths already treat as re-attempt. This matches the pre-existing rollback semantics (the old `after_ids - before_ids` delete was also unscoped). The success path's own `owner_source_id` usage is untouched.

## Tests

New `test/test_knowledge_ingest_created_ids.py` (all six fail on main before this change, pass after):

- **Sites 1 & 2 — rollback precision:** partial-failure ingest (second chunk's embed raises) with a pre-existing sibling item group AND a foreign item committed mid-ingest (injected inside `extract_batch`, i.e. after the point the old "before" snapshot was taken — the `import_bundle` misattribution case). Asserts the rollback deletes exactly what this call created: both foreign items survive, `sync_status` goes `error`. On main the mid-ingest foreign item is destroyed.
- **Ratchet — the snapshot query cannot creep back:** AST scan pinning occurrences of the `SELECT id FROM items WHERE source_id` literal per function (nested `_finalize` closures included, so re-adding the read on- or off-loop trips it): `_ingest_file_body` = 0, `ingest_artifact` = 0, `ingest_text` = exactly 2 (the out-of-scope `_old_item_ids` reads tracked by #4441 — the message tells the future fixer to repoint the ratchet). Counting occurrences, not timing, per the shape #3397 established.
- **Site 3 — state records what the pipeline reported:** a spy wraps `on_committed` and asserts `_set_state` stored exactly the reported ids, non-empty on the `completed` path (an empty list would silently lose the slug's claim/ownership record), and asserts `ingest_artifact` still passes `on_committed` at all.

Local gates: `isort` / `flake8` / `mypy` clean; full `pytest` 56640 passed, 296 skipped, 6 xfailed.

## Manual verification

N/A — unit coverage sufficient: the converted paths are exercised end-to-end through the real `IngestionPipeline` and SQLite store in the new tests, including the concurrent-writer interleaving.

## Related Issues

Closes #4431
Follow-up for the out-of-scope on-loop reads: #4441

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Tests added/updated for the change
- [x] Docs untouched — `docs/system-specs/modules/knowledge.md` already documents the collected-at-the-write contract this PR extends; no documented behavior changed


