### PR TITLE
fix: gatewayd cannot spawn any pooled MCP backend -- log-only redact() fail-closes

### DIFF
--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -98,6 +98,14 @@ Core code reads adapters directly when it has the context, or via
 `current_context()` for module-level functions (e.g. `hooks.py` deny path).
 `current_context()` lazily builds the standalone default if boot has not run.
 
+`installed_context()` returns the INSTALLED context or `None` as a bare
+attribute read — it never resolves, never raises, and does no I/O. Use it ONLY
+where the answer for "no context" is already the conservative one (the
+exempt-host lookup below is the one such caller), because it skips the config
+load and entry-point discovery that `current_context()` performs on every call
+while unbooted. A caller that must honour a companion's policy has to go through
+`current_context()` and take the fail-closed `PlatformCompositionError`.
+
 ## Boot sequence
 
 ```python
@@ -382,12 +390,22 @@ delegates to that same global. Wired sites:
   `getattr(policy, "exempt_exact_hosts", None)` (a pre-method companion adapter
   degrades to the empty set) and is NEVER sourced from `config.json` — an
   agent-writable exemption would be a hole in the redaction ceiling, so the
-  companion adapter is the only supplier. Degrade semantics are INVERTED vs
-  `redact_via_context`'s baseline-redact fallback: a `PlatformCompositionError`
-  propagates fail-closed, but any other adapter failure degrades to
+  companion adapter is the only supplier. EVERY failure degrades to
   `frozenset()` — the empty set means MORE redaction (every host runs the
-  heuristics), the safe direction; NO logging on the degrade path (runs inside
-  the stdio MCP servers). **Deferred-import exception:** `security` reads the set
+  heuristics), the safe direction, and stricter than any companion-supplied list
+  could be; NO logging on the degrade path (runs inside the stdio MCP servers).
+  The set is read via `installed_context()`, so a process with no installed
+  context takes that same empty set WITHOUT resolving one: resolving would load
+  config and discover entry points per call, and on a non-standalone profile
+  `current_context()` never memoizes its fail-closed verdict, so a per-line
+  caller (`_pump_stderr` redacting backend stderr) would re-pay that synchronous
+  I/O for every line on the gateway event loop. This is deliberately INVERTED vs
+  `redact_via_context`, which must keep propagating: that seam SUBSTITUTES a
+  companion's redaction for the baseline, so a missing context there would fail
+  OPEN, whereas here it fails STRICTER. Because this lookup only ever RELAXES the
+  heuristics, it can never be the reason a credential reaches a log — the
+  credential pass (`redact_credentials`) is independent of it and unchanged by a
+  missing context. **Deferred-import exception:** `security` reads the set
   through a FUNCTION-LOCAL import of `kiro_crew.platform.context` (the `sel.py`
   pattern), so the CPP import-direction invariant holds — `platform/defaults.py`
   imports `security` at module load, and `security` never reaches `platform` at

--- a/src/kiro_crew/platform/context.py
+++ b/src/kiro_crew/platform/context.py
@@ -370,6 +370,24 @@ def set_context(ctx: PlatformContext) -> None:
     _ACTIVE = ctx
 
 
+def installed_context() -> Optional[PlatformContext]:
+    """The INSTALLED context, or ``None``. Never resolves, never raises, no I/O.
+
+    Unlike :func:`current_context` this is a bare attribute read: it does NOT
+    load config, does NOT discover plugin entry points, and does NOT compose the
+    standalone default. For a caller on a hot path whose answer for "no context"
+    is the same as its answer for "the default context", that resolution is pure
+    cost -- and on a NON-standalone profile it is unmemoized cost, because
+    ``current_context()`` deliberately never caches its fail-closed verdict, so
+    every call re-pays the config load before raising.
+
+    Use this ONLY where the no-context answer is already the conservative one.
+    A caller that must honour a companion's policy has to go through
+    ``current_context()`` and take the fail-closed error.
+    """
+    return _ACTIVE
+
+
 def current_context() -> PlatformContext:
     """Return the active context, lazily building the standalone default.
 

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -7044,19 +7044,41 @@ def _exempt_exact_hosts() -> frozenset[str]:
     CPP import-direction invariant (``platform/defaults.py`` imports ``security``
     at top level).
 
-    Degrade semantics (INVERTED vs ``redact_via_context``'s baseline-redact
-    fallback): ``PlatformCompositionError`` propagates fail-closed, but any other
-    adapter failure degrades to ``frozenset()`` — the empty set means MORE
-    redaction (every host runs the heuristics), the SAFE direction here.  A
-    pre-method companion adapter (no ``exempt_exact_hosts``) degrades to the empty
-    set via ``getattr`` rather than raising.  NO logging on the degrade path: this
-    runs inside the stdio MCP servers whose stray writes corrupt the JSON-RPC
-    stream.
+    Degrade semantics: EVERY failure degrades to ``frozenset()`` — the empty set
+    means MORE redaction (every host runs the heuristics), the SAFE direction
+    here, and it is stricter than any companion-supplied exemption list could
+    be.  This lookup can only ever RELAX the heuristics, so there is no
+    fail-closed to protect: propagating an error would convert "redact slightly
+    more aggressively" into "the calling operation aborts", which took down every
+    pooled MCP backend spawn in ``gatewayd`` (an unbooted worker that calls
+    ``redact()`` on the spawn-log and stderr-drain paths).  Deliberately INVERTED
+    vs ``redact_via_context``'s propagation: that seam substitutes a companion's
+    redaction for the baseline, so a missing context there must not fail open.
+
+    NO-CONTEXT FAST PATH: when no context is INSTALLED this returns the empty set
+    without resolving one, via ``installed_context()``.  That is not merely an
+    optimization, it is the only way to keep this off the event loop.  Resolving
+    would load config + discover plugin entry points, and on a non-standalone
+    profile ``current_context()`` never memoizes its fail-closed verdict, so a
+    per-line caller (``_pump_stderr`` redacting backend stderr) would re-pay that
+    synchronous I/O for every line.  The answer is unchanged either way: the
+    public ``DefaultCredentialPolicy`` exempts no hosts, so a lazily-composed
+    standalone default yields this same empty set, and an unbooted
+    non-standalone process must not be handed exemptions at all.
+
+    A pre-method companion adapter (no ``exempt_exact_hosts``) degrades to the
+    empty set via ``getattr`` rather than raising.  NO logging on the degrade
+    path: this runs inside the stdio MCP servers whose stray writes corrupt the
+    JSON-RPC stream.
     """
-    from kiro_crew.platform.context import PlatformCompositionError, current_context
+    from kiro_crew.platform.context import installed_context
+
+    ctx = installed_context()
+    if ctx is None:
+        return frozenset()
 
     try:
-        policy = current_context().credentials
+        policy = ctx.credentials
         getter = getattr(policy, "exempt_exact_hosts", None)
         if getter is None:
             return frozenset()
@@ -7068,8 +7090,6 @@ def _exempt_exact_hosts() -> frozenset[str]:
         # to maximum redaction. Keep only str members; anything malformed degrades
         # to the empty set (the SAFE direction — more redaction).
         return frozenset(h for h in raw if isinstance(h, str))
-    except PlatformCompositionError:
-        raise
     except Exception:
         return frozenset()
 

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -3103,15 +3103,62 @@ class TestExfilExactHostExemption:
         assert secret not in result
         assert len(warnings) == 1
 
-    def test_composition_error_propagates_fail_closed(self) -> None:
-        """PlatformCompositionError from the adapter propagates (fail-closed),
-        never degrading to an empty set silently."""
+    def test_unbooted_path_does_no_context_resolution(self) -> None:
+        """The unbooted path must not RESOLVE a context -- not even once.
+
+        ``current_context()`` loads config and discovers plugin entry points
+        before it decides, and on a non-standalone profile it never memoizes its
+        fail-closed verdict, so a per-line caller (``_pump_stderr`` redacting
+        backend stderr) would re-pay that synchronous I/O for every single line
+        on the gateway event loop.  Pin that this lookup never reaches it: the
+        answer for "no context installed" is the same empty set the standalone
+        default would give, so resolving is pure cost.
+        """
+        import pytest as _pytest
+
+        from kiro_crew.config.loader import KiroCrewConfig
+        from kiro_crew.platform import context as context_mod
+        from kiro_crew.platform.context import reset_context
+        from kiro_crew.security import redact
+
+        calls: list[str] = []
+        real_current = context_mod.current_context
+        real_load = KiroCrewConfig.load
+
+        with _pytest.MonkeyPatch.context() as mp:
+            mp.setenv("KIROCREW_PROFILE", "enterprise")
+            reset_context()
+
+            def _spy_current():  # type: ignore[no-untyped-def]
+                calls.append("current_context")
+                return real_current()
+
+            def _spy_load(*a, **k):  # type: ignore[no-untyped-def]
+                calls.append("config_load")
+                return real_load(*a, **k)
+
+            mp.setattr(context_mod, "current_context", _spy_current)
+            mp.setattr(KiroCrewConfig, "load", _spy_load)
+            try:
+                # Redact many lines, as a stderr drain would.
+                for _ in range(25):
+                    redact("boot line https://example.com/mcp")
+                assert calls == [], f"unbooted path resolved a context: {calls}"
+            finally:
+                reset_context()
+
+    def test_composition_error_degrades_to_full_redaction(self) -> None:
+        """PlatformCompositionError from the adapter degrades to the empty set =
+        full redaction, and MUST NOT propagate: this lookup can only ever RELAX
+        the heuristics, so the empty set is already the strictest answer.
+        Propagation aborted the calling operation (issue #4561: every pooled MCP
+        backend spawn in gatewayd died building its own log line)."""
         import dataclasses
 
         from kiro_crew.config import KiroCrewConfig
         from kiro_crew.platform.bootstrap import build_default_context
         from kiro_crew.platform.context import PlatformCompositionError, set_context
-        from kiro_crew.security import scan_exfiltration_urls
+        from kiro_crew.security import redact_exfiltration_urls
 
         class _RaisingCredentialPolicy(self._StubCredentialPolicy):
             def exempt_exact_hosts(self) -> "frozenset[str]":
@@ -3119,8 +3166,51 @@ class TestExfilExactHostExemption:
 
         base = build_default_context(KiroCrewConfig())
         set_context(dataclasses.replace(base, credentials=_RaisingCredentialPolicy(frozenset())))
-        with pytest.raises(PlatformCompositionError):
-            scan_exfiltration_urls("https://contoso.sharepoint.com/doc?nav=eyJ" + "A" * 220)
+        url = self._long_nav_url("contoso.sharepoint.com")
+        result, warnings = redact_exfiltration_urls(f"Doc: {url}")
+        assert "[REDACTED" in result
+        assert len(warnings) == 1
+
+    def test_unbooted_nonstandalone_profile_still_redacts(self) -> None:
+        """Regression for issue #4561: ``redact()`` in an UNBOOTED worker under a
+        non-standalone profile must not raise.
+
+        ``gatewayd`` never installs a ``PlatformContext``; under
+        ``KIROCREW_PROFILE=enterprise`` ``current_context()`` fail-closes, and
+        the exempt-host lookup inside ``redact()`` used to propagate that error,
+        killing every pooled MCP backend spawn while it built the spawn log
+        line.  The lookup must degrade to the empty set (maximum redaction)
+        instead: the log line is still fully redacted, the operation survives.
+        """
+        import pytest as _pytest
+
+        from kiro_crew.platform.context import (
+            PlatformCompositionError,
+            current_context,
+            reset_context,
+        )
+        from kiro_crew.security import redact
+
+        with _pytest.MonkeyPatch.context() as mp:
+            mp.setenv("KIROCREW_PROFILE", "enterprise")
+            reset_context()
+            try:
+                # Precondition: the context itself still fail-closes (that
+                # contract is unchanged; only the exempt-host lookup degrades).
+                with _pytest.raises(PlatformCompositionError):
+                    current_context()
+                # The gatewayd spawn-log call shape: must not raise. Compare the
+                # WHOLE line rather than asking whether it contains the host --
+                # equality proves nothing was redacted away, and a bare host
+                # substring test is the incomplete-URL-sanitization pattern.
+                line = "cmd --flag https://example.com"
+                assert redact(line) == line
+                # Heuristic-tripping URL is still redacted (empty exempt set =
+                # maximum strictness, never fail-open).
+                url = self._long_nav_url("contoso.sharepoint.com")
+                assert "[REDACTED" in redact(f"Doc: {url}")
+            finally:
+                reset_context()
 
     def test_adapter_failure_degrades_to_full_redaction(self) -> None:
         """A transient (non-composition) adapter failure degrades to the empty


### PR DESCRIPTION
## 1. What is the problem?

When `mcp_gateway/gatewayd.py` runs under any profile other than `standalone`,
**every** pooled MCP backend spawn fails with `PlatformCompositionError` and no backend
is ever created. The exception is raised while evaluating an argument to a `logger.info`
call: `spawn_backend()` builds its "spawning backend" line with
`redact(" ".join(args))`, and `redact()` transitively reaches
`current_context()`, which `gatewayd` never installs.

```
File ".../mcp_gateway/backend.py", in spawn_backend
    pool_key.human_readable(), command, redact(" ".join(args)),
