### PR TITLE
chore: fail docs-lint on a git conflict marker left in a doc

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -396,7 +396,6 @@ src/kiro_crew/mcp_gateway/gatewayd.py
 src/kiro_crew/mcp_gateway/hazards.py
 src/kiro_crew/mcp_gateway/image_budget.py
 src/kiro_crew/mcp_gateway/manager.py
-src/kiro_crew/mcp_gateway/preflight.py
 src/kiro_crew/mcp_gateway/prewarm.py
 src/kiro_crew/mcp_gateway/rewriter.py
 src/kiro_crew/mcp_gateway/seed.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,8 @@ commit**. Concretely:
    history; the doc states current behavior in present tense.
 5. **Run the gate:** `./scripts/docs-lint.sh`. It fails on a broken internal link, a
    doc no index reaches, a directory with no index, a code comment citing a doc that
-   does not exist, and a renamed doc whose filename is hardcoded in code.
+   does not exist, a renamed doc whose filename is hardcoded in code, and a git
+   conflict marker left at the start of a line.
 
 Two constraints that are easy to miss:
 

--- a/scripts/docs_lint.py
+++ b/scripts/docs_lint.py
@@ -190,6 +190,9 @@ _HTML_LINK_RE = re.compile(r"""<(?:a|img)\s[^>]*?(?:href|src)\s*=\s*["']([^"']+)
 # redaction example rendered as `k[REDACTED: credential](raw)`.
 _FENCE_RE = re.compile(r"^\s*(```|~~~)")
 _INLINE_CODE_RE = re.compile(r"`+[^`\n]*`+")
+# Git conflict markers, as git itself writes them at column 0: the ``<``, ``|``
+# and ``>`` forms carry a trailing label, the ``=`` separator stands alone.
+_CONFLICT_MARKER_RE = re.compile(r"^(?:[<>|]{7}(?:\s|$)|={7}$)")
 # A documentation path cited from source code, e.g. ``docs/system-specs/x.md``.
 _CODE_DOC_REF_RE = re.compile(r"(?:website/)?docs/[A-Za-z0-9][A-Za-z0-9/_.-]*\.md")
 
@@ -242,6 +245,7 @@ class Findings:
     coupling: list[str] = field(default_factory=list)
     missing_index: list[str] = field(default_factory=list)
     changelog_preamble: list[str] = field(default_factory=list)
+    conflict_markers: list[str] = field(default_factory=list)
 
     def total(self) -> int:
         return (
@@ -251,6 +255,7 @@ class Findings:
             + len(self.coupling)
             + len(self.missing_index)
             + len(self.changelog_preamble)
+            + len(self.conflict_markers)
         )
 
 
@@ -476,6 +481,31 @@ def check_changelog_preambles(root: Path, docs: list[Path], findings: Findings) 
                 break
 
 
+def check_conflict_markers(root: Path, docs: list[Path], findings: Findings) -> None:
+    """No doc may ship a git conflict marker.
+
+    A half-resolved merge is invisible to every other check here, which reads
+    documents as a link graph rather than as text, and it survives review for a
+    second reason: a bare ``=======`` under a line of prose is a valid setext H1,
+    so it renders as a heading instead of erroring. Anchoring at column 0 keeps
+    prose that *discusses* markers (they appear mid-line, inside backticks)
+    clean, and fenced blocks are exempt so a doc can show a real conflict.
+
+    The ``=`` form is matched only as a bare 7-character line. That is the width
+    git writes, and the repo's docs head with ATX ``#`` throughout, so a setext
+    underline of exactly that width would be the one false positive; a heading
+    wanting an underline should use ``#`` instead.
+    """
+    # Unlike the style checks, this one does not skip uncurated trees or spare the
+    # entry points: a marker is corruption, not a curation question, and the entry
+    # points are the files most people edit and therefore the likeliest to conflict.
+    for doc in docs:
+        rel_doc = _rel(doc, root)
+        for lineno, line in enumerate(_strip_fences(_read(doc)).splitlines(), start=1):
+            if _CONFLICT_MARKER_RE.match(line):
+                findings.conflict_markers.append(f"{rel_doc}:{lineno}  {line.strip()[:40]}")
+
+
 def check_code_citations(root: Path, findings: Findings) -> None:
     """A documentation path cited from source code must exist ("phantom spec").
 
@@ -585,6 +615,7 @@ def run(root: Path) -> Findings:
     check_reachability(root, docs, findings)
     check_directory_indexes(root, docs, findings)
     check_changelog_preambles(root, docs, findings)
+    check_conflict_markers(root, docs + entry_points, findings)
     check_code_citations(root, findings)
     check_code_coupled_docs(root, findings)
     return findings
@@ -592,6 +623,11 @@ def run(root: Path) -> Findings:
 
 def _report(findings: Findings, doc_count: int) -> int:
     print(f"docs-lint: scanned {doc_count} markdown files under {', '.join(DOC_ROOTS)}")
+    _emit(
+        "git conflict markers left in docs",
+        findings.conflict_markers,
+        "finish the merge: keep one side and delete the markers",
+    )
     _emit(
         "broken internal links",
         findings.broken_links,
@@ -702,6 +738,27 @@ def _self_test() -> int:
         )
         return "changelog_preamble"
 
+    def plant_conflict_marker(root: Path) -> str:
+        # The separator alone, which is what a half-finished resolution leaves
+        # behind once the labelled <<< and >>> lines have been deleted.
+        (root / "docs" / "ok.md").write_text(
+            "# Ok\n\n- kept bullet\n=======\n- other side\n", encoding="utf-8"
+        )
+        return "conflict_markers"
+
+    def plant_conflict_marker_head(root: Path) -> str:
+        (root / "docs" / "ok.md").write_text(
+            "# Ok\n\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n", encoding="utf-8"
+        )
+        return "conflict_markers"
+
+    def plant_conflict_marker_uncurated(root: Path) -> str:
+        # Archival trees are exempt from the style checks but not from corruption.
+        archive = root / "docs" / "archive"
+        archive.mkdir()
+        (archive / "old.md").write_text("# Old\n\nkept\n=======\nother\n", encoding="utf-8")
+        return "conflict_markers"
+
     def plant_phantom_ref(root: Path) -> str:
         pkg = root / "src" / "kiro_crew"
         pkg.mkdir(parents=True)
@@ -718,15 +775,19 @@ def _self_test() -> int:
         )
         return "coupling"
 
