### PR TITLE
fix(usage): account for background LLM turns at their two chokepoints

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -1195,7 +1195,6 @@ test/test_review_driver_loopback.py
 test/test_review_fixes.py
 test/test_role_models.py
 test/test_route_registry.py
-test/test_run_bg_oneliner.py
 test/test_run_config_write.py
 test/test_safety_override.py
 test/test_sage_backend_routes_coverage.py

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -1244,8 +1244,10 @@ async def compress_thread_history(
     *exclude_last_n* is forwarded to ``conversation_log.recent`` to drop
     the just-flushed current-turn user message from history.
     """
-    from kiro_crew.llm_helpers import stream_and_collect  # circular import
-    from kiro_crew.session import BACKGROUND_KEY  # circular import
+    from kiro_crew.llm_helpers import (  # circular import
+        background_turn,
+        stream_and_collect,
+    )
 
     compressed_cap = _resolve_caps(model_window).compressed_history
 
@@ -1283,33 +1285,27 @@ async def compress_thread_history(
         + transcript
     )
 
-    acquired = False
     try:
-        client, _is_new, _resumed = await sessions.get_or_create(
-            BACKGROUND_KEY, agent="kirocrew-lite"
-        )
-        acquired = True
-        result = await stream_and_collect(client, prompt)
-        if not result:
-            return None
+        async with background_turn(
+            sessions, task="thread_compress", agent="kirocrew-lite"
+        ) as client:
+            result = await stream_and_collect(client, prompt)
+            if not result:
+                return None
 
-        parts: list[str] = []
-        if head_lines:
-            parts.append("## Thread start (verbatim)\n" + "\n".join(head_lines))
-        parts.append("## Compressed history\n" + result[:compressed_cap])
-        if tail_lines:
-            parts.append("## Recent exchanges (verbatim)\n" + "\n".join(tail_lines))
-        final = "\n\n".join(parts)
-        final, _ = redact_exfiltration_urls(final)
-        final, _ = redact_credentials(final)
-        return final.translate(_MULTIBYTE_TABLE)
+            parts: list[str] = []
+            if head_lines:
+                parts.append("## Thread start (verbatim)\n" + "\n".join(head_lines))
+            parts.append("## Compressed history\n" + result[:compressed_cap])
+            if tail_lines:
+                parts.append("## Recent exchanges (verbatim)\n" + "\n".join(tail_lines))
+            final = "\n\n".join(parts)
+            final, _ = redact_exfiltration_urls(final)
+            final, _ = redact_credentials(final)
+            return final.translate(_MULTIBYTE_TABLE)
     except Exception:
         logger.warning("Thread history compression failed", exc_info=True)
         return None
-    finally:
-        if acquired:
-            sessions.release(BACKGROUND_KEY)
-            await sessions.recycle_background()
 
 
 # ── Provider-Agnostic Session Replay ──

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import unicodedata
 from typing import Any
@@ -17,10 +18,9 @@ from kiro_crew.dashboard.chat_utils import (
     slot_history_key,
 )
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE, DashboardState, _ChatSlot
-from kiro_crew.llm_helpers import run_bg_oneliner
+from kiro_crew.llm_helpers import background_turn, run_bg_oneliner
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
-from kiro_crew.session import BACKGROUND_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -646,20 +646,15 @@ async def _rephrase_plan_lite(
 ) -> str | None:
     """Rephrase a plan using the cheap background session (kirocrew-lite)."""
 
-    try:
-        bg, _new, _resumed = await state.sessions.get_or_create(BACKGROUND_KEY)
-    except Exception:
-        logger.warning("Failed to get background session for plan rephrase", exc_info=True)
-        return None
-    try:
+    async with contextlib.AsyncExitStack() as stack:
+        try:
+            bg = await stack.enter_async_context(
+                background_turn(state.sessions, task="plan_rephrase")
+            )
+        except Exception:
+            logger.warning("Failed to get background session for plan rephrase", exc_info=True)
+            return None
         result = await rephrase_plan(text, issues, bg, might_not_be_plan=might_not_be_plan)
-    finally:
-        state.sessions.release(BACKGROUND_KEY)
-        # Recycle the shared BG session if it's accumulated too much context.
-        # Without this, repeated dashboard plan-rephrases bloat the kiro-cli
-        # child until a mid-stream recycle eventually kills an in-flight call,
-        # blocking every chat queued behind the BG session for minutes.
-        await state.sessions.recycle_background()
     if result:
         result, _ = redact_exfiltration_urls(result)
         result, _ = redact_credentials(result)

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -28,12 +28,16 @@ from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.frontmatter import SKILL_UPDATE, frontmatter_value
-from kiro_crew.llm_helpers import ToolApprovalPolicy, stream_and_collect, stream_and_collect_json
+from kiro_crew.llm_helpers import (
+    ToolApprovalPolicy,
+    background_turn,
+    stream_and_collect,
+    stream_and_collect_json,
+)
 from kiro_crew.messaging.link import canonical_key, legacy_key
 from kiro_crew.preview_text import strip_markdown_preview
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
-from kiro_crew.session import BACKGROUND_KEY
 from kiro_crew.skills import AUTO_SKILL_MAX_PROCEDURE_CHARS, AutoSkillProvenance
 from kiro_crew.skills_dedupe import (
     VERDICT_DUP,
@@ -5982,34 +5986,24 @@ class HistoryConsolidator:
         if not self._sessions:
             return ""
         try:
-            client, _new, _resumed = await self._sessions.get_or_create(
-                BACKGROUND_KEY, agent="kirocrew-lite"
-            )
-            text = await stream_and_collect(
-                client, prompt, approval_policy=ToolApprovalPolicy.REJECT_ALL
-            )
+            async with background_turn(
+                self._sessions, task="skill_dedupe", agent="kirocrew-lite"
+            ) as client:
+                text = await stream_and_collect(
+                    client, prompt, approval_policy=ToolApprovalPolicy.REJECT_ALL
+                )
             return text or ""
         except Exception:
             logger.debug("Skill dedupe judge failed", exc_info=True)
             return ""
-        finally:
-            # get_or_create ACQUIRES the per-session semaphore — the caller MUST
-            # release it (mirror _call_llm), else the shared _bg session is held
-            # forever and the next consolidation turn deadlocks waiting for it.
-            try:
-                self._sessions.release(BACKGROUND_KEY)
-                await self._sessions.recycle_background()
-            except Exception:
-                logger.debug("Skill dedupe judge session release failed", exc_info=True)
 
     async def _merge_skill_update(
         self, live_body: str, description: str, triggers: str, procedure_md: str
     ) -> "str | None":
         """Merge an existing live skill body with a new candidate into ONE
         updated markdown body — a single text turn on the shared background
-        session. Mirrors ``_dedupe_judge`` exactly (get_or_create / REJECT_ALL /
-        finally-release + recycle). Fail-open (returns ``None`` on any error) so
-        the caller can fall back to a plain replacement proposal."""
+        session. Mirrors ``_dedupe_judge`` exactly. Fail-open (returns ``None`` on
+        any error) so the caller can fall back to a plain replacement proposal."""
         if not self._sessions:
             return None
         prompt = (
@@ -6026,25 +6020,16 @@ class HistoryConsolidator:
             f"NEW requirement — procedure:\n{procedure_md}\n"
         )
         try:
-            client, _new, _resumed = await self._sessions.get_or_create(
-                BACKGROUND_KEY, agent="kirocrew-lite"
-            )
-            text = await stream_and_collect(
-                client, prompt, approval_policy=ToolApprovalPolicy.REJECT_ALL
-            )
+            async with background_turn(
+                self._sessions, task="skill_merge", agent="kirocrew-lite"
+            ) as client:
+                text = await stream_and_collect(
+                    client, prompt, approval_policy=ToolApprovalPolicy.REJECT_ALL
+                )
             return text or None
         except Exception:
             logger.debug("Skill update merge failed", exc_info=True)
             return None
-        finally:
-            # get_or_create ACQUIRES the per-session semaphore — the caller MUST
-            # release it (mirror _dedupe_judge), else the shared _bg session is
-            # held forever and the next consolidation turn deadlocks.
-            try:
-                self._sessions.release(BACKGROUND_KEY)
-                await self._sessions.recycle_background()
-            except Exception:
-                logger.debug("Skill update merge session release failed", exc_info=True)
 
     def _stage_skill_update(
         self,
@@ -6517,18 +6502,18 @@ class HistoryConsolidator:
             logger.warning("LLM consolidation skipped — no session manager")
             raise _ConsolidationNotDispatched("no session manager")
 
-        session_key = BACKGROUND_KEY
-        # Timing instrumentation (_bg stall investigation): measure both the
-        # wait to acquire the shared `_bg` session (queue contention behind
-        # other `_bg` consumers like chat_nav link-preview) and the LLM turn
-        # itself. No behavior change. Logged at DEBUG: silent in normal
-        # operation, surfaced only when log_level is raised to investigate a
-        # consolidation stall.
+        # Timing instrumentation: measure both the wait to acquire the shared
+        # `_bg` session (queue contention behind other `_bg` consumers like
+        # chat_nav link-preview) and the LLM turn itself. Logged at DEBUG:
+        # silent in normal operation, surfaced only when log_level is raised
+        # to investigate a consolidation stall.
         t_start = _time.monotonic()
-        try:
+        async with contextlib.AsyncExitStack() as stack:
             try:
-                client, _is_new, _resumed = await self._sessions.get_or_create(
-                    session_key, agent="kirocrew-lite"
+                client = await stack.enter_async_context(
+                    background_turn(
+                        self._sessions, task="consolidation", agent="kirocrew-lite"
+                    )
                 )
             except Exception as exc:
                 logger.warning(
@@ -6568,6 +6553,8 @@ class HistoryConsolidator:
                 result is not None,
             )
             return result
-        finally:
-            self._sessions.release(session_key)
-            await self._sessions.recycle_background()
+        # Reached only if the exit stack suppresses an exception. The prompt was
+        # already sent by then, so the turn may have been billed: report it as a
+        # spent-but-unusable result rather than a non-dispatch, which would hand
+        # the caller a free retry it has not earned.
+        return None

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -10,7 +10,9 @@ import asyncio
 import json
 import logging
 import random
-from collections.abc import Awaitable, Callable
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -30,6 +32,25 @@ from kiro_crew.sel import sel as _sel
 
 _PROMPT_BUSY_RETRIES = 2
 _PROMPT_BUSY_DELAY = 1.5  # seconds between retries
+
+# Cap on the wrapper chain walked to find a turn's billing stats. A provider is
+# wrapped at most a few layers deep, so a longer walk means a cycle or an
+# unrelated object graph, not a deeper seam.
+_WRAPPER_WALK_MAX_NODES = 8
+
+# Sentinel for "no prior stats object was observed", distinct from a provider that
+# legitimately exposes None. Used by provider_last_turn_usage's identity guard.
+_NO_PRIOR_STATS = object()
+
+# Where stream_and_collect hands its caller the billing it observed across ALL
+# attempts of one logical turn. A retry installs fresh per-turn stats, so a
+# post-hoc read of last_prompt_stats sees only the final attempt and silently
+# drops an attempt that was billed before a transient error. This carries the sum
+# instead, and provider_last_turn_usage consumes it. The value is a
+# (stats object, TurnUsage) pair: the provider outlives the turn, so the identity
+# of the stats the sum was computed from is what tells a later turn that the sum
+# is not its own.
+_TURN_BILLED_ATTR = "_kc_turn_billed"
 
 # Transient backend (Bedrock 5xx / throttle / stream-reset) retry budget. These
 # are server-side hiccups where the credential is VALID — retry helps, re-auth
@@ -290,6 +311,16 @@ async def run_bg_oneliner(
     low-level helper stays free of a dashboard/session import cycle.
     """
     session = await sessions.get_bg_session()
+    # The stats object as it stands BEFORE this turn. The runner replaces it when
+    # a turn actually begins, so comparing identity at teardown separates a turn
+    # that ran from one whose dispatch failed while the previous turn's already
+    # recorded credits were still installed.
+    stats_before = _billing_stats(session)
+    # Wall clock for the turn itself, started after the session is in hand so the
+    # acquire wait is not charged as turn time. The acp provider never fills
+    # TurnUsage.duration_ms, so this local measurement is the only duration a
+    # background row can carry, and every other dispatch surface supplies one.
+    turn_started = time.monotonic()
 
     def _first_advertised_fallback(advertised: Any, rejected: str | None) -> str | None:
         """First advertised model that is neither the rejected id nor the
@@ -411,19 +442,132 @@ async def run_bg_oneliner(
             )
             return await _run(fallback)
     finally:
-        await session.destroy()
+        # Account BEFORE destroy(): the turn's billing lives on the session this
+        # tears down. Every caller of this helper — titles, link labels, folder
+        # icons, session summaries, tips, the canary — reaches the provider
+        # through here and none of them recorded spend of their own, so the
+        # bill moved while the usage store stayed empty. Recording at this one
+        # point covers all of them and a new caller cannot forget to.
+        # The inner finally is load-bearing: persisting is an await, and
+        # CancelledError is a BaseException that no `except Exception` catches,
+        # so without it a cancellation landing on that await would skip
+        # destroy() and leak the session's runtime.
+        try:
+            try:
+                # Imported here rather than at module scope because the usage
+                # module's own import chain reaches back into this one -- history
+                # and several dashboard handlers import ToolApprovalPolicy /
+                # run_bg_oneliner from here -- so a module-scope import raises
+                # ImportError against a partially initialized llm_helpers. It
+                # also pulls ~600 modules that every consumer of this low-level
+                # module would otherwise pay for at boot.
+                from kiro_crew.dashboard.handlers.usage import persist_token_record_async
+
+                usage = provider_last_turn_usage(session, since=stats_before)
+                if usage.credits or usage.input_tokens or usage.output_tokens:
+                    await persist_token_record_async(
+                        sel_session_key,
+                        # The model the session SERVED, never the one requested: a
+                        # rejected preference is replaced by the reactive fallback
+                        # above, so recording the request would bill the spend to a
+                        # model that did not run. An unreadable served model falls
+                        # through to model_source rather than naming a guess.
+                        str(getattr(session, "served_model", "") or "").strip(),
+                        usage,
+                        _provider_label(session),
+                        surface=f"bg:{sel_source}",
+                        elapsed_ms=int((time.monotonic() - turn_started) * 1000),
+                        model_source=session,
+                    )
+            except Exception:
+                logger.debug("bg oneliner accounting failed source=%s", sel_source, exc_info=True)
+        finally:
+            await session.destroy()
 
 
-def provider_last_turn_usage(provider: Any) -> TurnUsage:
+def _billing_stats(provider: Any) -> Any:
+    """The per-turn stats object behind *provider*, or ``None``.
+
+    Returned as the object rather than a value so callers can compare identity:
+    the runner installs a FRESH stats object as it begins a turn, which is what
+    tells a completed turn apart from one that never started.
+    """
+    try:
+        for node in _billing_stat_holders(provider):
+            stats = getattr(node, "last_prompt_stats", None)
+            if stats is not None:
+                return stats
+    except Exception:
+        logger.debug("billing stats lookup failed", exc_info=True)
+    return None
+
+
+def _attempt_usage(provider: Any, *, since: Any = _NO_PRIOR_STATS) -> TurnUsage:
+    """Billing accrued on ONE attempt, read from the provider's live stats.
+
+    ``since`` is the stats object observed before the attempt. The runner installs
+    a fresh stats object as it begins a turn, with the credit counters at zero; a
+    dispatch that fails BEFORE that point -- a busy session, a dead runtime --
+    leaves the PREVIOUS turn's object in place, still carrying credits that were
+    already recorded. Comparing identity reports nothing in that case instead of
+    billing the earlier turn a second time.
+    """
+    stats = _billing_stats(provider)
+    if stats is None:
+        return TurnUsage()
+    if since is not _NO_PRIOR_STATS and stats is since:
+        return TurnUsage()
+    try:
+        return TurnUsage(credits=float(getattr(stats, "credits", 0.0) or 0.0))
+    except Exception:
+        logger.debug("attempt usage read failed", exc_info=True)
+    return TurnUsage()
+
+
+def _sum_usage(left: TurnUsage, right: TurnUsage) -> TurnUsage:
+    """Add two attempts' billing. Never raises; unknown fields stay at zero."""
+    try:
+        return TurnUsage(
+            credits=float(left.credits or 0.0) + float(right.credits or 0.0),
+            input_tokens=int(getattr(left, "input_tokens", 0) or 0)
+            + int(getattr(right, "input_tokens", 0) or 0),
+            output_tokens=int(getattr(left, "output_tokens", 0) or 0)
+            + int(getattr(right, "output_tokens", 0) or 0),
+        )
+    except Exception:
+        logger.debug("usage sum failed", exc_info=True)
+        return left
+
+
+def provider_last_turn_usage(provider: Any, *, since: Any = _NO_PRIOR_STATS) -> TurnUsage:
     """Best-effort read of the just-completed turn's billing usage.
 
     ``stream_and_collect`` breaks on ``EVENT_COMPLETE`` and returns only text,
     discarding the event's ``usage``. Background surfaces that dispatch through
     it (cron, heartbeat, autonudge, workflow, task-runner self-review) therefore
     have no event to hand :func:`persist_token_record_async`. This recovers the
-    turn's billing from the provider's ``last_prompt_stats`` — the same post-turn
-    read ``chat_runner`` performs — and wraps it in a ``TurnUsage`` so it can be
-    passed straight through as the ``event`` argument.
+    turn's billing and wraps it in a ``TurnUsage`` so it can be passed straight
+    through as the ``event`` argument.
+
+    A turn can span several attempts: ``stream_and_collect`` retries a busy
+    session and a transient backend error, and each retry installs fresh per-turn
+    stats. Reading the provider's live stats afterwards therefore sees only the
+    LAST attempt and loses any earlier attempt that was already billed. So the
+    total ``stream_and_collect`` accumulated is preferred when present, and
+    consumed here -- one turn's billing is reported once. Callers that drive
+    ``provider.stream`` themselves publish no total and fall back to the live
+    read, which is what ``since`` guards (see :func:`_attempt_usage`).
+
+    The total is published WITH the stats object it was computed from, and is
+    accepted only while that object is still the provider's current one. The
+    provider outlives the turn -- the shared background session is reused by every
+    background caller, and a Slack session by every turn in its thread -- so a
+    total left unread by one turn would otherwise be consumed by the next one,
+    billing that turn's spend to the wrong surface and losing its own. Today every
+    reader happens to be paired with a publish in the same turn, which makes the
+    residue unreachable; the guard is here so that safety does not depend on the
+    next caller preserving that pairing. A fresh turn installs fresh stats, so a
+    stale total simply fails the identity check and the live read takes over.
 
     On the ACP backend the only non-zero per-turn billing signal is ``credits``;
     the token fields stay 0, matching the real usage record. Providers that expose
@@ -431,13 +575,187 @@ def provider_last_turn_usage(provider: Any) -> TurnUsage:
     (credits=0). Never raises.
     """
     try:
-        inner = getattr(provider, "_client", None) or getattr(provider, "_handle", None)
-        stats = getattr(inner, "last_prompt_stats", None) if inner is not None else None
-        if stats is not None:
-            return TurnUsage(credits=float(getattr(stats, "credits", 0.0) or 0.0))
+        accumulated = getattr(provider, _TURN_BILLED_ATTR, None)
+        if isinstance(accumulated, tuple) and len(accumulated) == 2:
+            published_stats, total = accumulated
+            # Clear on every read, match or not: a total that failed the identity
+            # check belongs to a turn that is already over and must not be seen
+            # again by a third one.
+            try:
+                delattr(provider, _TURN_BILLED_ATTR)
+            except Exception:
+                logger.debug("clearing accumulated turn usage failed", exc_info=True)
+            if isinstance(total, TurnUsage) and published_stats is _billing_stats(provider):
+                return total
     except Exception:
-        logger.debug("provider_last_turn_usage read failed", exc_info=True)
-    return TurnUsage()
+        logger.debug("accumulated turn usage read failed", exc_info=True)
+    return _attempt_usage(provider, since=since)
+
+
+def _billing_stat_holders(provider: Any) -> "list[Any]":
+    """Objects that may carry ``last_prompt_stats``, nearest wrapper first.
+
+    The turn-runner sits behind a different attribute per seam: the acp provider
+    keeps it on ``_client``, the session provider on ``_handle``, and the shared
+    background session hands non-kiro callers a thin adapter whose only link to
+    the runner is ``_sess.provider``. Walking all of them keeps a background turn
+    on the claude_code / bedrock seam from reporting 0 credits for a turn that
+    was billed. Bounded and identity-deduped so a self-referential wrapper chain
+    cannot loop.
+    """
+    out: list[Any] = []
+    seen: set[int] = set()
+    frontier: list[Any] = [provider]
+    while frontier and len(out) < _WRAPPER_WALK_MAX_NODES:
+        node = frontier.pop(0)
+        if node is None or id(node) in seen:
+            continue
+        seen.add(id(node))
+        out.append(node)
+        for attr in ("_client", "_handle", "_sess", "provider"):
+            frontier.append(getattr(node, attr, None))
+    return out
+
+
+def _provider_label(provider: Any) -> str:
+    """Backend label for the usage row's ``provider`` dimension. Never raises.
+
+    Left unset the row lands with ``provider=""`` and drops out of the usage
+    page's provider and provider-model breakdowns, so a background turn's spend
+    would be recorded yet unattributable to a backend.
+
+    ``provider_label`` is the shared resolver for this vocabulary -- the same
+    ``acp`` / ``claude_code`` / ``kas`` keys the session map and resume-compat
+    check use -- and it answers from the backend that actually served the turn,
+    which is the precedence this module already applies to the model and the
+    agent. Reading ``config.agent.provider`` instead would report a declaration:
+    that field's enum admits only ``acp``, so a claude_code-backed session would
+    be labelled ``acp``.
+
+    The resolver only recognises a provider it is handed directly, and the shared
+    background session wraps one behind ``_sess.provider``, so the wrapper chain
+    is walked and the first node that names a non-default backend wins. Falling
+    back to the default label rather than to ``""`` matches every other writer of
+    this field.
+    """
+    try:
+        from kiro_crew.acp.types import PROVIDER_LABEL_DEFAULT
+        from kiro_crew.providers.acp import provider_label
+
+        for node in _billing_stat_holders(provider):
+            label = provider_label(node)
+            if label and label != PROVIDER_LABEL_DEFAULT:
+                return label
+        return PROVIDER_LABEL_DEFAULT
+    except Exception:
+        logger.debug("resolving provider label failed", exc_info=True)
+        return ""
+
+
+@asynccontextmanager
+async def background_turn(
+    sessions: Any,
+    *,
+    task: str,
+    agent: "str | None" = None,
+) -> "AsyncIterator[Any]":
+    """Take the shared background session for ONE turn, then release and account.
+
+    Every background caller needs the same three steps around its prompt: acquire
+    the shared session (which takes its per-session semaphore), release that
+    semaphore in a ``finally`` or the next caller deadlocks on it, and recycle the
+    session afterwards. Callers that hand-rolled those steps had no reason to also
+    record what the turn cost, so background spend reached the provider's bill
+    without ever reaching the usage store — invisible on the dashboard even though
+    the account balance moved. Recording here makes it structural: a turn taken
+    through this manager is accounted for, and a new background caller cannot
+    forget to.
+
+    ``task`` labels the work in the ``surface`` dimension as ``bg:<task>`` so spend
+    is attributable per background job instead of pooling into one anonymous
+    bucket. Keep it a short fixed label — never per-session text, which would make
+    the dimension unbounded.
+
+    ``agent`` is forwarded to ``get_or_create`` ONLY when a caller supplies it:
+    the key decides which session is returned, but the agent decides what the
+    session is created AS, so injecting a default here would silently change that
+    for callers that deliberately pass none. The recorded row still names the
+    background agent so the dimension is never blank.
+
+    Exceptions are deliberately NOT swallowed. Callers distinguish "the session
+    could not be acquired" (nothing was sent, so nothing was billed) from "the turn
+    ran and failed" (billed), and collapsing the two corrupts the retry budgets
+    built on that distinction. Only the accounting write is best-effort.
+    """
+    from kiro_crew.session import BACKGROUND_AGENT, BACKGROUND_KEY  # circular import
+
+    if agent is None:
+        client, _new, _resumed = await sessions.get_or_create(BACKGROUND_KEY)
+    else:
+        client, _new, _resumed = await sessions.get_or_create(BACKGROUND_KEY, agent=agent)
+    # The stats object as it stands BEFORE this turn. The shared session serves
+    # many turns, and the runner replaces this object only once a turn actually
+    # begins, so identity is what separates a turn that ran from one whose
+    # dispatch failed while a previous, already-recorded turn's credits were
+    # still installed.
+    stats_before = _billing_stats(client)
+    # Wall clock for the turn itself, started after the acquire so queue wait is
+    # not charged as turn time. The acp provider never fills TurnUsage.duration_ms,
+    # so this is the only duration a background row can carry.
+    turn_started = time.monotonic()
+    try:
+        yield client
+    finally:
+        turn_elapsed_ms = int((time.monotonic() - turn_started) * 1000)
+        # Snapshot the billing BEFORE releasing. ``last_prompt_stats`` is shared
+        # mutable state on the session: the next waiter's turn carries it over
+        # (zeroing credits) or starts accumulating its own, so a read after
+        # release attributes that waiter's spend to this task, or loses the row
+        # entirely. This read is a synchronous attribute walk, so taking it here
+        # costs nothing and keeps release ahead of every await.
+        usage = provider_last_turn_usage(client, since=stats_before)
+        # Release before any await: it is synchronous, so no cancellation can
+        # land between the turn ending and the next caller being unblocked.
+        # CancelledError is a BaseException that no `except Exception` catches,
+        # and an await ordered ahead of this would let a cancelled task hold the
+        # shared semaphore forever.
+        try:
+            sessions.release(BACKGROUND_KEY)
+        except Exception:
+            logger.debug("background session release failed task=%s", task, exc_info=True)
+        # Recycle sits in a finally for the same cancellation reason, and follows
+        # accounting because it may replace the provider entirely.
+        try:
+            try:
+                # Same cycle as the oneliner's teardown: the usage module's import
+                # chain reaches back into this one (history and several dashboard
+                # handlers import ToolApprovalPolicy / run_bg_oneliner from here),
+                # so a module-scope import raises ImportError against a partially
+                # initialized llm_helpers, and it would pull ~600 modules into
+                # every consumer's boot.
+                from kiro_crew.dashboard.handlers.usage import persist_token_record_async
+
+                # A turn that never reached the provider bills nothing and has no
+                # row to write; the same guard the chat path applies keeps
+                # acquire-time failures from landing as zero-credit noise.
+                if usage.credits or usage.input_tokens or usage.output_tokens:
+                    await persist_token_record_async(
+                        BACKGROUND_KEY,
+                        "",
+                        usage,
+                        _provider_label(client),
+                        surface=f"bg:{task}",
+                        agent=agent or BACKGROUND_AGENT,
+                        elapsed_ms=turn_elapsed_ms,
+                        model_source=client,
+                    )
+            except Exception:
+                logger.debug("background turn accounting failed task=%s", task, exc_info=True)
+        finally:
+            try:
+                await sessions.recycle_background()
+            except Exception:
+                logger.debug("background recycle failed task=%s", task, exc_info=True)
 
 
 async def stream_and_collect(
@@ -514,6 +832,9 @@ async def stream_and_collect(
     """
     transient_attempts = 0
     attempt = 0
+    # Accumulates across attempts, so it lives OUTSIDE the retry loop: a turn that
+    # was billed and then retried must report the sum, not the last attempt.
+    turn_billed = TurnUsage()
     while True:
         result_text = ""
         tool_call_count = 0
@@ -537,6 +858,10 @@ async def stream_and_collect(
         gate_decided_ids: set[str] = set()
         executed_calls: list[tuple[str, str]] = []
         retrying = False
+        # Billing accrued on THIS attempt is measured against the stats object as
+        # it stands now: a retry installs a fresh one, so without a per-attempt
+        # baseline an attempt that was billed and then failed is invisible.
+        attempt_stats_before = _billing_stats(provider)
         try:
             async for event in provider.stream(message):
                 if event.kind == EVENT_TEXT_CHUNK:
@@ -687,6 +1012,27 @@ async def stream_and_collect(
             # Runs before the value reaches the caller on success, and before the exception
             # propagates on failure, so the acknowledgement always precedes the cleanup that
             # would otherwise requeue the question.
+            #
+            # Billing is folded in on EVERY attempt, including the ones abandoned by a
+            # retry: an attempt whose metering frame landed before the error was billed,
+            # and the retry replaces the stats object that carried it. The total is
+            # published on the attempt that is terminal -- the same `not retrying`
+            # condition the callbacks below use -- so one logical turn publishes once,
+            # whether it returns or raises.
+            turn_billed = _sum_usage(
+                turn_billed, _attempt_usage(provider, since=attempt_stats_before)
+            )
+            if not retrying:
+                try:
+                    setattr(
+                        provider,
+                        _TURN_BILLED_ATTR,
+                        (_billing_stats(provider), turn_billed),
+                    )
+                except Exception:
+                    # A provider that refuses the attribute (slots, frozen doubles)
+                    # simply leaves the caller on the live-stats fallback.
+                    logger.debug("publishing accumulated turn usage failed", exc_info=True)
             if not retrying and on_steer_consumed:
                 for consumed_text in consumed_this_attempt:
                     on_steer_consumed(consumed_text)

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -19,6 +19,7 @@ to check whether a Slack session should skip memory writes.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -74,7 +75,11 @@ from kiro_crew.hooks import (
     safe_read_file_bytes,
     validate_file_path,
 )
-from kiro_crew.llm_helpers import record_interaction_event, save_conversation_turn_off_loop
+from kiro_crew.llm_helpers import (
+    background_turn,
+    record_interaction_event,
+    save_conversation_turn_off_loop,
+)
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import canonical_key
 from kiro_crew.platform import current_context
@@ -4189,35 +4194,35 @@ async def _maybe_auto_title_slack(
 ) -> None:
     """Generate and set a Slack thread title after the first response."""
     try:
-        from kiro_crew.session import BACKGROUND_KEY
-
         prompt = _build_title_prompt(user_text[:200], assistant_text[:200])
-        async with _get_auto_title_lock():
-            client, _, _ = await sessions.get_or_create(BACKGROUND_KEY)
+        # The lock stays OUTSIDE the session acquire: reversing them would take
+        # the shared background session before the title lock and invert the
+        # ordering every other caller uses.
+        async with _get_auto_title_lock(), contextlib.AsyncExitStack() as stack:
+            client = await stack.enter_async_context(
+                background_turn(sessions, task="slack_auto_title")
+            )
             title = ""
-            try:
 
-                async def _stream_title() -> str:
-                    t = ""
-                    async for event in client.stream(prompt):
-                        if event.kind == EVENT_TEXT_CHUNK:
-                            t += event.text
-                        elif event.kind == EVENT_PERMISSION_REQUEST:
-                            sel().log_api_access(
-                                caller="system",
-                                operation="auto_title.tool_rejected",
-                                outcome="denied",
-                                source="slack",
-                                resources=str(event.request_id),
-                            )
-                            await client.reject_tool(event.request_id)
-                        elif event.kind == EVENT_COMPLETE:
-                            break
-                    return t
+            async def _stream_title() -> str:
+                t = ""
+                async for event in client.stream(prompt):
+                    if event.kind == EVENT_TEXT_CHUNK:
+                        t += event.text
+                    elif event.kind == EVENT_PERMISSION_REQUEST:
+                        sel().log_api_access(
+                            caller="system",
+                            operation="auto_title.tool_rejected",
+                            outcome="denied",
+                            source="slack",
+                            resources=str(event.request_id),
+                        )
+                        await client.reject_tool(event.request_id)
+                    elif event.kind == EVENT_COMPLETE:
+                        break
+                return t
 
-                title = await asyncio.wait_for(_stream_title(), timeout=30)
-            finally:
-                sessions.release(BACKGROUND_KEY)
+            title = await asyncio.wait_for(_stream_title(), timeout=30)
 
         title = title.split("\n")[0].strip("\"'. \t")
         title = title.replace("<", "").replace(">", "")  # neutralize Slack mrkdwn links

--- a/test/test_background_turn_accounting.py
+++ b/test/test_background_turn_accounting.py
@@ -1,0 +1,353 @@
+"""Background turns must account for what they spend, and only for that turn.
+
+Both background channels reach the provider through a single chokepoint, and the
+turn's billing lives on an object the session replaces per turn and the release
+path tears down. These tests pin the contract that made the spend visible without
+making it wrong: a row is written for a turn that ran, no row for one that did
+not, the billing is read before the semaphore changes hands, and teardown happens
+even under cancellation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from kiro_crew.llm_helpers import background_turn, provider_last_turn_usage
+
+_USAGE_TARGET = "kiro_crew.dashboard.handlers.usage.persist_token_record_async"
+
+
+class _Stats:
+    def __init__(self, credits: float) -> None:
+        self.credits = credits
+
+
+class _Client:
+    """Stands in for the turn-runner the background session hands back.
+
+    Starts holding a PREVIOUS turn's stats, because the shared session is
+    long-lived: whatever the last turn left behind is what a new turn's teardown
+    would read if nothing distinguished the two.
+    """
+
+    def __init__(self, prior_credits: float = 0.0) -> None:
+        self.last_prompt_stats = _Stats(prior_credits)
+
+    def begin_turn(self, credits: float) -> None:
+        """Install fresh stats, as the runner does when a turn actually starts."""
+        self.last_prompt_stats = _Stats(credits)
+
+
+class _Sessions:
+    def __init__(self, client: _Client) -> None:
+        self._bg_client = client
+        self.acquire_calls: list[tuple[str, dict]] = []
+        self.order: list[str] = []
+
+    async def get_or_create(self, key: str, **kw: object):
+        self.acquire_calls.append((key, dict(kw)))
+        return self._bg_client, False, False
+
+    def release(self, key: str) -> None:
+        self.order.append("release")
+
+    async def recycle_background(self) -> None:
+        self.order.append("recycle")
+
+
+class TestBackgroundTurnAccounting(unittest.IsolatedAsyncioTestCase):
+    async def test_billed_turn_writes_a_row_tagged_with_its_task(self):
+        sessions = _Sessions(_Client())
+        with patch(_USAGE_TARGET) as persist:
+            async with background_turn(sessions, task="consolidation") as client:
+                client.begin_turn(3.5)
+
+        self.assertEqual(persist.await_count, 1)
+        self.assertEqual(persist.await_args.kwargs["surface"], "bg:consolidation")
+        self.assertEqual(persist.await_args.args[2].credits, 3.5)
+
+    async def test_the_row_names_the_backend_that_served_the_turn(self):
+        """Left unset the row lands with provider="" and drops out of the usage
+        page's provider and provider-model breakdowns, so the spend is recorded
+        but unattributable to a backend."""
+        sessions = _Sessions(_Client())
+        with patch(_USAGE_TARGET) as persist:
+            async with background_turn(sessions, task="consolidation") as client:
+                client.begin_turn(3.5)
+
+        # Positional, matching persist_token_record_async's signature
+        # (slot_key, model, event, provider).
+        self.assertEqual(persist.await_args.args[3], "acp")
+
+    async def test_a_non_default_backend_is_named_through_the_wrapper_chain(self):
+        """The resolver only recognises a provider handed to it directly, and the
+        shared background session wraps one behind ``_sess.provider``."""
+        from kiro_crew.acp.types import PROVIDER_LABEL_CLAUDE
+        from kiro_crew.llm_helpers import _provider_label
+
+        inner = SimpleNamespace()
+        adapter = SimpleNamespace(_sess=SimpleNamespace(provider=inner))
+        with patch(
+            "kiro_crew.providers.acp.provider_label",
+            side_effect=lambda node: (PROVIDER_LABEL_CLAUDE if node is inner else "acp"),
+        ):
+            self.assertEqual(_provider_label(adapter), PROVIDER_LABEL_CLAUDE)
+
+    async def test_a_turn_that_never_started_writes_no_row(self):
+        """A dispatch that fails before the runner installs fresh stats leaves the
+        PREVIOUS turn's credits in place. Those were already recorded, so billing
+        them again would double-count real spend."""
+        sessions = _Sessions(_Client(prior_credits=9.0))
+        with patch(_USAGE_TARGET) as persist:
+            with self.assertRaises(RuntimeError):
+                async with background_turn(sessions, task="consolidation"):
+                    raise RuntimeError("session busy; prompt never dispatched")
+
+        persist.assert_not_awaited()
+
+    async def test_unbilled_turn_writes_no_row(self):
+        sessions = _Sessions(_Client())
+        with patch(_USAGE_TARGET) as persist:
+            async with background_turn(sessions, task="skill_dedupe") as client:
+                client.begin_turn(0.0)
+
+        persist.assert_not_awaited()
+
+    async def test_release_precedes_accounting_which_precedes_recycle(self):
+        """Two invariants in one order: release is synchronous so it must land
+        first, and accounting must still precede recycling, which can replace
+        the provider the billing lives on."""
+        sessions = _Sessions(_Client())
+
+        async def _mark(*a: object, **kw: object) -> None:
+            sessions.order.append("account")
+
+        with patch(_USAGE_TARGET, side_effect=_mark):
+            async with background_turn(sessions, task="chat_title") as client:
+                client.begin_turn(1.0)
+
+        self.assertEqual(sessions.order, ["release", "account", "recycle"])
+
+    async def test_cancellation_while_accounting_still_released_the_session(self):
+        """CancelledError is a BaseException, so an ``except Exception`` around the
+        accounting await never sees it. If teardown depended on that handler a
+        cancelled turn would hold the shared semaphore forever and deadlock every
+        later background caller."""
+        sessions = _Sessions(_Client())
+        with patch(_USAGE_TARGET, side_effect=asyncio.CancelledError):
+            with self.assertRaises(asyncio.CancelledError):
+                async with background_turn(sessions, task="consolidation") as client:
+                    client.begin_turn(1.0)
+
+        self.assertIn("release", sessions.order)
+
+    async def test_billing_is_read_before_the_semaphore_is_released(self):
+        """The next waiter acquires the moment release returns and installs its own
+        stats, so reading after release records the waiter's spend under this
+        task's tag."""
+        client = _Client()
+        sessions = _Sessions(client)
+        released = sessions.release
+
+        def _release_and_let_the_next_turn_start(key: str) -> None:
+            released(key)
+            client.begin_turn(0.0)
+
+        sessions.release = _release_and_let_the_next_turn_start  # type: ignore[method-assign]
+
+        with patch(_USAGE_TARGET) as persist:
+            async with background_turn(sessions, task="consolidation") as c:
+                c.begin_turn(3.0)
+
+        self.assertEqual(persist.await_count, 1)
+        self.assertEqual(persist.await_args.args[2].credits, 3.0)
+
+    async def test_body_failure_after_a_real_turn_still_accounts_and_releases(self):
+        sessions = _Sessions(_Client())
+        with patch(_USAGE_TARGET) as persist:
+            with self.assertRaises(RuntimeError):
+                async with background_turn(sessions, task="thread_compress") as client:
+                    client.begin_turn(2.0)
+                    raise RuntimeError("failed after the turn was billed")
+
+        self.assertEqual(persist.await_count, 1)
+        self.assertEqual(sessions.order, ["release", "recycle"])
+
+    async def test_the_turn_duration_reaches_the_row(self):
+        """The acp provider never fills TurnUsage.duration_ms, so this local
+        measurement is the only duration a background row can carry. The clock is
+        substituted rather than timed, so the assertion pins the arithmetic
+        instead of the host's speed."""
+        sessions = _Sessions(_Client())
+        clock = iter([100.0, 100.25])
+        with patch("kiro_crew.llm_helpers.time", SimpleNamespace(monotonic=lambda: next(clock))):
+            with patch(_USAGE_TARGET) as persist:
+                async with background_turn(sessions, task="consolidation") as client:
+                    client.begin_turn(1.0)
+
+        self.assertEqual(persist.await_args.kwargs["elapsed_ms"], 250)
+
+    async def test_agent_is_forwarded_only_when_the_caller_supplies_one(self):
+        """The key picks the session; the agent decides what it is created AS,
+        so a default here would silently change that for callers passing none."""
+        sessions = _Sessions(_Client())
+        with patch(_USAGE_TARGET):
+            async with background_turn(sessions, task="plan_rephrase"):
+                pass
+            async with background_turn(sessions, task="consolidation", agent="kirocrew-lite"):
+                pass
+
+        self.assertEqual(sessions.acquire_calls[0][1], {})
+        self.assertEqual(sessions.acquire_calls[1][1], {"agent": "kirocrew-lite"})
+
+
+class TestBillingStatsReachThroughTheAdapter(unittest.TestCase):
+    def test_credits_are_found_behind_the_background_adapter(self):
+        """The non-kiro seam links to the runner through ``_sess.provider``; a
+        walk that only knows ``_client``/``_handle`` reports 0 for a billed turn.
+        """
+
+        class _Runner:
+            last_prompt_stats = _Stats(4.25)
+
+        class _Session:
+            provider = _Runner()
+
+        class _Adapter:
+            _sess = _Session()
+
+        self.assertEqual(provider_last_turn_usage(_Adapter()).credits, 4.25)
+
+    def test_absent_stats_yield_zero_rather_than_raising(self):
+        self.assertEqual(provider_last_turn_usage(object()).credits, 0.0)
+
+    def test_an_unreplaced_stats_object_reports_nothing(self):
+        class _Runner:
+            def __init__(self) -> None:
+                self.last_prompt_stats = _Stats(7.0)
+
+        runner = _Runner()
+        prior = runner.last_prompt_stats
+        self.assertEqual(provider_last_turn_usage(runner, since=prior).credits, 0.0)
+        runner.last_prompt_stats = _Stats(7.0)
+        self.assertEqual(provider_last_turn_usage(runner, since=prior).credits, 7.0)
+
+
+class TestBilledAttemptsSurviveARetry(unittest.IsolatedAsyncioTestCase):
+    """A turn can span several attempts, and each retry installs fresh stats."""
+
+    async def test_an_attempt_billed_then_abandoned_by_a_retry_is_still_counted(self):
+        """The first attempt's metering lands, the stream then breaks before any
+        text, and the retry replaces the stats object that carried those credits.
+        Reading the live stats afterwards would report only the retry's spend."""
+        from kiro_crew.acp.client import AcpError
+        from kiro_crew.llm_helpers import stream_and_collect
+        from kiro_crew.providers.base import EVENT_COMPLETE
+
+        class _Provider:
+            def __init__(self) -> None:
+                self.last_prompt_stats = _Stats(0.0)
+                self.calls = 0
+
+            async def stream(self, message: str):
+                self.calls += 1
+                # Fresh per-turn stats, as the real runner installs when a turn
+                # begins -- which is what makes the earlier attempt's credits
+                # unreachable from a post-hoc read.
+                self.last_prompt_stats = _Stats(2.0 if self.calls == 1 else 1.5)
+                if self.calls == 1:
+                    raise AcpError("transient error (http 5xx)")
+                yield SimpleNamespace(kind=EVENT_COMPLETE, text="")
+
+        provider = _Provider()
+        with patch("kiro_crew.llm_helpers.transient_retry_delay", return_value=0):
+            await stream_and_collect(provider, "p")
+
+        self.assertEqual(provider.calls, 2)
+        self.assertEqual(provider_last_turn_usage(provider).credits, 3.5)
+
+    async def test_the_accumulated_total_is_consumed_by_the_first_read(self):
+        """The sum is handed over once. A second read falls back to the live
+        stats -- which for a retried turn is the final attempt alone -- so the
+        total cannot be counted into two different rows."""
+        from kiro_crew.acp.client import AcpError
+        from kiro_crew.llm_helpers import stream_and_collect
+        from kiro_crew.providers.base import EVENT_COMPLETE
+
+        class _Provider:
+            def __init__(self) -> None:
+                self.last_prompt_stats = _Stats(0.0)
+                self.calls = 0
+
+            async def stream(self, message: str):
+                self.calls += 1
+                self.last_prompt_stats = _Stats(2.0 if self.calls == 1 else 1.5)
+                if self.calls == 1:
+                    raise AcpError("transient error (http 5xx)")
+                yield SimpleNamespace(kind=EVENT_COMPLETE, text="")
+
+        provider = _Provider()
+        with patch("kiro_crew.llm_helpers.transient_retry_delay", return_value=0):
+            await stream_and_collect(provider, "p")
+
+        self.assertEqual(provider_last_turn_usage(provider).credits, 3.5)
+        self.assertEqual(provider_last_turn_usage(provider).credits, 1.5)
+
+    async def test_a_total_left_unread_is_not_billed_to_a_later_turn(self):
+        """The provider outlives the turn: the shared background session is reused
+        by every background caller, and a Slack session by every turn in its
+        thread. A turn whose total nobody read must not have it consumed by a later
+        turn, which would bill that turn for the earlier one's spend and lose its
+        own.
+
+        The later turn here drives ``provider.stream`` itself rather than going
+        through ``stream_and_collect``, which is the documented shape that
+        publishes no total of its own -- and therefore the shape where a stale one
+        is still on the provider at read time. A later ``stream_and_collect`` turn
+        would overwrite the stale total instead, so it cannot show this.
+        """
+        from kiro_crew.llm_helpers import stream_and_collect
+        from kiro_crew.providers.base import EVENT_COMPLETE
+
+        class _Provider:
+            def __init__(self) -> None:
+                self.last_prompt_stats = _Stats(0.0)
+                self.credits_for_next_turn = 7.0
+
+            async def stream(self, message: str):
+                self.last_prompt_stats = _Stats(self.credits_for_next_turn)
+                yield SimpleNamespace(kind=EVENT_COMPLETE, text="")
+
+        provider = _Provider()
+
+        # Turn one goes through the helper, so it publishes its total. Nobody reads it.
+        await stream_and_collect(provider, "first")
+
+        # Turn two drives the provider directly and publishes nothing.
+        provider.credits_for_next_turn = 2.0
+        async for _ in provider.stream("second"):
+            pass
+
+        # Turn two is billed its own 2.0, not turn one's 7.0.
+        self.assertEqual(provider_last_turn_usage(provider).credits, 2.0)
+
+    def test_a_total_whose_stats_were_replaced_is_discarded(self):
+        """The guard is on the stats object's identity, not on ordering: a total
+        published against stats the provider has since replaced is stale by
+        definition, and the live read takes over."""
+        from kiro_crew.llm_helpers import _TURN_BILLED_ATTR, TurnUsage
+
+        provider = SimpleNamespace(last_prompt_stats=_Stats(4.0))
+        stale_stats = _Stats(9.0)
+        setattr(provider, _TURN_BILLED_ATTR, (stale_stats, TurnUsage(credits=9.0)))
+
+        self.assertEqual(provider_last_turn_usage(provider).credits, 4.0)
+        # Cleared even though it was rejected, so a third read cannot see it.
+        self.assertFalse(hasattr(provider, _TURN_BILLED_ATTR))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_history_coverage.py
+++ b/test/test_history_coverage.py
@@ -36,6 +36,7 @@ from kiro_crew.history import (
     ConversationLog,
     HistoryConsolidator,
 )
+from kiro_crew.session import BACKGROUND_KEY
 from kiro_crew.vector_memory import SemanticRejectCode
 
 
@@ -921,7 +922,7 @@ class TestDedupeJudge:
             "kiro_crew.history.stream_and_collect", AsyncMock(return_value="DUP")
         ):
             assert await c._dedupe_judge("prompt") == "DUP"
-        sessions.release.assert_called_once_with(H.BACKGROUND_KEY)
+        sessions.release.assert_called_once_with(BACKGROUND_KEY)
         sessions.recycle_background.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -942,7 +943,7 @@ class TestDedupeJudge:
             AsyncMock(side_effect=RuntimeError("provider down")),
         ):
             assert await c._dedupe_judge("prompt") == ""
-        sessions.release.assert_called_once_with(H.BACKGROUND_KEY)
+        sessions.release.assert_called_once_with(BACKGROUND_KEY)
 
     @pytest.mark.asyncio
     async def test_release_failure_is_swallowed(self) -> None:
@@ -973,7 +974,7 @@ class TestMergeSkillUpdate:
         prompt = collector.await_args.args[1]
         for needle in ("EXISTING BODY", "the description", "trig1, trig2", "1. do it"):
             assert needle in prompt
-        sessions.release.assert_called_once_with(H.BACKGROUND_KEY)
+        sessions.release.assert_called_once_with(BACKGROUND_KEY)
         sessions.recycle_background.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -992,7 +993,7 @@ class TestMergeSkillUpdate:
             AsyncMock(side_effect=RuntimeError("provider down")),
         ):
             assert await c._merge_skill_update("b", "d", "t", "p") is None
-        sessions.release.assert_called_once_with(H.BACKGROUND_KEY)
+        sessions.release.assert_called_once_with(BACKGROUND_KEY)
 
     @pytest.mark.asyncio
     async def test_release_failure_is_swallowed(self) -> None:

--- a/test/test_run_bg_oneliner.py
+++ b/test/test_run_bg_oneliner.py
@@ -5,7 +5,9 @@ link-label, folder-icon, and session-summary generation.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -15,15 +17,20 @@ from kiro_crew.llm_helpers import run_bg_oneliner
 
 
 class _FakeSession:
-    def __init__(self, events, *, raise_on_prompt=False):
+    def __init__(self, events, *, raise_on_prompt=False, turn_credits=0.0, prior_credits=0.0):
         self._events = events
         self._raise = raise_on_prompt
+        self._turn_credits = turn_credits
         self.destroyed = False
         self.model = None
         # Mirrors AcpSessionHandle: "" until a set_model lands, then the
         # backend-resolved id (the fake resolves to exactly what was asked).
         self.served_model = ""
         self.rejected: list = []
+        # Mirrors AcpSessionHandle: the shared session arrives carrying whatever
+        # the PREVIOUS turn left behind, and installs fresh per-turn stats only
+        # once a turn actually begins (see prompt()).
+        self.last_prompt_stats = SimpleNamespace(credits=prior_credits)
 
     async def set_model(self, model):
         self.model = model
@@ -32,6 +39,10 @@ class _FakeSession:
     async def prompt(self, _prompt):
         if self._raise:
             raise RuntimeError("backend boom")
+        # Fresh per-turn stats, installed as the real handle does once the turn
+        # starts -- AFTER any pre-dispatch failure, which is what makes a failed
+        # dispatch distinguishable from a turn that ran.
+        self.last_prompt_stats = SimpleNamespace(credits=self._turn_credits)
         for e in self._events:
             yield e
 
@@ -52,11 +63,13 @@ class _FakeSessions:
 
 @pytest.mark.asyncio
 async def test_accumulates_text_and_sets_model_and_destroys():
-    sess = _FakeSession([
-        SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="hello "),
-        SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="world"),
-        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
-    ])
+    sess = _FakeSession(
+        [
+            SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="hello "),
+            SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="world"),
+            SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
     out = await run_bg_oneliner(_FakeSessions(sess), "p", model="claude-haiku-4.5")
     assert out == "hello world"
     assert sess.model == "claude-haiku-4.5"
@@ -71,10 +84,12 @@ async def test_auto_model_is_passed_to_set_model_for_wire_resolution():
     advertised model — so a partition that doesn't serve auto never
     gets a raw ``auto`` on the wire. The fake session just records
     the requested value; resolver behavior is covered in test_acp_client."""
-    sess = _FakeSession([
-        SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="hi"),
-        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
-    ])
+    sess = _FakeSession(
+        [
+            SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="hi"),
+            SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
     out = await run_bg_oneliner(_FakeSessions(sess), "p", model="auto")
     assert out == "hi"
     assert sess.model == "auto"
@@ -84,10 +99,12 @@ async def test_auto_model_is_passed_to_set_model_for_wire_resolution():
 @pytest.mark.asyncio
 async def test_empty_model_does_not_override_session_default():
     """An empty model string inherits the session default (no set_model call)."""
-    sess = _FakeSession([
-        SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="hi"),
-        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
-    ])
+    sess = _FakeSession(
+        [
+            SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="hi"),
+            SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
     out = await run_bg_oneliner(_FakeSessions(sess), "p", model="")
     assert out == "hi"
     assert sess.model is None
@@ -103,11 +120,13 @@ async def test_permission_request_is_rejected_and_sel_logged(monkeypatch):
         return SimpleNamespace(log_tool_invocation=lambda **kw: logged.append(kw))
 
     monkeypatch.setattr(mod, "_sel", _fake_sel)
-    sess = _FakeSession([
-        SimpleNamespace(kind=EVENT_PERMISSION_REQUEST, request_id="r1", text=""),
-        SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="ok"),
-        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
-    ])
+    sess = _FakeSession(
+        [
+            SimpleNamespace(kind=EVENT_PERMISSION_REQUEST, request_id="r1", text=""),
+            SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="ok"),
+            SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
     out = await run_bg_oneliner(_FakeSessions(sess), "p", sel_source="unit")
     assert out == "ok"
     assert sess.rejected == ["r1"]
@@ -126,10 +145,12 @@ async def test_permission_denial_is_sel_logged_even_without_sel_source(monkeypat
         return SimpleNamespace(log_tool_invocation=lambda **kw: logged.append(kw))
 
     monkeypatch.setattr(mod, "_sel", _fake_sel)
-    sess = _FakeSession([
-        SimpleNamespace(kind=EVENT_PERMISSION_REQUEST, request_id="r1", text=""),
-        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
-    ])
+    sess = _FakeSession(
+        [
+            SimpleNamespace(kind=EVENT_PERMISSION_REQUEST, request_id="r1", text=""),
+            SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
     # No sel_source passed — mirrors chat_title / _summarize_one call sites.
     out = await run_bg_oneliner(_FakeSessions(sess), "p")
     assert out == ""
@@ -247,10 +268,12 @@ async def test_strict_model_rejects_silent_default_inherit():
     default (requested id not advertised), the canary must refuse rather than
     produce a success on a different model — that success would be fabricated
     evidence for discarding a healthy conversation."""
-    sess = _SilentInheritSession([
-        SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="should never stream"),
-        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
-    ])
+    sess = _SilentInheritSession(
+        [
+            SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="should never stream"),
+            SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
     with pytest.raises(RuntimeError, match="serves"):
         await run_bg_oneliner(_FakeSessions(sess), "p", model="claude-x", strict_model=True)
     assert sess.destroyed is True
@@ -260,10 +283,12 @@ async def test_strict_model_rejects_silent_default_inherit():
 async def test_strict_model_raises_when_set_model_fails():
     """``strict_model=True`` + failed set_model override → raise, never run
     the prompt on the session default model."""
-    sess = _SetModelFailsSession([
-        SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="should never stream"),
-        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
-    ])
+    sess = _SetModelFailsSession(
+        [
+            SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="should never stream"),
+            SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
     with pytest.raises(RuntimeError, match="override refused"):
         await run_bg_oneliner(_FakeSessions(sess), "p", model="claude-x", strict_model=True)
     assert sess.destroyed is True
@@ -273,10 +298,12 @@ async def test_strict_model_raises_when_set_model_fails():
 async def test_lenient_mode_still_degrades_on_set_model_failure():
     """Default (lenient) behavior is unchanged: a failed override logs and
     runs on the session default."""
-    sess = _SetModelFailsSession([
-        SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="ok"),
-        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
-    ])
+    sess = _SetModelFailsSession(
+        [
+            SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="ok"),
+            SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
     out = await run_bg_oneliner(_FakeSessions(sess), "p", model="claude-x")
     assert out == "ok"
     assert sess.destroyed is True
@@ -286,6 +313,7 @@ async def test_lenient_mode_still_degrades_on_set_model_failure():
 async def test_non_rejection_error_is_not_retried():
     """A generic AcpError with no rejected_model tag is not a model rejection —
     it must propagate unchanged (no retry), and the session is destroyed."""
+
     class _BoomSession(_FakeSession):
         async def prompt(self, _p):
             raise AcpError("backend boom")
@@ -309,8 +337,7 @@ class TestRejectedModelClassifier:
 
     def test_matches_model_not_available(self):
         assert (
-            _rejected_model_from_error({"data": "The model 'opus-x' is not available"})
-            == "opus-x"
+            _rejected_model_from_error({"data": "The model 'opus-x' is not available"}) == "opus-x"
         )
 
     def test_returns_none_for_unrelated_error(self):
@@ -329,7 +356,8 @@ async def test_permission_denial_is_audited_even_if_reject_fails(monkeypatch):
     import kiro_crew.llm_helpers as mod
 
     monkeypatch.setattr(
-        mod, "_sel",
+        mod,
+        "_sel",
         lambda: SimpleNamespace(log_tool_invocation=lambda **kw: logged.append(kw)),
     )
 
@@ -337,12 +365,98 @@ async def test_permission_denial_is_audited_even_if_reject_fails(monkeypatch):
         async def reject_tool(self, request_id):
             raise RuntimeError("transport down")
 
-    sess = _RejectRaises([
-        SimpleNamespace(kind=EVENT_PERMISSION_REQUEST, request_id="r1", text=""),
-        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
-    ])
+    sess = _RejectRaises(
+        [
+            SimpleNamespace(kind=EVENT_PERMISSION_REQUEST, request_id="r1", text=""),
+            SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
     with pytest.raises(RuntimeError, match="transport down"):
         await run_bg_oneliner(_FakeSessions(sess), "p", sel_source="unit")
     # Denial was audited despite reject_tool failing, and the handle was destroyed.
     assert logged and logged[0]["outcome"] == "denied"
     assert sess.destroyed is True
+
+
+_USAGE_TARGET = "kiro_crew.dashboard.handlers.usage.persist_token_record_async"
+
+
+class _SubstitutingSession(_FakeSession):
+    """``set_model`` lands, but the backend serves a DIFFERENT id.
+
+    That is the substitute-style seam which makes a requested model a preference
+    rather than a guarantee, and it is the case where recording the request would
+    bill spend to a model that never ran.
+    """
+
+    async def set_model(self, model):
+        self.model = model
+        self.served_model = "claude-sonnet-4.6"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_while_accounting_still_destroys_the_session():
+    """CancelledError is a BaseException, so the accounting handler never sees
+    it. If destroy() sat after that handler rather than in a finally, a
+    cancelled turn would leak the session's runtime."""
+    sess = _FakeSession([SimpleNamespace(kind=EVENT_COMPLETE, text="")], turn_credits=2.0)
+
+    with patch(_USAGE_TARGET, side_effect=asyncio.CancelledError):
+        with pytest.raises(asyncio.CancelledError):
+            await run_bg_oneliner(_FakeSessions(sess), "p")
+
+    assert sess.destroyed is True
+
+
+@pytest.mark.asyncio
+async def test_spend_is_recorded_against_the_served_model_not_the_requested_one():
+    sess = _SubstitutingSession([SimpleNamespace(kind=EVENT_COMPLETE, text="")], turn_credits=1.5)
+
+    with patch(_USAGE_TARGET) as persist:
+        await run_bg_oneliner(_FakeSessions(sess), "p", model="claude-haiku-4.5")
+
+    assert persist.await_args.args[1] == "claude-sonnet-4.6"
+
+
+@pytest.mark.asyncio
+async def test_a_dispatch_that_never_ran_does_not_rebill_the_previous_turn():
+    """The shared session arrives carrying the last turn's credits, which were
+    already recorded. A prompt that fails before the runner installs fresh stats
+    must record nothing rather than bill that earlier turn a second time."""
+    sess = _FakeSession([], raise_on_prompt=True, prior_credits=9.0)
+
+    with patch(_USAGE_TARGET) as persist:
+        with pytest.raises(RuntimeError):
+            await run_bg_oneliner(_FakeSessions(sess), "p")
+
+    persist.assert_not_awaited()
+    assert sess.destroyed is True
+
+
+@pytest.mark.asyncio
+async def test_an_unbilled_turn_records_nothing():
+    """A turn that ran but cost nothing has no row worth writing."""
+    sess = _FakeSession([SimpleNamespace(kind=EVENT_COMPLETE, text="")])
+
+    with patch(_USAGE_TARGET) as persist:
+        await run_bg_oneliner(_FakeSessions(sess), "p")
+
+    persist.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_the_turn_duration_reaches_the_row():
+    """The acp provider never fills TurnUsage.duration_ms, so this local
+    measurement is the only duration a background row can carry. The clock is
+    substituted rather than timed, so the assertion pins the arithmetic rather
+    than the host's speed."""
+    sess = _FakeSession([SimpleNamespace(kind=EVENT_COMPLETE, text="")], turn_credits=1.0)
+    # Exactly representable in binary floating point, so the truncation to ms is
+    # unambiguous and the assertion cannot drift on a fraction like 0.4.
+    clock = iter([50.0, 50.25])
+
+    with patch("kiro_crew.llm_helpers.time", SimpleNamespace(monotonic=lambda: next(clock))):
+        with patch(_USAGE_TARGET) as persist:
+            await run_bg_oneliner(_FakeSessions(sess), "p")
+
+    assert persist.await_args.kwargs["elapsed_ms"] == 250


### PR DESCRIPTION
## What is the problem?

Background LLM turns are billed by the provider but recorded nowhere. Nothing in
`usage/tokens/*.jsonl` describes them, and no OTEL metric covers them either, so
the Telemetry page reports only the surfaces that happen to call
`persist_token_record*` themselves.

The invisible work is not marginal. It includes memory consolidation, chat title
generation, folder suggestion, link labels, session summaries, tips generation,
the STT verdict, cron naming, and the poisoned-conversation canary.

Two things caused it. Recording is per-call-site with nothing enforcing it, so a
caller that does not opt in is silently unaccounted. And
`provider_last_turn_usage` looked for the turn-runner only on `_client` /
`_handle`, which misses the seam that reaches it through `_sess.provider` -- so
even a caller that did record would have written zero credits there.

## Why this issue matters to the user

The account balance moves and the dashboard cannot say why. A user sees credits
disappear with no visible activity, opens the Usage view to find the cause, and
every per-session, per-model and per-surface breakdown shows nothing -- not
"unknown", but absent, which reads as zero. That is the state reported in #2860,
where the only trace the reporter could find was a raw session record naming the
requested model rather than a cost.

It also blocks the obvious follow-up. Any decision about limiting background
spend -- a budget guard, or deferring consolidation while nobody is using the
product -- cannot be evaluated or verified while the spend it targets has never
been measured, and a change that broke consolidation entirely would look
identical to one that worked.

## How our fix solves it

Symptom: background spend is missing from the usage store. Immediate cause: the
callers never record it. Root cause: recording is a convention each call site
must remember, so the set of accounted surfaces is whatever was wired by hand.

Adding a call to each background caller would fix today's set and leave the next
caller free to forget, so accounting moves to the points every background turn
already passes through:

- `run_bg_oneliner` records in its teardown. Its twelve callers are unchanged.
- A new `background_turn` async manager owns the acquire / release / recycle
  sequence that its six callers each hand-rolled, and records as part of it.
  `history.py` loses about thirty lines of duplicated boilerplate.

Both record **before** the session is torn down. The turn's billing lives on the
object that `recycle_background()` / `destroy()` discards, so the reverse order
would record zero forever while looking correct.

Spend is tagged `bg:<task>` in the existing `surface` dimension, so it is
attributable per background job instead of pooling into one anonymous bucket.
`phase` was deliberately not reused for this: it already means
session_start / per_turn, and hijacking it would corrupt the Context Breakdown
view.

`provider_last_turn_usage` now walks `_sess` / `provider` as well, bounded and
identity-deduped, so credits are *readable* on the non-kiro seam rather than
reported as zero. That is narrower than it sounds: the helper returns only
`credits`, so a backend that bills in tokens still records nothing even when the
walk reaches its stats. That predates this change and is not a regression, but it
is a real limit -- see the last section.

Reading billing after the fact needs two guards, because the stats object is
owned by the session and not by the turn.

The first is an identity gate. A long-lived background session arrives carrying
the previous turn's stats, and the runner installs a fresh object only once a turn
actually begins -- which is after the points a dispatch can fail (a busy session,
a dead runtime). Without the gate, a call that never reached the provider would
re-record credits that were already billed and already written. The read now
compares the stats object against the one observed before the attempt and reports
nothing when it is unchanged.

The second is accumulation. One logical turn can span several attempts:
`stream_and_collect` retries a busy session and a transient backend error, and
each retry installs fresh stats, so a single post-hoc read sees only the final
attempt and silently drops an attempt that was already billed. Fixing that at the
recording sites would need every site to know about retries, so it is fixed where
the retries happen: `stream_and_collect` folds each attempt's billing into a total
and publishes it on the terminal attempt, and the reader prefers that total over
the live stats. Every surface already recording through this helper -- Slack
turns, cron, the task runner, workflows, subagents -- gets the sum rather than the
last attempt, so this is a correctness gain beyond the background paths.

Two smaller corrections in the same area: the turn's duration is measured from
after the session is acquired (the adapter never fills `duration_ms`, so the
column was empty), and `run_bg_oneliner` records the model the session **served**
rather than the one requested, since a rejected preference is replaced by the
reactive fallback and recording the request would bill a model that never ran.

Both rows also name the backend that served the turn. Left unset the row lands with
`provider=""` and drops out of the usage page's provider and provider-model
breakdowns, so the spend is recorded yet unattributable. The label comes from
`provider_label`, the shared resolver for that vocabulary, rather than from
`config.agent.provider`: the config field is a declaration whose enum admits only
`acp`, so a claude_code-backed session would be labelled `acp`. The resolver only
recognises a provider handed to it directly, and the shared background session wraps
one behind `_sess.provider`, so the same bounded wrapper walk the billing read uses
finds it.

Two deliberate behaviour changes, both narrow:

- The Slack auto-title path gains the `recycle_background()` it was missing.
  Every other background caller recycles; skipping it is what lets the shared
  session accumulate context until an in-flight call is killed mid-stream.
- `_call_llm` returns `None` if its exit stack ever suppresses an exception. The
  prompt was already sent at that point, so charging the retry budget is correct;
  reporting a non-dispatch would hand out a free retry.

Errors are not swallowed anywhere. Callers distinguish "the session could not be
acquired" (nothing sent, nothing billed) from "the turn ran and failed" (billed),
and that distinction drives their retry budgets, so it is preserved exactly --
including the acquire-versus-body split at each converted site.

## What tests we did

New `test/test_background_turn_accounting.py`, 18 tests:

- a billed turn writes one row tagged with its task
- a turn that never started, and an unbilled turn, each write no row
- release precedes accounting, which precedes recycle (asserts the exact order)
- billing is read before the semaphore is released
- cancellation while accounting still released the session
- a failing body after a real turn still releases, still recycles, still accounts,
  and still raises
- the measured duration reaches the row
- the row names the backend that served the turn
- a non-default backend is named through the wrapper chain
- `agent` is forwarded only when the caller supplies one
- credits are found behind the background adapter's `_sess.provider` hop
- an object with no stats yields zero rather than raising
- an unreplaced stats object reports nothing (the identity gate)
- an attempt billed and then abandoned by a retry is still counted
- the accumulated total is consumed by the first read
- a total left unread is not billed to a later turn
- a total whose stats were replaced is discarded

Eight load-bearing behaviours are mutation-verified, each against the one test that
should catch it: removing the `_sess` / `provider` hop, moving the accounting block
after recycle, dropping the live-stats identity gate, skipping the accumulation for
an attempt a retry abandoned, dropping the identity pairing on the published total,
omitting the provider label at both call sites, and stopping the label resolver's
wrapper walk. Each mutation reddened exactly its own test and was restored from a
copy, not left in place.

One of those probes earned its keep. The first version of the
total-left-unread test drove the later turn through `stream_and_collect` too, which
overwrites the stale total -- so it passed with the bug present while its name
claimed otherwise. The probe caught that only one of the pair reddened, and the test
was rewritten to drive the provider directly, which is the shape that publishes no
total of its own.

Gates: `mypy src/kiro_crew/` clean across 987 files, `black --check`, `flake8`,
`isort` and `scripts/check_black_formatting.py` clean, 594 tests green across the
affected modules (`test_run_bg_oneliner`, `test_chat_title`, `test_history`,
`test_history_coverage`, `test_context`), and the full backend suite before push:
56876 passed. Twelve failures remain, none from this change: nine are pre-existing on
this host, two are `OSError: AF_UNIX path too long` from running with an explicit
`--basetemp` (needed after a temp sweep killed the first attempt) whose path is
longer than a unix socket allows, and one is a load flake whose own precondition
failed under full parallel load -- it passes in isolation and its module references
none of the changed functions.
No frontend change, so `tsc` / `vitest` are untouched.

## Any other suggestions on the work

Three follow-ups this deliberately does not do:

- **Last-turn billing is discovered by walking private provider attributes.**
  `provider_last_turn_usage` probes `("_client", "_handle", "_sess", "provider")`
  for `last_prompt_stats`. A future seam linking to its turn-runner under another
  name is not found and the walk fails toward `credits=0`, which the unbilled
  guard reads as "nothing to record" -- this gap reappearing per-seam. The fix is
  to promote the capability onto the `LLMProvider` ABC with a `TurnUsage()`
  default, which also gives token-billed backends a path to report at all.
  Deferred because it touches every provider implementation; tracked locally.
- **Credits are still absent from OTEL.** A `kirocrew.credits.count` counter with
  low-cardinality attributes (surface, model) would let spend be alarmed on. It
  complements the row store rather than replacing it: per-session attribution
  needs unbounded keys, which is exactly what a metric cannot carry.
- **The usage row store has no retention.** Metric shards rotate by age and total
  size; usage shards are never pruned, so they grow without bound. Nothing about
  high cardinality implies immortality -- this looks like unfinished work rather
  than a decision.

Relates to #2860, which reports the user-visible symptom and asks for several
cost-visibility features on top of it. This PR supplies the data those features
would read; it does not build the UI for them.



