### PR TITLE
test(aidlc): drive list-ordering off a stub clock, not the returned dict

### DIFF
--- a/test/test_aidlc_store.py
+++ b/test/test_aidlc_store.py
@@ -26,16 +26,20 @@ class TestProjectCRUD:
         assert p["created_at"] > 0
         assert p["updated_at"] > 0
 
-    def test_list_projects(self, store):
+    def test_list_projects(self, store, monkeypatch):
+        # Hand the store a MONOTONIC counter instead of the wall clock: `time.time()`
+        # returns the same value for ~60% of adjacent calls on Windows (the ~15.6ms
+        # timer tick) and `sorted` is stable, so two back-to-back creates tie and the
+        # newest-first assertion below sees insertion order instead. The ordering is
+        # the subject, not the clock. Patched on `store` rather than `models`, because
+        # store.py did `from .models import _now` and so reads its OWN binding.
+        from kiro_crew.aidlc import store as store_mod
+
+        stamps = iter(range(1, 100))
+        monkeypatch.setattr(store_mod, "_now", lambda: float(next(stamps)))
+
         p1 = store.create_project("first")
         p2 = store.create_project("second")
-        # Separate the two timestamps EXPLICITLY rather than trusting the clock to
-        # advance between two back-to-back creates. `time.time()` returns the same
-        # value for ~60% of adjacent calls on Windows (the ~15.6ms timer tick), and
-        # `sorted` is stable, so on a tie the newest-first assertion below sees
-        # insertion order and fails — the ordering under test, not the clock, is the
-        # subject, so pin it instead of sleeping.
-        p2["updated_at"] = p1["updated_at"] + 1
 
         listed = store.list_projects()
         assert len(listed) == 2


### PR DESCRIPTION
## Problem

`test_aidlc_store.py::test_list_projects` pins its newest-first ordering by
mutating the dict `create_project` returned:

```python
p2["updated_at"] = p1["updated_at"] + 1
```

That works only while the store hands back its **live internal record**. A
copy-on-return refactor of `create_project` would leave the mutation invisible to
the sort, silently restoring the flake the line was added to fix — with no test
failure to announce it.

The underlying flake: `time.time()` returns the **same value for ~60% of adjacent
calls** on Windows (the ~15.6ms timer tick), and `sorted` is stable, so two
back-to-back creates tie and `list_projects` yields insertion order instead of
newest-first.

## Why it matters

This is the follow-up to Design Review's advisory note on #4512. The current fix
is correct today but load-bearing on an implementation detail of the code it
tests, which is exactly the shape that regresses quietly later.

## Fix (symptom → root cause → change)

Root cause: the test depends on the clock advancing (or, after #4512, on
identity-sharing between the returned dict and the stored one). Change: stub the
clock so the two timestamps are distinct **at the source** — a monotonic counter
via `monkeypatch` — and drop the post-hoc mutation.

Patched on `store` rather than `models`: `store.py` does
`from .models import _now`, so it reads its **own** module binding and patching
the defining module would be a silent no-op (the failure mode
`docs/system-specs/common/testing-conventions.md` § "Patch the defining module,
not a re-export" describes, in its reverse direction).

## Tests

No new tests — this hardens an existing one. Verified by mutation:

| Change | Expected | Result |
|---|---|---|
| unmodified | pass | 10/10 runs green |
| sort direction flipped (`reverse=True` dropped) | **fail** | fails — still guards the behavior |
| `create_project` given a copy-on-return (`p = dict(p)`) | pass | passes — the concern is closed; the previous fix failed here |

`test_aidlc_store.py` is 8 passed locally on Windows. isort, flake8 and the
baselined black gate are clean.

## Manual verification

N/A — unit coverage is sufficient; the behavior under test is a pure in-memory
sort, and the mutation matrix above covers both the regression it guards and the
refactor it must survive.

---

No linked issue: follow-up to the advisory note on #4512.
