### PR TITLE
fix(sidebar): merge authoritative slot lists instead of replacing them

### DIFF
--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -8,7 +8,7 @@ Backend and whole-system docs are in [`../../docs/`](../../docs/README.md).
 |---|---|
 | [page-layout.md](page-layout.md) | The page skeleton every dashboard page follows, and the layout patterns to copy. |
 | [theming-contract.md](theming-contract.md) | The CSS variable contract, the stable class hooks a theme may target, and what is deliberately not customizable. |
-| [frontend-conventions.md](frontend-conventions.md) | Shared components, accessibility, URL sanitization, data fetching, animation, and styling. |
+| [frontend-conventions.md](frontend-conventions.md) | Shared components, accessibility, URL sanitization, data fetching, live-collection identity, animation, and styling. |
 | [i18n-catalog.md](i18n-catalog.md) | Catalog structure, key naming, plurals, and the formatting seam. |
 | [testing.md](testing.md) | The three test layers, which to use when, how Playwright really runs, how to keep a test deterministic under a loaded shard, and the manual procedures. |
 | [extension-seams.md](extension-seams.md) | The registry seams a downstream edition composes against, and the fail-closed edition opt-in. |

--- a/website/docs/frontend-conventions.md
+++ b/website/docs/frontend-conventions.md
@@ -1,9 +1,9 @@
 # Frontend conventions
 
-Shared components, accessibility, security, data fetching, animation, styling,
-typography, and how a builtin app gets discovered. Page structure is in
-[page-layout](page-layout.md); color and CSS-var rules are in
-[theming-contract](theming-contract.md); user-facing strings are in
+Shared components, accessibility, security, data fetching, live-collection
+identity, animation, styling, typography, and how a builtin app gets discovered.
+Page structure is in [page-layout](page-layout.md); color and CSS-var rules are
+in [theming-contract](theming-contract.md); user-facing strings are in
 [i18n-catalog](i18n-catalog.md).
 
 ## Shared components
@@ -153,6 +153,47 @@ slices:
 
 Server data belongs in React Query, not in a slice. Reach for Redux only when the
 state is shell-wide and not a cached server read.
+
+## Live-updating collections: merge, don't replace
+
+A slice holding a collection the server re-broadcasts **in full** must merge the
+incoming list into the one it already holds, never assign it. Assigning hands
+every row a new object reference on every frame, so one row's change invalidates
+every selector over the collection, every `useMemo` keyed on the array, and every
+memoized child — and inside a Framer `LayoutGroup` it re-measures the entire list.
+The symptom is a collection that visibly reloads when one member changed, which
+reads as a bug rather than as an update. Broadcasts are coalesced server-side but
+not suppressed (slots at 200ms), so an active session delivers several full lists
+per second and the effect is continuous rather than incidental.
+
+What a merge has to hold:
+
+- **Membership and order come from the incoming list.** The server stays
+  authoritative on both; only per-row identity is carried across.
+- **Reuse a row only when it is structurally equal**, so no consumer can read
+  stale content off a kept reference.
+- **Leave the array itself alone when nothing moved.** This is the half that
+  pays: an equal-but-new array still reruns every downstream filter and sort.
+- **Compare field-agnostically and independently of key order.** A comparator
+  that enumerates the type's fields stops seeing a newly added one and pins a
+  stale row — a correctness bug, where a redundant re-render is only a cost. A
+  serialization compare calls a locally patched row unequal forever, because an
+  in-place patch can append a key the server payload spells earlier.
+
+`applySlots` in `dashboardSlice.ts` is the reference implementation, driving both
+authoritative writers (`sseSlots` and the `fetchSlots` refetch);
+`dashboardSlice.slotIdentity.test.ts` pins the contract. Reusing an Immer draft
+row inside a freshly assigned array is safe — a draft found in the assigned value
+is finalized within the same scope, so an untouched row resolves back to its base
+object and keeps its identity.
+
+Two habits belong to the same concern:
+
+- **Subscribe narrowly.** A selector returning a whole map re-renders its
+  component on any write to any member; pass `shallowEqual` when the component
+  only reads members out of it, as the sidebar does for `slotStatusDetail`.
+- **Don't re-rank a list on mid-turn activity.** An ordering key should move on
+  settled events only, or rows swap under the pointer while several sessions work.
 
 ## Animations
 

