### PR TITLE
fix(crew-store): survive a read that races a concurrent store replace

### DIFF
--- a/src/kiro_crew/atomic_write.py
+++ b/src/kiro_crew/atomic_write.py
@@ -176,6 +176,62 @@ def replace_with_retry(src: Path | str, dst: Path | str) -> None:
     os.replace(str(src), str(dst))
 
 
+def read_bytes_with_retry(path: Path | str) -> bytes:
+    """``Path.read_bytes()``, retrying the Windows sharing-violation window.
+
+    The read-side twin of :func:`replace_with_retry`, and the same OS fact seen
+    from the other end: on Windows a read fails with ``PermissionError``
+    (``WinError 32``) while another handle holds the file open for write, so a
+    reader can lose to a concurrent tmp-file-plus-rename writer that is
+    perfectly correct. POSIX permits the read, which is why this class of bug
+    only ever surfaces on the ``Backend Tests (Windows)`` matrix and on Windows
+    hosts.
+
+    Only ``PermissionError`` is retried. ``FileNotFoundError`` and a decode or
+    parse failure propagate untouched: they mean the file is absent or damaged,
+    and sleeping cannot change either.
+
+    Shares :data:`_REPLACE_MAX_ATTEMPTS` / :data:`_REPLACE_BACKOFF_SECONDS` with
+    the rename retry deliberately. Both bound the same transient — one Windows
+    sharing-violation window — so a second knob would only let the two halves of
+    one behaviour drift apart.
+
+    On POSIX a ``PermissionError`` is a genuine access fault and is re-raised
+    immediately rather than slept over, and the retry is gated on there being no
+    running event loop in this thread: a caller reached from the gateway loop
+    gets the plain single-attempt semantics instead of pausing the one loop for
+    the whole budget. Callers wanting the retry from a loop-driven path offload
+    the read (``asyncio.to_thread`` / ``run_in_executor``), which is what
+    ``CrewStore``'s builder already does.
+
+    The final attempt sits OUTSIDE the loop for the same reason it does in
+    :func:`replace_with_retry`: with it inside, a budget of 0 would fall out
+    having read nothing and return ``None`` to a caller expecting bytes.
+    """
+    target = Path(path)
+    for attempt in range(_REPLACE_MAX_ATTEMPTS - 1):
+        try:
+            return target.read_bytes()
+        except PermissionError:
+            if not platform_compat.IS_WINDOWS:
+                raise
+            if _on_event_loop():
+                logger.debug(
+                    "read contended at %s on the event loop; re-raising instead "
+                    "of sleeping (offload the read to retry)",
+                    target,
+                )
+                raise
+            logger.debug(
+                "read contended at %s; retrying (attempt %d/%d)",
+                target,
+                attempt + 1,
+                _REPLACE_MAX_ATTEMPTS,
+            )
+            time.sleep(_REPLACE_BACKOFF_SECONDS)
+    return target.read_bytes()
+
+
 def atomic_write(
     path: Path | str,
     content: str | bytes,

--- a/src/kiro_crew/crew_chat.py
+++ b/src/kiro_crew/crew_chat.py
@@ -29,6 +29,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from kiro_crew.atomic_write import read_bytes_with_retry
 from kiro_crew.config.loader import KiroCrewConfig, resolve_agent_bindings
 from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
@@ -261,7 +262,7 @@ class CrewStore:
         """
         path = self.dir / name
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
+            data = json.loads(read_bytes_with_retry(path).decode("utf-8"))
         except FileNotFoundError:
             return []
         except (json.JSONDecodeError, OSError) as exc:

--- a/test/test_crew_chat.py
+++ b/test/test_crew_chat.py
@@ -179,8 +179,8 @@ class TestWindowsReplaceWindow:
         """
         inflight: set[str] = set()
         gate = threading.Event()
-        real_write_text, real_replace, real_read_text = (
-            Path.write_text, Path.replace, Path.read_text)
+        real_write_text, real_replace, real_read_text, real_read_bytes = (
+            Path.write_text, Path.replace, Path.read_text, Path.read_bytes)
 
         def write_text(self, data, *a, **k):          # type: ignore[no-untyped-def]
             if self.name == f".{target}.tmp":
@@ -199,9 +199,21 @@ class TestWindowsReplaceWindow:
                 raise PermissionError(errno.EACCES, "Permission denied", str(self))
             return real_read_text(self, *a, **k)
 
+        def read_bytes(self, *a, **k):                # type: ignore[no-untyped-def]
+            # Faulted alongside read_text so the emulator stays armed against
+            # the call the store actually makes: ``CrewStore._load`` reads bytes
+            # through ``read_bytes_with_retry`` (#4331). Patching only read_text
+            # would leave the positive control below passing vacuously — it
+            # would observe no failure because it never intercepted the read,
+            # not because the window closed.
+            if str(self) in inflight:
+                raise PermissionError(errno.EACCES, "Permission denied", str(self))
+            return real_read_bytes(self, *a, **k)
+
         monkeypatch.setattr(Path, "write_text", write_text)
         monkeypatch.setattr(Path, "replace", replace)
         monkeypatch.setattr(Path, "read_text", read_text)
+        monkeypatch.setattr(Path, "read_bytes", read_bytes)
         return inflight, gate
 
     @pytest.mark.asyncio

--- a/test/test_crew_store_read_retry.py
+++ b/test/test_crew_store_read_retry.py
@@ -1,0 +1,148 @@
+"""The read half of the Windows sharing-violation window (issue #4331).
+
+``CrewStore._load`` read with a bare ``read_text`` and mapped every ``OSError``
+to a fatal ``RuntimeError``. On Windows a read raises ``PermissionError``
+(``WinError 32``) while another handle holds the file open for write, and the
+store's own builder admits two concurrent first messages for one slot both
+build a store — so one can read ``queue.json`` while the other is replacing it.
+The user gets a failed send that succeeds on retry, which reads as random.
+
+POSIX permits that read, which is why #4142 could only reproduce it in a test.
+``windows_sim.read_sharing_violation`` reproduces the fault deterministically on
+any OS, so these drive the exact path a Windows host takes. They do NOT prove
+the real OS behaviour end to end, only that the retry is wired, bounded, gated
+to Windows, and gated off the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from windows_sim import read_sharing_violation
+
+from kiro_crew import atomic_write as aw
+from kiro_crew import platform_compat
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch):
+    """Keep the bounded retry loop instant; attempt COUNT is what these pin."""
+    monkeypatch.setattr(aw, "_REPLACE_BACKOFF_SECONDS", 0)
+
+
+@pytest.fixture
+def _windows(monkeypatch):
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+
+
+def _seed(tmp_path, name: str = "queue.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps([{"id": "q1"}]), encoding="utf-8")
+    return path
+
+
+class TestReadBytesWithRetry:
+    def test_a_contended_read_retries_and_succeeds(self, tmp_path, _windows) -> None:
+        path = _seed(tmp_path)
+
+        with read_sharing_violation(match="queue.json", times=1) as state:
+            data = aw.read_bytes_with_retry(path)
+
+        assert json.loads(data.decode("utf-8")) == [{"id": "q1"}]
+        assert state["n"] == 2, "one faulted read, then one that succeeded"
+
+    def test_the_retry_is_bounded(self, tmp_path, _windows) -> None:
+        """A permanently contended file must fail, not spin forever."""
+        path = _seed(tmp_path)
+
+        with read_sharing_violation(match="queue.json", times=10_000):
+            with pytest.raises(PermissionError):
+                aw.read_bytes_with_retry(path)
+
+    def test_posix_permission_errors_are_not_slept_over(self, tmp_path, monkeypatch) -> None:
+        """On POSIX the OS permits the read, so a PermissionError is a REAL
+        access fault — retrying would just delay an honest failure."""
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        path = _seed(tmp_path)
+
+        with read_sharing_violation(match="queue.json", times=1) as state:
+            with pytest.raises(PermissionError):
+                aw.read_bytes_with_retry(path)
+
+        assert state["n"] == 1, "it must not have tried a second time"
+
+    @pytest.mark.asyncio
+    async def test_on_the_event_loop_it_does_not_sleep(self, tmp_path, _windows) -> None:
+        """The retry sleeps, so a caller on the gateway loop gets the plain
+        single-attempt semantics rather than pausing the one loop."""
+        path = _seed(tmp_path)
+
+        with read_sharing_violation(match="queue.json", times=1) as state:
+            with pytest.raises(PermissionError):
+                aw.read_bytes_with_retry(path)
+
+        assert state["n"] == 1
+        assert asyncio.get_running_loop() is not None
+
+    def test_a_missing_file_is_not_retried(self, tmp_path, _windows) -> None:
+        """Absence is not contention; sleeping cannot make the file appear."""
+        with pytest.raises(FileNotFoundError):
+            aw.read_bytes_with_retry(tmp_path / "absent.json")
+
+
+class TestCrewStoreLoadSurvivesAContendedRead:
+    def test_load_reads_through_the_retrying_helper(self, tmp_path, _windows, monkeypatch) -> None:
+        """The product path from #4331: a concurrent first message for the same
+        slot is replacing ``queue.json`` while this build reads it.
+
+        Asserted as WIRING, deliberately. The pre-fix read was
+        ``path.read_text(...)``, and none of the ``windows_sim`` faults reach it
+        — ``read_sharing_violation`` patches ``Path.read_bytes`` and
+        ``builtin_open_sharing_violation`` patches ``builtins.open``, while
+        ``pathlib`` opens through its own ``io.open`` binding. A test that only
+        wrapped the old call in a simulator would therefore pass on the unfixed
+        tree while proving nothing. Reading bytes is part of the fix precisely
+        because it puts the store on a path the existing simulator can fault.
+        """
+        from kiro_crew import crew_chat
+        from kiro_crew.crew_chat import CrewStore
+
+        seen: list[str] = []
+        real = crew_chat.read_bytes_with_retry
+
+        def _spy(path):
+            seen.append(str(path))
+            return real(path)
+
+        monkeypatch.setattr(crew_chat, "read_bytes_with_retry", _spy)
+
+        store = CrewStore.__new__(CrewStore)
+        store.dir = tmp_path
+        _seed(tmp_path)
+
+        with read_sharing_violation(match="queue.json", times=1):
+            assert store._load("queue.json") == [{"id": "q1"}]
+
+        assert seen, "the store must read through the retrying helper, not read_text"
+
+    def test_a_damaged_file_is_still_fatal(self, tmp_path, _windows) -> None:
+        """The retry must not soften the guard that exists so a broken file is
+        never read as an empty queue and saved back over the real one."""
+        from kiro_crew.crew_chat import CrewStore
+
+        store = CrewStore.__new__(CrewStore)
+        store.dir = tmp_path
+        (tmp_path / "queue.json").write_text("{not json", encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="unreadable"):
+            store._load("queue.json")
+
+    def test_a_missing_file_is_still_an_empty_queue(self, tmp_path, _windows) -> None:
+        from kiro_crew.crew_chat import CrewStore
+
+        store = CrewStore.__new__(CrewStore)
+        store.dir = tmp_path
+
+        assert store._load("queue.json") == []


### PR DESCRIPTION
## Problem / Motivation

`CrewStore._load` reads with a bare `path.read_text(...)` and maps every `OSError` to a fatal `RuntimeError`:

```python
data = json.loads(path.read_text(encoding="utf-8"))
except FileNotFoundError:
    return []
except (json.JSONDecodeError, OSError) as exc:
    raise RuntimeError(f"crew store: {path} is unreadable ({exc})") from exc
```

On Windows a read raises `PermissionError` (`WinError 32`) while another handle holds the file open for write. `PermissionError` is an `OSError`, so it lands in that second arm.

The overlap is not hypothetical — the store's own builder documents it. `_store_async`'s comment reads *"Two concurrent first messages both miss the cache above and both build a store"*; `setdefault` then picks one winner, only the winner reconciles, and `save()` hands all three files to the executor without awaiting them. Nothing orders the loser's read against the winner's write, and the write lock is per store **instance**, so two `CrewStore` objects hold different lock dicts and cannot order against each other.

The user sends a message and gets an error. Retrying works, so it looks random rather than like a bug. It needs two requests for one slot close together with nothing cached — a fresh gateway start, a reopened tab, or a Slack and a dashboard message landing together.

POSIX permits replacing a file under an open reader, which is why #4142 could only reproduce this in a test and why the product path was explicitly left out of #4150.

## Why it matters

It is a failed send on the primary surface, with an error message about an internal store file, on an install where nothing is wrong. Because it needs a race it appears at random and is not reproducible on the Linux dev/CI path, so it survives normal testing.

## What changed (motivation → approach → change)

`read_bytes_with_retry` — the read-side twin of the existing `replace_with_retry`, carrying the same four properties for the same reasons:

- **bounded** attempts, so a permanently contended file fails instead of spinning;
- **Windows-only** — on POSIX a `PermissionError` is a genuine access fault and is re-raised immediately rather than slept over;
- **never sleeps on the event loop** — a caller reached from the gateway loop gets plain single-attempt semantics instead of pausing the one loop for the whole budget. `CrewStore` is built in `run_in_executor`, so the retry applies where it matters;
- the **final attempt sits outside the loop**, so a budget of 0 degrades to a plain read rather than returning nothing.

Both directions share `_REPLACE_MAX_ATTEMPTS` / `_REPLACE_BACKOFF_SECONDS` deliberately: it is one OS window seen from two ends, and a second knob would only let the halves drift apart.

Only `PermissionError` is retried. `FileNotFoundError` still means "nothing enqueued yet", and a damaged file is still fatal — the guard that stops an unreadable queue being read as empty and then saved back over the real one is untouched. Both are pinned by tests.

**Reading bytes rather than text is part of the fix, not incidental.** `Path.read_bytes` is the call `windows_sim.read_sharing_violation` can fault, so the store now sits on a path the repo's deterministic emulator reaches. `Path.read_text` opens through pathlib's own `io.open` binding, which neither that helper nor `builtin_open_sharing_violation` (which patches `builtins.open`) intercepts — so the pre-fix read was not faultable by any existing simulator.

## Tests

**New — `test/test_crew_store_read_retry.py`** (8 tests), mirroring the four properties `test_atomic_write_retry.py` pins for the write side:

| Test | Behavior locked in |
|---|---|
| `test_a_contended_read_retries_and_succeeds` | One faulted read, then one that succeeds — asserted on the emulator's own count |
| `test_the_retry_is_bounded` | A permanently contended file raises rather than spinning |
| `test_posix_permission_errors_are_not_slept_over` | On POSIX it must not try a second time |
| `test_on_the_event_loop_it_does_not_sleep` | A loop-driven caller gets single-attempt semantics |
| `test_a_missing_file_is_not_retried` | Absence is not contention |
| `test_load_reads_through_the_retrying_helper` | The product path is wired to the helper |
| `test_a_damaged_file_is_still_fatal` | The retry does not soften the anti-erasure guard |
| `test_a_missing_file_is_still_an_empty_queue` | `FileNotFoundError` still means an empty queue |

**Fail-before.** With `crew_chat.py` reverted and the helper present, `test_load_reads_through_the_retrying_helper` fails (`module 'kiro_crew.crew_chat' has no attribute 'read_bytes_with_retry'`). With both reverted, the `TestReadBytesWithRetry` cases fail as well. With the fix: 8 passed.

That product-path case is written as a **wiring** assertion on purpose, and it is worth being explicit about why: I first wrote it as "wrap the store build in `read_sharing_violation` and assert it survives", and that version **passed on the unfixed tree** — the simulator patches `Path.read_bytes` while the old code called `read_text`, so it never armed. A test that cannot fail before the fix proves nothing, so it now asserts the call actually goes through the retrying helper.

**One existing test updated.** `test_crew_chat.py::TestWindowsReplaceWindow`'s emulator faulted only `read_text`. Its positive control asserts that a whole store build *does* fail in the window — "so a pass above is the fix working and not an emulator that never armed" — and after this change that control would have passed **vacuously**, observing no failure because it never intercepted the read. The emulator now faults `read_bytes` alongside `read_text`, keeping the control armed.

**Regressions**, `-p no:randomly`: `test_crew_store_read_retry.py`, `test_atomic_write_retry.py`, `test_windows_sim.py`, `test_crew_chat.py` — **201 passed**. A wider `-k "atomic_write or crew_store or crew_chat or autonudge or token_secret"` sweep gives **537 passed, 8 skipped**, plus 1 failure and 20 collection errors that reproduce with identical counts on pristine `origin/main` on this host (`test_bench_round14.py`'s `os.symlink` → `WinError 1314`, and `test_bench_download_fd.py`'s `KeyError: 'file'`), both in bench files the filter matched incidentally.

`flake8`, `isort`, `mypy --platform linux` and the Black ratchet all pass.

## Manual verification

None. The window is a race against a concurrent atomic replace; the emulator reproduces it deterministically on any OS, which is stronger evidence than trying to hit it by hand. These tests do not prove the real Windows OS behaviour end to end — only that the retry is wired, bounded, gated to Windows and gated off the event loop, which is the same claim `test_atomic_write_retry.py` makes for the write side.

## Screenshots / video

N/A — no user-visible surface changed.

## Scope

One new helper in `atomic_write.py`, one call site in `crew_chat.py`, one emulator repair in an existing test.

Noted but **not** changed: this store's write side still calls `tmp.replace()` directly rather than `replace_with_retry`, so it remains exposed to the other half of the same window. That is a separate change with its own blast radius, and this issue is the read.

## Related Issues

Fixes #4331

Same failure mode as #4142, which fixed only the test-side reads; the product path was called out as out of scope in #4150.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — n/a; the contract is documented on the helper
- [x] No secrets, credentials, or internal references in the diff
