### PR TITLE
fix(palette): preserve backend relevance order across knowledge, artifacts, and all tab (#4579)

### DIFF
--- a/website/src/components/commandPalette/providers/allAggregator.test.ts
+++ b/website/src/components/commandPalette/providers/allAggregator.test.ts
@@ -95,6 +95,18 @@ describe('createAllAggregator — fan-out + merge', () => {
     const arr = await Promise.resolve(agg.search('q'))
     expect(arr.map((r) => r.id)).toEqual(['a:1'])
   })
+
+  it('preserves each provider established internal order when scores are equal (issue #4579)', async () => {
+    // Providers a and b return body-only hits (score 0) in their own relevance order.
+    // The aggregator must preserve each provider's internal sequence rather than
+    // re-alphabetizing by title.
+    const a = provider('a', [result('a:z', 'a', 'Zebra item', 0), result('a:a', 'a', 'Alpha item', 0)])
+    const b = provider('b', [result('b:y', 'b', 'Yellow item', 0), result('b:b', 'b', 'Beta item', 0)])
+    const agg = make({ getProviders: () => [a, b] })
+
+    const arr = await Promise.resolve(agg.search('4579'))
+    expect(arr.map((r) => r.id)).toEqual(['a:z', 'a:a', 'b:y', 'b:b'])
+  })
 })
 
 describe('createAllAggregator — recents on empty query', () => {

--- a/website/src/components/commandPalette/providers/allAggregator.ts
+++ b/website/src/components/commandPalette/providers/allAggregator.ts
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react'
 import { useMemo } from 'react'
 import { Sparkles } from 'lucide-react'
 
-import { makeScoreThenNameComparator } from '../../../utils/fuzzyMatch'
 import { i18nT } from '../../../i18n/t'
 import type { ResourceProvider, Result } from '../types'
 import { getProviders as getRegisteredProviders, getProvider } from './index'
@@ -15,8 +14,9 @@ import { getProviders as getRegisteredProviders, getProvider } from './index'
  * of owning a data source it fans the query out to every *other* registered
  * provider, keeps the top-N hits per provider (so one chatty source can't
  * flood the blended list), then merges everything into a single list ordered
- * by score-descending, name-ascending (the same ordering every per-category
- * tab uses, via {@link makeScoreThenNameComparator}).
+ * by score-descending with a stable sort, so each provider's own internal
+ * ranking (including backend relevance order for body-only hits) is preserved
+ * as the tiebreak (issue #4579).
  *
  * Empty query is special-cased: rather than asking each provider for its
  * "everything" list, the All tab shows **recents** (recent sessions). This
@@ -52,10 +52,6 @@ function inlineIcon(): ReactNode {
   return createElement(Sparkles, { className: 'lucide-inline' })
 }
 
-const compareResults = makeScoreThenNameComparator<Result>(
-  (r) => r.score,
-  (r) => r.title,
-)
 
 /**
  * Injectable dependencies for {@link createAllAggregator}. Decoupling the
@@ -126,13 +122,14 @@ export function createAllAggregator(deps: AllAggregatorDeps): ResourceProvider {
       )
 
       // Cap each provider's contribution (top-N after its own ordering), then
-      // blend everything and re-sort by score-desc, name-asc.
+      // blend everything ordered by score-descending. Stable sort ensures
+      // each provider's established internal ranking (including backend tiebreaks
+      // for body-only hits, issue #4579) is preserved.
       const merged: Result[] = []
       for (const results of perProvider) {
-        const top = [...results].sort(compareResults).slice(0, perProviderLimit)
-        merged.push(...top)
+        merged.push(...results.slice(0, perProviderLimit))
       }
-      merged.sort(compareResults)
+      merged.sort((a, b) => b.score - a.score)
       return merged
     },
   }

--- a/website/src/components/commandPalette/providers/artifactsProvider.test.ts
+++ b/website/src/components/commandPalette/providers/artifactsProvider.test.ts
@@ -110,3 +110,40 @@ describe('createArtifactsProvider — search mapping', () => {
     ])
   })
 })
+
+describe('createArtifactsProvider — backend relevance order is the score tiebreak (issue #4579)', () => {
+  it('preserves backend order for body-only hits (all scores 0) instead of alphabetizing', async () => {
+    // Titles are in REVERSE-alphabetical order and share no characters with the
+    // query, so every row is a body hit with score 0. The backend ranked these
+    // by relevance / mtime; the old name tiebreak returned them alphabetized.
+    const items: Artifact[] = [
+      artifact({ slug: 'z-art', name: 'Zebra doc', snippet: 'mentions 4579' }),
+      artifact({ slug: 'm-art', name: 'Muffin doc', snippet: 'discusses 4579' }),
+      artifact({ slug: 'a-art', name: 'Alpha doc', snippet: '4579 details' }),
+    ]
+    const { d } = deps(items)
+    const p = createArtifactsProvider(d)
+    const results = await run(p, '4579')
+    expect(results).toHaveLength(3)
+    expect(results.every(r => r.score === 0)).toBe(true)
+    // Backend order, NOT ['Alpha doc', 'Muffin doc', 'Zebra doc'].
+    expect(results.map(r => r.title)).toEqual(['Zebra doc', 'Muffin doc', 'Alpha doc'])
+  })
+
+  it('still ranks a title match first even when the backend returned it last (bias preserved)', async () => {
+    const items: Artifact[] = [
+      artifact({ slug: 'u-1', name: 'Unrelated alpha', snippet: 'grid spec' }),
+      artifact({ slug: 'u-2', name: 'Unrelated beta', snippet: 'grid spec again' }),
+      artifact({ slug: 'g-1', name: 'grid design' }),
+    ]
+    const { d } = deps(items)
+    const p = createArtifactsProvider(d)
+    const results = await run(p, 'grid')
+    expect(results).toHaveLength(3)
+    expect(results[0].title).toBe('grid design')
+    expect(results[0].score).toBeGreaterThan(0)
+    // The remaining body-only rows keep their backend order between themselves.
+    expect(results.slice(1).map(r => r.title)).toEqual(['Unrelated alpha', 'Unrelated beta'])
+  })
+})
+

--- a/website/src/components/commandPalette/providers/artifactsProvider.ts
+++ b/website/src/components/commandPalette/providers/artifactsProvider.ts
@@ -6,7 +6,7 @@ import { useQueryClient } from '@tanstack/react-query'
 
 import { api } from '../../../api/client'
 import { i18nT } from '../../../i18n/t'
-import { fuzzyMatch, makeScoreThenNameComparator, substringIndices } from '../../../utils/fuzzyMatch'
+import { fuzzyMatch, substringIndices } from '../../../utils/fuzzyMatch'
 import type { Artifact } from '../../../types'
 import type { Result, ResourceProvider } from '../types'
 
@@ -116,11 +116,10 @@ export function createArtifactsProvider(deps: ArtifactsProviderDeps): ResourcePr
         }
       })
 
-      // Title matches first, then deterministic name order. Skip the re-rank on
-      // an empty query so the backend's recency ordering is preserved (the
-      // Artifacts tab + All-tab recents rely on it).
+      // Title matches first, then backend relevance/mtime order is preserved via stable sort (issue #4579).
+      // Skip the re-rank on an empty query so the backend's recency ordering is preserved.
       if (q.length > 0) {
-        results.sort(makeScoreThenNameComparator<Result>(r => r.score, r => r.title))
+        results.sort((a, b) => b.score - a.score)
       }
       return results
     },

--- a/website/src/components/commandPalette/providers/knowledgeProvider.test.ts
+++ b/website/src/components/commandPalette/providers/knowledgeProvider.test.ts
@@ -132,3 +132,39 @@ describe('createKnowledgeProvider — §2 Enter matrix', () => {
     expect(arr.find((r) => r.id === 'knowledge:k1')!.onCmdActivate).toBeUndefined()
   })
 })
+
+describe('createKnowledgeProvider — backend relevance order is the score tiebreak (issue #4579)', () => {
+  it('preserves backend order for body-only hits (all scores 0) instead of alphabetizing', async () => {
+    // Titles are in REVERSE-alphabetical order and share no characters with the
+    // query, so every row is a body hit with score 0. The backend ranked these
+    // by relevance (HybridRetriever); the old name tiebreak returned them
+    // alphabetized ('Alpha…' first). The response order must come back untouched.
+    const items: KnowledgeSearchItem[] = [
+      { id: 'k-z', title: 'Zebra runbook', summary: 'mentions 4579' },
+      { id: 'k-m', title: 'Muffin architecture', summary: 'discusses 4579' },
+      { id: 'k-a', title: 'Alpha deployment', summary: '4579 references' },
+    ]
+    const { d } = deps({ items })
+    const arr = await run(createKnowledgeProvider(d), '4579')
+    expect(arr).toHaveLength(3)
+    expect(arr.every((r) => r.score === 0)).toBe(true)
+    // Backend order, NOT ['Alpha deployment', 'Muffin architecture', 'Zebra runbook'].
+    expect(arr.map((r) => r.title)).toEqual(['Zebra runbook', 'Muffin architecture', 'Alpha deployment'])
+  })
+
+  it('still ranks a title match first even when the backend returned it last (bias preserved)', async () => {
+    const items: KnowledgeSearchItem[] = [
+      { id: 'k-1', title: 'Unrelated alpha', summary: 'mentions grid' },
+      { id: 'k-2', title: 'Unrelated beta', summary: 'grid details' },
+      { id: 'k-3', title: 'grid architecture', summary: 'summary' },
+    ]
+    const { d } = deps({ items })
+    const arr = await run(createKnowledgeProvider(d), 'grid')
+    expect(arr).toHaveLength(3)
+    expect(arr[0].title).toBe('grid architecture')
+    expect(arr[0].score).toBeGreaterThan(0)
+    // The remaining body-only rows keep their backend order between themselves.
+    expect(arr.slice(1).map((r) => r.title)).toEqual(['Unrelated alpha', 'Unrelated beta'])
+  })
+})
+

--- a/website/src/components/commandPalette/providers/knowledgeProvider.ts
+++ b/website/src/components/commandPalette/providers/knowledgeProvider.ts
@@ -7,7 +7,7 @@ import type { NavigateFunction } from 'react-router-dom'
 
 import { api } from '../../../api/client'
 import { i18nT } from '../../../i18n/t'
-import { fuzzyMatch, makeScoreThenNameComparator } from '../../../utils/fuzzyMatch'
+import { fuzzyMatch } from '../../../utils/fuzzyMatch'
 import type { Result, ResourceProvider } from '../types'
 
 /**
@@ -99,10 +99,6 @@ function knowledgeIcon() {
   return createElement(Brain, { className: 'lucide-inline' })
 }
 
-const compareResults = makeScoreThenNameComparator<Result>(
-  (r) => r.score,
-  (r) => r.title,
-)
 
 /**
  * Build the Knowledge {@link ResourceProvider} from injected dependencies.
@@ -153,10 +149,10 @@ export function createKnowledgeProvider(deps: KnowledgeProviderDeps): ResourcePr
         }
       })
 
-      // Title matches first, then deterministic name order. Skip the re-rank on
-      // an empty query so the backend's ordering is preserved.
+      // Title matches first, then backend relevance order is preserved via stable sort (issue #4579).
+      // Skip the re-rank on an empty query so the backend's ordering is preserved as-is.
       if (q.length > 0) {
-        results.sort(compareResults)
+        results.sort((a, b) => b.score - a.score)
       }
       return results
     },


### PR DESCRIPTION
## Problem / Motivation

In the Search Everywhere command palette, searching for terms that match document contents rather than titles (body-only hits) causes results to be re-alphabetized by title on the **Knowledge** tab, **Artifacts** tab, and **All** tab, discarding the relevance ranking established by the backend search endpoints.

Following the fix for the Sessions provider (#4568 / PR #4570), this PR addresses the remaining sibling instances identified in #4579:
1. `knowledgeProvider.ts`: wraps `api.knowledgeSearch(q)` (HybridRetriever relevance ranking).
2. `artifactsProvider.ts`: wraps `api.artifacts({ ... })` (mtime/relevance content scanning).
3. `allAggregator.ts`: re-sorted provider batches with `compareResults`, destroying the internal ordering established by individual providers (including the Sessions provider fix).

## Why it matters

Both the Knowledge search endpoint and the Artifacts content search rank hits server-side by relevance. Client-side scoring evaluates `fuzzyMatch(q, title)`, which yields `0` for all body-only hits. Falling back to an alphabetical `localeCompare` tiebreak in `makeScoreThenNameComparator` completely overrides the server's relevance ranking, pushing the most relevant document to the bottom if its title alphabetically follows other matches. Furthermore, the All tab's aggregator re-sorted results from every provider, causing the same issue across blended results.

## What changed

- **Knowledge Provider (`knowledgeProvider.ts`)**: Replaced `makeScoreThenNameComparator` with a stable score-descending sort (`(a, b) => b.score - a.score`). `Array.prototype.sort` is stable, so equal-score (body-only) hits keep the backend's relevance order as the tiebreak while title matches still rank first.
- **Artifacts Provider (`artifactsProvider.ts`)**: Applied the same stable score-descending sort.
- **All Aggregator (`allAggregator.ts`)**: Removed the pre-slice and post-merge `compareResults` re-sort. Slices `perProviderLimit` directly from each provider's already-ordered output and blends with a stable `sort((a, b) => b.score - a.score)`, preserving each provider's established internal ranking when scores are equal. Note this means equal-score rows on the All tab now group by provider (registration order) rather than interleaving alphabetically across providers — inherent to any per-provider-order-preserving blend, since no cross-provider score scale exists.
- **Deliberately untouched**: `makeScoreThenNameComparator` in `website/src/utils/fuzzyMatch.ts`, which continues to provide clean alphabetical tiebreaks for providers that score locally (skills, settings, prompts, pages, apps, actions).

## Tests

- Extended `knowledgeProvider.test.ts`:
  - Verified body-only query over reverse-alphabetical backend hits preserves server response order (all scores 0).
  - Verified title matches still rank first (bias preserved).
- Extended `artifactsProvider.test.ts`:
  - Verified body-only query over reverse-alphabetical artifact hits preserves server response order.
  - Verified title matches still rank first.
- Extended `allAggregator.test.ts`:
  - Verified blended search preserves each provider's internal sequence for equal-score items.
- All 24 test suites / 315 unit tests in `src/components/commandPalette` pass cleanly (`npx vitest run src/components/commandPalette`).
- TypeScript typecheck passes with 0 errors (`npx tsc --noEmit --project tsconfig.json`).

## Manual verification

N/A — unit coverage sufficient: verified via comprehensive unit tests in vitest directly exercising the provider and aggregator contracts.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** ordering-only change — every row renders pixel-identically; only which rows come first differs, which a static screenshot cannot demonstrate. The regression tests assert the exact order contract instead.

## Related Issues

Closes #4579

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior documented in code comments
- [x] No secrets, credentials, or internal references in the diff

