### PR TITLE
fix(kas): carry auto-approve and the agent definition across the KAS seam

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -206,7 +206,6 @@ src/kiro_crew/channel_transcript_migration.py
 src/kiro_crew/cli.py
 src/kiro_crew/cli_bench.py
 src/kiro_crew/cli_cloud.py
-src/kiro_crew/cli_commands.py
 src/kiro_crew/cli_desktop.py
 src/kiro_crew/cli_doctor.py
 src/kiro_crew/cli_server.py
@@ -415,7 +414,6 @@ src/kiro_crew/mcp_tools/skills.py
 src/kiro_crew/mcp_tools/spawn.py
 src/kiro_crew/mcp_tools/workflows.py
 src/kiro_crew/mcp_utils.py
-src/kiro_crew/memory.py
 src/kiro_crew/messaging/attachments.py
 src/kiro_crew/messaging/driver.py
 src/kiro_crew/messaging/link.py
@@ -447,7 +445,6 @@ src/kiro_crew/publish_governance.py
 src/kiro_crew/publish_sync.py
 src/kiro_crew/resource_status.py
 src/kiro_crew/safety_override.py
-src/kiro_crew/sandbox.py
 src/kiro_crew/security.py
 src/kiro_crew/seed.py
 src/kiro_crew/sel.py

