### PR TITLE
refactor(mcp): send artifact PATCHes through the verb helper

### DIFF
--- a/src/kiro_crew/mcp_tools/artifacts.py
+++ b/src/kiro_crew/mcp_tools/artifacts.py
@@ -16,10 +16,7 @@ every existing patch site.
 
 from __future__ import annotations
 
-import json
 import unicodedata
-import urllib.error
-import urllib.request
 from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlencode
@@ -762,31 +759,14 @@ def artifact_update(name: str, args: dict[str, Any]) -> str:
     # it from the X-Internal-Secret header presence (MCP=agent,
     # dashboard=user). This is more secure than trusting a body field
     # and saves the agent from having to remember to set it.
-    # _post helper sends POST; we need PATCH. Build the request directly
-    # and send it through loopback_urlopen, which drops any HTTP_PROXY so
-    # X-Internal-Secret cannot leave the host.
-    data = json.dumps(update_body).encode()
-    headers = {
-        "Content-Type": "application/json",
-        "X-Internal-Secret": mcp_core._internal_secret(),
-    }
-    sk = mcp_core._resolve_session_key()
-    if sk:
-        headers["X-Session-Key"] = sk
-    req = urllib.request.Request(
-        f"{mcp_core._api_base()}/api/artifacts/{slug}", data=data, headers=headers, method="PATCH"
-    )
-    try:
-        with mcp_core._api_urlopen(req, timeout=30) as http_resp:
-            d = json.loads(http_resp.read())
-    except urllib.error.HTTPError as exc:
-        try:
-            err_body = json.loads(exc.read()).get("error", str(exc))
-        except Exception:
-            err_body = str(exc)
-        return f"Error: {err_body}"
-    except Exception as exc:
-        return f"Error: {exc}"
+    # ``_patch`` is the PATCH verb helper (it did not exist when this was
+    # written, which is why the request used to be hand-rolled). Going through
+    # it buys the refusal-invalidate-re-resolve-replay recovery every
+    # other verb has, the ``X-Internal-Caller`` audit attribution, the
+    # latin-1 session-key guard, and redaction of the gateway's error body.
+    d = mcp_core._patch(f"/api/artifacts/{slug}", update_body)
+    if d.get("error"):
+        return f"Error: {d['error']}"
     out = [f"Updated artifact: slug={d.get('slug', slug)} version={d.get('version', '?')}"]
     # Surface source_path so the agent can emit unified-diff headers
     # when summarising the change in chat (powers the dashboard's
@@ -828,28 +808,9 @@ def artifact_revert(name: str, args: dict[str, Any]) -> str:
         "event_type": "reverted",
         "from_version": target_version,
     }
-    data = json.dumps(body).encode()
-    headers = {
-        "Content-Type": "application/json",
-        "X-Internal-Secret": mcp_core._internal_secret(),
-    }
-    sk = mcp_core._resolve_session_key()
-    if sk:
-        headers["X-Session-Key"] = sk
-    req = urllib.request.Request(
-        f"{mcp_core._api_base()}/api/artifacts/{slug}", data=data, headers=headers, method="PATCH"
-    )
-    try:
-        with mcp_core._api_urlopen(req, timeout=30) as http_resp:
-            d = json.loads(http_resp.read())
-    except urllib.error.HTTPError as exc:
-        try:
-            err_body = json.loads(exc.read()).get("error", str(exc))
-        except Exception:
-            err_body = str(exc)
-        return f"Error: {err_body}"
-    except Exception as exc:
-        return f"Error: {exc}"
+    d = mcp_core._patch(f"/api/artifacts/{slug}", body)
+    if d.get("error"):
+        return f"Error: {d['error']}"
     # Surface source_path on the response so the calling agent can build
     # a proper unified-diff header (--- <path>\n+++ <path>) when
     # summarising the revert in chat. The dashboard's diff renderer

--- a/test/test_mcp_artifacts.py
+++ b/test/test_mcp_artifacts.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import re
+import urllib.error
 from unittest.mock import patch
 
 import pytest
@@ -1226,3 +1227,114 @@ class TestArtifactDeleteCommentTool:
                     {"slug": "doc", "comment_id": "c1"},
                 )
         dl.assert_not_called()