--- a/website/src/store/dashboardSlice.ts
+++ b/website/src/store/dashboardSlice.ts
@@ -128,6 +128,74 @@ const evictSlotSubagents = (state: DashboardState, slotKey: string): void => {
   delete state.subagentText[slotKey]
 }
 
+/** Structural equality over the JSON shapes a slot payload is made of.
+ *
+ *  Key-order independent on purpose: one side is a fresh server payload, the
+ *  other may be a row an in-place reducer (`touchSlotActivity`, `updateSlot`,
+ *  `patchSlotLink`) has since patched, and a patch can append a key the payload
+ *  spells earlier. A serialization compare would call those unequal forever and
+ *  silently give back the wholesale-replacement behaviour this exists to avoid.
+ *
+ *  Field-agnostic for the same reason: a comparator listing `ChatSlot`'s fields
+ *  would stop seeing a newly added one and pin a stale row on screen, which is a
+ *  correctness bug where an extra re-render is only a cost. */
+const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false
+  const aArr = Array.isArray(a)
+  if (aArr !== Array.isArray(b)) return false
+  if (aArr) {
+    const x = a as unknown[]
+    const y = b as unknown[]
+    return x.length === y.length && x.every((v, i) => deepEqual(v, y[i]))
+  }
+  const x = a as Record<string, unknown>
+  const y = b as Record<string, unknown>
+  const keys = Object.keys(x)
+  if (keys.length !== Object.keys(y).length) return false
+  return keys.every(k => Object.prototype.hasOwnProperty.call(y, k) && deepEqual(x[k], y[k]))
+}
+
+/** Apply an authoritative slot list, reusing the object identity of every row
+ *  whose content is unchanged, and touching `state.slots` only when the list
+ *  actually moved.
+ *
+ *  Membership AND order come from `next` — the server is authoritative on both.
+ *  Only per-row identity is carried across, and only for a structurally equal
+ *  row, so no consumer can read stale content off a reused reference.
+ *
+ *  Identity is load-bearing here rather than a micro-optimisation. The sidebar
+ *  renders every row as a Framer `motion.div` with `layout="position"` inside one
+ *  `LayoutGroup`, and every selector over `dashboard.slots` invalidates when the
+ *  array or any row changes reference. Assigning the incoming array wholesale
+ *  hands every row a new reference on every frame, so one slot's status change
+ *  re-renders and re-measures the entire list — which reads as the sidebar
+ *  reloading rather than as one session becoming active. Slot pushes coalesce at
+ *  200ms server-side, so a single active turn delivers several full lists per
+ *  second and the effect is continuous.
+ *
+ *  Skipping the assignment (rather than assigning an equal array) is the half
+ *  that matters most: it leaves the array reference alone, which lets a
+ *  downstream `useMemo` skip its filter and sort entirely instead of recomputing
+ *  an equal result. */
+const applySlots = (state: DashboardState, next: ChatSlot[]): void => {
+  const prev = state.slots ?? []
+  const byKey = new Map(prev.map(s => [s.key, s]))
+  let changed = prev.length !== next.length
+  const merged = next.map((incoming, i) => {
+    const existing = byKey.get(incoming.key)
+    // Reusing a draft row inside a freshly assigned array is fine: Immer
+    // finalizes drafts found in the assigned value within the same scope, so an
+    // untouched row resolves back to its base object and keeps its identity.
+    const reused = existing !== undefined && deepEqual(existing, incoming) ? existing : incoming
+    // Positional compare, so a pure reorder counts as changed even though every
+    // row is individually reusable.
+    if (reused !== prev[i]) changed = true
+    return reused
+  })
+  if (changed) state.slots = merged
+}
+
 const dashboardSlice = createSlice({
   name: 'dashboard',
   initialState,
@@ -157,7 +225,7 @@ const dashboardSlice = createSlice({
       // the sidebar until restoration finishes, and marking it loaded would
       // claim a snapshot arrived when none has.
       if (action.payload.length === 0 && !state.slotsLoaded) return
-      state.slots = action.payload
+      applySlots(state, action.payload)
       state.slotsLoaded = true
       reconcileSlots(state, new Set(action.payload.map(s => s.key)))
     },
@@ -370,7 +438,7 @@ const dashboardSlice = createSlice({
         // unread drain still runs — that is this path's documented job, and a
         // badge self-heals — but eviction is withheld once the stream is live.
         const fresh = !state.slotsLoaded
-        state.slots = action.payload
+        applySlots(state, action.payload)
         state.slotsLoaded = true
         reconcileSlots(state, new Set(action.payload.map((s: { key: string }) => s.key)), fresh)
       })

--- a/website/src/test/dashboardSlice.slotIdentity.test.ts
+++ b/website/src/test/dashboardSlice.slotIdentity.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from 'vitest'
+import reducer, { sseSlots, touchSlotActivity, fetchSlots } from '../store/dashboardSlice'
+import type { ChatSlot } from '../types'
+
+vi.mock('../api/client', () => ({
+  api: { chatSlots: vi.fn(), chatMode: vi.fn() },
+}))
+
+/**
+ * Referential stability of `dashboard.slots` under the two authoritative
+ * writers.
+ *
+ * The sidebar renders each row as a Framer `motion.div` inside one
+ * `LayoutGroup`, and its filter/sort hangs off a `useMemo` keyed on the array.
+ * A writer that replaces the array wholesale therefore re-renders and
+ * re-measures every row on every frame — several times a second while any
+ * session is active — for what is usually one slot's change. These cases pin
+ * the identity contract that keeps that cost proportional to the change.
+ */
+
+const mk = (key: string, over: Partial<ChatSlot> = {}): ChatSlot => ({
+  key,
+  title: key,
+  messages: 1,
+  running: false,
+  pending_approval: false,
+  waiting_for_input: false,
+  last_activity_ts: undefined,
+  ...over,
+})
+
+// Fresh objects per frame: the real payload is parsed from the wire, so a
+// reducer that merely happened to receive the same reference would pass
+// vacuously.
+const frame = (...slots: ChatSlot[]): ChatSlot[] => slots.map(s => JSON.parse(JSON.stringify(s)) as ChatSlot)
+
+describe('dashboard.slots referential stability', () => {
+  const initial = reducer(undefined, { type: '@@INIT' })
+  const loaded = reducer(initial, sseSlots(frame(mk('a'), mk('b'), mk('c'))))
+
+  it('leaves the array untouched when a frame repeats the same content', () => {
+    const again = reducer(loaded, sseSlots(frame(mk('a'), mk('b'), mk('c'))))
+    expect(again.slots).toBe(loaded.slots)
+  })
+
+  it('ignores key order in the incoming payload', () => {
+    // Guards against a serialization-based comparator: a row an in-place
+    // reducer has patched can spell its keys in a different order than the
+    // server does, and calling that unequal would defeat the merge silently.
+    const reordered = loaded.slots.map(s => {
+      const flipped: Record<string, unknown> = {}
+      for (const k of Object.keys(s).reverse()) flipped[k] = (s as unknown as Record<string, unknown>)[k]
+      return flipped as unknown as ChatSlot
+    })
+    const again = reducer(loaded, sseSlots(reordered))
+    expect(again.slots).toBe(loaded.slots)
+  })
+
+  it('replaces only the row that changed', () => {
+    const next = reducer(loaded, sseSlots(frame(mk('a'), mk('b', { running: true }), mk('c'))))
+    expect(next.slots).not.toBe(loaded.slots)
+    expect(next.slots[0]).toBe(loaded.slots[0])
+    expect(next.slots[2]).toBe(loaded.slots[2])
+    expect(next.slots[1]).not.toBe(loaded.slots[1])
+    expect(next.slots[1].running).toBe(true)
+  })
+
+  it('reuses every row across a pure reorder while still publishing a new array', () => {
+    // The array must change so the sidebar's sort re-runs; the rows must not, so
+    // only the moved rows animate.
+    const next = reducer(loaded, sseSlots(frame(mk('c'), mk('a'), mk('b'))))
+    expect(next.slots).not.toBe(loaded.slots)
+    expect(next.slots.map(s => s.key)).toEqual(['c', 'a', 'b'])
+    expect(next.slots[0]).toBe(loaded.slots[2])
+    expect(next.slots[1]).toBe(loaded.slots[0])
+    expect(next.slots[2]).toBe(loaded.slots[1])
+  })
+
+  it('keeps surviving rows across an addition and a removal', () => {
+    const added = reducer(loaded, sseSlots(frame(mk('a'), mk('b'), mk('c'), mk('d'))))
+    expect(added.slots).toHaveLength(4)
+    expect(added.slots[0]).toBe(loaded.slots[0])
+
+    const removed = reducer(loaded, sseSlots(frame(mk('a'), mk('c'))))
+    expect(removed.slots.map(s => s.key)).toEqual(['a', 'c'])
+    expect(removed.slots[0]).toBe(loaded.slots[0])
+    expect(removed.slots[1]).toBe(loaded.slots[2])
+  })
+
+  it('settles a locally patched row without churning the array', () => {
+    // `touchSlotActivity` bumps recency off the finer-grained message stream, so
+    // the authoritative frame that follows usually agrees with what the row
+    // already holds. That agreement must cost nothing.
+    const ts = '2026-01-01T00:00:00Z'
+    const patched = reducer(loaded, touchSlotActivity({ key: 'b', ts, settled: true }))
+    expect(patched.slots).not.toBe(loaded.slots)
+
+    const confirmed = reducer(patched, sseSlots(frame(
+      mk('a'), mk('b', { last_ts: ts, last_turn_ts: ts }), mk('c'),
+    )))
+    expect(confirmed.slots).toBe(patched.slots)
+  })
+
+  it('applies the same contract to the HTTP refetch', () => {
+    const same = reducer(loaded, {
+      type: fetchSlots.fulfilled.type,
+      payload: frame(mk('a'), mk('b'), mk('c')),
+    })
+    expect(same.slots).toBe(loaded.slots)
+  })
+
+  it('still ignores an empty frame that arrives before the first snapshot', () => {
+    const early = reducer(initial, sseSlots([]))
+    expect(early.slotsLoaded).toBe(false)
+    expect(early.slots).toEqual([])
+  })
+
+  it('still tears down on an empty frame once loaded', () => {
+    const emptied = reducer(loaded, sseSlots([]))
+    expect(emptied.slots).toEqual([])
+    expect(emptied.slotsLoaded).toBe(true)
+  })
+})


### PR DESCRIPTION
## The problem

The session list in the left sidebar visibly reloads whenever any session does anything — a fast whole-list flash rather than the one changed row updating. That reads as a bug rather than as an update, which is the actual cost here: a user cannot tell a normal refresh apart from something having gone wrong.

## Root cause

Both authoritative writers assigned the incoming list wholesale:

```ts
state.slots = action.payload
```

Every row therefore gets a new object reference on every frame, even when its content is byte-identical. That invalidates every selector over `dashboard.slots`, the `useMemo` the sidebar's filter and sort hang off, and every row inside the Framer `LayoutGroup` — so one slot's status change re-renders and re-measures the entire list.

Slot broadcasts coalesce at 200ms server-side (`_SLOTS_BROADCAST_INTERVAL_S`) but are not suppressed, and `push_slots_update()` is called from the chat runner, the dashboard handlers and the channel gateways, so a single active turn delivers several full lists per second. The effect is continuous, not incidental.

The slice already applies the opposite discipline everywhere else — `sseTodoUpdate`, `sseSlotTitle`, `updateSlot` and `patchSlotLink` all patch in place, and `slotStatusDetail` is subscribed with `shallowEqual` under a comment noting that without it "any write to one slot's detail re-renders the entire sidebar". The authoritative path was the one place with no equivalent protection, and it is the highest-frequency one.

## The change

`applySlots` merges instead of assigning. Membership and order still come from the server — it stays authoritative on both — but a structurally equal row keeps its identity, and `state.slots` is not touched at all when nothing moved.

That second half is what pays. An equal-but-new array still reruns every downstream filter and sort; an unchanged reference lets the `useMemo` skip its work entirely.

Two deliberate properties of the comparator:

- **Field-agnostic.** A comparator that enumerates `ChatSlot`'s fields stops seeing a newly added one and pins a stale row on screen. That is a correctness bug, where a redundant re-render is only a cost.
- **Key-order independent.** A serialization compare would call a locally patched row unequal forever, because an in-place patch can append a key the server payload spells earlier — silently restoring the wholesale-replacement behaviour this exists to remove. There is a test for exactly this.

Reusing an Immer draft row inside a freshly assigned array is safe: a draft found in the assigned value is finalized within the same scope, so an untouched row resolves back to its base object and keeps its identity. The tests assert identity across a real `produce`, so this is pinned rather than assumed.

## Scope note

This removes the per-frame full re-render and full LayoutGroup re-measurement. It does not touch the row component itself — `renderSessionRow` is an inline function closing over ~50 locals, and extracting it into a `React.memo` component is a separate refactor. If any residual flicker remains after this, that is where it lives.

## Docs

The rule is generalized into `website/docs/frontend-conventions.md` under a new **Live-updating collections: merge, don't replace** section, since any slice holding a collection the server re-broadcasts in full carries the same obligation. It states the four properties a merge must hold, points at `applySlots` as the reference implementation, and adds the two habits that belong to the same concern (subscribe narrowly; don't re-rank a list on mid-turn activity). The docs index row and the file's own summary line are updated so neither goes stale.

## Testing

`website/src/test/dashboardSlice.slotIdentity.test.ts` — 9 cases pinning the contract:

- a repeated frame leaves the array reference untouched
- incoming key order is ignored (guards the serialization-compare trap)
- only the changed row is replaced; its neighbours keep identity
- a pure reorder reuses every row but still publishes a new array, so the sort reruns
- surviving rows keep identity across an addition and a removal
- a `touchSlotActivity` patch confirmed by a matching authoritative frame costs nothing
- the `fetchSlots` refetch honours the same contract
- both empty-frame guard branches are unchanged

Payloads are re-parsed per frame, so a reducer that merely received the same reference cannot pass vacuously.

**Revert-verified.** Reverting `if (changed) state.slots = merged` to `state.slots = next` fails 7 of the 9 cases, so the guard is not vacuous.

### Gates

- `npx tsc -b` — green
- full `vitest` — 21641 passed, 1 failed: `ChatSidebar.tagFilter.test.tsx:214`, which **fails identically on a clean `origin/main`** (verified by stashing). Pre-existing and unrelated — that test preloads the store directly and never dispatches `sseSlots`.
- backend cross-surface guard set (339 files) — 20313 passed, 11 failed, all environmental (`test_playwright_cli_installer.py` needs Node ≥ 20; `test_platform_compat.py` depends on `ps` visibility). All 11 reproduce identically on clean `origin/main`. This diff contains no Python.
- `isort --check-only` / `flake8` — green. `mypy` not run: zero Python files changed, so the result is identical to `main` by construction.


no linked issue: reported directly in the dashboard session as an observed sidebar flicker, never filed as a GitHub issue.
