### PR TITLE
test: fail CI when a builtin and the app registry claim the same name

### DIFF
--- a/test/test_builtin_name_collision.py
+++ b/test/test_builtin_name_collision.py
@@ -1,0 +1,71 @@
+"""A name may not be claimed by both a shipped builtin and the app registry.
+
+``list_registry`` deduplicates by NAME, and the precedence is fixed: builtin and
+seed entries enter first, then user-configured registries, and a later row whose
+name is already taken is skipped with **no diagnostic anywhere** -- no error, no
+log line, no "an entry was hidden" notice.
+
+So the moment an app is added under a name the other side already claims, the
+losing entry stops appearing in the store on every machine running that wheel.
+Its author cannot see why, and the only remedy is another release. This must fail
+in review, while it is still one line in a diff, rather than after it ships.
+
+The check is a set intersection, so it catches the collision from EITHER
+direction: an app added to the registry under a builtin's name, or a builtin
+renamed onto a name the registry already publishes.
+
+The seed (``app-registry.json``) is the right thing to compare against rather
+than the live catalog: a catalog ``git`` row is only kept when the seed or an
+external registry also names it, so the seed is the offline-complete list of
+third-party names that are actually installable, and reading it keeps this gate
+deterministic and network-free.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kiro_crew.apps import registry
+from kiro_crew.apps.discovery import _get_builtins_dir, discover_builtin_apps
+
+
+def _seed_third_party_names() -> set[str]:
+    """Names the bundled seed publishes, read straight from the shipped file."""
+    path: Path = registry._REGISTRY_FILE
+    assert path.is_file(), f"bundled seed missing at {path}"
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(rows, list), "bundled seed must be a JSON array"
+    return {r["name"] for r in rows if isinstance(r, dict) and isinstance(r.get("name"), str)}
+
+
+def _shipped_builtin_names() -> set[str]:
+    """Names this wheel's ``builtins/`` dir declares.
+
+    Deliberately NOT ``execution.builtin_app_names()``: that consults
+    ``installed.json`` to withdraw trust, so its answer depends on what the
+    machine running the test happens to have installed. A gate must read the
+    tree, not the desk.
+    """
+    return {
+        app["name"]
+        for app in discover_builtin_apps(_get_builtins_dir())
+        if isinstance(app.get("name"), str)
+    }
+
+
+def test_builtin_and_registry_names_never_collide() -> None:
+    builtins = _shipped_builtin_names()
+    seeded = _seed_third_party_names()
+    assert builtins, "no builtin apps discovered -- the gate would pass vacuously"
+    assert seeded, "no seed rows read -- the gate would pass vacuously"
+
+    collisions = sorted(builtins & seeded)
+    assert not collisions, (
+        f"name(s) {collisions} are claimed BOTH by a shipped builtin and by "
+        f"{registry._REGISTRY_FILE.name}. Whichever side this change added, the result "
+        "is the same: list_registry dedupes by name, the builtin/seed side wins, and "
+        "the losing entry vanishes from the store on every machine with no error, no "
+        "log line, and no notice to its author. Pick a different name, or remove the "
+        "other claim deliberately in this same change."
+    )


### PR DESCRIPTION
## The failure this turns red

`list_registry` deduplicates rows by **name**, with a fixed precedence:

```python
seen_names = {e.get("name") for e in entries}   # builtin + seed already here
for e in external_entries:
    if name not in seen_names:                 # collide -> skipped
        entries.append(e)
```

The loser is skipped **silently** — no error, no log line, no "an entry was
hidden" notice.

So the moment an app is added under a name the other side already claims, the
losing entry **stops appearing in the store on every machine running that wheel**.
Its author cannot see why. The only remedy is another release.

That is a one-line diff producing an invisible, release-gated outage for someone
else's app — and nothing in review was looking at it. This makes CI red instead.

## One assertion, both directions

The check is a set intersection of the shipped `builtins/` names and the seed's
names, so a single assertion covers however the collision arrives:

| What the diff does | Caught |
|---|---|
| adds an app to `app-registry.json` under a builtin's name | ✅ |
| renames a builtin onto a name the registry already publishes | ✅ |

The failure text names the colliding entries and does **not** presume which side
the diff touched — it says the name is claimed by both and that whichever side was
added, the losing row disappears.

## Two choices worth stating

**Seed, not the live catalog.** A catalog `git` row is kept only when the seed or
an external registry also names it, so the seed is the offline-complete list of
third-party names that are actually installable. Reading a file also keeps this
gate deterministic — a gate that needs the network goes red for reasons unrelated
to the diff.

**`discover_builtin_apps()`, not `execution.builtin_app_names()`.** The latter
consults `installed.json` to *withdraw* trust, so its answer depends on what the
machine running the test happens to have installed. A gate must read the tree, not
the desk.

Both sides are asserted non-empty: a gate that reads nothing passes for the wrong
reason, and that failure mode is invisible.

## Verification

Mutation-verified in **both** directions — an unproven direction is not a verified
one:

| Mutation | Result |
|---|---|
| add `meetings` to the seed | FAILS: `name(s) ['meetings'] are claimed BOTH by a shipped builtin and by app-registry.json` |
| add `papyrus` to the seed | FAILS by name |
| rename a shipped builtin to `todo-ledger` | FAILS by name |
| empty either side | FAILS on the vacuous-pass guard |
| tree restored | green |

`black`, `isort`, `flake8`, `mypy` clean on the new file.

## What this does not cover

A collision between two **user-added** registries, which is not a diff and has no
PR to gate — today the config order silently decides. That needs runtime
visibility (attribute each row to its registry, say so when a name is taken) and
belongs in its own change.

Related: [#4397](https://github.com/kirodotdev/KiroCrew/issues/4397) — the server
also stamps `origin` by name, so a row can contradict its own provenance. Same
root: a name is being treated as an identity across sources, which it is not.
