### PR TITLE
fix(dashboard): stop a partial /api/system frame crashing the app shell

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -396,7 +396,6 @@ src/kiro_crew/mcp_gateway/gatewayd.py
 src/kiro_crew/mcp_gateway/hazards.py
 src/kiro_crew/mcp_gateway/image_budget.py
 src/kiro_crew/mcp_gateway/manager.py
-src/kiro_crew/mcp_gateway/preflight.py
 src/kiro_crew/mcp_gateway/prewarm.py
 src/kiro_crew/mcp_gateway/rewriter.py
 src/kiro_crew/mcp_gateway/seed.py

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -174,6 +174,70 @@ export function metricColor(pct: number): string {
 }
 export const memColorClass = metricColor
 
+/**
+ * One `/api/system` metrics frame, as the topbar readout capsule consumes it.
+ *
+ * EVERY field is optional on purpose. `_collect_system_metrics` builds the
+ * payload key-by-key with per-probe `try/except: pass`, so a probe that fails
+ * (vm_stat timeout, unreadable /proc/meminfo, `system_memory()` returning None
+ * on Windows) simply omits its keys — while `mem_total_gb` can still be served
+ * from the cached STATIC system info the frame is seeded with. A frame with
+ * `mem_total_gb` but no `mem_used_gb` is therefore normal, not corrupt, and any
+ * readout must prove a value is a finite number before formatting it. Typing
+ * these as required `number` is what let `undefined.toFixed(1)` crash the root
+ * app-shell boundary; `api.system()` returns `any`, so only this annotation
+ * makes the compiler check the guards.
+ */
+export type SysMetricsFrame = {
+  memUsed?: number
+  memTotal?: number
+  cpuPct?: number
+  diskTotal?: number
+  diskFree?: number
+  posture?: 'ample' | 'tight' | 'critical' | 'unknown'
+  availableGb?: number
+  subagentCap?: number
+}
+
+/** Narrow a possibly-absent metric to a formattable number (excludes NaN/Infinity). */
+export function isMetricNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+/**
+ * Coerce a possibly-absent metric to a finite number, absent/NaN/Infinity -> 0.
+ *
+ * Paired with `isMetricNumber`: the guard decides whether a readout is SHOWN,
+ * this makes the formatting itself unable to throw, so a future gate that
+ * forgets a field degrades to a wrong-looking 0 instead of unmounting the app.
+ */
+export function metricNumber(v: unknown): number {
+  return isMetricNumber(v) ? v : 0
+}
+
+/**
+ * Validity flags + a sanitized frame for one metrics readout.
+ *
+ * Both readouts (the desktop button and the mobile passive row) derive their
+ * flags here so the two cannot drift apart: a `memTotal > 0` check says nothing
+ * about `memUsed`, and formatting a value the flag never proved is what crashed
+ * the shell.
+ */
+export function readMetricsFrame(raw: SysMetricsFrame) {
+  return {
+    cpuValid: isMetricNumber(raw.cpuPct),
+    memValid: isMetricNumber(raw.memUsed) && isMetricNumber(raw.memTotal) && raw.memTotal > 0,
+    dskValid: isMetricNumber(raw.diskTotal) && isMetricNumber(raw.diskFree) && raw.diskTotal > 0,
+    m: {
+      cpuPct: metricNumber(raw.cpuPct),
+      memUsed: metricNumber(raw.memUsed),
+      memTotal: metricNumber(raw.memTotal),
+      diskTotal: metricNumber(raw.diskTotal),
+      diskFree: metricNumber(raw.diskFree),
+    },
+  }
+}
+
 // The top-bar search is laid out by CSS, not measured here: `.topbar` in
 // index.css is a three-track grid whose centre track is
 // `clamp(240px, 22vw, 480px)` and whose side tracks are equal `minmax(0,1fr)`
