### PR TITLE
fix: deterministic list_projects order on equal timestamps (#4507)

### DIFF
--- a/src/kiro_crew/aidlc/store.py
+++ b/src/kiro_crew/aidlc/store.py
@@ -54,8 +54,29 @@ class AidlcStore:
     def get_project(self, pid: str) -> dict | None:
         return next((p for p in self._data["projects"] if p["id"] == pid), None)
 
+    @staticmethod
+    def _ts(record: dict, key: str) -> float:
+        # The store file is plain JSON a user can hand-edit, and _save's
+        # default=str can stringify odd values; a non-numeric timestamp must
+        # sort as 0 rather than raise on a str/float comparison.
+        try:
+            return float(record.get(key) or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
     def list_projects(self) -> list[dict]:
-        return sorted(self._data["projects"], key=lambda p: p.get("updated_at", 0), reverse=True)
+        # Newest first. updated_at alone under-determines the order: system
+        # clocks are coarse enough (~15.6ms on Windows) that back-to-back
+        # writes receive equal timestamps. created_at breaks that tie, and
+        # when it ties too, iterating in reverse insertion order lets the
+        # stable sort fall back to most-recently-created first (projects are
+        # appended on create), so the order is deterministic regardless of
+        # clock granularity.
+        return sorted(
+            reversed(self._data["projects"]),
+            key=lambda p: (self._ts(p, "updated_at"), self._ts(p, "created_at")),
+            reverse=True,
+        )
 
     def update_project(self, pid: str, **fields) -> dict | None:
         p = self.get_project(pid)

--- a/test/test_aidlc_store.py
+++ b/test/test_aidlc_store.py
@@ -35,6 +35,44 @@ class TestProjectCRUD:
         assert listed[0]["id"] == p2["id"]
         assert listed[1]["id"] == p1["id"]
 
+    def test_list_projects_equal_timestamps(self, store, monkeypatch):
+        # Coarse clocks (~15.6ms granularity on Windows) hand back-to-back
+        # creates identical timestamps; the order must stay deterministic:
+        # most recently created first.
+        monkeypatch.setattr("kiro_crew.aidlc.store._now", lambda: 1000.0)
+        projects = [store.create_project(f"proj-{i}") for i in range(3)]
+        assert all(p["created_at"] == 1000.0 for p in projects)
+        listed = store.list_projects()
+        assert [p["id"] for p in listed] == [p["id"] for p in reversed(projects)]
+
+    def test_list_projects_created_at_breaks_updated_at_tie(self, store, monkeypatch):
+        # When updated_at ties but created_at differs (e.g. the clock stepped
+        # backwards between creates), created_at decides — not insertion order.
+        clock = {"t": 1000.0}
+        monkeypatch.setattr("kiro_crew.aidlc.store._now", lambda: clock["t"])
+        newer = store.create_project("created-later-clock")
+        clock["t"] = 500.0
+        older = store.create_project("created-earlier-clock")
+        clock["t"] = 2000.0
+        store.update_project(newer["id"], description="x")
+        store.update_project(older["id"], description="x")
+        listed = store.list_projects()
+        assert all(p["updated_at"] == 2000.0 for p in listed)
+        # created_at desc: 1000.0 before 500.0, overriding reverse insertion.
+        assert [p["id"] for p in listed] == [newer["id"], older["id"]]
+
+    def test_list_projects_tolerates_non_numeric_timestamp(self, store, monkeypatch):
+        # The store file is hand-editable JSON; a stringified timestamp must
+        # not make listing raise on a str/float key comparison.
+        monkeypatch.setattr("kiro_crew.aidlc.store._now", lambda: 1000.0)
+        good = store.create_project("good")
+        bad = store.create_project("bad")
+        bad["created_at"] = "2026-01-01T00:00:00"
+        listed = store.list_projects()
+        # The corrupt record sorts as timestamp 0 on the tiebreak, so the
+        # intact record wins the equal-updated_at tie.
+        assert [p["id"] for p in listed] == [good["id"], bad["id"]]
+
     def test_update_project(self, store):
         p = store.create_project("old")
         updated = store.update_project(p["id"], name="new")


### PR DESCRIPTION
## Problem / Motivation

`test_list_projects` in `test/test_aidlc_store.py` creates two projects back-to-back and asserts the second one lists first (newest first). On Windows the system clock granularity (~15.6ms) frequently hands both `create_project()` calls an identical `time.time()` value, and `AidlcStore.list_projects()` sorted by `updated_at` alone — so the order of the tied records was undefined and the assertion flaked on Windows CI shards.

## Why it matters

A known-flaky test on the Windows shards costs a rerun (or a false red) on unrelated PRs. `AidlcStore` currently has no production importers — its consumer surface is the AIDLC frontend staged under `website/src/pages/aidlc/` — so the deterministic "newest project first" contract is fixed here at the store so that surface inherits it when wired up, and the Windows shards stop paying for the flake now.

## What changed (motivation → approach → change)

Symptom: undefined order for equal `updated_at`. Root cause: the sort key under-determines the ordering; on a coarse clock, ties are common rather than exotic. Change: make the ordering contract deterministic inside `list_projects()` itself, without touching the test's original assertions:

- Secondary sort key `created_at`, descending.
- On a full tie, the input is iterated in reverse insertion order, so Python's stable sort resolves it to most-recently-created first (projects are appended on create). A random-id tiebreaker was considered and rejected: `id` is a random UUID prefix, so it would make the order stable but arbitrary — the original test would still fail on roughly half of the equal-timestamp runs.
- Key values are coerced through a small `_ts()` helper (non-numeric → 0.0): the store file is hand-editable JSON and `_save`'s `default=str` can stringify odd values, and the new tuple key would otherwise introduce a `str`/`float` comparison `TypeError` the old single-key sort could not hit on the tiebreak path.

Pre-push review note: `list_activities()` has the same single-key sort pattern; it is deliberately not touched here (no changed lines, no production callers) and is tracked in a follow-up issue.

## Tests

- `test_list_projects_equal_timestamps` — freezes the clock across three creates and asserts most-recently-created-first order on a full timestamp tie (the exact Windows flake shape).
- `test_list_projects_created_at_breaks_updated_at_tie` — makes `updated_at` tie while `created_at` disagrees with insertion order, pinning the secondary key specifically (fails if `created_at` is dropped from the key tuple).
- `test_list_projects_tolerates_non_numeric_timestamp` — a stringified `created_at` sorts as 0 on the tiebreak instead of raising.
- Existing `test_list_projects` is unchanged and is now deterministic under this contract.

## Manual verification

N/A — unit coverage sufficient: the change is a pure in-memory sort-key change with no I/O or UI surface.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only sort-key change; no frontend paths touched.

## Related Issues

Closes #4507

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented API change
- [x] No secrets, credentials, or internal references in the diff

