### PR TITLE
fix(skills): gate auto-skill detection on recurrence, not effort

### DIFF
--- a/src/kiro_crew/builtin_skills/crystallize/SKILL.md
+++ b/src/kiro_crew/builtin_skills/crystallize/SKILL.md
@@ -26,13 +26,21 @@ the work is worth keeping.
 
 - The user says any trigger phrase above (candidate mode), or explicitly asks
   for a "live" / "active" skill (live mode).
-- The session contains a **non-trivial, reusable procedure** — a multi-step
-  workflow, a debugging path for a class of error, a fixed command/API
-  sequence, or a research-synthesis flow — that a future session would benefit
-  from.
+- The session demonstrated a procedure that will **recur** — one a future
+  session, working on a DIFFERENT target, would run again substantially
+  unchanged: a repeatable debugging method for a class of error, a fixed
+  command/API sequence, a verification technique, a research-synthesis flow.
 
-Do **not** crystallize a trivial one-shot answer, a one-off failure, or a
-session that touched credentials / sensitive paths.
+Apply the same recurrence test the automatic pass uses: name the future session
+that would load this skill and the different target it would run against. If the
+only honest answer reuses this session's own artifact — this bug, this file,
+this component, this one question — the procedure does not recur. Effort is not evidence of recurrence: a long, many-step, genuinely difficult session is still one-off if its steps were chosen for one target.
+
+Do **not** crystallize a task done once and now finished (a specific bug's fix,
+a one-time audit or trace of one component, a migration, a probe run to answer a
+question that is now answered), a design or planning discussion, a narrative of
+what happened in this session, a trivial one-shot answer, a one-off failure, or
+a session that touched credentials / sensitive paths. Being asked does not make a one-off reusable — but the call is the user's, not yours. When the session carries no recurring procedure, say so and name what makes it one-off, then let them decide; if they still want it captured, crystallize it. Never silently decline a direct request.
 
 ## Procedure
 

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -5747,6 +5747,17 @@ class HistoryConsolidator:
         been appended since the last pass, yet still forces a fresh pass after a
         transcript rotation (which swaps the window's content); genuine repeats
         are still caught by the dedupe verdict in ``_process_auto_skills``.
+
+        The prompt gates on RECURRENCE, not effort. A session can be long,
+        difficult, and rich in tool calls while still being one-off — a single
+        bug's fix, a one-time audit of one component, a probe answering a
+        question that is now answered — and the tool-call floor
+        (``auto_min_tool_calls``) cannot tell those apart from a repeatable
+        method. So the prompt makes the model name the future session and the
+        DIFFERENT target that would reuse the procedure, and return null when
+        the only honest answer reuses this session's own artifact. It also
+        prefers null under uncertainty: an unreusable candidate is not free,
+        because it spends the human's review attention on every later proposal.
         """
         if self._skills_loader is None:
             return
@@ -5789,24 +5800,37 @@ class HistoryConsolidator:
             )
         skill_keys = [
             '"new_skill": Object or null. Return an object ONLY if this '
-            "session contained a non-trivial reusable multi-step procedure "
-            "that future sessions would benefit from (e.g. debugging a "
-            "specific class of error, running a multi-command sequence, "
-            "a research synthesis flow). The procedure may be demonstrated by "
-            "only PART of the excerpt below — you do NOT need to cover the whole "
-            "session, just capture the one reusable procedure it contains. Shape: "
+            "session demonstrated a procedure that will RECUR — one a future "
+            "session, working on a DIFFERENT target, would run again "
+            "substantially unchanged (e.g. a repeatable debugging method for a "
+            "class of error, a fixed command/API sequence, a verification "
+            "technique). The procedure may be demonstrated by only PART of the "
+            "excerpt below — you do NOT need to cover the whole session. "
+            "Shape: "
             '{"slug": "<kebab-case-4-to-60-chars>", '
             '"description": "<=150 chars, starts with verb>", '
             '"triggers": "<3-8 comma-separated keywords/phrases>", '
             '"procedure_md": "<concise markdown body with '
             "## When to use / ## Steps / ## Gotchas sections, "
             '<=8000 chars>"' + scripts_field + "}. "
-            "Return null if the session was trivial, a single-shot answer, "
-            "a one-off failure with no reusable takeaway, or involved "
-            "sensitive paths. When a session plausibly contains a procedure "
-            "a future session could reuse, lean toward returning it — every "
-            "candidate is staged for human approval before it can activate, "
-            "so a borderline proposal is cheap while a miss is lost for good. "
+            "## The recurrence test (apply BEFORE returning an object)\n"
+            "Name the future session that would load this skill and the "
+            "DIFFERENT target it would run against. If the only honest answer "
+            "reuses this session's specific artifact — this bug, this file, "
+            "this component, this one question — the procedure does not recur "
+            "and you MUST return null. Effort is not evidence of recurrence: a "
+            "long, many-step, genuinely difficult session is still one-off if "
+            "its steps were chosen for one target.\n"
+            "Return null for: a task done once and now finished (a specific "
+            "bug's fix, a one-time audit/trace of one component, a migration, "
+            "a probe run to answer a question that is now answered); a design "
+            "or planning discussion; a narrative of what happened in this "
+            "session; a procedure whose steps only make sense against the "
+            "exact artifact at hand; a trivial or single-shot answer; a "
+            "one-off failure with no reusable takeaway; anything touching "
+            "sensitive paths. Prefer null when uncertain — an unreusable "
+            "candidate costs the user review effort on every future proposal, "
+            "so silence is cheaper than a plausible-looking one-off. "
             "Do NOT include absolute paths, credentials, tokens, or user PII "
             "in the procedure body."
         ]
@@ -5844,6 +5868,16 @@ class HistoryConsolidator:
         self._last_skillgen_marker[key] = marker
         if not result:
             return
+        # Log the verdict, not just the proposals. The prompt's default is null,
+        # so silence is the common outcome, and the staging log in
+        # ``_process_auto_skills`` only fires when a candidate is produced --
+        # which would leave the queue showing the false-POSITIVE rate while the
+        # false-negative rate had no signal at all.
+        logger.debug(
+            "Skill detection verdict for %s: %s",
+            key,
+            "candidate proposed" if result.get("new_skill") else "no recurring procedure",
+        )
         # _event_loop was captured by our caller (_consolidate) so the
         # thread-offloaded dedupe judge can marshal back onto the gateway loop.
         await asyncio.to_thread(self._process_auto_skills, result, key)

--- a/test/test_crystallize_skill.py
+++ b/test/test_crystallize_skill.py
@@ -23,3 +23,62 @@ def test_crystallize_builtin_present_and_triggers(tmp_path):
     # Trigger phrases the user would say.
     for phrase in ("crystallize this session", "create a skill from this", "make this reusable"):
         assert "crystallize" in loader.get_triggered_skills(phrase)
+
+
+def test_crystallize_gates_on_recurrence_like_the_auto_pass():
+    """crystallize must apply the SAME criterion as automatic skill detection.
+
+    Both paths stage into ``auto/.pending/``, so two different bars for what
+    qualifies means the queue's contents depend on which path proposed them.
+    ``_run_skill_detection`` gates on recurrence; this file used to gate on a
+    "non-trivial, reusable procedure" -- complexity, which an elaborate one-off
+    satisfies -- and excluded only small things (a trivial one-shot answer, a
+    one-off failure), never large one-off ones. Whitespace is normalized because
+    the file is hard-wrapped and a line break would otherwise split a phrase.
+    """
+    from pathlib import Path
+
+    import kiro_crew
+
+    body = (
+        Path(kiro_crew.__file__).parent / "builtin_skills" / "crystallize" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    text = " ".join(body.split())
+
+    assert "non-trivial, reusable procedure" not in text, (
+        "the complexity criterion is the defect the recurrence gate replaced -- "
+        "an elaborate one-off satisfies it truthfully"
+    )
+    assert (
+        "recurrence test" in text.lower()
+    ), "crystallize must apply the recurrence test, not just describe reusability"
+    assert "DIFFERENT target" in text, (
+        "naming a different future target is what separates a repeatable method "
+        "from a finished task"
+    )
+    assert (
+        "Effort is not evidence of recurrence" in text
+    ), "without this, a long difficult one-off session still reads as skill-worthy"
+    # crystallize is user-invoked, so it must not inherit the auto pass's
+    # "prefer null when uncertain" default -- the human already asked. What it
+    # DOES need is that the asking alone does not qualify a one-off.
+    assert (
+        "Being asked does not make a one-off reusable" in text
+    ), "an explicit user request must not be treated as evidence of recurrence"
+    # ...but stating that must not become a refusal. The invoker of crystallize
+    # IS the reviewer the auto pass is protecting, so declining their request
+    # makes them argue past their own tool to capture something they judged
+    # worth keeping. Surface the verdict, then let them decide.
+    assert "the call is the user's, not yours" in text, (
+        "crystallize must defer the final decision to the user rather than "
+        "applying the auto pass's refusal default to an explicit request"
+    )
+    assert "Never silently decline a direct request" in text, (
+        "a one-off verdict must be surfaced for the user to overrule, not "
+        "turned into a silent refusal"
+    )
+    for shape in ("one-time audit", "migration", "now answered"):
+        assert shape in text, (
+            f"crystallize must name {shape!r} as a do-not-crystallize shape, "
+            f"matching the auto pass's return-null list"
+        )

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -2893,6 +2893,89 @@ class TestConsolidationPromptJsonShape:
             "opener — don't split the value inside a quoted string."
         )
 
+    @pytest.mark.asyncio
+    async def test_prompt_gates_on_recurrence_not_effort(self, tmp_path):
+        """The built prompt must demand recurrence and must not bias toward yes.
+
+        The observed failure this pins: the prompt used to instruct the model to
+        "lean toward returning it" on any plausible procedure and judged only
+        triviality, so elaborate ONE-OFF sessions (a single bug's fix, a
+        one-time component audit, a probe answering a now-answered question)
+        were staged as skills and piled up unreviewable in the pending queue.
+        Asserts on the prompt the code actually builds, not on source text, so
+        the check survives refactors of how the string is assembled.
+        """
+        import asyncio as _asyncio
+        from unittest.mock import patch
+
+        from kiro_crew.memory import MemoryStore
+        from kiro_crew.skills import SkillsLoader
+
+        conv_log = ConversationLog(base_dir=tmp_path / "sessions")
+        conv_log.init()
+        mem = MemoryStore(workspace=tmp_path / "memory")
+        mem.init()
+        skills = SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False)
+        c = HistoryConsolidator(
+            log=conv_log,
+            memory=mem,
+            skills_loader=skills,
+            auto_skills_enabled=True,
+            approval_required=True,
+            auto_min_tool_calls=2,
+        )
+        key = "dashboard:chat-recurrence"
+        for i in range(4):
+            conv_log.append(key, "assistant", f"step {i}", tools=["execute_bash"])
+
+        captured: dict = {}
+
+        async def fake_llm(prompt):
+            captured["prompt"] = prompt
+            return {"new_skill": None}
+
+        c._event_loop = _asyncio.get_running_loop()
+        with patch.object(c, "_call_llm", side_effect=fake_llm):
+            await c._run_skill_detection(key)
+
+        prompt = " ".join(captured.get("prompt", "").split())
+        assert prompt, "skill detection must have built and issued a prompt"
+
+        # The yes-bias that caused the over-generation must be gone.
+        for banned in ("lean toward returning it", "a miss is lost for good"):
+            assert banned not in prompt, (
+                f"the prompt must not bias the model toward proposing a skill: "
+                f"found {banned!r}"
+            )
+
+        # Recurrence must be the actual gate, stated as a test the model applies.
+        assert "recurrence test" in prompt.lower(), (
+            "the prompt must make the model apply an explicit recurrence test "
+            "before returning a candidate"
+        )
+        assert "DIFFERENT target" in prompt, (
+            "the recurrence test must require naming a DIFFERENT future target — "
+            "that is what separates a repeatable method from a one-off task"
+        )
+        assert "Effort is not evidence of recurrence" in prompt, (
+            "the prompt must say effort is not evidence of recurrence, or a long "
+            "difficult one-off session still reads as skill-worthy"
+        )
+
+        # The one-off shapes actually observed in the pending queue.
+        for shape in ("one-time audit", "migration", "now answered"):
+            assert shape in prompt, (
+                f"the prompt must name {shape!r} as a return-null shape — these "
+                f"are the elaborate one-offs that polluted the pending queue"
+            )
+
+        # Uncertainty must resolve to null, and the reason must be stated in
+        # terms of the real cost (human review attention), not a free lunch.
+        assert "Prefer null when uncertain" in prompt, (
+            "the prompt must resolve uncertainty to null rather than to a "
+            "speculative candidate"
+        )
+
 
 class TestSkillDetectionFullWindow:
     """Skill detection judges the full-session window, not the consolidated tail.


### PR DESCRIPTION
## Problem

Auto-skill detection stages elaborate **one-off** sessions as skill candidates. Observed on a real install: 12 candidates accumulated in `auto/.pending/`, of which roughly three describe a procedure a future session could actually reuse. The rest are things that happened exactly once — a probe run to measure one model's context window, a one-time trace of one component's code paths, a fix for one specific bug, a design discussion. None were ever approved: a queue where most entries are unreusable is a queue nobody reads, which also costs the reusable ones their visibility.

## Why the existing filters cannot catch it

`_run_skill_detection` gates on three deterministic conditions before spending an LLM call — an unchanged `(rotation_generation, count)` marker, a tool-call floor (`skills.auto_min_tool_calls`, default 5), and a sensitive-path check. All three answer *"is this session worth asking about?"*, not *"is this a skill?"*

A one-time probe passes all three legitimately: it makes well over five tool calls, touches no sensitive path, and appends messages. Raising the tool-call floor does not help, because the offending sessions are the ones with **many** tool calls. The entire skill/not-skill decision therefore rests on the prompt, and the prompt judged the wrong property.

## Root cause, in the prompt

Three separate defects compounded:

1. **The positive criterion tested complexity, not recurrence.** It asked for a "non-trivial reusable multi-step procedure". A model can verify "non-trivial" and "multi-step"; "reusable" was an adjective with no stated test. A genuinely difficult one-off satisfies the checkable part *truthfully*.

2. **An explicit bias toward yes.** The prompt said to "lean toward returning it" whenever a session "plausibly" contained a reusable procedure, justified by: *"a borderline proposal is cheap while a miss is lost for good."* The first half of that is false — see below.

3. **The return-null list only excluded small things.** `trivial`, `single-shot answer`, `one-off failure with no reusable takeaway`. The actual queue pollution was large and elaborate, so nothing on that list matched it.

## Change

Gate on **recurrence**, as a test the model has to apply and answer:

> Name the future session that would load this skill and the DIFFERENT target it would run against. If the only honest answer reuses this session's specific artifact — this bug, this file, this component, this one question — the procedure does not recur and you MUST return null. Effort is not evidence of recurrence: a long, many-step, genuinely difficult session is still one-off if its steps were chosen for one target.

Requiring a *different* target is what separates a repeatable method from a finished task. "Verify a fix by reverting it and asserting the test fails" passes — every future PR is a different target. "Probe this model's context window" fails — the only reuse re-derives the number this session already has.

The `Effort is not evidence of recurrence` sentence is aimed at defect 1 specifically: without it, difficulty keeps reading as sedimentation-worthy.

The return-null list now names the large one-off shapes observed in the queue: a specific bug's fix, a one-time audit/trace of one component, a migration, a probe answering a now-answered question, a design or planning discussion, a session narrative, and a procedure whose steps only make sense against the artifact at hand.

Uncertainty resolves to null. The old cost model called a spurious candidate free because approval gates activation, but the scarce resource is review attention and it is spent on *every later proposal* — so an unreusable candidate is precisely what makes a reusable one easy to miss.

## Scope and limits

Prompt-level, so it shifts a probabilistic judgment rather than adding a hard filter — it should cut the false-positive rate, not drive it to zero. The hard guarantee remains `skills.approval_required` (default `true`): nothing activates without a human. What this buys is a pending queue whose entries are worth reading.

Two paths change, on different triggers. The **automatic** pass is gated by `skills.auto_create_from_sessions` (off by default), so installs with it off see no change until they enable it. The **crystallize** path is user-invoked and changes *regardless of that flag*: when a session carries no recurring procedure it now says so and names why, then leaves the decision with the user. It does not decline — the invoker of crystallize is the same person the auto pass's queue discipline protects, so refusing them would make them argue past their own tool to keep something they already judged worth keeping.

## Verification

- `test_prompt_gates_on_recurrence_not_effort` asserts on the prompt the code actually **builds** (mocking `_call_llm` and capturing its argument), not on `inspect.getsource` text, so it survives refactors of how the string is assembled. String-assertion tests execute none of the code they claim to cover; this one runs the real prompt-assembly path.
- Confirmed load-bearing: reverting `history.py` fails it (`the prompt must not bias the model toward proposing a skill`), restoring passes it.
- `test/test_history.py` 229 passed; skill-related suite 1245 passed; `isort`, `flake8`, `mypy src/kiro_crew/` (987 files) clean.
- Full backend suite: 56825 passed, 27 failed — all 27 reproduce identically on a clean `origin/main` worktree (`test_issue_triage_workflow`, `test_playwright_cli_installer`, `test_pr_readiness_publish`, `test_platform_compat`, `test_instances`), so they are pre-existing and environment-specific, not from this change.
- Backend-only diff; no frontend surface touched.