+
+
+class TestArtifactPatchUsesTheVerbHelper:
+    """The two artifact PATCH senders owe the same recovery every verb has (#4106).
+
+    They were hand-rolled because ``_post`` sends POST and PATCH was needed;
+    ``mcp_core._patch`` did not exist yet. It does now, and it carries the
+    refusal->invalidate->re-resolve->replay rule that a raw ``_api_urlopen``
+    does not: a gateway that came up (or moved ports) after this tool server
+    booted is recorded only in the run marker, so the first attempt is refused
+    and every other verb recovers from that while these two did not.
+
+    The resolver is scripted at ``_resolve_api_port`` — the one seam the whole
+    discovery chain funnels through — so these tests do not depend on how many
+    times a single attempt consults it.
+    """
+
+    def _moving_gateway(self, monkeypatch):
+        """First attempt refused; the gateway is then discoverable on a new port."""
+        import kiro_crew.mcp_core as mcp_core
+
+        monkeypatch.setattr(mcp_core, "_API_PORT", None)
+        monkeypatch.setattr(mcp_core, "_API", None)
+        monkeypatch.setattr(mcp_core, "_API_UNIX_SOCKET", None)
+        monkeypatch.setattr(mcp_core, "_internal_secret", lambda: "s")
+        monkeypatch.setattr(mcp_core, "_resolve_session_key", lambda: "")
+
+        state = {"port": 5476}
+        monkeypatch.setattr(mcp_core, "_resolve_api_port", lambda: (state["port"], "marker"))
+
+        attempts: list[str] = []
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return b'{"slug": "doc", "version": 5, "source_path": "/n/doc.md"}'
+
+        def fake_loopback(req, timeout=None, unix_socket_path=None):
+            attempts.append(req.full_url)
+            if ":5476" in req.full_url:
+                # The gateway moved; the marker now records the new port.
+                state["port"] = 7788
+                raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+            return _Resp()
+
+        monkeypatch.setattr(mcp_core, "loopback_urlopen", fake_loopback)
+        return attempts
+
+    def test_update_recovers_from_a_refused_first_attempt(self, monkeypatch) -> None:
+        attempts = self._moving_gateway(monkeypatch)
+
+        result = _call_tool_inner("artifact_update", {"slug": "doc", "content": "new"})
+
+        assert len(attempts) == 2, f"no replay: {attempts}"
+        assert ":5476" in attempts[0] and ":7788" in attempts[1]
+        assert all(u.endswith("/api/artifacts/doc") for u in attempts)
+        assert "Updated artifact" in result and "Error" not in result
+
+    def test_revert_recovers_from_a_refused_first_attempt(self, monkeypatch) -> None:
+        import kiro_crew.mcp_core as mcp_core
+
+        monkeypatch.setattr(
+            mcp_core, "_get", lambda *a, **k: {"slug": "doc", "version": 2, "content": "v2"}
+        )
+        attempts = self._moving_gateway(monkeypatch)
+
+        result = _call_tool_inner("artifact_revert", {"slug": "doc", "target_version": 2})
+
+        assert len(attempts) == 2, f"no replay: {attempts}"
+        assert ":5476" in attempts[0] and ":7788" in attempts[1]
+        assert "Reverted doc to v2" in result and "Error" not in result
+
+    def test_both_senders_carry_the_caller_attribution_header(self, monkeypatch) -> None:
+        """``X-Internal-Caller`` lets the gateway audit log name the component
+        that wrote (#3503). The hand-rolled requests omitted it, so an artifact
+        write was the one internal write the audit could not attribute."""
+        import kiro_crew.mcp_core as mcp_core
+
+        monkeypatch.setattr(mcp_core, "internal_caller", lambda: "kirocrew-artifacts")
+        seen: list[dict] = []
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return b'{"slug": "doc", "version": 5}'
+
+        def capture(req, timeout=None, unix_socket_path=None):
+            seen.append(dict(req.headers))
+            return _Resp()
+
+        monkeypatch.setattr(mcp_core, "_internal_secret", lambda: "s")
+        monkeypatch.setattr(mcp_core, "_resolve_session_key", lambda: "")
+        monkeypatch.setattr(mcp_core, "loopback_urlopen", capture)
+        monkeypatch.setattr(mcp_core, "_API", "http://127.0.0.1:5476")
+        monkeypatch.setattr(mcp_core, "_API_UNIX_SOCKET", "")
+
+        _call_tool_inner("artifact_update", {"slug": "doc", "content": "new"})
+
+        assert seen, "no request was sent"
+        headers = {k.lower(): v for k, v in seen[0].items()}
+        assert headers.get("X-internal-caller".lower()) == "kirocrew-artifacts"


### PR DESCRIPTION
## Problem / Motivation

`artifact_update` and `artifact_revert` each hand-roll their PATCH — build a `Request`, send it through `_api_urlopen`, decode an `HTTPError` body inline. The rationale is still in the comment:

```python
# _post helper sends POST; we need PATCH. Build the request directly
# and send it through loopback_urlopen, which drops any HTTP_PROXY so
# X-Internal-Secret cannot leave the host.
```

That was true when it was written. `mcp_core._patch` now exists and does exactly this, with the proxy-dropping transport underneath unchanged.

The consequence is not only ~50 duplicated lines. Both senders sit **outside `_send`**, so neither has the `refusal → invalidate → re-resolve → replay` recovery every other verb goes through. A gateway that came up — or moved ports — after this tool server booted records that only in its run marker, so the first attempt is refused. Every other verb re-resolves and replays once; these two returned `Error: <urlopen error ... Connection refused>` and stopped.

## Why it matters

This is the ordinary zero-config case, not a corner: the marker is exactly how a client finds a gateway it did not start. Today these two senders do not even attempt the recovery the other verbs attempt — they return `Error: <urlopen error ... Connection refused>` on the first refusal and stop. The failure is worst for `artifact_revert`, whose GET has already succeeded — the user is told the revert failed after the target content was fetched.

