### PR TITLE
fix(memory): protect the memory files from other local users on Windows

### DIFF
--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -243,6 +243,172 @@ security-warning handlers in each caller fire — a naive `if IS_POSIX: os.chmod
 guard would silently no-op on Windows, leaving secrets group/world-readable
 under NTFS.
 
+`memory.db` (semantic/episodic memories and their embeddings) is protected by an
+owner-only **directory**, not just an owner-only file. It runs under
+`journal_mode=WAL`, so SQLite keeps `memory.db-wal` and `memory.db-shm` beside
+it, and a *committed* row lives in the `-wal` until a checkpoint moves it — so
+locking the `.db` alone would leave committed memories readable under the DACL
+those sidecars inherited. SQLite creates and destroys them throughout the DB's
+life, at moments no caller can hook, which makes the directory the only place
+their access can be settled once. `make_owner_only_dir` handles the split that
+`restrict_to_owner` cannot: `0o700` on POSIX, because a directory needs the
+execute bit to be traversable.
+
+**On Windows the directory protects only itself**, which is why every
+memory-bearing file is named individually. Two separate reasons, and neither is
+obvious:
+
+- *Bypass Traverse Checking* is granted to Everyone by default, so a permissive
+  DACL on an existing file stays reachable even inside a tightened directory.
+- `restrict_to_owner` applies `/inheritance:r` plus **non-inheritable** grants (no
+  `(OI)(CI)`), so a file created later does not inherit owner-only access either —
+  it falls back to the creating process's token default DACL, usually owner +
+  SYSTEM + Administrators. Not world-readable, but a default rather than a
+  guarantee.
+
+So on Windows the per-file pass is the mechanism, not a belt-and-braces addition,
+and a sidecar created mid-session is covered from the next `init()`. On POSIX the
+directory *is* sufficient on its own: `0o700` stops another user traversing into
+it at all, whatever the files inside carry. That pass covers the `.db`, its `-wal`/`-shm` sidecars, and
+`memory.faiss` / `memory.ids.json` (the embedding index and its id map),
+and it runs on **every** `VectorMemoryStore.init()` rather than only when init
+created them — **twice**, once before `sqlite3.connect` and once after. The first
+call is what stops the schema migrations running against a file another local
+user can still write; the second covers whatever SQLite has just created.
+
+> **Scope note.** With the default `db_path`, "the directory" *is* the data home
+> (`config_dir()`), so a memory init tightens the whole home to owner-only.
+> That direction is right — the home also holds the security policy, sessions and
+> lessons, all private on the same boundary — but it is wider than memory, and it
+> is the only place in the tree that does it today. `memory.py`'s FTS index
+> (`memory_index.db`) and its sidecars carry the same secrets and are **not** yet
+> covered by the per-file pass. Tracked in
+> [#4543](https://github.com/kirodotdev/KiroCrew/issues/4543).
+
+**A caller-supplied `db_path` gets no lockdown at all**, and both halves of that are
+deliberate. Its directory belongs to the caller — the eval runner points one at a
+scenario workspace — so narrowing it could cut authorized users off from unrelated
+files they keep there. And tightening the *files* without first securing the
+directory would be a check/use race: the pathname the guard clears is re-opened by
+`restrict_to_owner`, so a user who can write the directory could swap the entry in
+between. There is no safe fd-based form to fall back on — `icacls` is path-only and
+`O_NOFOLLOW` does not exist on Windows — so the files are left exactly as the caller
+had them. The stores that take this branch (the eval runner, the bench ingester) hold
+scenario fixtures rather than the operator's memories; the real data home always
+takes the protected branch.
+
+A DB that already exists is exactly the one that may have lost its protection
+since: a restored backup, a home migration, a manual edit, or simply an install
+that predates this lockdown. Gating on creation would leave every one of those
+permanently readable, which is most of them.
+
+The pass skips a file that does not exist, checked with `exists()` rather than
+caught: `icacls` reports a missing file as `rc=2`, which surfaces as a plain
+`OSError` and not `FileNotFoundError`, so catching the subclass alone made every
+clean init warn "may be readable by other users" for each sidecar SQLite had yet
+to create. Measured on a fresh store, that check takes the Windows cost from 11
+`icacls` spawns per init down to 4.
+
+**The lockdown splits into validation and ACL tightening, and only the tightening is ever
+deferred.** The two differ in cost by nearly three orders of magnitude, which is where the
+line is drawn.
+
+*Validation* — deciding whether each memory path is a plain single-link file, clearing a
+recoverable one that is not, creating the directory, and recording what could not be
+secured — is pure `lstat`/`unlink`/`mkdir` with no subprocess at all: **~0.09ms** for the
+whole five-path sweep, measured. It **always runs inline**, on the calling thread, event
+loop or not, because it is what `init()` reads to decide whether to open the store. Defer
+it and `init()` would connect first and learn afterwards that the path was an attacker's
+link — the store would already be open through it. At that cost there is nothing to gain
+by deferring and a guarantee to lose.
+
+*ACL tightening* is the expensive half: each `restrict_to_owner` spawns `icacls` at
+**~70ms** (10s timeout) and there are up to five. Five call sites reach `init()` from
+inside an `async def` (`cli_server._run_task`, `dashboard.server.start_dashboard`,
+`eval.runner._run_scenario_in`), so spawning any of them on the loop would park it and
+every other coroutine on the gateway. On Windows-on-loop they all move to a worker —
+**including the directory's**, since nothing that spawns may touch the loop thread.
+Offloading rather than *skipping* is the point: a skip would leave a deployment whose only
+inits are those async sites permanently unprotected.
+
+The worker applies them **directory first**, which is a precondition rather than an
+ordering preference: until the directory is owner-only another local user can swap an entry
+between the validation and the `restrict_to_owner` that acts on it, so a directory that
+cannot be tightened abandons the file pass instead of proceeding without it.
+
+Each file is then **re-validated immediately before its own `restrict_to_owner`**, and that
+second check is what closes the swap window rather than merely narrowing it. Validation runs
+before the directory is owner-only — it has to, since it is what decides whether to open the
+store at all — so at that moment a local user who can write the directory could still
+replace an approved entry with a link and have its target re-permissioned. Re-checking after
+the directory is locked means the entry being acted on was confirmed while nobody else could
+write the directory. It costs one `lstat` against a ~70ms `icacls`.
+
+The directory takes **`0o700`** on POSIX rather than going through `restrict_to_owner`,
+which is `chmod(0o600)` there — right for a file, and for a directory it strips the execute
+bit that makes it *traversable*, so the next `sqlite3.connect` fails with "unable to open
+database file". Windows has no such distinction (the DACL carries both), so there the
+directory takes the same `restrict_to_owner` as everything else.
+
+The upshot is that **every refusal is synchronous on every platform**. A planted link, a
+linked data home, a sidecar that could not be cleared — all are decided before the connect,
+on the calling thread. What can land late is only the DACL of a file that already existed,
+never the decision to open the store.
+
+POSIX runs everything inline: `restrict_to_owner` is a bare `os.chmod` there, with no
+subprocess to block on.
+
+**A link planted at one of the memory filenames is never written through.** The
+lockdown refuses to re-permission a non-plain entry — a symlink, a directory, a device,
+or a hardlink alias (`st_nlink > 1`, which needs no privilege on Windows). Leaving it
+at that would be the worse half of both choices: we decline to touch the attacker's
+target, then fill it with the memories anyway. Every writer for these paths truncates
+in place — `faiss.write_index`, the id map's `write_text`, and SQLite's WAL append all
+write *through* an existing inode rather than creating a new one — so "skip" is not the
+neutral act it looks like.
+
+Which response the entry gets turns on whether losing the file would lose memories that
+exist nowhere else:
+
+| Path | Response | Why |
+|---|---|---|
+| `memory.db`, `memory.db-wal` | **`init()` raises `MemoryStoreUnsafeError`**, file left alone | Unrecoverable. A *committed* transaction lives in the `-wal` until a checkpoint moves it into the `.db`, so between the two sits every memory the user has. Unlinking either could discard acknowledged writes; connecting anyway would replay and extend a log another local user can read. Refusing to open is the only response that neither loses the rows nor leaks the new ones — and it leaves the operator holding the only copy instead of us deleting it for them. |
+| `memory.db-shm`, `memory.faiss`, `memory.ids.json` | **unlinked**, `init()` proceeds (and aborts if the unlink fails) | Recoverable. SQLite rebuilds the `-shm` from the `-wal` on connect, and `load_faiss_index` falls back to `build_faiss_index`. |
+
+`unlink` is safe for the recoverable set because it drops *our* directory entry only:
+the inode and the attacker's own name for it are untouched, so nothing of theirs is
+destroyed and nothing of the user's either. If the unlink itself **fails** — a read-only
+directory, or another process holding the index mapped on Windows — the entry is still
+there, so it falls back to the same refusal the unrecoverable paths get: `init()` raises
+rather than connecting. A warning alone would leave every future embedding landing in a
+file another local user can read, which is the outcome the removal exists to prevent, so
+"could not remove it" has to be as fatal as "must not remove it".
+
+An **absent** path is not a finding: `_is_lockdown_safe` refuses a missing file, so a
+clean open reaches the removal branch for every sidecar that does not exist yet, and it
+returns silently rather than warning on every first run.
+
+**The same refusal covers the data home itself.** The home is matched with `resolve()` so
+a legitimately relocated one still qualifies — but that means a symlink or junction
+*planted at* the home compares equal too, and `chmod`/`icacls` follow a directory link
+exactly as they follow a file one, which would re-permission whatever it points at. So a
+home that is a link is refused via `platform_compat.is_link_or_junction` (not
+`Path.is_symlink()`, which reports False for a junction, and a junction needs no
+privilege to create), the tree is left as found, and the per-file pass is abandoned with
+it. Relocate the home with `KIROCREW_HOME`, not with a link.
+
+The worker is **non-daemon**, which matters for the short-lived commands. A daemon
+thread is killed outright at interpreter exit, so a `kirocrew run` or a single eval
+scenario could finish before the lockdown landed and leave the files on their
+inherited DACL — the outcome this whole section exists to prevent. Non-daemon means
+the interpreter waits instead; the wait is bounded by `restrict_to_owner`'s own
+10-second-per-file `icacls` timeout, and it arises only when `init()` was called from
+an event loop in the first place.
+
+It is fail-soft (warn, keep going), which is the contract `restrict_to_owner`
+documents for its callers: memory being unavailable is a supported degraded
+state, so a read-only filesystem must not take init down.
+
 ## File locking on Windows
 
 `platform_compat.file_lock` / `acquire_lock` provide a genuine *blocking*

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -18,6 +18,7 @@ import json
 import logging
 import math
 import re
+import stat
 import struct
 import threading
 from collections import OrderedDict
@@ -53,6 +54,7 @@ except ImportError:
 import time
 
 from kiro_crew import platform_compat
+from kiro_crew.atomic_write import _on_event_loop
 from kiro_crew.config.loader import config_dir
 from kiro_crew.metrics.db_metrics import timed
 from kiro_crew.project_scope import (
@@ -617,6 +619,81 @@ def _mmr_rerank(
     return [candidates[i] for i in selected]
 
 
+def _path_present(path: Path) -> bool:
+    """Whether *path* names anything at all, INCLUDING a dangling symlink.
+
+    ``Path.exists()`` follows the link, so it answers False for a broken one -- which
+    would conflate "nothing here, safe to create" with "a link to somewhere else that
+    the next writer will follow". ``lstat`` inspects the entry itself and raises only
+    when the name is genuinely absent.
+    """
+    try:
+        path.lstat()
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+class MemoryStoreUnsafeError(RuntimeError):
+    """The memory DB path is not a plain file this process can safely own.
+
+    Raised by :meth:`VectorMemoryStore.init` instead of opening a path the lockdown
+    refused to secure -- a symlink, a directory or a multi-link entry planted at the DB
+    filename. Fatal rather than a warning: the alternative is writing every future
+    memory through a name another local user controls, and memory being unavailable is
+    a supported degraded state while silently leaking it is not.
+    """
+
+
+def _is_lockdown_safe(path: Path) -> bool:
+    """Whether *path* is a plain file this process may safely re-permission.
+
+    The lockdown REWRITES access on whatever it is handed, and both back ends follow
+    links: ``os.chmod`` resolves a symlink unless told otherwise, and ``icacls``
+    likewise applies to a link's target. So on a data home another local user can
+    write -- the legacy home, a restored backup, a misconfigured share -- an entry
+    planted at one of the memory filenames turns this hardening into a lever for
+    changing permissions on a file outside the home entirely.
+
+    Three rejects, each closing a distinct shape:
+
+    * **missing** -- the normal case on a clean open (SQLite and FAISS create theirs
+      on demand), and skipping it also avoids a false "may be readable" warning,
+      since ``icacls`` reports a missing file as ``rc=2`` -> plain ``OSError``.
+    * **not a regular file** -- a symlink (``lstat`` sees the link, ``stat`` the
+      target), a directory, or a device. A symlink is the classic redirect.
+    * **more than one hard link** -- a hardlink needs no privilege on Windows, so it
+      is the reachable version of the same attack there; the name we own and the
+      attacker's name are the same inode, and re-permissioning ours re-permissions
+      theirs.
+
+    Refusing is the safe direction: an un-tightened file is the status quo this PR
+    improves on, while following a link would be a new capability handed to a local
+    attacker. Logged at WARNING because a link at these names is never routine.
+    """
+    try:
+        st = path.lstat()  # lstat, not stat: a symlink must be seen AS a symlink
+    except (OSError, ValueError):
+        return False  # missing, or a name the OS refuses to stat
+    if not stat.S_ISREG(st.st_mode):
+        logger.warning(
+            "Refusing to restrict %s: not a regular file (mode=%s). A link or special "
+            "file at a memory filename would redirect the lockdown onto its target.",
+            path,
+            stat.filemode(st.st_mode),
+        )
+        return False
+    if getattr(st, "st_nlink", 1) > 1:
+        logger.warning(
+            "Refusing to restrict %s: it has %d hard links, so re-permissioning it "
+            "would also re-permission a name outside this directory.",
+            path,
+            st.st_nlink,
+        )
+        return False
+    return True
+
+
 # ── Store ──
 
 
@@ -689,10 +766,521 @@ class VectorMemoryStore:
         # episodic row. Backs the debounce in _touch_last_accessed; swept when it
         # grows past _LAST_ACCESSED_CACHE_MAX.
         self._last_accessed_touch: dict[str, float] = {}
+        # Memory paths the lockdown could neither secure nor clear, recorded by
+        # _validate_memory_tree and read by init(), which refuses to open the store
+        # while any remain. Not a cache: rebuilt from scratch on every pass, so it always
+        # describes the tree as it is now.
+        self._unsecured_paths: list[Path] = []
+
+    def _wal_path(self) -> Path:
+        """The write-ahead log, which holds committed rows the ``.db`` does not yet.
+
+        Its own accessor because it is the one sidecar that is NOT recreatable: under
+        ``journal_mode=WAL`` a COMMITTED transaction lives here until a checkpoint moves
+        it into the DB, so after a crash this file is the only copy of those memories.
+        That makes it unrecoverable state in the same sense the DB is, and it is treated
+        the same way -- see :meth:`_is_unrecoverable`.
+        """
+        return Path(f"{self._db_path}-wal")
+
+    def _secret_bearing_files(self) -> tuple[Path, ...]:
+        """Every file beside the DB that carries the user's memories.
+
+        All of them, not just the DB, because on Windows the owner-only DIRECTORY is
+        not sufficient for a file that already exists: **Bypass Traverse Checking** is
+        granted to Everyone by default, so a permissive DACL on the file itself stays
+        reachable even inside a tightened directory. The directory governs what SQLite
+        and FAISS create from now on; this list is what repairs an existing install.
+
+        - ``-wal``: a COMMITTED row lives here until a checkpoint moves it, so it is
+          unrecoverable state rather than a cache. Same suffix set ``memory.py`` uses
+          to drop a corrupt index.
+        - ``-shm``: the WAL's shared-memory index. Pure derived state -- SQLite rebuilds
+          it from the ``-wal`` on the next connect, so unlike the ``-wal`` itself it
+          holds no memory that is not stored elsewhere.
+        - ``memory.faiss`` / ``memory.ids.json``: the embedding index and its id map,
+          written with no lockdown of their own. (``with_suffix`` REPLACES ``.faiss``,
+          so the id map is ``memory.ids.json``; it is spelled here the way
+          :meth:`_save_faiss_index` spells it.)
+
+        Not exhaustive for the data home as a whole -- ``memory.py``'s FTS index
+        (``memory_index.db``) and its sidecars carry the same secrets and are not
+        this class's to open. Tracked separately rather than reached across a module
+        boundary from here.
+        """
+        return (
+            self._wal_path(),
+            Path(f"{self._db_path}-shm"),
+            self._faiss_path,
+            self._faiss_path.with_suffix(".ids.json"),
+        )
+
+    def _is_unrecoverable(self, path: Path) -> bool:
+        """Whether losing *path* would lose memories that exist nowhere else.
+
+        Splits the lockdown's two responses to a path it cannot secure. The DB and its
+        ``-wal`` are the store: a committed row lives in the ``-wal`` until a checkpoint
+        moves it into the ``.db``, so between those two files sits every memory the user
+        has, and unlinking either can discard acknowledged writes. Those abort
+        :meth:`init` instead.
+
+        Everything else -- ``-shm``, the FAISS index, its id map -- is rebuilt from the
+        pair above (SQLite recreates the ``-shm`` on connect; ``load_faiss_index`` falls
+        back to ``build_faiss_index``), so removing a planted entry at one of those names
+        costs nothing and is the only response that stops it being written through.
+        """
+        return path == self._db_path or path == self._wal_path()
+
+    def _lock_down_memory_tree_off_loop(self) -> None:
+        """Run the lockdown, keeping the SUBPROCESS off the event loop.
+
+        The split is **validation vs ACL tightening**, and it is drawn on cost because the
+        two differ by nearly three orders of magnitude.
+
+        VALIDATION -- deciding whether each memory path is a plain single-link file,
+        clearing a recoverable one that is not, and recording the rest -- is pure
+        ``lstat``/``unlink``/``mkdir`` with no subprocess at all: **~0.09ms** for the whole
+        five-path sweep, measured. It always runs INLINE, on the calling thread, event loop
+        or not, because it is what :meth:`init` reads to decide whether to open the store.
+        Deferring it would mean connecting first and learning afterwards that the path was
+        an attacker's link -- the store would already be open through it. At this cost
+        there is nothing to gain by deferring it and a guarantee to lose.
+
+        ACL TIGHTENING is the expensive half and the one that must not run on a loop: each
+        ``restrict_to_owner`` spawns ``icacls`` (**~70ms** each, 10s timeout) and there are
+        up to five of them. Five call sites reach :meth:`init` from inside an ``async def``
+        (``cli_server._run_task``, ``dashboard.server.start_dashboard``,
+        ``eval.runner._run_scenario_in``), so running these inline would park the loop and
+        every other coroutine on the gateway with it. On Windows-on-loop they are
+        offloaded to a worker. Offloading rather than SKIPPING is the point: a deployment
+        whose only inits are those async sites still gets tightened, which a skip would
+        have left permanently readable. Same shape ``mcp_gateway.manager`` uses for the
+        identical helper.
+
+        What that buys is that **every refusal is synchronous on every platform**. A
+        planted link, a linked data home, a sidecar that could not be cleared -- all are
+        decided before the connect on the calling thread. Only the DACL of an
+        already-existing file can land late, and never the decision to open the store.
+
+        A plain thread rather than ``asyncio.to_thread``, because this is a sync method
+        with nothing to await on -- and deliberately **non-daemon**: a daemon is killed
+        outright at interpreter exit, so a short-lived Windows task (``kirocrew run``,
+        one eval scenario) could exit before the tightening landed and leave those files on
+        their inherited DACL. Non-daemon means the interpreter waits for it instead,
+        bounded by ``restrict_to_owner``'s own 10s-per-file ``icacls`` timeout.
+
+        POSIX runs everything inline: ``restrict_to_owner`` is a bare ``os.chmod`` there,
+        with no subprocess to block on, so a thread hop would buy nothing.
+        """
+        if platform_compat.IS_POSIX or not _on_event_loop():
+            self._lock_down_memory_tree()
+            return
+        # Validate inline (cheap, and init() reads the verdict immediately); tighten off
+        # the loop (the icacls spawns). `_validate_memory_tree` returns the paths whose
+        # DACL still needs applying, so the worker does no deciding of its own.
+        to_tighten = self._validate_memory_tree()
+        if not to_tighten:
+            return
+        threading.Thread(
+            target=self._tighten_paths,
+            args=(to_tighten,),
+            name="memory-lockdown",
+            daemon=False,
+        ).start()
+
+    def _tighten_paths(self, paths: tuple[Path, ...]) -> None:
+        """Apply the owner-only DACL/mode to already-VALIDATED paths, in order.
+
+        Split out so it is the only thing that can run on a worker thread: it makes no
+        decisions, it just applies ``restrict_to_owner`` to what validation approved.
+
+        ``paths`` arrives DIRECTORY FIRST, and the first entry is a PRECONDITION rather
+        than merely the first item: if the directory cannot be tightened, the file pass is
+        abandoned rather than run anyway. Proceeding without an owner-only directory would
+        hand a local attacker a lever to have their own target re-permissioned; skipping
+        leaves the files as they were, which is the status quo this change improves on. So
+        the failure mode is "no worse than before", never worse.
+
+        Each FILE is RE-VALIDATED here, immediately before its ``restrict_to_owner``, and
+        that second check is what closes the swap window rather than merely narrowing it.
+        Validation ran before the directory was owner-only -- it has to, since it is what
+        decides whether to open the store at all -- so at that moment another local user
+        could still replace an approved entry with a link and have its target
+        re-permissioned. Re-checking after the directory is locked means the entry being
+        acted on was confirmed while nobody else could write the directory. It costs one
+        ``lstat`` against a ~70ms ``icacls``, so there is no reason to rely on the earlier
+        reading.
+
+        A per-FILE failure only warns and the walk continues, because memory being
+        unavailable is a supported degraded state and ``restrict_to_owner`` documents this
+        warn-and-continue handler as its caller contract.
+
+        The DIRECTORY does NOT go through ``restrict_to_owner`` on POSIX, because that is
+        ``chmod(0o600)`` -- correct for a file, and for a directory it strips the execute
+        bit that makes it TRAVERSABLE, so the very next ``sqlite3.connect`` fails with
+        "unable to open database file". A directory needs ``0o700``. On Windows there is no
+        such distinction (the DACL is the carrier for both), so the directory takes the
+        same ``restrict_to_owner`` as everything else there.
+        """
+        for index, path in enumerate(paths):
+            # Files only: `_is_lockdown_safe` demands a regular file, which the directory
+            # is not. The directory's own link/junction check ran in validation, and it is
+            # tightened here before anything else, so nobody can swap it in between.
+            if index > 0 and not _is_lockdown_safe(path):
+                logger.warning(
+                    "Not restricting %s: it is no longer a plain single-link file. It was "
+                    "one when the tree was validated, so it was replaced in between -- "
+                    "refusing rather than re-permissioning whatever it now points at.",
+                    path,
+                )
+                continue
+            try:
+                if index == 0 and platform_compat.IS_POSIX:
+                    path.chmod(0o700)
+                else:
+                    platform_compat.restrict_to_owner(path)
+            except OSError:
+                if index == 0:
+                    logger.warning(
+                        "Cannot restrict %s to owner, so the per-file lockdown is "
+                        "SKIPPED: without an owner-only directory another local user "
+                        "could swap a checked entry for a link and have its target "
+                        "re-permissioned. The memory files keep the access they "
+                        "already had.",
+                        path,
+                        exc_info=True,
+                    )
+                    return
+                logger.warning(
+                    "Cannot restrict %s to owner; it may be readable by other users",
+                    path,
+                    exc_info=True,
+                )
+
+    def _lock_down_memory_tree(self) -> None:
+        """Validate the memory tree, then make it owner-only. The fully inline form.
+
+        Used on POSIX and off the event loop. On Windows-on-loop
+        :meth:`_lock_down_memory_tree_off_loop` runs the same two steps with the
+        tightening on a worker; the validation is identical and always inline.
+        """
+        self._tighten_paths(self._validate_memory_tree())
+
+    def _validate_memory_dir(self) -> bool:
+        """Decide whether the memory DIRECTORY may be tightened, and create it.
+
+        Returns False when neither it nor the files inside it may be touched, in which case
+        the per-file pass must be ABANDONED rather than run anyway. Without an owner-only
+        directory there is nothing stopping another local user swapping a checked entry for
+        a link between :func:`_is_lockdown_safe` and ``restrict_to_owner``, and losing that
+        race would rewrite permissions on a file outside the home. Skipping leaves the
+        files exactly as they were, which is the status quo this change improves on;
+        proceeding would hand a local attacker a new capability. So the failure mode is
+        "no worse than before", never "worse than before".
+
+        A custom ``db_path`` also returns False, having applied the pre-existing POSIX
+        ``chmod`` -- that directory belongs to its caller, and the same race argument
+        applies to its contents.
+
+        No ``icacls`` here: this is the cheap half (``mkdir`` plus two stat-class checks)
+        so it can run on the event loop, and the caller applies the DACL.
+        """
+        parent = self._db_path.parent
+        # Only OUR OWN directory. A caller that passes a custom `db_path` -- the eval
+        # runner points one at a scenario workspace -- owns that directory and keeps
+        # unrelated files in it, so tightening it to owner-only could cut authorized
+        # users off from data that is not ours to re-permission. The default home is
+        # Kiro Crew's own, so tightening it is in scope; anywhere else, the per-file pass
+        # is the whole contribution. Compared resolved, so a symlinked or
+        # differently-spelled home still matches.
+        try:
+            owns_dir = parent.resolve() == (config_dir() / _DB_FILE).parent.resolve()
+        except OSError:
+            owns_dir = False
+        if not owns_dir:
+            # Nothing is locked down here, and that is deliberate on both halves. The
+            # directory belongs to its caller, so narrowing it could cut authorized users
+            # off from unrelated files they keep in it. And WITHOUT an owner-only
+            # directory the per-file pass would be a check/use race: `_is_lockdown_safe`
+            # inspects a pathname that `restrict_to_owner` then re-opens, so another
+            # local user who can write the directory could swap the entry in between.
+            # There is no fd-based alternative to fall back on -- `icacls` is path-only
+            # and `O_NOFOLLOW` does not exist on Windows -- so the honest choice is to
+            # leave the files exactly as the caller had them.
+            #
+            # Scope of the omission: the callers that pass a custom `db_path` are the
+            # eval runner and the bench ingester, whose stores hold scenario fixtures
+            # rather than the operator's memories. The real data home -- what this change
+            # exists to protect -- always takes the branch below.
+            logger.debug(
+                "Not tightening %s: a custom db_path's directory belongs to its caller, "
+                "and tightening the files without first securing it would be a "
+                "check/use race. Keeping the POSIX chmod only.",
+                parent,
+            )
+            # Keep the PRE-EXISTING POSIX guard, which this change must not remove:
+            # before it, `init()` applied `chmod_safe(db_path, 0o600)` unconditionally.
+            # `os.chmod` follows a symlink, so it carries the same swap hazard as the
+            # Windows leg -- but it is what the caller already had on this path, and
+            # dropping it would be a regression rather than the conservative choice.
+            # Windows gets nothing here: `restrict_to_owner` shells out to `icacls`,
+            # which is the leg that could re-permission an attacker-chosen target, and
+            # `chmod_safe` is a documented no-op there anyway.
+            if platform_compat.IS_POSIX:
+                platform_compat.chmod_safe(self._db_path, 0o600)
+            return False
+        # The same refusal the FILES get, for the DIRECTORY. `resolve()` above compares
+        # the home through any link, which is what lets a legitimately relocated home
+        # match -- but it also means a symlink or junction PLANTED at the home would
+        # compare equal and send the chmod/icacls below onto whatever it points at. Both
+        # back ends follow a directory link exactly as they follow a file one, so an
+        # attacker who can create the home path gets an arbitrary directory
+        # re-permissioned. `is_link_or_junction`, not `is_symlink()`, because a Windows
+        # junction is invisible to the latter and needs no privilege to create.
+        #
+        # Recorded as UNSECURED, not merely skipped, so `init()` refuses to open the store.
+        # There is no version of this that is safe to proceed through: tightening the link
+        # would re-permission its target, and NOT tightening it means every memory file is
+        # created inside a directory whose access we could not establish -- the DB, the WAL
+        # and the embeddings all land somewhere an attacker chose. Unlike a planted
+        # sidecar, we also cannot clear it: removing an operator's home directory link is
+        # far more destructive than declining to start.
+        if platform_compat.is_link_or_junction(parent):
+            logger.warning(
+                "Refusing to use %s as the memory home: it is a link or junction, not a "
+                "real directory, so its access cannot be established -- tightening it "
+                "would re-permission its target instead. The memory store will not be "
+                "opened. Replace that path with a real directory, or point KIROCREW_HOME "
+                "at one.",
+                parent,
+            )
+            self._unsecured_paths.append(parent)
+            return False
+        try:
+            # Only the mkdir here -- SQLite needs the directory to exist before the connect,
+            # and creating it spawns nothing. Tightening it is the CALLER's job
+            # (`_tighten_paths`), which is what may run on a worker.
+            #
+            # NOT `make_owner_only_dir`: that helper catches OSError and only logs, so it
+            # can report success on a directory it failed to tighten -- and this is a
+            # precondition whose failure must be observable.
+            parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            logger.warning(
+                "Cannot create %s, so the lockdown is SKIPPED: without an owner-only "
+                "directory another local user could swap a checked entry for a link and "
+                "have its target re-permissioned. The memory files keep the access they "
+                "already had.",
+                parent,
+                exc_info=True,
+            )
+            return False
+        return True
+
+    def _validate_memory_tree(self) -> tuple[Path, ...]:
+        """Decide the whole tree's fate WITHOUT spawning anything, and return what to tighten.
+
+        This is the cheap half of the lockdown -- ``mkdir``, ``lstat``, ``unlink``, no
+        subprocess, ~0.09ms for the five-path sweep -- so it runs inline on every platform
+        and on the event loop. Everything :meth:`init` needs in order to decide whether to
+        open the store at all is settled here, synchronously: which paths are plain files,
+        which planted entries were cleared, and which survived. The returned tuple is
+        DIRECTORY FIRST, then files, so a caller that applies them in order tightens the
+        directory before anything inside it.
+
+        That order is load-bearing rather than tidy. Once the directory is owner-only
+        another local user can no longer create, rename or swap an entry inside it, so the
+        entry :func:`_is_lockdown_safe` cleared is the same one ``restrict_to_owner``
+        later acts on. The files are included even though the directory covers what is
+        created from here, because an owner-only directory is not sufficient for a file
+        that already EXISTS on Windows: *Bypass Traverse Checking* is granted to Everyone
+        by default, so a permissive DACL on the file itself stays reachable from inside a
+        tightened directory. The per-file pass is what repairs an existing install.
+
+        This runs BEFORE the directory is owner-only -- it has to, since it is what decides
+        whether to open the store at all -- so its per-file verdicts are provisional: a
+        local user who can write the directory could swap an approved entry afterwards.
+        That is why :meth:`_tighten_paths` re-validates each file immediately before acting
+        on it, once the directory is locked. The approval here selects candidates; the
+        re-check is what the ``restrict_to_owner`` actually relies on.
+
+        The refusals are NOT provisional in the same way, because they only ever get
+        stricter: an entry that was a link when validated is refused now, and if it were
+        replaced by a plain file afterwards the worst outcome is that the store declines to
+        open. Failing closed on a stale reading is the safe direction.
+
+        A refused entry that is nonetheless PRESENT is not left as found, because skipping
+        it is not the neutral act it looks like: the writers truncate their file in place
+        (``faiss.write_index``, ``Path.write_text``, and SQLite's own WAL append all write
+        THROUGH an existing inode), so a planted link left behind at one of these names
+        keeps its permissive DACL and then receives every future embedding and every
+        committed row. "Skip" would mean the lockdown declines to re-permission the
+        attacker's file and then fills it with the memories anyway.
+
+        Which response it gets turns on whether the file is recoverable, per
+        :meth:`_is_unrecoverable`. Derived state (``-shm``, the FAISS index, its id map) is
+        UNLINKED: that drops our directory entry only, never the attacker's other name for
+        the inode, and its owner rebuilds it from the DB. The DB and its ``-wal`` hold
+        committed memories that exist nowhere else, so removing them could discard
+        acknowledged writes -- they are left in place for :meth:`init` to abort on instead.
+
+        An unsafe entry that SURVIVES its removal is recorded in :attr:`_unsecured_paths`
+        so :meth:`init` refuses to open the store at all. Same reasoning as the DB abort: a
+        planted link still there when the connect happens gets written through in place,
+        and a warning alone would let the embeddings land in it. Rebuilt from scratch on
+        every pass, so a path a later ``init()`` does clear stops being fatal.
+
+        Called twice by :meth:`init` -- before the connect so the migrations do not run
+        against a writable file, and after it for whatever SQLite just created.
+        """
+        # Rebuilt per pass rather than accumulated: this runs twice per init() and on
+        # every subsequent one, and the question is always "is the tree unsafe NOW".
+        self._unsecured_paths = []
+        if not self._validate_memory_dir():
+            return ()
+        # The directory leads, so the caller tightens it before anything inside it.
+        approved: list[Path] = [self._db_path.parent]
+        for path in (self._db_path, *self._secret_bearing_files()):
+            if not _is_lockdown_safe(path):
+                # The DB and the -wal are the memories themselves, so they are left for
+                # init()'s abort, which refuses to open the store at all rather than
+                # discarding committed rows. Only recoverable state is cleared here.
+                if not self._is_unrecoverable(path) and not self._remove_unsafe_sidecar(path):
+                    self._unsecured_paths.append(path)
+                continue
+            approved.append(path)
+        return tuple(approved)
+
+    def _remove_unsafe_sidecar(self, path: Path) -> bool:
+        """Drop a link or special file planted at a RECOVERABLE sidecar name.
+
+        Returns whether the name is clear afterwards -- True when it was already absent
+        or the unlink succeeded, False when an unsafe entry is still there. The caller
+        turns a False into a refusal to open the store, so this must not report success
+        on a path it did not clear.
+
+        Only ever called for a path :meth:`_is_unrecoverable` rejected, so a caller must
+        not hand it the DB or the ``-wal``: those hold committed memories and removing
+        them would discard acknowledged writes.
+
+        ``missing_ok``-style absence is the normal case and silent: a clean open has no
+        ``-shm`` and no FAISS index yet, and :func:`_is_lockdown_safe` refuses a missing
+        path for exactly that reason. Only a present-but-unsafe entry is news.
+
+        ``unlink`` and not a rewrite: it removes the NAME, which is the only part that
+        is ours. The inode and the attacker's own link to it are untouched, so this
+        destroys nothing that belongs to them -- and nothing that belongs to the user
+        either, since a recoverable sidecar is rebuilt from the DB.
+        """
+        if not _path_present(path):
+            return True
+        try:
+            path.unlink()
+        except OSError:
+            # Reachable on a read-only directory, and on Windows while another process
+            # holds the index mapped. Reported as NOT cleared, which makes init() refuse
+            # the store: the writers would otherwise write THROUGH this entry in place,
+            # and a warning alone would let the embeddings land in it.
+            logger.warning(
+                "Cannot remove the unsafe entry at %s. It is a link or special file, so "
+                "the writers would write THROUGH it and the memories would be readable "
+                "by another local user; the memory store will not be opened. Remove "
+                "that path.",
+                path,
+                exc_info=True,
+            )
+            return False
+        logger.warning(
+            "Removed the unsafe entry at %s: it was a link or special file, which the "
+            "lockdown cannot secure and the writers would have written through. It is "
+            "derived state and will be rebuilt from the database.",
+            path,
+        )
+        return True
 
     def init(self) -> None:
         """Create DB, apply migrations, set permissions."""
+        # Owner-only directory before the connect: WAL keeps `memory.db-wal` /
+        # `-shm` beside the DB and a COMMITTED row lives in the -wal until a
+        # checkpoint moves it, so the sidecars carry the same secrets and SQLite
+        # creates them at moments no caller can hook. 0o700 on POSIX (a directory
+        # needs the execute bit); on Windows the DACL governs the directory ONLY,
+        # so the per-file pass below is the mechanism there, not a belt-and-braces
+        # addition. Rationale and the Windows inheritance caveat:
+        # docs/guides/windows-install.md.
+        #
+        # SCOPE: with the default `db_path` this directory IS the data home, so a
+        # memory init tightens the whole home. Right direction, wider than memory;
+        # tracked in #4543.
+        # The directory ALWAYS exists before the connect two lines down, and the
+        # DIRECTORY is tightened before any file is touched. That order is what makes
+        # the per-file pass safe rather than racy: once the directory is owner-only,
+        # another local user can no longer create, rename or swap an entry inside it,
+        # so the entry `_is_lockdown_safe` inspects is the same one `restrict_to_owner`
+        # then acts on. Validating a pathname and re-opening it would otherwise be a
+        # check/use race.
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        # Before the connect, so the migrations do not run against a file another local
+        # user can still write. Repeated after it for what SQLite just created.
+        #
+        # The VALIDATION inside this call is inline and synchronous on every platform,
+        # including on the event loop, because it spawns nothing (~0.09ms of lstat/unlink).
+        # So every refusal below is decided before the connect, always. What can be
+        # deferred to a worker on Windows-on-loop is only the `icacls` that applies a DACL
+        # to an already-existing file: the migrations can win that race, leaving those
+        # files briefly on their inherited DACL. Accepted rather than joined, because
+        # blocking the loop on five subprocess spawns is the very thing the offload exists
+        # to avoid, and that residual is the PRE-EXISTING exposure this change otherwise
+        # closes -- never worse than the status quo. `context.get_memory_for` reaches
+        # init() from a worker thread, so even that path is fully ordered in practice.
+        self._lock_down_memory_tree_off_loop()
+        # Refuse to OPEN a store the lockdown refused to secure. Skipping a planted link
+        # and then connecting through it anyway would be the worse half of both choices:
+        # the lockdown declines to re-permission an attacker's target (right), but SQLite
+        # would then write every future memory through their name (wrong).
+        #
+        # The DB and its `-wal` BOTH abort, because both are unrecoverable: a committed
+        # transaction lives in the -wal until a checkpoint moves it into the .db, so
+        # between them sits every memory the user has. Unlinking an unsafe -wal the way a
+        # recoverable sidecar is unlinked would silently discard acknowledged writes --
+        # and connecting anyway would have SQLite replay and extend an attacker-readable
+        # log. Refusing to open is the only response that neither loses the rows nor
+        # leaks the new ones. A recoverable sidecar (`-shm`, the FAISS pair) is UNLINKED
+        # by the lockdown above, so normally it is already handled -- but a removal can
+        # FAIL (read-only directory; on Windows, another process holding the index
+        # mapped), and an entry that is still there when the connect happens gets written
+        # through in place exactly like an unsafe DB would. So `_unsecured_paths` is fatal
+        # too: the store is not opened while any memory path is both unsafe and present.
+        # Neither response is "skip": a planted link left at any of these names gets
+        # written through in place.
+        #
+        # Checked after the lockdown so a legitimately multi-linked-then-tightened file is
+        # not rejected on a stale reading. `lstat`, not `exists()`: the latter FOLLOWS a
+        # symlink, so a DANGLING one reports False and would slip through -- and SQLite
+        # would then create the link's target wherever it points, outside the protected
+        # home, and write the memories there. `lstat` sees the link itself and raises only
+        # when the path is genuinely absent, which is the case that legitimately proceeds.
+        for unrecoverable in (self._db_path, self._wal_path()):
+            if _path_present(unrecoverable) and not _is_lockdown_safe(unrecoverable):
+                raise MemoryStoreUnsafeError(
+                    f"refusing to open {self._db_path}: {unrecoverable} is not a plain "
+                    "single-link file, so another local user may be able to read the "
+                    "memories written through it. It holds committed memories, so Kiro "
+                    "Crew will not remove it for you. Move or delete that path and let "
+                    "Kiro Crew re-create the store."
+                )
+        if self._unsecured_paths:
+            # Wording stays generic across both causes: a sidecar whose removal failed, and
+            # a data home that is a link (which cannot be cleared at all -- deleting an
+            # operator's home link is worse than declining to start). Both mean the same
+            # thing here: a path we could not establish the access of is still in the way.
+            raise MemoryStoreUnsafeError(
+                f"refusing to open {self._db_path}: "
+                + ", ".join(str(p) for p in self._unsecured_paths)
+                + " is not a plain file or directory this process can secure, so the "
+                "memories written through it may be readable by another local user. "
+                "Replace that path and retry."
+            )
         self._db = sqlite3.connect(
             str(self._db_path), check_same_thread=False, isolation_level=None
         )
@@ -730,9 +1318,13 @@ class VectorMemoryStore:
                 self._db.commit()
                 logger.info("Applied memory schema migration v%s", ver)
 
-        # Set file permissions (owner-only). chmod_safe already logs+swallows
-        # OSError internally and is a no-op on Windows, so no wrapper needed.
-        platform_compat.chmod_safe(self._db_path, 0o600)
+        # Again after the connect, for what SQLite just created. `restrict_to_owner`
+        # and not `chmod_safe`, which is a documented no-op on Windows and so left the
+        # memories under the DACL the file inherited. Applied on EVERY init rather than
+        # only on create: an existing DB is exactly the one that may have lost its
+        # protection since (restored backup, home migration, an install predating this
+        # lockdown), and gating on creation would leave all of those readable.
+        self._lock_down_memory_tree_off_loop()
 
         # Load persisted FAISS index (or rebuild from SQLite embeddings)
         try:

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from conftest import requires_symlinks
 from kiro_crew.vector_memory import (
     _HAS_FAISS,
     _HAS_NUMPY,
@@ -636,11 +637,998 @@ class TestSchemaInit:
     def test_file_permissions(self, tmp_path: Path) -> None:
         import stat
 
-        db_path = tmp_path / "mem.db"
+        from kiro_crew import platform_compat
+
+        # DEFAULT db_path: the lockdown applies only to Kiro Crew's own data home, so a
+        # tmp_path DB would take the custom-path branch and be left alone by design.
+        # conftest pins KIROCREW_HOME per test, so this is still isolated.
+        store = VectorMemoryStore()
+        db_path = store._db_path
+        store.init()
+        # NTFS reports 0o666 for any file regardless of its DACL, so the mode
+        # assertion is meaningful only on POSIX. The routing assertion below is
+        # what covers Windows.
+        if platform_compat.IS_POSIX:
+            assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+
+    def test_the_memory_directory_stays_traversable_after_the_lockdown(
+        self, tmp_path: Path
+    ) -> None:
+        """The directory must end at 0o700, not the 0o600 a FILE gets.
+
+        ``restrict_to_owner`` is ``chmod(0o600)`` on POSIX, which is right for a file and
+        wrong for a directory: it strips the execute bit that makes the directory
+        TRAVERSABLE, so the very next ``sqlite3.connect`` fails with "unable to open
+        database file" and every store in the process goes with it. A directory needs
+        ``0o700``.
+
+        Asserted as an OUTCOME -- reopen the store and read back through it -- so it holds
+        whatever helper the lockdown routes the directory through. Windows has no execute
+        bit for a directory and NTFS does not report POSIX modes, so the mode half is
+        POSIX-only; the reopen half runs everywhere.
+        """
+        import stat
+
+        from kiro_crew import platform_compat
+
+        # DEFAULT db_path: the branch that actually tightens the directory.
+        store = VectorMemoryStore()
+        db_path = store._db_path
+        store.init()
+        assert store.set_semantic("user.name", "probe", 0.9, "test") is None
+        store.close()
+
+        if platform_compat.IS_POSIX:
+            mode = stat.S_IMODE(db_path.parent.stat().st_mode)
+            assert mode == 0o700, f"the memory directory is {mode:#o}, expected 0o700"
+            assert mode & stat.S_IXUSR, "the directory lost its execute bit; it is untraversable"
+
+        # The real regression this guards: a second open through that directory.
+        reopened = VectorMemoryStore(db_path=db_path)
+        reopened.init()
+        try:
+            row = reopened.get_semantic("user.name")
+            assert row is not None, "the reopened store could not read back through the directory"
+        finally:
+            reopened.close()
+
+    def test_the_directory_takes_0o700_and_never_the_file_lockdown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pins the ROUTING of the directory, so Windows CI covers the POSIX hazard too.
+
+        ``IS_POSIX`` is forced on, so this runs the POSIX branch from any host: the mode
+        bits that break are not observable on NTFS, but the choice of call is. The
+        directory must get ``chmod(0o700)`` and must never be handed to
+        ``restrict_to_owner``, which is ``chmod(0o600)`` there and would strip the execute
+        bit the directory needs to be traversable.
+        """
+        from kiro_crew import vector_memory as vm
+
+        home = tmp_path / "home"
+        calls: list[tuple[str, str]] = []
+
+        monkeypatch.setattr(vm, "config_dir", lambda: home)
+        monkeypatch.setattr(vm.platform_compat, "IS_POSIX", True)
+        monkeypatch.setattr(
+            vm.platform_compat, "restrict_to_owner", lambda p: calls.append(("restrict", str(p)))
+        )
+        monkeypatch.setattr(
+            Path, "chmod", lambda self, mode, **kw: calls.append((f"chmod:{mode:#o}", str(self)))
+        )
+
+        VectorMemoryStore(db_path=home / vm._DB_FILE)._lock_down_memory_tree()
+
+        assert ("chmod:0o700", str(home)) in calls, f"the directory did not get 0o700: {calls}"
+        assert ("restrict", str(home)) not in calls, (
+            "the directory went through restrict_to_owner, which is chmod(0o600) on POSIX "
+            "and strips the execute bit that makes it traversable"
+        )
+
+    def test_a_file_swapped_after_validation_is_re_checked_before_tightening(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An entry replaced between validation and tightening must be caught, not followed.
+
+        Validation necessarily runs BEFORE the directory is owner-only -- it is what decides
+        whether to open the store at all -- so at that moment a local user who can write the
+        directory can still swap an approved entry for a link. Relying on the earlier
+        reading would then apply the ACL to whatever the link points at, which is the exact
+        capability the whole guard exists to deny.
+
+        So each file is re-validated immediately before its ``restrict_to_owner``, once the
+        directory is locked. Simulated by swapping the entry during the directory's own
+        tightening call -- the one moment that is genuinely between the two checks. The
+        directory is tightened by ``chmod(0o700)`` on POSIX and ``restrict_to_owner`` on
+        Windows, so the swap is hooked onto whichever one this platform uses.
+        """
+        import os
+
+        from kiro_crew import vector_memory as vm
+
+        victim = tmp_path / "victim.txt"
+        victim.write_text("unrelated to memory", encoding="utf-8")
+
+        store = VectorMemoryStore()
+        db_path = store._db_path
+        store.init()
+        store.close()
+
+        home = db_path.parent
+        seen: list[str] = []
+
+        tightened_dir: list[str] = []
+
+        def _swap_the_db() -> None:
+            # The swap lands exactly in the window: after validation approved the DB (it is
+            # a plain file at that point), before the per-file leg reaches it.
+            tightened_dir.append(str(home))
+            real_unlink(db_path)
+            os.link(victim, db_path)
+
+        real_unlink = Path.unlink
+
+        def _restrict(p: object) -> None:
+            seen.append(str(p))
+            if Path(str(p)) == home:  # the directory leg, on Windows
+                _swap_the_db()
+
+        monkeypatch.setattr(vm.platform_compat, "restrict_to_owner", _restrict)
+        monkeypatch.setattr(vm.platform_compat, "make_owner_only_dir", lambda p: None)
+
+        if vm.platform_compat.IS_POSIX:
+            # On POSIX the directory is tightened with chmod(0o700), not restrict_to_owner,
+            # so that is the call the swap has to ride.
+            real_chmod = Path.chmod
+
+            def _chmod(self: Path, mode: int, **kw: object) -> None:
+                real_chmod(self, mode, **kw)  # type: ignore[arg-type]
+                if self == home:
+                    _swap_the_db()
+
+            monkeypatch.setattr(Path, "chmod", _chmod)
+
+        VectorMemoryStore(db_path=db_path)._lock_down_memory_tree()
+
+        assert tightened_dir, "the directory was never tightened, so there was no window"
+        assert str(db_path) not in seen, (
+            "the lockdown followed an entry swapped after validation; the pre-tighten "
+            "re-check did not happen"
+        )
+        assert victim.read_text(encoding="utf-8") == "unrelated to memory"
+
+    def test_the_lockdown_refuses_a_planted_link_at_a_memory_filename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A link planted at a memory filename must NOT have its target re-permissioned.
+
+        The lockdown rewrites access on whatever it is handed and both back ends follow
+        links (``os.chmod`` resolves a symlink unless told otherwise; ``icacls`` applies
+        to a link's target). On a data home another local user can write -- the legacy
+        home, a restored backup -- that turns this hardening into a lever for changing
+        permissions on a file outside the home. A hard link is the version that needs no
+        privilege on Windows, so it is the reachable shape there.
+        """
+        import os
+
+        from kiro_crew import vector_memory as vm
+
+        victim = tmp_path / "victim.txt"
+        victim.write_text("unrelated to memory", encoding="utf-8")
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            vm.platform_compat, "restrict_to_owner", lambda p: seen.append(str(p))
+        )
+        monkeypatch.setattr(vm.platform_compat, "make_owner_only_dir", lambda p: None)
+
+        # DEFAULT db_path: the lockdown applies only to Kiro Crew's own data home,
+        # and conftest pins KIROCREW_HOME per test, so this is isolated AND is the
+        # branch under test. A tmp_path/mem.db would take the custom-path branch,
+        # where the files are deliberately left alone.
+        db_path = VectorMemoryStore()._db_path
+        store = VectorMemoryStore(db_path=db_path)
+        store.init()  # creates the real DB, so the happy path is covered too
+        store.close()
+        seen.clear()
+
+        # Plant a hard link at one of the sidecar names the pass walks.
+        planted = store._faiss_path
+        planted.unlink(missing_ok=True)
+        os.link(victim, planted)
+        assert planted.stat().st_nlink > 1, "the hard link did not take"
+
+        store._lock_down_memory_tree()  # synchronous form; no worker to join
+
+        assert str(planted) not in seen, "the lockdown followed a planted hard link"
+        # The DB itself is a plain file, so it must still be restricted -- the guard
+        # must reject the link WITHOUT abandoning the rest of the pass.
+        assert str(db_path) in seen, f"the guard skipped the real DB too; saw {seen}"
+        # The victim keeps its own name and its contents: the lockdown drops OUR
+        # directory entry, never the attacker's other link to the same inode, so
+        # refusing to follow the link must not destroy what it pointed at either.
+        assert victim.exists(), "the lockdown deleted the link's target"
+        assert victim.read_text(encoding="utf-8") == "unrelated to memory"
+
+    def test_an_unsafe_sidecar_is_removed_rather_than_written_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A planted link at a SIDECAR name must be unlinked, not skipped.
+
+        Skipping looks neutral and is not. Every writer for these paths truncates in
+        place -- ``faiss.write_index``, the id map's ``write_text``, SQLite's WAL append
+        all write THROUGH an existing inode rather than creating a new one -- so a link
+        left behind at one of these names keeps its permissive DACL and then receives
+        every future embedding. Declining to re-permission the attacker's file and then
+        filling it with the memories anyway is the worst of both.
+
+        Unlinking is the fix that fits a SIDECAR specifically: it drops our directory
+        entry only, and the file is derived state rebuilt from SQLite. The DB gets the
+        fatal abort instead, which the neighbouring tests pin.
+        """
+        import os
+
+        from kiro_crew import vector_memory as vm
+
+        victim = tmp_path / "victim.txt"
+        victim.write_text("unrelated to memory", encoding="utf-8")
+
+        monkeypatch.setattr(vm.platform_compat, "restrict_to_owner", lambda p: None)
+        monkeypatch.setattr(vm.platform_compat, "make_owner_only_dir", lambda p: None)
+
+        # DEFAULT db_path: the lockdown applies only to Kiro Crew's own data home, and
+        # conftest pins KIROCREW_HOME per test, so this is both isolated and the branch
+        # under test.
+        db_path = VectorMemoryStore()._db_path
         store = VectorMemoryStore(db_path=db_path)
         store.init()
-        mode = stat.S_IMODE(db_path.stat().st_mode)
-        assert mode == 0o600
+        store.close()
+
+        planted = store._faiss_path
+        planted.unlink(missing_ok=True)
+        os.link(victim, planted)
+        assert planted.stat().st_nlink > 1, "the hard link did not take"
+
+        store._lock_down_memory_tree()
+
+        # Our name for the attacker's inode is gone, so the next FAISS save creates a
+        # fresh file inside the owner-only directory instead of truncating theirs.
+        # os.path.lexists, not exists(): the latter follows a link, so it would answer
+        # False for a DANGLING one and pass on a path that is still planted.
+        assert not os.path.lexists(planted), "the unsafe sidecar was left to be written through"
+        # Their own name and its contents are untouched: we removed a directory entry,
+        # not the file.
+        assert victim.exists(), "removing our entry destroyed the link's target"
+        assert victim.read_text(encoding="utf-8") == "unrelated to memory"
+
+    def test_an_unsafe_wal_is_kept_and_aborts_instead_of_being_removed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ``-wal`` is NOT recoverable state, so it must never be unlinked.
+
+        Under ``journal_mode=WAL`` a COMMITTED transaction lives in the ``-wal`` until a
+        checkpoint moves it into the ``.db``, so after a crash that file is the only copy
+        of those memories. Removing it the way a ``-shm`` or a FAISS index is removed
+        would silently discard acknowledged writes -- and connecting anyway would have
+        SQLite replay and extend a log another local user can read.
+
+        So it takes the DB's response instead: leave the file alone and refuse to open
+        the store. That neither loses the rows nor leaks the new ones, and it leaves the
+        operator holding the only copy rather than us deleting it for them.
+        """
+        import os
+
+        from kiro_crew import vector_memory as vm
+        from kiro_crew.vector_memory import MemoryStoreUnsafeError
+
+        victim = tmp_path / "victim-wal"
+        victim.write_text("committed rows nobody else has", encoding="utf-8")
+
+        monkeypatch.setattr(vm.platform_compat, "restrict_to_owner", lambda p: None)
+        monkeypatch.setattr(vm.platform_compat, "make_owner_only_dir", lambda p: None)
+
+        db_path = VectorMemoryStore()._db_path
+        store = VectorMemoryStore(db_path=db_path)
+        store.init()
+        store.close()
+
+        planted = store._wal_path()
+        planted.unlink(missing_ok=True)
+        os.link(victim, planted)
+        assert planted.stat().st_nlink > 1, "the hard link did not take"
+
+        # The lockdown must NOT clear it, and the reopen must refuse rather than connect.
+        with pytest.raises(MemoryStoreUnsafeError, match="refusing to open"):
+            VectorMemoryStore(db_path=db_path).init()
+
+        assert os.path.lexists(planted), "the -wal was removed, discarding committed rows"
+        assert victim.read_text(encoding="utf-8") == "committed rows nobody else has"
+
+    def test_a_sidecar_that_cannot_be_removed_refuses_to_open_the_store(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A removal that FAILS must abort, not warn and connect anyway.
+
+        Unlinking an unsafe sidecar can fail for reasons that have nothing to do with the
+        attacker -- a read-only directory, or another process holding the FAISS index
+        mapped on Windows. An entry that is still present when the connect happens gets
+        written through in place, exactly like an unsafe DB would, so a warning alone
+        would let every future embedding land in a file another local user can read.
+
+        The store therefore refuses to open while any memory path is both unsafe and
+        present, whichever of the two reasons left it there.
+        """
+        import os
+
+        from kiro_crew import vector_memory as vm
+        from kiro_crew.vector_memory import MemoryStoreUnsafeError
+
+        victim = tmp_path / "victim.txt"
+        victim.write_text("unrelated to memory", encoding="utf-8")
+
+        monkeypatch.setattr(vm.platform_compat, "restrict_to_owner", lambda p: None)
+        monkeypatch.setattr(vm.platform_compat, "make_owner_only_dir", lambda p: None)
+
+        db_path = VectorMemoryStore()._db_path
+        store = VectorMemoryStore(db_path=db_path)
+        store.init()
+        store.close()
+
+        planted = store._faiss_path
+        planted.unlink(missing_ok=True)
+        os.link(victim, planted)
+
+        # Stand in for the undeletable cases, which cannot be provoked portably: a
+        # read-only directory behaves differently across platforms, and the mapped-index
+        # case is Windows-only. The observable under test is the response to a removal
+        # that did not clear the path, not the reason it did not.
+        real_unlink = Path.unlink
+
+        def _refuse(self: Path, *a: object, **k: object) -> None:
+            if self == planted:
+                raise OSError("simulated: cannot unlink")
+            real_unlink(self, *a, **k)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "unlink", _refuse)
+
+        with pytest.raises(MemoryStoreUnsafeError, match="this process can secure"):
+            VectorMemoryStore(db_path=db_path).init()
+
+        assert os.path.lexists(planted), "the test did not exercise a surviving entry"
+
+    def test_an_unsafe_path_is_refused_even_when_init_runs_on_the_event_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The refusal must be SYNCHRONOUS, including on the loop where work is offloaded.
+
+        Windows-on-loop is the one path that hands work to a thread ``init()`` does not
+        wait for, so it is the path where a decision could arrive too late to matter. If
+        the VALIDATION went to that worker along with the ``icacls``, ``init()`` would
+        connect first and learn afterwards that the path was an attacker's link -- the
+        store would already be open through it, which is the whole outcome these refusals
+        exist to prevent.
+
+        Only the tightening may be deferred. This pins the split from the refusal side;
+        ``test_the_lockdown_lands_from_the_event_loop_without_blocking_it`` pins it from
+        the scheduling side. Asserted on both platforms: POSIX validates inline too, so a
+        regression that deferred validation everywhere fails on the Linux matrix as well.
+        """
+        import asyncio
+        import os
+
+        from kiro_crew import vector_memory as vm
+        from kiro_crew.vector_memory import MemoryStoreUnsafeError
+
+        victim = tmp_path / "victim.txt"
+        victim.write_text("unrelated to memory", encoding="utf-8")
+
+        monkeypatch.setattr(vm.platform_compat, "restrict_to_owner", lambda p: None)
+        monkeypatch.setattr(vm.platform_compat, "make_owner_only_dir", lambda p: None)
+
+        db_path = VectorMemoryStore()._db_path
+        store = VectorMemoryStore(db_path=db_path)
+        store.init()
+        store.close()
+
+        # Specifically the case that flows through `_unsecured_paths`: a planted sidecar
+        # whose removal fails. The DB and `-wal` are re-`lstat`ed by init() directly, so
+        # they would abort even if validation HAD been deferred -- only this one actually
+        # depends on the validation having run before the connect.
+        planted = store._faiss_path
+        planted.unlink(missing_ok=True)
+        os.link(victim, planted)
+        real_unlink = Path.unlink
+
+        def _refuse(self: Path, *a: object, **k: object) -> None:
+            if self == planted:
+                raise OSError("simulated: cannot unlink")
+            real_unlink(self, *a, **k)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "unlink", _refuse)
+
+        async def _init_on_loop() -> None:
+            VectorMemoryStore(db_path=db_path).init()
+
+        # Raises out of the coroutine, i.e. before the connect -- not eventually, on a
+        # worker, after the store is already open.
+        with pytest.raises(MemoryStoreUnsafeError, match="this process can secure"):
+            asyncio.run(_init_on_loop())
+
+        assert os.path.lexists(planted), "the test did not exercise a surviving entry"
+
+    def test_a_linked_data_home_is_not_re_permissioned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A link planted at the DATA HOME must not have its target tightened.
+
+        The home is compared with ``resolve()`` so a legitimately relocated home still
+        matches, but that also means a symlink or junction planted AT the home compares
+        equal -- and `chmod`/`icacls` follow a directory link exactly as they follow a
+        file one. So the same refusal the files get has to cover the directory, or the
+        lockdown becomes a lever for re-permissioning an arbitrary directory.
+
+        Uses ``symlink_or_junction``, which falls back to a junction on Windows and so
+        needs no privilege; a junction is also the shape ``is_link_or_junction`` exists
+        to catch, since ``Path.is_symlink()`` reports False for one.
+        """
+        from kiro_crew import platform_compat
+        from kiro_crew import vector_memory as vm
+
+        victim_dir = tmp_path / "victim-dir"
+        victim_dir.mkdir()
+        (victim_dir / "unrelated.txt").write_text("not ours", encoding="utf-8")
+
+        home = tmp_path / "linked-home"
+        platform_compat.symlink_or_junction(victim_dir, home)
+        assert platform_compat.is_link_or_junction(home), "the directory link did not take"
+
+        seen: list[str] = []
+        monkeypatch.setattr(vm.platform_compat, "restrict_to_owner", lambda p: seen.append(str(p)))
+        monkeypatch.setattr(vm.platform_compat, "make_owner_only_dir", lambda p: None)
+
+        db_path = home / vm._DB_FILE
+        # Make the linked path look like Kiro Crew's own home, so this takes the branch
+        # that tightens the directory rather than the custom-db_path branch that skips it.
+        monkeypatch.setattr(vm, "config_dir", lambda: home)
+
+        VectorMemoryStore(db_path=db_path)._lock_down_memory_tree()
+
+        assert str(home) not in seen, "the lockdown re-permissioned a linked data home"
+        assert str(victim_dir) not in seen, "the lockdown followed the link to its target"
+
+        # And it is FATAL, not merely skipped. There is no safe way to proceed: tightening
+        # the link re-permissions its target, while not tightening it means the DB, the WAL
+        # and every embedding are created inside a directory whose access we could not
+        # establish. Unlike a planted sidecar it also cannot be cleared -- deleting an
+        # operator's home link is worse than declining to start -- so refusing is all
+        # that is left.
+        from kiro_crew.vector_memory import MemoryStoreUnsafeError
+
+        with pytest.raises(MemoryStoreUnsafeError, match="this process can secure"):
+            VectorMemoryStore(db_path=db_path).init()
+
+        assert platform_compat.is_link_or_junction(home), "the test consumed its own setup"
+        assert (victim_dir / "unrelated.txt").read_text(encoding="utf-8") == "not ours"
+
+    def test_a_missing_sidecar_is_not_reported_as_unsafe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Absent sidecars are the normal case on a clean open and must stay silent.
+
+        ``_is_lockdown_safe`` refuses a missing path, so the removal branch is reached
+        for every sidecar that does not exist yet -- a fresh store has no ``-wal`` and no
+        FAISS index. That must be a no-op, not a warning and not an error: otherwise
+        every first run logs a security warning about files nobody planted.
+        """
+        from kiro_crew import vector_memory as vm
+
+        monkeypatch.setattr(vm.platform_compat, "restrict_to_owner", lambda p: None)
+        monkeypatch.setattr(vm.platform_compat, "make_owner_only_dir", lambda p: None)
+
+        db_path = VectorMemoryStore()._db_path
+        store = VectorMemoryStore(db_path=db_path)
+
+        warnings: list[str] = []
+        monkeypatch.setattr(vm.logger, "warning", lambda msg, *a, **k: warnings.append(str(msg)))
+
+        store.init()  # a clean create: no sidecars exist for most of the walk
+        store.close()
+
+        assert not any(
+            "unsafe entry" in w for w in warnings
+        ), f"a missing sidecar was reported as unsafe: {warnings}"
+
+    def test_init_refuses_to_open_a_db_it_could_not_secure(self, tmp_path: Path) -> None:
+        """A link planted at the DB filename must abort ``init()``, not be opened.
+
+        Skipping the lockdown on a planted entry and then connecting through it anyway
+        would be the worse half of both choices: we correctly decline to re-permission
+        the attacker's target, and then write every future memory through their name.
+        Fatal rather than a warning, because memory being unavailable is a supported
+        degraded state while silently leaking it is not.
+
+        A hard link is the shape that needs no privilege on Windows, so it is what an
+        attacker would actually use there.
+        """
+        import os
+
+        from kiro_crew.vector_memory import MemoryStoreUnsafeError
+
+        victim = tmp_path / "attacker-owned.db"
+        victim.write_text("attacker's file", encoding="utf-8")
+        db_path = tmp_path / "mem.db"
+        os.link(victim, db_path)  # no privilege needed, unlike a symlink
+        assert db_path.stat().st_nlink > 1, "the hard link did not take"
+
+        store = VectorMemoryStore(db_path=db_path)
+        with pytest.raises(MemoryStoreUnsafeError, match="refusing to open"):
+            store.init()
+
+    @requires_symlinks
+    def test_init_refuses_a_dangling_symlink_at_the_db_path(self, tmp_path: Path) -> None:
+        """A BROKEN link at the DB filename must abort too, not be created through.
+
+        ``Path.exists()`` follows the link, so a dangling one answers False -- which
+        would conflate "nothing here, safe to create" with "a link to somewhere else".
+        SQLite would then create the link's target wherever it points, outside the
+        protected home, and write the memories there. The presence check therefore uses
+        ``lstat``, which sees the entry itself.
+
+        Needs real symlink creation, so it is guarded: a junction cannot dangle the same
+        way, and this is precisely the file-symlink case.
+        """
+        import os
+
+        from kiro_crew.vector_memory import MemoryStoreUnsafeError
+
+        db_path = tmp_path / "mem.db"
+        os.symlink(tmp_path / "no-such-target.db", db_path)
+        assert not db_path.exists(), "the link must be dangling for this to be the case"
+
+        store = VectorMemoryStore(db_path=db_path)
+        with pytest.raises(MemoryStoreUnsafeError, match="refusing to open"):
+            store.init()
+
+    def test_a_custom_db_path_does_not_re_permission_its_parent_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A caller-supplied ``db_path`` keeps its directory's existing permissions.
+
+        ``eval/runner.py`` points a store at a scenario workspace, and
+        ``eval/bench/ingest.py`` at a bench directory -- both hold unrelated files the
+        caller owns. Tightening those to owner-only could cut authorized users off from
+        data that is not Kiro Crew's to re-permission, so the directory step applies only
+        to the default data home. The FILES are still locked down: that is the whole
+        contribution on a custom path.
+        """
+        from kiro_crew import vector_memory as vm
+
+        workspace = tmp_path / "eval-workspace"
+        workspace.mkdir()
+        (workspace / "unrelated.txt").write_text("someone else's file", encoding="utf-8")
+
+        db_path = workspace / "vector_memory.db"
+        seen: list[str] = []
+        real = vm.platform_compat.restrict_to_owner
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (seen.append(str(p)), real(p))[1],
+        )
+
+        store = VectorMemoryStore(db_path=db_path)
+        try:
+            store.init()
+        finally:
+            store.close()  # an open handle blocks tmp_path teardown on Windows
+
+        # NOTHING under a caller-owned directory is touched -- neither the directory nor
+        # the files. The directory is not ours to narrow, and tightening the files
+        # without first securing the directory would be a check/use race (the pathname
+        # `_is_lockdown_safe` clears is re-opened by `restrict_to_owner`, and a user who
+        # can write the directory could swap it in between). `icacls` is path-only and
+        # `O_NOFOLLOW` does not exist on Windows, so there is no safe fd-based form to
+        # fall back on.
+        assert seen == [], (
+            "a custom db_path's directory belongs to its caller, so nothing under it "
+            f"should be re-permissioned; saw {seen}"
+        )
+        if vm.platform_compat.IS_POSIX:
+            import stat as _stat
+
+            mode = _stat.S_IMODE(workspace.stat().st_mode)
+            assert mode != 0o700, f"the caller's directory was narrowed to {oct(mode)}"
+
+    def test_a_failed_directory_lockdown_abandons_the_per_file_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No owner-only directory means no per-file pass -- the directory is a precondition.
+
+        The per-file step validates a PATHNAME and then re-opens it, which is only safe
+        while nobody else can swap the entry in between. An owner-only directory is what
+        provides that; without it another local user could substitute a link after
+        ``_is_lockdown_safe`` cleared the entry and have their target re-permissioned.
+
+        Skipping leaves the files exactly as they were -- the status quo this change
+        improves on -- whereas proceeding would hand a local attacker a new capability.
+        So the failure mode must be "no worse than before", never "worse than before".
+        """
+        from kiro_crew import vector_memory as vm
+
+        # DEFAULT db_path on purpose: the directory lockdown applies only to Kiro Crew's
+        # own data home, and conftest pins KIROCREW_HOME to a tmp dir per test, so this
+        # is both isolated and the branch under test. A `tmp_path/mem.db` would take the
+        # custom-path branch, where the directory is deliberately left alone.
+        store = VectorMemoryStore()
+        db_path = store._db_path
+        store.init()  # real DB on disk first, so the files genuinely exist
+        store.close()
+
+        # Fail the DIRECTORY step only, and let the per-file calls record themselves.
+        # The directory is tightened via `chmod(0o700)` on POSIX and the fail-loud
+        # `restrict_to_owner` on Windows, so each platform needs its own seam broken.
+        restricted: list[str] = []
+        parent = db_path.parent
+
+        def _restrict(p: object) -> None:
+            if Path(str(p)) == parent:  # the directory leg, on Windows
+                raise OSError("simulated: a shared directory refuses its ACL change")
+            restricted.append(str(p))
+
+        monkeypatch.setattr(vm.platform_compat, "restrict_to_owner", _restrict)
+        if vm.platform_compat.IS_POSIX:
+            real_chmod = Path.chmod
+
+            def _chmod(self: Path, mode: int, **kw: object) -> None:
+                if self == parent:
+                    raise OSError("simulated: cannot chmod a shared directory")
+                real_chmod(self, mode, **kw)  # type: ignore[arg-type]
+
+            monkeypatch.setattr(Path, "chmod", _chmod)
+
+        store._lock_down_memory_tree()
+
+        assert restricted == [], (
+            "the per-file pass ran without an owner-only directory, leaving the "
+            f"check/use race open for {restricted}"
+        )
+
+    def test_the_lockdown_lands_from_the_event_loop_without_blocking_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``init()`` on a running loop must still lock down, with every ``icacls`` off-thread.
+
+        Three properties, and the fix is only correct with all three. On Windows each
+        ``restrict_to_owner`` spawns ``icacls`` (10s timeout) and five call sites reach
+        ``init()`` from inside an ``async def`` (``cli_server._run_task``,
+        ``dashboard.server.start_dashboard``, ``eval.runner._run_scenario_in``), so
+        spawning any of them inline would park the loop and every coroutine on the gateway
+        with it -- hence NOTHING that spawns may run on the loop thread, the directory
+        included. But merely SKIPPING would be worse than the bug this PR fixes: a
+        deployment whose only inits are those async sites would never be protected at all,
+        so the tightening must still happen.
+
+        And it must happen DIRECTORY FIRST even on that worker, which is what this test
+        pins beyond "something happened off-thread": until the directory is owner-only,
+        another local user can swap an entry between the validation and the
+        ``restrict_to_owner`` that acts on it.
+
+        What is *not* deferred is the validation -- it spawns nothing (~0.09ms of
+        lstat/unlink), so every decision ``init()`` makes about whether to open the store
+        at all is synchronous on every platform. The sibling refusal tests cover that;
+        this one covers the scheduling.
+
+        Asserted on both platforms: POSIX has no subprocess to block on (a bare
+        ``os.chmod``), so everything applies inline there, and a regression that dropped
+        the call entirely would fail on the Linux matrix too.
+
+        Every worker it spawns is JOINED before returning. A worker still
+        touching the monkeypatched helper or ``tmp_path`` after the test body ends would
+        race the fixture teardown -- the leak class this suite exists to keep out.
+        """
+        import asyncio
+        import threading
+
+        from kiro_crew import platform_compat
+        from kiro_crew import vector_memory as vm
+
+        loop_thread = threading.get_ident()
+        seen: list[tuple[str, int]] = []
+        lock = threading.Lock()
+        # Captured so every worker can be joined; the store spawns one per lockdown
+        # pass, and init() runs two.
+        spawned: list[threading.Thread] = []
+        real_thread = threading.Thread
+
+        def _tracking_thread(*args: object, **kwargs: object) -> threading.Thread:
+            t = real_thread(*args, **kwargs)  # type: ignore[arg-type]
+            if kwargs.get("name") == "memory-lockdown":
+                spawned.append(t)
+            return t
+
+        def _record(p: object) -> None:
+            with lock:
+                seen.append((str(p), threading.get_ident()))
+
+        monkeypatch.setattr(vm.platform_compat, "restrict_to_owner", _record)
+        monkeypatch.setattr(vm.platform_compat, "make_owner_only_dir", lambda p: None)
+        monkeypatch.setattr(vm.threading, "Thread", _tracking_thread)
+
+        async def _init_on_loop() -> None:
+            # Default db_path: the lockdown only runs for Kiro Crew's own data home,
+            # which conftest pins per test, so this is the branch that offloads.
+            store = VectorMemoryStore()
+            try:
+                store.init()
+            finally:
+                store.close()  # an open handle blocks tmp_path teardown on Windows
+
+        asyncio.run(_init_on_loop())
+
+        for t in spawned:
+            t.join(timeout=30)
+            assert not t.is_alive(), "a lockdown worker outlived the test"
+
+        with lock:
+            recorded = list(seen)
+        assert recorded, "the lockdown must happen, on either platform"
+        store_paths = VectorMemoryStore()
+        db_name = store_paths._db_path.name
+        assert any(
+            Path(p).name == db_name for p, _ in recorded
+        ), f"the DB itself was never locked down: {recorded}"
+        if not platform_compat.IS_POSIX:
+            home = str(store_paths._db_path.parent)
+            on_loop = [p for p, tid in recorded if tid == loop_thread]
+            # NOTHING that spawns icacls may touch the loop thread -- that is the whole
+            # point of the offload, and it includes the directory.
+            assert on_loop == [], f"icacls would have spawned on the loop for {on_loop}"
+            off_loop = [p for p, tid in recorded if tid != loop_thread]
+            assert off_loop, f"the tightening must still happen, off the loop; saw {recorded}"
+            # The directory is tightened FIRST on that worker: it is the precondition that
+            # closes the swap window for everything inside it.
+            assert off_loop[0] == home, (
+                "the directory must be tightened before any file inside it, or the "
+                f"per-file step is a check/use race; order was {off_loop}"
+            )
+
+    def test_creation_routes_through_restrict_to_owner(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The lockdown must go through ``restrict_to_owner``, on every platform.
+
+        ``chmod_safe`` is a no-op on Windows, so a regression back to it would leave
+        the user's memories and embeddings under the DACL the file inherits — and no
+        mode assertion can catch that, because NTFS has no mode bits to read. This
+        asserts the call, which is observable everywhere.
+        """
+        from kiro_crew import vector_memory as vm
+
+        seen: list[str] = []
+        real = vm.platform_compat.restrict_to_owner
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (seen.append(str(p)), real(p))[1],
+        )
+        # DEFAULT db_path: the lockdown applies only to Kiro Crew's own data home,
+        # and conftest pins KIROCREW_HOME per test, so this is isolated AND is the
+        # branch under test. A tmp_path/mem.db would take the custom-path branch,
+        # where the files are deliberately left alone.
+        db_path = VectorMemoryStore()._db_path
+        store = VectorMemoryStore(db_path=db_path)
+        try:
+            store.init()
+        finally:
+            store.close()  # an open handle blocks tmp_path teardown on Windows
+        # The main DB, plus whatever else legitimately routes through this helper.
+        # Asserted as a set of ALLOWED paths rather than an exact list, because the
+        # membership differs by platform for two reasons worth knowing:
+        #
+        #  * the WAL sidecars may or may not exist yet on a fresh create, and
+        #  * ``make_owner_only_dir`` reaches ``restrict_to_owner`` for the PARENT
+        #    DIRECTORY on Windows only -- on POSIX it uses ``chmod(0o700)``, because a
+        #    directory needs the execute bit. So the directory appears here on the
+        #    Windows shard and not on the POSIX matrix.
+        allowed = {
+            str(db_path),
+            f"{db_path}-wal",
+            f"{db_path}-shm",
+            str(db_path.parent / "memory.faiss"),
+            str(db_path.parent / "memory.ids.json"),
+            str(db_path.parent),
+        }
+        assert str(db_path) in seen, seen
+        assert set(seen) <= allowed, set(seen) - allowed
+
+    def test_the_directory_is_owner_only_so_wal_sidecars_inherit_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Locking the .db file alone does not protect the memories.
+
+        ``journal_mode=WAL`` makes SQLite create ``memory.db-wal`` and
+        ``memory.db-shm``, and a COMMITTED row lives in the ``-wal`` until a
+        checkpoint moves it. SQLite creates and destroys those files throughout the
+        DB's life, at moments no caller can hook, so the directory they inherit
+        access from is the only place it can be settled once. Without this, a
+        readable parent directory leaves committed memories readable on Windows even
+        though the .db file itself is locked down.
+        """
+        import stat as _stat
+
+        from kiro_crew import vector_memory as vm
+
+        # Asserted on the OUTCOME rather than on a call, because the directory step is
+        # deliberately not routed through `make_owner_only_dir` (that helper swallows
+        # OSError, and this step is a precondition whose failure must be observable).
+        # POSIX carries the answer in the mode bits; on Windows NTFS has none to read,
+        # so the observable is that the directory went through `restrict_to_owner`.
+        dirs: list[str] = []
+        real = vm.platform_compat.restrict_to_owner
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (dirs.append(str(p)), real(p))[1],
+        )
+        # DEFAULT db_path: the directory lockdown is scoped to Kiro Crew's own data home
+        # (a custom path's directory belongs to its caller and is left alone), and
+        # conftest pins KIROCREW_HOME to a tmp dir, so this stays isolated.
+        store = VectorMemoryStore()
+        db_path = store._db_path
+
+        try:
+            store.init()
+        finally:
+            store.close()  # an open handle blocks tmp_path teardown on Windows
+
+        if vm.platform_compat.IS_POSIX:
+            mode = _stat.S_IMODE(db_path.parent.stat().st_mode)
+            assert mode == 0o700, f"the memory directory is {oct(mode)}, not owner-only"
+        else:
+            assert str(db_path.parent) in dirs, (
+                f"the memory directory was never restricted; saw {dirs}"
+            )
+
+    def test_an_existing_wal_sidecar_is_repaired_on_open(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The directory fixes new sidecars; this fixes the ones already there.
+
+        A ``-wal`` created before the directory was tightened keeps the access it was
+        born with, and it can hold committed rows indefinitely if no checkpoint has
+        run -- so an existing install is not repaired by the directory alone.
+        """
+        from kiro_crew import vector_memory as vm
+
+        # DEFAULT db_path: the lockdown applies only to Kiro Crew's own data home,
+        # and conftest pins KIROCREW_HOME per test, so this is isolated AND is the
+        # branch under test. A tmp_path/mem.db would take the custom-path branch,
+        # where the files are deliberately left alone.
+        db_path = VectorMemoryStore()._db_path
+        first = VectorMemoryStore(db_path=db_path)
+        first.init()
+        # CLOSED before the sidecar is touched: Windows refuses a write to a file
+        # another handle holds open, and SQLite keeps -wal open for the life of the
+        # connection. Closing is also what the scenario describes -- an install whose
+        # sidecar was left behind by an earlier process.
+        first.close()
+        wal = Path(f"{db_path}-wal")
+        wal.write_bytes(b"pretend committed rows")
+
+        seen: list[str] = []
+        real = vm.platform_compat.restrict_to_owner
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (seen.append(str(p)), real(p))[1],
+        )
+        second = VectorMemoryStore(db_path=db_path)
+        try:
+            second.init()
+        finally:
+            second.close()
+
+        assert str(wal) in seen, seen
+
+    def test_the_faiss_index_is_repaired_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The embedding index carries the same secrets as the DB.
+
+        And the owner-only directory does not cover it on Windows: Bypass Traverse
+        Checking is granted to Everyone by default, so a permissive DACL on a file
+        that already exists stays reachable inside a tightened directory. An install
+        whose FAISS index predates the lockdown is therefore only fixed by naming the
+        file.
+        """
+        from kiro_crew import vector_memory as vm
+
+        # DEFAULT db_path: the lockdown applies only to Kiro Crew's own data home,
+        # and conftest pins KIROCREW_HOME per test, so this is isolated AND is the
+        # branch under test. A tmp_path/mem.db would take the custom-path branch,
+        # where the files are deliberately left alone.
+        db_path = VectorMemoryStore()._db_path
+        faiss = db_path.parent / "memory.faiss"
+        faiss.write_bytes(b"pretend embeddings")
+
+        seen: list[str] = []
+        real = vm.platform_compat.restrict_to_owner
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (seen.append(str(p)), real(p))[1],
+        )
+        store = VectorMemoryStore(db_path=db_path)
+        try:
+            store.init()
+        finally:
+            store.close()
+
+        assert str(faiss) in seen, seen
+
+    def test_an_existing_db_is_restricted_before_the_migrations_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ordering, not just coverage: the migrations must not run on a writable file.
+
+        An existing DB may still carry a writable inherited DACL. If the lockdown only
+        happened at the end of ``init()``, every schema migration would run against a
+        file another local user could concurrently write.
+        """
+        from kiro_crew import vector_memory as vm
+
+        # DEFAULT db_path: the lockdown applies only to Kiro Crew's own data home,
+        # and conftest pins KIROCREW_HOME per test, so this is isolated AND is the
+        # branch under test. A tmp_path/mem.db would take the custom-path branch,
+        # where the files are deliberately left alone.
+        db_path = VectorMemoryStore()._db_path
+        first = VectorMemoryStore(db_path=db_path)
+        first.init()
+        first.close()
+
+        events: list[str] = []
+        real_restrict = vm.platform_compat.restrict_to_owner
+        real_connect = vm.sqlite3.connect
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (events.append(f"restrict:{Path(p).name}"), real_restrict(p))[1],
+        )
+        monkeypatch.setattr(
+            vm.sqlite3,
+            "connect",
+            lambda *a, **k: (events.append("connect"), real_connect(*a, **k))[1],
+        )
+        store = VectorMemoryStore(db_path=db_path)
+        try:
+            store.init()
+        finally:
+            store.close()
+
+        assert "connect" in events, events
+        restricted_db_before = events.index(f"restrict:{db_path.name}") < events.index("connect")
+        assert restricted_db_before, events
+
+    def test_relaxed_mode_is_retightened_on_reopen(self, tmp_path: Path) -> None:
+        """A DB whose mode was widened after creation is locked down again.
+
+        Covers the POSIX arm of the every-init re-tighten: a home migration or a
+        restored backup can land ``memory.db`` group-readable, and only re-applying
+        the lockdown on open closes it.
+        """
+        import stat
+
+        from kiro_crew import platform_compat
+
+        if not platform_compat.IS_POSIX:
+            pytest.skip("POSIX mode bits")
+        # DEFAULT db_path, so the lockdown actually applies: a custom path's directory
+        # belongs to its caller and is deliberately left alone.
+        db_path = VectorMemoryStore()._db_path
+        VectorMemoryStore().init()
+        db_path.chmod(0o644)
+        VectorMemoryStore().init()  # the re-tighten a reopen must perform
+        assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
 
     def test_idempotent_init(self, tmp_path: Path) -> None:
         store = VectorMemoryStore(db_path=tmp_path / "mem.db")


### PR DESCRIPTION
## The gap

`memory.db` holds the user's semantic and episodic memories and their embeddings. It was locked down with `platform_compat.chmod_safe`, which is a **documented no-op on Windows** — so on that platform the file was left under whatever DACL it inherited from its parent directory, readable by anyone the parent allowed.

No test could have caught it: the existing permission test asserted a POSIX mode, and **NTFS reports `0o666` for any file regardless of its DACL**.

## The fix

`restrict_to_owner` — the shim [AGENTS.md](../blob/main/AGENTS.md) names for a secret at rest: POSIX `chmod 0o600`, and on Windows an owner-only DACL with inheritance stripped.

**Fail-soft on a failure to tighten, fail-loud on a path it cannot safely tighten at all** — the two are different and the second is a behavior change, called out in its own section below. A `restrict_to_owner` that *fails* warns and continues, which its docstring designates as the caller contract: memory being unavailable is a supported degraded state, so a read-only filesystem must not take init down. But a path that is not a plain file is not a failure to tighten, it is a request to re-permission something we do not own, and that aborts.

**What is covered, and why it is more than the `.db`:**

- **`memory.db`** — the fix proper.
- **`-wal` / `-shm`** — under `journal_mode=WAL` a *committed* row lives in the `-wal` until a checkpoint moves it, so locking the `.db` alone would leave committed memories readable.
- **`memory.faiss` / `memory.ids.json`** — the embedding index and its id map, previously written with no lockdown at all.
- **The containing directory** (`0o700` POSIX, owner-only DACL on Windows) — SQLite creates and destroys the sidecars at moments no caller can hook, so the directory is the only place their access can be settled once.

**Applied on every `init()`, not only when `init()` created the file.** An existing DB is exactly the one that may have lost its protection since — a restored backup, a home migration, a manual edit, or an install predating this lockdown. Gating on creation would leave every one of those permanently readable.

**Restricted before `sqlite3.connect` as well as after.** The first pass stops the schema migrations running against a file another local user can still write; the second covers what SQLite just created.

## A planted link is refused, and that is a behavior change

This is the rider an earlier revision of this description failed to declare. **It is derived from the fix rather than incidental to it:** `restrict_to_owner` follows links on both back ends (`os.chmod` resolves a symlink; `icacls` applies to a link's target), so hardening a path we do not control would hand a local attacker a lever for re-permissioning a file anywhere on the box. Doing nothing is not the free option it looks like. But the guard changes what `init()` does to a setup that works today, so it needs saying plainly:

"Unsafe" means: not a regular file (symlink, directory, device), or `st_nlink > 1` (a hardlink alias, which needs no privilege on Windows). Presence is checked with `lstat`, so a *dangling* symlink is caught too — `exists()` follows the link and would report False, and SQLite would then create the target wherever it points, outside the protected home.

**Leaving such an entry alone is not the neutral option it looks like.** Every writer for these paths truncates in place — `faiss.write_index`, the id map's `write_text`, and SQLite's WAL append all write *through* an existing inode rather than creating a new one — so a skipped entry keeps its permissive DACL and then receives every future embedding and every committed row. Which response it gets turns on whether losing the file would lose memories that exist nowhere else:

| Path | Response | Why |
|---|---|---|
| `memory.db`, `memory.db-wal` | **`init()` raises `MemoryStoreUnsafeError`**, file left alone | Unrecoverable. A *committed* transaction lives in the `-wal` until a checkpoint moves it into the `.db`, so between the two sits every memory the user has. Unlinking either could discard acknowledged writes; connecting anyway would replay and extend a log another local user can read. Refusing to open is the only response that neither loses the rows nor leaks the new ones — and it leaves the operator holding the only copy rather than us deleting it for them. |
| `memory.db-shm`, `memory.faiss`, `memory.ids.json` | **unlinked**, `init()` proceeds | Recoverable. SQLite rebuilds the `-shm` from the `-wal` on connect, and `load_faiss_index` falls back to `build_faiss_index`. |
| the data home itself, when it is a link or junction | **`init()` raises `MemoryStoreUnsafeError`**, link left in place | The home is matched with `resolve()` so a relocated one still qualifies — which means a link *planted at* it compares equal, and `chmod`/`icacls` follow a directory link exactly as they follow a file one. Checked with `platform_compat.is_link_or_junction`, since `Path.is_symlink()` reports False for a junction and a junction needs no privilege to create. Fatal because there is no safe way through: tightening it re-permissions its target, and *not* tightening it means the DB, the WAL and every embedding are created inside a directory whose access we could not establish. It also cannot be cleared the way a sidecar can — deleting an operator's home link is worse than declining to start. Relocate with `KIROCREW_HOME`, not a link. |
| any of the above, when the unlink **fails** | **`init()` raises `MemoryStoreUnsafeError`** | The entry is still there, and the writers truncate in place, so proceeding would land every future embedding in it. "Could not remove it" has to be as fatal as "must not remove it". Reachable on a read-only directory, and on Windows while another process holds the index mapped. |

`unlink` is safe for the recoverable set because it drops *our* directory entry only: the inode and the attacker's own name for it are untouched, so nothing of theirs is destroyed and nothing of the user's either.

- **The abort is a hard failure with no catchers.** `grep MemoryStoreUnsafeError src/` is 1 definition, 1 raise, 0 handlers, across all 11 `init()` call sites — gateway startup, `cli_server` and the Slack gateway included. A user who has symlinked `memory.db` to another volume gets a startup crash where they previously got a working store. That is the intended outcome (the alternative is writing their memories through a name someone else controls) but it is a real migration, so the message names which path was refused and says to move it aside.
- **An absent path is not a finding.** `_is_lockdown_safe` refuses a missing path, so a clean open reaches the removal branch for every sidecar that does not exist yet. It returns silently rather than warning on every first run.

Every row of that table came from review on an earlier revision of this PR, each closing the previous one's residual: the unlink closed "a skipped FAISS hardlink gets written through", the `-wal` row closed "unlinking *it* drops committed rows", and the failed-unlink row closed "a removal that fails warns and connects anyway". The invariant they converge on is **the store is never opened while any memory path is both unsafe and present** — the response differs only in whether the file can be replaced.

## Not on the event loop

The lockdown splits into **validation** and **ACL tightening**, and the line is drawn on cost: the two differ by nearly three orders of magnitude.

| | What it does | Cost (measured) | Scheduling |
|---|---|---|---|
| **Validation** | is each path a plain single-link file; clear the recoverable ones that are not; create the directory; record what could not be secured | **~0.09ms** for the whole five-path sweep (`lstat`/`unlink`/`mkdir`, no subprocess) | **always inline**, every platform, event loop included |
| **ACL tightening** | `restrict_to_owner` on the directory and each approved file | **~70ms per path** (`icacls`, 10s timeout), up to five | offloaded to a worker on Windows-on-loop |

Validation is never deferred because it is what `init()` reads to decide whether to open the store at all. Defer it and `init()` would connect first and learn afterwards that the path was an attacker's link — the store would already be open through it. At 0.09ms there is nothing to gain by deferring and a guarantee to lose.

Tightening is what must not run on a loop: five call sites reach `init()` from inside an `async def` (`cli_server._run_task`, `dashboard.server.start_dashboard`, `eval.runner._run_scenario_in`), so spawning `icacls` there would park the loop and every other coroutine on the gateway. On Windows-on-loop **all** of it moves to a worker, the directory's included — nothing that spawns touches the loop thread. Offloading rather than *skipping* is the point: a skip would leave a deployment whose only inits are those async sites permanently unprotected, and it would make the guarantee depend on call-graph accident rather than structure.

The worker applies them **directory first**, which is a precondition rather than an ordering preference: until the directory is owner-only another local user can swap an entry between the validation and the `restrict_to_owner` that acts on it, so a directory that cannot be tightened abandons the file pass rather than proceeding without it.

**Each file is then re-validated immediately before its own `restrict_to_owner`**, which is what closes that swap window rather than merely narrowing it. Validation runs before the directory is owner-only — it has to, being what decides whether to open the store at all — so at that moment an approved entry could still be replaced with a link and its target re-permissioned. The re-check confirms the entry while nobody else can write the directory, for one `lstat` against a ~70ms `icacls`. The *refusals* need no re-check: they only get stricter, and failing closed on a stale reading is the safe direction.

The directory takes **`0o700`** on POSIX rather than `restrict_to_owner`, which is `chmod(0o600)` there — right for a file, but on a directory it strips the execute bit that makes it traversable, so the next `sqlite3.connect` fails with "unable to open database file". Windows has no such distinction (the DACL carries both).

**So every refusal is synchronous on every platform.** A planted link, a linked data home, a sidecar that could not be cleared — all decided before the connect, on the calling thread. What can land late is only the DACL of a file that already existed, never the decision to open the store. Both operations are idempotent, so a worker that has not finished only means the next `init()` redoes the work.

Same shape `mcp_gateway/manager.py:343` already uses for the identical helper, and the loop probe is the existing `atomic_write._on_event_loop` rather than a second copy. The worker is non-daemon: a daemon is killed at interpreter exit, so a short-lived Windows task (`kirocrew run`, one eval scenario) could exit before the tightening landed. POSIX runs everything inline — a bare `os.chmod`, nothing to block on.

Measured on Windows with `restrict_to_owner` instrumented and thread ids recorded: **0** calls on the loop thread, and the directory first on the worker.

## Cost

A file that does not exist is skipped with `exists()` rather than by catching `FileNotFoundError` — `icacls` reports a missing file as `rc=2`, which surfaces as a plain `OSError`, so the subclass-only handler made **every clean init warn "may be readable by other users"** for each sidecar SQLite had yet to create. That check also takes the Windows cost from **11 `icacls` spawns per init down to 4**, once per workspace per process, beside the `sqlite3.connect`, the migrations and the FAISS index load already in that function.

## Scope note

With the default `db_path`, "the directory" *is* the data home (`config_dir()`), so a memory init tightens the whole home to owner-only. That direction is right — the home also holds the security policy, sessions and lessons, all private on the same boundary — but it is wider than memory and is the only place in the tree that does it today.

## Tests

The permission test now asserts the **routing**, observable on every platform, rather than a mode NTFS cannot express. Plus:

- `test_the_windows_lockdown_never_spawns_on_the_event_loop` — asserts both platforms with opposite expectations, so a revert that dropped the call entirely cannot pass on the Linux matrix. Mutation-verified: replacing the guard with `if False:` turns it red.
- the POSIX re-tighten on reopen, which is the arm that repairs an existing install.
- `test_an_unsafe_sidecar_is_removed_rather_than_written_through` — plants a hardlink at `memory.faiss` and asserts our entry is gone while the victim's own name and contents survive, so it pins both halves: the sidecar cannot be written through, and refusing it must not destroy the file it pointed at. Mutation-verified: restoring the bare `continue` turns it red.
- `test_an_unsafe_wal_is_kept_and_aborts_instead_of_being_removed` — plants a hardlink at `memory.db-wal` and asserts the file SURVIVES and the reopen refuses, so the recoverable/unrecoverable split cannot silently regress into deleting committed rows. Mutation-verified: narrowing `_is_unrecoverable` back to the DB alone turns it red.
- `test_a_sidecar_that_cannot_be_removed_refuses_to_open_the_store` — patches `Path.unlink` to fail on the planted path and asserts `init()` raises, since the undeletable cases (read-only directory; a mapped index on Windows) cannot be provoked portably and the observable under test is the response, not the cause. Mutation-verified: making `_unsecured_paths` non-fatal turns it red.
- `test_a_file_swapped_after_validation_is_re_checked_before_tightening` — swaps the DB for a hardlink *during* the directory's own tightening call, the one moment genuinely between the two checks, and asserts the swapped path is never handed to `restrict_to_owner`. Mutation-verified: removing the re-check turns it red.
- `test_the_directory_takes_0o700_and_never_the_file_lockdown` — forces `IS_POSIX` on so Windows CI covers the POSIX-only hazard, and pins that the directory gets `chmod(0o700)` and never `restrict_to_owner`. Plus `test_the_memory_directory_stays_traversable_after_the_lockdown`, which asserts the outcome by reopening the store and reading back through the directory. Both came from a real CI failure on this PR: routing the directory through `restrict_to_owner` stripped its execute bit and broke ~40 unrelated suites with "unable to open database file".
- `test_an_unsafe_path_is_refused_even_when_init_runs_on_the_event_loop` — runs `init()` inside `asyncio.run` with a sidecar whose removal fails, and asserts the raise comes out of the coroutine. Pins the refusal side of the split, and it is the one test that actually holds that line: mutation-verified by moving validation onto the worker, which turns it red while the DB/`-wal` cases stay green (those are re-checked inline regardless).
- `test_a_linked_data_home_is_not_re_permissioned` — plants a junction (no privilege needed, and the shape `is_symlink()` misses) at the home and asserts neither it nor its target is tightened. Mutation-verified: dropping the guard turns it red.
- `test_the_lockdown_lands_from_the_event_loop_without_blocking_it` now pins the scheduling side: **no** `icacls` on the loop thread, the tightening still happens, and the directory is tightened **first** on the worker. Mutation-verified: letting a failed directory ACL fall through to the files turns it red.
- `test_a_missing_sidecar_is_not_reported_as_unsafe` — the clean-open case, so the removal branch cannot start warning on every first run.
- the existing planted-link test also now asserts the victim survives, which nothing pinned before.

368 passed / 13 skipped across `test_vector_memory.py`, `test_vector_memory_coverage.py`, `test_memory.py` and `test_embedding_space_reconcile.py` on Windows, plus 1866 passed / 78 skipped across the wider `memory or faiss or snapshot` selection. isort, flake8, mypy (no new errors in the touched file) and docs-lint clean.

> The **black baselined gate reports a false "graduated" entry when run from a Windows checkout** — `core.autocrlf` makes the worktree CRLF and black treats a CRLF file as already normalized. Re-checked against the raw LF blobs CI checks out: `vector_memory.py` is still unformatted at `origin/main` and at this head, so it correctly stays in the baseline and the gate is unaffected on CI.

## Deferred, with an issue

[#4543](https://github.com/kirodotdev/KiroCrew/issues/4543) carries three residuals raised in review and deliberately not fixed here: `memory.py`'s FTS index (`memory_index.db`) and its sidecars, which are not this class's files to open; making the data home owner-only at the cause in `config_dir()` rather than as a side effect of memory init (blocked on an import-time `icacls` spawn hazard against the conftest's spawn guard); and the remaining `chmod_safe(..., 0o600)` call sites that are Windows no-ops on secret-bearing files.

## Provenance

Split out of #4529 (test-suite memory work) on review feedback: that PR is `test:`-typed, and a user-visible security fix riding it would be invisible to a changelog scan — the systematic omission AGENTS.md warns about. The two changes are independent; this one touches no test infrastructure.








