### PR TITLE
docs(chat): document and test the jump anchor opener-run walk (#4473)

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -3199,12 +3199,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     const chrome = pinnedJumpChrome()
     cancelAnimationFrame(navScrollRafRef.current)
     navPollCancelRef.current?.()
-    // Consecutive user rows (a steer follows its prompt directly): landing the
-    // clicked prompt at the chrome would leave the prompt above it straddling
-    // the hand-off line — unpinnable, while its top edge has already pushed the
-    // fallback banner fully out — so the banner unmounts and the chain dies.
-    // Anchor at the head of the run instead: the clicked prompt stays visible
-    // just below, and a non-prompt row takes the straddle.
+    // The jump lands at the head of the target's consecutive prompt run — a
+    // steer pair, a subagent fan-out, an unanswered nudge run — so the row on
+    // the hand-off line is a non-prompt and the previous turn's banner
+    // survives the landing. Rationale and near/far interaction: see
+    // jumpAnchorIdx's docblock (utils/pinnedPrompt.ts).
     const anchor = jumpAnchorIdx(displayItemsRef.current, target)
     const jumpedFar = mountIndexRef.current(anchor)
     if (jumpedFar) {

--- a/website/src/test/pinnedPrompt.jumpAnchor.test.ts
+++ b/website/src/test/pinnedPrompt.jumpAnchor.test.ts
@@ -6,6 +6,8 @@ import type { DisplayItem } from '../pages/chat/groupDisplayItems'
 const user = (): DisplayItem => ({ kind: 'single', msg: { role: 'user', content: 'q' } } as unknown as DisplayItem)
 const steer = (): DisplayItem => ({ kind: 'single', msg: { role: 'user', content: 's', meta: { steer: true } } } as unknown as DisplayItem)
 const asst = (): DisplayItem => ({ kind: 'single', msg: { role: 'assistant', content: 'a' } } as unknown as DisplayItem)
+const nudge = (): DisplayItem => ({ kind: 'single', msg: { role: 'nudge', content: 'n' } } as unknown as DisplayItem)
+const sub = (): DisplayItem => ({ kind: 'single', msg: { role: 'subagent', content: 'done' } } as unknown as DisplayItem)
 const turn = (): DisplayItem => ({ kind: 'turn', items: [] } as unknown as DisplayItem)
 
 describe('jumpAnchorIdx', () => {
@@ -35,5 +37,53 @@ describe('jumpAnchorIdx', () => {
   it('does not treat a turn group above the target as part of the run', () => {
     const items = [user(), turn(), user()]
     expect(jumpAnchorIdx(items, 2)).toBe(2)
+  })
+
+  // Machine turn openers (nudge, subagent — TURN_OPENER_ROLES) are prompts
+  // too: the walk consumes runs of them, anchoring at the head of the block
+  // so the row that explains the run is read first.
+
+  it('walks a subagent fan-out run to its head (synthesis still pending)', () => {
+    // 4-agent fan-out, no synthesis row yet: user(0), assistant(1),
+    // subagent(2..5). Pinning the third completion must anchor at the FIRST
+    // completion — the fan-out reads as one block opened by subagent[0], with
+    // the assistant's dispatch directly above it taking the straddle.
+    const items = [user(), asst(), sub(), sub(), sub(), sub()]
+    expect(jumpAnchorIdx(items, 4)).toBe(2)
+  })
+
+  it('walks consecutive unanswered nudge cycles to the head of the run', () => {
+    // Three nudged turns that persisted no reply (errored or cancelled cycles
+    // — a normal cycle interposes its tool/assistant rows): user(0),
+    // assistant(1), nudge(2..4), assistant(5). Pinning the middle nudge
+    // anchors at the first nudge of the run; the assistant row above it is
+    // NOT consumed (it is not a turn opener).
+    const items = [user(), asst(), nudge(), nudge(), nudge(), asst()]
+    expect(jumpAnchorIdx(items, 3)).toBe(2)
+  })
+
+  it('a turn group between machine openers breaks the run', () => {
+    // The shape a healthy babysit loop produces: each nudge's cycle collapses
+    // into a turn group, so consecutive CYCLES never form one run. The walk
+    // must stop at the turn group and return the target unchanged — walking
+    // across cycles would send the jump many turns up the transcript.
+    const items = [user(), asst(), nudge(), turn(), nudge()]
+    expect(jumpAnchorIdx(items, 4)).toBe(4)
+  })
+
+  it('consumes a mixed run of different machine opener types', () => {
+    // nudge(2) then subagent(3,4) back to back: the walk does not stop at a
+    // type boundary — any TURN_OPENER_ROLES row extends the run, so pinning
+    // the last subagent anchors at the nudge that heads the block.
+    const items = [user(), asst(), nudge(), sub(), sub(), asst()]
+    expect(jumpAnchorIdx(items, 4)).toBe(2)
+  })
+
+  it('extends a machine run into the user prompt that heads it', () => {
+    // A user prompt immediately followed by machine openers (dispatch with no
+    // assistant text row): the run is contiguous through the role change, so
+    // the anchor is the human prompt at its head.
+    const items = [asst(), user(), sub(), sub(), asst()]
+    expect(jumpAnchorIdx(items, 3)).toBe(1)
   })
 })

--- a/website/src/test/pinnedPrompt.nudgeSession.test.ts
+++ b/website/src/test/pinnedPrompt.nudgeSession.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { groupDisplayItems, applyRunningState, TURN_OPENER_ROLES } from '../pages/chat/groupDisplayItems'
-import { findPinnedPromptIdx } from '../utils/pinnedPrompt'
+import { findPinnedPromptIdx, jumpAnchorIdx } from '../utils/pinnedPrompt'
 import { isSubagentCompletionMessage } from '../pages/chat/subagentCompletion'
 import type { ChatMessage } from '../types'
 
@@ -75,6 +75,38 @@ describe('pinned prompt in a nudge-driven session', () => {
       expect(pinItem.msg.role).toBe('subagent')
       expect(pinItem.msg.content).toContain('agent-12')
     }
+  })
+
+  it('a fan-out under synthesisPending groups as one opener run and the jump anchors at its head', () => {
+    // Four completions carrying synthesisPending: groupDisplayItems suppresses
+    // each per-completion reply, so the four subagent rows are ADJACENT display
+    // items — the run shape jumpAnchorIdx's machine-opener walk exists for.
+    // Built through the real grouping pipeline so the adjacency is a checked
+    // fact, not a hand-shaped fixture.
+    const out: ChatMessage[] = []
+    const push = (role: string, content: string, meta?: Record<string, unknown>) =>
+      out.push({ role, content, ts: '2026-08-18T05:00:00Z', meta } as unknown as ChatMessage)
+    push('user', 'fan out over four agents')
+    push('assistant', 'dispatching')
+    for (let c = 1; c <= 4; c++) {
+      push('subagent', `[Subagent completion event] agent-${c}\n\nfindings for ${c}`,
+        { synthesisPending: true,
+          subagentCompletion: { kind: 'single', agentId: `agent-${c}`, outcome: 'ok', task: `task ${c}` } })
+      push('assistant', `ack ${c}`)
+    }
+    push('assistant', 'synthesis of all four')
+    const items = applyRunningState(groupDisplayItems(out), false)
+
+    // The four completions must be consecutive display items.
+    const subIdxs = items
+      .map((it, i) => (it.kind === 'single' && it.msg.role === 'subagent' ? i : -1))
+      .filter(i => i >= 0)
+    expect(subIdxs.length).toBe(4)
+    expect(subIdxs[3] - subIdxs[0]).toBe(3)
+
+    // Jumping to the third completion anchors at the first — the head of the
+    // block, with the dispatch that explains it directly above.
+    expect(jumpAnchorIdx(items, subIdxs[2])).toBe(subIdxs[0])
   })
 
   it('the pin scan and the grouping agree on the turn-opener roles', () => {

--- a/website/src/utils/pinnedPrompt.ts
+++ b/website/src/utils/pinnedPrompt.ts
@@ -108,15 +108,44 @@ export function findNextPromptIdx(items: DisplayItem[], afterIdx: number): numbe
  * user asks for `target`.
  *
  * Normally that is `target` itself. But when the rows immediately BEFORE the
- * target are also prompts (consecutive user rows — a steer message follows its
- * prompt with no assistant row between), landing the target at the jump chrome
- * leaves the previous prompt straddling the hand-off line: it cannot pin (its
- * bottom is still below the line) while its own top edge has already pushed the
- * fallback banner fully out — so the banner unmounts and the jump chain dies on
- * a landing the scan treats as a transient. Anchoring the jump at the FIRST
- * prompt of the consecutive run puts a non-prompt row (or nothing) on the line
- * instead, so the previous turn's banner survives and the chain continues. For
- * a target with a non-prompt row above it this returns `target` unchanged.
+ * target are also prompts (turn openers, per `isPrompt`), the jump anchors at
+ * the FIRST prompt of that consecutive run — the walk finds the top of the
+ * contextual block the target belongs to.
+ *
+ * Why not land on `target` directly: putting it at the jump chrome leaves the
+ * prompt above it straddling the hand-off line — it cannot pin (its bottom is
+ * still below the line) while its own top edge has already pushed the fallback
+ * banner fully out — so the banner unmounts and the jump chain dies on a
+ * landing the scan treats as a transient. Anchoring at the head of the run
+ * puts a non-prompt row (or the top of the list) on the line instead, so the
+ * previous turn's banner survives and the chain continues.
+ *
+ * The walk deliberately consumes MACHINE turn openers too (nudge and subagent
+ * rows — `isPrompt` derives from `TURN_OPENER_ROLES`), not only consecutive
+ * user rows like a steer following its prompt. The mechanism-backed case is a
+ * subagent fan-out whose synthesis is still pending: `groupDisplayItems`
+ * suppresses each per-completion reply under `synthesisPending`, so the
+ * completions lay out as one run of consecutive opener rows. Consecutive
+ * nudge rows arise only when nudged turns persist no reply (an errored or
+ * cancelled cycle — a normal cycle interposes its tool/assistant rows). In
+ * both shapes each row is pinnable, and each belongs to the same contextual
+ * block as the row directly above the run: jumping to any member lands at the
+ * block's top, where the exchange reads in order — stopping mid-run would
+ * drop the reader between two machine rows with the context that explains
+ * them still hidden above.
+ *
+ * Walking up lengthens the jump. The virtualizer's near/far decision
+ * (`mountIndex` in useVirtualChat) compares the anchor's jump window against
+ * the COMMITTED window with `NEAR_JUMP_OVERSCAN_MULT` overscan windows of
+ * slack (24 rows for the transcript, which passes `overscan: 6`) — a budget
+ * shared with the distance the jump already covers, so the walk consumes
+ * whatever slack a near jump has left over. In the common case (the pinned
+ * prompt is the previous turn) that leaves the glide untouched; a jump
+ * already sitting at the band's edge can be tipped onto the far path by the
+ * walk, and that is the right outcome there — the gap is unmounted spacer,
+ * and a glide across it would scrub blank.
+ *
+ * For a target with a non-prompt row above it this returns `target` unchanged.
  */
 export function jumpAnchorIdx(items: DisplayItem[], target: number): number {
   let anchor = target


### PR DESCRIPTION
Closes #4473

## What

`jumpAnchorIdx` (website/src/utils/pinnedPrompt.ts) walks up across runs of machine turn-openers (nudge, subagent) as well as consecutive user rows — intentional behavior (the anchor is the top of the contextual block), but the doc comment only described the steer-pair case and no test exercised machine-opener runs. Docs + tests only; the function body is untouched.

- **Doc comment rewrite** on `jumpAnchorIdx`: what the walk does (finds the block's top), which shapes actually produce machine-opener runs (a subagent fan-out under `synthesisPending`, whose per-completion replies `groupDisplayItems` suppresses; nudged turns that persisted no reply — a normal monitor cycle interposes tool/assistant rows and never forms a run), and the interaction with `mountIndex`'s near/far band (the walk consumes slack a near jump has left over — 24 rows for the transcript at `overscan: 6`; a jump already at the band edge can tip onto the far path, which is correct across unmounted spacer).
- **Call-site comment** in ChatPage.tsx now defers to the docblock instead of restating the narrow steer-pair case.
- **Unit tests** (pinnedPrompt.jumpAnchor.test.ts): fan-out run, unanswered-nudge run, mixed nudge+subagent run, user prompt heading a machine run, and the negative case — a turn group between openers breaks the run (the shape a healthy babysit loop produces every cycle).
- **Grouping-pipeline test** (pinnedPrompt.nudgeSession.test.ts): four `synthesisPending` completions built through the real `groupDisplayItems` pipeline lay out adjacent, and the jump anchors at the head of the run — the fan-out adjacency is a checked fact, not a hand-shaped fixture.

Note: the issue's expected anchors ("lands at the assistant") described the row above the anchor; the code anchors at the head of the opener run (an assistant row is never a valid anchor — `isPrompt` is false for it). Tests assert the implemented contract.

## Pre-push review

Two model-pinned reviewers ran on the pre-amend commit:
- GPT: 1 BLOCKING — the doc claimed the walk "cannot flip a near glide into a teleport"; the near/far band is shared with the distance the jump already covers, so a boundary-straddling jump can flip. **Taken**: the paragraph now states the real mechanism and why the flip is benign.
- Opus: 0 BLOCKING, 6 advisory — all taken (24-row figure for the transcript's `overscan: 6`; slack-not-length-budget framing; honest nudge-run provenance; call-site comment update; grouping-driven `synthesisPending` test; negative turn-group case).

## Testing

- `npx tsc -b` clean
- `npx vitest run src/test/pinnedPrompt.jumpAnchor.test.ts src/test/pinnedPrompt.nudgeSession.test.ts` — 15/15 pass

<!-- no-visual-delta -->
**Why no screenshot:** doc comments and unit tests only — the ChatPage edit is a comment block; no runtime behavior or rendered output changes.
