### PR TITLE
fix: open error handoff in a new chat session

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -80,7 +80,12 @@ const SCROLL_AFTER_RENDER_MS = 100
 // applier); re-exported here for this page's historical importers.
 export { PREFILL_STORAGE_KEY } from '../utils/navIntent'
 import { PREFILL_STORAGE_KEY, writePrefill } from '../utils/navIntent'
-import { consumeChatHandoff, subscribeChatHandoff } from '../utils/errorReport'
+import {
+  consumeChatHandoff,
+  handoffToChat,
+  persistClaimedChatHandoffs,
+  subscribeChatHandoff,
+} from '../utils/errorReport'
 import WelcomeView from '../components/WelcomeView'
 import { usePanelTabs, openPanelView, clearInlineDraft, getInlineDraft, claimAppAutoOpen, useAnyLiveAppTab } from '../hooks/usePanelTabs'
 import { useFilteredDropdown } from '../hooks/useFilteredDropdown'
@@ -1235,6 +1240,31 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // companion panel mounts ChatPage fresh, so it hits this double-invoke every
   // first open. See the draft-restore effect below.
   const consumedPrefillRef = useRef<string | null>(null)
+  // Error hand-offs are claimed into a component-owned FIFO immediately, even
+  // while disconnected. That removes the sessionStorage TTL from the reconnect
+  // wait, while the processing flag guarantees only one create/switch sequence
+  // can run at a time.
+  const errorHandoffQueueRef = useRef<string[]>([])
+  const errorHandoffActiveRef = useRef<string | null>(null)
+  const errorHandoffActiveDurableRef = useRef(false)
+  const errorHandoffProcessingRef = useRef(false)
+  const errorHandoffConnectedRef = useRef(connected)
+  const errorHandoffModeRef = useRef(mode)
+  const errorHandoffMountedRef = useRef(false)
+  // Invalidates async processors when this effect lifecycle ends. Mounted alone
+  // is insufficient because StrictMode can clean up and re-run effects on the
+  // same component instance, reusing every ref while an old create is pending.
+  const errorHandoffLifecycleRef = useRef(0)
+  const processErrorHandoffsRef = useRef<() => void>(() => {})
+  const persistErrorHandoffClaims = useCallback(() => {
+    const active = errorHandoffActiveRef.current
+    persistClaimedChatHandoffs([
+      ...(active && !errorHandoffActiveDurableRef.current ? [active] : []),
+      ...errorHandoffQueueRef.current,
+    ])
+  }, [])
+  errorHandoffConnectedRef.current = connected
+  errorHandoffModeRef.current = mode
 
   // Auto-dismiss prefill hint after 10 seconds
   useEffect(() => {
@@ -1243,46 +1273,194 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     return () => clearTimeout(t)
   }, [prefillHint])
 
