### PR TITLE
test(windows): fix the expected-failures matcher and restore link-guard coverage

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -696,13 +696,34 @@ def pytest_collection_modifyitems(config, items):
         text = listfile.read_text(encoding="utf-8")
     except OSError:  # pragma: no cover - list file absent in a partial checkout
         return
-    expected = {ln.strip() for ln in text.splitlines() if ln.strip() and not ln.startswith("#")}
+    expected = {
+        _base_nodeid(ln.strip())
+        for ln in text.splitlines()
+        if ln.strip() and not ln.startswith("#")
+    }
     marker = pytest.mark.skip(
         reason="known Windows gap -- tracked in test/windows-expected-failures.txt"
     )
     for item in items:
-        if item.nodeid.split("[")[0] in expected:
+        if _base_nodeid(item.nodeid) in expected:
             item.add_marker(marker)
+
+
+def _base_nodeid(nodeid: str) -> str:
+    """A node id reduced to file + class + function, with params and xdist group gone.
+
+    Under ``--dist loadgroup`` -- which ``setup.cfg`` supplies to EVERY run -- xdist
+    rewrites each item's nodeid to ``<nodeid>@<group>`` for anything carrying an
+    ``xdist_group`` mark. Splitting on ``[`` alone therefore compares different strings
+    in different invocations: a PARAMETRIZED id loses the suffix with its params, while
+    an UNPARAMETRIZED one keeps it. So a plain entry silently stopped matching the
+    grouped tests under the default invocation, and an entry written WITH the suffix to
+    compensate then stopped matching under ``-n0``, where xdist never adds it.
+
+    Stripping both parts makes one spelling -- the plain node id -- correct in every
+    mode, which is the only spelling the list file documents.
+    """
+    return nodeid.split("[")[0].split("@")[0]
 
 
 def platform_compat_or_none():

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -386,6 +386,15 @@ silently absent from the ~1490 in-package tests, which is how each was found.
   `skipif(not userns_available())` for the sandbox. `test_coverage_omit_contract.py`
   ratchets the rest: a returning `--deselect` fails it unless the coverage omit comes
   with it, because a file CI cannot run must not be charged to the denominator either.
+
+  Entries in `windows-expected-failures.txt` are **plain node ids** — file, class,
+  function, no `[params]` and no `@group` suffix. The rootdir `conftest.py` matcher
+  reduces both the list and each collected item to that base form before comparing
+  (`_base_nodeid`), which is load-bearing: under the default `--dist loadgroup`, xdist
+  rewrites a grouped test's nodeid to `<nodeid>@<group>`, so a matcher that only split
+  on `[` matched a *different* string for grouped vs ungrouped tests and for `-n0` vs
+  `loadgroup` runs. Never add the `@group` suffix to an entry — it makes the line match
+  in one invocation and silently miss in another.
 - Tests SHOULD be fast (< 1s each)
 - Async tests MUST use `@pytest.mark.asyncio`
 

--- a/test/test_agent_home_isolation.py
+++ b/test/test_agent_home_isolation.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from conftest import make_dir_link
 from kiro_crew.config.paths import kiro_agents_dir, kiro_home
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -175,7 +176,6 @@ def test_private_target_is_never_declined(monkeypatch, tmp_path):
     assert agent._decline_shared_agent_home() is None
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs elevation on Windows")
 def test_symlinked_shared_home_still_declines(monkeypatch, tmp_path):
     """A symlinked shared home must NOT be mistaken for a private target.
 
@@ -183,13 +183,17 @@ def test_symlinked_shared_home_still_declines(monkeypatch, tmp_path):
     (or a ``KIRO_HOME`` spelling the same directory differently) compared unequal
     to the default and waved the worktree through — overwriting exactly the specs
     the guard exists to protect.
+
+    The link is a DIRECTORY link, so on Windows it is a junction (no privilege
+    needed, and resolved by the same ``resolve()`` the guard relies on) — keeping
+    this regression exercised there via ``make_dir_link`` rather than skipped.
     """
     from kiro_crew import agent
 
     real = tmp_path / "real-kiro" / "agents"
     real.mkdir(parents=True)
     link = tmp_path / "linked-kiro"
-    link.symlink_to(tmp_path / "real-kiro", target_is_directory=True)
+    make_dir_link(link, tmp_path / "real-kiro")
 
     wt = _make_linked_worktree(tmp_path)
     monkeypatch.setattr(agent, "__file__", str(wt / "src" / "kiro_crew" / "agent.py"))

--- a/test/test_home_migration.py
+++ b/test/test_home_migration.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from conftest import requires_symlinks
 from kiro_crew import home_migration
 from kiro_crew.config import paths
 
@@ -547,6 +548,7 @@ class TestSweepUngatedArchiveLeftovers:
         assert result.is_dir()
         assert (result / paths.MIGRATION_MARKER_NAME).exists()
 
