### PR TITLE
feat(apps): give Channels, Dev Fleet and Workflows their own icons

### DIFF
--- a/src/kiro_crew/apps/builtins/channels/app.json
+++ b/src/kiro_crew/apps/builtins/channels/app.json
@@ -34,5 +34,6 @@
         "icon": "Users"
       }
     ]
-  }
+  },
+  "iconUrl": "/app-assets/channels/icon.svg"
 }

--- a/src/kiro_crew/apps/builtins/dev_fleet/app.json
+++ b/src/kiro_crew/apps/builtins/dev_fleet/app.json
@@ -38,6 +38,7 @@
     "port": "auto",
     "healthCheck": "/health"
   },
+  "iconUrl": "/app-assets/dev-fleet/icon.svg",
   "heroImage": "/app-assets/dev-fleet/hero-light.svg",
   "heroImageDark": "/app-assets/dev-fleet/hero-dark.svg",
   "heroImageDetail": "/app-assets/dev-fleet/hero-detail-light.svg",

--- a/src/kiro_crew/apps/builtins/workflows/app.json
+++ b/src/kiro_crew/apps/builtins/workflows/app.json
@@ -41,6 +41,7 @@
     "port": "auto",
     "healthCheck": "/health"
   },
+  "iconUrl": "/app-assets/workflows/icon.svg",
   "heroImage": "/app-assets/workflows/hero-light.svg",
   "heroImageDark": "/app-assets/workflows/hero-dark.svg",
   "heroImageDetail": "/app-assets/workflows/hero-detail-light.svg",

--- a/test/test_builtin_app_assets.py
+++ b/test/test_builtin_app_assets.py
@@ -60,13 +60,63 @@ def test_all_builtin_app_assets_exist() -> None:
     assert not missing, "builtin app-asset references with no file:\n" + "\n".join(missing)
 
 
-def test_agent_worlds_icon_wired_to_svg() -> None:
-    """Agent Worlds surfaces its colorful icon via top-level iconUrl.
+def test_every_builtin_declares_an_icon() -> None:
+    """Every builtin names its own mark in ``iconUrl``.
 
