### PR TITLE
test: install mint grant recorder before grant visibility (#4593)

### DIFF
--- a/test/test_connections_mint.py
+++ b/test/test_connections_mint.py
@@ -1093,10 +1093,25 @@ async def test_the_watcher_reads_a_real_grant_off_the_loop(
     assert entry["state"] == "waiting"
 
     # After the spawn, so the short-circuit above does not consume the grant and
-    # the recorder only sees the watcher's own reads.
-    _write_paired_grant_artifacts(_URL)
+    # the recorder only sees the watcher's own reads -- and the recorder BEFORE
+    # the grant becomes visible, so no poll issued after this point can read the
+    # grant through the un-instrumented predicate.
+    unwrapped = mint.grant_present
     seen: list[int] = []
     monkeypatch.setattr(mint, "grant_present", _grant_reads_recorded(seen))
+    # Ordering guard: the recorder is live while the grant is still invisible.
+    # Probes through the ORIGINAL predicate so this thread never enters ``seen``.
+    assert not unwrapped(_URL)
+    # Barrier for the in-flight tail: ``_grant_observed`` freezes the predicate
+    # object at ``to_thread`` submission, so a poll submitted before the setattr
+    # above can still complete after the write below. The watcher polls
+    # sequentially, so once one recorded (necessarily negative) read has landed,
+    # no un-instrumented poll remains in flight and the grant may become visible.
+    deadline = time.monotonic() + 5
+    while not seen and time.monotonic() < deadline:
+        await asyncio.sleep(0.001)
+    assert seen, "no recorded watcher poll arrived before the deadline"
+    _write_paired_grant_artifacts(_URL)
 
     await asyncio.wait_for(entry["watcher"], timeout=5)
 


### PR DESCRIPTION
## Problem

`test/test_connections_mint.py::test_the_watcher_reads_a_real_grant_off_the_loop` is flaky on loaded runners (#4593): it fails on `assert seen and threading.get_ident() not in seen` with `seen == []`, while the preceding `state == "granted"` assertion passes in the same run. The reporter hit it on a PR whose diff touches neither the test file nor the watcher path, with 8/8 local passes on an idle box.

## Why it matters

A flaky required check red-flags unrelated PRs and trains contributors to re-run CI instead of reading failures. The thread-identity property the test exists to verify (the grant stat runs off the event loop) is silently never evaluated in the failing runs, so the coverage the test claims is not delivered exactly when the runner is under load.

## Fix (symptoms → root cause → change)

- **Symptom:** `seen` empty while the mint still reaches `granted`.
- **Root cause:** the test races its own instrumentation. It pins `_MINT_GRANT_POLL_SECONDS` to 1ms, starts the watcher, then writes the paired grant artifacts **before** monkeypatching the `grant_present` recorder. A watcher poll landing between those two statements reads the grant through the un-instrumented predicate, transitions the mint to `granted`, and exits — the recorder is then installed on a function nobody calls again.
- **Change (test-only, one test):**
  1. **Reorder:** install the recorder before the artifacts are written, so no poll issued after the install can observe the grant unrecorded. Both statements stay after the `await mint.start_oauth_mint(...)` call, preserving the property the original comment protects (the pre-spawn short-circuit cannot consume the grant; the recorder sees only watcher reads).
  2. **Ordering guard:** `assert not unwrapped(_URL)` between the recorder install and the artifact write, probing through the *original* predicate so the test thread never enters `seen`. Reverting the reorder fails this assertion deterministically (mutation-verified: reverted order fails 100%, not timing-dependent).
  3. **In-flight-tail barrier:** `_grant_observed` passes the predicate *object* to `asyncio.to_thread`, freezing its identity at submission — so a poll submitted before the `setattr` could still complete after the write and consume the grant un-recorded. The watcher polls strictly sequentially (each poll awaited before the next), so the test now waits (bounded, 5s deadline) for one recorded — necessarily negative — read before making the grant visible: once it lands, no un-instrumented poll remains in flight. This is a pre-visibility synchronization point per testing-conventions § Determinism (bounded poll-for-condition), not a sleep/retry around the final assertion, which is unchanged.

**Sibling scan (per the issue's ask):** the same file was scanned for other tests installing instrumentation after making state visible — none share the hazard. The reconnect short-circuit test writes artifacts before the spawn by design (that ordering is its coverage); the audit-recorder tests install instrumentation before writing artifacts; the spec-removal tests instrument functions invoked only after installation.

## Tests

- The fixed test itself is the regression lock: the ordering guard plus barrier make the previously-racy ordering an asserted invariant. Mutation-verified — with the reorder reverted the test fails deterministically on the ordering guard; re-applied, `test/test_connections_mint.py` passes 97/97, repeated runs stable.

## Manual verification

N/A — unit coverage sufficient: the flake mechanism and its closure are both asserted in-test; the full backend suite ran locally (failures confined to pre-existing host-environmental tests: xdist host-budget caps, ssh-config, network-dependent installers, macOS release tooling — none touch connections/mint).

## Screenshots

N/A — backend test-only change, no user-visible surface.

<!-- no-visual-delta -->

Closes #4593
