### PR TITLE
feat: provision Python via pinned uv in cli.sh instead of the distro ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,11 +381,12 @@ the published manifest, installs through `pipx` when available or a managed
 virtual environment at `~/.kiro/crew-venv` (beside the data home; override with
 `KIROCREW_VENV`), and records the channel in `~/.kiro/crew/channel`. The channels
 are `stable`, `insider`, and `nightly`, and `KIROCREW_CHANNEL` sets the default.
-On Linux it installs a Python 3.10+ interpreter from your distro when the system
-lacks one — via `apt` on Debian/Ubuntu, `dnf` on Amazon Linux / RHEL / CentOS
-Stream, `yum` on CentOS 7. Where no base-repo package supplies 3.10+ (CentOS 7,
-older Ubuntu) it uses an already-installed [mise](https://mise.jdx.dev/) if you
-have one, otherwise it prints how to install a newer Python and stops. The
+On Linux and macOS, when the system lacks a Python 3.10+ interpreter the
+installer provisions one itself — no package manager, no sudo: it downloads a
+SHA-256-pinned [uv](https://docs.astral.sh/uv/) binary (or uses your installed
+`uv`) and installs a python-build-standalone CPython 3.12 into
+`~/.kiro/crew-python`. Pass `--managed-python` to always use the provisioned
+interpreter and skip the system ones. The
 signed installer never pipes an unsigned third-party script into a shell.
 
 **Pin an exact wheel.** You can also install one exact wheel directly and pin it to its published

--- a/cli.sh
+++ b/cli.sh
@@ -12,11 +12,19 @@
 # venv). No unsigned/checksum-only fallback exists. Unlike install.sh (which
 # builds from a git clone), this pulls the published wheel.
 #
+# Python: uses the system interpreter (>=3.10) when one exists; otherwise — or
+# always, with --managed-python — provisions a python-build-standalone CPython
+# via a SHA-256-pinned uv into a user-owned directory. No package manager, no
+# sudo, works on old-glibc distros (CentOS 7).
+#
 # Options / env:
 #   --channel <nightly|insider|stable>   (default: stable; env KIROCREW_CHANNEL)
 #   --version <X.Y.Z>                    pin an exact version, verified against
 #                                        its immutable signed CLI manifest
 #   --cdn <base-url>                     (default CloudFront; env KIROCREW_CDN_BASE)
+#   --managed-python                     skip the system interpreters and run on
+#                                        a uv-provisioned Python instead
+#                                        (env KIROCREW_MANAGED_PYTHON=1)
 # ──────────────────────────────────────────────────────────────────────
 set -eu
 
@@ -35,6 +43,23 @@ FEED_BASE="${KIROCREW_CDN_BASE:-https://updates.crew.kiro.dev}"
 ARTIFACT_BASE="${KIROCREW_CDN_BASE:-https://download.crew.kiro.dev}"
 CHANNEL="${KIROCREW_CHANNEL:-stable}"
 PIN_VERSION=""
+MANAGED_PYTHON="${KIROCREW_MANAGED_PYTHON:-0}"
+
+# Pinned uv release used to provision a managed Python interpreter when the
+# system has none (or when --managed-python asks for one). uv is only ever
+# fetched as a tarball and verified against these SHA-256 digests — the
+# astral.sh install script is never piped into a shell, keeping the signed
+# installer's no-unsigned-third-party-script invariant. Bump the version and
+# all four digests together (each uv release publishes <asset>.tar.gz.sha256
+# files beside the tarballs). Linux pins the musl builds: they are fully
+# static, so they run on any glibc age — old distros are the whole point of
+# this path.
+UV_VERSION="0.10.11"
+UV_PYTHON_SERIES="cpython-3.12"
+UV_SHA_LINUX_X64="d78246139dc6cf3ed6d03c84da762686bced7ad1de67977ee372a45b95a1f6d0"
+UV_SHA_LINUX_ARM64="5d80a7f6343d2676dfde1e5126582070a2bbc62df6f60d5527a169be3788532a"
+UV_SHA_MACOS_X64="ff90020b554cf02ef8008535c9aab6ef27bb7be6b075359300dec79c361df897"
+UV_SHA_MACOS_ARM64="437a7d498dd6564d5bf986074249ba1fc600e73da55ae04d7bd4c24d5f149b95"
 
 # Offline trust root for CLI artifact manifests. These two values are replaced
 # together during the operational KMS-key enablement documented in
@@ -55,6 +80,7 @@ while [ $# -gt 0 ]; do
     --version=*) PIN_VERSION="${1#*=}"; shift ;;
     --cdn) FEED_BASE="${2:?--cdn needs a value}"; ARTIFACT_BASE="$2"; shift 2 ;;
     --cdn=*) FEED_BASE="${1#*=}"; ARTIFACT_BASE="${1#*=}"; shift ;;
+    --managed-python) MANAGED_PYTHON=1; shift ;;
     -h|--help)
       cat <<'EOF'
 KiroCrew CLI installer (channel / wheel based).
@@ -74,7 +100,13 @@ Options / env:
   --version <X.Y.Z>                    pin an exact version, verified against
                                        its immutable signed CLI manifest
   --cdn <base-url>                     (default CloudFront; env KIROCREW_CDN_BASE)
+  --managed-python                     skip the system interpreters and run on a
+                                       uv-provisioned Python instead
+                                       (env KIROCREW_MANAGED_PYTHON=1)
   KIROCREW_VENV                        override the managed venv location
