### PR TITLE
fix(palette): use backend order as sessions score tiebreak (#4568)

### DIFF
--- a/website/src/components/commandPalette/providers/sessionsProvider.test.ts
+++ b/website/src/components/commandPalette/providers/sessionsProvider.test.ts
@@ -13,8 +13,9 @@ import {
  * mock `fetchSessions` + open spies — no React hooks, React-Query, or Redux.
  *
  * The provider keeps backend hits even when the client-side fuzzy pass does not
- * match (score 0), so test data is crafted so each result set has distinct
- * scores (the `compareByScoreThenName` sort only inspects names on a tie).
+ * match (score 0); ties in score fall back to the BACKEND's returned order
+ * (issue #4568), so test data either crafts distinct scores or asserts the
+ * response order directly.
  */
 
 function deps(over: Partial<SessionsProviderDeps> = {}): {
@@ -255,6 +256,53 @@ describe('createSessionsProvider — folder-fetch failure is distinct from searc
     const p = createSessionsProvider(d)
 
     await expect(p.search('my')).rejects.toThrow('search down')
+  })
+})
+
+describe('createSessionsProvider — backend relevance order is the score tiebreak (issue #4568)', () => {
+  it('preserves backend order for body-only hits (all scores 0) instead of alphabetizing', async () => {
+    // Titles are in REVERSE-alphabetical order and share no characters with the
+    // query, so every row is a body hit with score 0. The backend ranked these
+    // by relevance (search_sessions weighting); the old name tiebreak returned
+    // them alphabetized ('Alpha…' first). The response order must come back
+    // untouched — the clearest user-visible case is searching a PR/issue
+    // number, which lives in transcripts but almost never in a title.
+    const fetchSessions = vi.fn(
+      async (): Promise<SessionSearchResponse> => ({
+        sessions: [
+          { key: 'z', title: 'Zebra rollout', snippet: 'discussed 4568 here' },
+          { key: 'm', title: 'Muffin sync', snippet: 'follow-up on 4568' },
+          { key: 'a', title: 'Alpha rollout', snippet: '4568 mentioned once' },
+        ],
+      }),
+    )
+    const { d } = deps({ fetchSessions })
+    const results = await createSessionsProvider(d).search('4568')
+    expect(results).toHaveLength(3)
+    expect(results.every(r => r.score === 0)).toBe(true)
+    // Backend order, NOT ['Alpha rollout', 'Muffin sync', 'Zebra rollout'].
+    expect(results.map(r => r.title)).toEqual(['Zebra rollout', 'Muffin sync', 'Alpha rollout'])
+  })
+
+  it('still ranks a title match first even when the backend returned it last (bias preserved)', async () => {
+    // The title-match-first bias is deliberate and must survive the tiebreak
+    // change: a title hit outranks body-only hits regardless of backend index.
+    const fetchSessions = vi.fn(
+      async (): Promise<SessionSearchResponse> => ({
+        sessions: [
+          { key: 'b1', title: 'Unrelated alpha', snippet: 'body mentions grid' },
+          { key: 'b2', title: 'Unrelated beta', snippet: 'grid again' },
+          { key: 't', title: 'grid work' },
+        ],
+      }),
+    )
+    const { d } = deps({ fetchSessions })
+    const results = await createSessionsProvider(d).search('grid')
+    expect(results).toHaveLength(3)
+    expect(results[0].title).toBe('grid work')
+    expect(results[0].score).toBeGreaterThan(0)
+    // The remaining body-only rows keep their backend order between themselves.
+    expect(results.slice(1).map(r => r.title)).toEqual(['Unrelated alpha', 'Unrelated beta'])
   })
 })
 

--- a/website/src/components/commandPalette/providers/sessionsProvider.ts
+++ b/website/src/components/commandPalette/providers/sessionsProvider.ts
@@ -8,7 +8,7 @@ import { api } from '../../../api/client'
 import { useAppDispatch, useAppSelector } from '../../../store'
 import { resumeFromHistory } from '../../../store/chatSlice'
 import { useSelectInstance } from '../../../hooks/useSelectInstance'
-import { fuzzyMatch, makeScoreThenNameComparator, substringIndices } from '../../../utils/fuzzyMatch'
+import { fuzzyMatch, substringIndices } from '../../../utils/fuzzyMatch'
 import { i18nT } from '../../../i18n/t'
 import type { Result, ResourceProvider } from '../types'
 
@@ -164,7 +164,12 @@ export function createSessionsProvider(deps: SessionsProviderDeps): ResourceProv
         fid ? folders.find((f) => f.id === fid)?.name : undefined
       const sessions = data?.sessions ?? []
 
-      const results: Result[] = sessions.map((s) => {
+      // Backend position per row id, used as the sort tiebreak below. Kept in a
+      // parallel Map rather than on the row itself so the shared `Result` type
+      // (../types) is not widened with a field only this provider can populate.
+      const backendIndexById = new Map<string, number>()
+
+      const results: Result[] = sessions.map((s, backendIndex) => {
         const title = s.title || s.key
         // Highlight + client-side rank bias; never used to drop backend hits.
         const match = fuzzyMatch(q, title)
@@ -193,8 +198,10 @@ export function createSessionsProvider(deps: SessionsProviderDeps): ResourceProv
               ? subIdx.map((i) => i + prefix.length)
               : subIdx
             : undefined
+        const id = remote ? `${PROVIDER_ID}:${s.instance_id}:${s.key}` : `${PROVIDER_ID}:${s.key}`
+        backendIndexById.set(id, backendIndex)
         return {
-          id: remote ? `${PROVIDER_ID}:${s.instance_id}:${s.key}` : `${PROVIDER_ID}:${s.key}`,
+          id,
           providerId: PROVIDER_ID,
           title,
           subtitle,
@@ -221,11 +228,23 @@ export function createSessionsProvider(deps: SessionsProviderDeps): ResourceProv
         }
       })
 
-      // Title matches first, then deterministic name order. Skip the re-rank on
-      // an empty query so the backend's recency ordering is preserved (Sessions
-      // tab + All-tab recents rely on it).
+      // Title matches first, then the BACKEND's relevance order as the tiebreak
+      // (issue #4568). `search_sessions` already ranked these rows (weighted
+      // occurrence counts, phrase bonus, recency boost); an alphabetical
+      // fallback threw that ranking away whenever every hit was a body match
+      // (all scores 0 — e.g. searching a PR number that appears in transcripts
+      // but never in a title). Backend index is just as deterministic for
+      // rendering, and strictly more useful. Deliberately NOT the shared
+      // `makeScoreThenNameComparator`: its name tiebreak is right for the nine
+      // providers that score locally, wrong here where the server has already
+      // ranked. Skip the re-rank on an empty query so the backend's recency
+      // ordering is preserved as-is (Sessions tab + All-tab recents rely on it).
       if (q.length > 0) {
-        results.sort(makeScoreThenNameComparator<Result>(r => r.score, r => r.title))
+        results.sort(
+          (a, b) =>
+            b.score - a.score ||
+            (backendIndexById.get(a.id) ?? 0) - (backendIndexById.get(b.id) ?? 0),
+        )
       }
       return results
     },


### PR DESCRIPTION
## Problem / Motivation

The Search Everywhere command palette's **Sessions** tab throws away the relevance order that `/api/sessions/search` computed whenever the hits are body matches rather than title matches. The clearest user-visible case: searching a PR or issue number. The number is almost never in a session title, so every row is a body-only hit, every client-side fuzzy score is 0, and the session that actually owns that PR lands wherever the alphabet puts it.

## Why it matters

The discarded ordering is real work: `ConversationLog.search_sessions` (`history.py`) applies weighted per-needle occurrence counts, length normalization, a title field boost, a phrase bonus and a bounded recency boost. The same ranking already backs the dashboard history filter, the `search_chat_history` MCP tool and Discord resume — and ChatSidebar search renders it correctly. The palette was the one consumer alphabetizing it away, so the most relevant session for a body-only query could land at the bottom of the list.

## What changed (motivation → approach → change)

- **Symptom:** body-only hits come back alphabetized by title instead of by backend relevance.
- **Root cause:** the provider scores rows with `fuzzyMatch(q, title)` (0 for every body-only hit) and sorts with the shared `makeScoreThenNameComparator`, whose tiebreak is `localeCompare` on the title. With an all-zero score column, the tiebreak IS the order.
- **Change:** keep the deliberate title-match-first bias, but tiebreak by the backend's returned index instead of the title. The index is captured while mapping (`sessions.map((s, backendIndex) => …)`) and carried in a parallel `Map` keyed by result id, so the shared `Result` type is not widened with a field only this provider can populate. The sort in this provider becomes `score desc, then backend index asc`.
- **Deliberately untouched:** `makeScoreThenNameComparator` in `website/src/utils/fuzzyMatch.ts` — nine other palette providers (skills, settings, prompts, pages, knowledge, artifacts, apps, actions, allAggregator) score locally and depend on its name tiebreak; changing the shared helper would silently re-rank unrelated tabs. The `q.length === 0` short-circuit is also unchanged: the empty-query recents path already preserves backend recency order and keeps doing so.
- Backend index is exactly as deterministic for rendering as the alphabetical tiebreak was, while being strictly more useful.

## Tests

Extended `sessionsProvider.test.ts` (both new tests fail on the old comparator):
- **Body-only query preserves backend order:** a mocked `fetchSessions` response whose titles are in reverse-alphabetical order, queried with a string none of the titles contain (all scores 0), must come back in the response order — not alphabetized.
- **Title-match bias preserved:** a title hit returned LAST by the backend must still rank first (score outranks backend index), and the remaining body-only rows keep their backend order between themselves.

Full local gates: `npx tsc -b` clean, full `npx vitest run` (21856 tests, includes `sessionsProvider.hook.test.tsx` and `CommandPalette.test.tsx` which also exercise this provider), plus backend `isort`/`flake8`/`mypy`/`pytest` (57126 passed) — all green.

## Manual verification

N/A — unit coverage sufficient: the change is a pure comparator swap inside one provider, and the regression tests assert the exact observable contract (result order) through the provider's public `search()`.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** ordering-only change — every row renders pixel-identically; only which rows come first differs, which a static screenshot cannot demonstrate. The regression tests assert the exact order contract instead.

## Related Issues

Closes #4568

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior documented in code comments
- [x] No secrets, credentials, or internal references in the diff

