### PR TITLE
feat(lessons): scope a lesson to one repository via the skill scope gate

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -206,7 +206,6 @@ src/kiro_crew/channel_transcript_migration.py
 src/kiro_crew/cli.py
 src/kiro_crew/cli_bench.py
 src/kiro_crew/cli_cloud.py
-src/kiro_crew/cli_commands.py
 src/kiro_crew/cli_desktop.py
 src/kiro_crew/cli_doctor.py
 src/kiro_crew/cli_server.py
@@ -415,7 +414,6 @@ src/kiro_crew/mcp_tools/skills.py
 src/kiro_crew/mcp_tools/spawn.py
 src/kiro_crew/mcp_tools/workflows.py
 src/kiro_crew/mcp_utils.py
-src/kiro_crew/memory.py
 src/kiro_crew/messaging/attachments.py
 src/kiro_crew/messaging/driver.py
 src/kiro_crew/messaging/link.py
@@ -447,7 +445,6 @@ src/kiro_crew/publish_governance.py
 src/kiro_crew/publish_sync.py
 src/kiro_crew/resource_status.py
 src/kiro_crew/safety_override.py
-src/kiro_crew/sandbox.py
 src/kiro_crew/security.py
 src/kiro_crew/seed.py
 src/kiro_crew/sel.py

--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -316,8 +316,14 @@ TEI (Text Embeddings Inference) uses the candle Rust framework with a Metal back
 ### Lessons in Vector Memory
 
 When vector memory is active, lessons are stored as semantic entries:
-- Key: `lesson.<md5_of_rule>` (dedup via hash)
+- Key: `lesson.<md5_of_rule>` when the lesson is global (dedup via hash). A lesson
+  carrying `repo_scope` folds the scope into the hash, so the same rule scoped to two
+  repositories is two rows and an unscoped row keeps its historical key byte-for-byte.
 - Value: a mapping `{"rule": ..., "category": ..., "negative": ...}` — the NOT-clause
+  — plus `"repo_scope": ...` when the lesson is restricted to one repository. The key
+  is absent for a global lesson, so no migration was needed. A `repo_scope` that is
+  present but not a usable string is withheld from injection rather than read as
+  global, and is refused at every write surface.
   is its own field, so a rule containing the separator literal round-trips. Legacy
   rows written as `"rule text"` or `"rule text — NOT: negative text"` stay readable
   (read-time fallback, no migration); they upgrade to the mapping shape only when a
@@ -484,10 +490,16 @@ concurrent native write from being duplicated.
 
 User-taught corrections ("always do X", "never do Y"). Single write path through `vector_memory.write_lesson()`:
 
-1. **Vector memory** (primary): stored as `lesson.<md5hash>` semantic entries with `confidence=1.0, source=user_explicit`. The value is a mapping `{"rule", "category", "negative"}` — the NOT-clause is a separate field; legacy in-band `"rule — NOT: negative"` rows stay readable without migration. Injected via `get_lessons_context()` — separate from `[Semantic Memory]` block.
+1. **Vector memory** (primary): stored as `lesson.<md5hash>` semantic entries with `confidence=1.0, source=user_explicit`. The value is a mapping `{"rule", "category", "negative"}`, plus `"repo_scope"` when the lesson is restricted to one repository — the NOT-clause is a separate field; legacy in-band `"rule — NOT: negative"` rows stay readable without migration. Injected via `get_lessons_context()` — separate from `[Semantic Memory]` block. A scoped lesson is gated by `project_scope.project_scope_satisfied` against the session's active project BEFORE the shown/omitted counts are computed, using the same rule as a skill's `repo_scope`.
 2. **JSONL fallback** (`~/.kiro/crew/lessons.jsonl`): only used when vector memory is not initialized. Read-only migration source once vector memory is active.
 
-**Priority**: vector lessons override JSONL. If `vector_store.get_lessons()` returns entries, JSONL is skipped entirely.
+**Priority**: vector lessons override JSONL. The fallback is keyed on whether the
+vector store holds any renderable lesson at all (`has_any_lesson()`), NOT on whether
+the rendered block came back empty. The two are different: no rows means the JSONL
+store is still the authority (the first-boot migration window), while rows that exist
+but are all out of scope for this project means the vector store already answered, so
+falling back would resurrect lessons the user deleted and ignore the scope gate. A row
+whose `repo_scope` is present but unusable counts as neither.
 
 **Single write path** — all lesson writes go through `write_lesson()` which provides:
 - Substring dedup: "use dark mode" won't duplicate "always use dark mode"

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -2051,35 +2051,40 @@ class ContextBuilder:
                 parts.append(skills_ctx)
         _mark("skills")
 
-        # Lessons: global only — injected for ALL agents (skipped for temporary
-        # sessions).
+        # Lessons: injected for ALL agents (skipped for temporary sessions), gated
+        # by the same project scope the skill loader applies. A lesson with no
+        # ``repo_scope`` applies everywhere, so this changes nothing for an
+        # existing store; a scoped one reaches only sessions whose active project
+        # is inside the named tree.
         #
-        # Workspace-scoped lessons are deliberately NOT merged here. The scope
-        # dates from when a workspace WAS a project, so "workspace lessons" meant
-        # "this project's rules"; project identity now lives on the session
-        # (``slot.project``), leaving the scope with nothing to anchor to. The
-        # merge it replaced was also unreachable in practice: it required
-        # ``workspace != "default"`` while every member resolves to ``default``,
-        # so a lesson saved with ``scope="workspace"`` reported success and then
-        # never reached a prompt. Removing the read keeps that silent failure
-        # from looking like a working feature.
+        # The legacy ``scope="workspace"`` tier is NOT merged here. It dates from
+        # when a workspace WAS a project, and its read was removed because a
+        # workspace no longer identifies one -- project identity lives on the
+        # session (``slot.project``), which is what ``repo_scope`` keys on instead.
         #
         # ``LessonStore`` and ``get_lessons_for`` are intentionally left intact:
         # the per-member memory work re-targets the write side onto them, so the
         # store is dormant here, not dead.
         lessons_ctx = ""
         if not blocks_reads and _group_included(context_groups, CONTEXT_GROUP_LESSONS):
-            # One query, not two: get_lessons_context() already returns "" when the
-            # store holds no lessons, so a separate get_lessons() existence probe
-            # would be a duplicate SELECT * over the same rows (embedding blobs
-            # included) whose only use is an emptiness check.
-            lessons_ctx = (
-                memory.vector_store.get_lessons_context(query_text=query_text, cap=caps.lessons)
-                if memory.vector_store
-                else ""
-            )
-            if not lessons_ctx:
-                lessons_ctx = self.lessons.get_context()
+            # The JSONL store answers when the vector store is absent OR not yet
+            # populated, and stays silent once it holds lessons.
+            #
+            # Two real failures pull in opposite directions here and both are
+            # avoided by keying on POPULATION rather than on the rendered result.
+            # Keying on "the render came back empty" lets the JSONL store speak for
+            # a live store whose rows were simply all out of scope, re-injecting
+            # rows deleted from it. Keying on "a store object exists" instead
+            # silences saved corrections while a first-boot migration is still
+            # filling that store. Population tells the two apart: no rows at all
+            # means the JSONL store is still the authority, rows-but-none-in-scope
+            # means this store already answered.
+            if memory.vector_store and memory.vector_store.has_any_lesson():
+                lessons_ctx = memory.vector_store.get_lessons_context(
+                    query_text=query_text, cap=caps.lessons, project_dir=project
+                )
+            else:
+                lessons_ctx = self.lessons.get_context(project_dir=project)
             if lessons_ctx:
                 if len(lessons_ctx) > caps.lessons:
                     over = len(lessons_ctx) - caps.lessons

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -1070,6 +1070,10 @@ async def api_lessons_create(request: web.Request) -> web.Response:
     # omitted the kwarg -- so every NOT-clause sent to this route, from the
     # learn_add MCP tool, the dashboard, or the CLI, was silently lost.
     negative = cleaned.get("negative") or None
+    # Restricts the lesson to one repository; absent means it applies everywhere.
+    # Both write paths carry it, so the JSONL fallback store gates identically to
+    # the vector store rather than injecting a scoped lesson the other withholds.
+    repo_scope = cleaned.get("repo_scope") or None
     # Write to vector store if available, else JSONL
     vs = _get_memory(state).vector_store
     if vs:
@@ -1099,6 +1103,7 @@ async def api_lessons_create(request: web.Request) -> web.Response:
             "user_explicit",
             rule_emb,
             rule_emb_generation,
+            repo_scope,
         )
         # Sweep ONLY when the lesson actually landed. write_lesson returns False
         # for a value its preflight refuses (reachable now that ``negative`` is
@@ -1111,7 +1116,7 @@ async def api_lessons_create(request: web.Request) -> web.Response:
         # wrong for BOTH False cases, so gate on the result rather than the cause.
         if wrote:
             candidates = await asyncio.to_thread(
-                vs.find_contradiction_candidates, rule, 0.4, 0.85, rule_emb
+                vs.find_contradiction_candidates, rule, 0.4, 0.85, rule_emb, repo_scope
             )
             if candidates:
                 # Fire-and-forget via this module's _background_tasks
@@ -1129,6 +1134,7 @@ async def api_lessons_create(request: web.Request) -> web.Response:
             rule=rule,
             category=category,
             negative=negative,
+            repo_scope=repo_scope,
             ts=datetime.now(timezone.utc).isoformat(),
         )
         store = _get_lessons(state, cleaned.get("workspace")) if scope == "workspace" else (

--- a/src/kiro_crew/learn.py
+++ b/src/kiro_crew/learn.py
@@ -16,6 +16,7 @@ from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
 from kiro_crew.atomic_write import atomic_write
+from kiro_crew.project_scope import canonical_scope, project_scope_satisfied
 
 try:
     from kiro_crew.config.loader import config_dir as _config_dir
@@ -71,6 +72,11 @@ class Lesson:
     rule: str
     category: str  # "tool", "preference", "knowledge"
     negative: str | None = None
+    # Path fragment naming the repository this correction belongs to, or None for
+    # a correction that applies everywhere. Absent is the default so every stored
+    # lesson keeps applying exactly as before, and only a lesson that opts in is
+    # ever withheld. See ``kiro_crew.project_scope``.
+    repo_scope: str | None = None
 
 
 # ── Storage ──
@@ -226,6 +232,10 @@ class LessonStore:
             wanted_negative = (
                 lesson.negative.strip() or None if isinstance(lesson.negative, str) else None
             )
+            # Same normalisation for the scope key: a whitespace-only value is no
+            # scope, and a non-string is refused before ``.strip()`` can raise,
+            # because consolidation hands over a value the model produced.
+            wanted_scope = canonical_scope(lesson.repo_scope)
             # load_all() is called under the lock deliberately: it takes no lock of
             # its own, so this is not a re-entrant acquisition on a non-reentrant
             # Lock. Do NOT call save() from in here for the same reason.
@@ -235,9 +245,34 @@ class LessonStore:
             matched = False
             outcome = "inserted"
             for le in existing:
-                if not matched and le.rule.lower().strip() == wanted:
+                # Scope is part of a lesson's IDENTITY, not a field to overwrite, and
+                # the comparison is STRICT. The same rule with and without a scope is
+                # two lessons, exactly as in the vector store, where the scope is
+                # folded into the key so the two never share a row.
+                #
+                # Matching loosely broke it in both directions: on rule text alone a
+                # submission for repo B replaced repo A's scope and A lost the lesson,
+                # and treating an omitted scope as "no conflict" made a genuine
+                # save-this-globally request bind to a scoped row and report success
+                # without ever creating the global lesson. Addressing a scoped lesson
+                # therefore means naming its scope.
+                if (
+                    not matched
+                    and wanted_scope == le.repo_scope
+                    and (le.rule.lower().strip() == wanted)
+                ):
                     matched = True
-                    if not enrich or wanted_negative is None or le.negative == wanted_negative:
+                    # A field is enriched only when the submission carries a value
+                    # for it AND that value differs. A bare re-submit therefore
+                    # never strips a stored clause or scope -- it reports
+                    # ``unchanged``, matching the vector store for the same case.
+                    next_negative = le.negative
+                    if wanted_negative is not None:
+                        next_negative = wanted_negative
+                    next_scope = le.repo_scope
+                    if wanted_scope is not None:
+                        next_scope = wanted_scope
+                    if not enrich or (next_negative == le.negative and next_scope == le.repo_scope):
                         outcome = "unchanged"
                         updated.append(le)
                     else:
@@ -247,7 +282,7 @@ class LessonStore:
                         # edit followed by a failed write would leave the cache
                         # advertising a clause that was never persisted -- and that
                         # cache feeds context injection.
-                        updated.append(replace(le, negative=wanted_negative))
+                        updated.append(replace(le, negative=next_negative, repo_scope=next_scope))
                     continue
                 updated.append(le)
             if outcome == "unchanged":
@@ -255,7 +290,7 @@ class LessonStore:
             if not matched:
                 # Insert the normalised clause too, so a whitespace-only one is stored
                 # as absent rather than as blanks.
-                updated.append(replace(lesson, negative=wanted_negative))
+                updated.append(replace(lesson, negative=wanted_negative, repo_scope=wanted_scope))
                 if len(updated) > _MAX_LESSONS_TOTAL:
                     updated = updated[-_MAX_LESSONS_TOTAL:]
             self._write_all(updated)
@@ -296,12 +331,22 @@ class LessonStore:
                 continue
             try:
                 data = json.loads(line)
+                raw_scope = data.get("repo_scope")
+                # A PRESENT but unusable scope is not "applies everywhere": the row
+                # meant to be scoped and cannot say where, so it is dropped rather
+                # than admitted globally (fail-open) or passed to the gate, where a
+                # non-string would raise while a prompt is being assembled.
+                if raw_scope is not None and (
+                    not isinstance(raw_scope, str) or not raw_scope.strip()
+                ):
+                    continue
                 lessons.append(
                     Lesson(
                         ts=data.get("ts", ""),
                         rule=data.get("rule", ""),
                         category=data.get("category", "knowledge"),
                         negative=data.get("negative"),
+                        repo_scope=raw_scope,
                     )
                 )
             except (json.JSONDecodeError, KeyError):
@@ -309,9 +354,28 @@ class LessonStore:
         self._cache = (mtime, lessons)
         return lessons
 
-    def get_context(self) -> str:
-        """Format lessons as context for injection into prompts."""
-        lessons = self.load_all()
+    def _applicable(self, lessons: list[Lesson], project_dir: str | Path | None) -> list[Lesson]:
+        """Drop lessons whose ``repo_scope`` does not cover *project_dir*.
+
+        A lesson with no scope applies everywhere, so an existing store is
+        unaffected. A scoped one is withheld unless the session's project is
+        positively inside the named tree -- the gate fails closed, so a surface
+        with no project loses the scoped lessons rather than inheriting another
+        repository's rules.
+        """
+        return [
+            le
+            for le in lessons
+            if not le.repo_scope or project_scope_satisfied(le.repo_scope, project_dir)
+        ]
+
+    def get_context(self, project_dir: str | Path | None = None) -> str:
+        """Format lessons as context for injection into prompts.
+
+        *project_dir* is the session's active project, used only by the
+        ``repo_scope`` gate; omitting it withholds every scoped lesson.
+        """
+        lessons = self._applicable(self.load_all(), project_dir)
         if not lessons:
             return ""
 

--- a/src/kiro_crew/mcp_tools/learn.py
+++ b/src/kiro_crew/mcp_tools/learn.py
@@ -37,6 +37,10 @@ def schemas() -> list[dict[str, Any]]:
         (f.max_len for f in LEARN_ADD_SCHEMA.fields if f.name == "negative"),
         MAX_SHORT_STRING,
     )