-    def code_immunity_probe(label: str, body: str) -> None:
-        """Assert a link written inside code markup is NOT reported."""
+    def code_immunity_probe(label: str, body: str, field: str = "broken_links") -> None:
+        """Assert markup written inside code is NOT reported by ``field``.
+
+        The field is explicit because a probe that watches the wrong one cannot
+        fail: it would pass while the check it claims to guard regressed.
+        """
         nonlocal failures
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             (root / "docs").mkdir(parents=True)
             (root / "docs" / "README.md").write_text("# Docs\n\n- [Ok](ok.md)\n", encoding="utf-8")
             (root / "docs" / "ok.md").write_text(body, encoding="utf-8")
-            if run(root).broken_links:
+            if getattr(run(root), field):
                 print(f"  FAIL {label} was flagged")
                 failures += 1
             else:
@@ -739,12 +800,25 @@ def _self_test() -> int:
     probe("unreachable doc", plant_unreachable)
     probe("missing directory index", plant_missing_index)
     probe("changelog preamble", plant_changelog_preamble)
+    probe("conflict marker (bare separator)", plant_conflict_marker)
+    probe("conflict marker (full three-way)", plant_conflict_marker_head)
+    probe("conflict marker (uncurated tree)", plant_conflict_marker_uncurated)
     probe("phantom spec citation", plant_phantom_ref)
     probe("code-coupled doc missing", plant_coupling)
 
     # Code-markup immunity is an inverse assertion (nothing should fire).
     code_immunity_probe("fenced example link", "# Ok\n\n```md\n[example](does-not-exist.md)\n```\n")
     code_immunity_probe("inline-code example link", "# Ok\n\nSpoken as `[label](url)` aloud.\n")
