### PR TITLE
ci: stop the e2e chromium install eating the job budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1503,9 +1503,53 @@ jobs:
           mkdir -p src/kiro_crew/static
           cp -R website/dist src/kiro_crew/static/dist
 
-      - name: Install Playwright browser (Chromium)
+      # The browser install is the single largest source of red on this job, and
+      # never because a test failed: across 112 consecutive E2E jobs the
+      # conclusions were 76 success / 36 cancelled / 0 failure, and 22 of those
+      # cancels trace to this step. `--with-deps` runs `apt-get update` first, and
+      # when the runner's default mirror (azure.archive.ubuntu.com) answers `Ign:`
+      # apt falls back to archive.ubuntu.com and stalls silently -- observed at
+      # 23min, 15min and 12min, against a 25min job budget that then has nothing
+      # left for the specs.
+      #
+      # `--with-deps` is dropped rather than retried because it buys nothing this
+      # gate asserts on. Every shared library Chromium needs is already on the
+      # ubuntu-latest image (the apt log reports libnss3, libx11-6, libxcb1,
+      # libasound2 and libxkbcommon0 as `already the newest version`); the only
+      # packages it newly installs are 9 CJK/Thai/Cyrillic font packages. The suite
+      # has no pixel comparison (no toHaveScreenshot / toMatchSnapshot anywhere
+      # under website/), playwright.config.ts pins `locale: 'en-US'` so every spec
+      # renders the English catalog, and the i18n render gate below reads
+      # textContent rather than measuring geometry. A future spec that asserts
+      # glyph METRICS for a non-Latin script would need those fonts back -- add
+      # them as their own bounded, non-fatal step, not by restoring `--with-deps`.
+      #
+      # The version key must be exact: a restore-key prefix could hand the job a
+      # different Chromium revision than @playwright/test expects.
+      - name: Resolve Playwright version
+        id: playwright-version
         working-directory: website
-        run: npx playwright install --with-deps chromium
+        run: |
+          version="$(node -p \
+            "require('./package-lock.json').packages['node_modules/@playwright/test'].version")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
+
+      # Runs unconditionally rather than behind `cache-hit != 'true'`: on a hit it
+      # is a ~2s no-op, and that keeps a partially-written cache entry from turning
+      # into a missing-browser failure inside the specs.
+      - name: Install Playwright browser (Chromium)
+        # A step-level cap. The download itself takes ~7s, so anything approaching
+        # this is a stalled mirror or CDN -- fail here with budget left for the
+        # specs instead of consuming the job's 25min and reporting nothing.
+        timeout-minutes: 6
+        working-directory: website
+        run: npx playwright install chromium
 
       - name: i18n render-time gate (en-XA + shipped locales)
         # Phase 5 of the i18n plan. Every other i18n gate reads SOURCE or CATALOG

--- a/docs/ci/e2e-gate.md
+++ b/docs/ci/e2e-gate.md
@@ -93,7 +93,7 @@ Config facts worth knowing before you touch a spec:
 | `retries` | 2 under `CI` | Absorbs gateway-load timeout flakes. |
 | `timeout` | 30s per test | Assertion (`expect`/`poll`) timeout stays at Playwright's 5s default so a genuine slowdown surfaces instead of passing inside a wide window. |
 | `grepInvert` | excludes `@needs-agent` unless `PLAYWRIGHT_RUN_AGENT_SPECS` | The default run is the credential-less green set. The harness wires the fake backend, so it opts the agent specs back in. `@needs-live-agent` stays excluded either way and currently tags nothing. |
-| browser | Playwright's own bundled Chromium | This fork vends no browser binary; CI installs it with `npx playwright install --with-deps chromium`. |
+| browser | Playwright's own bundled Chromium | This fork vends no browser binary; CI installs it with `npx playwright install chromium`, restored from an `actions/cache` entry keyed on the exact `@playwright/test` version. `--with-deps` is deliberately NOT used — see [what CI does](#what-ci-does-around-the-command). |
 
 ### Auth flow
 
@@ -161,6 +161,30 @@ with `--group dev`, runs `npm ci` and `npm run build` in `website/`, stages
 bundled dashboard rather than a 404, installs Chromium, runs the i18n render-time
 gate (which reuses that Chromium install), and finally runs `python setup.py
 test_e2e`.
+
+### The browser install is budgeted, and installs no apt packages
+
+The job's ceiling is `timeout-minutes: 25`, and the browser install is the step
+that historically consumed it. It carries three constraints, all in service of
+leaving the specs enough of that budget to actually run:
+
+- **`~/.cache/ms-playwright` is cached**, keyed on the exact `@playwright/test`
+  version read out of `website/package-lock.json`. The key has no restore-key
+  prefix on purpose: a near-miss would hand the job a Chromium revision that
+  `@playwright/test` does not expect.
+- **`--with-deps` is not used.** It runs `apt-get update` first, and when the
+  runner's default mirror answers `Ign:` apt falls back and stalls — measured at
+  23, 15 and 12 minutes. It also buys nothing this gate asserts on: every shared
+  library Chromium needs is already on the `ubuntu-latest` image, and the only
+  packages it newly installs are 9 CJK/Thai/Cyrillic font packages. There is no
+  pixel comparison anywhere under `website/`, `locale` is pinned to `en-US`, and
+  the render gate reads `textContent` rather than measuring geometry. A spec that
+  asserts glyph **metrics** for a non-Latin script would need those fonts back —
+  as its own bounded, non-fatal step, not by restoring `--with-deps`.
+- **`timeout-minutes: 6` on the step.** The download is ~7s and a cache hit is a
+  no-op, so anything near the cap is a stalled mirror or CDN. Failing there
+  reports the real cause while the job still has budget, instead of the job
+  timing out having run zero specs.
 
 Related: [i18n-gates.md](i18n-gates.md) for the render-time gate that shares this
 job, and [ci-and-reviews.md](ci-and-reviews.md) for where `e2e` sits among the