+    _scope_max = next(
+        (f.max_len for f in LEARN_ADD_SCHEMA.fields if f.name == "repo_scope"),
+        MAX_SHORT_STRING,
+    )
     return [
         {
             "name": "learn_add",
@@ -74,14 +78,19 @@ def schemas() -> list[dict[str, Any]]:
                             "characters — rejected if exceeded."
                         ),
                     },
-                    "scope": {
+                    "repo_scope": {
                         "type": "string",
-                        "enum": ["global", "workspace"],
-                        "description": "Where to save: 'global' (default, all workspaces) or 'workspace' (active workspace only)",
-                    },
-                    "workspace": {
-                        "type": "string",
-                        "description": "Workspace name (required when scope='workspace'). Use the workspace name from your session context.",
+                        "maxLength": _scope_max,
+                        "description": (
+                            "Optional. Restrict this correction to ONE repository, "
+                            "given as a path fragment that repository contains "
+                            "(e.g. 'src/kiro_crew'). The correction then applies "
+                            "only in sessions whose project is inside that tree, "
+                            "and is withheld everywhere else. Use it for a rule "
+                            "that is only true of one codebase; omit it for a "
+                            "durable preference that should always apply. Omitted "
+                            "means it applies everywhere."
+                        ),
                     },
                 },
                 "required": ["rule", "category"],
@@ -117,8 +126,25 @@ def learn_add(name: str, args: dict[str, Any]) -> str:
     _gov_mem = mcp_core._vet_memory_writes_governance(mcp_core._resolve_session_key())
     if _gov_mem:
         return f"Error: {_gov_mem}"
-    scope = args.get("scope", "global")
-    payload: dict[str, str] = {"rule": rule, "category": category, "scope": scope}
+    # A stale client still holding the old advertised schema can send
+    # scope="workspace". Silently forcing that to "global" would take a correction
+    # meant for one workspace and inject it into EVERY session -- the exact harm
+    # this change exists to end, and worse than the old behaviour, where the tier
+    # was inert and reached no prompt at all. So a legacy scope asking for anything
+    # narrower than global is REFUSED, with the replacement named. Refusing loses
+    # nothing that ever worked, and it tells the caller instead of widening silently.
+    _legacy_scope = args.get("scope")
+    if isinstance(_legacy_scope, str) and _legacy_scope.strip() not in ("", "global"):
+        return (
+            f"Error: scope={_legacy_scope.strip()!r} is no longer accepted. That tier "
+            "never reached a prompt, and saving it as a global lesson would apply it "
+            "in every session. Use repo_scope to restrict a lesson to one repository."
+        )
+    # The tool no longer offers a workspace scope: that tier never reached a
+    # prompt, so a lesson saved under it reported success and changed nothing.
+    # Restricting a correction to one codebase is what repo_scope does, and the
+    # context builder enforces it before injection.
+    payload: dict[str, str] = {"rule": rule, "category": category, "scope": "global"}
     # The tool schema advertises ``negative`` -- and the ``rule`` description
     # explicitly tells the model to prefer it over inlining a "-- NOT: ..."
     # clause -- but this payload never forwarded it, so the clause was dropped
@@ -127,11 +153,9 @@ def learn_add(name: str, args: dict[str, Any]) -> str:
     negative = args.get("negative", "")
     if negative:
         payload["negative"] = negative
-    if scope == "workspace":
-        ws = args.get("workspace", "")
-        if not ws:
-            return "Error: workspace name is required when scope='workspace'"
-        payload["workspace"] = ws
+    repo_scope = args.get("repo_scope", "")
+    if repo_scope:
+        payload["repo_scope"] = repo_scope
     d = mcp_core._post("/api/lessons", payload)
     err_val = d.get("error")
     if err_val:
@@ -160,7 +184,9 @@ def learn_add(name: str, args: dict[str, Any]) -> str:
         # sentence naming the instance mix-up -- so every tool gets that copy,
         # not just this one.
         return f"Error: {err_val}"
-    return f"Saved lesson ({scope}): {rule}"
+    if repo_scope:
+        return f"Saved lesson (applies only in {repo_scope}): {rule}"
+    return f"Saved lesson: {rule}"
 
 
 def learn_list(name: str, args: dict[str, Any]) -> str:

--- a/src/kiro_crew/project_scope.py
+++ b/src/kiro_crew/project_scope.py
@@ -1,0 +1,201 @@
+"""The project-scope gate shared by every kind of injected instruction.
+
+Skills and lessons are both instructions that reach a session's prompt, so both
+need the same answer to one question: does this entry belong in THIS session?
+Keeping the rule here means the two surfaces cannot drift into two different
+notions of "in scope" -- a lesson scoped to a repository is admitted under
+exactly the conditions a skill scoped to that repository is.
+
+The gate is mechanical rather than prose. A scope guard written into the
+instruction text ("ignore this outside repo X") depends on the model choosing to
+obey it; this check runs while context is assembled, so an out-of-scope entry is
+never rendered into the prompt at all.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from kiro_crew.security import is_sensitive_path
+
+__all__ = ["SCOPE_FRAGMENT_RE", "project_scope_satisfied"]
+
+# One segment: no separator, and no ":" so a drive-qualified fragment cannot pass
+# (``pathlib`` treats "C:/x" as absolute and would discard the project root). The
+# lookahead rejects "." and ".." as whole segments -- "." is the dangerous one,
+# because every directory contains it, so a scoped entry carrying it would match
+# everywhere and silently become global.
+_SEGMENT = r"(?!\.\.?(?:/|$))[^/\\:]+"
+
+# The syntactic half of the scope rule, shared with the write surface so a value
+# the gate can never satisfy is refused when it is SAVED rather than stored as a
+# lesson that reports success and then applies nowhere. Keeping the pattern here,
+# next to the gate that enforces the rest, is what stops the two from drifting;
+# ``test_lesson_project_scope`` pins them to the same verdicts.
+#
+# No leading slash: an absolute path is not a fragment, and reducing one to a
+# relative fragment is what let "/etc/passwd" match from the "/" ancestor.
+SCOPE_FRAGMENT_RE = re.compile(rf"^{_SEGMENT}(?:/{_SEGMENT})*/?$")
+
+
+def scope_is_admissible(raw: object) -> bool:
+    """Whether the gate could EVER be satisfied by this raw stored scope.
+
+    The gate itself front-gates on this, so the two cannot drift apart. That
+    matters because a stored scope the gate can never satisfy is not merely
+    useless: it renders nothing while still looking like a real scope to any
+    reader that judges it by shape. Such a row must be classified as unusable
+    everywhere, or it counts as stored knowledge, suppresses the JSONL store, and
+    the lessons a user actually saved stop reaching the prompt.
+
+    Judged on the RAW stored string rather than a canonicalised one, because that
+    is what a reader will hand the gate. An imported row bypasses the write
+    surface, so it can hold a leading slash that canonicalisation would quietly
+    make look admissible while the gate still refuses it.
+    """
+    if not isinstance(raw, str):
+        return False
+    text = raw.strip().replace("\\", "/")
+    if text.startswith("/"):
+        return False
+    rel = text.strip("/")
+    return bool(rel) and SCOPE_FRAGMENT_RE.match(rel) is not None
+
+
+def canonical_scope(raw: object) -> str | None:
+    """The single stored form of a scope, or None when there is effectively none.
+
+    The gate normalises separators and strips them before matching, and the write
+    pattern accepts a trailing slash, so "src/pkg" and "src/pkg/" name the same
+    scope. Both stores canonicalise through here before the value becomes part of a
+    lesson's identity: storing the raw string made those two spellings distinct rows
+    that behaved identically, so both were injected and neither deduped the other.
+    Anything that is not a string has no scope.
+    """
+    if not isinstance(raw, str):
+        return None
+    return raw.strip().replace("\\", "/").strip("/") or None
+
+
+def project_scope_satisfied(relpath: str, project_dir: str | Path | None) -> bool:
+    """Whether an entry scoped to *relpath* applies to *project_dir*.
+
+    *relpath* is a path fragment that identifies a repository by something it
+    contains -- ``src/kiro_crew`` names the Kiro Crew source tree. The entry
+    applies when *project_dir* or any ancestor of it holds that fragment, so a
+    session working anywhere inside the tree qualifies while a session outside it
+    does not.
+
+    The fragment must be DISTINCTIVE to the repository, and that is the author's
+    responsibility rather than something this gate can check. A fragment many
+    repositories contain identifies many repositories: ``src``, ``test``,
+    ``docs``, ``README.md``, ``.gitignore`` and ``.git`` all satisfy this gate in
+    an unrelated checkout, and ``.git`` merely does so in every one by
+    definition. Refusing particular filenames would not change that -- the set is
+    open, and the most likely accident (``src``) is not a special case anyone
+    would think to list -- so the rule is stated here instead of pretended at.
+    The consequence of a vague fragment is a lesson applying more widely than
+    intended, which is what an unscoped lesson already does; it is not a way to
+    reach anything a caller could not reach by omitting the scope.
+
+    *project_dir* is the SESSION's active project, the same value the
+    ``[PROJECT]`` context block names. The process working directory is
+    deliberately not consulted: this runs in the gateway while it assembles
+    context, so ``Path.cwd()`` is the gateway's own directory and says nothing
+    about the repository the session works on. Answering from it would decide by
+    install shape instead of by work -- a gateway started inside a checkout of
+    the scoped repo would admit the entry into EVERY session, and a packaged
+    install would suppress it for every session.
+
+    Fails CLOSED. No project, an unusable one, a traversal fragment, or any
+    filesystem error all suppress the entry, so a surface whose project cannot be
+    established never inherits repository-specific instructions.
+
+    The fragment must name a path BELOW some ancestor, so every form that would
+    resolve somewhere else is refused before any filesystem access:
+
+    * ``.`` and ``..`` segments. ``.`` is the dangerous one -- it is a natural way
+      to write "this repo", and ``candidate / "."`` exists for every candidate, so
+      it would silently turn a scoped entry into a global one. That is fail-OPEN,
+      the one direction this gate must never take.
+    * Drive-qualified fragments. ``pathlib`` discards the left side when the right
+      is absolute, so ``candidate / "C:/x"`` is ``C:/x`` on Windows and the join
+      would answer about a path outside the project. A POSIX leading slash needs
+      no guard: it is stripped to a relative fragment, so the join stays under the
+      project and the only effect is that ``/src`` reads as ``src``.
+
+    A backslash is read as a separator rather than as a filename character, so a
+    Windows-style fragment is segmented and screened like any other.
+
+    A fragment naming a credential path (``.ssh/id_rsa``) is refused before any
+    filesystem call. Otherwise the walk would ``stat`` that path, and whether the
+    entry then appears in the prompt would answer "does this key exist" for a
+    surface that may be allowed to save a lesson while being denied file reads.
+
+    The ancestor walk STOPS at the repository root, and an absolute fragment is
+    refused rather than reinterpreted as a relative one. Both bound the same
+    fail-open: an unbounded walk reaches ``/``, where a fragment that merely names
+    a shared system directory -- ``tmp``, ``etc``, or ``/etc/passwd`` reduced to
+    ``etc/passwd`` -- exists for EVERY project on the host, so a repository-scoped
+    entry would silently apply everywhere. "Inside the repository identified by
+    this fragment" is the question, so nothing above that repository can answer it.
+    """
+    if not scope_is_admissible(relpath):
+        return False
+    rel = relpath.strip().replace("\\", "/").strip("/")
+    if not project_dir:
+        return False
+    try:
+        root = Path(project_dir).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+    for candidate in _walk_to_repo_root(root):
+        # Resolve FIRST, then judge the resolved path. Checking the unresolved join
+        # was a static bypass, not merely a race: a symlink already in the tree
+        # ("data" -> "~/.aws") gives a literal fragment that passes the sensitive
+        # check, and the existence probe then follows the link into the credential
+        # directory. Strict resolution doubles as the existence probe, so a path
+        # that does not exist and a path that resolves somewhere sensitive produce
+        # the SAME answer -- which is what leaves no existence oracle behind.
+        try:
+            resolved = (candidate / rel).resolve(strict=True)
+        except (OSError, RuntimeError, ValueError):
+            continue
+        # CONTAINMENT, the invariant the bounded walk only half-enforced. Bounding
+        # the walk at the repository root stops the SEARCH from climbing out, but
+        # strict resolution FOLLOWS symlinks, so a link inside the tree
+        # ("data" -> "/var/lib/x") answered the question from a path outside the
+        # repository entirely. The question is "is this fragment inside the
+        # repository it names", so a target that leaves the repository cannot answer
+        # it, whether or not that target is sensitive -- the sensitive check below
+        # only ever covered the subset that is.
+        if not resolved.is_relative_to(candidate):
+            return False
+        if is_sensitive_path(str(resolved)):
+            return False
+        return True
+    return False
+
+
+def _walk_to_repo_root(root: Path) -> list[Path]:
+    """*root* and its ancestors, stopping at the repository root inclusive.
+
+    A ``.git`` entry marks that boundary -- tested with ``exists()`` rather than
+    ``is_dir()`` because a worktree's ``.git`` is a FILE, and a worktree is exactly
+    where this repository's own contributors work.
+
+    With no ``.git`` anywhere above it, only *root* itself is offered: a fragment
+    that identifies a repository cannot be confirmed against a directory that is
+    not in one, and answering from an unbounded walk is what made a scoped entry
+    global. Fails closed, like every other branch of the gate.
+    """
+    chain: list[Path] = []
+    for candidate in (root, *root.parents):
+        chain.append(candidate)
+        try:
+            if (candidate / ".git").exists():
+                return chain
+        except OSError:
+            break
+    return [root]

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -31,6 +31,7 @@ from kiro_crew.hooks import (
 )
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.platform_compat import is_link_or_junction
+from kiro_crew.project_scope import project_scope_satisfied
 from kiro_crew.security import (
     is_sensitive_path,
     redact_credentials,
@@ -2030,23 +2031,12 @@ class SkillsLoader:
 
         Fails CLOSED — no project, an unusable one, or any error suppresses the
         skill, so an un-scoped surface never inherits repo-specific rules.
+
+        The rule itself lives in ``kiro_crew.project_scope`` because lessons are
+        scoped by the same key: both are instructions injected into a session, so
+        both must agree on what "in scope" means.
         """
