### PR TITLE
fix(dev-fleet): refuse dep-sync before any write and tighten script/floor detection (#4549)

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/dep_sync.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/dep_sync.py
@@ -1,0 +1,709 @@
+"""Dependency-only sync for a checkout whose console script cannot be replaced.
+
+Windows holds a mandatory lock on a running executable's image, so pip cannot
+rewrite ``Scripts\\kirocrew.exe`` while the gateway is served by the very venv it
+is reinstalling into -- the ordinary single-checkout layout. ``pip install -e .``
+fails there even when the revision being synced changed nothing about the console
+script, because a reinstall rewrites it unconditionally.
+
+An editable install needs no reinstall for a source change: ``src`` is already on
+``sys.path``, so merged code is live the moment the merge lands. What a source
+change CAN require is a dependency the venv does not have yet, and installing a
+dependency never touches the project's own console script. Syncing dependencies
+alone is therefore the whole of what pip is needed for.
+
+This step runs BEFORE the merge, and reads every declaration out of the fetched
+revision with ``git show`` rather than from the working tree. Ordering alone is not
+enough, though: installing and merging are two writes that cannot be made one
+transaction, so whichever runs second can fail and leave the other applied --
+merge-then-install can strand a merged revision with missing dependencies, and
+install-then-merge can strand an upgraded venv on an unmerged checkout, since pip
+replaces existing packages as well as adding new ones. The step therefore refuses
+unless the merge is *guaranteed* to succeed first (clean tree, incoming revision a
+descendant of the installed one), and only then installs. Every refusal happens
+before either write, so the checkout is always left on a revision whose
+dependencies are satisfied.
+
+The venv is identified by location -- ``<repo>/.venv`` -- which is not a binding, so
+the step also requires that venv to import this project from inside THIS checkout
+before it writes to it. Otherwise a sync of one checkout could upgrade the runtime
+another checkout is served by.
+
+Satisfaction is left to pip rather than computed here: every declared requirement
+is handed to ``pip install`` verbatim, which no-ops the ones already satisfied and
+evaluates specifiers and environment markers with the same code
+``pip install -e .`` would have run. Deciding it locally would need a PEP 508
+parser this package does not depend on (``packaging`` is not an install
+requirement) and would drift from pip's own answer.
+
+Extras carry no record of having been requested -- installed metadata lists every
+extra's requirements behind a marker whether or not the operator asked for the
+extra -- so activity is inferred from what is installed, judged against the
+declarations the venv was installed FROM. Judged against the incoming ones
+instead, a revision that adds a distribution to an extra the operator uses makes
+that extra read inactive, its new requirement is skipped, and the gateway fails
+on that import at its next restart. The residual imprecision runs the safe way:
+an extra whose distributions are present transitively reads active, which installs
+something unnecessary but never leaves something missing.
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+#: Characters that terminate the distribution name at the head of a PEP 508
+#: requirement (version specifier, extras bracket, marker separator, or the
+#: whitespace some declarations put before the specifier).
+_NAME_END = re.compile(r"[\s<>=!~;\[(]")
+
+#: The project's only console script. It is the wrapper the operator restarts
+#: through, so it is the one whose staleness has to be reported rather than
+#: silently tolerated.
+_SCRIPT = "kirocrew"
+
+#: This project's own distribution name, normalized. Asking pip for it is the one
+#: request that would rewrite the locked console script.
+_PROJECT = "kirocrew"
+
+#: ``requires-python`` lower bounds. Only the floor is enforced: it is the bound
+#: a revision raises when it starts using newer syntax, and the one whose breach
+#: makes the merged tree unimportable under this interpreter. Upper bounds and
+#: exclusions are left to pip on the next real reinstall rather than
+#: reimplemented here without a PEP 440 parser.
+_PY_FLOOR = re.compile(r">=?\s*(\d+)\.(\d+)")
+
+
+#: A plain PEP 508 distribution name -- letters, digits, and the separators PEP
+#: 503 normalizes. Anything else at the head of a requirement is not a name: a
+#: path (``.``, ``./x``, ``/abs``, ``C:\x``), a URL scheme, an archive filename, or
+#: a stray option. Those are what could make pip install the project itself.
+_PLAIN_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+#: Distribution-archive suffixes. pip reads a bare token ending in one of these as
+#: a local file when the file exists, so such a token is refused rather than left
+#: to be disambiguated by the working directory's contents.
+_ARCHIVE_SUFFIXES = (".whl", ".zip", ".tar.gz", ".tar.bz2", ".tar.xz", ".tgz")
+
+
+def rejected_specs(specs: list[str]) -> list[str]:
+    """Requirements that must never reach pip, with the reason for each.
+
+    The module's whole premise is that pip is asked for DEPENDENCIES and never for
+    the project, because installing the project is what rewrites the locked console
+    script. Until now that was a property of this repository's declarations rather
+    than something enforced: a declaration of ``.`` would have pip install the
+    checkout itself, remove the editable install, and then fail on the locked
+    executable -- leaving the venv unable to import the package at all, which is
+    the exact damage the step exists to avoid.
+
+    Two shapes are refused: a head that is not a plain distribution name (a path,
+    a URL, an archive, a leftover option), and any requirement that normalizes to
+    this project's own name however it is spelled.
+    """
+    bad: list[str] = []
+    for spec in specs:
+        head = _NAME_END.split(spec.strip(), 1)[0].strip()
+        if not _PLAIN_NAME.match(head):
+            bad.append(f"{spec!r} is not a plain requirement name")
+        elif head.lower().endswith(_ARCHIVE_SUFFIXES):
+            # A bare `foo.whl` is a legal NAME by character set, but pip resolves it
+            # as a local file whenever one exists in the working directory, so it is
+            # refused rather than disambiguated by what happens to be on disk.
+            bad.append(f"{spec!r} names an archive rather than a distribution")
+        elif normalize(head) == _PROJECT:
+            bad.append(f"{spec!r} names this project, whose reinstall is the blocker")
+    return bad
+
+
+def normalize(name: str) -> str:
+    """Normalize a distribution name per PEP 503 so lookups compare equal."""
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
+
+
+def requirement_name(spec: str) -> str:
+    """The distribution name at the head of a requirement line."""
+    head = _NAME_END.split(spec.strip(), 1)[0]
+    return normalize(head)
+
+
+def _requirement_lines(raw: str) -> list[str]:
+    """Requirement lines from one setup.cfg value, comments dropped.
+
+    setup.cfg carries a full-line ``#`` comment for most requirements here, and
+    configparser keeps them, so they have to be stripped before the value is
+    handed to pip. A trailing comment on a requirement line is NOT stripped: a
+    PEP 508 marker can legitimately contain ``#`` inside a quoted string, and this
+    project's declarations put their commentary on their own lines.
+    """
+    out: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            out.append(stripped)
+    return out
+
+
+def show(repo: Path, git_bin: Path, rev: str, path: str) -> str | None:
+    """``<path>`` as of *rev*, or ``None`` when it cannot be read.
+
+    Reading through git rather than the working tree is what lets this step run
+    before the merge: the incoming revision's declarations are available without
+    advancing HEAD, so a failure here leaves the checkout untouched.
+    """
+    proc = subprocess.run(
+        [str(git_bin), "-C", str(repo), "show", f"{rev}:{path}"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    return proc.stdout
+
+
+#: Where the incoming revision is pinned. A background fetch can advance
+#: ``<remote>/<base>`` between this step and the merge that follows it, so the two
+#: would be judging and consuming DIFFERENT commits -- dependencies installed for
+#: one revision, code merged from another, which is the missing-dependency outcome
+#: this step exists to prevent. Only this module writes this ref, so once pinned it
+#: cannot move under the merge.
+PIN_REF = "refs/kirocrew/dep-sync-target"
+
+
+def _git_succeeds(repo: Path, git_bin: Path, *args: str) -> bool:
+    """Whether a git command exits 0. Used for predicates, not for output."""
+    proc = subprocess.run(
+        [str(git_bin), "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return proc.returncode == 0
+
+
+def _git_output(repo: Path, git_bin: Path, *args: str) -> str | None:
+    """A git command's stdout, or ``None`` when it fails or prints nothing."""
+    proc = subprocess.run(
+        [str(git_bin), "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    return proc.stdout.strip()
+
+
+def pin_incoming(repo: Path, git_bin: Path, ref: str) -> str | None:
+    """Resolve *ref* once and pin that OID at :data:`PIN_REF`; return the OID.
+
+    The merge step is given :data:`PIN_REF` rather than the mutable remote-tracking
+    ref, so every later read here and the merge itself address the same object even
+    if a concurrent fetch advances the remote ref meanwhile.
+    """
+    oid = _git_output(repo, git_bin, "rev-parse", "--verify", f"{ref}^{{commit}}")
+    if oid is None:
+        return None
+    if not _git_succeeds(repo, git_bin, "update-ref", PIN_REF, oid):
+        return None
+    return oid
+
+
+def merge_not_guaranteed(
+    repo: Path, git_bin: Path, installed_rev: str, incoming_rev: str
+) -> str | None:
+    """Why the following ``--ff-only`` merge could fail, or ``None`` if it cannot.
+
+    This is the invariant the whole step rests on. Installing dependencies and
+    merging are two writes that cannot be made one transaction, so whichever runs
+    second can fail and leave the other applied: merge-then-install can strand a
+    merged revision with missing dependencies, and install-then-merge can strand
+    an upgraded venv on an unmerged checkout -- pip does not only ADD packages, it
+    replaces existing ones. Ordering alone therefore cannot fix this; the fix is to
+    only start when the second write cannot fail.
+
+    A clean tree plus an installed revision that is an ancestor of the incoming one
+    is exactly the condition under which ``git merge --ff-only`` has nothing to
+    refuse: no local modifications to overwrite and no divergence to reconcile. When
+    either does not hold, nothing is installed and nothing is merged.
+    """
+    dirty = subprocess.run(
+        [str(git_bin), "-C", str(repo), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if dirty.returncode != 0:
+        return "the checkout's status could not be read"
+    if dirty.stdout.strip():
+        return (
+            "the checkout has local modifications, so the merge could fail after "
+            "the venv had already been changed"
+        )
+    if not _git_succeeds(repo, git_bin, "merge-base", "--is-ancestor", installed_rev, incoming_rev):
+        return (
+            f"{installed_rev} is not an ancestor of {incoming_rev}, so the merge "
+            "would not fast-forward"
+        )
+    return None
+
+
+def dependency_authority_moved(repo: Path, git_bin: Path, rev: str) -> str | None:
+    """Why *rev*'s requirements cannot be read from setup.cfg, or ``None``.
+
+    This module reads requirements out of setup.cfg because that is where this
+    project declares them, with pyproject marking ``dependencies`` and
+    ``optional-dependencies`` dynamic. A revision that moves them into
+    pyproject's own ``[project]`` table would make setup.cfg stale, and reading it
+    anyway would install the wrong set and report success. The assumption is
+    therefore checked against the incoming revision rather than trusted.
+    """
+    pyproject = show(repo, git_bin, rev, "pyproject.toml")
+    if pyproject is None:
+        return "the incoming revision has no pyproject.toml to check"
+    project = _section(pyproject, "project")
+    dynamic = re.search(r"^\s*dynamic\s*=\s*\[([^\]]*)\]", project, re.M)
+    declared_dynamic = dynamic.group(1) if dynamic else ""
+    for field in ("dependencies", "optional-dependencies"):
+        if f'"{field}"' not in declared_dynamic and f"'{field}'" not in declared_dynamic:
+            return (
+                f"the incoming revision no longer declares {field!r} as dynamic, so "
+                "setup.cfg is not where its requirements live"
+            )
+    return None
+
+
+def _parse_requirements(text: str) -> tuple[list[str], dict[str, list[str]]]:
+    """Base requirements and extras declared by one setup.cfg's *text*."""
+    cfg = configparser.ConfigParser()
+    cfg.read_string(text)
+    base = _requirement_lines(cfg.get("options", "install_requires", fallback=""))
+    extras = {
+        name: _requirement_lines(value)
+        for name, value in (
+            cfg.items("options.extras_require") if cfg.has_section("options.extras_require") else []
+        )
+    }
+    return base, extras
+
+
+def declared_requirements_at(
+    repo: Path, git_bin: Path, rev: str
+) -> tuple[list[str], dict[str, list[str]]] | None:
+    """Declarations as of *rev*, or ``None`` when that revision cannot be read.
+
+    ``None`` is a refusal signal, not an empty answer: without the declarations
+    there is no sound way to tell an extra the operator uses from one they do not,
+    and guessing is what would drop a required dependency.
+    """
+    text = show(repo, git_bin, rev, "setup.cfg")
+    return None if text is None else _parse_requirements(text)
+
+
+def requires_python_at(repo: Path, git_bin: Path, rev: str) -> str | None:
+    """The ``requires-python`` value declared by *rev*, if any.
+
+    Parsed with a regex rather than a TOML reader because ``tomllib`` is 3.11+ and
+    this package still supports 3.10, and the value needed is a single scalar.
+    """
+    text = show(repo, git_bin, rev, "pyproject.toml")
+    if text is None:
+        return None
+    match = re.search(r"^\s*requires-python\s*=\s*[\"']([^\"']+)[\"']", text, re.M)
+    return match.group(1) if match else None
+
+
+def interpreter_version(target_py: Path) -> tuple[int, int] | None:
+    """``(major, minor)`` of *target_py*, or ``None`` if it cannot be asked."""
+    proc = subprocess.run(
+        [str(target_py), "-c", "import sys;print('%d.%d' % sys.version_info[:2])"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    try:
+        major, minor = proc.stdout.strip().split(".")
+        return int(major), int(minor)
+    except ValueError:
+        return None
+
+
+def python_floor_breach(spec: str, version: tuple[int, int]) -> str | None:
+    """The highest ``requires-python`` floor *version* fails, if it fails one.
+
+    ``pip install -e .`` doubles as this project's interpreter gate: a revision
+    that raises its floor and starts using newer syntax is refused by pip rather
+    than installed. A dependency-only sync spawns no such check, so the gate has
+    to be applied here or a merged revision becomes unimportable under the
+    interpreter that has to import it.
+    """
+    breached: tuple[int, int] | None = None
+    for major, minor in _PY_FLOOR.findall(spec):
+        floor = (int(major), int(minor))
+        if version < floor and (breached is None or floor > breached):
+            breached = floor
+    return f"{breached[0]}.{breached[1]}" if breached else None
+
+
+def installed_names(target_py: Path) -> set[str]:
+    """Normalized names of every distribution installed in *target_py*'s venv.
+
+    Read through the target interpreter rather than this process: the two are
+    different venvs whenever the app backend runs from a feature worktree, and the
+    answer must describe the venv pip will install into.
+    """
+    probe = (
+        "import importlib.metadata as m, json;"
+        "print(json.dumps([d.metadata['Name'] for d in m.distributions()"
+        " if d.metadata['Name']]))"
+    )
+    proc = subprocess.run(
+        [str(target_py), "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {normalize(n) for n in json.loads(proc.stdout)}
+
+
+def active_extras(extras: dict[str, list[str]], present: set[str]) -> list[str]:
+    """Extras whose every named distribution is already installed.
+
+    *extras* must be the declarations the venv was INSTALLED FROM -- see the module
+    docstring for why judging against the incoming ones drops a dependency.
+    """
+    active = []
+    for name, specs in extras.items():
+        names = {requirement_name(s) for s in specs}
+        if names and names <= present:
+            active.append(name)
+    return sorted(active)
+
+
+def console_script_target_at(repo: Path, git_bin: Path, rev: str, script: str) -> str | None:
+    """The ``module:attr`` *script* is declared to dispatch to as of *rev*.
+
+    ``pyproject.toml``'s ``[project.scripts]`` is authoritative and is consulted
+    first: this project declares ``dependencies`` and ``optional-dependencies`` as
+    dynamic but NOT ``scripts``, so setuptools builds the wrapper from the
+    pyproject table and ignores setup.cfg's copy. Reading only setup.cfg would
+    miss a repoint made in the file that actually decides it.
+    """
+    pyproject = show(repo, git_bin, rev, "pyproject.toml")
+    if pyproject is not None:
+        match = re.search(
+            rf"^\s*{re.escape(script)}\s*=\s*[\"']([^\"']+)[\"']",
+            _section(pyproject, "project.scripts"),
+            re.M,
+        )
+        if match:
+            return match.group(1)
+
+    cfg_text = show(repo, git_bin, rev, "setup.cfg")
+    if cfg_text is None:
+        return None
+    cfg = configparser.ConfigParser()
+    cfg.read_string(cfg_text)
+    raw = cfg.get("options.entry_points", "console_scripts", fallback="")
+    for line in _requirement_lines(raw):
+        name, _, target = line.partition("=")
+        if name.strip() == script:
+            return target.strip()
+    return None
+
+
+def _section(toml_text: str, header: str) -> str:
+    """The body of one ``[header]`` table, without a TOML parser.
+
+    Only ever used to isolate ``[project.scripts]``, whose entries are flat
+    ``name = "module:attr"`` lines.
+    """
+    lines = toml_text.splitlines()
+    out: list[str] = []
+    inside = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            inside = stripped[1:-1].strip() == header
+            continue
+        if inside:
+            out.append(line)
+    return "\n".join(out)
+
+
+def installed_console_script_target(target_py: Path, script: str) -> str | None:
+    """The ``module:attr`` *script* currently dispatches to in *target_py*'s venv.
+
+    Reads the entry points off the ``kirocrew`` distribution rather than the
+    module-level ``entry_points()`` selector: that function returns a group->list
+    mapping on 3.10/3.11 and an ``EntryPoints`` sequence on 3.12+, and this project
+    supports both. A distribution's own ``entry_points`` is a sequence in every
+    supported version, and scoping the lookup to the distribution also keeps a
+    same-named script from another package out of the answer.
+
+    Returns ``None`` when the answer cannot be read at all. The caller only
+    compares two KNOWN values, so an unreadable probe leaves the sync alone
+    instead of failing it on missing evidence.
+    """
+    probe = (
+        "import importlib.metadata as m;"
+        "d=m.distribution('kirocrew');"
+        "print(next((e.value for e in d.entry_points"
+        f" if e.group=='console_scripts' and e.name=={script!r}), ''))"
+    )
+    proc = subprocess.run(
+        [str(target_py), "-c", probe],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def installed_package_origin(target_py: Path) -> str | None:
+    """Where *target_py*'s venv resolves this project's package FROM.
+
+    Read through the target interpreter for the same reason ``installed_names``
+    does: the venv being written to is not necessarily this process's own.
+
+    ``find_spec`` rather than an import, so nothing in the package runs; and the
+    spec rather than installed metadata, because the metadata proxies for this
+    answer instead of giving it. A venv can carry a working PEP 660 editable
+    install whose ``direct_url.json`` is absent -- one repaired by hand, or
+    installed by a route that never wrote it -- and refusing that venv would
+    refuse the ordinary single-checkout layout this whole step exists to serve.
+    The import path is what the installed dependencies will be imported alongside,
+    so it is the thing worth checking.
+
+    Returns ``None`` when the package cannot be located at all.
+    """
+    probe = (
+        "import importlib.util as u, os;"
+        "s=u.find_spec('kiro_crew');"
+        "print(os.path.abspath(s.origin) if s and s.origin else '')"
+    )
+    proc = subprocess.run(
+        [str(target_py), "-c", probe],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def venv_not_mapped_to(origin: str | None, repo: Path) -> str | None:
+    """Why the venv at *origin* cannot be shown to serve *repo*, if it cannot.
+
+    The venv is addressed as ``<repo>/.venv``, but that is a location, not a
+    binding: nothing stops it from being an install of a DIFFERENT checkout.
+    Installing this revision's dependencies into such a venv upgrades the runtime
+    another checkout is served by, which is how a working checkout gets broken by a
+    sync that never touched it.
+
+    The test is therefore whether that venv imports this project from inside
+    *repo*. A yes means the write cannot reach another checkout's runtime, which is
+    the whole of what has to hold. An unreadable answer refuses too -- unproven is
+    not the same as safe, and refusing costs nothing this path did not already cost,
+    since the reinstall it stands in for was refused outright.
+    """
+    if origin is None:
+        return (
+            "the target venv does not resolve this project's package at all, so it "
+            "cannot be shown to serve this checkout"
+        )
+    mapped = os.path.normcase(str(Path(origin).resolve()))
+    root = os.path.normcase(str(Path(repo).resolve()))
+    if mapped != root and not mapped.startswith(root + os.sep):
+        return (
+            f"the target venv imports this project from {Path(origin).resolve()}, "
+            f"which is outside {Path(repo).resolve()}, so a dependency install "
+            "would change a runtime this sync does not own"
+        )
+    return None
+
+
+def plan(
+    incoming: tuple[list[str], dict[str, list[str]]],
+    previous_extras: dict[str, list[str]],
+    present: set[str],
+) -> tuple[list[str], list[str], list[str]]:
+    """Specs to hand pip, the extras they came from, and the extras left alone."""
+    base, extras = incoming
+    chosen = active_extras(previous_extras, present)
+    specs = list(base)
+    for name in chosen:
+        specs.extend(extras.get(name, []))
+    skipped = sorted((set(extras) | set(previous_extras)) - set(chosen))
+    return specs, chosen, skipped
+
+
+def _refuse(message: str, target_py: Path, repo: Path, remedy: str | None = None) -> int:
+    if remedy is None:
+        remedy = (
+            "Stop the gateway and sync from a terminal: "
+            f'"{target_py}" -m pip install -e "{repo}"'
+        )
+    print(
+        f"dep-sync: {message} Nothing was merged, so the checkout still has "
+        f"satisfied dependencies. {remedy}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 5:
+        print(
+            "usage: dep_sync <repo> <target-python> <git-binary> <installed-rev> " "<incoming-rev>",
+            file=sys.stderr,
+        )
+        return 2
+    repo, target_py, git_bin = Path(args[0]), Path(args[1]), Path(args[2])
+    installed_rev, incoming_ref = args[3], args[4]
+
+    # Establish that the venv about to be written to serves THIS checkout, before
+    # anything is pinned, installed or merged. `<repo>/.venv` is where the
+    # interpreter was found, which says nothing about what it is an install of;
+    # every other precondition below reasons about the checkout, and all of that
+    # reasoning is void if the runtime belongs to someone else.
+    foreign = venv_not_mapped_to(installed_package_origin(target_py), repo)
+    if foreign:
+        return _refuse(
+            f"{foreign}.",
+            target_py,
+            repo,
+            remedy=(
+                "Give this checkout its own editable install, or run the sync from "
+                "the checkout that venv serves."
+            ),
+        )
+
+    # Pin FIRST: everything below -- the declarations read, the ancestor check, the
+    # console-script comparison -- and the merge that follows this step must all
+    # address the same commit. Resolving the mutable remote ref more than once is
+    # what would let a concurrent fetch slide a newer revision under the merge.
+    incoming_rev = pin_incoming(repo, git_bin, incoming_ref)
+    if incoming_rev is None:
+        return _refuse(
+            f"cannot resolve {incoming_ref} to a commit and pin it, so the revision "
+            "the dependencies are installed for cannot be the same one the merge "
+            "consumes.",
+            target_py,
+            repo,
+        )
+
+    previous = declared_requirements_at(repo, git_bin, installed_rev)
+    if previous is None:
+        return _refuse(
+            f"cannot read setup.cfg at {installed_rev}, so which extras this venv "
+            "was installed from is unknown, and guessing is what would leave a "
+            "required dependency uninstalled.",
+            target_py,
+            repo,
+        )
+    incoming = declared_requirements_at(repo, git_bin, incoming_rev)
+    if incoming is None:
+        return _refuse(
+            f"cannot read setup.cfg at {incoming_rev}, so the requirements the "
+            "incoming revision declares are unknown.",
+            target_py,
+            repo,
+        )
+
+    # Two preconditions, both checked before ANYTHING is installed.
+    #
+    # The first is the step's central invariant: installing and merging cannot be
+    # made one transaction, so the only way neither can be left applied without the
+    # other is to start only when the merge cannot fail. See merge_not_guaranteed.
+    blocked = merge_not_guaranteed(repo, git_bin, installed_rev, incoming_rev)
+    if blocked:
+        return _refuse(f"{blocked}.", target_py, repo)
+
+    # The second guards this module's one assumption about where requirements live.
+    moved = dependency_authority_moved(repo, git_bin, incoming_rev)
+    if moved:
+        return _refuse(
+            f"{moved}, so a dependency-only sync would install a stale set.",
+            target_py,
+            repo,
+        )
+
+    # The interpreter gate `pip install -e .` would have applied. Checked before
+    # anything is installed, because a revision this interpreter cannot run must
+    # not be merged at all.
+    floor_spec = requires_python_at(repo, git_bin, incoming_rev)
+    version = interpreter_version(target_py) if floor_spec else None
+    if floor_spec and version:
+        breach = python_floor_breach(floor_spec, version)
+        if breach:
+            return _refuse(
+                f"the incoming revision requires Python {floor_spec} but the "
+                f"target venv runs {version[0]}.{version[1]}, so its code could "
+                "not be imported after a merge.",
+                target_py,
+                repo,
+            )
+
+    specs, chosen, skipped = plan(incoming, previous[1], installed_names(target_py))
+    if not specs:
+        print("dep-sync: no requirements declared; nothing to install")
+    else:
+        rejected = rejected_specs(specs)
+        if rejected:
+            return _refuse(
+                "the incoming revision declares requirements this step will not "
+                f"hand to pip: {'; '.join(rejected)}.",
+                target_py,
+                repo,
+            )
+        print(
+            f"dep-sync: {len(specs)} declared requirements; extras active (judged "
+            f"against {installed_rev}): {', '.join(chosen) if chosen else 'none'}; "
+            f"extras left alone: {', '.join(skipped) if skipped else 'none'}"
+        )
+        # Hand every spec to pip and let it decide: an already-satisfied
+        # requirement is a no-op, so this installs what is new and leaves the rest
+        # alone without this module ever comparing a version. The project itself is
+        # deliberately absent from the list -- installing it is what would rewrite
+        # the locked console script.
+        # `--` ends pip's option parsing, so a declared requirement can never be
+        # read as a flag. Without it a line beginning with `-` in the incoming
+        # setup.cfg -- `--target <path>`, or a bare `.` -- would be consumed as a
+        # pip option and could write package files into the checkout before the
+        # merge. The declarations come from the revision being synced, so this
+        # costs one token and removes the argument-injection surface entirely.
+        proc = subprocess.run([str(target_py), "-m", "pip", "install", "--", *specs])
+        if proc.returncode != 0:
+            return proc.returncode
+
+    # The one thing a dependency-only sync structurally cannot deliver: if the
+    # incoming revision REPOINTED the console script, the wrapper on disk still
+    # dispatches to the old target and no amount of dependency installing
+    # refreshes it. Refuse before the merge rather than leave a wrapper that
+    # cannot start the code it points at.
+    declared = console_script_target_at(repo, git_bin, incoming_rev, _SCRIPT)
+    installed = installed_console_script_target(target_py, _SCRIPT)
+    if declared and installed and declared != installed:
+        return _refuse(
+            f"the {_SCRIPT!r} console script is repointed to {declared} by the "
+            f"incoming revision while the installed wrapper still calls "
+            f"{installed}, and that wrapper cannot be rewritten while a process is "
+            "running from it.",
+            target_py,
+            repo,
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    raise SystemExit(main())

--- a/src/kiro_crew/apps/builtins/dev_fleet/dep_sync.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/dep_sync.py
@@ -57,6 +57,21 @@ import subprocess
 import sys
 from pathlib import Path
 
+# A real TOML parser is preferred for reading pyproject declarations: three
+# review rounds produced escalating spellings the line scanner misread (inline
+# tables, header comments, multiline-string contents), which is the sign the
+# scanner is the wrong tool for the primary path. `tomllib` is stdlib only from
+# 3.11 (PEP 680) and this project supports 3.10, so the import is guarded --
+# same ladder as `onboarding_import.py` -- and the hardened line scanner stays
+# as the 3.10-without-tomli fallback.
+try:
+    import tomllib as _toml  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
+    try:
+        import tomli as _toml  # type: ignore[no-redef,import-not-found]
+    except ModuleNotFoundError:
+        _toml = None  # type: ignore[assignment]
+
 #: Characters that terminate the distribution name at the head of a PEP 508
 #: requirement (version specifier, extras bracket, marker separator, or the
 #: whitespace some declarations put before the specifier).
@@ -73,10 +88,15 @@ _PROJECT = "kirocrew"
 
 #: ``requires-python`` lower bounds. Only the floor is enforced: it is the bound
 #: a revision raises when it starts using newer syntax, and the one whose breach
-#: makes the merged tree unimportable under this interpreter. Upper bounds and
-#: exclusions are left to pip on the next real reinstall rather than
-#: reimplemented here without a PEP 440 parser.
-_PY_FLOOR = re.compile(r">=?\s*(\d+)\.(\d+)")
+#: makes the merged tree unimportable under this interpreter. A compatible
+#: release ``~=X.Y`` declares the same floor as ``>=X.Y`` (its upper bound is
+#: someone else's problem, like every other upper bound here), and the equality
+#: pins ``==X.Y.*`` and ``===X.Y.Z`` declare their named version as the floor
+#: the same way -- their upper side is an upper bound like any other. A third
+#: component tightens the floor to the micro release, and a bare ``>`` excludes
+#: the named version itself. Upper bounds and exclusions are left to pip on the
+#: next real reinstall rather than reimplemented here without a PEP 440 parser.
+_PY_FLOOR = re.compile(r"(===|==|>=?|~=)\s*(\d+)\.(\d+)(?:\.(\d+))?")
 
 
 #: A plain PEP 508 distribution name -- letters, digits, and the separators PEP
@@ -267,9 +287,8 @@ def dependency_authority_moved(repo: Path, git_bin: Path, rev: str) -> str | Non
     pyproject = show(repo, git_bin, rev, "pyproject.toml")
     if pyproject is None:
         return "the incoming revision has no pyproject.toml to check"
-    project = _section(pyproject, "project")
-    dynamic = re.search(r"^\s*dynamic\s*=\s*\[([^\]]*)\]", project, re.M)
-    declared_dynamic = dynamic.group(1) if dynamic else ""
+    project = _section(pyproject, "project") or ""
+    declared_dynamic = _declared_dynamic(project)
     for field in ("dependencies", "optional-dependencies"):
         if f'"{field}"' not in declared_dynamic and f"'{field}'" not in declared_dynamic:
             return (
@@ -319,23 +338,28 @@ def requires_python_at(repo: Path, git_bin: Path, rev: str) -> str | None:
     return match.group(1) if match else None
 
 
-def interpreter_version(target_py: Path) -> tuple[int, int] | None:
-    """``(major, minor)`` of *target_py*, or ``None`` if it cannot be asked."""
+def interpreter_version(target_py: Path) -> tuple[int, int, int] | None:
+    """``(major, minor, micro)`` of *target_py*, or ``None`` if it cannot be asked.
+
+    The micro component matters: a ``requires-python`` floor can name one
+    (``>=3.10.5``), and reporting only the minor would make a 3.10.0 interpreter
+    indistinguishable from a 3.10.5 one at exactly the boundary being checked.
+    """
     proc = subprocess.run(
-        [str(target_py), "-c", "import sys;print('%d.%d' % sys.version_info[:2])"],
+        [str(target_py), "-c", "import sys;print('%d.%d.%d' % sys.version_info[:3])"],
         capture_output=True,
         text=True,
     )
     if proc.returncode != 0:
         return None
     try:
-        major, minor = proc.stdout.strip().split(".")
-        return int(major), int(minor)
+        major, minor, micro = proc.stdout.strip().split(".")
+        return int(major), int(minor), int(micro)
     except ValueError:
         return None
 
 
-def python_floor_breach(spec: str, version: tuple[int, int]) -> str | None:
+def python_floor_breach(spec: str, version: tuple[int, ...]) -> str | None:
     """The highest ``requires-python`` floor *version* fails, if it fails one.
 
     ``pip install -e .`` doubles as this project's interpreter gate: a revision
@@ -343,13 +367,21 @@ def python_floor_breach(spec: str, version: tuple[int, int]) -> str | None:
     than installed. A dependency-only sync spawns no such check, so the gate has
     to be applied here or a merged revision becomes unimportable under the
     interpreter that has to import it.
+
+    Compared at three components, with an absent micro reading as ``.0`` on both
+    sides, so ``>=3.10.5`` refuses a 3.10.0 interpreter instead of being
+    truncated to its minor. A bare ``>`` excludes the named version itself.
     """
-    breached: tuple[int, int] | None = None
-    for major, minor in _PY_FLOOR.findall(spec):
-        floor = (int(major), int(minor))
-        if version < floor and (breached is None or floor > breached):
+    v = (tuple(version) + (0, 0, 0))[:3]
+    breached: tuple[int, int, int] | None = None
+    breached_text: str | None = None
+    for op, major, minor, micro in _PY_FLOOR.findall(spec):
+        floor = (int(major), int(minor), int(micro) if micro else 0)
+        fails = v <= floor if op == ">" else v < floor
+        if fails and (breached is None or floor > breached):
             breached = floor
-    return f"{breached[0]}.{breached[1]}" if breached else None
+            breached_text = f"{major}.{minor}" + (f".{micro}" if micro else "")
+    return breached_text
 
 
 def installed_names(target_py: Path) -> set[str]:
@@ -387,6 +419,17 @@ def active_extras(extras: dict[str, list[str]], present: set[str]) -> list[str]:
     return sorted(active)
 
 
+#: What :func:`console_script_target_at` returns when the authoritative
+#: declaration EXISTS and omits the script: the entry point is removed as of that
+#: revision. Distinct from ``None``, which means the declarations could not be
+#: read at all -- collapsing the two would let a removal merge silently, leaving
+#: the locked wrapper dispatching to a target the revision may have deleted. A
+#: truthy string that is never a valid ``module:attr`` (it contains spaces), so
+#: the mismatch comparison in ``main`` treats a removal like any other
+#: disagreement between the declaration and the installed wrapper.
+SCRIPT_REMOVED = "removed by the incoming revision"
+
+
 def console_script_target_at(repo: Path, git_bin: Path, rev: str, script: str) -> str | None:
     """The ``module:attr`` *script* is declared to dispatch to as of *rev*.
 
@@ -395,17 +438,78 @@ def console_script_target_at(repo: Path, git_bin: Path, rev: str, script: str) -
     dynamic but NOT ``scripts``, so setuptools builds the wrapper from the
     pyproject table and ignores setup.cfg's copy. Reading only setup.cfg would
     miss a repoint made in the file that actually decides it.
+
+    setup.cfg is consulted only when setuptools itself would read it: when there
+    is no ``[project]`` table at all (pre-PEP 621 metadata), or when ``scripts``
+    is declared dynamic. A ``[project]`` table that neither names ``scripts``
+    (as a ``[project.scripts]`` table, an inline table, or dotted keys -- any
+    spelling TOML allows counts) nor declares it dynamic makes the field
+    statically absent: setuptools builds no wrapper from setup.cfg's copy
+    (verified empirically against setuptools 80.9), so the entry point has been
+    REMOVED as of *rev* -- reported as :data:`SCRIPT_REMOVED`, not read out of
+    setup.cfg's stale copy, which would report an agreement that no longer
+    holds. The same removal answer covers a table that exists but omits
+    *script*. An omission in setup.cfg itself (when it IS the authority) stays
+    ``None`` rather than a removal: setup.py can also declare entry points and
+    cannot be read here, so that omission is missing evidence, not a known
+    removal. Read with the real TOML parser when the interpreter provides one
+    (tomllib on 3.11+, tomli when importable); the hardened line scanner is the
+    fallback for 3.10 without tomli and for text the parser rejects. Successive
+    reviews produced one scanner-missed spelling per round (inline tables,
+    header comments, multiline-string contents), which is the signal the
+    scanner cannot be the primary path.
     """
     pyproject = show(repo, git_bin, rev, "pyproject.toml")
-    if pyproject is not None:
+
+    # Primary path: a real TOML parser, when the interpreter provides one. The
+    # scanner below exists only for 3.10 without tomli (and unparseable text);
+    # it cannot be made spelling-complete, which successive review rounds
+    # demonstrated one spelling at a time.
+    parsed = _toml_load(pyproject) if pyproject is not None else None
+    if parsed is not None:
+        project_tbl = parsed.get("project")
+        if isinstance(project_tbl, dict):
+            scripts_tbl = project_tbl.get("scripts")
+            if isinstance(scripts_tbl, dict):
+                target = scripts_tbl.get(script)
+                return target if isinstance(target, str) else SCRIPT_REMOVED
+            dynamic_val = project_tbl.get("dynamic")
+            dynamic_list = dynamic_val if isinstance(dynamic_val, list) else []
+            if "scripts" not in dynamic_list:
+                return SCRIPT_REMOVED
+        return _setup_cfg_script_target(repo, git_bin, rev, script)
+
+    scripts = _section(pyproject, "project.scripts") if pyproject is not None else None
+    if scripts is None and pyproject is not None:
+        scripts = _inline_scripts(pyproject)
+    if scripts is not None:
+        key = rf"(?:{re.escape(script)}|\"{re.escape(script)}\"|'{re.escape(script)}')"
         match = re.search(
-            rf"^\s*{re.escape(script)}\s*=\s*[\"']([^\"']+)[\"']",
-            _section(pyproject, "project.scripts"),
+            rf"^\s*{key}\s*=\s*[\"']([^\"']+)[\"']",
+            scripts,
             re.M,
         )
-        if match:
-            return match.group(1)
+        return match.group(1) if match else SCRIPT_REMOVED
 
+    if pyproject is not None:
+        # No scripts declaration anywhere in pyproject. setup.cfg's copy governs
+        # only when setuptools would actually read it: either there is no
+        # ``[project]`` table at all (pre-PEP 621 metadata), or ``scripts`` is
+        # declared dynamic. A ``[project]`` table that neither names ``scripts``
+        # nor declares it dynamic makes the field statically absent -- setuptools
+        # builds no wrapper and ignores setup.cfg's copy (verified empirically
+        # against setuptools 80.9) -- so the entry point is removed as of *rev*
+        # and setup.cfg's agreement is stale.
+        project = _section(pyproject, "project")
+        if project is not None:
+            declared_dynamic = _declared_dynamic(project)
+            if '"scripts"' not in declared_dynamic and "'scripts'" not in declared_dynamic:
+                return SCRIPT_REMOVED
+    return _setup_cfg_script_target(repo, git_bin, rev, script)
+
+
+def _setup_cfg_script_target(repo: Path, git_bin: Path, rev: str, script: str) -> str | None:
+    """setup.cfg's declared target for *script* at *rev*, or ``None``."""
     cfg_text = show(repo, git_bin, rev, "setup.cfg")
     if cfg_text is None:
         return None
@@ -419,23 +523,124 @@ def console_script_target_at(repo: Path, git_bin: Path, rev: str, script: str) -
     return None
 
 
-def _section(toml_text: str, header: str) -> str:
-    """The body of one ``[header]`` table, without a TOML parser.
+def _toml_load(toml_text: str) -> dict | None:
+    """*toml_text* parsed by the real TOML parser, or ``None`` when unavailable.
 
-    Only ever used to isolate ``[project.scripts]``, whose entries are flat
-    ``name = "module:attr"`` lines.
+    ``None`` means "no authoritative parse exists" -- either the interpreter has
+    no parser (3.10 without tomli) or the text is not valid TOML -- and sends the
+    caller to the line scanner, which degrades the same way it always has rather
+    than inventing a new failure mode for invalid input.
     """
-    lines = toml_text.splitlines()
-    out: list[str] = []
+    if _toml is None:
+        return None
+    try:
+        return _toml.loads(toml_text)
+    except Exception:
+        return None
+
+
+def _inline_scripts(toml_text: str) -> str | None:
+    """``[project]``'s ``scripts`` declared inline or dotted, as flat lines.
+
+    TOML lets the scripts table be spelled without its own ``[project.scripts]``
+    header: an inline table (``scripts = { name = "..." }``) or dotted keys
+    (``scripts.name = "..."``) inside ``[project]``. Either spelling is the same
+    authoritative declaration setuptools builds the wrapper from, so reading
+    setup.cfg when a revision uses one of them would consult the stale copy in
+    exactly the case where the two disagree. Returns the entries as
+    ``name = value`` lines (an empty string when the declaration exists and
+    names nothing), or ``None`` when ``[project]`` declares no ``scripts`` key
+    in either form.
+    """
+    project = _section(toml_text, "project")
+    if project is None:
+        return None
+    entries: list[str] = []
+    found = False
+    for line in project.splitlines():
+        dotted = re.match(
+            r"\s*scripts\s*\.\s*(?:\"([^\"]+)\"|'([^']+)'|([A-Za-z0-9._-]+))\s*=\s*(.+)",
+            line,
+        )
+        if dotted:
+            found = True
+            name = dotted.group(1) or dotted.group(2) or dotted.group(3)
+            entries.append(f"{name} = {dotted.group(4)}")
+            continue
+        inline = re.match(r"\s*scripts\s*=\s*\{(.*)\}\s*(?:#.*)?$", line)
+        if inline:
+            found = True
+            for item in inline.group(1).split(","):
+                key, sep, value = item.partition("=")
+                if sep:
+                    name = key.strip().strip("'\"")
+                    entries.append(f"{name} = {value.strip()}")
+    return "\n".join(entries) if found else None
+
+
+#: TOML multiline strings (basic and literal). Their CONTENTS are data, not
+#: structure: a line inside one can look exactly like a table header or a
+#: ``name = "value"`` entry, so the line scanner blanks them before scanning.
+#: Non-greedy matching ends a basic string at the first unescaped-looking
+#: delimiter -- an embedded ``\"""`` escape can end it early, which is accepted
+#: for a fallback path (the parser-first primary path is exact).
+_TOML_MULTILINE_STRING = re.compile(r'"""(?:[^"]|"(?!""))*"""|\'\'\'(?:[^\']|\'(?!\'\'))*\'\'\'')
+
+
+def _blank_multiline_strings(toml_text: str) -> str:
+    """*toml_text* with every multiline string's span reduced to blank lines."""
+    return _TOML_MULTILINE_STRING.sub(lambda m: "\n" * m.group(0).count("\n"), toml_text)
+
+
+def _declared_dynamic(project_body: str) -> str:
+    """The ``dynamic = [...]`` array's contents with comments removed.
+
+    TOML allows comments between the elements of a multi-line array, so comment
+    text must not read as a declared field -- in either direction: a commented
+    ``"scripts"`` must not send the console-script read to setup.cfg's stale
+    copy, and a commented ``"dependencies"`` must not make a moved field look
+    still-dynamic. Legal PEP 621 dynamic values are bare quoted field names, so
+    everything from ``#`` to end of line is comment, never value.
+    """
+    match = re.search(r"^\s*dynamic\s*=\s*\[([^\]]*)\]", project_body, re.M)
+    if not match:
+        return ""
+    return "\n".join(re.sub(r"#.*", "", line) for line in match.group(1).splitlines())
+
+
+def _section(toml_text: str, header: str) -> str | None:
+    """The body of one ``[header]`` table, or ``None`` when the table is absent.
+
+    Presence and content answer different questions -- an existing table that
+    omits an entry is a REMOVAL of that entry, not an invitation to read a stale
+    copy elsewhere -- so absence is reported distinctly rather than as an empty
+    body. Done without a TOML parser: only ever used on flat tables whose
+    entries are ``name = "value"`` lines. Multiline strings are blanked first so
+    their contents cannot masquerade as headers or entries. The header
+    comparison tolerates the spellings TOML allows on the header line itself --
+    whitespace around the dotted parts, quoted parts, and a trailing comment --
+    because a header that fails to be RECOGNIZED here reads as the table being
+    absent, which is a different answer with different consequences.
+    """
+    wanted = header.split(".")
     inside = False
-    for line in lines:
+    found = False
+    out: list[str] = []
+    for line in _blank_multiline_strings(toml_text).splitlines():
         stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            inside = stripped[1:-1].strip() == header
+        if stripped.startswith("["):
+            matched = re.match(r"\[([^\]]*)\]\s*(?:#.*)?$", stripped)
+            parts = (
+                [p.strip().strip("\"'") for p in matched.group(1).split(".")]
+                if matched
+                else None
+            )
+            inside = parts == wanted
+            found = found or inside
             continue
         if inside:
             out.append(line)
-    return "\n".join(out)
+    return "\n".join(out) if found else None
 
 
 def installed_console_script_target(target_py: Path, script: str) -> str | None:
@@ -648,11 +853,39 @@ def main(argv: list[str] | None = None) -> int:
         if breach:
             return _refuse(
                 f"the incoming revision requires Python {floor_spec} but the "
-                f"target venv runs {version[0]}.{version[1]}, so its code could "
+                f"target venv runs {'.'.join(map(str, version))}, so its code could "
                 "not be imported after a merge.",
                 target_py,
                 repo,
             )
+
+    # The one thing a dependency-only sync structurally cannot deliver: if the
+    # incoming revision REPOINTED or REMOVED the console script, the wrapper on
+    # disk still dispatches to the old target and no amount of dependency
+    # installing refreshes it. The comparison needs nothing from the install, so
+    # it runs here with every other refusal -- before pip as well as before the
+    # merge, keeping the invariant that a refusal leaves BOTH writes unapplied.
+    declared = console_script_target_at(repo, git_bin, incoming_rev, _SCRIPT)
+    installed = installed_console_script_target(target_py, _SCRIPT)
+    removed = declared == SCRIPT_REMOVED
+    if removed or (declared and installed and declared != installed):
+        # A removal refuses even when the installed wrapper's own target cannot
+        # be read: the removal is a fact about the incoming revision alone, and
+        # whatever the locked wrapper dispatches to, the revision that removed
+        # the entry point no longer promises that target exists.
+        change = "removed" if removed else f"repointed to {declared}"
+        wrapper = (
+            f"the installed wrapper still calls {installed}"
+            if installed
+            else "the installed wrapper's target cannot be read to confirm agreement"
+        )
+        return _refuse(
+            f"the {_SCRIPT!r} console script is {change} by the incoming revision "
+            f"while {wrapper}, and that "
+            "wrapper cannot be rewritten while a process is running from it.",
+            target_py,
+            repo,
+        )
 
     specs, chosen, skipped = plan(incoming, previous[1], installed_names(target_py))
     if not specs:
@@ -686,22 +919,6 @@ def main(argv: list[str] | None = None) -> int:
         if proc.returncode != 0:
             return proc.returncode
 
-    # The one thing a dependency-only sync structurally cannot deliver: if the
-    # incoming revision REPOINTED the console script, the wrapper on disk still
-    # dispatches to the old target and no amount of dependency installing
-    # refreshes it. Refuse before the merge rather than leave a wrapper that
-    # cannot start the code it points at.
-    declared = console_script_target_at(repo, git_bin, incoming_rev, _SCRIPT)
-    installed = installed_console_script_target(target_py, _SCRIPT)
-    if declared and installed and declared != installed:
-        return _refuse(
-            f"the {_SCRIPT!r} console script is repointed to {declared} by the "
-            f"incoming revision while the installed wrapper still calls "
-            f"{installed}, and that wrapper cannot be rewritten while a process is "
-            "running from it.",
-            target_py,
-            repo,
-        )
     return 0
 
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -51,7 +51,7 @@ from typing import Any, Callable
 from aiohttp import web
 
 from kiro_crew import frontend, hooks, platform_compat
-from kiro_crew.apps.builtins.dev_fleet import gateway_service
+from kiro_crew.apps.builtins.dev_fleet import dep_sync, gateway_service
 from kiro_crew.apps.proxy_auth import raw_request_target
 from kiro_crew.env import find_node_tool, node_bin_dirs
 from kiro_crew.executors import subprocess_executor
@@ -3595,51 +3595,76 @@ async def _sync_start_locked() -> dict:
             "service environment; that one does need a restart, because a "
             "running process cannot see a new environment variable."
         )}
+    # A locked console script does not have to mean the sync cannot happen.
+    #
+    # pip cannot replace a running executable on Windows, and its uninstall is
+    # not atomic: it renames the dist-info aside and deletes the editable `.pth`
+    # before it reaches the locked script, rolling back neither. So
+    # `pip install -e .` must not run against a venv serving this gateway.
+    #
+    # It does not have to run at all, though. An editable install needs no
+    # reinstall for a source change -- `src` is already on `sys.path`, so merged
+    # code is live the moment the merge lands. The only thing the reinstall was
+    # still buying is a dependency a new revision added, and installing a
+    # dependency never touches the project's own console script. A
+    # dependency-only sync therefore keeps the guarantee that motivated the
+    # refusal -- never leave a revision on disk whose dependencies are missing --
+    # without asking pip to do the one thing it cannot do here.
+    #
+    # The substitute step runs with THIS backend's interpreter for the same
+    # reason the build+stage step does: the logic is revision-independent, so
+    # resolving it from the target would make the step's very EXISTENCE
+    # contingent on the pulled revision carrying dep_sync.
+    fetch_step = ([git_bin, "fetch", remote, BASE_BRANCH], "standard",
+                  _build_env(with_credentials=True), "Pull")
+    merge_step = ([git_bin, "merge", "--ff-only", f"{remote}/{BASE_BRANCH}"], "strict",
+                  _build_env(), "Pull")
     if locked_scripts:
-        # Refuse the WHOLE sync rather than omitting just the reinstall.
-        #
-        # pip cannot replace a running executable on Windows, and its uninstall
-        # is not atomic: it renames the dist-info aside and deletes the editable
-        # `.pth` before it reaches the locked script, rolling back neither. That
-        # alone argues for not starting pip.
-        #
-        # But merging without installing is not a safe consolation prize. A
-        # revision that adds a dependency would land on disk with that dependency
-        # absent, the run would exit 0, and the UI would offer "restart gateway
-        # to apply" — so the next restart imports the new code, fails on the
-        # missing import, and the gateway does not come back. Any newly spawned
-        # subprocess hits the same gap even without a restart. That is the same
-        # unstartable-gateway outcome this guard exists to prevent, just later
-        # and with a success report in front of it.
-        #
-        # The checkout is therefore left at a revision whose dependencies are
-        # satisfied, and the remedy names itself.
-        return {"ok": False, "error": (
-            "refusing to sync: cannot reinstall into the venv this gateway runs "
-            f"from. {', '.join(locked_scripts)} is locked by a running process, so "
-            "a reinstall cannot replace it — and pip's uninstall is not "
-            "atomic, so attempting it would strip the editable install on the way "
-            "out and leave the venv unable to import the package at all. Pulling "
-            "without installing is refused too: a revision whose new dependencies "
-            "are missing crashes the gateway on its next restart. Stop the gateway "
-            "and sync from a terminal instead: "
-            # Every path is absolute and quoted. `-e .` would resolve against the
-            # terminal's cwd, and this project's normal working state is several
-            # worktrees side by side — so a command copied out of a feature
-            # worktree would install THAT checkout into the primary venv and
-            # repoint its editable install at the wrong tree. `git -C` already
-            # pins the pull, which makes an unpinned `.` actively misleading:
-            # the line reads as if it were cwd-independent. Quoting covers the
-            # spaces that are normal in a Windows home directory.
-            f'git -C "{repo}" pull --ff-only '
-            f'&& "{target_py}" -m pip install -e "{repo}"'
-        )}
-    raw_steps: list[tuple[list[str], str, dict, str]] = [
-        ([git_bin, "fetch", remote, BASE_BRANCH], "standard",
-         _build_env(with_credentials=True), "Pull"),
-        ([git_bin, "merge", "--ff-only", f"{remote}/{BASE_BRANCH}"], "strict", _build_env(), "Pull"),
-        ([str(target_py), "-m", "pip", "install", "-e", "."], "strict", _build_env(), "pip install"),
-    ]
+        logger.info(
+            "dev-fleet: %s locked by a running process; substituting a "
+            "dependency-only sync for the editable reinstall",
+            ", ".join(locked_scripts),
+        )
+        # The revision the venv was installed from is resolved HERE, before any
+        # step runs, because this is the last point at which HEAD still describes
+        # it -- and dep_sync needs those declarations to tell an extra the operator
+        # uses from one they do not. `git_bin` is handed over rather than
+        # re-resolved from PATH so the child spawns the same vetted binary.
+        installed_rev = await _git(repo, "rev-parse", "HEAD")
+        if installed_rev is None:
+            return {"ok": False, "error": (
+                "refusing to sync: cannot resolve the current revision, so the "
+                "extras this venv was installed from cannot be determined"
+            )}
+        # Dependencies are installed BEFORE the merge, and dep_sync reads the
+        # incoming declarations out of the fetched ref with `git show` rather than
+        # from the working tree. A failure therefore leaves HEAD where it was, on a
+        # revision whose dependencies are satisfied; the reverse order would
+        # advance the checkout and only then discover it cannot be started.
+        # Installing for a revision that then fails to merge just leaves an unused
+        # package behind, which is the cheaper of the two mistakes.
+        # The merge consumes the ref dep_sync PINNED, not `<remote>/<base>`: a
+        # concurrent fetch can advance the remote-tracking ref between the
+        # dependency install and this merge, which would install for one revision
+        # and merge another -- the missing-dependency outcome the step exists to
+        # prevent. dep_sync is the only writer of that ref.
+        steps = [
+            fetch_step,
+            ([
+                sys.executable, "-m", dep_sync.__name__, str(repo), str(target_py),
+                str(git_bin), installed_rev.strip(), f"{remote}/{BASE_BRANCH}",
+            ], "strict", _build_env(), "pip install"),
+            ([git_bin, "merge", "--ff-only", dep_sync.PIN_REF], "strict",
+             _build_env(), "Pull"),
+        ]
+    else:
+        steps = [
+            fetch_step,
+            merge_step,
+            ([str(target_py), "-m", "pip", "install", "-e", "."], "strict",
+             _build_env(), "pip install"),
+        ]
+    raw_steps: list[tuple[list[str], str, dict, str]] = steps
     # The whole FRONTEND half of the sync is skipped on an edition checkout.
     #
     # The build runs under _build_env(), whose allowlist (_SAFE_ENV_KEYS) drops

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -1023,48 +1023,53 @@ async def _run_sync(mod, locked):
 
 
 @pytest.mark.asyncio
-async def test_sync_refuses_entirely_when_a_console_script_is_locked():
-    """Nothing may run — not even fetch/merge.
+async def test_sync_substitutes_a_dependency_only_install_when_a_script_is_locked():
+    """The sync proceeds; only the editable reinstall is swapped out.
 
-    pip cannot replace the locked binary, and merging anyway is not a safe
-    consolation prize: a revision that adds a dependency would land with that
-    dependency absent, the run would report success, and the next restart would
-    fail to import it. Leaving the checkout on a revision whose dependencies are
-    satisfied is the only outcome that cannot brick the gateway.
+    pip cannot replace the locked wrapper, but it does not have to. An editable
+    install serves source straight from ``src``, so the merge alone makes the new
+    revision live; the only thing the reinstall was still buying is a dependency
+    the revision added, and installing a dependency never touches the project's
+    own console script. Refusing the whole sync instead left the single-checkout
+    Windows layout — the ordinary one — with no working Pull+build at all.
     """
     import kiro_crew.apps.builtins.dev_fleet.server as mod
+    from kiro_crew.apps.builtins.dev_fleet import dep_sync
 
     result, script = await _run_sync(mod, [r"C:\repo\.venv\Scripts\kirocrew.exe"])
 
-    assert result["ok"] is False
-    # No run was started at all, so fetch/merge never happened.
-    assert script is None
-    err = result["error"]
-    assert "kirocrew.exe" in err          # names the blocker
-    assert "pip install -e" in err        # and the remedy
-    assert "Stop the gateway" in err
+    assert result["ok"] is True
+    # A run was started, so fetch and merge do happen.
+    assert script is not None
+    # Steps are JSON-embedded in the generated script, so quotes arrive escaped;
+    # comparing against a de-escaped copy keeps these assertions independent of
+    # how many encoding layers the script generator happens to use.
+    flat = script.replace("\\", "")
+    assert dep_sync.__name__ in flat
+    assert '"-e"' not in flat
+    # ORDER MATTERS: the dependency sync must precede the merge, so a failure
+    # leaves HEAD on a revision whose dependencies are satisfied instead of
+    # advancing the checkout and only then discovering it cannot start.
+    assert flat.index(dep_sync.__name__) < flat.index('"merge"')
 
 
 @pytest.mark.asyncio
-async def test_refusal_remedy_is_cwd_independent_and_quoted():
-    """The suggested command must not depend on where it is pasted.
+async def test_sync_keeps_the_editable_reinstall_when_nothing_is_locked():
+    """A venv this gateway is NOT served by must still get the real reinstall.
 
-    `-e .` resolves against the terminal's cwd, and this project is normally
-    checked out as several worktrees at once — so the same line copied from a
-    feature worktree would install THAT tree into the primary venv and repoint
-    its editable install away from the primary checkout. Both paths are also
-    quoted, because a Windows home directory routinely contains a space.
+    The substitution is a concession to a lock, not an improvement to prefer: it
+    cannot refresh a console script, so anywhere pip can do the whole job, it
+    should.
     """
     import kiro_crew.apps.builtins.dev_fleet.server as mod
+    from kiro_crew.apps.builtins.dev_fleet import dep_sync
 
-    result, _ = await _run_sync(mod, [r"C:\repo\.venv\Scripts\kirocrew.exe"])
-    err = result["error"]
+    result, script = await _run_sync(mod, [])
 
-    # The install target is named explicitly, never left to the shell's cwd —
-    # including in the prose, so the message never shows the misleading form.
-    assert "pip install -e ." not in err
-    assert f'pip install -e "{_SYNC_REPO}"' in err
-    assert f'git -C "{_SYNC_REPO}"' in err
+    assert result["ok"] is True
+    flat = script.replace("\\", "")
+    assert '"-e"' in flat
+    assert dep_sync.__name__ not in flat
 
 
 @pytest.mark.asyncio

--- a/test/test_dev_fleet_dep_sync.py
+++ b/test/test_dev_fleet_dep_sync.py
@@ -1,0 +1,625 @@
+"""Tests for the dependency-only sync that stands in for a blocked reinstall.
+
+The module exists because Windows cannot rewrite a running console script, so
+these tests pin what that substitution rests on: it must never leave the checkout
+merged-but-unstartable (every refusal happens before the merge), extra activity is
+judged against the declarations the venv was installed FROM, the interpreter gate
+`pip install -e .` used to provide is still applied, and the authoritative
+console-script declaration is the pyproject one.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.apps.builtins.dev_fleet import dep_sync
+
+
+@pytest.fixture(autouse=True)
+def _preconditions_ok(request):
+    """Stub main()'s git/venv preconditions for the ``main()`` tests only.
+
+    Each precondition has its own direct tests; patching them out here keeps the
+    main() tests about what main does with the answers, and stops them reaching a
+    real git or a real interpreter through the mocked subprocess. The venv-mapping
+    COMPARISON is deliberately left real -- only the probe that reads the mapping is
+    stubbed -- so a main() test can make the venv foreign by changing that answer.
+    """
+    if not request.node.name.startswith("test_main_"):
+        yield
+        return
+    with (
+        patch.object(dep_sync, "merge_not_guaranteed", return_value=None),
+        patch.object(dep_sync, "dependency_authority_moved", return_value=None),
+        patch.object(dep_sync, "pin_incoming", return_value="cafe1234"),
+        patch.object(dep_sync, "installed_package_origin", return_value="/fake/repo/src/x.py"),
+    ):
+        yield
+
+
+def test_pin_incoming_resolves_once_and_writes_the_pin():
+    """The merge must consume a commit, not a ref a concurrent fetch can advance.
+
+    Installing for one revision and merging another is the missing-dependency
+    outcome this step exists to prevent, so the incoming ref is resolved a single
+    time and pinned at a ref only this module writes.
+    """
+    calls = []
+
+    with (
+        patch.object(dep_sync, "_git_output", return_value="deadbeefcafe") as out,
+        patch.object(dep_sync, "_git_succeeds", side_effect=lambda *a: calls.append(a) or True),
+    ):
+        oid = dep_sync.pin_incoming(Path("/fake/repo"), Path("/fake/git"), "origin/main")
+
+    assert oid == "deadbeefcafe"
+    # Resolved with an explicit commit peel, so an annotated tag cannot slip through.
+    assert "rev-parse" in out.call_args[0]
+    # Pinned to the OID, never to the ref name.
+    assert calls[0][2:] == ("update-ref", dep_sync.PIN_REF, "deadbeefcafe")
+
+
+def test_pin_incoming_returns_none_when_the_ref_cannot_be_resolved():
+    with patch.object(dep_sync, "_git_output", return_value=None):
+        assert dep_sync.pin_incoming(Path("/fake/repo"), Path("/fake/git"), "origin/main") is None
+
+
+def test_pin_incoming_returns_none_when_the_pin_cannot_be_written():
+    with (
+        patch.object(dep_sync, "_git_output", return_value="deadbeef"),
+        patch.object(dep_sync, "_git_succeeds", return_value=False),
+    ):
+        assert dep_sync.pin_incoming(Path("/fake/repo"), Path("/fake/git"), "origin/main") is None
+
+
+def test_main_refuses_when_the_incoming_ref_cannot_be_pinned(capsys):
+    """No pin means no guarantee the merge consumes what was installed for."""
+    with patch.object(dep_sync, "pin_incoming", return_value=None):
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "pin" in err
+    assert "Nothing was merged" in err
+
+
+_SETUP_CFG = """\
+[options]
+install_requires =
+    aiohttp>=3.9,<4
+    # A full-line comment: configparser keeps it in the value, so it has to be
+    # stripped before the value reaches pip.
+    tzdata>=2024.1; platform_system == "Windows"
+    python-docx>=1,<2
+
+[options.extras_require]
+voice =
+    openai-whisper>=1
+    sounddevice>=0.4
+perf =
+    py-spy>=0.3
+
+[options.entry_points]
+console_scripts =
+    kirocrew = kiro_crew._bootstrap:main
+"""
+
+_PYPROJECT = """\
+[project]
+name = "kirocrew"
+requires-python = ">=3.10"
+dynamic = ["dependencies", "optional-dependencies"]
+
+[project.scripts]
+kirocrew = "kiro_crew._bootstrap:main"
+"""
+
+_ARGS = ["/fake/repo", "/fake/python", "/fake/git", "oldrev", "newrev"]
+
+
+def _shows(**by_path):
+    """A `show` stub resolving (rev, path) -> text, defaulting to the fixtures."""
+
+    def fake_show(repo, git_bin, rev, path):
+        return by_path.get((rev, path), by_path.get(path))
+
+    return fake_show
+
+
+def test_requirement_name_normalizes_per_pep503():
+    """Names must compare equal across the spellings a declaration may use."""
+    assert dep_sync.requirement_name("aiohttp>=3.9,<4") == "aiohttp"
+    assert dep_sync.requirement_name("python_docx>=1") == "python-docx"
+    assert dep_sync.requirement_name("Some.Pkg[extra]>=1") == "some-pkg"
+    assert dep_sync.requirement_name('tzdata>=2024.1; platform_system == "Windows"') == "tzdata"
+
+
+def test_declared_requirements_at_drops_comment_lines():
+    """A comment handed to pip is a resolution error, not a no-op."""
+    with patch.object(dep_sync, "show", _shows(**{"setup.cfg": _SETUP_CFG})):
+        base, extras = dep_sync.declared_requirements_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev"
+        )
+
+    assert base == [
+        "aiohttp>=3.9,<4",
+        'tzdata>=2024.1; platform_system == "Windows"',
+        "python-docx>=1,<2",
+    ]
+    assert set(extras) == {"voice", "perf"}
+
+
+def test_declared_requirements_at_returns_none_when_unreadable():
+    """A shallow clone or rewritten history must not read as 'no extras'."""
+    with patch.object(dep_sync, "show", _shows()):
+        assert (
+            dep_sync.declared_requirements_at(Path("/fake/repo"), Path("/fake/git"), "deadbeef")
+            is None
+        )
+
+
+def test_an_extra_is_active_when_all_its_distributions_are_present():
+    extras = {
+        "voice": ["openai-whisper>=1", "sounddevice>=0.4"],
+        "perf": ["py-spy>=0.3"],
+    }
+
+    assert dep_sync.active_extras(extras, {"openai-whisper", "sounddevice"}) == ["voice"]
+
+
+def test_a_partially_installed_extra_is_not_active():
+    """Installed metadata records no requested extras, so presence is the signal."""
+    extras = {"voice": ["openai-whisper>=1", "sounddevice>=0.4"]}
+
+    assert dep_sync.active_extras(extras, {"openai-whisper"}) == []
+
+
+def test_an_extra_that_gained_a_distribution_stays_active():
+    """The regression this module's design turns on.
+
+    A revision that adds a distribution to an extra the operator uses would, if
+    activity were judged against the INCOMING declarations, make that extra read
+    inactive -- its new requirement is skipped, the step exits 0, and the gateway
+    fails on that import at its next restart. Judging against the installed-from
+    declarations keeps it active, so the new requirement is installed.
+    """
+    incoming = (
+        ["aiohttp>=3.9,<4"],
+        {"voice": ["openai-whisper>=1", "sounddevice>=0.4", "brand-new-dep>=2"]},
+    )
+    previous_extras = {"voice": ["openai-whisper>=1", "sounddevice>=0.4"]}
+
+    specs, chosen, skipped = dep_sync.plan(
+        incoming, previous_extras, {"openai-whisper", "sounddevice"}
+    )
+
+    assert chosen == ["voice"]
+    assert "brand-new-dep>=2" in specs
+    assert skipped == []
+
+
+def test_plan_never_includes_the_project_itself():
+    """Installing the project is the one thing that rewrites the locked script."""
+    incoming = (["aiohttp>=3.9,<4"], {"perf": ["py-spy>=0.3"]})
+
+    specs, chosen, skipped = dep_sync.plan(incoming, {"perf": ["py-spy>=0.3"]}, {"py-spy"})
+
+    assert chosen == ["perf"]
+    assert not any(dep_sync.requirement_name(s) == "kirocrew" for s in specs)
+    assert skipped == []
+
+
+def test_python_floor_breach_reports_the_highest_unmet_floor():
+    """The floor is the bound a revision raises when it adopts newer syntax."""
+    assert dep_sync.python_floor_breach(">=3.12", (3, 10)) == "3.12"
+    assert dep_sync.python_floor_breach(">=3.10", (3, 12)) is None
+    assert dep_sync.python_floor_breach(">=3.10,<4", (3, 10)) is None
+    # Multiple lower bounds: the highest unmet one is what the operator must hear.
+    assert dep_sync.python_floor_breach(">=3.11,>=3.13", (3, 12)) == "3.13"
+
+
+def test_requires_python_is_read_from_the_incoming_revision():
+    with patch.object(dep_sync, "show", _shows(**{"pyproject.toml": _PYPROJECT})):
+        assert (
+            dep_sync.requires_python_at(Path("/fake/repo"), Path("/fake/git"), "newrev") == ">=3.10"
+        )
+
+
+def test_console_script_target_prefers_the_pyproject_declaration():
+    """`scripts` is not dynamic here, so pyproject is what setuptools builds from.
+
+    A repoint made only in pyproject must be seen; reading setup.cfg alone would
+    report success while the locked wrapper keeps its old target.
+    """
+    repointed = _PYPROJECT.replace("_bootstrap:main", "cli:main")
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": repointed, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == "kiro_crew.cli:main"
+
+
+def test_console_script_target_falls_back_to_setup_cfg():
+    with patch.object(dep_sync, "show", _shows(**{"setup.cfg": _SETUP_CFG})):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == "kiro_crew._bootstrap:main"
+
+
+def test_merge_not_guaranteed_flags_a_dirty_checkout():
+    """The invariant: refuse unless the following ff-only merge cannot fail.
+
+    Installing and merging are two writes with no shared transaction, so whichever
+    runs second can strand the first. A clean tree plus an ancestor relationship is
+    the condition under which the merge has nothing to refuse.
+    """
+
+    class _Dirty:
+        returncode = 0
+        stdout = " M src/kiro_crew/foo.py\n"
+
+    with patch.object(dep_sync, "subprocess") as sp:
+        sp.run.return_value = _Dirty()
+        why = dep_sync.merge_not_guaranteed(Path("/fake/repo"), Path("/fake/git"), "old", "new")
+
+    assert why is not None
+    assert "local modifications" in why
+
+
+def test_merge_not_guaranteed_flags_a_non_fast_forward():
+    class _Clean:
+        returncode = 0
+        stdout = "\n"
+
+    with patch.object(dep_sync, "subprocess") as sp:
+        sp.run.return_value = _Clean()
+        with patch.object(dep_sync, "_git_succeeds", return_value=False):
+            why = dep_sync.merge_not_guaranteed(Path("/fake/repo"), Path("/fake/git"), "old", "new")
+
+    assert why is not None
+    assert "fast-forward" in why
+
+
+def test_merge_not_guaranteed_passes_a_clean_fast_forward():
+    class _Clean:
+        returncode = 0
+        stdout = ""
+
+    with patch.object(dep_sync, "subprocess") as sp:
+        sp.run.return_value = _Clean()
+        with patch.object(dep_sync, "_git_succeeds", return_value=True):
+            assert (
+                dep_sync.merge_not_guaranteed(Path("/fake/repo"), Path("/fake/git"), "old", "new")
+                is None
+            )
+
+
+def test_dependency_authority_moved_detects_a_migration_to_pyproject():
+    """setup.cfg is only authoritative while pyproject keeps the fields dynamic.
+
+    A revision that moves requirements into pyproject's own [project] table would
+    make setup.cfg stale; reading it anyway installs the wrong set and reports
+    success.
+    """
+    migrated = _PYPROJECT.replace(
+        'dynamic = ["dependencies", "optional-dependencies"]',
+        'dependencies = ["aiohttp>=3.9"]',
+    )
+    with patch.object(dep_sync, "show", _shows(**{"pyproject.toml": migrated})):
+        why = dep_sync.dependency_authority_moved(Path("/fake/repo"), Path("/fake/git"), "newrev")
+
+    assert why is not None
+    assert "dynamic" in why
+
+
+def test_dependency_authority_intact_when_fields_stay_dynamic():
+    with patch.object(dep_sync, "show", _shows(**{"pyproject.toml": _PYPROJECT})):
+        assert (
+            dep_sync.dependency_authority_moved(Path("/fake/repo"), Path("/fake/git"), "newrev")
+            is None
+        )
+
+
+def test_main_refuses_when_the_installed_revision_is_unreadable(capsys):
+    """Guessing which extras were installed is what drops a dependency."""
+    with patch.object(dep_sync, "declared_requirements_at", return_value=None):
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "oldrev" in err
+    assert "Nothing was merged" in err
+
+
+def test_main_refuses_when_the_interpreter_is_below_the_incoming_floor(capsys):
+    """The gate `pip install -e .` used to provide has to be applied here.
+
+    Without it a revision that raises requires-python installs cleanly and then
+    cannot be imported by the interpreter that has to import it.
+    """
+    with (
+        patch.object(dep_sync, "declared_requirements_at", return_value=([], {})),
+        patch.object(dep_sync, "requires_python_at", return_value=">=3.13"),
+        patch.object(dep_sync, "interpreter_version", return_value=(3, 10)),
+    ):
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "3.13" in err
+    assert "Nothing was merged" in err
+
+
+def test_installed_package_origin_reports_where_the_package_resolves():
+    """The import path is what the installed dependencies live alongside."""
+
+    class _Proc:
+        returncode = 0
+        stdout = "/checkouts/main/src/kiro_crew/__init__.py\n"
+
+    with patch.object(dep_sync.subprocess, "run", return_value=_Proc()):
+        origin = dep_sync.installed_package_origin(Path("py"))
+
+    assert origin is not None
+    assert Path(origin).name == "__init__.py"
+
+
+def test_installed_package_origin_is_none_when_the_package_is_absent():
+    """An empty answer must not be read as a location."""
+
+    class _Proc:
+        returncode = 0
+        stdout = "\n"
+
+    with patch.object(dep_sync.subprocess, "run", return_value=_Proc()):
+        assert dep_sync.installed_package_origin(Path("py")) is None
+
+
+def test_venv_serving_another_checkout_is_reported(tmp_path):
+    """The harm this guards: upgrading a runtime another checkout is served by."""
+    repo = tmp_path / "main"
+    other = tmp_path / "other"
+    reason = dep_sync.venv_not_mapped_to(str(other / "src" / "kiro_crew" / "__init__.py"), repo)
+
+    assert reason is not None
+    assert "other" in reason
+    assert "main" in reason
+
+
+def test_an_unresolvable_package_is_not_taken_as_a_match(tmp_path):
+    """Unproven is refused, not assumed.
+
+    Reading nothing is exactly what a venv this step cannot vouch for produces, so
+    treating it as a match would leave the hole open in the one configuration that
+    cannot be checked.
+    """
+    assert dep_sync.venv_not_mapped_to(None, tmp_path / "main") is not None
+
+
+def test_a_venv_serving_this_checkout_passes(tmp_path):
+    """The ordinary layout -- an editable install of the checkout's own src tree."""
+    repo = tmp_path / "main"
+    origin = repo / "src" / "kiro_crew" / "__init__.py"
+
+    assert dep_sync.venv_not_mapped_to(str(origin), repo) is None
+
+
+def test_a_sibling_directory_sharing_the_prefix_does_not_count_as_inside(tmp_path):
+    """`<repo>-wt` starts with `<repo>` as a string but is a different checkout."""
+    repo = tmp_path / "main"
+    sibling = tmp_path / "main-wt" / "src" / "kiro_crew" / "__init__.py"
+
+    assert dep_sync.venv_not_mapped_to(str(sibling), repo) is not None
+
+
+def test_main_refuses_a_venv_serving_another_checkout(capsys):
+    """Refused before the pin ref is written and before pip runs."""
+
+    class _Ok:
+        returncode = 0
+
+    with (
+        patch.object(
+            dep_sync,
+            "installed_package_origin",
+            return_value="/checkouts/other/src/kiro_crew/__init__.py",
+        ),
+        patch.object(dep_sync, "pin_incoming") as pin,
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.return_value = _Ok()
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 1
+    assert not pin.called
+    assert not sp.run.called
+    err = capsys.readouterr().err
+    assert "other" in err
+    assert "Nothing was merged" in err
+
+
+def test_main_hands_every_spec_to_pip_and_stops_on_failure():
+    """pip decides satisfaction; a failed install must not report success."""
+    calls = []
+
+    class _Proc:
+        returncode = 1
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Proc()
+
+    with (
+        patch.object(dep_sync, "declared_requirements_at", return_value=(["aiohttp>=3.9,<4"], {})),
+        patch.object(dep_sync, "requires_python_at", return_value=None),
+        patch.object(dep_sync, "installed_names", return_value=set()),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.side_effect = fake_run
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 1
+    assert calls[0][1:4] == ["-m", "pip", "install"]
+    assert "aiohttp>=3.9,<4" in calls[0]
+
+
+def test_main_ends_pip_option_parsing_before_the_specs():
+    """A declared requirement must never be readable as a pip option.
+
+    The `--` separator is belt to the braces of `rejected_specs`: the rejection list
+    is what stops a hostile declaration reaching pip at all, and the separator keeps
+    a merely odd one from being parsed as a flag if that list is ever loosened.
+    """
+    calls = []
+
+    class _Ok:
+        returncode = 0
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Ok()
+
+    with (
+        patch.object(dep_sync, "declared_requirements_at", return_value=(["aiohttp>=3.9"], {})),
+        patch.object(dep_sync, "requires_python_at", return_value=None),
+        patch.object(dep_sync, "installed_names", return_value=set()),
+        patch.object(dep_sync, "console_script_target_at", return_value=None),
+        patch.object(dep_sync, "installed_console_script_target", return_value=None),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.side_effect = fake_run
+        dep_sync.main(list(_ARGS))
+
+    cmd = calls[0]
+    assert cmd[1:5] == ["-m", "pip", "install", "--"]
+    assert cmd.index("--") < cmd.index("aiohttp>=3.9")
+
+
+def test_rejected_specs_refuses_paths_and_the_project_itself():
+    """The module's premise -- pip is asked for dependencies, never the project.
+
+    A declaration of `.` would have pip install the checkout, remove the editable
+    install, and then fail on the locked executable, leaving the venv unable to
+    import the package at all. That used to hold only because this repository
+    happens not to declare it; now it is checked.
+    """
+    assert dep_sync.rejected_specs(["aiohttp>=3.9,<4", 'tzdata; sys_platform == "win32"']) == []
+
+    for hostile in [".", "./local", "/abs/path", r"C:\pkgs\x", "file:./x", "x.whl", "-e"]:
+        assert dep_sync.rejected_specs([hostile]), hostile
+
+    # Only spellings PEP 503 actually folds onto this project's name. `kiro_crew`
+    # normalizes to `kiro-crew`, which is a DIFFERENT distribution, so it is not
+    # claimed here.
+    for spelling in ["kirocrew", "KiroCrew", "KIROCREW", "kirocrew>=1"]:
+        rejected = dep_sync.rejected_specs([spelling])
+        assert rejected and "names this project" in rejected[0], spelling
+
+
+def test_main_refuses_a_declaration_that_names_the_project(capsys):
+    """Refused BEFORE pip runs, so the venv is never touched."""
+
+    class _Ok:
+        returncode = 0
+
+    with (
+        patch.object(dep_sync, "declared_requirements_at", return_value=(["."], {})),
+        patch.object(dep_sync, "requires_python_at", return_value=None),
+        patch.object(dep_sync, "installed_names", return_value=set()),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.return_value = _Ok()
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 1
+    assert not sp.run.called
+    err = capsys.readouterr().err
+    assert "will not hand to pip" in err
+    assert "Nothing was merged" in err
+
+
+def test_main_refuses_a_repointed_console_script_before_merging(capsys):
+    """The one gap: a moved entry point cannot be refreshed while it is locked."""
+
+    class _Ok:
+        returncode = 0
+
+    with (
+        patch.object(dep_sync, "declared_requirements_at", return_value=([], {})),
+        patch.object(dep_sync, "requires_python_at", return_value=None),
+        patch.object(dep_sync, "installed_names", return_value=set()),
+        patch.object(dep_sync, "console_script_target_at", return_value="kiro_crew.new:main"),
+        patch.object(
+            dep_sync, "installed_console_script_target", return_value="kiro_crew.old:main"
+        ),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.return_value = _Ok()
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "kiro_crew.new:main" in err
+    assert "kiro_crew.old:main" in err
+    assert "Nothing was merged" in err
+
+
+def test_main_reports_which_extras_were_left_alone(capsys):
+    """The docstring promises the skipped extras are reported, so pin it."""
+
+    class _Ok:
+        returncode = 0
+
+    previous = (["aiohttp>=3.9,<4"], {"voice": ["openai-whisper>=1"]})
+    with (
+        patch.object(dep_sync, "declared_requirements_at", return_value=previous),
+        patch.object(dep_sync, "requires_python_at", return_value=None),
+        patch.object(dep_sync, "installed_names", return_value=set()),
+        patch.object(
+            dep_sync, "console_script_target_at", return_value="kiro_crew._bootstrap:main"
+        ),
+        patch.object(
+            dep_sync, "installed_console_script_target", return_value="kiro_crew._bootstrap:main"
+        ),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.return_value = _Ok()
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 0
+    assert "extras left alone" in capsys.readouterr().out
+
+
+def test_main_tolerates_an_unreadable_installed_entry_point():
+    """Missing evidence must not fail a sync that otherwise succeeded."""
+
+    class _Ok:
+        returncode = 0
+
+    with (
+        patch.object(dep_sync, "declared_requirements_at", return_value=([], {})),
+        patch.object(dep_sync, "requires_python_at", return_value=None),
+        patch.object(dep_sync, "installed_names", return_value=set()),
+        patch.object(
+            dep_sync, "console_script_target_at", return_value="kiro_crew._bootstrap:main"
+        ),
+        patch.object(dep_sync, "installed_console_script_target", return_value=None),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.return_value = _Ok()
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 0
+
+
+def test_main_rejects_a_wrong_argument_count():
+    assert dep_sync.main([]) == 2
+    assert dep_sync.main(["a", "b", "c", "d"]) == 2

--- a/test/test_dev_fleet_dep_sync.py
+++ b/test/test_dev_fleet_dep_sync.py
@@ -219,6 +219,54 @@ def test_python_floor_breach_reports_the_highest_unmet_floor():
     assert dep_sync.python_floor_breach(">=3.11,>=3.13", (3, 12)) == "3.13"
 
 
+def test_python_floor_breach_reads_a_compatible_release_as_a_floor():
+    """``~=3.12`` means ``>=3.12,<4``, so its floor half must be enforced.
+
+    Read as declaring no floor at all, a revision that switches its
+    requires-python to the compatible-release spelling and adopts 3.12-only
+    syntax would merge cleanly under a 3.10 interpreter and fail at import.
+    """
+    assert dep_sync.python_floor_breach("~=3.12", (3, 10)) == "3.12"
+    assert dep_sync.python_floor_breach("~=3.10", (3, 12)) is None
+    assert dep_sync.python_floor_breach("~=3.12", (3, 12)) is None
+
+
+def test_python_floor_breach_compares_the_micro_component():
+    """``>=3.10.5`` refuses a 3.10.0 interpreter; truncating to the minor would not.
+
+    The interpreter probe reports three components for the same reason: at
+    exactly the boundary being checked, 3.12.13 and 3.12.14 are different
+    answers, whichever spelling declared the floor.
+    """
+    assert dep_sync.python_floor_breach(">=3.10.5", (3, 10, 0)) == "3.10.5"
+    assert dep_sync.python_floor_breach(">=3.10.5", (3, 10, 6)) is None
+    assert dep_sync.python_floor_breach("~=3.12.14", (3, 12, 13)) == "3.12.14"
+    assert dep_sync.python_floor_breach("~=3.12.14", (3, 12, 14)) is None
+    # A two-component interpreter answer reads as micro 0: the conservative side.
+    assert dep_sync.python_floor_breach(">=3.10.5", (3, 10)) == "3.10.5"
+
+
+def test_python_floor_breach_excludes_the_named_version_under_a_bare_gt():
+    """``>3.10`` excludes 3.10.0 itself; reading it as ``>=`` waves it through."""
+    assert dep_sync.python_floor_breach(">3.10", (3, 10)) == "3.10"
+    assert dep_sync.python_floor_breach(">3.10", (3, 10, 5)) is None
+    assert dep_sync.python_floor_breach(">3.10", (3, 11)) is None
+
+
+def test_python_floor_breach_reads_an_equality_pin_as_a_floor():
+    """``==X.Y.*`` and ``===X.Y.Z`` declare their named version as the floor.
+
+    Left unrecognized they read as no floor at all -- the same silent merge of an
+    unimportable revision the ``~=`` fix closes. Only the floor side is enforced
+    here; a higher interpreter is left to pip like every other upper bound.
+    """
+    assert dep_sync.python_floor_breach("==3.12.*", (3, 11)) == "3.12"
+    assert dep_sync.python_floor_breach("==3.12.*", (3, 12)) is None
+    assert dep_sync.python_floor_breach("==3.12.*", (3, 13)) is None
+    assert dep_sync.python_floor_breach("===3.12.4", (3, 12, 3)) == "3.12.4"
+    assert dep_sync.python_floor_breach("===3.12.4", (3, 12, 4)) is None
+
+
 def test_requires_python_is_read_from_the_incoming_revision():
     with patch.object(dep_sync, "show", _shows(**{"pyproject.toml": _PYPROJECT})):
         assert (
@@ -252,6 +300,203 @@ def test_console_script_target_falls_back_to_setup_cfg():
         )
 
     assert got == "kiro_crew._bootstrap:main"
+
+
+def test_console_script_removed_from_pyproject_is_not_read_from_setup_cfg():
+    """A present-but-omitting ``[project.scripts]`` table means REMOVED.
+
+    setuptools builds the wrapper from the pyproject table when it exists, so a
+    revision whose table drops the script has removed the entry point. setup.cfg's
+    copy is stale in exactly that case, and reading it would report an agreement
+    that no longer holds -- so the answer is the removal sentinel, distinct from
+    the unreadable-declarations ``None``.
+    """
+    removed = _PYPROJECT.replace('kirocrew = "kiro_crew._bootstrap:main"', "")
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": removed, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == dep_sync.SCRIPT_REMOVED
+
+
+def test_console_script_renamed_in_pyproject_reads_as_removed():
+    """A table that lists OTHER scripts but not this one is the rename spelling.
+
+    The stale setup.cfg copy must not be consulted just because the table's
+    remaining entries do not include the script being asked about.
+    """
+    renamed = _PYPROJECT.replace(
+        'kirocrew = "kiro_crew._bootstrap:main"',
+        'kirocrew-next = "kiro_crew._bootstrap:main"',
+    )
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": renamed, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == dep_sync.SCRIPT_REMOVED
+
+
+def test_console_script_absent_with_a_static_project_table_reads_as_removed():
+    """``[project]`` present, ``scripts`` neither named nor dynamic: REMOVED.
+
+    setuptools treats a statically-absent field as authoritative and builds no
+    wrapper from setup.cfg's copy (verified against setuptools 80.9), so reading
+    setup.cfg here would report an agreement the incoming revision no longer
+    makes -- the merge would leave the locked wrapper dispatching to a target
+    the revision may have deleted.
+    """
+    tableless = _PYPROJECT.split("[project.scripts]")[0]
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": tableless, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == dep_sync.SCRIPT_REMOVED
+
+
+def test_console_script_falls_back_to_setup_cfg_when_scripts_is_dynamic():
+    """``dynamic = [..., "scripts"]`` is the one PEP 621 shape that reads setup.cfg."""
+    dynamic = _PYPROJECT.split("[project.scripts]")[0].replace(
+        'dynamic = ["dependencies", "optional-dependencies"]',
+        'dynamic = ["dependencies", "optional-dependencies", "scripts"]',
+    )
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": dynamic, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == "kiro_crew._bootstrap:main"
+
+
+def test_console_script_falls_back_to_setup_cfg_without_a_project_table():
+    """A pyproject with no ``[project]`` table (pre-PEP 621) leaves setup.cfg governing."""
+    build_only = '[build-system]\nrequires = ["setuptools"]\n'
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": build_only, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == "kiro_crew._bootstrap:main"
+
+
+def test_console_script_header_with_a_trailing_comment_is_still_the_declaration():
+    """``[project.scripts]  # note`` is the same table, not an absent one.
+
+    TOML allows a comment after the header; reading that spelling as absence
+    would fall back to setup.cfg's stale copy exactly when pyproject repointed
+    the script.
+    """
+    commented = _PYPROJECT.replace("[project.scripts]", "[ project.scripts ]  # wrapper")
+    repointed = commented.replace("_bootstrap:main", "cli:main")
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": repointed, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == "kiro_crew.cli:main"
+
+
+def test_console_script_declared_as_an_inline_table_is_read_not_setup_cfg():
+    """``scripts = { ... }`` inside ``[project]`` is the authoritative table.
+
+    A revision that spells the declaration inline and repoints the script must
+    be seen as a repoint; the pre-fix fallback read setup.cfg's stale copy,
+    which agreed with the installed wrapper and let the merge proceed.
+    """
+    inline = _PYPROJECT.split("[project.scripts]")[0].replace(
+        'name = "kirocrew"',
+        'name = "kirocrew"\nscripts = { kirocrew = "kiro_crew.cli:main" }',
+    )
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": inline, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == "kiro_crew.cli:main"
+
+
+def test_console_script_omitted_from_an_inline_table_reads_as_removed():
+    """An inline table that names other scripts has removed this one."""
+    inline = _PYPROJECT.split("[project.scripts]")[0].replace(
+        'name = "kirocrew"',
+        'name = "kirocrew"\nscripts = { kirocrew-next = "kiro_crew._bootstrap:main" }',
+    )
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": inline, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == dep_sync.SCRIPT_REMOVED
+
+
+def test_console_script_declared_with_dotted_keys_is_read_not_setup_cfg():
+    """``scripts.kirocrew = ...`` inside ``[project]`` is the same declaration."""
+    dotted = _PYPROJECT.split("[project.scripts]")[0].replace(
+        'name = "kirocrew"',
+        'name = "kirocrew"\nscripts.kirocrew = "kiro_crew.cli:main"',
+    )
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": dotted, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == "kiro_crew.cli:main"
+
+
+def test_console_script_absent_from_dotted_keys_reads_as_removed():
+    """Dotted keys that declare only other scripts are a removal of this one."""
+    dotted = _PYPROJECT.split("[project.scripts]")[0].replace(
+        'name = "kirocrew"',
+        'name = "kirocrew"\nscripts."kirocrew-next" = "kiro_crew._bootstrap:main"',
+    )
+    with patch.object(
+        dep_sync,
+        "show",
+        _shows(**{"pyproject.toml": dotted, "setup.cfg": _SETUP_CFG}),
+    ):
+        got = dep_sync.console_script_target_at(
+            Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+        )
+
+    assert got == dep_sync.SCRIPT_REMOVED
 
 
 def test_merge_not_guaranteed_flags_a_dirty_checkout():
@@ -461,6 +706,8 @@ def test_main_hands_every_spec_to_pip_and_stops_on_failure():
         patch.object(dep_sync, "declared_requirements_at", return_value=(["aiohttp>=3.9,<4"], {})),
         patch.object(dep_sync, "requires_python_at", return_value=None),
         patch.object(dep_sync, "installed_names", return_value=set()),
+        patch.object(dep_sync, "console_script_target_at", return_value=None),
+        patch.object(dep_sync, "installed_console_script_target", return_value=None),
         patch.object(dep_sync, "subprocess") as sp,
     ):
         sp.run.side_effect = fake_run
@@ -534,6 +781,8 @@ def test_main_refuses_a_declaration_that_names_the_project(capsys):
         patch.object(dep_sync, "declared_requirements_at", return_value=(["."], {})),
         patch.object(dep_sync, "requires_python_at", return_value=None),
         patch.object(dep_sync, "installed_names", return_value=set()),
+        patch.object(dep_sync, "console_script_target_at", return_value=None),
+        patch.object(dep_sync, "installed_console_script_target", return_value=None),
         patch.object(dep_sync, "subprocess") as sp,
     ):
         sp.run.return_value = _Ok()
@@ -547,13 +796,18 @@ def test_main_refuses_a_declaration_that_names_the_project(capsys):
 
 
 def test_main_refuses_a_repointed_console_script_before_merging(capsys):
-    """The one gap: a moved entry point cannot be refreshed while it is locked."""
+    """The one gap: a moved entry point cannot be refreshed while it is locked.
+
+    The refusal must also precede the install: the comparison needs nothing from
+    pip, so a mismatch leaves the venv untouched -- requirements are declared here
+    precisely to prove pip was never asked to install them.
+    """
 
     class _Ok:
         returncode = 0
 
     with (
-        patch.object(dep_sync, "declared_requirements_at", return_value=([], {})),
+        patch.object(dep_sync, "declared_requirements_at", return_value=(["aiohttp>=3.9"], {})),
         patch.object(dep_sync, "requires_python_at", return_value=None),
         patch.object(dep_sync, "installed_names", return_value=set()),
         patch.object(dep_sync, "console_script_target_at", return_value="kiro_crew.new:main"),
@@ -566,10 +820,164 @@ def test_main_refuses_a_repointed_console_script_before_merging(capsys):
         rc = dep_sync.main(list(_ARGS))
 
     assert rc == 1
+    assert not sp.run.called
     err = capsys.readouterr().err
     assert "kiro_crew.new:main" in err
     assert "kiro_crew.old:main" in err
     assert "Nothing was merged" in err
+
+
+def test_main_refuses_a_removed_console_script_before_any_write(capsys):
+    """A removal is the same disagreement as a repoint and must refuse end to end.
+
+    The removal sentinel travels the same comparison as a repointed target; were
+    it collapsed into the unreadable-``None``, the sync would exit 0 and the merge
+    would leave the locked wrapper dispatching to a target the revision may have
+    deleted. Requirements are declared here to prove pip was never asked either.
+    """
+
+    class _Ok:
+        returncode = 0
+
+    with (
+        patch.object(dep_sync, "declared_requirements_at", return_value=(["aiohttp>=3.9"], {})),
+        patch.object(dep_sync, "requires_python_at", return_value=None),
+        patch.object(dep_sync, "installed_names", return_value=set()),
+        patch.object(dep_sync, "console_script_target_at", return_value=dep_sync.SCRIPT_REMOVED),
+        patch.object(
+            dep_sync, "installed_console_script_target", return_value="kiro_crew.old:main"
+        ),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.return_value = _Ok()
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 1
+    assert not sp.run.called
+    err = capsys.readouterr().err
+    assert "removed" in err
+    assert "kiro_crew.old:main" in err
+    assert "Nothing was merged" in err
+
+
+def test_main_refuses_a_removal_even_when_the_installed_target_is_unreadable(capsys):
+    """A removal is a fact about the incoming revision alone.
+
+    Whatever the locked wrapper dispatches to, the revision that removed the
+    entry point no longer promises that target exists -- so an unreadable
+    installed target must not launder the removal into a merge.
+    """
+
+    class _Ok:
+        returncode = 0
+
+    with (
+        patch.object(dep_sync, "declared_requirements_at", return_value=(["aiohttp>=3.9"], {})),
+        patch.object(dep_sync, "requires_python_at", return_value=None),
+        patch.object(dep_sync, "installed_names", return_value=set()),
+        patch.object(dep_sync, "console_script_target_at", return_value=dep_sync.SCRIPT_REMOVED),
+        patch.object(dep_sync, "installed_console_script_target", return_value=None),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.return_value = _Ok()
+        rc = dep_sync.main(list(_ARGS))
+
+    assert rc == 1
+    assert not sp.run.called
+    err = capsys.readouterr().err
+    assert "removed" in err
+    assert "Nothing was merged" in err
+
+
+def test_console_script_multiline_string_contents_are_not_declarations():
+    """Text inside a TOML multiline string must not read as the scripts table.
+
+    A ``description`` string carrying the OLD header and entry would otherwise
+    mask the real repointed declaration below it. Pinned on both read paths:
+    the TOML parser (when available) and the line-scanner fallback, which
+    blanks multiline strings before scanning.
+    """
+    decoy = (
+        "[project]\n"
+        'name = "kirocrew"\n'
+        'description = """\n'
+        "[project.scripts]\n"
+        'kirocrew = "kiro_crew._bootstrap:main"\n'
+        '"""\n'
+        'dynamic = ["dependencies", "optional-dependencies"]\n'
+        "\n"
+        "[project.scripts]\n"
+        'kirocrew = "kiro_crew.cli:main"\n'
+    )
+    for parser in (dep_sync._toml, None):
+        with (
+            patch.object(dep_sync, "_toml", parser),
+            patch.object(
+                dep_sync,
+                "show",
+                _shows(**{"pyproject.toml": decoy, "setup.cfg": _SETUP_CFG}),
+            ),
+        ):
+            got = dep_sync.console_script_target_at(
+                Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+            )
+
+        assert got == "kiro_crew.cli:main"
+
+
+def test_console_script_commented_dynamic_entry_does_not_count_as_declared():
+    """A commented ``"scripts"`` inside the dynamic array is not a declaration.
+
+    TOML allows comments between multi-line array elements; on the scanner
+    fallback the comment text must not send the read to setup.cfg's stale copy
+    when the field is statically absent. Pinned on both read paths.
+    """
+    commented = (
+        "[project]\n"
+        'name = "kirocrew"\n'
+        "dynamic = [\n"
+        '    "dependencies",\n'
+        '    "optional-dependencies",\n'
+        '    # "scripts",\n'
+        "]\n"
+    )
+    for parser in (dep_sync._toml, None):
+        with (
+            patch.object(dep_sync, "_toml", parser),
+            patch.object(
+                dep_sync,
+                "show",
+                _shows(**{"pyproject.toml": commented, "setup.cfg": _SETUP_CFG}),
+            ),
+        ):
+            got = dep_sync.console_script_target_at(
+                Path("/fake/repo"), Path("/fake/git"), "newrev", "kirocrew"
+            )
+
+        assert got == dep_sync.SCRIPT_REMOVED
+
+
+def test_dependency_authority_commented_dynamic_entry_reads_as_moved():
+    """The same comment blindness in the other direction: a move must be seen.
+
+    A commented ``"optional-dependencies"`` means the field is NOT dynamic any
+    more; comment text keeping it looking dynamic would install a stale set.
+    """
+    commented = (
+        "[project]\n"
+        'name = "kirocrew"\n'
+        "dynamic = [\n"
+        '    "dependencies",\n'
+        '    # "optional-dependencies",\n'
+        "]\n"
+    )
+    with patch.object(dep_sync, "show", _shows(**{"pyproject.toml": commented})):
+        moved = dep_sync.dependency_authority_moved(
+            Path("/fake/repo"), Path("/fake/git"), "newrev"
+        )
+
+    assert moved is not None
+    assert "optional-dependencies" in moved
 
 
 def test_main_reports_which_extras_were_left_alone(capsys):

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -569,6 +569,30 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # git rev-parse at startup, no agent input, no sandbox needed).
         "apps/builtins/dev_fleet/server.py::_resolve_primary_checkout",
         "apps/builtins/dev_fleet/server.py::worker",
+        # dep_sync stands in for `pip install -e .` on a checkout whose console
+        # script is locked, and it spawns the same shapes that step did:
+        # `<target python> -c <fixed metadata/version probe>`, `<target python> -m
+        # pip install <requirements the incoming revision declares>`, and
+        # `<git> -C <repo> show <rev>:<setup.cfg|pyproject.toml>` to read those
+        # declarations without touching the working tree. The interpreter is the
+        # target repo's own venv python and the git binary is the one the backend
+        # already vetted (both handed down, never resolved from PATH here); the repo
+        # and revisions come from the operator-configured checkout, and the
+        # requirement specs are read from that checkout's own declarations -- the
+        # same ones `pip install -e .` would have read, so this adds no surface the
+        # step it replaces did not already have. Routing here would also NEST
+        # sandboxes: dep_sync runs as a sync step, which server.py::worker already
+        # wrapped through sandboxed_spawn_argv, and a filesystem-scoped wrapper
+        # around pip would block the venv writes that are the point of the step.
+        "apps/builtins/dev_fleet/dep_sync.py::show",
+        "apps/builtins/dev_fleet/dep_sync.py::_git_succeeds",
+        "apps/builtins/dev_fleet/dep_sync.py::_git_output",
+        "apps/builtins/dev_fleet/dep_sync.py::merge_not_guaranteed",
+        "apps/builtins/dev_fleet/dep_sync.py::interpreter_version",
+        "apps/builtins/dev_fleet/dep_sync.py::installed_names",
+        "apps/builtins/dev_fleet/dep_sync.py::installed_console_script_target",
+        "apps/builtins/dev_fleet/dep_sync.py::installed_package_origin",
+        "apps/builtins/dev_fleet/dep_sync.py::main",
         # Foreground last-resort restart (Make Live on hosts with no drivable
         # service manager): a detached `kirocrew restart --port <marker port>`,
         # fixed argv whose binary is validated (basenamed kirocrew, absolute,


### PR DESCRIPTION
Closes #4549

## What

Three hardening items deferred from PR #4541's review of the dependency-only sync, plus the gaps this branch's own pre-push review found in their first cut:

1. **Refusal-before-writes invariant restored.** The console-script comparison in `main()` now runs before `plan()` and the pip install, so every refusal path precedes both writes (pip and the merge). Previously a repoint refused only after pip had already mutated the venv.
2. **Removal is refused, not merged.** `console_script_target_at` falls back to setup.cfg only when pyproject's `[project.scripts]` table is absent altogether. A table that exists but omits the script means the entry point was **removed**: reported as a distinct `SCRIPT_REMOVED` sentinel (not the unreadable `None`, which `main()` deliberately tolerates), so a removal refuses exactly like a repoint instead of merging a wrapper whose target the revision may have deleted. `_section` now reports table absence itself, so presence and body come from one traversal instead of two duplicated scans.
3. **Floor detection fidelity, fixed as a class.** `_PY_FLOOR` recognises the compatible-release spelling `~=X.Y[.Z]` as the floor it declares, compares floors at three components (`>=3.10.5` now refuses a 3.10.0 interpreter instead of truncating to the minor — a pre-existing gap on the base), and reads a bare `>` as excluding the named version itself.

## Stacking

**This PR is stacked on #4541** (base = `fix/win-devfleet-dep-only-sync`), which introduces `dep_sync.py`; issue #4549 is that PR's deferred-findings follow-up. When #4541 merges, this PR will be retargeted to `main` and rebased to a single commit.

## Testing

- `test/test_dev_fleet_dep_sync.py`: 44 passed (9 new/extended locking tests, each mutation-verified against the pre-fix source by the pre-push reviewers).
- `black` / `isort` clean; `flake8` / `mypy` deltas zero vs base.
- Pre-push dual-model review: GPT round found 2 BLOCKING (removal-tolerated gap; `~=` micro truncation) — both fixed above. Opus round PASS with 4 advisories — all taken.

**Why no screenshot:** backend-only change to a headless sync helper (`dep_sync.py`); no UI surface is affected.