### PR TITLE
fix(browser): scope baseline install to Chromium

### DIFF
--- a/docs/system-specs/modules/browser.md
+++ b/docs/system-specs/modules/browser.md
@@ -88,11 +88,14 @@ once, at install, so registry auth applies at install time only.
 
 1. Detect `playwright-cli` on PATH and Node.js 20 or newer.
 2. Install when absent: `npm install -g @playwright/cli@latest`.
-3. `playwright-cli install-browser` for the browser binary. The CLI downloads one
-   on first use regardless, so the explicit step exists to give the operator a
-   progress surface and a visible failure rather than a stall inside the first
-   browse. `--with-deps` is appended only on an apt host, and a refusal there is
-   retried without it — see [OS dependencies](#os-dependencies).
+3. `playwright-cli install-browser chromium` for the baseline browser binary.
+   The engine argument is required: omitting it installs every engine and lets an
+   optional Firefox or WebKit dependency failure veto a working Chromium setup.
+   The CLI downloads Chromium on first use regardless, so the explicit step exists
+   to give the operator a progress surface and a visible failure rather than a
+   stall inside the first browse. `--with-deps` is appended only on an apt host,
+   and a refusal there is retried without it — see
+   [OS dependencies](#os-dependencies).
 4. `playwright-cli install --skills agents --global` so the command reference is
    discoverable from the skill file rather than occupying the system prompt.
    `--skills` accepts `claude` (default) or `agents`; `--global` targets the home

--- a/src/kiro_crew/browser_cli/install.py
+++ b/src/kiro_crew/browser_cli/install.py
@@ -195,6 +195,7 @@ def _browsers_cache_dir() -> Path | None:
 # tuple, not free input: it is what validates the engine name before it reaches
 # argv (see `install_browser`), which is what keeps that spawn benign.
 BROWSER_ENGINES: tuple[str, ...] = ("chromium", "firefox", "webkit")
+_DEFAULT_BROWSER_ENGINE = BROWSER_ENGINES[0]
 
 
 def _cached_browser_names() -> set[str] | None:
@@ -663,7 +664,10 @@ def _download_browser(path: str, engine: str | None = None) -> list[dict[str, An
     Every attempt is judged on its output as well as its exit code: a build whose
     libraries are missing downloads "successfully" and cannot launch.
     """
-    base = [path, "install-browser"] + ([engine] if engine else [])
+    selected_engine = engine or _DEFAULT_BROWSER_ENGINE
+    base = [path, "install-browser", selected_engine]
+    # Keep baseline step names stable for the dashboard; optional engine
+    # downloads name their engine so concurrent outcomes remain distinguishable.
     suffix = f"-{engine}" if engine else ""
     hint = os_deps.missing_deps_hint()
 

--- a/test/test_browser_cli_install.py
+++ b/test/test_browser_cli_install.py
@@ -191,7 +191,9 @@ def test_install_aborts_when_npm_is_missing(monkeypatch: pytest.MonkeyPatch) -> 
     assert calls == []
 
 
-def test_install_runs_all_three_steps_in_order(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_install_runs_all_three_steps_and_scopes_browser_to_chromium(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls = _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/playwright-cli"})
 
     result = mod.install()
@@ -203,7 +205,9 @@ def test_install_runs_all_three_steps_in_order(monkeypatch: pytest.MonkeyPatch) 
         "install-skills",
     ]
     assert calls[0] == ["/n/npm", "install", "-g", "@playwright/cli@latest"]
-    assert calls[1] == ["/n/playwright-cli", "install-browser"]
+    # Omitting the argument installs every engine. Optional WebKit dependencies
+    # must not veto a baseline Chromium install on a host where Chromium works.
+    assert calls[1] == ["/n/playwright-cli", "install-browser", "chromium"]
     assert calls[2] == [
         "/n/playwright-cli",
         "install",
@@ -222,12 +226,12 @@ def test_install_adds_with_deps_only_where_the_host_honours_it(
     monkeypatch.setattr(mod.os_deps, "with_deps_supported", lambda: True)
     apt_calls = _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/pw"})
     mod.install()
-    assert ["/n/pw", "install-browser", "--with-deps"] in apt_calls
+    assert ["/n/pw", "install-browser", "chromium", "--with-deps"] in apt_calls
 
     monkeypatch.setattr(mod.os_deps, "with_deps_supported", lambda: False)
     other_calls = _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/pw"})
     mod.install()
-    assert ["/n/pw", "install-browser"] in other_calls
+    assert ["/n/pw", "install-browser", "chromium"] in other_calls
     assert all("--with-deps" not in argv for argv in other_calls)
 
 
@@ -276,8 +280,8 @@ def test_install_falls_back_without_deps_when_the_package_step_is_refused(
     assert result["steps"][1]["ok"] is False
     # ...but it must not veto an install the retry completed.
     assert result["steps"][2]["ok"] is True
-    assert ["/n/pw", "install-browser", "--with-deps"] in calls
-    assert ["/n/pw", "install-browser"] in calls
+    assert ["/n/pw", "install-browser", "chromium", "--with-deps"] in calls
+    assert ["/n/pw", "install-browser", "chromium"] in calls
 
 
 def test_a_zero_exit_carrying_the_host_validation_warning_is_a_failure(


### PR DESCRIPTION
## Problem / Motivation

The Settings browser installer can report failure on rpm-based/Amazon Linux hosts even when the configured Chromium browser is usable. The baseline setup called `playwright-cli install-browser` without an engine, so Playwright installed every engine and emitted host-validation warnings for optional WebKit libraries. KiroCrew correctly treats those warnings as failure because an affected selected browser would not launch, but in this case the optional engine vetoed a working Chromium setup.

## Why it matters

The one-click browser setup appears broken and stops the remaining setup flow on hosts where Chromium works. Users are left troubleshooting irrelevant WebKit dependencies instead of getting the baseline browser KiroCrew actually uses.

## What changed (motivation → approach → change)

The failure comes from an unscoped baseline install, not from warning handling. The fix keeps warning-as-failure semantics intact for the selected browser and explicitly scopes baseline provisioning to Chromium:

- default `_download_browser()` calls now run `playwright-cli install-browser chromium`;
- explicit optional Firefox/WebKit installs remain available and retain engine-labeled step names;
- baseline dashboard step names remain stable;
- the browser subsystem specification now documents why the engine argument is required.

## Tests

- Updated installer sequencing, `--with-deps`, and fallback assertions to require the explicit Chromium argument.
- Full backend suite: 57,289 passed, 122 skipped, 6 xfailed.
- Complete Node 24 frontend profile passed, including build, TypeScript, ESLint, i18n checks/rendering, Playwright Chromium provisioning, website tests, and Electron tests (1,041 passed, 1 skipped).
- Black ratchet, isort, flake8, mypy, brand/harness/changelog ratchets, docs lint, per-file coverage self-test, vendor manifest, scrub lint, and pinned cfn-lint passed.
- After the final rebase over independently inspected upstream commits, change-scoped browser CLI tests passed (73 installer + 18 view/journey), and all fast static/policy/docs/vendor gates remained green.
- Model-pinned local reviews (`gpt-5.6-sol` and `claude-opus-4.8`) found no blocking or advisory findings.

## Manual verification

A real `playwright-cli install-browser chromium --dry-run` selected only Chromium 1237, FFmpeg 1011, and Chromium Headless Shell 1237; it did not select Firefox or WebKit.

## Related Issues

no linked issue: this fix responds directly to an observed dashboard installation failure.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