-        rel = relpath.strip().strip("/")
-        if not rel or ".." in rel.split("/"):
-            return False
-        if not project_dir:
-            return False
-        try:
-            root = Path(project_dir).resolve()
-        except (OSError, RuntimeError, ValueError):
-            return False
-        for candidate in (root, *root.parents):
-            try:
-                if (candidate / rel).exists():
-                    return True
-            except OSError:
-                continue
-        return False
+        return project_scope_satisfied(relpath, project_dir)
     # ── Auto skill lifecycle: pin / archive / restore / eviction ──
 
     @staticmethod

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -32,6 +32,7 @@ from typing import Any
 # reads as "the computer-use vocabulary" rather than bare names.
 from kiro_crew.computer_use import types as _cu_types
 from kiro_crew.constants import WINDOWS_DEVICE_STEMS
+from kiro_crew.project_scope import SCOPE_FRAGMENT_RE
 
 # ── Constants ──
 
@@ -1033,9 +1034,18 @@ LEARN_ADD_SCHEMA = ToolSchema(
         FieldSpec("rule", str, required=True, max_len=MAX_SHORT_STRING),
         FieldSpec("category", str, allowed=ALLOWED_LESSON_CATEGORIES, default="knowledge"),
         FieldSpec("negative", str, max_len=MAX_SHORT_STRING),
-        # scope/workspace: the learn_add MCP tool (mcp_core.py) and the
-        # /api/lessons handler support workspace-scoped lessons. The "workspace
-        # required when scope='workspace'" rule is enforced in the handler.
+        # Path fragment naming the repository a correction belongs to; absent means
+        # it applies everywhere. The pattern is the gate's own (imported, not
+        # restated), so a value the gate could never satisfy -- a dot segment,
+        # traversal, an empty segment, a drive-qualified path -- is refused HERE
+        # rather than stored as a lesson that reports success and applies nowhere.
+        # Whether the named path exists is still the gate's business, at injection.
+        FieldSpec("repo_scope", str, max_len=MAX_SHORT_STRING, pattern=SCOPE_FRAGMENT_RE),
+        # scope/workspace: the /api/lessons handler stores and lists
+        # workspace-scoped lessons, but that tier does NOT reach a prompt -- the
+        # context builder gates injected lessons on repo_scope instead. The
+        # "workspace required when scope='workspace'" rule is enforced in the
+        # handler.
         FieldSpec("scope", str, allowed=ALLOWED_LESSON_SCOPES, default="global"),
         FieldSpec("workspace", str, max_len=MAX_SHORT_STRING, pattern=WORKSPACE_NAME_RE),
     ],

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -55,6 +55,11 @@ import time
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import config_dir
 from kiro_crew.metrics.db_metrics import timed
+from kiro_crew.project_scope import (
+    canonical_scope,
+    project_scope_satisfied,
+    scope_is_admissible,
+)
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.validation import ALLOWED_LESSON_CATEGORIES, normalize_lesson_category
 
@@ -322,6 +327,27 @@ def _lesson_slug(rule: str) -> str:
     return hashlib.md5(rule.encode(), usedforsecurity=False).hexdigest()[:12]
 
 
+def _lesson_key(rule: str, repo_scope: str | None = None) -> str:
+    """The semantic key a lesson is stored under.
+
+    An unscoped lesson keys on the rule alone, byte-identical to what it has always
+    been, so no stored row moves and the legacy-string reader in ``_split_stored``
+    (which confirms a candidate prefix by re-deriving ``_lesson_slug``) keeps
+    working -- legacy rows are always unscoped.
+
+    A scoped lesson folds its scope into the digest, because the same rule scoped to
+    two repositories is two lessons. Sharing one key would let the second write
+    overwrite the first through ``set_semantic`` and silently re-scope it, which is
+    worse than the cross-scope superseding this separation prevents.
+    """
+    if not repo_scope:
+        return f"lesson.{_lesson_slug(rule)}"
+    # NUL separator so a rule ending in the scope text cannot collide with a
+    # differently-split pair. Reuses the one digest helper rather than hashing here.
+    basis = f"{rule}\x00{repo_scope}"
+    return f"lesson.{_lesson_slug(basis)}"
+
+
 def _lesson_fields(decoded: object) -> tuple[str, str | None] | None:
     """Extract ``(rule, negative)`` from a mapping-shaped lesson value.
 
@@ -345,6 +371,48 @@ def _lesson_fields(decoded: object) -> tuple[str, str | None] | None:
     else:
         negative = negative.strip()
     return rule.strip(), negative
+
+
+def _lesson_scope(decoded: object) -> str | None:
+    """Extract ``repo_scope`` from a lesson value, or None when unscoped.
+
+    Only the mapping shape can carry a scope. A legacy string row has nowhere to
+    put one, so it reads as unscoped and keeps applying everywhere -- which is
+    what an existing store expects. A blank or non-string value normalizes to
+    None, mirroring the write path, so a round-trip compares equal.
+    """
+    if not isinstance(decoded, dict):
+        return None
+    scope = decoded.get("repo_scope")
+    if not isinstance(scope, str) or not scope.strip():
+        return None
+    return scope.strip()
+
+
+def _lesson_scope_unusable(decoded: object) -> bool:
+    """Whether a lesson carries a ``repo_scope`` that is PRESENT but unusable.
+
+    Absent and present-but-broken are different answers and must not collapse.
+    Absent means "applies everywhere", which is the correct default. A present
+    value that is not a usable string -- a list or a number from an imported or
+    hand-edited row -- means "this was meant to be scoped and we cannot tell
+    where", so the row is withheld at injection rather than admitted globally.
+    Treating it as absent is fail-OPEN: the one direction this gate must never
+    take.
+    """
+    if not isinstance(decoded, dict):
+        return False
+    if "repo_scope" not in decoded:
+        return False
+    scope = decoded["repo_scope"]
+    if scope is None:
+        return False
+    # Asks the GATE's own admissibility test rather than carrying a second notion
+    # of "usable". A non-blank string is not enough: "." is a string and the gate
+    # refuses it, so judging by shape marked it usable, it rendered nothing, and it
+    # still counted as stored knowledge -- which silenced the JSONL store and lost
+    # the lessons the user saved. Deferring here is what keeps the two in step.
+    return not scope_is_admissible(scope)
 
 
 def _lesson_display_text(decoded: object) -> str:
@@ -775,16 +843,27 @@ class VectorMemoryStore:
         if key.startswith("lesson.") and isinstance(value, dict) and _lesson_fields(value) is not None:
             cat = value.get("category")
             raw_negative = value.get("negative")
+            raw_scope = value.get("repo_scope")
             if (
-                set(value.keys()) <= {"rule", "category", "negative"}
+                set(value.keys()) <= {"rule", "category", "negative", "repo_scope"}
                 and (cat is None or (isinstance(cat, str) and cat in ALLOWED_LESSON_CATEGORIES))
                 and (raw_negative is None or isinstance(raw_negative, str))
+                and (raw_scope is None or isinstance(raw_scope, str))
             ):
                 raw_rule = value["rule"]  # _lesson_fields guarantees a str
                 if isinstance(raw_negative, str):
                     size_basis = f"{raw_rule}{_LESSON_NEGATIVE_SEP}{raw_negative}"
                 else:
                     size_basis = raw_rule
+                # A scope is measured at its RAW size too, rather than trusted to be
+                # bounded by the write surface's cap: set_semantic is reachable
+                # directly, so assuming a constant here would be the one unmeasured
+                # byte the invariant above forbids. Excluding repo_scope from the
+                # key set instead would drop a scoped lesson out of the exemption
+                # entirely, so a near-limit multibyte rule would be refused while a
+                # caller with a JSONL fallback reported it saved.
+                if isinstance(raw_scope, str):
+                    size_basis = f"{size_basis}{_LESSON_NEGATIVE_SEP}{raw_scope}"
         vj_bytes = len(size_basis.encode("utf-8"))
         if vj_bytes > _MAX_VALUE_BYTES:
             return (
@@ -2124,6 +2203,7 @@ class VectorMemoryStore:
         source: str = "user_explicit",
         rule_emb: list[float] | None = None,
         rule_emb_generation: int | None = None,
+        repo_scope: str | None = None,
     ) -> bool:
         """Write a lesson as a semantic entry with key lesson.<hash>.
 
