### PR TITLE
fix(agent): prefer relocatable bin/kirocrew.cmd on Windows (#4439)

### DIFF
--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -161,6 +161,10 @@ gateway can't find the built-in `kirocrew-cron` / `kirocrew-core` MCP servers,
 that dir is appended to the MCP spawn `PATH` automatically
 (`env.augmented_path`), and the managed-server invocation falls back to
 `python -m kiro_crew <sub>` when the `kirocrew.exe` wrapper isn't resolvable.
+In the desktop bundle the relocatable `bin\kirocrew.cmd` shim is preferred
+over `Scripts\kirocrew.exe` (whose embedded interpreter path names the build
+machine) and is unwrapped to `<root>\python.exe -P -s -m kiro_crew <sub>` when
+spawned.
 
 ## The unsandboxed-exec opt-in
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -328,7 +328,13 @@ def _bin_is_usable(path: Path) -> bool:
     except OSError:
         return False
     if not head.startswith(b"#!"):
-        return True  # compiled launcher (pip's Windows .exe, a frozen binary)
+        # Compiled launcher (pip's Windows .exe, a frozen binary) or a Windows
+        # batch shim (`bin\kirocrew.cmd` starts with `@`). The shim DOES name
+        # its interpreter (`"%~dp0..\python.exe"`), but we choose not to parse
+        # the batch body here; the consumer that spawns it
+        # (`_kirocrew_mcp_invocation`) resolves and validates that sibling
+        # interpreter itself, mirroring website/electron/main.js.
+        return True
     text = head.decode("utf-8", errors="replace")
 
     shebang = text.splitlines()[0][2:].strip()
@@ -397,8 +403,23 @@ def _kirocrew_bin_subpath(root: Path) -> Path:
     on Windows finds nothing, which silently drops the built-in
     ``kirocrew-cron`` / ``kirocrew-core`` MCP servers (``command not found:
     .../bin/kirocrew``). Branch on the platform so both layouts resolve.
+
+    On Windows a relocatable ``bin\\kirocrew.cmd`` shim is preferred over the
+    pip-generated ``Scripts\\kirocrew.exe`` when it exists. The desktop bundle
+    (``packaging/build-desktop.sh``) ships BOTH: pip drops a console-script
+    ``.exe`` in ``Scripts\\``, but distlib embeds the ABSOLUTE interpreter path
+    of the machine that built it, so inside a shipped bundle that ``.exe``
+    points at a build-agent path that does not exist on the user's machine.
+    The ``.cmd`` shim resolves the interpreter via ``%~dp0`` and is the only
+    relocatable launcher of the two. The Electron resolver
+    (``website/electron/find-bin.js``) ranks them the same way — keep the two
+    in sync. Plain pip installs ship no ``bin\\kirocrew.cmd``, so they keep
+    resolving ``Scripts\\kirocrew.exe`` via the fallback.
     """
     if platform_compat.IS_WINDOWS:
+        cmd_shim = root / "bin" / "kirocrew.cmd"
+        if cmd_shim.is_file():
+            return cmd_shim
         return root / "Scripts" / "kirocrew.exe"
     return root / "bin" / "kirocrew"
 
@@ -586,9 +607,36 @@ def _kirocrew_mcp_invocation(subcommand: str) -> tuple[str, list[str]]:
     ``sys.executable`` is the absolute path of the running interpreter, so it
     needs no PATH entry and ignores any broken launcher. ``python -m
     kiro_crew`` dispatches the same CLI as the ``kirocrew`` console script.
+
+    A resolved ``bin\\kirocrew.cmd`` (the Windows bundle's relocatable shim,
+    see :func:`_kirocrew_bin_subpath`) is unwrapped to the sibling
+    interpreter — ``<root>\\python.exe -P -s -m kiro_crew <sub>`` — instead of
+    being emitted verbatim. This mirrors ``website/electron/main.js``, which
+    refuses to spawn the shim it resolved (Node's ``spawn()`` rejects
+    ``.cmd``/``.bat`` without ``shell:true``, CVE-2024-27980 hardening) and
+    substitutes exactly this invocation. Whether kiro-cli's spawner handles a
+    batch file is its own implementation detail; emitting the interpreter
+    directly removes the question — the shim exists for humans and find-bin
+    identity, the process tree runs ``python.exe``. When the sibling
+    interpreter is missing (corrupted bundle), fall back to
+    ``sys.executable``, which inside the bundle IS that interpreter.
     """
     bin_path = _resolve_kirocrew_bin()
     if bin_path == "kirocrew":  # unresolved sentinel from _resolve_kirocrew_bin
+        return sys.executable, ["-m", "kiro_crew", subcommand]
+    if bin_path.endswith(".cmd"):
+        interpreter = Path(bin_path).parent.parent / "python.exe"
+        if _interpreter_runnable(interpreter):
+            # ``-P`` (safe path, 3.11+) keeps the spawn CWD off ``sys.path``:
+            # kiro-cli spawns managed servers with the user's project as CWD,
+            # so with ``-m`` alone a cloned repo carrying a ``kiro_crew/``
+            # package would shadow the real one and run unconfined. Safe to
+            # pin here because this interpreter is always the bundle's own
+            # python-build-standalone 3.12 (packaging/build-desktop.sh); the
+            # generic ``sys.executable`` fallbacks below and above stay
+            # ``-P``-free because the project still supports Python 3.10,
+            # which lacks the flag.
+            return str(interpreter), ["-P", "-s", "-m", "kiro_crew", subcommand]
         return sys.executable, ["-m", "kiro_crew", subcommand]
     return bin_path, [subcommand]
 

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -930,9 +930,11 @@ def _fix_stale_managed_command(name: str, spec: dict) -> None:
 
     Delegates to :func:`kiro_crew.agent._kirocrew_mcp_invocation`, the single
     source of truth for the managed invocation. That handles every layout:
-    a standalone ``bin/kirocrew`` (POSIX) / ``Scripts\\kirocrew.exe`` (Windows)
-    console script when one resolves, and otherwise the
-    ``<interpreter> -m kiro_crew <sub>`` fallback. Both ``command`` AND ``args``
+    a standalone ``bin/kirocrew`` (POSIX) / ``Scripts\\kirocrew.exe`` (Windows
+    pip install) console script when one resolves, the Windows bundle's
+    ``bin\\kirocrew.cmd`` shim (unwrapped to ``<root>\\python.exe -P -s -m
+    kiro_crew <sub>``), and otherwise the ``<interpreter> -m kiro_crew <sub>``
+    fallback. Both ``command`` AND ``args``
     are rewritten — the fallback needs ``["-m", "kiro_crew", <sub>]``, so
     re-resolving the command alone (the old behavior) silently dropped the args
     and spawned a bare ``kirocrew`` that isn't on PATH (Windows: ``command not

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -1035,6 +1035,112 @@ class TestResolveKirocrewBin:
             agent_mod._KIROCREW_BIN = old_val
 
 
+class TestKirocrewBinSubpath:
+    """Tests for the per-OS console-script subpath (#4439).
+
+    On Windows the resolver must prefer the relocatable ``bin\\kirocrew.cmd``
+    shim over the pip-generated ``Scripts\\kirocrew.exe``: inside the shipped
+    desktop bundle the ``.exe`` embeds the ABSOLUTE interpreter path of the
+    build agent and can never run on the user's machine, while the ``.cmd``
+    resolves its interpreter via ``%~dp0``. Mirrors the ranking in
+    ``website/electron/find-bin.js``.
+    """
+
+    def test_posix_returns_bin_kirocrew(self, tmp_path: Path, monkeypatch):
+        from kiro_crew import platform_compat
+        from kiro_crew.agent import _kirocrew_bin_subpath
+
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        # Even with a stray kirocrew.cmd present, POSIX resolution is unchanged.
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "kirocrew.cmd").write_text("@echo off\n")
+        assert _kirocrew_bin_subpath(tmp_path) == tmp_path / "bin" / "kirocrew"
+
+    def test_windows_prefers_relocatable_cmd_shim(self, tmp_path: Path, monkeypatch):
+        """Bundle layout: BOTH launchers exist -> the .cmd shim wins."""
+        from kiro_crew import platform_compat
+        from kiro_crew.agent import _kirocrew_bin_subpath
+
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+        (tmp_path / "bin").mkdir()
+        cmd_shim = tmp_path / "bin" / "kirocrew.cmd"
+        cmd_shim.write_text('@echo off\r\n"%~dp0..\\python.exe" -s -m kiro_crew %*\r\n')
+        (tmp_path / "Scripts").mkdir()
+        (tmp_path / "Scripts" / "kirocrew.exe").write_bytes(b"MZ")
+        assert _kirocrew_bin_subpath(tmp_path) == cmd_shim
+
+    def test_windows_falls_back_to_scripts_exe_without_cmd(self, tmp_path: Path, monkeypatch):
+        """Plain pip install: no .cmd shim -> Scripts/kirocrew.exe as before."""
+        from kiro_crew import platform_compat
+        from kiro_crew.agent import _kirocrew_bin_subpath
+
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+        (tmp_path / "Scripts").mkdir()
+        (tmp_path / "Scripts" / "kirocrew.exe").write_bytes(b"MZ")
+        expected = tmp_path / "Scripts" / "kirocrew.exe"
+        assert _kirocrew_bin_subpath(tmp_path) == expected
+
+    def test_windows_cmd_must_be_a_file(self, tmp_path: Path, monkeypatch):
+        """A directory named kirocrew.cmd does not shadow the .exe fallback."""
+        from kiro_crew import platform_compat
+        from kiro_crew.agent import _kirocrew_bin_subpath
+
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+        (tmp_path / "bin" / "kirocrew.cmd").mkdir(parents=True)
+        expected = tmp_path / "Scripts" / "kirocrew.exe"
+        assert _kirocrew_bin_subpath(tmp_path) == expected
+
+    def test_bin_is_usable_accepts_cmd_batch_shim(self, tmp_path: Path):
+        """A `.cmd` starts with `@`, not `#!` -> no shebang to validate, usable."""
+        from kiro_crew.agent import _bin_is_usable
+
+        shim = tmp_path / "kirocrew.cmd"
+        shim.write_text('@echo off\r\n"%~dp0..\\python.exe" -s -m kiro_crew %*\r\n')
+        assert _bin_is_usable(shim) is True
+
+    def test_resolver_walk_finds_cmd_shim_in_bundle_layout(self, tmp_path: Path, monkeypatch):
+        """End-to-end: the parent walk PREFERS the bundle's .cmd on Windows.
+
+        Pins the issue's failure mode: the bundle ships BOTH launchers, and
+        resolving the co-present ``Scripts\\kirocrew.exe`` instead of the
+        ``.cmd`` shim is exactly the #4439 defect.
+        """
+        import kiro_crew.agent as agent_mod
+        from kiro_crew import platform_compat
+        from kiro_crew.agent import _resolve_kirocrew_bin
+
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+
+        # Bundle layout (packaging/build-desktop.sh build_backend_windows):
+        # <root>/Lib/site-packages/kiro_crew + <root>/bin/kirocrew.cmd
+        # + the pip-dropped <root>/Scripts/kirocrew.exe (non-relocatable).
+        root = tmp_path / "kirocrew-backend"
+        pkg_dir = root / "Lib" / "site-packages" / "kiro_crew"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "__init__.py").write_text("")
+        (root / "bin").mkdir()
+        cmd_shim = root / "bin" / "kirocrew.cmd"
+        cmd_shim.write_text('@echo off\r\n"%~dp0..\\python.exe" -s -m kiro_crew %*\r\n')
+        # The test host is POSIX, where the resolver's X_OK gate is real.
+        cmd_shim.chmod(0o755)
+        (root / "Scripts").mkdir()
+        dead_exe = root / "Scripts" / "kirocrew.exe"
+        dead_exe.write_bytes(b"MZ")
+        dead_exe.chmod(0o755)
+
+        mock_mc = unittest.mock.MagicMock()
+        mock_mc.__file__ = str(pkg_dir / "__init__.py")
+
+        old_val = agent_mod._KIROCREW_BIN
+        try:
+            agent_mod._KIROCREW_BIN = None
+            with patch.dict("sys.modules", {"kiro_crew": mock_mc}):
+                result = _resolve_kirocrew_bin()
+            assert result == str(cmd_shim)
+        finally:
+            agent_mod._KIROCREW_BIN = old_val
+
+
 class TestKirocrewMcpInvocation:
     """Tests for built-in MCP server invocation resolution.
 
@@ -1059,6 +1165,44 @@ class TestKirocrewMcpInvocation:
 
         # Bare "kirocrew" is the unresolved sentinel from _resolve_kirocrew_bin.
         with patch("kiro_crew.agent._resolve_kirocrew_bin", return_value="kirocrew"):
+            cmd, args = _kirocrew_mcp_invocation("mcp-core")
+        assert cmd == sys.executable
+        assert args == ["-m", "kiro_crew", "mcp-core"]
+
+    def test_unwraps_cmd_shim_to_sibling_interpreter(self, tmp_path: Path):
+        """A resolved bin/kirocrew.cmd is never emitted verbatim (#4439).
+
+        Mirrors website/electron/main.js: the shim is unwrapped to
+        ``<root>/python.exe -s -m kiro_crew <sub>`` so kiro-cli spawns the
+        interpreter, not a batch file.
+        """
+        from kiro_crew.agent import _kirocrew_mcp_invocation
+
+        root = tmp_path / "kirocrew-backend"
+        (root / "bin").mkdir(parents=True)
+        shim = root / "bin" / "kirocrew.cmd"
+        shim.write_text('@echo off\r\n"%~dp0..\\python.exe" -s -m kiro_crew %*\r\n')
+        interpreter = root / "python.exe"
+        interpreter.write_bytes(b"MZ")
+        interpreter.chmod(0o755)  # X_OK is real on the POSIX test host
+
+        with patch("kiro_crew.agent._resolve_kirocrew_bin", return_value=str(shim)):
+            cmd, args = _kirocrew_mcp_invocation("mcp-cron")
+        assert cmd == str(interpreter)
+        # -P keeps the spawn CWD off sys.path (the bundle interpreter is
+        # pinned 3.12, so the 3.11+ flag is safe); -s drops user site-packages.
+        assert args == ["-P", "-s", "-m", "kiro_crew", "mcp-cron"]
+
+    def test_cmd_shim_without_interpreter_falls_back_to_sys_executable(self, tmp_path: Path):
+        """Corrupted bundle: shim present but python.exe missing -> sys.executable."""
+        from kiro_crew.agent import _kirocrew_mcp_invocation
+
+        root = tmp_path / "kirocrew-backend"
+        (root / "bin").mkdir(parents=True)
+        shim = root / "bin" / "kirocrew.cmd"
+        shim.write_text('@echo off\r\n"%~dp0..\\python.exe" -s -m kiro_crew %*\r\n')
+
+        with patch("kiro_crew.agent._resolve_kirocrew_bin", return_value=str(shim)):
             cmd, args = _kirocrew_mcp_invocation("mcp-core")
         assert cmd == sys.executable
         assert args == ["-m", "kiro_crew", "mcp-core"]


### PR DESCRIPTION
## Summary

Closes #4439

On Windows, `_kirocrew_bin_subpath` in `src/kiro_crew/agent.py` returned only
`Scripts/kirocrew.exe` — a pip-generated console script whose embedded
interpreter path is absolute and non-relocatable inside the shipped desktop
bundle (it names the build agent's path, e.g. `D:\a\KiroCrew\...`). The
Electron resolver (`website/electron/find-bin.js`) already ranks the
`%~dp0`-based `bin/kirocrew.cmd` shim above the `.exe` for exactly this
reason. This PR aligns the Python resolver.

## Changes

- `_kirocrew_bin_subpath`: on Windows, prefer `root/bin/kirocrew.cmd` when it
  exists; fall back to `root/Scripts/kirocrew.exe`. Plain pip installs ship no
  `.cmd`, so they are unchanged. POSIX untouched.
- `_kirocrew_mcp_invocation`: a resolved `.cmd` is **never emitted verbatim**
  into `kirocrew.json` — it is unwrapped to `<root>\python.exe -s -m kiro_crew
  <sub>`, mirroring the substitution `website/electron/main.js` performs before
  spawning (Node refuses `spawn()` of `.cmd`/`.bat` without `shell:true`;
  whether kiro-cli's spawner handles batch files is a question this shape
  removes entirely). A shim whose sibling `python.exe` is missing (corrupted
  bundle) falls back to `sys.executable`, which inside the bundle IS that
  interpreter.
- `_bin_is_usable` comment corrected: the shim does name its interpreter; we
  choose not to parse the batch body because the spawning consumer validates
  the sibling interpreter itself.
- Doc sync: `mcp_discovery._fix_stale_managed_command` docstring +
  `docs/guides/windows-install.md` now describe the `.cmd`-preferred shape.

## Testing

- 8 new tests: helper-level preference/fallback/is_file guard, POSIX isolation
  against a stray `.cmd`, `_bin_is_usable` on a batch shim, end-to-end resolver
  walk preferring the `.cmd` over a co-present dead `.exe` in the
  `Lib/site-packages` bundle layout, and both unwrap branches of
  `_kirocrew_mcp_invocation`.
- Targeted run: `pytest test/test_agent.py test/test_mcp_discovery.py
  test/test_installer_shim_and_cleanup.py test/test_cpp_seam_failclosed.py
  test/test_cli_doctor.py` → 510 passed. isort/flake8/mypy clean.
- Pre-push dual-model review: GPT PASS; Opus 1 BLOCKING (verbatim `.cmd` spawn
  risk — fixed with the `main.js`-mirroring unwrap) + 3 advisories (all taken).

<!-- no-visual-delta -->
No visual delta: backend-only change to the Python-side binary resolver and
managed MCP invocation shaping; no frontend or rendered-UI code touched.
