### PR TITLE
fix(aidlc): break equal-timestamp ties newest-first in list_activities (#4518)

### DIFF
--- a/src/kiro_crew/aidlc/store.py
+++ b/src/kiro_crew/aidlc/store.py
@@ -125,7 +125,12 @@ class AidlcStore:
             items = [a for a in items if a.get("target_type") == target_type]
         if target_id:
             items = [a for a in items if a.get("target_id") == target_id]
-        return sorted(items, key=lambda a: a.get("timestamp", 0), reverse=True)[:limit]
+        # Newest first. timestamp alone under-determines the order: clocks are
+        # coarse enough (~15.6ms on Windows) that a burst of activities ties.
+        # Iterating in reverse insertion order lets the stable sort resolve a
+        # tied group most-recently-logged first, so the [:limit] slice keeps
+        # the most recent activities instead of dropping them.
+        return sorted(reversed(items), key=lambda a: a.get("timestamp", 0), reverse=True)[:limit]
 
     # ── Comments ──
 

--- a/test/test_aidlc_store.py
+++ b/test/test_aidlc_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import types
+
 import pytest
 
 from kiro_crew.aidlc.store import AidlcStore
@@ -60,6 +62,35 @@ class TestProjectCRUD:
         task_acts = store.list_activities(project_id=p["id"], target_type="task")
         assert len(task_acts) == 1
         assert task_acts[0]["action"] == "completed"
+
+    def test_list_activities_equal_timestamps(self, store, monkeypatch):
+        # Coarse clocks (~15.6ms granularity on Windows) hand a burst of
+        # activities identical timestamps; the feed must stay deterministic:
+        # distinct timestamps strictly newest-first, and a tied group most
+        # recently logged first. Activity.timestamp's default_factory
+        # captured _now at class definition, so patch the time module that
+        # _now reads at call time (scoped to aidlc.models only).
+        clock = {"t": 500.0}
+        monkeypatch.setattr(
+            "kiro_crew.aidlc.models.time", types.SimpleNamespace(time=lambda: clock["t"])
+        )
+        earlier = store.log_activity("p1", "task", "t-early", action="updated")
+        clock["t"] = 1000.0
+        acts = [store.log_activity("p1", "task", f"t{i}", action="updated") for i in range(3)]
+        assert all(a["timestamp"] == 1000.0 for a in acts)
+        listed = store.list_activities()
+        assert [a["id"] for a in listed] == [a["id"] for a in reversed(acts)] + [earlier["id"]]
+
+    def test_list_activities_limit_keeps_most_recent_of_tied_group(self, store, monkeypatch):
+        # When a tied group is larger than limit, the slice must keep the
+        # MOST RECENT activities, not the oldest members of the group.
+        monkeypatch.setattr(
+            "kiro_crew.aidlc.models.time", types.SimpleNamespace(time=lambda: 1000.0)
+        )
+        acts = [store.log_activity("p1", "task", f"t{i}", action="updated") for i in range(5)]
+        assert all(a["timestamp"] == 1000.0 for a in acts)
+        listed = store.list_activities(limit=2)
+        assert [a["id"] for a in listed] == [acts[4]["id"], acts[3]["id"]]
 
     def test_comments(self, store):
         c = store.add_comment("project", "p1", "hello")


### PR DESCRIPTION
# fix(aidlc): break equal-timestamp ties newest-first in list_activities

Closes #4518

## Problem

`AidlcStore.list_activities` sorts the filtered activity list by `timestamp`
alone with `reverse=True` and slices `[:limit]`. `Activity.timestamp` is a
`float` from `time.time()`, so every activity logged inside one clock tick
carries the same key — ordinary for a burst on a coarse clock (~15.6ms
granularity on Windows). Python's sort is stable and the list is in insertion
order, so a tied group is emitted **oldest-first** in a feed whose contract is
newest-first. When a tie group is larger than `limit` (default 50), the slice
keeps the **oldest** members of the group and drops the most recent ones — the
inverse of what a recent-activity query promises.

## Why it matters

A recent-activity feed that silently returns the oldest members of a burst and
drops the newest is a wrong-result defect, not an unspecified order: a caller
paging the 50 most recent activities after a busy burst never sees the latest
ones. `AidlcStore` currently has no production callers, which bounds the blast
radius — it does not make the sort correct.

## Fix (symptoms → root cause → change)

Wrong tie order → the stable sort inherits insertion (oldest-first) order for
equal keys → iterate the input in **reverse insertion order** so the stable
sort resolves tied groups most-recently-logged first:

```python
return sorted(reversed(items), key=lambda a: a.get("timestamp", 0), reverse=True)[:limit]
```

The key expression is unchanged. `reversed()` is safe in both branches: with no
filters `items` is the live `self._data["activities"]` list (`reversed` is a
non-mutating iterator fully consumed inside `sorted`); with filters it is a
fresh list. This deliberately mirrors the mechanism open PR #4517 chose for the
sibling `list_projects` — a different mechanism in the adjacent function is
exactly the drift this bug class comes from.

**`list_comments` is intentionally untouched:** its sort is ascending over the
forward list, so stable-sort ties already resolve chronologically — there is no
defect there. The numeric coercion it (and this method) could use belongs with
#4517's `_ts()` helper, not here.

## Coordination with open PR #4517

PR #4517 (operator bolichen97) edits the same two files. The hunks are in
different functions ~70 lines apart, so they merge independently in either
order — this PR does not wait for it and does not branch off it. Deliberately
**not** added here: a `_ts()` numeric-coercion helper — #4517 introduces
`AidlcStore._ts`, and a second definition in the same class would be a hard
merge conflict plus a duplicate.

**Follow-up once #4517 lands:** `list_activities` and `list_comments` should
adopt `self._ts` so all three sorts share one coercion. If the test-file hunks
conflict on rebase, resolve by keeping both tests.

## Tests

Two regression tests in `test/test_aidlc_store.py`, both mutation-verified
(reverting the one-line fix fails both; dropping `reverse=True` fails the
first):

- `test_list_activities_equal_timestamps` — logs an earlier activity at t=500,
  then a 3-member burst tied at t=1000; asserts distinct timestamps come back
  strictly newest-first AND the tied group most-recently-logged first. The
  distinct-timestamp assertion pins `reverse=True` so a future refactor (e.g.
  folding in `_ts()` after #4517) cannot silently flip the feed to oldest-first
  with the suite green.
- `test_list_activities_limit_keeps_most_recent_of_tied_group` — logs 5 tied
  activities, calls with `limit=2`, asserts the slice contains the two MOST
  RECENT ones (the user-visible harm the ordering assertion alone misses).

Note: the tests patch `kiro_crew.aidlc.models.time` (module-scoped stub) rather
than `store._now`, because `Activity.timestamp`'s `default_factory` captured
`_now` at class definition and a `store._now` patch never reaches it — verified
empirically before writing the tests.

Local gates: isort ✅ flake8 ✅ mypy ✅ (988 files) pytest 57,226 passed (31
failures reproduce identically on pristine main — environment-inherited,
none in aidlc).

## Manual verification

N/A — unit coverage sufficient: the defect and fix are fully exercised by the
deterministic-clock tests; the method has no production callers.

<!-- no-visual-delta -->
Backend-only change; no user-visible UI surface is touched.
