### PR TITLE
fix: resolve scaffold_app write paths against the app dir (#4599)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -206,7 +206,6 @@ src/kiro_crew/channel_transcript_migration.py
 src/kiro_crew/cli.py
 src/kiro_crew/cli_bench.py
 src/kiro_crew/cli_cloud.py
-src/kiro_crew/cli_commands.py
 src/kiro_crew/cli_desktop.py
 src/kiro_crew/cli_doctor.py
 src/kiro_crew/cli_server.py
@@ -415,7 +414,6 @@ src/kiro_crew/mcp_tools/skills.py
 src/kiro_crew/mcp_tools/spawn.py
 src/kiro_crew/mcp_tools/workflows.py
 src/kiro_crew/mcp_utils.py
-src/kiro_crew/memory.py
 src/kiro_crew/messaging/attachments.py
 src/kiro_crew/messaging/driver.py
 src/kiro_crew/messaging/link.py
@@ -447,7 +445,6 @@ src/kiro_crew/publish_governance.py
 src/kiro_crew/publish_sync.py
 src/kiro_crew/resource_status.py
 src/kiro_crew/safety_override.py
-src/kiro_crew/sandbox.py
 src/kiro_crew/security.py
 src/kiro_crew/seed.py
 src/kiro_crew/sel.py

--- a/src/kiro_crew/apps/scaffold.py
+++ b/src/kiro_crew/apps/scaffold.py
@@ -11,6 +11,53 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+
+def _resolve_for_write(root: Path, *rel: str) -> Path:
+    """Resolve ``root/*rel`` for writing; raise ``ValueError`` on any symlink.
+
+    The resolved target must EQUAL its lexical path beneath the resolved root.
+    Plain containment (``is_relative_to``) is not enough: it refuses escapes
+    but admits an intra-root alias -- ``out/victim -> out/existing`` resolves
+    inside the root, and scaffolding "victim" would truncate the sibling
+    project's files. Exact equality refuses every symlink beneath the root:
+    an escaping one (``Path.exists()`` is ``False`` for a dangling symlink, so
+    an existence test falls through to a write that follows the link), a
+    symlinked parent directory, and an in-root alias alike. An ABSOLUTE
+    component is refused before the comparison: ``joinpath`` discards the root
+    for one, making target equal expected trivially while both point outside
+    it. The root itself may still be a symlink (a symlinked home, ``/tmp`` on
+    macOS): both sides are built from ``root.resolve()``, so it compares
+    equal.
+
+    A refusal aborts the scaffold rather than skipping the site: a skipped
+    write would leave a partial app (no ``app.json``, no agent) while the CLI
+    reports success. Resolution failing outright (a symlink loop raises
+    ``OSError`` on Python 3.10/3.11 and ``RuntimeError`` on 3.12+) is refused
+    the same way rather than crashing with an unexplained traceback.
+    """
+    target = root.joinpath(*rel)
+    try:
+        resolved_root = root.resolve()
+        expected = resolved_root.joinpath(*rel)
+        # An absolute component (or a Windows drive-relative one) makes
+        # joinpath DISCARD the root, so target equals expected trivially while
+        # both point outside it; require the expected path to sit strictly
+        # beneath the resolved root before comparing. is_relative_to is
+        # lexical, so a ".." component passes here and is refused by the
+        # equality check below instead (resolve() normalizes it away).
+        if not expected.is_relative_to(resolved_root) or expected == resolved_root:
+            raise ValueError(f"refusing a path component that leaves {root}: {rel}")
+        resolved = target.resolve()
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"cannot resolve {target} under {root}: {exc}") from exc
+    if resolved != expected:
+        raise ValueError(
+            f"refusing to write through a symlink or traversal: "
+            f"{target} resolves to {resolved}, expected {expected}"
+        )
+    return resolved
+
+
 _MANIFEST_TEMPLATE = {
     "name": "",
     "version": "0.1.0",
@@ -233,6 +280,9 @@ def scaffold_app(
         author = os.environ.get("USER", "developer")
 
     app_dir = output_dir / name
+    # Refuses both a traversal in *name* and a pre-existing symlink at
+    # output_dir/name that would relocate every write outside the output dir.
+    _resolve_for_write(output_dir, name)
     app_dir.mkdir(parents=True, exist_ok=True)
 
     # Manifest
@@ -266,49 +316,46 @@ def scaffold_app(
                 "message": f"Run periodic check for {display_name}",
             }
         ]
-    (app_dir / "app.json").write_text(
+    _resolve_for_write(app_dir, "app.json").write_text(
         json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
     )
 
     # Agent
-    agents_dir = app_dir / "agents"
-    agents_dir.mkdir(exist_ok=True)
-    (agents_dir / "sample-agent.json").write_text(
+    _resolve_for_write(app_dir, "agents").mkdir(exist_ok=True)
+    _resolve_for_write(app_dir, "agents", "sample-agent.json").write_text(
         json.dumps(_AGENT_TEMPLATE, indent=2) + "\n", encoding="utf-8"
     )
 
     # Skill
-    skill_dir = app_dir / "skills" / "sample-skill"
-    skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "SKILL.md").write_text(
+    _resolve_for_write(app_dir, "skills", "sample-skill").mkdir(
+        parents=True, exist_ok=True
+    )
+    _resolve_for_write(app_dir, "skills", "sample-skill", "SKILL.md").write_text(
         _SKILL_TEMPLATE.format(name=name, display_name=display_name),
         encoding="utf-8",
     )
 
     # Backend (optional)
     if include_backend:
-        backend_dir = app_dir / "backend"
-        backend_dir.mkdir(exist_ok=True)
-        (backend_dir / "server.py").write_text(
+        _resolve_for_write(app_dir, "backend").mkdir(exist_ok=True)
+        _resolve_for_write(app_dir, "backend", "server.py").write_text(
             _BACKEND_TEMPLATE.format(name=name), encoding="utf-8"
         )
 
     # UI (optional)
     if include_ui:
-        ui_dir = app_dir / "ui"
-        ui_dir.mkdir(exist_ok=True)
-        src_dir = ui_dir / "src"
-        src_dir.mkdir(exist_ok=True)
+        _resolve_for_write(app_dir, "ui").mkdir(exist_ok=True)
+        _resolve_for_write(app_dir, "ui", "src").mkdir(exist_ok=True)
 
         component_name = name.replace("-", " ").title().replace(" ", "")
 
-        (ui_dir / "package.json").write_text(
+        _resolve_for_write(app_dir, "ui", "package.json").write_text(
             _UI_PACKAGE_JSON_TEMPLATE.format(name=name), encoding="utf-8"
         )
-        (ui_dir / "vite.config.ts").write_text(
+        _resolve_for_write(app_dir, "ui", "vite.config.ts").write_text(
             _UI_VITE_CONFIG_TEMPLATE.format(), encoding="utf-8"
         )
-        (src_dir / "App.tsx").write_text(
+        _resolve_for_write(app_dir, "ui", "src", "App.tsx").write_text(
             _UI_APP_TSX_TEMPLATE.format(
                 component_name=component_name,
                 display_name=display_name,
@@ -316,12 +363,12 @@ def scaffold_app(
             ),
             encoding="utf-8",
         )
-        (ui_dir / ".gitignore").write_text(
+        _resolve_for_write(app_dir, "ui", ".gitignore").write_text(
             _UI_GITIGNORE_TEMPLATE, encoding="utf-8"
         )
 
     # README
-    (app_dir / "README.md").write_text(
+    _resolve_for_write(app_dir, "README.md").write_text(
         _README_TEMPLATE.format(
             name=name, display_name=display_name, description=description
         ),

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -735,13 +735,20 @@ def _handle_app(args: argparse.Namespace) -> None:
         include_backend = getattr(args, "backend", False)
         include_ui = getattr(args, "ui", False)
         include_cron = getattr(args, "cron", False)
-        app_dir = scaffold_app(
-            output,
-            args.name,
-            include_backend=include_backend,
-            include_ui=include_ui,
-            include_cron=include_cron,
-        )
+        try:
+            app_dir = scaffold_app(
+                output,
+                args.name,
+                include_backend=include_backend,
+                include_ui=include_ui,
+                include_cron=include_cron,
+            )
+        except ValueError as exc:
+            # scaffold_app raises when a write path escapes the app directory
+            # (traversal in the name, a symlink in the tree). Match the clean
+            # error contract of the sibling app actions, not a raw traceback.
+            print(f"❌ {exc}", file=sys.stderr)
+            sys.exit(1)
         print(f"✅ Scaffolded app: {app_dir}")
         print("   Edit app.json, add agents and skills, then:")
         if include_ui:

--- a/test/test_app_scaffold.py
+++ b/test/test_app_scaffold.py
@@ -3,8 +3,192 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
+from conftest import make_dir_link, requires_symlinks
 from kiro_crew.apps.manifest import AppManifest
 from kiro_crew.apps.scaffold import scaffold_app
+
+# Every file scaffold_app writes and every directory it creates (all options
+# on), relative to the app dir. The containment tests parameterize over these,
+# and test_site_list_matches_what_scaffold_creates pins the list against what
+# scaffold_app actually produces — so a newly added write site that is not
+# also added here (and thereby covered by the symlink cases) fails the suite.
+_SCAFFOLD_FILES = [
+    "app.json",
+    "agents/sample-agent.json",
+    "skills/sample-skill/SKILL.md",
+    "backend/server.py",
+    "ui/package.json",
+    "ui/vite.config.ts",
+    "ui/src/App.tsx",
+    "ui/.gitignore",
+    "README.md",
+]
+_SCAFFOLD_DIRS = [
+    "agents",
+    "skills",
+    "skills/sample-skill",
+    "backend",
+    "ui",
+    "ui/src",
+]
+
+
+def _scaffold_all(output_dir, name):
+    return scaffold_app(
+        output_dir, name,
+        include_backend=True, include_ui=True, include_cron=True,
+    )
+
+
+class TestWriteContainment:
+    """Every write site refuses a path that resolves outside the app dir.
+
+    Path.exists() is False for a dangling symlink, so an existence test on the
+    joined path falls through to a write that follows the link and lands
+    outside the app directory; a symlinked parent directory escapes the same
+    way. Both shapes are exercised per write site. A refusal aborts the
+    scaffold (never a silent skip: a skipped write would leave a partial app
+    while the CLI reports success), and nothing lands outside the app dir.
+    """
+
+    def test_site_list_matches_what_scaffold_creates(self, tmp_path):
+        app_dir = _scaffold_all(tmp_path, "probe")
+        # as_posix(): the pinned lists use forward slashes; str() of a relative
+        # WindowsPath yields backslashes and fails the comparison on Windows.
+        files = {p.relative_to(app_dir).as_posix() for p in app_dir.rglob("*") if p.is_file()}
+        dirs = {p.relative_to(app_dir).as_posix() for p in app_dir.rglob("*") if p.is_dir()}
+        assert files == set(_SCAFFOLD_FILES)
+        assert dirs == set(_SCAFFOLD_DIRS)
+
+    @requires_symlinks
+    @pytest.mark.parametrize("relpath", _SCAFFOLD_FILES)
+    def test_write_refuses_to_follow_an_escaping_symlink(self, tmp_path, relpath):
+        # requires_symlinks: a DANGLING file symlink has no junction equivalent
+        # (junctions target existing directories), so unelevated Windows skips.
+        outside = tmp_path / "outside-target"
+        out = tmp_path / "out"
+        link = out / "victim" / relpath
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(outside)
+
+        with pytest.raises(ValueError):
+            _scaffold_all(out, "victim")
+
+        assert not outside.exists(), f"{relpath} wrote through a dangling symlink"
+
+    @pytest.mark.parametrize("reldir", _SCAFFOLD_DIRS)
+    def test_mkdir_refuses_an_escaping_dir_symlink(self, tmp_path, reldir):
+        outside = tmp_path / "outside-dir"
+        outside.mkdir()
+        out = tmp_path / "out"
+        link = out / "victim" / reldir
+        link.parent.mkdir(parents=True, exist_ok=True)
+        # make_dir_link: a junction on Windows needs no privilege and resolves
+        # through the same reparse machinery, so this stays exercised there.
+        make_dir_link(link, outside)
+
+        with pytest.raises(ValueError):
+            _scaffold_all(out, "victim")
+
+        assert list(outside.iterdir()) == [], (
+            f"{reldir} let writes land outside the app dir"
+        )
+
+    def test_app_dir_symlink_escaping_output_dir_is_refused(self, tmp_path):
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        make_dir_link(out / "victim", outside)
+
+        with pytest.raises(ValueError):
+            _scaffold_all(out, "victim")
+
+        assert list(outside.iterdir()) == []
+
+    def test_name_with_traversal_is_refused(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+
+        with pytest.raises(ValueError):
+            scaffold_app(out, "../evil")
+
+        assert not (tmp_path / "evil").exists()
+
+    def test_absolute_name_is_refused(self, tmp_path):
+        """joinpath discards the root for an absolute component, so an absolute
+        name would compare equal trivially while writing outside --dir."""
+        out = tmp_path / "out"
+        out.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+
+        with pytest.raises(ValueError):
+            scaffold_app(out, str(elsewhere / "evil"))
+
+        assert not (elsewhere / "evil").exists()
+
+    def test_app_dir_alias_of_a_sibling_project_is_refused(self, tmp_path):
+        """An IN-ROOT alias passes plain containment: out/victim -> out/existing
+        resolves inside the output dir, and scaffolding "victim" would truncate
+        the sibling project's files. Exact-path equality refuses it."""
+        out = tmp_path / "out"
+        out.mkdir()
+        existing = out / "existing"
+        existing.mkdir()
+        (existing / "app.json").write_text('{"name": "existing"}', encoding="utf-8")
+        make_dir_link(out / "victim", existing)
+
+        with pytest.raises(ValueError):
+            _scaffold_all(out, "victim")
+
+        assert (existing / "app.json").read_text(encoding="utf-8") == (
+            '{"name": "existing"}'
+        )
+
+    def test_in_app_alias_of_a_sibling_dir_is_refused(self, tmp_path):
+        """Same alias shape one level down: agents -> ./real inside the app dir
+        resolves inside the root but is not the lexical path; refused."""
+        out = tmp_path / "out"
+        app_dir = out / "victim"
+        (app_dir / "real").mkdir(parents=True)
+        make_dir_link(app_dir / "agents", app_dir / "real")
+
+        with pytest.raises(ValueError):
+            _scaffold_all(out, "victim")
+
+        assert list((app_dir / "real").iterdir()) == []
+
+    @requires_symlinks
+    def test_symlink_loop_raises_a_clear_error(self, tmp_path):
+        """A self-referential symlink makes resolve() raise; the scaffold must
+        abort with the containment ValueError, not an unexplained OSError.
+        requires_symlinks: a junction cannot point at itself pre-creation, so
+        the loop shape has no junction equivalent on unelevated Windows."""
+        out = tmp_path / "out"
+        app_dir = out / "victim"
+        app_dir.mkdir(parents=True)
+        (app_dir / "agents").symlink_to(app_dir / "agents")
+
+        with pytest.raises(ValueError):
+            _scaffold_all(out, "victim")
+
+        assert not (app_dir / "agents" / "sample-agent.json").exists()
+
+    def test_scaffold_through_a_symlinked_output_dir_succeeds(self, tmp_path):
+        """A symlink in the user's own --dir is not an escape: both sides are
+        resolved, so a symlinked home or /tmp on macOS compares equal."""
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        make_dir_link(link, real)
+
+        app_dir = _scaffold_all(link, "my-app")
+
+        assert (real / "my-app" / "app.json").is_file()
+        assert (app_dir / "README.md").is_file()
 
 
 class TestScaffold:
@@ -86,6 +270,28 @@ class TestScaffold:
         captured = capsys.readouterr()
         assert "Scaffolded" in captured.out
         assert (tmp_path / "cli-scaffolded" / "app.json").is_file()
+
+    def test_scaffold_cli_refusal_prints_clean_error(self, tmp_path, monkeypatch, capsys):
+        """A containment refusal exits 1 with the app actions' clean error
+        contract on stderr, not a raw ValueError traceback."""
+        home = tmp_path / "kirocrew-home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+
+        import argparse
+
+        from kiro_crew.cli_commands import _handle_app
+        out = tmp_path / "out"
+        out.mkdir()
+        ns = argparse.Namespace(app_action="init", name="../evil", dir=str(out), backend=False)
+        with pytest.raises(SystemExit) as excinfo:
+            _handle_app(ns)
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        # Pin the contract (clean error prefix on stderr), not the specific
+        # refusal wording, which differs by escape shape.
+        assert captured.err.startswith("\u274c ")
+        assert not (tmp_path / "evil").exists()
 
     def test_scaffold_with_ui(self, tmp_path):
         """--ui generates ui/ directory with package.json, vite config, and App.tsx."""


### PR DESCRIPTION
## What is the problem?

`scaffold_app` (`src/kiro_crew/apps/scaffold.py`) writes 9 files and creates 6 directories under the app directory by joining filenames onto `app_dir` and writing without resolving the path first. A pre-existing symlink in the scaffold target -- an `agents/`, `skills/`, `backend/`, `ui/` or `ui/src/` directory symlinked outside the app, or any written filename present as a dangling symlink -- makes the write follow the link and land outside the app directory. The dangling-symlink case is the sharper one: `Path.exists()` returns `False` for a dangling symlink, so an existence test on the joined path falls through to a write that then follows the link.

## Why this issue matters to the user

Severity is low as it stands: the only caller is the `kirocrew app init` CLI, whose output directory comes from the user's own `--dir` argument, and no Kiro Crew code path scaffolds into an attacker-populated directory. This is defence-in-depth on a developer tool, plus fixing a copy-worthy shape: `scaffold_app` is the obvious template for future manifest-to-tree helpers, and an unguarded template propagates the defect into paths that may not stay low-severity.

## How our fix solves it

One containment helper, `_resolve_for_write(target, root)`, is routed through every mkdir and write site. It requires the resolved target to EQUAL its lexical path beneath the resolved app dir, raising `ValueError` otherwise and aborting the scaffold. Chain from symptom to root cause:

- Writes followed symlinks because the joined path was never resolved before the write; the helper resolves it and compares against the expected lexical path, so a dangling filename symlink or a symlinked parent directory is refused before any write happens.
- Plain containment (`is_relative_to`) is NOT enough: an in-root alias (`out/victim -> out/existing`) resolves inside the root, and scaffolding "victim" would truncate the sibling project's files (review round 2 finding). Exact-path equality refuses every symlink beneath the root.
- An ABSOLUTE component is refused before the comparison: `joinpath` discards the root for one, making the equality trivially true while writing outside `--dir` (review round 3 finding -- an absolute app name reached the filesystem).
- BOTH sides are resolved, so a symlink in the user's own output directory (a symlinked home, `/tmp` on macOS) compares equal instead of reading as an escape -- scaffolding through a symlinked `--dir` keeps working (both sides are built from `root.resolve()`).
- A refusal ABORTS the scaffold rather than log-and-skip. A skipped site would leave a partial app -- a dangling `app.json` symlink would produce a scaffold with no manifest -- while the CLI reports success: the fail-open shape the repo's security rules forbid. (Review round 1 flagged exactly this on the skip variant; fixed forward to abort.)
- A resolution failure (a symlink loop raises `OSError` on Python 3.10/3.11, `RuntimeError` on 3.12+) is refused with the same `ValueError` rather than surfacing an unexplained traceback shape.

## What tests we did

- `test/test_app_scaffold.py` adds `TestWriteContainment`: the dangling-file-symlink and symlinked-parent-directory shapes parameterized over every write site (9 files, 6 directories), each asserting the scaffold raises AND nothing landed outside the app dir; plus root-site refusal, in-root alias refusals (the round-2 sibling-truncation scenario, at the app-dir and in-app levels), `name` traversal and absolute-`name` refusals, symlink-loop refusal, and a positive case scaffolding through a symlinked output directory.
- A completeness test pins the parameterized site lists against what `scaffold_app` actually creates, so a newly added write site that is not routed through containment (and thereby covered by the symlink cases) fails the suite.
- Mutation-verified: bypassing the helper at one write site reddens that site's parameterized case (re-verified after the abort-semantics change); neutering the resolution-failure guard reddens the symlink-loop test.
- Local gates green: `isort`, `flake8`, `mypy` (the 4 pre-existing `transcribe.py`/`cloudwatch.py` stub errors reproduce identically on a clean checkout), full `pytest` (57456 passed; the 41 failures reproduce identically on the clean base and are host-environment failures unrelated to this change).
- Two pre-push review passes ran before the PR opened; one found the bare-`resolve()` crash on symlink loops (fixed, test added). The server-side GPT lane's round-1 blocking finding (silent skip = partial app reported as success) is fixed by the abort semantics above.

## Any other suggestions on the work

PR #4585 (open) adds an icon write with its own inline containment check that logs and skips -- correct for that site, since the icon is optional artwork deliberately written only when absent. Once both land, the icon site can reuse `_resolve_for_write` with a caught `ValueError` in whichever PR rebases second.

Closes #4599
