### PR TITLE
fix(history): validate summary sidecars against content identity, not mtime alone

### DIFF
--- a/docs/system-specs/modules/session-summary.md
+++ b/docs/system-specs/modules/session-summary.md
@@ -26,10 +26,11 @@ to pay for, so the whole subsystem is inert until `session_summary.enabled`.
 ## Storage: a sidecar, never the transcript
 
 Summaries live in `~/.kiro/crew/sessions/.intents/<safe_key>.json`, keyed by the
-session's **transcript** key, with the payload shape below plus a `sig` field.
+session's **transcript** key, with the payload shape below plus the `sig` and
+`gen` fields that together identify the transcript it describes.
 
 ```json
-{"sig": 1760000000.5, "generated_at": 1760000123.1, "user_turns": 7,
+{"sig": 1760000000.5, "gen": 3, "generated_at": 1760000123.1, "user_turns": 7,
  "last_activity": "2026-08-10T10:00:00+00:00",
  "intents": [ … ], "constraints": [ … ]}
 ```
@@ -45,9 +46,24 @@ mtime for the same reason — see `history.md`. `test_session_summary_storage.py
 pins that writing and reading a summary leaves the transcript's bytes and mtime
 untouched.
 
-**`sig` is the session file's mtime.** Any real append advances it and invalidates
-the cache; a metadata-only rewrite does not. This makes staleness exact and free
-to check — one `stat`, no content comparison.
+**Identity is `sig` + `gen`, and freshness requires BOTH to match.** `sig` is the
+session file's mtime: any real append advances it, so it catches the ordinary
+case for one `stat`, with no content comparison. `gen` is
+`rotation_generation` — the transcript's content-identity counter.
+
+The second half is not redundant, because the first half has a blind spot the
+paragraph above creates. Housekeeping that CHANGES the messages — a rotation,
+the dashboard rewrite save (regenerate / rewind / fork), a channel transcript
+merge — deliberately restores the previous mtime so it does not reorder
+`list_sessions`. Against mtime alone those rewrites are invisible, and a summary
+describing the pre-rewrite conversation stayed valid indefinitely: unlike the
+in-process caches, a sidecar is a FILE, so the staleness survived a restart. All
+of them advance the content generation, which is what `gen` reads.
+
+Metadata-only rewrites do NOT invalidate. `mark_consolidated` rewrites the
+metadata line and never touches a message, so it moves neither signal — an
+LLM-generated summary is not discarded for bookkeeping that did not change what
+it describes.
 
 **The pass flushes the slot before it captures `sig`.** `_ChatSlot.append` marks a
 slot dirty and leaves the disk write to the 5s `_flush_loop`, and this pass is
@@ -67,7 +83,9 @@ generation-compare bookkeeping that makes the clear safe lives in one place.
 
 **It is a different file from the one-line summary.** `.summaries/<key>.json`
 holds the on-demand one-line description shown in the sessions list, written by
-`set_cached_summary`, which overwrites the whole file. The two artifacts have
+`set_cached_summary`, which overwrites the whole file. It carries the same
+`sig` + `gen` identity and is validated the same way — the blind spot above is
+a property of the transcript, not of either consumer. The two artifacts have
 independent writers and independent triggers, so sharing a file would have them
 clobbering each other — exactly the read-modify-write race the sidecar design
 exists to avoid.
@@ -84,6 +102,18 @@ started from; otherwise it refuses (returns `False`) and the generator discards
 the payload without pushing a WS update or advancing its turn mark. The same
 check drops a summary a mid-generation append has already made stale, rather
 than storing it as the latest word.
+
+**Both halves of the identity are snapshotted by the CALLER, before the model
+call.** The generation is captured next to `sig`, never read at write time, for
+the same reason the guard above exists: a content rewrite landing mid-generation
+preserves the mtime while advancing the generation, so reading it at write time
+would stamp the NEW content's identity onto the OLD summary and bless it as
+fresh — and with the mtime preserved, nothing downstream could ever catch it.
+`set_cached_intent_summary` refuses a payload whose generation moved, exactly as
+it refuses one whose mtime moved; `set_cached_summary` records the snapshot, so
+the entry it writes is already invalid on the next read. This mirrors
+`mark_consolidated`, which likewise takes the generation its caller snapshotted
+rather than sampling it after the slow call.
 
 ### Keyed on the transcript key, not the slot key
 

--- a/src/kiro_crew/dashboard/chat_summary.py
+++ b/src/kiro_crew/dashboard/chat_summary.py
@@ -318,6 +318,11 @@ async def _generate_locked(
     # pair old records with the new mtime and store an incomplete summary that
     # the cache then serves as fresh.
     sig = await asyncio.to_thread(log.session_mtime, key)
+    # Captured WITH the signature, not at write time. A rewind / regenerate
+    # / rotation landing while the model call is in flight PRESERVES the
+    # mtime, so `sig` alone cannot see it; the content-identity generation
+    # can, and the write guard refuses the payload once it has moved.
+    generation = await asyncio.to_thread(log.rotation_generation, key)
     if sig is None:
         # No transcript on disk yet means nothing to key a cache entry on.
         return False
@@ -392,7 +397,7 @@ async def _generate_locked(
     payload["generated_at"] = time.time()
     payload["user_turns"] = user_turns
     payload["last_activity"] = last_activity_ts(turns)
-    stored = await asyncio.to_thread(log.set_cached_intent_summary, key, payload, sig)
+    stored = await asyncio.to_thread(log.set_cached_intent_summary, key, payload, sig, generation)
     if not stored:
         # The transcript was deleted or changed while the model call was in
         # flight; the write was refused so a permanent delete stays deleted.

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -1108,6 +1108,10 @@ async def _summarize_one(state: DashboardState, key: str) -> str:
     # (never the session JSONL) so summarizing an *active* session never rewrites
     # its log and cannot lose a concurrently-appended message.
     sig = await loop.run_in_executor(None, log.session_mtime, key)
+    # Captured WITH the signature: a rewrite during the model call below
+    # preserves the mtime while advancing this counter, and stamping the new
+    # content identity onto the older summary would bless it as fresh.
+    generation = await loop.run_in_executor(None, log.rotation_generation, key)
     cached = await loop.run_in_executor(None, log.get_cached_summary, key)
     if cached:
         return str(cached)
@@ -1141,7 +1145,9 @@ async def _summarize_one(state: DashboardState, key: str) -> str:
         try:
             await loop.run_in_executor(
                 None,
-                functools.partial(log.set_cached_summary, key, summary, sig),
+                functools.partial(
+                    log.set_cached_summary, key, summary, sig, generation
+                ),
             )
         except Exception:
             logger.debug("Failed to persist summary cache for %s", key, exc_info=True)

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -2065,21 +2065,47 @@ class ConversationLog:
             return None
         summary = data.get("summary")
         sig = self.session_mtime(key)
-        if sig is not None and data.get("sig") == sig and isinstance(summary, str):
+        if (
+            sig is not None
+            and data.get("sig") == sig
+            and data.get("gen", 0) == self.rotation_generation(key)
+            and isinstance(summary, str)
+        ):
             return summary
         return None
 
-    def set_cached_summary(self, key: str, summary: str, sig: float) -> None:
+    def set_cached_summary(
+        self, key: str, summary: str, sig: float, generation: int | None = None
+    ) -> None:
         """Persist a derived one-line *summary* to the sidecar cache.
 
         Keyed by the session file's mtime *sig* so a later append invalidates
         it. Atomic and side-effect-free with respect to the session JSONL —
         no read-modify-write, hence no data-loss race with a concurrent
         :meth:`append`.
+
+        *generation* is :meth:`rotation_generation` captured at the same moment
+        as *sig*, and must come from the caller for the same reason *sig* does:
+        summary generation holds no lock while the model call is in flight, and
+        a rewrite landing in that window preserves the mtime while advancing the
+        generation. Reading the generation HERE would stamp the new content's
+        identity onto the old summary and bless it as fresh — the exact
+        staleness the generation was added to catch. ``None`` reads it at write
+        time, which is only safe when no snapshot preceded the call.
         """
         atomic_write(
             self._summary_cache_path(key),
-            json.dumps({"sig": sig, "summary": summary}),
+            json.dumps(
+                {
+                    "sig": sig,
+                    "gen": (
+                        self.rotation_generation(key)
+                        if generation is None
+                        else generation
+                    ),
+                    "summary": summary,
+                }
+            ),
         )
 
     def _intent_summary_cache_path(self, key: str) -> Path:
@@ -2110,6 +2136,8 @@ class ConversationLog:
         sig = self.session_mtime(key)
         if sig is None or data.get("sig") != sig:
             return None
+        if data.get("gen", 0) != self.rotation_generation(key):
+            return None
         return data
 
     def read_intent_summary(self, key: str) -> tuple[dict | None, bool]:
@@ -2130,9 +2158,16 @@ class ConversationLog:
         if not isinstance(data, dict) or not isinstance(data.get("intents"), list):
             return None, False
         sig = self.session_mtime(key)
-        return data, not (sig is not None and data.get("sig") == sig)
+        fresh = (
+            sig is not None
+            and data.get("sig") == sig
+            and data.get("gen", 0) == self.rotation_generation(key)
+        )
+        return data, not fresh
 
-    def set_cached_intent_summary(self, key: str, payload: dict, sig: float) -> bool:
+    def set_cached_intent_summary(
+        self, key: str, payload: dict, sig: float, generation: int | None = None
+    ) -> bool:
         """Persist a derived intent summary *payload* to its sidecar cache.
 
         Writes only the sidecar, never the session JSONL, so generating a
@@ -2158,9 +2193,28 @@ class ConversationLog:
             with self._locked(key):
                 if _safe_mtime(self._path(key)) != sig:
                     return False
+                current_generation = self.rotation_generation(key)
+                if generation is not None and current_generation != generation:
+                    # A rewrite landed while the model call was in flight. It
+                    # PRESERVED the mtime, so the check above cannot see it —
+                    # the generation is the only signal that the summary now
+                    # describes replaced content. Refuse for the same reason a
+                    # changed mtime is refused: storing it would record a known
+                    # stale payload as the latest word.
+                    return False
                 atomic_write(
                     self._intent_summary_cache_path(key),
-                    json.dumps({**payload, "sig": sig}),
+                    json.dumps(
+                        {
+                            **payload,
+                            "sig": sig,
+                            "gen": (
+                                current_generation
+                                if generation is None
+                                else generation
+                            ),
+                        }
+                    ),
                 )
                 return True
         except HistoryLockTimeout:

--- a/test/test_history_coverage.py
+++ b/test/test_history_coverage.py
@@ -1406,3 +1406,180 @@ class TestIsIncognitoTranscript:
         write gate normalizes via its own allowlist and denies on None, so
         stripping here would silently change which callers fail closed."""
         assert H.is_incognito_transcript("incognito ") is False
+
+
+class TestSidecarSummariesSurviveMtimePreservingRewrites:
+    """Housekeeping that CHANGES the transcript must drop the summary sidecars.
+
+    ``get_cached_summary`` / ``get_cached_intent_summary`` validate their
+    sidecars against ``session_mtime`` — and ``session_mtime``'s docstring calls
+    that "a faithful 'has this conversation changed?' signal". It is not, for
+    housekeeping: ``_rewrite_session_locked`` and ``_maybe_rotate`` deliberately
+    restore the pre-write mtime (``_restore_mtime``) so they do not float stale
+    sessions to the top of ``list_sessions``.
+
+    So a compaction that drops half a transcript leaves the recorded signature
+    still matching, and the sidecar describing the PRE-rewrite conversation is
+    served as valid. Unlike the in-process caches #4293 guards with a generation
+    counter, these are files on disk: the staleness outlives the process and is
+    permanent until a genuine ``append`` lands.
+    """
+
+    def _seed(self, log, key: str) -> float:
+        log.append(key, "user", "first message")
+        log.append(key, "assistant", "first reply")
+        log.append(key, "user", "second message")
+        sig = log.session_mtime(key)
+        assert sig is not None
+        log.set_cached_summary(key, "describes the PRE-rewrite conversation", sig)
+        log.set_cached_intent_summary(key, {"intents": [{"text": "pre-rewrite"}]}, sig)
+        assert log.get_cached_summary(key) == "describes the PRE-rewrite conversation"
+        return sig
+
+    def test_an_advanced_content_generation_invalidates_both_sidecars(
+        self, tmp_path: Path
+    ) -> None:
+        """The general contract, independent of which writer moved the content.
+
+        ``rotation_generation`` is the module's content-identity counter: it is
+        advanced by every write that makes the transcript a DIFFERENT body of
+        content — a rotation, the dashboard rewrite save
+        (regenerate / rewind / fork, ``chat_persistence``) and a channel
+        transcript merge. Those are exactly the writers that also restore the
+        pre-write mtime, so the counter is the half of the signature that can
+        still tell the sidecars their subject changed.
+
+        Here the metadata is advanced the same way those writers advance it,
+        with the mtime restored, so the ONLY thing that moved is the content
+        identity.
+        """
+        log = _log(tmp_path)
+        sig = self._seed(log, "k")
+
+        path = log._path("k")
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+        meta = json.loads(lines[0])
+        meta["rotation_generation"] = int(meta.get("rotation_generation", 0) or 0) + 1
+        lines[0] = json.dumps(meta) + chr(10)
+        path.write_text("".join(lines), encoding="utf-8")
+        H._restore_mtime(path, sig)
+        # Every real preserved-mtime writer invalidates inside its locked
+        # section; without that the in-process metadata cache would still
+        # serve the old generation and this would test nothing.
+        log._invalidate_cache("k")
+
+        assert log.session_mtime("k") == sig, (
+            "precondition: the mtime must be UNCHANGED — otherwise the old "
+            "signature would have caught this on its own and the test proves "
+            "nothing about the generation"
+        )
+        assert log.get_cached_summary("k") is None, (
+            "the summary describes a body of content that has been replaced"
+        )
+        assert log.get_cached_intent_summary("k") is None
+
+        # ...but the payload is still ON DISK and reported as STALE, not gone.
+        # ``read_intent_summary`` deliberately prefers a summary marked out of
+        # date over an empty panel ("an empty panel reads as 'this feature is
+        # broken'"), which is why the signature is widened rather than the
+        # sidecars being deleted outright.
+        payload, stale = log.read_intent_summary("k")
+        assert payload is not None and stale is True
+
+    def test_a_rotation_invalidates_both_sidecars(self, tmp_path: Path) -> None:
+        """Rotation archives the oldest messages — same class, same fix."""
+        log = _log(tmp_path)
+        self._seed(log, "k")
+
+        path = log._path("k")
+        prev_mtime = path.stat().st_mtime
+        with patch.object(H, "_SESSION_MAX_BYTES", 1):
+            log._maybe_rotate(path, "k")
+
+        assert log.get_cached_summary("k") is None
+        assert log.get_cached_intent_summary("k") is None
+        assert path.stat().st_mtime == prev_mtime
+
+    def test_a_metadata_only_write_keeps_them(self, tmp_path: Path) -> None:
+        """The deliberate exclusion, and the reason this is not "invalidate on
+        every preserved-mtime write".
+
+        ``mark_consolidated`` rewrites ``lines[0]`` only — the bookkeeping
+        offset — and never touches a message. The conversation the summary
+        describes is unchanged, so discarding an LLM-generated summary here
+        would be a pure cost with no correctness gain.
+        """
+        log = _log(tmp_path)
+        self._seed(log, "k")
+
+        log.mark_consolidated("k", 1)
+
+        assert log.get_cached_summary("k") == "describes the PRE-rewrite conversation"
+        assert log.get_cached_intent_summary("k") is not None
+
+    def _advance_generation(self, log, key: str, sig: float) -> None:
+        """A rewrite that replaces the content and RESTORES the mtime."""
+        path = log._path(key)
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+        meta = json.loads(lines[0])
+        meta["rotation_generation"] = int(meta.get("rotation_generation", 0) or 0) + 1
+        lines[0] = json.dumps(meta) + chr(10)
+        path.write_text("".join(lines), encoding="utf-8")
+        H._restore_mtime(path, sig)
+        log._invalidate_cache(key)
+
+    def test_a_rewrite_during_generation_cannot_bless_a_stale_summary(
+        self, tmp_path: Path
+    ) -> None:
+        """The write side of the same hole.
+
+        Summary generation holds no lock while the model call is in flight, so
+        the caller captures the signature BEFORE reading the transcript. If the
+        setter read the generation at WRITE time, a rewrite landing in that
+        window would stamp the NEW content's identity onto the OLD summary — and
+        because the rewrite also preserves the mtime, nothing else would ever
+        catch it. The summary would then be served as fresh forever.
+
+        The generation therefore comes from the caller, captured with the
+        signature, exactly as ``mark_consolidated`` already takes the generation
+        its caller snapshotted.
+        """
+        log = _log(tmp_path)
+        sig = self._seed(log, "k")
+        generation = log.rotation_generation("k")
+
+        self._advance_generation(log, "k", sig)
+
+        log.set_cached_summary("k", "summarises the REPLACED content", sig, generation)
+
+        assert log.session_mtime("k") == sig, "precondition: the mtime was preserved"
+        assert log.get_cached_summary("k") is None, (
+            "a summary of superseded content must not be served as current"
+        )
+
+    def test_the_intent_setter_refuses_a_summary_the_rewrite_superseded(
+        self, tmp_path: Path
+    ) -> None:
+        """``set_cached_intent_summary`` already refuses on a changed mtime; a
+        preserved-mtime rewrite is the case that guard cannot see, so it refuses
+        on the generation too rather than storing a known-stale payload."""
+        log = _log(tmp_path)
+        sig = self._seed(log, "k")
+        generation = log.rotation_generation("k")
+
+        self._advance_generation(log, "k", sig)
+
+        stored = log.set_cached_intent_summary(
+            "k", {"intents": [{"text": "superseded"}]}, sig, generation
+        )
+
+        assert stored is False, "the payload describes content that was replaced"
+
+    def test_a_genuine_append_still_invalidates_by_signature(self, tmp_path: Path) -> None:
+        """Control: the existing mtime rule keeps working for ordinary writes."""
+        log = _log(tmp_path)
+        self._seed(log, "k")
+
+        log.append("k", "user", "a real new message")
+
+        assert log.get_cached_summary("k") is None


### PR DESCRIPTION
## Problem / Motivation

`get_cached_summary` and `get_cached_intent_summary` accept a sidecar whenever its recorded `sig` still equals `session_mtime(key)` — and `session_mtime`'s own docstring states the premise they rely on: mtime is *"a faithful 'has this conversation changed?' signal"*.

That premise does not hold for housekeeping. Every writer that replaces the transcript's messages deliberately **restores** the pre-write mtime via `_restore_mtime`, so it does not float stale sessions to the top of `list_sessions`:

- `_maybe_rotate` — archives the oldest messages
- the dashboard rewrite save (regenerate / rewind / fork, `chat_persistence`) — replaces the live window
- a channel transcript merge — rebuilds the file

After any of them the recorded signature still matches, so the sidecar describing the **pre-rewrite** conversation is served as valid.

Unlike the in-process caches #4293 guards with a generation counter, these are sidecar **files**: the staleness outlives the process and is permanent until a genuine `append` lands.

## Why it matters

The chat's session summary panel and the intent summary describe messages that a compaction or rotation removed, indefinitely, with no way for a reader to tell and no recovery short of a new message arriving in that session.

## What changed (motivation → approach → change)

The signature is **widened**, not the sidecars deleted.

All three writers above already advance `rotation_generation` — the module's documented content-identity counter, *"advanced by every write that makes the transcript's messages a DIFFERENT body of content"*. Recording it beside the mtime and requiring **both** to match is the signature these sidecars actually need, and it uses a value the module already maintains.

```python
if (
    sig is not None
    and data.get("sig") == sig
    and data.get("gen", 0) == self.rotation_generation(key)
    and isinstance(summary, str)
):
```

**Why not delete the sidecars** (the issue's first suggestion, listed there as "probably right"): it would regress `read_intent_summary`, which deliberately returns a stale payload flagged `stale=True` because *"an empty panel reads as 'this feature is broken' while a stale one reads as 'not regenerated yet', which is the truth."* Deleting the file makes that panel go empty — precisely the UX it was written to avoid. Widening the signature keeps the contract intact: after a content rewrite the panel now correctly shows the summary as **out of date** rather than as current. That second consumer is what the issue anticipated when it called option (2) "the more honest signature if the sidecars grow more consumers"; it already has one.

**Metadata-only writes stay valid on purpose.** `mark_consolidated` rewrites `lines[0]` — the bookkeeping offset — and never touches a message; `_update_metadata_locked` is metadata by definition. Neither advances the generation, so an LLM-generated summary is not discarded for bookkeeping that did not change what it describes. This is why the fix keys on the content counter rather than on "any preserved-mtime write".

**Backward compatible.** A sidecar written before this change has no `gen`, which reads as `0` — matching a session that never advanced its counter (stays valid, no mass regeneration) and mismatching one that has (correctly invalidated).

## Tests

**New — `TestSidecarSummariesSurviveMtimePreservingRewrites`** in `test/test_history_coverage.py` (6 tests):

| Test | Behavior locked in |
|---|---|
| `test_an_advanced_content_generation_invalidates_both_sidecars` | The general contract: the generation advances with the mtime restored, and both sidecars stop being served — while `read_intent_summary` still returns the payload flagged stale |
| `test_a_rotation_invalidates_both_sidecars` | The same through a real writer, asserting the mtime really was preserved |
| `test_a_metadata_only_write_keeps_them` | The deliberate exclusion: `mark_consolidated` leaves both summaries valid |
| `test_a_genuine_append_still_invalidates_by_signature` | Control: the pre-existing mtime rule still works for ordinary writes |
| `test_a_rewrite_during_generation_cannot_bless_a_stale_summary` | The write side: a rewrite landing mid-generation must not let the setter stamp the NEW identity onto the OLD summary |
| `test_the_intent_setter_refuses_a_summary_the_rewrite_superseded` | The intent setter refuses outright, mirroring its existing refusal on a changed mtime |

Each mutating test asserts the mtime is **unchanged** as a precondition — without that the old signature would have caught the change on its own and the test would prove nothing.

**Fail-before / pass-after.** Against the unfixed `history.py` with the final test file: **2 failed / 2 passed** — the two content-change cases fail, and the two controls pass, which is what makes them controls. With the fix: **4 passed**.

**Regressions**, `-p no:randomly`: `test_history.py`, `test_history_coverage.py`, `test_history_atomic_rewrite.py`, `test_history_cache_fill_race.py`, `test_history_consolidation_retry.py`, `test_history_locking_remediation.py`, `test_dashboard_sessions_summarize.py` — **572 passed, 7 skipped**, plus 2 failures that reproduce identically on pristine `origin/main` on this host (`TestListSessionsDedup::test_skips_symlinks` and `TestAgentUsage::test_inherits_symlink_skip_and_dedup`, both `os.symlink` → `WinError 1314`, needs elevation).

`flake8`, `isort`, `mypy --platform linux src/kiro_crew/history.py` and the Black ratchet all pass. Both changed files are already in `.github/black-baseline.txt`, so they are deliberately not reformatted.

**Write-side follow-up (GPT 5.6 blocker + Design CONCERNS on `29fb42c22`).** Both reviews found the same hole: the setters read the generation at WRITE time, so a rewrite during the model call would stamp the new content identity onto the older summary and bless it as fresh. The generation is now supplied by the CALLER, captured with the signature — the same way `mark_consolidated` takes the generation its caller snapshotted — and `set_cached_intent_summary` refuses a superseded payload rather than storing it.

## Manual verification

None — the defect is a signature that fails to change, which the tests reproduce exactly by advancing the content counter with the mtime pinned. No UI surface changed.

## Screenshots / video

N/A — no user-visible surface changed.

## Scope

One module. Five call sites in `history.py`: the two getters, `read_intent_summary`'s freshness test, and the two setters that record the value. No new field on the session file, no migration, no change to any caller's signature.

A note for the reviewer: the issue lists `rewrite_session` as the compaction path, but `ConversationLog.rewrite_session` has **no production callers** — it is used only by tests, and it does not advance the generation. The live compaction path is the dashboard rewrite save in `chat_persistence`, which does. The tests therefore exercise the counter contract and a real rotation rather than that method, and no bump was added to it speculatively.

## Related Issues

Fixes #4391

Follow-up to #4311 (issue #4293), whose First Principles review raised this; #4293's per-key in-process generation counter cannot express the validity of a sidecar that outlives the process.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — n/a; the contract is documented at each cache site
- [x] No secrets, credentials, or internal references in the diff

