### PR TITLE
fix(i18n): route two display counts through fmtNumber

### DIFF
--- a/website/src/components/WebAppArtifactCard.tsx
+++ b/website/src/components/WebAppArtifactCard.tsx
@@ -21,6 +21,7 @@ import { useCloudDeploymentEnabled } from '../hooks/useCloudDeploymentEnabled'
 import type { Artifact, WebAppMetadata } from '../types'
 
 import { i18nT } from '../i18n/t'
+import { fmtNumber } from '../i18n/format'
 function statusBadgeVariant(status: string): 'ok' | 'warn' | 'err' | 'aim' {
   switch (status) {
     case 'live': return 'ok'
@@ -132,7 +133,7 @@ function CostPills({ cost, label }: { cost: WebAppMetadata['cost']; label: strin
             key={i}
             className="inline-flex items-baseline gap-1.5 rounded-full border border-border bg-bg-elevated px-2.5 py-1"
           >
-            <span className="text-[11px] text-muted">{Number(e.views ?? 0).toLocaleString()} {i18nT('components.webAppArtifactCard.views')}</span>
+            <span className="text-[11px] text-muted">{fmtNumber(Number(e.views ?? 0))} {i18nT('components.webAppArtifactCard.views')}</span>
             <span className="text-[12px] font-medium text-text-strong">${Number(e.usd ?? 0).toFixed(4)}</span>
           </span>
         ))}

--- a/website/src/i18n/localeFormatting.test.ts
+++ b/website/src/i18n/localeFormatting.test.ts
@@ -106,7 +106,7 @@ const PREFIX = 'website/src/'
  * deleted and the assertion becomes `[]`, which is the phase's stated acceptance
  * gate ("zero bare `toLocale*`/`localeCompare` outside `format.ts`").
  */
-const BASELINE = 37
+const BASELINE = 25
 
 /** The seam itself. It is where a locale is legitimately resolved. */
 const SEAM = new Set(['i18n/format.ts'])

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -209,7 +209,7 @@ import { i18nT } from '../i18n/t'
 import { parseNudgeMessage, nudgeLabel } from './chat/NudgeCard'
 import { parseSubagentCompletionMessage } from './chat/subagentCompletion'
 import { headline as subagentHeadline } from './chat/SubagentCompletionCard'
-import { fmtDateFields } from '../i18n/format'
+import { fmtDateFields, fmtNumber } from '../i18n/format'
 import { fmtMessageTime, fmtMessageTimeFull } from './chat/messageTime'
 /**
  * Human-readable reason from a rejected thunk. `unwrap()` rejects with RTK's
@@ -403,7 +403,7 @@ function KnowledgeBubbleChip({ knowledge }: { knowledge: { items: number; tokens
         aria-expanded={expanded}
         aria-label={expanded ? i18nT('pages.chatPage.collapse_knowledge_context') : i18nT('pages.chatPage.expand_knowledge_context')}
       >
-        <BookOpen size={12} className="shrink-0" /> {i18nT('pages.chatPage.knowledge_item', { count: knowledge.items })} · {knowledge.tokens.toLocaleString()} {i18nT('pages.chatPage.tokens')}
+        <BookOpen size={12} className="shrink-0" /> {i18nT('pages.chatPage.knowledge_item', { count: knowledge.items })} · {fmtNumber(knowledge.tokens)} {i18nT('pages.chatPage.tokens')}
       </button>
       {expanded && knowledge.content && (
         <div className="mt-1 max-h-[300px] overflow-auto rounded border border-border bg-bg-elevated p-2 text-[11px]">


### PR DESCRIPTION
## Problem / Motivation

Two counts in the dashboard are still formatted with a bare `toLocaleString()`:

- the knowledge-context chip's token count in the chat transcript (`src/pages/ChatPage.tsx:406`)
- the estimated-views pill on the web-app artifact card (`src/components/WebAppArtifactCard.tsx:135`)

A bare `toLocaleString()` formats in the **browser's** locale, not the dashboard language. `LanguageProvider` sets `<html lang>`, but `Intl` does not read that attribute, so a dashboard running in Chinese on an en-US browser renders `1,234` for the token count: English grouping rules, sitting right next to a Chinese label. On a German browser the same count renders `1.234`. The labels around both numbers already go through `i18nT()`; only the numbers were left behind.

## Why it matters

The dashboard ships in twelve languages, and this failure mode is quiet. When the browser locale and the app language agree, everything looks correct, so the break only surfaces for people who deliberately run the UI in a different language than their OS. Those are exactly the users the translation program exists for. Leaving these two sites unmigrated keeps the host-locale ratchet's live count inflated and leaves a visible inconsistency (translated label, untranslated number formatting) on two surfaces that users see during normal chat and artifact use.

## What changed (motivation → approach → change)

Symptom: two display counts ignore the dashboard language. Root cause: both call `toLocaleString()` with no locale argument, which `Intl` resolves to the host environment. Fix: route both through `fmtNumber()` from `src/i18n/format.ts`, the seam that reads the active language per call and formats with `Intl.NumberFormat`. That is the same helper issue-radar, Mochi, and other pages already use, so this PR follows an established pattern rather than inventing one.

Two alternatives, and why I did not take them:

- Pinning a locale (`toLocaleString('en-US')`) would satisfy the gate's matcher but is the wrong fix here. These are display values that should follow the app language, not machine-parsed values that need a fixed format. The seam exists precisely so the locale choice stays dynamic.
- Migrating more of the remaining call sites in the same PR would be the helpful-looking move, but most of what is left is `localeCompare` sort order, which is a different discussion (some of those sorts may want byte order instead). Keeping this PR to two display counts keeps it reviewable in one pass.

The change is three files:

- `src/pages/ChatPage.tsx` — `knowledge.tokens.toLocaleString()` → `fmtNumber(knowledge.tokens)`
- `src/components/WebAppArtifactCard.tsx` — `Number(e.views ?? 0).toLocaleString()` → `fmtNumber(Number(e.views ?? 0))`
- `src/i18n/localeFormatting.test.ts` — `BASELINE` 37 → 25

The baseline edit is the gate doing its job. `BASELINE` is an upward-only ceiling on un-migrated host-locale calls; the live count had drifted to 27 under the old ceiling of 37, and the test itself prints "Lower BASELINE to 27 in src/i18n/localeFormatting.test.ts to keep it measuring something" whenever a migration shrinks the count. This PR does both halves at once: it removes two offenders (27 → 25) and resets the ceiling to the new live count, per the file's own instruction to keep the ceiling tight rather than leaving slack a merge-conflict resolution could spend.

No catalog files change. Neither site gains or loses a string; only the number formatting moved, so there is no translation work for the other eleven languages.

For users whose browser locale matches the dashboard language, the rendered output is byte-identical to before. The PR only changes what mismatched-locale users see, and for them it changes it to match everything else on screen.

## Tests

- The ratchet is the regression lock. I lowered `BASELINE` to 25 **before** migrating the call sites and watched the gate fail (`expected 27 to be less than or equal to 25`), then migrated and watched it pass. So the assertion is proven to catch a regression at these sites, not merely observed going green.
- `I18N_BASE_REF=main npx vitest run src/i18n/localeFormatting.test.ts` — 7/7, including both diff-scoped gates (`[added-lines]`, `[vs-base]`).
- `npm run i18n:check` — all 18 checks pass.
- `npx tsc -b` — clean. `npm run build` — succeeds.
- `src/test/WebAppArtifactCard.test.tsx` — 28 tests pass, unchanged by the migration.

## Manual verification

The gates prove the locale is chosen; they cannot prove the pixel. A quick eyeball for a reviewer who wants one: set the dashboard language to `zh-CN` in an en-US browser, open a chat whose context includes knowledge items totaling at least 1,000 tokens, and expand the knowledge chip. The count should render without an English thousands separator. Then check a web-app artifact card with traffic estimates: the views pill follows the app language too. With matching locales there is nothing to see, which is the point.

## Screenshots / video

The only observable difference is a grouping separator under mismatched locales, and the ratchet plus diff-scoped gates lock the behavior change itself. The manual steps above reproduce the visual in a few seconds, so I skipped committing screenshots for a two-line rendering change. Say the word if you would rather have captures, and I will add them under `temp-screenshots/`.

## Related Issues

Part of the dashboard i18n remediation program #1004 (Phase 4, the host-locale ratchet). There is no dedicated issue for these two specific sites.

## Checklist

- [x] Existing tests pass and the gate was tightened to lock the change
- [x] Self-review completed; change follows the existing `format.ts` seam pattern
- [x] Documentation updated (if applicable) — N/A: this enforces the documented seam rule in `website/AGENTS.md`; no doc describes these two call sites
- [x] No secrets, credentials, or internal references in the diff
