### PR TITLE
test: fail review when a builtin takes a seeded third-party app's name

### DIFF
--- a/test/test_builtin_name_collision.py
+++ b/test/test_builtin_name_collision.py
@@ -1,0 +1,63 @@
+"""A builtin may not take a name the bundled seed already gives a third party.
+
+``list_registry`` deduplicates by NAME, and the order is fixed: official/seed
+entries enter first, then user-configured registries, and a later row whose name
+is already taken is skipped with no diagnostic. So the day a builtin is added
+under a name the seed already publishes for a third-party app, that third-party
+app stops appearing on every machine running the new wheel -- its author cannot
+see why, and the only remedy is another release.
+
+The seed (``app-registry.json``) is the right thing to compare against rather
+than the live catalog: a catalog ``git`` row is only kept when the seed or an
+external registry also names it, so the seed is the offline-complete list of
+third-party names that are actually installable, and reading it keeps this gate
+deterministic and network-free.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kiro_crew.apps import registry
+from kiro_crew.apps.discovery import _get_builtins_dir, discover_builtin_apps
+
+
+def _seed_third_party_names() -> set[str]:
+    """Names the bundled seed publishes, read straight from the shipped file."""
+    path: Path = registry._REGISTRY_FILE
+    assert path.is_file(), f"bundled seed missing at {path}"
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(rows, list), "bundled seed must be a JSON array"
+    return {r["name"] for r in rows if isinstance(r, dict) and isinstance(r.get("name"), str)}
+
+
+def _shipped_builtin_names() -> set[str]:
+    """Names this wheel's ``builtins/`` dir declares.
+
+    Deliberately NOT ``execution.builtin_app_names()``: that consults
+    ``installed.json`` to withdraw trust, so its answer depends on what the
+    machine running the test happens to have installed. A gate must read the
+    tree, not the desk.
+    """
+    return {
+        app["name"]
+        for app in discover_builtin_apps(_get_builtins_dir())
+        if isinstance(app.get("name"), str)
+    }
+
+
+def test_no_builtin_shadows_a_seeded_third_party_app() -> None:
+    builtins = _shipped_builtin_names()
+    seeded = _seed_third_party_names()
+    assert builtins, "no builtin apps discovered -- the gate would pass vacuously"
+    assert seeded, "no seed rows read -- the gate would pass vacuously"
+
+    collisions = sorted(builtins & seeded)
+    assert not collisions, (
+        f"builtin app name(s) {collisions} are already published to third parties by "
+        f"{registry._REGISTRY_FILE.name}. list_registry dedupes by name and the seed "
+        "wins, so shipping this would silently remove those apps from the store for "
+        "every user, with no message to their authors. Rename the builtin, or remove "
+        "the seed entry deliberately in the same change."
+    )


### PR DESCRIPTION
## The failure this makes impossible

`list_registry` deduplicates rows by **name**, with a fixed precedence:

```python
seen_names = {e.get("name") for e in entries}   # official catalog + seed already here
for e in external_entries:
    if name not in seen_names:                 # collide -> skipped
        entries.append(e)
```

Official and seed entries enter first. A later row whose name is already taken is
**skipped silently** — no error, no log line, no "an entry was hidden" notice.

So the day someone adds a builtin named `todo-ledger`, the third-party app of
that name **stops appearing in the store on every machine running the new
wheel**. Its author cannot see why: the row is simply gone. The remedy is another
release.

## Why nothing caught it

The catalog direction is already covered: KiroCrewApps' `tools/validate.py` errors
when one document declares a name twice, and the 20 builtins live in that same
document — so a third-party PR cannot squat a builtin's name.

The reverse direction — a **KiroCrew PR** introducing the collision — had no gate
at all. That is the half this adds.

| Path a name takes to an official surface | Reviewed where | Gate before | Gate now |
|---|---|---|---|
| Third party publishes, collides with a builtin | KiroCrewApps PR | `Counter(names)` error | unchanged |
| **Builtin added/renamed, collides with a published third party** | **KiroCrew PR** | **none** | **this test** |
| User's own registry collides | not reviewed (local config) | silent drop | still silent — see below |

## The check

The shipped `builtins/` names intersected with the bundled seed's names must be
empty.

**Why the seed and not the live catalog.** A catalog `git` row is kept only when
the seed or an external registry also names it, so the seed is the
offline-complete list of third-party names that are actually installable. Reading
a file also keeps the gate deterministic and network-free — a gate that needs the
network is a gate that goes red for reasons unrelated to the diff.

**Why `discover_builtin_apps()` and not `execution.builtin_app_names()`.** The
latter consults `installed.json` to *withdraw* trust, so its answer depends on
what the machine running the test happens to have installed. A gate must read the
tree, not the desk.

Both sides are asserted non-empty: a gate that reads nothing passes for the wrong
reason, and that failure mode is invisible.

## Verification

Mutation-verified — the gate is only evidence if it reddens for the right reason:

| Mutation | Result |
|---|---|
| rename a shipped builtin to `todo-ledger` | FAILS: `builtin app name(s) ['todo-ledger'] are already published to third parties by app-registry.json` |
| empty the seed | FAILS on the vacuous-pass guard |
| tree restored | green |

`black`, `isort`, `flake8`, `mypy` all clean on the new file.

## Deliberately out of scope

The third row of the table above: when a **user's own** registry collides, the
row is still dropped silently. That has no PR to gate, so it needs runtime
visibility instead — attributing each row to its registry and saying so when a
name is taken. That is a UI contract change and belongs in its own PR.

Related: [#4397](https://github.com/kirodotdev/KiroCrew/issues/4397) is the same
family — the server stamps `origin` by name too, so a row can contradict its own
provenance. Both come from treating a name as an identity across sources, which
it is not.
