### PR TITLE
fix(mcp): resolve one (base, socket_path) pair per request attempt

### DIFF
--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -125,9 +125,10 @@ _STABLE_PORT_SOURCES = frozenset({"cli", "env", "bound", "config"})
 # Deliberately NOT computed at import: resolution reads config and the
 # gateway's live run-marker, both of which can change between process start
 # and the first gateway call — an import-time snapshot froze a wrong guess
-# for the whole process lifetime. The URL and the socket path both derive
-# from the single ``_API_PORT`` resolution, so the two transports can never
-# name different gateways.
+# for the whole process lifetime. A REQUEST derives its URL and socket path
+# from one resolution (``_resolve_api_target``), so the two transports of an
+# attempt can never name different gateways; these caches hold that pair only
+# for the stable sources that are safe to pin.
 _API_PORT: int | None = None
 _API: str | None = None
 _API_UNIX_SOCKET: str | None = None
@@ -196,9 +197,8 @@ def _api_unix_socket() -> str:
     """
     global _API_UNIX_SOCKET
     if _API_UNIX_SOCKET is None:
-        try:
-            path = str(dashboard_socket_path(_api_port()))
-        except Exception:
+        path = _socket_path_for(_api_port())
+        if not path:
             _API_UNIX_SOCKET = ""
             return _API_UNIX_SOCKET
         if _API_PORT is None:
@@ -208,9 +208,81 @@ def _api_unix_socket() -> str:
     return _API_UNIX_SOCKET
 
 
-def _api_urlopen(req: urllib.request.Request | str, timeout: float):
-    """``loopback_urlopen`` against the API base with the unix-socket preference."""
-    return loopback_urlopen(req, timeout=timeout, unix_socket_path=_api_unix_socket() or None)
+def _socket_path_for(port: int) -> str:
+    """Unix-socket path for *port*, or ``""`` when one cannot be derived.
+
+    Split out of :func:`_api_unix_socket` so a caller that already holds a
+    resolved port can derive the socket from THAT port instead of re-running
+    the discovery chain to find one.
+    """
+    try:
+        return str(dashboard_socket_path(port))
+    except Exception:
+        return ""
+
+
+def _resolve_api_target() -> tuple[str, str]:
+    """The ``(base, socket_path)`` pair for ONE request attempt, from ONE resolution.
+
+    ``_api_base`` and ``_api_unix_socket`` are correct for callers that want one
+    of the two, but a request needs BOTH, and on a marker-discovered port
+    neither is cached — so asking each of them ran the discovery chain twice
+    for a single attempt. Two forks of ``lsof`` per gateway call is the cost;
+    the correctness half is that the two answers are independent, and the
+    marker rule exists precisely because the answer can change between them. A
+    gateway that exits and is replaced mid-attempt would leave the TCP base
+    naming one gateway and the unix socket another — and ``loopback_urlopen``
+    PREFERS the socket, so the component actually carrying the request is the
+    one ``_send``'s replay guard never inspected.
+
+    Resolving once and deriving both halves from that single port restores the
+    "both transports derive from one resolution" invariant the cache comment
+    and :func:`_invalidate_api_base` already claim.
+
+    This does NOT weaken the ownership proof. The proof is per ATTEMPT, not per
+    process: a marker resolution is still never pinned, every attempt still
+    re-runs the chain, and the replay in :func:`_send` resolves a FRESH pair
+    rather than reusing the refused one. What changes is that one attempt now
+    proves ownership once instead of twice.
+    """
+    global _API, _API_UNIX_SOCKET
+    if _API is not None and _API_UNIX_SOCKET is not None:
+        # Both memos populated: hand back exactly what the standalone getters
+        # would answer. The condition is deliberately NOT also `_API_PORT is not
+        # None`. `_api_base` / `_api_unix_socket` return a populated memo
+        # whatever the port cache holds, and tests pre-seed these two directly
+        # (the cache comment above documents that) -- requiring the port here
+        # made this resolver discard a seeded pair and re-resolve, which is the
+        # very drift between `_send` and the getters this function exists to
+        # remove. In production the two are written together and
+        # `_invalidate_api_base` clears them together, so they stay consistent.
+        return _API, _API_UNIX_SOCKET
+    port = _api_port()
+    base = f"http://127.0.0.1:{port}"
+    sock = _socket_path_for(port)
+    if _API_PORT is not None:
+        # Stable source (env / bound / config): pin exactly as the individual
+        # getters do. A marker or default resolution is left unpinned.
+        _API = base
+        _API_UNIX_SOCKET = sock
+    return base, sock
+
+
+def _api_urlopen(
+    req: urllib.request.Request | str,
+    timeout: float,
+    *,
+    unix_socket_path: str | None = None,
+):
+    """``loopback_urlopen`` against the API base with the unix-socket preference.
+
+    *unix_socket_path* lets a caller that already resolved a target supply the
+    socket belonging to THAT resolution (see :func:`_resolve_api_target`); the
+    default keeps the standalone behavior for callers holding only a base.
+    """
+    if unix_socket_path is None:
+        unix_socket_path = _api_unix_socket()
+    return loopback_urlopen(req, timeout=timeout, unix_socket_path=unix_socket_path or None)
 
 
 def _invalidate_api_base() -> None:
@@ -979,15 +1051,18 @@ def _send(
     was wrong.
     """
 
