### PR TITLE
fix(apps): keep the app-config writes off the event loop

### DIFF
--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -116,7 +116,6 @@ from kiro_crew.apps.registry import (
 from kiro_crew.apps.spawn_sdk import build_spawn_impl
 from kiro_crew.apps.teardown import forget_app_hooks, teardown_app_runtime
 from kiro_crew.apps.version import check_min_version as _check_min_version_str
-from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import (
     ConfigReadError,
     KiroCrewConfig,
@@ -3919,11 +3918,36 @@ async def handle_registries(request: web.Request) -> web.Response:
             )
         validated.append({"name": name, "repo": repo, "branch": branch, "trust": trust})
 
-    # Update config file (atomic write to prevent corruption on crash)
+    # The registry list is part of config.json, so its read-modify-write must
+    # serialize against BOTH config writer generations, not just one: the sidecar
+    # advisory flock that ``update_config_locked`` takes, and the loop-side
+    # ``_get_config_lock`` asyncio lock that the legacy dashboard writers (agents
+    # endpoint, updates.py, security.py, messaging.py, mcp.py, core.py STT) still
+    # serialize on ALONE. Holding only the flock does not exclude that family, so
+    # a concurrent PUT there could commit from a snapshot taken before this write
+    # and silently revert it — the lost update ``config/loader.py`` warns about
+    # when it says such callers must ALSO hold the in-process asyncio lock.
+    # ``run_config_write`` is the one entry point that holds both, and it still
+    # hands the blocking work to a worker, so the loop never stalls.
+    #
+    # Imported at call time rather than module scope for the same layering reason
+    # ``handle_app_uninstall`` imports ``_get_config_lock`` lazily: ``apps`` sits
+    # below ``dashboard`` in the package tree, and a load-time import would invert
+    # that direction.
+    from kiro_crew.dashboard.chat_utils import run_config_write
+
     cfg = Path(config_path())
     try:
-        data = json.loads(cfg.read_text(encoding="utf-8")) if cfg.is_file() else {}
-    except json.JSONDecodeError:
+        newly_trusted = await run_config_write(_write_registries_config, cfg, validated)
+    except ConfigReadError as exc:
+        if isinstance(exc.__cause__, OSError):
+            sel().log_api_access(
+                caller="dashboard",
+                operation="registries.update",
+                outcome="failed",
+                resources=f"config read error: {exc.__cause__}",
+            )
+            return web.json_response({"error": f"cannot read config: {exc.__cause__}"}, status=500)
         sel().log_api_access(
             caller="dashboard",
             operation="registries.update",
@@ -3939,43 +3963,27 @@ async def handle_registries(request: web.Request) -> web.Response:
             caller="dashboard",
             operation="registries.update",
             outcome="failed",
-            resources=f"config read error: {exc}",
+            resources=f"config write error: {exc}",
         )
-        return web.json_response({"error": f"cannot read config: {exc}"}, status=500)
-    # Detect hosts this PUT newly introduces to the registry trust set. A
-    # configured registry host is fed into the loosened-sandbox / SSH-clone
-    # trust set (see registry._configured_registry_hosts) AND its apps become
-    # installable with gateway privileges, so admitting a host is a genuine
-    # trust grant — not just a config edit. The generic ``registries.update``
-    # event does not record WHICH host gained trust, leaving an unreconstructable
-    # audit gap; emit a distinct, per-host ``registries.host_trust_granted``
-    # event so incident response can always establish when/how a host entered
-    # the trust set. Compare against the PRIOR on-disk config, not the freshly
-    # validated list, so re-saving an unchanged list emits nothing.
-    # ``data.get("registries") or []`` (not ``data.get("registries", [])``):
-    # a config carrying an explicit ``"registries": null`` loads fine elsewhere
-    # via the same ``or []`` idiom, so iterating the bare ``.get`` default would
-    # attempt to loop over ``None`` and turn this repair-PUT into an HTTP 500,
-    # blocking the only dashboard path that could fix the malformed value.
-    prior = data.get("registries") or []
-    prior_hosts = {
-        h for r in prior if isinstance(r, dict) and (h := _git_url_host(str(r.get("repo", ""))))
-    }
-    newly_trusted_hosts: list[str] = []
-    for r in validated:
-        host = _git_url_host(r["repo"])
-        if host and host not in prior_hosts and host not in newly_trusted_hosts:
-            newly_trusted_hosts.append(host)
-            sel().log_api_access(
-                caller="dashboard",
-                operation="registries.host_trust_granted",
-                outcome="success",
-                resources=f"host={host} repo={_strip_git_target_userinfo(r['repo'])}",
-            )
+        return web.json_response(
+            {
+                "error": f"cannot write config: {exc}",
+                "code": "registries_config_write_failed",
+            },
+            status=500,
+        )
 
-    data["registries"] = validated
-    cfg.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write(cfg, json.dumps(data, indent=2) + "\n")
+    # Audit trust grants only after the locked update succeeds.  This keeps the
+    # event stream aligned with the persisted trust set when a Windows sharing
+    # violation or another write failure prevents the config change.
+    newly_trusted_hosts = [host for host, _repo in newly_trusted]
+    for host, public_repo in newly_trusted:
+        sel().log_api_access(
+            caller="dashboard",
+            operation="registries.host_trust_granted",
+            outcome="success",
+            resources=f"host={host} repo={public_repo}",
+        )
 
     sel().log_api_access(
         caller="dashboard",
@@ -3996,6 +4004,49 @@ async def handle_registries(request: web.Request) -> web.Response:
             "newlyTrustedHosts": newly_trusted_hosts,
         }
     )
