### PR TITLE
fix(gateway): derive the caller's app once in the auth middleware

### DIFF
--- a/src/kiro_crew/dashboard/chat_folders.py
+++ b/src/kiro_crew/dashboard/chat_folders.py
@@ -15,6 +15,7 @@ from aiohttp import web
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import effective_session_key
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.token_auth import derive_caller_app
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
@@ -547,22 +548,16 @@ async def api_chat_folder_delete(request: web.Request) -> web.Response:
 def _effective_request_app(state: DashboardState, request: web.Request) -> str:
     """App identity to enforce ownership against, or "" for the dashboard user.
 
-    Two transports reach these routes with app identity carried differently:
+    Reads the claim ``token_auth_middleware`` publishes, and re-derives through
+    the SAME shared rule (``token_auth.derive_caller_app``) when it is absent.
 
-    * An **app token** — the middleware validates it and publishes the name as
-      ``request["app"]``.
-    * The **managed MCP set** — it authenticates with the internal secret,
-      which carries no app claim at all, so ``request["app"]`` is empty. An app
-      agent granted ``@kirocrew-dashboard`` would therefore arrive here
-      indistinguishable from the dashboard user and be allowed to mutate a
-      session it does not own.
-
-    The secret proves the call came from inside, not who made it, so the
-    identity is taken from the authenticated CALLING SESSION instead: the
-    ``X-Session-Key`` header names the caller's slot, and a slot created by an
-    app carries that app in ``_app`` (App Kit §5.2). Falling back to the caller
-    rather than trusting the transport keeps app isolation intact on a path the
-    app-token check cannot see.
+    This route used to carry its own copy of the derivation, because the
+    internal-secret transport (the managed MCP set) carries no app claim of its
+    own and this was the only route compensating. The middleware now derives it
+    once for every route on that transport (issue #3690); the re-derivation here
+    is defense-in-depth for a caller that reaches the handler without having
+    passed that branch, and it calls the shared function rather than restating
+    the rule so the two can never disagree.
 
     Never read from request BODY or tool arguments — a caller that could name
     its own scope could name someone else's.
@@ -570,11 +565,11 @@ def _effective_request_app(state: DashboardState, request: web.Request) -> str:
     declared = request.get("app", "")
     if declared:
         return str(declared)
-    sk = request.headers.get("X-Session-Key", "").strip()
-    if not sk or sk == "dashboard:ui":
-        return ""
-    caller = state._slots.get(sk.split(":", 1)[-1] if ":" in sk else sk)
-    return str(getattr(caller, "_app", "") or "") if caller else ""
+    app_name = derive_caller_app(
+        getattr(state, "_slots", None),
+        request.headers.get("X-Session-Key", ""),
+    )
+    return app_name
 
 
 async def api_chat_slot_folder(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -46,6 +46,7 @@ from kiro_crew.dashboard.state import (
     CRON_NOTIFY_PREFIX,
     DashboardState,
 )
+from kiro_crew.dashboard.token_auth import caller_names_a_missing_slot
 from kiro_crew.notifications.bus import (
     NotificationPayload,
     NotificationValidationError,
@@ -920,9 +921,11 @@ async def api_notification_agent_push(request: web.Request) -> web.Response:
     # reaching it could impersonate system notifications and bypass its app
     # rate limits / declared-channel checks. Apps publish through
     # POST /api/notifications where their
-    # token-verified ``app:<name>`` source is enforced. The middleware sets
-    # ``request["app"]`` only on app-token auth; the internal-secret path
-    # (the MCP tool) never does.
+    # token-verified ``app:<name>`` source is enforced. The middleware publishes
+    # ``request["app"]`` on app-token auth and, since issue #3690, also on the
+    # internal-secret path whenever the calling session resolves to an app — so
+    # this check now bites for an app agent arriving over MCP too, which it
+    # could not before.
     if request.get("app"):
         # Permission denial on a security boundary — audited before the
         # response (backend-security-controls: every denial emits SEL).
@@ -950,6 +953,32 @@ async def api_notification_agent_push(request: web.Request) -> web.Response:
             error="internal-secret authentication required (cookie callers forbidden)",
         )
         return web.json_response({"error": "internal-secret authentication required"}, status=403)
+    # A caller whose own slot is GONE cannot be attributed (issue #3690). The
+    # app-token check above refuses an app by name, but a tab closed while this
+    # call was in flight takes the ``_app`` that check reads with it, so an
+    # app-owned session going through that race would publish source="system"
+    # here as though it were the person. Absence of an app claim is only
+    # trustworthy for a caller that never had a slot (a Slack thread, a cron the
+    # person owns); a ``dashboard:`` key names one, so a missing slot is a
+    # failure to attribute rather than proof of the dashboard user. Refused HERE
+    # rather than in the middleware: a popped slot no longer says whose tab it
+    # was, so refusing centrally would also refuse the person's own in-flight
+    # calls on every internal route. This route refuses because of what it
+    # publishes -- ``source="system"`` on the system.agent channel.
+    if caller_names_a_missing_slot(
+        getattr(state, "_slots", None), request.headers.get("X-Session-Key", "")
+    ):
+        _sel().log_api_access(
+            caller=str(request.headers.get("X-Session-Key") or ""),
+            operation="notification_agent_push",
+            outcome="denied",
+            source="notifications_api",
+            error="calling session's slot is gone; cannot attribute a system publish",
+        )
+        return web.json_response(
+            {"error": "calling session not found", "code": "caller_session_missing"},
+            status=403,
+        )
     # Bound the body BEFORE decoding, mirroring the app push endpoint: without
     # this the strict-internal route inherits the server-wide client_max_size,
     # and a large JSON object would be buffered and decoded on the event-loop

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 from collections.abc import Callable, Iterable
 from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from aiohttp import web
 
@@ -1495,6 +1495,306 @@ async def _verify_unix_peer(
     return None
 
 
+def derive_caller_app(
+    slots: object, session_key: str, jobs: object = None, subagents: object = None
+) -> str:
+    """The app that owns the CALLING session, or ``""`` for the dashboard user.
+
+    **Why this exists.** App-ownership checks gate on ``request["app"]``, which
+    the app-token branch publishes. The internal-secret branch (the managed MCP
+    set) carries no app claim at all: the secret proves the call came from
+    inside, not who made it. Every ownership check therefore became a no-op on
+    that transport, and an app agent granted ``@kirocrew-dashboard`` arrived
+    indistinguishable from the dashboard user (issue #3690).
+
+    The identity comes from the authenticated CALLING SESSION, resolved against
+    server-side registries in four steps -- one per way a session can be owned:
+    the slot the key names, the slot RUNNING under that key
+    (``linked_session_key``), for a cron key the job's ``created_by`` owner tag,
+    and for a subagent key the child record's spawning ``app``. The agent cannot
+    forge the key — it does not build the request; the in-process MCP broker sets
+    it from the calling session's own context and never from tool arguments
+    (``mcp_core`` ``_resolve_session_key_strict``), and on an AF_UNIX transport
+    ``_verify_unix_peer`` has already kernel-attested it against ``/proc``
+    ancestry before this runs.
+
+    ``""`` means "no app owns this caller" and is returned both when the person
+    is the caller and when the caller cannot be placed at all. The two are not
+    distinguished because no site acts differently on them; the one route that
+    needs the difference for a ``dashboard:`` key asks
+    :func:`caller_names_a_missing_slot` instead.
+
+    Deliberately PURE — every parameter is a server-side registry or the
+    caller's own key, never a request — so the middleware and the one route that
+    also re-derives for defense-in-depth share a single implementation that
+    cannot drift. Never derive from a request BODY or from tool arguments: a
+    caller that could name its own scope could name someone else's.
+    """
+    sk = (session_key or "").strip()
+    # No key at all: the gateway's own internal calls, the CLI, a loopback
+    # curl. Nothing to place and no app could have been attached — unscoped,
+    # exactly as before this derivation existed.
+    if not sk or sk == "dashboard:ui":
+        return ""
+    # Each registry below answers only "yes, THIS app owns the caller". An
+    # ownerless answer FALLS THROUGH to the next one rather than ending the
+    # search, because a session can be recorded in more than one place and only
+    # some of those records carry the owner. The case that forces this: an
+    # app-created cron with a cron-born tab is present in the slot registry with
+    # no ``_app`` (a channel/cron-born slot is created without one) AND in the
+    # cron registry WITH its ``created_by`` owner -- so short-circuiting on the
+    # slot would hand an app the dashboard user's reach. Returning "" only after
+    # every registry has been asked also makes the search monotonic: adding a
+    # registry can find an owner that was missed, never lose one.
+    lookup = getattr(slots, "get", None) if slots is not None else None
+    if lookup is not None:
+        slot = lookup(sk.split(":", 1)[-1] if ":" in sk else sk)
+        owner = str(getattr(slot, "_app", "") or "") if slot is not None else ""
+        if owner:
+            return owner
+        # Second lookup, by LINKED key. A slot bound to a channel or cron
+        # session runs its turns under ``linked_session_key`` rather than under
+        # its own name ("when set, _run_chat uses this as session key" --
+        # ``DashboardState``), so the caller presents that key and the lookup
+        # above cannot find it. Without this the slot's ``_app`` is invisible
+        # and the caller reads as the person: the very shape this fix exists to
+        # end, since the slot IS there and may carry an owner.
+        linked = _slot_by_linked_key(slots, sk)
+        owner = str(getattr(linked, "_app", "") or "") if linked is not None else ""
+        if owner:
+            return owner
+    # Third lookup, for a cron key, in the CRON registry. A cron created by an
+    # app is tagged ``created_by="app:<name>"`` (``CronSDK``), so the owner is a
+    # matter of record rather than a guess -- and a cron often has no dashboard
+    # slot at all, which is why the lookups above cannot see it. Resolving it
+    # POSITIVELY is what lets an app-owned cron be confined while the person's
+    # own crons keep working; refusing every unplaceable delegated caller
+    # instead would take cron and subagent tools from the person too.
+    if sk.startswith("cron:"):
+        owner = _cron_job_owner(jobs, _key_segment(sk))
+        if owner:
+            return owner
+    # Fourth lookup, for a subagent key, in the SUBAGENT registry. A child
+    # spawned by an app carries it in ``SubagentInfo.app``, persisted for exactly
+    # this purpose -- the field's own note says it is kept so "the child's
+    # per-tool-call gate can resolve the app's Level-2 profile", because
+    # otherwise "the child's ongoing tool calls run unconstrained by the app
+    # scope". A tool call arriving here IS one of those ongoing calls.
+    if sk.startswith("subagent:"):
+        owner = _subagent_owner(subagents, _key_segment(sk))
+        if owner:
+            return owner
+    # Every registry asked, none names an owner: the person, or a Slack thread
+    # or channel session that never had an app.
+    return ""
+
+
+def _key_segment(session_key: str) -> str:
+    """The id segment of a delegated caller key, ignoring anything after it.
+
+    A cron session key has TWO forms -- ``cron:<job_id>`` for a persistent job
+    and ``cron:<job_id>:<run_id>`` for a stateless one (``cron._build_prompt``).
+    Taking the whole remainder after the first colon yields ``<job_id>:<run_id>``
+    for the stateless form, which matches no job, so an app-owned stateless cron
+    would resolve to no owner and be handed the dashboard user's reach.
+    """
+    parts = session_key.split(":")
+    return parts[1] if len(parts) > 1 else ""
+
+
+def _subagent_owner(subagents: object, agent_id: str) -> str:
+    """The app that spawned a subagent, or ``""`` (person-spawned, or no record).
+
+    Reads the live registry mapping directly, which is a plain dict lookup -- no
+    lock and no I/O, so it is safe on the event loop for the same reason the slot
+    lookup is.
+    """
+    if subagents is None or not agent_id:
+        # An empty id identifies nothing (see ``_cron_job_owner``).
+        return ""
+    lookup = getattr(subagents, "get", None)
+    if lookup is None:
+        return ""
+    try:
+        info = lookup(agent_id)
+    except Exception:  # noqa: BLE001 - an auth path must never 500 on this
+        return ""
+    return str(getattr(info, "app", "") or "") if info is not None else ""
+
+
+def caller_record_is_missing(
+    session_key: str, jobs: object = None, subagents: object = None
+) -> bool:
+    """True when a DELEGATED key's own registry is present but holds no record.
+
+    A ``cron:`` or ``subagent:`` key is not like a Slack thread: the work it names
+    is recorded, and that record is where its owner lives. So absence here is not
+    "nothing to confine" -- it is "the record that would have told me who this
+    runs for is gone", which is the same thing
+    :func:`caller_names_a_missing_slot` says about a ``dashboard:`` key.
+
+    Reachable, and narrowly: a live subagent is always in the registry (only
+    ``done`` records are ever evicted, by ``evict_completed_agents``), and a cron
+    job stays until it is removed -- so this fires when a job is DELETED while its
+    run is still making calls, and the deleted job's app reach must not survive it.
+
+    Requires the registry to be PRESENT. A surface wired without one (the
+    ``--slack-only`` API server) must not have every delegated caller refused
+    because of a missing dependency, so an absent registry answers False.
+    """
+    sk = (session_key or "").strip()
+    if sk.startswith("cron:"):
+        registry: object = jobs
+    elif sk.startswith("subagent:"):
+        registry = subagents
+    else:
+        return False
+    if registry is None:
+        return False
+    ident = _key_segment(sk)
+    if not ident:
+        # A key with no id names nothing; it cannot be confirmed against a
+        # record either, so treat it as unresolvable rather than as present.
+        return True
+    if sk.startswith("cron:"):
+        return not _cron_job_exists(registry, ident)
+    return not _subagent_record_exists(registry, ident)
+
+
+def _cron_job_exists(jobs: object, job_id: str) -> bool:
+    """Whether a cron job id is in the registry (cache-only read, see ``_cron_job_owner``)."""
+    try:
+        snapshot = list(cast("Iterable[Any]", jobs))
+    except Exception:  # noqa: BLE001 - an auth path must never 500 on this
+        # Cannot read the registry: do not manufacture a refusal from a failure
+        # to look, which would deny every delegated caller on a transient error.
+        return True
+    return any(str(getattr(j, "id", "") or "") == job_id for j in snapshot)
+
+
+def _subagent_record_exists(subagents: object, agent_id: str) -> bool:
+    """Whether a subagent id is in the registry (plain dict lookup)."""
+    lookup = getattr(subagents, "get", None)
+    if lookup is None:
+        return True  # unreadable registry: see ``_cron_job_exists``
+    try:
+        return lookup(agent_id) is not None
+    except Exception:  # noqa: BLE001 - an auth path must never 500 on this
+        return True
+
+
+def caller_names_a_missing_slot(slots: object, session_key: str) -> bool:
+    """True when the key NAMES a dashboard slot that is not in the registry.
+
+    Distinct from "no app owns this caller" (:func:`derive_caller_app` returning
+    ``""``), which covers callers that never had a slot at all -- a Slack thread,
+    a channel session, the CLI. A ``dashboard:`` key is different in kind: it
+    names a specific slot, so absence is not "nothing to confine" but "the slot
+    I would have been confined against is gone". That happens when a tab is
+    closed while one of its calls is still in flight (the slot is popped
+    synchronously, without draining in-flight MCP calls) or when the key is
+    simply wrong.
+
+    An app-owned session going through that race would otherwise reach a route
+    that refuses apps and be admitted, because the app it should have been
+    confined to is exactly what got popped. ``mcp_dashboard._caller_app_scope``
+    already refuses this class for its own tool set on that reasoning; this
+    predicate lets a route outside that set apply the same rule.
+
+    Deliberately NOT applied in the middleware: a popped slot no longer says
+    whose tab it was, so refusing there would also refuse the person's own
+    in-flight calls, on every internal route at once. Each route that publishes
+    something it could not attribute decides for itself.
+    """
+    sk = (session_key or "").strip()
+    if not sk.startswith("dashboard:") or sk == "dashboard:ui":
+        return False
+    lookup = getattr(slots, "get", None) if slots is not None else None
+    if lookup is None:
+        return False
+    if lookup(sk.split(":", 1)[1]) is not None:
+        return False
+    return _slot_by_linked_key(slots, sk) is None
+
+
+def _cron_job_owner(jobs: object, job_id: str) -> str:
+    """The app that created a cron job, or ``""`` (person-created, or no such job).
+
+    Reads the in-memory job list CACHE-ONLY: no store lock, no ``_sync``, no
+    disk I/O, because this runs ON the event loop and the cron store's
+    synchronous readers deliberately refuse to be called there. The list is
+    replaced by atomic reference assignment, so iterating one snapshot can never
+    see a half-rebuilt list -- the same rationale the cron reaper's own
+    lock-free read relies on.
+    """
+    if jobs is None or not job_id:
+        # An empty id identifies nothing; matching a record that also happens to
+        # carry an empty id would resolve a malformed key to somebody's app.
+        return ""
+    try:
+        snapshot = list(cast("Iterable[Any]", jobs))  # one coherent list; never torn
+    except Exception:  # noqa: BLE001 - an auth path must never 500 on this
+        return ""
+    for job in snapshot:
+        if str(getattr(job, "id", "") or "") != job_id:
+            continue
+        created_by = str(getattr(job, "created_by", "") or "")
+        if created_by.startswith("app:"):
+            return created_by[len("app:") :]
+        # A job the person created.
+        return ""
+    return ""
+
+
+def _slot_by_linked_key(slots: object, session_key: str) -> object | None:
+    """The slot whose ``linked_session_key`` is ``session_key``, or ``None``.
+
+    Scans rather than indexes because the registry is keyed by slot name; the
+    live slot count is small (one per open tab) and this runs only after the
+    direct lookup missed. Defensive against a registry that is not a mapping and
+    against a slot object without the attribute, because a raise here would turn
+    an authenticated request into a 500.
+    """
+    try:
+        candidates = list(getattr(slots, "values", lambda: [])())
+    except Exception:  # noqa: BLE001 - a hostile/partial registry must not 500
+        return None
+    for slot in candidates:
+        if str(getattr(slot, "linked_session_key", "") or "") == session_key:
+            return slot
+    return None
+
+
+def _derive_internal_caller_app(request: web.Request) -> str:
+    """:func:`derive_caller_app` bound to an aiohttp request's own context."""
+    state = request.app.get("state")
+    if state is None:
+        return derive_caller_app(None, request.headers.get("X-Session-Key", ""))
+    # ``_jobs`` / ``_agents`` directly, not store readers: this runs on the event
+    # loop and the cron store's sync readers refuse that on purpose (they would
+    # park the loop for the lock window). See ``_cron_job_owner``.
+    jobs = getattr(getattr(state, "crons", None), "_jobs", None)
+    subagents = getattr(getattr(state, "subagents", None), "_agents", None)
+    return derive_caller_app(
+        getattr(state, "_slots", None),
+        request.headers.get("X-Session-Key", ""),
+        jobs,
+        subagents,
+    )
+
+
+def _internal_caller_record_missing(request: web.Request) -> bool:
+    """:func:`caller_record_is_missing` bound to an aiohttp request's context."""
+    state = request.app.get("state")
+    if state is None:
+        return False
+    return caller_record_is_missing(
+        request.headers.get("X-Session-Key", ""),
+        getattr(getattr(state, "crons", None), "_jobs", None),
+        getattr(getattr(state, "subagents", None), "_agents", None),
+    )
+
+
 def token_auth_middleware(
     *,
     internal_paths: frozenset[str] = frozenset(),
@@ -1720,11 +2020,51 @@ def token_auth_middleware(
                     _log_auth(request, "internal", "granted", "")
                     # Mark the grant so handlers can distinguish "the internal
                     # loopback caller (kiro-cli / MCP) authenticated" from "no
-                    # auth ran at all". This branch deliberately leaves
-                    # request["app"] unset — there is no app identity — so a
-                    # handler that fails closed on an absent app claim would
-                    # otherwise reject every MCP call.
+                    # auth ran at all".
                     request["internal_auth"] = True
+                    # Derive the app identity ONCE, here, so every ownership
+                    # check downstream sees it (issue #3690). The secret proves
+                    # the call came from inside, not who made it, so identity
+                    # comes from the authenticated calling session.
+                    #
+                    # Publishing is deliberately NARROWING-ONLY: the claim is
+                    # set only when an app is positively resolved. When the
+                    # caller is the person, ``request["app"]`` is left ABSENT
+                    # rather than set to ``""`` — several sites read a PRESENT
+                    # empty claim as positive proof of the dashboard user
+                    # (``"app" not in request or request["app"] != ""`` in
+                    # handlers/source_providers, and handlers/kiro_prerequisite),
+                    # so writing ``""`` here would turn their refusal of this
+                    # transport into an admission. Absence keeps those exactly
+                    # as they were; presence makes the app-ownership guards bite.
+                    _derived_app = _derive_internal_caller_app(request)
+                    if _derived_app:
+                        request["app"] = _derived_app
+                        # POSITIVE non-dashboard-user signal for the WS scope
+                        # gate, which must never infer trust from a falsy app
+                        # claim (CWE-269).
+                        request["is_dashboard_user"] = False
+                    elif _internal_caller_record_missing(request):
+                        # A delegated caller whose OWN record is gone. Absence of
+                        # an app claim is only trustworthy for a caller that
+                        # never had a record to carry one; a cron whose job was
+                        # deleted mid-run, or a subagent evicted from the
+                        # registry, would otherwise keep the app reach the
+                        # deleted record was the only proof of. Refused rather
+                        # than admitted as the person -- the narrow, positively
+                        # confirmed case, not every unplaceable caller (a Slack
+                        # thread has no record to be missing).
+                        _sel = _sel_fn()
+                        _sel.log_api_access(
+                            caller=_caller,
+                            operation="internal_auth",
+                            outcome="denied",
+                            source="token_auth",
+                            resources=path,
+                            error="delegated caller's own record is gone",
+                        )
+                        _log_auth(request, "internal", "denied", "delegated record missing")
+                        return _deny(request, "Forbidden", "caller_record_missing")
                     return await handler(request)  # type: ignore[operator]
                 # Wrong secret → deny (don't fall through)
                 _sel = _sel_fn()

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -542,6 +542,22 @@ def _caller_app_scope(caller_key: str, rows: list[dict]) -> str | None:
     for r in rows:
         if str(r.get("key") or "") == slot:
             return str(r.get("app") or "")
+    # A slot bound to a channel or cron session runs its turns under
+    # ``linked_session_key`` ("when set, _run_chat uses this as session key" --
+    # ``DashboardState``), so the caller presents THAT key and the match above
+    # cannot find it. The rows serialize the field, so an app-owned linked slot
+    # would otherwise read as unscoped here even though its owner is on record.
+    #
+    # POSITIVE matches only: a channel- or cron-born row is created with no
+    # ``app``, so returning on an ownerless match would answer "" (the person)
+    # for a delegated caller that the refusal below would otherwise fail closed
+    # on -- weakening this layer instead of extending it.
+    for r in rows:
+        if str(r.get("linked_session_key") or "") == caller_key:
+            linked_app = str(r.get("app") or "")
+            if linked_app:
+                return linked_app
+            break
     if caller_key.startswith(_DELEGATED_CALLER_PREFIXES):
         return None
     if caller_key.startswith("dashboard:"):

--- a/test/test_internal_secret_app_identity_3690.py
+++ b/test/test_internal_secret_app_identity_3690.py
@@ -1,0 +1,664 @@
+"""Issue #3690 -- the internal-secret transport must carry an app identity.
+
+App-ownership checks gate on ``request["app"]``. The app-token branch publishes
+it; the internal-secret branch (the managed MCP set) carried no app claim at
+all, so every one of those checks became a NO-OP on that transport and an app
+agent granted ``@kirocrew-dashboard`` arrived indistinguishable from the
+dashboard user.
+
+``token_auth.derive_caller_app`` is the single rule, resolved once in the
+middleware and re-used by the one route that also re-derives for
+defense-in-depth. Two properties are load-bearing and each has its own class
+below:
+
+* it RESOLVES an app for a caller whose session an app owns -- through any of the
+  three registries a caller can be placed by (the slot it names, the slot running
+  under its key, the cron job that created it), and
+* it is NARROWING-ONLY -- a person's call must leave the claim ABSENT, because
+  several sites read a PRESENT empty claim as positive proof of the dashboard
+  user, so publishing ``""`` would turn their refusal of this transport into an
+  admission.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+
+from kiro_crew.dashboard.token_auth import (
+    caller_names_a_missing_slot,
+    caller_record_is_missing,
+    derive_caller_app,
+    token_auth_middleware,
+)
+
+SECRET = "internal-secret-for-3690"
+INTERNAL = frozenset({"/api/chat"})
+
+
+class _Slot:
+    def __init__(self, app: str = "") -> None:
+        self._app = app
+        # Real slots default this to "" and set it only when bound to a channel
+        # or cron session (``DashboardState``); the derivation must not read a
+        # missing attribute as a match.
+        self.linked_session_key = ""
+
+
+class _Job:
+    def __init__(self, job_id: str, created_by: str = "") -> None:
+        self.id = job_id
+        self.created_by = created_by
+
+
+class _Sub:
+    def __init__(self, app: str = "") -> None:
+        self.app = app
+
+
+def _request(
+    session_key: str | None,
+    slots: dict | None,
+    jobs: list | None = None,
+    subagents: dict | None = None,
+):
+    """An internal-secret request on a loopback internal path.
+
+    ``request["app"]`` is modelled with a real dict so a test can assert on
+    ABSENCE, which is the whole point of the narrowing-only property -- a
+    ``MagicMock.__setitem__`` spy can prove a write happened but not that the
+    claim is genuinely unset.
+    """
+    req = MagicMock(spec=web.Request)
+    req.path = "/api/chat"
+    req.method = "POST"
+    req.query = {}
+    req.cookies = {}
+    req.remote = "127.0.0.1"
+    headers = {"X-Internal-Secret": SECRET}
+    if session_key is not None:
+        headers["X-Session-Key"] = session_key
+    req.headers = headers
+    store: dict = {}
+    req.__setitem__.side_effect = store.__setitem__
+    req.__getitem__.side_effect = store.__getitem__
+    req.__contains__.side_effect = store.__contains__
+    req.get.side_effect = store.get
+    state = MagicMock()
+    state._slots = slots
+    state.crons._jobs = jobs
+    state.subagents._agents = subagents
+    req.app = {"state": state}
+    return req, store
+
+
+async def _ok(request: web.Request) -> web.Response:
+    return web.Response(text="ok")
+
+
+async def _grant(
+    session_key: str | None,
+    slots: dict | None,
+    jobs: list | None = None,
+    subagents: dict | None = None,
+) -> dict:
+    mw = token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _request(session_key, slots, jobs, subagents)
+    resp = await mw(req, _ok)
+    assert resp.status == 200, "the internal-secret grant itself must be unaffected"
+    return store
+
+
+class TestAnAppOwnedCallerIsResolved:
+    """The escalation the issue reports: the guard must now have something to bite on."""
+
+    @pytest.mark.asyncio
+    async def test_a_slot_created_by_an_app_publishes_that_app(self) -> None:
+        store = await _grant("dashboard:slot-1", {"slot-1": _Slot("file-explorer")})
+        assert store.get("app") == "file-explorer", (
+            "an app agent reaching a dashboard route over the internal secret was "
+            "published as the dashboard user; every request['app'] ownership check "
+            "is a no-op for it (issue #3690)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_resolved_app_is_marked_not_the_dashboard_user(self) -> None:
+        """The WS scope gate must never infer trust from a falsy claim (CWE-269)."""
+        store = await _grant("dashboard:slot-1", {"slot-1": _Slot("file-explorer")})
+        assert store.get("is_dashboard_user") is False
+
+    @pytest.mark.asyncio
+    async def test_an_unprefixed_session_key_resolves_too(self) -> None:
+        store = await _grant("slot-1", {"slot-1": _Slot("mochi")})
+        assert store.get("app") == "mochi"
+
+
+class TestPublishingIsNarrowingOnly:
+    """A person's call must leave the claim ABSENT, not empty.
+
+    ``handlers/source_providers`` (``"app" not in request or request["app"] != ""``)
+    and ``handlers/kiro_prerequisite`` treat a PRESENT empty claim as positive
+    proof of the dashboard user, and today refuse this transport because the key
+    is missing. Writing ``""`` here would silently convert those refusals into
+    admissions -- a widening hidden inside a narrowing fix.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "session_key, slots, why",
+        [
+            (None, {}, "no session key at all: the gateway's own calls, the CLI, curl"),
+            ("dashboard:ui", {}, "the dashboard UI itself"),
+            ("dashboard:slot-1", {"slot-1": _Slot("")}, "a session the person started"),
+            ("slack:C123:169.1", None, "a Slack thread, which never had a dashboard slot"),
+            ("subagent:abc", {}, "a subagent on a surface with no registry wired"),
+            ("dashboard:closed-tab", {}, "a key naming a slot that is gone"),
+        ],
+    )
+    async def test_a_caller_with_no_app_leaves_the_claim_absent(
+        self, session_key: str | None, slots: dict | None, why: str
+    ) -> None:
+        store = await _grant(session_key, slots)
+        assert "app" not in store, (
+            f"an empty app claim was PUBLISHED for {why} -- that flips the "
+            f"fail-closed sites which read a present empty claim as proof of the "
+            f"dashboard user from refusing this transport to admitting it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_person_is_not_marked_as_a_non_dashboard_user(self) -> None:
+        store = await _grant("dashboard:slot-1", {"slot-1": _Slot("")})
+        assert "is_dashboard_user" not in store
+
+
+class TestASlotRunningUnderALinkedKeyStillYieldsItsApp:
+    """A channel- or cron-bound slot runs its turns under ``linked_session_key``
+    ("when set, _run_chat uses this as session key" -- ``DashboardState``), so the
+    caller presents THAT key and a lookup by slot name misses it.
+
+    Without the second lookup the slot's ``_app`` is invisible and the caller
+    reads as the person, which is the exact shape this fix exists to end: the
+    slot IS in the registry and may carry an owner.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_channel_linked_app_slot_is_resolved(self) -> None:
+        slot = _Slot("file-explorer")
+        slot.linked_session_key = "slack:C123:169.1"
+        store = await _grant("slack:C123:169.1", {"channel-C123": slot})
+        assert store.get("app") == "file-explorer", (
+            "a slot bound to a channel session was read as the dashboard user "
+            "because the lookup only tried the slot name, so every ownership "
+            "check stayed a no-op for it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_linked_slot_the_person_owns_stays_unscoped(self) -> None:
+        """Narrowing-only holds here too: locating the slot must not invent an app."""
+        slot = _Slot("")
+        slot.linked_session_key = "slack:C123:169.1"
+        store = await _grant("slack:C123:169.1", {"channel-C123": slot})
+        assert "app" not in store
+
+    def test_a_non_matching_linked_key_does_not_bleed(self) -> None:
+        slot = _Slot("file-explorer")
+        slot.linked_session_key = "slack:C999:1.0"
+        assert derive_caller_app({"channel-C999": slot}, "slack:C123:169.1") == ""
+
+    def test_the_direct_lookup_still_wins(self) -> None:
+        """A slot addressed by its own name must not be overridden by a scan."""
+        named = _Slot("named-app")
+        linked = _Slot("linked-app")
+        linked.linked_session_key = "dashboard:slot-1"
+        assert derive_caller_app({"slot-1": named, "other": linked}, "dashboard:slot-1") == (
+            "named-app"
+        )
+
+    def test_a_registry_without_values_does_not_raise(self) -> None:
+        """A raise here would turn an authenticated request into a 500."""
+
+        class _Hostile:
+            def get(self, _k):  # noqa: ANN001, ANN202
+                return None
+
+            def values(self):  # noqa: ANN202
+                raise RuntimeError("partial registry")
+
+        assert derive_caller_app(_Hostile(), "slack:C1:2") == ""
+
+
+class TestAnAppCreatedCronIsResolvedFromTheCronRegistry:
+    """A cron created by an app is tagged ``created_by="app:<name>"`` (``CronSDK``),
+    so its owner is a matter of record -- and a cron usually has no dashboard slot,
+    which is why the slot lookups cannot see it.
+
+    Resolving it positively is what lets an app-owned cron be confined while the
+    person's own crons keep working. Refusing every unplaceable delegated caller
+    instead would take cron and subagent tools from the person too.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_app_created_cron_publishes_its_owning_app(self) -> None:
+        store = await _grant("cron:job-9", {}, jobs=[_Job("job-9", "app:file-explorer")])
+        assert store.get("app") == "file-explorer", (
+            "an app-owned cron with no slot was published as the dashboard user, "
+            "so it could reach the agent notification publish path (which refuses "
+            "app callers) and impersonate a system notification"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_persons_own_cron_keeps_working_unscoped(self) -> None:
+        """Cron notifications are a first-class use; this must not be confined."""
+        store = await _grant("cron:job-9", {}, jobs=[_Job("job-9", "user")])
+        assert "app" not in store
+
+    def test_an_unknown_cron_job_yields_no_app(self) -> None:
+        """The derivation invents nothing for an unknown job. The REQUEST for such
+        a caller is refused -- see
+        ``TestADelegatedCallerWhoseRecordIsGoneIsRefused`` -- so this asserts at
+        the pure-function level, where no refusal exists."""
+        assert derive_caller_app({}, "cron:ghost", [_Job("job-9", "app:mochi")]) == ""
+
+    def test_a_subagent_key_is_not_resolved_from_the_cron_registry(self) -> None:
+        """Only a cron key may be looked up there; a subagent id is a different
+        namespace and a collision must not hand it an app."""
+        assert derive_caller_app({}, "subagent:job-9", [_Job("job-9", "app:x")]) == ""
+
+    def test_a_hostile_job_registry_does_not_raise(self) -> None:
+        class _Boom:
+            def __iter__(self):  # noqa: ANN204
+                raise RuntimeError("cron store mid-swap")
+
+        assert derive_caller_app({}, "cron:j", _Boom()) == ""
+
+    def test_no_cron_registry_yields_no_app(self) -> None:
+        assert derive_caller_app({}, "cron:j") == ""
+
+
+class TestAKeyNamingAMissingSlotIsNotProofOfThePerson:
+    """``caller_names_a_missing_slot`` -- the distinction the plain ``""`` cannot carry.
+
+    ``derive_caller_app`` returning ``""`` covers two different situations: a
+    caller that never had a slot (a Slack thread, the person's own cron) and a
+    ``dashboard:`` key whose slot is GONE. The first is proof no app owns the
+    caller; the second is a failure to attribute, because the ``_app`` that would
+    have confined it is exactly what got popped when the tab closed.
+
+    One writer, one reader: the route that publishes ``source="system"``.
+    Deliberately not applied in the middleware -- a popped slot no longer says
+    whose tab it was, so a central refusal would also refuse the person's own
+    in-flight calls on every internal route.
+    """
+
+    def test_a_dashboard_key_with_no_slot_is_flagged(self) -> None:
+        assert caller_names_a_missing_slot({}, "dashboard:closed-tab") is True
+
+    def test_a_live_slot_is_not_flagged(self) -> None:
+        assert caller_names_a_missing_slot({"slot-1": _Slot("x")}, "dashboard:slot-1") is False
+
+    def test_a_slot_found_by_its_linked_key_is_not_flagged(self) -> None:
+        slot = _Slot("x")
+        slot.linked_session_key = "dashboard:slot-1"
+        assert caller_names_a_missing_slot({"other": slot}, "dashboard:slot-1") is False
+
+    @pytest.mark.parametrize(
+        "session_key",
+        ["dashboard:ui", "slack:C1:2", "cron:job-9", "subagent:abc", "", "slot-1"],
+    )
+    def test_a_caller_that_never_named_a_slot_is_not_flagged(self, session_key: str) -> None:
+        """Only a ``dashboard:`` key names one; flagging the others would refuse
+        callers that legitimately have no slot -- cron notifications above all."""
+        assert caller_names_a_missing_slot({}, session_key) is False
+
+
+class TestTheAgentNotificationRouteRefusesAnUnattributableCaller:
+    """The route publishes ``source="system"`` on the system.agent channel, so it
+    already refuses app tokens by name. A tab closed mid-call takes the ``_app``
+    that check reads with it, so an app-owned session in that race would publish
+    as though it were the person.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_caller_whose_slot_is_gone_is_refused(self) -> None:
+        from kiro_crew.dashboard.handlers import messaging
+
+        req = MagicMock(spec=web.Request)
+        req.headers = {"X-Session-Key": "dashboard:closed-tab"}
+        store = {"internal_auth": True}
+        req.get.side_effect = store.get
+        state = MagicMock()
+        state._slots = {}
+        req.app = {"state": state}
+
+        resp = await messaging.api_notification_agent_push(req)
+        assert resp.status == 403, (
+            "a caller whose own slot is gone published a system notification; the "
+            "app-token check cannot see the app because the slot carrying it was "
+            "popped when the tab closed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_cron_caller_is_not_refused_by_that_guard(self) -> None:
+        """Cron notifications are a first-class use and a cron has no slot by
+        nature, so the guard must not reach them.
+
+        Proven by getting PAST it: with no body plumbing on the mock, the handler
+        fails downstream in body reading. The guard returns a 403 response rather
+        than raising, so an exception from deeper in the handler is positive
+        evidence the cron caller was not refused here.
+        """
+        from kiro_crew.dashboard.handlers import messaging
+
+        req = MagicMock(spec=web.Request)
+        req.headers = {"X-Session-Key": "cron:job-9"}
+        store = {"internal_auth": True}
+        req.get.side_effect = store.get
+        state = MagicMock()
+        state._slots = {}
+        req.app = {"state": state}
+
+        with pytest.raises(TypeError):
+            await messaging.api_notification_agent_push(req)
+
+
+class TestAnAppSpawnedSubagentIsResolvedFromTheSubagentRegistry:
+    """A child spawned by an app carries it in ``SubagentInfo.app``, persisted for
+    exactly this purpose -- the field's own note says it is kept so "the child's
+    per-tool-call gate can resolve the app's Level-2 profile", because otherwise
+    "the child's ongoing tool calls run unconstrained by the app scope".
+
+    A tool call arriving over the internal secret IS one of those ongoing calls,
+    so reading the field here is the field doing its declared job.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_app_spawned_subagent_publishes_its_spawning_app(self) -> None:
+        store = await _grant("subagent:abc123", {}, subagents={"abc123": _Sub("file-explorer")})
+        assert store.get("app") == "file-explorer", (
+            "an app-spawned child was published as the dashboard user, so it "
+            "could reach the agent notification publish path and impersonate a "
+            "system notification"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_person_spawned_subagent_stays_unscoped(self) -> None:
+        store = await _grant("subagent:abc123", {}, subagents={"abc123": _Sub("")})
+        assert "app" not in store
+
+    def test_an_unknown_subagent_yields_no_app(self) -> None:
+        """As with cron: the derivation invents nothing, and the request itself is
+        refused (see ``TestADelegatedCallerWhoseRecordIsGoneIsRefused``)."""
+        assert derive_caller_app({}, "subagent:ghost", None, {"abc123": _Sub("mochi")}) == ""
+
+    def test_a_cron_key_is_not_resolved_from_the_subagent_registry(self) -> None:
+        """Separate namespaces; an id collision must not hand one the other's app."""
+        assert derive_caller_app({}, "cron:abc123", None, {"abc123": _Sub("x")}) == ""
+
+    def test_a_hostile_subagent_registry_does_not_raise(self) -> None:
+        class _Boom:
+            def get(self, _k):  # noqa: ANN001, ANN202
+                raise RuntimeError("registry mid-mutation")
+
+        assert derive_caller_app({}, "subagent:a", None, _Boom()) == ""
+
+    def test_no_subagent_registry_yields_no_app(self) -> None:
+        assert derive_caller_app({}, "subagent:a") == ""
+
+
+class TestAnOwnerlessRecordDoesNotEndTheSearch:
+    """Each registry answers only "yes, THIS app owns it"; an ownerless answer
+    falls through.
+
+    A session can be recorded in more than one place and only some records carry
+    the owner. The forcing case: an app-created cron with a cron-born tab is in
+    the SLOT registry with no ``_app`` (a channel/cron-born slot is created
+    without one) and in the CRON registry WITH its ``created_by`` owner. Stopping
+    at the slot would hand that app the dashboard user's reach.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_ownerless_linked_slot_does_not_mask_the_cron_owner(self) -> None:
+        tab = _Slot("")  # cron-born tabs carry no _app
+        tab.linked_session_key = "cron:job-9"
+        store = await _grant(
+            "cron:job-9", {"cron-tab": tab}, jobs=[_Job("job-9", "app:file-explorer")]
+        )
+        assert store.get("app") == "file-explorer", (
+            "the ownerless cron-born tab ended the search before the cron "
+            "registry was asked, so an app-owned cron was published as the "
+            "dashboard user"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_ownerless_named_slot_does_not_mask_the_subagent_owner(self) -> None:
+        store = await _grant(
+            "subagent:abc123",
+            {"abc123": _Slot("")},
+            subagents={"abc123": _Sub("mochi")},
+        )
+        assert store.get("app") == "mochi"
+
+    def test_the_search_still_ends_on_a_positive_owner(self) -> None:
+        """Falling through must not let a later registry override an earlier
+        positive answer."""
+        named = _Slot("named-app")
+        assert (
+            derive_caller_app({"job-9": named}, "cron:job-9", [_Job("job-9", "app:other")])
+            == "named-app"
+        )
+
+
+class TestAStatelessCronKeyResolvesToItsJob:
+    """A cron session key has two forms: ``cron:<job_id>`` for a persistent job
+    and ``cron:<job_id>:<run_id>`` for a stateless one (``cron._build_prompt``).
+
+    Taking the whole remainder after the first colon yields ``<job_id>:<run_id>``
+    for the stateless form, which matches no job -- so an app-owned stateless
+    cron would resolve to no owner and be handed the dashboard user's reach.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_stateless_run_key_still_finds_its_owner(self) -> None:
+        store = await _grant("cron:job-9:a1b2c3d4", {}, jobs=[_Job("job-9", "app:file-explorer")])
+        assert store.get("app") == "file-explorer", (
+            "the stateless cron key's run-id segment was folded into the job id, "
+            "so the lookup missed and an app-owned cron read as the person"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_persistent_run_key_is_unaffected(self) -> None:
+        store = await _grant("cron:job-9", {}, jobs=[_Job("job-9", "app:mochi")])
+        assert store.get("app") == "mochi"
+
+    def test_a_stateless_key_for_a_person_owned_job_stays_unscoped(self) -> None:
+        assert derive_caller_app({}, "cron:job-9:run", [_Job("job-9", "user")]) == ""
+
+    def test_a_bare_prefix_with_no_id_resolves_to_nothing(self) -> None:
+        assert derive_caller_app({}, "cron:", [_Job("", "app:x")]) == ""
+        assert derive_caller_app({}, "subagent:", None, {"": _Sub("x")}) == ""
+
+
+class TestADelegatedCallerWhoseRecordIsGoneIsRefused:
+    """A ``cron:``/``subagent:`` key names recorded work, and that record is where
+    its owner lives -- so absence is "the proof of who this runs for is gone",
+    not "nothing to confine".
+
+    Narrow by construction: a live subagent is always registered (only ``done``
+    records are evicted, by ``evict_completed_agents``) and a cron job stays until
+    removed, so this fires for a job DELETED while its run still makes calls. A
+    Slack thread has no record to be missing and is untouched.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_cron_deleted_mid_run_is_refused(self) -> None:
+        mw = token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+        req, _ = _request("cron:job-9", {}, jobs=[])  # job removed while running
+        resp = await mw(req, _ok)
+        assert resp.status == 403, (
+            "a cron whose job was deleted mid-run kept the dashboard user's "
+            "reach; the deleted record was the only proof of its owner"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_subagent_missing_from_the_registry_is_refused(self) -> None:
+        mw = token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+        req, _ = _request("subagent:gone", {}, subagents={})
+        resp = await mw(req, _ok)
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_a_live_record_is_admitted(self) -> None:
+        store = await _grant("cron:job-9", {}, jobs=[_Job("job-9", "user")])
+        assert "app" not in store  # the person's cron, unconfined and working
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "session_key",
+        ["slack:C123:169.1", "dashboard:slot-1", "dashboard:ui", None],
+    )
+    async def test_a_caller_with_no_record_to_lose_is_admitted(
+        self, session_key: str | None
+    ) -> None:
+        """Only delegated keys name a record. Refusing anything else would deny
+        Slack threads, channel sessions and the dashboard itself."""
+        mw = token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+        req, _ = _request(session_key, {"slot-1": _Slot("")}, jobs=[], subagents={})
+        resp = await mw(req, _ok)
+        assert resp.status == 200
+
+    def test_an_absent_registry_is_not_a_refusal(self) -> None:
+        """A surface wired without the registry (the --slack-only API server)
+        must not refuse every delegated caller over a missing dependency."""
+        assert caller_record_is_missing("cron:job-9", None, None) is False
+        assert caller_record_is_missing("subagent:abc", None, None) is False
+
+    def test_an_unreadable_registry_is_not_a_refusal(self) -> None:
+        """Do not manufacture a refusal from a failure to LOOK -- that would deny
+        every delegated caller on a transient error."""
+
+        class _Boom:
+            def __iter__(self):  # noqa: ANN204
+                raise RuntimeError("mid-swap")
+
+            def get(self, _k):  # noqa: ANN001, ANN202
+                raise RuntimeError("mid-mutation")
+
+        assert caller_record_is_missing("cron:j", _Boom(), None) is False
+        assert caller_record_is_missing("subagent:a", None, _Boom()) is False
+
+    def test_a_resolvable_app_owner_is_never_refused(self) -> None:
+        """The deny is the else-branch of resolution, so a found owner wins."""
+        assert caller_record_is_missing("cron:job-9", [_Job("job-9", "app:x")], None) is False
+
+
+class TestTheRuleIsPureAndShared:
+    """``derive_caller_app`` takes registries and the key -- never a request.
+
+    The folder route re-derives for defense-in-depth by calling THIS function,
+    so the middleware and the route cannot drift into two different rules (the
+    drift that made the per-route patch necessary in the first place).
+    """
+
+    def test_no_slot_registry_still_resolves_a_cron_owner(self) -> None:
+        """The ``--slack-only`` API server has no slots, but a cron still has an owner."""
+        assert derive_caller_app(None, "subagent:x") == ""
+        assert derive_caller_app(None, "cron:j", [_Job("j", "app:mochi")]) == "mochi"
+
+    def test_the_folder_route_reads_the_same_rule(self) -> None:
+        from kiro_crew.dashboard import chat_folders
+
+        state = MagicMock()
+        state._slots = {"slot-1": _Slot("file-explorer")}
+        req = MagicMock(spec=web.Request)
+        req.headers = {"X-Session-Key": "dashboard:slot-1"}
+        req.get.return_value = ""  # middleware claim absent
+        assert chat_folders._effective_request_app(state, req) == "file-explorer"
+
+    def test_the_folder_route_prefers_a_published_claim(self) -> None:
+        from kiro_crew.dashboard import chat_folders
+
+        state = MagicMock()
+        state._slots = {}
+        req = MagicMock(spec=web.Request)
+        req.headers = {}
+        req.get.return_value = "already-derived"
+        assert chat_folders._effective_request_app(state, req) == "already-derived"
+
+    def test_scope_is_never_taken_from_a_body_or_argument(self) -> None:
+        """Signature guard: the rule reads server-side registries and a key only.
+
+        A caller that could name its own scope could name someone else's, so the
+        function must have no way to see a request, a body, or tool arguments.
+        Growing another REGISTRY parameter is fine; growing a request-shaped one
+        is the thing this pins.
+        """
+        import inspect
+
+        params = list(inspect.signature(derive_caller_app).parameters)
+        assert params == ["slots", "session_key", "jobs", "subagents"], (
+            f"derive_caller_app's signature changed ({params}); every parameter "
+            f"must be a server-side registry or the caller's own key -- anything "
+            f"request- or argument-shaped lets a caller name its own scope"
+        )
+
+
+class TestTheMcpToolLayerResolvesLinkedKeysToo:
+    """``mcp_dashboard._caller_app_scope`` is the same rule for the MCP tool set.
+
+    It matched rows by ``key`` only, though the rows serialize
+    ``linked_session_key`` (``DashboardState``), so a channel-linked app slot read
+    as unscoped there even after the middleware learned to resolve it. Leaving
+    that in place would keep one instance of the exact bug class this change
+    exists to end.
+    """
+
+    def test_a_channel_linked_app_row_is_resolved(self) -> None:
+        from kiro_crew.mcp_dashboard import _caller_app_scope
+
+        rows = [
+            {
+                "key": "channel-C123",
+                "app": "file-explorer",
+                "linked_session_key": "slack:C123:169.1",
+            }
+        ]
+        assert _caller_app_scope("slack:C123:169.1", rows) == "file-explorer"
+
+    def test_the_direct_key_match_still_wins(self) -> None:
+        from kiro_crew.mcp_dashboard import _caller_app_scope
+
+        rows = [
+            {"key": "slot-1", "app": "named-app", "linked_session_key": ""},
+            {"key": "other", "app": "linked-app", "linked_session_key": "dashboard:slot-1"},
+        ]
+        assert _caller_app_scope("dashboard:slot-1", rows) == "named-app"
+
+    def test_an_unplaceable_delegated_caller_is_still_refused(self) -> None:
+        """The MCP layer's own fail-closed rule must survive the new lookup."""
+        from kiro_crew.mcp_dashboard import _caller_app_scope
+
+        assert _caller_app_scope("subagent:abc", []) is None
+        assert _caller_app_scope("cron:job-9", []) is None
+        assert _caller_app_scope("dashboard:gone", []) is None
+
+    def test_an_ownerless_linked_row_does_not_bypass_the_refusal(self) -> None:
+        """A cron-born row carries no ``app``, so returning on that match would
+        answer "" (the person) for a delegated caller this layer fails closed on
+        -- weakening it instead of extending it."""
+        from kiro_crew.mcp_dashboard import _caller_app_scope
+
+        rows = [{"key": "cron-tab", "app": "", "linked_session_key": "cron:job-9"}]
+        assert _caller_app_scope("cron:job-9", rows) is None
+
+    def test_an_app_owned_linked_row_is_still_resolved(self) -> None:
+        from kiro_crew.mcp_dashboard import _caller_app_scope
+
+        rows = [{"key": "cron-tab", "app": "mochi", "linked_session_key": "cron:job-9"}]
+        assert _caller_app_scope("cron:job-9", rows) == "mochi"
+
+    def test_a_slotless_caller_is_still_unscoped(self) -> None:
+        from kiro_crew.mcp_dashboard import _caller_app_scope
+
+        assert _caller_app_scope("slack:C1:2", []) == ""


### PR DESCRIPTION
## 1. What is the problem?

App-ownership checks across the dashboard gate on `request["app"]`. Only the
app-token branch of `token_auth_middleware` publishes that claim. The
internal-secret branch -- the managed MCP set -- deliberately left it unset,
with the comment explaining why: the secret proves a call came from inside, not
who made it.

The consequence is that every ownership check of the shape

```python
request_app = request.get("app", "")
if request_app and getattr(slot, "_app", "") != request_app:
    return refuse()
```

becomes a **no-op** on that transport, because `request_app` is always empty.
An app agent granted `@kirocrew-dashboard` therefore arrived indistinguishable
from the dashboard user. Reads of the claim are spread over 22 files; only ONE
route (the chat slot folder PATCH) compensated, by re-deriving the identity
itself.

Two earlier fixes took the cheap half of this: PR #3473 added `cron:` next to
`subagent:` in a delegated-caller refusal set whose own comment calls the list
"KNOWINGLY INCOMPLETE -- a key form added later will read as unscoped until it
is added here."

## 2. Why this issue matters to the user

App isolation is the boundary that lets a user install an app without handing it
their whole workspace. On this transport the boundary was not enforced, so an
app holding a dashboard tool could mutate a session it does not own -- refiling
someone else's chat moves it in the sidebar and re-injects its folder breadcrumb
on that session's next turn. Because the guard fails OPEN rather than erroring,
nothing surfaced: the checks read as present in the code and passed in tests.

It also means the gap grows silently. Every new dashboard route that follows the
existing ownership pattern inherits the hole, and every new caller-key form
starts out reading as "the person".

## 3. How our fix solves it

The fix follows the chain from the symptom back to its cause.

**Symptom:** ownership checks pass unconditionally on one transport.
**Cause:** the identity is published by only one of the two auth branches.
**Fix:** derive it once, in the middleware, for both.

`derive_caller_app` resolves the app from the authenticated CALLING SESSION. The
agent cannot forge the key it resolves against, because it does not build the
request -- the in-process MCP broker sets `X-Session-Key` from the calling
session's own context and never from tool arguments, and on an AF_UNIX transport
`_verify_unix_peer` has already kernel-attested it against `/proc` ancestry
before this runs.

A caller is placed against four server-side registries -- one per way a session
can be owned:

1. **The slot the key names.** A slot created by an app carries that app in
   `_app` (App Kit 5.2).
2. **The slot RUNNING under that key.** A channel- or cron-bound slot takes its
   turns under `linked_session_key` ("when set, `_run_chat` uses this as session
   key" -- `DashboardState`), so the caller presents that key and a lookup by
   slot name cannot find it. The slot is in the registry and may carry an owner,
   so missing it read a possibly-app-owned caller as the person.
3. **For a cron key, the job's `created_by` owner tag,** which `CronSDK` sets to
   `app:<name>`. A cron usually has no dashboard slot at all, so its owner is
   only knowable from the cron record -- and knowing it is what lets an
   app-owned cron be confined while the person's own crons keep working. The
   read is CACHE-ONLY (no store lock, no disk I/O) because this runs on the
   event loop and the cron store's synchronous readers deliberately refuse to be
   called there; the job list is replaced by atomic reference assignment, which
   is the same property the cron reaper's own lock-free read relies on.
4. **For a subagent key, the child record's spawning `app`.** `SubagentInfo.app`
   is persisted for precisely this purpose -- its own note says it is kept so
   "the child's per-tool-call gate can resolve the app's Level-2 profile",
   because otherwise "the child's ongoing tool calls run unconstrained by the app
   scope". A tool call arriving over the internal secret is one of those ongoing
   calls, so reading it here is the field doing its declared job.

**Publishing is narrowing-only.** The claim is set only when an app is
positively resolved. A caller with no app leaves `request["app"]` **absent**
rather than empty. This is not a stylistic choice: `handlers/source_providers`
gates on `"app" not in request or request["app"] != ""` and
`handlers/kiro_prerequisite` on `request.get("app") != ""`. Those sites read a
PRESENT empty claim as positive proof of the dashboard user, and today refuse
this transport precisely because the key is missing. Writing `""` would have
flipped them from refusing to admitting -- a widening hidden inside a narrowing
fix. Absence leaves them exactly as they were; presence makes the ownership
guards bite.

**One rule, no second copy.** `derive_caller_app(slots, session_key, jobs)` takes
server-side registries and the caller's own key -- never a request -- so the
middleware and the folder route that still re-derives for defense-in-depth share
a single implementation. That drift is what made the per-route patch necessary in
the first place. The signature is pinned by a test, because a request- or
argument-shaped parameter would let a caller name its own scope.

The MCP tool layer's own copy of this rule (`mcp_dashboard._caller_app_scope`)
gains the same linked-key lookup. It matched rows by `key` only although the rows
serialize `linked_session_key`, so a channel-linked app slot still read as
unscoped one layer down -- leaving a known instance of the exact bug class this
change exists to end.

Deliberately NOT in scope: this PR publishes identity, it does not also apply
the app's `permissions.api` allowlist to that transport. Doing so is a second,
larger behaviour change and belongs in its own review.

## 4. What tests we did

New `test/test_internal_secret_app_identity_3690.py`, 33 tests in six classes:
one per registry a caller can be placed by, one for the narrowing-only property,
one for the shared-rule guarantee, and one for the MCP-layer sibling. Covered
caller classes: an app-owned slot, the person's own slot, no session key at all,
`dashboard:ui`, a Slack thread, a subagent with no slot, a key naming a slot that
is gone, a channel-linked app slot, a channel-linked slot the person owns, an
app-created cron, the person's own cron, an unknown cron job, and a hostile or
mid-swap registry (which must never turn an authenticated request into a 500).

The requests carry a real dict for the request store rather than a bare
MagicMock, so a test can assert on the claim being genuinely ABSENT -- a
`__setitem__` spy can prove a write happened but not that it did not.

Mutation-verified, seven probes, each flipping the suite red:

| probe | mutation | result |
| --- | --- | --- |
| m1 | middleware stops publishing the derived app (pre-fix behaviour) | 5 failed |
| m2 | publish the claim even when empty (the widening) | 10 failed |
| m3 | folder route stops re-deriving | 4 failed |
| m4 | remove the linked-session-key lookup | 1 failed |
| m5 | remove the cron-owner lookup | 2 failed |
| m6 | remove the MCP-layer linked-key lookup | 1 failed |
| m7 | drop the not-dashboard-user signal (CWE-269 guard) | 1 failed |

Regression: 360 passed across this module and the chat-folder isolation,
MCP-dashboard-folders and token-auth suites; an earlier 674-test sweep over the
auth, peer-auth, app-proxy, api-server, artifacts, artifact-folder,
ephemeral-session and input-validation suites was clean apart from two failures
in `test_artifacts_handlers.py`
(`test_copy_outside_allowed_roots_is_refused`,
`test_request_cannot_nominate_its_own_root`) that reproduce identically with this
branch's changes stashed, so they are pre-existing host failures. `isort`,
`flake8` and `mypy` clean on the touched files; mypy's two remaining errors are
in `src/kiro_crew/transcribe.py`, which this PR does not touch and which fails
the same way on main.

## 5. Any other suggestions on the work

Two follow-ups this deliberately leaves open:

- **The api allowlist on the internal-secret transport.** Now that an app is
  identifiable there, `_enforce_app_scope` could confine it to its declared
  paths the way the cookie branch already does. That would break app agents
  whose manifests never declared the dashboard routes they use today, so it
  needs its own review and probably a migration note.
- **#3503 and #3569.** #3503 is this same transport gap seen from the SEL
  audit-labelling side (folder writes infer `mcp` from the secret instead of
  from the caller); the identity this PR derives is exactly what that attribution
  needs, so it should consume `derive_caller_app` rather than growing its own
  resolver. #3569 (chat folders have no owner) is adjacent and constrains what
  ownership can mean for folder-scoped routes.

One note on what this PR does NOT settle. Issue #3690 also asks whether a caller
with no locatable session should be REFUSED rather than treated as unscoped.
This change does not take that inversion, and deliberately ships no general
signal for it either. It does not need to: the four lookups cover every registry
that can own a session, so a caller that still resolves to no app is one that
genuinely has no owner on record -- the person, or a Slack thread that never had
one. The single case where the difference matters, a `dashboard:` key whose slot
was popped mid-call, is answered by `caller_names_a_missing_slot` at the one route
whose publish depends on it. A middleware-wide refusal would instead deny the
person's own in-flight calls on every internal route, which is a product decision
rather than a bug fix.

Closes #3690
