### PR TITLE
fix(apps): actually remove a failed clone's partial checkout on Windows

### DIFF
--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -3487,8 +3487,11 @@ async def _git_fetch_commit(
         succeeded = True
         return None
     finally:
+        # `created_here` means the destination is this call's own `git init`, so a
+        # failed fetch leaves a repository holding read-only pack files -- the same
+        # removal requirement as the clone path in `_git_clone_or_pull`.
         if created_here and not succeeded:
-            await asyncio.to_thread(shutil.rmtree, dest, True)
+            await asyncio.to_thread(platform_compat.rmtree_force, dest)
 
 
 async def _git_clone_or_pull(
@@ -3739,19 +3742,33 @@ async def _git_clone_or_pull(
             creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
             env=clone_env,
         )
+        # `rmtree_force`, never `shutil.rmtree(..., ignore_errors=True)`: what a
+        # half-finished `git clone` leaves at *dest* is a git checkout, and git
+        # creates `.git/objects/pack/*.{pack,idx,rev}` READ-ONLY. On Windows that
+        # is the FILE_ATTRIBUTE_READONLY bit, so the unlink raises, `ignore_errors`
+        # swallows it, and the tree stays on disk while this returns an error the
+        # caller reads as "nothing was left behind".
+        #
+        # Only the FRESH-INSTALL path reaches the three removals below; when an
+        # existing checkout was moved aside the `finally` owns the unwind and
+        # already copes with a surviving tree. That asymmetry is the bug: with
+        # nothing moved aside, an undeletable partial clone is never noticed, and
+        # the next install finds `dest/.git` present with a matching origin and
+        # takes the fast-forward branch instead -- `git pull` in a repo the clone
+        # never finished, which fails, so every retry of that install fails too.
         try:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_CLONE_TIMEOUT)
             log_lines.append(stdout.decode(errors="replace").strip())
         except asyncio.TimeoutError:
             await _kill_process_group(proc)
-            await asyncio.to_thread(shutil.rmtree, dest, True)
+            await asyncio.to_thread(platform_compat.rmtree_force, dest)
             return {"ok": False, "name": dest.name, "error": "git clone timed out"}
         except asyncio.CancelledError:
             await _kill_process_group(proc)
-            await asyncio.to_thread(shutil.rmtree, dest, True)
+            await asyncio.to_thread(platform_compat.rmtree_force, dest)
             raise
         if proc.returncode != 0:
-            await asyncio.to_thread(shutil.rmtree, dest, True)
+            await asyncio.to_thread(platform_compat.rmtree_force, dest)
             return {"ok": False, "name": dest.name, "error": "git clone failed"}
         clone_succeeded = True
         return None
@@ -3773,10 +3790,12 @@ async def _git_clone_or_pull(
             else:
                 # Clone did NOT succeed — remove any partial dest and restore
                 # the old checkout so the user's code is not stranded.
-                await asyncio.to_thread(shutil.rmtree, dest, True)
-                # If dest still exists (rmtree silently failed, e.g. locked
-                # files on Windows), move IT aside so the restore rename
-                # cannot collide. Keep the path inside app-sources.
+                await asyncio.to_thread(platform_compat.rmtree_force, dest)
+                # If dest still exists the removal genuinely could not finish:
+                # `rmtree_force` clears the read-only bit, but a file another
+                # process holds OPEN still refuses to unlink on Windows. Move IT
+                # aside so the restore rename cannot collide. Keep the path inside
+                # app-sources.
                 if dest.exists():
                     partial_name = f"{dest.name}.partial-{uuid.uuid4().hex[:8]}"
                     partial_aside = dest.with_name(partial_name)

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import stat
 import sys
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1733,3 +1735,139 @@ class TestCatalogFailureNeverBreaksTheStore:
             await self._rows(monkeypatch)
         assert any("catalog" in r.message for r in caplog.records)
         assert any(r.exc_info for r in caplog.records), "expected a traceback"
+
+
+# ---------------------------------------------------------------------------
+# A failed FRESH clone must actually remove the partial checkout on Windows.
+#
+# git writes `.git/objects/pack/*.{pack,idx,rev}` read-only. On Windows that is
+# FILE_ATTRIBUTE_READONLY, so `shutil.rmtree(..., ignore_errors=True)` cannot
+# unlink them and silently reports success over a tree that is still on disk.
+# The update path already copes with a surviving tree -- its `finally` moves the
+# leftover aside so the restore rename cannot collide -- but the fresh-install
+# path had no such guard, so the leftover became permanent: the next install
+# sees `dest/.git` with a matching origin, takes the fast-forward branch, and
+# `git pull` in a never-finished clone fails on every retry.
+#
+# POSIX cannot express this: the read-only bit there does not govern unlink (the
+# parent directory's write permission does), so `rmtree` succeeds either way and
+# the test would be green before the fix. Hence a platform gate rather than a
+# simulated failure -- the real file attribute is the entire mechanism.
+# ---------------------------------------------------------------------------
+
+
+def _partial_clone(dest):
+    """What a `git clone` killed partway through leaves behind at *dest*."""
+    pack = dest / ".git" / "objects" / "pack"
+    pack.mkdir(parents=True, exist_ok=True)
+    (dest / ".git" / "config").write_text(
+        '[remote "origin"]\n\turl = https://example.com/demo.git\n', encoding="utf-8"
+    )
+    blob = pack / "pack-0123456789abcdef0123456789abcdef01234567.pack"
+    blob.write_bytes(b"PACK")
+    os.chmod(blob, stat.S_IREAD)
+    return blob
+
+
+def _fresh_clone_harness(monkeypatch, dest, *, mode):
+    """Patch registry so a fresh clone into *dest* fails in *mode*."""
+    monkeypatch.setattr(registry, "is_clone_host_trusted", lambda url: True)
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+    monkeypatch.setattr(registry, "_kill_process_group", AsyncMock())
+    monkeypatch.setattr(registry, "_CLONE_TIMEOUT", 0.05)
+
+    class _Proc:
+        returncode = 1 if mode == "exit" else 0
+        pid = 4242
+
+        async def communicate(self):
+            if mode == "timeout":
+                await asyncio.sleep(30)
+            if mode == "cancel":
+                raise asyncio.CancelledError()
+            return b"fatal: early EOF", b""
+
+    async def _fake_spawn(*argv, **kwargs):
+        # git created the destination and wrote pack files before it died.
+        _partial_clone(dest)
+        return _Proc()
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_spawn)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    platform_compat.IS_POSIX,
+    reason="the read-only attribute only blocks unlink on Windows",
+)
+@pytest.mark.parametrize("mode", ["exit", "timeout", "cancel"])
+async def test_failed_fresh_clone_removes_read_only_partial_checkout(
+    monkeypatch, tmp_path, mode
+):
+    """Every fresh-clone failure exit must leave no destination behind."""
+    dest = tmp_path / "app-sources" / "demoapp"
+    _fresh_clone_harness(monkeypatch, dest, mode=mode)
+
+    if mode == "cancel":
+        with pytest.raises(asyncio.CancelledError):
+            await registry._git_clone_or_pull(
+                "https://example.com/demo.git", "main", dest, []
+            )
+    else:
+        err = await registry._git_clone_or_pull(
+            "https://example.com/demo.git", "main", dest, []
+        )
+        assert err is not None and err["ok"] is False
+
+    assert not dest.exists(), (
+        "the partial checkout survived: the next install would find its .git, "
+        "take the fast-forward branch and fail on every retry"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    platform_compat.IS_POSIX,
+    reason="the read-only attribute only blocks unlink on Windows",
+)
+async def test_failed_pinned_fetch_removes_read_only_partial_checkout(
+    monkeypatch, tmp_path
+):
+    """The pinned path materialises its own destination with `git init`; a failed
+    fetch must discard it as completely as the clone path does."""
+    dest = tmp_path / "app-sources" / "pinnedapp"
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+    monkeypatch.setattr(registry, "_kill_process_group", AsyncMock())
+
+    class _Proc:
+        pid = 4242
+
+        def __init__(self, rc):
+            self.returncode = rc
+
+        async def communicate(self):
+            return b"fatal: could not read from remote repository", b""
+
+    async def _fake_spawn(*argv, **kwargs):
+        if "init" in argv:
+            _partial_clone(dest)  # git init made it; the fetch left pack files
+            return _Proc(0)
+        if "fetch" in argv:
+            return _Proc(1)
+        return _Proc(0)
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_spawn)
+
+    err = await registry._git_fetch_commit(
+        "https://example.com/demo.git",
+        "a" * 40,
+        dest,
+        [],
+        clone_env={},
+        sandbox_mode="strict",
+    )
+
+    assert err is not None and err["ok"] is False
+    assert not dest.exists(), "the pinned path left an undeletable checkout behind"