+  KIROCREW_PYTHON_DIR                  override where uv-provisioned interpreters
+                                       are stored (default: beside the data home,
+                                       ~/.kiro/crew-python)
 EOF
       exit 0 ;;
     *) echo "kirocrew-install: unknown argument '$1'" >&2; exit 2 ;;
@@ -123,6 +155,13 @@ _is_within() {
 
 command -v curl    >/dev/null 2>&1 || err "curl is required"
 command -v openssl >/dev/null 2>&1 || err "openssl is required to verify the signed manifest"
+if command -v sha256sum >/dev/null 2>&1; then SHA_CMD="sha256sum"
+elif command -v shasum  >/dev/null 2>&1; then SHA_CMD="shasum -a 256"
+else err "need sha256sum or shasum to verify the download"; fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
 # KiroCrew needs Python >=3.10 at runtime (contextlib.aclosing, etc.) even
 # though older published wheels' METADATA claimed >=3.9 -- pip would install
 # fine on 3.9 and then crash on first run. Prefer the newest interpreter the
@@ -188,76 +227,84 @@ _resolve_python() {
   return 1
 }
 
-# Privilege prefix for a package-manager install: empty when already root or
-# when no sudo exists; otherwise `sudo`. Two sudo shapes by context:
-#   - A real terminal on stdin (`sh cli.sh` run interactively): use a normal
-#     `sudo`, which may prompt for a password the user can actually type. A
-#     non-interactive `sudo -n` here would fail on any password-protected sudo
-#     and drop the whole distro-install path (a fresh Ubuntu never installs
-#     python3-venv, then the venv step aborts).
-#   - No controlling TTY (the documented `curl ... | sh` pipe): only a
-#     passwordless `sudo -n` can work, so gate on it and otherwise leave SUDO
-#     empty and let the install attempt fail through to the guidance below.
-SUDO=""
-if [ "$(id -u)" != "0" ] && command -v sudo >/dev/null 2>&1; then
-  # A terminal on EITHER stdin or stderr means a password prompt can be shown
-  # and answered -- true for `sh cli.sh` and also for `curl ... | sh` in a normal
-  # shell, where stdin is the pipe but stderr is still the tty. Only when
-  # neither is a terminal (cron, CI, fully redirected) do we require a
-  # passwordless `sudo -n` and otherwise leave SUDO empty.
-  if [ -t 0 ] || [ -t 2 ]; then
-    SUDO="sudo"
-  elif sudo -n true 2>/dev/null; then
-    SUDO="sudo -n"
+# ── Managed-Python provisioning (uv + python-build-standalone) ──────────────
+# Provision a CPython interpreter without touching the system: uv is a static,
+# dependency-free binary, and the interpreters it installs are prebuilt
+# python-build-standalone archives that unpack into a user-owned directory —
+# no package manager, no sudo, and they run on old-glibc distros (CentOS 7)
+# whose base repos never reach 3.10. An installed `uv` on PATH is used as-is
+# (the user already made that trust decision); otherwise the pinned uv release
+# is downloaded and verified against the SHA-256 digests above before it runs.
+# Sets PY on success. Network/platform failures return 1 so the caller can
+# print guidance; a digest mismatch is a security stop and errs immediately.
+_provision_python_via_uv() {
+  _uv_bin=""
+  if command -v uv >/dev/null 2>&1; then
+    _uv_bin="$(command -v uv)"
+    echo "Using installed uv ($_uv_bin) to provision Python ($UV_PYTHON_SERIES) ..."
+  else
+    # GNU tar's -z shells out to gzip, so both must exist before downloading.
+    for _uv_tool in tar gzip; do
+      if ! command -v "$_uv_tool" >/dev/null 2>&1; then
+        echo "kirocrew-install: $_uv_tool is required to unpack uv" >&2
+        return 1
+      fi
+    done
+    case "$(uname -s)/$(uname -m)" in
+      Linux/x86_64)              _uv_target="x86_64-unknown-linux-musl";  _uv_sha="$UV_SHA_LINUX_X64" ;;
+      Linux/aarch64|Linux/arm64) _uv_target="aarch64-unknown-linux-musl"; _uv_sha="$UV_SHA_LINUX_ARM64" ;;
+      Darwin/x86_64)             _uv_target="x86_64-apple-darwin";        _uv_sha="$UV_SHA_MACOS_X64" ;;
+      Darwin/arm64)              _uv_target="aarch64-apple-darwin";       _uv_sha="$UV_SHA_MACOS_ARM64" ;;
+      *)
+        echo "kirocrew-install: no pinned uv build for $(uname -s)/$(uname -m)" >&2
+        return 1 ;;
+    esac
+    echo "Downloading uv $UV_VERSION ($_uv_target) ..."
+    # -L: GitHub release assets redirect to a storage host; --proto-redir keeps
+    # every hop on HTTPS (curl's redirect default would also allow plain http).
+    curl -fsSL --proto '=https' --proto-redir '=https' \
+      "https://github.com/astral-sh/uv/releases/download/$UV_VERSION/uv-$_uv_target.tar.gz" \
+      -o "$TMP/uv.tar.gz" || return 1
+    _uv_got="$($SHA_CMD "$TMP/uv.tar.gz" | awk '{print $1}')"
+    [ "$_uv_got" = "$_uv_sha" ] \
+      || err "uv download SHA-256 mismatch (expected $_uv_sha, got $_uv_got) — refusing to continue"
+    ( cd "$TMP" && tar -xzf uv.tar.gz ) || return 1
+    _uv_bin="$TMP/uv-$_uv_target/uv"
+    [ -x "$_uv_bin" ] || return 1
   fi
