### PR TITLE
fix(agent): retry the agent-config rename on a Windows sharing violation

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -49,6 +49,7 @@ from kiro_crew.agent_files import (
     REQUIRED_KIRO_AGENT_FILES,
 )
 from kiro_crew.agent_files import RESEARCH_AGENT_FILENAME as _RESEARCH_AGENT_FILENAME
+from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.config import config_dir
 from kiro_crew.config import config_path as _mc_config_path
 from kiro_crew.config.paths import (
@@ -87,6 +88,16 @@ def _atomic_json_write(path: Path, data: dict) -> None:
     ACP process with exit code 1.  rename() is atomic on Linux when source
     and destination are on the same filesystem.
 
+    The rename goes through ``replace_with_retry`` because atomicity is not the
+    only way that step fails. On Windows ``os.replace`` raises
+    ``PermissionError`` while ANY other handle is open on either path, and a
+    just-written temp file is exactly what an indexer or AV scanner opens —
+    so a correct atomic write can still lose its payload for reasons unrelated
+    to this caller. Here that surfaces as a failed spawn, since these are the
+    configs kiro-cli reads. The helper is Windows-only and never sleeps on the
+    event loop; ``ensure_agent_materialized`` reaches this from
+    ``asyncio.to_thread``, so the retry applies on the path that matters.
+
     Uses mkstemp for a unique temp file per call so concurrent writers
     to the same path don't clobber each other's temp files.
     """
@@ -100,7 +111,7 @@ def _atomic_json_write(path: Path, data: dict) -> None:
             platform_compat.fchmod_safe(f.fileno(), mode)
             json.dump(data, f, indent=2)
             f.write("\n")
-        os.replace(tmp_name, path)
+        replace_with_retry(tmp_name, path)
     except BaseException:
         try:
             os.unlink(tmp_name)

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -11,8 +11,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from windows_sim import replace_sharing_violation
 
 from kiro_crew import agent_state
+from kiro_crew import atomic_write as aw
 from kiro_crew.agent import install_agent, migrate_agent_specs
 
 
@@ -475,6 +477,52 @@ class TestAtomicJsonWrite:
 
         assert stat.S_IMODE(target.stat().st_mode) == 0o644
         assert json.loads(target.read_text(encoding="utf-8")) == {"new": True}
+
+    def test_a_contended_rename_is_retried_on_windows(self, tmp_path: Path, monkeypatch):
+        """The rename this writer ends on is the one Windows can refuse.
+
+        The docstring reasons about Linux, where `rename()` is atomic and a
+        reader holding the destination cannot block it. On Windows `os.replace`
+        raises `PermissionError` (`WinError 32`) while ANY other handle is open
+        on either path, and a freshly written temp file is exactly what an
+        indexer or AV scanner touches. `replace_with_retry` exists for that
+        window and every other tmp-plus-rename writer in the tree goes through
+        it; this one hand-rolled the rename and did not.
+
+        It matters here more than most: these are the agent configs kiro-cli
+        reads at spawn, so a refused rename surfaces as a failed spawn.
+        """
+        from kiro_crew import platform_compat
+        from kiro_crew.agent import _atomic_json_write
+
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+        monkeypatch.setattr(aw, "_REPLACE_BACKOFF_SECONDS", 0)
+        target = tmp_path / "agent.json"
+        target.write_text("{}", encoding="utf-8")
+
+        with replace_sharing_violation(match="agent.json", times=1) as state:
+            _atomic_json_write(target, {"key": "value"})
+
+        assert state["n"] == 2, "one refused rename, then one that succeeded"
+        assert json.loads(target.read_text(encoding="utf-8")) == {"key": "value"}
+
+    def test_a_posix_permission_error_still_propagates(self, tmp_path: Path, monkeypatch):
+        """POSIX permits replacing an open file, so a PermissionError there is a
+        real access fault — retrying would only delay an honest failure, and
+        the temp file must still be cleaned up."""
+        from kiro_crew import platform_compat
+        from kiro_crew.agent import _atomic_json_write
+
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        target = tmp_path / "agent.json"
+        target.write_text("{}", encoding="utf-8")
+
+        with replace_sharing_violation(match="agent.json", times=1):
+            with pytest.raises(PermissionError):
+                _atomic_json_write(target, {"key": "value"})
+
+        assert list(tmp_path.glob("*.tmp")) == [], "the temp file must not be left behind"
+        assert target.read_text(encoding="utf-8") == "{}", "the target is unchanged"
 
     def test_no_temp_file_left_on_success(self, tmp_path: Path):
         from kiro_crew.agent import _atomic_json_write


### PR DESCRIPTION
## Problem / Motivation

`agent._atomic_json_write` hand-rolls its tmp-plus-rename and ends on a bare `os.replace`:

```python
fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
...
os.replace(tmp_name, path)
```

Its docstring reasons only about Linux — *"rename() is atomic on Linux when source and destination are on the same filesystem"* — and atomicity is not the only way that step fails.

On Windows `os.replace` raises `PermissionError` (`WinError 32`) while **any** other handle is open on either path, and a just-written temp file is exactly what an indexer or an AV scanner opens. So a correct atomic write can still lose its payload for reasons that have nothing to do with this caller.

`replace_with_retry` (`atomic_write.py:125`) exists for precisely that window, added in #1105, and it is what every other tmp-plus-rename writer in the tree goes through. This one predates it and never adopted it.

## Why it matters

These are the agent configs **kiro-cli reads at spawn and `set_mode`** — the function exists in the first place because a bad write there crashes the ACP process with exit code 1. A refused rename therefore surfaces as a failed spawn, on Windows only, at random, from a scanner touching a file this process just created.

## What changed (motivation → approach → change)

One line: `os.replace(tmp_name, path)` → `replace_with_retry(tmp_name, path)`, plus the docstring paragraph explaining why the rename needs more than atomicity.

The helper's own gates are the right ones here and are inherited unchanged:

- **Windows-only.** On POSIX a `PermissionError` is a genuine access fault and still propagates on the first attempt rather than being slept over.
- **Bounded**, so a permanently contended path fails instead of spinning.
- **Never sleeps on the event loop.** That gate costs nothing on this path: `ensure_agent_materialized` reaches this from `asyncio.to_thread` in both `acp/client.py:2685` and `acp/runtime.py:905`, so the worker has no loop of its own and the retry applies where it matters.

Temp-file cleanup is unchanged — the `except BaseException` arm still unlinks it, so an exhausted retry leaves nothing behind. That is asserted.

## Tests

**New — two cases in the existing `TestAtomicJsonWrite`:**

| Test | Behavior locked in |
|---|---|
| `test_a_contended_rename_is_retried_on_windows` | A refused rename is retried and the write lands; asserted on the emulator's own count (one refused, then one that succeeded) |
| `test_a_posix_permission_error_still_propagates` | On POSIX the error is raised, the target is unchanged, and no `.tmp` is left behind |

Driven by `windows_sim.replace_sharing_violation`, the repo's deterministic emulator for this fault — the same one `test_atomic_write_retry.py` uses for the helper itself. These do not prove real Windows OS behaviour end to end, only that this writer is now on the retrying path and still fails honestly on POSIX.

**Fail-before / pass-after.** On `origin/main` `test_a_contended_rename_is_retried_on_windows` fails with `PermissionError: [WinError 32] simulated sharing violation replacing ...agent.json`; the POSIX case passes on both, which is what makes it a control. With the change: 3 passed, 2 skipped (the two mode-preservation cases skip on Windows).

**Regressions**, `-p no:randomly`: `test_agent.py`, `test_atomic_write_capabilities.py`, `test_connections_mint.py`, `test_connections_tool_aliases.py` — **502 passed, 14 skipped**, plus 15 failures that reproduce with an identical count on pristine `origin/main` on this host (14 × `os.symlink` → `WinError 1314`, and one subprocess-spawn case). The branch adds exactly the two new passing tests against that same baseline.

`flake8`, `isort`, `mypy --platform linux src/kiro_crew/agent.py` and the Black ratchet all pass.

## Manual verification

None — the fault is a race against a scanner holding a handle, which the emulator reproduces deterministically on any OS and a manual attempt could only reproduce by luck.

## Scope

One production line plus its docstring, in one file, and two tests in the class that already covers this function. No new helper, no new knob — the retry budget and gating are the shared ones.

`agent.py` is the only remaining hand-rolled tmp-plus-rename writer in `src/kiro_crew/` core; the other direct `os.replace` sites live under `src/kiro_crew/apps/builtins/`, which are separate app codebases and are deliberately out of scope here rather than swept in.

## Related Issues

No open issue tracks this specific caller. It is the same defect class as #1105, which added `replace_with_retry` and migrated the writers known at the time; this is one that was missed.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the function's own docstring now states the Windows failure mode
- [x] No secrets, credentials, or internal references in the diff