File ".../security.py", in _exempt_exact_hosts
    policy = current_context().credentials
File ".../platform/context.py", in current_context
    raise PlatformCompositionError(...)
```

## 2. Why this issue matters to the user

MCP pooling is not merely bypassed on such a host -- it is fully broken, and the failure
looks unrelated to pooling. Servers the rewriter leaves *unwrapped* (for instance because
they declare `env` while `mcp_gateway.forward_declared_env` is off) are spawned directly
by the session and keep working, so the operator sees "some MCP servers work, some
silently have no tools", with the error visible only in the daemon's own stdout log and
not in the session. Turning **on** `forward_declared_env` -- normally a RAM improvement --
makes it worse: previously-working servers become poolable, get wrapped, and die too.

## 3. How our fix solves it

Chain from symptom to root cause:

- Symptom: zero pooled MCP backends spawn; `ensure_backend internal error` per server.
- Immediate cause: `spawn_backend()` calls `redact()` to format a log argument.
- Transitive cause: `redact()` -> `redact_exfiltration_urls()` ->
  `scan_exfiltration_urls()` -> `_exfil_exempt_hosts()` -> `_exempt_exact_hosts()` ->
  `current_context().credentials`.
- Root cause: `_exempt_exact_hosts()` re-raised `PlatformCompositionError` instead of
  degrading, and `current_context()` correctly fail-closes in an unbooted worker under a
  non-standalone profile.

The fix has three parts, all in the same seam:

1. `_exempt_exact_hosts()` no longer re-raises `PlatformCompositionError` -- every
   failure degrades to `frozenset()`, as it already did for any other adapter failure.
2. It reads the context through a NEW zero-I/O accessor,
   `platform.context.installed_context()`, instead of `current_context()`. This is a
   new public function; it returns the installed context or `None` as a bare attribute
   read, never resolving and never raising.
3. A no-context early return, so an unbooted process takes the empty set without
   resolving a context at all.

Part 2 is not cosmetic. `current_context()` loads config and discovers plugin entry
points before it decides, and on a non-standalone profile it deliberately never
memoizes its fail-closed verdict, so every call re-pays that synchronous I/O. Once the
fix lets the stderr drain survive, `_pump_stderr` redacts every backend stderr line, and
with only part 1 it would re-pay that load per line on the gateway event loop. Parts 2
and 3 remove the I/O rather than trading the outage for it. The answer is unchanged
either way, because the public `DefaultCredentialPolicy` exempts no hosts, so a lazily
composed standalone default yields the same empty set.

This does not weaken redaction anywhere. The lookup returns hosts that SKIP the
base64-blob / query-length heuristics, so it can only ever RELAX them -- the empty set is
already the strictest possible answer, stricter than any companion-supplied list. What
propagation actually bought was not extra safety but "the calling operation aborts".

Deliberately NOT changed:

- `current_context()` keeps fail-closing. That contract is right and the regression test
  asserts it still holds.
- `redact_via_context` keeps propagating. That seam substitutes a companion's redaction
  for the baseline, so a missing context there would fail OPEN. Here it fails STRICTER --
  the inversion is the point, and the docstring now states it.
- `safe_context_call` was not used: it also re-raises `PlatformCompositionError` by
  design, so routing through it would not change the outcome.
- The credential pass is untouched. `redact_credentials()` never consults the context
  on any host -- `security.py`'s only context reads are the unrelated governance
  ceiling and this exempt-host lookup -- so companion credential patterns were never
  reachable from `security.redact()`, booted or not. Callers that need companion-grade
  redaction go through `redact_via_context`. A missing context therefore cannot cause a
  credential to reach a log via this path.

Two follow-ups from the issue are left out of scope on purpose: installing a
`PlatformContext` in `gatewayd.main()` (option B) needs a ruling on whether composition
failure should be fatal at daemon startup, and removing `redact()` from log-argument
construction (option C) is hardening rather than a root-cause fix. Either can land
independently on top of this.

## 4. What tests we did

- Flipped `test_composition_error_propagates_fail_closed` to
  `test_composition_error_degrades_to_full_redaction`: it now pins the new contract --
  the adapter raising `PlatformCompositionError` yields FULL redaction, not an abort.
- Added `test_unbooted_nonstandalone_profile_still_redacts`, a direct regression for the
  reported failure: with `KIROCREW_PROFILE=enterprise` and no installed context, it first
  asserts `current_context()` still raises (the unchanged contract), then asserts the
  `gatewayd` call shape `redact("cmd --flag https://example.com")` returns instead of
  raising, and that a heuristic-tripping URL is still `[REDACTED` (no fail-open).
- Added `test_unbooted_path_does_no_context_resolution`, which spies on
  `current_context` and `KiroCrewConfig.load` and asserts ZERO calls across 25
  `redact()` calls -- pinning that the per-line event-loop I/O is gone and cannot
  regress.
- Measured the two states directly to check whether a missing context weakens
  redaction. Credential output is byte-identical with and without a context; the only
  difference a context makes is that a companion exempt-host list lets a
  heuristic-tripping URL through UNREDACTED. The no-context empty set is therefore the
  stricter of the two states.
- Drove the real daemon spawn path under `KIROCREW_PROFILE=enterprise` with no
  installed context: a backend subprocess spawns with the fix and dies with
  `PlatformCompositionError` without it.
- `docs/system-specs/modules/platform-context.md` updated in the same commit: it had
  documented the removed propagation as the contract, and did not mention the new
  accessor.
- Mutation-verified: restoring the `except PlatformCompositionError: raise` branch turns
  both tests red, and the regression test fails with the exact error from the issue
  (`profile resolved to 'enterprise'`).
- `test_security.py`, `test_platform_context.py`, `test_cpp_seam_failclosed.py`,
  `test_redaction_mirror_parity.py`, `test_redact_meta_snapshot.py`: 642 passed, 1
  skipped.
- Checked no other suite pinned the old behaviour:
  `test_cross_surface_mirror.py`, `test_governance_chokepoints.py`,
  `test_governance_policy.py`, `test_update_provider.py` -- 366 passed. The surviving
  `test_composition_error_propagates` there is on the governance plane, which is
  untouched.
- Gates: `black` (26.3.1, baseline-aware `scripts/check_black_formatting.py` passes; no
  hunk falls in the changed regions), `isort`, `flake8`, `mypy` all clean.

## 5. Any other suggestions on the work

The issue's three maintainer questions still stand and are worth a ruling independently of
this PR: whether `redact()` is meant to be usable with no context installed, whether
worker entrypoints such as `gatewayd` should be required to install one at startup, and
whether CI should exercise `gatewayd` under a non-standalone profile at all -- the absence
of that coverage is why a total pooling outage went unnoticed, since everything works
under `standalone`.

Fixes #4561