+    code_immunity_probe(
+        "prose discussing conflict markers",
+        "# Ok\n\ngit emits `<<<<<<< HEAD` / `=======` /\n`>>>>>>>` around the region.\n",
+        "conflict_markers",
+    )
+    code_immunity_probe(
+        "fenced conflict demonstration",
+        "# Ok\n\n```diff\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n```\n",
+        "conflict_markers",
+    )
 
     if failures:
         print(f"\nSELF-TEST FAILED: {failures} check(s) do not fire")


### PR DESCRIPTION
## What

`docs-lint` now fails on a git conflict marker sitting at the start of a line in
any scanned doc.

## Why this gap existed

Every check in `docs_lint.py` reads a document as a **link graph** — broken
links, index reachability, directory indexes, code citations, code-coupled docs.
None of them reads the text for corruption, so a half-resolved merge passed the
whole gate.

It survived human review for a second, more interesting reason: a bare `=======`
directly under a line of prose is a valid **setext H1**. It renders as a heading.
Nothing errors, and the rendered diff does not look wrong.

This is not hypothetical — it shipped. #4298 carried a stray separator plus a
duplicated bullet in `docs/guides/windows-install.md` through a green
`docs-lint` run and into review, where an AI reviewer caught it by reading the
prose rather than by any deterministic check.

## Design, and the one tradeoff

**Column 0 only.** Prose that *discusses* markers writes them mid-line inside
backticks — which is exactly what the single existing occurrence in
`docs/system-specs/modules/ops-mission-control.md:133-134` does. Anchoring at the
line start makes that case clean with no allowlist to maintain.

**Fenced blocks are exempt** via the existing `_strip_fences`, so a doc can
demonstrate a real conflict. Nothing does today; something eventually will.

**The `=` form is matched only as a bare seven-character line.** It has to
trigger on its own: the case that got through had already lost its labelled
`<<<<<<<` / `>>>>>>>` sides, so requiring a companion marker would have missed
the real bug entirely. Seven is the width git writes. The cost is that a setext
underline of *precisely* seven `=` would be a false positive — these docs head
with ATX `#` throughout (zero all-`=` lines across all 213 scanned files), and a
heading that wants an underline should use `#`.

## Verification

- **Scanned first, then designed.** All three doc roots, 213 files: zero markers,
  zero all-`=` lines, one legitimate mid-line prose reference (immune).
- **Self-test gains 6 probes** (15 total, all pass): bare separator caught, full
  three-way caught, an uncurated tree caught, and the prose + fenced forms proven
  immune — each immunity probe asserting `conflict_markers`, the field actually
  under test.
- **Mutation-tested rather than asserted.** The anchoring is enforced twice (a
  `^` in the pattern AND `re.match`), so a single-point mutation is inert and
  proves nothing; removing both together makes the prose probe fail, and stubbing
  `_strip_fences` makes the fenced probe fail. Each guard has a mutation that
  reddens the probe describing it.
- **Replayed the real defect** — reinstated #4298's two lines verbatim and the
  gate reports `docs/guides/windows-install.md:56  =======`.
- Real tree still 0 findings · `scrub-lint --no-history` clean · flake8 + isort
  clean on the changed file.

## Scope

One check, its report line, six self-test probes, and the one-sentence rule list
in `docs/README.md`. No existing check's behaviour is touched;
`code_immunity_probe` gains a `field` parameter that defaults to its current
behaviour.

**One line rides along, declared: `.github/black-baseline.txt` loses
`src/kiro_crew/mcp_gateway/preflight.py`.** That file is not in this diff — it
became black-clean on `main`, and the ratchet bills whichever Python-touching PR
comes next. Dropping the prune is not a zero-cost option: head `919d3fa6d`,
without it, failed `Backend Lint & Type Check` on exactly this. So the choice is
prune it here or leave the PR permanently red, not prune-or-nothing.

Note that CI's `flake8`/`isort`/`mypy` steps cover `src/kiro_crew` and `test`
only, so `scripts/` is gated by the `docs-lint` job itself — which is why the
self-test probes matter more here than usual: they are the only thing proving
this check can fail.
