### PR TITLE
fix: judge a git checkout out of date by commit distance

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -823,10 +823,39 @@ underlying `journalctl`/`tail` process.
 
 ## Dashboard Self-Update
 
-On gateway startup and every 12 hours, a background task runs `git fetch`
-and compares the remote `__version__` with the local version. Only triggers
-when the remote version is strictly higher (commits without a version bump
-are ignored).
+On gateway startup and every 12 hours, a background task runs `git fetch` and
+reports an update when EITHER the checkout can be FAST-FORWARDED
+(`git rev-list --count --left-right HEAD...@{u}` shows commits behind and none
+ahead) OR the pull already landed and only a restart is missing (`HEAD` equals
+its upstream while the on-disk `__version__` outranks the one this process
+imported).
+
+Commit distance is the primary signal because `__version__` is bumped only at a
+release: comparing version strings alone reported "you're on the latest version"
+to a checkout hundreds of commits behind `main`, for as long as the next bump
+took.
+
+Both conditions are narrower than "is it behind", because `available` is also
+read by an unattended apply. `GatewayOrchestrator._auto_apply_update` applies
+`git fetch` + `git reset --hard origin/<branch>` with no prompt, so:
+
+- "Behind" alone is true both for a checkout that is purely behind and for a
+  DIVERGED one carrying its own commits, and the second would have those commits
+  reset away. Only a fast-forwardable checkout is offered an update.
+- The version signal is required to come with `HEAD == @{u}`. A checkout that
+  pulled a version bump and then committed on top is ahead, so its upstream
+  still reads newer than the imported version; without that requirement the
+  same reset would drop those commits.
+
+**The unattended apply is triggered by the version, not by commit distance.**
+The check reports `version_newer` beside `available`, and the git branch of the
+`auto_update` path requires both. `available` is what the dashboard shows, and
+on commit distance alone that would mean any upstream commit — resetting a
+source checkout within 12 hours of one, where the version-only verdict only did
+so at a release. Requiring both keeps that path firing no more often than
+before. Commit distance without a version bump lights the dashboard badge, and
+`POST /api/update` (`git pull`, dirty tree refused with 409) is the
+non-destructive way to apply it.
 
 - Topbar shows `📦 v0.1.3` badge — click to check and view changelog
 - If newer version found: badge turns into "📦 Update Available"

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -61,6 +61,18 @@ _update_info: dict[str, object] = {
     "self_updatable": False,
     "channel": "",
     "update_command": "",
+    #: Did the RELEASE VERSION move? Reported separately from ``available``
+    #: because the two answer different questions and one consumer needs the
+    #: narrower one.
+    #:
+    #: ``available`` is what the dashboard shows, and for a git checkout it is
+    #: true on commit distance alone. The unattended
+    #: ``GatewayOrchestrator._auto_apply_update`` applies `git reset --hard`, so
+    #: it requires BOTH: acting on commit distance alone would reset a
+    #: developer's checkout within 12 hours of any upstream commit, where before
+    #: it only did so at a release. Requiring both keeps that path firing no more
+    #: often than it did while the verdict was version-only.
+    "version_newer": False,
     "error": "",
 }
 _UPDATE_CHECK_INTERVAL = 43200  # 12 hours
@@ -363,6 +375,7 @@ def _set_update_info(**fields: object) -> None:
             "self_updatable": False,
             "channel": "",
             "update_command": "",
+            "version_newer": False,
             "error": "",
         }
     )
@@ -396,8 +409,10 @@ async def _do_update_check() -> None:
     Three install layouts, three answers:
 
     * **git checkout** — ``KIROCREW_PROJECT_DIR`` with a ``.git``. Fetch the
-      remote and compare its ``src/kiro_crew/__init__.py`` ``__version__``. This
-      is also the only layout ``POST /api/update`` can act on.
+      remote, then report an update when the checkout can be FAST-FORWARDED
+      (behind its upstream and not ahead of it) OR when the on-disk
+      ``__version__`` outranks the imported one. This is also the only layout
+      ``POST /api/update`` can act on.
     * **externally managed** — a desktop bundle or a container
       (:data:`_EXTERNALLY_MANAGED`). This gateway is NOT the update surface, so
       it reports which surface is instead of guessing a verdict.