+  const processErrorHandoffs = useCallback(async () => {
+    if (
+      errorHandoffProcessingRef.current
+      || !errorHandoffMountedRef.current
+      || !errorHandoffConnectedRef.current
+    ) return
+    const prompt = errorHandoffQueueRef.current[0]
+    if (!prompt) return
+
+    const lifecycle = errorHandoffLifecycleRef.current
+    const ownsLifecycle = () => (
+      errorHandoffMountedRef.current
+      && errorHandoffLifecycleRef.current === lifecycle
+    )
+    let failureRestageAttempted = false
+    const restageFailure = (error: unknown) => {
+      failureRestageAttempted = true
+      const queued = errorHandoffQueueRef.current
+      const restaged = handoffToChat([prompt, ...queued])
+      if (restaged) {
+        queued.splice(0)
+        // Ingress now owns the entire FIFO in one atomic write. Clear the
+        // claimed copy only after that write succeeds.
+        persistClaimedChatHandoffs([])
+      } else {
+        // Keep a same-document retry path as well as the unchanged claimed
+        // crash copy when sessionStorage rejected the ingress write.
+        queued.unshift(prompt)
+      }
+      dispatch(addNotification({
+        ts: uniqueNotificationTs(),
+        kind: 'agent',
+        priority: 'critical',
+        title: i18nT('pages.chatPage.could_not_start_a_new_session'),
+        body: i18nT('pages.chatPage.could_not_start_session_message_restored', {
+          error: createFailReason(error),
+        }),
+      }))
+    }
+    errorHandoffProcessingRef.current = true
+    errorHandoffActiveRef.current = prompt
+    errorHandoffActiveDurableRef.current = false
+    // Persist the complete local FIFO before removing its head. A reload can
+    // now recover both the active diagnostic and every prompt waiting behind it.
+    persistClaimedChatHandoffs(errorHandoffQueueRef.current)
+    errorHandoffQueueRef.current.shift()
+    try {
+      let slotKey: string
+      try {
+        const slot = await dispatch(createSlot({ mode: errorHandoffModeRef.current, activate: false })).unwrap()
+        if (!slot?.key) throw new Error('the server returned no session')
+        slotKey = slot.key
+      } catch (e) {
+        // Cleanup may already have handed this FIFO to a newer ChatPage. An old
+        // rejection must not append a duplicate batch or clear its replacement's
+        // crash snapshot.
+        if (!ownsLifecycle()) return
+        restageFailure(e)
+        return
+      }
+
+      // A route remount may have re-staged this prompt while createSlot was in
+      // flight. The abandoned request may leave an unused server slot, but it
+      // must not write shared recovery state or steal focus from its successor.
+      if (!ownsLifecycle()) return
+      // Seed before switching: the draft-restore effect runs in the same commit
+      // as switchSlot.pending and would otherwise overwrite pendingInput with
+      // the new slot's empty draft. The keyed prefill survives that race.
+      if (!writePrefill(slotKey, prompt)) {
+        // Do not acknowledge durability or activate an empty session when the
+        // keyed prompt was rejected. Preserve active + queued work together.
+        restageFailure(new Error('browser storage is unavailable'))
+        return
+      }
+      // The keyed target-slot prefill is now the durable owner. A reload no
+      // longer needs to replay this active prompt, but queued prompts still do.
+      errorHandoffActiveDurableRef.current = true
+      persistErrorHandoffClaims()
+      try {
+        await dispatch(switchSlot(slotKey)).unwrap()
+      } catch {
+        // switchSlot.pending already activated the fresh slot. Its detail fetch
+        // may fail independently; keep the seeded composer usable in that slot.
+      }
+      // Do not dispatch pendingInput after the detail fetch. The keyed prefill
+      // seeded the composer when switchSlot.pending activated the slot; a late
+      // second write would overwrite anything the user typed during the fetch.
+      //
+      // The prefill channel is single-slot and the seeded prompt only becomes
+      // durable-in-slot when the input commit's persist effect records it under
+      // the fresh slot's draft key. Hold this turn (bounded well inside the
+      // prefill's 30s staleness window) until one of those in-component signals
+      // confirms the seed landed: yielding a single task is not enough — the
+      // next handoff's slot switch can outrun the consuming commit, and its
+      // outgoing-slot save would then overwrite this slot's draft with the
+      // stale empty composer, silently dropping the diagnostic.
+      for (let i = 0; i < 300 && ownsLifecycle(); i++) {
+        // Seed committed: the persist effect keyed a draft to the fresh slot,
+        // or the composer already holds exactly this prompt (a same-text
+        // setInput bails out of re-rendering, so no draft write follows).
+        if (Object.prototype.hasOwnProperty.call(drafts.current, slotKey)) break
+        if (inputRef.current === prompt) break
+        // User deliberately moved on; the keyed prefill stays staged for the
+        // fresh slot and expires on its own clock.
+        if (activeSlotRef.current !== slotKey) break
+        await new Promise(resolve => setTimeout(resolve, 10))
+      }
+    } finally {
+      // A newer lifecycle owns the shared claim key after unmount/remount. The
+      // stale processor may clean up only its abandoned local promise state.
+      if (!ownsLifecycle()) return
+      errorHandoffActiveRef.current = null
+      errorHandoffActiveDurableRef.current = false
+      errorHandoffProcessingRef.current = false
+      if (!failureRestageAttempted) persistErrorHandoffClaims()
+      // Yield a task between sessions. React gets a commit in which the current
+      // slot consumes its keyed prefill before another handoff can replace the
+      // single prefill channel and activate the next fresh slot. A create failure
+      // deliberately stops here: the atomically re-staged FIFO waits for a later
+      // user handoff/remount instead of entering an immediate retry loop.
+      if (
+        !failureRestageAttempted
+        && errorHandoffConnectedRef.current
+        && errorHandoffQueueRef.current.length
+      ) {
+        setTimeout(() => processErrorHandoffsRef.current(), 0)
+      }
+    }
+  }, [dispatch, persistErrorHandoffClaims])
+  processErrorHandoffsRef.current = () => { void processErrorHandoffs() }
+
   // Drain the error hand-off channel ("Ask the agent" on an error surface).
   // sessionStorage rather than Redux because the root ErrorBoundary's button has
   // to work after a hard reload, when the store it would have dispatched to is
