### PR TITLE
feat(mcp): let an agent open a session and move a stalled one along

### DIFF
--- a/src/kiro_crew/mcp_tools/sessions.py
+++ b/src/kiro_crew/mcp_tools/sessions.py
@@ -23,9 +23,11 @@ from typing import Any
 from kiro_crew import mcp_core
 from kiro_crew.history import ConversationLog
 from kiro_crew.validation import (
+    CREATE_SESSION_SCHEMA,
     GET_CHAT_SESSION_SCHEMA,
     LIST_SESSIONS_SCHEMA,
     SEARCH_CHAT_HISTORY_SCHEMA,
+    SEND_TO_SESSION_SCHEMA,
     validate_tool_args,
 )
 
@@ -106,6 +108,100 @@ def schemas() -> list[dict[str, Any]]:
                     },
                 },
                 "required": ["session_key"],
+            },
+        },
+        {
+            "name": "create_session",
+            "description": (
+                "Open a NEW dashboard chat session and optionally give it its "
+                "first instruction. Use when work deserves its own thread rather "
+                "than another turn in this one: a task that will run long, needs "
+                "its own project directory, or should be worked in parallel with "
+                "what you are doing now. The new session appears in the user's "
+                "dashboard exactly as one they opened themselves, and they can "
+                "take it over at any time.\n\n"
+                "This SPENDS the user's credits: passing `goal` starts a turn "
+                "immediately, and that agent runs on its own from then on. Prefer "
+                "spawn_run for work you need the ANSWER to (a sub-agent reports "
+                "back to you and ends); create a session for work that should "
+                "outlive this conversation and stay visible to the user.\n\n"
+                "Omit `agent` to bind the default. `project` sets the session's "
+                "working directory, which is what makes file work land in the "
+                "right tree. Returns the new session key so you can read it back "
+                "later with get_chat_session."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": (
+                            "Short human-readable title, as the user will see it in "
+                            "their session list."
+                        ),
+                    },
+                    "goal": {
+                        "type": "string",
+                        "description": (
+                            "First instruction to send. Omit to open the session "
+                            "without starting a turn -- nothing is spent until "
+                            "someone sends a message."
+                        ),
+                    },
+                    "agent": {
+                        "type": "string",
+                        "description": ("Agent/crew to bind. Omit for the default agent."),
+                    },
+                    "model": {
+                        "type": "string",
+                        "description": "Model override. Omit to inherit.",
+                    },
+                    "project": {
+                        "type": "string",
+                        "description": ("Absolute path to the session's project directory."),
+                    },
+                },
+                "required": ["title"],
+            },
+        },
+        {
+            "name": "send_to_session",
+            "description": (
+                "Send a message into an EXISTING dashboard session, to move work "
+                "along that has stopped for a reason you can supply. The intended "
+                "use is a session stalled on a missing FACT -- a path, a version, "
+                "an answer you already hold -- where handing it over lets the "
+                "agent continue.\n\n"
+                "This starts a turn in that session and spends the user's credits, "
+                "and the message arrives as if the user sent it. `reason` is "
+                "REQUIRED and recorded in the audit log, because an action taken "
+                "on someone else's session has to be answerable for afterwards.\n\n"
+                "It REFUSES a session that is waiting on an approval: a message "
+                "cannot answer an approval, and the decision belongs to the user. "
+                "It also refuses private sessions and your own session. To ask the "
+                "user something, use send_message; to run work yourself, use "
+                "spawn_run; to open new work, use create_session."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "session_key": {
+                        "type": "string",
+                        "description": ("Target session key, as list_sessions reports it."),
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "What to send. Supply the fact; do not decide.",
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": (
+                            "Why this intervention is warranted. Recorded in the "
+                            "audit log and shown to the user."
+                        ),
+                    },
+                },
+                "required": ["session_key", "message", "reason"],
             },
         },
         {
@@ -426,8 +522,288 @@ def list_sessions(name: str, args: dict[str, Any]) -> str:
     return output
 
 
+def _slot_rows(caller: str) -> list[dict[str, Any]] | None:
+    """Every live slot as ``GET /api/chat/slots`` serializes it, or None.
+
+    This endpoint, not ``/api/chat/slots/{slot}``, is the one that carries the
+    fields these tools gate on. The detail route builds its own body
+    (``key``/``title``/``running``/``queue``/``total`` plus pagination) and has
+    neither ``pending_approval`` nor ``memory_mode``, so guards written against
+    it read missing keys and pass. The list route is ``serialize_slots`` over
+    ``_ChatSlot.to_dict()``, which has all of them, and it does not touch the
+    transcript -- the detail route reads the FULL chained history through a
+    regex redaction pass, which is both wasteful as an existence probe and slow
+    enough on a large session to time out and report a false not-found.
+
+    Typed as Any at the boundary because this path answers with a JSON ARRAY
+    while ``_get`` is annotated for the dict case.
+    """
+    raw: Any = mcp_core._get("/api/chat/slots", session_key=caller)
+    if isinstance(raw, list):
+        return [row for row in raw if isinstance(row, dict)]
+    # A dict here is an error envelope, never a slot list.
+    return None
+
+
+def _find_slot(rows: list[dict[str, Any]], target: str) -> dict[str, Any] | None:
+    return next((row for row in rows if str(row.get("key") or "") == target), None)
+
+
+def create_session(name: str, args: dict[str, Any]) -> str:
+    """Open a new dashboard chat session, optionally seeding its first turn.
+
+    Governed by ``capabilities.spawn``: what this does, in the sense policy cares
+    about, is start a turn that spends the user's credits and runs an agent.
+
+    Three writes, ordered so a failure cannot leave a session running work in the
+    wrong place -- create the slot, set the project directory, then send the goal.
+    Sending first would let the turn begin in the wrong tree, which no later
+    correction undoes.
+
+    The goal is sent with ``?ws=1``. Without it ``/api/chat`` answers with an SSE
+    STREAM for an idle slot (its JSON early-returns are the busy branches), so a
+    successful delivery came back unparseable and was reported as a failure while
+    a merely-queued one reported success -- the receipt inverted on the exact path
+    this tool exists for.
+    """
+    args = validate_tool_args(args, CREATE_SESSION_SCHEMA)
+    title = str(args.get("title") or "").strip()
+    goal = str(args.get("goal") or "").strip()
+    agent = str(args.get("agent") or "").strip()
+    model = str(args.get("model") or "").strip()
+    project = str(args.get("project") or "").strip()
+
+    # STRICT resolution (no /proc ancestor walk): this tool acts on state outside
+    # the caller, and a subagent lives under its parent slot's process tree, so a
+    # lenient walk would vet governance against the parent's surface and audit the
+    # action under the parent's key. Same rule control.py states for autonudge_stop.
+    caller = mcp_core._resolve_session_key_strict()
+    if not caller:
+        return (
+            "Refused: cannot identify the calling session, so this action could "
+            "not be attributed or governed."
+        )
+
+    from kiro_crew.subagent import _vet_spawn_governance
+
+    denied = _vet_spawn_governance(caller, agent, app=mcp_core._governance_app())
+    if denied:
+        mcp_core.sel().log_tool_invocation(
+            session_key=caller,
+            source="mcp",
+            tool_name="create_session",
+            outcome="denied",
+            metadata={"denial": denied, "agent": agent or "default"},
+        )
+        return f"Refused: {denied}"
+
+    body: dict[str, Any] = {"title": title}
+    if agent:
+        body["agent"] = agent
+    if model:
+        body["model"] = model
+    created = mcp_core._post("/api/chat/slots", body)
+    slot = ""
+    if isinstance(created, dict):
+        slot = str(created.get("key") or created.get("slot") or "")
+    if not slot:
+        # The endpoint answers with actionable bodies (409 memory_mode mismatch,
+        # 400 crew_unsupported_slot, 404 slot_not_found, 400 folder_not_found);
+        # reporting a generic failure mis-describes every one of them.
+        detail = ""
+        if isinstance(created, dict) and created.get("error"):
+            detail = f": {created['error']}"
+        mcp_core.sel().log_tool_invocation(
+            session_key=caller,
+            source="mcp",
+            tool_name="create_session",
+            outcome="error",
+            metadata={"stage": "create", "error": detail[2:] or "no session key returned"},
+        )
+        return f"Could not create the session{detail or ': the gateway returned no session key'}."
+
+    # Reported, not raised: the session EXISTS from here on, so an exception would
+    # tell the caller it does not and a silent success would misdescribe it.
+    project_note = ""
+    if project:
+        # The handler reads body["project"]. Sending any other key means it reads
+        # "" and CLEARS the directory while answering 200.
+        resp = mcp_core._post(f"/api/chat/slots/{slot}/project", {"project": project})
+        if isinstance(resp, dict) and resp.get("error"):
+            project_note = (
+                f"\n\nThe project directory was NOT set ({resp['error']}), "
+                "so this session works from the default directory."
+            )
+
+    goal_note = "\n\nNothing is running yet -- it has no instruction."
+    if goal:
+        sent = mcp_core._post("/api/chat?ws=1", {"message": goal, "slot": slot})
+        if isinstance(sent, dict) and sent.get("error"):
+            goal_note = (
+                f"\n\nThe session was created but the first instruction was NOT "
+                f"delivered ({sent['error']}). Nothing is running yet."
+            )
+        elif isinstance(sent, dict) and sent.get("queued"):
+            goal_note = "\n\nThe instruction is queued behind a turn already in flight."
+        else:
+            goal_note = "\n\nIts first turn is running now."
+
+    mcp_core.sel().log_tool_invocation(
+        session_key=caller,
+        source="mcp",
+        tool_name="create_session",
+        outcome="success",
+        metadata={
+            "slot": slot,
+            "agent": agent or "default",
+            "seeded": bool(goal),
+            "project_set": bool(project and not project_note),
+        },
+    )
+    lines = [f"\U0001f195 Opened session **{title or slot}**  \u00b7  `{slot}`"]
+    if agent:
+        lines.append(f"_agent={agent}_")
+    if project and not project_note:
+        lines.append(f"_project={project}_")
+    return mcp_core._redact_history_output("\n".join(lines) + project_note + goal_note)
+
+
+def send_to_session(name: str, args: dict[str, Any]) -> str:
+    """Deliver a message into another live session.
+
+    Governed by ``capabilities.spawn``, as ``create_session`` is, and for the same
+    reason: it starts a turn.
+
+    Every refusal is decided from ONE read of ``GET /api/chat/slots`` and the
+    message is posted to the canonical ``key`` that read returned, not to the
+    caller's string. Checking one endpoint and acting on another let the two
+    disagree: the detail route resolves ``state._slots.get(name)`` raw while
+    ``/api/chat`` goes through ``get_or_create_slot``, which normalizes the name
+    and MINTS a slot when it is absent -- so "an absent session is refused rather
+    than created" rested on the two resolutions happening to agree.
+
+    Guards fail CLOSED on a missing field: a response shape that stops carrying
+    ``pending_approval`` must refuse, not silently permit.
+    """
+    args = validate_tool_args(args, SEND_TO_SESSION_SCHEMA)
+    target = str(args.get("session_key") or "").strip()
+    message = str(args.get("message") or "").strip()
+    reason = str(args.get("reason") or "").strip()
+
+    caller = mcp_core._resolve_session_key_strict()
+
+    def _deny(outcome: str, text: str, denial: str = "") -> str:
+        mcp_core.sel().log_tool_invocation(
+            session_key=caller,
+            source="mcp",
+            tool_name="send_to_session",
+            outcome=outcome,
+            # caller_reason is the agent's justification; denial is why policy or
+            # a guard refused. One field cannot mean both.
+            metadata={"target": target, "caller_reason": reason, "denial": denial or outcome},
+        )
+        return f"Refused: {text}"
+
+    if not caller:
+        return (
+            "Refused: cannot identify the calling session, so this action could "
+            "not be attributed or governed."
+        )
+    if not message:
+        return _deny("invalid", "the message is empty.")
+
+    from kiro_crew.subagent import _vet_spawn_governance
+
+    denied = _vet_spawn_governance(caller, "", app=mcp_core._governance_app())
+    if denied:
+        return _deny("denied", denied, denial=denied)
+
+    rows = _slot_rows(caller)
+    if rows is None:
+        return _deny("unreadable", "could not read the session list, so nothing was sent.")
+    row = _find_slot(rows, target)
+    if row is None:
+        return _deny("not_found", f"no live session {target!r}. Check the slot keys in the board.")
+
+    # Compared on the key the LIST reports, so the guard cannot be defeated by a
+    # differently-shaped identifier. dashboard_slot_key owns the session-key ->
+    # slot-name mapping: a "dashboard:" prefix strip gets it wrong for a
+    # channel-born conversation, whose session key is the channel's own even
+    # while its tab is open.
+    from kiro_crew.dashboard.chat_utils import dashboard_slot_key
+
+    if dashboard_slot_key(caller) == str(row.get("key") or ""):
+        return _deny(
+            "self_target",
+            "that is this session. Use monitor_start to re-prompt yourself on an interval.",
+        )
+    if "memory_mode" not in row:
+        return _deny("shape", "cannot tell whether that session is private, so nothing was sent.")
+    if mcp_core._history_is_incognito(row):
+        return _deny("private", "that session is private.")
+    if "pending_approval" not in row:
+        return _deny(
+            "shape", "cannot tell whether that session owes an approval, so nothing was sent."
+        )
+    if row.get("pending_approval"):
+        return _deny(
+            "awaiting_approval",
+            "that session is waiting on an approval, which only the user can "
+            "answer. Tell the user what it needs instead.",
+        )
+
+    # Audited BEFORE the send, synchronously: log_tool_invocation enqueues by
+    # default and returns success even when the record cannot be written, so a
+    # post-hoc record does not gate anything. critical=True writes through and
+    # re-raises, which is what makes the audit a precondition of the action
+    # rather than a description of it.
+    mcp_core.sel().log_tool_invocation(
+        session_key=caller,
+        source="mcp",
+        tool_name="send_to_session",
+        outcome="invoked",
+        metadata={"target": row.get("key"), "caller_reason": reason},
+        critical=True,
+    )
+
+    sent = mcp_core._post("/api/chat?ws=1", {"message": message, "slot": row.get("key")})
+    if isinstance(sent, dict) and sent.get("error"):
+        mcp_core.sel().log_tool_invocation(
+            session_key=caller,
+            source="mcp",
+            tool_name="send_to_session",
+            outcome="error",
+            metadata={
+                "target": row.get("key"),
+                "caller_reason": reason,
+                "error": str(sent["error"]),
+            },
+        )
+        return f"Could not deliver it: {sent['error']}"
+
+    queued = bool(isinstance(sent, dict) and sent.get("queued"))
+    mcp_core.sel().log_tool_invocation(
+        session_key=caller,
+        source="mcp",
+        tool_name="send_to_session",
+        outcome="success",
+        metadata={"target": row.get("key"), "caller_reason": reason, "queued": queued},
+    )
+    title = str(row.get("title") or target)
+    outcome = (
+        "It is queued behind the turn already in flight, and will be read when that turn ends."
+        if queued
+        else "Its turn is running now."
+    )
+    return mcp_core._redact_history_output(
+        f"\u2192 Sent to **{title}**  \u00b7  `{row.get('key')}`\n_reason: {reason}_\n\n{outcome}"
+    )
+
+
 HANDLERS: dict[str, Callable[[str, dict[str, Any]], str]] = {
     "search_chat_history": search_chat_history,
     "get_chat_session": get_chat_session,
     "list_sessions": list_sessions,
+    "create_session": create_session,
+    "send_to_session": send_to_session,
 }

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2421,6 +2421,26 @@ LIST_SESSIONS_SCHEMA = ToolSchema(
     ],
 )
 