-fi
+  # The interpreter store lives BESIDE the data home, like the managed venv and
+  # for the same blast-radius reason: no data-home-wide operation may ever
+  # reach the interpreter that the venv's shebangs point at.
+  _uv_data_home="${KIROCREW_HOME:-$HOME/.kiro/crew}"
+  _uv_py_dir="${KIROCREW_PYTHON_DIR:-${_uv_data_home%/}-python}"
+  UV_PYTHON_INSTALL_DIR="$_uv_py_dir" "$_uv_bin" python install "$UV_PYTHON_SERIES" \
+    || return 1
+  # only-managed: resolve the interpreter just installed, never a system one
+  # that happens to satisfy the series (matters under --managed-python, where
+  # a usable system 3.12 may exist but was explicitly opted out of).
+  _cand="$(UV_PYTHON_INSTALL_DIR="$_uv_py_dir" UV_PYTHON_PREFERENCE=only-managed \
+    "$_uv_bin" python find "$UV_PYTHON_SERIES" 2>/dev/null || true)"
+  if [ -n "$_cand" ] && _py_usable "$_cand"; then
+    PY="$_cand"
+    echo "Provisioned managed Python: $_cand"
+    return 0
+  fi
+  return 1
+}
 
 PY=""
-_resolve_python || true
-if [ -z "$PY" ]; then
-  # No system Python >=3.10. Try the distro package manager first, then re-probe.
-  # Covers Debian/Ubuntu (apt), Amazon Linux 2023 / RHEL 8+ / CentOS Stream
-  # (dnf), and RHEL/CentOS 7 (yum). The apt branch also pulls python3-venv, which
-  # Debian splits out of the base interpreter (see the venv step below).
-  if command -v apt-get >/dev/null 2>&1; then
-    echo "No Python >=3.10 found; attempting: apt-get install python3 python3-venv python3-pip ..."
-    $SUDO apt-get update -qq >/dev/null 2>&1 || true
-    $SUDO apt-get install -y python3 python3-venv python3-pip >/dev/null 2>&1 || true
-  elif command -v dnf >/dev/null 2>&1; then
-    echo "No Python >=3.10 found; attempting: dnf install python3.11 ..."
-    $SUDO dnf install -y -q python3.11 python3.11-pip >/dev/null 2>&1 || true
-  elif command -v yum >/dev/null 2>&1; then
-    echo "No Python >=3.10 found; attempting: yum install python3 ..."
-    $SUDO yum install -y -q python3 python3-pip >/dev/null 2>&1 || true
-  fi
+if [ "$MANAGED_PYTHON" = "1" ]; then
+  echo "--managed-python: skipping system interpreters."
+  _provision_python_via_uv \
+    || err "could not provision a managed Python via uv. Check the network connection, or install Python >=3.10 yourself and re-run without --managed-python."
+else
   _resolve_python || true
-fi
-if [ -z "$PY" ]; then
-  # The distro packages could not supply >=3.10: RHEL/CentOS 7 ships 3.6 and
-  # older Ubuntu 3.8, and neither has a >=3.10 package in its base repos. If the
-  # operator has ALREADY installed mise (its python-build-standalone runs on old
-  # glibc and bundles venv/pip), use it. This installer never bootstraps mise
-  # itself: piping an unsigned third-party script into `sh` would break the
-  # whole point of a signed installer (pinned key + SHA-256-verified wheel, no
-  # unsigned fallback). A source build MAY provision mise -- see
-  # ensure-python.sh -- but that is an explicit, non-piped path, not this
-  # published one-liner.
-  MISE="$HOME/.local/bin/mise"
-  [ -x "$MISE" ] || MISE="$(command -v mise 2>/dev/null || true)"
-  if [ -n "$MISE" ] && [ -x "$MISE" ]; then
-    echo "No system Python >=3.10; using your installed mise to provision one ..."
-    "$MISE" use -g "python@3.12" >/dev/null 2>&1 || true
-    _cand="$("$MISE" which python 2>/dev/null || true)"
-    if _py_usable "$_cand"; then PY="$_cand"; fi
+  if [ -z "$PY" ]; then
+    echo "No system Python >=3.10 found; provisioning one via uv ..."
+    _provision_python_via_uv || true
   fi
 fi
-[ -n "$PY" ] || err "Python >=3.10 is required and could not be found. Install it (Debian/Ubuntu: 'sudo apt-get install python3 python3-venv python3-pip'; RHEL/CentOS 8+/Amazon Linux: 'sudo dnf install python3.11'; CentOS 7: install a newer Python via SCL or mise, e.g. 'curl https://mise.run | sh && mise use -g python@3.12'), then re-run."
-if command -v sha256sum >/dev/null 2>&1; then SHA_CMD="sha256sum"
-elif command -v shasum  >/dev/null 2>&1; then SHA_CMD="shasum -a 256"
-else err "need sha256sum or shasum to verify the download"; fi
-
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT INT TERM
+[ -n "$PY" ] || err "Python >=3.10 is required and could not be found or provisioned. Install Python 3.10+ yourself (your distro's packages, or https://www.python.org/downloads/), then re-run."
 
 # Materialize and self-check the embedded trust root. The key id is the SHA-256
 # fingerprint of SubjectPublicKeyInfo DER, so an accidental edit to either
@@ -437,22 +484,14 @@ else
   # Debian/Ubuntu ship the base `python3` WITHOUT the venv/ensurepip module (it
   # lives in the separate `python3-venv` / `python3.X-venv` package), so
   # `python3 -m venv` there dies with "ensurepip is not available" and, under
