### PR TITLE
fix(test_acp_client_more_coverage): use short socket dirs in acp-client and gatewayd coverage tests

### DIFF
--- a/test/test_acp_client_more_coverage.py
+++ b/test/test_acp_client_more_coverage.py
@@ -263,16 +263,20 @@ class TestDrainOversizeLine:
 
 @_POSIX_ONLY
 class TestResolveSshAuthSock:
-    def test_live_socket_is_kept(self, tmp_path):
-        sock_path = tmp_path / "live.sock"
+    def test_live_socket_is_kept(self, short_sock_dir):
+        sock_path = short_sock_dir / "live.sock"
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as srv:
             srv.bind(str(sock_path))
             env = {"SSH_AUTH_SOCK": str(sock_path)}
             _resolve_ssh_auth_sock(env)
         assert env["SSH_AUTH_SOCK"] == str(sock_path)
 
-    def test_stale_pointer_is_repaired_to_newest_socket(self, tmp_path, monkeypatch):
-        old, new = tmp_path / "agent.1", tmp_path / "agent.2"
+    def test_stale_pointer_is_repaired_to_newest_socket(
+        self, tmp_path, short_sock_dir, monkeypatch
+    ):
+        # Bound endpoints must live under a short root (sun_path cap); the
+        # "gone.sock" pointer below never binds, so it can stay on tmp_path.
+        old, new = short_sock_dir / "agent.1", short_sock_dir / "agent.2"
         socks = []
         for path in (old, new):
             s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/test/test_gatewayd_more_coverage.py
+++ b/test/test_gatewayd_more_coverage.py
@@ -904,14 +904,19 @@ class TestDisconnectTeardown:
 class TestRunGatewaydLifecycle:
     @pytest.mark.asyncio
     async def test_prewarm_count_is_clamped_and_persisted_hot_keys_are_warmed(
-        self, tmp_path, monkeypatch
+        self, tmp_path, short_sock_dir, monkeypatch
     ):
         """``prewarm_count >= max_backends`` would pin the whole pool, so it is
         clamped to leave one reclaimable slot -- and only the clamped number of
         persisted hot keys is warmed."""
-        socket_path = tmp_path / "gw.sock"
+        # The endpoint must bind under a short root (sun_path cap). The daemon
+        # derives its hot-keys store as a sibling of the socket
+        # (``default_hot_keys_path``), so the seed file has to live in the same
+        # short dir. The credential watch path is passed explicitly, so it can
+        # stay on tmp_path.
+        socket_path = short_sock_dir / "gw.sock"
         socket_path.parent.mkdir(parents=True, exist_ok=True)
-        hot_keys_path = tmp_path / "hot-keys.json"
+        hot_keys_path = short_sock_dir / "hot-keys.json"
         now = time.time()
         hot_keys_path.write_text(
             json.dumps(
@@ -977,9 +982,9 @@ class TestRunGatewaydLifecycle:
 
     @pytest.mark.asyncio
     async def test_a_crashing_connection_handler_is_logged_and_the_daemon_keeps_serving(
-        self, tmp_path, monkeypatch, caplog
+        self, short_sock_dir, monkeypatch, caplog
     ):
-        socket_path = tmp_path / "gw-crash.sock"
+        socket_path = short_sock_dir / "gw-crash.sock"
         handled = asyncio.Event()
 
         async def _explode(*args, **kwargs):

--- a/test/test_gatewayd_self_exit.py
+++ b/test/test_gatewayd_self_exit.py
@@ -148,10 +148,10 @@ class TestSocketLivenessSweeper:
 class TestRunGatewaydSelfExit:
     @pytest.mark.asyncio
     async def test_daemon_self_exits_when_socket_is_unlinked(
-        self, tmp_path: Path
+        self, short_sock_dir: Path
     ) -> None:
         """End to end: bind a real endpoint, unlink it, daemon exits cleanly."""
-        socket_path = tmp_path / "gw-selfexit.sock"
+        socket_path = short_sock_dir / "gw-selfexit.sock"
         stop_event = asyncio.Event()
 
         def _resolver(pool_key):  # never invoked — no stub connects
@@ -184,13 +184,13 @@ class TestRunGatewaydSelfExit:
 
     @pytest.mark.asyncio
     async def test_windows_never_arms_the_liveness_sweeper(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, short_sock_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """With IS_WINDOWS=True the sweeper is not created: unlinking the
         endpoint path must NOT terminate the daemon (named pipes have no
         directory entry, so the probe would be meaningless there)."""
         monkeypatch.setattr(gw, "IS_WINDOWS", True)
-        socket_path = tmp_path / "gw-win.sock"
+        socket_path = short_sock_dir / "gw-win.sock"
         stop_event = asyncio.Event()
 
         def _resolver(pool_key):


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 1 related change:
- **Use short socket dirs in acp-client and gatewayd coverage tests**

## Changes and rationale

### Use short socket dirs in acp-client and gatewayd coverage tests
**Problem:** Six tests bind real AF_UNIX sockets at paths derived from pytest tmp_path (verified on upstream/main d90b2330d): test/test_acp_client_more_coverage.py::TestResolveSshAuthSock:: test_stale_pointer_is_repaired_to_newest_socket and test_live_socket_is_kept (sock_path = tmp_path / "live.sock", ~line 267) test/test_gatewayd_self_exit.py::TestRunGatewaydSelfExit:: test_daemon_self_exits_when_socket_is_unlinked and test_windows_never_arms_the_liveness_sweeper (tmp_path / "gw*.sock", ~lines 154/193)…
**Why it matters:** Deterministic full-suite failure on any deep checkout (6 failed in one shard). It burned attempt 1 of fix-chatslice-case-collision on 2026-08-13 (gate-pytest run at 22:54Z, 6 failed / 533 passed in the shard). The six tests are temporarily deselected in the local gate-pytest HOST_ENV_DESELECTS (entry 7) — remove that entry when this fix merges upstream.
**Fix (symptoms → root cause → change):** Switch the socket-BINDING paths in the affected tests from tmp_path to the existing short_sock_dir conftest fixture (mirror #3319's adoption in test_dashboard_server_startup_coverage.py). Keep tmp_path for anything that is not a bound socket (e.g. TestResolveSshAuthSock's nonexistent "gone.sock" probe path never binds and may stay on tmp_path). No behavior change, no skips — the tests must actually run.
**Tests:** Run the six tests with a deliberately long --basetemp (>90 chars): all pass. Control: they fail with OSError on pre-fix code under the same basetemp. Normal full-file runs stay green; no leaked temp dirs (short_sock_dir cleans up). .venv/bin/python -m pytest test/test_acp_client_more_coverage.py test/test_gatewayd_self_exit.py…
**Review focus:** backend

## Review map

| Change | Primary files |
|---|---|
| Use short socket dirs in acp-client and gatewayd coverage tests | `test/test_acp_client_more_coverage.py`<br>`test/test_gatewayd_more_coverage.py`<br>`test/test_gatewayd_self_exit.py` |

## Commits
- [`0d70b3f`](https://github.com/kirodotdev/KiroCrew/pull/4595/commits/0d70b3fa3ee2344dbf2fa6a9e754e0b0d2bf5c0b) fix(test_acp_client_more_coverage): use short socket dirs in acp-clie…

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (3 files, +22/-13)</summary>

- `test/test_acp_client_more_coverage.py` (+8/-4)
- `test/test_gatewayd_more_coverage.py` (+10/-5)
- `test/test_gatewayd_self_exit.py` (+4/-4)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->