+SEND_TO_SESSION_SCHEMA = ToolSchema(
+    tool_name="send_to_session",
+    fields=[
+        FieldSpec("session_key", str, required=True, max_len=MAX_SHORT_STRING),
+        FieldSpec("message", str, required=True, max_len=MAX_MEDIUM_STRING),
+        FieldSpec("reason", str, required=True, max_len=MAX_SHORT_STRING),
+    ],
+)
+
+CREATE_SESSION_SCHEMA = ToolSchema(
+    tool_name="create_session",
+    fields=[
+        FieldSpec("title", str, required=True, max_len=MAX_SHORT_STRING),
+        FieldSpec("goal", str, required=False, max_len=MAX_MEDIUM_STRING),
+        FieldSpec("agent", str, required=False, max_len=MAX_SHORT_STRING),
+        FieldSpec("model", str, required=False, max_len=MAX_SHORT_STRING),
+        FieldSpec("project", str, required=False, max_len=MAX_SHORT_STRING),
+    ],
+)
+
 # ── Schema Registry ──
 
 MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
@@ -2452,6 +2472,8 @@ MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
     "search_chat_history": SEARCH_CHAT_HISTORY_SCHEMA,
     "get_chat_session": GET_CHAT_SESSION_SCHEMA,
     "list_sessions": LIST_SESSIONS_SCHEMA,