-  # `set -eu`, aborts the whole install with a raw stack trace. Probe the
-  # capability first; if it is missing, try to apt-install the version-matched
-  # venv package, then re-probe. A minimal RHEL/CentOS python bundles venv, so
-  # this only bites apt systems.
+  # `set -eu`, aborts the whole install with a raw stack trace. Rather than
+  # driving the system package manager with sudo, fall back to a managed
+  # interpreter: python-build-standalone bundles venv and pip, so the re-probe
+  # always passes on it.
   if ! "$PY" -c 'import ensurepip, venv' >/dev/null 2>&1; then
-    if command -v apt-get >/dev/null 2>&1; then
-      # e.g. "3.12" -> python3.12-venv; also install the generic python3-venv so
-      # a bare `python3` interpreter is covered too.
-      _pyminor="$("$PY" -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || true)"
-      echo "Installing the venv module (python3-venv) ..."
-      $SUDO apt-get update -qq >/dev/null 2>&1 || true
-      $SUDO apt-get install -y "python${_pyminor}-venv" python3-venv >/dev/null 2>&1 \
-        || $SUDO apt-get install -y python3-venv >/dev/null 2>&1 || true
-    fi
-    "$PY" -c 'import ensurepip, venv' >/dev/null 2>&1 \
-      || err "$PY cannot create a virtual environment (the venv/ensurepip module is missing). On Debian/Ubuntu install it with 'sudo apt-get install python3-venv' (or 'python${_pyminor:-3}-venv'), then re-run."
+    echo "$PY cannot create a virtual environment (venv/ensurepip missing); provisioning a managed Python via uv instead ..."
+    _provision_python_via_uv \
+      || err "$PY cannot create a virtual environment (the venv/ensurepip module is missing) and a managed Python could not be provisioned. On Debian/Ubuntu install the module with 'sudo apt-get install python3-venv', then re-run."
   fi
   "$PY" -m venv "$VENV"
   "$VENV/bin/pip" install --quiet --upgrade pip >/dev/null 2>&1 || true

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -148,17 +148,21 @@ home (`~/.kiro/crew-venv`, override with `KIROCREW_VENV`) and symlinks
 data home, so no whole-home operation can ever delete the live interpreter. The
 selected channel is recorded to `~/.kiro/crew/channel`.
 