@@ -1552,7 +1616,7 @@ export default function App() {
   // separate strip inset to relay to Electron — positionTrafficLights centers on
   // the header height directly. Remote panes get their own inset via `macInset`.
   const macInset = isMacElectron && !macFullscreen
-  const { data: sysMetrics, isError: sysMetricsError, dataUpdatedAt: sysMetricsUpdatedAt } = useQuery({ queryKey: ['system-metrics'], queryFn: () => api.system().then(d => ({ memUsed: d.mem_used_gb, memTotal: d.mem_total_gb, cpuPct: d.cpu_pct, diskTotal: d.disk_total_gb, diskFree: d.disk_free_gb, posture: d.resource_posture as 'ample' | 'tight' | 'critical' | 'unknown' | undefined, availableGb: d.resource_available_gb as number | undefined, subagentCap: d.subagent_cap as number | undefined })), refetchInterval: metricsOpen ? 30_000 : 60_000, enabled: true })
+  const { data: sysMetrics, isError: sysMetricsError, dataUpdatedAt: sysMetricsUpdatedAt } = useQuery({ queryKey: ['system-metrics'], queryFn: () => api.system().then((d): SysMetricsFrame => ({ memUsed: d.mem_used_gb, memTotal: d.mem_total_gb, cpuPct: d.cpu_pct, diskTotal: d.disk_total_gb, diskFree: d.disk_free_gb, posture: d.resource_posture as 'ample' | 'tight' | 'critical' | 'unknown' | undefined, availableGb: d.resource_available_gb as number | undefined, subagentCap: d.subagent_cap as number | undefined })), refetchInterval: metricsOpen ? 30_000 : 60_000, enabled: true })
   // Tick every 10s while widget is open so `sysMetricsStale` re-evaluates even when the query stops refetching (backgrounded tab, network drop).
   const [, setStaleTick] = useState(0)
   useEffect(() => {
@@ -1995,13 +2059,15 @@ export default function App() {
               } else if (!sysMetrics) {
                 if (sysMetricsError) segments.push(<button key="metrics" className={`${seg} text-danger text-[11px]`} title={i18nT('app.click_to_hide')} onClick={() => { setMetricsOpen(false); safeSetItem('mc-topbar-metrics', '0') }}><AudioWaveform size={11} /> {i18nT('app.metrics_unavailable')}</button>)
               } else {
-                const m = sysMetrics
-                const memPct = m.memTotal > 0 ? m.memUsed / m.memTotal : 0
+                // Validity is decided on the RAW frame; formatting happens on a
+                // sanitized copy. A `memTotal > 0` check says nothing about
+                // `memUsed`, and a frame carrying a total with no used is normal
+                // (see SysMetricsFrame) — that mismatch is what crashed the root
+                // app-shell boundary with `undefined.toFixed(1)`.
+                const { cpuValid, memValid, dskValid, m } = readMetricsFrame(sysMetrics)
+                const memPct = memValid ? m.memUsed / m.memTotal : 0
                 const dskUsed = m.diskTotal - m.diskFree
-                const dskPct = m.diskTotal > 0 ? dskUsed / m.diskTotal : 0
-                const memValid = m.memTotal > 0
-                const dskValid = m.diskTotal > 0
-                const cpuValid = typeof m.cpuPct === 'number' && Number.isFinite(m.cpuPct)
+                const dskPct = dskValid ? dskUsed / m.diskTotal : 0
                 const staleTitle = sysMetricsStale ? ` ${i18nT('app.stale_fetch_failing')}` : ''
                 // The container query can collapse this button to a bare icon, and
                 // the per-value tooltips ride on the spans it hides — so the
@@ -2045,13 +2111,12 @@ export default function App() {
             // capsule is expanded and data is available. No independent toggle —
             // visibility is tied to the capsule expand/collapse state.
             if (isMobile && sysMetrics) {
-              const m = sysMetrics
-              const memPct = m.memTotal > 0 ? m.memUsed / m.memTotal : 0
+              // Same derivation as the desktop readout, from the one helper, so
+              // the two cannot disagree about what a partial frame means.
+              const { cpuValid, memValid, dskValid, m } = readMetricsFrame(sysMetrics)
+              const memPct = memValid ? m.memUsed / m.memTotal : 0
               const dskUsed = m.diskTotal - m.diskFree
-              const dskPct = m.diskTotal > 0 ? dskUsed / m.diskTotal : 0
-              const cpuValid = typeof m.cpuPct === 'number' && Number.isFinite(m.cpuPct)
-              const memValid = m.memTotal > 0
-              const dskValid = m.diskTotal > 0
+              const dskPct = dskValid ? dskUsed / m.diskTotal : 0
               segments.push(<span key="metrics-mobile" className={`${seg} gap-2 text-[11px] font-mono tabular-nums`} aria-label={i18nT('app.system_metrics')}>
                 <span className={cpuValid ? metricColor(m.cpuPct / 100) : 'text-muted'}>{i18nT('app.cpu')} {cpuValid ? fmtPercent(m.cpuPct / 100) : '\u2014'}</span>
                 <span className={memValid ? metricColor(memPct) : 'text-muted'}>{i18nT('app.mem')} {memValid ? fmtPercent(memPct) : '\u2014'}</span>

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -1133,6 +1133,55 @@ describe('TopbarMetrics widget', () => {
     localStorage.removeItem('mc-topbar-metrics')
   })
 
+  it('renders "MEM —" instead of crashing when mem_used_gb is missing but mem_total_gb is present', async () => {
+    const { api } = await import('../api/client')
+    const sysMock = vi.mocked(api.system)
+    // The shape that crashed the root app-shell boundary with
+    // "Cannot read properties of undefined (reading 'toFixed')":
+    // `_collect_system_metrics` seeds the frame from the CACHED static system
+    // info (which carries mem_total_gb) and then computes mem_used_gb/
+    // mem_free_gb under `try/except: pass`, so a failed memory probe yields a
+    // total with no used. A `memTotal > 0` gate admits that frame and then
+    // formats `undefined.toFixed(1)`.
+    sysMock.mockResolvedValueOnce({ mem_total_gb: 16.0, cpu_pct: 25.0, disk_total_gb: 100.0, disk_free_gb: 60.0 } as never)
+    localStorage.setItem('mc-topbar-metrics', '1')
+    renderWithProviders(<App />, { route: '/chat' })
+    expect(await screen.findByText(/MEM —/)).toBeInTheDocument()
+    // The rest of the same frame still renders — one absent probe must not
+    // blank the whole capsule, let alone unmount the app.
+    expect(screen.getByText(/CPU 25%/)).toBeInTheDocument()
+    expect(screen.getByText(/DSK 40%/)).toBeInTheDocument()
+    sysMock.mockResolvedValue({ mem_used_gb: 4.0, mem_total_gb: 16.0, cpu_pct: 25.0, disk_total_gb: 100.0, disk_free_gb: 60.0 } as never)
+    localStorage.removeItem('mc-topbar-metrics')
+  })
+
+  it('renders "DSK —" instead of NaN when disk_free_gb is missing but disk_total_gb is present', async () => {
+    const { api } = await import('../api/client')
+    const sysMock = vi.mocked(api.system)
+    sysMock.mockResolvedValueOnce({ mem_used_gb: 4.0, mem_total_gb: 16.0, cpu_pct: 25.0, disk_total_gb: 100.0 } as never)
+    localStorage.setItem('mc-topbar-metrics', '1')
+    renderWithProviders(<App />, { route: '/chat' })
+    expect(await screen.findByText(/DSK —/)).toBeInTheDocument()
+    expect(screen.getByText(/MEM 25%/)).toBeInTheDocument()
+    sysMock.mockResolvedValue({ mem_used_gb: 4.0, mem_total_gb: 16.0, cpu_pct: 25.0, disk_total_gb: 100.0, disk_free_gb: 60.0 } as never)
+    localStorage.removeItem('mc-topbar-metrics')
+  })
+
+  it('renders every readout as "—" instead of crashing when the frame carries non-finite numbers', async () => {
+    const { api } = await import('../api/client')
+    const sysMock = vi.mocked(api.system)
+    // NaN/Infinity reach the frame when a probe divides by an unmeasured total;
+    // they must take the placeholder path, not render "NaN%".
+    sysMock.mockResolvedValueOnce({ mem_used_gb: NaN, mem_total_gb: 16.0, cpu_pct: NaN, disk_total_gb: Infinity, disk_free_gb: 60.0 } as never)
+    localStorage.setItem('mc-topbar-metrics', '1')
+    renderWithProviders(<App />, { route: '/chat' })
+    expect(await screen.findByText(/CPU —/)).toBeInTheDocument()
+    expect(screen.getByText(/MEM —/)).toBeInTheDocument()
+    expect(screen.getByText(/DSK —/)).toBeInTheDocument()
+    sysMock.mockResolvedValue({ mem_used_gb: 4.0, mem_total_gb: 16.0, cpu_pct: 25.0, disk_total_gb: 100.0, disk_free_gb: 60.0 } as never)
+    localStorage.removeItem('mc-topbar-metrics')
+  })
+
   it('renders "CPU —" instead of crashing when cpu_pct is undefined', async () => {
     const { api } = await import('../api/client')
     const sysMock = vi.mocked(api.system)


### PR DESCRIPTION
## Problem / Motivation

The dashboard white-screened. An error report captured from a live session:

```
Route:   /chat/kiro-crew-roadmap-planning
Code:    app-shell
Source:  render
Message: Cannot read properties of undefined (reading 'toFixed')
```

The route in the report is a red herring — nothing on the chat page is at fault. The throw comes from the topbar system-metrics readout capsule, which renders on every route inside the root `scope="app-shell"` ErrorBoundary in `website/src/main.tsx`, so it takes the whole dashboard down with it and gets attributed to whatever route happened to be mounted.

The capsule gated its memory reading on `memTotal` but then formatted `memUsed`:

```tsx
const memValid = m.memTotal > 0
… title={memValid ? `Memory: ${m.memUsed.toFixed(1)}/${m.memTotal.toFixed(1)} GB…`}
```

Those are two different backend probes. `_collect_system_metrics` in `src/kiro_crew/dashboard/handlers_system.py` seeds its payload from the **cached** static system info — which already carries `mem_total_gb` — and only then computes `mem_used_gb`/`mem_free_gb`, inside a per-probe `try/except: pass`. So a frame carrying a total with no used is normal, not corrupt, and it arrives whenever that one probe fails:

- **macOS** — the `vm_stat` subprocess times out or fails.
- **Linux** — `/proc/meminfo` is unreadable or unparseable (restricted containers).
- **Windows** — `platform_compat.system_memory()` returns `None`. This one needs **no exception at all**: the static cache holds a total from an earlier successful call, the live call returns `None`, all three keys are skipped, and the payload is inconsistent with nothing raised.

`api.system()` is typed `any`, so nothing type-checked the gate. `cpu_pct` had already been hardened against exactly this shape (there is an existing test for it); `mem_used_gb` and `disk_free_gb` were left behind.

## Why it matters

A single failed memory probe on the gateway host unmounts the entire dashboard for that user — every route, not just the topbar. There is no partial degradation and no in-app recovery: the capsule re-renders on each 30s/60s poll, so as long as the probe keeps failing the app keeps crashing. The user sees a blank shell and an error card, with the blame pointing at whatever page they were on.

## What changed (motivation → approach → change)

Symptom: `undefined.toFixed(1)` unmounts the app shell. Root cause: a validity gate that checks one field and formats another, over a payload whose fields are independently optional by construction. The fix makes the gate cover exactly the values each readout formats, and makes the formatting itself unable to throw even if a future gate misses a field.

- `readMetricsFrame()` derives the three validity flags from the **raw** frame, each requiring every value its readout formats (`memValid` now needs `isMetricNumber(memUsed) && isMetricNumber(memTotal) && memTotal > 0`, not just a positive total), and returns a **sanitized** copy alongside them where any absent/`NaN`/`Infinity` value is `0`. The flag decides whether a reading is *shown*; the sanitized copy means a missed field degrades to a visibly-wrong `0` instead of unmounting the app.
- Both readouts now derive from that one helper — the desktop button **and** the mobile passive row, which carried the same `memTotal > 0` gate. The mobile row never crashed (it formats through `fmtPercent`, which already renders a non-finite ratio as an em dash), but leaving it on the old gate would let the next edit that swaps `fmtPercent` for `toFixed` reintroduce the crash. Its visible text is unchanged; the only delta is that a partial mem frame now resolves to `text-muted` instead of `metricColor(NaN)`.
- `SysMetricsFrame` types every field optional, which is what makes the compiler enforce the guards from here on. This is the part that prevents recurrence — the previous shape was unfalsifiable because `api.system()` returns `any`.

The three JSX readout lines are deliberately **byte-identical** to base. They carry pre-existing untranslated `%`/`GB` unit literals, and the i18n `unit-added-lines` gate re-attributes that frozen debt to whoever touches the line — confirmed by trying it (3 literals flagged on the first attempt, clean once the sanitizing moved above the JSX). Migrating those literals to `fmtUnit`/`fmtPercent` is a separate, wider change across 13 catalogues.

Backend deliberately untouched: a best-effort partial frame is a legitimate contract, and filling a `0` for unmeasured memory would render a confident, wrong `MEM 0%` where the frontend now correctly shows `—`.

## Tests

Three regression tests in `website/src/test/App.test.tsx`, alongside the existing `cpu_pct` one:

| Test | Locks in |
|---|---|
| `mem_used_gb` missing, `mem_total_gb` present | The exact crashing shape renders `MEM —`, and CPU/DSK from the same frame still render — one absent probe must not blank the capsule, let alone unmount the app |
| `disk_free_gb` missing, `disk_total_gb` present | `DSK —` rather than a `NaN`-derived reading |
| `NaN`/`Infinity` in the frame | Every readout takes the placeholder path instead of rendering `NaN%` |

All three are **revert-verified**: with the fix removed they fail, and the failure is `TypeError: Cannot read properties of undefined (reading 'toFixed')` — byte-identical to the reported error, so the tests pin this defect and not a formatting coincidence.

## Unrelated CI ratchet folded in

Backend Lint & Type Check went red on the first round, naming a file this PR does not touch:

```
1 baselined file(s) are now black-clean. Remove them so the baseline keeps shrinking
  src/kiro_crew/mcp_gateway/preflight.py
black gate FAILED: 0 new offender(s), 1 graduated entr(y/ies) to prune.
```

The black gate is diff-scoped for *new* offenders but whole-tree for *graduations*, so once
main formats a file without pruning `.github/black-baseline.txt`, that stale entry fails the
check on **every** open PR until somebody removes it. Reproduced locally with the pinned
`black==26.3.1` and fixed with the gate's own `--update-baseline`, which only ever deletes
lines: one deletion, no reformatting. The `0 new offender(s)` line confirms nothing in this
diff needed formatting.

## Manual verification

N/A for browser steps — reproducing it live requires making the gateway's memory probe fail, and the rendered delta is fully exercised by the three tests above (they drive the real `App` with a mocked partial `/api/system` payload and assert the DOM). The reported crash is reproduced and closed by the revert-verification rather than by hand.

Gates run locally on the pushed head: `tsc -b`, `eslint src/` (0 errors), all 9 i18n gates and the i18n render gate under `I18N_BASE_REF=$(git merge-base HEAD origin/main)`, `npm run build`, and the 19 test suites coupled to `App`/the metrics helpers (168 tests). The Python lanes are otherwise unaffected: apart from the one-line black-baseline prune described above, the diff is two `.tsx` files and zero Python source.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the diff touches no watched visual path (`website/src/App.tsx` and `.github/black-baseline.txt` are not under `components/**`, `pages/**`, `apps/**`, or any `*.css`, and the test file is excluded), and there is no pixel delta on a healthy frame — identical readings render identically. The only rendered difference appears on a partial `/api/system` frame, where the capsule shows `MEM —` instead of unmounting the app, which the three tests assert on the real DOM.

## Related Issues

no linked issue: this arrived as a dashboard error report rather than a filed issue, and no open issue covers it (searched `toFixed` / metrics crash / app-shell).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff
