### PR TITLE
feat(i18n): gate catalog values that are still English

### DIFF
--- a/website/scripts/check-source-strings.mjs
+++ b/website/scripts/check-source-strings.mjs
@@ -54,6 +54,7 @@ import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { changedValueFindings, flatten as qaFlatten } from './lib/qa-checks.mjs'
+import { passthroughChecks, passthroughFindings } from './lib/passthrough-checks.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
@@ -241,14 +242,36 @@ function readFlat(paths, ref) {
 
 const byLang = catalogFiles()
 const enHead = readFlat(byLang.en ?? [], null)
+// The do-not-translate list is the exclusion set the language checks measure against:
+// a value made only of product names is not untranslated, it is correct.
+const dnt = JSON.parse(
+  fs.readFileSync(path.join(ROOT, 'src', 'i18n', 'glossary.json'), 'utf-8'),
+).dnt ?? []
+const ptChecks = passthroughChecks(dnt)
 const qaFindings = []
+const ptFindings = []
 for (const [lang, paths] of Object.entries(byLang)) {
+  // Read each catalog once at each ref: both checks want the same two snapshots, and
+  // a second `git show` per locale doubles the I/O of the slowest part of this gate.
+  const catalogBase = readFlat(paths, BASE_REF)
+  const catalogHead = readFlat(paths, null)
   qaFindings.push(
     ...changedValueFindings({
       lang,
-      base: readFlat(paths, BASE_REF),
-      head: readFlat(paths, null),
+      base: catalogBase,
+      head: catalogHead,
       enHead,
+    }),
+  )
+  // English is the source; there is nothing for it to be an untranslated copy of.
+  if (lang === 'en') continue
+  ptFindings.push(
+    ...passthroughFindings({
+      lang,
+      base: catalogBase,
+      head: catalogHead,
+      enHead,
+      checks: ptChecks,
     }),
   )
 }
@@ -275,7 +298,32 @@ if (qaFindings.length > 0) {
   )
 }
 
-if (findings.length === 0 && qaFindings.length === 0) {
+console.log(
+  `[changed-passthrough] ${ptFindings.length} untranslated value(s) among values changed vs ${BASE_REF}.`,
+)
+
+if (ptFindings.length > 0) {
+  const byPassthroughId = {}
+  for (const f of ptFindings) {
+    (byPassthroughId[f.check.id] = byPassthroughId[f.check.id] || []).push(f)
+  }
+  console.error('')
+  for (const [id, list] of Object.entries(byPassthroughId)) {
+    console.error(`${id} — ${list[0].check.describe}`)
+    for (const f of list) console.error(`    ${f.lang}:${f.key}\n      ${JSON.stringify(f.value)}`)
+    console.error('')
+  }
+  console.error(
+    'These values are NEW or EDITED on this branch and still read as English, so they are\n'
+    + 'not inherited debt and there is no ceiling to raise. Translate them.\n\n'
+    + 'If a value is legitimately identical in this locale — a product name, a command, an\n'
+    + 'identifier — add the term to `dnt` in src/i18n/glossary.json instead of working around\n'
+    + 'the check. That list is what every locale is measured against, so registering it once\n'
+    + 'exempts it everywhere and documents why.',
+  )
+}
+
+if (findings.length === 0 && qaFindings.length === 0 && ptFindings.length === 0) {
   process.exit(0)
 }
 

--- a/website/scripts/check-untranslated-values.mjs
+++ b/website/scripts/check-untranslated-values.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * How many catalog values are still English where a translation is expected.
+ *
+ * ## Why this cannot fail the step
+ *
+ * The count is inherited. Eleven catalogs carry roughly 2,700 such values, and the
+ * branch that happens to touch a catalog next did not put them there — failing on the
+ * total would red-line PRs whose diff is clean, which is the exact failure mode the
+ * gate runner's three-tier table exists to prevent. So this is an `info` row: it
+ * measures, it prints, and it exits 0 with findings.
+ *
+ * Enforcement lives entirely in the diff: `check-source-strings.mjs` runs the same
+ * predicates over the values a branch added or changed, at zero tolerance, where there
+ * is no ceiling to raise and no one else to wait for.
+ *
+ * ## Why there is no committed ceiling either
+ *
+ * A stored total would only exist to notice growth, and the diff-scoped check already
+ * refuses growth at the moment it is introduced. A second number would add a file to
+ * update, a review ritual for raising it, and a way for two branches to conflict over
+ * a count — buying nothing the zero-tolerance check does not already guarantee.
+ *
+ * Set `I18N_PASSTHROUGH_REPORT=1` for the per-key worklist; the default prints
+ * per-locale counts, because 2,700 lines in every CI log is not a worklist anyone reads.
+ *
+ * Exit codes: 0 always, findings or not · 2 cannot run.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { flatten } from './lib/qa-checks.mjs'
+import {
+  FUNCTION_WORDS,
+  TARGET_SCRIPTS,
+  passthroughChecks,
+  passthroughViolations,
+} from './lib/passthrough-checks.mjs'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const I18N = join(HERE, '..', 'src', 'i18n')
+const LOCALES_DIR = join(I18N, 'locales')
+const VERBOSE = process.env.I18N_PASSTHROUGH_REPORT === '1'
+
+/** English is the source, and the pseudolocale is a mechanical transform of it. */
+const SKIP = new Set(['en.json', 'en.manual.json', 'en-XA.json'])
+
+const die = msg => {
+  process.stdout.write(`\n[untranslated-passthrough] ${msg}\n`)
+  process.exit(2)
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'))
+  } catch (err) {
+    die(`could not read ${path}: ${err.message}`)
+  }
+}
+
+const glossary = readJson(join(I18N, 'glossary.json'))
+if (!Array.isArray(glossary.dnt) || !glossary.dnt.length) {
+  die('glossary.json has no `dnt` array. Without it every product name reads as'
+    + ' untranslated English, so the numbers below would be meaningless.')
+}
+const checks = passthroughChecks(glossary.dnt)
+
+// The English source is split across two files with no overlapping keys; the
+// identical-to-English half needs both or it silently skips a third of the corpus.
+const enFlat = {
+  ...flatten(readJson(join(LOCALES_DIR, 'en.manual.json'))),
+  ...flatten(readJson(join(LOCALES_DIR, 'en.json'))),
+}
+
+const catalogs = readdirSync(LOCALES_DIR)
+  .filter(f => f.endsWith('.json') && !SKIP.has(f))
+  .sort()
+if (!catalogs.length) die(`no locale catalog in ${LOCALES_DIR} — nothing to measure.`)
+
+const findings = []
+const perLocale = []
+const unruled = []
+let scanned = 0
+
+for (const file of catalogs) {
+  const lang = file.replace(/\.json$/, '')
+  if (!TARGET_SCRIPTS[lang] && !FUNCTION_WORDS[lang]) unruled.push(lang)
+  const catalog = flatten(readJson(join(LOCALES_DIR, file)))
+  const total = Object.keys(catalog).length
+  scanned += total
+  const hits = passthroughViolations({ lang, catalog, enFlat, checks })
+  findings.push(...hits)
+  perLocale.push({ lang, total, hits })
+}
+
+process.stdout.write(`OK: ${findings.length} untranslated passthrough value(s) across `
+  + `${catalogs.length} catalog(s) — ${scanned} value(s) scanned.\n`)
+
+if (unruled.length) {
+  process.stdout.write(`NOTE: no language rule for ${unruled.join(', ')} — `
+    + 'these catalogs are counted as scanned but nothing about them is judged. Add the '
+    + 'locale to TARGET_SCRIPTS or TARGET_FUNCTION in lib/passthrough-checks.mjs.\n')
+}
+
+const width = Math.max(...perLocale.map(p => p.lang.length))
+for (const { lang, total, hits } of perLocale) {
+  const byCheck = {}
+  for (const h of hits) byCheck[h.check.id] = (byCheck[h.check.id] || 0) + 1
+  const detail = Object.entries(byCheck).map(([id, n]) => `${id} ${n}`).join(' · ') || 'clean'
+  const pct = total ? ((100 * hits.length) / total).toFixed(1) : '0.0'
+  process.stdout.write(`  ${lang.padEnd(width)}  ${String(hits.length).padStart(5)} of ${total}`
+    + `  (${pct}%)  ${detail}\n`)
+}
+
+if (findings.length && !VERBOSE) {
+  process.stdout.write('\nSet I18N_PASSTHROUGH_REPORT=1 for the per-key worklist.\n')
+}
+
+if (findings.length && VERBOSE) {
+  process.stdout.write('\n')
+  for (const { lang, hits } of perLocale) {
+    if (!hits.length) continue
+    process.stdout.write(`${lang}\n`)
+    for (const h of hits) {
+      process.stdout.write(`  ${h.check.id}  ${h.key}\n    ${JSON.stringify(h.value)}\n`)
+    }
+    process.stdout.write('\n')
+  }
+}
+
+process.exit(0)

--- a/website/scripts/lib/i18n-gate-table.mjs
+++ b/website/scripts/lib/i18n-gate-table.mjs
@@ -22,7 +22,7 @@
 
 /** @typedef {'PASS'|'FAIL'|'MISSING'|'NOT RUN'} RowState */
 
-/** The eight processes. Each may host more than one check. */
+/** The ten processes. Each may host more than one check. */
 export const SCRIPTS = [
   { key: 'pseudo', argv: ['gen-pseudolocale.mjs', '--check'] },
   { key: 'keys', argv: ['check-i18n-keys.mjs'] },
@@ -33,10 +33,11 @@ export const SCRIPTS = [
   { key: 'dnt', argv: ['check-dnt-catalogs.mjs'] },
   { key: 'manifest', argv: ['check-app-manifest-sync.mjs'] },
   { key: 'units', argv: ['check-unit-literals.mjs'] },
+  { key: 'passthrough', argv: ['check-untranslated-values.mjs'] },
 ]
 
 /**
- * The thirteen checks, in reading order within their section.
+ * The eighteen checks, in reading order within their section.
  *
  * `find` pulls the numbers out of the owning script's output on the PASSING path;
  * `whenFailed` does the same for the failing path, because most of these scripts print
@@ -93,6 +94,17 @@ export const CHECKS = [
     find: /^\[changed-values\] (\d+) catalog QA finding/m,
     ok: m => m[1] === '0',
     summary: m => `${m[1]} QA finding(s) among catalog values you added or changed`,
+  },
+  {
+    // Separate from `changed-values` although the same script hosts both: "you left
+    // this in English" and "your quotes do not pair" are different work, and folding
+    // the counts together would make the row's number mean two things. This is the
+    // ONLY tier the language checks can fail in — the whole-catalog total they share
+    // predicates with is inherited debt and reports instead.
+    id: 'changed-passthrough', script: 'source', scope: 'diff', enforce: 'zero',
+    find: /^\[changed-passthrough\] (\d+) untranslated value\(s\)/m,
+    ok: m => m[1] === '0',
+    summary: m => `${m[1]} value(s) you added or changed still read as English`,
   },
   // ---- whole-repo: may be inherited, but can still fail this step ------------
   {
@@ -207,6 +219,17 @@ export const CHECKS = [
       find: /^\[allcaps\] REPORT: (\d+) untranslated string\(s\) sit inside ALL-CAPS module\n?constants, (\d+) above the ceiling of (\d+)/m,
       summary: m => `${m[1]} inside ALL-CAPS constants — ${m[2]} over the ceiling of ${m[3]}`,
     },
+  },
+  {
+    // Deliberately has no ceiling, unlike every other info row. A stored total would
+    // exist only to notice growth, and `changed-passthrough` already refuses growth at
+    // the moment it is introduced — so the number would buy nothing while adding a file
+    // to update, a ritual for raising it, and a way for two branches to conflict over a
+    // count. What it reports is the backfill worklist, per locale.
+    id: 'untranslated-passthrough', script: 'passthrough', scope: 'repo', enforce: 'info',
+    find: /^OK: (\d+) untranslated passthrough value\(s\) across (\d+) catalog\(s\) — (\d+) value/m,
+    summary: m => `${m[1]} English value(s) across ${m[2]} catalog(s)`,
+    note: m => `${m[3]} scanned · no ceiling, enforced on the diff instead`,
   },
 ]
 

--- a/website/scripts/lib/passthrough-checks.mjs
+++ b/website/scripts/lib/passthrough-checks.mjs
@@ -1,0 +1,344 @@
+/**
+ * Is a catalog value written in its locale's language, or is it English standing in
+ * for a translation?
+ *
+ * ## Why this is not one of the `CHECKS` in `qa-checks.mjs`
+ *
+ * Two reasons, and both would silently disable it.
+ *
+ * `changedValueFindings` excuses a translation when the ENGLISH source trips the same
+ * check — an unbalanced English source cannot have a balanced translation. For a
+ * language check that exemption is total: the English source is English for every key,
+ * so every finding would be excused and the check would measure nothing while passing.
+ *
+ * And `qa.test.ts` gates every member of that array against a per-check ceiling, which
+ * makes the whole-catalog count a failure. The debt here is ~2,700 values across eleven
+ * catalogs, none of it the fault of the branch that happens to touch the file next.
+ * The whole-catalog number belongs in the report-only tier; only the diff can fail.
+ *
+ * ## Two mechanisms, because one alphabet cannot answer for eleven locales
+ *
+ * `untranslated-script` covers the six locales written in a non-Latin script: a value
+ * with no character of the target script in it is not in the target language. This is
+ * decidable from the codepoints alone.
+ *
+ * `untranslated-english` covers the five Latin-script locales, where that question
+ * cannot be asked of the alphabet at all — `de` and English share it. It fires when the
+ * value is typographically identical to the English source, or when English function
+ * words outnumber the target's by 3:1. Both need a length floor: below six words the
+ * signal is noise, and an identical short value is usually correct (`Status`, `Admin`,
+ * `Frontend` are the same word in five languages).
+ *
+ * ## What is stripped before judging
+ *
+ * Everything locale-invariant: interpolation placeholders, URLs, paths, filenames, CLI
+ * flags, code spans, markup, digits — plus every do-not-translate term from
+ * `glossary.json`, which is the exclusion list this check needs and the repo already
+ * maintains. A value that is nothing but those is not judged at all, which is what
+ * keeps `us-east-1`, `localhost:5173` and `{{count}} cron` out of the findings without
+ * a hand-written allowlist.
+ */
+
+/** Codepoint ranges per script, enough to classify a letter's writing system. */
+const SCRIPT_RANGES = {
+  Bengali: [[0x0980, 0x09ff]],
+  Devanagari: [[0x0900, 0x097f], [0xa8e0, 0xa8ff], [0x11b00, 0x11b5f]],
+  Hiragana: [[0x3041, 0x309f], [0x1b001, 0x1b11f]],
+  Katakana: [[0x30a0, 0x30ff], [0x31f0, 0x31ff], [0xff66, 0xff9d]],
+  Han: [
+    [0x2e80, 0x2eff], [0x3005, 0x3005], [0x3007, 0x3007], [0x3400, 0x4dbf],
+    [0x4e00, 0x9fff], [0xf900, 0xfaff], [0x20000, 0x2a6df], [0x2a700, 0x2ebef],
+    [0x2f800, 0x2fa1f],
+  ],
+  Hangul: [[0x1100, 0x11ff], [0x3130, 0x318f], [0xa960, 0xa97f], [0xac00, 0xd7ff], [0xffa0, 0xffdc]],
+  Cyrillic: [[0x0400, 0x052f], [0x1c80, 0x1c8f], [0x2de0, 0x2dff], [0xa640, 0xa69f]],
+}
+
+/**
+ * The script a translation of each of these locales must actually be written in.
+ * A locale absent from this map is never judged by `untranslated-script` — that
+ * includes `en`, the generated pseudolocale, and the five Latin-script locales.
+ */
+export const TARGET_SCRIPTS = {
+  bn: ['Bengali'],
+  hi: ['Devanagari'],
+  ja: ['Hiragana', 'Katakana', 'Han'],
+  ko: ['Hangul'],
+  ru: ['Cyrillic'],
+  'zh-CN': ['Han'],
+}
+
+/**
+ * Locale-invariant spans, removed before any language judgement. Order matters:
+ * fenced and inline code go first so their contents are never mined for words, and
+ * digits go last so a version or a size cannot be mistaken for prose.
+ */
+const NOISE = [
+  /```[\s\S]*?```/g,
+  /`[^`]*`/g,
+  /(?:https?|ftp|file|mailto):\/\/\S+|\bwww\.[\w.-]+\S*/g,
+  /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g,
+  /[A-Za-z]:\\[^\s,;]*/g,
+  /~\/[\w./-]*/g,
+  /(?:\/[\w.-]+){2,}\/?/g,
+  /\b[\w.-]+\/[\w./-]*\.\w+\b/g,
+  /\{\{[^{}]*\}\}/g,
+  /\$\{[^{}]*\}/g,
+  /\{[^{}]*\}/g,
+  /%\([^)]*\)[sdifr]|%[sdifr]\b|%\d*\$?[sd]/g,
+  /<\/?[A-Za-z][\w.:-]*(?:\s+[^<>]*?)?\/?>|<[a-z_][\w.-]*>/g,
+  /(?<![\w-])--?[A-Za-z][\w-]*/g,
+  /\b[\w-]+\.(?:json|py|ts|tsx|js|jsx|md|yml|yaml|toml|sh|html|css|png|jpg|svg|log|txt|lock|cfg|ini|env)\b/g,
+]
+
+/**
+ * Removed separately from `NOISE`, and with NOTHING in their place.
+ *
+ * Substituting a space would split a sample identifier such as `E0123ABC456` into two
+ * tokens and so defeat the single-token exemption, reporting one opaque literal as if
+ * it were a sentence.
+ */
+const DIGITS = /\d+/g
+
+const LETTER = /\p{L}/u
+const NON_WORD = /[^\p{L}\p{N}\s']/gu
+
+/** Escape a DNT term for use in a word-boundary regex. */
+const escapeRe = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/**
+ * A term is removed only where it stands as a word, so `Git` does not eat the `Git`
+ * inside a longer identifier and leave a fragment behind to be scored.
+ */
+const dntPattern = terms =>
+  (terms.length
+    ? new RegExp(`(?<![\\p{L}\\p{N}])(?:${terms.map(escapeRe).join('|')})(?![\\p{L}\\p{N}])`, 'giu')
+    : null)
+
+/** Strip every locale-invariant span, then the DNT terms, then collapse whitespace. */
+export function strippedProse(value, dntRe = null) {
+  let out = value
+  for (const rx of NOISE) out = out.replace(rx, ' ')
+  if (dntRe) out = out.replace(dntRe, ' ')
+  out = out.replace(DIGITS, '')
+  return out.replace(/\s+/g, ' ').trim()
+}
+
+/** Lowercased word tokens of the stripped prose. */
+export function words(stripped) {
+  return stripped.toLowerCase().replace(NON_WORD, ' ').split(/\s+/).filter(Boolean)
+}
+
+/**
+ * Whitespace-separated tokens that contain a letter, which is NOT the same count as
+ * `words`.
+ *
+ * The single-token guard exists to exempt labels and identifiers, and those are held
+ * together by punctuation: splitting on it would read `us-east-1` as two tokens and
+ * judge a region name as a sentence. Punctuation left standing alone is not a token
+ * either — counting it made `cleared ·`, `& Issue` and `Worktrees ({{count}})` look
+ * like two-word phrases and reported one word each as untranslated prose.
+ */
+export function tokenCount(stripped) {
+  return stripped.split(/\s+/).filter(t => LETTER.test(t)).length
+}
+
+const scriptOf = cp => {
+  for (const [name, ranges] of Object.entries(SCRIPT_RANGES)) {
+    for (const [lo, hi] of ranges) if (cp >= lo && cp <= hi) return name
+  }
+  return 'Other'
+}
+
+/**
+ * Fraction of the value's letters that belong to the locale's script.
+ *
+ * Combining marks are excluded from both sides: a Bengali or Devanagari vowel sign
+ * never appears without a base letter of its own script, so counting it would change
+ * nothing but the denominator.
+ */
+export function scriptRatio(stripped, scripts) {
+  const want = new Set(scripts)
+  let letters = 0
+  let onTarget = 0
+  for (const ch of stripped) {
+    if (!LETTER.test(ch)) continue
+    letters += 1
+    if (want.has(scriptOf(ch.codePointAt(0)))) onTarget += 1
+  }
+  return { letters, onTarget, ratio: letters === 0 ? null : onTarget / letters }
+}
+
+// ---- Latin-script locales: English function words vs the target's ------------
+
+const EN_FUNCTION = `the a an and or but not no nor of to in on at by for with from into over
+under after before between through during without within about above below again further as is
+are was were be been being has have had having do does did doing can could will would shall
+should may might must this that these those there here what which who whom whose how why when
+where while until because since though although unless whether if so than too very just now
+then once all any each both few more most other some such only own same up down out off also
+still even ever never always already instead rather however therefore thus hence else otherwise
+you your yours we our ours they their them theirs it its he she his her him us me my mine i`
+
+/**
+ * Function words of each Latin-script locale, including the ones that collide with
+ * English. The collisions are what the scorer must NOT count, and they can only be
+ * subtracted if both lists name them: a target list missing Romance `a` or Italian
+ * `me` scores `Assegnate a me` as English on the strength of its own vocabulary.
+ */
+const TARGET_FUNCTION = {
+  de: `der die das den dem des ein eine einen einem einer eines und oder aber nicht kein keine
+keinen mit von zu zur zum fuer für auf aus bei nach über unter durch ohne gegen um an im in ist
+sind war waren wird werden wurde wurden hat haben hatte kann können muss müssen soll sollen darf
+dürfen wenn dass weil damit wie was wer wo welche welcher welches diese dieser dieses sich sie
+er es ich du wir ihr ihnen mein dein sein ihre unser alle auch noch nur schon sehr mehr dann
+hier dort jetzt bereits wieder immer nie sowie beim vom dazu dabei dafür danach davor als bis
+etwa jedoch sondern zwar dessen deren wobei sobald falls so man da`,
+  es: `el la los las un una unos unas de del al y o pero no que con para por en sin sobre entre
+desde hasta hacia es son era eran ser está están estar hay tiene tienen puede pueden debe deben
+se su sus tu tus mi mis este esta estos estas ese esa eso cuando como donde si más menos muy ya
+también aún todavía siempre nunca cada todo toda todos todas otro otra algún alguna ningún lo le
+les nos te me ha han había será sea aquí allí ahora luego entonces porque aunque mientras antes
+después durante cual cuales quien quienes a son van he mas`,
+  fr: `le la les un une des du de au aux et ou mais ne pas que qui quoi dont où avec pour par en
+dans sur sous sans entre depuis vers chez est sont était étaient être a ont avait avoir peut
+peuvent doit doivent se son sa ses votre vos mon ma mes notre nos ce cette ces cet quand comme
+comment si plus moins très déjà aussi encore toujours jamais chaque tout toute tous toutes autre
+autres ici là maintenant ensuite alors parce donc ainsi avant après pendant lors leur leurs nous
+vous elle il ils elles je tu on cela ceci ceux celle car lorsque afin sur or ces no`,
+  it: `il lo la i gli le un uno una del della dei delle dal dalla al alla ai alle nel nella e ed
+o ma non che chi con per tra fra da di in su senza sopra sotto è sono era erano essere ha hanno
+aveva avere può possono deve devono si suo sua suoi sue tuo tua mio mia questo questa questi
+queste quello quella quando dove se più meno molto già anche ancora sempre mai ogni tutto tutta
+tutti tutte altro altra qui qua ora poi allora perché mentre prima dopo durante loro noi voi lei
+lui io tu ci vi ne dell nell all cui quindi però oppure a me come do no`,
+  pt: `o a os as um uma uns umas do da dos das no na nos nas ao aos à às e ou mas não nao que
+quem com para por em sem sobre entre desde até é são era eram ser está estão estar há tem têm
+pode podem deve devem se seu sua seus suas teu meu minha este esta estes estas esse essa isso
+quando como onde mais menos muito já também ainda sempre nunca cada todo toda todos todas outro
+outra aqui ali agora depois então porque enquanto antes durante deles nós você ele ela eles elas
+eu tu lhe lhes qual quais pelo pela pelos pelas num numa me ha`,
+}
+
+const wordSet = spec => new Set(spec.split(/\s+/).filter(Boolean))
+
+const EN_ALL = wordSet(EN_FUNCTION)
+
+/**
+ * Per locale: the English function words that are NOT also the target's, and the
+ * target's that are not also English. Everything in the intersection is invisible to
+ * the scorer, in both directions.
+ */
+export const FUNCTION_WORDS = Object.fromEntries(
+  Object.entries(TARGET_FUNCTION).map(([lang, spec]) => {
+    const target = wordSet(spec)
+    const collisions = new Set([...EN_ALL].filter(w => target.has(w)))
+    return [lang, {
+      collisions: [...collisions].sort(),
+      enOnly: new Set([...EN_ALL].filter(w => !collisions.has(w))),
+      targetOnly: new Set([...target].filter(w => !collisions.has(w))),
+    }]
+  }),
+)
+
+/** Typographic variants that make an otherwise identical value look different. */
+export const normalizeTypography = s =>
+  s
+    .replace(/[\u2018\u2019\u02bc\u2032]/g, "'")
+    .replace(/[\u201c\u201d\u2033]/g, '"')
+    .replace(/[\u2010-\u2015\u2212]/g, '-')
+    .replace(/[\u00a0\u202f\u2009\u200a]/g, ' ')
+    .replace(/\u2026/g, '...')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+/** Minimum letters in a non-Latin value before its script is worth judging. */
+export const MIN_LETTERS = 4
+/** A single token is a label or an identifier, not prose. */
+export const MIN_TOKENS = 2
+/** Minimum words before an English-vs-target judgement means anything. */
+export const MIN_WORDS = 6
+/** English function words needed, and by what margin over the target's. */
+export const MIN_EN_HITS = 2
+export const EN_MARGIN = 3
+
+/**
+ * The two checks, shaped like `CHECKS` in `qa-checks.mjs` so the reporting is the
+ * same, plus a third argument: the English source for the key, which the
+ * identical-to-English half cannot do without.
+ *
+ * `dnt` is passed in rather than read here so this module stays free of file I/O and
+ * the caller keeps one source of truth for the term list.
+ */
+export function passthroughChecks(dnt = []) {
+  const dntRe = dntPattern(dnt)
+  return [
+    {
+      id: 'untranslated-script',
+      describe: 'a value must contain at least one character of its locale\'s script',
+      violates: (value, lang) => {
+        const scripts = TARGET_SCRIPTS[lang]
+        if (!scripts) return false
+        const stripped = strippedProse(value, dntRe)
+        const { letters, onTarget } = scriptRatio(stripped, scripts)
+        if (letters < MIN_LETTERS) return false
+        if (tokenCount(stripped) < MIN_TOKENS) return false
+        return onTarget === 0
+      },
+    },
+    {
+      id: 'untranslated-english',
+      describe: 'a Latin-script value must not be the English source or read as English',
+      violates: (value, lang, source) => {
+        const sets = FUNCTION_WORDS[lang]
+        if (!sets) return false
+        const stripped = strippedProse(value, dntRe)
+        const tokens = words(stripped)
+        if (tokens.length < MIN_WORDS) return false
+        if (
+          typeof source === 'string'
+          && normalizeTypography(stripped)
+            === normalizeTypography(strippedProse(source, dntRe))
+        ) return true
+        let en = 0
+        let target = 0
+        for (const t of tokens) {
+          if (sets.enOnly.has(t)) en += 1
+          else if (sets.targetOnly.has(t)) target += 1
+        }
+        return en >= MIN_EN_HITS && en >= EN_MARGIN * target
+      },
+    },
+  ]
+}
+
+/**
+ * Findings among the values a branch ADDED or CHANGED, at zero tolerance.
+ *
+ * There is no inherited-defect exemption and there must not be one: a new key whose
+ * translation was filled in with the English source is precisely the defect, and
+ * excusing it because English "also fails" would excuse every case.
+ */
+export function passthroughFindings({ lang, base, head, enHead = {}, checks }) {
+  const findings = []
+  for (const [key, value] of Object.entries(head)) {
+    if (typeof value !== 'string' || !value) continue
+    if (base[key] === value) continue
+    for (const check of checks) {
+      if (check.violates(value, lang, enHead[key])) findings.push({ lang, key, value, check })
+    }
+  }
+  return findings
+}
+
+/** Every violation in a whole catalog — the report-only inventory, never a gate. */
+export function passthroughViolations({ lang, catalog, enFlat = {}, checks }) {
+  const findings = []
+  for (const [key, value] of Object.entries(catalog)) {
+    if (typeof value !== 'string' || !value) continue
+    for (const check of checks) {
+      if (check.violates(value, lang, enFlat[key])) findings.push({ lang, key, value, check })
+    }
+  }
+  return findings
+}

--- a/website/src/test/i18nGateTable.test.ts
+++ b/website/src/test/i18nGateTable.test.ts
@@ -39,8 +39,9 @@ const HEALTHY: Record<string, { status: number, text: string }> = {
   dnt: run(0, 'OK: 19 DNT term(s) intact across 9 catalog(s) — 62207 value(s) scanned.'),
   manifest: run(0, 'OK: 16 built-in manifests, 147 strings match locales/en.json exactly.'),
   units: run(0, '[added-lines] 0 number+unit literal(s) on lines you wrote\n[vs-base] 0 touched file(s) gained number+unit literals\nOK: 52 un-migrated number+unit literal(s) across 1026 file(s), baseline 74.'),
-  source: run(0, '[source-strings] 0 new key(s) vs origin/main, 0 finding(s).\n[changed-values] 0 catalog QA finding(s) among values changed vs origin/main.'),
+  source: run(0, '[source-strings] 0 new key(s) vs origin/main, 0 finding(s).\n[changed-values] 0 catalog QA finding(s) among values changed vs origin/main.\n[changed-passthrough] 0 untranslated value(s) among values changed vs origin/main.'),
   strings: run(0, '[added-lines] 0 untranslated string(s) on lines this branch wrote.\n[vs-base] 0 touched file(s) gained untranslated strings vs the base.\nOK: 1324 untranslated strings across 241 files, at or below the baseline of 1837.\nOK: 1118 untranslated string(s) inside ALL-CAPS constants across 249 files, at or below the ceiling of 1118.'),
+  passthrough: run(0, 'OK: 3352 untranslated passthrough value(s) across 11 catalog(s) — 118913 value(s) scanned.'),
 }
 
 const runsOf = (over: Record<string, { status: number, text: string }> = {}) => {
@@ -241,7 +242,7 @@ describe('a whole-repo total over its ceiling reports and does NOT fail', () => 
 })
 
 describe('the table covers the chain it replaced', () => {
-  it('runs exactly the nine scripts, with the flags the && chain used', () => {
+  it('runs exactly the ten scripts, with the flags the && chain used', () => {
     // Dropping a script from this table is a silent loss of coverage, and this is the
     // only test that would notice. `--baseline=3` is part of the contract: the codemod
     // ratchet lived in the package.json chain and moved here.
@@ -255,6 +256,7 @@ describe('the table covers the chain it replaced', () => {
       'check-dnt-catalogs.mjs',
       'check-app-manifest-sync.mjs',
       'check-unit-literals.mjs',
+      'check-untranslated-values.mjs',
     ])
   })
 
@@ -274,10 +276,36 @@ describe('the table covers the chain it replaced', () => {
     // whole-repo number is a stored total another branch can move without touching your
     // files, so it reports. `dynamic-keys` was the last bidirectional ratchet in the repo.
     expect(CHECKS.filter(c => c.enforce === 'info').map(c => c.id))
-      .toEqual(['unit-ceiling', 'dynamic-keys', 'extractable', 'untranslated', 'allcaps'])
+      .toEqual(['unit-ceiling', 'dynamic-keys', 'extractable', 'untranslated', 'allcaps',
+        'untranslated-passthrough'])
     for (const c of CHECKS.filter(x => x.scope === 'repo' && x.enforce !== 'hard-zero')) {
       expect(c.enforce, `${c.id} is whole-repo and not a hard zero, so it must be info`)
         .toBe('info')
     }
+  })
+})
+
+describe('untranslated passthrough — the total reports, only the diff fails', () => {
+  it('reports thousands of inherited English values without failing the step', () => {
+    // The whole-catalog total is inherited debt: eleven catalogs carry it, and the branch
+    // that touches a catalog next did not put it there. Failing on this number would
+    // red-line PRs whose own diff is clean.
+    const { rows, failed } = decide({
+      passthrough: run(0, 'OK: 3352 untranslated passthrough value(s) across 11 catalog(s) — 118913 value(s) scanned.'),
+    })
+    expect(row(rows, 'untranslated-passthrough').state).toBe('PASS')
+    expect(row(rows, 'untranslated-passthrough').summary).toContain('3352')
+    expect(failed).toBe(false)
+  })
+
+  it('fails when values THIS branch changed are still English', () => {
+    const { rows, failed } = decide({
+      source: run(1, '[source-strings] 0 new key(s) vs origin/main, 0 finding(s).\n[changed-values] 0 catalog QA finding(s) among values changed vs origin/main.\n[changed-passthrough] 2 untranslated value(s) among values changed vs origin/main.'),
+    })
+    expect(row(rows, 'changed-passthrough').state).toBe('FAIL')
+    // Its own row, so the sibling's number keeps meaning what it meant: a reader can
+    // tell "you left this in English" from "your quotes do not pair".
+    expect(row(rows, 'changed-values').state).toBe('PASS')
+    expect(failed).toBe(true)
   })
 })

--- a/website/src/test/passthroughChecks.test.ts
+++ b/website/src/test/passthroughChecks.test.ts
@@ -1,0 +1,216 @@
+/**
+ * The two language checks behind `changed-passthrough` and `untranslated-passthrough`.
+ *
+ * All the judgement in this feature lives in two predicates and four numbers, and the
+ * numbers are not arbitrary — each was chosen against the shipped catalogs, where a
+ * looser one produced a measured false positive. A false positive here is expensive in
+ * a way a missed defect is not: the diff-scoped check has no ceiling to raise, so a
+ * wrong finding blocks a PR with no way around it but to argue. Every case below that
+ * asserts `false` is therefore a guard rail, not a nicety, and the ones naming a
+ * specific string are the strings that actually broke an earlier rule.
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  FUNCTION_WORDS,
+  MIN_WORDS,
+  TARGET_SCRIPTS,
+  passthroughChecks,
+  strippedProse,
+  tokenCount,
+} from '../../scripts/lib/passthrough-checks.mjs'
+
+/** The real do-not-translate list is small and stable; these are enough of it. */
+const DNT = [
+  'AWS', 'GitHub', 'Kiro', 'Python', 'Slack', 'JSON', 'MCP', 'npm', 'Git',
+  'KiroCrew', // brand-ok: the product name as `dnt` itself spells it
+]
+
+const [script, english] = passthroughChecks(DNT)
+const flagsScript = (v: string, lang: string) => script.violates(v, lang)
+const flagsEnglish = (v: string, lang: string, source?: string) =>
+  english.violates(v, lang, source)
+
+describe('untranslated-script — a value must carry its locale’s script', () => {
+  it('flags plain English in every non-Latin locale', () => {
+    for (const lang of Object.keys(TARGET_SCRIPTS)) {
+      expect(flagsScript('Host memory is tight', lang), lang).toBe(true)
+    }
+  })
+
+  it('accepts a genuine translation in each of them', () => {
+    const translated: Record<string, string> = {
+      ja: 'ホストのメモリが不足しています',
+      'zh-CN': '主机内存不足，请避免并行任务',
+      ko: '호스트 메모리가 부족합니다',
+      ru: 'Недостаточно памяти на хосте',
+      hi: 'होस्ट मेमोरी कम है',
+      bn: 'হোস্ট মেমরি কম আছে',
+    }
+    for (const [lang, value] of Object.entries(translated)) {
+      expect(flagsScript(value, lang), lang).toBe(false)
+    }
+  })
+
+  it('accepts a translation that keeps an English product name in it', () => {
+    // The common and correct shape: prose in the target script, brand left alone.
+    expect(flagsScript('GitHub のトークンを設定してください', 'ja')).toBe(false)
+    expect(flagsScript('在 Slack 中打开此会话', 'zh-CN')).toBe(false)
+  })
+
+  it('never judges English, the pseudolocale, or a Latin-script locale', () => {
+    for (const lang of ['en', 'en-XA', 'de', 'fr', 'es', 'it', 'pt']) {
+      expect(flagsScript('Host memory is tight', lang), lang).toBe(false)
+    }
+  })
+
+  it('leaves short labels and abbreviations alone', () => {
+    // Below four letters there is no language in a string, only a label. These are all
+    // real standalone values in the shipped catalogs.
+    for (const v of ['OK', 'ID', 'CPU', 'MEM', 'DSK', 'v', 'Aa']) {
+      expect(flagsScript(v, 'ja'), v).toBe(false)
+    }
+  })
+
+  it('leaves a single token alone however long it is', () => {
+    // One token is an identifier, a brand or a status word — not a sentence. Hyphens and
+    // colons hold a token together, which is why the count is whitespace-based.
+    for (const v of ['us-east-1', 'localhost:5173', 'BucketOwnerEnforced', 'STAYGREEN',
+      'profiles/*.json', 'github_pat_…', 'mcpServers']) {
+      expect(flagsScript(v, 'zh-CN'), v).toBe(false)
+    }
+  })
+
+  it('ignores a value that is only placeholders, markup and noise', () => {
+    for (const v of ['{{count}} cron', '(v{{from}} → v{{to}})', '`npm ci`', '0 B', '120s',
+      'https://example.com/docs', '~/.kiro/crew', '--no-verify']) {
+      expect(flagsScript(v, 'ru'), v).toBe(false)
+    }
+  })
+
+  it('ignores a value made only of do-not-translate terms', () => {
+    // This is what keeps the exclusion list out of a hand-maintained allowlist: register
+    // the product name once in glossary.json and every locale stops reporting it.
+    expect(flagsScript('GitHub MCP', 'ja')).toBe(false)
+    expect(flagsScript('AWS JSON', 'ko')).toBe(false)
+  })
+})
+
+describe('untranslated-english — a Latin-script value must not read as English', () => {
+  const LONG_EN = 'Host memory is critically low and heavy parallel work should be avoided'
+
+  it('flags English prose in every Latin-script locale', () => {
+    for (const lang of Object.keys(FUNCTION_WORDS)) {
+      expect(flagsEnglish(LONG_EN, lang), lang).toBe(true)
+    }
+  })
+
+  it('flags a value that is the English source verbatim', () => {
+    const source = 'Every configured source answered the last poll successfully.'
+    expect(flagsEnglish(source, 'de', source)).toBe(true)
+  })
+
+  it('flags a value differing from the source only in typography', () => {
+    // Measured on the shipped catalogs: five locales store the same English string as
+    // the source with a curly apostrophe, which byte-identity alone does not catch.
+    const source = "The parent instance's configuration is required for this to work."
+    const value = 'The parent instance\u2019s configuration is required for this to work.'
+    expect(flagsEnglish(value, 'fr', source)).toBe(true)
+  })
+
+  it('accepts genuine translations', () => {
+    const translated: Record<string, string> = {
+      de: 'Der Hostspeicher ist knapp, daher kann schwere Arbeit langsamer werden.',
+      es: 'La memoria del host es escasa, por lo que el trabajo pesado puede ser lento.',
+      fr: 'La mémoire de l’hôte est faible, donc le travail lourd peut être plus lent.',
+      it: 'La memoria dell’host è insufficiente, quindi il lavoro pesante può rallentare.',
+      pt: 'A memória do host está baixa, portanto o trabalho pesado pode ficar mais lento.',
+    }
+    for (const [lang, value] of Object.entries(translated)) {
+      expect(flagsEnglish(value, lang), lang).toBe(false)
+    }
+  })
+
+  it('does not fire on the cognate collisions that broke a hand-written list', () => {
+    // `a` is a preposition in every Romance language and an article in English; `me` and
+    // `do` collide the same way. A scorer that counted them as English evidence flagged
+    // these real translated values — which is why the collision set is DERIVED from the
+    // intersection of the two lists rather than typed out.
+    expect(flagsEnglish('Assegnate a me e ancora da completare oggi', 'it')).toBe(false)
+    expect(flagsEnglish('Asignadas a mi cuenta y todavia sin completar hoy', 'es')).toBe(false)
+    expect(flagsEnglish('Adicionar a base de conhecimento do seu projeto agora', 'pt')).toBe(false)
+  })
+
+  it('derives the collision set in both directions', () => {
+    for (const [lang, sets] of Object.entries(FUNCTION_WORDS)) {
+      for (const w of sets.collisions) {
+        expect(sets.enOnly.has(w), `${lang} ${w}`).toBe(false)
+        expect(sets.targetOnly.has(w), `${lang} ${w}`).toBe(false)
+      }
+    }
+    // The two that a hand-written list missed, and cost real false positives.
+    expect(FUNCTION_WORDS.it.collisions).toContain('a')
+    expect(FUNCTION_WORDS.it.collisions).toContain('me')
+    expect(FUNCTION_WORDS.pt.collisions).toContain('a')
+  })
+
+  it('says nothing below the word floor, in either direction', () => {
+    // Under six words the signal is noise, and an identical short value is usually
+    // correct: `Status`, `Admin` and `Frontend` are the same word in five languages.
+    for (const v of ['Status', 'Admin', 'Frontend', 'Pull requests', 'Max cycles',
+      'Kiro Crew Dashboard']) {
+      expect(flagsEnglish(v, 'de', v), v).toBe(false)
+    }
+    const five = 'Host memory is very low'
+    expect(five.split(' ').length).toBeLessThan(MIN_WORDS)
+    expect(flagsEnglish(five, 'de', five)).toBe(false)
+  })
+
+  it('never judges English, the pseudolocale, or a non-Latin locale', () => {
+    for (const lang of ['en', 'en-XA', 'ja', 'zh-CN', 'ru', 'ko', 'hi', 'bn']) {
+      expect(flagsEnglish(LONG_EN, lang), lang).toBe(false)
+    }
+  })
+})
+
+describe('stripping', () => {
+  it('removes every locale-invariant span before anything is judged', () => {
+    expect(strippedProse('Open {{name}} at https://x.dev/a/b using `npm ci` v2')).toBe('Open at using v')
+  })
+
+  it('removes a do-not-translate term only where it stands as a word', () => {
+    const dntRe = passthroughChecks(['Git'])
+    // Quick check: the factory returns checks, and the term itself disappears...
+    expect(dntRe).toHaveLength(2)
+    expect(strippedProse('Git is required', /(?<![\p{L}\p{N}])(?:Git)(?![\p{L}\p{N}])/giu))
+      .toBe('is required')
+    // ...but a longer identifier containing it is left whole, so no fragment is scored.
+    expect(strippedProse('GitLab is required', /(?<![\p{L}\p{N}])(?:Git)(?![\p{L}\p{N}])/giu))
+      .toBe('GitLab is required')
+  })
+
+  it('counts tokens by whitespace, not by punctuation', () => {
+    expect(tokenCount('us-east-1')).toBe(1)
+    expect(tokenCount('localhost:5173')).toBe(1)
+    expect(tokenCount('Host memory is tight')).toBe(4)
+  })
+
+  it('does not count punctuation left standing alone as a token', () => {
+    // Real values from the shipped catalogs. Each is ONE word plus punctuation, which is
+    // exactly what the single-token exemption is for — counting the bullet or the
+    // ampersand reported them as two-word English phrases.
+    for (const v of ['cleared ·', '· main', '& Issue', 'Worktrees ({{count}})',
+      'Transcribe (AWS)', 'Apache 2.0', '{{label}} — Kiro Crew']) {
+      expect(flagsScript(v, 'ja'), v).toBe(false)
+    }
+  })
+
+  it('removes digits without splitting the token around them', () => {
+    // Substituting a space would turn a sample identifier into `E ABC` — two tokens,
+    // four letters — and report an opaque literal as a sentence.
+    expect(strippedProse('E0123ABC456')).toBe('EABC')
+    expect(tokenCount(strippedProse('E0123ABC456'))).toBe(1)
+    expect(flagsScript('E0123ABC456', 'ko')).toBe(false)
+    expect(flagsScript('U0123ABC456', 'ru')).toBe(false)
+  })
+})


### PR DESCRIPTION
## The hole

Nothing in the repo compared a non-English catalog value against English. `englishIdentity.test.ts` imports only `en.json` and `en.manual.json`, so a PR could add a key and copy the English source into all eleven locales unchallenged — which is how the Security panel's strings shipped as English "translations".

The style suites cannot catch it either, and the reason is worth stating: each one uses its locale's script regex as a **filter**.

```js
if (!DEVANAGARI.test(value)) continue      // hiStyle.test.ts
const prose = entries.filter(([, v]) => JP_RE.test(v))   // jaStyle.test.ts
```

A purely English value has zero target-script characters, so it is skipped by every one of them. The less translated a string is, the less it is checked.

## What this adds

Two predicates in `website/scripts/lib/passthrough-checks.mjs`:

| check | locales | fires when |
|---|---|---|
| `untranslated-script` | bn, hi, ja, ko, ru, zh-CN | no character of the target script survives stripping |
| `untranslated-english` | de, es, fr, it, pt | typographically identical to the English source, **or** English function words outnumber the target's 3:1 |

Deliberately **not** members of `CHECKS` in `qa-checks.mjs`. Two reasons, and either would silently disable them:

1. `changedValueFindings` excuses a translation when the English source trips the same check. For a language check that exemption is total — the English source is English for every key — so every finding would be excused while the check reported nothing.
2. `qa.test.ts` gates every member of that array against a per-check ceiling, which would make the whole-catalog count a *failure*.

### Thresholds, and why each one exists

Every number was chosen against the shipped catalogs, and a looser one produced a measured false positive:

- **4 letters / 2 tokens** (non-Latin) — below that a value is a label, not language: `OK`, `ID`, `CPU`, `MEM`.
- **Tokens are whitespace-separated and must contain a letter** — splitting on punctuation reads `us-east-1` as two tokens; counting bare punctuation made `cleared ·`, `& Issue` and `Worktrees ({{count}})` look like two-word English phrases.
- **Digits are removed with nothing in their place** — a space splits the sample identifier `E0123ABC456` into `E ABC`, two tokens and four letters, and reports an opaque literal as a sentence.
- **6 words** (Latin) — below it, identical is normal: 574 of German's 1,097 English-identical values are single words like `Status` and `Admin`.
- **Collision set derived as EN ∩ TARGET** — `a` is a preposition in every Romance language and an article in English; `me` and `do` collide the same way. A hand-written list missing them scores the real translation `Assegnate a me` as English.

### Exclusions are derived, never hand-maintained

Placeholders, URLs, paths, filenames, CLI flags, code spans, markup and digits are stripped, then every `dnt` term from `glossary.json`. Registering a product name there exempts it in all eleven locales and documents why — no per-key allowlist to drift.

## Only the diff can fail

| row | tier | behaviour |
|---|---|---|
| `[changed-passthrough]` | `zero` (diff-scoped) | fails on any value this branch added or changed |
| `[untranslated-passthrough]` | `info` (whole repo) | prints the total, **exits 0 with findings** |

It carries **no committed ceiling**, unlike every other `info` row. A stored total would exist only to notice growth, and the diff-scoped check already refuses growth at the moment it is introduced — so the number would buy nothing while adding a file to update, a ritual for raising it, and a way for two branches to conflict over a count.

Inherited debt therefore never red-lines a PR whose own diff is clean, which is the failure mode the three-tier table exists to prevent.

## What it finds today

3,232 values across 11 catalogs, 118,913 scanned.

| | bn | hi | ru | zh-CN | ja | ko | de | es | fr | it | pt |
|---|---|---|---|---|---|---|---|---|---|---|---|
| findings | 449 | 452 | 453 | 429 | 167 | 185 | 214 | 221 | 221 | 221 | 220 |

Classified by cause: **68% is plain missing prose**, 18% short labels, 10% proper nouns that belong in `dnt`, and under 2% command literals and unit templates. It is not spread evenly — 238 of the 342 affected keys are one app (`apps.opsMissionControl`) translated into ja and ko only, and 270 keys are missing in exactly `bn,hi,ru,zh-CN`. A follow-up PR puts the proper nouns in `dnt` and backfills that app.

## Testing

- `src/test/passthroughChecks.test.ts` — 16 cases. Every one that asserts `false` is a guard rail, and the ones naming a specific string are strings that actually broke an earlier version of the rule.
- `src/test/i18nGateTable.test.ts` — two cases pinning the tier contract: a large whole-catalog total passes the step; a changed value fails it while `[changed-values]` stays PASS, so the two numbers keep meaning different things.
- The existing table tests already pinned the script list and the `info` id list, so this change had to update both — which is what they are for.

Verified end to end by injecting one defect per mechanism:

```
clean     [i18n] 18 checks · PASS                          exit 0
          [untranslated-passthrough]  3232 ...  report only
injected  [i18n] 18 checks · FAIL 1                        exit 1
          FAIL [changed-passthrough]  2 value(s) you added or changed still read as English
          PASS [untranslated-passthrough]  3233 ...  report only
```

Local gates: vitest 41 files / 650 passed + 1 expected fail, `tsc -b`, `eslint src/ --max-warnings 1116` (0 errors), full `npm run i18n:check` green.

One environment note: this host is AL2 (glibc 2.26) and cannot run Node 20+, which vitest requires and which the repo's eslint config needs for `structuredClone`. The frontend gates were run in a `node:22` container mounted at the identical absolute path, because a git worktree's `.git` is a file holding an absolute gitdir — mounted anywhere else every git command fails and four diff-scoped rows read MISSING for the wrong reason. CI uses Node 24.
