### PR TITLE
fix: make probe-derived system metrics optional in SystemData (#4466)

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -32,6 +32,7 @@ import { api, isAuthBannerShown } from './api/client'
 import type { KiroCreditUsage, KiroUsagePayload } from './api/client'
 import { safeSetItem } from './utils/safeStorage'
 import { gcOrphanedStorage } from './utils/storageGc'
+import { isMetricNumber, metricNumber } from './utils/metrics'
 import { Rocket, Menu, Bell, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, AudioWaveform, ChevronUp, MoreHorizontal, Coins, ArrowLeftToLine, LayoutGrid, SquareTerminal, Bot, Search as SearchIcon } from 'lucide-react'
 import { GithubIcon, DiscordIcon } from './components/BrandIcon'
 import { Toggle } from './components/ui'
@@ -188,7 +189,7 @@ export const memColorClass = metricColor
  * app-shell boundary; `api.system()` returns `any`, so only this annotation
  * makes the compiler check the guards.
  */
-export type SysMetricsFrame = {
+type SysMetricsFrame = {
   memUsed?: number
   memTotal?: number
   cpuPct?: number
@@ -199,22 +200,6 @@ export type SysMetricsFrame = {
   subagentCap?: number
 }
 
-/** Narrow a possibly-absent metric to a formattable number (excludes NaN/Infinity). */
-export function isMetricNumber(v: unknown): v is number {
-  return typeof v === 'number' && Number.isFinite(v)
-}
-
-/**
- * Coerce a possibly-absent metric to a finite number, absent/NaN/Infinity -> 0.
- *
- * Paired with `isMetricNumber`: the guard decides whether a readout is SHOWN,
- * this makes the formatting itself unable to throw, so a future gate that
- * forgets a field degrades to a wrong-looking 0 instead of unmounting the app.
- */
-export function metricNumber(v: unknown): number {
-  return isMetricNumber(v) ? v : 0
-}
-
 /**
  * Validity flags + a sanitized frame for one metrics readout.
  *
@@ -223,7 +208,7 @@ export function metricNumber(v: unknown): number {
  * about `memUsed`, and formatting a value the flag never proved is what crashed
  * the shell.
  */
-export function readMetricsFrame(raw: SysMetricsFrame) {
+function readMetricsFrame(raw: SysMetricsFrame) {
   return {
     cpuValid: isMetricNumber(raw.cpuPct),
     memValid: isMetricNumber(raw.memUsed) && isMetricNumber(raw.memTotal) && raw.memTotal > 0,

--- a/website/src/pages/system/PerformanceTab.tsx
+++ b/website/src/pages/system/PerformanceTab.tsx
@@ -13,6 +13,7 @@ import { api } from '../../api/client'
 import { Card } from '../../components/ui'
 import { fmtBytes, fmtNumber, fmtPercent, fmtUnit } from '../../i18n/format'
 import { i18nT } from '../../i18n/t'
+import { isMetricNumber, metricNumber } from '../../utils/metrics'
 import type { SessionStorageReport, SystemData } from '../../types'
 import type { PlaneState } from '../SystemPage'
 import SessionStorageScreen from './SessionStorageScreen'
@@ -33,15 +34,27 @@ interface HistoryPoint {
   netTx: number
 }
 
-/** Headline value shown on the left rail tile for each resource. */
+/** Headline value shown on the left rail tile for each resource.
+ *
+ * Probe-derived fields are optional (see SystemData), so each headline proves
+ * its inputs before dividing — the same predicate set as the topbar capsule's
+ * memValid/dskValid, so one frame cannot show '—' in the topbar and a number
+ * here. A zero total means "unmeasured", not "divide by a placeholder": the
+ * frame {mem_used_gb: 4, mem_total_gb: 0} must read '—', never 400%.
+ */
 function headline(d: SystemData | null, resource: Resource): string {
   if (!d) return '—'
   switch (resource) {
-    case 'cpu': return fmtPercent(d.cpu_pct / 100)
-    case 'memory': return fmtPercent(d.mem_used_gb / (d.mem_total_gb || 1))
+    case 'cpu':
+      return isMetricNumber(d.cpu_pct) ? fmtPercent(d.cpu_pct / 100) : '—'
+    case 'memory':
+      return isMetricNumber(d.mem_used_gb) && isMetricNumber(d.mem_total_gb) && d.mem_total_gb > 0
+        ? fmtPercent(d.mem_used_gb / d.mem_total_gb)
+        : '—'
     case 'disk': {
+      if (!isMetricNumber(d.disk_total_gb) || d.disk_total_gb <= 0 || !isMetricNumber(d.disk_free_gb)) return '—'
       const used = d.disk_total_gb - d.disk_free_gb
-      return fmtPercent(used / (d.disk_total_gb || 1))
+      return fmtPercent(used / d.disk_total_gb)
     }
     case 'network': return fmtUnit(d.net_rx_kbs + d.net_tx_kbs, 'kilobyte-per-second', { maximumFractionDigits: 0 })
   }
@@ -120,12 +133,25 @@ export default function PerformanceTab({ planeStateRef }: { planeStateRef: Mutab
     if (!data || !dataUpdatedAt) return
     if (dataUpdatedAt === lastDataId.current) return
     lastDataId.current = dataUpdatedAt
+    // The history buffer requires numbers, but any probe-derived field can be
+    // absent (see SystemData) — including net_rx_kbs/net_tx_kbs, which the
+    // server assigns inside the same per-probe try/except. An unmeasured
+    // sample records as 0 (a one-sample dip; the tile headline's '—' is the
+    // signal that it was unmeasured, and fabricating a carried-forward value
+    // would be worse) — never NaN, which would render as invalid clip-path
+    // vertices and blank the trace for the whole buffer. A subtraction from
+    // an absent operand must not coerce it: a missing disk_free_gb would
+    // otherwise read as a 100%-full disk.
+    const memTotal = metricNumber(data.mem_total_gb)
+    const diskTotal = metricNumber(data.disk_total_gb)
     const point: HistoryPoint = {
-      cpu: data.cpu_pct,
-      mem: data.mem_total_gb > 0 ? (data.mem_used_gb / data.mem_total_gb) * 100 : 0,
-      disk: data.disk_total_gb > 0 ? ((data.disk_total_gb - data.disk_free_gb) / data.disk_total_gb) * 100 : 0,
-      netRx: data.net_rx_kbs,
-      netTx: data.net_tx_kbs,
+      cpu: metricNumber(data.cpu_pct),
+      mem: memTotal > 0 ? (metricNumber(data.mem_used_gb) / memTotal) * 100 : 0,
+      disk: diskTotal > 0 && isMetricNumber(data.disk_free_gb)
+        ? ((diskTotal - data.disk_free_gb) / diskTotal) * 100
+        : 0,
+      netRx: metricNumber(data.net_rx_kbs),
+      netTx: metricNumber(data.net_tx_kbs),
     }
     setHistory(prev => {
       const next = [...prev, point]
@@ -400,7 +426,9 @@ function ResourceSubtitle({ d, resource }: { d: SystemData | null; resource: Res
       return (
         <>
           {i18nT('pages.performanceTab.memory_subtitle', {
-            size: fmtUnit(d.mem_total_gb, 'gigabyte', { maximumFractionDigits: 1 }),
+            size: isMetricNumber(d.mem_total_gb)
+              ? fmtUnit(d.mem_total_gb, 'gigabyte', { maximumFractionDigits: 1 })
+              : '—',
           })}
         </>
       )
@@ -408,7 +436,9 @@ function ResourceSubtitle({ d, resource }: { d: SystemData | null; resource: Res
       return (
         <>
           {i18nT('pages.performanceTab.disk_subtitle', {
-            size: fmtUnit(d.disk_total_gb, 'gigabyte', { maximumFractionDigits: 0 }),
+            size: isMetricNumber(d.disk_total_gb)
+              ? fmtUnit(d.disk_total_gb, 'gigabyte', { maximumFractionDigits: 0 })
+              : '—',
           })}
         </>
       )
@@ -425,7 +455,7 @@ function ResourceStats({ d, resource }: { d: SystemData | null; resource: Resour
     case 'cpu':
       return (
         <>
-          <Stat label={i18nT('pages.performanceTab.utilization')} value={fmtPercent(d.cpu_pct / 100)} />
+          <Stat label={i18nT('pages.performanceTab.utilization')} value={isMetricNumber(d.cpu_pct) ? fmtPercent(d.cpu_pct / 100) : '—'} />
           <Stat label={i18nT('pages.performanceTab.gateway_cpu')} value={fmtPercent(d.proc_cpu_pct / 100)} />
           <Stat label={i18nT('pages.performanceTab.cores')} value={fmtNumber(d.cpu_count)} />
           <Stat label={i18nT('pages.performanceTab.load_1m')} value={fmtNumber(d.load_1m, { maximumFractionDigits: 2 })} />
@@ -446,20 +476,24 @@ function ResourceStats({ d, resource }: { d: SystemData | null; resource: Resour
     case 'memory':
       return (
         <>
-          <Stat label={i18nT('pages.performanceTab.total')} value={fmtUnit(d.mem_total_gb, 'gigabyte', { maximumFractionDigits: 1 })} />
-          <Stat label={i18nT('pages.performanceTab.used')} value={fmtUnit(d.mem_used_gb, 'gigabyte', { maximumFractionDigits: 1 })} />
-          <Stat label={i18nT('pages.performanceTab.free')} value={fmtUnit(d.mem_free_gb, 'gigabyte', { maximumFractionDigits: 1 })} />
+          <Stat label={i18nT('pages.performanceTab.total')} value={isMetricNumber(d.mem_total_gb) ? fmtUnit(d.mem_total_gb, 'gigabyte', { maximumFractionDigits: 1 }) : '—'} />
+          <Stat label={i18nT('pages.performanceTab.used')} value={isMetricNumber(d.mem_used_gb) ? fmtUnit(d.mem_used_gb, 'gigabyte', { maximumFractionDigits: 1 }) : '—'} />
+          <Stat label={i18nT('pages.performanceTab.free')} value={isMetricNumber(d.mem_free_gb) ? fmtUnit(d.mem_free_gb, 'gigabyte', { maximumFractionDigits: 1 }) : '—'} />
           <Stat label={i18nT('pages.performanceTab.gateway_rss')} value={fmtUnit(d.proc_mem_mb, 'megabyte', { maximumFractionDigits: 0 })} />
         </>
       )
     case 'disk':
       return (
         <>
-          <Stat label={i18nT('pages.performanceTab.total')} value={fmtUnit(d.disk_total_gb, 'gigabyte', { maximumFractionDigits: 0 })} />
-          <Stat label={i18nT('pages.performanceTab.free')} value={fmtUnit(d.disk_free_gb, 'gigabyte', { maximumFractionDigits: 0 })} />
+          <Stat label={i18nT('pages.performanceTab.total')} value={isMetricNumber(d.disk_total_gb) ? fmtUnit(d.disk_total_gb, 'gigabyte', { maximumFractionDigits: 0 }) : '—'} />
+          <Stat label={i18nT('pages.performanceTab.free')} value={isMetricNumber(d.disk_free_gb) ? fmtUnit(d.disk_free_gb, 'gigabyte', { maximumFractionDigits: 0 }) : '—'} />
           <Stat
             label={i18nT('pages.performanceTab.used_pct')}
-            value={fmtPercent((d.disk_total_gb - d.disk_free_gb) / (d.disk_total_gb || 1))}
+            value={
+              isMetricNumber(d.disk_total_gb) && d.disk_total_gb > 0 && isMetricNumber(d.disk_free_gb)
+                ? fmtPercent((d.disk_total_gb - d.disk_free_gb) / d.disk_total_gb)
+                : '—'
+            }
           />
         </>
       )

--- a/website/src/test/PerformancePartialFrame.test.tsx
+++ b/website/src/test/PerformancePartialFrame.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { createRef, type MutableRefObject } from 'react'
+import { renderWithProviders } from './helpers'
+import PerformanceTab from '../pages/system/PerformanceTab'
+import type { PlaneState } from '../pages/SystemPage'
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as typeof ResizeObserver
+
+// Fields the static info block guarantees; every frame below carries these.
+const STATIC = {
+  hostname: 'test',
+  os: 'linux',
+  python: '3.12',
+  cwd: '/tmp',
+  arch: 'x86_64',
+  cpu_count: 8,
+  load_1m: 1,
+  load_5m: 1,
+  load_15m: 1,
+  proc_cpu_pct: 1,
+  proc_mem_mb: 200,
+  thread_count: 10,
+  ip: '127.0.0.1',
+  mcp_total: 2,
+}
+
+const systemMock = vi.fn()
+
+vi.mock('../api/client', () => ({
+  api: { system: () => systemMock() },
+}))
+
+async function mountAndSample() {
+  const ref = createRef<PlaneState>() as MutableRefObject<PlaneState>
+  ref.current = {}
+  renderWithProviders(<PerformanceTab planeStateRef={ref} />)
+  await waitFor(() => {
+    expect(ref.current.performance?.history.length).toBeGreaterThan(0)
+  }, { timeout: 8000 })
+  return ref
+}
+
+describe('PerformanceTab with a partial metrics frame', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('renders placeholders for failed probes and never lets NaN into the history', async () => {
+    // Failed cpu, memory-used and network probes: the server skips their keys,
+    // while the cached static info still supplies mem_total_gb. An ordinary
+    // outcome, not a corrupt payload.
+    systemMock.mockResolvedValue({
+      ...STATIC,
+      mem_total_gb: 16,
+      disk_total_gb: 500,
+      disk_free_gb: 250,
+    })
+    const ref = await mountAndSample()
+
+    // cpu_pct and mem_used_gb are absent, so the CPU and Memory rail tiles show
+    // the placeholder instead of a percentage computed from nothing.
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2)
+
+    // Absent probes degrade their history samples to 0; the intact disk probe
+    // still yields its real value. NaN must never enter the buffer — it would
+    // render as invalid clip-path vertices, a silently blank trace.
+    const pt = ref.current.performance!.history[0]
+    expect(pt.cpu).toBe(0)
+    expect(pt.mem).toBe(0)
+    expect(pt.disk).toBeCloseTo(50)
+    expect(pt.netRx).toBe(0)
+    expect(pt.netTx).toBe(0)
+    for (const v of [pt.cpu, pt.mem, pt.disk, pt.netRx, pt.netTx]) {
+      expect(Number.isFinite(v)).toBe(true)
+    }
+  })
+
+  it('records a missing disk_free_gb sample as 0, never as a full disk', async () => {
+    // A frame with a total but no free reading: coercing the absent operand to
+    // 0 would invert "unmeasured" into a false 100%-full alarm on the graph.
+    systemMock.mockResolvedValue({
+      ...STATIC,
+      cpu_pct: 25,
+      mem_used_gb: 4,
+      mem_total_gb: 16,
+      net_rx_kbs: 10,
+      net_tx_kbs: 5,
+      disk_total_gb: 500,
+    })
+    const ref = await mountAndSample()
+    const pt = ref.current.performance!.history[0]
+    expect(pt.disk).toBe(0)
+  })
+
+  it('shows the placeholder for a zero total instead of dividing by a stand-in', async () => {
+    // Declared supported by the topbar regression tests: mem_total_gb 0 with a
+    // finite mem_used_gb. The rail must agree with the topbar's '—', not
+    // fabricate 400% from a stand-in denominator.
+    systemMock.mockResolvedValue({
+      ...STATIC,
+      cpu_pct: 25,
+      mem_used_gb: 4,
+      mem_total_gb: 0,
+      disk_total_gb: 0,
+      disk_free_gb: 0,
+      net_rx_kbs: 0,
+      net_tx_kbs: 0,
+    })
+    await mountAndSample()
+    expect(screen.queryByText(/400/)).toBeNull()
+    // Memory and Disk tiles both read '—'.
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -64,11 +64,20 @@ export interface StatusData {
 
 export interface SystemData {
   hostname: string; os: string; arch: string; cpu_count: number
-  load_1m: number; load_5m: number; load_15m: number; cpu_pct: number
-  mem_total_gb: number; mem_used_gb: number; mem_free_gb: number
+  load_1m: number; load_5m: number; load_15m: number
+  /**
+   * Probe-derived metrics are OPTIONAL by construction. The server assembles
+   * `/api/system` key-by-key under a per-probe `try/except: pass`, seeded from
+   * cached static info — so a frame carrying `mem_total_gb` (static cache) with
+   * no `mem_used_gb` (live probe failed or returned nothing) is an ordinary
+   * outcome, not an error. Narrow through `utils/metrics.ts` before any
+   * arithmetic or formatting; a bare `.toFixed()` on one of these is a crash.
+   */
+  cpu_pct?: number
+  mem_total_gb?: number; mem_used_gb?: number; mem_free_gb?: number
   ip: string; net_rx_mb: number; net_tx_mb: number
   net_rx_kbs: number; net_tx_kbs: number
-  disk_total_gb: number; disk_free_gb: number
+  disk_total_gb?: number; disk_free_gb?: number
   python: string; pid: number; cwd: string
   proc_mem_mb: number; proc_cpu_pct: number
   child_processes: number; thread_count: number

--- a/website/src/utils/metrics.ts
+++ b/website/src/utils/metrics.ts
@@ -1,0 +1,30 @@
+/**
+ * Narrowing predicates for probe-derived `/api/system` metrics.
+ *
+ * The server builds that payload key-by-key with a per-probe
+ * `try/except: pass`, seeded from cached static system info, so any
+ * probe-derived field (`cpu_pct`, the `mem_*_gb` trio, the `disk_*_gb`
+ * pair) can be absent on an ordinary frame — a memory total with no used
+ * value is normal, not corrupt. A failed probe can also surface as
+ * NaN/Infinity when a consumer divides by an unmeasured total.
+ *
+ * Every reader of those fields (the topbar metrics capsule and the System
+ * page tabs) narrows through these two helpers, so the frame is proven
+ * formattable in exactly one way instead of one way per consumer.
+ */
+
+/** Narrow a possibly-absent metric to a formattable number (excludes NaN/Infinity). */
+export function isMetricNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+/**
+ * Coerce a possibly-absent metric to a finite number, absent/NaN/Infinity -> 0.
+ *
+ * Paired with `isMetricNumber`: the guard decides whether a readout is SHOWN,
+ * this makes the formatting itself unable to throw, so a future gate that
+ * forgets a field degrades to a wrong-looking 0 instead of unmounting the app.
+ */
+export function metricNumber(v: unknown): number {
+  return isMetricNumber(v) ? v : 0
+}


### PR DESCRIPTION
## Problem

`SystemData` in `website/src/types/index.ts` declares six probe-derived `/api/system` fields as required numbers: `cpu_pct`, `mem_total_gb`, `mem_used_gb`, `mem_free_gb`, `disk_total_gb`, `disk_free_gb`. The server does not guarantee them: `_collect_system_metrics` builds the payload key-by-key under per-probe `try/except: pass`, seeded from cached static info — so a frame with a memory total but no used value is an ordinary outcome (vm_stat timeout on macOS, unreadable `/proc/meminfo` in a restricted container, `system_memory()` returning `None` on Windows).

## Why it matters

This exact type-level overstatement already produced a user-visible crash: a dashboard white-screen (`TypeError: Cannot read properties of undefined (reading 'toFixed')`) at app-shell scope, fixed for one consumer in #4452. Two consumers (`PerformanceTab`, `ServicesTab`) still read through the required-field contract, and the lie will mislead the next person who writes a bare `.toFixed()` against these fields — which is exactly how the first crash happened.

## Fix (symptoms → root cause → change)

The root cause is the contract, not the consumers — the server's per-probe tolerance is intended behavior the type must admit.

1. **`website/src/types/index.ts`** — the six probe-derived fields become optional, with a comment stating why. Static-info fields (hostname, os, arch, pid, …) stay required: they are not probe-gated.
2. **`website/src/utils/metrics.ts` (new)** — `isMetricNumber` / `metricNumber` lifted out of `App.tsx` so all consumers narrow the frame one way. This supersedes the "narrow the four unused exports" subtraction from #4452's review: the predicates gained real importers, and `SysMetricsFrame` / `readMetricsFrame` went module-private in `App.tsx` (no importers, verified by grep).
3. **`website/src/pages/system/PerformanceTab.tsx`** — the guards `tsc -b` then demands, expressed as narrowing (no `!`, no casts):
   - headline / subtitle / stats render `—` for an absent probe (same glyph the formatters emit for non-finite input);
   - the memory/disk percentage sites now require a finite total `> 0` instead of dividing by `(total || 1)` — the frame `{mem_used_gb: 4, mem_total_gb: 0}` (declared supported by the topbar regression tests) previously rendered **400%** here while the topbar showed `—`; both now agree, using the same predicate set as `memValid`/`dskValid`;
   - the history buffer coerces absent probes to 0 so NaN can never reach the clip-path vertices, with one asymmetry handled explicitly: a missing `disk_free_gb` must not be coerced inside the subtraction, or an unmeasured disk records as 100% full. `net_rx_kbs`/`net_tx_kbs` are wrapped too — the server assigns them inside the same `try/except`, and an omitted pair previously poisoned the network trace with NaN for the whole 30-sample buffer.
4. `ServicesTab.tsx` needed no change: it reads none of the six fields (`tsc -b` confirms), so it takes the corrected contract without edits.

Out of scope, noted for follow-up: `net_rx_kbs`/`net_tx_kbs`/`net_rx_mb`/`net_tx_mb`/`load_*` come from the same `except: pass` blocks and are still typed required. This PR guards the one render defect reachable through them (the history buffer); the type-accuracy correction is deliberately left out to keep this PR on the six fields the issue enumerates.

## Tests

`website/src/test/PerformancePartialFrame.test.tsx` (new), locking the real guards:
- a partial frame (failed cpu/mem-used/net probes) renders placeholders and only finite values enter the history buffer;
- a frame with `disk_total_gb` but no `disk_free_gb` records the sample as 0, never as a false 100%-full reading;
- a zero-total frame renders `—` and never 400% (`queryByText(/400/)` is asserted null).

The existing partial-frame regression tests in `App.test.tsx` stay green unchanged.

## Manual verification

N/A — unit coverage is sufficient: the normal path (all probes present) is output-identical to base (verified by a focused diff review), and the degraded frames are asserted directly in vitest. Producing a genuinely degraded frame end-to-end would require breaking the host's own probes.

Gates run locally (node:22 / python:3.12 containers): `npx tsc -b` 0 — and a falsification probe confirmed an unguarded `d.cpu_pct.toFixed()` now fails with TS18048; vitest 1396 files / 21634 passed including the new tests; `npm run build` 0; eslint 0 errors; i18n:check 0; brand + scrub-lint clean; backend isort/flake8/mypy/black-gate green (no backend files touched).

## Screenshots

<!-- no-visual-delta -->
**Why no screenshot:** the normal path (all probes reporting) renders pixel-identical to base — verified by a focused diff review. The renders this PR changes exist only in probe-failure states (placeholder instead of a fabricated 400%/100% reading), which cannot be produced end-to-end without breaking the host's own probes; those DOM outputs are asserted directly in `PerformancePartialFrame.test.tsx`.

Closes #4466

