### PR TITLE
fix(dashboard): refuse unknown-slot approval-mode requests before any global mutation

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -23,7 +23,7 @@ KiroCrew implements defense-in-depth security across multiple layers: OS-level p
 | Destructive CLI commands | LLM runs `rm -rf /`, `git push --force` | Built-in denied-command rules (`BUILTIN_DENIED_RULES`, default-on / user-disableable) enforced at the hooks PreToolUse gate + governance `commands` force-deny (enterprise, un-opt-out-able) + 55 suspicious bash patterns with per-segment matching (`security.py`) |
 | Frontend XSS | `dangerouslySetInnerHTML` with unsanitized content | DOMPurify + safe DOM APIs + Mermaid `securityLevel: 'strict'` (iframe sandbox) |
 | Widget postMessage forged turn | LLM-emitted `<script>` in a sandboxed `<mcwidget>` iframe calls `parent.postMessage({type:'mc-widget-action'})`, bypassing the in-iframe `isTrusted` click guard | Frontend requires a human gesture: a widget action only PRE-FILLS the composer (never auto-submits) and tags the resulting user-initiated send `meta.origin='widget'`. Backend deny-by-default: `api_chat` refuses the sole chat-text-reachable privilege escalation — orchestrator `go`/`go all` auto-run — for `origin='widget'` turns (SEL `auto_run_denied`), letting the text fall through to a normal fully-gated turn. Mode changes and tool approvals are on separate endpoints the iframe cannot reach |
-| YOLO mode abuse | Unbounded auto-approve window | Time-limited safety override: Slack 30min, dashboard 6h, config 24h (no permanent mode). Re-auth required after expiry. SEL audit on every lifecycle event |
+| YOLO mode abuse | Unbounded auto-approve window | Time-limited safety override: one ad-hoc duration for every surface (`agent.yolo_duration`, default 6h, hard ceiling 24h); the declared config grant is governed separately. Re-auth required after expiry. SEL audit on every lifecycle event |
 | Trust reads bypass | Read-only command classification tricked into approving writes | Deny-by-default: rejects redirections, command substitutions, newline separator bypasses. Prefix matching only |
 | Port-forward auth bypass | socat/ssh -R makes remote traffic appear as 127.0.0.1 | Loopback bypass removed; all requests require token auth. File-based IPC secret for internal paths |
 | Observe-mode context poisoning | Non-owner messages in shared channels influence LLM context | `channel_history.push` gated on `_user_authorized` |
@@ -1374,13 +1374,7 @@ Non-owners receive ephemeral message: "⛔ Only the KiroCrew owner can use these
 
 **Safety override (YOLO) — time-limited with re-authorization** (`safety_override.py`):
 
-Permanent YOLO mode has been eliminated. All activations go through the `SafetyOverride` singleton which enforces a hard ceiling of 24 hours. The tiered TTL defaults are:
-
-| Source | Default TTL | Max TTL |
-|--------|------------|---------|
-| Slack (`!yolo on`) | 30 minutes | 24 hours |
-| Dashboard YOLO button | 6 hours | 24 hours |
-| Config `approval_mode: "auto"` | 24 hours | 24 hours |
+Permanent YOLO mode has been eliminated. All activations go through the `SafetyOverride` singleton, which enforces a single ad-hoc duration shared by every surface (`agent.yolo_duration`, default 6 hours, hard ceiling 24 hours). Per-surface TTLs (Slack 30 min / dashboard 6 h / config 24 h) were removed: the same operator re-enabling the same grant got a different lifetime depending on where they clicked, which was unpredictable without buying any security. The declared `dangerouslySkipPermissions` grant and the `until_shutdown` ad-hoc duration are governed separately (see `safety_override.py`).
 
 After expiry, re-authorization is required. A 5-minute grace window allows `!yolo renew` (Slack) or the dashboard re-auth button to extend the session without creating a new one. Outside the grace window, a fresh activation is needed.
 

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -5453,7 +5453,33 @@ async def api_chat_mode(request: web.Request) -> web.Response:
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
     mode = body.get("mode", "normal")
