### PR TITLE
fix(instance-tab-bar): make crew pin checkbox toggle on keyboard and re-render

### DIFF
--- a/website/src/components/InstanceTabBar.tsx
+++ b/website/src/components/InstanceTabBar.tsx
@@ -480,11 +480,18 @@ function SwitcherMenu({
                   ? i18nT('components.instanceTabBar.unpin_crew', { name: entry.name })
                   : i18nT('components.instanceTabBar.pin_crew', { name: entry.name })
               }
-              // Two handlers, deliberately: `onClick` is the plain DOM event and is
-              // what actually toggles, while `onSelect` exists only to
-              // preventDefault so the menu stays open for a second pin.
-              onClick={() => onTogglePin(id)}
-              onSelect={(e: Event) => e.preventDefault()}
+              // Toggle from `onSelect`, the one activation handler Radix fires
+              // exactly once for BOTH pointer and keyboard (Enter/Space) — the
+              // menuitemcheckbox is unreachable by keyboard otherwise. Hanging the
+              // toggle on the raw DOM `onClick` also dropped pointer clicks: the
+              // whole entries list re-renders on every pin change (the check glyph
+              // flips), so the item pressed could be replaced between pointerdown
+              // and click and never receive the event. preventDefault keeps the
+              // menu open so a second crew can be pinned without reopening it.
+              onSelect={(e: Event) => {
+                e.preventDefault()
+                onTogglePin(id)
+              }}
             >
               <span
                 aria-hidden


### PR DESCRIPTION
## Problem

In the instance tab bar's crew switcher dropdown, the **PIN CREWS** checkboxes could not be toggled reliably. Clicking a pin row (other than the first) often did nothing, and the rows were completely unreachable by keyboard.

## Root cause

The pin row (`DropdownMenuItem` with `role="menuitemcheckbox"`) split its behavior across two handlers:

```tsx
onClick={() => onTogglePin(id)}                 // did the toggle
onSelect={(e: Event) => e.preventDefault()}     // only kept the menu open
```

Two failure modes result:

1. **Keyboard activation never toggled.** Radix fires `onSelect` (not a raw DOM `click`) for Enter/Space activation of a menu item. With the toggle living only on `onClick`, keyboard users could never pin a crew.
2. **Pointer clicks were dropped on re-render.** The entire `entries` list re-renders on every pin change (the check glyph flips `isPinned`), so the `DropdownMenuItem` under the pointer can be unmounted/replaced between `pointerdown` and the native `click`, and `onClick` never lands on the pressed node. The first pin often took; subsequent clicks on other rows were dropped.

## Fix

Move the toggle into `onSelect` — the single activation handler Radix fires exactly once for **both** pointer and keyboard — and keep `preventDefault()` so the menu stays open for pinning a second crew. `onClick` is removed.

```tsx
onSelect={(e: Event) => {
  e.preventDefault()
  onTogglePin(id)
}}
```

## Testing

- `npx tsc -b` — clean.
- `npx vitest run` — **1409 files, 21905 passed** (2 expected-fail, 3 skipped).

No behavior change for a mouse click on the first pin; the fix restores toggling for keyboard activation and for subsequent pointer clicks across the re-render.