+    "create_session": CREATE_SESSION_SCHEMA,
+    "send_to_session": SEND_TO_SESSION_SCHEMA,
     "set_project": SET_PROJECT_SCHEMA,
     "suggest_followup": SUGGEST_FOLLOWUP_SCHEMA,
     "artifact_save": ARTIFACT_SAVE_SCHEMA,

--- a/test/test_mcp_session_tools.py
+++ b/test/test_mcp_session_tools.py
@@ -1,0 +1,414 @@
+"""Behaviour of ``create_session`` and ``send_to_session``.
+
+The endpoint SHAPES these depend on are pinned separately, in
+``test_mcp_session_tools_contract.py``, against the real handlers -- because the
+first version of these tests was written against fakes the author also wrote, and
+three defects passed straight through them (guards reading fields the endpoint
+never returns, a project write with the wrong body key, and a response parsed as
+JSON when it is a stream).
+
+Two rules follow from that and are enforced by the fake here:
+
+* an unscripted path RAISES. A fake that answers every URL with success cannot
+  fail when the code calls the wrong one, which is exactly how the project bug
+  survived.
+* request BODIES are asserted, not just paths.
+
+Identifiers are the real two shapes: a caller holds a SESSION key
+(``dashboard:chat-1-...``) while a slot row holds a SLOT key (``chat-4-...``).
+The earlier tests used one value for both, which made the self-target guard look
+like it worked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kiro_crew import mcp_core
+from kiro_crew.mcp_tools import sessions
+
+CALLER_SESSION = "dashboard:chat-1-1787000000"
+CALLER_SLOT = "chat-1-1787000000"
+TARGET_SLOT = "chat-4-1786999999"
+NEW_SLOT = "chat-9-1787000001"
+
+
+class _Gateway:
+    """Scripted loopback. Unscripted paths raise, so a wrong URL fails a test."""
+
+    def __init__(self, posts: dict[str, Any] | None = None, rows: Any = None) -> None:
+        self.posts = posts or {}
+        self.rows = rows
+        self.calls: list[tuple[str, dict]] = []
+
+    def post(self, path: str, body: dict | None = None, **kw: Any) -> Any:
+        self.calls.append((path, dict(body or {})))
+        if path not in self.posts:
+            raise AssertionError(f"unscripted POST {path!r} -- the tool called an unexpected URL")
+        return self.posts[path]
+
+    def get(self, path: str, **kw: Any) -> Any:
+        if path != "/api/chat/slots":
+            raise AssertionError(f"unscripted GET {path!r}")
+        return self.rows
+
+    @property
+    def paths(self) -> list[str]:
+        return [p for p, _ in self.calls]
+
+    def body(self, path: str) -> dict:
+        return next(b for p, b in self.calls if p == path)
+
+
+def _row(**over: Any) -> dict[str, Any]:
+    """A slot row shaped as ``GET /api/chat/slots`` serializes it."""
+    base: dict[str, Any] = {
+        "key": TARGET_SLOT,
+        "title": "Fix the migration",
+        "memory_mode": "default",
+        "pending_approval": False,
+        "running": False,
+    }
+    base.update(over)
+    return base
+
+
+@pytest.fixture()
+def audit(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    entries: list[dict] = []
+
+    class _Sel:
+        def log_tool_invocation(self, **kw: Any) -> None:
+            entries.append(kw)
+
+    monkeypatch.setattr(mcp_core, "sel", lambda: _Sel())
+    # STRICT resolver: the tools must not accept the lenient PID-walk identity.
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: CALLER_SESSION)
+    monkeypatch.setattr(mcp_core, "_governance_app", lambda: "")
+    monkeypatch.setattr(mcp_core, "_redact_history_output", lambda text: text)
+    import kiro_crew.dashboard.chat_utils as chat_utils
+
+    monkeypatch.setattr(chat_utils, "dashboard_slot_key", lambda sk: CALLER_SLOT)
+    import kiro_crew.subagent as subagent
+
+    monkeypatch.setattr(subagent, "_vet_spawn_governance", lambda *a, **k: None)
+    return entries
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, gw: _Gateway) -> _Gateway:
+    monkeypatch.setattr(mcp_core, "_post", gw.post)
+    monkeypatch.setattr(mcp_core, "_get", gw.get)
+    return gw
+
+
+class TestCreateSession:
+    def test_orders_the_three_writes_and_sends_the_right_bodies(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        gw = _wire(
+            monkeypatch,
+            _Gateway(
+                {
+                    "/api/chat/slots": {"key": NEW_SLOT},
+                    f"/api/chat/slots/{NEW_SLOT}/project": {"ok": True},
+                    "/api/chat?ws=1": {"ok": True},
+                }
+            ),
+        )
+
+        sessions.create_session(
+            "create_session",
+            {"title": "Fix the build", "goal": "Find why CI is red", "project": "/repo"},
+        )
+
+        # Order: a turn that begins before the directory is set runs file work in
+        # the wrong tree, and nothing recovers a turn that already ran.
+        assert gw.paths == [
+            "/api/chat/slots",
+            f"/api/chat/slots/{NEW_SLOT}/project",
+            "/api/chat?ws=1",
+        ]
+        # Bodies, not just URLs. `path` instead of `project` silently CLEARED the
+        # directory while answering 200.
+        assert gw.body(f"/api/chat/slots/{NEW_SLOT}/project") == {"project": "/repo"}
+        assert gw.body("/api/chat?ws=1") == {"message": "Find why CI is red", "slot": NEW_SLOT}
+        assert gw.body("/api/chat/slots")["title"] == "Fix the build"
+
+    def test_does_not_start_a_turn_without_a_goal(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        gw = _wire(monkeypatch, _Gateway({"/api/chat/slots": {"key": NEW_SLOT}}))
+
+        out = sessions.create_session("create_session", {"title": "Parked for later"})
+
+        # No /api/chat at all: opening a session must be free, so an orchestrator
+        # can set work up without committing the user's credits to it.
+        assert gw.paths == ["/api/chat/slots"]
+        assert "Nothing is running yet" in out
+        assert audit[-1]["metadata"]["seeded"] is False
+
+    def test_says_queued_when_the_slot_was_busy(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        _wire(
+            monkeypatch,
+            _Gateway(
+                {
+                    "/api/chat/slots": {"key": NEW_SLOT},
+                    "/api/chat?ws=1": {"ok": True, "queued": True},
+                }
+            ),
+        )
+
+        out = sessions.create_session("create_session", {"title": "Busy", "goal": "Go"})
+
+        # "Its first turn is running now" would be false, and a caller polling for
+        # movement would conclude the session ignored the instruction.
+        assert "queued" in out
+
+    def test_surfaces_the_gateway_error_when_no_key_comes_back(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        _wire(monkeypatch, _Gateway({"/api/chat/slots": {"error": "crew_unsupported_slot"}}))
+
+        out = sessions.create_session("create_session", {"title": "Nope", "goal": "Go"})
+
+        # The endpoint returns actionable bodies; a generic failure mis-describes
+        # every one of them.
+        assert "crew_unsupported_slot" in out
+        assert audit[-1]["outcome"] == "error"
+
+    def test_reports_a_session_whose_project_did_not_take(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        _wire(
+            monkeypatch,
+            _Gateway(
+                {
+                    "/api/chat/slots": {"key": NEW_SLOT},
+                    f"/api/chat/slots/{NEW_SLOT}/project": {"error": "Not a directory"},
+                    "/api/chat?ws=1": {"ok": True},
+                }
+            ),
+        )
+
+        out = sessions.create_session(
+            "create_session", {"title": "Wrong tree", "project": "/nope", "goal": "Go"}
+        )
+
+        assert "was NOT set" in out
+        assert "Not a directory" in out
+        assert audit[-1]["metadata"]["project_set"] is False
+
+    def test_refuses_without_a_strict_identity(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "")
+        gw = _wire(monkeypatch, _Gateway({}))
+
+        out = sessions.create_session("create_session", {"title": "Anon"})
+
+        # Without a strict identity the action cannot be governed or attributed,
+        # and a lenient PID walk would resolve a subagent to its parent's slot.
+        assert "cannot identify the calling session" in out
+        assert gw.calls == []
+
+    def test_omits_a_blank_agent_rather_than_sending_it(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        gw = _wire(monkeypatch, _Gateway({"/api/chat/slots": {"key": NEW_SLOT}}))
+
+        sessions.create_session("create_session", {"title": "Plain"})
+
+        assert "agent" not in gw.body("/api/chat/slots")
+        assert audit[-1]["metadata"]["agent"] == "default"
+
+    def test_refuses_when_governance_denies(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        import kiro_crew.subagent as subagent
+
+        monkeypatch.setattr(
+            subagent, "_vet_spawn_governance", lambda *a, **k: "spawn capability disabled"
+        )
+        gw = _wire(monkeypatch, _Gateway({}))
+
+        out = sessions.create_session("create_session", {"title": "Denied"})
+
+        assert "Refused" in out
+        assert gw.calls == []
+        assert audit[-1]["outcome"] == "denied"
+        # The denial record must carry WHY policy refused.
+        assert audit[-1]["metadata"]["denial"] == "spawn capability disabled"
+
+
+class TestSendToSession:
+    def _gw(self, monkeypatch, rows, posts=None) -> _Gateway:
+        return _wire(monkeypatch, _Gateway(posts or {"/api/chat?ws=1": {"ok": True}}, rows=rows))
+
+    def _args(self, **over: Any) -> dict:
+        base = {
+            "session_key": TARGET_SLOT,
+            "message": "The path is /repo/app",
+            "reason": "unblocking",
+        }
+        base.update(over)
+        return base
+
+    def test_delivers_to_the_canonical_key_and_records_the_reason(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        gw = self._gw(monkeypatch, [_row()])
+
+        out = sessions.send_to_session(
+            "send_to_session", self._args(reason="it stalled on a missing path")
+        )
+
+        # Posted to the key the LIST returned, not the caller's raw string: the
+        # send path goes through get_or_create_slot, which normalizes and MINTS
+        # on a miss, so the two resolutions must not be allowed to disagree.
+        assert gw.body("/api/chat?ws=1") == {
+            "message": "The path is /repo/app",
+            "slot": TARGET_SLOT,
+        }
+        outcomes = [e["outcome"] for e in audit]
+        # Audited BEFORE the send, synchronously, so the record gates the action.
+        assert outcomes == ["invoked", "success"]
+        assert audit[0]["critical"] is True
+        assert audit[-1]["metadata"]["caller_reason"] == "it stalled on a missing path"
+        assert "Its turn is running now" in out
+
+    def test_says_queued_rather_than_running_when_the_slot_is_busy(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        self._gw(monkeypatch, [_row()], {"/api/chat?ws=1": {"ok": True, "queued": True}})
+
+        out = sessions.send_to_session("send_to_session", self._args())
+
+        assert "queued behind the turn" in out
+        assert audit[-1]["metadata"]["queued"] is True
+
+    def test_refuses_a_session_waiting_on_an_approval(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        gw = self._gw(monkeypatch, [_row(pending_approval=True)])
+
+        out = sessions.send_to_session("send_to_session", self._args())
+
+        assert "only the user can" in out
+        assert gw.calls == []
+        assert audit[-1]["outcome"] == "awaiting_approval"
+
+    def test_refuses_when_the_row_cannot_say_whether_an_approval_is_owed(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        row = _row()
+        del row["pending_approval"]
+        gw = self._gw(monkeypatch, [row])
+
+        out = sessions.send_to_session("send_to_session", self._args())
+
+        # Fail CLOSED. A response shape that stops carrying the field must refuse,
+        # which is the defect that made this guard inert in the first version.
+        assert "cannot tell" in out
+        assert gw.calls == []
+        assert audit[-1]["outcome"] == "shape"
+
+    def test_refuses_a_private_session(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        gw = self._gw(monkeypatch, [_row(memory_mode="incognito")])
+
+        out = sessions.send_to_session("send_to_session", self._args())
+
+        assert "private" in out
+        assert gw.calls == []
+
+    def test_refuses_when_the_row_cannot_say_whether_it_is_private(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        row = _row()
+        del row["memory_mode"]
+        gw = self._gw(monkeypatch, [row])
+
+        out = sessions.send_to_session("send_to_session", self._args())
+
+        assert "cannot tell" in out
+        assert gw.calls == []
+
+    def test_refuses_its_own_session_across_the_two_identifier_shapes(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        # The caller holds dashboard:chat-1-...; the row holds chat-1-.... The
+        # guard must see through that, which is why it maps via
+        # dashboard_slot_key rather than comparing the raw strings.
+        gw = self._gw(monkeypatch, [_row(key=CALLER_SLOT)])
+
+        out = sessions.send_to_session("send_to_session", self._args(session_key=CALLER_SLOT))
+
+        assert "this session" in out
+        assert gw.calls == []
+        assert audit[-1]["outcome"] == "self_target"
+
+    def test_refuses_a_session_that_is_not_on_the_board(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        gw = self._gw(monkeypatch, [_row(key="chat-77-1")])
+
+        out = sessions.send_to_session("send_to_session", self._args())
+
+        # Refused, not created: a typo must not open a thread nobody asked for.
+        assert "no live session" in out
+        assert gw.calls == []
+        assert audit[-1]["outcome"] == "not_found"
+
+    def test_refuses_when_the_session_list_cannot_be_read(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        # An error envelope, not a list.
+        gw = self._gw(monkeypatch, {"error": "transport"})
+
+        out = sessions.send_to_session("send_to_session", self._args())
+
+        assert "could not read the session list" in out
+        assert gw.calls == []
+        assert audit[-1]["outcome"] == "unreadable"
+
+    def test_reports_a_failed_delivery_rather_than_claiming_success(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        self._gw(monkeypatch, [_row()], {"/api/chat?ws=1": {"error": "slot busy"}})
+
+        out = sessions.send_to_session("send_to_session", self._args())
+
+        assert "Could not deliver" in out
+        assert audit[-1]["outcome"] == "error"
+
+    def test_refuses_without_a_strict_identity(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "")
+        gw = self._gw(monkeypatch, [_row()])
+
+        out = sessions.send_to_session("send_to_session", self._args())
+
+        assert "cannot identify the calling session" in out
+        assert gw.calls == []
+
+    def test_separates_the_callers_justification_from_the_policy_denial(
+        self, monkeypatch: pytest.MonkeyPatch, audit: list[dict]
+    ) -> None:
+        import kiro_crew.subagent as subagent
+
+        monkeypatch.setattr(subagent, "_vet_spawn_governance", lambda *a, **k: "policy says no")
+        gw = self._gw(monkeypatch, [_row()])
+
+        sessions.send_to_session("send_to_session", self._args(reason="my justification"))
+
+        # One field cannot mean both "why the agent wanted this" and "why policy
+        # refused" -- the denial query exists to answer the second.
+        assert audit[-1]["metadata"]["caller_reason"] == "my justification"
+        assert audit[-1]["metadata"]["denial"] == "policy says no"
+        assert gw.calls == []

--- a/test/test_mcp_session_tools_contract.py
+++ b/test/test_mcp_session_tools_contract.py
@@ -1,0 +1,200 @@
+"""The endpoint contracts ``create_session`` / ``send_to_session`` depend on.
+
+These tools are thin HTTP proxies, so a test that hands the handler a dict the
+author wrote proves nothing about them. Three defects shipped behind exactly that
+kind of test, and each is pinned here against the REAL handler:
+
+* the guards read ``pending_approval`` / ``memory_mode``, which the DETAIL route
+  does not return -- both guards passed on hand-built fixtures and failed OPEN in
+  production. Asserted both ways: present on the list, absent on the detail, so
+  the endpoint choice is deliberate rather than incidental.
+* the project write sent ``{"path": ...}``; the handler reads ``body["project"]``,
+  so it received ``""`` and CLEARED the directory while answering 200.
+* ``POST /api/chat`` answers with a stream unless ``?ws=1``, and its early JSON
+  returns are the BUSY branches -- so a successful delivery to an idle slot came
+  back unparseable while a merely-queued one returned JSON, inverting the receipt
+  on the path the tool exists for.
+
+Driven over a loopback aiohttp server with a real ``DashboardState``, the same way
+``test_chat_slot_create_folder.py`` does.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+# Bare import: `test/` is not a package and `test` is a stdlib package name.
+from chat_test_helpers import _make_ready_kiro_prerequisite
+
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.history import ConversationLog
+
+
+def _make_state(tmp_path) -> DashboardState:
+    sessions = MagicMock(count=0)
+    sessions.remove = AsyncMock()
+    sessions.recycle_background = AsyncMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    state = DashboardState(
+        sessions=sessions,
+        crons=MagicMock(list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})),
+        lessons=MagicMock(load_all=MagicMock(return_value=[])),
+        start_time=0.0,
+        conversation_log=ConversationLog(base_dir=tmp_path),
+    )
+    state.kiro_prerequisite_service = _make_ready_kiro_prerequisite()
+    return state
+
+
+def _app(state: DashboardState) -> web.Application:
+    from kiro_crew.dashboard.chat import (
+        api_chat_slot_create,
+        api_chat_slot_detail,
+        api_chat_slot_project,
+        api_chat_slots,
+    )
+
+    app = web.Application()
+    app["state"] = state
+    app.router.add_post("/api/chat/slots", api_chat_slot_create)
+    app.router.add_get("/api/chat/slots", api_chat_slots)
+    app.router.add_get("/api/chat/slots/{slot}", api_chat_slot_detail)
+    app.router.add_post("/api/chat/slots/{slot}/project", api_chat_slot_project)
+    return app
+
+
+async def _new_slot(cl: TestClient, title: str = "Contract") -> str:
+    resp = await cl.post("/api/chat/slots", json={"title": title})
+    assert resp.status == 200, await resp.text()
+    return str((await resp.json())["key"])
+
+
+class TestSlotResponseShapes:
+    @pytest.mark.asyncio
+    async def test_the_list_route_carries_the_fields_the_guards_read(self, tmp_path):
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_app(state))) as cl:
+            key = await _new_slot(cl)
+            rows: Any = await (await cl.get("/api/chat/slots")).json()
+
+            assert isinstance(rows, list), "the tools branch on a JSON array here"
+            row = next(r for r in rows if r["key"] == key)
+            # The private-session and approval refusals are decided from these two.
+            assert "memory_mode" in row
+            assert "pending_approval" in row
+            # And the queued-vs-running receipt from this one.
+            assert "running" in row
+
+    @pytest.mark.asyncio
+    async def test_the_detail_route_does_not_carry_them(self, tmp_path):
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_app(state))) as cl:
+            key = await _new_slot(cl)
+            body = await (await cl.get(f"/api/chat/slots/{key}")).json()
+
+            # This is WHY the tools read the list. If the detail route ever grows
+            # these fields, this fails and the choice can be revisited
+            # deliberately -- rather than the guards silently failing open again.
+            assert "pending_approval" not in body
+            assert "memory_mode" not in body
+
+    @pytest.mark.asyncio
+    async def test_create_returns_a_key_the_sibling_routes_accept(self, tmp_path):
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_app(state))) as cl:
+            key = await _new_slot(cl, title="Round trip")
+
+            # The create response's `key` must work as {slot} on the sibling
+            # routes. The descriptor previously promised it was a
+            # get_chat_session identifier, which is a different space --
+            # transcript stems are `dashboard_<slot>`.
+            assert key in state._slots
+            assert (await cl.get(f"/api/chat/slots/{key}")).status == 200
+            rows = await (await cl.get("/api/chat/slots")).json()
+            assert any(r["key"] == key for r in rows)
+
+
+class TestProjectWrite:
+    @pytest.mark.asyncio
+    async def test_the_project_key_is_what_sets_the_directory(self, tmp_path):
+        state = _make_state(tmp_path)
+        # A REAL directory: the handler rejects a non-existent path with 400
+        # "Not a directory", which is itself part of the contract the tool
+        # inherits -- an agent passing a plausible-but-absent path is refused.
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        async with TestClient(TestServer(_app(state))) as cl:
+            key = await _new_slot(cl)
+
+            ok = await cl.post(f"/api/chat/slots/{key}/project", json={"project": str(repo)})
+            assert ok.status == 200, await ok.text()
+            assert state._slots[key].project == str(repo)
+
+    @pytest.mark.asyncio
+    async def test_an_absent_directory_is_refused(self, tmp_path):
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_app(state))) as cl:
+            key = await _new_slot(cl)
+
+            resp = await cl.post(
+                f"/api/chat/slots/{key}/project", json={"project": str(tmp_path / "nope")}
+            )
+            assert resp.status == 400
+            assert state._slots[key].project == ""
+
+    @pytest.mark.asyncio
+    async def test_any_other_body_key_clears_it_and_still_answers_200(self, tmp_path):
+        state = _make_state(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        async with TestClient(TestServer(_app(state))) as cl:
+            key = await _new_slot(cl)
+            await cl.post(f"/api/chat/slots/{key}/project", json={"project": str(repo)})
+            assert state._slots[key].project == str(repo)
+
+            # The shipped defect: `path` is not read, so the handler sees "" and
+            # CLEARS the directory -- while answering 200, which the tool then
+            # reported and audited as success.
+            resp = await cl.post(f"/api/chat/slots/{key}/project", json={"path": str(repo)})
+            assert resp.status == 200
+            assert state._slots[key].project == "", "a wrong body key silently clears the project"
+
+
+def test_the_chat_route_streams_unless_ws_is_set() -> None:
+    """``/api/chat`` returns a stream; only ``?ws=1`` makes it answer JSON.
+
+    Read from the handler rather than driven, because driving a real turn needs a
+    live agent. What matters for the tools is the ORDER: the early JSON returns
+    are the busy branches and the ws switch sits after them, so an idle slot --
+    the case ``send_to_session`` targets -- takes the stream path.
+    """
+    from kiro_crew.dashboard import chat_handlers
+
+    src = inspect.getsource(chat_handlers.api_chat)
+    assert 'request.query.get("ws") == "1"' in src
+    assert src.index('ws_mode = request.query.get("ws")') > src.index(
+        '{"ok": True, "queued": True}'
+    )
+
+
+def test_both_tools_send_chat_with_ws_set() -> None:
+    """The tools must carry ``?ws=1``, or they parse a stream as JSON."""
+    from kiro_crew.mcp_tools import sessions
+
+    for fn in (sessions.create_session, sessions.send_to_session):
+        src = inspect.getsource(fn)
+        assert '"/api/chat?ws=1"' in src, f"{fn.__name__} must post to /api/chat?ws=1"
+
+
+def test_the_project_write_uses_the_project_key() -> None:
+    """Pins the body key in the TOOL, so the contract above cannot drift from it."""
+    from kiro_crew.mcp_tools import sessions
+
+    src = inspect.getsource(sessions.create_session)
+    assert '{"project": project}' in src


### PR DESCRIPTION
Two MCP tools for the orchestrator case: one agent holding a long conversation that farms work out to sessions the user can see and take over.

`create_session` opens a dashboard chat slot, optionally sets its project directory, and optionally sends the first instruction. `send_to_session` delivers a message into a session that already exists, for the one case the spec allows — a session stalled on a missing **fact** the agent can supply.

## Placement is contested, and I want reviewers to settle it

`mcp_dashboard.py`'s module docstring already legislates this shape:

> a capability whose blast radius DOES require authorization needs its own keystone leaf, and being merely unreferenced in the default spec is not that. **Session control (driving or stopping another session) is that shape.**

and

> Deliberately NOT part of `kirocrew-core`. Core is the tool surface EVERY session carries […] anything listed there spends context in every request of every session forever.

This PR puts them in `kirocrew-core` governed by `capabilities.spawn`. That is deliberate but arguable, and the alternatives are real:

1. **Move to `kirocrew-dashboard`** (assignable) with its own keystone leaf, as that docstring prescribes.
2. **Ship them from an app instead.** The intended consumer is Crew Manager, which is becoming a first-class builtin app; a builtin can ship its own MCP server (`kiro_crew.apps.builtins.<app>.mcp_server`, as `mochi` does) and call the gateway internals in-process, which removes the whole HTTP-shape defect class described below. This is where the work is ultimately headed.

Reusing `capabilities.spawn` rather than adding a gate is defended on the grounds that creating a session and spawning a sub-agent are the same act in the only sense policy cares about — a new agent context starts running and spends the user's credits — so an operator who has already forbidden spawning gets these forbidden too. The counter-argument is equally real: an operator who wants sub-agents but *not* cross-session driving cannot express that.

**`send_to_session` also amends an invariant that is not mine to amend.** The orchestrator-chat-sessions RFC scopes to one session at a time with a single decision in flight per session; acting across the fleet changes that, and that is a joint decision with its author. If the answer is "not yet", this PR should land as `create_session` alone.

## What the guards do

`send_to_session` refuses four cases, and the refusals are the tool:

- a session **awaiting an approval** — a message cannot answer an approval, so the send would be noise or an attempt to talk around a decision that belongs to the user. This is the boundary that keeps it inside "supply a fact" rather than "exercise authority".
- a **private** session, matching the read tools, which never open an incognito transcript.
- the **caller's own** session — that is a nudge loop, and there is a governed primitive for it.
- an **absent** session, refused rather than created, so a typo cannot open a thread nobody asked for.

Guards **fail closed** on a missing field: a response shape that stops carrying `pending_approval` refuses rather than silently permitting.

`reason` is required and audited, because an action taken on someone else's session has to be answerable for afterwards. The pre-action record is `critical=True` so it gates the send instead of describing it — `log_tool_invocation` enqueues by default and returns success even when the record cannot be written.

Identity uses `_resolve_session_key_strict()`. A lenient PID walk resolves a sub-agent to its parent slot, which would vet governance against the wrong surface, misattribute the audit, and make the self-target guard protect the wrong session.

## Three defects an earlier revision shipped, and why they are pinned now

The first version of this change had 14 passing tests and 13 killed mutations, and was wrong in three ways — every one because the tests drove a fake whose shape never matched the real endpoint:

| defect | consequence |
|---|---|
| guards read `pending_approval` / `memory_mode` off `GET /api/chat/slots/{slot}` | that route does not return them (they are on the slots **list**), so both guards **failed open** |
| project write sent `{"path": …}` | the handler reads `body["project"]`, so it received `""` and **cleared** the directory while answering 200 |
| `POST /api/chat` without `?ws=1` | returns an SSE stream on the idle path, so a successful delivery was reported and audited as a **failure** while a merely-queued one reported success |

`test/test_mcp_session_tools_contract.py` now drives the **real handlers** against a real `DashboardState` over a loopback aiohttp server (idiom copied from `test_chat_slot_create_folder.py`) and asserts the shapes both ways — the fields are present on the list route and **absent** on the detail route — so the endpoint choice is deliberate and a future shape change fails here rather than in production.

## Deliberately not included

Answering an approval, and stopping another session. Both are irreversible or reserved for the developer.

Also missing, and belonging server-side on the target slot rather than in these tools: an agent-vs-human **attribution marker** on `api_chat` (an agent send is currently indistinguishable from a human turn), a **repeat-send cap**, an **undo** story, and a per-session **report-only** marking.

## Verification

89 tests across three files. 16 mutations, all killed — including one for each of the three defects above. One equivalent mutant was removed with its reason recorded rather than left as a permanent false gap: `_find_slot` matches on exact equality, so the caller's raw key and the canonical key are provably identical on every path that reaches the post.

`mypy` clean over 989 files; black ratchet, `isort` and `flake8` clean at CI scope. Rebased onto current main.
