### PR TITLE
fix(mcp-gateway): bound the first initialize handshake and reap a wedged backend

### DIFF
--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -485,6 +485,14 @@ class Backend:
     # freshly spawned backend so stub traffic only resumes when the new
     # backend is handshake-complete.
     _init_done_event: asyncio.Event = field(default_factory=asyncio.Event)
+    # Bounds the FIRST upstream handshake. A backend that is alive but never
+    # answers ``initialize`` leaves ``_init_state`` at "in_flight" forever:
+    # every queued stub waits on a reply that never comes, and because the
+    # process has not died no death-driven recovery (breaker, zombie sweep)
+    # observes it. The timer turns that silence into the terminal "failed"
+    # state and reaps the process group. Respawn priming carries its own
+    # bounded wait, so only the lazy first handshake arms this.
+    _init_deadline_task: Optional[asyncio.Task[None]] = None
     _dead_reason: Optional[str] = None
     # Idempotency guard for _broadcast_backend_gone (see there): the terminal
     # "backend gone" broadcast is reachable near-simultaneously from several
@@ -822,6 +830,64 @@ class Backend:
         except (BrokenPipeError, ConnectionResetError) as exc:
             self._dead_reason = f"stdin closed: {exc}"
             raise BackendGone(self._dead_reason) from exc
+        # Armed only once the forward is on the wire: a write that failed never
+        # started a handshake, and arming there would leave a timer with no
+        # in-flight window to close.
+        self._arm_init_deadline()
+
+    def _arm_init_deadline(self) -> None:
+        """Start the timer that fails and reaps a backend which never answers
+        the first ``initialize``.
+
+        Idempotent per in-flight window: an already-armed timer is left alone
+        so queued stubs cannot each extend the deadline.
+        """
+        if self._init_deadline_task is not None and not self._init_deadline_task.done():
+            return
+        self._init_deadline_task = asyncio.create_task(
+            self._init_deadline(_DEFAULT_INITIALIZE_TIMEOUT_SECS)
+        )
+
+    def _cancel_init_deadline(self) -> None:
+        """Disarm the first-handshake timer once init reaches a terminal state.
+
+        Safe from inside the timer's own coroutine: cancelling the currently
+        running task is skipped, so a terminal transition driven BY the
+        deadline does not cancel itself mid-flight.
+        """
+        task = self._init_deadline_task
+        if task is None:
+            return
+        self._init_deadline_task = None
+        if task is asyncio.current_task():
+            return
+        if not task.done():
+            task.cancel()
+
+    async def _init_deadline(self, timeout: float) -> None:
+        """Fail and reap a backend whose first ``initialize`` never resolves.
+
+        ``_fail_init`` performs the terminal transition every waiter observes
+        (failed state, done event, an explicit JSON-RPC error to each queued
+        stub); ``shutdown`` then reaps the process group, since a wedged
+        backend that is still running would otherwise hold its core until the
+        idle sweep reclaims it. shutdown() touches no pool bookkeeping, so
+        there is no reserve/evict race with a concurrent acquirer.
+        """
+        try:
+            await asyncio.sleep(timeout)
+        except asyncio.CancelledError:
+            return
+        # The handshake may have resolved while this coroutine was scheduled;
+        # only a still-in-flight window is this timer's to close.
+        if self._init_state != "in_flight":
+            return
+        reason = f"initialize did not complete within {timeout:g}s"
+        self._dead_reason = self._dead_reason or reason
+        with contextlib.suppress(Exception):
+            await self._fail_init(reason)
+        with contextlib.suppress(Exception):
+            await self.shutdown()
 
     async def _deliver_cached_initialize(
         self,
@@ -846,7 +912,7 @@ class Backend:
         self,
         init_msg: dict[str, Any],
         *,
-        timeout: float = 15.0,
+        timeout: float = _DEFAULT_INITIALIZE_TIMEOUT_SECS,
     ) -> None:
         """Re-drive the MCP ``initialize`` handshake on a freshly respawned
         backend using a stub's captured ``initialize`` request, WITHOUT
@@ -934,6 +1000,10 @@ class Backend:
         if self._gone_broadcast:
             return
         self._gone_broadcast = True
+        # The backend is terminal from here, so the first-handshake timer has
+        # nothing left to close. Disarming is a no-op when the deadline itself
+        # drove this broadcast.
+        self._cancel_init_deadline()
         # Fast-fail any in-flight prime_initialize() waiter. If the backend
         # dies mid-handshake (stdout EOF before it answered initialize),
         # neither _on_upstream_initialize nor _fail_init fires, so a
@@ -1306,6 +1376,7 @@ class Backend:
         self._init_state = "failed"
         self._dead_reason = self._dead_reason or f"init failed: {reason}"
         self._init_done_event.set()
+        self._cancel_init_deadline()
         logger.error("backend pid=%s %s", self.pid, self._dead_reason)
         pending = list(self._init_pending)
         self._init_pending.clear()
@@ -1349,6 +1420,7 @@ class Backend:
         self._init_result = result
         self._init_state = "ready"
         self._init_done_event.set()
+        self._cancel_init_deadline()
         capabilities = result.get("capabilities") or {}
         experimental = capabilities.get("experimental") or {}
         self.supports_caller_identity = isinstance(experimental, dict) and (
@@ -1935,6 +2007,10 @@ class Backend:
         keeps running and leaks its stderr pipe fd whenever the
         process outlives SIGKILL — across LRU-eviction churn this exhausts fds.
         """