### PR DESCRIPTION
## The E2E gate does not fail. It runs out of time.

Across the last **112 consecutive `E2E (stub ACP backend, offline)` jobs**:

| conclusion | count |
|---|---|
| success | 76 |
| cancelled | 36 |
| **failure** | **0** |

Not one test failed. Every red is the 25-minute job budget being consumed, and **22 of the 36 cancels trace to one step**: `npx playwright install --with-deps chromium`.

## Where the time goes

From run `32271335627`, the install step's own log:

```
15:45:55  Get:1 file:/etc/apt/apt-mirrors.txt
15:46:26  Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease   <- runner's default mirror unreachable
15:46:33  Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease        <- apt falls back
          ... 22 minutes 36 seconds of no output ...
16:09:09  Terminate orphan process: pid (2582) (npm exec playwright install --with-deps chromium)
```

`--with-deps` runs `apt-get update` before anything else. When the runner's default mirror answers `Ign:`, apt silently falls back to the public archive and stalls. Measured across runs: **23.2m** (`32271335627`), **23.3m** (`32271033202`), **23.1m** (`32268915463`), and partial stalls of **15.2m** / **14.7m** / **12.6m** that let the install finish but left too little budget for the i18n render gate plus the specs (`32268474474`, `32267219455`, `32268751093` — all 25.2m totals).

19 cancels died *inside* this step; 3 more died in `Run E2E` after it had already eaten 12–15 minutes. The remaining cancels are ordinary `cancel-in-progress` supersession, not failures.

## Why `--with-deps` is dropped rather than retried

It installs nothing this gate depends on. From a **successful** run's apt log (`32263441944`):

- Every shared library Chromium needs is already on the `ubuntu-latest` image — `libnss3`, `libx11-6`, `libxcb1`, `libasound2`, `libxkbcommon0`, `libfreetype6`, `libfontconfig1`, `fonts-liberation` all report `is already the newest version`.
- `0 upgraded, 9 newly installed` — and all 9 are fonts: `fonts-wqy-zenhei`, `fonts-ipafont-gothic`, `xfonts-cyrillic`, `fonts-unifont`, `fonts-freefont-ttf`, `fonts-tlwg-loma-otf`, `xfonts-encodings`, `xfonts-utils`, `xfonts-scalable`.
- The Chromium download itself takes **7 seconds** (`14:26:17` → `14:26:24`).

Those fonts cannot change a verdict in this suite:

- **No pixel comparison exists.** `toHaveScreenshot` / `toMatchSnapshot` have zero occurrences anywhere under `website/`.
- **`playwright.config.ts` pins `locale: 'en-US'`**, so every spec renders the English catalog. Latin glyphs come from `fonts-liberation`, already present.
- **The i18n render gate reads text, not geometry.** `scripts/check-i18n-render.mjs` has no `getBoundingClientRect` / `scrollWidth` / `offsetWidth` / `clientWidth` call — it reads `textContent`, which font availability does not affect.
- The 8 geometry assertions that do exist (`sidebar-folder-alignment`, `session-tags-e2e`, `session-tags-folders`) measure container widths, indentation x-offsets and drag-drop centre points — never text extent, and never non-Latin script.

A future spec asserting glyph **metrics** for a non-Latin script would need those fonts back. Both the workflow comment and `docs/ci/e2e-gate.md` say so, and say to add them as their own bounded non-fatal step rather than by restoring `--with-deps`.

## The three changes

1. **Cache `~/.cache/ms-playwright`**, keyed on the exact `@playwright/test` version read from `website/package-lock.json` (currently `1.58.2`). No restore-key prefix: a near-miss would hand the job a Chromium revision the test runner does not expect. Reuses the `actions/cache` SHA already pinned in this workflow.
2. **`npx playwright install chromium`** — no apt leg. The install still runs unconditionally rather than behind `cache-hit != 'true'`, because on a hit it is a ~2s no-op and that keeps a partially written cache entry from becoming a missing-browser failure inside the specs.
3. **`timeout-minutes: 6` on the step.** The download is ~7s and a cache hit is a no-op, so anything near the cap is a stalled mirror or CDN. Failing there names the real cause while the job still has budget, instead of the job timing out having run zero specs.

`timeout-minutes: 25` on the job is unchanged. Raising it would have hidden this.

## Verification

- `python3 -c "yaml.safe_load(...)"` — parses; step order and the single `timeout-minutes: 6` confirmed on the right step.
- `node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version"` → `1.58.2`.
- `scripts/docs-lint.sh` — 213 files, pass.
- `scripts/scrub-lint.sh` — pass.
- `scripts/check_brand_name.py` (`BRAND_BASE_REF=origin/main`) — pass.
- `scripts/check_harness_parity.py` — pass.
- `pytest test/test_browser_recording_skill.py test/test_spawn_audit.py` — 24 passed, 1 skipped. These are the only tests that reference `playwright install`; neither pins the workflow's command string. `test_browser_recording_skill.py:56` already asserts the no-`--with-deps` form for the skill body, so that spelling is existing precedent in this repo.

**Not verified locally, deliberately:** that Chromium launches without `--with-deps` on `ubuntu-latest`. This desk is not that image, so a local run would prove nothing about it. The evidence is the runner's own apt log reporting every required library as already installed, and the E2E job on this PR is the real test.

## Risk

If some library genuinely turns out to be missing on the runner, this job fails fast with a Chromium launch error naming the library, in the first few minutes rather than at minute 25 — a strictly better failure than the one being fixed, and revertible by restoring one flag.