-    def _once(base: str) -> dict:
+    def _once(target: tuple[str, str]) -> dict:
+        base, socket_path = target
         req = urllib.request.Request(f"{base}{path}", data=data, headers=headers, method=method)
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_api_base(): 127.0.0.1 plus a port from config/env or a run-marker whose ownership is re-verified per request) + a fixed internal path; never user-controlled  # noqa: E501
-        with _api_urlopen(req, timeout=timeout) as resp:
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_resolve_api_target(): 127.0.0.1 plus a port from config/env or a run-marker whose ownership is re-verified per request) + a fixed internal path; never user-controlled  # noqa: E501
+        with _api_urlopen(req, timeout=timeout, unix_socket_path=socket_path) as resp:
             return json.loads(resp.read())
 
-    base = _api_base()
+    # ONE resolution for this attempt; both transports derive from it.
+    target = _resolve_api_target()
+    base = target[0]
     try:
-        return _once(base)
+        return _once(target)
     except urllib.error.HTTPError as e:
         # urlopen raises HTTPError on 4xx/5xx; str(e) is only "HTTP Error 400:
         # Bad Request" — the structured {"error": ...} body lives in e.read().
@@ -1006,16 +1081,20 @@ def _send(
             # request payload; the replay exists to chase POSITIVE evidence
             # of a moved gateway, so a no-evidence fall-through ends here.
             return {"error": str(e)}
-        # Build the base from the very resolution whose source was just
-        # checked (same shape as _api_base) — re-resolving again could race a
-        # marker disappearing between the check and the dial.
-        retry_base = f"http://127.0.0.1:{retry_port}"
+        # Build BOTH halves from the very resolution whose source was just
+        # checked (same shape as _resolve_api_target) — re-resolving again
+        # could race a marker disappearing between the check and the dial, and
+        # deriving the socket separately let the replay's two transports name
+        # different gateways. This is a FRESH pair, never the refused one: the
+        # ownership proof is per attempt.
+        retry_target = (f"http://127.0.0.1:{retry_port}", _socket_path_for(retry_port))
+        retry_base = retry_target[0]
         if retry_base == base:
             # Nothing was ever handed to a live gateway, so this is a definite
             # rejection: no transport ambiguity to report.
             return {"error": str(e)}
         try:
-            return _once(retry_base)
+            return _once(retry_target)
         except urllib.error.HTTPError as retry_exc:
             return _http_error_body(retry_exc)
         except urllib.error.URLError as retry_exc:

--- a/test/test_issue_radar_crew_mcp_tools.py
+++ b/test/test_issue_radar_crew_mcp_tools.py
@@ -130,7 +130,7 @@ class TestGatewayPathsAreReachableWithTheInternalSecret(unittest.TestCase):
                     def read(self):
                         return b"{}"
 
-                def _capture(req: urllib.request.Request, timeout=None):
+                def _capture(req: urllib.request.Request, timeout=None, unix_socket_path=None):
                     seen["key"] = req.headers.get("X-session-key")
                     return _Resp()
 
@@ -148,6 +148,9 @@ class TestGatewayPathsAreReachableWithTheInternalSecret(unittest.TestCase):
                         # so patching it succeeded while the real request went out
                         # unpatched, got swallowed into `{"error": ...}`, and the
                         # capture never ran — green locally, red on the merge.
+                        # It now also carries the attempt's resolved socket path
+                        # (#4106 item 1), so the fake must accept it or the same
+                        # swallow-into-error failure returns.
                         with patch.object(mcp_core, "_api_urlopen", _capture):
                             got = helper("/api/x", session_key="MINE", **kwargs)
 

--- a/test/test_mcp_api_base_resolution.py
+++ b/test/test_mcp_api_base_resolution.py
@@ -33,10 +33,16 @@ def mcp(monkeypatch: pytest.MonkeyPatch) -> Any:
 
 
 def _bases(monkeypatch: pytest.MonkeyPatch, mcp: Any, sequence: list[str]) -> None:
-    """Feed ``_api_base`` a scripted resolution sequence (first attempts)."""
+    """Feed the first-attempt resolution a scripted sequence of bases.
+
+    Scripted at ``_resolve_api_target`` rather than ``_api_base``: one attempt
+    now resolves its ``(base, socket_path)`` pair once and threads both halves
+    through (#4106 item 1). The empty socket keeps these TCP-only cases dialling
+    the base they name, which is what they assert on.
+    """
     it = iter(sequence)
     last = sequence[-1]
-    monkeypatch.setattr(mcp, "_api_base", lambda: next(it, last))
+    monkeypatch.setattr(mcp, "_resolve_api_target", lambda: (next(it, last), ""))
 
 
 def _retry_resolution(monkeypatch: pytest.MonkeyPatch, mcp: Any, port: int, source: str) -> None:
@@ -65,7 +71,7 @@ def refusing_gateway(mcp: Any, monkeypatch):
     _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
     _retry_resolution(monkeypatch, mcp, 7788, "marker")
 
-    def fake_open(req, timeout=None):
+    def fake_open(req, timeout=None, unix_socket_path=None):
         urls.append(req.full_url)
         if ":5476" in req.full_url:
             raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
@@ -73,6 +79,50 @@ def refusing_gateway(mcp: Any, monkeypatch):
 
     monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
     return mcp, urls
+
+
+def _scripted_resolutions(
+    monkeypatch: pytest.MonkeyPatch, mcp: Any, sequence: list[tuple[int, str]]
+) -> list[tuple[int, str]]:
+    """Script ``_resolve_api_port`` and RECORD every run of the discovery chain.
+
+    ``_resolve_api_port`` is the one seam the whole chain funnels through, and
+    it is what actually forks ``lsof`` on the marker step -- so counting calls
+    here counts real discovery cost without needing a gateway, a marker, or a
+    live port. The returned list is the count.
+    """
+    runs: list[tuple[int, str]] = []
+    it = iter(sequence)
+    last = sequence[-1]
+
+    def _resolve() -> tuple[int, str]:
+        answer = next(it, last)
+        runs.append(answer)
+        return answer
+
+    monkeypatch.setattr(mcp, "_resolve_api_port", _resolve)
+    return runs
+
+
+def _capture_transport(
+    monkeypatch: pytest.MonkeyPatch, mcp: Any, *, refuse: str | None = None
+) -> list[tuple[str, str]]:
+    """Record the ``(url, unix_socket_path)`` each attempt actually dials.
+
+    Patched at ``loopback_urlopen`` rather than at ``_api_urlopen``: the socket
+    path is chosen inside the latter, and a fake there would hide the very pair
+    these tests are about.
+    """
+    seen: list[tuple[str, str]] = []
+
+    def fake_loopback(req, timeout=None, unix_socket_path=None):
+        seen.append((req.full_url, str(unix_socket_path or "")))
+        if refuse is not None and refuse in req.full_url:
+            raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+        return _Resp()
+
+    monkeypatch.setattr(mcp, "loopback_urlopen", fake_loopback)
+    return seen
 
 
 class _Resp:
@@ -107,7 +157,7 @@ def test_no_replay_when_rediscovery_returns_the_same_base(mcp: Any, monkeypatch)
     _bases(monkeypatch, mcp, ["http://127.0.0.1:7788"])
     _retry_resolution(monkeypatch, mcp, 7788, "marker")
 
-    def fake_open(req, timeout=None):
+    def fake_open(req, timeout=None, unix_socket_path=None):
         attempts.append(req.full_url)
         raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
 
@@ -128,7 +178,7 @@ def test_no_replay_when_rediscovery_falls_through_to_default(mcp: Any, monkeypat
     _bases(monkeypatch, mcp, ["http://127.0.0.1:9999"])
     _retry_resolution(monkeypatch, mcp, 5476, "default")
 
-    def fake_open(req, timeout=None):
+    def fake_open(req, timeout=None, unix_socket_path=None):
         attempts.append(req.full_url)
         raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
 
@@ -143,7 +193,7 @@ def test_only_post_reports_transport_error(mcp: Any, monkeypatch) -> None:
     """``transport_error`` is spawn_run's signal; other verbs keep their shape."""
     _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
 
-    def fake_open(req, timeout=None):
+    def fake_open(req, timeout=None, unix_socket_path=None):
         raise urllib.error.URLError(socket.timeout("slow"))
 
     monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
@@ -163,7 +213,7 @@ def test_replay_that_fails_after_connecting_stays_ambiguous(mcp: Any, monkeypatc
     _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
     _retry_resolution(monkeypatch, mcp, 7788, "marker")
 
-    def fake_open(req, timeout=None):
+    def fake_open(req, timeout=None, unix_socket_path=None):
         if ":5476" in req.full_url:
             raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
         raise TimeoutError("read timed out after the spawn was accepted")
@@ -178,7 +228,7 @@ def test_replay_refused_again_is_a_definite_rejection(mcp: Any, monkeypatch) -> 
     _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
     _retry_resolution(monkeypatch, mcp, 7788, "marker")
 
-    def fake_open(req, timeout=None):
+    def fake_open(req, timeout=None, unix_socket_path=None):
         raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
 
     monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
@@ -192,7 +242,7 @@ def test_http_error_on_replay_surfaces_the_backend_body(mcp: Any, monkeypatch) -
     _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
     _retry_resolution(monkeypatch, mcp, 7788, "marker")
 
-    def fake_open(req, timeout=None):
+    def fake_open(req, timeout=None, unix_socket_path=None):
         if ":5476" in req.full_url:
             raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
         raise urllib.error.HTTPError(
@@ -219,7 +269,7 @@ class TestMcpComputerReplay:
         monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:5476")
         monkeypatch.setattr(computer, "_resolve_api_port", lambda: (7788, "marker"))
 
-        def fake_open(req, timeout=None):
+        def fake_open(req, timeout=None, unix_socket_path=None):
             urls.append(req.full_url)
             if ":5476" in req.full_url:
                 raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
@@ -235,7 +285,7 @@ class TestMcpComputerReplay:
         monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:7788")
         monkeypatch.setattr(computer, "_resolve_api_port", lambda: (7788, "marker"))
 
-        def fake_open(req, timeout=None):
+        def fake_open(req, timeout=None, unix_socket_path=None):
             attempts.append(req.full_url)
             raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
 
@@ -253,7 +303,7 @@ class TestMcpComputerReplay:
         monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:9999")
         monkeypatch.setattr(computer, "_resolve_api_port", lambda: (5476, "default"))
 
-        def fake_open(req, timeout=None):
+        def fake_open(req, timeout=None, unix_socket_path=None):
             attempts.append(req.full_url)
             raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
 
@@ -272,7 +322,7 @@ class TestMcpComputerReplay:
         monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:5476")
         monkeypatch.setattr(computer, "_resolve_api_port", lambda: (7788, "marker"))
 
-        def fake_open(req, timeout=None):
+        def fake_open(req, timeout=None, unix_socket_path=None):
             if ":5476" in req.full_url:
                 raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
             raise urllib.error.HTTPError(
@@ -286,3 +336,121 @@ class TestMcpComputerReplay:
         monkeypatch.setattr(computer, "loopback_urlopen", fake_open)
         out = computer._invoke("dashboard:chat-1", "computer_get_state", {})
         assert out == {"error": "unknown session"}
+
+
+class TestOneResolutionPerAttempt:
+    """#4106 item 1: one request attempt resolves ONE ``(base, socket_path)`` pair.
+
+    On a marker-discovered port -- the zero-config case -- neither the port, the
+    base nor the socket path is cached: a marker resolution is proven for that
+    instant only, so every secret-bearing request must re-run the discovery
+    chain and re-prove ownership. That rule is right, but ``_api_base()`` and
+    ``_api_unix_socket()`` each apply it INDEPENDENTLY, so one attempt runs the
+    chain twice and its two transports are derived from two different
+    resolutions. ``loopback_urlopen`` prefers the socket, so the component that
+    actually carries the request is the one the refusal logic never inspected.
+
+    These tests pin the pair, not the plumbing: what matters is that one attempt
+    resolves once, and that both of its transports name the same gateway.
+    """
+
+    def test_one_attempt_resolves_the_chain_once(self, mcp: Any, monkeypatch) -> None:
+        """Two independent resolutions per attempt is two ``lsof`` forks per
+        gateway call, on hot callers (the 5s keepalive poll, spawn batches)."""
+        runs = _scripted_resolutions(monkeypatch, mcp, [(7788, "marker")])
+        _capture_transport(monkeypatch, mcp)
+
+        assert mcp._send("/api/x", headers={}, method="GET") == {"ok": True}
+        assert len(runs) == 1, f"one attempt ran the discovery chain {len(runs)} times: {runs}"
+
+    def test_both_transports_of_one_attempt_name_one_gateway(self, mcp: Any, monkeypatch) -> None:
+        """The disagreement is reachable, not theoretical.
+
+        A gateway that exits and is replaced between the two resolutions is
+        exactly the event the no-caching rule exists for, so the two calls can
+        legitimately answer differently. When they do, the TCP base aims at one
+        gateway and the preferred unix socket at another — and the socket wins.
+        """
+        _scripted_resolutions(monkeypatch, mcp, [(7788, "marker"), (9999, "marker")])
+        seen = _capture_transport(monkeypatch, mcp)
+
+        assert mcp._send("/api/x", headers={}, method="GET") == {"ok": True}
+        ((url, sock),) = seen
+        assert ":7788" in url
+        assert (
+            "7788" in sock and "9999" not in sock
+        ), f"one attempt aimed TCP at {url} and the unix socket at {sock}"
+
+    def test_a_stable_source_still_resolves_once_and_pins(self, mcp: Any, monkeypatch) -> None:
+        """Control: the caching rule for stable sources must not change.
+
+        ``env`` / ``bound`` / ``config`` are user decisions, cached for the
+        process lifetime. This already resolved once; it must still resolve
+        once, and still pin.
+        """
+        runs = _scripted_resolutions(monkeypatch, mcp, [(7788, "env")])
+        _capture_transport(monkeypatch, mcp)
+
+        assert mcp._send("/api/x", headers={}, method="GET") == {"ok": True}
+        assert len(runs) == 1
+        assert mcp._API_PORT == 7788, "a stable source must still be pinned"
+
+    def test_a_seeded_pair_is_handed_back_untouched(self, mcp: Any, monkeypatch) -> None:
+        """The resolver must answer exactly what the standalone getters answer.
+
+        ``_api_base`` and ``_api_unix_socket`` return a populated memo whatever
+        the port cache holds, and the cache comment documents that tests may
+        pre-seed any of the three with a concrete value —
+        ``test_dashboard_peer_auth`` seeds the socket and base to point the
+        client at a real ``AF_UNIX`` server.
+
+        A resolver that additionally demanded ``_API_PORT`` would discard that
+        seeded pair and re-resolve, sending the request somewhere else entirely.
+        That is drift between ``_send`` and the getters, which is the exact
+        thing this function exists to remove — so it is asserted here rather
+        than left to a POSIX-only integration test to catch.
+        """
+        monkeypatch.setattr(mcp, "_API_PORT", None)
+        monkeypatch.setattr(mcp, "_API", "http://127.0.0.1:1")
+        monkeypatch.setattr(mcp, "_API_UNIX_SOCKET", "/tmp/seeded.sock")
+        runs = _scripted_resolutions(monkeypatch, mcp, [(7788, "marker")])
+
+        assert mcp._resolve_api_target() == ("http://127.0.0.1:1", "/tmp/seeded.sock")
+        assert runs == [], "a populated memo must not re-run the discovery chain"
+        assert mcp._api_base() == "http://127.0.0.1:1"
+        assert mcp._api_unix_socket() == "/tmp/seeded.sock"
+
+    def test_the_replay_resolves_one_fresh_pair_and_uses_both_halves(
+        self, mcp: Any, monkeypatch
+    ) -> None:
+        """The replay is where the split resolution bites hardest.
+
+        ``_send`` builds ``retry_base`` from the very resolution whose source it
+        just checked — deliberately, so the check and the dial cannot race --
+        but the socket path is then resolved AGAIN, independently. The replay's
+        two transports can therefore name different gateways, and the
+        ``retry_base == base`` guard that decides whether to replay at all is
+        computed on the half that may never be dialled.
+
+        Ownership re-proof is per ATTEMPT, so the replay must resolve a FRESH
+        pair (never reuse the refused one) — exactly one, used for both halves.
+        """
+        # A distinct port per run: the pair invariant is then visible without
+        # the script having to predict HOW MANY times the chain is asked.
+        runs = _scripted_resolutions(
+            monkeypatch,
+            mcp,
+            [(5476, "marker"), (7788, "marker"), (9999, "marker"), (11111, "marker")],
+        )
+        seen = _capture_transport(monkeypatch, mcp, refuse=":5476")
+
+        assert mcp._send("/api/x", headers={}, method="GET") == {"ok": True}
+        assert len(seen) == 2, "the refused attempt must still be replayed once"
+        assert len(runs) == 2, f"two attempts ran the discovery chain {len(runs)} times: {runs}"
+        (url1, sock1), (url2, sock2) = seen
+        assert ":5476" in url1 and "5476" in sock1, "first attempt must be self-consistent"
+        assert ":7788" in url2, "the replay must dial the re-resolved port"
+        assert (
+            "7788" in sock2 and "9999" not in sock2
+        ), f"the replay aimed TCP at {url2} and the unix socket at {sock2}"
+        assert "5476" not in sock2, "the replay must not reuse the refused resolution"

--- a/test/test_mcp_internal_caller.py
+++ b/test/test_mcp_internal_caller.py
@@ -48,13 +48,16 @@ def captured(monkeypatch: pytest.MonkeyPatch) -> _CapturedRequest:
         def __exit__(self, *a: Any) -> None:
             self.close()
 
-    def _fake_urlopen(req: Any, timeout: float = 0) -> _Resp:
+    def _fake_urlopen(req: Any, timeout: float = 0, unix_socket_path: Any = None) -> _Resp:
         cap.req = req
         return _Resp(json.dumps({}).encode())
 
     monkeypatch.setattr(mcp_core, "_api_urlopen", _fake_urlopen)
     monkeypatch.setattr(mcp_core, "_internal_secret", lambda: "sekrit")
     monkeypatch.setattr(mcp_core, "_resolve_session_key", lambda: "")
+    # One attempt resolves its (base, socket_path) pair once (#4106 item 1), so
+    # the base is scripted at that seam; the empty socket keeps this TCP-only.
+    monkeypatch.setattr(mcp_core, "_resolve_api_target", lambda: ("http://127.0.0.1:1", ""))
     monkeypatch.setattr(mcp_core, "_api_base", lambda: "http://127.0.0.1:1")
     return cap
 


### PR DESCRIPTION
## Problem / Motivation

On a marker-discovered port — the zero-config case — neither the port, the base nor the socket path is cached. That is deliberate: a marker resolution is proven for *that instant* only, so every secret-bearing request must re-run the discovery chain and re-prove ownership (`_gateway_owns_port`).

The rule is right. The problem is that `_api_base()` and `_api_unix_socket()` each apply it **independently**, so one `_send` attempt runs the chain twice and derives its two transports from two different resolutions:

```
_send                     -> _api_base()         -> _api_port() -> discovery #1
  _once -> _api_urlopen   -> _api_unix_socket()  -> _api_port() -> discovery #2
```

Measured on current `main` (`03e63514e`), scripting the resolver to answer `7788` then `9999`:

```
attempt url    : http://127.0.0.1:7788/api/x
attempt socket : <data-home>/dashboard-9999.sock
```

One attempt, two gateways. This is not a theoretical race: a gateway that exits and is replaced between the two calls is precisely the event the no-caching rule exists for. And `loopback_urlopen` **prefers** the unix socket, so the component that actually carries the request is the one `_send`'s replay guard never inspected.

The replay path is the worse case. `retry_base` is built from the very resolution whose source was just checked — deliberately, so the check and the dial cannot race — but the socket then resolves *again*, independently:

```
resolutions run  : 4
attempt 1 url    : http://127.0.0.1:5476/api/x   socket: dashboard-5476.sock
attempt 2 url    : http://127.0.0.1:7788/api/x   socket: dashboard-9999.sock
```

The `retry_base == base` guard that decides whether to replay at all is computed on the half that may never be dialled.

## Why it matters

Two `lsof` forks per gateway call is a real cost on hot callers — the 5s keepalive `wait` poll and spawn batches both go through here — but the cost is the smaller half. The larger half is that `_invalidate_api_base()`'s docstring and the cache comment both already **claim** the invariant "both transports derive from one resolution", and on the zero-config path that claim was not true. A request that dials one gateway over TCP while preferring another over the socket sends the internal secret and the payload to a gateway the refusal logic never evaluated.

## What changed (motivation → approach → change)

`_resolve_api_target()` resolves once and derives both halves from that single port; `_send` calls it once per attempt and threads the pair through `_once` / `_api_urlopen`. The replay builds a **fresh** pair from `retry_port` — both halves — rather than re-resolving the socket separately.

Measured on the marker path: one attempt **2 → 1** resolutions; a refused-then-replayed request **4 → 2**.

**The ownership proof is not weakened.** It is per *attempt*, not per process: a marker resolution is still never pinned, every attempt still re-runs the chain, and the replay never reuses the refused pair. One attempt now proves ownership once instead of twice. Stable sources (`env` / `bound` / `config`) are still pinned exactly as before — a control test asserts that.

`_api_urlopen` gained an optional `unix_socket_path`; the default keeps its standalone behavior. `_api_base()` and `_api_unix_socket()` are unchanged in behavior, so callers that want one of the two are unaffected — `_api_unix_socket` now shares `_socket_path_for` with the new resolver instead of repeating the derivation.

## Scope — item 1 of #4106 only

- **Item 1** (this PR): one resolution pair per request attempt.
- **Item 2** — the refusal→invalidate→re-resolve→replay rule duplicated in `mcp_computer._invoke` with a different error contract — **untouched**.
- **Item 3** — the three direct senders in `mcp_tools/artifacts.py` and `mcp_tools/browser.py` — **untouched**. They call `_api_base()` / `_api_urlopen(req, timeout=...)`, both of which keep their existing behavior; their tests pass unchanged.
- No public or MCP error-contract changes. Every error branch in `_send` is byte-identical.
- One fresh resolution pair **per attempt**; refusal replay still invalidates and re-resolves.

Deliberately **not** folded in: `_internal_secret()` (added by #3879) calls `read_local_secret(_api_port())` from the verb helpers *before* `_send` runs, so on the marker path a verb call still runs a third, separate discovery. Unifying it would mean moving `X-Internal-Secret` construction into `_send` across all five verbs — a wider change than item 1, and it interacts with the replay in a way worth its own analysis. Flagged rather than smuggled in here.

## Tests

**New — `TestOneResolutionPerAttempt`** in `test/test_mcp_api_base_resolution.py` (5 tests). Scripted at `_resolve_api_port`, the one seam the whole chain funnels through and the one that actually forks `lsof`, so counting calls there counts real discovery cost with no gateway, no marker and no live port. Transport captured at `loopback_urlopen`, not `_api_urlopen`, because the socket is chosen inside the latter and a fake there would hide the very pair under test.

| Test | Behavior locked in |
|---|---|
| `test_one_attempt_resolves_the_chain_once` | One attempt runs the discovery chain once |
| `test_both_transports_of_one_attempt_name_one_gateway` | The TCP base and the preferred unix socket of one attempt name the same gateway |
| `test_the_replay_resolves_one_fresh_pair_and_uses_both_halves` | The replay resolves exactly one fresh pair, uses both halves, and never reuses the refused resolution |
| `test_a_stable_source_still_resolves_once_and_pins` | Control: `env` / `bound` / `config` still resolve once **and still pin** |
| `test_a_seeded_pair_is_handed_back_untouched` | A populated `(_API, _API_UNIX_SOCKET)` pair is returned unchanged and re-runs no discovery — the resolver must answer exactly what the standalone getters answer |

No sleeps, no real `lsof`, no gateway.

**Fail-before / pass-after.** With the new tests added and production untouched: **3 failed / 17 passed** — the three invariants fail, the stable-source control and all 12 pre-existing tests pass. After the change: **20 passed**.

One note in the interest of accuracy: the final test file cannot be run wholesale against `main`, because re-pointing the shared `_bases()` helper onto `_resolve_api_target` means the pre-existing cases reference a seam that does not exist there. The honest fail-before is the measurement above, taken before that helper moved.

**Caught by CI, fixed here.** The first push required `_API_PORT` alongside the two memos in the resolver's fast path, so a pre-seeded `(_API, _API_UNIX_SOCKET)` pair was discarded and re-resolved — `test_dashboard_peer_auth.py::test_mcp_core_post_prefers_unix_socket` (POSIX-only, so it does not run on the author's host) caught it. That was a real divergence between `_send` and the getters, i.e. the opposite of this PR's purpose. The condition now matches the getters, and `test_a_seeded_pair_is_handed_back_untouched` pins it platform-independently.

**Updated seams (mechanical).** `_send` no longer calls `_api_base()`, and `_api_urlopen` now receives the attempt's socket, so three test fakes had to follow: the shared `_bases()` helper, `test_issue_radar_crew_mcp_tools.py`'s `_capture`, and `test_mcp_internal_caller.py`'s `_fake_urlopen`. No assertion changed. (`_capture`'s own comment warns about exactly this class of drift — "green locally, red on the merge" — so it is updated with a note.)

**Regressions**, `-p no:randomly`: `test_mcp_api_base_resolution.py`, `test_mcp_api_port_resolution.py`, `test_instance_credential_pairing.py`, `test_loopback_proxy.py`, `test_mcp_core.py`, `test_mcp_core_coverage.py`, `test_mcp_computer.py`, `test_mcp_artifacts.py`, `test_mcp_browser_tool.py`, `test_mcp_call_site_auth_coverage.py` — **554 passed, 1 skipped**. Plus `test_issue_radar_crew_mcp_tools.py` (77 passed), `test_mcp_internal_caller.py` + `test_mcp_browser_tool.py` (33 passed), and `test_mcp_core_wait.py` / `test_ephemeral_sessions.py` / `test_identity_topology.py` / `test_mcp_shared.py` / `test_mcp_shared_cache.py` — **204 passed**, with 6 failures that reproduce identically on pristine `origin/main` on this host (3 × `WinError 1314` symlink privilege, 3 × `os.set_blocking`, which Windows does not have).

`flake8`, `isort` and `mypy --platform linux src/kiro_crew/mcp_core.py` clean.

## Manual verification

The two measurements quoted under **Problem / Motivation** were taken with a standalone probe against a clean `origin/main` checkout, outside pytest, so the resolution counts and the mismatched socket path do not depend on any fixture.

## Screenshots / video

N/A — no user-visible surface changed.

## Related Issues

Part of #4106 — **item 1 only**. Items 2 and 3 remain open and are intentionally not implemented here, so this does not close the issue.

Follow-up to #2671, whose Design Review and First Principles reviewers identified these three consolidations.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — n/a; the invariant is documented at the resolver and at both `_send` call sites
- [x] No secrets, credentials, or internal references in the diff