-    slot_key = body.get("slot") or None
+    raw_slot = body.get("slot")
+    slot_key = raw_slot or None
+
+    # Refuse an unresolvable slot key BEFORE anything mutates: a slot-scoped
+    # request that names a slot which does not exist — or which is not a string
+    # at all — must neither widen to every slot (#4454) nor revoke the global
+    # grant, and its refusal must leave grant and slots exactly as they were.
+    # Falsy non-strings (``[]``, ``{}``, ``0``, ``False``) are refused on the
+    # raw value here, before ``raw_slot or None`` can erase them into the
+    # documented all-slots request. The resolved slot reference is what every
+    # branch writes through — nothing below re-indexes state._slots[slot_key]
+    # after the offloaded deactivate await, so a concurrent slot deletion
+    # cannot open a check/use gap. ``yolo`` is global and ignores ``slot``
+    # entirely (a stale key must not refuse it).
+    slot, denied = None, None
+    if mode != "yolo":
+        if raw_slot is not None and not isinstance(raw_slot, str):
+            denied = web.json_response({"ok": False, "error": "unknown slot"}, status=400)
+        elif slot_key is not None:
+            # An absent key is the documented "all slots" request; a present
+            # key must name a live slot or the whole request is refused here,
+            # before any mutation.
+            slot = state._slots.get(slot_key)
+            if slot is None:
+                denied = web.json_response({"ok": False, "error": "unknown slot"}, status=400)
+    if denied is not None:
+        return denied
 
     # The safety override (YOLO) is PROCESS-GLOBAL while an approval mode is
     # per-slot, so revoking it on behalf of a request that named ONE slot drops
@@ -5473,7 +5499,11 @@ async def api_chat_mode(request: web.Request) -> web.Response:
     # `until_shutdown` ad-hoc pick is equally permanent and must stay protected.
     slot_scoped_trust = slot_key is not None and mode in _SLOT_SCOPED_TRUST_MODES
     if mode != "yolo" and (not slot_scoped_trust or safety_override().is_declared):
-        safety_override().deactivate("dashboard")
+        # deactivate() writes a SEL event, so it is offloaded exactly like the
+        # sibling activate() — never run on the gateway loop (#4454). Safe after
+        # the resolution above: every branch mutates the captured slot, never
+        # re-indexing state._slots.
+        await asyncio.to_thread(safety_override().deactivate, "dashboard")
 
     if mode == "yolo":
         result = await asyncio.to_thread(safety_override().activate, "dashboard")
@@ -5492,15 +5522,15 @@ async def api_chat_mode(request: web.Request) -> web.Response:
         except Exception:
             logger.warning("SEL audit failed for YOLO mode activation", exc_info=True)
     elif mode == "trust_reads":
-        if slot_key and slot_key in state._slots:
-            state._slots[slot_key]._trust = False
-            state._slots[slot_key]._trust_reads = True
-            state.sessions.set_approval_policy(effective_session_key(state._slots[slot_key]), "")
+        if slot is not None:
+            slot._trust = False
+            slot._trust_reads = True
+            state.sessions.set_approval_policy(effective_session_key(slot), "")
         else:
