### PR TITLE
test: fix four vacuous loop-liveness asserts and two shared-state races

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1020,17 +1020,6 @@ def _git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _no_load_check(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Skip system load checks in tests — avoids real asyncio.sleep delays."""
-    from unittest.mock import AsyncMock
-
-    try:
-        monkeypatch.setattr("kiro_crew.task_executor._wait_for_load", AsyncMock())
-    except AttributeError:
-        pass  # load guard not present in this branch
-
-
-@pytest.fixture(autouse=True)
 def _enterprise_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
     """Set a default validated team_id so _route_message doesn't reject messages."""
     monkeypatch.setattr("kiro_crew.slack.enterprise._validated_team_id", "TTEST")

--- a/test/test_aidlc_store.py
+++ b/test/test_aidlc_store.py
@@ -29,6 +29,14 @@ class TestProjectCRUD:
     def test_list_projects(self, store):
         p1 = store.create_project("first")
         p2 = store.create_project("second")
+        # Separate the two timestamps EXPLICITLY rather than trusting the clock to
+        # advance between two back-to-back creates. `time.time()` returns the same
+        # value for ~60% of adjacent calls on Windows (the ~15.6ms timer tick), and
+        # `sorted` is stable, so on a tie the newest-first assertion below sees
+        # insertion order and fails — the ordering under test, not the clock, is the
+        # subject, so pin it instead of sleeping.
+        p2["updated_at"] = p1["updated_at"] + 1
+
         listed = store.list_projects()
         assert len(listed) == 2
         # sorted by updated_at desc → second first

--- a/test/test_app_backend.py
+++ b/test/test_app_backend.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from conftest import requires_symlinks
 from kiro_crew.apps.backend import (
     AppProcess,
     PortUnavailableError,
@@ -159,11 +160,16 @@ def app_env(tmp_path, monkeypatch, worker_id):
 
 
 class TestPortAllocation:
-    def test_find_free_port(self):
-        port = _find_free_port()
-        assert 9100 <= port <= 9200
+    def test_find_free_port(self, app_env):
+        import kiro_crew.apps.backend as bmod
 
-    def test_concurrent_allocation_never_hands_out_the_same_port(self, monkeypatch):
+        port = _find_free_port()
+        # Bounds read off the module, not the 9100/9200 literals: ``app_env`` gives
+        # each xdist worker a DISJOINT window, so a hardcoded range would fail on
+        # every worker but gw0.
+        assert bmod._MIN_PORT <= port <= bmod._MAX_PORT
+
+    def test_concurrent_allocation_never_hands_out_the_same_port(self, app_env, monkeypatch):
         """Parallel boot spawns must not collide on one auto-allocated port.
 
         Boot starts app backends concurrently, so two apps can select a port at
@@ -764,6 +770,7 @@ class TestBackendLifecycle:
         result = start_app_backend("bad-entry")
         assert result is None
 
+    @requires_symlinks
     def test_backend_entrypoint_escapes_app_root(self, tmp_path, app_env, caplog):
         # The boot path (start_installed_backends) spawns persisted manifests
         # WITHOUT re-running validate(), so a manifest whose backend.entryPoint

--- a/test/test_cron_locking_regression.py
+++ b/test/test_cron_locking_regression.py
@@ -835,7 +835,7 @@ class TestMutatorContract:
 
             async def ticker() -> None:
                 nonlocal ticks
-                for _ in range(5):
+                while True:
                     await asyncio.sleep(0.02)
                     ticks += 1
 
@@ -849,12 +849,22 @@ class TestMutatorContract:
                     await svc.remove_job_async(job.id)
                 with pytest.raises(CronStoreBusy):
                     await svc.enable_job_async(job.id, enabled=False)
+                # Sampled while the lock is still held, BEFORE the ticker is
+                # stopped: reading it afterwards would count ticks that ran once
+                # the mutators had returned, so the assertion would hold even for
+                # a mutator that parked the loop outright.
+                ticks_while_contended = ticks
             finally:
+                tick_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await tick_task
                 platform_compat.release_lock(holder.fileno())
                 holder.close()
-                await tick_task
             # The event loop advanced its other task while mutators waited.
-            assert ticks == 5
+            assert ticks_while_contended >= 1, (
+                "event loop parked while the contended mutators waited "
+                f"(ticks={ticks_while_contended})"
+            )
 
         asyncio.run(scenario())
 
@@ -932,7 +942,7 @@ class TestMergeResultOffLoop:
 
         async def ticker() -> None:
             nonlocal ticks
-            for _ in range(5):
+            while True:
                 await asyncio.sleep(0.02)
                 ticks += 1
 
@@ -944,13 +954,20 @@ class TestMergeResultOffLoop:
             # _run_job_isolated swallows it (best-effort) and completes without
             # ever parking the loop.
             await svc._run_job_isolated(job)
-            await tick_task
+            # Sampled before the ticker is stopped: counting ticks that ran after
+            # the merge returned would hold even for a merge that parked the loop.
+            ticks_during_merge = ticks
         finally:
+            tick_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await tick_task
             platform_compat.release_lock(holder.fileno())
             holder.close()
 
         assert merged_off_loop["ok"], "merge must run off the event loop (to_thread)"
-        assert ticks == 5, "the event loop must keep ticking while the merge waits"
+        assert ticks_during_merge >= 1, (
+            f"the event loop must keep ticking while the merge waits (ticks={ticks_during_merge})"
+        )
 
     @pytest.mark.asyncio
     async def test_merge_result_persists_uncontended(self, tmp_path: Path) -> None:
@@ -1228,7 +1245,7 @@ class TestTerminalStateMergeLocked:
 
         async def ticker() -> None:
             nonlocal ticks
-            for _ in range(5):
+            while True:
                 await asyncio.sleep(0.02)
                 ticks += 1
 
@@ -1239,13 +1256,20 @@ class TestTerminalStateMergeLocked:
             # The merge raises CronStoreBusy inside to_thread (store contended);
             # _force_reap swallows it (best-effort) and never parks the loop.
             await svc._force_reap(job.id, 5.0, 1)
-            await tick_task
+            # Sampled before the ticker is stopped: counting ticks that ran after
+            # the reap returned would hold even for a reap that parked the loop.
+            ticks_during_merge = ticks
         finally:
+            tick_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await tick_task
             platform_compat.release_lock(holder.fileno())
             holder.close()
 
         assert merged_off_loop["ok"], "terminal merge must run off the event loop"
-        assert ticks == 5, "the event loop must keep ticking while the merge waits"
+        assert ticks_during_merge >= 1, (
+            f"the event loop must keep ticking while the merge waits (ticks={ticks_during_merge})"
+        )
 
 
 def _bounded_lock(svc: CronService):  # type: ignore[no-untyped-def]

--- a/test/test_hooks.py
+++ b/test/test_hooks.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from conftest import requires_symlinks
 from kiro_crew.hooks import (
     HOOK_INJECT_CONTEXT,
     HOOK_MODIFY,
@@ -768,8 +769,13 @@ class TestSafeReadFile:
         # bytes variant returns None (rejected) rather than leaking content
         assert safe_read_file_bytes(str(link)) is None
 
+    @requires_symlinks
     def test_allows_benign_symlink(self, tmp_path):
-        """A symlink to a non-sensitive file is still readable via its target."""
+        """A symlink to a non-sensitive file is still readable via its target.
+
+        A FILE symlink, so a junction cannot stand in for it — the marker skips
+        this only where symlink creation needs a privilege the shell lacks.
+        """
         from kiro_crew.hooks import safe_read_file_bytes
 
         real = tmp_path / "real.txt"

--- a/test/test_ws_offload.py
+++ b/test/test_ws_offload.py
@@ -18,6 +18,7 @@ thread and that the loop stays responsive while it runs.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import threading
 import time
 from types import SimpleNamespace
@@ -67,7 +68,7 @@ async def test_load_status_counts_does_not_block_the_loop():
 
     async def _ticker():
         nonlocal ticks
-        for _ in range(10):
+        while True:
             await asyncio.sleep(0.01)
             ticks += 1
 
@@ -82,8 +83,19 @@ async def test_load_status_counts_does_not_block_the_loop():
 
     ticker = asyncio.create_task(_ticker())
     crons, lessons = await _load_status_counts(state)  # type: ignore[arg-type]
-    await ticker
+    # Sampled the instant the load returns, BEFORE the ticker is awaited: reading
+    # `ticks` after awaiting it to completion would count the ticks that ran after
+    # the load, so the assertion would hold even for a load that blocked the loop
+    # outright. The ticker also runs unbounded rather than a fixed 10 iterations,
+    # so it cannot reach the floor on its own.
+    ticks_during_load = ticks
+    ticker.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await ticker
 
     assert (crons, lessons) == (1, 0)
-    # The loop advanced the ticker concurrently with the 0.1s blocking load.
-    assert ticks >= 5, f"event loop appears stalled during blocking load (ticks={ticks})"
+    # 0.1s of blocking load at a 0.01s tick interval leaves ample room; the floor is
+    # low because Windows rounds sleeps up to the ~15.6ms timer tick.
+    assert (
+        ticks_during_load >= 2
+    ), f"event loop appears stalled during blocking load (ticks={ticks_during_load})"


### PR DESCRIPTION
## Problem

An audit sweep of the test suite surfaced three defect classes that all share one
symptom: a test that reports green while proving nothing, or that can only fail
when it races a sibling.

1. **Four event-loop-liveness assertions are vacuous.** Each starts a bounded
   ticker task, `await`s it to **completion**, and only then asserts on the tick
   count — so the count always reaches its ceiling and the assertion holds even
   if the code under test blocked the loop outright.
2. **Two port-allocation tests race under xdist.** They probe the real 9100–9200
   range and clear the shared `_allocated_ports` global without requesting
   `app_env`, the fixture that gives each xdist worker a **disjoint** port window
   and reaps `_processes` around the test.
3. **A clock-tie flake.** `test_aidlc_store`'s `test_list_projects` creates two
   projects back-to-back and asserts newest-first ordering, but `time.time()`
   returns the **same value for ~60% of adjacent calls** on Windows (the ~15.6ms
   timer tick) and `sorted` is stable — so on a tie the assertion sees insertion
   order and fails. This one regressed onto `main` via #4467, which un-skipped it
   on the strength of a local pass; CI's Windows shard caught it.
4. **One autouse fixture is dead.** `_no_load_check` patched
   `kiro_crew.task_executor._wait_for_load`, a symbol that has never existed in
   `src/`.

## Why it matters

A liveness test that cannot fail is worse than no test: it occupies the slot where
a real regression guard should be, so a change that parks the event loop — the
thing these tests exist to catch, and which stalls every other WebSocket and
coroutine on the gateway — ships green. The port race surfaces as flakiness rather
than a reproducible failure, which is the hardest kind to chase. The dead fixture
is paid on every one of ~26.5k tests.

## Fix (symptom → root cause → change)

- **Liveness asserts.** Root cause: the counter is read after the ticker is
  drained, so it measures ticks that ran *after* the operation returned. Change:
  sample the counter while the operation is still in flight, make the ticker
  unbounded so it cannot reach the floor on its own, and `cancel()` it rather
  than draining it (which also avoids leaving a task at loop teardown).
- **Port race.** Request `app_env`, and read the range bounds off the module
  rather than the `9100`/`9200` literals — those only hold on `gw0` once the
  window is partitioned per worker.
- **Clock tie.** Separate the two timestamps explicitly rather than sleeping:
  the ordering is the subject, not the clock. Verified 15/15 runs; a flipped
  sort direction still fails it.
- **Dead fixture.** Removed. The patch raised `AttributeError` on every test and
  its own `except` swallowed it, so it only ever imported `task_executor` as a
  side effect. No load guard exists under any name (the two `getloadavg` call
  sites are pure reads with no sleep), so nothing replaces it. It entered with the
  fork's first commit — the symbol was scrubbed along with the internal code.

## Tests

No new tests; this repairs existing ones. Each fix is **mutation-verified** —
the production code the test covers was broken and the test confirmed to fail:

| Mutation | Before | After |
|---|---|---|
| `_load_status_counts` reads moved back on-loop | test passed | fails, `ticks=0` |
| cron mutators' persistence moved back on-loop | test passed | fails, "event loop parked" |

Local runs on Windows: `test_ws_offload.py` 2 passed, `test_cron_locking_regression.py`
35 passed, `test_app_backend.py` 43 passed / 8 skipped under `-n 4 --dist loadgroup`,
`test_hooks.py` 116 passed / 3 skipped (was 1 failed). A 1,171-test per-file sample
across `test_config_loader`, `test_security`, `test_session` and others confirms the
conftest change breaks nothing.

## Manual verification

Ran on native Windows (unprivileged shell, Python 3.13) in an isolated git
worktree. Validation is **per-file**: a 4-way `--splits` shard aborted with
`INTERNALERROR ... KeyError: <WorkerController gw0>` (an xdist worker-startup crash
that erases the failure list and reports only a count), which is a pre-existing
harness instability on this host and the reason
`docs/system-specs/common/testing-conventions.md` prescribes per-file comparison.

Two unrelated **pre-existing** `WinError 1314` failures turned up while validating
and are fixed here rather than left red: `test_app_backend`'s entrypoint-escape and
`test_hooks`' benign-symlink read both create a **file** symlink with no guard, so
they fail on any unprivileged Windows shell while passing on CI's admin runner. A
junction cannot model a file link, so these take `requires_symlinks` (skip only
where symlink creation is unavailable) rather than a junction conversion.

---

No linked issue: found by a proactive audit sweep, not a filed bug.