+
+
+def _write_registries_config(cfg: Path, validated: list[dict[str, str]]) -> list[tuple[str, str]]:
+    """Replace the registry trust set under the config lock, off the loop.
+
+    Returns each newly trusted ``(host, public_repo)`` pair so the async handler
+    can emit SEL events after, and only after, the write commits.  Host discovery
+    belongs inside the locked mutation: comparing with a pre-lock snapshot would
+    race a concurrent config writer and could report a grant that was not new.
+
+    Why the returned hosts are audited at all: a configured registry host is fed
+    into the loosened-sandbox / SSH-clone trust set (see
+    ``registry._configured_registry_hosts``) AND its apps become installable with
+    gateway privileges, so admitting a host is a genuine trust grant, not just a
+    config edit.  The generic ``registries.update`` event does not record WHICH
+    host gained trust, leaving an unreconstructable audit gap; the caller emits a
+    distinct per-host ``registries.host_trust_granted`` event so incident response
+    can always establish when and how a host entered the trust set.  Comparison is
+    against the PRIOR on-disk config rather than the freshly validated list, so
+    re-saving an unchanged list emits nothing.
+    """
+    newly_trusted: list[tuple[str, str]] = []
+
+    def _mutate(data: dict) -> dict:
+        # ``or []`` deliberately treats a legacy explicit null as an empty list,
+        # keeping PUT as the repair path for that otherwise valid JSON value.
+        prior = data.get("registries") or []
+        prior_hosts = {
+            host
+            for row in prior
+            if isinstance(row, dict) and (host := _git_url_host(str(row.get("repo", ""))))
+        }
+        seen_hosts: set[str] = set()
+        for row in validated:
+            host = _git_url_host(row["repo"])
+            if host and host not in prior_hosts and host not in seen_hosts:
+                seen_hosts.add(host)
+                newly_trusted.append((host, _strip_git_target_userinfo(row["repo"])))
+        data["registries"] = validated
+        return data
+
+    update_config_locked(cfg, mutate=_mutate)
+    return newly_trusted
 
 
 async def handle_registries_refresh(request: web.Request) -> web.Response:

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -3930,10 +3930,25 @@ async def handle_registries(request: web.Request) -> web.Response:
     # ``run_config_write`` is the one entry point that holds both, and it still
     # hands the blocking work to a worker, so the loop never stalls.
     #
-    # Imported at call time rather than module scope for the same layering reason
-    # ``handle_app_uninstall`` imports ``_get_config_lock`` lazily: ``apps`` sits
-    # below ``dashboard`` in the package tree, and a load-time import would invert
-    # that direction.
+    # Call-time import, deliberately, and NOT under AUTOSDE ``top-level-imports``'
+    # circular-import exception -- there is no cycle on this edge today; every
+    # import order was checked.  The reason is layering and load cost, both
+    # checkable:
+    #
+    #   * No module in ``src/kiro_crew/apps/`` imports ``kiro_crew.dashboard`` at
+    #     module scope.  Not one.  ``apps`` sits below ``dashboard``, and hoisting
+    #     this would create the package's first load-time edge in the wrong
+    #     direction -- into a package that already imports back into this one
+    #     (``dashboard/routes/system.py``, ``dashboard/handlers/security.py``).
+    #     ``apps.manager`` already defers its ``apps.routes`` import for a cycle
+    #     that IS real; widening the graph here makes that worse, not better.
+    #   * Measured: hoisting pulls 117 additional modules into every importer of
+    #     ``apps.routes`` (479 -> 596), and loads the whole ``dashboard.chat_utils``
+    #     tree on paths that today never touch it.
+    #
+    # Same reasoning, same file, as ``handle_app_uninstall``'s lazy
+    # ``_get_config_lock`` import; ``run_config_write`` itself defers that import
+    # for an outright cycle.
     from kiro_crew.dashboard.chat_utils import run_config_write
 
     cfg = Path(config_path())