@@ -2162,6 +2242,25 @@ class VectorMemoryStore:
         # guidance, and str()-ifying it would store a repr as if the user wrote it,
         # so treat it as absent.
         negative = negative.strip() or None if isinstance(negative, str) else None
+        # Same normalisation and the same non-string guard as the clause above:
+        # consolidation forwards the model's own value unchecked, so a blank scope
+        # stores as absent (applies everywhere) and a non-string is treated as
+        # absent rather than reaching .strip() and aborting the run.
+        # Canonicalise to the form the GATE compares, so storage and the gate agree
+        # on what one scope is. See canonical_scope for why the raw string is wrong.
+        #
+        # A scope the gate can NEVER satisfy is refused here rather than normalised
+        # or dropped. Both alternatives are wrong in opposite directions:
+        # canonicalising "/src/pkg" strips the slash and ACTIVATES the lesson in
+        # every repository holding src/pkg, which it was never validly scoped to;
+        # returning None instead would store it GLOBALLY, which is the fail-open a
+        # scoped lesson must never take. Refusing is the only answer that neither
+        # invents a scope nor widens one, and it keeps this surface consistent with
+        # the schema, which already rejects the same shapes.
+        if repo_scope is not None and isinstance(repo_scope, str) and repo_scope.strip():
+            if not scope_is_admissible(repo_scope):
+                return False
+        repo_scope = canonical_scope(repo_scope)
         # The category is now part of the stored value, so an unusable one would be
         # scanned by validate_semantic and could REJECT the whole lesson -- turning a
         # bad label into lost guidance. Consolidation passes the LLM's own
@@ -2200,8 +2299,7 @@ class VectorMemoryStore:
         # then set_semantic refused the replacement, and the route still returned
         # HTTP 200 with no lesson stored. Validating here makes the whole call a
         # no-op when the replacement cannot land.
-        slug = _lesson_slug(rule)
-        key = f"lesson.{slug}"
+        key = _lesson_key(rule, repo_scope)
         # The mapping shape keeps the two halves as separate fields, so they
         # survive a round-trip regardless of what characters the rule contains.
         # The legacy in-band form ("<rule><sep><negative>") is still READ below
@@ -2209,7 +2307,16 @@ class VectorMemoryStore:
         # re-submit rewrites them anyway. validate_semantic size-gates lesson
         # mappings on their content (legacy-equivalent bytes), so the JSON
         # envelope does not shrink the accepted rule capacity.
-        value: object = {"rule": rule, "category": category, "negative": negative}
+        lesson_value: dict[str, object] = {
+            "rule": rule,
+            "category": category,
+            "negative": negative,
+        }
+        # The key is added only when a scope was given, so an unscoped lesson keeps
+        # the exact stored shape it has always had and no existing row is churned.
+        if repo_scope:
+            lesson_value["repo_scope"] = repo_scope
+        value: object = lesson_value
         confidence = 1.0 if source == "user_explicit" else 0.9
         preflight = self.validate_semantic(key, value, confidence, source)
         if preflight is not None:
@@ -2244,7 +2351,33 @@ class VectorMemoryStore:
         # enrichment we had already selected, and the clause was dropped on HTTP 200.
         # Resolving the exact match first makes the result order-independent, and
         # pass 2 is skipped entirely once pass 1 claims the write.
-        lesson_rows = self.get_lessons()
+        # Deduplication is SCOPE-LOCAL, and both passes below share this list.
+        #
+        # A lesson scoped to one repository and a global one are different lessons
+        # even when their wording is close, so a scoped write must never supersede,
+        # enrich, or be discarded against a row from another scope. Without this the
+        # generic dedup rules (substring containment, >50% keyword overlap, high
+        # cosine similarity) reach across scopes and DELETE guidance the submitter
+        # never addressed -- writing a repo-scoped rule could retire a global one
+        # that merely shared most of its significant words.
+        #
+        # A row whose value will not parse is dropped here rather than compared,
+        # matching what ``_as_text`` does with a value that has no lesson shape.
+        lesson_rows = []
+        for _row in self.get_lessons():
+            try:
+                _decoded = json.loads(_row["value_json"])
+            except (ValueError, TypeError):
+                continue
+            # A row whose scope is present but unusable belongs to NO partition. It
+            # is withheld at injection, so letting it read as unscoped here would let
+            # it dedup away a genuine global write: the caller would be told the
+            # lesson was saved while the only row carrying that rule never reaches a
+            # prompt. All three readers of this field agree on that now.
+            if _lesson_scope_unusable(_decoded):
+                continue
+            if _lesson_scope(_decoded) == repo_scope:
+                lesson_rows.append(_row)
 
         def _as_text(row: dict) -> str | None:
             """The row's value as lesson TEXT, or None when it has no lesson shape.
@@ -2326,11 +2459,19 @@ class VectorMemoryStore:
                     _flush_backfills()
                     return False
                 stored_category = decoded.get("category")
-                target: object = {
+                enriched: dict[str, object] = {
                     "rule": stored_rule,
                     "category": stored_category if isinstance(stored_category, str) else category,
                     "negative": negative,
                 }
+                # The scope is WRITE-ONCE for the same reason the category is: the
+                # intent of a re-submit-with-clause is "attach the clause", not
+                # "re-scope". Carrying the STORED value forward means enrichment can
+                # never strip a scope, and re-scoping is a delete + re-add.
+                stored_scope = _lesson_scope(decoded)
+                if stored_scope:
+                    enriched["repo_scope"] = stored_scope
+                target: object = enriched
             else:
                 # Legacy string row. Recompose from the STORED base so a
                 # case-variant re-submit attaches its clause without silently
@@ -2504,6 +2645,7 @@ class VectorMemoryStore:
         threshold_low: float = 0.4,
         threshold_high: float = 0.85,
         rule_emb: list[float] | None = None,
+        repo_scope: str | None = None,
     ) -> list[dict]:
         """Find lessons related to rule but not caught by standard dedup.
 
@@ -2511,6 +2653,13 @@ class VectorMemoryStore:
         — candidates that may contradict the new rule. Pass ``rule_emb`` to reuse
         an embedding already computed by the caller and avoid a second blocking
         embed of the identical text.
+
+        Candidates are SCOPE-LOCAL: only rows whose stored ``repo_scope`` equals
+        *repo_scope* are considered. Superseding resolves a contradiction by
+        DELETING the losing row, and a repository-scoped rule that contradicts a
+        global one inside its own tree does not contradict it anywhere else --
+        sweeping across scopes would retire the global rule for every other
+        repository on the strength of one repo's exception.
         """
         if rule_emb is None:
             rule_emb = self._try_embed(rule) if self.embed_fn else None
@@ -2526,14 +2675,55 @@ class VectorMemoryStore:
         for existing in self.get_lessons():
             sim = similarity(existing)
             if threshold_low <= sim < threshold_high:
+                try:
+                    decoded = json.loads(existing["value_json"])
+                except (ValueError, TypeError):
+                    continue
+                if _lesson_scope_unusable(decoded):
+                    continue
+                if _lesson_scope(decoded) != repo_scope:
+                    continue
                 # Rendered text, not str(): a mapping-shaped row would otherwise
                 # hand its Python repr to the contradiction prompt as the "rule".
-                existing_val = _lesson_display_text(json.loads(existing["value_json"]))
+                existing_val = _lesson_display_text(decoded)
                 if not existing_val:
                     continue
                 candidates.append({"key": existing["key"], "rule": existing_val, "similarity": sim})
         candidates.sort(key=lambda x: x["similarity"], reverse=True)
         return candidates[:5]
+
+    def has_any_lesson(self) -> bool:
+        """Whether any active row decodes to RENDERABLE lesson data, ignoring scope.
+
+        Distinguishes "this store is not populated yet" from "this store is
+        populated but nothing is in scope for this project". Those look identical
+        in a rendered context block and need opposite handling: the first means the
+        JSONL store is still the authority, the second means this store already
+        answered and the JSONL store must stay silent.
+
+        A ``lesson.*`` key is not sufficient evidence. ``set_semantic`` accepts any
+        object, so an import or a legacy migration can leave a list or a rule-less
+        dict under one -- which every renderer already skips. Counting such a row as
+        population would silence the JSONL store while nothing renders, so saved
+        corrections would vanish. The decode is the same one the renderer uses.
+
+        Selects ``value_json`` only, never ``SELECT *``: reading every embedding
+        blob is the duplicate-SELECT cost the rendering path was written to avoid.
+        """
+        rows = self._fetch_all_locked(
+            "SELECT value_json FROM semantic_memory "
+            "WHERE is_deleted = 0 AND key LIKE 'lesson.%'"
+        )
+        for row in rows:
+            try:
+                decoded = json.loads(row["value_json"])
+            except (ValueError, TypeError):
+                continue
+            if _lesson_scope_unusable(decoded):
+                continue
+            if _lesson_display_text(decoded):
+                return True
+        return False
 
     def get_lessons(self, limit: int | None = None) -> list[dict]:
         """Return lesson.* entries ordered by most recently updated."""
@@ -2569,7 +2759,9 @@ class VectorMemoryStore:
                 deleted = True
         return deleted
 
-    def get_lessons_context(self, query_text: str = "", cap: int = 0) -> str:
+    def get_lessons_context(
+        self, query_text: str = "", cap: int = 0, project_dir: str | Path | None = None
+    ) -> str:
         """Format lessons for prompt injection, most relevant first.
 
         Lessons are ranked against *query_text* using the same hybrid
@@ -2581,12 +2773,25 @@ class VectorMemoryStore:
         Args:
             query_text: Request to rank against. Empty keeps recency order.
             cap: Character budget for the rendered block. 0 means unbounded.
