### PR TITLE
fix(acp): delete an ephemeral session's transcript even when teardown is cancelled

### DIFF
--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -1555,7 +1555,9 @@ class AcpSessionHandle:
         a finished session's state stays resident in the multiplexed process
         forever, so RSS climbs with cumulative sessions (the background-runtime
         unbounded-growth bug). ``terminate_session`` is best-effort + bounded and
-        ALWAYS unregisters the queue, so teardown neither hangs nor raises.
+        ALWAYS unregisters the queue, so teardown neither hangs nor fails on a
+        dead or slow runtime -- but see the `finally` below for the one
+        exception it cannot swallow.
 
         Each session on a shared runtime (a ``_bg`` op or a session-sharing
         subagent) is a distinct ``session/new`` with its own persisted
@@ -1574,9 +1576,19 @@ class AcpSessionHandle:
         still runs unconditionally: it is the RSS reclaim on the multiplexed
         process; only the unlink is deferred.
         """
-        await self._runtime.terminate_session(self._session_id)
-        if not getattr(self, "keep_transcript", False):
-            self._cleanup_transcript()
+        # The unlink runs in a `finally`, for the same reason
+        # `terminate_session` unregisters the queue in one: that method swallows
+        # `Exception`, but `asyncio.CancelledError` is a `BaseException` and
+        # propagates straight out of the await. Cancellation is exactly when
+        # teardown runs -- gateway shutdown, an abandoned turn -- so the
+        # sequential form skipped the cleanup on the path that produces the most
+        # of these files, and every survivor is permanent: nothing else deletes
+        # an ephemeral session's transcript.
+        try:
+            await self._runtime.terminate_session(self._session_id)
+        finally:
+            if not getattr(self, "keep_transcript", False):
+                self._cleanup_transcript()
 
     def _cleanup_transcript(self) -> None:
         """Best-effort delete of this session's kiro-cli transcript files.

--- a/test/test_subagent_continuable.py
+++ b/test/test_subagent_continuable.py
@@ -15,6 +15,7 @@ Covers the hibernate-first lifecycle slice:
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -455,6 +456,90 @@ class TestKeepTranscript:
         await manager._teardown_run_session(info, "subagent:sh1")
         shared.set_keep_transcript.assert_called_once_with(True)
         shared.shutdown.assert_awaited_once()
