### PR TITLE
feat(app-sdk): add ChatEmbed aboveComposer slot

### DIFF
--- a/website/src/app-sdk/ChatEmbed.tsx
+++ b/website/src/app-sdk/ChatEmbed.tsx
@@ -7,7 +7,7 @@
  * State management: polling via useQuery refetchInterval.
  * Poll faster during streaming (1s), slower when idle (5s).
  */
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef, useCallback, useEffect, type ReactNode } from 'react'
 import { useImeGuard } from '../hooks/useImeGuard'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { ArrowUp, Loader2 } from 'lucide-react'
@@ -47,6 +47,14 @@ export interface ChatEmbedProps {
    * refuse a stale send. Omitted, behaviour is unchanged.
    */
   onSend?: (message: string) => Promise<unknown> | void
+  /**
+   * Content rendered in normal flow directly ABOVE the composer, inside the
+   * embed's own column, so it always sits on top of the input regardless of the
+   * composer's height. A host uses this for a docked quote / reference bar
+   * instead of absolutely positioning one over the transcript with a brittle
+   * fixed offset that breaks whenever the composer's height changes.
+   */
+  aboveComposer?: ReactNode
 }
 
 /** Minimal shape of the chat-slot payload consumed by this embed. */
@@ -56,7 +64,7 @@ interface ChatSlotData {
   title?: string
 }
 
-function ChatEmbed({ slotKey, agent, placeholder, frameless, startAtBottom, onSend }: ChatEmbedProps) {
+function ChatEmbed({ slotKey, agent, placeholder, frameless, startAtBottom, onSend, aboveComposer }: ChatEmbedProps) {
   const api = useAppApi()
   const ime = useImeGuard()
   const [input, setInput] = useState('')
@@ -175,6 +183,8 @@ function ChatEmbed({ slotKey, agent, placeholder, frameless, startAtBottom, onSe
         <ChatMessageList messages={messages} running={running} onApprove={approve} />
         <div ref={endRef} />
       </div>
+
+      {aboveComposer && <div className="shrink-0">{aboveComposer}</div>}
 
       <div className={`flex items-center gap-2 px-3 py-2 shrink-0 ${frameless ? '' : 'border-t border-border bg-bg-subtle'}`}>
         <input


### PR DESCRIPTION
## What & why

Adds an optional `aboveComposer?: ReactNode` prop to the shared `ChatEmbed`. It renders in **normal flow directly above the composer**, inside the embed's own column, so it always sits on top of the input regardless of the composer's height.

Today a host that wants a docked quote / reference bar has to absolutely-position one over the transcript with a fixed `bottom` offset — which silently breaks whenever the composer's height changes (e.g. the opt-in `slotControls` composer is taller than the bare input row). This slot removes the magic number.

## Change

- `aboveComposer?: ReactNode` on `ChatEmbedProps`.
- Rendered as `{aboveComposer && <div className="shrink-0">…</div>}` between the transcript scroller and the composer.

Purely additive — default `undefined` renders nothing, so every existing embed is unchanged.

## Motivating consumer

Crew Manager's Conductor quote/reference bar (the "Instructing goal" / "Asking about PR" chip that names the send target above the input).
