### PR TITLE
fix(test_playwright_cli_installer): fix macos killpg permissionerror in pwcli rebootstrap test

### DIFF
--- a/test/test_playwright_cli_installer.py
+++ b/test/test_playwright_cli_installer.py
@@ -1738,6 +1738,28 @@ def test_a_node_that_does_not_run_here_leaves_the_previous_one_in_place(
     )
 
 
+def _signal_installer_group(pid: int, sig: int) -> None:
+    """Signal the installer's whole process group, tolerating the macOS EPERM
+    that ``killpg`` raises when it cannot signal every group member.
+
+    The installer is spawned with ``start_new_session=True``, so ``pid`` is the
+    group leader and ``killpg(pid, ...)`` targets the bootstrap's ``curl``/``tar``
+    children too. On macOS, BSD ``kill(2)`` returns EPERM for a group signal when
+    any member is in a state it cannot signal (e.g. a child mid-``exec`` or a
+    reaped group leader) -- a documented divergence from Linux, where the same
+    call succeeds. The intent here is only to interrupt the bootstrap, so on
+    EPERM fall back to signaling the group leader (``sh``) directly: it forwards
+    the signal or dies, and the EXIT trap still runs the restore the test
+    asserts on. A group that has already exited is a no-op.
+    """
+    try:
+        os.killpg(pid, sig)
+    except PermissionError:
+        os.kill(pid, sig)
+    except ProcessLookupError:
+        pass
+
+
 @posix_only
 def test_an_interrupted_rebootstrap_restores_the_previous_node(
     tmp_path: Path, stubs: Path, node_mirror: Path
@@ -1791,11 +1813,11 @@ def test_an_interrupted_rebootstrap_restores_the_previous_node(
     try:
         # Long enough to be inside the bootstrap, short enough to be mid-unpack.
         time.sleep(2.5)
-        os.killpg(proc.pid, signal.SIGINT)
+        _signal_installer_group(proc.pid, signal.SIGINT)
         proc.communicate(timeout=60)
     finally:
         if proc.poll() is None:
-            os.killpg(proc.pid, signal.SIGKILL)
+            _signal_installer_group(proc.pid, signal.SIGKILL)
             proc.communicate()
 
     # Whatever stage it died in, a Node must be present and it must be the old one


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 1 related change:
- **Fix macOS killpg PermissionError in pwcli rebootstrap test**

## Changes and rationale

### Fix macOS killpg PermissionError in pwcli rebootstrap test
**Problem:** test/test_playwright_cli_installer.py::test_an_interrupted_rebootstrap_restores_the_previous_node fails deterministically on macOS (reproduced 3x on the bare primary worktree at trunk, zero local diff, 2026-08-16 — post #3916, so this is NOT the fixed BSD-chmod class): `os.killpg(proc.pid, signal.SIGINT)` at line 1794 raises `PermissionError: [Errno 1] Operation not permitted`. The test spawns the installer with `start_new_session=True` and signals the whole group ~2.5s in; on macOS, killpg to a group returns…
**Why it matters:** macOS is a first-class target; any Mac contributor running the file gets a deterministic failure unrelated to the code under test. The whole-file deselect it previously forced also hid 117 healthy tests from local gates.
**Tests:** `.venv/bin/python -m pytest test/test_playwright_cli_installer.py -o addopts="" -p no:cacheprovider` fully green on this macOS host (currently 1 failed / 117 passed). Loop the test ~5x to confirm no flake signature remains. CI (Linux) behavior unchanged.
**Review focus:** backend

## Review map

| Change | Primary files |
|---|---|
| Fix macOS killpg PermissionError in pwcli rebootstrap test | `test/test_playwright_cli_installer.py` |

## Commits
- [`6331e54`](https://github.com/kirodotdev/KiroCrew/pull/4603/commits/6331e544d9c3e10cb8e6efaec25c8a012979aa9c) fix(test_playwright_cli_installer): fix macos killpg permissionerror …

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (1 files, +24/-2)</summary>

- `test/test_playwright_cli_installer.py` (+24/-2)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->