@@ -548,6 +563,57 @@ async def _check_git_checkout(proj: str) -> None:
         _set_update_info(**base, error=_ERR_GIT_READ_FAILED)
         return
 
+    # How far the checkout is from its upstream, BOTH directions. This — not the
+    # version string — is what "up to date" means for a git checkout: the
+    # version is bumped only at a release, so a checkout hundreds of commits
+    # behind reads as current for as long as the next bump takes.
+    #
+    # Both counts are needed because one of the apply paths is DESTRUCTIVE.
+    # ``GatewayOrchestrator._auto_apply_update`` runs unattended under
+    # ``auto_update`` and applies ``git fetch`` + ``git reset --hard``, so an
+    # update offered on a branch carrying local commits discards them with no
+    # prompt. ``behind > 0`` alone is not safe: it is true both for a checkout
+    # that is purely behind AND for a DIVERGED one (ahead and behind at once),
+    # and the second is precisely the case with commits to lose. Only a checkout
+    # that is behind and NOT ahead can be fast-forwarded, so only that one is
+    # offered an update.
+    ahead = behind = 0
+    count = await asyncio.create_subprocess_exec(
+        "git",
+        "rev-list",
+        "--count",
+        "--left-right",
+        "HEAD...@{u}",
+        cwd=proj,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    try:
+        count_out, _ = await asyncio.wait_for(count.communicate(), timeout=10)
+    except asyncio.TimeoutError:
+        try:
+            count.kill()
+        except ProcessLookupError:
+            pass
+        await count.communicate()
+        _set_update_info(**base, error=_ERR_GIT_READ_FAILED)
+        return
+    if count.returncode != 0:
+        logger.warning("Could not count commits against upstream in %s", proj)
+        _set_update_info(**base, error=_ERR_GIT_READ_FAILED)
+        return
+    # ``--left-right`` with the three-dot range prints "<ahead>\t<behind>": left
+    # is reachable from HEAD only, right from the upstream only.
+    try:
+        ahead_text, behind_text = count_out.decode(errors="replace").split()
+        ahead, behind = int(ahead_text), int(behind_text)
+    except ValueError:
+        logger.warning("Unparseable rev-list count in %s", proj)
+        _set_update_info(**base, error=_ERR_GIT_READ_FAILED)
+        return
+    # Fast-forwardable: behind, and carrying nothing of its own to lose.
+    can_fast_forward = behind > 0 and ahead == 0
+
     # Compare the remote's version (or the on-disk one when already pulled).
     target_sha = remote_sha if local_sha != remote_sha else local_sha
     show = await asyncio.create_subprocess_exec(
@@ -574,8 +640,16 @@ async def _check_git_checkout(proj: str) -> None:
         _set_update_info(**base, error=_ERR_GIT_READ_FAILED)
         return
     remote_version = match.group(1)
-    available = _is_newer(remote_version, _local_version)
-    if available is None:
+    # Two independent reasons a checkout is out of date, either one sufficient:
+    #   * it is behind its upstream — commits to pull;
+    #   * the on-disk ``__version__`` outranks the one this process IMPORTED, so
+    #     the pull already landed and only a restart is missing.
+    version_newer = _is_newer(remote_version, _local_version)
+    if version_newer is None and not can_fast_forward:
+        # Nothing left to go on: the version comparison failed AND there is no
+        # fast-forwardable distance. A check that could not answer must not
+        # answer "you are on the latest version". A fast-forwardable checkout is
+        # a verdict on its own, so an unparseable version does not discard it.
         logger.warning(
             "Cannot compare local version %s against remote %s",
             _local_version,
@@ -583,6 +657,21 @@ async def _check_git_checkout(proj: str) -> None:
         )
         _set_update_info(**base, remote_version=remote_version, error=_ERR_VERSION_UNPARSEABLE)
         return
+    # The version signal answers one question only: the pull already landed and
+    # this process is still running the code from before it. That state IS
+    # ``local_sha == remote_sha``, so requiring it is not a restriction but the
+    # signal's actual domain.
+    #
+    # Without that gate the term reaches a case it was never about. A checkout
+    # that pulled a version bump and then committed on top is AHEAD, so its
+    # upstream still reads newer than the version this process imported — and
+    # the unattended ``_auto_apply_update`` would answer that by resetting hard
+    # onto the upstream, dropping those commits. Its own preflight does not
+    # catch it either: ``git diff HEAD origin/<branch> --quiet`` compares tree
+    # CONTENT, so an ahead checkout whose commits changed anything reads as
+    # "has new commits" and proceeds to the reset.
+    restart_pending = bool(version_newer) and local_sha == remote_sha
+    available = can_fast_forward or restart_pending
 
     changes = ""
     if available:
@@ -620,6 +709,7 @@ async def _check_git_checkout(proj: str) -> None:
         available=available,
         changes=changes,
         remote_version=remote_version,
+        version_newer=bool(version_newer),
         checked=True,
     )
 
@@ -727,6 +817,10 @@ async def _check_release_feed(install_kind: str) -> None:
         **base,
         available=available,
         remote_version=remote_version,
+        # For a feed-checkable install the verdict IS the version comparison, so
+        # the two agree by construction. Reported anyway so the field means the
+        # same thing on every layout and no consumer has to special-case one.
+        version_newer=available,
         checked=True,
         **extra,
     )

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -6739,7 +6739,22 @@ class GatewayOrchestrator:
                 from kiro_crew.config import KiroCrewConfig
 
                 cfg = KiroCrewConfig.load()