-  // gone. Feeding pendingInput keeps a single downstream prefill path.
+  // gone. Claim every prompt synchronously into the local FIFO; processing waits
+  // for connection and opens one fresh slot at a time.
   //
   // Two triggers: on mount (arriving from another route, or a full reload) and on
   // the subscription (an error surface inside chat hands off with no route
   // change, so nothing remounts).
   useEffect(() => {
     if (embedded) return
-    // Wait for a slot before consuming. The channel is SINGLE-USE, and on the
-    // hard-nav path (the root ErrorBoundary reloads the page) this effect runs
-    // with activeSlot still null: the pending-input consumer then cannot persist
-    // the prompt as a draft, and the slot-restore that follows overwrites the
-    // composer — losing the prompt for good. The 60s hand-off TTL covers the wait,
-    // and this effect re-runs once the slot appears.
-    if (!activeSlot) return
+    errorHandoffLifecycleRef.current += 1
+    errorHandoffMountedRef.current = true
+    const handoffQueue = errorHandoffQueueRef.current
     const drain = () => {
-      const prompt = consumeChatHandoff()
-      if (!prompt) return
-      // APPEND when the composer already holds unsent text — same hazard, and
-      // same helper, as `followupAddToSession` below: the pending-input consumer
-      // replaces the draft AND persists it, so a plain set would silently
-      // destroy whatever the user was mid-way through typing. This is reachable
-      // precisely because the subscription fires with no route change, while
-      // error surfaces INSIDE chat (a failed PR action, a message that failed to
-      // render) hand off from under a composer in use.
-      // Merge against the text that actually belongs to `activeSlot`. On the
-      // hard-nav path the composer may not have adopted this slot's stored draft
-      // yet — `composerSlotRef` lags `activeSlot` — and merging against an empty
-      // composer would make the pending-input consumer persist the prompt OVER
-      // the stored draft. When they agree, the live composer value is the truth.
-      const base = composerSlotRef.current === activeSlot
-        ? inputRef.current
-        : drafts.current[activeSlot] ?? ''
-      dispatch(setPendingInput(mergeIntoDraft(base, prompt)))
+      let prompt: string | null
+      while ((prompt = consumeChatHandoff()) !== null) {
+        // A repeated click while the same diagnostic is creating/retrying is one
+        // retry request, not a request for a duplicate session.
+        if (
+          prompt !== errorHandoffActiveRef.current
+          && !handoffQueue.includes(prompt)
+        ) handoffQueue.push(prompt)
+      }
+      persistErrorHandoffClaims()
+      processErrorHandoffsRef.current()
     }
     drain()
-    return subscribeChatHandoff(drain)
-  }, [dispatch, embedded, activeSlot])
+    const unsubscribe = subscribeChatHandoff(drain)
+    return () => {
+      errorHandoffMountedRef.current = false
+      errorHandoffLifecycleRef.current += 1
+      unsubscribe()
+      // Atomically return every nondurable item in original FIFO order. The
+      // lifecycle token prevents the abandoned processor from later clearing a
+      // newer component's claim or switching its active slot.
+      const active = errorHandoffActiveRef.current
+      const restaged = [
+        ...(active && !errorHandoffActiveDurableRef.current ? [active] : []),
+        ...handoffQueue,
+      ]
+      if (handoffToChat(restaged)) {
+        handoffQueue.splice(0)
+        errorHandoffActiveRef.current = null
+        errorHandoffActiveDurableRef.current = false
+        errorHandoffProcessingRef.current = false
+        persistClaimedChatHandoffs([])
+      }
+    }
+  }, [embedded, persistErrorHandoffClaims])
+
+  // A disconnected mount still CLAIMS the handoff above. Reconnection only
+  // starts its queued network work, so waiting longer than the storage TTL cannot
+  // discard the diagnostic.
+  useEffect(() => {
+    if (!embedded && connected) processErrorHandoffsRef.current()
+  }, [embedded, connected, mode])
 
   // Consume pendingInput from Redux (e.g. from "Chat" button on Projects page)
   useEffect(() => {

--- a/website/src/test/ChatPageDrafts.test.tsx
+++ b/website/src/test/ChatPageDrafts.test.tsx
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { ReactNode } from 'react'
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import type { RootState } from '../store'
@@ -11,8 +11,16 @@ import { configureStore } from '@reduxjs/toolkit'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from '../hooks/useTheme'
 import chatReducer, { setActiveSlot, switchSlot, createSlot } from '../store/chatSlice'
-import dashboardReducer from '../store/dashboardSlice'
+import dashboardReducer, { sseConnected, sseDisconnected } from '../store/dashboardSlice'
 import notificationsReducer from '../store/notificationsSlice'
+import {
+  consumeChatHandoff,
+  handoffToChat,
+  installSoftNavigate,
+  sendErrorToChat,
+  __resetNavSeamForTests,
+} from '../utils/errorReport'
+import { PREFILL_STORAGE_KEY } from '../utils/navIntent'
 
 vi.mock('react-virtuoso', () => ({
   Virtuoso: ({ data, itemContent }: { data?: unknown[]; itemContent: (index: number, item: unknown) => ReactNode }) => (
@@ -112,8 +120,282 @@ async function renderAndWaitForInput(store: ReturnType<typeof makeStore>, mode?:
 }
 
 beforeEach(() => {
+  vi.clearAllMocks()
   sessionStorage.clear()
   localStorage.clear()
+  __resetNavSeamForTests()
+  installSoftNavigate(() => {})
+})
+
+afterEach(() => {
+  __resetNavSeamForTests()
+  vi.restoreAllMocks()
+})
+
+describe('ChatPage error handoff', { timeout: 15_000 }, () => {
+  it('opens a staged hard-reload handoff in a fresh seeded session', async () => {
+    const prompt = 'Diagnose the browser installation failure'
+    localStorage.setItem('mc-chat-drafts', JSON.stringify({ 'slot-a': 'keep this draft' }))
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    const originalMessages = store.getState().chat.messages
+    handoffToChat(prompt)
+
+    await renderAndWaitForInput(store)
+
+    const { api } = await import('../api/client')
+    await waitFor(() => expect(store.getState().chat.activeSlot).toBe('new-slot'))
+    expect(api.createChatSlot).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value).toBe(prompt)
+    })
+    expect(JSON.parse(localStorage.getItem('mc-chat-drafts') || '{}')['slot-a']).toBe('keep this draft')
+    expect(store.getState().chat.slotMessages['slot-a']).toEqual(originalMessages)
+  })
+
+  it('opens an already-mounted handoff in a fresh session without changing the current draft', async () => {
+    const prompt = 'Diagnose the failed PR action'
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+    fireEvent.change(screen.getByLabelText('Message input'), { target: { value: 'question in progress' } })
+
+    act(() => { sendErrorToChat(prompt) })
+
+    const { api } = await import('../api/client')
+    await waitFor(() => expect(store.getState().chat.activeSlot).toBe('new-slot'))
+    expect(api.createChatSlot).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value).toBe(prompt)
+    })
+    expect(JSON.parse(localStorage.getItem('mc-chat-drafts') || '{}')['slot-a']).toBe('question in progress')
+  })
+
+  it('re-stages a failed handoff without retrying against the mounted subscriber', async () => {
+    const prompt = 'Diagnose the persistent session creation failure'
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+    const { api } = await import('../api/client')
+    vi.mocked(api.createChatSlot).mockRejectedValueOnce(new Error('gateway unavailable'))
+
+    act(() => { sendErrorToChat(prompt) })
+
+    await waitFor(() => {
+      expect(store.getState().notifications.items).toEqual([
+        expect.objectContaining({
+          kind: 'agent',
+          priority: 'critical',
+          body: expect.stringContaining('Your message was restored'),
+        }),
+      ])
+    })
+    expect(api.createChatSlot).toHaveBeenCalledTimes(1)
+    expect(store.getState().chat.activeSlot).toBe('slot-a')
+    expect(consumeChatHandoff()).toBe(prompt)
+  })
+
+  it('re-stages the full FIFO when keyed prefill persistence fails', async () => {
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+    const { api } = await import('../api/client')
+    vi.mocked(api.createChatSlot).mockResolvedValueOnce({
+      key: 'unseeded-slot', title: 'unseeded-slot', messages: 0, running: false,
+    })
+    const originalSetItem = Storage.prototype.setItem
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (key, value) {
+      if (this === sessionStorage && key === PREFILL_STORAGE_KEY) {
+        throw new DOMException('quota exceeded', 'QuotaExceededError')
+      }
+      return originalSetItem.call(this, key, value)
+    })
+
+    act(() => {
+      sendErrorToChat('failed prefill diagnostic')
+      sendErrorToChat('queued successor')
+    })
+
+    await waitFor(() => expect(store.getState().notifications.items).toHaveLength(1))
+    expect(api.createChatSlot).toHaveBeenCalledTimes(1)
+    expect(store.getState().chat.activeSlot).toBe('slot-a')
+    expect(sessionStorage.getItem(PREFILL_STORAGE_KEY)).toBeNull()
+    expect(consumeChatHandoff()).toBe('failed prefill diagnostic')
+    expect(consumeChatHandoff()).toBe('queued successor')
+    expect(consumeChatHandoff()).toBeNull()
+  })
+
+  it('opens rapid handoffs sequentially and keeps each prompt with its fresh slot', async () => {
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+    const { api } = await import('../api/client')
+    vi.mocked(api.createChatSlot)
+      .mockResolvedValueOnce({ key: 'error-one', title: 'error-one', messages: 0, running: false })
+      .mockResolvedValueOnce({ key: 'error-two', title: 'error-two', messages: 0, running: false })
+
+    act(() => {
+      sendErrorToChat('first diagnostic')
+      sendErrorToChat('second diagnostic')
+    })
+
+    await waitFor(() => expect(api.createChatSlot).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(store.getState().chat.activeSlot).toBe('error-two'))
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value).toBe('second diagnostic')
+    })
+    await waitFor(() => {
+      const drafts = JSON.parse(localStorage.getItem('mc-chat-drafts') || '{}')
+      expect(drafts['error-one']).toBe('first diagnostic')
+    })
+    expect(consumeChatHandoff()).toBeNull()
+  })
+
+  it('does not overwrite edits typed while the fresh slot detail is loading', async () => {
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+    const { api } = await import('../api/client')
+    let resolveDetail!: (detail: Awaited<ReturnType<typeof api.chatSlotDetail>>) => void
+    const pendingDetail = new Promise<Awaited<ReturnType<typeof api.chatSlotDetail>>>(resolve => {
+      resolveDetail = resolve
+    })
+    vi.mocked(api.createChatSlot).mockResolvedValueOnce({
+      key: 'slow-error-slot', title: 'slow-error-slot', messages: 0, running: false,
+    })
+    vi.mocked(api.chatSlotDetail).mockImplementationOnce(() => pendingDetail)
+
+    act(() => { sendErrorToChat('original diagnostic') })
+
+    await waitFor(() => expect(store.getState().chat.activeSlot).toBe('slow-error-slot'))
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value).toBe('original diagnostic')
+    })
+    fireEvent.change(screen.getByLabelText('Message input'), {
+      target: { value: 'original diagnostic with user edits' },
+    })
+
+    await act(async () => {
+      resolveDetail({ messages: [], running: false, has_more: false, total: 0 })
+      await pendingDetail
+    })
+
+    expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value)
+      .toBe('original diagnostic with user edits')
+  })
+
+  it('re-stages the full FIFO after the first create failure and stops processing', async () => {
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    await renderAndWaitForInput(store)
+    const { api } = await import('../api/client')
+    let rejectFirst!: (reason?: unknown) => void
+    const firstCreate = new Promise<Awaited<ReturnType<typeof api.createChatSlot>>>((_, reject) => {
+      rejectFirst = reject
+    })
+    vi.mocked(api.createChatSlot).mockImplementationOnce(() => firstCreate)
+
+    act(() => {
+      sendErrorToChat('first diagnostic')
+      sendErrorToChat('second diagnostic')
+    })
+
+    await waitFor(() => expect(api.createChatSlot).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      rejectFirst(new Error('first gateway failure'))
+      await firstCreate.catch(() => undefined)
+    })
+    await waitFor(() => expect(store.getState().notifications.items).toHaveLength(1))
+    // The successor stays behind the failed head in one ingress FIFO, and the
+    // mounted processor does not immediately retry either item.
+    expect(api.createChatSlot).toHaveBeenCalledTimes(1)
+    expect(consumeChatHandoff()).toBe('first diagnostic')
+    expect(consumeChatHandoff()).toBe('second diagnostic')
+    expect(consumeChatHandoff()).toBeNull()
+  })
+
+  it('prevents an unmounted processor from clearing a remounted FIFO or stealing focus', async () => {
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    const firstPage = await renderAndWaitForInput(store)
+    const { api } = await import('../api/client')
+    let resolveAbandoned!: (slot: Awaited<ReturnType<typeof api.createChatSlot>>) => void
+    const abandonedCreate = new Promise<Awaited<ReturnType<typeof api.createChatSlot>>>(resolve => {
+      resolveAbandoned = resolve
+    })
+    vi.mocked(api.createChatSlot).mockImplementationOnce(() => abandonedCreate)
+
+    act(() => {
+      sendErrorToChat('active diagnostic')
+      sendErrorToChat('queued diagnostic')
+    })
+    await waitFor(() => expect(api.createChatSlot).toHaveBeenCalledTimes(1))
+
+    firstPage.unmount()
+
+    let resolveReplacement!: (slot: Awaited<ReturnType<typeof api.createChatSlot>>) => void
+    const replacementCreate = new Promise<Awaited<ReturnType<typeof api.createChatSlot>>>(resolve => {
+      resolveReplacement = resolve
+    })
+    vi.mocked(api.createChatSlot).mockImplementationOnce(() => replacementCreate)
+    const replacementPage = await renderAndWaitForInput(store)
+    await waitFor(() => expect(api.createChatSlot).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      resolveAbandoned({ key: 'abandoned-slot', title: 'abandoned-slot', messages: 0, running: false })
+      await abandonedCreate
+    })
+
+    // The stale processor neither switches the live view nor erases the newer
+    // component's active + queued crash snapshot.
+    expect(store.getState().chat.activeSlot).toBe('slot-a')
+    expect(JSON.parse(sessionStorage.getItem('kirocrew_error_handoff_claimed') || '[]'))
+      .toEqual([{ prompt: 'active diagnostic' }, { prompt: 'queued diagnostic' }])
+
+    replacementPage.unmount()
+    expect(consumeChatHandoff()).toBe('active diagnostic')
+    expect(consumeChatHandoff()).toBe('queued diagnostic')
+    expect(consumeChatHandoff()).toBeNull()
+
+    await act(async () => {
+      resolveReplacement({ key: 'replacement-slot', title: 'replacement-slot', messages: 0, running: false })
+      await replacementCreate
+    })
+    expect(store.getState().chat.activeSlot).toBe('slot-a')
+  })
+
+  it('re-stages locally claimed handoffs if ChatPage unmounts before reconnect', async () => {
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    store.dispatch(sseDisconnected())
+    handoffToChat('first disconnected diagnostic')
+    handoffToChat('second disconnected diagnostic')
+
+    const page = await renderAndWaitForInput(store)
+    expect(consumeChatHandoff()).toBeNull()
+
+    page.unmount()
+
+    expect(consumeChatHandoff()).toBe('first disconnected diagnostic')
+    expect(consumeChatHandoff()).toBe('second disconnected diagnostic')
+    expect(consumeChatHandoff()).toBeNull()
+  })
+
+  it('claims a disconnected handoff before its storage TTL and opens it after reconnect', async () => {
+    const prompt = 'Diagnose a gateway connection failure'
+    const now = Date.now()
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now)
+    const store = makeStore('slot-a', [{ key: 'slot-a' }])
+    store.dispatch(sseDisconnected())
+    handoffToChat(prompt)
+
+    await renderAndWaitForInput(store)
+
+    const { api } = await import('../api/client')
+    expect(api.createChatSlot).not.toHaveBeenCalled()
+    // Claimed into ChatPage's local FIFO: it is no longer aging in storage.
+    expect(consumeChatHandoff()).toBeNull()
+    nowSpy.mockReturnValue(now + 10 * 60_000)
+
+    act(() => { store.dispatch(sseConnected()) })
+
+    await waitFor(() => expect(store.getState().chat.activeSlot).toBe('new-slot'))
+    expect(api.createChatSlot).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value).toBe(prompt)
+    })
+  })
 })
 
 // the per-slot draft fix relies on a load-bearing effect ORDER --