--- a/test/test_external_registry.py
+++ b/test/test_external_registry.py
@@ -3282,7 +3282,10 @@ class TestRestoreCollision:
         rmtree_call_count = 0
         original_rmtree = __import__("shutil").rmtree
 
-        def _stubborn_rmtree(path, ignore_errors=False):
+        # `**kwargs` absorbs the `onexc=`/`onerror=` hook that
+        # `platform_compat.rmtree_force` passes: the removal this test pins is
+        # the one that CANNOT delete dest, whichever spelling the caller uses.
+        def _stubborn_rmtree(path, ignore_errors=False, **kwargs):
             nonlocal rmtree_call_count
             rmtree_call_count += 1
             # ALL rmtree calls on dest silently fail (simulating locked files).


### PR DESCRIPTION
Fixes #4615

## Problem / Motivation

A `git clone` that dies partway leaves a destination whose
`.git/objects/pack/*.{pack,idx,rev}` files git created **read-only**. On Windows
that is `FILE_ATTRIBUTE_READONLY`, so the unlink raises,
`shutil.rmtree(..., ignore_errors=True)` swallows it, and the tree stays on disk
while the caller is told the cleanup succeeded.

Measured on Windows 11 with git for Windows, no KiroCrew code involved:

```
read-only files in a fresh `git clone --depth 1`: 3
    .git\objects\pack\pack-<sha>.idx
    .git\objects\pack\pack-<sha>.pack
    .git\objects\pack\pack-<sha>.rev
after shutil.rmtree(dest, ignore_errors=True): exists = True   (3 survivors)
after platform_compat.rmtree_force(dest):      exists = False
```

