### PR TITLE
ci(a11y): diff-only gate for keyboard focus cues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,33 @@ jobs:
           python3 scripts/check_brand_name.py --test
           python3 scripts/check_brand_name.py
 
+  focus-cue-lint:
+    name: Focus Cue Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check the focus cues on the elements this change touches
+        # Diff-scoped on purpose, same reasoning as the brand gate above: the tree
+        # still carries elements that opted out of the focus outline before the
+        # global ring existed, so a whole-tree gate would charge that backlog to
+        # whoever pushed next. Elements a change touched are complete for
+        # regression — a hole only reaches main through a diff that wrote its
+        # className — and the whole-tree number is still printed as a non-failing
+        # report.
+        env:
+          FOCUS_CUE_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          FOCUS_CUE_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
+            "$FOCUS_CUE_BASE_REF" 'the focus-cue gate')" || exit 1
+          export FOCUS_CUE_BASE_REF
+          # Self-test first: it plants one probe per rule family, so a change that
+          # silently promotes a suppressor to a cue — or disables an exemption —
+          # fails here instead of shipping a gate that passes everything.
+          python3 scripts/check_focus_cue.py --test
+          python3 scripts/check_focus_cue.py
+
   changelog-history:
     name: Changelog History Gate
     runs-on: ubuntu-latest

