### PR TITLE
fix(dev-fleet): dependency-only sync when a console script is locked

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/dep_sync.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/dep_sync.py
@@ -1,0 +1,620 @@
+"""Dependency-only sync for a checkout whose console script cannot be replaced.
+
+Windows holds a mandatory lock on a running executable's image, so pip cannot
+rewrite ``Scripts\\kirocrew.exe`` while the gateway is served by the very venv it
+is reinstalling into -- the ordinary single-checkout layout. ``pip install -e .``
+fails there even when the revision being synced changed nothing about the console
+script, because a reinstall rewrites it unconditionally.
+
+An editable install needs no reinstall for a source change: ``src`` is already on
+``sys.path``, so merged code is live the moment the merge lands. What a source
+change CAN require is a dependency the venv does not have yet, and installing a
+dependency never touches the project's own console script. Syncing dependencies
+alone is therefore the whole of what pip is needed for.
+
+The step is deliberately shaped as PARITY with the reinstall it stands in for, not
+as an improvement on it. Every other platform runs ``fetch -> merge ->
+pip install -e .``; this runs ``fetch -> merge -> pip install <the project's
+requirements>``. The scope matches too: a plain ``pip install -e .`` resolves
+``install_requires`` and nothing else, so this installs exactly that and leaves
+extras alone. Anything beyond parity was tried and removed -- inferring which
+extras the operator requested (pip records no such thing, so the inference has
+unavoidable false negatives) and proving in advance that the merge cannot fail
+(which needs a growing set of preconditions and still cannot be complete).
+
+That parity includes one exposure, stated plainly rather than guarded against: the
+merge lands first, so a failed dependency install leaves the checkout on a revision
+whose dependencies are not satisfied, and the operator has to finish by hand. That
+is exactly what happens on every other platform when the reinstall step fails, and
+it is the accepted behaviour of this workflow rather than something this substitute
+introduces. Raising that bar is worth doing for ALL platforms at once, not for this
+one path.
+
+Satisfaction is left to pip rather than computed here: every declared requirement
+is handed to ``pip install`` verbatim, which no-ops the ones already satisfied and
+evaluates specifiers and environment markers with the same code
+``pip install -e .`` would have run. Deciding it locally would need a PEP 508
+parser this package does not depend on (``packaging`` is not an install
+requirement) and would drift from pip's own answer.
+
+Two things a dependency-only install cannot deliver that a reinstall does, so both
+are checked rather than left silent: the ``requires-python`` gate pip applies when
+it builds the project, and a rewrite of the console script when the incoming
+revision repoints it.
+"""
+
+from __future__ import annotations
+
+import configparser
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - exercised by whichever interpreter runs this
+    import tomllib as _toml
+except ImportError:  # Python 3.10, which this project still supports
+    try:
+        import tomli as _toml  # type: ignore[no-redef,import-not-found]
+    except ImportError:
+        _toml = None  # type: ignore[assignment]
+
+#: Characters that terminate the distribution name at the head of a PEP 508
+#: requirement (version specifier, extras bracket, marker separator, or the
+#: whitespace some declarations put before the specifier).
+_NAME_END = re.compile(r"[\s<>=!~;\[(]")
+
+#: The project's only console script. It is the wrapper the operator restarts
+#: through, so it is the one whose staleness has to be reported rather than
+#: silently tolerated.
+_SCRIPT = "kirocrew"
+
+#: This project's own distribution name, normalized. Asking pip for it is the one
+#: request that would rewrite the locked console script.
+_PROJECT = "kirocrew"
+
+#: ``requires-python`` lower bounds. Only the floor is enforced: it is the bound
+#: a revision raises when it starts using newer syntax, and the one whose breach
+#: makes the merged tree unimportable under this interpreter. Upper bounds and
+#: exclusions are left to pip on the next real reinstall rather than
+#: reimplemented here without a PEP 440 parser. ``~=`` is included because a
+#: compatible-release clause declares its own lower bound, and ``>`` is kept
+#: distinct from ``>=`` because it excludes the version it names.
+_PY_FLOOR = re.compile(r"(?P<op>~=|>=|>)\s*(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<micro>\d+))?")
+
+#: A plain PEP 508 distribution name -- letters, digits, and the separators PEP
+#: 503 normalizes. Anything else at the head of a requirement is not a name: a
+#: path (``.``, ``./x``, ``/abs``, ``C:\x``), a URL scheme, an archive filename, or
+#: a stray option. Those are what could make pip install the project itself.
+_PLAIN_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+#: Distribution-archive suffixes. pip reads a bare token ending in one of these as
+#: a local file when the file exists, so such a token is refused rather than left
+#: to be disambiguated by the working directory's contents.
+_ARCHIVE_SUFFIXES = (".whl", ".zip", ".tar.gz", ".tar.bz2", ".tar.xz", ".tgz")
+
+
+def normalize(name: str) -> str:
+    """Normalize a distribution name per PEP 503 so lookups compare equal."""
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
+
+
+def rejected_specs(specs: list[str]) -> list[str]:
+    """Requirements that must never reach pip, with the reason for each.
+
+    The module's whole premise is that pip is asked for DEPENDENCIES and never for
+    the project, because installing the project is what rewrites the locked console
+    script. Without this the property would hold only because this repository's
+    declarations happen not to name a path: a declaration of ``.`` would have pip
+    install the checkout itself, remove the editable install, and then fail on the
+    locked executable -- leaving the venv unable to import the package at all,
+    which is the exact damage the step exists to avoid.
+
+    Two shapes are refused: a head that is not a plain distribution name (a path,
+    a URL, an archive, a leftover option), and any requirement that normalizes to
+    this project's own name however it is spelled.
+    """
+    bad: list[str] = []
+    for spec in specs:
+        head = _NAME_END.split(spec.strip(), 1)[0].strip()
+        if not _PLAIN_NAME.match(head):
+            bad.append(f"{spec!r} is not a plain requirement name")
+        elif head.lower().endswith(_ARCHIVE_SUFFIXES):
+            # A bare `foo.whl` is a legal NAME by character set, but pip resolves it
+            # as a local file whenever one exists in the working directory, so it is
+            # refused rather than disambiguated by what happens to be on disk.
+            bad.append(f"{spec!r} names an archive rather than a distribution")
+        elif normalize(head) == _PROJECT:
+            bad.append(f"{spec!r} names this project, whose reinstall is the blocker")
+    return bad
+
+
+def _requirement_lines(raw: str) -> list[str]:
+    """Requirement lines from one setup.cfg value, comments dropped.
+
+    setup.cfg carries a full-line ``#`` comment for most requirements here, and
+    configparser keeps them, so they have to be stripped before the value is
+    handed to pip. A trailing comment on a requirement line is NOT stripped: a
+    PEP 508 marker can legitimately contain ``#`` inside a quoted string, and this
+    project's declarations put their commentary on their own lines.
+    """
+    out: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            out.append(stripped)
+    return out
+
+
+def read_text(repo: Path, name: str) -> str | None:
+    """``<repo>/<name>`` as text, or ``None`` when it cannot be read.
+
+    The working tree is the right source here because this step runs AFTER the
+    merge, so the tree already IS the revision being synced -- the same tree
+    ``pip install -e .`` would have read on any other platform.
+    """
+    try:
+        return (repo / name).read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def declared_requirements(repo: Path) -> list[str] | None:
+    """The project's ``install_requires``, or ``None`` if it cannot be read.
+
+    Extras are deliberately not collected. ``pip install -e .`` installs no extra
+    either, so re-resolving them here would give this path a behaviour the
+    reinstall it substitutes for does not have.
+    """
+    text = read_text(repo, "setup.cfg")
+    if text is None:
+        return None
+    cfg = configparser.ConfigParser()
+    try:
+        cfg.read_string(text)
+    except configparser.Error:
+        return None
+    if not cfg.has_option("options", "install_requires"):
+        return None
+    return _requirement_lines(cfg.get("options", "install_requires"))
+
+
+def dependency_authority_moved(repo: Path) -> str | None:
+    """Why setup.cfg is no longer where the requirements live, if it moved.
+
+    This module reads ONE file. A revision that migrates requirements into
+    pyproject's ``[project]`` table would leave setup.cfg stale, and reading it
+    would install yesterday's set while reporting success. setuptools treats a
+    field listed in ``[tool.setuptools.dynamic]`` as still coming from setup.cfg,
+    so only a NON-dynamic declaration in ``[project]`` means the move happened.
+
+    ``dynamic`` is matched item by item rather than as a substring: the list
+    ``["optional-dependencies"]`` CONTAINS the text ``dependencies`` while
+    declaring nothing about ``dependencies`` itself, and reading that as "still
+    dynamic" is what would let an explicit ``[project].dependencies`` be ignored
+    in favour of a stale setup.cfg.
+    """
+    text = read_text(repo, "pyproject.toml")
+    if text is None:
+        return None
+    table = project_table(repo)
+    if table is not None:
+        if "dependencies" not in table:
+            return None
+        if "dependencies" in _as_str_list(table.get("dynamic")):
+            return None
+        return "pyproject declares dependencies non-dynamically, so setup.cfg is stale"
+    project = _section(text, "[project]")
+    if not re.search(r"^\s*dependencies\s*=", project, re.MULTILINE):
+        return None
+    if "dependencies" in _dynamic_fields(project):
+        return None
+    return "pyproject declares dependencies non-dynamically, so setup.cfg is stale"
+
+
+def _as_str_list(value: object) -> list[str]:
+    """*value* as a list of strings, empty for anything else."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _dynamic_fields(project: str) -> set[str]:
+    """The field names in ``[project]``'s ``dynamic`` list, unquoted."""
+    match = re.search(r"^\s*dynamic\s*=\s*\[(?P<items>[^\]]*)\]", project, re.MULTILINE)
+    if not match:
+        return set()
+    return {item.strip().strip("\"'") for item in match.group("items").split(",")}
+
+
+def requires_python(repo: Path) -> str | None:
+    """The interpreter floor the checkout declares, from whichever file owns it.
+
+    pyproject's ``[project].requires-python`` is read FIRST because setuptools
+    reads it from there and IGNORES setup.cfg's ``python_requires`` whenever a
+    ``[project]`` table exists -- this repository says so in pyproject itself, and
+    carries the value in both files, so a revision that raises the floor in the
+    authoritative one would leave the setup.cfg copy stale. Reading the file the
+    build backend ignores is how this gate would silently stop firing.
+
+    setup.cfg remains the fallback for a checkout with no ``[project]`` table, or
+    one that declares the field dynamic.
+    """
+    text = read_text(repo, "pyproject.toml")
+    if text is not None:
+        table = project_table(repo)
+        if table is not None:
+            spec = table.get("requires-python")
+            if isinstance(spec, str) and "requires-python" not in _as_str_list(
+                table.get("dynamic")
+            ):
+                return spec.strip() or None
+        else:
+            project = _section(text, "[project]")
+            if "requires-python" not in _dynamic_fields(project):
+                match = re.search(
+                    r"^\s*requires-python\s*=\s*[\"'](?P<spec>[^\"']+)[\"']",
+                    project,
+                    re.MULTILINE,
+                )
+                if match:
+                    return match.group("spec").strip() or None
+    text = read_text(repo, "setup.cfg")
+    if text is None:
+        return None
+    cfg = configparser.ConfigParser()
+    try:
+        cfg.read_string(text)
+    except configparser.Error:
+        return None
+    if not cfg.has_option("options", "python_requires"):
+        return None
+    return cfg.get("options", "python_requires").strip() or None
+
+
+def interpreter_version(target_py: Path) -> tuple[int, int, int] | None:
+    """``(major, minor, micro)`` of *target_py*, or ``None`` if it cannot be asked."""
+    proc = subprocess.run(
+        [str(target_py), "-c", "import sys;print('%d.%d.%d' % sys.version_info[:3])"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    try:
+        major, minor, micro = proc.stdout.strip().split(".")
+        return int(major), int(minor), int(micro)
+    except ValueError:
+        return None
+
+
+def python_floor_breach(spec: str, version: tuple[int, int, int]) -> str | None:
+    """The highest ``requires-python`` floor *version* fails, if it fails one.
+
+    ``pip install -e .`` doubles as this project's interpreter gate: a revision
+    that raises its floor and starts using newer syntax is refused by pip rather
+    than installed. A dependency-only sync builds nothing, so pip applies no such
+    check and the gate has to be applied here or the merged revision becomes
+    unimportable under the interpreter that has to import it.
+
+    Three spellings all declare a floor and all have to be read as one, because a
+    floor this misses is a gate that does not fire: ``>=`` names the floor
+    directly, ``~=`` (compatible release) names it as its own lower bound, and
+    ``>`` names a floor the interpreter must EXCEED rather than merely meet.
+    Comparison is at three components, so ``>=3.10.5`` is not truncated to the
+    minor and then passed by a 3.10.0 interpreter.
+    """
+    breached: tuple[int, int, int] | None = None
+    for match in _PY_FLOOR.finditer(spec):
+        floor = (
+            int(match.group("major")),
+            int(match.group("minor")),
+            int(match.group("micro") or 0),
+        )
+        exclusive = match.group("op") == ">"
+        fails = version <= floor if exclusive else version < floor
+        if fails and (breached is None or floor > breached):
+            breached = floor
+    if breached is None:
+        return None
+    return f"{breached[0]}.{breached[1]}.{breached[2]}"
+
+
+def installed_package_origin(target_py: Path) -> str | None:
+    """Where *target_py*'s venv resolves this project's package FROM.
+
+    Read through the target interpreter because the venv being written to is not
+    necessarily this process's own. ``find_spec`` rather than an import, so nothing
+    in the package runs; and the spec rather than installed metadata, because the
+    metadata only proxies for this answer -- a working PEP 660 editable install can
+    have no ``direct_url.json`` at all, and refusing that venv would refuse the
+    ordinary single-checkout layout this step exists to serve. The import path is
+    what the installed dependencies will be imported alongside, so it is the thing
+    worth checking.
+
+    Returns ``None`` when the package cannot be located at all.
+    """
+    probe = (
+        "import importlib.util as u, os;"
+        "s=u.find_spec('kiro_crew');"
+        "print(os.path.abspath(s.origin) if s and s.origin else '')"
+    )
+    proc = subprocess.run(
+        [str(target_py), "-c", probe],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def venv_not_mapped_to(origin: str | None, repo: Path) -> str | None:
+    """Why the venv at *origin* cannot be shown to serve *repo*, if it cannot.
+
+    The venv is addressed as ``<repo>/.venv``, but that is a location, not a
+    binding: nothing stops it from being an install of a DIFFERENT checkout.
+    Installing this revision's dependencies into such a venv upgrades the runtime
+    another checkout is served by, which is how a working checkout gets broken by a
+    sync that never touched it.
+
+    The test is whether that venv imports this project from inside *repo*. An
+    unreadable answer refuses too -- unproven is not the same as safe.
+    """
+    if origin is None:
+        return (
+            "the target venv does not resolve this project's package at all, so it "
+            "cannot be shown to serve this checkout"
+        )
+    mapped = os.path.normcase(str(Path(origin).resolve()))
+    root = os.path.normcase(str(Path(repo).resolve()))
+    if mapped != root and not mapped.startswith(root + os.sep):
+        return (
+            f"the target venv imports this project from {Path(origin).resolve()}, "
+            f"which is outside {Path(repo).resolve()}, so a dependency install "
+            "would change a runtime this sync does not own"
+        )
+    return None
+
+
+def project_table(repo: Path) -> dict[str, Any] | None:
+    """pyproject's ``[project]`` table, PARSED, or ``None`` if it cannot be.
+
+    Every question this module asks of pyproject -- where the requirements live,
+    what the interpreter floor is, what the console script dispatches to -- was
+    first answered by matching text, and each round of review found another
+    spelling where matching text and reading TOML disagree: a list item whose name
+    merely CONTAINS another (`optional-dependencies`), and a table header with a
+    trailing comment (``[project] # comment``). Those are not three bugs, they are
+    one: a hand-rolled reader answering a question only a parser can answer.
+
+    So a parser answers it wherever one exists -- ``tomllib`` on 3.11+, ``tomli``
+    if the venv happens to carry it, exactly the ladder ``onboarding_import``
+    already uses. ``None`` means neither was importable (a 3.10 venv without
+    ``tomli``), and each caller then falls back to its text reader, which is
+    best-effort by nature; that residual is stated in the PR rather than hidden.
+    """
+    if _toml is None:
+        return None
+    text = read_text(repo, "pyproject.toml")
+    if text is None:
+        return None
+    try:
+        parsed = _toml.loads(text)
+    except Exception:
+        # A pyproject this module cannot parse is not a pyproject it should guess
+        # about; the caller's text reader is no better informed, so say so once.
+        return None
+    project = parsed.get("project")
+    return project if isinstance(project, dict) else None
+
+
+def _section(toml_text: str, header: str) -> str:
+    """The body of one top-level TOML table, by literal header line.
+
+    A regex read of one table, not a TOML parse: ``tomllib`` is 3.11+ and this
+    project supports 3.10, so a dependency-free read of two well-known tables is
+    preferred over adding a parser for it.
+    """
+    lines = toml_text.splitlines()
+    out: list[str] = []
+    inside = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("["):
+            if inside:
+                break
+            # `[project] # comment` is a valid header. Comparing the whole line
+            # would read it as a different table and skip the body underneath.
+            inside = stripped.split("#", 1)[0].strip() == header
+            continue
+        if inside:
+            out.append(line)
+    return "\n".join(out)
+
+
+def console_script_target(repo: Path, script: str) -> str | None:
+    """The ``module:attr`` *script* is declared to dispatch to, or ``None``.
+
+    pyproject's ``[project.scripts]`` is read FIRST because that is what setuptools
+    builds the wrapper from whenever ``scripts`` is not listed as dynamic; setup.cfg
+    is the fallback for a checkout that still declares them there.
+    """
+    pyproject = read_text(repo, "pyproject.toml")
+    if pyproject:
+        table = project_table(repo)
+        if table is not None:
+            scripts = table.get("scripts")
+            if isinstance(scripts, dict):
+                target = scripts.get(script)
+                if isinstance(target, str) and target.strip():
+                    return target.strip()
+        else:
+            scripts_text = _section(pyproject, "[project.scripts]")
+            match = re.search(
+                rf'^\s*["\']?{re.escape(script)}["\']?\s*=\s*["\'](?P<target>[^"\']+)["\']',
+                scripts_text,
+                re.MULTILINE,
+            )
+            if match:
+                return match.group("target").strip()
+    cfg_text = read_text(repo, "setup.cfg")
+    if cfg_text is None:
+        return None
+    cfg = configparser.ConfigParser()
+    try:
+        cfg.read_string(cfg_text)
+    except configparser.Error:
+        return None
+    if not cfg.has_option("options.entry_points", "console_scripts"):
+        return None
+    for line in _requirement_lines(cfg.get("options.entry_points", "console_scripts")):
+        name, _, target = line.partition("=")
+        if name.strip() == script:
+            return target.strip() or None
+    return None
+
+
+def installed_console_script_target(target_py: Path, script: str) -> str | None:
+    """The ``module:attr`` *script* currently dispatches to in *target_py*'s venv.
+
+    Reads the entry points off the ``kirocrew`` distribution rather than the
+    module-level ``entry_points()`` selector: that function returns a group->list
+    mapping on 3.10/3.11 and an ``EntryPoints`` sequence on 3.12+, and this project
+    supports both. A distribution's own ``entry_points`` is a sequence in every
+    supported version, and scoping the lookup to the distribution also keeps a
+    same-named script from another package out of the answer.
+
+    Returns ``None`` when the answer cannot be read at all. The caller only
+    compares two KNOWN values, so an unreadable probe stays quiet instead of
+    reporting a problem it has no evidence for.
+    """
+    probe = (
+        "import importlib.metadata as m;"
+        "d=m.distribution('kirocrew');"
+        "print(next((e.value for e in d.entry_points"
+        f" if e.group=='console_scripts' and e.name=={script!r}), ''))"
+    )
+    proc = subprocess.run(
+        [str(target_py), "-c", probe],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _refuse(message: str, target_py: Path, repo: Path, remedy: str | None = None) -> int:
+    if remedy is None:
+        remedy = (
+            "Stop the gateway and finish the sync from a terminal: "
+            f'"{target_py}" -m pip install -e "{repo}"'
+        )
+    print(
+        f"dep-sync: {message} No dependency was installed. {remedy}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 2:
+        print("usage: dep_sync <repo> <target-python>", file=sys.stderr)
+        return 2
+    repo, target_py = Path(args[0]), Path(args[1])
+
+    # Establish that the venv about to be written to serves THIS checkout before
+    # anything is installed. `<repo>/.venv` is where the interpreter was found,
+    # which says nothing about what it is an install of.
+    foreign = venv_not_mapped_to(installed_package_origin(target_py), repo)
+    if foreign:
+        return _refuse(
+            f"{foreign}.",
+            target_py,
+            repo,
+            remedy=(
+                "Give this checkout its own editable install, or run the sync from "
+                "the checkout that venv serves."
+            ),
+        )
+
+    # This module reads one file for the requirements, so a revision that moved
+    # them elsewhere has to stop the step rather than have it install a stale set.
+    moved = dependency_authority_moved(repo)
+    if moved:
+        return _refuse(f"{moved}, so this step would install a stale set.", target_py, repo)
+
+    specs = declared_requirements(repo)
+    if specs is None:
+        return _refuse(
+            "cannot read install_requires from setup.cfg, so the requirements to "
+            "install are unknown.",
+            target_py,
+            repo,
+        )
+
+    # The interpreter gate `pip install -e .` applies while building the project.
+    floor_spec = requires_python(repo)
+    version = interpreter_version(target_py) if floor_spec else None
+    if floor_spec and version:
+        breach = python_floor_breach(floor_spec, version)
+        if breach:
+            return _refuse(
+                f"the merged revision requires Python {floor_spec} but the target "
+                f"venv runs {version[0]}.{version[1]}.{version[2]}, so its code "
+                "cannot be imported.",
+                target_py,
+                repo,
+            )
+
+    if not specs:
+        print("dep-sync: no requirements declared; nothing to install")
+    else:
+        rejected = rejected_specs(specs)
+        if rejected:
+            return _refuse(
+                "the merged revision declares requirements this step will not hand "
+                f"to pip: {'; '.join(rejected)}.",
+                target_py,
+                repo,
+            )
+        print(
+            f"dep-sync: installing {len(specs)} declared requirements; extras are "
+            "left alone, exactly as a plain `pip install -e .` leaves them"
+        )
+        # Hand every spec to pip and let it decide: an already-satisfied requirement
+        # is a no-op, so this installs what is new and leaves the rest alone without
+        # this module ever comparing a version or evaluating a marker. The project
+        # itself is deliberately absent -- installing it is what would rewrite the
+        # locked console script.
+        # `--` ends pip's option parsing, so a declared requirement can never be
+        # read as a flag.
+        proc = subprocess.run([str(target_py), "-m", "pip", "install", "--", *specs])
+        if proc.returncode != 0:
+            return proc.returncode
+
+    # The one thing a dependency-only install cannot deliver: if the merged
+    # revision REPOINTED the console script, the wrapper on disk still dispatches
+    # to the old target and no amount of dependency installing refreshes it. The
+    # dependencies are installed by now, so this reports rather than refuses.
+    declared = console_script_target(repo, _SCRIPT)
+    installed = installed_console_script_target(target_py, _SCRIPT)
+    if declared and installed and declared != installed:
+        print(
+            f"dep-sync: dependencies are installed, but the {_SCRIPT!r} console "
+            f"script is repointed to {declared} by the merged revision while the "
+            f"installed wrapper still calls {installed}. That wrapper cannot be "
+            "rewritten while a process is running from it: stop the gateway and run "
+            f'"{target_py}" -m pip install -e "{repo}" before restarting.',
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    raise SystemExit(main())

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -42,6 +42,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from datetime import datetime, timezone
@@ -51,7 +52,7 @@ from typing import Any, Callable
 from aiohttp import web
 
 from kiro_crew import frontend, hooks, platform_compat
-from kiro_crew.apps.builtins.dev_fleet import gateway_service
+from kiro_crew.apps.builtins.dev_fleet import dep_sync, gateway_service
 from kiro_crew.apps.proxy_auth import raw_request_target
 from kiro_crew.env import find_node_tool, node_bin_dirs
 from kiro_crew.executors import subprocess_executor
@@ -1366,8 +1367,24 @@ async def _start_run(
                 _RUNS[rid]["output"].append("[error] " + str(exc))
         finally:
             for cp in (cleanup_paths or []):
+                # A caller may register a temp FILE, or a temp directory it
+                # created for one (the dependency-only sync stages a snapshot
+                # that way). unlink refuses a directory, so fall back to rmdir
+                # rather than leaking one temp dir per run.
                 try:
                     os.unlink(cp)
+                except IsADirectoryError:
+                    try:
+                        os.rmdir(cp)
+                    except OSError:
+                        pass
+                except PermissionError:
+                    # Windows raises PermissionError, not IsADirectoryError,
+                    # when unlink is handed a directory.
+                    try:
+                        os.rmdir(cp)
+                    except OSError:
+                        pass
                 except OSError:
                     pass
 
@@ -3595,51 +3612,81 @@ async def _sync_start_locked() -> dict:
             "service environment; that one does need a restart, because a "
             "running process cannot see a new environment variable."
         )}
+    # A locked console script does not have to mean the sync cannot happen.
+    #
+    # pip cannot replace a running executable on Windows, and its uninstall is
+    # not atomic: it renames the dist-info aside and deletes the editable `.pth`
+    # before it reaches the locked script, rolling back neither. So
+    # `pip install -e .` must not run against a venv serving this gateway.
+    #
+    # It does not have to run at all, though. An editable install needs no
+    # reinstall for a source change -- `src` is already on `sys.path`, so merged
+    # code is live the moment the merge lands. The only thing the reinstall was
+    # still buying is a dependency a new revision added, and installing a
+    # dependency never touches the project's own console script.
+    #
+    # The substitute keeps the SAME shape as the reinstall it stands in for:
+    # `fetch -> merge -> install the project's requirements`, in that order, with
+    # the project itself left out. Deviating from that shape -- installing before
+    # the merge so a failure cannot strand a merged checkout -- was tried and
+    # abandoned: it requires proving in advance that the merge cannot fail, which
+    # needs a growing set of preconditions that still cannot be complete. A failed
+    # install after a landed merge is what every other platform already does when
+    # its reinstall step fails.
+    #
+    # The substitute step runs with THIS backend's interpreter for the same
+    # reason the build+stage step does: the logic is revision-independent, so
+    # resolving it from the target would make the step's very EXISTENCE
+    # contingent on the pulled revision carrying dep_sync.
+    #
+    # It runs a pre-merge SNAPSHOT of that module, by path, and neither half of
+    # that is incidental. `-m kiro_crew...dep_sync` would import the module from
+    # the working tree AFTER the merge has landed, dragging in the whole package
+    # __init__ chain with it -- so a revision that raises the `requires-python`
+    # floor and uses newer syntax anywhere in that chain would die with a
+    # SyntaxError while being parsed, and the floor refusal that exists for
+    # exactly that revision could never run. Copying the module first and
+    # executing the copy keeps the only parsed file one this interpreter has
+    # already imported, which makes the refusal reachable in the case it is
+    # written for. Running it by path rather than by module name is what keeps
+    # the package chain out of it; the module imports nothing but the standard
+    # library, so it needs no package context.
+    #
+    # This mirrors pip rather than deviating from it: the INSTALLED pip reads the
+    # merged project's metadata, and an old pip refusing a too-new project is the
+    # behaviour being stood in for here.
+    fetch_step = ([git_bin, "fetch", remote, BASE_BRANCH], "standard",
+                  _build_env(with_credentials=True), "Pull")
+    merge_step = ([git_bin, "merge", "--ff-only", f"{remote}/{BASE_BRANCH}"], "strict",
+                  _build_env(), "Pull")
+    dep_sync_snapshot: Path | None = None
     if locked_scripts:
-        # Refuse the WHOLE sync rather than omitting just the reinstall.
-        #
-        # pip cannot replace a running executable on Windows, and its uninstall
-        # is not atomic: it renames the dist-info aside and deletes the editable
-        # `.pth` before it reaches the locked script, rolling back neither. That
-        # alone argues for not starting pip.
-        #
-        # But merging without installing is not a safe consolation prize. A
-        # revision that adds a dependency would land on disk with that dependency
-        # absent, the run would exit 0, and the UI would offer "restart gateway
-        # to apply" — so the next restart imports the new code, fails on the
-        # missing import, and the gateway does not come back. Any newly spawned
-        # subprocess hits the same gap even without a restart. That is the same
-        # unstartable-gateway outcome this guard exists to prevent, just later
-        # and with a success report in front of it.
-        #
-        # The checkout is therefore left at a revision whose dependencies are
-        # satisfied, and the remedy names itself.
-        return {"ok": False, "error": (
-            "refusing to sync: cannot reinstall into the venv this gateway runs "
-            f"from. {', '.join(locked_scripts)} is locked by a running process, so "
-            "a reinstall cannot replace it — and pip's uninstall is not "
-            "atomic, so attempting it would strip the editable install on the way "
-            "out and leave the venv unable to import the package at all. Pulling "
-            "without installing is refused too: a revision whose new dependencies "
-            "are missing crashes the gateway on its next restart. Stop the gateway "
-            "and sync from a terminal instead: "
-            # Every path is absolute and quoted. `-e .` would resolve against the
-            # terminal's cwd, and this project's normal working state is several
-            # worktrees side by side — so a command copied out of a feature
-            # worktree would install THAT checkout into the primary venv and
-            # repoint its editable install at the wrong tree. `git -C` already
-            # pins the pull, which makes an unpinned `.` actively misleading:
-            # the line reads as if it were cwd-independent. Quoting covers the
-            # spaces that are normal in a Windows home directory.
-            f'git -C "{repo}" pull --ff-only '
-            f'&& "{target_py}" -m pip install -e "{repo}"'
-        )}
-    raw_steps: list[tuple[list[str], str, dict, str]] = [
-        ([git_bin, "fetch", remote, BASE_BRANCH], "standard",
-         _build_env(with_credentials=True), "Pull"),
-        ([git_bin, "merge", "--ff-only", f"{remote}/{BASE_BRANCH}"], "strict", _build_env(), "Pull"),
-        ([str(target_py), "-m", "pip", "install", "-e", "."], "strict", _build_env(), "pip install"),
-    ]
+        logger.info(
+            "dev-fleet: %s locked by a running process; substituting a "
+            "dependency-only sync for the editable reinstall",
+            ", ".join(locked_scripts),
+        )
+        # mkdtemp, not a fixed path under the system temp dir: executing a script
+        # by path puts its DIRECTORY on sys.path, so a shared or predictable
+        # directory would let anything dropped beside the snapshot shadow a
+        # stdlib module the snapshot imports. mkdtemp is unguessable and 0o700.
+        snapshot_dir = Path(tempfile.mkdtemp(prefix="kirocrew-dep-sync-"))
+        dep_sync_snapshot = snapshot_dir / "dep_sync.py"
+        shutil.copyfile(dep_sync.__file__, dep_sync_snapshot)
+        steps = [
+            fetch_step,
+            merge_step,
+            ([sys.executable, str(dep_sync_snapshot), str(repo), str(target_py)],
+             "strict", _build_env(), "pip install"),
+        ]
+    else:
+        steps = [
+            fetch_step,
+            merge_step,
+            ([str(target_py), "-m", "pip", "install", "-e", "."], "strict",
+             _build_env(), "pip install"),
+        ]
+    raw_steps: list[tuple[list[str], str, dict, str]] = steps
     # The whole FRONTEND half of the sync is skipped on an edition checkout.
     #
     # The build runs under _build_env(), whose allowlist (_SAFE_ENV_KEYS) drops
@@ -3690,6 +3737,10 @@ async def _sync_start_locked() -> dict:
              "strict", _build_env(), "npm build + stage"),
         ]
     cleanups: list[str] = []
+    if dep_sync_snapshot is not None:
+        # File first, then its directory: the cleanup loop removes entries in
+        # order, and a directory cannot go until it is empty.
+        cleanups += [str(dep_sync_snapshot), str(dep_sync_snapshot.parent)]
     wrapped_steps: list[dict] = []
     loop = asyncio.get_running_loop()
     for argv, mode, base_env, label in raw_steps:

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -1019,52 +1019,82 @@ async def _run_sync(mod, locked):
             result = await mod._sync_start_locked()
     mod._UPSTREAM_REMOTE = None
     script = mock_start.call_args[0][1][2] if mock_start.call_args else None
+    # Stubbing _start_run also stubs out its `finally` cleanup, so anything the
+    # sync staged for removal (the dependency-only path snapshots dep_sync into a
+    # temp dir) would outlive the test. Remove exactly what it registered, in the
+    # order it registered it — file before directory.
+    if mock_start.call_args:
+        for path in mock_start.call_args.kwargs.get("cleanup_paths") or []:
+            try:
+                os.unlink(path)
+            except OSError:
+                try:
+                    os.rmdir(path)
+                except OSError:
+                    pass
     return result, script
 
 
 @pytest.mark.asyncio
-async def test_sync_refuses_entirely_when_a_console_script_is_locked():
-    """Nothing may run — not even fetch/merge.
+async def test_sync_substitutes_a_dependency_only_install_when_a_script_is_locked():
+    """The sync proceeds; only the editable reinstall is swapped out.
 
-    pip cannot replace the locked binary, and merging anyway is not a safe
-    consolation prize: a revision that adds a dependency would land with that
-    dependency absent, the run would report success, and the next restart would
-    fail to import it. Leaving the checkout on a revision whose dependencies are
-    satisfied is the only outcome that cannot brick the gateway.
+    pip cannot replace the locked wrapper, but it does not have to. An editable
+    install serves source straight from ``src``, so the merge alone makes the new
+    revision live; the only thing the reinstall was still buying is a dependency
+    the revision added, and installing a dependency never touches the project's
+    own console script. Refusing the whole sync instead left the single-checkout
+    Windows layout — the ordinary one — with no working Pull+build at all.
     """
     import kiro_crew.apps.builtins.dev_fleet.server as mod
+    from kiro_crew.apps.builtins.dev_fleet import dep_sync
 
     result, script = await _run_sync(mod, [r"C:\repo\.venv\Scripts\kirocrew.exe"])
 
-    assert result["ok"] is False
-    # No run was started at all, so fetch/merge never happened.
-    assert script is None
-    err = result["error"]
-    assert "kirocrew.exe" in err          # names the blocker
-    assert "pip install -e" in err        # and the remedy
-    assert "Stop the gateway" in err
+    assert result["ok"] is True
+    # A run was started, so fetch and merge do happen.
+    assert script is not None
+    # Steps are JSON-embedded in the generated script, so quotes arrive escaped;
+    # comparing against a de-escaped copy keeps these assertions independent of
+    # how many encoding layers the script generator happens to use.
+    flat = script.replace("\\", "")
+    assert "dep_sync.py" in flat
+    assert '"-e"' not in flat
+    # It must NOT be run as `-m kiro_crew...dep_sync`. That would import the
+    # module from the working tree after the merge has landed, pulling the whole
+    # package __init__ chain with it, so a revision that raises the
+    # `requires-python` floor with newer syntax would SyntaxError while being
+    # parsed and the floor refusal written for that revision could never run.
+    assert dep_sync.__name__ not in flat
+    assert '"-m"' not in flat.split('"merge"', 1)[1]
+    # The file it runs is a snapshot taken BEFORE the merge, so it lives outside
+    # the checkout being synced.
+    assert r"C:repo\dep_sync.py" not in flat
+    # ORDER MATTERS, and it is the SAME order the reinstall it replaces uses:
+    # fetch -> merge -> install. Installing first would need the merge to be
+    # proven impossible to fail, which cannot be done completely; a failed install
+    # after a landed merge is exactly what the reinstall path already does.
+    assert flat.index('"merge"') < flat.index("dep_sync.py")
 
 
 @pytest.mark.asyncio
-async def test_refusal_remedy_is_cwd_independent_and_quoted():
-    """The suggested command must not depend on where it is pasted.
+async def test_sync_keeps_the_editable_reinstall_when_nothing_is_locked():
+    """A venv this gateway is NOT served by must still get the real reinstall.
 
-    `-e .` resolves against the terminal's cwd, and this project is normally
-    checked out as several worktrees at once — so the same line copied from a
-    feature worktree would install THAT tree into the primary venv and repoint
-    its editable install away from the primary checkout. Both paths are also
-    quoted, because a Windows home directory routinely contains a space.
+    The substitution is a concession to a lock, not an improvement to prefer: it
+    cannot refresh a console script, so anywhere pip can do the whole job, it
+    should.
     """
     import kiro_crew.apps.builtins.dev_fleet.server as mod
+    from kiro_crew.apps.builtins.dev_fleet import dep_sync
 
-    result, _ = await _run_sync(mod, [r"C:\repo\.venv\Scripts\kirocrew.exe"])
-    err = result["error"]
+    result, script = await _run_sync(mod, [])
 
-    # The install target is named explicitly, never left to the shell's cwd —
-    # including in the prose, so the message never shows the misleading form.
-    assert "pip install -e ." not in err
-    assert f'pip install -e "{_SYNC_REPO}"' in err
-    assert f'git -C "{_SYNC_REPO}"' in err
+    assert result["ok"] is True
+    flat = script.replace("\\", "")
+    assert '"-e"' in flat
+    assert dep_sync.__name__ not in flat
+    assert "dep_sync.py" not in flat
 
 
 @pytest.mark.asyncio

--- a/test/test_dev_fleet_dep_sync.py
+++ b/test/test_dev_fleet_dep_sync.py
@@ -1,0 +1,481 @@
+"""Tests for the dependency-only sync that stands in for a blocked reinstall.
+
+The module exists because Windows cannot rewrite a running console script, so
+these tests pin what the substitution rests on: it is shaped as PARITY with
+``pip install -e .`` rather than as an improvement on it (same order, same scope,
+extras left alone), it never hands the project itself to pip, it applies the two
+gates a dependency-only install cannot inherit from pip (the interpreter floor and
+a repointed console script), and it refuses to write to a venv that serves a
+different checkout.
+"""
+
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.apps.builtins.dev_fleet import dep_sync
+
+_SETUP_CFG = textwrap.dedent("""
+    [options]
+    python_requires = >=3.10
+    install_requires =
+        # a full-line comment configparser keeps
+        aiohttp>=3.9
+        tzdata>=2024.1; platform_system == "Windows"
+
+    [options.extras_require]
+    voice =
+        boto3>=1.34,<2
+    """).strip()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A checkout whose working tree carries the declarations, post-merge."""
+    (tmp_path / "setup.cfg").write_text(_SETUP_CFG, encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _preconditions_ok(request):
+    """Stub the venv probe for the ``main()`` tests only.
+
+    The probe has its own direct tests; stubbing it here keeps the main() tests
+    about what main does with the answers, and stops them reaching a real
+    interpreter through the mocked subprocess. The venv-mapping COMPARISON is
+    deliberately left real, so a main() test can make the venv foreign by changing
+    the probe's answer.
+    """
+    if not request.node.name.startswith("test_main_"):
+        yield
+        return
+    with patch.object(dep_sync, "installed_package_origin", side_effect=_origin_inside):
+        yield
+
+
+def _origin_inside(target_py):
+    """A probe answer that resolves inside whatever repo the test passed."""
+    return str(Path(_origin_inside.repo) / "src" / "kiro_crew" / "__init__.py")
+
+
+def test_normalize_folds_the_spellings_pep503_treats_as_one():
+    """The folding matters only through `rejected_specs`, so it is tested here."""
+    assert dep_sync.normalize("Kiro_Crew") == "kiro-crew"
+    assert dep_sync.normalize("KIROCREW") == "kirocrew"
+    assert dep_sync.normalize("kiro.crew") == "kiro-crew"
+
+
+def test_declared_requirements_reads_install_requires_and_drops_comments(repo):
+    specs = dep_sync.declared_requirements(repo)
+
+    assert specs == ["aiohttp>=3.9", 'tzdata>=2024.1; platform_system == "Windows"']
+
+
+def test_declared_requirements_leaves_extras_alone(repo):
+    """`pip install -e .` installs no extra, so neither does this.
+
+    Inferring which extras the operator asked for is what this design removed: pip
+    records no such thing, so the inference has unavoidable false negatives -- an
+    extra whose platform-specific dependency legitimately went uninstalled reads as
+    inactive and its other requirements get skipped.
+    """
+    specs = dep_sync.declared_requirements(repo)
+
+    assert specs is not None
+    assert not any("boto3" in spec for spec in specs)
+
+
+def test_declared_requirements_returns_none_when_unreadable(tmp_path):
+    assert dep_sync.declared_requirements(tmp_path) is None
+
+
+def test_pyproject_is_read_with_a_parser_not_by_matching_text(repo):
+    """A table header may carry a trailing comment, and a parser knows that.
+
+    `[project] # comment` is valid TOML. The text reader compared the whole
+    header line, so it read this as a different table and skipped the body --
+    which meant an explicit `dependencies` and a raised floor underneath it were
+    both invisible, and the step installed a stale setup.cfg list. Every question
+    asked of pyproject now goes through a real parser wherever one exists.
+    """
+    (repo / "pyproject.toml").write_text(
+        "[project] # the table this module has to read\n"
+        'name = "kirocrew"\n'
+        'requires-python = ">=3.13"\n'
+        'dependencies = ["aiohttp"]\n',
+        encoding="utf-8",
+    )
+
+    assert dep_sync.project_table(repo) is not None
+    assert dep_sync.requires_python(repo) == ">=3.13"
+    assert dep_sync.dependency_authority_moved(repo) is not None
+
+
+def test_text_fallback_also_survives_a_commented_header(repo, monkeypatch):
+    """The 3.10-without-tomli path has no parser, so its reader must not regress."""
+    monkeypatch.setattr(dep_sync, "_toml", None)
+    (repo / "pyproject.toml").write_text(
+        '[project]   # trailing comment\nname = "kirocrew"\n'
+        'requires-python = ">=3.13"\ndependencies = ["aiohttp"]\n',
+        encoding="utf-8",
+    )
+
+    assert dep_sync.project_table(repo) is None
+    assert dep_sync.requires_python(repo) == ">=3.13"
+    assert dep_sync.dependency_authority_moved(repo) is not None
+
+
+def test_requires_python_is_read_from_the_working_tree(repo):
+    assert dep_sync.requires_python(repo) == ">=3.10"
+
+
+def test_requires_python_prefers_pyproject_because_setuptools_ignores_setup_cfg(repo):
+    """The gate must read the file the BUILD reads, or it stops firing.
+
+    Once a ``[project]`` table exists setuptools takes ``requires-python`` from it
+    and ignores setup.cfg's ``python_requires``. This repository carries the value
+    in both files, so a revision raising the floor in the authoritative one would
+    leave the setup.cfg copy stale -- and a gate reading the stale copy is a gate
+    that silently passes the interpreter it should refuse.
+    """
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\nrequires-python = ">=3.13"\n' 'dynamic = ["dependencies"]\n',
+        encoding="utf-8",
+    )
+
+    # setup.cfg still says >=3.10; pyproject wins.
+    assert dep_sync.requires_python(repo) == ">=3.13"
+
+
+def test_requires_python_falls_back_when_pyproject_declares_it_dynamic(repo):
+    """A field listed as dynamic is still setup.cfg's to declare."""
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\ndynamic = ["requires-python", "dependencies"]\n',
+        encoding="utf-8",
+    )
+
+    assert dep_sync.requires_python(repo) == ">=3.10"
+
+
+def test_python_floor_breach_reports_the_highest_unmet_floor():
+    assert dep_sync.python_floor_breach(">=3.10", (3, 12, 0)) is None
+    assert dep_sync.python_floor_breach(">=3.13", (3, 10, 0)) == "3.13.0"
+    assert dep_sync.python_floor_breach(">=3.11,>=3.13", (3, 10, 0)) == "3.13.0"
+    assert dep_sync.python_floor_breach(">=3.10,<4", (3, 10, 0)) is None
+
+
+def test_python_floor_breach_reads_every_spelling_that_declares_a_floor():
+    """A floor spelling this misses is a gate that does not fire."""
+    # Compatible release: `~=3.11` is `>=3.11, ==3.*`, so it declares a floor.
+    assert dep_sync.python_floor_breach("~=3.11", (3, 10, 7)) == "3.11.0"
+    assert dep_sync.python_floor_breach("~=3.10", (3, 12, 0)) is None
+    # Three components compared as three: `>=3.10.5` must not truncate to (3, 10)
+    # and then be satisfied by 3.10.0.
+    assert dep_sync.python_floor_breach(">=3.10.5", (3, 10, 0)) == "3.10.5"
+    assert dep_sync.python_floor_breach(">=3.10.5", (3, 10, 5)) is None
+    # `>` excludes the version it names, unlike `>=`.
+    assert dep_sync.python_floor_breach(">3.10", (3, 10, 0)) == "3.10.0"
+    assert dep_sync.python_floor_breach(">3.10", (3, 10, 1)) is None
+    assert dep_sync.python_floor_breach(">=3.10", (3, 10, 0)) is None
+
+
+def test_dependency_authority_moved_detects_a_migration_to_pyproject(repo):
+    """This module reads ONE file; a move would make it install yesterday's set."""
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\ndependencies = ["aiohttp"]\n', encoding="utf-8"
+    )
+
+    assert dep_sync.dependency_authority_moved(repo) is not None
+
+
+def test_dependency_authority_moved_matches_dynamic_items_not_substrings(repo):
+    """`["optional-dependencies"]` contains the text but declares nothing here.
+
+    Reading it as a substring would treat explicit `[project].dependencies` as
+    still dynamic and install a stale setup.cfg list while reporting success.
+    """
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\ndependencies = ["aiohttp"]\n'
+        'dynamic = ["optional-dependencies"]\n',
+        encoding="utf-8",
+    )
+
+    assert dep_sync.dependency_authority_moved(repo) is not None
+
+
+def test_dependency_authority_intact_when_fields_stay_dynamic(repo):
+    """setuptools keeps reading setup.cfg for a field listed as dynamic."""
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\ndynamic = ["dependencies", "version"]\n',
+        encoding="utf-8",
+    )
+
+    assert dep_sync.dependency_authority_moved(repo) is None
+
+
+def test_console_script_target_prefers_the_pyproject_declaration(repo):
+    """`scripts` is not dynamic here, so pyproject is what builds the wrapper."""
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\ndynamic = ["dependencies"]\n\n'
+        '[project.scripts]\nkirocrew = "kiro_crew.new:main"\n',
+        encoding="utf-8",
+    )
+
+    assert dep_sync.console_script_target(repo, "kirocrew") == "kiro_crew.new:main"
+
+
+def test_console_script_target_falls_back_to_setup_cfg(repo):
+    (repo / "setup.cfg").write_text(
+        _SETUP_CFG + "\n\n[options.entry_points]\nconsole_scripts =\n"
+        "    kirocrew = kiro_crew.old:main\n",
+        encoding="utf-8",
+    )
+
+    assert dep_sync.console_script_target(repo, "kirocrew") == "kiro_crew.old:main"
+
+
+def test_rejected_specs_refuses_paths_archives_and_the_project_itself():
+    """The premise -- pip is never asked for the project -- is enforced, not assumed."""
+    for hostile in [".", "./local", "/abs/path", r"C:\pkgs\x", "file:./x", "x.whl", "-e"]:
+        assert dep_sync.rejected_specs([hostile]), hostile
+
+    # Only spellings PEP 503 actually folds onto this project's name. `kiro_crew`
+    # normalizes to `kiro-crew`, which is a DIFFERENT distribution, so it is not
+    # claimed here.
+    for spelling in [
+        "kirocrew",
+        "KiroCrew",  # brand-ok: a PEP 503 spelling of the distribution name
+        "KIROCREW",
+        "kirocrew>=1",
+    ]:
+        rejected = dep_sync.rejected_specs([spelling])
+        assert rejected and "names this project" in rejected[0], spelling
+
+    assert dep_sync.rejected_specs(["aiohttp>=3.9", "boto3"]) == []
+
+
+def test_installed_package_origin_reports_where_the_package_resolves():
+    """The import path is what the installed dependencies live alongside."""
+
+    class _Proc:
+        returncode = 0
+        stdout = "/checkouts/main/src/kiro_crew/__init__.py\n"
+
+    with patch.object(dep_sync.subprocess, "run", return_value=_Proc()):
+        origin = dep_sync.installed_package_origin(Path("py"))
+
+    assert origin is not None
+    assert Path(origin).name == "__init__.py"
+
+
+def test_installed_package_origin_is_none_when_the_package_is_absent():
+    class _Proc:
+        returncode = 0
+        stdout = "\n"
+
+    with patch.object(dep_sync.subprocess, "run", return_value=_Proc()):
+        assert dep_sync.installed_package_origin(Path("py")) is None
+
+
+def test_venv_serving_another_checkout_is_reported(tmp_path):
+    """The harm this guards: upgrading a runtime another checkout is served by."""
+    reason = dep_sync.venv_not_mapped_to(
+        str(tmp_path / "other" / "src" / "kiro_crew" / "__init__.py"), tmp_path / "main"
+    )
+
+    assert reason is not None
+    assert "other" in reason
+    assert "main" in reason
+
+
+def test_an_unresolvable_package_is_not_taken_as_a_match(tmp_path):
+    """Unproven is refused, not assumed."""
+    assert dep_sync.venv_not_mapped_to(None, tmp_path / "main") is not None
+
+
+def test_a_venv_serving_this_checkout_passes(tmp_path):
+    repo = tmp_path / "main"
+    origin = repo / "src" / "kiro_crew" / "__init__.py"
+
+    assert dep_sync.venv_not_mapped_to(str(origin), repo) is None
+
+
+def test_a_sibling_directory_sharing_the_prefix_does_not_count_as_inside(tmp_path):
+    """`<repo>-wt` starts with `<repo>` as a string but is a different checkout."""
+    sibling = tmp_path / "main-wt" / "src" / "kiro_crew" / "__init__.py"
+
+    assert dep_sync.venv_not_mapped_to(str(sibling), tmp_path / "main") is not None
+
+
+def test_main_hands_every_spec_to_pip_and_stops_on_failure(repo):
+    """pip decides satisfaction; a failed install must not report success."""
+    _origin_inside.repo = repo
+    calls = []
+
+    class _Proc:
+        def __init__(self, rc):
+            self.returncode = rc
+            self.stdout = ""
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "pip" in cmd:
+            return _Proc(1)
+        return _Proc(0)
+
+    with patch.object(dep_sync.subprocess, "run", side_effect=fake_run):
+        rc = dep_sync.main([str(repo), "py"])
+
+    assert rc == 1
+    pip_call = next(c for c in calls if "pip" in c)
+    assert "aiohttp>=3.9" in pip_call
+    assert 'tzdata>=2024.1; platform_system == "Windows"' in pip_call
+    assert "-e" not in pip_call
+
+
+def test_main_ends_pip_option_parsing_before_the_specs(repo):
+    """A declaration beginning with `-` must never be read as a pip option."""
+    _origin_inside.repo = repo
+    calls = []
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Proc()
+
+    with (
+        patch.object(dep_sync, "declared_requirements", return_value=["aiohttp"]),
+        patch.object(dep_sync, "installed_console_script_target", return_value=None),
+        patch.object(dep_sync.subprocess, "run", side_effect=fake_run),
+    ):
+        rc = dep_sync.main([str(repo), "py"])
+
+    assert rc == 0
+    pip_call = next(c for c in calls if "pip" in c)
+    assert pip_call.index("--") == pip_call.index("install") + 1
+    assert pip_call[-1] == "aiohttp"
+
+
+def test_main_refuses_a_declaration_that_names_the_project(repo, capsys):
+    """Refused BEFORE pip runs, so the venv is never touched."""
+    _origin_inside.repo = repo
+
+    with (
+        patch.object(dep_sync, "declared_requirements", return_value=["."]),
+        patch.object(dep_sync, "requires_python", return_value=None),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        rc = dep_sync.main([str(repo), "py"])
+
+    assert rc == 1
+    assert not sp.run.called
+    err = capsys.readouterr().err
+    assert "will not hand to pip" in err
+    assert "No dependency was installed" in err
+
+
+def test_main_refuses_when_the_interpreter_is_below_the_declared_floor(repo, capsys):
+    """The gate `pip install -e .` applies while building; nothing else provides it."""
+    _origin_inside.repo = repo
+
+    with (
+        patch.object(dep_sync, "requires_python", return_value=">=3.13"),
+        patch.object(dep_sync, "interpreter_version", return_value=(3, 10, 4)),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        rc = dep_sync.main([str(repo), "py"])
+
+    assert rc == 1
+    assert not sp.run.called
+    err = capsys.readouterr().err
+    assert "3.13" in err
+
+
+def test_main_refuses_a_venv_serving_another_checkout(repo, capsys):
+    """Refused before pip runs, on the venv's identity alone."""
+    with (
+        patch.object(
+            dep_sync,
+            "installed_package_origin",
+            return_value="/checkouts/other/src/kiro_crew/__init__.py",
+        ),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        rc = dep_sync.main([str(repo), "py"])
+
+    assert rc == 1
+    assert not sp.run.called
+    err = capsys.readouterr().err
+    assert "other" in err
+
+
+def test_main_refuses_when_the_requirements_moved_to_pyproject(repo, capsys):
+    """Reading a stale setup.cfg while reporting success is the failure to avoid."""
+    _origin_inside.repo = repo
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\ndependencies = ["aiohttp"]\n', encoding="utf-8"
+    )
+
+    with patch.object(dep_sync, "subprocess") as sp:
+        rc = dep_sync.main([str(repo), "py"])
+
+    assert rc == 1
+    assert not sp.run.called
+    assert "stale" in capsys.readouterr().err
+
+
+def test_main_reports_a_repointed_console_script_after_installing(repo, capsys):
+    """The one gap: a moved entry point cannot be refreshed while it is locked.
+
+    The dependencies are already installed by the time this is known, so it is
+    reported as a failure of the step with the manual remedy -- not dressed up as a
+    refusal that left the checkout untouched, which would be false.
+    """
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+
+    _origin_inside.repo = repo
+
+    with (
+        patch.object(dep_sync, "console_script_target", return_value="kiro_crew.new:main"),
+        patch.object(
+            dep_sync, "installed_console_script_target", return_value="kiro_crew.old:main"
+        ),
+        patch.object(dep_sync.subprocess, "run", return_value=_Proc()),
+    ):
+        rc = dep_sync.main([str(repo), "py"])
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "kiro_crew.new:main" in err
+    assert "kiro_crew.old:main" in err
+    assert "No dependency was installed" not in err
+
+
+def test_main_tolerates_an_unreadable_installed_entry_point(repo):
+    """An unreadable probe must not fail a sync it has no evidence against."""
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+
+    _origin_inside.repo = repo
+
+    with (
+        patch.object(dep_sync, "console_script_target", return_value="kiro_crew.cli:main"),
+        patch.object(dep_sync, "installed_console_script_target", return_value=None),
+        patch.object(dep_sync.subprocess, "run", return_value=_Proc()),
+    ):
+        assert dep_sync.main([str(repo), "py"]) == 0
+
+
+def test_main_rejects_a_wrong_argument_count():
+    assert dep_sync.main(["only-one"]) == 2
+    assert dep_sync.main(["a", "b", "c"]) == 2

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -574,6 +574,24 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # git rev-parse at startup, no agent input, no sandbox needed).
         "apps/builtins/dev_fleet/server.py::_resolve_primary_checkout",
         "apps/builtins/dev_fleet/server.py::worker",
+        # dep_sync stands in for `pip install -e .` on a checkout whose console
+        # script is locked, and it spawns the same shapes that step did:
+        # `<target python> -c <fixed metadata/version probe>` and `<target python>
+        # -m pip install <requirements the merged revision declares>`. It spawns no
+        # git at all -- it runs after the merge, so it reads the declarations
+        # straight from the working tree. The interpreter is the target repo's own
+        # venv python (handed down, never resolved from PATH here); the repo comes
+        # from the operator-configured checkout, and the requirement specs are read
+        # from that checkout's own declarations -- the same ones `pip install -e .`
+        # would have read, so this adds no surface the step it replaces did not
+        # already have. Routing here would also NEST sandboxes: dep_sync runs as a
+        # sync step, which server.py::worker already wrapped through
+        # sandboxed_spawn_argv, and a filesystem-scoped wrapper around pip would
+        # block the venv writes that are the point of the step.
+        "apps/builtins/dev_fleet/dep_sync.py::interpreter_version",
+        "apps/builtins/dev_fleet/dep_sync.py::installed_console_script_target",
+        "apps/builtins/dev_fleet/dep_sync.py::installed_package_origin",
+        "apps/builtins/dev_fleet/dep_sync.py::main",
         # Foreground last-resort restart (Make Live on hosts with no drivable
         # service manager): a detached `kirocrew restart --port <marker port>`,
         # fixed argv whose binary is validated (basenamed kirocrew, absolute,


### PR DESCRIPTION
## Problem / Motivation

On the ordinary single-checkout Windows layout, Dev Fleet's **Pull + build** could never succeed. Windows holds a mandatory lock on a running executable's image, so pip cannot rewrite `Scripts\kirocrew.exe` while the gateway is served by the very venv it is reinstalling into. The sync detected that lock and refused the WHOLE run before any step executed, with a message telling the operator to stop the gateway and sync from a terminal.

That made the button structurally unusable there, not merely failing on some recoverable state: every press on the layout most Windows developers actually have ends in the same refusal.

## Why it matters

Pull + build is how a developer moves a checkout to the latest `main` from the dashboard. On this layout the feature is not degraded, it is absent -- and the workaround (stop the gateway, run pip by hand, start it again) costs the operator their running sessions every time they want to update.

## What changed (motivation -> approach -> change)

The refusal existed to protect a real invariant: never leave a revision on disk whose dependencies are missing, because the gateway then fails to start. Merging without installing would break that, so refusing the whole sync was the conservative call.

The root cause is narrower than the refusal, though. An editable install serves source straight from `src`, which is already on `sys.path`, so **merged code is live the moment the merge lands** -- no reinstall is needed for a source change at all. The only thing the reinstall was still buying is a dependency the new revision added, and installing a dependency never rewrites the project's own console script. So the reinstall step is replaced by a dependency-only install, and nothing else about the sync changes.

The substitute is deliberately shaped as **parity** with the reinstall rather than as an improvement on it:

- **Same order.** `fetch -> merge -> install`, exactly as the reinstall path runs on every other platform.
- **Same scope.** `pip install -e .` resolves `install_requires` and no extra, because extras are opt-in. This installs exactly that and leaves extras alone.
- **Same delegation.** Every declared requirement is handed to `pip install` verbatim, so specifiers and environment markers are evaluated by pip, not reimplemented here.

Two earlier attempts to do *better* than the reinstall were removed as unsound, and both are worth recording because they look reasonable:

1. **Inferring which extras the operator requested.** pip records no trace of `pip install -e ".[voice]"`, so the only reconstruction available is "an extra whose every declared distribution is installed is active". That misreads any extra carrying a marker-gated dependency: on a platform where the marker is false, pip correctly did not install it, the extra reads inactive, and its other new requirements get skipped -- the exact missing-dependency outcome the inference was added to prevent. A plain `pip install -e .` would not have installed that extra's new dependency either, so the inference was reaching past parity to a guarantee that cannot be made soundly.
2. **Installing before the merge**, so a failed install could not strand a merged checkout. That requires proving in advance that the merge cannot fail, which needs a growing set of preconditions (clean tree, ancestor check, a pinned ref so a concurrent fetch cannot slide a different commit under it) and still cannot be complete -- `git status --porcelain`, for one, honours `status.showUntrackedFiles=no` and can report a dirty tree as clean.

**The accepted exposure, stated rather than guarded:** the merge lands first, so a failed dependency install leaves the checkout on a revision whose dependencies are unsatisfied, and the operator finishes by hand. That is what every other platform already does when its reinstall step fails. It is the accepted behaviour of this workflow, not something this change introduces; raising that bar is worth doing for all platforms at once, in its own change.

Four things a dependency-only install cannot inherit from pip are therefore checked explicitly, because pip is not building the project:

- **`requires-python`.** A reinstall is refused by pip when the interpreter is below the declared floor; a dependency-only install builds nothing, so the floor is read from the merged tree and compared against the target interpreter.
- **A repointed console script.** If the merged revision moves the `kirocrew` entry point, the wrapper on disk still dispatches to the old target and no amount of dependency installing refreshes it. This is reported after the install with the manual remedy -- the wrapper cannot be rewritten while a process is running from it.
- **Requirements that have moved out of setup.cfg.** This module reads one file for the requirements, so a revision that migrates them into pyproject’s [project] table non-dynamically would leave setup.cfg stale; the step refuses rather than installing yesterday’s set while reporting success.
- **Requirements that are not plain distribution names.** A path, an archive filename, or the project itself would have pip reinstall the checkout and hit the very locked executable this avoids, so those are refused before pip is invoked. This enforces the module's premise instead of relying on this repository's declarations happening not to contain one.

The step also refuses unless the target venv imports this project from **inside the checkout being synced**. `<repo>/.venv` is a location, not a binding: nothing stops it from being an install of a different checkout, and installing this revision's dependencies into such a venv would change a runtime this sync does not own.

## Tests

- `test/test_dev_fleet_dep_sync.py` (new, 26 tests) -- the parity scope (`install_requires` only, extras left alone, full-line comments stripped, markers passed through verbatim); every refusal path with `subprocess.run` asserted un-called, so each one provably precedes pip; the `--` option-separator guard; the rejection of paths, archives and every PEP 503 spelling that folds onto this project's name; the venv-identity comparison including a `<repo>-wt` sibling that shares the string prefix; and the post-install console-script report.
- `test/test_dev_fleet_app.py` -- the substitution happens when a script is locked, the real reinstall is kept when nothing is locked, and the step order is `fetch -> merge -> install` (the assertion that previously pinned the opposite order now pins this one).
- `test/test_spawn_audit.py` -- the module's four spawning functions are allowlisted with the justification the ratchet requires.

## Manual verification

Ran the module's reads against a real single-checkout install (the layout this fixes): 25 base requirements resolved with no extra leaking in, `requires-python` read as `>=3.10`, setup.cfg confirmed still authoritative, declared and installed console scripts equal (so no staleness report), no requirement rejected, and the venv correctly recognised as serving its own checkout. The same probe against a different checkout's venv correctly reports it as foreign.

Not exercised end-to-end by pressing the button, because doing so would move the checkout this gateway runs from; the local suite covers the step's decisions and the surrounding fetch/merge steps are unchanged.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to the sync's step list; no dashboard surface renders differently.

## Related Issues

no linked issue: found while diagnosing Pull + build on Windows, no tracked issue was open for it.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

### The step runs a pre-merge snapshot, by path

The substitute is a module in this package, and the naive way to invoke it -- python -m kiro_crew.apps.builtins.dev_fleet.dep_sync -- would import it from the working tree AFTER the merge landed, dragging the whole package __init__ chain in with it. A revision that raises the floor and uses newer syntax anywhere in that chain would then die being parsed, and the 
equires-python refusal written for exactly that revision could never run: the validator would live inside the thing it validates.

So the module is copied to a temp file before the merge and the copy is executed by path. The only parsed file is one this interpreter has already imported, which makes the refusal reachable in its own case; running it by path (rather than by module name) is what keeps the package chain out of it, and the module imports nothing but the standard library, so it needs no package context. The snapshot directory comes from mkdtemp because executing a script by path puts its directory on sys.path -- a predictable directory would let anything dropped beside the snapshot shadow a stdlib module it imports. Both the file and its directory are registered for cleanup after the run.

This mirrors pip rather than deviating from it: the INSTALLED pip reads the merged project metadata, and an old pip refusing a too-new project is the behaviour being stood in for.

## Scope left out

Four other call sites reinstall editable into the venv of a running process and hit the same Windows lock: dashboard/handlers/updates.py:992, slack/gateway.py:7172, cli_server.py:1118, and _bootstrap.py:82 (whose docstring already skips the heal on Windows for exactly this lock). Only Dev Fleet’s sync gets the substitute here; routing the others through a shared step is genuinely larger work and is filed as #4601.