-                if cfg.auto_update and _update_info.get("self_updatable"):
+                if (
+                    cfg.auto_update
+                    and _update_info.get("self_updatable")
+                    and _update_info.get("version_newer")
+                ):
+                    # A git checkout is applied by `git reset --hard`, so this
+                    # path needs more than "the dashboard would show a badge".
+                    # ``available`` is true on commit distance alone, which for a
+                    # source checkout means any upstream commit — acting on that
+                    # would reset a developer's tree within 12 hours of one,
+                    # where before it only happened at a release. Requiring the
+                    # version to have moved as well keeps this firing no more
+                    # often than it did while the verdict was version-only.
+                    # Commit distance without a version bump lights the badge
+                    # below instead, and the dashboard's own apply path (`git
+                    # pull`, dirty tree refused) is the non-destructive way in.
                     logger.info("Auto-update enabled — applying update")
                     await self._auto_apply_update()
                 elif (

--- a/test/test_dashboard_updates_coverage.py
+++ b/test/test_dashboard_updates_coverage.py
@@ -234,8 +234,8 @@ class TestGitCheckoutFailurePaths:
         self._assert_failed_check(updates._ERR_GIT_READ_FAILED)
 
     @pytest.mark.asyncio
-    async def test_version_read_timeout(self, monkeypatch, tmp_path):
-        argv = await self._run(
+    async def test_behind_count_timeout(self, monkeypatch, tmp_path):
+        await self._run(
             monkeypatch,
             tmp_path,
             [
@@ -246,12 +246,10 @@ class TestGitCheckoutFailurePaths:
             ],
         )
         self._assert_failed_check(updates._ERR_GIT_READ_FAILED)
-        # The version is read at the REMOTE sha when the two differ, not at HEAD:
-        # comparing HEAD against itself can never detect an update.
-        assert argv[-1] == ("git", "show", "bbb222:src/kiro_crew/__init__.py")
 
     @pytest.mark.asyncio
-    async def test_a_version_that_cannot_be_parsed_is_reported_as_such(self, monkeypatch, tmp_path):
+    async def test_behind_count_that_is_not_a_number_is_a_failed_check(self, monkeypatch, tmp_path):
+        """A count we cannot read is not licence to answer "up to date"."""
         await self._run(
             monkeypatch,
             tmp_path,
@@ -259,6 +257,44 @@ class TestGitCheckoutFailurePaths:
                 _FakeProc(),
                 _FakeProc(out=b"aaa111\n"),
                 _FakeProc(out=b"bbb222\n"),
+                _FakeProc(out=b"not a number\n"),
+            ],
+        )
+        self._assert_failed_check(updates._ERR_GIT_READ_FAILED)
+
+    @pytest.mark.asyncio
+    async def test_version_read_timeout(self, monkeypatch, tmp_path):
+        argv = await self._run(
+            monkeypatch,
+            tmp_path,
+            [
+                _FakeProc(),
+                _FakeProc(out=b"aaa111\n"),
+                _FakeProc(out=b"bbb222\n"),
+                _FakeProc(out=b"0\t7\n"),
+                _FakeProc(time_out=True, kill_raises=True),
+            ],
+        )
+        self._assert_failed_check(updates._ERR_GIT_READ_FAILED)
+        # The version is read at the REMOTE sha when the two differ, not at HEAD:
+        # comparing HEAD against itself can never detect an update.
+        assert argv[-1] == ("git", "show", "bbb222:src/kiro_crew/__init__.py")
+
+    @pytest.mark.asyncio
+    async def test_a_version_that_cannot_be_parsed_is_reported_as_such(self, monkeypatch, tmp_path):
+        """Unparseable version AND no commit distance — nothing left to answer with.
+
+        ``behind`` is scripted to 0 on purpose: a non-zero count is a verdict in
+        its own right and would (correctly) rescue the check.
+        """
+        await self._run(
+            monkeypatch,
+            tmp_path,
+            [
+                _FakeProc(),
+                _FakeProc(out=b"aaa111\n"),
+                _FakeProc(out=b"bbb222\n"),
+                _FakeProc(out=b"0\t0\n"),
                 _FakeProc(out=b'__version__ = "not/a/version"\n'),
             ],
         )
@@ -280,6 +316,7 @@ class TestGitCheckoutFailurePaths:
                 _FakeProc(),
                 _FakeProc(out=b"aaa111\n"),
                 _FakeProc(out=b"bbb222\n"),
+                _FakeProc(out=b"0\t7\n"),
                 _FakeProc(out=b'__version__ = "999.0.0"\n'),
                 _FakeProc(time_out=True, kill_raises=True),
             ],