`_git_clone_or_pull` already handles this on the **update** path: when an
existing checkout was moved aside, its `finally` re-checks `dest.exists()` after
the removal and moves the undeletable leftover to a `.partial-*` sibling so the
restore rename cannot collide.

That entire block is guarded by `if moved_aside is not None`. On a **fresh
install** there is nothing to move aside, so it never runs, and the only cleanup
is the bare `shutil.rmtree(dest, True)` on the three clone-failure exits
(timeout, cancellation, non-zero exit) — no exists-check, no move-aside, no log
line.

## Why it matters

The leftover is permanent, not cosmetic. The next install finds `dest/.git`
present; `.git/config` was written early in the clone so its `origin` matches the
catalog URL, the origin-mismatch gate passes, and the function takes the
**fast-forward branch** instead of re-cloning. `git pull --ff-only` in a
repository whose clone never finished fails, and the function then correctly
refuses to install stale code:

> git pull failed (exit N); not installing stale code

So every retry of that app's install fails, and the retry path the cleanup was
written to enable never becomes reachable. The user's only way out is deleting
the directory by hand.

`_git_fetch_commit` (the pinned-install path) has the same shape: its `finally`
removes the destination when `created_here and not succeeded`, and that
destination is its own `git init` holding the same read-only pack files.

## What changed (motivation → approach → change)

`platform_compat.rmtree_force` exists for exactly this — it clears the read-only
bit, retries, and returns whether the path is really gone; its docstring names
this failure mode. The five `dest` removals in `_git_clone_or_pull` and
`_git_fetch_commit` now route through it instead of
`shutil.rmtree(dest, ignore_errors=True)`.

The `finally`'s `dest.exists()` fallback **stays**. `rmtree_force` clears the
read-only attribute, but a file another process holds open still refuses to
unlink on Windows, and that residual case still needs the move-aside. The
comment there now says which case it is covering.

No behaviour change on POSIX: the read-only bit does not govern unlink there
(the parent directory's write permission does), so both spellings already
removed the tree.

## Tests

Four Windows-gated regressions in `test/test_apps_registry.py`, each driving a
production entry point rather than a helper:

- `_git_clone_or_pull` for all three fresh-clone failure exits
  (`exit` / `timeout` / `cancel`), with the fake spawn leaving behind exactly
  what a killed clone leaves — `.git/config` with an origin, plus a read-only
  `.git/objects/pack/*.pack`.
- `_git_fetch_commit` for the pinned path, where `git init` materialises the
  destination and the fetch then fails.

Each asserts the destination is gone afterwards.

```
pytest test/test_apps_registry.py -k read_only_partial
```

| | result |
|---|---|
| against `origin/main` (`7cd987ee3`), pristine worktree | **4 failed** — *"the partial checkout survived"* |
| with this change | **4 passed** |

They `skipif(platform_compat.IS_POSIX)` rather than simulate the failure: the
real file attribute is the entire mechanism, and on POSIX the test would be
green before the fix. The file already uses platform gates this way.

Relevant suite, this branch, Windows:

```
pytest test/test_apps_registry.py test/test_external_registry.py test/test_catalog_inventory.py
→ 335 passed, 3 failed, 3 skipped
```

The 3 failures are `WinError 1314` (symlink creation needs a privilege this box
does not hold) and reproduce identically on pristine `origin/main`.

`flake8` clean on all three files. The baselined black gate reports **0 new
offenders**; its one failure (`src/kiro_crew/sandbox.py` has graduated and needs
pruning from the baseline) reproduces unchanged on pristine `origin/main` and is
left alone.

### One existing test adjusted

`test_external_registry.py::TestRestoreCollision::test_undeletable_dest_moved_aside_before_restore`
stubs `shutil.rmtree` to simulate a dest that cannot be deleted. Its stub now
absorbs the `onexc=`/`onerror=` hook `rmtree_force` passes (`**kwargs`), so it
still pins the move-aside behaviour it was written for — that behaviour is
deliberately unchanged, and the test passes on this branch.

## Manual verification

The read-only-pack measurement above was run directly against `git clone` and
`platform_compat.rmtree_force` on this Windows box; it is what identified the
mechanism before any code was changed. The end-to-end install flow against a
real registry was not exercised — that needs a configured registry host.