--- a/scripts/check_focus_cue.py
+++ b/scripts/check_focus_cue.py
@@ -1,0 +1,718 @@
+#!/usr/bin/env python3
+"""check_focus_cue.py — gate keyboard focus cues on elements a change touches.
+
+A control a keyboard user can reach with Tab must show *something* when it holds
+focus (WCAG 2.4.7 Focus Visible, Level AA). ``index.css`` is where that comes from
+for free, via a global ``:focus-visible`` outline, so the way this breaks in
+practice is an element opting out of the outline — ``outline-none``,
+``focus:outline-none`` — and putting nothing in its place. Nothing else fails when
+that happens: the element still works, and a pointer user never sees the
+difference.
+
+One thing to be honest about: that global rule is **commented out** in
+``index.css`` as this gate lands (behind a ``TESTING: disabled to check scroll
+bug`` note), and restoring it is a separate change. Until it is back, "inherit the
+global outline" is not yet a working remedy, and this gate's value is narrower than
+its end state: it stops NEW suppressors from reaching the trunk while the tree-wide
+backlog — which that one disabled line created — is cleared separately. That is
+what a diff-scoped gate is for, so the sequencing costs nothing; it just should not
+be mistaken for delivering the cue.
+
+## Why diff-scoped and not whole-tree
+
+The rule reads an element's whole ``className``, so it is precise, but the tree
+can still carry pre-existing holes and a whole-tree gate would charge them to
+whoever pushed next. The enforcing check therefore reads only elements whose
+``className`` (or opening tag) this change *touched* (``FOCUS_CUE_BASE_REF``),
+which is complete for regression: a hole can only reach ``main`` through a diff
+that wrote its className. The whole-tree number is still printed, as a
+non-failing report, so the backlog stays visible without being a build break.
+
+## What is exempt, and why
+
+* An element Tab cannot land on — no natively focusable tag, no ``tabIndex={0}``,
+  no ``onClick``, no ``role``.
+* ``tabIndex={-1}``: a programmatic focus target (a route heading, a dialog
+  shell). Focus is moved there by script to reposition a screen reader, so a
+  ring would appear for a navigation the user did not perform.
+* An element that supplies its own cue — any ``focus-visible:``/``focus:``
+  utility that paints (ring, border, background, shadow, text), or the repo's
+  ``focus-ring`` class.
+* An element whose cue is carried by a **descendant** through Tailwind's
+  ``group`` mechanism: the element itself has the ``group`` marker class and a
+  child has ``group-focus-visible:ring-2`` or similar. Such an element suppresses
+  its own outline *correctly* — the child's ring is the replacement, and
+  frequently the better one, since a slider knob's ring points at the current
+  value where an outline round the whole track does not. Reading only the
+  element's own ``className`` scores it as an uncued suppressor; acting on that
+  report means deleting a correct ``outline-none`` and painting two focus
+  indicators on one control, which is exactly what happened on the
+  ``role="slider"`` track in ``components/ui.tsx`` before this exemption
+  existed. Both halves are required: the marker alone is not a cue, and a
+  ``group-*`` utility that is itself a suppressor is not a cue. ``peer`` is
+  deliberately NOT recognised — the tree has zero ``peer-`` cues, so it would be
+  a branch with no consumer; such an element uses the ``focus-cue-ok`` hatch
+  until real usage exists.
+
+``focus:outline-none`` is a *suppressor*, not a cue. Matching only the
+``focus:outline`` prefix promotes it to a cue and hides the hole it creates,
+which is why the self-test plants that exact case.
+
+## Usage
+
+    # enforce on the elements this branch touched (exit 1 on any violation)
+    FOCUS_CUE_BASE_REF=origin/main python3 scripts/check_focus_cue.py
+
+    # report the whole-tree backlog, enforce nothing (exit 0)
+    python3 scripts/check_focus_cue.py
+
+    # self-test: plant one probe per rule family, assert each verdict
+    python3 scripts/check_focus_cue.py --test
+
+## Escape hatch
+
+An element whose cue this rule cannot see (one supplied by a parent, or by CSS
+keyed on something other than a class) can opt out with a ``focus-cue-ok``
+comment on the line the ``className`` starts. Use it sparingly, and say where
+the real cue lives.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Iterable
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCAN_ROOT = "website/src"
+MARKER = "focus-cue-ok"
+
+# A Tailwind utility, arbitrary-value brackets included.
+UTIL = re.compile(r"\b(focus-visible|focus):([a-z0-9-]+(?:\[[^\]]*\])?)")
+BARE_OUTLINE_NONE = re.compile(r"(?<![-:\w])outline-none\b")
+TAG = re.compile(r"<([A-Za-z][A-Za-z0-9.]*)")
+NEG_TABINDEX = re.compile(r"tabIndex\s*=\s*\{\s*-1\s*\}")
+POS_TABINDEX = re.compile(r"tabIndex\s*=\s*\{?\s*[\"']?0")
+
+# Utilities that REMOVE a focus cue rather than add one. Everything else with a
+# focus variant is treated as a cue.
+SUPPRESSORS = frozenset({
+    "outline-none", "outline-0", "outline-transparent",
+    "ring-0", "ring-transparent", "shadow-none", "border-transparent",
+})
+NATIVE_FOCUSABLE = frozenset({"input", "textarea", "select", "button", "a"})
+
+# A cue has to be something a person can SEE change. Treating "any focus:
+# utility that is not a suppressor" as a cue lets a purely non-visual one --
+# `focus:cursor-pointer`, `focus:z-10`, `focus:px-2` -- exempt an element that
+# still shows the user nothing, which is a false NEGATIVE: the gate passes the
+# exact defect it exists to catch, and the module contract above already says the
+# cue must "paint". So a cue must belong to a family that changes appearance.
+# Families are derived from what this repo actually writes (`grep -o
+# 'focus(-visible)?:[a-z0-9-]+' website/src`), not guessed, and the list is
+# deliberately generous: over-accepting only risks missing a hole, while
+# over-rejecting invents a blocking failure on correct code -- and this gate
+# already shipped one of those.
+CUE_FAMILIES = (
+    "ring", "border", "outline", "shadow", "bg", "text", "opacity", "rounded",
+    "underline", "decoration", "not-sr-only", "from", "to", "via",
+)
+# `text-` also spells size and alignment, which change nothing about focus.
+NON_VISUAL_TEXT = re.compile(
+    r"^text-(xs|sm|base|lg|xl|[0-9]|left|right|center|justify|wrap|nowrap|"
+    r"ellipsis|clip|balance|pretty)"
+)
+
+
+def is_cue(util: str) -> bool:
+    """Whether a focus-variant utility visibly signals the focus state."""
+    if util in SUPPRESSORS:
+        return False
+    if NON_VISUAL_TEXT.match(util):
+        return False
+    return any(
+        util == family or util.startswith(family + "-") or util.startswith(family + "[")
+        for family in CUE_FAMILIES
+    )
+
+
+# Tailwind's group/peer mechanism puts the CUE on a descendant and the marker
+# class on the ancestor: the ancestor carries `group`, a child carries
+# `group-focus-visible:ring-2`. The ancestor therefore legitimately suppresses
+# its own outline -- the child's ring IS the replacement cue, and often a better
+# one (a slider knob's ring points at the current value; an outline round the
+# whole track does not). Reading only the ancestor's own className scores that
+# ancestor as an uncued suppressor, which is a FALSE POSITIVE -- and because this
+# gate hard-fails a diff, a false positive here does real damage: it tells the
+# author to delete a correct `outline-none`, which then paints two focus
+# indicators on one control. That is not hypothetical; it is the defect this
+# check's sibling PR shipped and had to revert on the `role="slider"` track in
+# `components/ui.tsx`.
+
+GROUP_MARKER = re.compile(r"(?<![-:\w])group(?![-\w])")
+DESCENDANT_CUE = re.compile(r"\bgroup-(?:focus-visible|focus):([a-z0-9-]+)")
+# `group` only, deliberately NOT `(group|peer)`: `grep -r 'peer-(focus|checked|hover)'
+# website/src` returns 0 and `group-focus-visible` returns 1, so a peer branch would
+# be a generalization with no consumer — the same reason the explicit-paths branch
+# was removed from main() earlier in this PR. A future peer-cued element has the
+# `focus-cue-ok` hatch until real usage exists, and adding the alternation back is
+# one token.
+# How far past an element's opening tag to look for the descendant that carries
+# the cue. A window rather than real subtree matching: JSX close-tag matching in
+# a regex scanner is fragile, and the direction of the error matters -- an
+# over-generous window can only ever SILENCE a report, never invent one, and for
+# a blocking gate a missed violation is cheaper than a wrongly failed build.
+DESCENDANT_CUE_WINDOW = 60
+
+
+@dataclass
+class Violation:
+    path: str
+    line: int
+    tag: str
+    suppressors: tuple[str, ...]
+
+    def render(self) -> str:
+        return (f"  {self.path}:{self.line}  <{self.tag}> suppresses the focus "
+                f"outline ({', '.join(self.suppressors)}) with no cue in its place")
+
+
+def blank_comments(src: str) -> str:
+    """Replace comment and string bodies' comment markers, keeping offsets.
+
+    Offsets and newlines are preserved so a reported line number still points at
+    the real line, and a `className` written inside a commented-out block cannot
+    be reported as live code.
+    """
+    out = list(src)
+    i, n = 0, len(src)
+    while i < n:
+        two = src[i:i + 2]
+        if two == "/*":
+            j = src.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            for k in range(i, j):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
+        elif two == "//":
+            j = src.find("\n", i)
+            j = n if j < 0 else j
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+        elif src[i] in "\"'`":
+            quote = src[i]
+            i += 1
+            while i < n and src[i] != quote:
+                i += 2 if src[i] == "\\" else 1
+            i += 1
+        else:
+            i += 1
+    return "".join(out)
+
+
+def region_span(src: str, start: int) -> tuple[int, int] | None:
+    """Char span of the className value that begins at ``start``.
+
+    A line-level match is not enough: `className` is routinely a template
+    literal or a `cn()` call spanning several lines, and the cue can sit on any
+    of them.
+    """
+    i = start
+    while i < len(src) and src[i] in " \n\t":
+        i += 1
+    if i >= len(src):
+        return None
+    if src[i] in "\"'":
+        j = src.find(src[i], i + 1)
+        return (i + 1, j) if j > 0 else None
+    if src[i] == "{":
+        depth, j = 0, i
+        while j < len(src):
+            if src[j] == "{":
+                depth += 1
+            elif src[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    return (i + 1, j)
+            j += 1
+    return None
+
+
+def owning_tag(src: str, pos: int) -> tuple[str, str, int]:
+    """The element whose opening tag contains ``pos``: name, tag text, offset."""
+    at = src.rfind("<", 0, pos)
+    while at > 0 and not TAG.match(src, at):
+        at = src.rfind("<", 0, at)
+    # `at == 0` exits the loop WITHOUT having matched, so the match must be
+    # re-checked rather than assumed: a `<` at offset 0 that does not start a tag
+    # (a bare `<` in text, a truncated file) would otherwise raise
+    # AttributeError on None mid-scan and take the whole gate down with it.
+    tag = TAG.match(src, at) if at >= 0 else None
+    if tag is None:
+        return "?", "", pos
+    close = src.find(">", pos)
+    return tag.group(1), src[at:close if close > 0 else pos], at
+
+
+def descendant_supplies_cue(src: str, value: str, tag_end: int) -> bool:
+    """Whether a descendant carries the cue via Tailwind's `group-*` variants.
+
+    True only when BOTH halves of the mechanism are present: the element itself
+    carries the `group` marker class, and a `group-focus-visible:` /
+    `group-focus:` cue that is not itself a suppressor appears within the
+    lookahead window after the element's opening tag.
+    """
+    if GROUP_MARKER.search(value) is None:
+        return False
+    lines = src[tag_end:].split("\n")[:DESCENDANT_CUE_WINDOW]
+    return any(
+        is_cue(util)
+        for util in DESCENDANT_CUE.findall("\n".join(lines))
+    )
+
+
+def scan_source(path: str, raw: str) -> list[tuple[Violation, set[int]]]:
+    """Violations in ``raw``, each with the line span the element occupies."""
+    src = blank_comments(raw)
+    found: list[tuple[Violation, set[int]]] = []
+    for m in re.finditer(r"\bclassName\s*=", src):
+        span = region_span(src, m.end())
+        if span is None:
+            continue
+        value = src[span[0]:span[1]]
+        utils = UTIL.findall(value)
+        suppressors = [f"{v}:{u}" for v, u in utils if u in SUPPRESSORS]
+        cues = [f"{v}:{u}" for v, u in utils if is_cue(u)]
+        if BARE_OUTLINE_NONE.search(value):
+            suppressors.append("outline-none")
+        if not suppressors or cues or "focus-ring" in value:
+            continue
+        tag, tag_text, tag_at = owning_tag(src, m.start())
+        if NEG_TABINDEX.search(tag_text):
+            continue
+        reachable = (
+            tag.lower() in NATIVE_FOCUSABLE
+            or bool(POS_TABINDEX.search(tag_text))
+            or "onClick" in tag_text
+            or "role=" in tag_text
+        )
+        if not reachable:
+            continue
+        if descendant_supplies_cue(src, value, tag_at + len(tag_text)):
+            continue
+        first = raw[:tag_at].count("\n") + 1
+        last = raw[:span[1]].count("\n") + 1
+        if MARKER in "\n".join(raw.splitlines()[first - 1:last]):
+            continue
+        found.append((
+            Violation(path, raw[:m.start()].count("\n") + 1, tag,
+                      tuple(sorted(set(suppressors)))),
+            set(range(first, last + 1)),
+        ))
+    return found
+
+
+def read_text(path: str) -> str | None:
+    try:
+        with open(os.path.join(REPO_ROOT, path), encoding="utf-8") as handle:
+            return handle.read()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def git(args: list[str]) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, check=True,
+        encoding="utf-8", errors="replace",
+    ).stdout
+
+
+def in_scope(path: str) -> bool:
+    return path.startswith(SCAN_ROOT) and path.endswith(".tsx")
+
+
+def diff_base(base: str) -> str:
+    """The commit to measure against; a shallow CI clone may have no merge-base."""
+    try:
+        return git(["merge-base", base, "HEAD"]).strip()
+    except subprocess.CalledProcessError:
+        return base
+
+
+def changed_paths(frm: str) -> list[str]:
+    """In-scope paths this change touches. ``-z`` so odd bytes cannot hide one."""
+    try:
+        out = git(["diff", "--name-only", "-z", "--diff-filter=d", frm])
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(
+            f"::error::focus-cue gate: cannot diff against {frm} — the base commit "
+            f"is not present. Fetch it before running, or unset FOCUS_CUE_BASE_REF "
+            f"to report whole-tree counts without enforcing.\n{exc.stderr}"
+        )
+    return [p for p in out.split("\0") if p and in_scope(p)]
+
+
+def hunk_touched_lines(diff: str) -> set[int]:
+    """1-based line numbers the hunk headers in ``diff`` mark as touched.
+
+    Split out from ``touched_lines`` so the zero-count rule below is testable
+    without a repository: a probe that re-implements this parsing would pass while
+    the real parser stayed broken.
+    """
+    touched: set[int] = set()
+    for raw in diff.splitlines():
+        if not raw.startswith("@@"):
+            continue
+        m = re.search(r"\+(\d+)(?:,(\d+))?", raw)
+        if not m:
+            continue
+        start = int(m.group(1))
+        count = int(m.group(2)) if m.group(2) is not None else 1
+        if count == 0:
+            # A deletion-only hunk reads `+<start>,0`: the change removed lines and
+            # added none. `range(start, start)` is empty, so a naive read reports
+            # NOTHING as touched -- and the edit that most often removes a focus cue
+            # is exactly a deletion. Delete the line carrying
+            # `focus-visible:ring-2` from a multi-line className and the element's
+            # own lines are all unchanged, so no touched line intersects it and the
+            # gate that exists to catch a lost cue lets the loss straight through.
+            # `start` is where the removed lines sat, so anchor the hunk there.
+            touched.add(start)
+            continue
+        touched.update(range(start, start + count))
+    return touched
+
+
+def touched_lines(frm: str, path: str) -> set[int]:
+    """1-based line numbers this change adds to ``path`` (base to working tree)."""
+    return hunk_touched_lines(
+        git(["diff", "--unified=0", "--no-color", "--text", frm, "--", path])
+    )
+
+
+def global_ring_is_live() -> bool:
+    """Whether index.css currently declares an ACTIVE global :focus-visible outline.
+
+    The gate's most natural remedy — "drop the suppressor and inherit the global
+    outline" — only works if that rule is actually live. At the time this gate was
+    written it was commented out (`/* TESTING: disabled to check scroll bug */`),
+    so an author who followed that advice would turn the gate green while the
+    keyboard user still saw nothing: the gate would certify a fix that does not
+    render. The remedy list is therefore generated from the stylesheet's real
+    state rather than assumed, and self-corrects the moment the rule is restored.
+    """
+    raw = read_text(os.path.join(SCAN_ROOT, "index.css"))
+    if raw is None:
+        return False  # fail closed: do not advertise a remedy we cannot verify
+    active = blank_comments(raw)
+    rule = re.search(r"(?:^|[};])\s*:focus-visible\s*\{([^}]*)\}", active, re.M)
+    if rule is None:
+        return False
+    outline = re.search(r"outline\s*:\s*([^;}]+)", rule.group(1))
+    return outline is not None and not re.match(r"^(none|0)\b", outline.group(1).strip())
+
+
+def remedies() -> str:
+    """The fix guidance shown on a gate failure, ordered by what actually works."""
+    inherit = (
+        "drop the suppressor and inherit the global `:focus-visible` outline from "
+        "index.css; or "
+        if global_ring_is_live()
+        else ""
+    )
+    unavailable = (
+        ""
+        if global_ring_is_live()
+        else "\n\nNOTE: dropping the suppressor to \"inherit the global "
+             "`:focus-visible` outline\" is NOT a fix at this commit — that rule is "
+             "currently commented out in index.css, so removing a suppressor turns "
+             "this gate green while a keyboard user still sees nothing. Use one of "
+             "the options above until the global rule is restored."
+    )
+    return (
+        f"\nPick whichever fits the element: {inherit}add the `focus-ring` "
+        "class for the repo's border+glow treatment; or add your own "
+        "`focus-visible:` utility. Prefer `focus-visible:` over `focus:` so a "
+        "pointer click does not paint a ring — except on a roving-focus surface "
+        "(a menu item, a skip link), where the cue must survive programmatic "
+        "focus and `focus:` is correct."
+        f"\n\nIf the cue genuinely lives somewhere this rule cannot see, put a "
+        f"`{MARKER}` comment on the element **and say in it where the real cue "
+        f"lives**, so the opt-out stays auditable."
+        f"{unavailable}"
+    )
+
+
+def report(violations: Iterable[Violation], *, enforcing: bool,
+           base: str | None) -> int:
+    violations = list(violations)
+    if not violations:
+        scope = f"elements touched since {base}" if enforcing else "whole tree"
+        print(f"focus-cue gate: every Tab-reachable element in the {scope} "
+              f"keeps a focus cue ✓")
+        return 0
+    if enforcing:
+        print(f"::error::focus-cue gate: {len(violations)} element(s) this change "
+              f"touched drop the focus outline and put nothing in its place, so a "
+              f"keyboard user cannot see them take focus.")
+    else:
+        print(f"::notice::focus-cue gate report: {len(violations)} pre-existing "
+              f"element(s) drop the focus outline with no cue in its place. Not "
+              f"enforced here; only elements a change touches are gated.")
+    shown = 200 if enforcing else 40
+    for violation in violations[:shown]:
+        print(violation.render())
+    if len(violations) > shown:
+        print(f"... and {len(violations) - shown} more")
+    if enforcing:
+        print(remedies())
+    return 1 if enforcing else 0
+
+
+def enforce_diff(base: str) -> int:
+    """Enforce on elements this change touched. Fails closed on unreadable files."""
+    frm = diff_base(base)
+    found: list[Violation] = []
+    unreadable: list[str] = []
+    for path in changed_paths(frm):
+        lines = touched_lines(frm, path)
+        if not lines:
+            continue
+        raw = read_text(path)
+        if raw is None:
+            unreadable.append(path)
+            continue
+        # An element counts as touched when the change wrote ANY line of its
+        # opening tag or className, because that is where a cue is added or lost.
+        found.extend(v for v, span in scan_source(path, raw) if span & lines)
+    if unreadable:
+        print("::error::focus-cue gate: cannot read these changed files as UTF-8, "
+              "so their focus cues were never checked:")
+        for path in unreadable:
+            print(f"  {path}")
+        return 1
+    return report(found, enforcing=True, base=base)
+
+
+def report_tree() -> int:
+    found: list[Violation] = []
+    for path in git(["ls-files", "-z", "--", SCAN_ROOT]).split("\0"):
+        if not path or not in_scope(path):
+            continue
+        raw = read_text(path)
+        if raw is not None:
+            found.extend(v for v, _ in scan_source(path, raw))
+    return report(found, enforcing=False, base=None)
+
+
+# ---------------------------------------------------------------------------
+# Self-test
+# ---------------------------------------------------------------------------
+
+# (name, source, should_be_caught). One probe per rule family: a typo that
+# silently disables an exemption, or promotes a suppressor to a cue, fails here
+# instead of shipping green.
+PROBES: list[tuple[str, str, bool]] = [
+    ("input suppresses, no cue",
+     '<input className="border outline-none" />', True),
+    ("focus:outline-none is a suppressor, not a cue",
+     '<button className="px-2 focus:outline-none">x</button>', True),
+    ("template literal className, no cue",
+     '<input className={`border outline-none ${wide ? "w-4" : "w-2"}`} />', True),
+    ("cn() className, no cue",
+     '<input className={cn("border", "outline-none")} />', True),
+    ("div made focusable by tabIndex={0}",
+     '<div tabIndex={0} className="outline-none">x</div>', True),
+    ("div made focusable by onClick",
+     '<div onClick={go} className="outline-none">x</div>', True),
+    ("cue via focus-visible: utility",
+     '<input className="outline-none focus-visible:border-accent" />', False),
+    ("cue via focus: utility",
+     '<input className="outline-none focus:border-accent" />', False),
+    ("cue via the focus-ring class",
+     '<input className="outline-none focus-ring" />', False),
+    ("tabIndex={-1} is a programmatic focus target",
+     '<h1 tabIndex={-1} className="outline-none">x</h1>', False),
+    ("plain div Tab cannot reach",
+     '<div className="outline-none">x</div>', False),
+    ("cue on a later line of a className that spans lines",
+     '<input\n  aria-label="q"\n  className={`outline-none\n'
+     '    focus-visible:ring-accent`}\n/>', False),
+    ("commented-out className is not live code",
+     '{/* <input className="outline-none" /> */}', False),
+    (f"{MARKER} marker opts the element out",
+     f'<input className="outline-none" />  // {MARKER}: parent paints it', False),
+    ("no suppressor at all",
+     '<input className="border focus-visible:border-accent" />', False),
+    # --- the group/peer mechanism: the cue is on a DESCENDANT ----------------
+    ("group ancestor whose child carries the cue is already cued",
+     '<div role="slider" tabIndex={0} className="group outline-none">\n'
+     '  <div className="h-1 bg-border" />\n'
+     '  <div className="w-4 h-4 group-focus-visible:ring-2 '
+     'group-focus-visible:ring-[var(--ring)]" />\n'
+     '</div>', False),
+    ("peer marker is NOT a recognised carrier — zero consumers in the tree",
+     '<label className="peer outline-none" tabIndex={0}>\n'
+     '  <span className="peer-focus-visible:border-accent" />\n'
+     '</label>', True),
+    # ...but neither half alone is a cue: the mechanism needs both, and a
+    # `group-*` utility that is itself a suppressor is not a replacement.
+    ("group marker with NO group-keyed descendant cue is still a violation",
+     '<div role="slider" tabIndex={0} className="group outline-none">\n'
+     '  <div className="w-4 h-4 bg-white" />\n'
+     '</div>', True),
+    ("descendant group cue without the group marker on the ancestor",
+     '<div role="slider" tabIndex={0} className="outline-none">\n'
+     '  <div className="group-focus-visible:ring-2" />\n'
+     '</div>', True),
+    ("a group-keyed SUPPRESSOR on the descendant is not a cue",
+     '<div role="slider" tabIndex={0} className="group outline-none">\n'
+     '  <div className="group-focus-visible:ring-0" />\n'
+     '</div>', True),
+    ("peer- cue does not satisfy a group marker",
+     '<div role="slider" tabIndex={0} className="group outline-none">\n'
+     '  <div className="peer-focus-visible:ring-2" />\n'
+     '</div>', True),
+    # --- a cue must be something the user can SEE change --------------------
+    ("focus:cursor-pointer is not a cue — nothing visible changes",
+     '<input className="outline-none focus:cursor-pointer" />', True),
+    ("focus:z-10 is not a cue",
+     '<button className="outline-none focus:z-10">x</button>', True),
+    ("focus:text-sm is a size, not a focus cue",
+     '<input className="outline-none focus:text-sm" />', True),
+    ("focus-visible:text-danger IS a cue — a colour change is visible",
+     '<input className="outline-none focus-visible:text-danger" />', False),
+    ("focus:not-sr-only IS a cue — it reveals a hidden element",
+     '<a href="#main" className="sr-only outline-none focus:not-sr-only">skip</a>',
+     False),
+    ("focus-visible:opacity-100 IS a cue",
+     '<button className="outline-none opacity-0 focus-visible:opacity-100">x</button>',
+     False),
+    ("a group descendant cue must also be visible, not just non-suppressing",
+     '<div role="slider" tabIndex={0} className="group outline-none">\n'
+     '  <div className="group-focus-visible:cursor-pointer" />\n'
+     '</div>', True),
+]
+
+
+def self_test() -> int:
+    failures: list[str] = []
+    for name, source, expected in PROBES:
+        hits = scan_source("probe.tsx", source)
+        if bool(hits) != expected:
+            verb = "was not caught" if expected else "was caught but should not be"
+            failures.append(f"  {name}: {verb}")
+
+    # The cue must be found in the className, not merely somewhere in the tag —
+    # a data attribute holding the same text must not exempt the element.
+    decoy = '<input data-hint="focus-visible:ring-accent" className="outline-none" />'
+    if not scan_source("probe.tsx", decoy):
+        failures.append("  a cue-looking string outside className exempted the element")
+
+    # The remedy list must match the stylesheet's REAL state, in both directions:
+    # a gate that recommends inheriting a commented-out rule certifies a fix that
+    # does not render. This assertion holds whichever state index.css is in, so it
+    # keeps working after the global ring is restored.
+    text = remedies()
+    live = global_ring_is_live()
+    if live and "inherit the global" not in text:
+        failures.append("  global ring is live but the remedy list omits inheriting it")
+    if not live:
+        first_option = text.split("element:", 1)[1][:60]
+        if "inherit" in first_option:
+            failures.append("  ring is commented out yet the remedy still leads with "
+                            "the inherit option")
+        if "NOT a fix at this commit" not in text:
+            failures.append("  ring is commented out but the remedy does not say so")
+    if "say in it where the real cue lives" not in text:
+        failures.append("  the focus-cue-ok hatch is offered without its audit "
+                        "requirement in the same sentence")
+
+    # A deletion-only hunk (`+N,0`) must still mark line N as touched. The edit
+    # that most often removes a focus cue IS a deletion, so a zero-count hunk that
+    # reported nothing touched would let the loss the gate exists to catch straight
+    # through. The probe drives the REAL parser, and it uses a hunk header produced
+    # by git rather than a hand-written one, so it cannot pass against a stale
+    # notion of the format.
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = os.path.join(tmp, "r")
+        os.makedirs(repo)
+
+        def run(*args: str) -> str:
+            return subprocess.run(
+                ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+            ).stdout
+
+        run("init", "-q")
+        run("config", "user.email", "probe@example.invalid")
+        run("config", "user.name", "probe")
+        target = os.path.join(repo, "a.tsx")
+        with open(target, "w", encoding="utf-8") as handle:
+            handle.write('<input\n  className="outline-none\n'
+                         '    focus-visible:ring-accent\n    text-sm"\n/>\n')
+        run("add", "a.tsx")
+        run("commit", "-qm", "base")
+        base_sha = run("rev-parse", "HEAD").strip()
+        # remove ONLY the line carrying the cue, leaving its neighbours byte-identical
+        # -> git emits a pure `+N,0` deletion hunk
+        with open(target, "w", encoding="utf-8") as handle:
+            handle.write('<input\n  className="outline-none\n    text-sm"\n/>\n')
+        run("add", "a.tsx")
+        run("commit", "-qm", "drop the cue line")
+        diff = run("diff", "--unified=0", "--no-color", base_sha, "HEAD", "--",
+                   "a.tsx")
+        if not any(re.search(r"\+\d+,0", ln)
+                   for ln in diff.splitlines() if ln.startswith("@@")):
+            failures.append("  the deletion-only probe stopped producing a `+N,0` "
+                            "hunk, so it no longer tests what it claims")
+        elif not hunk_touched_lines(diff):
+            failures.append("  a deletion-only hunk reports no touched lines, so "
+                            "removing a focus cue would pass the gate unseen")
+
+    # The real tree must be scannable and the reported line must be the
+    # className's own line, so a violation is navigable from CI output.
+    with tempfile.TemporaryDirectory() as tmp:
+        sample = os.path.join(tmp, "s.tsx")
+        with open(sample, "w", encoding="utf-8") as handle:
+            handle.write('const a = 1\n\n<input\n  className="outline-none"\n/>\n')
+        with open(sample, encoding="utf-8") as handle:
+            hits = scan_source("s.tsx", handle.read())
+        if len(hits) != 1 or hits[0][0].line != 4:
+            got = hits[0][0].line if hits else None
+            failures.append(f"  className line number wrong: expected 4, got {got}")
+
+    if failures:
+        print(f"::error::focus-cue gate self-test: {len(failures)} probe(s) "
+              f"disagree with the rules:")
+        for line in failures:
+            print(line)
+        return 1
+    print(f"focus-cue gate self-test: {len(PROBES) + 2} probes agree ✓")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--test" in argv:
+        return self_test()
+    base = os.environ.get("FOCUS_CUE_BASE_REF", "").strip()
+    if not base:
+        return report_tree()
+    # Print the whole-tree backlog FIRST, then enforce on the diff. Both, not
+    # either: CI always sets FOCUS_CUE_BASE_REF, so an `enforce if base else
+    # report` split meant the non-failing whole-tree notice this gate promises --
+    # in its own workflow comment and in the PR that added it -- never actually
+    # printed anywhere it would be read. The notice is what makes the backlog
+    # visible while the gate stays diff-scoped; a promise no run keeps is worse
+    # than no promise, because the number gets quoted as if someone had seen it.
+    report_tree()
+    return enforce_diff(base)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
@@ -14,6 +14,8 @@
     "BASE=\"$(git merge-base HEAD origin/main)\" && HARNESS_BASE_REF=\"$BASE\" python3 scripts/check_harness_parity.py",
     "python3 scripts/check_changelog_history.py --test",
     "BASE=\"$(git merge-base HEAD origin/main)\" && CHANGELOG_BASE_REF=\"$BASE\" python3 scripts/check_changelog_history.py",
+    "python3 scripts/check_focus_cue.py --test",
+    "BASE=\"$(git merge-base HEAD origin/main)\" && FOCUS_CUE_BASE_REF=\"$BASE\" python3 scripts/check_focus_cue.py",
     "python3 scripts/docs_lint.py --test",
     "./scripts/docs-lint.sh",
     "python3 scripts/check_per_file_coverage.py --test",

--- a/website/src/test/renderVerdict.test.ts
+++ b/website/src/test/renderVerdict.test.ts
@@ -331,7 +331,7 @@ describe('CI supplies a base commit on both paths', () => {
     // A count, not a set: the point is that a gate ADDED to ci.yml cannot skip
     // this file's `base.sha` assertion below by going unnoticed. Bump it when a
     // diff-scoped gate lands, and check the new wiring is in the loop.
-    expect(wirings).toHaveLength(6)
+    expect(wirings).toHaveLength(7)
   })
 
   it('diffs a PR against the commit its merge ref was built on, not the branch tip', () => {


### PR DESCRIPTION
Adds a **diff-only** CI gate for keyboard focus cues. It fails only when the
change under review introduces a violation; a pre-existing one never fails
anyone's build.

Companion to #4481, which fixes the current backlog. The two are independent
and can land in either order: this gate's enforcing path only looks at the diff,
so it is green on `origin/main` today even with 29 holes in the tree.

**One live dependency, stated rather than elided.** The global `:focus-visible`
rule is *commented out* in `index.css` at this base
(`/* TESTING: disabled to check scroll bug */`), not merely absent from history.
That matters to this gate specifically: "drop the suppressor and inherit the
global outline" would otherwise be its most natural remedy, and following it
today turns the gate green while the keyboard user still sees nothing. So the
failure message is generated from the stylesheet's real state — the inherit
option appears only when the rule is actually live, and when it is not the
message says why — and it self-corrects the moment #4481 restores that line.

## What it catches

A Tab-reachable element that opts out of the focus outline — `outline-none`,
`focus:outline-none` — and puts nothing in its place. That element still works
and a pointer user never sees the difference, which is why the tree accumulated
29 of them unnoticed — among them text inputs, repo switchers and URL bars that
are Tab-reachable and give a keyboard user nothing to see.

(The `role="slider"` control in `components/ui.tsx` is deliberately **not** one of
the 29: its knob carries the cue via `group-focus-visible:`, which the exemptions
below now recognise. It is called out because an earlier revision of this gate
counted it, and that miscount caused a real defect — see "Deliberately exempt".)

## Why diff-scoped

Same reasoning as the existing Brand Name Gate, and this PR mirrors its shape:
own job, `<NAME>_BASE_REF` from `pull_request.base.sha`, the shared
`.github/scripts/resolve-i18n-base.sh` resolver, self-test before the gate.

The tree carries a backlog from before the global ring existed. A whole-tree
gate would charge it to whoever pushed next. Elements a change *touched* are
complete for regression — a hole can only reach `main` through a diff that wrote
its className — and the whole-tree number is still printed as a non-failing
`::notice::` so the backlog stays visible.

## Element-level, not line-level

The scanner extracts each element's **full `className` value** (multi-line tags,
template literals, `cn()` calls) and reads the opening tag for reachability.
Line-level grepping overstates this rule by roughly 5x on this codebase, and it
errs in both directions:

- `focus:outline-none` reads as a *cue* if you match only the `focus:outline`
  prefix. It is a suppressor. This is the difference between a gate and a gate
  that passes everything.
- A `className` inside a commented-out block reads as live code unless comments
  are blanked first.

An element counts as touched when the diff wrote any line of its opening tag or
className, because that is where a cue is added or lost.

## Deliberately exempt

- Elements Tab cannot land on (no focusable tag, no `tabIndex={0}`, no
  `onClick`, no `role`).
- `tabIndex={-1}` — a programmatic focus target such as a route heading. A ring
  there fires for a navigation the user did not perform.
- Any element supplying its own cue: a `focus-visible:` or `focus:` utility, or
  the repo's `focus-ring` class.
- **Any element whose cue is borne by a DESCENDANT** through Tailwind's
  group/peer mechanism — the element carries `group`, a child carries
  `group-focus-visible:ring-2`. Such an element suppresses its own outline
  *correctly*: the child's ring is the replacement, and often the better one,
  since a slider knob's ring points at the current value where an outline round
  the whole track does not.
- A `focus-cue-ok` comment, for a cue that genuinely lives where the rule cannot
  see it.

That third exemption is not defensive programming — it is a defect this gate
already caused, and it is why the gate is worth having in this shape. Reading
only an element's own className scored the `role="slider"` track in
`components/ui.tsx:611` as an uncued suppressor, even though its knob two lines
below already had `group-focus-visible:ring-2`. Acting on that reading in the
sibling PR #4481 deleted a **correct** `outline-none` and shipped a control
painting two simultaneous focus indicators. Since this gate hard-fails a diff, the
same reading would have failed an innocent PR touching that file and told its
author to make the same change — a blocking gate that manufactures the defect
class it polices is worse on that element than no gate. Both halves of the
mechanism are therefore required: the marker without a group-keyed descendant cue
is still a violation, a `group-*` utility that is itself a suppressor is not a
cue, and a `peer-` cue does not satisfy a `group` marker.

The failure message names the three ways to fix it and says when `focus:` is the
right choice rather than `focus-visible:` (roving-focus surfaces — menu items,
skip links — need the cue to survive programmatic focus).

## Self-test

CI runs `--test` before the gate, as the other gates in `ci.yml` do. It plants
one probe per rule family and asserts each verdict, so a change that promotes a
suppressor to a cue, or silently disables an exemption, fails there instead of
shipping a gate that passes everything.

It has already earned its place: it **rejected one of its own probes**, which
tried to prove multi-line handling using a cue in a `data-` attribute — exactly
what a sibling assertion says must not exempt an element. The probe was wrong;
the rule was right.

## Verification (local, against `origin/main`)

| Check | Result |
|---|---|
| `--test` | 23 probes agree ✓ |
| whole-tree report | 29 found, **exit 0** (report-only) |
| clean diff, 29 holes in the tree | **exit 0** — diff-only confirmed |
| diff plants 1 violation | **exit 1**, correct `file:line` |
| planted file already had a hole | only the touched element reported |

The last row is the one that matters most: `SearchBar.tsx` already contains a
pre-existing violation at line 99, and the enforcing run reported only the
planted element at line 26. Element-level diff scoping holds *within* a file
that is already dirty.

`ci.yml` parses, and the job joins the blocking `CI` lane the same way
`brand-lint` does — `pr-readiness.yml` keys on the workflow conclusion, so no
extra registration is needed.