-            for slot in state._slots.values():
-                slot._trust = False
-                slot._trust_reads = True
-                state.sessions.set_approval_policy(effective_session_key(slot), "")
+            for s in state._slots.values():
+                s._trust = False
+                s._trust_reads = True
+                state.sessions.set_approval_policy(effective_session_key(s), "")
         try:
             sel().log_api_access(
                 caller="dashboard:mode",
@@ -5512,27 +5542,25 @@ async def api_chat_mode(request: web.Request) -> web.Response:
             logger.warning("SEL audit failed for trust_reads mode activation", exc_info=True)
     elif mode == "trust":
         mgr = getattr(state, "channel_manager", None)
-        if slot_key is not None:
-            if slot_key not in state._slots:
-                return web.json_response({"ok": False, "error": "unknown slot"}, status=400)
+        if slot is not None:
             # Every slot that SHARES the session, matching the revoke below. The
             # policy is per session while the flag is per slot, so setting one of
             # two sharing slots leaves them disagreeing about a session they both
             # address, and the propagation pass would then be decided by slot
             # iteration order rather than by what the operator asked for.
-            _granted_key = effective_session_key(state._slots[slot_key])
+            _granted_key = effective_session_key(slot)
             for _sharing in state._slots.values():
                 if effective_session_key(_sharing) == _granted_key:
                     _sharing._trust = True
             state.sessions.set_approval_policy(_granted_key, "auto")
-            linked_ch = getattr(state._slots[slot_key], "_slack_channel", None)
+            linked_ch = getattr(slot, "_slack_channel", None)
             if mgr and linked_ch and linked_ch in mgr._channels:
                 mgr._channels[linked_ch].trusted = True
                 mgr._channels[linked_ch]._save()
         else:
-            for slot in state._slots.values():
-                slot._trust = True
-                state.sessions.set_approval_policy(effective_session_key(slot), "auto")
+            for s in state._slots.values():
+                s._trust = True
+                state.sessions.set_approval_policy(effective_session_key(s), "auto")
             if mgr:
                 for ch in mgr._channels.values():
                     ch.trusted = True
@@ -5552,30 +5580,28 @@ async def api_chat_mode(request: web.Request) -> web.Response:
             logger.warning("SEL audit failed for trust mode activation", exc_info=True)
     else:  # normal
         mgr = getattr(state, "channel_manager", None)
-        if slot_key is not None:
-            if slot_key not in state._slots:
-                return web.json_response({"ok": False, "error": "unknown slot"}, status=400)
+        if slot is not None:
             # Several slots can address ONE session (a rehydrated owner slot and
             # the alias its turns run under both resolve to the same effective
             # key), so revoking the selected slot alone leaves the others holding
             # a stale `_trust`, and the propagation below then rewrites the shared
             # session back to "auto" from it. The policy is per SESSION; the flag
             # is per slot; so the revoke has to clear every slot that shares it.
-            _revoked_key = effective_session_key(state._slots[slot_key])
+            _revoked_key = effective_session_key(slot)
             for _sharing in state._slots.values():
                 if effective_session_key(_sharing) == _revoked_key:
                     _sharing._trust = False
                     _sharing._trust_reads = False
             state.sessions.set_approval_policy(_revoked_key, "")
-            linked_ch = getattr(state._slots[slot_key], "_slack_channel", None)
+            linked_ch = getattr(slot, "_slack_channel", None)
             if mgr and linked_ch and linked_ch in mgr._channels:
                 mgr._channels[linked_ch].trusted = False
                 mgr._channels[linked_ch]._save()
         else:
-            for slot in state._slots.values():
-                slot._trust = False
-                slot._trust_reads = False
-                state.sessions.set_approval_policy(effective_session_key(slot), "")
+            for s in state._slots.values():
+                s._trust = False
+                s._trust_reads = False
+                state.sessions.set_approval_policy(effective_session_key(s), "")
             if mgr:
                 for ch in mgr._channels.values():
                     ch.trusted = False

--- a/test/test_chat_mode_security.py
+++ b/test/test_chat_mode_security.py
@@ -1,0 +1,379 @@
+"""Security contract of ``api_chat_mode`` (issue #4454).
+
+``api_chat_mode`` (``src/kiro_crew/dashboard/chat_handlers.py``) carried three
+defects, all in the ordering between slot validation and global mutation:
+
+1. ``trust_reads`` silently widened to EVERY slot when the named slot did not
+   resolve — its ``trust``/``normal`` siblings answer ``400 unknown slot``.
+2. A request rejected for an unknown slot had already revoked the
+   process-global safety override (``safety_override().deactivate()`` ran
+   before the ``400``). A refused request must leave the global grant and
+   every slot untouched.
+3. ``deactivate()`` — which writes a SEL event — ran inline on the gateway
+   loop, unlike the sibling ``activate()`` which is offloaded with
+   ``asyncio.to_thread``.
+
+Every test drives the real handler through an aiohttp ``TestClient``; the auth
+middleware is stood in by ``_dashboard_owner_request``, and ``safety_override``
+is either the real singleton (happy paths) or a recording fake (the rejection
+paths, where the contract is "never even called").
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard.chat_handlers import api_chat_mode
+from kiro_crew.safety_override import (
+    reset_singleton,
+)
+from kiro_crew.safety_override import safety_override as real_safety_override
+
+
+@web.middleware
+async def _dashboard_owner_request(request: web.Request, handler):
+    """Stand in for the auth middleware: a dashboard-owner request.
+
+    ``deny_non_dashboard_caller`` accepts a caller matching the configured
+    owner, or a local bootstrap subject when no owner is configured; these
+    tests configure no owner, so ``local-app`` passes.
+    """
+    request["app"] = ""
+    request["user"] = "local-app"
+    return await handler(request)
+
+
+def _make_mode_app(state) -> web.Application:
+    app = web.Application(middlewares=[_dashboard_owner_request])
+    app["state"] = state
+    app.router.add_post("/api/chat/mode", api_chat_mode)
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_home(tmp_path, monkeypatch):
+    """Redirect KIROCREW_HOME so SEL writes never touch the developer's home."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_safety_override():
+    reset_singleton()
+    yield
+    reset_singleton()
+
+
+@pytest.fixture
+def state(tmp_path, monkeypatch):
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    st = _make_state(tmp_path)
+    st.broadcast_ws = MagicMock()
+    st.push_slots_update = MagicMock()
+    st.owner_id = ""
+    return st
+
+
+def _client(state) -> TestClient:
+    return TestClient(TestServer(_make_mode_app(state)))
+
+
+class _FakeOverride:
+    """Recording stand-in for the SafetyOverride singleton.
+
+    ``active`` starts True when the test wants a live global grant; a grant a
+    rejected request must not have touched stays True. ``is_declared`` mirrors
+    the real singleton's property — a declared grant is exempt from the
+    slot-scoped narrowing, so the fake defaults to the common ad-hoc case.
+    """
+
+    def __init__(self, *, active: bool = False) -> None:
+        self.active = active
+        self.deactivate_calls: list[str] = []
+        self.is_declared = False
+
+    def deactivate(self, source: str) -> None:
+        self.deactivate_calls.append(source)
+        self.active = False
+
+    def is_active(self) -> bool:
+        return self.active
+
+
+# ── defect 1: trust_reads must not widen on an unknown slot ──
+
+
+@pytest.mark.asyncio
+async def test_trust_reads_unknown_slot_is_400_and_revokes_nothing(state) -> None:
+    """A slot-scoped request naming a missing slot widens to nothing.
+
+    The live global grant must survive the refusal: ``deactivate`` is never
+    even reached, and no slot's flags change.
+    """
+    state.get_or_create_slot("s1")
+    state.get_or_create_slot("s2")
+    override = _FakeOverride(active=True)
+    with patch("kiro_crew.dashboard.chat_handlers.safety_override", return_value=override):
+        async with _client(state) as client:
+            resp = await client.post(
+                "/api/chat/mode", json={"mode": "trust_reads", "slot": "ghost"}
+            )
+            assert resp.status == 400
+            assert (await resp.json()) == {"ok": False, "error": "unknown slot"}
+    assert override.active is True
+    assert override.deactivate_calls == []
+    assert all(not s._trust_reads and not s._trust for s in state._slots.values())
+
+
+@pytest.mark.asyncio
+async def test_trust_reads_non_string_slot_key_is_rejected(state) -> None:
+    """A truthy non-string key used to fall through to the all-slots branch."""
+    state.get_or_create_slot("s1")
+    async with _client(state) as client:
+        resp = await client.post("/api/chat/mode", json={"mode": "trust_reads", "slot": 123})
+        assert resp.status == 400
+    assert state._slots["s1"]._trust_reads is False
+
+
+@pytest.mark.asyncio
+async def test_falsy_non_string_slot_key_is_rejected_for_trust(state) -> None:
+    """Falsy non-strings (``[]``/``{}``/``0``/``False``) must not erase into the all-slots scope.
+
+    ``body.get("slot") or None`` collapses an empty list -- and every other
+    falsy non-string -- into ``None``, which is the documented "all slots"
+    request; before this fix ``{"mode": "trust", "slot": []}`` trusted EVERY
+    slot. The raw value must be refused before that normalization, and the
+    live global grant must survive the refusal.
+    """
+    state.get_or_create_slot("s1")
+    state.get_or_create_slot("s2")
+    override = _FakeOverride(active=True)
+    with patch("kiro_crew.dashboard.chat_handlers.safety_override", return_value=override):
+        async with _client(state) as client:
+            for bad in ([], {}, 0, False):
+                resp = await client.post("/api/chat/mode", json={"mode": "trust", "slot": bad})
+                assert resp.status == 400, bad
+                assert (await resp.json()) == {"ok": False, "error": "unknown slot"}
+    assert override.active is True
+    assert override.deactivate_calls == []
+    assert all(not s._trust_reads and not s._trust for s in state._slots.values())
+
+
+@pytest.mark.asyncio
+async def test_falsy_non_string_slot_key_is_rejected_for_trust_reads(state) -> None:
+    state.get_or_create_slot("s1")
+    override = _FakeOverride(active=True)
+    with patch("kiro_crew.dashboard.chat_handlers.safety_override", return_value=override):
+        async with _client(state) as client:
+            resp = await client.post("/api/chat/mode", json={"mode": "trust_reads", "slot": []})
+            assert resp.status == 400
+            assert (await resp.json()) == {"ok": False, "error": "unknown slot"}
+    assert override.active is True
+    assert override.deactivate_calls == []
+    assert state._slots["s1"]._trust_reads is False
+    assert state._slots["s1"]._trust is False
+
+
+# ── defect 2: a rejected request must leave the global grant untouched ──
+
+
+@pytest.mark.asyncio
+async def test_rejected_normal_request_leaves_the_global_grant_active(state) -> None:
+    """'{"mode": "normal", "slot": " "}' must not revoke the grant.
+
+    The exact shape from the issue: the unknown-slot 400 used to sit AFTER the
+    revocation, so a refused request silently ended YOLO mode.
+    """
+    state.get_or_create_slot("s1")
+    override = _FakeOverride(active=True)
+    with patch("kiro_crew.dashboard.chat_handlers.safety_override", return_value=override):
+        async with _client(state) as client:
+            resp = await client.post("/api/chat/mode", json={"mode": "normal", "slot": " "})
+            assert resp.status == 400
+            assert (await resp.json()) == {"ok": False, "error": "unknown slot"}
+    assert override.active is True
+    assert override.deactivate_calls == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_trust_request_leaves_the_global_grant_active(state) -> None:
+    state.get_or_create_slot("s1")
+    override = _FakeOverride(active=True)
+    with patch("kiro_crew.dashboard.chat_handlers.safety_override", return_value=override):
+        async with _client(state) as client:
+            resp = await client.post("/api/chat/mode", json={"mode": "trust", "slot": "ghost"})
+            assert resp.status == 400
+    assert override.active is True
+    assert override.deactivate_calls == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_trust_reads_does_not_touch_existing_slots(state) -> None:
+    state.get_or_create_slot("s1")
+    state.get_or_create_slot("s2")
+    with patch(
+        "kiro_crew.dashboard.chat_handlers.safety_override",
+        return_value=_FakeOverride(active=True),
+    ):
+        async with _client(state) as client:
+            resp = await client.post(
+                "/api/chat/mode", json={"mode": "trust_reads", "slot": "ghost"}
+            )
+            assert resp.status == 400
+    assert all(not s._trust_reads and not s._trust for s in state._slots.values())
+
+
+# ── happy paths: the repaired scope semantics hold ──
+
+
+@pytest.mark.asyncio
+async def test_trust_reads_named_slot_only(state) -> None:
+    """The named slot is the only one that trusts reads (widening regression)."""
+    state.get_or_create_slot("s1")
+    state.get_or_create_slot("s2")
+    async with _client(state) as client:
+        resp = await client.post("/api/chat/mode", json={"mode": "trust_reads", "slot": "s1"})
+        assert resp.status == 200
+        assert (await resp.json())["mode"] == "trust_reads"
+    assert state._slots["s1"]._trust_reads is True
+    assert state._slots["s2"]._trust_reads is False
+
+
+@pytest.mark.asyncio
+async def test_trust_named_slot_only(state) -> None:
+    """The named slot is the only one trusted (mirrors the trust_reads case).
+
+    Guards the same widening regression on the ``trust`` branch: a slot-scoped
+    trust request must not flip its siblings, and the approval policy must be
+    set to ``auto`` for the named slot's session only.
+    """
+    state.get_or_create_slot("s1")
+    state.get_or_create_slot("s2")
+    async with _client(state) as client:
+        resp = await client.post("/api/chat/mode", json={"mode": "trust", "slot": "s1"})
+        assert resp.status == 200
+        assert (await resp.json())["mode"] == "trust"
+    assert state._slots["s1"]._trust is True
+    assert state._slots["s2"]._trust is False
+    state.sessions.set_approval_policy.assert_any_call("dashboard:s1", "auto")
+
+
+@pytest.mark.asyncio
+async def test_trust_without_a_slot_is_still_global(state) -> None:
+    """An absent slot key keeps the documented all-slots meaning for trust."""
+    state.get_or_create_slot("s1")
+    state.get_or_create_slot("s2")
+    async with _client(state) as client:
+        resp = await client.post("/api/chat/mode", json={"mode": "trust"})
+        assert resp.status == 200
+    assert all(s._trust for s in state._slots.values())
+
+
+# ── interplay with #4416: a slot-scoped trust/trust_reads must not revoke
+# ── the process-global YOLO grant (the grant is global, the mode is per-slot)
+
+
+@pytest.mark.asyncio
+async def test_named_slot_trust_reads_leaves_an_active_grant_live(state) -> None:
+    """A named-slot trust_reads applies to that slot and does NOT revoke YOLO.
+
+    The narrowing from #4416 and the slot isolation from #4454 must hold
+    together: only the named slot trusts reads, and the operator's live grant
+    survives the request.
+    """
+    state.get_or_create_slot("s1")
+    state.get_or_create_slot("s2")
+    override = _FakeOverride(active=True)
+    with patch("kiro_crew.dashboard.chat_handlers.safety_override", return_value=override):
+        async with _client(state) as client:
+            resp = await client.post("/api/chat/mode", json={"mode": "trust_reads", "slot": "s1"})
+            assert resp.status == 200
+    assert override.active is True
+    assert override.deactivate_calls == []
+    assert state._slots["s1"]._trust_reads is True
+    assert state._slots["s2"]._trust_reads is False
+
+
+@pytest.mark.asyncio
+async def test_named_slot_trust_leaves_an_active_grant_live(state) -> None:
+    """A named-slot trust applies to that slot and does NOT revoke YOLO."""
+    state.get_or_create_slot("s1")
+    state.get_or_create_slot("s2")
+    override = _FakeOverride(active=True)
+    with patch("kiro_crew.dashboard.chat_handlers.safety_override", return_value=override):
+        async with _client(state) as client:
+            resp = await client.post("/api/chat/mode", json={"mode": "trust", "slot": "s1"})
+            assert resp.status == 200
+    assert override.active is True
+    assert override.deactivate_calls == []
+    assert state._slots["s1"]._trust is True
+    assert state._slots["s2"]._trust is False
+
+
+@pytest.mark.asyncio
+async def test_trust_reads_without_a_slot_is_still_global(state) -> None:
+    """An absent slot key keeps its documented all-slots meaning."""
+    state.get_or_create_slot("s1")
+    state.get_or_create_slot("s2")
+    async with _client(state) as client:
+        resp = await client.post("/api/chat/mode", json={"mode": "trust_reads"})
+        assert resp.status == 200
+    assert all(s._trust_reads for s in state._slots.values())
+
+
+@pytest.mark.asyncio
+async def test_normal_mode_named_slot_only(state) -> None:
+    """A named-slot normal request revokes that slot, not its siblings."""
+    state.get_or_create_slot("s1")
+    state.get_or_create_slot("s2")
+    state._slots["s1"]._trust = True
+    state._slots["s2"]._trust = True
+    async with _client(state) as client:
+        resp = await client.post("/api/chat/mode", json={"mode": "normal", "slot": "s1"})
+        assert resp.status == 200
+    assert state._slots["s1"]._trust is False
+    assert state._slots["s2"]._trust is True
+
+
+# ── defect 3: deactivate runs off the event loop ──
+
+
+@pytest.mark.asyncio
+async def test_deactivate_runs_off_the_event_loop(state) -> None:
+    """deactivate() writes a SEL event and must not run on the gateway loop."""
+    state.get_or_create_slot("s1")
+    captured: dict[str, int] = {}
+
+    class _TrackingOverride:
+        is_declared = False
+
+        def deactivate(self, source: str) -> None:
+            captured["thread"] = threading.get_ident()
+
+        def is_active(self) -> bool:
+            return False
+
+    with patch(
+        "kiro_crew.dashboard.chat_handlers.safety_override",
+        return_value=_TrackingOverride(),
+    ):
+        async with _client(state) as client:
+            loop_thread = threading.get_ident()
+            resp = await client.post("/api/chat/mode", json={"mode": "normal"})
+            assert resp.status == 200
+    assert captured["thread"] != loop_thread
+
+
+@pytest.mark.asyncio
+async def test_valid_normal_mode_touches_the_real_singleton(state) -> None:
+    """The happy path exercises the real SafetyOverride, not just the fake."""
+    state.get_or_create_slot("s1")
+    async with _client(state) as client:
+        resp = await client.post("/api/chat/mode", json={"mode": "normal"})
+        assert resp.status == 200
+    assert real_safety_override().is_active() is False


### PR DESCRIPTION
## Problem / Motivation

`POST /api/chat/mode` (`src/kiro_crew/dashboard/chat_handlers.py`) carried three defects in the ordering between slot validation and global mutation:

1. A `trust_reads` request naming a slot that does not resolve silently fell through to the all-slots path, widening a slot-scoped request across every slot on the gateway. Its `trust`/`normal` siblings answer `400 unknown slot`.
2. The unknown-slot `400` sat after `safety_override().deactivate()`, so a refused request (`{"mode": "normal", "slot": " "}`) still revoked the process-global grant -- a rejected request mutated global state.
3. `deactivate()` -- which emits a SEL event -- ran inline on the gateway loop, while the sibling `activate()` is offloaded with `asyncio.to_thread`.

## Why it matters

The unknown-slot cases are exactly the malformed or stale requests an automation sends (e.g. a session created against a slot that was since deleted). Today those requests either widen a slot-scoped intent across every slot (defect 1 -- the `trust_reads` path that other modes explicitly refuse) or withdraw a global grant the operator relies on (defect 2), while the blocked-`deactivate` inline run puts SEL I/O on the gateway event loop (defect 3). None of the three has a good outcome for the operator; each is a "rejected input should be a no-op" violation.

## What changed (motivation -> approach -> change)

- **Root cause**: validation was interleaved with mutation -- `trust_reads` never validated, and `trust`/`normal` validated only *after* the global grant was already revoked. The fix is to make "slot does not resolve" a refusal that happens before any mutation, for every slot-scoped branch, and to stop re-indexing `state._slots[slot_key]` after an `await` (no check/use gap for a concurrent slot deletion).
- **Approach**: the slot key is resolved once, inline at the top of `api_chat_mode`, and an unresolvable key returns `400` before touching grant or slots. Branches mutate the captured slot reference instead of re-indexing the dict. `yolo` is global and keeps ignoring `slot` (a stale key must not refuse it), preserving upstream behavior.
- **Non-string slots refused**: `body.get("slot") or None` previously collapsed falsy non-strings (`[]`, `{}`, `0`, `False`) into the documented all-slots request -- so `{"mode": "trust", "slot": []}` trusted every slot (the same widening defect as #4454 through a normalization back door). The raw value is now type-checked before that normalization: any present non-string `slot` answers `400 unknown slot`, while `yolo` still ignores `slot` entirely.
- **Change**: `src/kiro_crew/dashboard/chat_handlers.py` -- hoist validation ahead of the conditional `deactivate()`; refuse present non-string slots on the raw value; offload `deactivate()` with `await asyncio.to_thread(...)` matching the sibling `activate()`. A slot-scoped `trust`/`trust_reads` leaves the process-global grant alone (a per-slot request cannot be answered by withdrawing authority elsewhere); a grant declared in owner-only config is exempt from the narrowing, since selecting another approval mode is the one documented action that ends it.

This branch is rebased onto the current `main`. The branch bodies adopt main's `effective_session_key()` shared-session propagation (the policy is per session, the flag is per slot, so a grant/revoke clears every slot sharing the session) while keeping this PR's up-front validation; main's now-redundant late unknown-slot checks inside the `trust`/`normal` branches are dropped in favor of the single up-front refusal. Per the First Principles review: `error-code-baseline.json` is reverted to base (the diff removes two uncoded `unknown slot` responses and adds two -- net zero -- so no regeneration is needed), and the single-consumer `_resolve_mode_slot()` helper is inlined at its call site.

## Tests

`test/test_chat_mode_security.py` -- 16 tests:

- Rejected `trust_reads`/`trust`/`normal` on an unknown slot answer `400 unknown slot` and never call `deactivate`.
- No slot flags change after a refusal; a rejected request leaves an active grant live.
- Falsy non-string slots (`[]`, `{}`, `0`, `False`) on `trust`/`trust_reads` answer `400` and do not widen (addresses the GPT 5.6 review back-door finding).
- Named-slot requests affect only the named slot and set the approval policy for that session's key.
- Absent slot keys keep the documented all-slots meaning; a non-string slot key is refused.
- Named-slot `trust`/`trust_reads` do not revoke an active grant (the #4416 x #4454 interplay).
- `deactivate()` runs off the event loop.

Regression -- `test_trust_reads.py`, `test_channel_trust_revoke.py`, `test_dashboard_chat.py` (785 passed; one pre-existing `TestIsReadOnlyBash` failure reproduces on `origin/main` and is unrelated to this diff). `test/test_error_code_contract.py` passes with the baseline at base.

## Manual verification

N/A -- unit coverage sufficient: the change is confined to one handler whose every branch is exercised directly by the new contract tests, including the SEL event path.

## Screenshots / video

N/A -- no user-visible UI change.

## Related Issues

Closes #4454

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(dashboard): ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- `docs/system-specs/modules/security.md` TTL table corrected
- [x] No secrets, credentials, or internal references in the diff
