### PR TITLE
fix(test_spawn_exec_shim): fix macos/deep-worktree host-env failures in test_spawn_exec_shim.py

### DIFF
--- a/test/test_spawn_exec_shim.py
+++ b/test/test_spawn_exec_shim.py
@@ -438,6 +438,13 @@ class TestSyncReportedArgv:
     none of them can pass by the shim quietly ceasing to be prepended.
     """
 
+    # The regression these guards pin was an 8815-char message that was nearly
+    # all shim source. A generous cap still catches that leak while a clean,
+    # shim-free message can never trip it just because the interpreter path is
+    # long (a deep CI worktree or venv pushes a bare ``sys.executable`` message
+    # past a tight 200-char bound with zero code signal).
+    _MAX_REPORTED_MESSAGE_LEN = 1000
+
     def _shim_is_prepended(self, spawned: "list[str]") -> bool:
         return len(strip_spawn_shim(spawned)) < len(spawned)
 
@@ -458,14 +465,13 @@ class TestSyncReportedArgv:
             run_limited(cmd, check=True, capture_output=True)
         assert caught.value.cmd == cmd
         assert caught.value.returncode == 1
-        # The regression this guards: the message was 8815 chars, nearly all shim.
-        assert len(str(caught.value)) < 200
+        assert len(str(caught.value)) < self._MAX_REPORTED_MESSAGE_LEN
 
     def test_timeout_expired_names_the_command_not_the_shim(self):
         with pytest.raises(subprocess.TimeoutExpired) as caught:
             run_limited([sys.executable, "-c", "import time;time.sleep(30)"], timeout=0.3)
         assert caught.value.cmd == [sys.executable, "-c", "import time;time.sleep(30)"]
-        assert len(str(caught.value)) < 200
+        assert len(str(caught.value)) < self._MAX_REPORTED_MESSAGE_LEN
 
     def test_popen_communicate_timeout_names_the_command_not_the_shim(self):
         """``communicate(timeout=...)`` builds TimeoutExpired from ``Popen.args``."""
@@ -476,7 +482,7 @@ class TestSyncReportedArgv:
             assert proc.args == [sys.executable, "-c", "import time;time.sleep(30)"]
             with pytest.raises(subprocess.TimeoutExpired) as caught:
                 proc.communicate(timeout=0.3)
-            assert len(str(caught.value)) < 200
+            assert len(str(caught.value)) < self._MAX_REPORTED_MESSAGE_LEN
         finally:
             proc.kill()
             proc.wait()


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 1 related change:
- **Fix macOS/deep-worktree host-env failures in test_spawn_exec_shim.py**

## Changes and rationale

### Fix macOS/deep-worktree host-env failures in test_spawn_exec_shim.py
**Problem:** (Rescoped 2026-08-16: the original items 1 and 3 — hardcoded /bin/false and the unguarded RLIMIT negative control — merged upstream inside PR #3916's second commit, 'fix(test): make spawn_exec_shim tests host-NOFILE independent'. Verified on fresh upstream/main: test_called_process_error now uses sys.executable, and test_the_cap_is_lower_than_an_unwrapped_spawn raises its own soft limit first. ONE item remains.)
**Why it matters:** The failures are deterministic per host layout and unrelated to the shim code under test; they burn full-suite runs for any contributor whose interpreter path is long. The regression the bound guards (an 8815-char message that was nearly all shim) does not need a tight 200-char bound to stay pinned.
**Tests:** `.venv/bin/python -m pytest test/test_spawn_exec_shim.py -o addopts="" -p no:cacheprovider` passes on this host. Control: temporarily re-embed the shim source in the reported argv (break strip_spawn_shim locally, do not commit) → all three tests still fail. The regression guard keeps teeth. CI (Linux + Windows) behavior unchanged.
**Review focus:** backend

## Review map

| Change | Primary files |
|---|---|
| Fix macOS/deep-worktree host-env failures in test_spawn_exec_shim.py | `test/test_spawn_exec_shim.py` |

## Commits
- [`6f61613`](https://github.com/kirodotdev/KiroCrew/pull/4527/commits/6f616132f62affa8441972e474b7e22aec4ceb40) fix(test_spawn_exec_shim): fix macos/deep-worktree host-env failures …

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (1 files, +10/-4)</summary>

- `test/test_spawn_exec_shim.py` (+10/-4)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->