--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -87,8 +87,31 @@ def build_session_new_params(
     if claude_meta:
         params["_meta"] = {"claudeCode": {"options": {}}}
     if kas_custom_agents:
-        params["_meta"] = {"kiro": {"customAgents": kas_custom_agents}}
+        attach_kas_custom_agents(params, kas_custom_agents)
     return params
+
+
+def attach_kas_custom_agents(
+    params: dict[str, Any],
+    agents: list[dict[str, Any]] | None,
+) -> None:
+    """Put agent definitions in the ``_meta`` envelope KAS reads them from.
+
+    Shared by ``session/new`` and ``session/load`` so the envelope's shape has
+    one owner: a resumed session needs the same definitions a new one gets, and
+    two hand-built copies of the same nesting would be free to drift.
+
+    Merges into any existing ``_meta`` rather than replacing it. Today's other
+    writer is a kiro-cli-only transcript path, so in practice they never both
+    apply — but a future third writer should not be able to silently drop one.
+    """
+    if not agents:
+        return
+    meta = params.get("_meta")
+    if not isinstance(meta, dict):
+        meta = {}
+        params["_meta"] = meta
+    meta["kiro"] = {"customAgents": agents}
 
 
 def set_mode_params(session_id: str, agent: str) -> dict[str, Any]:

--- a/src/kiro_crew/acp/kas_agents.py
+++ b/src/kiro_crew/acp/kas_agents.py
@@ -25,11 +25,17 @@ rediscover:
   name regardless of where it was declared.
 * ``model`` — the model is set through its own protocol verb, so it has exactly
   one owner rather than being pinned in two places that can disagree.
-* ``permissions`` — KAS's inline policy is keyed by ITS capability vocabulary,
-  not by tool names, so translating Crew's auto-approve list would mean guessing
-  identifiers. A wrong guess either no-ops or over-allows, and over-allowing is
-  not a risk worth taking for a convenience feature; omitting the field leaves
-  KAS's own default policy in force. Auto-approval parity is a follow-up.
+
+``permissions`` IS projected, and is the one field that changes behaviour rather
+than just describing it. KAS's policy is keyed by its own capability vocabulary
+instead of by tool name, so it is not a rename of Crew's ``allowedTools`` — see
+:mod:`kiro_crew.acp.kas_permissions` for the mapping and for why an entry it
+cannot classify is left to prompt. Omitting the field is not the neutral choice
+it looks like: with no policy, KAS resolves every request to ``ask``, so a spec
+that auto-approves a dozen tools on kiro-cli would prompt for all of them here.
+It is derived from ``allowedTools`` and from nothing else: a ``permissions``
+block already in the spec is NOT relayed, because ``allowedTools`` is the only
+auto-approve input Crew's governance ceiling has filtered.
 """
 
 from __future__ import annotations
@@ -39,7 +45,10 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from kiro_crew.acp.kas_permissions import allowed_tools_to_permissions
+from kiro_crew.platform.governance import may_skip_gate_now
 from kiro_crew.security import is_sensitive_path
+from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
 
@@ -51,12 +60,19 @@ _PROMPT_FILE_SCHEME = "file://"
 #: Pseudo-filesystems whose contents are process/kernel state, not documents.
 _PSEUDO_FS_ROOTS = ("/proc", "/sys", "/dev")
 
-#: Spec keys Crew writes that KAS's ``ClientCustomAgent`` has no home for.
-#: Dropped with a named warning so a lost capability shows up in the log instead
-#: of being discovered as missing behaviour later.
+#: Spec keys with no slot in KAS's ``ClientCustomAgent`` wire schema.
+#:
+#: "No slot on the wire" is NOT "no such capability in KAS" — conflating the two
+#: is what kept ``hooks`` written off as unsupported. KAS runs pre/post-tool-use
+#: hooks natively and loads them from an agent profile ON DISK (it even accepts
+#: Crew's object form), so what is lost here is a delivery path, not a feature:
+#: an agent injected over the wire cannot carry them.
+#:
+#: ``allowedTools`` is deliberately NOT in this set. It has no slot either, but
+#: :mod:`kiro_crew.acp.kas_permissions` translates it into ``permissions``, so
+#: the capability survives under another name.
 UNSUPPORTED_SPEC_KEYS = frozenset(
     {
-        "allowedTools",
         "hooks",
         "slashCommand",
         "toolsSettings",
@@ -208,6 +224,65 @@ def _project_tools(spec: dict[str, Any], agent_id: str) -> str | list[str]:
     return []
 
 
+def _ceiling_permitted(allowed_tools: Any, agent_id: str) -> list[str]:
+    """``allowedTools`` with every entry the governance ceiling withholds removed.
+
+    The five writers of an ``allowedTools`` list already consult the ceiling when
+    they WRITE, so on a freshly rebuilt spec this changes nothing. It is here
+    because projection READS a file, and the file can predate the ceiling that now
+    governs it: a spec written on an ungoverned host, restored from a backup, or
+    edited by hand carries grants nobody ever cleared. Re-asking at the moment of
+    projection is the same shape as the final sanitizer pass ``rebuild_agent_config``
+    runs over ``mcpServers`` — the last chance to withhold, taken deliberately.
+
+    ``may_skip_gate_now`` fails closed (an unreadable ceiling withholds), which is
+    the direction that matters: what is dropped here keeps prompting.
+    """
+    if not isinstance(allowed_tools, list):
+        return []
+    permitted: list[str] = []
+    withheld: list[str] = []
+    for raw in allowed_tools:
+        if not isinstance(raw, str) or not raw.strip():
+            continue
+        entry = raw.strip()
+        if may_skip_gate_now(entry):
+            permitted.append(entry)
+        else:
+            withheld.append(entry)
+    if withheld:
+        names = ", ".join(sorted(withheld))
+        logger.info(
+            "agent %r: the governance ceiling withholds auto-approval for %s; "
+            "projecting no rule for them, so they keep prompting",
+            agent_id,
+            names,
+        )
+        # A withhold is a permission DECISION, and the other writers that reach
+        # this state — app-agent materialization, the host shared-MCP sync,
+        # doctor's auto-fix — all record it in the security event log. Projection
+        # is the fourth, and the only one whose input is a file it did not write,
+        # so a stale grant is likelier to be withheld HERE than anywhere else;
+        # leaving it at a log line would make the most likely case the one with no
+        # audit trail. Never fail the projection on an audit error: the withhold
+        # itself has already happened and is the safe direction.
+        try:
+            sel().log_api_access(
+                caller="system",
+                operation="mcp_auto_approve_withheld",
+                outcome="ok",
+                source="kas_agent_projection",
+                resources=(
+                    f"{names} projected without auto-approve "
+                    f"(governance ceiling) for agent {agent_id or '?'}; "
+                    "calls go through the approval gate"
+                ),
+            )
+        except Exception:  # noqa: BLE001 — audit must not break projection
+            logger.debug("SEL audit unavailable for KAS projection withhold", exc_info=True)
+    return permitted
+
+
 def to_client_custom_agent(
     agent_id: str,
     spec: dict[str, Any],
@@ -224,8 +299,14 @@ def to_client_custom_agent(
 
     dropped = sorted(k for k in UNSUPPORTED_SPEC_KEYS if spec.get(k))
     if dropped:
-        logger.warning(
-            "agent %r: dropping spec keys with no KAS equivalent: %s",
+        # Says WHY the key is dropped, because the previous wording ("no KAS
+        # equivalent") reads as "KAS cannot do this" and sent readers looking for
+        # a missing feature instead of a missing wire field. Debug, not warning:
+        # this fires on every session/new with a constant payload, so at WARNING
+        # it drowns the log without ever telling anyone something new.
+        logger.debug(
+            "agent %r: spec keys the customAgents wire schema cannot carry, "
+            "so an injected agent runs without them: %s",
             agent_id,
             ", ".join(dropped),
         )
@@ -235,6 +316,23 @@ def to_client_custom_agent(
         "prompt": prompt,
         "tools": _project_tools(spec, agent_id),
     }
+
+    # Derived from `allowedTools` and from nothing else. A `permissions` block
+    # sitting in the spec is deliberately NOT forwarded, even though it is already
+    # in KAS's vocabulary and forwarding it would be one line: it has not passed
+    # Crew's governance ceiling, so projecting one would hand any editor of the
+    # file a grant the ceiling never saw — and an auto-approved call never reaches
+    # Crew's permission callback, so the deny-list and the audit trail are skipped
+    # with it. One governed input, one derivation.
+    #
+    # A hand-written block is not ignored, just not Crew's to relay: it lives in
+    # the profile on disk, which the backend reads itself when Crew is not
+    # injecting an agent over the wire.
+    permissions = allowed_tools_to_permissions(
+        _ceiling_permitted(spec.get("allowedTools"), agent_id), agent_id=agent_id
+    )
+    if permissions:
+        out["permissions"] = permissions
 
     description = spec.get("description")
     if isinstance(description, str) and description:

--- a/src/kiro_crew/acp/kas_permissions.py
+++ b/src/kiro_crew/acp/kas_permissions.py
@@ -1,0 +1,231 @@
+"""Translate a Crew agent's ``allowedTools`` into a KAS inline permissions policy.
+
+kiro-cli and KAS express "do not prompt for this" in two different currencies.
+kiro-cli takes a flat allowlist of TOOL NAMES (``allowedTools``); KAS takes a
+rules list keyed by CAPABILITY plus a resource glob::
+
+    {"rules": [{"capability": "mcp", "match": ["srv/*"], "effect": "allow"}]}
+
+KAS declares ``allowedTools`` a CLI-only field, so the name has no counterpart —
+but the CAPABILITY it is trying to express does, and that makes the translation
+mechanical rather than a guess. Two properties of KAS's evaluator are what keep
+it safe:
+
+* An unmatched request resolves to ``ask``, so a tool this module cannot
+  classify keeps prompting. Silence is the fail-closed direction, which is why
+  an unmappable entry emits NO rule instead of a broad one.
+* ``match`` omitted means "every resource" (KAS defaults it to ``['**']``).
+  That is exactly what a kiro-cli ``allowedTools`` entry means — auto-approve
+  the tool whatever it is pointed at — so the omission is faithful, not lax.
+
+The vocabulary is deliberately narrow. A tool-name allowlist carries no resource
+pattern, so every rule derived from it is unscoped — "allow the ``shell``
+capability for any command" is the faithful translation of auto-approving
+``execute_bash``, and that is precisely why the shell and filesystem families are
+refused rather than translated (see :data:`WITHHELD_FROM_AUTO_APPROVE`). Auto-
+approval means no permission request, and no permission request means the deny
+floor and the sensitive-path check never run.
+
+Both consumers use this one module so the wire projection
+(``kas_agents.to_client_custom_agent``) and the on-disk spec Crew writes
+(``agent.rebuild_agent_config``) cannot drift into disagreeing about what a
+given ``allowedTools`` list means.
+
+``allowedTools`` is also the ONLY input either consumer derives from. A
+``permissions`` block already present in a spec is never read back and never
+translated: it has not passed Crew's governance ceiling, and an auto-approved
+call never reaches Crew's permission callback, so relaying one would route around
+the deny-list and the audit trail at once. On disk such a block is left untouched
+(it is the user's file, and it applies when Crew is not injecting an agent); on
+the wire it is simply not Crew's to forward.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Marks an MCP server (or one of its tools) in a Crew ``tools``/``allowedTools``
+#: entry: ``@server`` for the whole server, ``@server/tool`` for one action.
+_MCP_PREFIX = "@"
+
+#: KAS's capability for any MCP-served tool.
+_MCP_CAPABILITY = "mcp"
+
+#: Tool name -> KAS capability, mirroring KAS's own tool classification for the
+#: built-in tools Crew's specs actually name. Deliberately NOT exhaustive over
+#: KAS's table: an entry here is a promise that auto-approving the Crew tool and
+#: allowing the KAS capability mean the same thing. Anything absent is treated as
+#: unclassifiable and left to prompt (see the module docstring).
+CAPABILITY_BY_TOOL: dict[str, str] = {
+    # Network.
+    "web_fetch": "web_fetch",
+    "web_search": "web_search",
+    # Sub-agents and skills.
+    "invoke_sub_agent": "subagent",
+    "disclose_context": "skill",
+}
+
+#: Tools this module refuses to translate even though the capability exists.
+#:
+#: Auto-approval is not just "one fewer prompt" — it is the absence of a
+#: permission request, and a Crew control that runs ON that request does not run
+#: at all: the deny floor, the sensitive-path check, the ceiling's own last word.
+#: For the shell and filesystem families the cost of losing those is the whole
+#: blast radius (an arbitrary command, an overwritten file, a credential file
+#: read), and the grant they would produce is unscoped, because a tool-name
+#: allowlist carries no resource pattern to narrow it with.
+#:
+#: This is not a behaviour change for anything Crew ships: its own spec
+#: deliberately keeps these OUT of ``allowedTools`` (see ``TestTheRealAllowlist``),
+#: and on a governed host the ceiling withholds them anyway. What the refusal buys
+#: is that a spec which asks for them — from an app manifest, or a hand edit on an
+#: ungoverned host — cannot obtain here what it would obtain on kiro-cli. That
+#: asymmetry is deliberate and it is the safe direction: no rule means prompt.
+WITHHELD_FROM_AUTO_APPROVE: frozenset[str] = frozenset(
+    {
+        # Filesystem reads.
+        "fs_read",
+        "read",
+        "read_file",
+        "grep",
+        "glob",
+        "code",
+        # Filesystem writes.
+        "fs_write",
+        "fs_append",
+        "str_replace",
+        "write",
+        # Shell.
+        "execute_bash",
+        "execute_pwsh",
+        "control_bash_process",
+    }
+)
+
+
+#: Glob syntax KAS's resource matcher honours, and Crew's auto-approve check does
+#: not. An entry carrying any of these means one thing to the list it was written
+#: on and something wider here, so it is never translated (see
+#: :func:`_mcp_pattern`).
+_GLOB_METACHARACTERS = frozenset("*?[]{}!")
+
+
+def _mcp_pattern(entry: str) -> str | None:
+    """Resource glob for an ``@server`` / ``@server/tool`` entry.
+
+    KAS addresses an MCP tool as ``<server>/<tool>``, so a bare server becomes a
+    one-level glob and a named action becomes an exact match.
+
+    ``None`` for a reference that is not a plain name. Crew's own auto-approve
+    check compares ``allowedTools`` entries literally, so ``@*`` on that list
+    grants a server actually called ``*`` — nothing. Here it would become the
+    pattern ``*/*``, which KAS resolves as every tool on every server: the same
+    text would mean "no grant" on one backend and "grant everything" on the
+    other. Translation must not be the step that widens a grant, so an entry we
+    cannot read as one literal server (optionally one literal tool) is left to
+    prompt instead of being guessed at.
+    """
+    ref = entry[len(_MCP_PREFIX) :]
+    if _GLOB_METACHARACTERS.intersection(ref):
+        return None
+    return ref if "/" in ref else f"{ref}/*"
+
+
+def _collapse_mcp_patterns(patterns: set[str]) -> list[str]:
+    """Drop per-tool patterns already covered by their server's wildcard.
+
+    ``@srv`` and ``@srv/one`` commonly appear together (the broad entry was
+    added later and the narrow ones were never cleaned up). Emitting both is
+    harmless to the evaluator but misleading to read, and a reviewer comparing
+    the policy against the allowlist should not have to work out that one line
+    subsumes another.
+    """
+    servers = {p[:-2] for p in patterns if p.endswith("/*")}
+    return sorted(p for p in patterns if p.endswith("/*") or p.split("/", 1)[0] not in servers)
+
+
+def allowed_tools_to_permissions(
+    allowed_tools: Any,
+    *,
+    agent_id: str = "",
+) -> dict[str, Any] | None:
+    """Build a KAS inline permissions policy from a Crew ``allowedTools`` list.
+
+    Returns ``None`` when there is nothing to say — no usable entries, or none
+    that classify — so callers can omit the field entirely rather than sending
+    an empty ``rules`` array. An empty policy and an absent one are NOT
+    equivalent to read: absent says "this spec never described auto-approval",
+    which is the truth in that case.
+
+    Entries that cannot be classified are reported once, at debug, listing the
+    names. They are not an error: they keep prompting, which is the same
+    behaviour as having no policy at all, and a WARNING for a tool the user
+    never asked to auto-approve would be noise.
+    """
+    if not isinstance(allowed_tools, list):
+        return None
+
+    mcp_patterns: set[str] = set()
+    capabilities: set[str] = set()
+    unclassified: list[str] = []
+    withheld: list[str] = []
+
+    for raw in allowed_tools:
+        if not isinstance(raw, str) or not raw.strip():
+            continue
+        entry = raw.strip()
+        if entry.startswith(_MCP_PREFIX):
+            pattern = _mcp_pattern(entry)
+            # `None` for a glob; `@` alone or `@/tool` names no server. Neither
+            # describes a grant we can honour, so both keep prompting.
+            if pattern is None or pattern.startswith("/"):
+                unclassified.append(entry)
+                continue
+            mcp_patterns.add(pattern)
+            continue
+        if entry in WITHHELD_FROM_AUTO_APPROVE:
+            withheld.append(entry)
+            continue
+        capability = CAPABILITY_BY_TOOL.get(entry)
+        if capability is None:
+            unclassified.append(entry)
+            continue
+        capabilities.add(capability)
+
+    if unclassified:
+        logger.debug(
+            "agent %r: allowedTools entries with no KAS capability, left to prompt: %s",
+            agent_id,
+            ", ".join(sorted(unclassified)),
+        )
+    if withheld:
+        # Louder than `unclassified`, and separate from it: this one is a policy
+        # decision the spec asked us to reverse, so a reader comparing the spec
+        # against the projected policy should not have to guess which it was.
+        logger.info(
+            "agent %r: not auto-approving %s on this backend — an auto-approved call "
+            "raises no permission request, so Crew's deny floor and sensitive-path "
+            "check would not run for it",
+            agent_id,
+            ", ".join(sorted(withheld)),
+        )
+
+    rules: list[dict[str, Any]] = []
+    if mcp_patterns:
+        rules.append(
+            {
+                "capability": _MCP_CAPABILITY,
+                "match": _collapse_mcp_patterns(mcp_patterns),
+                "effect": "allow",
+            }
+        )
+    # `match` is deliberately omitted: a tool-name allowlist entry carries no
+    # resource scope, and KAS reads a missing `match` as every resource.
+    rules.extend({"capability": cap, "effect": "allow"} for cap in sorted(capabilities))
+
+    if not rules:
+        return None
+    return {"rules": rules}

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -29,6 +29,7 @@ from typing import Any, Callable, TypeVar
 
 from kiro_crew import platform_compat
 from kiro_crew.acp._dispatch import (
+    attach_kas_custom_agents,
     build_session_new_params,
     parse_session_modes,
     redact_text,
@@ -2543,8 +2544,9 @@ class AcpRuntime:
         # silently un-pooling the session for the rest of its life. Resolved off
         # the event loop — the overlay lookup stats and reads files. Empty when
         # the shared gateway is disabled, so non-pooled installs still send [].
+        active_agent = agent or self._agent
         mcp_servers = await asyncio.to_thread(
-            pooled_session_servers, self._mcp_gateway_overlay, agent or self._agent
+            pooled_session_servers, self._mcp_gateway_overlay, active_agent
         )
         load_params: dict[str, Any] = {
             "sessionId": resume_sid,
@@ -2556,6 +2558,29 @@ class AcpRuntime:
             # the session itself from sessionId is called with an empty path, and
             # sending the field anyway would advertise a path that does not exist.
             load_params["_meta"] = {"_kiro.dev/session_file": session_file}
+        # Re-inject the agent definition, for the same reason create_session()
+        # does: KAS registers client agents per session and has no --agent flag,
+        # so a resumed session that is not handed them again advertises only the
+        # modes it can find on disk. That set is NOT a superset of what
+        # session/new had — KAS skips an agent profile written for kiro-cli — so
+        # omitting this made the requested mode genuinely absent on resume, and
+        # Guard A below then refused the load rather than run the backend default.
+        #
+        # Guarded on the backend rather than relying on _kas_custom_agents()
+        # answering None, so the kiro resume path reaches a comparison and stops:
+        # no awaited step, nothing to unwind, no shared coroutine that could grow
+        # a failure mode later. create_session() enters the same seam
+        # unconditionally, which is the shape this one deliberately does NOT copy
+        # — reading a backend and stopping is the smallest non-zero delta the kiro
+        # path can take for KAS behaviour to exist here at all, and it is the
+        # positive `== ACP_BACKEND_KAS` dispatch harness-parity H5 asks for (see
+        # _deliver_kas_access_token, and six other call sites in this file).
+        # H13 governs the REGISTRATION seam — ProviderRegistry and
+        # create_provider_factory, per its own row in harness-parity.md — not
+        # per-request dispatch inside the runtime; a reading that reached here
+        # would forbid those seven shipped call sites too.
+        if self._acp_backend == ACP_BACKEND_KAS:
+            attach_kas_custom_agents(load_params, await self._kas_custom_agents(active_agent))
         budget = await self._session_start_budget()
         self._session_inits_in_flight += 1
         loaded_session_id = ""

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2709,6 +2709,55 @@ def _strip_ungoverned_auto_approve(servers: dict[str, Any]) -> dict[str, Any]:
     return dict(strip_ungoverned_auto_approve(servers))
 
 
+def _seed_kas_permissions(config: dict[str, Any]) -> None:
+    """Give the spec a KAS ``permissions`` block if it has none. Never edit one.
+
+    Two things ride on this field, and the second is the surprising one:
+
+    1. It is how the auto-approve list reaches the KAS backend at all, since
+       ``allowedTools`` is a kiro-cli-only field there.
+    2. Its mere PRESENCE is what makes KAS load this file. KAS classifies a JSON
+       agent profile carrying kiro-cli-only fields and no KAS field as written
+       for the other runtime and skips it outright — so without ``permissions``
+       the agent is not among the modes KAS advertises, and anything that asks
+       for it by name (a resumed session, notably) fails to find it.
+
+    That second point is why an empty policy is still written when nothing
+    qualifies for auto-approve: ``{"rules": []}`` says "no tool is
+    pre-approved", which is both true and enough to keep the file loadable.
+    Dropping the key instead would silently un-register the agent. (The wire
+    projection makes the opposite choice and omits the field entirely — there,
+    presence buys nothing and absence is the honest report.)
+
+    **Seed, never refresh.** Once the key exists it belongs to whoever edits the
+    file, and this function does not touch it again. The obvious alternative —
+    recognising Crew's own output by its shape and regenerating that — was
+    written first and removed: the shapes overlap (a blanket ``allow`` is exactly
+    what a user writes too), so the rule that keeps a derived policy current is
+    the same rule that silently overwrites a hand-written one, and losing a
+    user's policy is the worse failure. What it costs is staleness: a policy
+    written before ``allowedTools`` changed keeps describing the old list. That
+    is bounded, because the wire projection derives afresh from ``allowedTools``
+    on every session and outranks the file — the block on disk is what applies
+    when Crew is NOT injecting an agent.
+    """
+    if config.get("permissions") is not None:
+        return
+
+    # circular import: `kiro_crew.acp.__init__` pulls in the runtime, which reaches
+    # back into config/agent — and it is also the whole ACP stack, which this
+    # module has no business dragging onto the gateway boot path just to write one
+    # JSON field. The imported module itself depends on nothing in the package.
+    from kiro_crew.acp.kas_permissions import (  # noqa: PLC0415
+        allowed_tools_to_permissions,
+    )
+
+    derived = allowed_tools_to_permissions(
+        config.get("allowedTools"), agent_id=Path(AGENT_FILENAME).stem
+    )
+    config["permissions"] = derived if derived is not None else {"rules": []}
+
+
 def _may_auto_approve(ref: str) -> bool:
     """Whether ``ref`` may go on an auto-approve list, per the governance ceiling.
 
@@ -3555,6 +3604,10 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
 
     def _finalize_and_write() -> None:
         servers_map = config.get("mcpServers")
+        # Runs here, at the single funnel every write path goes through, and AFTER
+        # the passes that mutate `allowedTools` (managed/shared MCP sync) — a policy
+        # seeded before them would describe a list that no longer exists.
+        _seed_kas_permissions(config)
         if isinstance(servers_map, dict):
             # LAST governance pass over the assembled server map. `autoApprove` can
             # arrive from an app manifest, a per-agent policy, a managed spec or an

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -40,6 +40,7 @@ from kiro_crew.acp.runtime import (
     AcpSessionHandle,
 )
 from kiro_crew.acp.types import (
+    ACP_BACKEND_KAS,
     EVENT_COMPLETE,
     EVENT_TEXT_CHUNK,
     METHOD_COMMANDS_EXECUTE,
@@ -3328,6 +3329,118 @@ class TestAcpRuntimeLoadSession:
             await rt.load_session("/f.json", "sid-y", agent="kirocrew")
         # The queue registered before the send must be cleaned up on failure.
         assert "sid-y" not in rt._session_queues
+
+    @pytest.mark.asyncio
+    async def test_load_session_reinjects_the_kas_agent_definition(self, monkeypatch):
+        """Resume must re-send the agent, for the same reason session/new sends it.
+
+        KAS registers client agents PER SESSION and has no ``--agent`` flag, so a
+        resumed session that is not handed them again advertises only the modes it
+        can find on disk — and that set is not a superset of what session/new had,
+        because KAS skips an agent profile written for kiro-cli. Omitting this made
+        the requested mode genuinely absent on resume, and the mode guard then
+        refused the load rather than silently running the backend default.
+        """
+        from kiro_crew.acp._dispatch import build_session_new_params
+
+        rt, _, _ = _make_runtime()
+        rt._can_load_session = True
+        sent: list[tuple[str, dict]] = []
+
+        async def _fake_send(method, params, timeout=None):
+            sent.append((method, params))
+            if method == METHOD_SESSION_LOAD:
+                return {"modes": {"currentModeId": "kirocrew"}, "models": []}
+            return {}
+
+        async def _fake_agents(agent):
+            return [{"id": agent, "prompt": "p", "tools": []}]
+
+        monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+        monkeypatch.setattr(rt, "_kas_custom_agents", _fake_agents)
+        rt._acp_backend = ACP_BACKEND_KAS
+
+        await rt.load_session("", "sid-kas", cwd="/work", agent="kirocrew")
+
+        load_params = sent[0][1]
+        assert load_params["_meta"]["kiro"]["customAgents"] == [
+            {"id": "kirocrew", "prompt": "p", "tools": []}
+        ]
+        # Same envelope as session/new, because both go through one builder. Two
+        # hand-built copies of this nesting would be free to drift, and a resumed
+        # session that got a subtly different shape would fail the same way the
+        # missing injection did: mode absent, load refused.
+        assert (
+            load_params["_meta"]["kiro"]
+            == build_session_new_params(
+                "/work", kas_custom_agents=[{"id": "kirocrew", "prompt": "p", "tools": []}]
+            )["_meta"]["kiro"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_load_session_keeps_the_transcript_path_alongside_the_agents(
+        self, monkeypatch
+    ):
+        """Merged, not assigned: a third _meta writer must not drop an earlier one.
+
+        The two envelopes belong to different backends today (a transcript path is
+        kiro-cli-only), so in practice they do not collide — which is exactly why a
+        plain assignment would survive review and then lose a field later.
+        """
+        rt, _, _ = _make_runtime()
+        rt._can_load_session = True
+        sent: list[tuple[str, dict]] = []
+
+        async def _fake_send(method, params, timeout=None):
+            sent.append((method, params))
+            if method == METHOD_SESSION_LOAD:
+                return {"modes": {"currentModeId": "kirocrew"}, "models": []}
+            return {}
+
+        async def _fake_agents(agent):
+            return [{"id": agent, "prompt": "p", "tools": []}]
+
+        monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+        monkeypatch.setattr(rt, "_kas_custom_agents", _fake_agents)
+        rt._acp_backend = ACP_BACKEND_KAS
+
+        await rt.load_session("/t.json", "sid-both", cwd="/work", agent="kirocrew")
+
+        meta = sent[0][1]["_meta"]
+        assert meta["_kiro.dev/session_file"] == "/t.json"
+        assert "kiro" in meta
+
+    @pytest.mark.asyncio
+    async def test_the_kiro_resume_path_never_reaches_the_adapter(self, monkeypatch):
+        """harness-parity H13: the kiro construction path must not change at all.
+
+        Relying on ``_kas_custom_agents`` to answer ``None`` would leave the kiro
+        resume awaiting an adapter coroutine — working, but changed, and free to
+        grow a failure mode later. The backend guard is what makes the kiro path
+        reach a comparison and stop, so this asserts the adapter is never called.
+        """
+        rt, _, _ = _make_runtime()
+        rt._can_load_session = True
+        sent: list[tuple[str, dict]] = []
+        calls: list[str] = []
+
+        async def _fake_send(method, params, timeout=None):
+            sent.append((method, params))
+            if method == METHOD_SESSION_LOAD:
+                return {"modes": {"currentModeId": "kirocrew"}, "models": []}
+            return {}
+
+        async def _fake_agents(agent):
+            calls.append(agent)
+            return [{"id": agent, "prompt": "p", "tools": []}]
+
+        monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+        monkeypatch.setattr(rt, "_kas_custom_agents", _fake_agents)
+
+        await rt.load_session("/t.json", "sid-kiro", cwd="/work", agent="kirocrew")
+
+        assert calls == []
+        assert sent[0][1]["_meta"] == {"_kiro.dev/session_file": "/t.json"}
 
     @pytest.mark.asyncio
     async def test_load_session_params_match_acp_client(self, monkeypatch):

--- a/test/test_kas_agents.py
+++ b/test/test_kas_agents.py
@@ -9,11 +9,13 @@ the one the operator configured.
 from __future__ import annotations
 
 import json
+import types
 from pathlib import Path
 
 import pytest
 
 from kiro_crew import config as kiro_crew_config
+from kiro_crew.acp import kas_agents
 from kiro_crew.acp.kas_agents import (
     _KAS_FALLBACK_PROMPT,
     KAS_MAX_CUSTOM_AGENTS,
@@ -22,6 +24,11 @@ from kiro_crew.acp.kas_agents import (
     resolve_prompt,
     to_client_custom_agent,
 )
+
+
+def _rule(policy, capability):
+    """The single rule for ``capability`` in a projected policy."""
+    return next(r for r in policy["rules"] if r["capability"] == capability)
 
 
 def _spec(**over):
@@ -93,11 +100,12 @@ class TestDeliberateOmissions:
     """Fields left out on purpose; each would misbehave if projected.
 
     ``mcpServers`` would double-register against the session-level injection,
-    ``model`` would compete with the dedicated model verb, and ``permissions``
-    would require guessing KAS's capability identifiers.
+    and ``model`` would compete with the dedicated model verb. ``permissions``
+    is NOT in this list — see :class:`TestPermissionsProjection`; it is absent
+    only when the spec gives nothing to derive it from.
     """
 
-    @pytest.mark.parametrize("key", ["mcpServers", "model", "permissions", "welcomeMessage"])
+    @pytest.mark.parametrize("key", ["mcpServers", "model", "welcomeMessage"])
     def test_key_is_not_projected(self, key):
         assert key not in to_client_custom_agent("a", _spec(), "p")
 
@@ -128,20 +136,196 @@ class TestOptionalPassThrough:
         assert "excludedTools" not in out
 
 
-class TestUnsupportedKeysAreLoud:
-    """A dropped capability must be visible in the log, not silent."""
+class TestPermissionsProjection:
+    """``allowedTools`` has no slot on the wire; its MEANING travels as a policy.
 
-    def test_dropped_keys_are_named(self, caplog):
-        spec = _spec(allowedTools=["fs_read"], toolsSettings={"x": 1})
-        with caplog.at_level("WARNING"):
+    Omitting the field is not neutral: with no policy KAS resolves every request
+    to ``ask``, so an injected agent would prompt for the whole list its kiro-cli
+    twin auto-approves. The translation itself is pinned in
+    ``test_kas_permissions.py``; here we pin only that it is wired in, and that a
+    hand-written block outranks it.
+    """
+
+    def test_the_allowlist_is_translated_rather_than_dropped(self):
+        out = to_client_custom_agent("a", _spec(allowedTools=["web_fetch"]), "p")
+        assert out["permissions"] == {"rules": [{"capability": "web_fetch", "effect": "allow"}]}
+
+    def test_the_cli_only_key_itself_never_goes_on_the_wire(self):
+        out = to_client_custom_agent("a", _spec(allowedTools=["web_fetch"]), "p")
+        assert "allowedTools" not in out
+
+    def test_a_spec_with_nothing_to_derive_omits_the_field(self):
+        """Absent says "this spec never described auto-approval", which is true."""
+        assert "permissions" not in to_client_custom_agent("a", _spec(), "p")
+
+    def test_an_unclassifiable_allowlist_omits_the_field(self):
+        out = to_client_custom_agent("a", _spec(allowedTools=["introspect"]), "p")
+        assert "permissions" not in out
+
+    def test_a_hand_written_policy_is_not_relayed(self):
+        """The wire carries only what passed Crew's governance ceiling.
+
+        Forwarding an author block would be one line and it is already in KAS's
+        vocabulary — which is the trap. ``allowedTools`` is the only auto-approve
+        input the ceiling (``_may_auto_approve``) has seen, so relaying a block
+        from the file would hand any editor of it a grant the ceiling never
+        reviewed. An auto-approved call never reaches Crew's permission callback,
+        so the deny-list and the audit trail would be skipped with it.
+        """
+        mine = {"rules": [{"capability": "shell", "effect": "allow"}]}
+        out = to_client_custom_agent("a", _spec(allowedTools=["web_fetch"], permissions=mine), "p")
+        assert out["permissions"] == {"rules": [{"capability": "web_fetch", "effect": "allow"}]}
+
+    def test_a_hand_written_policy_cannot_smuggle_a_grant_past_the_allowlist(self):
+        """The sharp case: the block grants a capability the allowlist withholds."""
+        mine = {"rules": [{"capability": "shell", "effect": "allow"}]}
+        out = to_client_custom_agent("a", _spec(allowedTools=[], permissions=mine), "p")
+        assert "permissions" not in out
+
+    def test_the_derivation_tracks_the_allowlist_not_the_stored_block(self):
+        """So a block that has gone stale on disk cannot resurrect an old grant."""
+        out = to_client_custom_agent(
+            "a",
+            _spec(
+                allowedTools=["web_fetch"],
+                permissions={"rules": [{"capability": "web_search", "effect": "allow"}]},
+            ),
+            "p",
+        )
+        assert out["permissions"]["rules"] == [{"capability": "web_fetch", "effect": "allow"}]
+
+
+class TestTheCeilingIsReAskedAtProjectionTime:
+    """The write-time ceiling check is not enough, because projection READS a file.
+
+    The five writers of an ``allowedTools`` list consult the ceiling when they
+    write, so a freshly rebuilt spec is already clean. A spec written on an
+    ungoverned host, restored from a backup, or edited by hand is not — and
+    projection is the last place to notice before the grant reaches the backend.
+    """
+
+    def test_a_withheld_entry_is_dropped_from_the_projected_policy(self, monkeypatch):
+        monkeypatch.setattr(
+            kas_agents, "may_skip_gate_now", lambda ref: ref != "@denied-srv"
+        )
+        out = to_client_custom_agent(
+            "a", _spec(allowedTools=["@denied-srv", "@ok-srv"]), "p"
+        )
+        assert _rule(out["permissions"], "mcp")["match"] == ["ok-srv/*"]
+
+    def test_withholding_everything_omits_the_field(self, monkeypatch):
+        monkeypatch.setattr(kas_agents, "may_skip_gate_now", lambda ref: False)
+        out = to_client_custom_agent("a", _spec(allowedTools=["web_fetch"]), "p")
+        assert "permissions" not in out
+
+    def test_the_withholding_is_reported_so_a_missing_grant_is_explainable(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(kas_agents, "may_skip_gate_now", lambda ref: False)
+        with caplog.at_level("INFO", logger="kiro_crew.acp.kas_agents"):
+            to_client_custom_agent("kirocrew", _spec(allowedTools=["web_fetch"]), "p")
+        assert "withholds auto-approval for web_fetch" in caplog.text
+
+    def test_an_ungoverned_host_keeps_every_grant(self, monkeypatch):
+        """``may_skip_gate_now`` answers True with no ceiling installed."""
+        monkeypatch.setattr(kas_agents, "may_skip_gate_now", lambda ref: True)
+        out = to_client_custom_agent("a", _spec(allowedTools=["web_fetch"]), "p")
+        assert out["permissions"]["rules"] == [{"capability": "web_fetch", "effect": "allow"}]
+
+    def test_the_withhold_is_recorded_in_the_security_event_log(self, monkeypatch):
+        """A permission decision, so it belongs in SEL and not only in a log line.
+
+        The other three writers that produce this state (app-agent
+        materialization, the host shared-MCP sync, doctor's auto-fix) all emit the
+        same ``mcp_auto_approve_withheld`` event. Projection is the one whose
+        input is a file it did not write, so a stale grant is likeliest to be
+        withheld here — the path that most needs the trail must not be the one
+        without it.
+        """
+        monkeypatch.setattr(kas_agents, "may_skip_gate_now", lambda ref: False)
+        events: list[dict] = []
+        monkeypatch.setattr(
+            kas_agents,
+            "sel",
+            lambda: types.SimpleNamespace(
+                log_api_access=lambda **kw: events.append(kw)
+            ),
+        )
+
+        to_client_custom_agent("kirocrew", _spec(allowedTools=["@denied-srv"]), "p")
+
+        assert len(events) == 1
+        assert events[0]["operation"] == "mcp_auto_approve_withheld"
+        assert events[0]["source"] == "kas_agent_projection"
+        assert "@denied-srv" in events[0]["resources"]
+        assert "kirocrew" in events[0]["resources"]
+
+    def test_nothing_withheld_emits_no_event(self, monkeypatch):
+        monkeypatch.setattr(kas_agents, "may_skip_gate_now", lambda ref: True)
+        events: list[dict] = []
+        monkeypatch.setattr(
+            kas_agents,
+            "sel",
+            lambda: types.SimpleNamespace(
+                log_api_access=lambda **kw: events.append(kw)
+            ),
+        )
+
+        to_client_custom_agent("a", _spec(allowedTools=["web_fetch"]), "p")
+
+        assert events == []
+
+    def test_an_audit_failure_does_not_undo_the_withhold(self, monkeypatch):
+        """The withhold has already happened and is the safe direction.
+
+        Failing the projection because the audit sink is unavailable would turn a
+        missing log line into a session that cannot start.
+        """
+        monkeypatch.setattr(kas_agents, "may_skip_gate_now", lambda ref: False)
+
+        def _broken():
+            raise RuntimeError("no sink")
+
+        monkeypatch.setattr(kas_agents, "sel", _broken)
+
+        out = to_client_custom_agent("a", _spec(allowedTools=["web_fetch"]), "p")
+        assert "permissions" not in out
+
+
+class TestKeysTheWireCannotCarry:
+    """A key with no slot in the schema is reported — and only reported once.
+
+    The wording matters as much as the level: the previous message said "no KAS
+    equivalent", which reads as "KAS cannot do this" and sends a reader looking
+    for a missing feature. ``hooks`` in particular IS a KAS feature; what is
+    missing is a way to deliver it on an agent injected over the wire.
+
+    Every ``at_level`` here names the logger. Left to the root logger it passes
+    alone and fails in the full suite (something else has raised the package
+    level by then), and the negative assertions would pass VACUOUSLY.
+    """
+
+    def test_the_keys_are_named(self, caplog):
+        spec = _spec(hooks={"postToolUse": []}, toolsSettings={"x": 1})
+        with caplog.at_level("DEBUG", logger="kiro_crew.acp.kas_agents"):
             to_client_custom_agent("kirocrew", spec, "p")
-        msg = caplog.text
-        assert "allowedTools" in msg and "toolsSettings" in msg
+        assert "toolsSettings" in caplog.text
+
+    def test_it_does_not_warn_on_every_session(self, caplog):
+        """Constant payload on a per-session path: at WARNING it is pure noise."""
+        with caplog.at_level("WARNING"):
+            to_client_custom_agent("kirocrew", _spec(toolsSettings={"x": 1}), "p")
+        assert caplog.text.strip() == ""
+
+    def test_the_translated_key_is_not_reported_as_lost(self, caplog):
+        with caplog.at_level("DEBUG", logger="kiro_crew.acp.kas_agents"):
+            to_client_custom_agent("kirocrew", _spec(allowedTools=["web_fetch"]), "p")
+        assert "allowedTools" not in caplog.text
 
     def test_nothing_logged_when_the_spec_has_none(self, caplog):
-        with caplog.at_level("WARNING"):
+        with caplog.at_level("DEBUG", logger="kiro_crew.acp.kas_agents"):
             to_client_custom_agent("kirocrew", _spec(), "p")
-        assert "no KAS equivalent" not in caplog.text
+        assert "cannot carry" not in caplog.text
 
 
 class TestPromptResolution:

--- a/test/test_kas_permissions.py
+++ b/test/test_kas_permissions.py
@@ -1,0 +1,315 @@
+"""``allowedTools`` -> KAS ``permissions``, and the two places it has to land.
+
+The translation is not a preference: each assertion here pins a fact read off
+KAS's own policy engine, and getting one wrong is silent in both directions.
+
+* Its evaluator resolves an unmatched request to ``ask``. A capability this
+  module fails to emit therefore keeps prompting (safe), and one it emits too
+  broadly stops prompting (not safe) — so the vocabulary is pinned, and an
+  unclassifiable entry must produce NO rule rather than a guess.
+* ``match`` omitted means every resource. That is what a tool-name allowlist
+  entry means, so the omission is load-bearing rather than an oversight, and a
+  test that expected ``match: ["**"]`` would be pinning the wrong thing.
+* An MCP tool is addressed as ``<server>/<tool>``, which is what makes
+  per-server and per-action grants expressible at all.
+* And the field's PRESENCE decides whether KAS will load the on-disk profile,
+  which is why the disk writer keeps an empty policy where the wire projection
+  drops the key.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.acp.kas_agents import to_client_custom_agent
+from kiro_crew.acp.kas_permissions import (
+    CAPABILITY_BY_TOOL,
+    WITHHELD_FROM_AUTO_APPROVE,
+    allowed_tools_to_permissions,
+)
+from kiro_crew.agent import _seed_kas_permissions
+
+
+def _rule(policy: dict, capability: str) -> dict:
+    """The single rule for *capability*, asserting there is exactly one."""
+    found = [r for r in policy["rules"] if r["capability"] == capability]
+    assert len(found) == 1, f"expected one {capability} rule, got {found}"
+    return found[0]
+
+
+class TestBuiltinToolsBecomeCapabilities:
+    def test_a_named_tool_maps_to_its_capability(self):
+        policy = allowed_tools_to_permissions(["web_fetch"])
+        assert policy == {"rules": [{"capability": "web_fetch", "effect": "allow"}]}
+
+    def test_match_is_omitted_because_a_tool_entry_carries_no_resource_scope(self):
+        """KAS reads a missing ``match`` as every resource — the intended meaning."""
+        assert "match" not in _rule(allowed_tools_to_permissions(["web_search"]), "web_search")
+
+    def test_rules_are_ordered_deterministically(self):
+        """Two rebuilds of the same list must produce byte-identical output."""
+        entries = ["web_search", "invoke_sub_agent", "web_fetch"]
+        first = allowed_tools_to_permissions(entries)
+        second = allowed_tools_to_permissions(list(reversed(entries)))
+        assert first == second
+
+
+class TestTheShellAndFilesystemFamiliesAreRefused:
+    """The one place this module declines to translate something it could.
+
+    Auto-approval is not "one fewer prompt", it is the ABSENCE of a permission
+    request — and Crew's deny floor and sensitive-path check run on that request.
+    A rule derived from a tool-name allowlist is also unscoped, because the
+    allowlist carries no resource pattern, so the grant would be "any command" /
+    "any path". Refusing means no rule, and no rule means prompt.
+    """
+
+    @pytest.mark.parametrize(
+        "tool",
+        sorted(WITHHELD_FROM_AUTO_APPROVE),
+    )
+    def test_a_withheld_tool_produces_no_rule(self, tool):
+        assert allowed_tools_to_permissions([tool]) is None
+
+    def test_a_withheld_tool_does_not_suppress_the_rest_of_the_list(self):
+        policy = allowed_tools_to_permissions(["execute_bash", "web_fetch"])
+        assert policy["rules"] == [{"capability": "web_fetch", "effect": "allow"}]
+
+    def test_the_refusal_is_reported_at_info_because_it_reverses_the_spec(self, caplog):
+        """Distinct from an unmappable entry: this one the spec explicitly asked for."""
+        with caplog.at_level("INFO", logger="kiro_crew.acp.kas_permissions"):
+            allowed_tools_to_permissions(["execute_bash"], agent_id="kirocrew")
+        assert "not auto-approving execute_bash" in caplog.text
+
+    def test_no_withheld_tool_is_also_in_the_capability_table(self):
+        """A tool in both places would translate anyway; the two must not overlap."""
+        assert WITHHELD_FROM_AUTO_APPROVE.isdisjoint(CAPABILITY_BY_TOOL)
+
+
+class TestMcpEntries:
+    def test_a_bare_server_becomes_a_one_level_glob(self):
+        policy = allowed_tools_to_permissions(["@kirocrew-core"])
+        assert _rule(policy, "mcp")["match"] == ["kirocrew-core/*"]
+
+    def test_a_named_action_stays_exact(self):
+        policy = allowed_tools_to_permissions(["@kirocrew-cron/cron_list"])
+        assert _rule(policy, "mcp")["match"] == ["kirocrew-cron/cron_list"]
+
+    def test_all_servers_share_one_rule(self):
+        policy = allowed_tools_to_permissions(["@a", "@b"])
+        assert _rule(policy, "mcp")["match"] == ["a/*", "b/*"]
+
+    def test_a_server_wildcard_absorbs_its_own_per_tool_entries(self):
+        """The real spec carries both; emitting both is misleading to read.
+
+        A reviewer comparing policy against allowlist should not have to work out
+        that one line already subsumes another.
+        """
+        policy = allowed_tools_to_permissions(
+            ["@kirocrew-cron/cron_list", "@kirocrew-cron/cron_pause", "@kirocrew-cron"]
+        )
+        assert _rule(policy, "mcp")["match"] == ["kirocrew-cron/*"]
+
+    def test_another_servers_per_tool_entry_is_not_absorbed(self):
+        policy = allowed_tools_to_permissions(["@a", "@b/one"])
+        assert _rule(policy, "mcp")["match"] == ["a/*", "b/one"]
+
+    @pytest.mark.parametrize("bad", ["@", "@/tool"])
+    def test_an_entry_naming_no_server_grants_nothing(self, bad):
+        """Better to prompt than to emit a pattern that could match anything."""
+        assert allowed_tools_to_permissions([bad]) is None
+
+
+class TestTranslationNeverWidensAGrant:
+    """A glob in the source list must not become a glob in the projected policy.
+
+    Crew's own auto-approve check compares ``allowedTools`` entries literally, so
+    ``@*`` there grants a server named ``*`` — nothing at all. Translated naively
+    it becomes the pattern ``*/*``, which KAS resolves as every tool on every
+    server: one line of text meaning "no grant" on one backend and "grant
+    everything" on the other. The widening is what is under test, not the syntax.
+    """
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "@*",
+            "@*/*",
+            "@kirocrew-*",
+            "@kirocrew-core/*",
+            "@kirocrew-core/cron_?",
+            "@kirocrew-core/[abc]",
+            "@{a,b}",
+            "@!kirocrew-core",
+        ],
+    )
+    def test_a_glob_reference_yields_no_rule(self, entry):
+        assert allowed_tools_to_permissions([entry]) is None
+
+    def test_a_glob_does_not_suppress_the_literal_entries_beside_it(self):
+        policy = allowed_tools_to_permissions(["@*", "@kirocrew-core", "web_fetch"])
+        assert _rule(policy, "mcp")["match"] == ["kirocrew-core/*"]
+        assert _rule(policy, "web_fetch")["effect"] == "allow"
+
+    def test_a_rejected_glob_is_explainable_from_the_log(self, caplog):
+        with caplog.at_level("DEBUG", logger="kiro_crew.acp.kas_permissions"):
+            allowed_tools_to_permissions(["@*"], agent_id="a")
+        assert "@*" in caplog.text
+
+
+class TestUnclassifiableEntriesFailClosed:
+    @pytest.mark.parametrize("entry", ["introspect", "session", "report", "tool_search"])
+    def test_a_tool_with_no_kas_capability_emits_no_rule(self, entry):
+        """It keeps prompting, which is the same as having no policy for it."""
+        assert allowed_tools_to_permissions([entry]) is None
+
+    def test_it_does_not_suppress_the_entries_that_do_map(self):
+        policy = allowed_tools_to_permissions(["introspect", "web_fetch"])
+        assert policy["rules"] == [{"capability": "web_fetch", "effect": "allow"}]
+
+    def test_the_names_are_reported_so_a_missing_grant_is_explainable(self, caplog):
+        # Names the logger: left to the root logger this passes alone and fails in
+        # the full suite, once something else has raised the package level.
+        with caplog.at_level("DEBUG", logger="kiro_crew.acp.kas_permissions"):
+            allowed_tools_to_permissions(["introspect"], agent_id="kirocrew")
+        assert "introspect" in caplog.text
+
+    @pytest.mark.parametrize("bad", [None, "fs_read", 42, {}])
+    def test_a_non_list_is_not_coerced(self, bad):
+        assert allowed_tools_to_permissions(bad) is None
+
+    @pytest.mark.parametrize("junk", [[""], ["   "], [None, 7], []])
+    def test_no_usable_entries_yields_no_policy_rather_than_an_empty_one(self, junk):
+        """Absent and empty are different claims; only the caller knows which fits."""
+        assert allowed_tools_to_permissions(junk) is None
+
+
+class TestTheRealAllowlist:
+    """The spec Crew actually ships, so a drift in it shows up here.
+
+    Pinned as behaviour rather than a literal: what matters is which capabilities
+    end up auto-approved and — more importantly — which do not.
+    """
+
+    ALLOWED = [
+        "web_fetch",
+        "web_search",
+        "introspect",
+        "session",
+        "report",
+        "@kirocrew-cron/cron_list",
+        "@kirocrew-cron/cron_pause",
+        "@kirocrew-core",
+        "@notes-mcp",
+        "@tickets-mcp",
+        "@kirocrew-cron",
+        "@weather-mcp",
+    ]
+
+    def test_the_excluded_tools_gain_no_grant(self):
+        """``execute_bash``/``fs_write``/``code`` are held back on purpose.
+
+        They are in ``tools`` but NOT ``allowedTools``, and with no rule KAS
+        resolves them to ``ask`` — which is the whole point of the exclusion.
+        """
+        policy = allowed_tools_to_permissions(self.ALLOWED)
+        granted = {r["capability"] for r in policy["rules"]}
+        assert granted == {"mcp", "web_fetch", "web_search"}
+        assert "shell" not in granted
+        assert "fs_write" not in granted
+        assert "fs_read" not in granted
+
+    def test_the_computer_use_server_is_not_auto_approved(self):
+        """It is absent from the allowlist, and it can drive a logged-in app."""
+        policy = allowed_tools_to_permissions(self.ALLOWED)
+        assert not any("computer" in p for p in _rule(policy, "mcp")["match"])
+
+
+class TestTheDiskWriter:
+    """What the agent spec on disk must say, which is NOT what the wire says.
+
+    KAS classifies a JSON agent profile that carries kiro-cli-only fields and no
+    KAS field as written for the other runtime, and skips it outright. So on disk
+    the presence of ``permissions`` is what keeps the agent loadable at all —
+    independently of whether it grants anything.
+    """
+
+    @staticmethod
+    def _config(**over) -> dict:
+        base: dict = {"name": "kirocrew", "tools": ["fs_read"], "allowedTools": ["web_fetch"]}
+        base.update(over)
+        return base
+
+    def test_the_policy_is_derived_from_the_allowlist(self):
+        config = self._config()
+        _seed_kas_permissions(config)
+        assert config["permissions"] == {"rules": [{"capability": "web_fetch", "effect": "allow"}]}
+
+    def test_an_empty_policy_is_still_written_so_the_profile_stays_loadable(self):
+        """Dropping the key would silently un-register the agent on KAS.
+
+        ``{"rules": []}`` is both true (nothing is pre-approved) and enough to
+        keep the file from being classified as kiro-cli-only. This is the one
+        place the disk and wire behaviours deliberately differ.
+        """
+        config = self._config(allowedTools=[])
+        _seed_kas_permissions(config)
+        assert config["permissions"] == {"rules": []}
+
+    def test_an_allowlist_of_only_unmappable_tools_still_marks_the_profile(self):
+        config = self._config(allowedTools=["introspect", "session"])
+        _seed_kas_permissions(config)
+        assert config["permissions"] == {"rules": []}
+
+    @pytest.mark.parametrize(
+        "existing",
+        [
+            {"rules": [{"capability": "shell", "match": ["rm -rf *"], "effect": "deny"}]},
+            {"rules": [{"capability": "shell", "effect": "allow"}]},
+            {"rules": [], "policies": ["team-base"]},
+            {"rules": []},
+            {},
+        ],
+        ids=["deny", "blanket-allow", "policy-bundle", "empty-rules", "empty-block"],
+    )
+    def test_an_existing_block_is_never_touched_whatever_its_shape(self, existing):
+        """Once the key exists it belongs to whoever edits the file.
+
+        Recognising Crew's own output by shape and regenerating that was the
+        first design and is gone: a blanket ``allow`` is exactly what a user
+        writes too, so the rule that keeps a derived policy current is the same
+        rule that silently destroys a hand-written one.
+        """
+        config = self._config(allowedTools=["@srv"], permissions=dict(existing))
+        _seed_kas_permissions(config)
+        assert config["permissions"] == existing
+
+    def test_a_stale_block_is_the_accepted_cost_and_the_wire_covers_it(self):
+        """Seeding-not-refreshing means the file can lag ``allowedTools``.
+
+        Bounded on purpose: the wire projection derives afresh every session and
+        outranks the file, so the block on disk is what applies when Crew is not
+        injecting an agent at all.
+        """
+        config = self._config(
+            allowedTools=["@srv"],
+            permissions={"rules": [{"capability": "web_fetch", "effect": "allow"}]},
+        )
+        _seed_kas_permissions(config)
+        assert config["permissions"]["rules"] == [{"capability": "web_fetch", "effect": "allow"}]
+        assert to_client_custom_agent("kirocrew", {**config, "prompt": "p"}, "p")[
+            "permissions"
+        ] == {"rules": [{"capability": "mcp", "match": ["srv/*"], "effect": "allow"}]}
+
+    def test_the_cli_only_key_is_kept_so_kiro_cli_still_works(self):
+        """The spec has to serve both runtimes: KAS ignores what it does not use."""
+        config = self._config()
+        _seed_kas_permissions(config)
+        assert config["allowedTools"] == ["web_fetch"]
+
+    def test_it_is_idempotent(self):
+        config = self._config()
+        _seed_kas_permissions(config)
+        once = dict(config["permissions"])
+        _seed_kas_permissions(config)
+        assert config["permissions"] == once


### PR DESCRIPTION
## Problem

Crew's agent spec distinguishes two things the KAS backend only heard one of:

- `tools` — this agent may use the tool
- `allowedTools` — …and it need not ask first

Only the first crossed the seam. `allowedTools` was listed as having "no KAS
equivalent" and dropped, so the entire auto-approve tier disappeared on that
backend and every call fell back to prompting — a spec that auto-approves a
dozen tools on kiro-cli prompted for all twelve here.

A second, louder symptom turned out to share a root:

```
Agent mode 'kirocrew' is not available for resumed session sess_… (advertised
modes: ['vibe', 'spec', 'quick-spec', …]); Refusing to run the backend default
mode vibe in its place.
```

`session/new` injects the agent definition; **`session/load` never did**. So a
resumed session had to find the agent on disk instead — and a spec carrying
kiro-cli-only fields and no KAS field is not a shape that backend loads, so the
mode came back unadvertised and the resume guard (correctly) refused rather than
silently running a different agent. Every resume of a KAS session lost its
context.

And the log line that reported all of it was actively misleading, which is why
the auto-approve gap sat unexamined:

```
WARNING agent 'kirocrew': dropping spec keys with no KAS equivalent: allowedTools, hooks
```

"No KAS equivalent" reads as *the backend cannot do this*. What is true is much
narrower: the `customAgents` message has no field for them. For `hooks` that
difference is the whole answer — they are supported, and load from an agent
profile on disk. What is lost is a delivery path, not a feature.

## What changed

**A new shared translator** (`src/kiro_crew/acp/kas_permissions.py`) turns
`allowedTools` into the backend's own `permissions` rules: one rule per
capability, MCP entries merged into a single server-glob rule. An entry it
cannot classify emits **no** rule, because with no matching rule the request
resolves to *ask* — silence is the fail-closed direction.

**Both consumers use that one module** — the wire projection and the on-disk spec
Crew writes — so the two paths cannot drift into disagreeing about what the same
allowlist means.

**`allowedTools` is the only input either path derives from.** A `permissions`
block already in the spec is never read back and never relayed. It has not passed
Crew's governance ceiling (`_may_auto_approve`), and an auto-approved call never
reaches Crew's permission callback — so forwarding one would hand any editor of
the file a grant the ceiling never saw, and route around the deny-list and the
audit trail with it.

**On disk, Crew seeds the key and never edits it.** An existing block belongs to
whoever wrote it, whatever its shape. Recognising Crew's own output by shape and
regenerating that was the first design and is gone: a blanket `allow` is exactly
what a user writes too, so the rule that keeps a derived policy current is the
same rule that silently destroys a hand-written one. The cost is a file that can
lag `allowedTools`, bounded because the wire derives afresh every session and
outranks the file — the on-disk block governs only when Crew is not injecting.

Seeding writes `{"rules": []}` when nothing qualifies. Presence is what keeps the
profile loadable at all, so an empty policy ("no tool is pre-approved") is both
true and load-bearing. The wire projection makes the opposite choice and omits
the field, where absence is the honest report.

**Resume reinjects the definition**, through the same `_meta` builder
`session/new` uses, so the envelope has one owner instead of two hand-built
copies free to drift.

**The log line names the channel** and drops to debug: the dropped set is static
per agent, so at WARNING it fired once per session without ever telling anyone
something new.

## Verification

`58004 passed` locally; black / isort / flake8 / mypy / brand / harness-parity /
docs-lint / scrub-lint clean. Three unrelated failures (`test_xdist_host_budget`
×2, one `test_history_coverage` sidecar test) reproduce on the base commit with
the branch stashed — host-shape and pre-existing.

New tests, 39 on the translator plus the wiring:

- capability mapping, MCP glob merge and subsumption, entries naming no server
- the excluded tools (`execute_bash` / `fs_write` / `code`) gain **no** grant, so
  they keep prompting — the point of excluding them
- the wire projection: translated not dropped, the CLI-only key never on the
  wire, a spec-resident block neither relayed nor able to smuggle a grant past
  the allowlist, the derivation tracking the allowlist rather than the stored
  block
- the disk writer: seeded from the allowlist, empty policy still written, an
  existing block untouched across five shapes, idempotent
- resume: the definition is reinjected, the transcript path survives alongside
  it, and the envelope matches what `session/new` builds

## Scope

Three things this deliberately does **not** do:

- **It does not make the on-disk `hooks` fire.** A client-provided agent outranks
  every file-based source, so as long as Crew injects over the wire the disk copy
  is overridden — `hooks` with it. Making the profile loadable fixes *finding the
  mode by name*, not *running its hooks*. Closing that means choosing: stop
  injecting, or move the hook into Crew's own engine. Left as a follow-up so the
  choice is made on its own merits.
- **It does not add granularity that does not exist.** A spec auto-approving
  `execute_bash` becomes "allow the shell capability for any command" — a
  faithful reading of what the spec already asked for on kiro-cli, since neither
  side scopes a tool-name allowlist by command.
- **It does not touch an existing on-disk spec.** The new field is seeded by the
  agent-config rebuild, so a spec already on disk picks it up on the next
  rebuild. The resume fix does not wait for that — it travels on the wire.

One unrelated line-level change: the black gate reports three baseline entries as
graduated and fails until they are pruned, so `.github/black-baseline.txt` loses
three entries that have nothing to do with this diff.

no linked issue: found while reading the logs of a resume failure, not filed
first.
