### PR TITLE
refactor(five-whys): flatten chained ternaries and a redundant flag

### DIFF
--- a/src/kiro_crew/builtin_skills/five-whys/scripts/five_whys.py
+++ b/src/kiro_crew/builtin_skills/five-whys/scripts/five_whys.py
@@ -31,6 +31,7 @@ Usage:
   Free-text via stdin, e.g.:  five_whys.py ask <log> --parent 1 --stage what --stdin-json < fields.json
   where fields.json is {"q": "..."} written with a file tool (never interpolated).
 """
+
 import argparse
 import contextlib
 import json
@@ -190,6 +191,7 @@ def _append(path, ev):
 
 # ---- fold helpers -----------------------------------------------------------
 
+
 def _asks(events):
     """id -> ask event (first definition wins; duplicates are integrity errors)."""
     out: dict = {}
@@ -205,14 +207,11 @@ def _pruned(events, asks):
     pruned = set()
     for nid in asks:
         cur = nid
-        hit = False
         while cur is not None:
             if cur in roots:
-                hit = True
+                pruned.add(nid)
                 break
             cur = asks.get(cur, {}).get("parent")
-        if hit:
-            pruned.add(nid)
     return pruned
 
 
@@ -243,6 +242,7 @@ def _sort_key(nid):
 
 def _alloc_id(asks, parent):
     """Next child id under parent (None => root). Counts pruned ids to avoid reuse."""
+
     def _tail_num(nid):
         try:
             return int(str(nid).split(".")[-1])
@@ -277,14 +277,15 @@ def _children(asks, pruned, parent):
 
 # ---- commands ---------------------------------------------------------------
 
+
 def cmd_ask(a):
     _apply_stdin_json(a, "q", "stage")
     if not a.q:
         raise SystemExit("ask requires --q or a 'q' field in --stdin-json")
     if a.stage not in STAGES:
         raise SystemExit(
-            "ask requires --stage one of: %s (got %r)" % (
-                ", ".join(sorted(STAGES)), a.stage))
+            "ask requires --stage one of: %s (got %r)" % (", ".join(sorted(STAGES)), a.stage)
+        )
     events = _load(a.log)
     asks = _asks(events)
     parent = None if a.parent in (None, "", "root", "null") else a.parent
@@ -293,10 +294,20 @@ def cmd_ask(a):
     if parent is not None and parent in _pruned(events, asks):
         raise SystemExit(
             "parent %r is pruned; a child added under it would be dropped from "
-            "every projection" % parent)
+            "every projection" % parent
+        )
     nid = _alloc_id(asks, parent)
-    _append(a.log, {"type": "ask", "id": nid, "parent": parent,
-                    "stage": a.stage, "q": a.q, "origin": a.origin})
+    _append(
+        a.log,
+        {
+            "type": "ask",
+            "id": nid,
+            "parent": parent,
+            "stage": a.stage,
+            "q": a.q,
+            "origin": a.origin,
+        },
+    )
     print(nid)
 
 
@@ -359,7 +370,8 @@ def cmd_prune(a):
     if cur is not None and (cur == a.id or cur.startswith(a.id + ".")):
         raise SystemExit(
             "%r is the current focus or an ancestor of it; focus elsewhere "
-            "first so resume cannot land on a pruned node" % a.id)
+            "first so resume cannot land on a pruned node" % a.id
+        )
     _append(a.log, {"type": "prune", "id": a.id, "reason": a.reason})
     print("ok")
 
@@ -384,7 +396,8 @@ def cmd_event(a):
     if ev["type"] in CORE_TYPES:
         raise SystemExit(
             "event type %r is a core type; use its dedicated subcommand so the "
-            "required fields are validated" % ev["type"])
+            "required fields are validated" % ev["type"]
+        )
     _append(a.log, ev)
     print("ok")
 
@@ -400,11 +413,18 @@ def cmd_tree(a):
 
     def walk(nid, depth):
         node = asks[nid]
-        mark = " ✅" if nid in dones else (" ⏳" if nid == cur else "")
+        if nid in dones:
+            mark = " ✅"
+        elif nid == cur:
+            mark = " ⏳"
+        else:
+            mark = ""
         ans = answers.get(nid)
         tail = " → %s" % ans if ans else ""
-        lines.append("%s- [%s] (%s) %s%s%s" % (
-            "  " * depth, nid, node.get("stage", ""), node.get("q", ""), tail, mark))
+        lines.append(
+            "%s- [%s] (%s) %s%s%s"
+            % ("  " * depth, nid, node.get("stage", ""), node.get("q", ""), tail, mark)
+        )
         for kid in _children(asks, pruned, nid):
             walk(kid, depth + 1)
 
@@ -419,8 +439,11 @@ def _frontier(events):
     answers = _answers(events)
     dones = _dones(events)
     cur = _last(events, "focus")
-    return [i for i in sorted(asks, key=_sort_key)
-            if i not in pruned and i not in answers and i not in dones and i != cur]
+    return [
+        i
+        for i in sorted(asks, key=_sort_key)
+        if i not in pruned and i not in answers and i not in dones and i != cur
+    ]
 
 
 def cmd_frontier(a):
@@ -445,15 +468,17 @@ def cmd_view(a):
         print("open branches: %d" % len(fr))
         return
     parts = cur.split(".")
-    chain = [".".join(parts[:k + 1]) for k in range(len(parts))]
+    chain = [".".join(parts[: k + 1]) for k in range(len(parts))]
     print("current path:")
     for depth, nid in enumerate(chain):
         node = asks.get(nid, {})
         ans = answers.get(nid)
         tail = " → %s" % ans if ans else ""
         star = "  ← current" if nid == cur else ""
-        print("%s- [%s] (%s) %s%s%s" % (
-            "  " * depth, nid, node.get("stage", ""), node.get("q", ""), tail, star))
+        print(
+            "%s- [%s] (%s) %s%s%s"
+            % ("  " * depth, nid, node.get("stage", ""), node.get("q", ""), tail, star)
+        )
     print("open branches: %d" % len(fr))
 
 
@@ -466,8 +491,11 @@ def cmd_report(a):
     dones = _dones(events)
     roots = _children(asks, pruned, None)
     title = a.title or (asks[roots[0]].get("q") if roots else "5 Whys")
-    out = ["# 5 Whys report — %s" % title,
-           "_Generated: %s · %d events_" % (_now(), len(events)), ""]
+    out = [
+        "# 5 Whys report — %s" % title,
+        "_Generated: %s · %d events_" % (_now(), len(events)),
+        "",
+    ]
     out.append("## Starting point")
     for r in roots:
         out.append("- %s" % asks[r].get("q", ""))
@@ -477,10 +505,16 @@ def cmd_report(a):
         node = asks[nid]
         ans = answers.get(nid)
         tail = " → %s" % ans if ans else ""
-        flag = "  **[root]**" if dones.get(nid, {}).get("kind") == "root" else (
-            "  _[takeaway]_" if nid in dones else "")
-        out.append("%s- **[%s]** (%s) %s%s%s" % (
-            "  " * depth, nid, node.get("stage", ""), node.get("q", ""), tail, flag))
+        if dones.get(nid, {}).get("kind") == "root":
+            flag = "  **[root]**"
+        elif nid in dones:
+            flag = "  _[takeaway]_"
+        else:
+            flag = ""
+        out.append(
+            "%s- **[%s]** (%s) %s%s%s"
+            % ("  " * depth, nid, node.get("stage", ""), node.get("q", ""), tail, flag)
+        )
         for kid in _children(asks, pruned, nid):
             walk(kid, depth + 1)
 
@@ -517,8 +551,11 @@ def cmd_validate(a):
         t = e["type"]
         if t == "ask":
             aid = e.get("id")
-            if not isinstance(aid, str) or not aid or not all(
-                    part.isdigit() for part in aid.split(".")):
+            if (
+                not isinstance(aid, str)
+                or not aid
+                or not all(part.isdigit() for part in aid.split("."))
+            ):
                 issues.append("line %d: ask has invalid id %r" % (n, aid))
                 continue
             if "q" not in e:


### PR DESCRIPTION
## Problem / Motivation

Two projection markers in the five-whys mechanical core were written as chained
conditional expressions, so a reader had to unpack operator precedence to answer a
question the code should have stated outright — which label wins when a node is
both `done` and the current focus:

```python
mark = " ✅" if nid in dones else (" ⏳" if nid == cur else "")
flag = "  **[root]**" if dones.get(nid, {}).get("kind") == "root" else (
    "  _[takeaway]_" if nid in dones else "")
```

`_pruned()` had a second, smaller version of the same problem: it set a `hit` flag
inside the ancestor walk purely so it could re-test that flag after the loop, which
splits one decision across two places.

Separately, this file is a latent trap for anyone who touches it: it is absent from
`.github/black-baseline.txt` and yet has never been black-clean, so the
diff-scoped black gate (`ci.yml`) fails for **any** change that touches it, and the
gate deliberately offers no operation that adds a baseline entry.

## Why it matters

The chained ternaries are the last two sites the module-simplification detector
reports for `builtin_skills`; both are the class where a reader silently mis-reads
the precedence, and this file is the deterministic core the five-whys skill is not
allowed to drift on.

The black trap is the more expensive part. It costs the *next* contributor a full
red CI round for a file they only touched incidentally, with no way to resolve it
except the reformat this PR performs. Formatting it once also means the ratchet
keeps it clean from here on, since the file is not baselined.

## What changed (motivation → approach → change)

Three semantic changes, all in `src/kiro_crew/builtin_skills/five-whys/scripts/five_whys.py`:

1. **`cmd_tree`'s `walk`** — the `mark` chained ternary becomes `if`/`elif`/`else`,
   which states the `done`-beats-focus precedence the reader was inferring.
2. **`cmd_report`'s `walk`** — same for the `flag` chained ternary
   (`**[root]**` / `_[takeaway]_` / no marker).
3. **`_pruned`** — the `hit` flag and the post-loop `if hit:` are dropped; the id is
   added where the ancestor walk already decided the answer, immediately before the
   `break`. Same set, same termination, one decision point instead of two.

The remaining ~73 lines of the diff are `black --target-version py310` output on
this one file, for the reason given above. `origin/main`'s copy needs 80 lines of
black reformat; after the refactor it needed 73, so none of the drift originates
here. Every non-refactor hunk is reproducible with
`black --target-version py310 --diff` against the base-ref copy.

Behavior is preserved throughout: no branch order, condition, or short-circuit
change, and no `is not None` ↔ truthiness swap. `mark` and `flag` are locals of
nested functions in both forms, so no closure read became a local binding.

## Tests

No test changes. Nothing in `test/` references `five_whys.py`, and this PR
deliberately does not add coverage for it — a behavior-preserving refactor is the
wrong PR to introduce a new test surface in, since a test written alongside the
rewrite proves only that the rewrite matches itself.

The existing suites that assert on this module's packaging and skill bundling were
run and are green: `test_skills.py`, `test_builtin_skill_packaging.py`,
`test_builtin_skill_sync_safety.py`, `test_skill_home_paths.py`,
`test_prepare_pr_profiles.py` — 226 passed.

## Manual verification

Behavior equivalence was proven differentially rather than by inspection: the
base-ref copy and the patched copy were driven over identical synthetic event logs
and their `tree`, `frontier`, `view`, `report` and `validate` output plus exit codes
diffed. **Byte-identical on every run** (only the report's `_Generated:` timestamp
normalised).

The scenarios were chosen to reach every branch of both rewrites, since a chained
ternary rewrite fails precisely on precedence:

| Scenario | Covers |
|---|---|
| tree/report with a `done` root, a live focus, and unmarked nodes | `✅`, `⏳`, `""`; `**[root]**`, `""` |
| a node that is BOTH `done` and the current focus | `done`-over-`focus` precedence — the one case the ternary's nesting encoded |
| a hand-appended `done` with an off-schema `kind` | the report's "in `dones` but not `root`" branch, which argparse's `choices` cannot produce |
| a pruned mid-level node with a child and a grandchild | `_pruned`'s ancestor walk, including transitive descendants |
| error paths: off-schema `--stage`, missing parent, pruned parent, a core type via `event`, a corrupt log line | stderr text and exit codes |

Gates, all on the Python 3.12 CI-parity venv: `flake8`, `isort --check-only`,
`mypy`, `check_brand_name.py`, `check_harness_parity.py`, `docs_lint.py --test`,
`docs-lint.sh`, `check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history`, `check_black_formatting.py` — every one exit 0.

### Pre-submission review

Five independent read-only reviewers were run against this diff before opening —
one per lens: AUTOSDE blocking rules plus the deterministic `code-review.yml` grep
rules; adversarial equivalence falsification; import/module-scope/packaging
semantics; security-guard and boot-path shape; comment accuracy and scope. **No
blocking or advisory finding survived.**

Two results are worth surfacing because they are stronger than an eyeball pass:

- **The "everything else is black" claim was verified mechanically, not read.**
  Three reviewers independently formatted the base-ref blob with the repo's pinned
  black and diffed the result against this branch's file. The residual is exactly
  the three semantic hunks, with no extra hunk. An AST-level comparison agrees: of
  43 module-scope bindings and every top-level node, only `_pruned`, `cmd_tree` and
  `cmd_report` differ.
- **`_pruned` is load-bearing for refusals, not just display** — `_require_live`
  gates `answer`/`focus`/`done`, and `cmd_ask` refuses a child under a pruned
  parent — so a false negative would let a write land under a pruned node.
  Reviewers checked that specifically, by proof and by bounded differential fuzz
  (5,000 / 20,000 / 200,000 randomized event lists across three reviewers, covering
  dotted, skip-level, dangling and non-string parents and prunes on ghost ids):
  **0 mismatches.**

Pre-existing observations that reviewers raised and this PR deliberately does
**not** change, so they are not mistaken for oversights:

- `_pruned`'s ancestor walk has no visited-set guard, so an `ask` parent cycle in a
  hand-edited log spins forever. The `while` condition and the `cur` reassignment
  are byte-identical between base and head, so the diff neither introduces nor
  widens it — and fixing it here would be an undocumented behavior change riding in
  a cleanup PR. Deferred to its own change.
- `cmd_discuss` checks anchor existence but not liveness, and the report's "Side
  discussions" section is not pruned-filtered the way its `done` list is.
- The module docstring advertises "Stdlib only, Python 3.8+" while the file is now
  formatted under `--target-version py310`. Today's output is 3.8-valid; the pin is
  the repo-wide one, not a choice made here.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff in one bundled skill script; it touches no
`website/` path and renders nothing in the dashboard.

## Related Issues

no linked issue: a scheduled module-simplification sweep, not a filed defect.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
