### PR TITLE
fix(chat): guard cron origin-injection and autonudge against mid-plan clobber

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3535,15 +3535,21 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
         )
         merge = False
 
+    in_stage = bool(slot._in_stage_execution)
     hold_users = bool(
         (
             state.subagents is not None
             and state.subagents.running_agents_for(f"dashboard:{slot.key}")
         )
-        or slot._in_stage_execution
+        or in_stage
     )
     if hold_users:
-        next_msg, consumed = _dequeue_next_system_message(slot)
+        # During a multi-stage plan hold cron notifications too: each stage is
+        # its own _run_chat whose tail-drain runs while _in_stage_execution is
+        # still set, so draining a cron here starts an unrelated turn between
+        # stages and scatters the plan. It drains at end-of-plan once the gate
+        # clears. Sub-agent completions / recovery still flow.
+        next_msg, consumed = _dequeue_next_system_message(slot, exclude_cron=in_stage)
     else:
         next_msg, consumed = _dequeue_next_message(slot, merge_enabled=merge)
     if next_msg is None:
@@ -6701,9 +6707,7 @@ async def _run_chat(
                     _ac = slot._acp_client
                     _awaiting = bool(
                         getattr(_ac, "_awaiting_permission", False)
-                        or getattr(
-                            getattr(_ac, "_handle", None), "_awaiting_permission", False
-                        )
+                        or getattr(getattr(_ac, "_handle", None), "_awaiting_permission", False)
                     )
                     emit_counter(
                         TURN_TIMEOUT_CAUSE,

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -1624,7 +1624,7 @@ def _dequeue_next_message(slot, merge_enabled: bool) -> tuple:
     return item["content"], [item]
 
 
-def _dequeue_next_system_message(slot) -> tuple:
+def _dequeue_next_system_message(slot, *, exclude_cron: bool = False) -> tuple:
     """Pop the first queued sub-agent-completion or cron injection, leaving
     plain user messages queued.
 
@@ -1634,9 +1634,19 @@ def _dequeue_next_system_message(slot) -> tuple:
     keep flowing (sub-agent completions, cron notifications) are still drained.
     Returns ``(content, [item])`` for the drained item, or ``(None, [])`` when
     only held (user) messages remain queued.
+
+    ``exclude_cron`` additionally holds cron notifications. A multi-stage plan
+    runs each stage as its own ``_run_chat`` whose tail-drain fires while
+    ``_in_stage_execution`` is still set; without this a cron notification
+    queued during the plan is pulled BETWEEN stages and starts a turn that
+    scatters the plan's output. Sub-agent completions and synthetic recovery
+    still flow (a stage may legitimately spawn sub-agents or re-queue a
+    continuation) -- only the external cron injection waits for the plan to end.
     """
     for i, item in enumerate(slot._queue):
         if is_system_injection_item(item):
+            if exclude_cron and item.get("kind") == CRON_NOTIFICATION_KIND:
+                continue
             popped = slot.queue_pop(i)
             return popped["content"], [popped]
     return None, []

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -1322,7 +1322,13 @@ async def api_send_message(request: web.Request) -> web.Response:
                     # cronLabel in cls JSON provides structured data for frontend.
                     wrapped = f'{CRON_NOTIFY_PREFIX}"{label}"]\n{text}\n{CRON_NOTIFY_END}'
                     inject_cls = json.dumps({"cronLabel": label})
-                    if slot.running:
+                    # Queue while a turn is live OR a multi-stage plan is mid-flight.
+                    # During stage execution slot.task is None between stages (see
+                    # chat_orchestrator), so slot.running alone reads False in that
+                    # window and would let this injection start a concurrent turn that
+                    # clobbers the plan. _in_stage_execution closes it — same predicate
+                    # the user-typed path uses (chat_handlers._api_chat).
+                    if slot.running or slot._in_stage_execution:
                         if len(slot._queue) >= 50:
                             evicted = slot.queue_pop(0)
                             logger.warning(

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -4190,11 +4190,13 @@ class GatewayOrchestrator:
             _run_chat,  # circular import: gateway -> dashboard.chat -> gateway (chat dispatch references GatewayOrchestrator)
         )
 
-        if slot.running:
-            # Turn still active — drop this nudge. Next idle-timer tick will
-            # schedule again once the turn ends. Queueing would stack
-            # identical 3KB+ nudges and blow up the context window.
-            # Returning False keeps cycle_count accurate (only delivered
+        if slot.running or slot._in_stage_execution:
+            # Turn still active, OR a multi-stage plan is mid-flight (slot.task is
+            # None between stages, so slot.running alone misses that window and the
+            # nudge would start a concurrent turn that clobbers the plan) — drop this
+            # nudge. Next idle-timer tick will schedule again once the turn/plan ends.
+            # Queueing would stack identical 3KB+ nudges and blow up the context
+            # window. Returning False keeps cycle_count accurate (only delivered
             # nudges count toward max_cycles).
             logger.info(
                 "AutoNudge skip: slot %s is running (loop %s cycle %d)",

--- a/test/test_autonudge_dashboard_fire.py
+++ b/test/test_autonudge_dashboard_fire.py
@@ -38,10 +38,15 @@ def _loop(slot_key: str = "chat-1-1785") -> NudgeLoop:
     )
 
 
-def _slot(key: str = "chat-1-1785", *, running: bool = False) -> MagicMock:
+def _slot(
+    key: str = "chat-1-1785", *, running: bool = False, in_stage: bool = False
+) -> MagicMock:
     slot = MagicMock()
     slot.key = key
     slot.running = running
+    # Real _ChatSlot defaults this False; a bare MagicMock would return a truthy
+    # Mock and trip the busy guard, so model the default explicitly.
+    slot._in_stage_execution = in_stage
     return slot
 
 
@@ -208,6 +213,31 @@ class TestDashboardNudgeSlotResolution:
         loop = _loop()
         before = loop.cycle_count
         orch.dashboard_state.get_slot = MagicMock(return_value=_slot(running=True))
+        spawn = _fake_spawn()
+        with (
+            patch.object(gw, "spawn_guarded_turn", spawn),
+            patch("kiro_crew.dashboard.chat._run_chat", new=AsyncMock()),
+        ):
+            assert await orch._fire_dashboard_nudge(loop) is False
+        orch.autonudge_svc.remove.assert_not_awaited()
+        assert spawn.calls == []
+        assert loop.cycle_count == before
+
+    @pytest.mark.asyncio
+    async def test_stage_execution_slot_skips_without_retiring_the_loop(self) -> None:
+        """A multi-stage plan mid-flight defers the cycle; it must not clobber it.
+
+        Between stages the plan sets ``slot.task = None`` (chat_orchestrator), so
+        ``slot.running`` reads False even though the plan is still executing. The
+        nudge must still defer on ``_in_stage_execution`` — firing here would start
+        a concurrent turn that scatters the plan's output.
+        """
+        orch = _orchestrator()
+        loop = _loop()
+        before = loop.cycle_count
+        orch.dashboard_state.get_slot = MagicMock(
+            return_value=_slot(running=False, in_stage=True)
+        )
         spawn = _fake_spawn()
         with (
             patch.object(gw, "spawn_guarded_turn", spawn),

--- a/test/test_cron_origin_injection.py
+++ b/test/test_cron_origin_injection.py
@@ -53,6 +53,19 @@ def _state_with_job(*, slot, session_key="dashboard:chat-2-origin"):
 def _live_running_slot():
     slot = MagicMock()
     slot.running = True
+    slot._in_stage_execution = False
+    slot._queue = []
+    slot.queue_append.return_value = "q1"
+    return slot
+
+
+def _mid_plan_slot():
+    """A slot whose plan is executing but is BETWEEN stages: the orchestrator
+    has set slot.task = None (so slot.running is False) while _in_stage_execution
+    stays True. slot.running alone would misread this as idle."""
+    slot = MagicMock()
+    slot.running = False
+    slot._in_stage_execution = True
     slot._queue = []
     slot.queue_append.return_value = "q1"
     return slot
@@ -95,6 +108,35 @@ async def test_caller_session_resolves_and_injects(mock_sel):
         data = await resp.json()
     assert data["session"] is True
     slot.queue_append.assert_called_once()
+    state.notify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mid_plan_stage_window_queues_not_concurrent_turn(mock_sel):
+    """Regression: an origin injection landing in a plan's between-stages window
+    must QUEUE, not start a concurrent turn.
+
+    During multi-stage execution the orchestrator nulls slot.task between stages,
+    so slot.running reads False even though the plan is still running. Guarding on
+    slot.running alone let the cron injection start a second turn that scattered
+    the plan's output. The guard now also checks _in_stage_execution.
+    """
+    slot = _mid_plan_slot()
+    state = _state_with_job(slot=slot)
+    with (
+        patch("kiro_crew.dashboard.chat_runner._run_chat") as run_chat,
+        patch("kiro_crew.dashboard.turn_dispatch.spawn_guarded_turn") as spawn,
+    ):
+        async with TestClient(TestServer(_make_app(state))) as c:
+            resp = await c.post(
+                "/api/send-message",
+                json={"text": "comments!", "session": "origin", "caller_session": f"cron:{JOB_ID}"},
+            )
+            data = await resp.json()
+    assert data["session"] is True
+    slot.queue_append.assert_called_once()  # queued, not run
+    spawn.assert_not_called()
+    run_chat.assert_not_called()
     state.notify.assert_not_called()
 
 

--- a/test/test_dashboard_file_io.py
+++ b/test/test_dashboard_file_io.py
@@ -471,6 +471,10 @@ class TestSendMessage:
         # Mock a slot that the cron originated from
         mock_slot = MagicMock()
         mock_slot.running = False
+        # Real _ChatSlot defaults this False; a bare MagicMock returns a truthy
+        # Mock and would trip the busy guard (running or _in_stage_execution),
+        # diverting origin-inject to the queue branch.
+        mock_slot._in_stage_execution = False
         mock_slot.task = None
         mock_slot.key = "chat-1-1712793600"
         state.get_slot = MagicMock(return_value=mock_slot)
@@ -576,6 +580,10 @@ class TestSendMessage:
         # Rehydrate helper returns a slot reconstructed from persisted history.
         mock_slot = MagicMock()
         mock_slot.running = False
+        # Real _ChatSlot defaults this False; a bare MagicMock returns a truthy
+        # Mock and would trip the busy guard (running or _in_stage_execution),
+        # diverting origin-inject to the queue branch.
+        mock_slot._in_stage_execution = False
         mock_slot.task = None
         mock_slot.key = "chat-1-1712793600"
         state._background_tasks = set()
@@ -667,6 +675,10 @@ class TestSendMessage:
         state = _mock_state()
         mock_slot = MagicMock()
         mock_slot.running = False
+        # Real _ChatSlot defaults this False; a bare MagicMock returns a truthy
+        # Mock and would trip the busy guard (running or _in_stage_execution),
+        # diverting origin-inject to the queue branch.
+        mock_slot._in_stage_execution = False
         mock_slot.task = None
         mock_slot.key = "chat-1-1712793600"
         state.get_slot = MagicMock(return_value=mock_slot)

--- a/test/test_queue_during_subagents.py
+++ b/test/test_queue_during_subagents.py
@@ -91,6 +91,67 @@ class TestDequeueNextSystemMessage:
         assert [q["content"] for q in slot._queue] == ["user follow-up"]
 
 
+class TestDequeueExcludeCron:
+    """`exclude_cron=True` holds cron notifications while a multi-stage plan runs.
+
+    Each stage is its own ``_run_chat`` whose tail-drain fires while
+    ``_in_stage_execution`` is still set (chat_runner ``_start_next_queued_turn``
+    passes ``exclude_cron=in_stage``). A cron queued mid-plan must NOT be pulled
+    between stages; sub-agent completions and recovery still flow.
+    """
+
+    def test_holds_cron_when_only_cron_queued(self):
+        """A lone cron notification is held (drains nothing) under exclude_cron."""
+        cron = f"{CRON_NOTIFY_PREFIX}daily]: run report"
+        slot = _ChatSlot("s1")
+        slot._queue = [{"id": "a", "content": cron, "kind": CRON_NOTIFICATION_KIND}]
+
+        next_msg, consumed = _dequeue_next_system_message(slot, exclude_cron=True)
+
+        assert next_msg is None
+        assert consumed == []
+        # Cron stays queued for the end-of-plan drain.
+        assert [q["content"] for q in slot._queue] == [cron]
+
+    def test_still_drains_subagent_completion(self):
+        """A sub-agent completion still flows even with exclude_cron=True."""
+        sa = f"{SUBAGENT_COMPLETION_PREFIX}\nAgent `a1` completed ✅\nResult"
+        slot = _ChatSlot("s1")
+        slot._queue = [{"id": "a", "content": sa, "kind": SUBAGENT_COMPLETION_KIND}]
+
+        next_msg, consumed = _dequeue_next_system_message(slot, exclude_cron=True)
+
+        assert next_msg == sa
+        assert slot._queue == []
+
+    def test_skips_cron_drains_later_subagent(self):
+        """Cron ahead of a sub-agent completion is skipped; the completion drains."""
+        cron = f"{CRON_NOTIFY_PREFIX}daily]: run report"
+        sa = f"{SUBAGENT_COMPLETION_PREFIX}\nAgent `a1` completed ✅\nResult"
+        slot = _ChatSlot("s1")
+        slot._queue = [
+            {"id": "a", "content": cron, "kind": CRON_NOTIFICATION_KIND},
+            {"id": "b", "content": sa, "kind": SUBAGENT_COMPLETION_KIND},
+        ]
+
+        next_msg, consumed = _dequeue_next_system_message(slot, exclude_cron=True)
+
+        assert next_msg == sa
+        # The cron is left queued; only the completion was consumed.
+        assert [q["content"] for q in slot._queue] == [cron]
+
+    def test_default_still_drains_cron(self):
+        """Default (exclude_cron=False) keeps the pre-fix behavior: cron drains."""
+        cron = f"{CRON_NOTIFY_PREFIX}daily]: run report"
+        slot = _ChatSlot("s1")
+        slot._queue = [{"id": "a", "content": cron, "kind": CRON_NOTIFICATION_KIND}]
+
+        next_msg, consumed = _dequeue_next_system_message(slot)
+
+        assert next_msg == cron
+        assert slot._queue == []
+
+
 # ── API test: api_chat ingest gate (idle + sub-agents running) ──
 
 

--- a/test/test_slack_gateway_coverage.py
+++ b/test/test_slack_gateway_coverage.py
@@ -1254,6 +1254,9 @@ class TestFireDashboardNudgeDispatch:
         ds = _mock_dashboard_state()
         slot = MagicMock()
         slot.running = False
+        # Real _ChatSlot defaults this False; a bare MagicMock returns a truthy
+        # Mock and would make the nudge defer on the busy guard.
+        slot._in_stage_execution = False
         slot.key = "chat-1"
         ds.get_slot.return_value = slot
         orch.dashboard_state = ds
@@ -1292,6 +1295,7 @@ class TestFireDashboardNudgeDispatch:
 
         restored = MagicMock()
         restored.running = False
+        restored._in_stage_execution = False
         restored.key = "chat-9"
 
         async def _rehydrate(_state, _key, *, adopt_closed=False):

--- a/test/test_unattended_slot_guardrails.py
+++ b/test/test_unattended_slot_guardrails.py
@@ -425,6 +425,9 @@ def _bg_slot(key: str) -> MagicMock:
     slot = MagicMock()
     slot.key = key
     slot.running = False
+    # Real _ChatSlot defaults this False; a bare MagicMock returns a truthy Mock
+    # and would trip the nudge busy guard (running or _in_stage_execution).
+    slot._in_stage_execution = False
     return slot
 
 


### PR DESCRIPTION
## Problem / Motivation

A cron that delivers via `session="origin"`, or an armed AutoNudge loop, can start a **concurrent turn** in a dashboard chat while a multi-stage plan is executing in that same chat. The injected turn runs alongside the plan and scatters/overwrites the plan's in-progress output.

## Why it matters

Anyone running a multi-stage plan in a chat that also drives a periodic `session="origin"` cron (or has an armed AutoNudge loop) gets their plan interrupted mid-execution. It is not a rare edge: a long plan has many between-stage windows and a periodic injector eventually lands in one, so the clobber is effectively inevitable over time. Ordinary single-turn chat is unaffected.

## What changed (motivation → approach → change)

- Symptom: a cron/nudge turn starts concurrently with an executing multi-stage plan and scatters its output.
- Root cause: during stage execution the orchestrator sets `slot.task = None` between stages (`dashboard/chat_orchestrator.py`), so `slot.running` (`task is not None and not task.done()`) reads **False** in that window even though the plan is still running; `slot._in_stage_execution` stays **True**. The user-typed submit path already guards on `slot.running or slot._in_stage_execution` (`dashboard/chat_handlers.py`), but the two asynchronous injectors gated on `slot.running` alone, so a fire landing in the between-stages window slipped past and started a concurrent turn.
- Change: gate both injectors on `slot.running or slot._in_stage_execution` — the same predicate the user-typed path uses.
  - cron `session="origin"` (`dashboard/handlers/messaging.py`, `api_send_message`): now **queues** in that window; the queued message drains after the plan via the existing `_start_next_queued_turn`.
  - AutoNudge dashboard fire (`slack/gateway.py`, `_fire_dashboard_nudge`): now **defers** (skip + re-arm on the next idle tick), matching its existing running-slot behavior.

## Tests

- `test/test_cron_origin_injection.py::test_mid_plan_stage_window_queues_not_concurrent_turn` — an origin injection with `running=False, _in_stage_execution=True` queues and starts no turn.
- `test/test_autonudge_dashboard_fire.py::test_stage_execution_slot_skips_without_retiring_the_loop` — the nudge defers (returns False, starts no turn, loop not retired) in the same window.
- The `_slot` helper in the autonudge test now models the real `_ChatSlot` default (`_in_stage_execution=False`) explicitly so a bare mock cannot trip the busy guard.

## Manual verification

N/A — unit coverage sufficient. The two regression tests exercise the exact between-stages predicate at both injection sites, and the change touches no user-visible surface.

## Related Issues

Fixes #4513

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user docs affected
- [x] No secrets, credentials, or internal references in the diff