@@ -309,6 +346,7 @@ class TestGitCheckoutFailurePaths:
                 _FakeProc(),
                 _FakeProc(out=b"aaa111\n"),
                 _FakeProc(out=b"bbb222\n"),
+                _FakeProc(out=b"0\t7\n"),
                 _FakeProc(out=b'__version__ = "999.0.0"\n'),
                 _FakeProc(out=diff),
             ],

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -874,6 +874,70 @@ class TestCheckForUpdates:
         ds.push_refresh.assert_called_with("update_available")
 
     @pytest.mark.asyncio
+    async def test_commit_distance_alone_lights_the_badge_but_does_not_auto_apply(self):
+        """A git checkout behind upstream with an UNCHANGED version is not reset.
+
+        `available` is true on commit distance alone so the dashboard stops
+        claiming "you're on the latest version". This path is not the dashboard:
+        it applies `git reset --hard`, so acting on commit distance would reset a
+        developer's checkout within 12 hours of any upstream commit, where before
+        it only did so at a release. The badge is lit instead; the dashboard's own
+        apply (`git pull`, dirty tree refused) is the non-destructive way in.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch._auto_apply_update = AsyncMock()
+        import kiro_crew.dashboard.handlers as _h
+
+        fake_cfg = MagicMock()
+        fake_cfg.auto_update = True
+        orig = _h._update_info.copy()
+        try:
+            _h._update_info.update(
+                {"available": True, "self_updatable": True, "version_newer": False}
+            )
+            with patch.object(_h, "_do_update_check", new_callable=AsyncMock):
+                with patch("kiro_crew.config.KiroCrewConfig.load", return_value=fake_cfg):
+                    with patch(
+                        "kiro_crew.platform.update_governance.update_required",
+                        return_value=False,
+                    ):
+                        await orch._check_for_updates()
+        finally:
+            _h._update_info.clear()
+            _h._update_info.update(orig)
+        orch._auto_apply_update.assert_not_awaited()
+        ds.push_refresh.assert_called_with("update_available")
+
+    @pytest.mark.asyncio
+    async def test_a_version_bump_still_auto_applies(self):
+        """The pre-existing trigger is unchanged: a release moved, so apply."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch._auto_apply_update = AsyncMock()
+        import kiro_crew.dashboard.handlers as _h
+
+        fake_cfg = MagicMock()
+        fake_cfg.auto_update = True
+        orig = _h._update_info.copy()
+        try:
+            _h._update_info.update(
+                {"available": True, "self_updatable": True, "version_newer": True}
+            )
+            with patch.object(_h, "_do_update_check", new_callable=AsyncMock):
+                with patch("kiro_crew.config.KiroCrewConfig.load", return_value=fake_cfg):
+                    with patch(
+                        "kiro_crew.platform.update_governance.update_required",
+                        return_value=False,
+                    ):
+                        await orch._check_for_updates()
+        finally:
+            _h._update_info.clear()
+            _h._update_info.update(orig)
+        orch._auto_apply_update.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_min_version_mandate_fires_even_when_not_available(self):
         """The mandate is about THIS host, not the availability heuristic.
 

--- a/test/test_update_check_install_aware.py
+++ b/test/test_update_check_install_aware.py
@@ -363,6 +363,7 @@ class TestGitCheckoutStillWorks:
                 (0, b""),  # git fetch
                 (0, b"aaaa\n"),  # rev-parse HEAD
                 (0, b"bbbb\n"),  # rev-parse @{u}
+                (0, b"0\t1\n"),  # rev-list --count --left-right HEAD...@{u}
                 (0, b'__version__ = "0.1.3rc2"\n'),  # git show
                 (0, b"+### 0.1.3rc2\n+- thing\n"),  # git diff CHANGELOG.md
             ],
@@ -381,6 +382,160 @@ class TestGitCheckoutStillWorks:
         assert info["channel"] == ""
         assert info["update_command"] == ""
         assert any("fetch" in c for c in calls)
+
+    def test_commits_behind_with_an_unchanged_version_is_an_update(self, _git_install, monkeypatch):
+        """The reported bug: 219 commits behind, both sides still ``0.3.0``.
+
+        ``__version__`` is bumped only at a release, so comparing version
+        strings reported "you're on the latest version" to a checkout days of
+        merges behind ``origin/main`` — for as long as the next bump took.
+        """
+        self._git_script(
+            monkeypatch,
+            [
+                (0, b""),  # git fetch
+                (0, b"aaaa\n"),  # rev-parse HEAD
+                (0, b"bbbb\n"),  # rev-parse @{u}
+                (0, b"0\t219\n"),  # rev-list: 0 ahead, 219 behind
+                (0, b'__version__ = "0.3.0"\n'),  # git show — SAME version
+                (0, b""),  # git diff CHANGELOG.md
+            ],
+        )
+        monkeypatch.setattr(updates, "_local_version", "0.3.0")
+        asyncio.run(updates._do_update_check())
+
+        info = updates.get_update_info()
+        assert info["available"] is True
+        assert info["checked"] is True
+        assert info["error"] == ""
+
+    def test_ahead_after_a_version_bump_pull_is_not_an_update(self, _git_install, monkeypatch):
+        """A checkout that pulled a bump and committed on top must not be reset.
+
+        Its upstream still reads NEWER than the version this process imported,
+        so an ungated version signal marks it available and the unattended
+        ``_auto_apply_update`` resets hard onto the upstream, dropping the local
+        commits. The version signal only ever meant "pull landed, restart
+        pending", which is ``local_sha == remote_sha``.
+        """
+        self._git_script(
+            monkeypatch,
+            [
+                (0, b""),  # git fetch
+                (0, b"dddd\n"),  # rev-parse HEAD — local commits on top
+                (0, b"bbbb\n"),  # rev-parse @{u}
+                (0, b"2\t0\n"),  # rev-list: 2 ahead, 0 behind
+                (0, b'__version__ = "0.4.0"\n'),  # git show — upstream bumped
+            ],
+        )
+        monkeypatch.setattr(updates, "_local_version", "0.3.0")
+        asyncio.run(updates._do_update_check())
+
+        info = updates.get_update_info()
+        assert info["available"] is False
+        assert info["checked"] is True
+        assert info["error"] == ""
+
+    def test_a_pull_awaiting_a_restart_is_still_reported(self, _git_install, monkeypatch):
+        """The version signal's real case survives the gate: shas agree.
+
+        The pull landed, so HEAD == upstream and there is no commit distance;
+        only the imported ``__version__`` is stale. Applying here is a restart,
+        not a reset, so this must still light up.
+        """
+        self._git_script(
+            monkeypatch,
+            [
+                (0, b""),  # git fetch
+                (0, b"eeee\n"),  # rev-parse HEAD
+                (0, b"eeee\n"),  # rev-parse @{u} — SAME sha
+                (0, b"0\t0\n"),  # rev-list: level with upstream
+                (0, b'__version__ = "0.4.0"\n'),  # git show — on-disk is newer
+                (0, b""),  # git diff CHANGELOG.md
+            ],
+        )
+        monkeypatch.setattr(updates, "_local_version", "0.3.0")
+        asyncio.run(updates._do_update_check())
+
+        info = updates.get_update_info()
+        assert info["available"] is True
+        assert info["checked"] is True
+        assert info["error"] == ""
+
+    def test_a_diverged_checkout_is_not_offered_a_destructive_update(
+        self, _git_install, monkeypatch
+    ):
+        """Behind AND ahead: an update here would discard the local commits.
+
+        ``GatewayOrchestrator._auto_apply_update`` applies ``git fetch`` +
+        ``git reset --hard`` unattended under ``auto_update``, so a diverged
+        branch offered an update loses its own commits with no prompt. Only a
+        fast-forwardable checkout is offered one.
+        """
+        self._git_script(
+            monkeypatch,
+            [
+                (0, b""),  # git fetch
+                (0, b"cccc\n"),  # rev-parse HEAD
+                (0, b"bbbb\n"),  # rev-parse @{u}
+                (0, b"3\t219\n"),  # rev-list: 3 ahead, 219 behind — DIVERGED
+                (0, b'__version__ = "0.3.0"\n'),  # git show
+            ],
+        )
+        monkeypatch.setattr(updates, "_local_version", "0.3.0")
+        asyncio.run(updates._do_update_check())
+
+        info = updates.get_update_info()
+        assert info["available"] is False
+        assert info["checked"] is True
+        assert info["error"] == ""
+
+    def test_a_checkout_only_ahead_is_up_to_date(self, _git_install, monkeypatch):
+        """Unpushed local commits are not an update to offer.
+
+        ``HEAD != @{u}`` is also true for a checkout that is merely AHEAD, and
+        the unattended apply path resets hard to the remote, so treating that as
+        an update would recommend discarding the user's own commits.
+        """
+        self._git_script(
+            monkeypatch,
+            [
+                (0, b""),  # git fetch
+                (0, b"cccc\n"),  # rev-parse HEAD — ahead of upstream
+                (0, b"aaaa\n"),  # rev-parse @{u}
+                (0, b"2\t0\n"),  # rev-list: 2 ahead, 0 behind
+                (0, b'__version__ = "0.3.0"\n'),  # git show
+            ],
+        )
+        monkeypatch.setattr(updates, "_local_version", "0.3.0")
+        asyncio.run(updates._do_update_check())
+
+        info = updates.get_update_info()
+        assert info["available"] is False
+        assert info["checked"] is True
+        assert info["error"] == ""
+
+    def test_an_unparseable_version_does_not_discard_a_commit_distance_verdict(
+        self, _git_install, monkeypatch
+    ):
+        """``behind > 0`` answers on its own, so a junk version is not fatal."""
+        self._git_script(
+            monkeypatch,
+            [
+                (0, b""),
+                (0, b"aaaa\n"),
+                (0, b"bbbb\n"),
+                (0, b"0\t4\n"),
+                (0, b'__version__ = "not-a-version"\n'),
+                (0, b""),
+            ],
+        )
+        monkeypatch.setattr(updates, "_local_version", "0.3.0")
+        asyncio.run(updates._do_update_check())
+
+        info = updates.get_update_info()
+        assert info["available"] is True
+        assert info["error"] == ""
 
     def test_git_fetch_failure_is_reported_not_swallowed(self, _git_install, monkeypatch):
         self._git_script(monkeypatch, [(128, b"")])
@@ -403,7 +558,13 @@ class TestGitCheckoutStillWorks:
     def test_unreadable_remote_version_is_reported(self, _git_install, monkeypatch):
         self._git_script(
             monkeypatch,
-            [(0, b""), (0, b"aaaa\n"), (0, b"bbbb\n"), (0, b"# no version here\n")],
+            [
+                (0, b""),
+                (0, b"aaaa\n"),
+                (0, b"bbbb\n"),
+                (0, b"0\t1\n"),
+                (0, b"# no version here\n"),
+            ],
         )
         asyncio.run(updates._do_update_check())
         assert updates.get_update_info()["error"] == "git_read_failed"
@@ -421,6 +582,7 @@ class TestGitCheckoutStillWorks:
                 (0, b""),
                 (0, b"aaaa\n"),
                 (0, b"aaaa\n"),
+                (0, b"0\t0\n"),
                 (0, b'__version__ = "0.1.2rc3"\n'),
             ],
         )
@@ -605,9 +767,21 @@ class TestAutoApplyGuard:
         # The wheel auto-apply IS called (new behavior).
         orch._auto_apply_wheel_update.assert_awaited_once()
 
-    def test_git_checkout_still_auto_applies(self):
+    def test_git_checkout_auto_applies_when_the_version_moved(self):
+        """The git apply needs `version_newer`, not just `available`.
+
+        `available` is true on commit distance alone for a checkout, and this
+        path applies `git reset --hard`. Requiring the version to have moved
+        keeps it firing no more often than while the verdict was version-only
+        (see `TestCheckForUpdates` in `test_slack_gateway.py` for the negative).
+        """
         orch = self._run(
-            {"available": True, "self_updatable": True, "install_kind": "git"},
+            {
+                "available": True,
+                "self_updatable": True,
+                "install_kind": "git",
+                "version_newer": True,
+            },
             auto_update=True,
         )
         orch._auto_apply_update.assert_awaited_once()


### PR DESCRIPTION
## Problem

For a git checkout, the update check read the remote's `src/kiro_crew/__init__.py` `__version__`, compared it against the imported one, and called anything else up to date.

`__version__` is bumped only at a release. So a checkout can fall arbitrarily far behind `origin/main` and still be told it is current, for as long as the next bump takes. Reproduced on a live install: **219 commits behind, both sides `0.3.0`**, About panel reporting "You're on the latest version."

`_check_git_checkout` already resolved `HEAD` and `@{u}` — it computed the fact that they differed and then discarded it in favour of the version strings.

## The verdict

Report an update when **either** holds:

* the checkout can be **fast-forwarded** — behind its upstream and not ahead of it, from `git rev-list --count --left-right HEAD...@{u}`;
* a pull **already landed and only a restart is missing** — `HEAD == @{u}` while the on-disk `__version__` outranks the one this process imported.

Both are narrower than "is it behind", because `available` is also read by an unattended apply that runs `git reset --hard`:

* **Behind is not enough.** It is true both for a checkout that is purely behind and for a **diverged** one carrying its own commits, and the second is exactly the case with commits to lose.
* **The version signal needs `HEAD == @{u}`.** That equality *is* the "pull landed, restart pending" state, so requiring it is the signal's domain rather than a restriction. A checkout that pulled a version bump and then committed on top is ahead, so its upstream still reads newer than the imported version.

## The badge and the unattended apply are separate signals

`GatewayOrchestrator._auto_apply_update` applies `git fetch` + `git reset --hard origin/<branch>` with no prompt, and `auto_update` defaults to `true`. Making `available` true on commit distance would move that path from reachable roughly per release to reachable per 12-hour check — on the one install shape whose working tree is normally dirty.

So the two questions are reported separately. The check now publishes `version_newer` beside `available`, and the git branch of the `auto_update` path requires **both**:

```python
if cfg.auto_update and _update_info.get("self_updatable") and _update_info.get("version_newer"):
```

That is strictly a subset of the trigger on `main`: this path never fires where it did not fire before, and it now also declines the ahead-after-bump and diverged cases that `main` would have reset. Commit distance without a version bump lights the dashboard badge instead, and `POST /api/update` (`git pull`, dirty tree refused with 409) is the non-destructive way to apply it.

The apply path itself is **not** touched by this PR. Hardening it — refusing a dirty tree, and requiring `HEAD` to be an ancestor of the reset target — is tracked in #4503; it is worth doing, but it is a decision about that path (including how it interacts with `min_version` enforcement, which calls that function directly) rather than part of fixing the verdict.

## Failed checks still refuse to answer

The `checked` flag invariant is preserved. A fast-forwardable distance is a verdict in its own right, so an unparseable version no longer discards it; but with neither a usable comparison nor a fast-forwardable distance, the check still reports `version_unparseable` rather than claiming up to date. A rev-list timeout, non-zero exit, or garbled count is `git_read_failed`, not a verdict.

## Scope

`version_newer` is an additive field on the update-check payload; `available` / `remote_version` / `checked` / `error` all keep their meaning, so no frontend or i18n change. The release-feed branch for wheel installs is untouched and still version-compared — correct there, because a wheel's granularity *is* the release, and it reports `version_newer` equal to `available` so the field means the same thing on every layout.

Deferred:

* **#4498** — a diverged checkout now renders as "You're on the latest version", wrong in the other direction. Saying "diverged" needs a new state on the wire plus copy in 13 locales.
* **#4503** — hardening the unattended `reset --hard` (dirty tree, non-ancestor target) and how that interacts with the mandatory `min_version` path.

## Tests

`test/test_update_check_install_aware.py` — the verdict:

* `test_commits_behind_with_an_unchanged_version_is_an_update` — the reported bug: 219 behind, both `0.3.0`.
* `test_a_diverged_checkout_is_not_offered_a_destructive_update` — 3 ahead, 219 behind.
* `test_a_checkout_only_ahead_is_up_to_date`
* `test_ahead_after_a_version_bump_pull_is_not_an_update` — the version-signal gate.
* `test_a_pull_awaiting_a_restart_is_still_reported` — the gate keeps the signal's real case.
* `test_an_unparseable_version_does_not_discard_a_commit_distance_verdict`
* `test_git_checkout_auto_applies_when_the_version_moved` — renamed from `test_git_checkout_still_auto_applies`, whose fixture asserted the old trigger.

`test/test_slack_gateway.py` — the trigger:

* `test_commit_distance_alone_lights_the_badge_but_does_not_auto_apply`
* `test_a_version_bump_still_auto_applies`

`test/test_dashboard_updates_coverage.py` — keeping that module's "one `wait_for` per git call, one error each" contract intact:

* `test_behind_count_timeout`
* `test_behind_count_that_is_not_a_number_is_a_failed_check`

## Verification

* `pytest test/test_slack_gateway.py test/test_update_check_install_aware.py test/test_dashboard_updates_coverage.py test/test_governance_updates.py` — 401 passed
* `pytest test/test_coverage_omit_contract.py test/test_ci_surface_tests.py test/test_pr_quality_gates.py` — 99 passed
* `check_black_formatting.py`, `isort --check-only`, `flake8`, `mypy` (988 files), `docs-lint.sh` — all clean by exit code

## Docs

`docs/system-specs/modules/cli.md` § Dashboard Self-Update documented the old rule verbatim ("commits without a version bump are ignored"); updated in the same commit, and it now records that the badge and the unattended apply read different signals.
