### PR TITLE
fix(chat): pin the nudge that opened the turn so the jump stays one turn away

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -144,7 +144,7 @@ import { loadFileDrafts, saveFileDrafts as persistFileDrafts, setFileDraft } fro
 import { loadPasteDrafts, savePasteDrafts as persistPasteDrafts, setPasteDraft } from '../utils/chatPasteDrafts'
 import { loadSessionRefDrafts, saveSessionRefDrafts as persistSessionRefDrafts, setSessionRefDraft } from '../utils/chatSessionRefDrafts'
 import { addSessionRef, removeSessionRef, mergeSessionRefs, appendSessionRefLinks, type SessionRef } from '../utils/sessionRefs'
-import { findPinnedPromptIdx, findNextPromptIdx, computePinPush, promptPreview, promptImages, promptBody, pinHandoffY, pinPushTravel, DEFAULT_PINNED_CARD_H } from '../utils/pinnedPrompt'
+import { findPinnedPromptIdx, findNextPromptIdx, computePinPush, promptPreview, promptImages, promptBody, pinHandoffY, pinPushTravel, jumpAnchorIdx, DEFAULT_PINNED_CARD_H } from '../utils/pinnedPrompt'
 import {
   adoptSourceSelections,
   commitRevealedSource,
@@ -206,6 +206,9 @@ import { rewindWithRollback } from '../lib/rewindCall'
 
 
 import { i18nT } from '../i18n/t'
+import { parseNudgeMessage, nudgeLabel } from './chat/NudgeCard'
+import { parseSubagentCompletionMessage } from './chat/subagentCompletion'
+import { headline as subagentHeadline } from './chat/SubagentCompletionCard'
 import { fmtDateFields } from '../i18n/format'
 import { fmtMessageTime, fmtMessageTimeFull } from './chat/messageTime'
 /**
@@ -3047,7 +3050,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const pinFoldRef = useRef<HTMLDivElement | null>(null)
   const pinCardRef = useRef<HTMLDivElement | null>(null)
   const pinEnabledRef = useRef(true)
-  const [pinned, setPinned] = useState<{ idx: number; ts?: string; text: string; raw: string; full: string; images: string[]; push: number; bannerH: number } | null>(null)
+  const [pinned, setPinned] = useState<{ idx: number; ts?: string; text: string; raw: string; full: string; images: string[]; bodyBeyondPreview: boolean; push: number; bannerH: number } | null>(null)
   const [pinExpanded, setPinExpanded] = useState(false)
   // Collapsed card height — the hand-off line is derived from it, so it must be
   // known even while nothing is pinned (no card mounted to measure). Seeded with
@@ -3116,7 +3119,24 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // and browser zoom — a bubble fragment parked over the prompt being read.
     if (push >= pinPushTravel(bannerH)) { setPinned(null); return }
     const full = pinItem.msg.content
-    const text = promptPreview(full)
+    // A nudge's content is a machine-facing instruction payload behind an
+    // `[auto-nudge cycle N]` tag, and a subagent completion's is a header block
+    // plus digest. Quoting either verbatim would park kilobytes of machine text
+    // over the transcript, so both reuse the compact label their transcript card
+    // already shows and keep the body for the expanded state.
+    const nudge = pinItem.msg.role === 'nudge' ? parseNudgeMessage(pinItem.msg) : null
+    // Detected by PARSING, not by role: the same completion event reaches the
+    // transcript under `subagent`, `assistant` (delivery-timeout variant) and
+    // `user` (older scrollback), and the parser already tolerates all three.
+    // Matching on the role here would both miss those variants and duplicate
+    // dispatch knowledge this file has no business holding.
+    const sub = nudge ? null : parseSubagentCompletionMessage(pinItem.msg)
+    const machineLabel = nudge
+      ? nudgeLabel(nudge.cycle)
+      : sub
+        ? subagentHeadline(sub)
+        : null
+    const text = machineLabel ?? promptPreview(full)
     // Compare the RAW content (`prev.raw`), not `text` or the derived body:
     // `text`, `full` and `images` are all derived from it, and an edit-and-resend
     // that changes ONLY an attached image leaves the flattened preview text
@@ -3127,7 +3147,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     setPinned(prev => (prev && prev.idx === pinIdx && prev.push === push
       && prev.raw === full && prev.bannerH === bannerH && prev.ts === pinItem.msg.ts)
       ? prev
-      : { idx: pinIdx, ts: pinItem.msg.ts, text, raw: full, full: promptBody(full), images: promptImages(full), push, bannerH })
+      : { idx: pinIdx, ts: pinItem.msg.ts, text, raw: full, full: nudge ? nudge.body : (sub ? full : promptBody(full)), images: machineLabel ? [] : promptImages(full), bodyBeyondPreview: !!machineLabel, push, bannerH })
   }, [scrollerRef])
   // rAF-throttle the per-scroll recompute: updatePinnedPrompt does a
   // querySelectorAll + getBoundingClientRect loop (a forced layout read), and a
@@ -3179,12 +3199,19 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     const chrome = pinnedJumpChrome()
     cancelAnimationFrame(navScrollRafRef.current)
     navPollCancelRef.current?.()
-    const jumpedFar = mountIndexRef.current(target)
+    // Consecutive user rows (a steer follows its prompt directly): landing the
+    // clicked prompt at the chrome would leave the prompt above it straddling
+    // the hand-off line — unpinnable, while its top edge has already pushed the
+    // fallback banner fully out — so the banner unmounts and the chain dies.
+    // Anchor at the head of the run instead: the clicked prompt stays visible
+    // just below, and a non-prompt row takes the straddle.
+    const anchor = jumpAnchorIdx(displayItemsRef.current, target)
+    const jumpedFar = mountIndexRef.current(anchor)
     if (jumpedFar) {
       // Far target: the window was REPLACED, the path between is unmounted
       // spacer — a glide would scrub blank. Teleport via the convergence
       // path, same as every other far jump.
-      navToDisplayIndex(target, { behavior: 'auto', align: 'start', offset: -chrome })
+      navToDisplayIndex(anchor, { behavior: 'auto', align: 'start', offset: -chrome })
       return
     }
     // NEAR jump — the common case: the pinned prompt is the previous turn.
@@ -3198,7 +3225,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // teleport. A user scroll or a newer navigation aborts the wait.
     window.dispatchEvent(new Event('mc-chat-scroll-jump'))
     const rowEl = (): HTMLElement | null =>
-      (scrollerRef.current?.querySelector(`[data-display-index="${target}"]`) as HTMLElement | null)
+      (scrollerRef.current?.querySelector(`[data-display-index="${anchor}"]`) as HTMLElement | null)
     let lastH: number | null = null
     let stable = 0
     let frames = 0
@@ -6480,6 +6507,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                   text={pinned.text}
                   fullText={pinned.full}
                   images={pinned.images}
+                  bodyBeyondPreview={pinned.bodyBeyondPreview}
                   pushUp={pinned.push}
                   bannerH={pinned.bannerH}
                   expanded={pinExpanded}

--- a/website/src/pages/chat/NudgeCard.tsx
+++ b/website/src/pages/chat/NudgeCard.tsx
@@ -39,6 +39,19 @@ export function parseNudgeMessage(
 }
 
 /**
+ * The chip's one-line label for a nudge turn.
+ *
+ * Exported because the pinned-prompt banner shows the same label for a pinned
+ * nudge: two spellings of this ternary over the same two keys would drift the
+ * moment the chip's wording changes.
+ */
+export function nudgeLabel(cycle: number | null): string {
+  return cycle !== null
+    ? i18nT('pages.chat.nudgeCard.auto_nudge_cycle', { count: cycle })
+    : i18nT('pages.chat.nudgeCard.auto_nudge')
+}
+
+/**
  * True when this nudge row belongs to the loop that is currently active.
  *
  * The Loop button opens the popover for whatever loop is bound to the slot
@@ -73,7 +86,7 @@ export default memo(function NudgeCard({
   const [expanded, setExpanded] = useRowDisclosure(disclosureKey, false)
   const { cycle, body } = parseNudgeMessage(message)
   const firstLine = body.split('\n').find(l => l.trim().length > 0)?.trim() ?? ''
-  const label = cycle !== null ? i18nT('pages.chat.nudgeCard.auto_nudge_cycle', { count: cycle }) : i18nT('pages.chat.nudgeCard.auto_nudge')
+  const label = nudgeLabel(cycle)
 
   return (
     <div

--- a/website/src/pages/chat/PinnedPrompt.tsx
+++ b/website/src/pages/chat/PinnedPrompt.tsx
@@ -14,6 +14,16 @@ interface PinnedPromptProps {
    * whole content was an image pins as an empty card.
    */
   images: string[]
+  /**
+   * True when `fullText` carries content the preview cannot show at all, so the
+   * expand affordance must mount regardless of clamping.
+   *
+   * A pinned nudge is the case: its preview is a short "cycle N" label that never
+   * clamps and it has no images, so neither of the gates below would fire and the
+   * instruction body would be unreachable — the same dead end images already have
+   * an exemption for.
+   */
+  bodyBeyondPreview?: boolean
   /** px to translate up so the incoming prompt pushes this banner out of view. */
   pushUp: number
   /** Measured card height, used to shrink the backing band as the card is pushed. */
@@ -97,7 +107,7 @@ const MORPH_EASE = 'cubic-bezier(0.2,0,0,1)'
  *     image used to pin as a blank card.
  */
 export default function PinnedPrompt({
-  text, fullText, images, pushUp, bannerH, expanded, onToggleExpanded, onJump, cardRef, onCollapsedHeight,
+  text, fullText, images, bodyBeyondPreview, pushUp, bannerH, expanded, onToggleExpanded, onJump, cardRef, onCollapsedHeight,
 }: PinnedPromptProps) {
   const textRef = useRef<HTMLParagraphElement | null>(null)
   const boxRef = useRef<HTMLDivElement | null>(null)
@@ -201,7 +211,7 @@ export default function PinnedPrompt({
   // exists to preserve. Widening the box is not a concern in that case: parity with
   // the bubble is already unattainable for a prompt whose bubble is a full-size
   // image, and a clamped prompt has by definition already hit its max width.
-  const showChevron = clamped || images.length > 0 || expanded
+  const showChevron = clamped || images.length > 0 || bodyBeyondPreview || expanded
 
   return (
     <div

--- a/website/src/pages/chat/SubagentCompletionCard.tsx
+++ b/website/src/pages/chat/SubagentCompletionCard.tsx
@@ -34,7 +34,7 @@ function outcomeLabel(outcome: SubagentOutcome): string {
 }
 
 /** Headline for the card: what happened, in the user's language. */
-function headline(parsed: ParsedSubagentCompletion): string {
+export function headline(parsed: ParsedSubagentCompletion): string {
   if (parsed.kind === 'single') {
     // The cap keeps one long task from pushing the chips and controls off the
     // row. CSS `truncate` cannot supply the cue here — it only fires when the

--- a/website/src/pages/chat/groupDisplayItems.ts
+++ b/website/src/pages/chat/groupDisplayItems.ts
@@ -8,6 +8,18 @@ import { isSubagentCompletionMessage } from './subagentCompletion'
  *  collapsible would bury and mislabel it. */
 export const GROUPABLE = new Set(['permission'])
 
+/**
+ * Roles that OPEN a turn, and are therefore the rows a reader can be anchored to.
+ *
+ * `nudge` and `subagent` are machine-injected but they ARE the thing that started
+ * the turn below them, so a reader looking for "what am I inside" needs them. This
+ * set is exported because the pinned-prompt scan has to agree with the grouping
+ * exactly: when the two lists were maintained by hand they drifted, and a role
+ * that opened a turn without being pinnable made the pin scan walk past every one
+ * of them — measured at a 61-display-row gap in a loop-driven session.
+ */
+export const TURN_OPENER_ROLES = new Set(['user', 'nudge', 'subagent'])
+
 export interface GroupedTurns {
   turns: DisplayItem[]
   /** Index into `turns` of the turn object produced by the TRAILING flush, or
@@ -82,7 +94,7 @@ export function groupDisplayItems(messages: ChatMessage[]): GroupedTurns {
     // collapsed step group and the cycle chip disappears. A sub-agent
     // completion is the same case: the gateway injects it as the next turn's
     // input, so the agent's reply belongs BELOW the card, not beside it.
-    if (item.kind === 'single' && (item.msg.role === 'user' || item.msg.role === 'nudge' || item.msg.role === 'subagent')) {
+    if (item.kind === 'single' && TURN_OPENER_ROLES.has(item.msg.role)) {
       if (turnItems.length > 0) { flushTurn(turnItems, true); turnItems = [] }
       // Track whether this subagent completion has synthesis pending
       _lastSubagentHadSynthesis = item.msg.role === 'subagent' &&

--- a/website/src/test/PinnedPrompt.nudgeExpand.test.tsx
+++ b/website/src/test/PinnedPrompt.nudgeExpand.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import PinnedPrompt from '../pages/chat/PinnedPrompt'
+
+// A pinned nudge shows a short "cycle N" label and carries no images, so neither
+// the clamp gate nor the image gate fires. Without an explicit flag the expand
+// affordance never mounts and the instruction body it was handed is unreachable.
+function renderBanner(over: Partial<Parameters<typeof PinnedPrompt>[0]> = {}) {
+  return render(
+    <PinnedPrompt
+      text="Auto-nudge · cycle 17"
+      fullText="Babysit PR #4449. Check CI and review comments…"
+      images={[]}
+      pushUp={0}
+      bannerH={40}
+      expanded={false}
+      onToggleExpanded={() => {}}
+      onJump={() => {}}
+      onCollapsedHeight={() => {}}
+      {...over}
+    />,
+  )
+}
+
+describe('PinnedPrompt expand affordance', () => {
+  it('mounts the chevron for a body the preview cannot show', () => {
+    renderBanner({ bodyBeyondPreview: true })
+    expect(screen.getByLabelText(/expand/i)).toBeTruthy()
+  })
+
+  it('omits the chevron when the preview already shows everything', () => {
+    renderBanner({ bodyBeyondPreview: false })
+    expect(screen.queryByLabelText(/expand/i)).toBeNull()
+  })
+
+  it('reveals the body once expanded', () => {
+    renderBanner({ bodyBeyondPreview: true, expanded: true })
+    expect(screen.getByText(/Babysit PR #4449/)).toBeTruthy()
+  })
+
+  it('calls onToggleExpanded when the chevron is pressed', () => {
+    const onToggleExpanded = vi.fn()
+    renderBanner({ bodyBeyondPreview: true, onToggleExpanded })
+    screen.getByLabelText(/expand/i).click()
+    expect(onToggleExpanded).toHaveBeenCalledTimes(1)
+  })
+})

--- a/website/src/test/pinnedPrompt.jumpAnchor.test.ts
+++ b/website/src/test/pinnedPrompt.jumpAnchor.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { jumpAnchorIdx } from '../utils/pinnedPrompt'
+import type { DisplayItem } from '../pages/chat/groupDisplayItems'
+
+// Minimal display items: only kind and msg.role are read by the helper.
+const user = (): DisplayItem => ({ kind: 'single', msg: { role: 'user', content: 'q' } } as unknown as DisplayItem)
+const steer = (): DisplayItem => ({ kind: 'single', msg: { role: 'user', content: 's', meta: { steer: true } } } as unknown as DisplayItem)
+const asst = (): DisplayItem => ({ kind: 'single', msg: { role: 'assistant', content: 'a' } } as unknown as DisplayItem)
+const turn = (): DisplayItem => ({ kind: 'turn', items: [] } as unknown as DisplayItem)
+
+describe('jumpAnchorIdx', () => {
+  it('returns the target itself when a non-prompt row precedes it', () => {
+    const items = [user(), asst(), user()]
+    expect(jumpAnchorIdx(items, 2)).toBe(2)
+  })
+
+  it('walks to the head of a consecutive prompt run (steer after its prompt)', () => {
+    // question(1) + steer(2) back to back: jumping to the steer must anchor at
+    // the question, otherwise the question straddles the hand-off line after
+    // landing and the banner unmounts (dead jump chain).
+    const items = [asst(), user(), steer(), asst()]
+    expect(jumpAnchorIdx(items, 2)).toBe(1)
+  })
+
+  it('walks across multiple consecutive user rows', () => {
+    const items = [turn(), user(), user(), steer()]
+    expect(jumpAnchorIdx(items, 3)).toBe(1)
+  })
+
+  it('stops at index 0 when the run reaches the top of the list', () => {
+    const items = [user(), steer()]
+    expect(jumpAnchorIdx(items, 1)).toBe(0)
+  })
+
+  it('does not treat a turn group above the target as part of the run', () => {
+    const items = [user(), turn(), user()]
+    expect(jumpAnchorIdx(items, 2)).toBe(2)
+  })
+})

--- a/website/src/test/pinnedPrompt.nudgeSession.test.ts
+++ b/website/src/test/pinnedPrompt.nudgeSession.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { groupDisplayItems, applyRunningState, TURN_OPENER_ROLES } from '../pages/chat/groupDisplayItems'
+import { findPinnedPromptIdx } from '../utils/pinnedPrompt'
+import { isSubagentCompletionMessage } from '../pages/chat/subagentCompletion'
+import type { ChatMessage } from '../types'
+
+// Reproduces the transcript shape a babysit/monitor loop produces: a few typed
+// turns, then many auto-nudge cycles, each opening its own turn.
+function nudgeSession(cycles: number): ChatMessage[] {
+  const out: ChatMessage[] = []
+  const push = (role: string, content: string, meta?: Record<string, unknown>) =>
+    out.push({ role, content, ts: '2026-08-18T05:00:00Z', meta } as unknown as ChatMessage)
+
+  push('user', 'the last thing the human actually typed')
+  push('assistant', 'reply')
+  for (let c = 1; c <= cycles; c++) {
+    push('nudge', `[auto-nudge cycle ${c}]\nBabysit PR #4378 …`, { nudge: { cycle: c, loop_id: 'l1' } })
+    push('tool', `Health check ${c}`)
+    push('assistant', `cycle ${c} report`)
+  }
+  return out
+}
+
+describe('pinned prompt in a nudge-driven session', () => {
+  it('pins the nudge that opened the turn being read, not a prompt many cycles above', () => {
+    const items = applyRunningState(groupDisplayItems(nudgeSession(20)), false)
+
+    // Read position: the last row of the transcript (inside the final cycle).
+    const handoffIdx = items.length - 1
+    const pinIdx = findPinnedPromptIdx(items, handoffIdx)
+    expect(pinIdx).toBeGreaterThanOrEqual(0)
+
+    // The pinned row must be the nearest turn opener above the read position.
+    // Skipping every nudge makes the banner point at the human's last typed
+    // message — dozens of turns and tens of thousands of pixels away — which is
+    // what makes the jump read as "teleported to the top".
+    const gap = handoffIdx - pinIdx
+    expect(gap).toBeLessThan(8)
+  })
+
+  it('the pinned row is a turn opener', () => {
+    const items = applyRunningState(groupDisplayItems(nudgeSession(20)), false)
+    const pinIdx = findPinnedPromptIdx(items, items.length - 1)
+    const item = items[pinIdx]
+    expect(item.kind).toBe('single')
+    if (item.kind === 'single') {
+      expect(TURN_OPENER_ROLES.has(item.msg.role)).toBe(true)
+    }
+  })
+
+  // A workflow fan-out is the long-transcript twin of a babysit loop: subagent
+  // completions open turns the same way nudges do, so excluding them would
+  // reproduce the identical gap.
+  it('pins a subagent completion that opened the turn being read', () => {
+    const out: ChatMessage[] = []
+    const push = (role: string, content: string, meta?: Record<string, unknown>) =>
+      out.push({ role, content, ts: '2026-08-18T05:00:00Z', meta } as unknown as ChatMessage)
+    push('user', 'the last thing the human actually typed')
+    push('assistant', 'reply')
+    for (let c = 1; c <= 12; c++) {
+      push('subagent', `[Subagent completion event] agent-${c}\n\nfindings for ${c}`,
+        { subagentCompletion: { kind: 'single', agentId: `agent-${c}`, outcome: 'ok', task: `task ${c}` } })
+      push('assistant', `synthesis ${c}`)
+    }
+    expect(out.filter(m => isSubagentCompletionMessage(m)).length).toBe(12)
+    const items = applyRunningState(groupDisplayItems(out), false)
+    const handoffIdx = items.length - 1
+    const pinIdx = findPinnedPromptIdx(items, handoffIdx)
+    // Assert IDENTITY, not distance: with subagent excluded the transcript
+    // collapses into few display items, so a gap threshold stays satisfied while
+    // the banner silently points at the human's first message instead.
+    const pinItem = items[pinIdx]
+    expect(pinItem.kind).toBe('single')
+    if (pinItem.kind === 'single') {
+      expect(pinItem.msg.role).toBe('subagent')
+      expect(pinItem.msg.content).toContain('agent-12')
+    }
+  })
+
+  it('the pin scan and the grouping agree on the turn-opener roles', () => {
+    // Single-sourced on purpose: a role that opens a turn without being pinnable
+    // is exactly the drift that produced the 61-row gap. Each role needs a row
+    // the grouping actually emits — a `subagent` row that is not a completion is
+    // dropped before it becomes a display item, so it opens nothing.
+    const validRow = (role: string): ChatMessage => role === 'subagent'
+      ? ({ role, content: '[Subagent completion event] agent-1\n\nfindings', ts: 't',
+           meta: { subagentCompletion: { kind: 'single', agentId: 'agent-1', outcome: 'ok', task: 'task' } } } as unknown as ChatMessage)
+      : ({ role, content: 'opener', ts: 't' } as unknown as ChatMessage)
+
+    for (const role of TURN_OPENER_ROLES) {
+      const opener = validRow(role)
+      if (role === 'subagent') expect(isSubagentCompletionMessage(opener)).toBe(true)
+      const items = applyRunningState(groupDisplayItems([
+        opener,
+        { role: 'assistant', content: 'body', ts: 't' } as unknown as ChatMessage,
+      ]), false)
+      const pinIdx = findPinnedPromptIdx(items, items.length - 1)
+      expect(pinIdx, `role ${role} opens a turn but is not pinnable`).toBeGreaterThanOrEqual(0)
+    }
+  })
+})

--- a/website/src/utils/pinnedPrompt.ts
+++ b/website/src/utils/pinnedPrompt.ts
@@ -1,4 +1,5 @@
 import type { DisplayItem } from '../pages/chat/types'
+import { TURN_OPENER_ROLES } from '../pages/chat/groupDisplayItems'
 import { mdImageDestToPath } from './fileTokens'
 
 /**
@@ -57,9 +58,19 @@ export function pinHandoffY(foldY: number, collapsedCardH: number): number {
   return foldY + ROW_PAD_Y * 2 + collapsedCardH
 }
 
-/** Only user-typed prompts pin. `nudge` opens a turn too but is machine-injected. */
+/**
+ * Rows that can take the pin: the ones that OPEN a turn.
+ *
+ * Derived from `TURN_OPENER_ROLES` rather than restated, because the two lists
+ * disagreeing is the defect this exists to prevent. A nudge and a subagent
+ * completion are machine-injected, but each IS the thing that started the turn
+ * being read, and a session made almost entirely of them (a babysit loop, a
+ * workflow fan-out) otherwise offers no pinnable row cycle after cycle — the walk
+ * upward skips every one and lands on the human's last typed message, dozens of
+ * turns and tens of thousands of pixels away.
+ */
 function isPrompt(item: DisplayItem | undefined): boolean {
-  return !!item && item.kind === 'single' && item.msg.role === 'user'
+  return !!item && item.kind === 'single' && TURN_OPENER_ROLES.has(item.msg.role)
 }
 
 /**
@@ -90,6 +101,27 @@ export function findNextPromptIdx(items: DisplayItem[], afterIdx: number): numbe
     if (isPrompt(items[i])) return i
   }
   return -1
+}
+
+/**
+ * Display index of the row the pinned-prompt jump should scroll to when the
+ * user asks for `target`.
+ *
+ * Normally that is `target` itself. But when the rows immediately BEFORE the
+ * target are also prompts (consecutive user rows — a steer message follows its
+ * prompt with no assistant row between), landing the target at the jump chrome
+ * leaves the previous prompt straddling the hand-off line: it cannot pin (its
+ * bottom is still below the line) while its own top edge has already pushed the
+ * fallback banner fully out — so the banner unmounts and the jump chain dies on
+ * a landing the scan treats as a transient. Anchoring the jump at the FIRST
+ * prompt of the consecutive run puts a non-prompt row (or nothing) on the line
+ * instead, so the previous turn's banner survives and the chain continues. For
+ * a target with a non-prompt row above it this returns `target` unchanged.
+ */
+export function jumpAnchorIdx(items: DisplayItem[], target: number): number {
+  let anchor = target
+  while (anchor > 0 && isPrompt(items[anchor - 1])) anchor -= 1
+  return anchor
 }
 
 /**


### PR DESCRIPTION
## Problem / Motivation

In a session driven by a monitor/babysit loop, the pinned-prompt banner's jump is
broken in three ways the reporter hit repeatedly:

- clicking it teleports to the top of the transcript with no scroll animation;
- clicking again does nothing at all;
- sometimes it moves only a few hundred pixels and stops.

## Why it matters

The banner exists to walk back through a long transcript one turn at a time. A
babysit/monitor session is the longest transcript the product produces — and it is
exactly the case where the affordance fails, so the feature is unusable in the
sessions that need it most.

## What changed (motivation → approach → change)

`autonudge` persists its injected message with `role="nudge"`
(`src/kiro_crew/slack/gateway.py`, `slot.append("nudge", …)`).
`groupDisplayItems` treats a nudge as a turn opener, exactly like a user message,
but `isPrompt` accepted only `role === 'user'`. A session made of nudge cycles
therefore offers no pinnable row cycle after cycle, so the walk upward skips every
one of them and lands on the human's last typed message.

Measured on a 20-cycle transcript: the pinned row sits **61 display rows** above
the read position. That single index gap produces all three symptoms — the
distance trips the far-jump path (an instant teleport, which reads as jumping to
the top), the re-pin after landing picks the same far row (so the next click
appears dead), and a distance under the far threshold cannot finish inside the
glide's duration (so it stops partway).

Both predicates now derive from one exported `TURN_OPENER_ROLES` set in
`groupDisplayItems.ts`, so the pin is the nearest turn opener and the jump is one
turn away — and *these two* can no longer disagree.

Scope of that claim, stated precisely: a third hand-spelled copy of the same
turn-opener decision lives in `website/src/app-sdk/ChatMessageList.tsx` and has
already drifted (it lists `user | subagent` and never gained `nudge`). It is NOT
fixed here. Deriving it from the shared set would change turn grouping on a
separate downstream surface, which is a behaviour change this defect does not
license, and `transcriptRenderers.test.tsx` records that converging the two row
sets was considered and rejected (#3332). Tracked separately. That set is `user | nudge | subagent`: a subagent-completion
fan-out is the long-transcript twin of a babysit loop and reproduces the identical
gap, so it pins too.

A pinned nudge or subagent completion renders as the compact label its transcript
card already computes (`nudgeLabel` / `headline`, both exported for reuse rather
than re-spelled), with the machine body reachable through the expand affordance —
so kilobytes of loop instructions never sit over the transcript. The chevron gate
needed a new `bodyBeyondPreview` term for that: a short label never clamps and
these rows carry no images, so neither existing term fired and the body would have
been unreachable.

This also anchors a jump at the head of a run of consecutive prompts. A steer
message follows its prompt with no assistant row between; landing on the steer
left the prompt above it straddling the hand-off line — unpinnable, yet already
pushing the fallback banner fully out — which unmounted the banner and ended the
chain.

## Tests

- `pinnedPrompt.nudgeSession.test.ts` — builds a 20-cycle nudge transcript through
  the real `groupDisplayItems` and pins the pin-to-read gap under 8 rows. Mutation
  (reverting `isPrompt` to user-only) fails it at 61.
- `pinnedPrompt.nudgeSession.test.ts` also pins the subagent case by IDENTITY
  (the pinned row IS the last completion). A distance threshold was tried first
  and was a false positive: with `subagent` excluded the transcript collapses into
  few display items, so a small-gap assertion stays satisfied while the banner
  points at the human's first message. The mutation now reads
  `expected 'user' to be 'subagent'`.
- `PinnedPrompt.nudgeExpand.test.tsx` — the first test that RENDERS
  `PinnedPrompt` (every existing test mocks it as `() => null`, so the component
  had no render coverage). Mutation on the chevron gate turns 2 of 4 red.
- `pinnedPrompt.jumpAnchor.test.ts` — covers the consecutive-prompt anchor (steer
  directly after its prompt, multi-row runs, list head, turn-group boundary). Two
  independent mutations verified red.

## Manual verification

The reporter cut the gateway over to this branch and confirmed the banner now
names the cycle instead of a message from far above. The full chain-back walk
(clicking repeatedly to step up cycle by cycle) was not exercised beyond that, so
the deterministic gap assertion in the unit test is the stronger guarantee here.

Note on scope: an earlier round of this investigation reproduced and fixed the
consecutive-prompt case but did NOT fix the reported symptom, because the seeded
transcripts used `tool`/`assistant` rows to stand in for large turns and never
contained a real `role: "nudge"` row. The nudge row is the load-bearing
ingredient; the unit test encodes it so this cannot regress silently.

<!-- no-visual-delta -->
**Why no screenshot:** the banner's own layout, size and position are unchanged.
What changes is which row it points at, and the label text when the pinned row is
a nudge.

## Related Issues

no linked issue: reported directly in chat as follow-up to #4378.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changes
- [x] No secrets, credentials, or internal references in the diff