+
+    # ── cancellation ──
+    #
+    # `AcpRuntime.terminate_session` swallows `Exception` and unregisters the
+    # queue in a `finally`, precisely because `asyncio.CancelledError` is a
+    # `BaseException` that would otherwise slip past its `except Exception`.
+    # `destroy()` awaits it and then unlinks the transcript, so before the fix
+    # that same cancellation carried straight out of the await and skipped the
+    # unlink -- on gateway shutdown and abandoned turns, which is where most
+    # ephemeral sessions are torn down. Nothing else deletes an ephemeral
+    # session's transcript, so each skipped unlink leaks a file permanently.
+    #
+    # These drive the real `_cleanup_transcript` against a real sessions dir
+    # rather than asserting on a mock, so they measure the file, not the call.
+
+    def _handle_with_transcript(self, tmp_path, sid="sid-cancel"):  # type: ignore[no-untyped-def]
+        from kiro_crew.acp.session_handle import AcpSessionHandle
+
+        with patch.object(AcpSessionHandle, "__init__", lambda self: None):
+            h = AcpSessionHandle()  # type: ignore[call-arg]
+        h._session_id = sid
+        h.keep_transcript = False
+        h._runtime = MagicMock()
+        sessions = tmp_path / "sessions" / "cli"
+        sessions.mkdir(parents=True)
+        files = [sessions / f"{sid}.json", sessions / f"{sid}.jsonl"]
+        for f in files:
+            f.write_text("{}", encoding="utf-8")
+        return h, sessions, files
+
+    @pytest.mark.asyncio
+    async def test_destroy_deletes_transcript_when_terminate_is_cancelled(
+        self, tmp_path
+    ) -> None:
+        """A cancelled teardown must still unlink; the cancellation must propagate."""
+        h, sessions, files = self._handle_with_transcript(tmp_path)
+        h._runtime.terminate_session = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with patch(
+            "kiro_crew.acp.session_handle.kiro_sessions_dir", lambda: sessions
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await h.destroy()
+
+        assert [f for f in files if f.exists()] == [], (
+            "a cancelled teardown leaked this session's transcript; nothing else "
+            "deletes it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_destroy_deletes_transcript_when_terminate_raises(
+        self, tmp_path
+    ) -> None:
+        """Same for an ordinary exception escaping the runtime call."""
+        h, sessions, files = self._handle_with_transcript(tmp_path, sid="sid-raise")
+        h._runtime.terminate_session = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch(
+            "kiro_crew.acp.session_handle.kiro_sessions_dir", lambda: sessions
+        ):
+            with pytest.raises(RuntimeError):
+                await h.destroy()
+
+        assert [f for f in files if f.exists()] == []
+
+    @pytest.mark.asyncio
+    async def test_cancelled_teardown_still_honours_keep_transcript(
+        self, tmp_path
+    ) -> None:
+        """The `finally` must not override the subagent resume guard."""
+        h, sessions, files = self._handle_with_transcript(tmp_path, sid="sid-keep")
+        h.keep_transcript = True
+        h._runtime.terminate_session = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with patch(
+            "kiro_crew.acp.session_handle.kiro_sessions_dir", lambda: sessions
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await h.destroy()
+
+        assert all(f.exists() for f in files), (
+            "keep_transcript=True is the subagent resume material and must "
+            "survive a cancelled teardown too"
+        )
 
 
 class TestPersistenceGuards:


### PR DESCRIPTION
Fixes #4619

## Problem / Motivation

`AcpSessionHandle.destroy()` awaited `terminate_session` and *then* unlinked the
session's kiro-cli transcript, sequentially:

```python
await self._runtime.terminate_session(self._session_id)
if not getattr(self, "keep_transcript", False):
    self._cleanup_transcript()
```

`AcpRuntime.terminate_session` already handles this hazard for its own cleanup —
it swallows `Exception` and unregisters the queue in a `finally` — and its
docstring says exactly why:

> including when the enclosing task is cancelled mid-await
> (`asyncio.CancelledError` is a `BaseException`, so it would otherwise slip past
> the `except Exception`).

`destroy()` did not apply that lesson to the unlink. A cancellation carries
straight out of the await, and `_cleanup_transcript()` never runs.

## Why it matters

Cancellation is not the exotic case — it is *when teardown happens*: gateway
shutdown, an abandoned turn, a cancelled task tree. That is the path that tears
down most ephemeral sessions.

Each skipped unlink is permanent. `destroy()`'s own docstring states nothing else
deletes these files:

> The shared runtime is not killed on teardown, so we also delete the transcript
> here — otherwise these files would accumulate for the gateway lifetime
> (titles/suggestions/folders/nav run on nearly every chat).

So `~/.kiro/sessions/cli/` gains one `{sid}.json` + `{sid}.jsonl` pair per
cancelled teardown and never gives it back, at roughly one ephemeral session per
chat interaction.

## What changed (motivation → approach → change)

The unlink moves into a `finally`, matching the callee's own defence against the
same `BaseException`:

```python
try:
    await self._runtime.terminate_session(self._session_id)
finally:
    if not getattr(self, "keep_transcript", False):
        self._cleanup_transcript()
```

`keep_transcript` still gates it, so a subagent's resume material is untouched.
The cancellation still propagates — nothing is swallowed, only the cleanup is
made unconditional.

The docstring line claiming teardown "neither hangs nor raises" is corrected. It
is true for a dead or slow runtime and false for cancellation, and it is the one
sentence that made the sequential form read as safe.

## Tests

Three cases added to the existing `TestKeepTranscript` in
`test/test_subagent_continuable.py`. They drive the real `_cleanup_transcript`
against a real sessions directory (`kiro_sessions_dir` patched to `tmp_path`)
and assert on the files, rather than asserting a mock was called:

- `terminate_session` raises `CancelledError` → transcript gone, `CancelledError`
  still propagates
- `terminate_session` raises `RuntimeError` → transcript gone, error propagates
- `keep_transcript=True` under cancellation → transcript **kept**

```
pytest test/test_subagent_continuable.py -k TestKeepTranscript
```

| | result |
|---|---|
| against `origin/main` (`7cd987ee3`), pristine worktree | **2 failed, 4 passed** — *"a cancelled teardown leaked this session's transcript"* |
| with this change | **6 passed** |

The third case passes before and after by design: it is there to pin the fix
against over-deleting, not to fail first.

Wider relevant suite on this branch:

```
pytest test/test_subagent_continuable.py test/test_acp_runtime.py \
       test/test_acp_session_provider.py test/test_session_coverage.py \
       test/test_session_sharing.py test/test_acp_provider.py
→ 549 passed, 2 skipped, 0 failed
```

`flake8` clean. The baselined black gate reports **0 new offenders**; its one
failure (`src/kiro_crew/sandbox.py` has graduated and needs pruning from the
baseline) reproduces unchanged on pristine `origin/main` and is left alone.

## Manual verification

Not applicable — reproducing this by hand means cancelling a teardown mid-await
on a live gateway and then counting files in `~/.kiro/sessions/cli/`. The tests
drive the same production entry point directly and measure the same files.