### PR TITLE
fix(chat): anchor preserved reasoning on the following tool call

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1169,33 +1169,61 @@ const OUT_OF_BAND_ROLES = new Set(['permission', 'queued', 'error', 'mcp_oauth']
 const isOutOfBandRow = (m: { role: string; kind?: string }): boolean =>
   OUT_OF_BAND_ROLES.has(m.role) || m.kind === 'stop_event'
 
+/** What a preserved reasoning block re-attaches to on the server-refreshed list:
+ *  a tool call addressed by its server-minted id, or a run of answer text
+ *  addressed by its content. */
+type ThinkingAnchor = { tool: string; text?: undefined } | { tool?: undefined; text: string }
+
 /** Re-insert client-only reasoning (`thinking`) messages into a server-refreshed
  *  message list. The backend never persists reasoning, so a refresh (e.g. the
  *  one fired on chat_done) would otherwise drop the thinking block the instant a
- *  turn finishes. Each preserved block is anchored to the assistant message that
- *  immediately followed it in the old list (matched by finalized content) and
- *  re-inserted just before it. At most one reasoning block per assistant. Any
- *  block whose anchor isn't found is appended so it is never silently lost.
- *  Returns `incoming` unchanged (reference-equal) when there is nothing to
- *  preserve. */
+ *  turn finishes. Each preserved block is anchored to the first row that followed
+ *  it in the old list and re-inserted just before that row again. Any block whose
+ *  anchor isn't found is appended so it is never silently lost. Returns
+ *  `incoming` unchanged (reference-equal) when there is nothing to preserve.
+ *
+ *  The anchor is the FOLLOWING TOOL CALL's `tool_call_id` when there is one, and
+ *  the following answer text only otherwise. A tool id is the sharper key and
+ *  the only one that scales: `_tool_meta` mints it server-side and persists it on
+ *  the tool row, so it survives into history and reads back identically on a
+ *  historical replay. Answer content does not scale, because a turn that reasons
+ *  before each of N tool calls emits no text at those boundaries — the backend's
+ *  segment flush is gated on pending text (`chat_runner._flush_segment`, called
+ *  under `if not in_tool_group and assistant_text`) — so history holds ONE
+ *  assistant row for all N bursts. Anchoring every burst on that single row let
+ *  exactly one land and parked the other N-1 at the tail, below the answer and
+ *  its footer, as a column of collapsed rows that read as duplicates (#4218).
+ *
+ *  Bursts and anchors are 1:1 under the tool rule: burst k is followed by tool k,
+ *  and the final burst by the answer. An auto-approved call emits two tool rows
+ *  sharing one id (🔧 pre-approval + ✅ post-approval, see
+ *  `applyToolOutputToMessages`); `used` makes the first win, which is the earlier
+ *  row and so the correct side of the pair. */
 function mergePreservedThinking<M extends { role: string; content: string; cls?: string; meta?: Record<string, unknown> }>(
   existing: M[],
   incoming: M[],
 ): M[] {
-  const preserved: Array<{ msg: M; anchor: string | null }> = []
+  const toolAnchorId = (m: M): string => {
+    if (m.role !== 'tool') return ''
+    const id = m.meta?.tool_call_id
+    return typeof id === 'string' ? id : ''
+  }
+  const preserved: Array<{ msg: M; anchor: ThinkingAnchor | null }> = []
   for (let i = 0; i < existing.length; i++) {
     const m = existing[i]
     if (m.role !== 'thinking' || !m.content) continue
-    let anchor: string | null = null
+    let anchor: ThinkingAnchor | null = null
     for (let j = i + 1; j < existing.length; j++) {
-      const r = existing[j].role
-      if (r === 'assistant' || r === 'streaming') { anchor = existing[j].content.trimEnd(); break }
-      // A confirmed steer does not end this block's turn, so the assistant row
-      // after it is still its anchor. Breaking here instead leaves `anchor`
-      // null, and an unanchored block is appended at the tail — below the answer
-      // and its footer — where the forward scan can never reach an assistant row
-      // again, so it stays there and is re-appended on every later refresh.
-      if (isTurnBoundaryUser(existing[j])) break
+      const cand = existing[j]
+      const tid = toolAnchorId(cand)
+      if (tid) { anchor = { tool: tid }; break }
+      if (cand.role === 'assistant' || cand.role === 'streaming') { anchor = { text: cand.content.trimEnd() }; break }
+      // A confirmed steer does not end this block's turn, so the row after it is
+      // still its anchor. Breaking here instead leaves `anchor` null, and an
+      // unanchored block is appended at the tail — below the answer and its
+      // footer — where the forward scan can never reach an anchorable row again,
+      // so it stays there and is re-appended on every later refresh.
+      if (isTurnBoundaryUser(cand)) break
     }
     preserved.push({ msg: m, anchor })
   }
@@ -1203,10 +1231,15 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
   const used = new Set<number>()
   const result: M[] = []
   for (const item of incoming) {
-    if (item.role === 'assistant' || item.role === 'streaming') {
-      const c = item.content.trimEnd()
+    const tid = toolAnchorId(item)
+    const isText = item.role === 'assistant' || item.role === 'streaming'
+    if (tid || isText) {
+      const c = isText ? item.content.trimEnd() : ''
       for (let p = 0; p < preserved.length; p++) {
-        if (!used.has(p) && preserved[p].anchor === c) {
+        if (used.has(p)) continue
+        const a = preserved[p].anchor
+        if (!a) continue
+        if (tid ? a.tool === tid : a.tool === undefined && a.text === c) {
           result.push({ ...preserved[p].msg }); used.add(p); break
         }
       }
@@ -3709,7 +3742,16 @@ const chatSlice = createSlice({
         // in-flight turn (the bubbles only reappeared on a later full fetch).
         // Routing every slot-detail reducer through the one helper is what keeps
         // this from silently diverging from switchSlot/refreshSlot again.
-        state.slotMessages[safeKey(key)] = hydrateQueuedBubbles(hydrated, queue)
+        // mergePreservedThinking for the same reason: a slot the user switched
+        // AWAY from mid-turn has its reasoning in this cache (switchSlot.pending
+        // caches `state.messages` wholesale), and this warm is driven by that
+        // slot's own chat_done — so overwriting with server history, which never
+        // holds a thinking row, dropped every block instead of only misplacing
+        // the later ones.
+        state.slotMessages[safeKey(key)] = hydrateQueuedBubbles(
+          mergePreservedThinking(state.slotMessages[key] || [], hydrated),
+          queue,
+        )
         // Clear the per-slot run indicator (the _done frame already idles it;
         // this is belt-and-braces for the fetch-completes-after-_done ordering).
         const run = (state.slotRun[safeKey(key)] ??= { state: 'idle' })

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -2228,13 +2228,15 @@ describe('thinking survives refreshSlot (client-only reasoning)', () => {
     expect(state.messages.filter(m => m.role === 'thinking')).toHaveLength(1)
   })
 
-  it('parks the extra bursts of a multi-tool turn at the tail (known limit, #4218)', () => {
+  it('rebuilds the burst order of a multi-tool turn from tool ids (#4218)', () => {
     // Reasoning is client-only, so the refresh rebuilds the array from server
-    // history that has never seen a thinking row — the position of burst 2+ is
-    // unreconstructible here and they land below the answer. Pinned so the
-    // follow-up that fixes it (producer-side segment boundary, or the
-    // append-only transcript) shows the improvement in its diff rather than
-    // silently changing an untested behaviour. NOT a desired end state.
+    // history that has never seen a thinking row. The position is recoverable
+    // anyway: each burst is followed by its own tool row, whose server-minted
+    // `tool_call_id` persists into history, so the post-refresh order must equal
+    // the live order exactly. Anchoring on answer CONTENT instead cannot do this
+    // — a reason-then-tool turn flushes no text at the tool boundary, so history
+    // holds one assistant row for every burst and all but one were parked below
+    // the answer.
     let state = reducer(base, setActiveSlot('chat-1'))
     state = reducer(state, sseThinkingChunk({ slot: 'chat-1', content: 'why t1' }))
     state = reducer(state, sseChatMessage({ slot: 'chat-1', role: 'tool', content: '🔧 grep', meta: { tool_call_id: 't1' } }))
@@ -2244,18 +2246,70 @@ describe('thinking survives refreshSlot (client-only reasoning)', () => {
     // live: each burst above the step it explains
     expect(state.messages.map(m => m.role)).toEqual(['thinking', 'tool', 'thinking', 'assistant'])
 
+    const payload = refreshPayload('chat-1', [
+      { role: 'tool', content: '🔧 grep', cls: '', meta: { tool_call_id: 't1' } },
+      { role: 'assistant', content: 'The answer', cls: 'msg msg-a' },
+    ])
+    state = reducer(state, refreshSlot.fulfilled(payload, 'r1', 'chat-1'))
+
+    expect(state.messages.filter(m => m.role === 'thinking').map(m => m.content))
+      .toEqual(['why t1', 'why t2'])
+    expect(state.messages.map(m => m.role)).toEqual(['thinking', 'tool', 'thinking', 'assistant'])
+
+    // Idempotent: a second refresh must not re-park or duplicate a block.
+    state = reducer(state, refreshSlot.fulfilled(payload, 'r2', 'chat-1'))
+    expect(state.messages.map(m => m.role)).toEqual(['thinking', 'tool', 'thinking', 'assistant'])
+  })
+
+  it('keeps every burst in place as the tool count grows (#4218)', () => {
+    // Severity scaled with burst count before the fix: only one block could
+    // anchor, so a turn that reasons before each of 10 calls left 9 stacked
+    // below the answer. Drive the count that was reported in the wild.
+    const N = 10
+    let state = reducer(base, setActiveSlot('chat-1'))
+    for (let n = 1; n <= N; n++) {
+      state = reducer(state, sseThinkingChunk({ slot: 'chat-1', content: `why t${n}` }))
+      state = reducer(state, sseChatMessage({ slot: 'chat-1', role: 'tool', content: '🔧 grep', meta: { tool_call_id: `t${n}` } }))
+    }
+    state = reducer(state, sseChatMessage({ slot: 'chat-1', role: 'chunk', content: 'Done', seq: 0 }))
+    state = reducer(state, sseChatMessage({ slot: 'chat-1', role: '_done', content: '' }))
+    const live = state.messages.map(m => m.role)
+
+    const history = []
+    for (let n = 1; n <= N; n++) {
+      history.push({ role: 'tool', content: '🔧 grep', cls: '', meta: { tool_call_id: `t${n}` } })
+    }
+    history.push({ role: 'assistant', content: 'Done', cls: 'msg msg-a' })
+    state = reducer(state, refreshSlot.fulfilled(refreshPayload('chat-1', history), 'r1', 'chat-1'))
+
+    expect(state.messages.map(m => m.role)).toEqual(live)
+    expect(state.messages.filter(m => m.role === 'thinking').map(m => m.content))
+      .toEqual(Array.from({ length: N }, (_, i) => `why t${i + 1}`))
+    // No tail stack: nothing reasoning-shaped after the answer.
+    expect(state.messages[state.messages.length - 1].role).toBe('assistant')
+  })
+
+  it('anchors on the earlier row of an auto-approved tool pair (#4218)', () => {
+    // An auto-approved call persists TWO tool rows sharing one tool_call_id
+    // (🔧 pre-approval + ✅ post-approval). The block reasoned its way TO the
+    // call, so it belongs above the first of the pair, not between them.
+    let state = reducer(base, setActiveSlot('chat-1'))
+    state = reducer(state, sseThinkingChunk({ slot: 'chat-1', content: 'why t1' }))
+    state = reducer(state, sseChatMessage({ slot: 'chat-1', role: 'tool', content: '🔧 grep', meta: { tool_call_id: 't1' } }))
+    state = reducer(state, sseChatMessage({ slot: 'chat-1', role: 'chunk', content: 'The answer', seq: 0 }))
+    state = reducer(state, sseChatMessage({ slot: 'chat-1', role: '_done', content: '' }))
+
     state = reducer(state, refreshSlot.fulfilled(
       refreshPayload('chat-1', [
         { role: 'tool', content: '🔧 grep', cls: '', meta: { tool_call_id: 't1' } },
+        { role: 'tool', content: '✅ grep', cls: '', meta: { tool_call_id: 't1' } },
         { role: 'assistant', content: 'The answer', cls: 'msg msg-a' },
       ]),
       'r1', 'chat-1',
     ))
 
-    // Both blocks survive with the right text; the second one's POSITION does not.
-    expect(state.messages.filter(m => m.role === 'thinking').map(m => m.content))
-      .toEqual(['why t1', 'why t2'])
-    expect(state.messages.map(m => m.role)).toEqual(['tool', 'thinking', 'assistant', 'thinking'])
+    expect(state.messages.map(m => m.role)).toEqual(['thinking', 'tool', 'tool', 'assistant'])
+    expect(state.messages.filter(m => m.role === 'thinking')).toHaveLength(1)
   })
 })
 


### PR DESCRIPTION
## What

Fixes #4218: after a turn ends, a multi-burst turn's reasoning blocks stacked below the answer instead of staying next to the steps they explain.

| | row order |
|---|---|
| live (streaming) | `thinking → tool → thinking → tool → thinking → assistant` |
| after `chat_done` refresh, before | `tool → tool → thinking → assistant → thinking → thinking` |
| after `chat_done` refresh, now | identical to live |

## Why the previous anchor could not work

Reasoning is broadcast-only and never persisted, so the `chat_done` refresh rebuilds `state.messages` from server history that has never held a `thinking` row. `mergePreservedThinking` re-anchored each block on the trimmed **content** of the next assistant row.

That anchor does not scale, and the issue's own option 1 does not fix it either. The backend cuts a segment at a tool boundary only when text is pending — `chat_runner.py`'s `EVENT_TOOL_CALL` branch flushes under `if not in_tool_group and assistant_text:` — so a turn that reasons *instead of* speaking before each tool flushes nothing there, and history holds **one** assistant row for **all N** bursts. All N computed the same anchor string, `used` let exactly one land, and the rest fell to the tail-append path. Once parked, a block sits after the last assistant row, so its forward scan finds no anchor on the next refresh and it is re-parked forever.

Severity scaled with tool count. At N=10 that is 9 consecutive collapsed rows below the answer's footer, and a collapsed row renders no preview text, so they are indistinguishable from each other — it reads as a rendering bug rather than misplaced reasoning.

## The fix

Anchor on the following tool call's `tool_call_id`, falling back to answer content only when there is no tool.

That key is minted server-side by `_tool_meta` and persisted on the tool row, and its own docstring states the intent: the frontend join works "whether the entry came from the live tool-call event or from a historical replay." So it survives the refresh, which answers the issue's "no canonical row identity" concern for exactly the row type the fix needs. Supply is 1:1 with the bursts — burst *k* is followed by tool *k*, the final burst by the answer.

An auto-approved call persists **two** tool rows sharing one id (🔧 pre-approval + ✅ post-approval, per `applyToolOutputToMessages`). `used` makes the first win, which is the earlier row and the correct side of the pair — the block reasoned its way *to* the call.

Blocks that genuinely cannot be placed (scan hits a turn boundary first) are still appended rather than dropped, so this is not option 2: no user-visible text disappears. The two tests that pin that survival pass **unchanged**.

### Second defect fixed alongside

`warmSlotCache.fulfilled` never called the helper at all. A slot the user switched away from mid-turn holds its reasoning in `slotMessages` (`switchSlot.pending` caches `state.messages` wholesale), and that slot's own `chat_done` drives this warm — so it dropped **every** block rather than only misplacing the later ones. Routed through the same path.

## Tests

The `#4218` known-limit pin in `chatSlice.test.ts` asked to be flipped by whichever change fixed it ("Pinned so the follow-up that fixes it shows the improvement in its diff … NOT a desired end state"). It now asserts the post-refresh order equals the live order, plus a second refresh to prove idempotence. Two new cases: N=10 (the count reported in the wild) and the auto-approved duplicate-id pair.

## Verification

- `npx tsc --noEmit` clean
- `vitest run` full suite: 21905 passed. The 2 failures in `CliPanelCoverage.test.tsx` (CliPanel theme sync) are a pre-existing full-suite pollution flake — that file passes in isolation both with and without this change, and it touches `document.head` / `data-theme` globals.
- brand gate exit 0, `i18n:check` exit 0 (no new user-facing strings)

## Scope note

Option 3 in the issue — the append-only session transcript RFC — remains the correct root fix and is untouched by this PR. It is worth noting its RFC baseline is 252 commits stale and has three factual drifts, so it should not gate a visible rendering bug.