**What this PR does and does not claim.** It puts both senders on the shared helper, so they now make the same replay *attempt* every other verb makes. It does **not** claim end-to-end recovery against a moved gateway: the verb helpers build `X-Internal-Secret` *before* handing the request to `_send`, and since #3879 that credential is per-listener (`run/gateway-<port>.secret`). A replay that re-resolves to a different port therefore carries the previous listener's credential and is answered 403, not 200. That gap is in the shared helper and predates this change; it is called out below rather than papered over.

## What changed (motivation → approach → change)

Both senders now call `mcp_core._patch(f"/api/artifacts/{slug}", body)` and map the standard error dict to the tool's string contract:

```python
d = mcp_core._patch(f"/api/artifacts/{slug}", update_body)
if d.get("error"):
    return f"Error: {d['error']}"
```

Beyond the replay, this picks up three things the hand-rolled requests were missing:

- **`X-Internal-Caller`** — so the gateway's audit log can attribute an artifact write to the component that made it, instead of inferring "some internal caller" from the secret's presence (#3503). Artifact writes were the internal write the audit could not name. Attribution only; the secret still authenticates.
- **The latin-1 session-key guard** (`_session_key_header_error`) — turns a raw `UnicodeEncodeError` from a non-latin-1 tab title into an actionable message instead of a codec traceback.
- **Redaction of the gateway's error body** — `_http_error_body` runs `redact_exfiltration_urls` + `redact_credentials` before the message is handed back to a caller that echoes it to the LLM, dashboard or Slack. The inline decoder did not.

Net **−50 / +8** lines. No behavior change on the success path: the response dict is parsed the same way, `timeout` is the same 30s, and the transport is still `loopback_urlopen`.

## Tests

**New — `TestArtifactPatchUsesTheVerbHelper`** in `test/test_mcp_artifacts.py` (3 tests):

| Test | Behavior locked in |
|---|---|
| `test_update_recovers_from_a_refused_first_attempt` | A refused first attempt re-resolves and replays exactly once, against the new port (routing, not authentication — the fake transport answers 200) |
| `test_revert_recovers_from_a_refused_first_attempt` | Same for the revert path, whose GET has already succeeded by then |
| `test_both_senders_carry_the_caller_attribution_header` | `X-Internal-Caller` is present on the outgoing request |

The moving gateway is scripted at `_resolve_api_port` — the one seam the whole discovery chain funnels through — and the port advances when the refusal is raised, so the test does not depend on how many times a single attempt consults the resolver. No sleeps, no real gateway, no marker.

**Fail-before / pass-after.** On `origin/main` all three fail — the two replay cases with `no replay: ['http://127.0.0.1:5476/api/artifacts/doc']` (one attempt, no second), and the attribution case with `assert None == 'kirocrew-artifacts'`. On this branch, 3 passed.

**Existing tests pass unchanged.** They patch `kiro_crew.mcp_core.loopback_urlopen` and assert on the outgoing `Request`, which is still the transport underneath `_patch` — so the migration required no test edits. `test_mcp_artifacts.py` + `test_mcp_artifact_folders.py`: **86 passed**.

**Regressions**, `-p no:randomly`: those two plus `test_mcp_core.py`, `test_mcp_core_coverage.py`, `test_mcp_api_base_resolution.py`, `test_mcp_api_port_resolution.py`, `test_dashboard_peer_auth.py`, `test_mcp_call_site_auth_coverage.py`, `test_mcp_internal_caller.py`, `test_mcp_browser_tool.py` — **353 passed, 18 skipped**.

Black ratchet passes, `isort`, `flake8` and `mypy --platform linux src/kiro_crew/mcp_tools/artifacts.py` clean. Both touched files are already in `.github/black-baseline.txt`, so they are deliberately **not** reformatted — doing so would pull ~40 lines of unrelated churn into this diff, which is what the baseline exists to prevent.

## Manual verification

None — the defect is "a refused connection is not retried", which the scripted resolver reproduces exactly and a live gateway would only reproduce by being restarted mid-call.

## Screenshots / video

N/A — no user-visible surface changed.

## Scope

Item 3 of #4106, **artifacts only**. Two call sites in one file, plus three now-dead imports.

`mcp_tools/browser.py` is deliberately left alone: the issue itself flags its error-shape contract as needing to be checked before migrating, and it is not a PATCH sender, so it shares neither the duplicated block nor its fix.

**The credential-refresh gap is deliberately not fixed here.** Rebuilding `X-Internal-Secret` for the retry port means moving header construction into `_send` across all five verbs, and `_send`'s replay branch is the exact block #4504 rewrites. Doing it in this PR would collide with active work and would turn an artifacts consolidation into shared-transport surgery. It is worth its own change.

Item 1 is #4504. Item 2 (the refusal rule duplicated in `mcp_computer._invoke`) is untouched here — it overlaps the same `_send` block #4504 rewrites, so it is better done once that lands.

## Related Issues

Part of #4106 — item 3, artifacts half. The issue stays open for item 2 and the browser sender.

Follow-up to #2671.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — n/a; the stale hand-roll rationale is replaced in place
- [x] No secrets, credentials, or internal references in the diff