-If the host has no Python 3.10+, the installer installs one from your distro:
-`apt` on Debian/Ubuntu (including the split `python3-venv` package), `dnf` on
-Amazon Linux / RHEL / CentOS Stream, and `yum` on CentOS 7. Where no base-repo
-package supplies 3.10+ (CentOS 7 ships 3.6, older Ubuntu 3.8) it uses an
-**already-installed** [mise](https://mise.jdx.dev/) python-build-standalone
-interpreter if you have one (it runs on the older glibc those releases carry);
-otherwise it prints how to get a newer Python and stops. The signed installer
-never pipes an unsigned third-party script into a shell — to use the mise path,
-install mise yourself first (`curl https://mise.run | sh`). When it finishes it
-prints the next step: `kirocrew gateway` to start now, or `kirocrew service
-install` to run it as a service.
+If the host has no Python 3.10+, the installer provisions one itself instead of
+touching the system: it downloads a SHA-256-pinned [uv](https://docs.astral.sh/uv/)
+binary (or uses an already-installed `uv` on `PATH`), then installs a
+[python-build-standalone](https://github.com/astral-sh/python-build-standalone)
+CPython 3.12 into a user-owned directory beside the data home
+(`~/.kiro/crew-python`, override with `KIROCREW_PYTHON_DIR`). No package
+manager, no sudo, and the prebuilt interpreter runs on old-glibc distros
+(CentOS 7) whose base repos never reach 3.10. Pass `--managed-python` (or set
+`KIROCREW_MANAGED_PYTHON=1`) to always use the uv-provisioned interpreter and
+skip the system ones entirely — useful when the system Python is fragile or
+version-managed. The signed installer never pipes an unsigned third-party
+script into a shell: uv is fetched as a tarball and verified against pinned
+digests, exactly like the wheel itself. When it finishes it prints the next
+step: `kirocrew gateway` to start now, or `kirocrew service install` to run it
+as a service.
 
 ### b. From source (development)
 

--- a/test/test_installer_distro.py
+++ b/test/test_installer_distro.py
@@ -1,17 +1,13 @@
-"""Distro-bootstrap coverage for the shell installers.
+"""Managed-Python (uv) bootstrap coverage for the shell installers.
 
 The published one-liner ``curl … cli.sh | sh`` must bring up a runnable gateway
-on Ubuntu (apt, and the split ``python3-venv`` package), RHEL/CentOS 7 (yum,
-Python 3.6 baseline), and RHEL/CentOS 8+/Amazon Linux (dnf). Before this
-coverage existed cli.sh had ONLY a dnf branch, so Ubuntu and CentOS 7 hard-
-failed at the "Python >=3.10 is required" gate, and no test ever entered the
-Python-resolution block (the signing harness leaks the host ``python3``).
-
-These tests run the real ``cli.sh`` under a fabricated ``PATH`` that contains NO
-usable ``python3`` plus fake package managers, so the script is forced through
-its distro-detection ladder. Each fake records that it ran; the assertion is
-which manager cli.sh reached for on which distro. POSIX-only scripts, so the
-suite skips on native Windows.
+even when the host has no usable Python 3.10+. cli.sh does this WITHOUT the
+system package manager: it fetches a SHA-256-pinned uv tarball (or uses an
+already-installed ``uv``) and provisions a python-build-standalone CPython into
+a user-owned directory. These tests run the real ``cli.sh`` under a fabricated
+``PATH`` that contains NO usable ``python3``, with a recording ``curl`` stub,
+so the script is forced through the managed-Python path. POSIX-only scripts,
+so the suite skips on native Windows.
 """
 
 from __future__ import annotations
@@ -46,21 +42,21 @@ def test_shell_installers_parse() -> None:
 def _run_cli_with_fake_env(
     tmp_path: Path,
     *,
-    managers: list[str],
     interpreters: dict[str, str] | None = None,
     with_timeout: bool = True,
+    with_uv: str | None = None,
+    curl_stub: str | None = None,
+    extra_args: list[str] | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
-    """Run cli.sh with a PATH that has NO python3 and only the named package
-    managers (each a stub that records its name and args). Returns the process
-    result plus the marker directory the stubs wrote to.
-
-    The stubs deliberately do NOT install a working python, so cli.sh proceeds
-    through every branch and then errs at the final "Python >=3.10 is required"
-    guard — by which point the marker proves which manager it tried.
+    """Run cli.sh with a PATH that has NO usable python3 and a recording
+    ``curl`` stub. Returns the process result plus the marker directory the
+    stubs wrote to.
 
     ``interpreters`` replaces the default too-old stub for the named
     interpreters, which is how a scenario expresses a usable or a wedged
-    candidate.
+    candidate. ``with_uv`` plants an executable ``uv`` stub with the given
+    body. ``curl_stub`` replaces the default recording curl (which exits 22,
+    modelling a failed download).
     """
     tools = tmp_path / "tools"
     tools.mkdir()
@@ -69,10 +65,7 @@ def _run_cli_with_fake_env(
 
     # The PATH is ISOLATED to `tools` plus symlinks to the specific real
     # coreutils cli.sh needs. It deliberately does NOT include /usr/bin etc.,
-    # because `command -v <mgr>` skips a non-executable shadow and finds the
-    # host's real binary beneath it (CI's Ubuntu runner HAS a real apt-get) —
-    # so a distro is "absent" here simply by NOT creating its stub, not by
-    # shadowing. Only managers this scenario declares present exist on PATH.
+    # so no real curl, uv, or interpreter can leak into the ladder.
     def _link_real(name: str) -> None:
         real = shutil.which(name)
         if real:
@@ -81,6 +74,7 @@ def _run_cli_with_fake_env(
     for _util in ("sh", "env", "id", "awk", "sed", "mktemp", "rm", "rmdir",
                   "mkdir", "cat", "printf", "chmod", "ln", "date", "grep",
                   "tr", "head", "cut", "dirname", "basename", "uname", "sleep",
+                  "tar", "gzip", "sha256sum",
                   # cli.sh bounds its interpreter probe with `timeout` when one
                   # exists, so the isolated PATH must expose it for that guard
                   # to be exercised here at all. ``with_timeout=False`` models a
@@ -89,46 +83,37 @@ def _run_cli_with_fake_env(
                   *(("timeout",) if with_timeout else ())):
         _link_real(_util)
 
-    # A manager "under test" is an EXECUTABLE stub that records its args. The
-    # marker path is baked in absolutely: cli.sh does not EXPORT its variables,
-    # so a child stub would not inherit an env var.
-    for name in ("apt-get", "dnf", "yum"):
-        if name in managers:
-            marker = markers / name
-            stub = tools / name
-            stub.write_text(
-                "#!/bin/sh\n"
-                f'printf "%s\\n" "$*" >> "{marker}"\n'
-                "exit 0\n"
-            )
-            stub.chmod(0o755)
-    # mise, pipx are simply absent (never created) so the fallback finds none.
-
-    # Fake `sudo`: strip a leading `-n` / option flags and exec the rest through
-    # the SAME isolated PATH. Without this the test is not hermetic — a CI
-    # runner with passwordless sudo makes cli.sh pick `sudo -n`, and the real
-    # `sudo` resets PATH via secure_path so `sudo -n apt-get` would run the
-    # host's real apt-get instead of our recording stub. `exec env PATH=... "$@"`
-    # re-imposes the isolated PATH the way real sudo would impose secure_path.
-    sudo_stub = tools / "sudo"
-    sudo_stub.write_text(
-        "#!/bin/sh\n"
-        'while [ "$#" -gt 0 ]; do\n'
-        '  case "$1" in\n'
-        "    -n|-E|-H) shift ;;\n"
-        "    -*) shift ;;\n"
-        "    *) break ;;\n"
-        "  esac\n"
-        "done\n"
-        f'exec env "PATH={tools}" "$@"\n'
+    # Recording curl: the marker path is baked in absolutely because cli.sh
+    # does not EXPORT its variables, so a child stub would not inherit an env
+    # var. The default stub records the request and fails (exit 22, curl's
+    # HTTP-error code), which is how a scenario proves WHICH URL cli.sh
+    # reached for without any network.
+    curl_marker = markers / "curl"
+    curl = tools / "curl"
+    curl.write_text(
+        curl_stub
+        if curl_stub is not None
+        else (
+            "#!/bin/sh\n"
+            f'printf "%s\\n" "$*" >> "{curl_marker}"\n'
+            "exit 22\n"
+        )
     )
-    sudo_stub.chmod(0o755)
+    curl.chmod(0o755)
+
+    if with_uv is not None:
+        uv = tools / "uv"
+        uv.write_text(with_uv)
+        uv.chmod(0o755)
 
     # Every interpreter cli.sh probes for is an executable stub reporting an
     # OLD (<3.10) version, so the isolated PATH guarantees the "no usable
     # python" branch. The stub answers cli.sh's version check (exit 1) and
-    # `--version`.
-    for name in ("python3.13", "python3.12", "python3.11", "python3.10", "python3", "python"):
+    # `--version`. Extra names in ``interpreters`` (e.g. the fake interpreter a
+    # uv stub claims to have installed) are created too.
+    default_names = ("python3.13", "python3.12", "python3.11",
+                     "python3.10", "python3", "python")
+    for name in {*default_names, *(interpreters or {})}:
         stub = tools / name
         stub.write_text(
             interpreters.get(name)
@@ -144,22 +129,22 @@ def _run_cli_with_fake_env(
         )
         stub.chmod(0o755)
 
-    # curl/openssl/sha256sum need to exist so cli.sh's tool preflight passes and
-    # it reaches the Python block; they are never actually called before the
-    # python gate fails, but `command -v` must find them.
-    for name in ("curl", "openssl", "sha256sum"):
-        stub = tools / name
-        stub.write_text("#!/bin/sh\nexit 0\n")
-        stub.chmod(0o755)
+    # openssl needs to exist so cli.sh's tool preflight passes and it reaches
+    # the Python block; it is never actually reached in these scenarios, but
+    # `command -v` must find it.
+    openssl = tools / "openssl"
+    openssl.write_text("#!/bin/sh\nexit 0\n")
+    openssl.chmod(0o755)
 
     env = {
         # Isolated: ONLY the fake tools dir. No system bin dirs, so no real
-        # package manager or interpreter can leak into cli.sh's ladder.
+        # curl, uv, or interpreter can leak into cli.sh's ladder.
         "PATH": str(tools),
         "HOME": str(tmp_path / "home"),
         "KIROCREW_HOME": str(tmp_path / "data-home"),
     }
-    result = run_bounded([str(tools / "sh"), str(CLI_SH)], env)
+    argv = [str(tools / "sh"), str(CLI_SH), *(extra_args or [])]
+    result = run_bounded(argv, env)
     return result, markers
 
 
@@ -172,7 +157,6 @@ def test_cli_fails_over_from_a_wedged_interpreter_candidate(tmp_path: Path) -> N
     """
     result, _markers = _run_cli_with_fake_env(
         tmp_path,
-        managers=["apt-get"],
         interpreters={
             "python3.12": "#!/bin/sh\nexec sleep 300\n",
             "python3": (
@@ -200,7 +184,6 @@ def test_cli_bounds_wedged_interpreter_without_timeout_binary(tmp_path: Path) ->
     """
     result, _markers = _run_cli_with_fake_env(
         tmp_path,
-        managers=["apt-get"],
         with_timeout=False,
         interpreters={
             "python3.12": "#!/bin/sh\nexec sleep 300\n",
@@ -224,69 +207,154 @@ def test_cli_watchdog_path_still_rejects_too_old_interpreters(tmp_path: Path) ->
 
     With `timeout` absent, every candidate is the default too-old stub (exits 1
     at the version gate). If the watchdog path swallowed that status, cli.sh
-    would accept Python 3.6 as usable and skip the distro-install branch; the
-    apt-get marker proves the "no usable python" path was taken instead.
+    would accept Python 3.6 as usable and skip the managed-Python branch; the
+    curl marker reaching for the uv tarball proves the "no usable python" path
+    was taken instead.
     """
+    result, markers = _run_cli_with_fake_env(tmp_path, with_timeout=False)
+
+    assert (markers / "curl").exists(), result.stderr
+    assert "astral-sh/uv/releases/download" in (markers / "curl").read_text()
+
+
+def test_cli_falls_back_to_pinned_uv_when_no_python(tmp_path: Path) -> None:
+    """With no usable interpreter anywhere, cli.sh must reach for the PINNED uv
+    release tarball over HTTPS — not a package manager, not the astral install
+    script — and fail with actionable guidance when that download fails."""
+    result, markers = _run_cli_with_fake_env(tmp_path)
+
+    assert result.returncode != 0
+    recorded = (markers / "curl").read_text()
+    assert "https://github.com/astral-sh/uv/releases/download/" in recorded
+    assert ".tar.gz" in recorded
+    # The failure guidance must tell the user what to do next, without
+    # hardcoding one distro's package manager as the answer.
+    combined = result.stdout + result.stderr
+    assert "Python >=3.10 is required and could not be found or provisioned" in combined
+
+
+def test_cli_uses_installed_uv_before_downloading_one(tmp_path: Path) -> None:
+    """An already-present `uv` on PATH is the user's own trust decision — the
+    installer must drive IT (python install + python find) instead of
+    downloading another copy."""
+    uv_marker = tmp_path / "markers" / "uv"
+    fake_python = tmp_path / "tools" / "uv-python"
+    uv_stub = (
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> "{uv_marker}"\n'
+        'case "$*" in\n'
+        f'  *"python find"*) echo "{fake_python}" ;;\n'
+        "esac\n"
+        "exit 0\n"
+    )
     result, markers = _run_cli_with_fake_env(
-        tmp_path, managers=["apt-get"], with_timeout=False
+        tmp_path,
+        with_uv=uv_stub,
+        # The provisioned interpreter must satisfy the same >=3.10 usability
+        # probe as a system one; this stub models the PBS python uv installed.
+        interpreters={
+            "uv-python": (
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                "  *version_info*) exit 0 ;;\n"
+                "  *--version*) echo 'Python 3.12.0' ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n"
+            ),
+        },
     )
 
-    assert (markers / "apt-get").exists(), result.stderr
+    recorded = (markers / "uv").read_text()
+    assert "python install cpython-3.12" in recorded
+    assert "python find cpython-3.12" in recorded
+    # No uv tarball download happened: the only curl traffic (if any) is the
+    # manifest fetch that comes AFTER the python gate passed.
+    curl_marker = markers / "curl"
+    if curl_marker.exists():
+        assert "astral-sh/uv" not in curl_marker.read_text()
+    # The run got PAST the python gate: whatever it fails on later (this
+    # hermetic env cannot satisfy the trust-root/manifest steps), it must not
+    # be the interpreter requirement.
+    combined = result.stdout + result.stderr
+    assert "Python >=3.10 is required" not in combined, combined
+    assert "could not provision a managed Python" not in combined, combined
 
 
-def test_cli_uses_apt_on_debian_ubuntu(tmp_path: Path) -> None:
-    result, markers = _run_cli_with_fake_env(tmp_path, managers=["apt-get"])
-    # No python was produced, so the run fails at the python gate — but it must
-    # have reached for apt-get first (the Ubuntu path that did not exist before).
-    assert (markers / "apt-get").exists(), result.stderr
-    assert "install" in (markers / "apt-get").read_text()
-    assert "python3-venv" in (markers / "apt-get").read_text()
+def test_cli_managed_python_flag_skips_system_interpreters(tmp_path: Path) -> None:
+    """--managed-python must go straight to uv even when a usable system
+    interpreter exists — that is the flag's whole contract."""
+    result, markers = _run_cli_with_fake_env(
+        tmp_path,
+        extra_args=["--managed-python"],
+        interpreters={
+            "python3.12": (
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                "  *version_info*) exit 0 ;;\n"  # usable — and must be skipped
+                "  *--version*) echo 'Python 3.12.0' ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n"
+            ),
+        },
+    )
+
+    # It reached for the uv tarball despite the usable python3.12 on PATH.
+    assert (markers / "curl").exists(), result.stderr
+    assert "astral-sh/uv/releases/download" in (markers / "curl").read_text()
+    assert result.returncode != 0  # recording curl fails the download
+    combined = result.stdout + result.stderr
+    assert "could not provision a managed Python via uv" in combined
 
 
-def test_cli_uses_yum_on_centos7(tmp_path: Path) -> None:
-    # CentOS 7 has yum but not dnf and no >=3.10 in base repos: the pre-fix
-    # script had no yum branch and died with dnf-only advice.
-    result, markers = _run_cli_with_fake_env(tmp_path, managers=["yum"])
-    assert (markers / "yum").exists(), result.stderr
-    assert "install" in (markers / "yum").read_text()
+def test_cli_rejects_a_tampered_uv_download(tmp_path: Path) -> None:
+    """A uv tarball whose digest does not match the pinned SHA-256 must stop the
+    install as a security failure — never be extracted or executed."""
+    # This curl "succeeds" and writes attacker-controlled bytes to -o <file>.
+    curl_stub = (
+        "#!/bin/sh\n"
+        "out=''\n"
+        'while [ "$#" -gt 0 ]; do\n'
+        '  case "$1" in\n'
+        "    -o) out=\"$2\"; shift 2 ;;\n"
+        "    *) shift ;;\n"
+        "  esac\n"
+        "done\n"
+        '[ -n "$out" ] && printf "not-really-uv" > "$out"\n'
+        "exit 0\n"
+    )
+    result, _markers = _run_cli_with_fake_env(tmp_path, curl_stub=curl_stub)
 
-
-def test_cli_uses_dnf_on_modern_rhel(tmp_path: Path) -> None:
-    result, markers = _run_cli_with_fake_env(tmp_path, managers=["dnf"])
-    assert (markers / "dnf").exists(), result.stderr
-    assert "python3.11" in (markers / "dnf").read_text()
-
-
-def test_cli_prefers_apt_over_a_present_yum(tmp_path: Path) -> None:
-    # Debian derivatives can carry a yum-alike; the apt branch must win so a
-    # Debian box never drives an rpm manager.
-    _result, markers = _run_cli_with_fake_env(tmp_path, managers=["apt-get", "yum"])
-    assert (markers / "apt-get").exists()
-    assert not (markers / "yum").exists()
-
-
-def test_cli_error_message_is_distro_neutral_when_no_manager(tmp_path: Path) -> None:
-    # With no package manager AND no mise reachable, the final error must not
-    # hardcode Amazon-Linux/dnf advice (the pre-fix message did): it names the
-    # Debian/Ubuntu and RHEL-family paths so a user on any target distro gets a
-    # command that applies to them.
-    result, _markers = _run_cli_with_fake_env(tmp_path, managers=[])
     assert result.returncode != 0
     combined = result.stdout + result.stderr
-    assert "apt-get" in combined and "dnf" in combined and "CentOS 7" in combined
+    assert "uv download SHA-256 mismatch" in combined
+    assert "refusing to continue" in combined
 
 
 def test_cli_does_not_pipe_an_unsigned_installer_into_a_shell() -> None:
-    # The signed installer must never fetch-and-execute a third-party script: a
-    # `curl … mise.run | sh` bootstrap was removed for exactly this reason. It
-    # may USE an already-installed mise, but never install one itself. Any
-    # remaining `mise.run` reference must live INSIDE the final `err "…"`
-    # guidance string — text the user chooses to run, not a line the installer
-    # executes.
+    # The signed installer must never fetch-and-execute a third-party script:
+    # `curl … mise.run | sh` and `curl … astral.sh | sh` bootstraps are the
+    # exact pattern this invariant exists to prevent. uv arrives as a tarball
+    # verified against a pinned digest, never as a piped script.
+    text = CLI_SH.read_text()
+    for needle in ("mise.run", "astral.sh"):
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if needle in line and "| sh" in line:
+                raise AssertionError(
+                    f"cli.sh:{lineno} pipes a third-party script into a shell: {line!r}"
+                )
+
+
+def test_cli_never_drives_the_system_package_manager() -> None:
+    # Provisioning Python is a user-directory download, never a system
+    # mutation: no branch of the installer may invoke a package manager or
+    # sudo. (Package-manager names inside err() guidance strings are fine —
+    # text the user chooses to run themselves.)
     for lineno, line in enumerate(CLI_SH.read_text().splitlines(), start=1):
-        if "mise.run" not in line:
-            continue
         stripped = line.lstrip()
-        assert stripped.startswith("[ -n \"$PY\" ] || err ") or stripped.startswith("err "), (
-            f"cli.sh:{lineno} references mise.run outside the err() guidance string: {line!r}"
-        )
+        if stripped.startswith("#"):
+            continue
+        for needle in ("sudo ", "apt-get ", "dnf ", "yum "):
+            if needle in stripped:
+                assert stripped.startswith("err ") or "|| err " in stripped, (
+                    f"cli.sh:{lineno} drives the system package manager: {line!r}"
+                )


### PR DESCRIPTION
## Summary

`cli.sh` no longer drives the system package manager to obtain Python. When the host has no usable Python >=3.10 — or always, with the new `--managed-python` flag — it downloads a **SHA-256-pinned uv** release (or uses an already-installed `uv` on PATH) and provisions a **python-build-standalone CPython 3.12** into a user-owned directory beside the data home (`~/.kiro/crew-python`, override `KIROCREW_PYTHON_DIR`).

Deleted: the `apt`/`dnf`/`yum` ladder, the sudo/TTY probing machinery, the mise fallback, and the `python3-venv` apt-install branch (a system interpreter that cannot create a venv now falls back to the managed one, which bundles venv+pip).

### Why

- The distro ladder had a **hard-failure branch**: CentOS 7 / older Ubuntu have no >=3.10 in base repos, so the one-liner printed instructions and stopped. PBS interpreters are built against an old glibc baseline, so this path now succeeds there.
- **No installer should sudo into the system package manager.** A survey of 12 comparable Python CLIs (aider, AWS CLI v2, Azure CLI, gcloud, PDM, Hatch, pipx, Poetry, yt-dlp, certbot, HTTPie, Ansible) found none that installs Python via the distro package manager: they either bundle an interpreter, provision via uv (aider's installer is built on exactly this mechanism), or require one and stop. Provisioning becomes a user-directory download, never a system mutation.
- The desktop lane (`packaging/build-desktop.sh`) already pins the same uv version as a build dependency, so this **extends an existing trust surface** rather than adding a new kind — and narrows the CLI/desktop divergence to what it should be (self-contained embed vs `py3-none-any` wheel).

### Security invariants preserved

- The manifest-signature core (pinned RSA key, canonical-JSON verification, SHA-256'd wheel) is untouched.
- The signed installer still **never pipes an unsigned third-party script into a shell**: uv arrives as a tarball verified against digests pinned in the script (all four platform digests bump together with `UV_VERSION`). A digest mismatch is a hard stop, not a fallthrough. A new test (`test_cli_never_drives_the_system_package_manager`) pins the no-sudo/no-package-manager property; the existing no-piped-installer test now also covers `astral.sh`.
- Linux pins the **musl** uv builds (fully static — old-glibc distros are the point of this path).

### Behavior

| Scenario | Before | After |
|---|---|---|
| System Python >=3.10 present | used as-is | used as-is (unchanged; zero migration for existing installs) |
| No usable Python | sudo apt/dnf/yum, then mise, then hard fail | pinned uv → PBS 3.12 into `~/.kiro/crew-python` |
| Debian without `python3-venv` | sudo apt-get install python3-venv | fall back to managed interpreter |
| `--managed-python` / `KIROCREW_MANAGED_PYTHON=1` | n/a | skip system interpreters, always provision via uv |

## Tested

- **Real end-to-end on this host** (aarch64 Linux) with an isolated PATH containing no Python: uv 0.10.11 downloaded + digest-verified → CPython 3.12.13 provisioned → signed manifest verified → wheel 0.2.0 downloaded + verified → installed into the managed venv → `kirocrew --version` runs on the PBS interpreter.
- Rewrote `test/test_installer_distro.py` for the new path (10 tests): uv-tarball reach on no-Python, installed-uv preference (no second download), `--managed-python` skipping a usable system 3.12, tampered-download rejection (digest mismatch stops the install), watchdog/wedged-shim scenarios retained, plus the two static invariants above.
- Full local floor: pytest 57k+ green (10 failures verified pre-existing on clean `origin/main` on this host: `test_artifact_source`/`test_artifacts_handlers`/`test_host_isolation_floor`/`test_xdist_host_budget`), isort/flake8/mypy clean, `tsc -b` clean, vitest 21903 passed (2 `CliPanelCoverage` theme-timing failures under full-suite parallelism; same file passes 3/3 standalone on this branch — no frontend files in this diff), docs-lint + brand gate green.
- Docs updated in the same commit: README installer paragraph, `docs/guides/install.md`.

## Not in scope

- `install.sh` (git source build) keeps its own `ensure-python.sh` path.
- The desktop lane is unchanged (already uv+PBS).