+            project_dir: The session's active project, used only by the
+                ``repo_scope`` gate. Omitting it withholds every scoped lesson.
         """
-        entries = [
-            (row, text)
-            for row in self.get_lessons()
-            if (text := _lesson_display_text(json.loads(row["value_json"])))
-        ]
+        # Scope is applied BEFORE the counts are taken, so a lesson withheld as
+        # out-of-scope is not reported as "omitted" -- omitted means "did not fit
+        # the budget", and conflating the two would tell the model that rules it
+        # should never see are being kept from it for space.
+        entries: list[tuple[dict, str]] = []
+        for row in self.get_lessons():
+            decoded = json.loads(row["value_json"])
+            text = _lesson_display_text(decoded)
+            if not text:
+                continue
+            scope = _lesson_scope(decoded)
+            if _lesson_scope_unusable(decoded):
+                continue
+            if scope and not project_scope_satisfied(scope, project_dir):
+                continue
+            entries.append((row, text))
         if not entries:
             return ""
         total = len(entries)
@@ -3288,8 +3493,26 @@ class VectorMemoryStore:
                     data = json.loads(line)
                     rule = data.get("rule", "")
                     negative = data.get("negative")
+                    # This loop reads lessons.jsonl DIRECTLY rather than through
+                    # LessonStore.load_all, so it needs the same three-state rule:
+                    # an absent scope means global, but a PRESENT unusable one means
+                    # the row wanted a scope and cannot say which. Passing that to
+                    # write_lesson would normalise it to None and inject the
+                    # correction everywhere -- fail-open. Counted as skipped, like
+                    # any other row this loop cannot use.
+                    raw_scope = data.get("repo_scope")
+                    if raw_scope is not None and not scope_is_admissible(raw_scope):
+                        counts["skipped"] += 1
+                        continue
+                    # Carry the scope across. Dropping it would silently widen a
+                    # repository-scoped correction into a global one, which is the
+                    # one direction the scope gate must never move.
                     if rule and self.write_lesson(
-                        rule, data.get("category", "knowledge"), negative, source="migration"
+                        rule,
+                        data.get("category", "knowledge"),
+                        negative,
+                        source="migration",
+                        repo_scope=raw_scope,
                     ):
                         counts["semantic"] += 1
                     else:
@@ -3566,7 +3789,13 @@ class VectorMemoryStore:
         return {r["event_type"]: r["count"] for r in rows}
 
     def get_context_preview(self, query_text: str = "") -> dict:
-        """Preview what would be injected into context (for debugging)."""
+        """Preview what would be injected into context (for debugging).
+
+        Reports the UNSCOPED view. A ``project_dir`` parameter was offered here
+        briefly and removed: the only caller never passed one, so it could not
+        change any observed output, and a knob nobody turns still has to be read
+        and trusted by whoever comes next.
+        """
         semantic = self.get_semantic_context(query_text=query_text)
         episodic = self.get_episodic_context(query_text=query_text)
         lessons = self.get_lessons_context(query_text=query_text)

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1209,6 +1209,46 @@ class TestMemoryGetContextQueryWiring:
         kwargs = fake_memory.get_context.call_args.kwargs
         assert kwargs["query"] == "what did we decide about paris"
 
+    def test_an_empty_scoped_lesson_result_does_not_fall_back_to_jsonl(self, tmp_path):
+        # A POPULATED vector store whose rows are all out of scope has already
+        # answered. Falling through would let the JSONL store speak for it and
+        # re-inject rows deleted from it.
+        from types import SimpleNamespace
+
+        from kiro_crew.learn import Lesson
+
+        builder = self._builder(tmp_path)
+        store = builder.get_memory_for(None)
+        store._vector_store = SimpleNamespace(
+            get_episodic_context=lambda query_text, cap: "",
+            get_semantic_context=lambda query_text, cap: "",
+            get_lessons_context=lambda query_text, cap, project_dir=None: "",
+            has_any_lesson=lambda: True,
+        )
+        builder.lessons.save(Lesson(ts="t", rule="JSONL-SENTINEL", category="tool"))
+        msg, _ = builder.build_message("q", True, "s1")
+        assert "JSONL-SENTINEL" not in msg
+
+    def test_an_unpopulated_vector_store_still_yields_jsonl_lessons(self, tmp_path):
+        # The opposite failure: while a first-boot migration is still filling the
+        # vector store it exists but holds nothing, and saved corrections must not
+        # vanish from the prompt in the meantime.
+        from types import SimpleNamespace
+
+        from kiro_crew.learn import Lesson
+
+        builder = self._builder(tmp_path)
+        store = builder.get_memory_for(None)
+        store._vector_store = SimpleNamespace(
+            get_episodic_context=lambda query_text, cap: "",
+            get_semantic_context=lambda query_text, cap: "",
+            get_lessons_context=lambda query_text, cap, project_dir=None: "",
+            has_any_lesson=lambda: False,
+        )
+        builder.lessons.save(Lesson(ts="t", rule="JSONL-SENTINEL", category="tool"))
+        msg, _ = builder.build_message("q", True, "s1")
+        assert "JSONL-SENTINEL" in msg
+
     def test_episodic_injected_exactly_once(self, tmp_path):
         from types import SimpleNamespace
 
@@ -1217,7 +1257,8 @@ class TestMemoryGetContextQueryWiring:
         store._vector_store = SimpleNamespace(
             get_episodic_context=lambda query_text, cap: "[EPISODIC-SENTINEL]",
             get_semantic_context=lambda query_text, cap: "",
-            get_lessons_context=lambda query_text, cap: "",
+            get_lessons_context=lambda query_text, cap, project_dir=None: "",
+            has_any_lesson=lambda: True,
         )
         msg, _ = builder.build_message("q", True, "s1")
         assert msg.count("[EPISODIC-SENTINEL]") == 1
@@ -1236,7 +1277,8 @@ class TestMemoryGetContextQueryWiring:
         store._vector_store = SimpleNamespace(
             get_episodic_context=_episodic,
             get_semantic_context=lambda query_text, cap: "",
-            get_lessons_context=lambda query_text, cap: "",
+            get_lessons_context=lambda query_text, cap, project_dir=None: "",
+            has_any_lesson=lambda: True,
         )
         builder.build_message("find my tokyo notes", True, "s2")
         assert seen == ["find my tokyo notes"]

--- a/test/test_lesson_project_scope.py
+++ b/test/test_lesson_project_scope.py
@@ -1,0 +1,722 @@
+"""The project-scope gate, and the lesson paths that apply it.
+
+Covers the shared rule itself, the JSONL store's filter, and that the skill
+loader answers through the same function -- the property that keeps skills and
+lessons from drifting into two notions of "in scope".
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from conftest import requires_symlinks
+from kiro_crew.learn import Lesson, LessonStore
+from kiro_crew.project_scope import project_scope_satisfied
+from kiro_crew.vector_memory import _lesson_display_text, _lesson_scope, _lesson_slug
+
+
+class TestProjectScopeSatisfied:
+    """The shared gate. Fails closed on everything it cannot confirm."""
+
+    def test_project_containing_the_fragment_qualifies(self, tmp_path):
+        (tmp_path / "src" / "pkg").mkdir(parents=True)
+        assert project_scope_satisfied("src/pkg", tmp_path) is True
+
+    def test_descendant_of_the_project_qualifies(self, tmp_path):
+        # The walk up exists so a session working DEEPER in the repository still
+        # qualifies. A ".git" entry is what marks the repository, so the fixture
+        # carries one -- without it there is no boundary to walk to and the gate
+        # only answers for the project dir itself (see the next test).
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "src" / "pkg").mkdir(parents=True)
+        deep = tmp_path / "src" / "pkg" / "sub"
+        deep.mkdir()
+        assert project_scope_satisfied("src/pkg", deep) is True
+
+    def test_the_walk_stops_at_the_repository_root(self, tmp_path):
+        # Above the repository root a fragment can name a shared directory that
+        # exists for every project on the host, which would turn a repo-scoped
+        # entry global. The walk must not reach there.
+        outer = tmp_path / "outer"
+        repo = outer / "repo"
+        (repo / ".git").mkdir(parents=True)
+        (outer / "marker").mkdir()
+        assert project_scope_satisfied("marker", repo) is False
+        # Same fragment INSIDE the repository still qualifies.
+        (repo / "marker").mkdir()
+        assert project_scope_satisfied("marker", repo) is True
+
+    def test_a_non_repository_project_answers_only_for_itself(self, tmp_path):
+        # No .git anywhere: there is no repository boundary to confirm against, so
+        # only the project dir itself is offered rather than an unbounded walk.
+        (tmp_path / "src" / "pkg").mkdir(parents=True)
+        deep = tmp_path / "src" / "pkg" / "sub"
+        deep.mkdir()
+        assert project_scope_satisfied("src/pkg", tmp_path) is True
+        assert project_scope_satisfied("src/pkg", deep) is False
+
+    def test_absolute_fragment_refused(self, tmp_path):
+        # An absolute path is not a fragment. Reducing "/etc/passwd" to
+        # "etc/passwd" and matching it against an ancestor is what let a
+        # repo-scoped entry apply to every project on the host.
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "src").mkdir()
+        assert project_scope_satisfied("/src", tmp_path) is False
+        assert project_scope_satisfied("/etc/passwd", tmp_path) is False
+
+    def test_trailing_slash_ignored(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "src" / "pkg").mkdir(parents=True)
+        assert project_scope_satisfied("src/pkg/", tmp_path) is True
+
+    def test_unrelated_project_does_not_qualify(self, tmp_path):
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        assert project_scope_satisfied("src/pkg", other) is False
+
+    def test_absent_project_fails_closed(self, tmp_path):
+        # The gate cannot confirm the project, so the entry is withheld rather
+        # than admitted into a session whose repository is unknown.
+        assert project_scope_satisfied("src/pkg", None) is False
+        assert project_scope_satisfied("src/pkg", "") is False
+
+    def test_traversal_fragment_refused(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        assert project_scope_satisfied("../src", tmp_path) is False
+
+    def test_dot_fragment_refused(self, tmp_path):
+        # "." is a natural way to write "this repo" and every directory contains it,
+        # so accepting it would silently make a scoped entry global -- fail-OPEN.
+        assert project_scope_satisfied(".", tmp_path) is False
+        assert project_scope_satisfied("./", tmp_path) is False
+        assert project_scope_satisfied("src/./pkg", tmp_path) is False
+        assert project_scope_satisfied("..", tmp_path) is False
+
+    def test_drive_qualified_fragment_refused(self, tmp_path):
+        # pathlib discards the left side of the join when the right is absolute, so
+        # on Windows this would answer about a path outside the project entirely.
+        # A POSIX leading slash needs no such guard: it is stripped to a relative
+        # fragment, so the join stays under the project either way.
+        (tmp_path / "etc").mkdir()
+        assert project_scope_satisfied("C:/etc", tmp_path) is False
+        assert project_scope_satisfied("C:\\etc", tmp_path) is False
+
+    def test_empty_segment_refused(self, tmp_path):
+        (tmp_path / "src" / "pkg").mkdir(parents=True)
+        assert project_scope_satisfied("src//pkg", tmp_path) is False
+
+    def test_the_schema_refuses_a_scope_the_gate_cannot_satisfy(self):
+        # Storing "." reported success and then applied nowhere -- the same
+        # silent-success shape this feature exists to end. The write surface now
+        # refuses it instead of persisting an inert lesson.
+        from kiro_crew.validation import LEARN_ADD_SCHEMA, ValidationError, validate_tool_args
+
+        base = {"rule": "r", "category": "tool"}
+        for bad in (".", "..", "src/./pkg", "C:/x"):
+            with pytest.raises(ValidationError):
+                validate_tool_args({**base, "repo_scope": bad}, LEARN_ADD_SCHEMA)
+        cleaned = validate_tool_args({**base, "repo_scope": "src/pkg"}, LEARN_ADD_SCHEMA)
+        assert cleaned["repo_scope"] == "src/pkg"
+
+    @requires_symlinks
+    def test_a_symlink_out_of_the_repository_is_refused(self, tmp_path):
+        # The bounded walk stops the SEARCH from climbing out; strict resolution
+        # still followed a link out. A target outside the repository cannot answer
+        # "is this fragment inside the repository it names", sensitive or not -- this
+        # one deliberately is NOT sensitive, so only containment can refuse it.
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        outside = tmp_path / "outside" / "payload"
+        outside.mkdir(parents=True)
+        (repo / "data").symlink_to(outside)
+
+        assert project_scope_satisfied("data", repo) is False
+        # A target that stays inside still qualifies, so containment has not simply
+        # disabled the gate.
+        (repo / "src").mkdir()
+        assert project_scope_satisfied("src", repo) is True
+
+    @requires_symlinks
+    def test_a_symlink_into_a_sensitive_tree_is_refused(self, tmp_path, monkeypatch):
+        # The static bypass, no race needed: a symlink already in the tree makes the
+        # literal fragment look harmless while the probe follows it into the
+        # credential directory. Judging the RESOLVED path is what closes it.
+        from kiro_crew import project_scope as ps
+        from kiro_crew.security import is_sensitive_path
+
+        # Aim check: the real predicate flags the shape the guard exists for.
+        assert is_sensitive_path(str(Path.home() / ".ssh" / "id_rsa")) is True
+
+        (tmp_path / ".git").mkdir()
+        secret_dir = tmp_path / "pretend_home" / ".ssh"
+        secret_dir.mkdir(parents=True)
+        (secret_dir / "id_rsa").write_text("x", encoding="utf-8")
+        (tmp_path / "data").symlink_to(secret_dir)
+
+        # Flag the resolved location, as the real predicate would for a true home.
+        # Judge by path SEGMENTS, not by a separator: resolve() yields backslashes
+        # on Windows, so a hardcoded "/.ssh/" would silently never match there and
+        # the assertion below would pass for the wrong reason.
+        monkeypatch.setattr(
+            ps, "is_sensitive_path", lambda p, base_dir=None: ".ssh" in Path(p).parts
+        )
+        assert project_scope_satisfied("data/id_rsa", tmp_path) is False
+        # A non-sensitive target through the same tree still qualifies.
+        (tmp_path / "src").mkdir()
+        assert project_scope_satisfied("src", tmp_path) is True
+
+    def test_a_nonexistent_and_a_sensitive_fragment_are_indistinguishable(self, tmp_path):
+        # Both answer False, so the gate leaks no existence bit for a path it
+        # refuses to look at.
+        (tmp_path / ".git").mkdir()
+        assert project_scope_satisfied("no/such/thing", tmp_path) is False
+
+    def test_the_write_pattern_and_the_gate_agree(self, tmp_path):
+        # The write surface screens the RAW submitted value with SCOPE_FRAGMENT_RE
+        # and the gate enforces the rest. If they disagree, a value is either stored
+        # and never usable or refused while being perfectly fine -- so pin both
+        # surfaces, against the raw value, to the same verdicts.
+        from kiro_crew.project_scope import SCOPE_FRAGMENT_RE
+
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "src" / "pkg").mkdir(parents=True)
+        accept = ["src/pkg", "src/pkg/", "src"]
+        reject = [
+            ".",
+            "..",
+            "./",
+            "src/./pkg",
+            "src/../pkg",
+            "src//pkg",
+            "C:/x",
+            "C:\\x",
+            "",
+            "/src/pkg",
+            "/etc/passwd",
+        ]
+        for value in accept:
+            assert SCOPE_FRAGMENT_RE.match(value), value
+            assert project_scope_satisfied(value, tmp_path) is True, value
+        for value in reject:
+            assert not SCOPE_FRAGMENT_RE.match(value), value
+            assert project_scope_satisfied(value, tmp_path) is False, value
+
+    def test_blank_fragment_refused(self, tmp_path):
+        assert project_scope_satisfied("", tmp_path) is False
+        assert project_scope_satisfied("   ", tmp_path) is False
+        assert project_scope_satisfied("/", tmp_path) is False
+
+    def test_a_leading_slash_is_no_longer_tolerated(self, tmp_path):
+        # Earlier this reduced "/src/pkg" to "src/pkg" and matched. That tolerance
+        # is what made "/etc/passwd" reachable as "etc/passwd" from the "/" ancestor,
+        # so an absolute fragment is now refused outright.
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "src" / "pkg").mkdir(parents=True)
+        assert project_scope_satisfied("/src/pkg/", tmp_path) is False
+        assert project_scope_satisfied("src/pkg", tmp_path) is True
+
+
+class TestSkillLoaderSharesTheGate:
+    """The skill gate must answer through the shared function, not a copy."""
+
+    def test_skill_gate_delegates_to_the_shared_rule(self, tmp_path, monkeypatch):
+        from kiro_crew import skills as skills_mod
+
+        calls: list[tuple[str, object]] = []
+
+        def _spy(relpath, project_dir):
+            calls.append((relpath, project_dir))
+            return True
+
+        monkeypatch.setattr(skills_mod, "project_scope_satisfied", _spy)
+        assert skills_mod.SkillsLoader._repo_scope_satisfied("src/pkg", tmp_path) is True
+        # A second implementation in skills.py would leave this empty, which is the
+        # drift this test exists to prevent.
+        assert calls == [("src/pkg", tmp_path)]
+
+
+class TestLessonStoreScope:
+    """The JSONL store's pre-injection filter."""
+
+    def _store(self, tmp_path):
+        return LessonStore(base_dir=tmp_path)
+
+    def test_unscoped_lesson_reaches_every_session(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save(Lesson(ts="t", rule="always rebase", category="tool"))
+        # No project at all: an unscoped lesson is unaffected, which is what an
+        # existing store expects.
+        assert "always rebase" in store.get_context()
+        assert "always rebase" in store.get_context(project_dir=tmp_path)
+
+    def test_scoped_lesson_withheld_outside_its_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / "src" / "pkg").mkdir(parents=True)
+        outside = tmp_path / "other"
+        outside.mkdir()
+        store = self._store(tmp_path)
+        store.save(Lesson(ts="t", rule="run the repo gate", category="tool", repo_scope="src/pkg"))
+        assert "run the repo gate" in store.get_context(project_dir=repo)
+        assert "run the repo gate" not in store.get_context(project_dir=outside)
+
+    def test_scoped_lesson_withheld_when_project_unknown(self, tmp_path):
+        (tmp_path / "src" / "pkg").mkdir(parents=True)
+        store = self._store(tmp_path)
+        store.save(Lesson(ts="t", rule="scoped rule", category="tool", repo_scope="src/pkg"))
+        # Fail-closed: a surface with no project must not inherit another
+        # repository's rules.
+        assert store.get_context() == ""
+
+    def test_scope_survives_a_round_trip(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save(Lesson(ts="t", rule="r", category="tool", repo_scope="src/pkg"))
+        assert self._store(tmp_path).load_all()[0].repo_scope == "src/pkg"
+
+    def test_blank_scope_stores_as_absent(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save(Lesson(ts="t", rule="r", category="tool", repo_scope="   "))
+        assert store.load_all()[0].repo_scope is None
+
+    def test_scoping_an_existing_lesson_adds_a_row_rather_than_mutating_it(self, tmp_path):
+        # Scope is WRITE-ONCE here, the posture the vector store already documents:
+        # re-scoping is a delete plus re-add, not an enrichment. Submitting a scope
+        # for a rule stored globally yields a second, scoped lesson.
+        store = self._store(tmp_path)
+        store.save_or_enrich(Lesson(ts="t", rule="r", category="tool"))
+        assert (
+            store.save_or_enrich(Lesson(ts="t", rule="r", category="tool", repo_scope="src/pkg"))
+            == "inserted"
+        )
+        scopes = sorted((le.repo_scope or "") for le in store.load_all())
+        assert scopes == ["", "src/pkg"]
+
+    def test_a_stored_scope_is_never_stripped(self, tmp_path):
+        # The guarantee that matters: no later write quietly removes a scope already
+        # on a row.
+        store = self._store(tmp_path)
+        store.save_or_enrich(Lesson(ts="t", rule="r", category="tool", repo_scope="src/pkg"))
+        store.save_or_enrich(Lesson(ts="t", rule="r", category="tool"))
+        assert len([le for le in store.load_all() if le.repo_scope == "src/pkg"]) == 1
+
+    def test_a_malformed_scope_row_is_dropped(self, tmp_path):
+        # Same rule on the JSONL side: a present non-string scope is neither global
+        # nor handed to the gate (where it would raise mid-prompt-assembly).
+        (tmp_path / "lessons.jsonl").write_text(
+            json.dumps({"ts": "t", "rule": "listy scope", "category": "tool", "repo_scope": []})
+            + "\n"
+            + json.dumps(
+                {"ts": "t", "rule": "stringy scope", "category": "tool", "repo_scope": ["a"]}
+            )
+            + "\n"
+            + json.dumps({"ts": "t", "rule": "fine", "category": "tool"})
+            + "\n",
+            encoding="utf-8",
+        )
+        store = LessonStore(base_dir=tmp_path)
+        rules = [le.rule for le in store.load_all()]
+        assert rules == ["fine"]
+        assert "listy scope" not in store.get_context()
+
+    def test_a_second_repo_gets_its_own_row_not_a_stolen_one(self, tmp_path):
+        # Scope is part of identity. Saving the same rule for repo B must not take
+        # repo A's row: A would lose the lesson entirely.
+        store = self._store(tmp_path)
+        store.save_or_enrich(Lesson(ts="t", rule="bump first", category="tool", repo_scope="a"))
+        assert (
+            store.save_or_enrich(Lesson(ts="t", rule="bump first", category="tool", repo_scope="b"))
+            == "inserted"
+        )
+        scopes = sorted(le.repo_scope for le in store.load_all())
+        assert scopes == ["a", "b"]
+
+    def test_an_unscoped_save_does_not_claim_a_scoped_row(self, tmp_path):
+        # Strict identity, matching the vector store: (rule, None) and (rule, "a")
+        # are two lessons. My earlier guard treated an omitted scope as "no
+        # conflict", so a genuine save-this-globally request bound to the scoped row
+        # and reported success without ever creating the global lesson.
+        store = self._store(tmp_path)
+        store.save_or_enrich(Lesson(ts="t", rule="r", category="tool", repo_scope="a"))
+        assert store.save_or_enrich(Lesson(ts="t", rule="r", category="tool")) == "inserted"
+        scopes = sorted((le.repo_scope or "") for le in store.load_all())
+        assert scopes == ["", "a"]
+
+    def test_addressing_a_scoped_lesson_means_naming_its_scope(self, tmp_path):
+        # The other side of strict identity: a clause attaches when the submission
+        # names the same scope, and only then.
+        store = self._store(tmp_path)
+        store.save_or_enrich(Lesson(ts="t", rule="r", category="tool", repo_scope="a"))
+        assert (
+            store.save_or_enrich(
+                Lesson(ts="t", rule="r", category="tool", negative="not this", repo_scope="a")
+            )
+            == "enriched"
+        )
+        rows = store.load_all()
+        assert len(rows) == 1
+        assert (rows[0].repo_scope, rows[0].negative) == ("a", "not this")
+
+    def test_a_scoped_submission_carries_its_own_clause(self, tmp_path):
+        # A scoped submission is its own lesson, so its NOT-clause lands on that new
+        # row and the pre-existing global lesson is untouched.
+        store = self._store(tmp_path)
+        store.save_or_enrich(Lesson(ts="t", rule="r", category="tool"))
+        store.save_or_enrich(
+            Lesson(ts="t", rule="r", category="tool", negative="not this", repo_scope="src/pkg")
+        )
+        rows = {le.repo_scope: le.negative for le in store.load_all()}
+        assert rows == {None: None, "src/pkg": "not this"}
+
+
+class TestVectorStoreLessonScope:
+    """The vector store is the PRIMARY injection path, so the gate must hold here.
+
+    Filtering only the JSONL fallback would leave the scope key inert in
+    production -- advertised and enforced nowhere, which is the failure this
+    whole mechanism exists to end.
+    """
+
+    def _store(self, tmp_path):
+        from kiro_crew.vector_memory import VectorMemoryStore
+
+        store = VectorMemoryStore(db_path=tmp_path / "m.db", embedding_dim=4)
+        store.init()
+        return store
+
+    def test_scoped_lesson_reaches_only_its_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / "src" / "pkg").mkdir(parents=True)
+        outside = tmp_path / "other"
+        outside.mkdir()
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("gate the repo", "tool", None, repo_scope="src/pkg")
+            assert "gate the repo" in store.get_lessons_context(project_dir=repo)
+            assert "gate the repo" not in store.get_lessons_context(project_dir=outside)
+            # Fail-closed with no project at all.
+            assert store.get_lessons_context() == ""
+        finally:
+            store.close()
+
+    def test_unscoped_lesson_is_unaffected(self, tmp_path):
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("applies anywhere", "tool")
+            assert "applies anywhere" in store.get_lessons_context()
+        finally:
+            store.close()
+
+    def test_a_scoped_write_does_not_supersede_a_global_lesson(self, tmp_path):
+        # Deliberately the near-identical wording that the generic dedup rules
+        # (substring / keyword overlap / cosine) treat as the same lesson. Across
+        # scopes they are NOT, and superseding here would delete global guidance the
+        # scoped write never addressed.
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("visible rule", "tool")
+            assert store.write_lesson("hidden rule", "tool", None, repo_scope="src/pkg")
+            texts = [_lesson_display_text(json.loads(r["value_json"])) for r in store.get_lessons()]
+            assert "visible rule" in texts
+            assert "hidden rule" in texts
+        finally:
+            store.close()
+
+    def test_the_same_rule_in_two_scopes_is_two_rows(self, tmp_path):
+        # Same rule text, different scope. A shared key would let the second write
+        # overwrite the first and silently re-scope it.
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("run the gate", "tool")
+            assert store.write_lesson("run the gate", "tool", None, repo_scope="src/pkg")
+            rows = store.get_lessons()
+            scopes = {_lesson_scope(json.loads(r["value_json"])) for r in rows}
+            assert scopes == {None, "src/pkg"}
+            assert len({r["key"] for r in rows}) == 2
+        finally:
+            store.close()
+
+    def test_an_unscoped_lesson_keeps_its_historical_key(self, tmp_path):
+        # The unscoped key must not move, or every stored row would need migrating.
+        store = self._store(tmp_path)
+        try:
+            store.write_lesson("keep my key", "tool")
+            assert store.get_lessons()[0]["key"] == f"lesson.{_lesson_slug('keep my key')}"
+        finally:
+            store.close()
+
+    def test_the_contradiction_sweep_is_scope_local(self, tmp_path):
+        # Superseding resolves a contradiction by DELETING the loser, so a scoped
+        # exception must not put a global rule up for deletion: it contradicts that
+        # rule only inside its own tree. A global rule retired on the strength of
+        # one repository's exception is gone for every other repository.
+        store = self._store(tmp_path)
+        try:
+            # Without an embedder the scan returns early, so the loop under test
+            # would never run. A constant vector makes every pair score 1.0, which
+            # keeps the assertion about SCOPE rather than about similarity.
+            store.embed_fn = lambda text: [1.0, 0.0, 0.0, 0.0]
+            store.write_lesson("never commit directly to main", "tool")
+            emb = [1.0, 0.0, 0.0, 0.0]
+            scoped = store.find_contradiction_candidates(
+                "commit hotfixes directly to main", 0.0, 1.5, emb, "src/pkg"
+            )
+            unscoped = store.find_contradiction_candidates(
+                "commit hotfixes directly to main", 0.0, 1.5, emb, None
+            )
+            assert [c["rule"] for c in unscoped] == ["never commit directly to main"]
+            assert scoped == []
+        finally:
+            store.close()
+
+    def test_migration_skips_a_malformed_scope_instead_of_globalising_it(
+        self, tmp_path, monkeypatch
+    ):
+        # migrate_from_markdown reads lessons.jsonl directly, so it needs the same
+        # three-state rule as the store: a present unusable scope is skipped, not
+        # normalised to None and injected everywhere.
+        from kiro_crew import vector_memory as vm
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "lessons.jsonl").write_text(
+            json.dumps({"ts": "t", "rule": "listy", "category": "tool", "repo_scope": []})
+            + "\n"
+            + json.dumps({"ts": "t", "rule": "fine", "category": "tool"})
+            + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(vm, "config_dir", lambda: home)
+        store = self._store(tmp_path)
+        try:
+            counts = store.migrate_from_markdown()
+            rules = [_lesson_display_text(json.loads(r["value_json"])) for r in store.get_lessons()]
+            assert rules == ["fine"]
+            assert counts["skipped"] >= 1
+        finally:
+            store.close()
+
+    def test_migration_preserves_a_scoped_lesson(self, tmp_path, monkeypatch):
+        # A scoped lesson that migrates in as global is silently widened, which is
+        # the one direction the gate must never move. Drives the real
+        # migrate_from_markdown, which reads its source dir from config_dir().
+        from kiro_crew import vector_memory as vm
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "lessons.jsonl").write_text(
+            json.dumps(
+                {
+                    "ts": "t",
+                    "rule": "bump the manifest before tagging",
+                    "category": "tool",
+                    "negative": None,
+                    "repo_scope": "src/pkg",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(vm, "config_dir", lambda: home)
+        store = self._store(tmp_path)
+        try:
+            counts = store.migrate_from_markdown()
+            assert counts["semantic"] >= 1
+            scopes = {_lesson_scope(json.loads(r["value_json"])) for r in store.get_lessons()}
+            assert scopes == {"src/pkg"}
+        finally:
+            store.close()
+
+    def _plant_malformed(self, store, rule):
+        """Store *rule* then corrupt its scope to a present-but-unusable value."""
+        store.write_lesson(rule, "tool")
+        row = store.get_lessons()[0]
+        value = json.loads(row["value_json"])
+        value["repo_scope"] = []
+        store.db.execute(
+            "UPDATE semantic_memory SET value_json = ? WHERE key = ?",
+            (json.dumps(value), row["key"]),
+        )
+        store.db.commit()
+
+    def test_a_malformed_row_does_not_dedup_away_a_global_write(self, tmp_path):
+        # The row is withheld at injection, so if the dedup scan read it as unscoped
+        # a genuine global write would be discarded against it and the caller told
+        # the lesson was saved while nothing reaches a prompt.
+        store = self._store(tmp_path)
+        try:
+            self._plant_malformed(store, "always rebase before pushing")
+            assert store.write_lesson("always rebase before pushing", "tool") is True
+            assert "always rebase before pushing" in store.get_lessons_context()
+        finally:
+            store.close()
+
+    def test_a_malformed_row_does_not_count_as_population(self, tmp_path):
+        # It renders fine but is never injected, so counting it would silence the
+        # JSONL store while nothing reaches the prompt.
+        store = self._store(tmp_path)
+        try:
+            self._plant_malformed(store, "some rule")
+            assert store.has_any_lesson() is False
+        finally:
+            store.close()
+
+    def test_a_trailing_slash_is_the_same_scope_in_both_stores(self, tmp_path):
+        # The gate strips separators before matching, so these two spellings behave
+        # identically. Storing them raw made two rows that were both injected and
+        # neither deduped the other.
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("r", "tool", repo_scope="src/pkg") is True
+            store.write_lesson("r", "tool", repo_scope="src/pkg/")
+            assert len(store.get_lessons()) == 1
+        finally:
+            store.close()
+
+    def test_a_near_limit_multibyte_scoped_lesson_is_still_accepted(self, tmp_path):
+        # Adding repo_scope to the mapping must not drop the lesson out of the size
+        # exemption: the envelope would then be measured and a rule that the bare
+        # form always allowed would be refused, while a caller with a JSONL fallback
+        # reported it saved.
+        store = self._store(tmp_path)
+        try:
+            rule = "\u4e00" * 500
+            negative = "\u4e00" * 500
+            assert store.write_lesson(rule, "tool", negative=negative, repo_scope="src/pkg") is True
+            assert len(store.get_lessons()) == 1
+        finally:
+            store.close()
+
+    def test_an_inadmissible_scope_is_refused_not_laundered(self, tmp_path):
+        # Two of this change's own rules disagreed on "/src/pkg": the canonicaliser
+        # strips the leading slash (making it admissible) while the gate refuses it.
+        # The write surface must not resolve that by normalising -- that ACTIVATES
+        # the lesson in every repository holding src/pkg -- nor by dropping the
+        # scope, which stores it globally. It refuses.
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("r", "tool", repo_scope="/src/pkg") is False
+            assert store.get_lessons() == []
+            # A trailing slash is an equivalent SPELLING, not an invalid scope, so it
+            # still folds and still writes.
+            assert store.write_lesson("r", "tool", repo_scope="src/pkg/") is True
+            assert _lesson_scope(json.loads(store.get_lessons()[0]["value_json"])) == "src/pkg"
+        finally:
+            store.close()
+
+    def test_no_caller_can_launder_an_inadmissible_scope(self, tmp_path, monkeypatch):
+        # The write surface is the single chokepoint, so the migration is covered by
+        # it rather than by its own guard -- verified by probe: reverting the
+        # migration's condition alone does NOT reopen this. That is the point. The
+        # migration's condition is kept so its own skip COUNT is right for the right
+        # reason, but the property below holds for every caller, including ones this
+        # PR never touched.
+        from kiro_crew import vector_memory as vm
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "lessons.jsonl").write_text(
+            json.dumps({"ts": "t", "rule": "r", "category": "tool", "repo_scope": "/src/pkg"})
+            + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(vm, "config_dir", lambda: home)
+        store = self._store(tmp_path / "vs")
+        try:
+            store.migrate_from_markdown()
+            # Neither activated in src/pkg nor widened to global: not stored at all.
+            assert store.get_lessons() == []
+        finally:
+            store.close()
+
+    def test_a_stale_client_legacy_scope_is_refused_not_globalised(self):
+        # The fail direction matters more than the refusal: before this change the
+        # workspace tier was inert, so converting it to a global lesson would inject
+        # a one-workspace correction into every session -- worse than the dead tier
+        # it replaced.
+        from kiro_crew.mcp_tools import learn as mcp_learn
+
+        out = mcp_learn.learn_add("learn_add", {"rule": "r", "scope": "workspace"})
+        assert out.startswith("Error:")
+        assert "repo_scope" in out
+        # An explicit global, and an absent scope, are both still fine.
+        for args in ({"rule": "r", "scope": "global"}, {"rule": "r"}):
+            assert not mcp_learn.learn_add("learn_add", args).startswith("Error: scope=")
+
+    def test_a_gate_invalid_string_scope_does_not_count_as_population(self, tmp_path):
+        # "." is a non-blank string, so judging by shape called it usable while the
+        # gate refuses it. The row then rendered nothing yet still counted as stored
+        # knowledge, which silenced the JSONL store and lost the saved lessons.
+        # "/etc" is the same hole reached differently: an imported row skips the
+        # write surface, so it keeps a leading slash the gate refuses.
+        for bad in (".", "..", "/etc", "  "):
+            store = self._store(tmp_path / f"s{abs(hash(bad))}")
+            try:
+                store.write_lesson("some rule", "tool")
+                row = store.get_lessons()[0]
+                value = json.loads(row["value_json"])
+                value["repo_scope"] = bad
+                store.db.execute(
+                    "UPDATE semantic_memory SET value_json = ? WHERE key = ?",
+                    (json.dumps(value), row["key"]),
+                )
+                store.db.commit()
+                assert store.has_any_lesson() is False, bad
+            finally:
+                store.close()
+
+    def test_a_junk_lesson_row_does_not_count_as_population(self, tmp_path):
+        # A lesson.* key holding non-lesson data is skipped by every renderer, so
+        # counting it as population would silence the JSONL store while nothing
+        # renders and saved corrections would vanish.
+        store = self._store(tmp_path)
+        try:
+            assert store.has_any_lesson() is False
+            store.set_semantic("lesson.junk", ["not", "a", "lesson"], 1.0, "import")
+            assert store.has_any_lesson() is False
+            assert store.write_lesson("a real one", "tool")
+            assert store.has_any_lesson() is True
+        finally:
+            store.close()
+
+    def test_a_malformed_scope_is_withheld_not_globalised(self, tmp_path):
+        # A PRESENT but unusable scope (a list from an imported or hand-edited row)
+        # must not read as "applies everywhere". The row meant to be scoped and
+        # cannot say where, so withholding is the only safe answer.
+        store = self._store(tmp_path)
+        try:
+            store.write_lesson("keep me out", "tool")
+            row = store.get_lessons()[0]
+            value = json.loads(row["value_json"])
+            value["repo_scope"] = []
+            store.db.execute(
+                "UPDATE semantic_memory SET value_json = ? WHERE key = ?",
+                (json.dumps(value), row["key"]),
+            )
+            store.db.commit()
+            assert "keep me out" not in store.get_lessons_context(project_dir=tmp_path)
+            assert "keep me out" not in store.get_lessons_context()
+        finally:
+            store.close()
+
+    def test_out_of_scope_lesson_is_not_counted_as_omitted(self, tmp_path):
+        # "omitted" means "did not fit the budget". Reporting an out-of-scope
+        # lesson there would tell the model rules are being withheld for space.
+        repo = tmp_path / "repo"
+        (repo / "src" / "pkg").mkdir(parents=True)
+        outside = tmp_path / "other"
+        outside.mkdir()
+        store = self._store(tmp_path)
+        try:
+            # Deliberately unrelated wording: write_lesson's dedup replaces an
+            # older lesson that shares most of its significant words, which would
+            # collapse two similarly-worded rules into one row.
+            store.write_lesson("prefer tabs over spaces", "preference")
+            store.write_lesson("bump the manifest version", "tool", None, repo_scope="src/pkg")
+            out = store.get_lessons_context(project_dir=outside)
+            assert "prefer tabs over spaces" in out
+            assert "bump the manifest version" not in out
+            assert "omitted" not in out
+        finally:
+            store.close()

--- a/test/test_mcp_core_more_coverage.py
+++ b/test/test_mcp_core_more_coverage.py
@@ -58,6 +58,15 @@ from kiro_crew.mcp_shared import ToolCancelled
 _GOV = "kiro_crew.platform.governance_profiles"
 
 
+def _learn_add_properties() -> dict[str, Any]:
+    """The ``learn_add`` tool's advertised input properties."""
+    from kiro_crew.mcp_tools.learn import schemas
+
+    spec = next(s for s in schemas() if s["name"] == "learn_add")
+    props: dict[str, Any] = spec["inputSchema"]["properties"]
+    return props
+
+
 class _RecordingSel:
     """Stand-in for ``sel()`` that records instead of writing the SEL log."""
 
@@ -749,16 +758,40 @@ class TestLearnAddTool:
     def _allowed(self):
         return patch.object(mcp_core, "_vet_memory_writes_governance", return_value=None)
 
-    def test_a_workspace_scoped_lesson_requires_a_workspace_name(self) -> None:
+    def test_the_tool_no_longer_offers_a_workspace_scope(self) -> None:
+        # The workspace tier never reached a prompt, so advertising it told the
+        # model it could restrict a correction when the save changed nothing.
+        #
+        # A stale client still holding that schema is REFUSED, not silently
+        # converted. This test previously pinned the opposite ("ignored rather than
+        # honoured"), which was wrong in the dangerous direction: forcing the
+        # payload to global takes a correction meant for one workspace and applies
+        # it in every session, which is worse than the inert tier it replaced.
         with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
             with self._allowed():
-                with patch.object(mcp_core, "_post", side_effect=AssertionError("no write")):
+                with patch.object(mcp_core, "_post", return_value={"ok": True}) as p:
                     out = _call_tool_inner(
-                        "learn_add", {"rule": "r", "scope": "workspace"}
+                        "learn_add",
+                        {"rule": "r", "category": "tool", "scope": "workspace", "workspace": "w"},
                     )
-        assert out == "Error: workspace name is required when scope='workspace'"
+        assert out.startswith("Error:")
+        assert "repo_scope" in out
+        p.assert_not_called()
+        props = _learn_add_properties()
+        assert "workspace" not in props
+        assert "scope" not in props
 
-    def test_the_negative_clause_and_workspace_are_forwarded(self) -> None:
+    def test_an_absent_scope_still_saves_globally(self) -> None:
+        # The refusal above must not catch the normal path: no scope key at all is
+        # the ordinary global save, and that is what the payload still carries.
+        with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
+            with self._allowed():
+                with patch.object(mcp_core, "_post", return_value={"ok": True}) as p:
+                    out = _call_tool_inner("learn_add", {"rule": "r", "category": "tool"})
+        assert out == "Saved lesson: r"
+        assert p.call_args.args[1] == {"rule": "r", "category": "tool", "scope": "global"}
+
+    def test_the_negative_clause_and_repo_scope_are_forwarded(self) -> None:
         with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
             with self._allowed():
                 with patch.object(mcp_core, "_post", return_value={"ok": True}) as p:
@@ -767,22 +800,29 @@ class TestLearnAddTool:
                         {
                             "rule": "always X",
                             "category": "preference",
-                            "scope": "workspace",
-                            "workspace": "default",
                             "negative": "never Y",
+                            "repo_scope": "src/kiro_crew",
                         },
                     )
-        assert out == "Saved lesson (workspace): always X"
+        assert out == "Saved lesson (applies only in src/kiro_crew): always X"
         assert p.call_args.args == (
             "/api/lessons",
             {
                 "rule": "always X",
                 "category": "preference",
-                "scope": "workspace",
+                "scope": "global",
                 "negative": "never Y",
-                "workspace": "default",
+                "repo_scope": "src/kiro_crew",
             },
         )
+
+    def test_the_advertised_repo_scope_cap_tracks_the_enforced_one(self) -> None:
+        # The hint must be derived from the field the validator enforces, so a
+        # future cap change cannot leave the model told an obsolete limit.
+        from kiro_crew.validation import LEARN_ADD_SCHEMA
+
+        enforced = next(f.max_len for f in LEARN_ADD_SCHEMA.fields if f.name == "repo_scope")
+        assert _learn_add_properties()["repo_scope"]["maxLength"] == enforced
 
     def test_an_unknown_session_error_becomes_an_actionable_message(self) -> None:
         with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):

--- a/test/test_perf_memory_quickwins.py
+++ b/test/test_perf_memory_quickwins.py
@@ -250,28 +250,47 @@ class TestLessonsSingleQuery:
         vector_store.get_lessons.assert_not_called()
         assert vector_store.get_lessons_context.call_count == 1
 
-    def test_empty_store_falls_back_to_file_lessons(self, tmp_path: Path) -> None:
-        """An empty vector store still yields the file-backed lessons."""
+    def test_file_lessons_answer_only_when_there_is_no_vector_store(
+        self, tmp_path: Path
+    ) -> None:
+        """The file store is the fallback for HAVING no vector store.
+
+        It is deliberately NOT the fallback for a vector store that returned
+        nothing. Scope filtering gave "empty" a second meaning -- it also means
+        "every lesson is out of scope here" -- so answering from the file store on
+        empty would let it speak for a live vector store and re-inject rows that
+        were deleted from it.
+        """
         from kiro_crew.context import ContextBuilder
         from kiro_crew.learn import Lesson, LessonStore
 
         lessons = LessonStore(base_dir=tmp_path)
         lessons.save(Lesson(ts="1", rule="never force push to mainline", category="knowledge"))
 
+        # No vector store: the file store answers.
+        no_vs = MagicMock()
+        no_vs.vector_store = None
+        no_vs.get_context.return_value = ""
+        builder = self._builder(tmp_path)
+        builder.lessons = lessons
+        with patch.object(ContextBuilder, "get_memory_for", return_value=no_vs):
+            ctx = builder.build_session_context(session_key="sess-lessons-no-vs")
+        assert "never force push to mainline" in ctx
+
+        # Live vector store returning nothing: the file store stays silent.
         vector_store = MagicMock()
         vector_store.get_lessons_context.return_value = ""
         vector_store.get_semantic_context.return_value = ""
         vector_store.get_episodic_context.return_value = ""
-        fake_memory = MagicMock()
-        fake_memory.vector_store = vector_store
-        fake_memory.get_context.return_value = ""
-
-        builder = self._builder(tmp_path)
-        builder.lessons = lessons
-        with patch.object(ContextBuilder, "get_memory_for", return_value=fake_memory):
-            ctx = builder.build_session_context(session_key="sess-lessons-empty")
-
-        assert "never force push to mainline" in ctx
+        with_vs = MagicMock()
+        with_vs.vector_store = vector_store
+        with_vs.get_context.return_value = ""
+        builder2 = self._builder(tmp_path)
+        builder2.lessons = lessons
+        with patch.object(ContextBuilder, "get_memory_for", return_value=with_vs):
+            ctx2 = builder2.build_session_context(session_key="sess-lessons-empty")
+        assert "never force push to mainline" not in ctx2
+        assert vector_store.get_lessons_context.call_count == 1
 
 
 class _ByteCountingOpen:

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -346,6 +346,10 @@ class TestRepoScope:
     def _repo(self, tmp_path: Path, name: str = "checkout") -> Path:
         repo = tmp_path / name
         (repo / "src" / "kiro_crew").mkdir(parents=True)
+        # A real checkout carries a .git entry, and the gate reads it as the
+        # boundary the ancestor walk stops at, so the fixture needs one to model a
+        # repository rather than a bare directory tree.
+        (repo / ".git").mkdir()
         return repo
 
     def test_scoped_skill_suppressed_without_a_project(self, tmp_path: Path) -> None:

--- a/test/test_subagent_context_groups.py
+++ b/test/test_subagent_context_groups.py
@@ -186,7 +186,8 @@ class TestEpisodicMemoryGate:
         store._vector_store = SimpleNamespace(
             get_episodic_context=lambda query_text, cap: "[EPISODIC-SENTINEL]",
             get_semantic_context=lambda query_text, cap: "",
-            get_lessons_context=lambda query_text, cap: "",
+            get_lessons_context=lambda query_text, cap, project_dir=None: "",
+            has_any_lesson=lambda: True,
         )
         return builder
 


### PR DESCRIPTION
## 1. What is the problem?

Every lesson is injected into every session, whatever that session is working on. A
correction that is only true of one codebase ("bump the manifest before tagging")
becomes permanent global context for unrelated work.

A scope tier for this already existed on paper and did not work. `validation.py`
still defines `ALLOWED_LESSON_SCOPES = {"global", "workspace"}` and the `learn_add`
MCP tool advertised `scope: ["global", "workspace"]` to the model, described as
"active workspace only". Trace one such call on `main` before this change:

- `dashboard/handlers/cron.py` accepts `scope="workspace"` and writes to the
  per-workspace store. `learn_add` returns `Saved lesson (workspace): ...`.
- `context.py` never reads that store, so the lesson reaches **no prompt**.
- The dashboard list merges workspace lessons only when `workspace != "default"`,
  which every member resolves to, so in the common case it is not even listed.

So the tool offered a behaviour-changing option that changed no behaviour, and
reported success doing it. `context.py` names the reason the read was removed: the
scope dates from when a workspace WAS a project, and project identity now lives on
the session, leaving that tier with nothing to anchor to.

## 2. Why this issue matters to the user

Two costs, one per half.

Unscoped injection is a correctness and cost problem at once: repo-specific rules
steer sessions they do not apply to, and they spend context budget in every session
to do it. Lessons are the least inspectable input in the context pipeline, so a rule
misfiring on the wrong project is hard to attribute.

The dead scope is worse than absent, because it is indistinguishable from working.
A user who reaches for it gets a success message and no effect, and nothing anywhere
reports the gap.

## 3. How our fix solves it

Skills already solved this exact problem: `repo_scope` frontmatter, gated
mechanically before the skill can reach the context, keyed on the session's active
project. Lessons are the same kind of thing -- an instruction injected into every
session -- so they now share that key rather than growing a second vocabulary.

The chain from symptom to root cause:

- Root cause is that lesson injection had no notion of the session's project at all.
  `context.py` already resolves one for the skill gate; the lessons block simply
  never received it. It does now, on both paths.
- The rule itself moves to `src/kiro_crew/project_scope.py` and the skill gate
  delegates to it. Sharing the function, not the idea, is what stops the two
  surfaces drifting into two definitions of "in scope"; a test asserts the skill
  loader answers through it.
- **This is not a pure move: the shared gate is materially STRICTER than the skill
  gate it replaces, so some existing `repo_scope:` skills will stop loading.** The
  old loop walked `root.parents` unbounded and only rejected `..`. The shared gate
  bounds the walk at the repository root, refuses a `.` segment, refuses a leading
  slash or drive-qualified fragment, refuses a fragment resolving into a sensitive
  location, and requires the resolved target to stay inside the repository. Each
  refusal closes a fail-open (a `.` scope matched every directory; an unbounded walk
  let `tmp` or `etc` match every project on the host; a symlink escaped the
  repository), so the tightening is deliberate. The operator-visible consequence is
  that a skill which previously matched via an ancestor ABOVE the repository root, a
  project dir that is not a checkout, or a broad fragment can silently go from shown
  to suppressed. `test_skills.py`'s fixture needing a `.git` directory is that change
  made visible. Attribute a vanished scoped skill here first.
- A stale MCP client still holding the old advertised schema can send
  `scope="workspace"`. That is REFUSED with the replacement named, not converted:
  forcing it to global would take a correction meant for one workspace and apply it
  in every session, which is worse than the inert tier it replaced.
- Both lesson injection paths filter: the vector store (the path `context.py`
  actually calls) and the JSONL store behind it. Filtering only the fallback would
  have left the key inert in production, which is the defect this PR exists to end.
- Scope is applied BEFORE the "showing N of M, K omitted" counts are taken.
  "Omitted" means "did not fit the budget"; conflating the two would tell the model
  that rules it must never see are being withheld for space.
- The inert `scope: workspace` advertisement is retired from the MCP tool, so the
  model is no longer offered an option that does nothing. The dashboard's own
  store and list are untouched.

Compatibility is by construction. A lesson with no scope applies everywhere, so
every stored lesson behaves exactly as before and there is no migration. The key is
written into the stored JSON only when it has a value, so unscoped rows stay byte
identical. Legacy string-shaped rows have nowhere to carry a scope, so they read as
unscoped and keep applying. The gate fails closed: a scoped lesson is withheld
unless the project is positively confirmed, matching the skill gate's posture.

On enrichment the scope is WRITE-ONCE in the vector store, the same posture that
file already documents for `category` -- the intent of a re-submit-with-clause is
"attach the clause", not "re-scope", so the stored value is carried forward and
re-scoping is a delete plus re-add. The JSONL store additionally applies a
submitted scope and never strips a stored one on a bare re-submit, so a scope
change cannot be silently dropped the way `negative` once was.

## 4. What tests we did

New `test/test_lesson_project_scope.py`, 19 cases:

- The shared gate: ancestor match, unrelated project, absent project, traversal
  fragment, blank fragment, surrounding slashes.
- A drift guard that spies the shared function and asserts the skill loader calls
  it -- a second copy in `skills.py` fails this.
- The JSONL store: unscoped reaches every session, scoped withheld outside its repo
  and when the project is unknown, round-trip, blank normalizes to absent, re-submit
  attaches a new scope, bare re-submit never strips one, scope and clause enrich
  together.
- The vector store (the primary injection path): scoped reaches only its repo,
  unscoped unaffected, and an out-of-scope lesson is not reported as "omitted".

Mutation verified on both injection paths independently: neutering the vector-store
filter reddens 2 vector tests, neutering the JSONL filter reddens 2 store tests.
Both restored and the diffstat confirmed unchanged.

Two existing tests pinned the retired workspace contract and were replaced with
tests pinning the new one (plus a ratchet that the advertised `repo_scope` cap is
derived from the enforced schema field, so the hint cannot drift). Three test
doubles of `get_lessons_context` gained the new keyword.

Gates: isort, flake8, mypy (989 files) clean. Full backend suite 53389 passed with
zero regressions -- the 11 failures were each attributed, 9 reproducing on an
unmodified checkout of the same base and 2 timing tests that pass in isolation.
Post-rebase the static gates and the 234 directly affected tests were re-run clean;
the full-suite re-run was cut short locally, so CI's sharded run is the check on
that. No frontend files are touched: the dashboard's `createLesson` only ever sent
`rule` and `category`, so there is no UI surface for scope to update and no new
i18n.

## 5. Any other suggestions on the work

Three things I deliberately did not do here.

`validation.py` still accepts `scope="workspace"` and the dashboard still stores and
lists it. Only the model-facing advertisement is retired, because that is the half
that was provably lying. Removing the tier outright is a wider change and worth its
own decision.

The `evidence` half of the referenced issue is untouched. It wants a different
mechanism (a required, tightly capped write-time attribute) and belongs in its own
PR.

Related open work touches neighbouring files: two PRs edit `skills.py` and one adds
a separate scope cascade for template variables. This PR keeps its `skills.py` diff
to an import plus a delegation for that reason. The variables cascade is a value
resolution order, whereas this is an eligibility gate, so they are different axes
rather than a third competing vocabulary -- worth confirming when both land.

One line that is NOT this feature. `.github/black-baseline.txt` drops three entries
(`cli_commands.py`, `memory.py`, `sandbox.py`). None of those files appear anywhere
else in this diff -- `main` itself made them black-clean and left their baseline lines
behind, and the ratchet half of the gate (`graduated = baseline - unformatted`) is
computed over the WHOLE baseline rather than scoped to the change, unlike
`new_offenders` directly above it, whose comment explains that scoping exists so a
PR's colour does not depend on other people's formatting. So the gate fails every open
PR until someone prunes. AGENTS.md routes the OPTIONAL case (formatting a baselined
file you touched) to its own commit; this is the involuntary case, and the same
inherited-graduation prune landed in PR #4323. Worth fixing the unscoped half of that
gate separately.

Refs #2149