-    Regression: the shipped ``worlds/icon.svg`` was present but unreferenced, so
-    the app fell back to the lucide Gamepad2 glyph in both the store and nav.
+    Existence checks alone leave the store green when a manifest omits ``iconUrl``
+    entirely: the app then falls through ``AppIconTile``'s last resort — a
+    name-hashed gradient carrying the generic lucide ``Package`` glyph — and reads
+    as a stray placeholder among 20 apps that have real identities. That is how
+    Channels, Dev Fleet and Workflows shipped iconless, and how Dev Fleet's
+    ``icon.svg`` sat on disk unreferenced. The lucide name under
+    ``ui.pages[].icon`` does not substitute: it dresses the sidebar nav row, and
+    ``AppIcon``'s ICON_MAP carries only a handful of names, so most fall back to
+    ``Package`` too.
+    """
+    iconless = [
+        a.get("name") for a in _all_builtin_apps()
+        if not isinstance(a.get("iconUrl"), str) or not a["iconUrl"]
+    ]
+    assert not iconless, (
+        "builtins with no iconUrl (they render the gradient + Package "
+        f"placeholder): {sorted(map(str, iconless))}"
+    )
+
+
+def test_builtin_svg_icons_are_themeable() -> None:
+    """Builtin SVG icons paint through the ``--ico-a``/``--ico-b`` tokens.
+
+    ``AppIcon`` inlines these SVGs specifically so the active theme cascades in,
+    driving idle (muted + accent highlight) versus selected (accent-dominant)
+    from two custom properties. An icon that hardcodes its colours — a lucide
+    glyph pasted in with ``stroke="#8b90a5"``, say — opts out of both states: it
+    never lights up on selection and it keeps a light-theme grey on dark themes,
+    where it is the one low-contrast mark in the list. Raster icons are exempt;
+    their bytes are fixed, which is what ``iconUrlDark`` exists for.
+    """
+    unthemed: list[str] = []
+    for app in _all_builtin_apps():
+        for field, path in _asset_refs(app):
+            if field != "iconUrl" or not path.endswith(".svg"):
+                continue
+            markup = _resolve(path).read_text(encoding="utf-8")
+            if "--ico-a" not in markup and "--ico-b" not in markup:
+                unthemed.append(f"{app.get('name')} -> {path}")
+    assert not unthemed, (
+        "builtin SVG icons with hardcoded colours instead of --ico-a/--ico-b:\n"
+        + "\n".join(unthemed)
+    )
+
+
+def test_agent_worlds_icon_wired_to_svg() -> None:
+    """Agent Worlds' ``iconUrl`` still points at ``worlds/icon.svg`` specifically.
+
+    Only the literal path is this test's own: that the value exists is covered by
+    ``test_every_builtin_declares_an_icon`` and that it resolves by
+    ``test_all_builtin_app_assets_exist``. What neither can see is a manifest
+    silently repointed at some other app's art, which renders a plausible icon
+    and reads as green.
     """
     worlds = next((a for a in _all_builtin_apps() if a["name"] == "agent-worlds"), None)
     assert worlds is not None, "agent-worlds builtin missing from every registration path"
     assert worlds.get("iconUrl") == "/app-assets/worlds/icon.svg"
-    assert _resolve(worlds["iconUrl"]).is_file()

--- a/website/public/app-assets/channels/icon.svg
+++ b/website/public/app-assets/channels/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <!-- One room, drawn as a single bubble: the app's thesis is that there is no
+       private agent-to-agent channel, so every participant and every link has to
+       sit INSIDE one container rather than beside it. -->
+  <path d="M5.8,3.4 L18.2,3.4 Q21.4,3.4 21.4,6.6 L21.4,14.4 Q21.4,17.6 18.2,17.6 L10.6,17.6 L6.6,21.2 L6.6,17.6 L5.8,17.6 Q2.6,17.6 2.6,14.4 L2.6,6.6 Q2.6,3.4 5.8,3.4 Z" fill="var(--ico-a, currentColor)" fill-opacity="0.16" stroke="var(--ico-a, currentColor)" stroke-width="1.7" stroke-linejoin="round"/>
+  <!-- Three role-assigned agents, mutually linked: the closed triangle is the
+       readable transcript — each pair's exchange is visible to the third. -->
+  <path d="M8.2,8.2 L15.8,8.2 L12,13.2 Z" stroke="var(--ico-b, currentColor)" stroke-width="1.3" stroke-opacity="0.6" stroke-linejoin="round"/>
+  <circle cx="8.2" cy="8.2" r="1.75" fill="var(--ico-b, currentColor)"/>
+  <circle cx="15.8" cy="8.2" r="1.75" fill="var(--ico-b, currentColor)" fill-opacity="0.8"/>
+  <circle cx="12" cy="13.2" r="1.75" fill="var(--ico-b, currentColor)" fill-opacity="0.8"/>
+</svg>

--- a/website/public/app-assets/design-tweak/icon.svg
+++ b/website/public/app-assets/design-tweak/icon.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#8b90a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="var(--ico-a, currentColor)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <path d="m14.622 17.897-10.68-2.913"/>
-  <path d="M18.376 2.622a1 1 0 1 1 3.002 3.002L17.36 9.643a.5.5 0 0 0 0 .707l.944.944a2.41 2.41 0 0 1 0 3.408l-.944.944a.5.5 0 0 1-.707 0L8.354 7.348a.5.5 0 0 1 0-.707l.944-.944a2.41 2.41 0 0 1 3.408 0l.944.944a.5.5 0 0 0 .707 0z"/>
+  <path d="M18.376 2.622a1 1 0 1 1 3.002 3.002L17.36 9.643a.5.5 0 0 0 0 .707l.944.944a2.41 2.41 0 0 1 0 3.408l-.944.944a.5.5 0 0 1-.707 0L8.354 7.348a.5.5 0 0 1 0-.707l.944-.944a2.41 2.41 0 0 1 3.408 0l.944.944a.5.5 0 0 0 .707 0z" stroke="var(--ico-b, currentColor)"/>
   <path d="M9 8c-1.804 2.71-3.97 3.46-6.583 3.948a.507.507 0 0 0-.302.819l7.32 8.883a1 1 0 0 0 1.185.204C12.735 20.405 16 16.792 16 15"/>
 </svg>

--- a/website/public/app-assets/dev-fleet/icon.svg
+++ b/website/public/app-assets/dev-fleet/icon.svg
@@ -1,1 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="2" rx="2" ry="2"/><rect width="20" height="8" x="2" y="14" rx="2" ry="2"/><line x1="6" x2="6.01" y1="6" y2="6"/><line x1="6" x2="6.01" y1="18" y2="18"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <!-- Main, with feature worktrees curving off it: the fleet view is a list of
+       branches, not a rack of servers, so the trunk carries the shape. The
+       elbows matter — three straight stubs off a bar read as sliders. -->
+  <line x1="4.6" y1="4.8" x2="4.6" y2="19.2" stroke="var(--ico-a, currentColor)" stroke-width="1.9" stroke-linecap="round" stroke-opacity="0.5"/>
+  <path d="M4.6,9.4 Q4.6,6.4 7.6,6.4 L15.4,6.4" stroke="var(--ico-b, currentColor)" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M4.6,11.6 L12.6,11.6" stroke="var(--ico-a, currentColor)" stroke-width="1.6" stroke-linecap="round" stroke-opacity="0.5"/>
+  <path d="M4.6,14.8 Q4.6,17.8 7.6,17.8 L12.6,17.8" stroke="var(--ico-a, currentColor)" stroke-width="1.6" stroke-linecap="round" stroke-opacity="0.5"/>
+  <!-- One worktree is up as a pod, so it sits further out than the branches it
+       came from: that offset is the app's thesis, and it also keeps the lit node
+       clear of its neighbour at 16px. -->
+  <circle cx="17.8" cy="6.4" r="2.3" fill="var(--ico-b, currentColor)"/>
+  <circle cx="14.8" cy="11.6" r="1.7" fill="var(--ico-a, currentColor)" fill-opacity="0.16" stroke="var(--ico-a, currentColor)" stroke-width="1.4"/>
+  <circle cx="14.8" cy="17.8" r="1.7" fill="var(--ico-a, currentColor)" fill-opacity="0.16" stroke="var(--ico-a, currentColor)" stroke-width="1.4"/>
+</svg>

--- a/website/public/app-assets/workflows/icon.svg
+++ b/website/public/app-assets/workflows/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <!-- One phase fans out to several agents and converges into the next: the graph
+       IS the product here, so the edges are drawn rather than implied by a list. -->
+  <path d="M6.9,10.7 C8.3,8.2 8.3,6.4 9.9,6.4" stroke="var(--ico-a, currentColor)" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.55"/>
+  <path d="M6.9,13.3 C8.3,15.8 8.3,17.6 9.9,17.6" stroke="var(--ico-a, currentColor)" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.55"/>
+  <path d="M14.1,6.4 C15.7,6.4 15.7,8.2 17.1,10.7" stroke="var(--ico-a, currentColor)" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.55"/>
+  <path d="M14.1,17.6 C15.7,17.6 15.7,15.8 17.1,13.3" stroke="var(--ico-a, currentColor)" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.55"/>
+  <!-- Descending fill = the run streaming through: finished, in flight, queued,
+       and an outlined terminal phase not yet reached. -->
+  <circle cx="4.6" cy="12" r="2.4" fill="var(--ico-b, currentColor)"/>
+  <circle cx="12" cy="6.4" r="2.2" fill="var(--ico-b, currentColor)" fill-opacity="0.75"/>
+  <circle cx="12" cy="17.6" r="2.2" fill="var(--ico-b, currentColor)" fill-opacity="0.3"/>
+  <circle cx="19.4" cy="12" r="2.4" fill="var(--ico-a, currentColor)" fill-opacity="0.16" stroke="var(--ico-a, currentColor)" stroke-width="1.7"/>
+</svg>


### PR DESCRIPTION
## What

Three builtin apps shipped with no icon. `channels`, `dev_fleet` and `workflows` declared no top-level `iconUrl`, so `AppIconTile` fell through to its last resort — a name-hashed gradient carrying the generic lucide `Package` glyph — while the other 18 builtins rendered their own mark. The same omission hits the sidebar, which prefers `iconUrl` over the lucide name in `ui.pages[].icon`.

| app | before | after |
|---|---|---|
| `channels` | no `iconUrl`, no `app-assets/channels/` at all | new themeable `icon.svg` |
| `dev_fleet` | no `iconUrl`; `dev-fleet/icon.svg` on disk but unreferenced, and a raw lucide `Server` dump | icon redrawn on the theme tokens, wired up |
| `workflows` | no `iconUrl`, only hero art | new themeable `icon.svg` |
| `design_tweak` | had an icon, but hardcoded `stroke="#8b90a5"` | same paths, now on `--ico-a`/`--ico-b` |

`design_tweak` is the same defect one step along: because it hardcoded its colour it opted out of both of `AppIcon`'s states — it never lit up on selection, and it kept a light-theme grey on dark themes, where it was the one low-contrast mark in the list. The paths are untouched; only the colour source changed.

## The icons

Each follows the existing vocabulary: a 24×24 viewBox, `--ico-a` for structure and `--ico-b` for the thesis element, and descending `fill-opacity` for sequence.

- **Channels** — three linked agents *inside* one bubble. The app's premise is that there is no private agent-to-agent channel, so the participants and every link between them had to sit inside one container; the closed triangle is the readable transcript.
- **Dev Fleet** — worktrees curving off main, with one lifted further out as a running pod. The offset is the app's thesis (any worktree can come up as an isolated instance) and it also keeps the lit node clear of its neighbour at 16px. Three straight stubs off a bar read as a sliders glyph, hence the elbows.
- **Workflows** — one phase fanning out to several agents and converging into the next, the nodes filled by run progress: finished, in flight, queued, and an outlined terminal phase not yet reached.

All three were rendered and checked at 96px, 30px and the 16px sidebar size against four existing icons before being committed.

## Why it shipped green

`test_builtin_app_assets.py` guarded that every `/app-assets/…` reference *resolves to a file*. It could not see either failure mode here: a manifest that names no asset at all has nothing to resolve, and a file that resolves fine can still hardcode its colours. Two guards close that:

- `test_every_builtin_declares_an_icon` — every builtin names its own mark. The lucide name under `ui.pages[].icon` does not substitute: it dresses the sidebar nav row, and `AppIcon`'s `ICON_MAP` carries only a handful of names, so most of them land on `Package` too.
- `test_builtin_svg_icons_are_themeable` — every builtin SVG icon paints through `--ico-a`/`--ico-b`, which is the whole reason `AppIcon` inlines them rather than using `<img>`. Raster icons are exempt; their bytes are fixed, which is what `iconUrlDark` is for.

Both were mutation-checked: dropping `iconUrl` from a manifest and hardcoding a hex in an icon each turn the corresponding test red, and both go green again on restore.

## Verification

- `pytest` (full suite, 56925 passed) — 70 failures, each reproduced on a clean `origin/main` with the same interpreter. The one branch-only difference is `test_browser_recording_skill.py::test_records_a_webm`, which *skips* on a tree without `website/node_modules` and fails on this host once they exist because Playwright needs Node ≥18 and the host runs 16. Unrelated to this change; CI runs Node 22.
- `isort`, `flake8` clean. `mypy src/kiro_crew/` clean at the pinned 1.14.1 without `faiss`, i.e. CI parity.
- `tsc -b`, `eslint src/ --max-warnings 1116`, `jscpd` clean. `vitest run`: 1395 files, 21633 passed, 2 expected fail, 3 skipped.
- `check_black_formatting.py` reports `0 new offender(s), 7 graduated entr(y/ies) to prune` — reproduced identically on clean `origin/main`; it is local black 24.10.0 against the repo's pinned 26.3.1, not this branch.
- `npm run build` confirms all three `icon.svg` files land in `dist/app-assets/`, which is where the gateway's `/app-assets` mount serves from.