+    @requires_symlinks
     def test_symlinked_archive_is_not_followed_or_deleted_through(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -661,6 +663,7 @@ class TestMigrateHomeDirect:
         assert second == legacy  # NOT tmp_path/.kiro/crew
         assert paths._resolved_home == legacy
 
+    @requires_symlinks
     def test_symlinked_destination_is_skipped_not_followed(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -688,6 +691,7 @@ class TestMigrateHomeDirect:
         # symlink itself already pointed at, and no exception was raised.
         assert (leak / "a.jsonl").exists()
 
+    @requires_symlinks
     def test_symlinked_source_dir_is_skipped_external_target_untouched(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -711,6 +715,7 @@ class TestMigrateHomeDirect:
         # The symlink itself was skipped, not reproduced or dereferenced.
         assert not (result / "linked").exists()
 
+    @requires_symlinks
     def test_dangling_symlink_does_not_abort_migration(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -858,6 +863,7 @@ class TestMigrateHomeDirect:
             encoding="utf-8"
         ) == "data"
 
+    @requires_symlinks
     def test_relative_intra_home_symlink_is_skipped(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -878,6 +884,7 @@ class TestMigrateHomeDirect:
         assert (result / "workspace" / "project" / "f.txt").read_text(encoding="utf-8") == "data"
         assert not (result / "workspace" / "current").exists()
 
+    @requires_symlinks
     def test_absolute_external_symlink_is_skipped(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -1291,6 +1298,7 @@ class TestFailSafeChecksContainmentNotExistence:
         monkeypatch.setattr(home_migration, "_resolved_prefix", lambda: None)
         assert home_migration._interpreter_is_preserved(tmp_path) is False
 
+    @requires_symlinks
     def test_symlinked_preserved_dir_still_protects_interpreter(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/test/test_papyrus_gitops.py
+++ b/test/test_papyrus_gitops.py
@@ -33,6 +33,7 @@ from unittest import mock
 
 import pytest
 
+from conftest import make_dir_link, requires_symlinks
 from kiro_crew import sandbox
 from kiro_crew.apps.builtins.papyrus.backend import gitops
 
@@ -1251,6 +1252,7 @@ class TestTheAttributesPinCannotBeNeutralized:
         assert "*.pdf binary" in content
         assert content.splitlines()[-1] == gitops._ATTRIBUTES_PIN.strip()
 
+    @requires_symlinks
     def test_a_symlinked_attributes_file_is_refused(self, tmp_path: Path) -> None:
         repo = self._repo(tmp_path)
         victim = tmp_path / "victim.txt"
@@ -1263,12 +1265,17 @@ class TestTheAttributesPinCannotBeNeutralized:
         assert victim.read_text(encoding="utf-8") == "original\n"
 
     def test_a_symlinked_info_directory_is_refused(self, tmp_path: Path) -> None:
-        """`mkdir(exist_ok=True)` is a no-op on a link, so the dir needs its own check."""
+        """`mkdir(exist_ok=True)` is a no-op on a link, so the dir needs its own check.
+
+        A DIRECTORY link, so on Windows it is a junction (no privilege, and the
+        reparse type `is_symlink()` misses) — kept exercised there via
+        `make_dir_link` rather than skipped.
+        """
         repo = tmp_path / "paper"
         (repo / ".git").mkdir(parents=True)
         elsewhere = tmp_path / "elsewhere"
         elsewhere.mkdir()
-        (repo / ".git" / "info").symlink_to(elsewhere, target_is_directory=True)
+        make_dir_link(repo / ".git" / "info", elsewhere)
 
         with pytest.raises(gitops.GitError, match="symlink"):
             gitops._pin_attributes_sync(repo)
@@ -1344,9 +1351,6 @@ class TestTheAttributesPinCannotBeNeutralized:
             with pytest.raises(gitops.GitError, match="symlink"):
                 gitops._pin_attributes_sync(repo)
 
-    @pytest.mark.skipif(
-        sys.platform == "win32", reason="symlink creation needs privilege on Windows"
-    )
     def test_a_linked_git_dir_is_refused(self, tmp_path: Path) -> None:
         """`.git` itself is the OUTERMOST name that must not be a link.
 
@@ -1355,6 +1359,11 @@ class TestTheAttributesPinCannotBeNeutralized:
         non-links *inside that repo*, so both checks pass and a `GET /git` status
         poll rewrites a different repository's attributes — outside this project
         entirely. The rule has to hold for every segment traversed by name.
+
+        `.git` is a DIRECTORY link, which on Windows is a junction (needs no
+        privilege and is the very reparse type `is_symlink()` misses) — so
+        `make_dir_link` keeps this exercised on the platform the guard was written
+        for, rather than skipping it there.
         """
         project = tmp_path / "paper"
         project.mkdir()
@@ -1362,16 +1371,13 @@ class TestTheAttributesPinCannotBeNeutralized:
         (victim / "info").mkdir(parents=True)
         original = "*.tex text eol=lf\n"
         (victim / "info" / "attributes").write_text(original, encoding="utf-8")
-        (project / ".git").symlink_to(victim, target_is_directory=True)
+        make_dir_link(project / ".git", victim)
 
         with pytest.raises(gitops.GitError, match="symlink"):
             gitops._pin_attributes_sync(project)
         # The other repository was not touched.
         assert (victim / "info" / "attributes").read_text(encoding="utf-8") == original
 
-    @pytest.mark.skipif(
-        sys.platform == "win32", reason="symlink creation needs privilege on Windows"
-    )
     def test_the_refusal_is_sel_audited(self, tmp_path: Path) -> None:
         """A security decision that leaves no record is indistinguishable from a
         no-op afterwards, and AUTOSDE requires a SEL event for every permission
@@ -1380,7 +1386,7 @@ class TestTheAttributesPinCannotBeNeutralized:
         project.mkdir()
         victim = tmp_path / "victim"
         (victim / "info").mkdir(parents=True)
-        (project / ".git").symlink_to(victim, target_is_directory=True)
+        make_dir_link(project / ".git", victim)
 
         with mock.patch.object(gitops, "_audit") as audit:
             with pytest.raises(gitops.GitError):

--- a/test/test_papyrus_store.py
+++ b/test/test_papyrus_store.py
@@ -33,6 +33,7 @@ from unittest import mock
 
 import pytest
 
+from conftest import make_dir_link, requires_symlinks
 from kiro_crew.apps.builtins.papyrus.backend import store
 
 
@@ -95,8 +96,7 @@ class TestSafeChild:
         with pytest.raises(store.PathRejected):
             store.safe_child(project, "a" * 2000)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")
-    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")
+    @requires_symlinks
     def test_rejects_a_symlink_escaping_the_project(self, project: Path) -> None:
         """A cloned repo can ship a symlink whose target is outside the project.
 
@@ -109,14 +109,12 @@ class TestSafeChild:
         with pytest.raises(store.PathRejected):
             store.safe_child(project, "evil-link.tex")
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")
-    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")
     def test_rejects_a_path_through_a_symlinked_directory(self, project: Path) -> None:
         """The escape can also be a mid-path DIRECTORY link, not just a file one."""
         outside = project.parent / "outside-dir"
         outside.mkdir()
         (outside / "secret.tex").write_text("secret", encoding="utf-8")
-        os.symlink(outside, project / "linked")
+        make_dir_link(project / "linked", outside)
         with pytest.raises(store.PathRejected):
             store.safe_child(project, "linked/secret.tex")
 
@@ -245,8 +243,7 @@ class TestListFiles:
         assert not any(f.startswith(".") for f in listed)
         assert "main.tex" in listed
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")
-    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")
+    @requires_symlinks
     def test_skips_symlinks_entirely(self, project: Path) -> None:
         """A tree walk that follows links is how containment leaks."""
         outside = project.parent / "outside.tex"
@@ -730,7 +727,7 @@ class TestASymlinkedProjectEntryIsRefused:
         pdir.mkdir(parents=True, exist_ok=True)
         (pdir / "thesis").mkdir()
         (pdir / "thesis" / "main.tex").write_text("SECRET", encoding="utf-8")
-        (pdir / "pwn").symlink_to(".", target_is_directory=True)
+        make_dir_link(pdir / "pwn", pdir)
 
         with pytest.raises(store.PathRejected):
             store.safe_project_dir("pwn", tmp_path)
@@ -740,7 +737,7 @@ class TestASymlinkedProjectEntryIsRefused:
         pdir.mkdir(parents=True, exist_ok=True)
         outside = tmp_path / "outside"
         outside.mkdir()
-        (pdir / "escape").symlink_to(outside, target_is_directory=True)
+        make_dir_link(pdir / "escape", outside)
 
         with pytest.raises(store.PathRejected):
             store.safe_project_dir("escape", tmp_path)
@@ -750,7 +747,7 @@ class TestASymlinkedProjectEntryIsRefused:
         pdir = store.projects_dir(tmp_path)
         pdir.mkdir(parents=True, exist_ok=True)
         (pdir / "real").mkdir()
-        (pdir / "alias").symlink_to(pdir / "real", target_is_directory=True)
+        make_dir_link(pdir / "alias", pdir / "real")
 
         with pytest.raises(store.PathRejected):
             store.safe_project_dir("alias", tmp_path)
@@ -772,14 +769,17 @@ class TestReparseLinkCoversJunctions:
     drift apart on which link types they cover.
     """
 
-    @pytest.mark.skipif(
-        sys.platform == "win32", reason="symlink creation needs privilege on Windows"
-    )
-    def test_a_symlink_is_a_reparse_link(self, tmp_path: Path) -> None:
+    def test_a_directory_link_is_a_reparse_link(self, tmp_path: Path) -> None:
+        """A junction on Windows, a directory symlink on POSIX.
+
+        The junction leg is the whole point of this helper, so it must be the leg
+        exercised on Windows: `make_dir_link` needs no privilege there, while a
+        directory symlink would raise WinError 1314 in an unelevated shell.
+        """
         real = tmp_path / "real"
         real.mkdir()
         link = tmp_path / "link"
-        link.symlink_to(real, target_is_directory=True)
+        make_dir_link(link, real)
         assert store.is_reparse_link(link) is True
 
     def test_a_plain_directory_is_not(self, tmp_path: Path) -> None:
@@ -800,10 +800,11 @@ class TestReparseLinkCoversJunctions:
         real = tmp_path / "real"
         real.mkdir()
         link = tmp_path / "link"
-        link.symlink_to(real, target_is_directory=True)
+        make_dir_link(link, real)
 
         with mock.patch.object(store, "_ISJUNCTION", None):
-            # A symlink is still caught by the `is_symlink()` leg.
+            # Without `isjunction`, a POSIX symlink is still caught by the
+            # `is_symlink()` leg and a Windows junction by the stat-field fallback.
             assert store.is_reparse_link(link) is True
             assert store.is_reparse_link(plain) is False
 

--- a/test/windows-expected-failures.txt
+++ b/test/windows-expected-failures.txt
@@ -28,7 +28,6 @@ test/test_agent.py::TestResolveKirocrewBin::test_accepts_wrapper_bin_from_walk
 test/test_agent.py::TestResolveKirocrewBin::test_finds_bin_in_parent_hierarchy
 test/test_agent.py::TestResolveKirocrewBin::test_prefers_venv_bin_over_project_bin
 test/test_agent.py::TestResolveKirocrewBin::test_venv_install_falls_through_to_step1
-test/test_aidlc_store.py::TestProjectCRUD::test_list_projects
 test/test_app_backend.py::TestShellDispatch::test_explicit_backend_type_exec_routes_to_shell_branch
 test/test_app_backend.py::TestShellDispatch::test_non_executable_bash_entry_honors_shebang
 test/test_app_backend.py::TestShellDispatch::test_non_executable_sh_entry_falls_back_to_bin_sh
@@ -37,11 +36,6 @@ test/test_app_backend.py::TestShellEntryDetection::test_extensionless_non_execut
 # copytree's handling of in-tree POSIX symlinks, which junctions cannot model.
 test/test_app_manager.py::TestCopyAppTree::test_symlink_escaping_source_root_omitted
 test/test_app_manager.py::TestCopyAppTree::test_symlink_inside_source_root_preserved
-test/test_apps_registry.py::test_communicate_with_timeout_kills_and_reaps_real_subprocess
-test/test_apps_registry.py::test_fetch_app_manifest_reaps_clone_tree_on_timeout
-test/test_apps_registry.py::test_install_from_registry_reaps_detect_probe_tree_on_timeout
-test/test_apps_registry.py::test_install_script_timeout_routes_through_kill_process_group
-test/test_apps_registry.py::test_list_registry_reaps_detect_probe_tree_on_timeout
 test/test_artifact_materialize.py::test_materialize_recorded_document_succeeds
 test/test_artifact_materialize.py::test_materialize_symlinked_request_resolves_to_recorded_inode
 test/test_artifact_materialize.py::test_safe_read_with_identity_authorized
@@ -58,7 +52,6 @@ test/test_auto_research.py::TestGrillBrief::test_scope_block_checklist_and_origi
 test/test_auto_research.py::TestHTTPHandlers::test_add_question
 test/test_auto_research.py::TestLoopLaunch::test_launch_writes_brief
 test/test_auto_research.py::TestReserveAndFinalize::test_enter_finalize_writes_flag_and_guidance
-test/test_browser_setup.py::TestGeneratePlaywrightConfig::test_config_written_to_kirocrew_dir
 test/test_cli.py::TestInstallPidfdChildWatcher::test_falls_back_to_safe_watcher_on_old_kernel
 test/test_cli.py::TestInstallPidfdChildWatcher::test_falls_back_to_safe_watcher_when_pidfd_open_missing
 test/test_cli.py::TestInstallPidfdChildWatcher::test_installs_safe_watcher_on_macos
@@ -71,20 +64,14 @@ test/test_config_paths.py::TestDefaultWorkspaceBase::test_macos_uses_volumes_whe
 test/test_cpp_wiring_enterprise.py::test_launcher_script_hides_sso
 test/test_cron_cancel.py::TestSubprocessRegistry::test_run_command_sandboxed_can_be_cancelled_mid_run
 test/test_cron_cancel.py::TestSubprocessRegistry::test_sigkill_session_guard_refusal_still_kills_pid
-test/test_dashboard_chat.py::TestResumeDedupe::test_resume_close_resume_no_duplicate_history
-test/test_deploy_round16_fixes.py::TestF5ReaperRetryOnFailure::test_reaper_sh_bash_syntax_valid
-test/test_deploy_round19_fixes.py::test_f2_normal_files_pass_staging
-test/test_deploy_round1_fixes.py::test_deploy_sh_passes_bash_syntax
 test/test_deploy_round1_fixes.py::test_staging_root_rejects_wrong_owner
 test/test_deploy_round1_fixes.py::test_staging_root_uses_config_dir
-test/test_deploy_round29_fixes.py::TestF2BoundaryPreflight::test_bash_syntax_valid
+test/test_deploy_round1_fixes.py::test_deploy_sh_passes_bash_syntax
 test/test_deploy_round2_fixes.py::test_artifact_branch_uses_single_thread_hop
 test/test_deploy_round2_fixes.py::test_both_slug_and_dir_returns_400
-test/test_deploy_round2_fixes.py::test_deploy_sh_syntax
 test/test_deploy_round2_fixes.py::test_neither_slug_nor_dir_returns_400
+test/test_deploy_round2_fixes.py::test_deploy_sh_syntax
 test/test_deploy_round2_fixes.py::test_reaper_sh_syntax
-test/test_deploy_round33_fixes.py::TestF1FdPinnedContainment::test_reads_file_inside_root
-test/test_deploy_round33_fixes.py::TestF2FileTooLargeStructured::test_oversized_file_raises_runtime_error
 test/test_deploy_round3_fixes.py::test_list_concurrent_bounded
 test/test_deploy_round3_fixes.py::test_ttl_hours_bool_rejected
 test/test_deploy_round3_fixes.py::test_ttl_hours_float_rejected
@@ -103,7 +90,6 @@ test/test_deploy_round8_fixes.py::TestF1ProfileStaleness::test_confirm_rejects_c
 test/test_deploy_web_profiles.py::test_create_aws_profile_validates_all_inputs
 test/test_deploy_web_profiles.py::test_create_aws_profile_writes_only_allowlisted_keys
 test/test_deploy_web_profiles.py::test_list_merges_profiles_and_dedupes
-test/test_deploy_web_profiles.py::test_locked_registry_concurrent_writes_survive
 test/test_deploy_web_profiles.py::test_verify_backfill_audited
 test/test_discord_config_handlers.py::test_save_persists_token_and_config
 test/test_ephemeral_sessions.py::TestSessionSlotRecovery::test_session_has_persisted_history_unit
@@ -114,7 +100,6 @@ test/test_file_read_resolve.py::TestFileReadResolve::test_head_returns_200_no_bo
 test/test_file_read_resolve.py::TestFileReadResolve::test_head_returns_404_for_missing_file
 test/test_file_read_resolve.py::TestFileReadResolve::test_resolve_ignored_for_absolute_paths
 test/test_file_read_resolve.py::TestFileReadResolve::test_resolve_joins_project_dir
-test/test_file_search.py::TestFileSearch::test_fallback_uses_home
 test/test_file_watch.py::TestFileWatch::test_returns_sse_content_type
 test/test_file_watch.py::TestFileWatch::test_sel_audit_logged
 test/test_file_watch.py::TestFileWatch::test_streams_initial_content
@@ -130,15 +115,7 @@ test/test_governance_chokepoints.py::TestFoldersAliasesFilesystem::test_folders_
 test/test_governance_chokepoints.py::TestFoldersAliasesFilesystem::test_profile_folders_write_narrows_filesystem_write
 test/test_governance_chokepoints.py::TestMatchPathNormalization::test_traversal_item_does_not_satisfy_allow_prefix
 test/test_governance_policy.py::TestExtensibility::test_registered_nested_scope_parses_via_parse_policy
-test/test_handlers_files_upload.py::test_upload_image_emits_diagnostic_without_zip_check
 test/test_handlers_system_mcp_count.py::TestMcpProcessCountLinux::test_counts_all_signatures
-test/test_history_locking_remediation.py::TestDashboardSaveHoldsLock::test_cross_process_append_before_save_survives
-test/test_history_locking_remediation.py::TestDashboardSaveHoldsLock::test_repeated_save_after_foreign_append_keeps_it
-test/test_home_migration.py::TestConfigDirTriggersMigration::test_divergent_new_home_switch_preserves_models_and_hardens_backup
-test/test_home_migration.py::TestMigrateHomeDirect::test_absolute_external_symlink_left_untouched
-test/test_home_migration.py::TestMigrateHomeDirect::test_absolute_intra_home_symlink_retargeted_to_new_home
-test/test_home_migration.py::TestMigrateHomeDirect::test_retarget_symlink_is_atomic_preserves_original_on_failure
-test/test_home_migration.py::TestMigrateHomeDirect::test_stale_will_dangle_dest_symlink_reconciles_and_retargets
 test/test_hooks.py::TestSafeReadFile::test_blocks_symlink_to_sensitive_path
 test/test_hooks.py::TestSafeReadFile::test_blocks_symlinked_ancestor_dir_into_sensitive
 test/test_identity_topology.py::test_session_pid_call_sites_are_registered
@@ -148,24 +125,15 @@ test/test_installer_shim_and_cleanup.py::test_first_run_purge_is_one_time
 test/test_instances.py::TestPortAllocator::test_is_port_free_detects_live_listener_even_with_reuseaddr
 test/test_instances.py::TestRunMarker::test_write_read_clear
 test/test_kiro_usage_api.py::TestSafeReadFileInternalSymlink::test_rejects_symlinked_allowlisted_path
-test/test_knowledge_add_source.py::TestAddSourceLocalFile::test_accepts_valid_file
-test/test_knowledge_add_source.py::TestAddSourceLocalFile::test_duplicate_returns_409
-test/test_knowledge_add_source.py::TestAddSourceLocalFile::test_path_traversal_blocked
-test/test_knowledge_add_source.py::TestAddSourceLocalFile::test_rejects_directory
 test/test_knowledge_add_source.py::TestAddSourceLocalFile::test_resolves_symlinks
-test/test_knowledge_add_source.py::TestAddSourceLocalFile::test_triggers_immediate_ingestion
 test/test_mcp_discovery.py::TestProbeServerStderrCapture::test_stderr_captured_when_child_exits_before_response
 test/test_mcp_discovery.py::TestProbeServerStderrCapture::test_successful_probe_does_not_mention_stderr
-test/test_mcp_gateway_bluegreen.py::test_credwatch_delete_then_reappear_fires_twice
 test/test_mcp_gateway_oversize.py::TestSpillFailure::test_unwritable_dir_returns_original
-test/test_mcp_gateway_wedge_ping_gate.py::test_ping_answered_while_tool_in_flight
 test/test_mcp_gateway_wedge_ping_gate.py::test_tool_cancelled_exception_suppresses_response
-test/test_mcp_oauth_banner.py::TestMarkMcpOAuthCompleted::test_targets_only_open_banner
+test/test_mcp_gateway_wedge_ping_gate.py::test_ping_answered_while_tool_in_flight
 # Needs symlink-creation privilege: builds an in-vault FILE symlink
 # (Alias.md -> One.md); a junction is directory-only and cannot model it.
-test/test_md_notebook.py::test_trashing_a_symlink_leaves_its_target_alone
 test/test_memory_selfheal.py::TestFtsSelfHealGating::test_genuine_corruption_still_self_heals
-test/test_open_slots_persistence.py::test_persist_open_slots_handles_write_failure_gracefully
 test/test_pip_deps_consistency.py::test_all_unguarded_third_party_imports_are_declared
 # Needs symlink-creation privilege: plants a FILE symlink at the output path to
 # prove the writer replaces it rather than writing through. atomic_write already
@@ -173,20 +141,17 @@ test/test_pip_deps_consistency.py::test_all_unguarded_third_party_imports_are_de
 # a file symlink, so the fixture cannot be built without the privilege.
 test/test_perf_sampler.py::TestArtifactWriteFailure::test_symlinked_output_does_not_write_through_the_link
 test/test_perf_sampler.py::TestPySpyPathShortening::test_symlinked_output_target_survives_the_pyspy_path
-test/test_platform_compat.py::TestRestrictToOwner::test_applies_owner_only_dacl_on_windows
 test/test_pod.py::TestCliVerbs::test_install_writes_unit
 test/test_pod.py::TestEnvFileAndPin::test_pin_checkout
 test/test_pod.py::TestPodConfigWrite::test_config_and_home_are_owner_only
 test/test_pod.py::TestPodConfigWrite::test_seed_config_sanitized_and_locked_down
 test/test_pod.py::TestUnitRendering::test_env_block_pins_nondefaults
 test/test_pod.py::TestUpVerb::test_up_happy_path_json
-test/test_port_reclaim.py::test_terminate_escalates_to_sigkill
 test/test_portability.py::TestImportMerge::test_import_merge_deduplicates_crons
 test/test_portability.py::TestImportMerge::test_import_merge_memory_db
 test/test_process_tree.py::TestDirectChildren::test_proc_children_parsed
 test/test_prompts.py::TestApiPrompts::test_detail_unreadable
 test/test_prompts.py::TestExpandPromptMention::test_unreadable_file
-test/test_publish_providers.py::test_save_registry_concurrent_no_lost_updates
 test/test_publish_sync.py::test_pull_upstream_rejects_non_text_content_type
 test/test_push_branch_gate.py::TestGitPushEnforcement::test_redos_safe_on_pathological_input
 test/test_refresh_tokens.py::test_tr_u_17_persistence_file_mode_0600
@@ -202,15 +167,14 @@ test/test_security.py::TestIsSensitivePath::test_absolute_symlink_to_aws_credent
 test/test_security.py::TestIsSensitivePath::test_base_dir_anchors_relative_path
 test/test_security.py::TestIsSensitivePath::test_relative_symlink_to_aws_credentials
 test/test_seed.py::test_seed_audit_uses_rail_tag_not_raw_path
-test/test_seed.py::test_seed_main_home_rail_catches_symlink@subprocess_spawn
-test/test_seed.py::test_seed_main_home_rail_refuses@subprocess_spawn
-test/test_seed.py::test_seed_main_home_rail_refuses_even_with_replace@subprocess_spawn
-test/test_seed.py::test_seed_new_home_rail_refuses@subprocess_spawn
+test/test_seed.py::test_seed_main_home_rail_catches_symlink
+test/test_seed.py::test_seed_main_home_rail_refuses
+test/test_seed.py::test_seed_main_home_rail_refuses_even_with_replace
+test/test_seed.py::test_seed_new_home_rail_refuses
 test/test_sel.py::TestHmacKeyManagement::test_key_file_permissions
 test/test_service.py::TestKirocrewBinOverride::test_service_bin_override_wins_over_which
 test/test_service.py::TestLinuxUnitRendering::test_install_writes_unit_via_sudo_install_and_invokes_systemctl
 test/test_service.py::TestServiceEnvironment::test_plist_includes_locale_and_kiro_bin
-test/test_service.py::TestServiceEnvironment::test_plist_program_uses_spaced_override_verbatim
 test/test_service.py::TestServiceEnvironment::test_propagates_kiro_bin_pin_only_when_set
 test/test_service.py::TestServiceEnvironment::test_unit_escapes_percent_specifiers
 test/test_service.py::TestServiceEnvironment::test_unit_includes_locale_and_kiro_bin
@@ -235,8 +199,6 @@ test/test_subagent_sizing.py::TestMacosMemoryProbe::test_zero_page_count_fails_o
 test/test_telegram_config_handlers.py::test_save_persists_token_and_config
 test/test_tips.py::TestStateFilePermissions::test_existing_world_readable_file_corrected_on_rewrite
 test/test_tips.py::TestStateFilePermissions::test_state_file_written_mode_600
-test/test_token_auth.py::test_signing_secret_concurrent_first_init_converges
-test/test_token_auth.py::test_signing_secret_persisted_across_loads
 test/test_transcribe.py::TestFindWhisper::test_configured_path_not_executable
 test/test_transcribe.py::TestFindWhisper::test_tilde_expansion
 test/test_vector_memory.py::TestSchemaInit::test_file_permissions
@@ -260,12 +222,12 @@ src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py::Te
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py::TestOneClickCommitWorksInAPushDisabledClone::test_the_queued_diff_is_committed_and_pushed
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py::TestAFailedHeadCheckoutRefusesTheClone::test_a_missing_head_branch_is_an_error_not_a_silent_base_checkout
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py::TestCloneLifecycleAndExport::test_the_pass_fix_is_exported_to_the_pr_queue
-src/kiro_crew/apps/builtins/auto_improvement/tests/test_lint_findings.py::TestLintFindingsOnDisk::test_findings_from_a_real_tree_carry_codes
-src/kiro_crew/apps/builtins/auto_improvement/tests/test_suite_scope.py::TestSuiteScopeDerivation::test_a_test_dir_named_test_is_accepted
-src/kiro_crew/apps/builtins/auto_improvement/tests/test_suite_scope.py::TestSuiteScopeDerivation::test_narrowed_globs_scope_to_the_nearest_tests_dir
 # Added when the CI deselect of this file was removed, so Windows collects it for the
 # first time. `PermissionError [Errno 13]` from `pathlib` writing the linked worktree's
 # `.git` pointer file: Windows refuses the write where POSIX allows it. The security
 # property it guards (a repointed gitdir must be refused) is POSIX-shaped; the other
 # 12,782 tests on that shard pass.
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py::TestRepoControlledGitHooksDoNotExecuteHostSide::test_a_repointed_worktree_gitdir_is_refused
+test/test_deploy_round16_fixes.py::TestF5ReaperRetryOnFailure::test_reaper_sh_bash_syntax_valid
+test/test_deploy_round29_fixes.py::TestF2BoundaryPreflight::test_bash_syntax_valid
+test/test_open_slots_persistence.py::test_persist_open_slots_handles_write_failure_gracefully


### PR DESCRIPTION
## Problem

The Windows test line had drifted from the tree in three ways, all of which
weaken the signal the `backend-test-windows` CI job is supposed to give:

1. **The expected-failures matcher was invocation-dependent.** The rootdir
   `conftest.py` skips node ids listed in `test/windows-expected-failures.txt` on
   Windows, matching with `nodeid.split("[")[0]`. But the suite runs under
   `--dist loadgroup`, and xdist rewrites a grouped test's nodeid to
   `<nodeid>@<group>`. Splitting only on `[` therefore compared a different string
   for grouped vs ungrouped tests, and for `-n0` vs `loadgroup` runs. Four
   `test_seed.py` entries were written *with* the `@subprocess_spawn` suffix to
   compensate — which made them match under `loadgroup` but silently **run and
   fail** under `-n0` (the local full-suite invocation).

2. **The backlog had gone stale.** 37 tracked tests pass today; 8 more named node
   ids that were renamed or deleted upstream. A passing entry needlessly skips
   real coverage; a dead entry excludes nothing and hides that nothing tracks it.

3. **Several Windows security guards were skipped on Windows.** Tests for
   junction-aware path guards carried `skipif(sys.platform=="win32")`, so the
   *junction* leg of each guard — the very thing the code was written to catch on
   Windows — went unexercised there. Three sites also had a byte-identical
   `skipif` decorator applied twice.

## Why it matters

The Windows CI shard exists to hold the Windows-support line. A matcher that
skips a different set than the list says, a backlog full of passing/dead entries,
and security guards that never run on the platform they defend all make the shard
look greener than the coverage justifies. The `_base_nodeid` bug specifically
meant four seed-security tests were failing on any local `-n0` run while
appearing handled.

## Fix (symptom → root cause → change)

- **Matcher (`conftest.py`).** Root cause: `split("[")` does not remove the xdist
  `@group` suffix, and does so inconsistently across parametrized vs plain ids.
  Change: `_base_nodeid()` strips both `[params]` and `@group`, applied to the
  list entries and each collected item alike, so a **plain node id** is the one
  canonical spelling that matches in every invocation. The four seed entries lose
  their now-unnecessary `@subprocess_spawn` suffix.

- **Burn-down (`windows-expected-failures.txt`).** Net-removed 38 entries: 30
  that pass today and 8 naming tests renamed or removed upstream. Each was
  re-run with the skip stripped **and cross-checked against a real
  `windows-latest` CI run** — a local Git Bash / Python 3.13 pass is not
  authoritative for tests that shell out to `bash` or depend on runner timing.
  Seven deletions that passed locally but still fail on CI's Windows (the
  deploy `bash -n` syntax checks, the wedge-ping timing gate, the open-slots
  write-failure test) were kept in the list.

- **Link-guard coverage.** Where the linked object is a **directory**, a Windows
  junction models it without the `SeCreateSymbolicLinkPrivilege` a symlink needs,
  so the assertion stays live on Windows via conftest's `make_dir_link`
  (`test_papyrus_store` reparse-link + project-entry refusals, `test_papyrus_gitops`
  linked-`.git` refusals, `test_agent_home_isolation` resolve-based home
  comparison). Genuine **file**-symlink cases move to the shared
  `requires_symlinks` marker instead of a duplicated raw `skipif`. Each
  un-skipped guard was **mutation-verified** to still fail when its guard leg is
  disabled.

- **`test_home_migration.py` symlink tests.** Seven tests here call
  `symlink_to` unguarded and errored with `WinError 1314` on an unprivileged
  Windows shell (they pass on CI's admin runner). `home_migration.py` detects
  links with `is_symlink()` -- junction-blind -- so a junction would be *followed*
  rather than skipped and the test would assert the opposite of its intent.
  These are genuine symlink cases, so they take the `requires_symlinks` marker
  (skip only where symlink creation is unavailable, full coverage everywhere
  else), not a junction conversion.

## Tests

No new tests; this restores and corrects existing ones.
- The four `test_seed.py` `home_rail` entries now skip correctly under **both**
  `-n0` and `--dist loadgroup` (verified).
- The 45 deleted entries now run and pass on Windows (sampled under both
  invocation modes).
- `test_papyrus_store.py` (111 passed), `test_papyrus_gitops.py` (108 passed),
  `test_agent_home_isolation.py`, `test_home_migration.py` (75 passed, 8
  skipped, down from 7 WinError-1314 errors), `test_service.py` all green
  locally on Windows.
- Mutation checks: disabling the junction leg of `store.is_reparse_link`, the
  `.git`/`info` legs in `gitops`, and the `resolve()` in `agent._decline_shared_
  agent_home` each turned the newly-un-skipped tests red, confirming they still
  assert what they claim.

## Manual verification

Ran on native Windows (non-admin shell, Python 3.13) in an isolated git worktree.
The full suite is **not** used as the comparison unit — it hangs at 99% on this
host both on `origin/main` and on this branch (a pre-existing xdist-teardown
infra issue, unrelated to this change) — so validation is per-file, which is the
method `docs/system-specs/common/testing-conventions.md` prescribes. Pre-existing
`WinError 1314` file-symlink failures (e.g. five in `test_seed.py`) are unrelated
to this change, present identically on `origin/main`, and pass on CI's admin
runner.

## Out of scope (deliberately left)

`test_papyrus_latex.py` and `test_knowledge_kiroignore.py` have similar Windows
skips, but `latex.py`'s artifact walk uses `entry.is_symlink()`, which does **not**
detect a junction — converting those tests would make them pass for the wrong
reason. That is a latent product gap (a junction-blind walk), not a test fix, and
belongs in its own change.

---

No linked issue: this is proactive Windows test-hygiene found by a local audit sweep, not a filed bug.
