### PR TITLE
fix: resume cron turn once after post-token transient error (#4228)

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -213,6 +213,7 @@ from kiro_crew.slack.outbound import PostedOptions
 from kiro_crew.slack.retry import open_dm_with_retry
 from kiro_crew.slack.scope_probe import warn_unreadable_tracked_channels
 from kiro_crew.subagent import (
+    _TRANSIENT_CONTINUE_MSG,
     DIGEST_HOLD_SECS,
     INJECTION_TIMEOUT,
     SubagentInfo,
@@ -336,6 +337,15 @@ def _injection_slot_busy(slot: Any) -> bool:
 # client creation / context assembly), mirroring the subagent path's budget.
 # In-stream transient errors are retried separately by stream_and_collect.
 _CRON_TRANSIENT_RETRIES = 2
+
+# Continuation prompt for the one-shot post-token resume below. Reuses the
+# subagent path's constant verbatim (gateway.py already imports from
+# kiro_crew.subagent) instead of adding a third hand-maintained copy next to
+# the dashboard's _POSTTOKEN_RECOVER_MSG — see the PARITY NOTE in
+# dashboard/chat_runner.py. The cron result is delivered once at the end of
+# the turn, so the preserved partial is concatenated with the continuation
+# instead of being re-shown to a live viewer.
+_CRON_POSTTOKEN_CONTINUE_MSG = _TRANSIENT_CONTINUE_MSG
 
 logger = logging.getLogger(__name__)
 
@@ -734,6 +744,113 @@ def _apply_gate_verdict(job: CronJob, tally: _GateTally) -> bool:
     job.last_failure_at = 0.0
     job.record_success()
     return False
+
+
+async def _cron_stream_with_posttoken_resume(
+    client: Any, message: str, *, job_name: str, **stream_kwargs: Any
+) -> tuple[str, float | None]:
+    """Run a cron agent turn, resuming ONCE after a post-token transient error.
+
+    Closes the seam between the two existing transient-retry layers:
+    stream_and_collect's in-stream retry stops once tokens have streamed
+    (re-running would duplicate the already-emitted output), and
+    _cron_callback's whole-callback retry stops once the prompt is dispatched
+    (tools may have run). A transient backend error raised AFTER the first
+    token therefore failed the whole cycle even though the live session still
+    holds the interrupted turn's context.
+
+    Recovery mirrors the dashboard's post-token CONTINUE re-prompt
+    (chat_runner's ``_posttoken_retry_used`` branch) and the subagent's
+    ``_stream_with_transient_retry`` post-activity arm: the streamed partial is
+    preserved, the SAME live session is re-prompted with a continuation
+    instruction (never the original message, so completed work is not re-run),
+    and the returned result is partial + continuation. The allowance is a
+    strict one-shot per turn (``_resume_used``, same style as
+    ``_posttoken_retry_used``): a transient error during the continuation
+    propagates unchanged, so the unrecovered path records the error exactly as
+    before.
+
+    Returns ``(text, carried_credits)``. ``carried_credits`` is ``None`` when
+    the turn completed without a resume; on a resumed turn it is the credits
+    the INTERRUPTED prompt accumulated — snapshotted before the continuation
+    prompt's ``AcpPromptStats.carry_over()`` zeroes the per-turn counter — so
+    the caller's usage row can bill both prompts instead of only the
+    continuation.
+
+    Eligibility deliberately reuses ``acp_error_is_transient`` — the one
+    authoritative classifier — so auth/validation failures and every other
+    non-transient error propagate untouched. With NO tokens streamed the error
+    also propagates untouched: that window is stream_and_collect's own retry's
+    job, and by the time it raises here its budget is spent.
+
+    Inherited tradeoffs, stated for the record (both are the mirrored owner
+    decisions from chat_runner/subagent, extended here to the cron surface):
+
+    - A side-effecting tool that was IN FLIGHT (dispatched, no completion)
+      when the transient hit may be legitimately re-issued by the continuation
+      turn — the CONTINUE instruction forbids re-running *completed* tools
+      only. On an ``approval_mode == "auto"`` job that re-issue meets no gate
+      and no human, an unattended posture narrower than the live-viewer
+      surface the tradeoff was originally accepted for. Accepted: the window
+      is rare (mid-flight tool AND a transient), and failing the whole cycle
+      fast was exactly the behaviour this fix exists to remove.
+    - The resume adds at most one bounded prompt plus one backoff sleep to the
+      cycle's worst case, inside the same per-wake ``asyncio.wait_for``
+      deadline. A deadline firing mid-continuation degrades exactly as a
+      deadline mid-turn does today (``CancelledError`` is not caught here), so
+      no remaining-budget plumbing is added for a one-shot.
+
+    ``parts`` observes chunks across stream_and_collect's internal attempts.
+    Its transient retry only fires while no text has streamed, and — a stated
+    ASSUMPTION about the provider, not an enforced invariant — a prompt-busy
+    error is only raised at prompt submission, before this turn's stream emits
+    chunks. Under that assumption the accumulated text never contains chunks
+    from an abandoned attempt.
+    """
+    parts: list[str] = []
+    preserved = ""
+    carried_credits: float | None = None
+    _resume_used = False  # one-shot, same style as slot._posttoken_retry_used
+    msg = message
+    while True:
+        try:
+            text = await stream_and_collect(
+                client,
+                msg,
+                on_chunk=parts.append,
+                # The continuation call owns NO further transient budget: its
+                # in-stream retry re-sends the prompt whenever no text has
+                # streamed, so a mutating tool completed by the continuation
+                # followed by a pre-text transient would be re-run by the
+                # inner replay — amplifying the one-shot. The first call keeps
+                # the default (existing pre-token behaviour, unchanged).
+                retry_transient=not _resume_used,
+                **stream_kwargs,
+            )
+            return preserved + text, carried_credits
+        except Exception as exc:
+            partial = "".join(parts)
+            if _resume_used or not partial or not acp_error_is_transient(exc):
+                raise
+            _resume_used = True
+            preserved = partial
+            parts.clear()
+            # Snapshot the interrupted prompt's billing NOW: sending the
+            # continuation runs AcpPromptStats.carry_over(), which zeroes the
+            # per-turn credit counter, and the caller's single post-turn read
+            # would otherwise bill only the continuation.
+            carried_credits = provider_last_turn_usage(client).credits
+            _delay = transient_retry_delay(1)
+            logger.warning(
+                "Cron '%s': transient backend error after %d chars streamed — "
+                "one-shot CONTINUE re-prompt of live session in %.1fs: %s",
+                job_name,
+                len(preserved),
+                _delay,
+                exc,
+            )
+            await asyncio.sleep(_delay)
+            msg = _CRON_POSTTOKEN_CONTINUE_MSG
 
 
 def _result_hash(text: str) -> str:
@@ -2832,9 +2949,10 @@ class GatewayOrchestrator:
                         # the episodic-query embed above are setup, not the turn.
                         _turn_t0 = time.monotonic()
                         _prompt_dispatched = True
-                        result_text = await stream_and_collect(
+                        result_text, _carried_credits = await _cron_stream_with_posttoken_resume(
                             client,
                             full_message,
+                            job_name=job.name,
                             approval_policy=(
                                 ToolApprovalPolicy.AUTO_APPROVE
                                 if job.approval_mode == "auto"
@@ -2856,6 +2974,12 @@ class GatewayOrchestrator:
                         try:
 
                             _used, _window = read_context_tokens(client)
+                            _turn_usage = provider_last_turn_usage(client)
+                            if _carried_credits:
+                                # A resumed turn's post-turn read sees only the
+                                # continuation prompt; bill the interrupted
+                                # prompt's snapshotted credits too.
+                                _turn_usage.credits += _carried_credits
                             await persist_token_record_async(
                                 agent_session_key,
                                 # Blank on a downgrade: the configured model was
@@ -2864,7 +2988,7 @@ class GatewayOrchestrator:
                                 # that never executed. Blank defers to
                                 # model_source, which reports what actually ran.
                                 "" if _seq_downgraded else (job.model or ""),
-                                provider_last_turn_usage(client),
+                                _turn_usage,
                                 provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
                                 surface="cron",
                                 agent=read_effective_agent(client) or agent or "",
@@ -2960,9 +3084,10 @@ class GatewayOrchestrator:
                 _turn_t0 = time.monotonic()
                 _gate = _GateTally()
                 _prompt_dispatched = True
-                result_text = await stream_and_collect(
+                result_text, _carried_credits = await _cron_stream_with_posttoken_resume(
                     client,
                     full_message,
+                    job_name=job.name,
                     approval_policy=(
                         ToolApprovalPolicy.AUTO_APPROVE
                         if job.approval_mode == "auto"
@@ -2994,11 +3119,17 @@ class GatewayOrchestrator:
                 try:
 
                     _used, _window = read_context_tokens(client)
+                    _turn_usage = provider_last_turn_usage(client)
+                    if _carried_credits:
+                        # See the sequential site above: bill the interrupted
+                        # prompt's snapshotted credits alongside the
+                        # continuation's on a resumed turn.
+                        _turn_usage.credits += _carried_credits
                     await persist_token_record_async(
                         session_key,
                         # Blank on a downgrade — see the sequential site above.
                         "" if _model_downgraded else (job.model or ""),
-                        provider_last_turn_usage(client),
+                        _turn_usage,
                         provider=_provider,
                         surface="cron",
                         agent=read_effective_agent(client) or job.agent_id or "",

--- a/test/test_cron_wake_budget.py
+++ b/test/test_cron_wake_budget.py
@@ -362,6 +362,210 @@ class TestCronTransientRetry:
         assert job.consecutive_failures == 0
 
 
+class TestCronPostTokenResume:
+    """One-shot post-token resume for transient errors inside the prompt stream.
+
+    Closes the seam between the two existing retry layers: a transient error
+    raised AFTER the prompt was dispatched AND after at least one token had
+    streamed used to fail the whole cycle (stream_and_collect stops retrying
+    once tokens streamed; the whole-callback retry stops once the prompt is
+    dispatched). The callback now re-prompts the SAME live session ONCE with a
+    continuation instruction, preserving the partial instead of re-running the
+    turn — mirroring chat_runner's ``_posttoken_retry_used`` branch and the
+    subagent's post-activity arm.
+    """
+
+    def _run(
+        self,
+        gw_and_cb: tuple[Any, Any, Any],
+        job: CronJob,
+        *,
+        mock_stream: Any,
+    ) -> Any:
+        gw, get_cb, capture_cron = gw_and_cb
+        with (
+            patch("kiro_crew.slack.gateway.stream_and_collect", side_effect=mock_stream),
+            patch("kiro_crew.slack.gateway.redact_exfiltration_urls", return_value=("", False)),
+            patch("kiro_crew.slack.gateway.redact_credentials", return_value=("", False)),
+            patch(
+                "kiro_crew.slack.gateway.CronService.create",
+                new=AsyncMock(side_effect=capture_cron),
+            ),
+            patch("kiro_crew.slack.gateway.transient_retry_delay", return_value=0.0),
+        ):
+
+            async def _init_and_run() -> Any:
+                await gw._init_cron()
+                cb = get_cb()
+                assert cb is not None
+                return await cb(job)
+
+            return asyncio.run(_init_and_run())
+
+    def test_posttoken_transient_recovers_and_records_success(
+        self, gw_and_cb: tuple[Any, Any, Any]
+    ) -> None:
+        """Transient after tokens: continuation resumes, partial preserved,
+        record_success() runs and the failure counter is untouched."""
+        from kiro_crew.slack.gateway import _CRON_POSTTOKEN_CONTINUE_MSG
+
+        calls: list[str] = []
+
+        async def mock_stream(client: Any, message: str, **kw: Any) -> str:
+            calls.append(message)
+            if len(calls) == 1:
+                kw["on_chunk"]("partial ")
+                raise _transient_err()
+            return "continued"
+
+        job = _job("pt1")
+        job.consecutive_failures = 3  # record_success() must reset this
+        result = self._run(gw_and_cb, job, mock_stream=mock_stream)
+        # Partial is preserved and the continuation appended — never re-run.
+        assert result == "partial continued"
+        assert len(calls) == 2
+        # The resume sends the CONTINUE instruction, not the original message.
+        assert calls[1] == _CRON_POSTTOKEN_CONTINUE_MSG
+        # Recovered cycle counts as a success: counter reset, no failure spent.
+        assert job.consecutive_failures == 0
+        assert not job.auto_paused
+
+    def test_pretoken_transient_still_takes_existing_path(
+        self, gw_and_cb: tuple[Any, Any, Any]
+    ) -> None:
+        """Transient with NO tokens streamed: existing path, no resume.
+
+        stream_and_collect owns that window (its budget is spent by the time
+        the error propagates here), so the callback must not add a resume.
+        """
+        stream_calls = 0
+
+        async def mock_stream(client: Any, message: str, **kw: Any) -> str:
+            nonlocal stream_calls
+            stream_calls += 1
+            raise _transient_err()
+
+        job = _job("pt2")
+        with pytest.raises(AcpError):
+            self._run(gw_and_cb, job, mock_stream=mock_stream)
+        assert stream_calls == 1
+        assert job.consecutive_failures == 1
+
+    def test_non_transient_error_after_tokens_does_not_resume(
+        self, gw_and_cb: tuple[Any, Any, Any]
+    ) -> None:
+        """A non-transient error after tokens fails fast — no continuation."""
+        stream_calls = 0
+
+        async def mock_stream(client: Any, message: str, **kw: Any) -> str:
+            nonlocal stream_calls
+            stream_calls += 1
+            kw["on_chunk"]("partial ")
+            err = AcpError("ValidationException: prompt rejected")
+            err.transient = False  # type: ignore[attr-defined]
+            raise err
+
+        job = _job("pt3")
+        with pytest.raises(AcpError):
+            self._run(gw_and_cb, job, mock_stream=mock_stream)
+        assert stream_calls == 1
+        assert job.consecutive_failures == 1
+
+    def test_posttoken_resume_is_one_shot_per_turn(
+        self, gw_and_cb: tuple[Any, Any, Any]
+    ) -> None:
+        """A transient error during the continuation propagates: the one shot
+        is spent, and the unrecovered cycle records the error exactly as
+        before (one failure, no third prompt)."""
+        stream_calls = 0
+
+        async def mock_stream(client: Any, message: str, **kw: Any) -> str:
+            nonlocal stream_calls
+            stream_calls += 1
+            kw["on_chunk"](f"chunk{stream_calls} ")
+            raise _transient_err()
+
+        job = _job("pt4")
+        with pytest.raises(AcpError):
+            self._run(gw_and_cb, job, mock_stream=mock_stream)
+        # Original + exactly ONE continuation — never a loop.
+        assert stream_calls == 2
+        assert job.consecutive_failures == 1
+
+    def test_continuation_owns_no_inner_transient_budget(
+        self, gw_and_cb: tuple[Any, Any, Any]
+    ) -> None:
+        """The continuation call passes retry_transient=False: its in-stream
+        retry re-sends the prompt whenever no text has streamed, so a mutating
+        tool completed by the continuation followed by a pre-text transient
+        would otherwise be re-run — amplifying the one-shot."""
+        flags: list[Any] = []
+
+        async def mock_stream(client: Any, message: str, **kw: Any) -> str:
+            flags.append(kw.get("retry_transient", "default"))
+            if len(flags) == 1:
+                kw["on_chunk"]("partial ")
+                raise _transient_err()
+            return "continued"
+
+        job = _job("pt6")
+        result = self._run(gw_and_cb, job, mock_stream=mock_stream)
+        assert result == "partial continued"
+        # First call keeps the default budget; the continuation gets none.
+        assert flags == [True, False]
+
+    def test_resumed_turn_bills_both_prompts(self, gw_and_cb: tuple[Any, Any, Any]) -> None:
+        """The usage row for a resumed cycle carries the interrupted prompt's
+        credits plus the continuation's — not only the continuation's, which a
+        single post-turn read of the (carried-over) per-turn stats would see.
+        """
+        from kiro_crew.acp.types import TurnUsage
+
+        async def mock_stream(client: Any, message: str, **kw: Any) -> str:
+            if not getattr(mock_stream, "_failed", False):
+                mock_stream._failed = True  # type: ignore[attr-defined]
+                kw["on_chunk"]("partial ")
+                raise _transient_err()
+            return "continued"
+
+        persisted: list[TurnUsage] = []
+
+        async def capture_persist(session_key: Any, model: Any, usage: Any, **kw: Any) -> None:
+            persisted.append(usage)
+
+        job = _job("pt5")
+        gw, get_cb, capture_cron = gw_and_cb
+        with (
+            patch("kiro_crew.slack.gateway.stream_and_collect", side_effect=mock_stream),
+            patch("kiro_crew.slack.gateway.redact_exfiltration_urls", return_value=("", False)),
+            patch("kiro_crew.slack.gateway.redact_credentials", return_value=("", False)),
+            patch(
+                "kiro_crew.slack.gateway.CronService.create",
+                new=AsyncMock(side_effect=capture_cron),
+            ),
+            patch("kiro_crew.slack.gateway.transient_retry_delay", return_value=0.0),
+            patch(
+                "kiro_crew.slack.gateway.provider_last_turn_usage",
+                side_effect=[TurnUsage(credits=3.0), TurnUsage(credits=2.0)],
+            ),
+            patch(
+                "kiro_crew.slack.gateway.persist_token_record_async",
+                side_effect=capture_persist,
+            ),
+        ):
+
+            async def _init_and_run() -> Any:
+                await gw._init_cron()
+                cb = get_cb()
+                assert cb is not None
+                return await cb(job)
+
+            result = asyncio.run(_init_and_run())
+        assert result == "partial continued"
+        assert len(persisted) == 1
+        assert persisted[0].credits == pytest.approx(5.0)
+
+
 class TestWakeBudgetSubprocessGuard:
     """The wake budget must cover a command/script subprocess timeout."""
 


### PR DESCRIPTION
## Problem / Motivation

An agent cron that hits a transient model-backend error (HTTP 5xx / throttle) **after tokens have started streaming** loses its whole cycle: the run is caught, marked error, and the job waits for its next scheduled slot. Three occurrences were logged on 4h and 1h jobs, each costing a full interval, near-silently (the job stays healthy and the schedule is untouched).

Two transient-retry layers already exist, and the lost cycles fall in the seam between them:

1. `stream_and_collect` retries in-stream, but only while `not result_text` (`llm_helpers.py:664`) — re-running after tokens streamed would duplicate the already-emitted output.
2. `_cron_callback` retries the whole callback, but only while `not _prompt_dispatched` (`gateway.py`) — after dispatch, tools may have run.

The uncovered window is precisely a transient error raised **after** the prompt was dispatched **and** after at least one token streamed — which is where a long agent turn spends nearly all of its wall clock.

## Why it matters

Perpetual/background agent jobs silently skip work on pure infrastructure weather. A 4h job that hits one mid-stream 5xx does nothing for 8 hours. Script crons already have a recovery path for this (`raise Skip()`); agent crons had no equivalent.

## What changed (motivation → approach → change)

The dashboard chat path already solves exactly this case with a bounded one-shot post-token resume (`chat_runner.py`, the `_posttoken_retry_used` branch), and the subagent path mirrors it (`_stream_with_transient_retry`'s post-activity arm). This PR brings the cron path to the same semantics with the least new surface:

- New module helper `_cron_stream_with_posttoken_resume` in `src/kiro_crew/slack/gateway.py` wraps `stream_and_collect` for both cron agent call sites (sequential-agent and single-agent). It accumulates streamed chunks; on an exception it resumes **only when** the error is classified transient by the existing `acp_error_is_transient` helper (no second predicate) **and** at least one token streamed. The resume re-prompts the SAME live session once with the subagent path's `_TRANSIENT_CONTINUE_MSG` continuation instruction (imported, not a third copy) and returns partial + continuation — streamed output is never re-delivered and completed tools are not re-run.
- Strict one-shot per turn (`_resume_used`, same style as `_posttoken_retry_used`): a transient error during the continuation propagates unchanged, so a cycle that exhausts the one shot records the error exactly as today.
- A recovered cycle flows through the normal success path, so `record_success()` runs and the failure counter / auto-pause budget are untouched — matching `Skip()` semantics on the script path.
- The usage row for a resumed cycle bills **both** prompts: the helper snapshots the interrupted prompt's credits before the continuation's `carry_over()` zeroes the per-turn stats, and both call sites add the carry into the persisted `TurnUsage` (local review finding, both lanes).
- Transient errors with **no** tokens streamed keep the existing path untouched (that window belongs to `stream_and_collect`'s own retry, whose budget is spent by the time it raises here).

The alternative design floated in the issue (a `retry_on_transient` budget honoured by the scheduler via re-queueing) was deliberately **not** implemented: it changes the schedule contract for every job kind to fix a defect on one path. The one-shot resume preserved partial text without any scheduler change.

Two inherited, documented tradeoffs (mirrored owner decisions from the chat/subagent paths, stated in the helper's docstring): a side-effecting tool that was in flight when the transient hit may be re-issued by the continuation turn (rare: requires a mid-flight tool AND a transient; the previous behaviour was failing the whole cycle), and the resume adds at most one bounded prompt to the cycle's worst case inside the same per-wake deadline (a deadline firing mid-continuation degrades exactly as a mid-turn deadline does today).

## Tests

Five new tests in `test/test_cron_wake_budget.py` (`TestCronPostTokenResume`), driving the real `_cron_callback` via the existing fixture:

- `test_posttoken_transient_recovers_and_records_success` — transient after tokens: exactly one continuation prompt (the CONTINUE message, not the original), result is partial + continuation, `record_success()` resets a pre-seeded failure counter, no auto-pause.
- `test_pretoken_transient_still_takes_existing_path` — transient with no tokens streamed: no resume, one stream call, one failure recorded (existing behaviour preserved).
- `test_non_transient_error_after_tokens_does_not_resume` — an auth/validation error after tokens fails fast, no continuation.
- `test_posttoken_resume_is_one_shot_per_turn` — a transient during the continuation propagates: two stream calls total, never a third, one failure recorded.
- `test_resumed_turn_bills_both_prompts` — the persisted usage row carries interrupted-prompt credits + continuation credits.

The pre-existing `TestCronTransientRetry` suite (pre-dispatch retry semantics) passes unchanged.

## Manual verification

N/A — unit coverage sufficient: the seam is fully exercisable through the mocked stream in the cron-callback tests, and the recovery path has no UI or external-service surface.

## Related Issues

Fixes #4228

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (cron retry path); no watched frontend path touched and no rendered pixel changes.