+        # Disarmed rather than awaited: teardown is reachable from inside the
+        # deadline's own coroutine (it calls shutdown), and awaiting the
+        # current task would deadlock. _cancel_init_deadline skips that case.
+        self._cancel_init_deadline()
         for attr in ("_stdout_task", "_stderr_task"):
             task = getattr(self, attr)
             if task is not None:

--- a/test/test_mcp_gateway_backend_coverage.py
+++ b/test/test_mcp_gateway_backend_coverage.py
@@ -590,6 +590,147 @@ class TestUpstreamInitializeResolution:
         assert "missing/malformed result" in (backend.dead_reason or "")
 
 
+class TestFirstHandshakeDeadline:
+    """The timer that closes an in-flight window a backend never resolves.
+
+    A backend that stays alive but never answers ``initialize`` is invisible to
+    every death-driven recovery path, so the deadline is the only thing that
+    turns that silence into a terminal state and reclaims the process.
+    """
+
+    @staticmethod
+    def _init(id_: Any = 1) -> dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": id_, "method": "initialize",
+                "params": {"capabilities": {}}}
+
+    @staticmethod
+    async def _expire_now(backend: Backend) -> None:
+        """Close the in-flight window without a wall-clock wait.
+
+        The zero-timeout coroutine is installed AS the stored task, so a disarm
+        reached from inside it sees the timer's own identity -- the property
+        ``test_disarm_from_inside_the_timer_does_not_self_cancel`` pins.
+        """
+        backend._cancel_init_deadline()
+        backend._init_deadline_task = asyncio.create_task(backend._init_deadline(0))
+        await backend._init_deadline_task
+
+    @pytest.mark.asyncio
+    async def test_respawn_priming_shares_the_one_handshake_bound(self) -> None:
+        # Two paths drive the same handshake, so they must expire together. A
+        # literal default here is how they silently came to differ.
+        import inspect
+        default = inspect.signature(Backend.prime_initialize).parameters["timeout"].default
+        assert default == backend_mod._DEFAULT_INITIALIZE_TIMEOUT_SECS
+
+    @pytest.mark.asyncio
+    async def test_first_handshake_arms_the_deadline(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", self._init(1))
+        task = backend._init_deadline_task
+        assert task is not None and not task.done()
+        backend._cancel_init_deadline()
+
+    @pytest.mark.asyncio
+    async def test_write_failure_does_not_arm(self) -> None:
+        # No handshake ever started, so there is no window for a timer to close.
+        backend = _make_backend()
+        cast(Any, backend.stdin).write.side_effect = ConnectionResetError("reset")
+        with pytest.raises(BackendGone):
+            await backend.forward_from_stub("s1", self._init(1))
+        assert backend._init_deadline_task is None
+
+    @pytest.mark.asyncio
+    async def test_arming_twice_keeps_one_timer(self) -> None:
+        # A second arm must not replace the task: the displaced one would never
+        # be cancelled and would outlive the window it was meant to close.
+        backend = _make_backend()
+        backend._init_state = "in_flight"
+        backend._arm_init_deadline()
+        first = backend._init_deadline_task
+        backend._arm_init_deadline()
+        assert backend._init_deadline_task is first
+        backend._cancel_init_deadline()
+
+    @pytest.mark.asyncio
+    async def test_queued_stubs_do_not_extend_the_deadline(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", self._init(1))
+        armed = backend._init_deadline_task
+        await backend.forward_from_stub("s2", self._init(2))
+        assert backend._init_deadline_task is armed
+        backend._cancel_init_deadline()
+
+    @pytest.mark.asyncio
+    async def test_expiry_fails_init_errors_waiters_and_reaps(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", self._init(7))
+        await self._expire_now(backend)
+        assert backend._init_state == "failed"
+        assert "initialize did not complete within 0s" in cast(str, backend._dead_reason)
+        reply = await _drain(inbox)
+        assert reply["id"] == 7
+        assert "init failed" in reply["error"]["message"]
+        # Reaped rather than left running: closing stdin is shutdown's first act.
+        assert cast(Any, backend.stdin).close.called
+
+    @pytest.mark.asyncio
+    async def test_expiry_after_the_handshake_resolved_touches_nothing(self) -> None:
+        # The timer may be scheduled a tick before the reply lands. A resolved
+        # window is not its to close -- firing anyway would kill a healthy
+        # backend every time a handshake finished near the deadline.
+        backend = _make_backend()
+        backend._init_state = "ready"
+        await backend._init_deadline(0)
+        assert backend._init_state == "ready"
+        assert not cast(Any, backend.stdin).close.called
+        assert backend._dead_reason is None
+
+    @pytest.mark.asyncio
+    async def test_successful_handshake_disarms_the_deadline(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", self._init(1))
+        await backend._on_upstream_initialize(
+            {"jsonrpc": "2.0", "id": "gw-4242-1",
+             "result": {"protocolVersion": "2024-11-05", "capabilities": {}}}
+        )
+        assert backend._init_state == "ready"
+        assert backend._init_deadline_task is None
+
+    @pytest.mark.asyncio
+    async def test_failed_handshake_disarms_the_deadline(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", self._init(1))
+        await backend._fail_init("upstream said no")
+        assert backend._init_deadline_task is None
+
+    @pytest.mark.asyncio
+    async def test_backend_gone_disarms_the_deadline(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", self._init(1))
+        await backend._broadcast_backend_gone("stdout eof")
+        assert backend._init_deadline_task is None
+
+    @pytest.mark.asyncio
+    async def test_disarm_from_inside_the_timer_does_not_self_cancel(self) -> None:
+        # Teardown runs inside the timer's own coroutine (the deadline calls
+        # shutdown), so cancelling the current task would abort the very
+        # transition being made. The expiry path must still complete.
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", self._init(1))
+        await self._expire_now(backend)
+        assert backend._init_state == "failed"
+        assert cast(Any, backend.stdin).close.called
+
+
 class TestPrimeInitialize:
     @pytest.mark.asyncio
     async def test_ready_backend_is_a_noop(self) -> None:


### PR DESCRIPTION
## What is the problem?

The first MCP `initialize` handshake has no bound of its own. A pooled backend
that stays alive but never answers it is caught only incidentally, by a generic
sweeper, on a horizon of minutes to tens of minutes.

`Backend._handle_initialize` sets `_init_state = "in_flight"`, forwards the
request upstream under a gateway id, and returns. Resolution depends entirely on
the stdout pump reaching `_on_upstream_initialize` or `_fail_init`. A backend
that answers neither leaves every stub queued in `_init_pending` waiting, and
leaves the process running.

What does eventually catch it is `_heartbeat_once`'s wedge rule, which keys on
`_pending_requests` -- and the init forward is registered there, so a wedged
handshake presents to it as just another old in-flight request. That rule has two
arms, and neither is a handshake bound:

- **Two-condition arm:** oldest pending request older than
  `HEARTBEAT_TIMEOUT_SECS` (300s) AND ping staleness past `PING_STALE_SECS`
  (150s). A fully silent backend is recycled at roughly 300s.
- **Hard ceiling:** `HARD_WEDGE_CEILING_SECS` (2100s), regardless of ping
  freshness.

The gap this leaves is the specific shape of the bug: a backend that is
**responsive at the transport level but never completes `initialize`** answers
heartbeat pings, so the two-condition arm never fires, and it is held until the
2100s hard ceiling -- 35 minutes of a process nobody can use, with every session
that asked for it stuck behind the handshake for the whole window.

Two supporting facts:

- The code already flags this state as pathological. The oversize-initialize
  branch recycles the whole backend rather than failing one request, because
  `_init_state` stuck at `in_flight` leaves every queued stub hanging. It pops
  the pending entry first, which is why *that* path is invisible to the wedge
  rule and needed its own handling.
- `prime_initialize`, the respawn path, already has the right treatment: a
  bounded wait, then mark init failed, wake every waiter, and `shutdown()` to
  reap the process group. The first handshake had no equivalent -- and the two
  paths' timeouts had silently diverged (10s vs a 15s literal).

## Why this issue matters to the user

The user-visible failure is a session that stalls on one MCP server while that
server's process occupies a core with no consumer, and the stall lasts minutes
even in the best case.

The reduction is one to two orders of magnitude, not a fix for an unbounded hang:

| case | before | after |
|---|---|---|
| backend fully silent (no ping answers) | ~300s | 10s |
| backend answers pings, never answers `initialize` | 2100s | 10s |

Which end of that range applies is not something the operator can predict, since
it depends on whether the wedged process happens to service the transport. Both
ends are long enough that a user reads the session as broken rather than as
waiting, and the second end holds a core for over half an hour.

## How our fix solves it -- chain from symptom to root cause

Symptom to cause, one link at a time:

1. **Queued stubs wait on a reply that has no deadline.** They sit in
   `_init_pending`, which is flushed only by `_on_upstream_initialize` (success)
   or `_fail_init` (failure).
2. **Both are driven by an inbound frame from the backend.** Silence reaches
   neither, so `_init_state` stays `in_flight` and later stubs keep queueing
   because `is_alive` is still True.
3. **The only thing that notices is a generic in-flight-request sweeper.** It
   does not know a handshake from a slow tool call, so it applies a
   tool-call-shaped rule: minutes of age plus ping staleness. A backend that
   keeps its transport alive slips past that rule to the 2100s ceiling.
4. **Root cause: the handshake is bounded by something that does not know it is
   a handshake.** The fix belongs where the contract is known, and the treatment
   already exists 30 lines away rather than needing invention.

The change arms a timer when the first handshake goes on the wire. On expiry, if
and only if the window is still `in_flight`, it calls `_fail_init` -- which
already performs the whole terminal transition every waiter observes (failed
state, done event set, an explicit JSON-RPC error delivered to each queued stub)
-- then `shutdown()`, which reaps the process group. Same order
`prime_initialize` uses on its own timeout.

It also removes the divergence: `prime_initialize`'s literal `15.0` becomes
`_DEFAULT_INITIALIZE_TIMEOUT_SECS`, so both handshake paths now genuinely share
one bound, and a test pins that structurally so they cannot drift apart again.

The timer is disarmed on every terminal transition: success
(`_on_upstream_initialize`), failure (`_fail_init`), the backend-gone broadcast,
and backend teardown.

Three details the implementation is careful about, each pinned by a test:

- **A resolved window is not the timer's to close.** The timer re-checks
  `_init_state == "in_flight"` after waking. Without it, a handshake completing
  a tick before the deadline would still be killed, making a healthy backend a
  casualty of finishing near the boundary.
- **Disarming must survive being called from inside the timer.** The deadline
  calls `shutdown()`, which reaches `_cancel_background_tasks`. Cancelling the
  running task there would abort the transition being made and awaiting it would
  deadlock, so the disarm helper skips `asyncio.current_task()` and is not added
  to the cancel-and-await loop.
- **Arming is idempotent per window.** A second arm would replace the stored
  task and orphan the first, leaving a timer nobody cancels.

Arming happens only after the forward is successfully written -- a write that
raised never started a handshake, so there is no window to close.

## What tests we did

Eleven new tests in `test/test_mcp_gateway_backend_coverage.py`, in the file's
existing in-memory style (mock process and stdin, no subprocess, no wall-clock
waits -- expiry cases install a zero-timeout coroutine as the stored task):

- respawn priming shares the one handshake bound (structural drift ratchet)
- the first handshake arms the deadline
- a failed write does not arm
- arming twice keeps one timer (no orphan)
- a stub queued during the in-flight window does not extend the deadline
- expiry marks init failed, delivers a JSON-RPC error to each queued stub, and
  reaps the process
- expiry after the handshake already resolved touches nothing (no false kill)
- a successful handshake disarms
- a failed handshake disarms
- the backend-gone broadcast disarms
- disarming from inside the timer does not self-cancel, and expiry still
  completes

Every production edit is mutation-verified: nine mutations, one per changed
behaviour (drop the arming, drop the resolved-window guard, drop the reap, drop
each of the three disarms, drop the arm-once guard, drop the current-task guard,
let respawn priming diverge again). All nine are killed by a test. An earlier
sweep found the arm-once guard SURVIVING, because a queued stub short-circuits
before reaching the helper; the test was rewritten to pin the helper's contract
directly rather than left as untested code.

Gates: `isort` clean, `flake8` clean, `mypy` clean over 988 source files (mypy
1.14.1, matching the pin, in a venv without `faiss` so it is not stricter than
CI), 317 passed across the changed test file plus the gatewayd and wedge-ping
suites, and the full backend suite 57083 passed. The suite's failures were
checked back to back against a clean base: re-running exactly those in isolation
produces a **byte-identical** failure set on the base and on this branch (all
pre-existing environment failures, plus a few that pass in isolation and only
time out under full-suite parallel load). Zero failures in `mcp_gateway`. The
frontend surface is untouched -- no API field, i18n key, config key or
TypeScript type is added -- and the repo's own gate classifier reports a
backend-only diff; its cross-surface guard specs were run too, and their
failures are likewise identical on the clean base.

## Any other suggestions on the work

**This bounds the pooled path, and only the pooled path.** A server the agent
runtime spawns directly from the generated agent config is not the gateway's
child, so the gateway holds no handle to it and no readiness signal for it, and
cannot apply this bound. Stating that plainly so the fix is not read as covering
more than it does. The two levers that reach those servers are the mount
decision and routing them through the gateway; both are separate changes, and
routing them here would put them behind exactly this bound, which is the
argument for landing this first rather than after.

**Deliberately not included:** a config key for the deadline. The bound has
never been tuned, and adding a surface for it now would be speculative. If real
backends on slow hosts need longer, it belongs in config beside the other MCP
timeouts rather than as a third constant.

Related read-only context: #2960 describes the same failure family from the
direct-spawn side, where the load-bearing fix is a product decision about
whether a probe verdict may override an explicit operator enable. This PR does
not fix that issue and does not close it.