--- a/website/src/test/errorToAgent.test.tsx
+++ b/website/src/test/errorToAgent.test.tsx
@@ -5,7 +5,7 @@
  *  1. the transport journals every API failure with its full context, so a UI
  *     holding only `e.message` can recover it (the zero-migration path);
  *  2. nothing credential-shaped reaches the prompt (it is fed to an LLM);
- *  3. the button lands the prompt in the chat composer.
+ *  3. the button stages the diagnostic for a fresh chat session.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -26,8 +26,10 @@ import {
   handoffToChat,
   installSoftNavigate,
   parseErrorCode,
+  persistClaimedChatHandoffs,
   recentErrors,
   recordError,
+  recoverClaimedChatHandoffs,
   redactSecrets,
   requestPath,
   sendErrorToChat,
@@ -328,6 +330,45 @@ describe('chat hand-off channel', () => {
     expect(consumeChatHandoff()).toBeNull()
   })
 
+  it('queues concurrent hand-offs without overwriting either diagnostic', () => {
+    handoffToChat('first diagnostic')
+    handoffToChat('second diagnostic')
+
+    expect(consumeChatHandoff()).toBe('first diagnostic')
+    expect(consumeChatHandoff()).toBe('second diagnostic')
+    expect(consumeChatHandoff()).toBeNull()
+  })
+
+  it('handoffToChat appends a whole batch behind existing ingress, in order', () => {
+    // The failed-create path re-stages [failed head, ...queued successors] as
+    // one atomic write; a reload must then replay them in original FIFO order.
+    handoffToChat('already staged diagnostic')
+    expect(handoffToChat(['failed head', 'queued successor'])).toBe(true)
+
+    expect(consumeChatHandoff()).toBe('already staged diagnostic')
+    expect(consumeChatHandoff()).toBe('failed head')
+    expect(consumeChatHandoff()).toBe('queued successor')
+    expect(consumeChatHandoff()).toBeNull()
+  })
+
+  it('handoffToChat with no prompts reports success and stages nothing', () => {
+    expect(handoffToChat([])).toBe(true)
+    expect(sessionStorage.getItem(ERROR_HANDOFF_KEY)).toBeNull()
+    expect(consumeChatHandoff()).toBeNull()
+  })
+
+  it('recovers a claimed FIFO ahead of newer ingress after a reload', () => {
+    expect(persistClaimedChatHandoffs(['active diagnostic', 'locally queued diagnostic'])).toBe(true)
+    handoffToChat('newer ingress diagnostic')
+
+    recoverClaimedChatHandoffs()
+
+    expect(consumeChatHandoff()).toBe('active diagnostic')
+    expect(consumeChatHandoff()).toBe('locally queued diagnostic')
+    expect(consumeChatHandoff()).toBe('newer ingress diagnostic')
+    expect(consumeChatHandoff()).toBeNull()
+  })
+
   it('drops a stale hand-off instead of ambushing a later visit', () => {
     sessionStorage.setItem(ERROR_HANDOFF_KEY, JSON.stringify({ prompt: 'old', ts: Date.now() - 600_000 }))
     expect(consumeChatHandoff()).toBeNull()
@@ -345,21 +386,6 @@ describe('chat hand-off channel', () => {
     off()
     expect(seen).toEqual(['please fix'])
     expect(navigated).toEqual(['/chat'])
-  })
-
-  it('a subscriber can append the prompt to an in-progress draft', () => {
-    // Pins the ChatPage drain contract: the hand-off fires with no route change
-    // while the composer may hold unsent text, and the pending-input consumer
-    // REPLACES + persists the draft. A drain that plain-sets destroys the
-    // user's typing unrecoverably, so it must append via mergeIntoDraft.
-    let delivered = ''
-    const off = subscribeChatHandoff(() => {
-      const prompt = consumeChatHandoff()
-      if (prompt) delivered = mergeIntoDraft('half-typed question  ', prompt)
-    })
-    sendErrorToChat('- Message: save failed')
-    off()
-    expect(delivered).toBe('half-typed question\n\n- Message: save failed')
   })
 
   it('mergeIntoDraft leaves a draft untouched when there is nothing to append', () => {

--- a/website/src/utils/errorReport.ts
+++ b/website/src/utils/errorReport.ts
@@ -280,38 +280,157 @@ export function __resetErrorJournalForTests(): void {
 // close the import graph into a runtime cycle. Import it from
 // `./errorReport.prompt` directly.
 
+type ChatHandoffEntry = { prompt: string; ts: number }
+type ClaimedChatHandoffEntry = { prompt: string }
+
 /**
- * Stage a prompt for the chat composer.
+ * Locally claimed hand-offs awaiting a durable target-slot prefill.
+ *
+ * This is separate from {@link ERROR_HANDOFF_KEY}: subscribers may append and
+ * drain that ingress queue while a session request is pending. Keeping the
+ * claimed FIFO under its own key prevents a later diagnostic from consuming
+ * the active diagnostic's crash-recovery copy.
+ */
+const ERROR_HANDOFF_CLAIMED_KEY = 'kirocrew_error_handoff_claimed'
+
+/** Decode both the original single entry and the queued wire shape. */
+function decodeChatHandoffs(raw: string | null): ChatHandoffEntry[] {
+  if (!raw) return []
+  try {
+    const decoded: unknown = JSON.parse(raw)
+    const entries = Array.isArray(decoded) ? decoded : [decoded]
+    const now = Date.now()
+    return entries.flatMap((entry): ChatHandoffEntry[] => {
+      if (!entry || typeof entry !== 'object') return []
+      const { prompt, ts } = entry as { prompt?: unknown; ts?: unknown }
+      if (typeof prompt !== 'string' || !prompt) return []
+      if (typeof ts !== 'number' || now - ts > HANDOFF_TTL_MS) return []
+      return [{ prompt, ts }]
+    })
+  } catch {
+    return []
+  }
+}
+
+function decodeClaimedChatHandoffs(raw: string | null): ClaimedChatHandoffEntry[] {
+  if (!raw) return []
+  try {
+    const decoded: unknown = JSON.parse(raw)
+    const entries = Array.isArray(decoded) ? decoded : [decoded]
+    return entries.flatMap((entry): ClaimedChatHandoffEntry[] => {
+      if (!entry || typeof entry !== 'object') return []
+      const { prompt } = entry as { prompt?: unknown }
+      return typeof prompt === 'string' && prompt ? [{ prompt }] : []
+    })
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Mirror ChatPage's active + local FIFO while durable ingress storage is empty.
+ * Claimed entries deliberately do not age out: ChatPage may own them while
+ * disconnected for longer than the ingress TTL, and ownership must not turn a
+ * saved diagnostic into an expiring one.
+ */
+export function persistClaimedChatHandoffs(prompts: readonly string[]): boolean {
+  if (!prompts.length) {
+    try {
+      sessionStorage.removeItem(ERROR_HANDOFF_CLAIMED_KEY)
+      return true
+    } catch {
+      return false
+    }
+  }
+  return safeSetSessionItem(
+    ERROR_HANDOFF_CLAIMED_KEY,
+    JSON.stringify(prompts.map(prompt => ({ prompt }))),
+  )
+}
+
+/**
+ * Recover a prior page's claimed FIFO ahead of newer ingress entries.
+ *
+ * This runs once when this module loads. A same-document ChatPage remount does
+ * not replay an active request that the old component instance still owns, but
+ * a reload gets a new module instance and atomically promotes the crash copy
+ * back to the normal ingress queue. Write before delete: a failed promotion
+ * leaves the claimed copy available for the next reload rather than losing it.
+ */
+export function recoverClaimedChatHandoffs(): void {
+  let claimedRaw: string | null
+  try {
+    claimedRaw = sessionStorage.getItem(ERROR_HANDOFF_CLAIMED_KEY)
+  } catch {
+    return
+  }
+  if (claimedRaw === null) return
+
+  const claimed = decodeClaimedChatHandoffs(claimedRaw)
+  if (!claimed.length) {
+    try { sessionStorage.removeItem(ERROR_HANDOFF_CLAIMED_KEY) } catch { /* best effort */ }
+    return
+  }
+
+  let queued: ChatHandoffEntry[] = []
+  try {
+    queued = decodeChatHandoffs(sessionStorage.getItem(ERROR_HANDOFF_KEY))
+  } catch { /* best-effort storage: safeSetSessionItem handles the write */ }
+  const now = Date.now()
+  const recovered = [
+    ...claimed.map(({ prompt }) => ({ prompt, ts: now })),
+    ...queued,
+  ]
+  if (!safeSetSessionItem(ERROR_HANDOFF_KEY, JSON.stringify(recovered))) return
+  try { sessionStorage.removeItem(ERROR_HANDOFF_CLAIMED_KEY) } catch { /* duplicate-safe on retry */ }
+}
+
+/**
+ * Stage a prompt for a fresh chat session.
  *
  * sessionStorage rather than a Redux dispatch because the most valuable caller
  * is the root ErrorBoundary: when the React tree has already thrown, the store
  * and router may be exactly what is broken, so the hand-off has to survive a
  * hard `location.assign`. Same channel serves the healthy in-app path, so there
  * is one code path to reason about instead of two.
+ *
+ * The stored value is a queue. Two error surfaces can hand off before the first
+ * session request settles, and replacing a single entry would silently discard
+ * one diagnostic if both requests later needed to be re-staged.
  */
-export function handoffToChat(prompt: string): void {
-  safeSetSessionItem(ERROR_HANDOFF_KEY, JSON.stringify({ prompt, ts: Date.now() }))
+export function handoffToChat(prompt: string | readonly string[]): boolean {
+  const prompts = typeof prompt === 'string' ? [prompt] : prompt
+  if (!prompts.length) return true
+  let queued: ChatHandoffEntry[] = []
+  try {
+    queued = decodeChatHandoffs(sessionStorage.getItem(ERROR_HANDOFF_KEY))
+  } catch { /* best-effort storage: safeSetSessionItem handles the write */ }
+  const now = Date.now()
+  queued.push(...prompts.map(item => ({ prompt: item, ts: now })))
+  return safeSetSessionItem(ERROR_HANDOFF_KEY, JSON.stringify(queued))
 }
 
-/** Drain the hand-off channel. Returns the prompt, or null when absent/stale. */
+/** Drain one queued hand-off. Returns the oldest prompt, or null when absent/stale. */
 export function consumeChatHandoff(): string | null {
   let raw: string | null = null
   try {
     raw = sessionStorage.getItem(ERROR_HANDOFF_KEY)
+    // Claim the snapshot before decoding it. If rewriting the remainder fails,
+    // a consumed prompt still cannot be delivered twice.
     if (raw !== null) sessionStorage.removeItem(ERROR_HANDOFF_KEY)
   } catch {
     return null
   }
-  if (!raw) return null
-  try {
-    const { prompt, ts } = JSON.parse(raw) as { prompt?: unknown; ts?: unknown }
-    if (typeof prompt !== 'string' || !prompt) return null
-    if (typeof ts !== 'number' || Date.now() - ts > HANDOFF_TTL_MS) return null
-    return prompt
-  } catch {
-    return null
-  }
+  const queued = decodeChatHandoffs(raw)
+  const next = queued.shift()
+  if (!next) return null
+  if (queued.length) safeSetSessionItem(ERROR_HANDOFF_KEY, JSON.stringify(queued))
+  return next.prompt
 }
+
+// Module evaluation is the page-lifetime boundary: it repeats on reload but not
+// on a same-document React remount, which is exactly when claimed work is orphaned.
+recoverClaimedChatHandoffs()
 
 // ── Soft-navigation seam ─────────────────────────────────────────────────────
 //
@@ -345,7 +464,7 @@ export function subscribeChatHandoff(fn: () => void): () => void {
 }
 
 /**
- * Stage the prompt and get the user to the composer.
+ * Stage the prompt and get the user to a fresh chat session.
  *
  * `hard: true` forces a full page load — for the root ErrorBoundary, where a
  * soft navigation would re-render the very tree that just threw.

--- a/website/src/utils/navIntent.ts
+++ b/website/src/utils/navIntent.ts
@@ -12,9 +12,9 @@ import { safeSetSessionItem } from './safeStorage'
  */
 export const PREFILL_STORAGE_KEY = 'kirocrew_prefill'
 
-/** Seed the composer prefill for a slot (consumed by ChatPage when that slot activates). */
-export function writePrefill(slotKey: string, prompt: string): void {
-  safeSetSessionItem(PREFILL_STORAGE_KEY, JSON.stringify({ slotKey, prompt, ts: Date.now() }))
+/** Seed the composer prefill for a slot. Returns whether sessionStorage accepted it. */
+export function writePrefill(slotKey: string, prompt: string): boolean {
+  return safeSetSessionItem(PREFILL_STORAGE_KEY, JSON.stringify({ slotKey, prompt, ts: Date.now() }))
 }
 
 /**


### PR DESCRIPTION
## Problem / Motivation

The **Ask the agent** action on an error surface merged its prepared diagnostic prompt into the active chat's composer. The action is intended to start a separate diagnostic conversation instead of changing an in-progress draft or attaching error context to unrelated work.

## Why it matters

A fresh session preserves the current session's draft and history while giving the diagnostic prompt an isolated context. Rapid handoffs, long disconnects, and a reload while asynchronous session creation is in progress must not drop, reorder, or overwrite diagnostics.

## What changed (motivation → approach → change)

`ChatPage` now serializes one create/prefill/switch sequence at a time after connectivity returns. Each diagnostic is seeded through the fresh slot's keyed prefill before activation, preserving the current session and preventing a later handoff from replacing an earlier slot's prompt. The processor waits for bounded in-component acknowledgment that the keyed prefill was consumed before advancing, while a late session-detail fetch never rewrites the composer. Identical clicks already active or queued are deduplicated.

A lifecycle ownership token invalidates stale async processors across cleanup/remount, so an abandoned create cannot clear a newer component's recovery snapshot or steal active-slot focus. Cleanup and failure paths atomically re-stage the nondurable active prompt with all queued successors in original FIFO order and stop local processing after the first failure.

The persistent `sessionStorage` ingress channel is an append-only FIFO that accepts both the legacy single-entry wire shape and the queued shape. A separate claimed-handoff snapshot durably mirrors the active nondurable prompt and locally queued successors before ingress is drained. On a full reload, claimed work is promoted ahead of newer ingress entries; after `writePrefill` succeeds, the keyed prefill becomes the durable owner and the claimed copy is cleared. Creation failures retain the existing behavior of re-staging the complete FIFO into the 60-second ingress channel without an immediate retry loop. Keyed-prefill persistence now reports success explicitly; if browser storage rejects that write, the processor does not mark the prompt durable or activate an empty session, and instead preserves the active prompt plus queued successors through the same atomic recovery path.

## Tests

- Focused error-handoff regressions: 74 passed
  - hard-reload and already-mounted handoffs
  - prior draft/history preservation and fresh-slot activation
  - rapid successful handoffs remain sequential and keep each prompt with its slot
  - concurrent failures re-stage both diagnostics in FIFO order
  - disconnected handoffs survive beyond the ingress TTL and reconnect correctly
  - active and locally queued diagnostics survive reload during a pending `createSlot`
  - claimed work recovers ahead of newer ingress entries
  - late session-detail completion preserves edits typed after keyed prefill
  - create failure re-stages the complete FIFO and stops processing
  - stale unmounted processors cannot clear remounted claims or steal focus
  - rejected keyed-prefill persistence preserves active and queued diagnostics without activating an empty slot
  - localized creation-failure recovery copy
- Complete `npm test` passed (website and Electron phases; Electron: 1,173 passed, 1 skipped)
- TypeScript: passed
- Targeted ESLint: 0 errors (repository-existing warnings only)
- Production frontend build: passed
- `git diff --check`: passed
- Full backend suite and Python lint/type checks passed before publication; backend is unchanged by this PR

## Manual verification

N/A — this is routing, queueing, and recovery behavior with no component/layout/style redesign. Deterministic session routing, reload recovery, and composer preservation are covered by `ChatPage` regressions.

## Related Issues

No linked issue: no matching tracker item exists for this requested behavior change.

## Checklist

- [x] Conventional Commits titles (`fix: ...`)
- [x] Existing tests pass and new tests added for the changed behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated where applicable (handoff comments)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — no contributor action is defined by the repository template yet.

<!-- no-visual-delta -->
**Why no screenshot:** This change adds no component, layout, or styling delta. It reuses an existing localized recovery notification only when session creation fails; a still image cannot demonstrate FIFO preservation, serialized fresh-session routing, reload recovery, reconnect survival, or preservation of the prior session's draft and history.