@@ -3973,17 +3988,12 @@ async def handle_registries(request: web.Request) -> web.Response:
             status=500,
         )
 
-    # Audit trust grants only after the locked update succeeds.  This keeps the
-    # event stream aligned with the persisted trust set when a Windows sharing
-    # violation or another write failure prevents the config change.
+    # The per-host trust grants are audited by ``_write_registries_config`` itself,
+    # on the worker thread that committed them -- see the comment there for why
+    # this cannot be done here.  What remains is the API-outcome event, which
+    # correctly belongs to the request: if the caller was cancelled it never runs,
+    # because the request did not succeed.
     newly_trusted_hosts = [host for host, _repo in newly_trusted]
-    for host, public_repo in newly_trusted:
-        sel().log_api_access(
-            caller="dashboard",
-            operation="registries.host_trust_granted",
-            outcome="success",
-            resources=f"host={host} repo={public_repo}",
-        )
 
     sel().log_api_access(
         caller="dashboard",
@@ -4009,19 +4019,20 @@ async def handle_registries(request: web.Request) -> web.Response:
 def _write_registries_config(cfg: Path, validated: list[dict[str, str]]) -> list[tuple[str, str]]:
     """Replace the registry trust set under the config lock, off the loop.
 
-    Returns each newly trusted ``(host, public_repo)`` pair so the async handler
-    can emit SEL events after, and only after, the write commits.  Host discovery
-    belongs inside the locked mutation: comparing with a pre-lock snapshot would
-    race a concurrent config writer and could report a grant that was not new.
+    Emits a per-host ``registries.host_trust_granted`` SEL event after, and only
+    after, the write commits, and returns each newly trusted ``(host, repo)`` pair
+    for the response body.  Host discovery belongs inside the locked mutation:
+    comparing with a pre-lock snapshot would race a concurrent config writer and
+    could report a grant that was not new.
 
     Why the returned hosts are audited at all: a configured registry host is fed
     into the loosened-sandbox / SSH-clone trust set (see
     ``registry._configured_registry_hosts``) AND its apps become installable with
     gateway privileges, so admitting a host is a genuine trust grant, not just a
     config edit.  The generic ``registries.update`` event does not record WHICH
-    host gained trust, leaving an unreconstructable audit gap; the caller emits a
-    distinct per-host ``registries.host_trust_granted`` event so incident response
-    can always establish when and how a host entered the trust set.  Comparison is
+    host gained trust, leaving an unreconstructable audit gap; a distinct per-host
+    ``registries.host_trust_granted`` event lets incident response always establish
+    when and how a host entered the trust set.  Comparison is
     against the PRIOR on-disk config rather than the freshly validated list, so
     re-saving an unchanged list emits nothing.
     """
@@ -4046,6 +4057,29 @@ def _write_registries_config(cfg: Path, validated: list[dict[str, str]]) -> list
         return data
 
     update_config_locked(cfg, mutate=_mutate)
+
+    # Audit HERE, in the worker, and not in the async caller.  ``run_config_write``
+    # shields this thread and drains it across cancellation, then re-raises
+    # ``CancelledError`` and DISCARDS the return value.  A gateway shutdown or a
+    # client disconnect landing in that window therefore commits the trust grant
+    # and never reaches an audit emitted by the caller -- persisted trust with no
+    # ``host_trust_granted`` record, which is precisely the reconstruction gap
+    # this event exists to close.  Emitting on the thread that completed the write
+    # binds the event to the commit: the two cannot disagree, because nothing can
+    # interrupt a thread between these two statements.
+    #
+    # Still strictly after ``update_config_locked`` returns, so a failed write
+    # raises before any grant is announced.  SEL is thread-safe and adapts to an
+    # off-loop caller (``_on_event_loop``), and a non-critical event swallows
+    # filesystem errors rather than raising, so this cannot turn a committed
+    # write into a 500.
+    for host, public_repo in newly_trusted:
+        sel().log_api_access(
+            caller="dashboard",
+            operation="registries.host_trust_granted",
+            outcome="success",
+            resources=f"host={host} repo={public_repo}",
+        )
     return newly_trusted
 
 

--- a/test/test_apps_instances_loop_offload.py
+++ b/test/test_apps_instances_loop_offload.py
@@ -241,11 +241,13 @@ class _BlockingRegistry(_RecordingRegistry):
 
     def __init__(self) -> None:
         super().__init__()
+        self.started = threading.Event()
         self.release = threading.Event()
         self.completed = False
 
     def update(self, instance_id: str, **changes: object) -> Any:
-        self.release.wait(timeout=10)
+        self.started.set()
+        assert self.release.wait(timeout=10), "test never released the registry write"
         self.completed = True
         return super().update(instance_id, **changes)
 
@@ -264,14 +266,22 @@ async def test_cancelled_persist_waits_for_the_worker_write(
     # Pin the forwarder-identity branch UNREACHABLE: the subject here is the
     # cancellation window around the BLOCKED registry write, so this wants the
     # shortest deterministic route to it. Taking the identity branch instead
-    # would add two more to_thread hops ahead of that write, narrowing the
-    # sleep window below for no gain — test 1 above covers that branch.
+    # would add two more to_thread hops ahead of that write for no gain — test
+    # 1 above covers that branch.
     _pin_forwarder_identity(monkeypatch, reachable=False)
 
     task = asyncio.create_task(mgr._mark_recovered("inst"))
-    await asyncio.sleep(0.05)  # the worker write is submitted and blocked
+    assert await asyncio.to_thread(
+        registry.started.wait, 10
+    ), "registry write never reached its deterministic blocking point"
     task.cancel()
-    await asyncio.sleep(0.05)  # cancellation delivered
+
+    # Task.cancel() queues the cancelled task before this sentinel. Awaiting the
+    # sentinel therefore observes the state after cancellation was delivered,
+    # without guessing how long the scheduler or worker pool might take.
+    cancellation_delivered = asyncio.get_running_loop().create_future()
+    asyncio.get_running_loop().call_soon(cancellation_delivered.set_result, None)
+    await cancellation_delivered
 
     # The frame must still be waiting on the in-flight worker write.
     assert not task.done(), (
@@ -462,7 +472,15 @@ def test_no_direct_registry_call_in_instances_handler_async_frames() -> None:
 async def test_registries_config_write_runs_off_the_loop_thread(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The real PUT handler hands the locked config mutation to a worker."""
+    """The real PUT handler hands the locked config mutation to a worker.
+
+    The per-host trust audit is deliberately NOT asserted here any more: it is
+    emitted by ``_write_registries_config`` itself, on the thread that commits
+    the write, so that a cancellation drained by ``run_config_write`` cannot
+    persist a grant with no record. This stub replaces that function, so the
+    handler must not be the one emitting -- which is what the last assertion
+    pins. See ``test_cancelled_registries_write_still_audits_the_trust_grant``.
+    """
     loop_thread = threading.current_thread()
     write_threads: list[threading.Thread] = []
     audits: list[dict[str, Any]] = []
@@ -488,7 +506,10 @@ async def test_registries_config_write_runs_off_the_loop_thread(
     assert response.status == 200
     assert write_threads, "the registry config write was never invoked"
     assert all(thread is not loop_thread for thread in write_threads)
-    assert any(event.get("operation") == "registries.host_trust_granted" for event in audits)
+    assert response.text is not None
+    assert json.loads(response.text)["newlyTrustedHosts"] == ["github.com"]
+    assert any(event.get("operation") == "registries.update" for event in audits)
+    assert all(event.get("operation") != "registries.host_trust_granted" for event in audits)
 
 
 @pytest.mark.asyncio
@@ -516,8 +537,141 @@ async def test_failed_registries_config_write_does_not_audit_a_trust_grant(
     response = await routes_mod.handle_registries(request)
 
     assert response.status == 500
+    assert response.text is not None
     assert json.loads(response.text)["code"] == "registries_config_write_failed"
     assert all(event.get("operation") != "registries.host_trust_granted" for event in audits)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_registries_write_still_audits_the_trust_grant(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cancellation between commit and audit must not lose the grant record.
+
+    ``run_config_write`` shields its worker and drains it, so a cancellation
+    arriving while the write is in flight still commits the config -- and then
+    re-raises ``CancelledError``, discarding the return value. An audit emitted
+    by the async caller is therefore skipped on exactly the path where the trust
+    grant DID land, leaving persisted trust with no ``host_trust_granted``
+    event. Gateway shutdown and a client disconnect mid-PUT both reach it.
+
+    Red-before with the audit in the handler: config contains the registry and
+    ``grants == []``.
+    """
+    cfg = tmp_path / "config.json"
+    cfg.write_text("{}", encoding="utf-8")
+    validated = [
+        {
+            "name": "example",
+            "repo": "https://github.com/example/apps.git",
+            "branch": "main",
+            "trust": "",
+        }
+    ]
+
+    audits: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        routes_mod,
+        "sel",
+        lambda: SimpleNamespace(log_api_access=lambda **kwargs: audits.append(kwargs)),
+    )
+
+    inside_write = threading.Event()
+    may_finish = threading.Event()
+    real_update = routes_mod.update_config_locked
+
+    def _blocking_update(path: Path, *, mutate: Callable[[dict], dict | None]) -> dict:
+        # Park the worker INSIDE the locked write so the cancellation is
+        # delivered at the one moment that matters, with no sleeps.
+        inside_write.set()
+        assert may_finish.wait(10), "test never released the worker"
+        return real_update(path, mutate=mutate)
+
+    monkeypatch.setattr(routes_mod, "update_config_locked", _blocking_update)
+
+    from kiro_crew.dashboard.chat_utils import run_config_write
+
+    task = asyncio.ensure_future(
+        run_config_write(routes_mod._write_registries_config, cfg, validated)
+    )
+    await asyncio.to_thread(inside_write.wait, 10)
+    task.cancel()
+    may_finish.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # 1. the write committed despite the cancellation
+    written = json.loads(cfg.read_text(encoding="utf-8"))
+    assert [row["repo"] for row in written["registries"]] == [
+        "https://github.com/example/apps.git"
+    ]
+    # 2. and every host it newly trusted was audited
+    grants = [e for e in audits if e.get("operation") == "registries.host_trust_granted"]
+    assert len(grants) == 1
+    assert "host=github.com" in grants[0]["resources"]
+
+
+def test_registries_write_audits_each_new_host_exactly_once(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No duplicate on the normal path, and nothing for an already-trusted host."""
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps({"registries": [{"repo": "https://github.com/old/apps.git"}]}),
+        encoding="utf-8",
+    )
+    audits: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        routes_mod,
+        "sel",
+        lambda: SimpleNamespace(log_api_access=lambda **kwargs: audits.append(kwargs)),
+    )
+
+    validated = [
+        {"name": "old", "repo": "https://github.com/old/apps.git", "branch": "", "trust": ""},
+        {"name": "new", "repo": "https://gitlab.com/new/apps.git", "branch": "", "trust": ""},
+        # A second path on the SAME new host must not double-audit it.
+        {"name": "new2", "repo": "https://gitlab.com/new/other.git", "branch": "", "trust": ""},
+    ]
+    granted = routes_mod._write_registries_config(cfg, validated)
+
+    assert granted == [("gitlab.com", "https://gitlab.com/new/apps.git")]
+    grants = [e for e in audits if e.get("operation") == "registries.host_trust_granted"]
+    assert len(grants) == 1
+    assert "host=gitlab.com" in grants[0]["resources"]
+
+
+def test_failed_registries_write_audits_no_trust_grant(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The audit stays strictly after the commit, so a failed write announces nothing.
+
+    Guards the ordering the fix depends on: the emission moved into the worker,
+    but it must not move ahead of ``update_config_locked``.
+    """
+    cfg = tmp_path / "config.json"
+    cfg.write_text("{}", encoding="utf-8")
+    audits: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        routes_mod,
+        "sel",
+        lambda: SimpleNamespace(log_api_access=lambda **kwargs: audits.append(kwargs)),
+    )
+
+    def _boom(path: Path, *, mutate: Callable[[dict], dict | None]) -> dict:
+        mutate({})  # host discovery runs, exactly as it does on the happy path
+        raise OSError("sharing violation")
+
+    monkeypatch.setattr(routes_mod, "update_config_locked", _boom)
+
+    validated = [
+        {"name": "x", "repo": "https://github.com/example/apps.git", "branch": "", "trust": ""}
+    ]
+    with pytest.raises(OSError):
+        routes_mod._write_registries_config(cfg, validated)
+
+    assert [e for e in audits if e.get("operation") == "registries.host_trust_granted"] == []
 
 
 def test_registries_config_write_uses_the_locked_update(

--- a/test/test_apps_instances_loop_offload.py
+++ b/test/test_apps_instances_loop_offload.py
@@ -26,10 +26,11 @@ from __future__ import annotations
 import ast
 import asyncio
 import inspect
+import json
 import threading
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import pytest
 from aiohttp.test_utils import make_mocked_request
@@ -357,7 +358,17 @@ def _module_tree(module: Any) -> ast.AST:
         # the disk-touching primitive behind the publish-provider collection: a
         # future async call with an injected non-disk resolver must not trip
         # this gate, while the default resolver's file reads must.
-        (routes_mod, {"list_apps", "_provider_is_configured"}),
+        # The registry config helper performs a locked read-modify-atomic-write.
+        # Besides filesystem latency, the Windows rename retry is intentionally
+        # available only when no event loop is running in the calling thread.
+        (
+            routes_mod,
+            {
+                "list_apps",
+                "_provider_is_configured",
+                "_write_registries_config",
+            },
+        ),
         (hooks_mod, {"list_apps"}),
         (bridges_mod, {"list_apps"}),
     ],
@@ -440,3 +451,232 @@ def test_no_direct_registry_call_in_instances_handler_async_frames() -> None:
         if is_reg_name or is_registry_call:
             offenders.append(f"{owner}:{call.lineno} calls registry .{func.attr}() on the loop")
     assert not offenders, "direct registry call on the event loop:\n" + "\n".join(offenders)
+
+
+# ---------------------------------------------------------------------------
+# App config writes (#4548's class, one module over)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registries_config_write_runs_off_the_loop_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real PUT handler hands the locked config mutation to a worker."""
+    loop_thread = threading.current_thread()
+    write_threads: list[threading.Thread] = []
+    audits: list[dict[str, Any]] = []
+
+    def _write(_cfg: Path, _validated: list[dict[str, str]]) -> list[tuple[str, str]]:
+        write_threads.append(threading.current_thread())
+        return [("github.com", "https://github.com/example/apps.git")]
+
+    async def _json() -> dict[str, object]:
+        return {"registries": [{"name": "example", "repo": "https://github.com/example/apps.git"}]}
+
+    monkeypatch.setattr(routes_mod, "_write_registries_config", _write)
+    monkeypatch.setattr(routes_mod, "_pinned_registries", lambda: [])
+    monkeypatch.setattr(
+        routes_mod,
+        "sel",
+        lambda: SimpleNamespace(log_api_access=lambda **kwargs: audits.append(kwargs)),
+    )
+
+    request = cast(Any, SimpleNamespace(method="PUT", json=_json))
+    response = await routes_mod.handle_registries(request)
+
+    assert response.status == 200
+    assert write_threads, "the registry config write was never invoked"
+    assert all(thread is not loop_thread for thread in write_threads)
+    assert any(event.get("operation") == "registries.host_trust_granted" for event in audits)
+
+
+@pytest.mark.asyncio
+async def test_failed_registries_config_write_does_not_audit_a_trust_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed write cannot produce a trust event for state that never landed."""
+    audits: list[dict[str, Any]] = []
+
+    def _write(_cfg: Path, _validated: list[dict[str, str]]) -> list[tuple[str, str]]:
+        raise OSError("sharing violation")
+
+    async def _json() -> dict[str, object]:
+        return {"registries": [{"repo": "https://github.com/example/apps.git"}]}
+
+    monkeypatch.setattr(routes_mod, "_write_registries_config", _write)
+    monkeypatch.setattr(routes_mod, "_pinned_registries", lambda: [])
+    monkeypatch.setattr(
+        routes_mod,
+        "sel",
+        lambda: SimpleNamespace(log_api_access=lambda **kwargs: audits.append(kwargs)),
+    )
+
+    request = cast(Any, SimpleNamespace(method="PUT", json=_json))
+    response = await routes_mod.handle_registries(request)
+
+    assert response.status == 500
+    assert json.loads(response.text)["code"] == "registries_config_write_failed"
+    assert all(event.get("operation") != "registries.host_trust_granted" for event in audits)
+
+
+def test_registries_config_write_uses_the_locked_update(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The worker computes host grants from the state protected by the lock."""
+    observed: dict[str, object] = {}
+
+    def _update_config_locked(path: Path, *, mutate: Callable[[dict], dict | None]) -> dict:
+        data = {
+            "unrelated": {"keep": True},
+            "registries": [{"repo": "https://github.com/existing/apps.git"}],
+        }
+        result = mutate(data)
+        assert result is not None
+        observed["path"] = path
+        observed["data"] = result
+        return result
+
+    monkeypatch.setattr(routes_mod, "update_config_locked", _update_config_locked)
+    validated = [
+        {
+            "name": "same-host",
+            "repo": "https://github.com/other/apps.git",
+            "branch": "main",
+            "trust": "index",
+        },
+        {
+            "name": "new-host",
+            "repo": "https://gitlab.com/new/apps.git",
+            "branch": "main",
+            "trust": "index",
+        },
+        {
+            "name": "same-new-host",
+            "repo": "https://gitlab.com/new/other.git",
+            "branch": "main",
+            "trust": "index",
+        },
+    ]
+    cfg = tmp_path / "config.json"
+
+    grants = routes_mod._write_registries_config(cfg, validated)
+
+    assert observed["path"] == cfg
+    assert observed["data"] == {
+        "unrelated": {"keep": True},
+        "registries": validated,
+    }
+    assert grants == [("gitlab.com", "https://gitlab.com/new/apps.git")]
+
+
+@pytest.mark.asyncio
+async def test_registries_config_write_holds_the_loop_side_config_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The registry PUT must serialize against the asyncio-lock-only writers.
+
+    ``config.json`` has two writer generations and they do not exclude each
+    other. ``_write_registries_config`` reaches the file through
+    ``update_config_locked``, which takes the sidecar advisory flock ONLY; the
+    dashboard's legacy writers (agents endpoint, ``updates.py``, ``security.py``,
+    ``messaging.py``, ``mcp.py``, ``core.py`` STT) take ``_get_config_lock``
+    ONLY. Dispatching this write with a bare ``asyncio.to_thread`` therefore
+    holds nothing the legacy family respects, and a concurrent PUT there can
+    commit a snapshot taken before this write and silently revert it.
+
+    ``run_config_write`` is the one entry point that holds BOTH, so the loop-side
+    lock must be held while the worker runs. Reverting the dispatch to
+    ``asyncio.to_thread`` makes ``locked()`` observe ``False`` and fails here.
+    """
+    from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+    lock_held: list[bool] = []
+    write_threads: list[threading.Thread] = []
+    loop_thread = threading.current_thread()
+
+    def _write(_cfg: Path, _validated: list[dict[str, str]]) -> list[tuple[str, str]]:
+        # Probed from the worker thread. ``LoopBoundLock.locked()`` outside a
+        # running loop reports whether ANY live loop holds it, which is exactly
+        # the question here.
+        lock_held.append(_get_config_lock().locked())
+        write_threads.append(threading.current_thread())
+        return [("github.com", "https://github.com/example/apps.git")]
+
+    async def _json() -> dict[str, object]:
+        return {"registries": [{"name": "example", "repo": "https://github.com/example/apps.git"}]}
+
+    monkeypatch.setattr(routes_mod, "_write_registries_config", _write)
+    monkeypatch.setattr(routes_mod, "_pinned_registries", lambda: [])
+    monkeypatch.setattr(
+        routes_mod,
+        "sel",
+        lambda: SimpleNamespace(log_api_access=lambda **kwargs: None),
+    )
+
+    assert not _get_config_lock().locked(), "precondition: the config lock starts free"
+
+    request = cast(Any, SimpleNamespace(method="PUT", json=_json))
+    response = await routes_mod.handle_registries(request)
+
+    assert response.status == 200
+    assert lock_held == [True], "the loop-side config lock was not held across the write"
+    # The lock must not outlive the request, or the next config writer deadlocks.
+    assert not _get_config_lock().locked()
+    # And the fix must not have pulled the blocking work back onto the loop.
+    assert write_threads and all(thread is not loop_thread for thread in write_threads)
+
+
+def test_registries_config_write_is_not_dispatched_with_a_bare_to_thread() -> None:
+    """``_write_registries_config`` may not be handed straight to a raw offload.
+
+    The behavioral test above proves the lock is held on the path it drives;
+    this ratchet stops a SECOND dispatch site reintroducing the bare form
+    somewhere that test does not reach. ``asyncio.to_thread`` is legitimate
+    throughout this module for work that touches no shared config file, so the
+    scan is deliberately narrow: it fires only when the callable being offloaded
+    is ``_write_registries_config`` itself.
+    """
+    offenders: list[str] = []
+    for owner, call in _calls_in_async_frames(_module_tree(routes_mod)):
+        func = call.func
+        is_to_thread = (
+            isinstance(func, ast.Attribute)
+            and func.attr == "to_thread"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "asyncio"
+        )
+        if not is_to_thread or not call.args:
+            continue
+        first = call.args[0]
+        if isinstance(first, ast.Name) and first.id == "_write_registries_config":
+            offenders.append(
+                f"{owner}:{call.lineno} offloads _write_registries_config with a bare "
+                "asyncio.to_thread; use dashboard.chat_utils.run_config_write so the "
+                "loop-side config lock is held too"
+            )
+    assert not offenders, "config write bypasses the loop-side lock:\n" + "\n".join(offenders)
+
+
+def test_the_registry_write_ratchet_can_actually_fail() -> None:
+    """Self-check: a scan that matches nothing would pass vacuously.
+
+    Feeds the ratchet's own predicate the shape it exists to reject, so a future
+    edit that breaks the AST matching (a renamed helper, a changed call form)
+    cannot leave the ratchet silently green.
+    """
+    tree = ast.parse(
+        "import asyncio\n"
+        "async def handler():\n"
+        "    return await asyncio.to_thread(_write_registries_config, cfg, validated)\n"
+    )
+    matched = [
+        call
+        for _owner, call in _calls_in_async_frames(tree)
+        if isinstance(call.func, ast.Attribute)
+        and call.func.attr == "to_thread"
+        and call.args
+        and isinstance(call.args[0], ast.Name)
+        and call.args[0].id == "_write_registries_config"
+    ]
+    assert len(matched) == 1, "the ratchet no longer recognises the shape it must reject"


### PR DESCRIPTION
## Problem / Motivation

PUT /api/apps/registries performed its config.json read-modify-write synchronously on the asyncio event loop and without holding both config-writer lock generations. A concurrent writer could therefore lose unrelated configuration.

The trust audit also had two opposite failure modes:

- auditing before persistence could claim a trust grant after a failed write;
- auditing after run_config_write in the async handler could be skipped on cancellation even though the shielded worker completed the write.

Current main already contains the earlier enable/disable offload work. This PR is intentionally limited to the remaining registry PUT path.

## What changed

- Move the complete registry read-modify-write into _write_registries_config.
- Dispatch it through dashboard.chat_utils.run_config_write, which holds the loop-side async config lock while the worker uses update_config_locked and its cross-process sidecar lock.
- Compute newly trusted hosts from the state protected by that locked mutation.
- Emit each registries.host_trust_granted event in the same worker immediately after the write commits. Failed writes emit no grant, while cancellation can no longer leave persisted trust without an audit record.
- Preserve unrelated config, existing error contracts, grant deduplication, and the request-level registries.update event.
- Keep the run_config_write import call-time. This avoids introducing the first module-scope dependency from apps into dashboard and avoids loading the dashboard tree for routes that never write config.

The previous unrelated SessionManager teardown rider was removed in full while resolving the merge conflict. The PR now contains exactly two cohesive commits and changes only:

- src/kiro_crew/apps/routes.py
- test/test_apps_instances_loop_offload.py

## Concurrency and cancellation contract

config.json currently has two writer generations:

- update_config_locked takes the cross-process advisory lock;
- legacy dashboard writers serialize on the in-process async config lock.

Holding only one permits stale-snapshot overwrites across the two families. run_config_write is the existing bridge that holds both while keeping blocking I/O off the event loop. It shields and drains the worker across cancellation, so the grant audit must live with the worker's committed mutation rather than in the cancelled caller.

## Tests

The focused file now has 23 deterministic tests covering:

- worker-thread dispatch and loop responsiveness;
- ownership and release of the loop-side lock;
- locked mutation, unrelated-config preservation, and grant deduplication;
- failed writes producing neither persistence nor a trust-grant audit;
- cancellation at a controlled threading.Event boundary still producing both the committed config and exactly one grant audit;
- AST ratchets preventing a bare asyncio.to_thread regression;
- cancellation of another blocked registry write using events and an event-loop sentinel, replacing its former sleep(0.05) timing guesses.

Validation on the pushed head:

- test/test_apps_instances_loop_offload.py: **23 passed** under strict RuntimeWarning and PytestUnraisableExceptionWarning handling;
- mypy on both changed files: pass;
- flake8 and isort on both changed files: pass;
- official Black changed-file gate: pass;
- import smoke test, git diff --check, and merge-tree against the then-current main (901ef092b): pass.

No retries, warning filters, relaxed assertions, longer acceptance timeouts, or scheduler-time sleeps were added.

## Related pending PRs

The shared apps/routes.py changes in #6854 and #5488 are in separate semantic regions. #6206 is a broader 27-file App Store refresh PR that is itself conflicting; this smaller config-writer correctness fix is resolved first so #6206 can reconcile against the stable owner.

## Checklist

- [x] At most two commits (this PR has exactly two)
- [x] Merge conflict resolved without restoring unrelated changes
- [x] Deterministic targeted tests cover the behavior
- [x] Static and formatting gates pass
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
